### PR TITLE
fix(ci): use commit SHA tags and rollout restart in all pipelines

### DIFF
--- a/.github/workflows/control-plane-api-ci.yml
+++ b/.github/workflows/control-plane-api-ci.yml
@@ -209,6 +209,9 @@ jobs:
             control-plane-api=$IMAGE \
             -n stoa-system
 
+          # Force rollout restart to ensure new image is pulled
+          kubectl rollout restart deployment/control-plane-api -n stoa-system
+
           # Wait for rollout
           kubectl rollout status deployment/control-plane-api -n stoa-system --timeout=300s
 

--- a/.github/workflows/control-plane-ui-ci.yml
+++ b/.github/workflows/control-plane-ui-ci.yml
@@ -207,6 +207,9 @@ jobs:
             control-plane-ui=${{ needs.docker.outputs.image_tag }} \
             -n stoa-system
 
+          # Force rollout restart to ensure new image is pulled
+          kubectl rollout restart deployment/control-plane-ui -n stoa-system
+
           # Wait for rollout
           kubectl rollout status deployment/control-plane-ui -n stoa-system --timeout=300s
 

--- a/.github/workflows/mcp-gateway-ci.yml
+++ b/.github/workflows/mcp-gateway-ci.yml
@@ -197,7 +197,7 @@ jobs:
         if: steps.cluster-check.outputs.CLUSTER_EXISTS == 'true'
         run: |
           ENV="${{ steps.env.outputs.ENVIRONMENT }}"
-          IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${ENV}-latest"
+          IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${ENV}-${{ github.sha }}"
 
           echo "Updating mcp-gateway to image: $IMAGE"
 

--- a/.github/workflows/stoa-portal-ci.yml
+++ b/.github/workflows/stoa-portal-ci.yml
@@ -202,6 +202,9 @@ jobs:
             stoa-portal=${{ needs.docker.outputs.image_tag }} \
             -n stoa-system
 
+          # Force rollout restart to ensure new image is pulled
+          kubectl rollout restart deployment/stoa-portal -n stoa-system
+
           # Wait for rollout
           kubectl rollout status deployment/stoa-portal -n stoa-system --timeout=300s
 


### PR DESCRIPTION
## Summary
- All 4 CI/CD pipelines now use `dev-<commit-sha>` image tags instead of mutable `dev-latest`
- Added `kubectl rollout restart` to UI, API, and Portal deploys (MCP Gateway already had it)
- Keycloak pipeline was already correct (uses SHA tag + rollout restart)
- Also includes backend fix: `/v1/gateway/apis` and `/applications` return `[]` instead of HTTP 500 when gateway is unreachable

## Pipelines fixed
| Pipeline | SHA tag | rollout restart |
|----------|---------|-----------------|
| control-plane-ui | PR #35 + this | this PR |
| control-plane-api | PR #37 + this | this PR |
| stoa-portal | PR #37 + this | this PR |
| mcp-gateway | this PR | already had it |
| keycloak-theme | already correct | already correct |

## Test plan
- [ ] Next deploy creates new pods with updated code
- [ ] Gateway Status dashboard loads without 500 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)