### PR TITLE
fix(mcp): use CPU-only PyTorch to reduce Docker image size

### DIFF
--- a/mcp-gateway/Dockerfile
+++ b/mcp-gateway/Dockerfile
@@ -17,6 +17,9 @@ COPY static/ ./static/
 COPY migrations/ ./migrations/
 COPY alembic.ini ./
 
+# Install CPU-only PyTorch first (avoids pulling ~2GB CUDA version)
+RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
+
 # Install dependencies using pip (including k8s extras for CRD watcher)
 RUN pip install --no-cache-dir hatchling && \
     pip install --no-cache-dir ".[k8s]"


### PR DESCRIPTION
## Summary
- MCP Gateway image was 4.4GB because `sentence-transformers` pulls full PyTorch with CUDA
- Pods evicted by kubelet: `low on resource: ephemeral-storage`
- Fix: Install CPU-only torch first via `https://download.pytorch.org/whl/cpu`
- Expected image size: ~1.2GB (down from 4.4GB)

## Test plan
- [ ] Docker image builds successfully
- [ ] MCP Gateway pods start without eviction
- [ ] `mcp.gostoa.dev/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)