### PR TITLE
fix(docs): CAB-358 add credentials management stub

### DIFF
--- a/docs/deployment/credentials.md
+++ b/docs/deployment/credentials.md
@@ -1,0 +1,10 @@
+# Credentials Management
+
+All production credentials are stored in HashiCorp Vault.
+
+## Access
+- **Vault UI**: https://vault.gostoa.dev
+- **Auth method**: OIDC via Keycloak
+
+## Local Development
+See `.env.example` for required environment variables.


### PR DESCRIPTION
## Summary

- Create `docs/deployment/credentials.md` stub referencing Vault for credential management
- Replaces inline credentials removed from README during CAB-358 audit

## Test plan

- [ ] Verify `docs/deployment/credentials.md` exists and contains Vault reference
- [ ] Verify README links to this file resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)