### PR TITLE
fix(mcp): disable redirect_slashes to prevent 307 on /mcp (CAB-1040)

### DIFF
--- a/mcp-gateway/src/main.py
+++ b/mcp-gateway/src/main.py
@@ -245,6 +245,7 @@ def create_app() -> FastAPI:
         redoc_url="/redoc" if settings.debug else None,
         openapi_url="/openapi.json" if settings.debug else None,
         lifespan=lifespan,
+        redirect_slashes=False,  # CAB-1040: Prevent 307 redirects that break MCP clients
     )
 
     # Shadow mode middleware for Python → Rust migration


### PR DESCRIPTION
## Summary
- Disable FastAPI's `redirect_slashes` to prevent 307 redirects from `/mcp` to `/mcp/`
- Fixes protocol downgrade issue (HTTPS → HTTP) when behind Cloudflare/ALB
- Unblocks MCP client integrations that don't follow redirects properly

## Test plan
- [x] Verified `/mcp` currently returns 307 redirect
- [ ] After deploy: `curl -s -w "%{http_code}" -X POST https://mcp.gostoa.dev/mcp -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'` should return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)