### PR TITLE
fix(mcp): skip audience validation for tokens without aud claim

### DIFF
--- a/mcp-gateway/src/middleware/auth.py
+++ b/mcp-gateway/src/middleware/auth.py
@@ -329,9 +329,11 @@ class OIDCAuthenticator:
             )
 
             # CAB-938: Manual audience validation for multi-audience support
+            # Skip validation if token has no audience claim (e.g. dynamically
+            # registered OAuth clients like Claude.ai)
             allowed = self.settings.allowed_audiences_list
-            if allowed:
-                token_aud = payload.get("aud", [])
+            token_aud = payload.get("aud")
+            if allowed and token_aud is not None:
                 if isinstance(token_aud, str):
                     token_aud = [token_aud]
                 if not any(aud in allowed for aud in token_aud):


### PR DESCRIPTION
## Summary
- Claude.ai dynamically registers OAuth clients in Keycloak via DCR
- These tokens have `aud=None` — no audience claim at all
- Fix: skip audience check when `aud` is absent (token still validated by signature + issuer)

## Debug evidence
```
Token claims (unverified): iss=https://auth.gostoa.dev/realms/stoa aud=None azp=5bcf026c-...
validate_token FAILED: Invalid audience. Expected one of: ['stoa-mcp-gateway', 'account']
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)