### PR TITLE
ci: add CODEOWNERS for maintainer review policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# STOA Platform — Code Owners
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default — all changes require maintainer review
+* @stoa-platform/maintainers
+
+# Security-critical paths
+/control-plane-api/src/auth/          @stoa-platform/maintainers
+/control-plane-api/src/core/security/ @stoa-platform/maintainers
+/mcp-gateway/src/auth/                @stoa-platform/maintainers
+
+# CI/CD — prevent workflow tampering
+/.github/workflows/ @stoa-platform/maintainers
+
+# Helm / Infrastructure
+/charts/            @stoa-platform/maintainers
+/deploy/            @stoa-platform/maintainers
+
+# Documentation
+/docs/              @stoa-platform/maintainers


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` to enforce review policies
- All paths require `@stoa-platform/maintainers` review
- Security-critical paths (auth, CI/CD, Helm) explicitly listed

Part of CAB-1019 — Secure GitHub Repository Configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)