### PR TITLE
fix(mcp): add missing numpy and sentence-transformers deps

### DIFF
--- a/mcp-gateway/pyproject.toml
+++ b/mcp-gateway/pyproject.toml
@@ -42,6 +42,9 @@ dependencies = [
     "asyncpg>=0.29.0",
     "sqlalchemy[asyncio]>=2.0.0",
     "alembic>=1.13.0",
+    # Semantic cache (CAB-881)
+    "numpy>=1.24.0",
+    "sentence-transformers>=2.2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- MCP Gateway pods in CrashLoopBackOff due to `ModuleNotFoundError: No module named 'numpy'`
- The semantic cache embedder (CAB-881) imports `numpy` and `sentence-transformers` but they were not in `pyproject.toml`

## Test plan
- [ ] MCP Gateway pods start successfully after deploy
- [ ] `mcp.gostoa.dev` responds to health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)