### PR TITLE
fix(ci): use commit SHA image tags in API and portal pipelines

### DIFF
--- a/.github/workflows/control-plane-api-ci.yml
+++ b/.github/workflows/control-plane-api-ci.yml
@@ -201,7 +201,7 @@ jobs:
         if: steps.cluster-check.outputs.CLUSTER_EXISTS == 'true'
         run: |
           ENV="${{ steps.env.outputs.ENVIRONMENT }}"
-          IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${ENV}-latest"
+          IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${ENV}-${{ github.sha }}"
 
           echo "Updating control-plane-api to image: $IMAGE"
 

--- a/.github/workflows/stoa-portal-ci.yml
+++ b/.github/workflows/stoa-portal-ci.yml
@@ -98,7 +98,7 @@ jobs:
       id-token: write
 
     outputs:
-      image_tag: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.env.outputs.ENVIRONMENT }}-latest
+      image_tag: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.env.outputs.ENVIRONMENT }}-${{ github.sha }}
       image_digest: ${{ steps.build.outputs.digest }}
 
     steps:


### PR DESCRIPTION
## Summary
- Same bug as PR #35: mutable `dev-latest` tag made `kubectl set image` a no-op
- Fixed in control-plane-api-ci.yml and stoa-portal-ci.yml
- Now all 3 CI pipelines (UI, API, Portal) use `dev-<sha>` for unique deploys

## Test plan
- [ ] API and Portal deploys create new pods after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)