### PR TITLE
fix(mcp): require auth on POST /mcp/sse for OAuth flow

### DIFF
--- a/mcp-gateway/src/handlers/mcp_sse.py
+++ b/mcp-gateway/src/handlers/mcp_sse.py
@@ -366,6 +366,16 @@ async def mcp_sse_post_endpoint(
 
     print(f"[MCP-AUTH] POST /sse - session={session_id[:8]}... new={is_new} user={user.subject if user else 'None'}", flush=True)
 
+    # MCP OAuth flow: if no auth token provided, return 401 to trigger OAuth discovery.
+    # Per MCP spec, the client should then check /.well-known/oauth-protected-resource
+    # and complete the OAuth flow before retrying with a Bearer token.
+    if user is None and settings.keycloak_url:
+        raise HTTPException(
+            status_code=401,
+            detail="Authentication required",
+            headers={"WWW-Authenticate": 'Bearer resource_metadata="/.well-known/oauth-protected-resource"'},
+        )
+
     # Parse the JSON-RPC message
     try:
         body = await request.json()


### PR DESCRIPTION
## Summary
- Claude.ai needs a 401 on the first POST to trigger OAuth discovery
- Without this, `get_optional_user` returns None and initialize succeeds without auth
- Claude.ai never obtains a token and tools/call fails silently

## Fix
Return 401 with `WWW-Authenticate` header pointing to `/.well-known/oauth-protected-resource` when no Bearer token is provided on POST /mcp/sse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)