### PR TITLE
chore: add Loki/Promtail observability stack and expand CLAUDE.md

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,11 @@
+# Trivy ignore list for upstream base image CVEs
+# These are Alpine/OpenSSL vulnerabilities in base images that we cannot fix
+# until the upstream base image is updated. Reviewed and accepted.
+#
+# Review this file monthly and remove entries once base images are patched.
+# Last reviewed: 2026-02-02
+
+# OpenSSL vulnerabilities in Alpine 3.22.2 base image (libcrypto3, libssl3)
+# Fixed in Alpine 3.22.3+ (openssl 3.5.5-r0) — waiting for upstream image update
+CVE-2025-15467
+CVE-2025-69419

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,137 @@
+# STOA Platform — BACKLOG.md
+
+> **Migré depuis Linear le 2026-02-04** dans le cadre du Mode Phase (CAB-1051)
+>
+> Ce fichier remplace le Backlog Linear. Les idées ici sont valides mais pas prioritaires pour le MVP.
+
+---
+
+## 🎯 Post-MVP Explicites
+
+| ID | Titre | Notes |
+|----|-------|-------|
+| CAB-1054 | [MEGA] Portal & Console UX — Post-MVP | UX polish après démo |
+| CAB-1055 | [MEGA] DX & Community — Post-MVP | Community features |
+| CAB-1049 | [Plan] Roadmap Q2 Post-Démo — Gaps Concurrentiels | Planning stratégique |
+
+---
+
+## 🔮 Vision & Strategy
+
+| ID | Titre | Notes |
+|----|-------|-------|
+| CAB-1046 | Enterprise MCP Federation — N Devs/Agents → 1 Master Account | Vision enterprise |
+| CAB-1045 | STOA = MCP to Everything — Gap Analysis & North Star | Positionnement long terme |
+
+---
+
+## ⚡ MCP Gateway & Features Avancées
+
+| ID | Titre | Notes |
+|----|-------|-------|
+| CAB-1053 | [MEGA] MCP Gateway & Platform Features | Features MCP avancées |
+| CAB-1047 | STOA Skills System - Context injection hiérarchique | Skills pour agents IA |
+| CAB-1037 | Automated Tenant Provisioning — "One API Call" Onboarding | Self-service tenants |
+| CAB-1032 | Consumer Execution View UI — Error taxonomy dashboard | Dashboard erreurs |
+| CAB-952 | UAC ConfigMap-based Architecture — OpenShift/Enterprise | Compatibilité OpenShift |
+| CAB-962 | Intermediate Hop Detection — Network Path Analysis | Observabilité réseau |
+| CAB-961 | Self-Diagnostic Engine — Auto Root Cause Analysis | RCA automatique |
+| CAB-725 | MCP Developer Self-Service (Logs, Metrics, Models Discovery) | Self-service dev |
+| CAB-822 | MCP Proxy Hardening — OAuth flows, Lazy discovery, Circuit Breaker | Hardening Phase 3 |
+
+---
+
+## 👥 Community
+
+| ID | Titre | Notes |
+|----|-------|-------|
+| CAB-1027 | GitHub Templates — Issues & PR Templates | Templates contribution |
+| CAB-386 | Good First Issues — 10 Starter Issues Template | Onboarding contributeurs |
+
+---
+
+## 🔧 Infra & DevOps
+
+| ID | Titre | Notes |
+|----|-------|-------|
+| CAB-1026 | Évaluation Migration Scaleway Kapsule — Souveraineté & Coûts | Alternative cloud souverain |
+| CAB-441 | Multi-Arch Docker Build — Mac ARM → AWS AMD64 | Build cross-platform |
+| CAB-980 | Helm: Auto-sync postgres-exporter secret | Secret management |
+| CAB-977 | Multi-Staging Pattern OpenShift & Enterprise CI/CD | Pattern enterprise |
+| CAB-1020 | [MEGA] Repo Consolidation — stoa/ cleanup + stoa-charts | Réorg repos |
+
+---
+
+## 📊 Observability
+
+| ID | Titre | Notes |
+|----|-------|-------|
+| CAB-357 | Monitoring Alerts Tuning | Fine-tuning alertes |
+| CAB-934 | Evaluate Ansible-style UAC inheritance at 15+ tenants | Scalabilité config |
+
+---
+
+## 🖥️ Portal & UX
+
+| ID | Titre | Notes |
+|----|-------|-------|
+| CAB-849 | Communautés Multi-Audience — Filtrage Public/Internal | Multi-audience portal |
+| CAB-700 | RBAC Affinage complet UI — Widgets, Tenant Isolation, Grafana | RBAC fine-grained |
+| CAB-789 | PERSONA: CPI Proxy Owner Dashboard | Dashboard persona spécifique |
+
+---
+
+## 🏗️ Architecture
+
+| ID | Titre | Notes |
+|----|-------|-------|
+| CAB-850 | Runtime Data Governance — Control Plane vs Git | Data governance pattern |
+| CAB-408 | Prospect Self-Onboarding — Zero-Touch Trial Experience | Onboarding prospects |
+
+---
+
+## 📋 Règles
+
+1. **Pas de ticket Linear** pour ces items tant qu'ils ne sont pas priorisés
+2. **Review mensuelle** : trier KEEP / KILL / DEFER
+3. **Promotion** : Si un item devient critique → créer ticket Linear + supprimer d'ici
+
+---
+
+---
+
+## 📦 Phase 3 — Todo Migrated (16 tickets)
+
+### Demo Content
+- [ ] **CAB-833** : Valider scénarios Ready Player One sur Portal UI
+- [ ] **CAB-920** : Demo: La Citadelle — Enterprise Fonction Publique (RGS/SecNumCloud)
+- [ ] **CAB-923** : Demo: Neo's Workshop — Personal AI Gateway (Token Optimization)
+- [ ] **CAB-916** : Demo: Middle-Earth Banking — Enterprise Banque (NIS2/DORA)
+- [ ] **CAB-915** : EPIC: Demo Content Library — 8 Univers Thématiques HLFH
+
+### UX & Portal
+- [ ] **CAB-1029** : Full Feature UX Audit — Apple-Style Minimalism Pass
+- [ ] **CAB-971** : Portal Governance — Multi-Audience + RBAC Affinage
+
+### MCP Gateway
+- [ ] **CAB-1038** : Hot-Reload Tools — notifications/tools/list_changed via SSE
+
+### Observability
+- [ ] **CAB-892** : UAC-Driven Observability — Debug chirurgical sans tcpdump
+- [ ] **CAB-801** : Hybrid Observability Dashboard — Cloud + On-Prem Unified
+
+### Community & Docs
+- [ ] **CAB-994** : Community Launch Preparation — Checklist Pré-Partage Réseau
+- [ ] **CAB-731** : Docs as Code + RAG Chatbot — Eat Your Own Dog Food
+- [ ] **CAB-1015** : Documentation Separation - Notion vs docs.gostoa.dev
+
+### Demo & CI
+- [ ] **CAB-453** : Living Demo Instance — Animated Scenarios per Sector
+- [ ] **CAB-979** : CI Security Showcase — Gestion exemplaire code AI-generated
+
+### Ops
+- [ ] **CAB-853** : PostgreSQL Backup — Retention Policy + Test Restore
+
+---
+
+*Dernière mise à jour : 2026-02-04*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,3 +157,136 @@ See `deploy/config/{dev,staging,prod}.env` for environment-specific configuratio
 | `OPA_EMBEDDED` | `true` | Use embedded evaluator |
 | `METERING_ENABLED` | `true` | Enable Kafka metering |
 | `K8S_WATCHER_ENABLED` | `false` | Enable CRD watcher |
+
+## Runtime Versions
+
+| Tool   | Version | Notes                          |
+|--------|---------|--------------------------------|
+| Python | 3.11    | control-plane-api, mcp-gateway |
+| Python | 3.12    | landing-api                    |
+| Node   | 20      | portal, control-plane-ui       |
+
+## Code Style
+
+### Python (ruff + black + isort)
+- **Line length**: 100 (mcp-gateway, landing-api), 120 (control-plane-api)
+- **Ruff rules**: E, W, F, I, B, C4, UP, ARG, SIM, S, DTZ, LOG, RUF
+- **Type checking**: mypy with `disallow_untyped_defs = true`
+- **First-party package**: `src`
+- Run: `ruff check . && black --check . && mypy src/`
+
+### TypeScript / React (eslint + prettier)
+- **Line length**: 100
+- **Prettier**: semicolons, single quotes, trailing commas (es5), LF
+- **Path alias**: `@/*` maps to `src/*`
+- **Unused args**: prefix with `_` (e.g., `_unused`)
+- **Max warnings**: 0 (control-plane-ui), 20 (portal)
+- Run: `npm run lint && npm run format:check`
+
+## Testing Standards
+
+### Python (pytest)
+- Framework: pytest + pytest-asyncio (asyncio_mode = "auto")
+- Test paths: `tests/`
+- File naming: `test_*.py` or `*_test.py`
+- Markers: `@slow`, `@integration`, `@unit`
+- **Coverage minimum: 70%** (`fail_under = 70`)
+- Run: `pytest --cov=src --cov-fail-under=70`
+
+### TypeScript (vitest)
+- Framework: **vitest** (NOT Jest) + React Testing Library
+- Coverage: v8 provider
+- Run: `npm run test` or `npm run test:coverage`
+
+### E2E (Playwright + BDD)
+- Location: `e2e/`
+- Framework: Playwright + playwright-bdd (Gherkin `.feature` files)
+- Test projects: `auth-setup`, `portal-chromium`, `console-chromium`, `gateway`, `ttftc`
+- Markers: `@smoke`, `@critical`, `@portal`, `@console`, `@gateway`, `@rpo`
+- Auth: persona-based storage states in `fixtures/.auth/`
+- Run: `npx playwright test` (from `e2e/`)
+
+## Commit & Branch Conventions
+
+### Commit Messages (commitlint enforced via husky)
+- Format: `<type>(<scope>): <subject>` (max 72 chars subject, 100 chars header)
+- **Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert`
+- **Scopes**: `api`, `ui`, `portal`, `mcp`, `gateway`, `helm`, `ci`, `docs`, `deps`, `security`, `demo`
+- Example: `fix(api): escape LIKE wildcards in portal search (CAB-1044)`
+
+### Branch Naming
+- `feat/<ticket-id>-<description>` for new features
+- `fix/<ticket-id>-<description>` for bug fixes
+- Example: `fix/cab-1044-search-escape`
+
+## Project Structure
+
+```
+stoa/
+├── control-plane-api/     # FastAPI backend (Python 3.11)
+├── control-plane-ui/      # Console UI - API Provider (React/TS)
+├── portal/                # Developer Portal - API Consumer (React/Vite/TS)
+├── mcp-gateway/           # MCP Gateway - edge-mcp mode (Python/FastAPI)
+├── stoa-gateway/          # Future Rust gateway (Tokio)
+├── landing-api/           # Landing page backend (Python 3.12, Poetry)
+├── e2e/                   # Playwright BDD E2E tests
+├── apis/                  # OpenAPI specs (per component)
+├── charts/                # Helm charts
+├── terraform/             # AWS IaC (EKS, RDS, etc.)
+├── ansible/               # AWX playbooks
+├── argocd/                # GitOps manifests
+├── webmethods/            # webMethods gateway configs
+├── docker/                # Docker / observability configs
+└── deploy/                # Docker Compose, env configs
+```
+
+No workspace tool — each component has independent dependencies and CI.
+
+## CI/CD (GitHub Actions)
+
+- **Path-based triggers**: each component has its own workflow, triggered only on relevant file changes
+- **Python CI**: ruff lint, mypy, pytest, bandit/safety audit
+- **Node CI**: npm install, lint, format check, vitest, coverage
+- **Security pipeline** (CAB-979): SAST, dependency audit, gitleaks, SBOM, container scan, DCO check
+- **Dependabot**: weekly (Monday), max 5 PRs/ecosystem, prefix `chore(deps)`
+
+## Database Migrations
+
+- Tool: **Alembic** (in `control-plane-api/alembic/`)
+- Create migration: `alembic revision --autogenerate -m "description"`
+- Apply: `alembic upgrade head`
+
+## Security Checklist
+
+- **Gitleaks**: configured at `.gitleaks.toml` with allowlist for docs/examples
+- **Bandit**: Python SAST — run `bandit -r src/`
+- **Safety / pip-audit**: dependency vulnerability scanning
+- **Signed commits**: verified in CI (warning-only)
+- **Never commit**: `.env*`, `*.pem`, `*.key`, `*credentials*`, `*.tfvars`
+
+## Workflow AI-Native
+
+### Nouvelle Feature
+
+1. **Nouvelle session** Claude Code (contexte frais)
+2. **Explorer** : "Propose 3 options pour `<feature>`, ne code pas"
+3. **Choisir** une option → "Plan en 5 étapes max, ne code pas"
+4. **Valider** le plan → "Go"
+5. **Vérifier** : tests green → commit
+
+### Review (Décisions Importantes)
+
+| Session | Rôle | Objectif |
+|---------|------|----------|
+| Session 1 | Architecte | Produire le plan d'implémentation |
+| Session 2 (fresh) | Staff Engineer | Review critique du plan |
+| Session 3 (fresh, optionnel) | Security Engineer | Review sécurité |
+
+**Verdict binaire** : `Go` / `Fix` / `Refaire` — pas de "peut-être".
+
+### Règles
+
+- **1 chose à la fois** — ne jamais mélanger feature + refactor + fix
+- **Ne jamais coder sans plan validé**
+- **Red flags** (tests cassés, dette technique, faille sécu) → fix avant de continuer
+- **Si > 10 min à structurer manuellement** → STOP, lance Claude Code

--- a/deploy/docker-compose/config/grafana/dashboards/stoa-logs.json
+++ b/deploy/docker-compose/config/grafana/dashboards/stoa-logs.json
@@ -1,0 +1,396 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "STOA Platform Logs - Quick Start",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "gridPos": {"h": 2, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "options": {
+        "code": {"language": "plaintext", "showLineNumbers": false, "showMiniMap": false},
+        "content": "# STOA Platform - Logs Dashboard\n\nView logs from all STOA services. Use the filters below to narrow down results.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.2.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 2},
+      "id": 101,
+      "panels": [],
+      "title": "Log Statistics",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "description": "Total log entries",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 3},
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["sum"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "editorMode": "code",
+          "expr": "count_over_time({namespace=~\"$namespace\", app=~\"$app\"} [$__range])",
+          "legendFormat": "Total Logs",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Log Entries",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "description": "Error logs",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 10},
+              {"color": "red", "value": 100}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 3},
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["sum"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "editorMode": "code",
+          "expr": "count_over_time({namespace=~\"$namespace\", app=~\"$app\"} |~ \"(?i)error\" [$__range])",
+          "legendFormat": "Errors",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Logs",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "description": "Warning logs",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 50},
+              {"color": "orange", "value": 200}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 3},
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["sum"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "editorMode": "code",
+          "expr": "count_over_time({namespace=~\"$namespace\", app=~\"$app\"} |~ \"(?i)warn\" [$__range])",
+          "legendFormat": "Warnings",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Warning Logs",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "description": "Log rate per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "logs/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 3},
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["mean"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "editorMode": "code",
+          "expr": "sum(rate({namespace=~\"$namespace\", app=~\"$app\"} [5m]))",
+          "legendFormat": "Rate",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Rate",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 7},
+      "id": 102,
+      "panels": [],
+      "title": "Log Volume",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "description": "Log volume by service over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "normal"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 8},
+      "id": 10,
+      "options": {
+        "legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "editorMode": "code",
+          "expr": "sum by (app) (count_over_time({namespace=~\"$namespace\", app=~\"$app\"} [$__interval]))",
+          "legendFormat": "{{app}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Volume by Service",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 16},
+      "id": 103,
+      "panels": [],
+      "title": "Log Stream",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "description": "Live log stream",
+      "gridPos": {"h": 15, "w": 24, "x": 0, "y": 17},
+      "id": 20,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "editorMode": "code",
+          "expr": "{namespace=~\"$namespace\", app=~\"$app\"} |~ \"$search\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Stream",
+      "type": "logs"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 32},
+      "id": 104,
+      "panels": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "description": "Error logs only",
+          "gridPos": {"h": 12, "w": 24, "x": 0, "y": 33},
+          "id": 30,
+          "options": {
+            "dedupStrategy": "none",
+            "enableLogDetails": true,
+            "prettifyLogMessage": true,
+            "showCommonLabels": false,
+            "showLabels": true,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "pluginVersion": "10.2.2",
+          "targets": [
+            {
+              "datasource": {"type": "loki", "uid": "loki"},
+              "editorMode": "code",
+              "expr": "{namespace=~\"$namespace\", app=~\"$app\"} |~ \"(?i)error\"",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Error Logs",
+          "type": "logs"
+        }
+      ],
+      "title": "Error Logs",
+      "type": "row"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "tags": ["stoa", "logs", "loki"],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {"selected": true, "text": "All", "value": "$__all"},
+        "datasource": {"type": "loki", "uid": "loki"},
+        "definition": "label_values(namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(namespace)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {"selected": true, "text": "All", "value": "$__all"},
+        "datasource": {"type": "loki", "uid": "loki"},
+        "definition": "label_values({namespace=~\"$namespace\"}, app)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Application",
+        "multi": false,
+        "name": "app",
+        "options": [],
+        "query": "label_values({namespace=~\"$namespace\"}, app)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {"selected": false, "text": "", "value": ""},
+        "hide": 0,
+        "label": "Search",
+        "name": "search",
+        "options": [{"selected": true, "text": "", "value": ""}],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {"refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h"]},
+  "timezone": "browser",
+  "title": "STOA Platform - Logs",
+  "uid": "stoa-logs",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/docker-compose/config/grafana/dashboards/stoa-overview.json
+++ b/deploy/docker-compose/config/grafana/dashboards/stoa-overview.json
@@ -48,7 +48,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -95,7 +95,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "sum(increase(stoa_control_plane_http_requests_total[1h]))",
           "legendFormat": "Requests",
@@ -108,7 +108,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -163,7 +163,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "histogram_quantile(0.95, sum(rate(stoa_control_plane_http_request_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p95",
@@ -176,7 +176,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -231,7 +231,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "sum(rate(stoa_control_plane_http_requests_total{status_code=~\"5..\"}[5m])) / sum(rate(stoa_control_plane_http_requests_total[5m])) or vector(0)",
           "legendFormat": "Error Rate",
@@ -244,7 +244,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -291,7 +291,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "sum(stoa_control_plane_http_requests_in_progress)",
           "legendFormat": "In Progress",
@@ -304,7 +304,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -384,7 +384,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "sum(rate(stoa_control_plane_http_requests_total[1m])) by (method)",
           "legendFormat": "{{method}}",
@@ -397,7 +397,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -477,7 +477,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "histogram_quantile(0.50, sum(rate(stoa_control_plane_http_request_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p50",
@@ -486,7 +486,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "histogram_quantile(0.95, sum(rate(stoa_control_plane_http_request_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p95",
@@ -495,7 +495,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "histogram_quantile(0.99, sum(rate(stoa_control_plane_http_request_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p99",
@@ -508,7 +508,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -633,7 +633,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "sum(rate(stoa_control_plane_http_requests_total[1m])) by (status_code)",
           "legendFormat": "{{status_code}}",

--- a/deploy/docker-compose/config/grafana/provisioning/datasources/datasources.yml
+++ b/deploy/docker-compose/config/grafana/provisioning/datasources/datasources.yml
@@ -10,6 +10,7 @@ datasources:
   # ---------------------------------------------------------------------------
   - name: Prometheus
     type: prometheus
+    uid: prometheus
     access: proxy
     url: http://prometheus:9090
     isDefault: true
@@ -17,3 +18,16 @@ datasources:
     jsonData:
       timeInterval: "15s"
       httpMethod: POST
+
+  # ---------------------------------------------------------------------------
+  # Loki - Logs
+  # ---------------------------------------------------------------------------
+  - name: Loki
+    type: loki
+    uid: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+    jsonData:
+      maxLines: 1000
+      timeout: 60

--- a/deploy/docker-compose/config/loki/loki-config.yml
+++ b/deploy/docker-compose/config/loki/loki-config.yml
@@ -1,0 +1,72 @@
+# =============================================================================
+# STOA Platform - Loki Configuration (Quick Start)
+# =============================================================================
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /loki/tsdb-index
+    cache_location: /loki/tsdb-cache
+
+limits_config:
+  retention_period: 168h  # 7 days for quick start
+  ingestion_rate_mb: 8
+  ingestion_burst_size_mb: 16
+  per_stream_rate_limit: 3MB
+  per_stream_rate_limit_burst: 10MB
+  max_query_parallelism: 16
+  max_entries_limit_per_query: 5000
+  allow_structured_metadata: true
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  delete_request_store: filesystem
+
+analytics:
+  reporting_enabled: false
+
+frontend:
+  max_outstanding_per_tenant: 1024
+  compress_responses: true
+
+querier:
+  max_concurrent: 10

--- a/deploy/docker-compose/config/promtail/promtail-config.yml
+++ b/deploy/docker-compose/config/promtail/promtail-config.yml
@@ -1,0 +1,93 @@
+# =============================================================================
+# STOA Platform - Promtail Configuration (Quick Start)
+# =============================================================================
+
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+  log_level: info
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+    batchwait: 1s
+    batchsize: 1048576
+    timeout: 10s
+
+scrape_configs:
+  # ==========================================================================
+  # Docker Container Logs
+  # ==========================================================================
+  - job_name: docker-containers
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      # Keep only STOA platform containers
+      - source_labels: ['__meta_docker_container_name']
+        regex: '.*stoa.*|.*control-plane.*|.*mcp-gateway.*|.*keycloak.*|.*postgres.*'
+        action: keep
+      # Extract container name
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/?(.*)'
+        target_label: container
+      # Extract service name from compose
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: service
+      # Set app label from service name (for dashboard compatibility)
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: app
+      # Extract compose project
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_project']
+        target_label: project
+      # Set namespace from project (for dashboard compatibility with K8s queries)
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_project']
+        target_label: namespace
+      # Extract container ID
+      - source_labels: ['__meta_docker_container_id']
+        target_label: container_id
+    pipeline_stages:
+      # Parse JSON logs (structlog format)
+      - json:
+          expressions:
+            level: level
+            message: event
+            msg: msg
+            timestamp: timestamp
+            logger: logger
+            request_id: request_id
+            trace_id: trace_id
+            tenant_id: tenant_id
+            user_id: user_id
+            endpoint: endpoint
+            path: path
+            method: method
+            status_code: status_code
+            duration_ms: duration_ms
+            component: component
+            environment: environment
+            error: error
+            error_type: error_type
+      # Normalize message field
+      - template:
+          source: message
+          template: '{{ if .message }}{{ .message }}{{ else if .event }}{{ .event }}{{ else }}{{ .msg }}{{ end }}'
+      # Extract log level as label
+      - labels:
+          level:
+          logger:
+          tenant_id:
+          component:
+          environment:
+      # Set timestamp from log
+      - timestamp:
+          source: timestamp
+          format: RFC3339Nano
+          fallback_formats:
+            - RFC3339
+            - '2006-01-02T15:04:05.000Z'
+      # Output structured fields
+      - output:
+          source: message

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -196,6 +196,45 @@ services:
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
+      - loki
+    networks:
+      - stoa-network
+    restart: unless-stopped
+
+  # ==========================================================================
+  # Loki (Log Aggregation)
+  # ==========================================================================
+  loki:
+    image: grafana/loki:2.9.3
+    container_name: stoa-loki
+    ports:
+      - "${PORT_LOKI:-3100}:3100"
+    volumes:
+      - ./config/loki/loki-config.yml:/etc/loki/local-config.yaml:ro
+      - loki-data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - stoa-network
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3100/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  # ==========================================================================
+  # Promtail (Log Shipping)
+  # ==========================================================================
+  promtail:
+    image: grafana/promtail:2.9.3
+    container_name: stoa-promtail
+    volumes:
+      - ./config/promtail/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      - loki
     networks:
       - stoa-network
     restart: unless-stopped
@@ -215,3 +254,4 @@ volumes:
   keycloak-data:
   prometheus-data:
   grafana-data:
+  loki-data:

--- a/docker/observability/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/observability/grafana/provisioning/datasources/prometheus.yml
@@ -13,8 +13,10 @@ datasources:
 
   - name: Loki
     type: loki
+    uid: loki
     access: proxy
     url: http://loki:3100
     editable: true
     jsonData:
       maxLines: 1000
+      timeout: 60

--- a/docker/observability/promtail/promtail-config.yml
+++ b/docker/observability/promtail/promtail-config.yml
@@ -43,9 +43,15 @@ scrape_configs:
       # Extract service name from compose
       - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
         target_label: service
+      # Set app label from service name (for dashboard compatibility)
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: app
       # Extract compose project
       - source_labels: ['__meta_docker_container_label_com_docker_compose_project']
         target_label: project
+      # Set namespace from project (for dashboard compatibility with K8s queries)
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_project']
+        target_label: namespace
       # Extract container ID
       - source_labels: ['__meta_docker_container_id']
         target_label: container_id


### PR DESCRIPTION
## Summary

- **Observability**: Add Loki + Promtail log aggregation stack to docker-compose, with Grafana datasource provisioning, a dedicated `stoa-logs` dashboard, and fixed prometheus datasource UIDs across all panels
- **Promtail**: Add `app` and `namespace` relabel rules for K8s dashboard query compatibility
- **CLAUDE.md**: Expand with runtime versions, code style, testing standards, commit/branch conventions, project structure, CI/CD, database migrations, security checklist, and AI-Native workflow section
- **Misc**: Add `.trivyignore` for container scan config, `BACKLOG.md` for project tracking

## Test plan

- [ ] Run `docker compose up -d` from `deploy/docker-compose/` and verify Loki + Promtail + Grafana start correctly
- [ ] Open Grafana → Data Sources and confirm Prometheus + Loki are provisioned
- [ ] Open the `stoa-logs` dashboard and verify log queries work
- [ ] Open the `stoa-overview` dashboard and confirm panels still load (prometheus UID fix)
- [ ] Review CLAUDE.md sections for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)