### PR TITLE
fix(mcp): allow initialize without auth to unblock OAuth flow

### DIFF
--- a/mcp-gateway/src/handlers/mcp_sse.py
+++ b/mcp-gateway/src/handlers/mcp_sse.py
@@ -366,17 +366,7 @@ async def mcp_sse_post_endpoint(
 
     print(f"[MCP-AUTH] POST /sse - session={session_id[:8]}... new={is_new} user={user.subject if user else 'None'}", flush=True)
 
-    # MCP OAuth flow: if no auth token provided, return 401 to trigger OAuth discovery.
-    # Per MCP spec, the client should then check /.well-known/oauth-protected-resource
-    # and complete the OAuth flow before retrying with a Bearer token.
-    if user is None and settings.keycloak_url:
-        raise HTTPException(
-            status_code=401,
-            detail="Authentication required",
-            headers={"WWW-Authenticate": 'Bearer resource_metadata="/.well-known/oauth-protected-resource"'},
-        )
-
-    # Parse the JSON-RPC message
+    # Parse the JSON-RPC message first (needed to check method before auth)
     try:
         body = await request.json()
     except json.JSONDecodeError as e:
@@ -387,6 +377,18 @@ async def mcp_sse_post_endpoint(
         )
 
     method = body.get("method")
+
+    # MCP OAuth flow: require auth for all methods EXCEPT initialize and ping.
+    # The initialize handshake must succeed without auth so the client can discover
+    # the server capabilities and then trigger the OAuth flow for subsequent calls.
+    if user is None and settings.keycloak_url and method not in ("initialize", "ping"):
+        print(f"[MCP-AUTH] 401 for unauthenticated {method} request", flush=True)
+        raise HTTPException(
+            status_code=401,
+            detail="Authentication required",
+            headers={"WWW-Authenticate": 'Bearer resource_metadata="/.well-known/oauth-protected-resource"'},
+        )
+
     msg_id = body.get("id")
 
     # Debug logging to stdout


### PR DESCRIPTION
## Summary
- Move JSON body parsing before the auth check in POST `/mcp/sse`
- Allow `initialize` and `ping` methods through without authentication
- Return 401 with `WWW-Authenticate` header only for authenticated methods (`tools/list`, `tools/call`, etc.)

This fixes Claude.ai spinning infinitely when adding the MCP connector. The previous fix (PR #53) returned 401 before the client could complete the MCP handshake, preventing the OAuth flow from ever starting.

## Test plan
- [ ] `curl -X POST https://mcp.gostoa.dev/mcp/sse` with `initialize` body — should return 200
- [ ] `curl -X POST https://mcp.gostoa.dev/mcp/sse` with `tools/list` body (no auth) — should return 401
- [ ] Add MCP connector in Claude.ai — should complete OAuth flow and list tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)