### PR TITLE
fix(api): return empty arrays instead of 500 when gateway unreachable

### DIFF
--- a/control-plane-api/src/routers/gateway.py
+++ b/control-plane-api/src/routers/gateway.py
@@ -131,7 +131,7 @@ async def list_gateway_apis(
         ]
     except Exception as e:
         logger.error(f"Failed to list Gateway APIs: {e}")
-        raise HTTPException(status_code=500, detail=f"Gateway error: {str(e)}")
+        return []
 
 
 @router.post("/apis", response_model=ImportAPIResponse)
@@ -296,7 +296,7 @@ async def list_gateway_applications(
         ]
     except Exception as e:
         logger.error(f"Failed to list Gateway applications: {e}")
-        raise HTTPException(status_code=500, detail=f"Gateway error: {str(e)}")
+        return []
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- `/v1/gateway/apis` and `/v1/gateway/applications` threw HTTP 500 when webMethods was down
- Now returns empty arrays on error, matching `/v1/gateway/health`'s graceful behavior
- Fixes the Gateway Status dashboard crash regardless of frontend version

## Test plan
- [ ] Gateway Status page loads without error when webMethods is unreachable
- [ ] APIs and Applications sections show empty state instead of error

🤖 Generated with [Claude Code](https://claude.com/claude-code)