### PR TITLE
docs(demo): demo script, checklist, and blocker fixes (CAB-1074)

### DIFF
--- a/control-plane-api/src/routers/catalog_admin.py
+++ b/control-plane-api/src/routers/catalog_admin.py
@@ -3,13 +3,19 @@
 Provides endpoints for managing the catalog cache synchronization.
 These endpoints require admin role (cpi-admin or tenant-admin).
 """
+import json
 import logging
-from typing import Optional
+from datetime import datetime, timezone
+from typing import List, Optional
+
 from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks, Query
+from pydantic import BaseModel
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth.dependencies import get_current_user, User
 from ..database import get_db as get_async_db
+from ..models.catalog import APICatalog
 from ..services.catalog_sync_service import CatalogSyncService
 from ..services.git_service import git_service
 from ..repositories.catalog import CatalogRepository
@@ -288,3 +294,128 @@ async def invalidate_cache(
         "status": "ok",
         "message": "Cache invalidated. Use POST /sync to refresh data from GitLab."
     }
+
+
+# ============================================================================
+# Direct Catalog Seed (offline mode — bypasses GitLab)
+# ============================================================================
+
+class CatalogSeedAPIEntry(BaseModel):
+    """Single API entry for direct catalog seeding."""
+    name: str
+    display_name: str
+    version: str = "1.0.0"
+    description: str = ""
+    backend_url: str = ""
+    tags: List[str] = []
+    category: Optional[str] = None
+    openapi_spec: Optional[str] = None  # JSON string
+
+
+class CatalogSeedRequest(BaseModel):
+    """Request to seed APIs directly into catalog (bypasses GitLab)."""
+    tenant_id: str
+    apis: List[CatalogSeedAPIEntry]
+
+
+class CatalogSeedResponse(BaseModel):
+    """Response from catalog seed operation."""
+    seeded: int
+    failed: int
+    results: dict
+
+
+@router.post("/seed")
+async def seed_catalog_directly(
+    data: CatalogSeedRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """
+    Seed APIs directly into the catalog cache (bypasses GitLab).
+
+    Use this when GitLab is not connected (e.g., demo environments,
+    local development). Inserts or updates entries in the api_catalog table.
+
+    Requires: cpi-admin role
+    """
+    if "cpi-admin" not in user.roles:
+        raise HTTPException(status_code=403, detail="Platform admin access required")
+
+    seeded = 0
+    failed = 0
+    results = {}
+
+    for api_entry in data.apis:
+        api_id = api_entry.name
+        tags = api_entry.tags
+        promotion_tags = {"portal:published", "promoted:portal", "portal-promoted"}
+        portal_published = any(tag.lower() in promotion_tags for tag in tags)
+
+        # Build metadata dict (same shape as GitLab api.yaml)
+        api_metadata = {
+            "name": api_entry.name,
+            "display_name": api_entry.display_name,
+            "version": api_entry.version,
+            "description": api_entry.description,
+            "backend_url": api_entry.backend_url,
+            "tags": tags,
+            "status": "active",
+            "deployments": {"dev": True, "staging": False},
+        }
+
+        # Parse openapi_spec from JSON string if provided
+        openapi_spec = None
+        if api_entry.openapi_spec:
+            try:
+                openapi_spec = json.loads(api_entry.openapi_spec)
+            except (json.JSONDecodeError, TypeError):
+                openapi_spec = None
+
+        try:
+            stmt = insert(APICatalog).values(
+                tenant_id=data.tenant_id,
+                api_id=api_id,
+                api_name=api_entry.display_name,
+                version=api_entry.version,
+                status="active",
+                category=api_entry.category,
+                tags=tags,
+                portal_published=portal_published,
+                api_metadata=api_metadata,
+                openapi_spec=openapi_spec,
+                git_path=None,
+                git_commit_sha=None,
+                synced_at=datetime.now(timezone.utc),
+                deleted_at=None,
+            ).on_conflict_do_update(
+                index_elements=["tenant_id", "api_id"],
+                set_={
+                    "api_name": api_entry.display_name,
+                    "version": api_entry.version,
+                    "status": "active",
+                    "category": api_entry.category,
+                    "tags": tags,
+                    "portal_published": portal_published,
+                    "api_metadata": api_metadata,
+                    "openapi_spec": openapi_spec,
+                    "synced_at": datetime.now(timezone.utc),
+                    "deleted_at": None,
+                },
+            )
+            await db.execute(stmt)
+            seeded += 1
+            results[api_id] = "seeded"
+        except Exception as e:
+            logger.error(f"Failed to seed API {api_id}: {e}")
+            failed += 1
+            results[api_id] = f"failed: {str(e)[:100]}"
+
+    await db.commit()
+
+    logger.info(
+        f"Catalog seed by {user.username}: {seeded} seeded, {failed} failed "
+        f"(tenant: {data.tenant_id})"
+    )
+
+    return CatalogSeedResponse(seeded=seeded, failed=failed, results=results)

--- a/control-plane-api/src/routers/portal_applications.py
+++ b/control-plane-api/src/routers/portal_applications.py
@@ -89,7 +89,7 @@ def _get_user_applications(user: User) -> List[dict]:
     """Get all applications owned by the user."""
     return [
         app for app in _applications.values()
-        if app.get("owner_id") == user.sub or app.get("owner_id") == user.username
+        if app.get("owner_id") == user.id or app.get("owner_id") == user.username
     ]
 
 
@@ -168,7 +168,7 @@ async def get_application(
         raise HTTPException(status_code=404, detail=f"Application {app_id} not found")
 
     # Check ownership
-    if app.get("owner_id") not in [user.sub, user.username]:
+    if app.get("owner_id") not in [user.id, user.username]:
         raise HTTPException(status_code=403, detail="Access denied")
 
     return ApplicationResponse(
@@ -212,7 +212,7 @@ async def create_application(
             "client_id": client_id,
             "client_secret_hash": "hashed",  # In real impl, store hash
             "tenant_id": data.tenant_id,
-            "owner_id": user.sub or user.username,
+            "owner_id": user.id or user.username,
             "status": "active",
             "redirect_uris": data.redirect_uris,
             "api_subscriptions": [],
@@ -258,7 +258,7 @@ async def update_application(
         raise HTTPException(status_code=404, detail=f"Application {app_id} not found")
 
     # Check ownership
-    if app.get("owner_id") not in [user.sub, user.username]:
+    if app.get("owner_id") not in [user.id, user.username]:
         raise HTTPException(status_code=403, detail="Access denied")
 
     # Update fields
@@ -301,7 +301,7 @@ async def delete_application(
         raise HTTPException(status_code=404, detail=f"Application {app_id} not found")
 
     # Check ownership
-    if app.get("owner_id") not in [user.sub, user.username]:
+    if app.get("owner_id") not in [user.id, user.username]:
         raise HTTPException(status_code=403, detail="Access denied")
 
     del _applications[app_id]
@@ -328,7 +328,7 @@ async def regenerate_secret(
         raise HTTPException(status_code=404, detail=f"Application {app_id} not found")
 
     # Check ownership
-    if app.get("owner_id") not in [user.sub, user.username]:
+    if app.get("owner_id") not in [user.id, user.username]:
         raise HTTPException(status_code=403, detail="Access denied")
 
     # Generate new secret

--- a/demo/CHECKLIST-J1.md
+++ b/demo/CHECKLIST-J1.md
@@ -1,0 +1,177 @@
+# Checklist J-1 — Verifications avant demo
+
+> **CAB-1074** | A executer **la veille** de la presentation.
+> Demo cible : 24 February 2026 | "Excel + mails -> Portal + 2 clics"
+
+---
+
+## J-1 : Preparation complete
+
+### Infrastructure
+
+- [ ] **Portal UP** — `curl -s -o /dev/null -w "%{http_code}" https://portal.gostoa.dev` -> 200
+- [ ] **Console UP** — `curl -s -o /dev/null -w "%{http_code}" https://console.gostoa.dev` -> 200
+- [ ] **API UP** — `curl -s -o /dev/null -w "%{http_code}" https://api.gostoa.dev/health/ready` -> 200
+- [ ] **Keycloak UP** — `curl -s -o /dev/null -w "%{http_code}" https://auth.gostoa.dev` -> 200
+
+Script rapide :
+
+```bash
+for url in \
+  https://portal.gostoa.dev \
+  https://console.gostoa.dev \
+  https://api.gostoa.dev/health/ready \
+  https://auth.gostoa.dev; do
+  code=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+  echo "$code $url"
+done
+```
+
+### Donnees de demo
+
+- [ ] **Seed execute** — Les 3 APIs sont dans le catalogue
+
+```bash
+# Obtenir un token (necessaire pour les endpoints portal)
+TOKEN=$(curl -s -X POST "https://auth.gostoa.dev/realms/stoa/protocol/openid-connect/token" \
+  -d "grant_type=password&client_id=control-plane-ui&username=anorak&password=demo" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))")
+
+# Verifier les APIs demo
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.gostoa.dev/v1/portal/apis" | python3 -m json.tool | grep -c '"name"'
+# Attendu : >= 3 (Petstore, Account Management, Payments)
+```
+
+- [ ] **Petstore API** visible dans le catalogue
+- [ ] **Account Management API** visible
+- [ ] **Payments API** visible
+- [ ] **OASIS Mobile App** existe (application active)
+- [ ] **Gunter Analytics Dashboard** en statut **Pending** (pour l'Acte 3 — Approval)
+
+Si les donnees manquent :
+
+```bash
+ANORAK_PASSWORD=<password> python scripts/seed-demo-data.py
+```
+
+### Comptes Keycloak
+
+- [ ] **art3mis** peut se connecter sur le Portal
+
+```bash
+# Test auth art3mis
+curl -s -X POST https://auth.gostoa.dev/realms/stoa/protocol/openid-connect/token \
+  -d "grant_type=password&client_id=portal-ui&username=art3mis&password=<password>" \
+  | python3 -c "import sys,json; t=json.load(sys.stdin); print('OK' if 'access_token' in t else 'FAIL')"
+```
+
+- [ ] **parzival** peut se connecter sur la Console
+
+```bash
+# Test auth parzival
+curl -s -X POST https://auth.gostoa.dev/realms/stoa/protocol/openid-connect/token \
+  -d "grant_type=password&client_id=console-ui&username=parzival&password=<password>" \
+  | python3 -c "import sys,json; t=json.load(sys.stdin); print('OK' if 'access_token' in t else 'FAIL')"
+```
+
+---
+
+## J-1 : Dry Run
+
+### Dry Run 1 — Technique (filmer en `dry-run-1.mp4`)
+
+Derouler le script complet (SCRIPT.md) en filmant l'ecran :
+
+- [ ] **Acte 1 — Intro** : Texte fluide, < 30s
+- [ ] **Acte 2 — Discovery** : Catalogue -> Recherche -> Spec -> Subscribe -> Try It
+  - [ ] Recherche "petstore" fonctionne
+  - [ ] Page detail affiche Endpoints + OpenAPI Spec
+  - [ ] Subscribe genere une API Key
+  - [ ] Try It retourne 200 OK
+- [ ] **Acte 3 — Approval** : Console -> Applications -> Approve
+  - [ ] Gunter Analytics Dashboard visible en Pending
+  - [ ] Approve fonctionne (ou 409 si deja fait -> noter pour le reset)
+  - [ ] Monitoring affiche des donnees
+- [ ] **Acte 4 — API Call** : Terminal -> curl -> Dashboard
+  - [ ] curl avec API Key retourne 200 + donnees JSON
+  - [ ] Metriques visibles dans le dashboard
+- [ ] **Acte 5 — Outro** : Texte fluide, < 30s
+- [ ] **Timing total** : < 5 min
+
+### Reset entre dry runs
+
+Apres un dry run, il faut reinitialiser :
+
+```bash
+# Re-seed pour reinitialiser les statuts (idempotent)
+ANORAK_PASSWORD=<password> python scripts/seed-demo-data.py
+```
+
+Verifier que **Gunter Analytics Dashboard** est bien en **Pending** a nouveau.
+
+### Dry Run 2 — Fluide (filmer en `dry-run-2.mp4`)
+
+- [ ] Memes verifications que Dry Run 1
+- [ ] Transitions fluides (pas d'hesitation entre les onglets)
+- [ ] Texte dit sans regarder le script
+- [ ] Timing < 5 min
+- [ ] Pas de bug rencontre
+
+### Backup Video (filmer en `backup-final.mp4`)
+
+- [ ] **Meilleur dry run** selectionne ou nouvel enregistrement HD
+- [ ] Resolution >= 1080p
+- [ ] Audio clair (micro teste)
+- [ ] Fichier accessible **offline** (pas sur le cloud uniquement)
+- [ ] Teste en lecture complete sans coupure
+
+---
+
+## J-1 : Materiel
+
+### Laptop
+
+- [ ] Batterie > 80% ou branche secteur
+- [ ] Adaptateur HDMI/USB-C pour le projecteur
+- [ ] Luminosite ecran au max
+- [ ] Mode "Ne pas deranger" active
+- [ ] Notifications desactivees (Slack, Mail, Calendar)
+- [ ] Onglets personnels fermes
+
+### Navigateur (Chrome recommande)
+
+- [ ] Zoom a **125%** (lisibilite salle)
+- [ ] Dark mode **desactive** (meilleure projection)
+- [ ] Barre de favoris **masquee**
+- [ ] Historique barre d'adresse nettoyee (pas d'URL embarrassante en autocomplete)
+- [ ] Extensions non essentielles desactivees
+
+### Reseau
+
+- [ ] Wifi du lieu teste (ou confirmation de l'orga)
+- [ ] Hotspot mobile pret en backup (verifier forfait data)
+- [ ] VPN **deconnecte**
+
+### Slides
+
+- [ ] Slide deck export en **PDF** (backup si PowerPoint plante)
+- [ ] QR code genere et teste -> https://docs.gostoa.dev
+- [ ] Screenshots de secours integres dans le deck (Plan B)
+
+---
+
+## J-1 : Recap final
+
+| Element | Statut |
+|---------|--------|
+| Infrastructure UP (4 services) | [ ] |
+| Donnees seedees (3 APIs, 2 apps) | [ ] |
+| Comptes OK (art3mis, parzival) | [ ] |
+| Dry Run 1 filme | [ ] |
+| Dry Run 2 filme | [ ] |
+| Backup video HD offline | [ ] |
+| Materiel pret | [ ] |
+| Slides + QR code | [ ] |
+
+> **Regle** : Si un element est KO, le fixer **maintenant**. Pas le jour J.

--- a/demo/SCRIPT.md
+++ b/demo/SCRIPT.md
@@ -1,0 +1,235 @@
+# Demo Script — "Excel + mails -> Portal + 2 clics" (5 min)
+
+> **CAB-1074** | Presentation: 24 February 2026
+> Presenter: Christophe Aboulicam | Platform: STOA
+
+---
+
+## Vue d'ensemble
+
+| Acte | Timing | Duree | Action cle |
+|------|--------|-------|------------|
+| Intro | 0:00 - 0:30 | 30s | "Excel + mails -> Portal + 2 clics" |
+| Discovery | 0:30 - 2:00 | 1m30 | Portal -> Search -> Spec -> Try It |
+| Approval | 2:00 - 3:00 | 1m | Owner approve en 1 clic |
+| API Call | 3:00 - 4:30 | 1m30 | Credentials -> curl -> Dashboard |
+| Outro | 4:30 - 5:00 | 30s | "5-10 jours -> 2 minutes" |
+
+### Personas
+
+| Persona | URL | Role | Actes |
+|---------|-----|------|-------|
+| art3mis | portal.gostoa.dev | devops (consumer) | Discovery, API Call |
+| parzival | console.gostoa.dev | tenant-admin (provider) | Approval |
+
+### Setup navigateur
+
+| Onglet | URL | Pre-logged |
+|--------|-----|------------|
+| 1 | https://portal.gostoa.dev/apis | art3mis |
+| 2 | https://console.gostoa.dev | parzival |
+| 3 | Terminal avec curl pret | — |
+
+---
+
+## Acte 1 — INTRO (0:00 - 0:30)
+
+**[Ecran : Portal ouvert sur le catalogue]**
+
+> "Aujourd'hui dans la plupart des grandes entreprises, pour consommer une API, il faut un fichier Excel pour trouver la bonne API, 3 mails pour demander l'acces, et 5 a 10 jours d'attente."
+
+*Pause 2 secondes.*
+
+> "Avec STOA, c'est un portail et 2 clics. Je vais vous le montrer en live."
+
+**Checkpoint 0:30** — Si > 0:35, couper la pause et enchainer.
+
+---
+
+## Acte 2 — DISCOVERY (0:30 - 2:00)
+
+**[Onglet 1 : Portal — https://portal.gostoa.dev/apis]**
+
+> "Je suis Art3mis, developpeur dans l'equipe mobile. J'ai besoin d'integrer l'API Petstore."
+
+### 2.1 — Catalogue (0:30 - 0:50)
+
+1. Le catalogue est deja affiche (page `/apis`)
+2. Pointer les cartes API visibles
+
+> "Premier changement : toutes les APIs de l'entreprise sont ici, dans un catalogue en self-service. Plus besoin de chercher dans un Excel."
+
+### 2.2 — Recherche + Spec (0:50 - 1:15)
+
+1. Taper `petstore` dans la barre de recherche
+2. Cliquer sur la carte **Petstore API**
+3. La page detail s'ouvre
+4. Cliquer sur l'onglet **Endpoints**
+5. Cliquer sur l'onglet **OpenAPI Spec**
+
+> "La spec OpenAPI complete, directement dans le portail. Plus besoin de demander au tech lead ou de fouiller Confluence."
+
+### 2.3 — Souscription (1:15 - 1:45)
+
+1. Cliquer sur **Subscribe**
+2. Selectionner **OASIS Mobile App**
+3. Selectionner **Standard Plan**
+4. Confirmer
+
+> "Un clic. Pas de mail, pas de reunion, pas de ticket ServiceNow."
+
+5. La modale affiche **l'API Key generee**
+6. Montrer le message "Copy and save this API key now"
+
+> "Credentials generees instantanement."
+
+7. **Copier la cle** (on en aura besoin a l'Acte 4)
+
+### 2.4 — Try It (1:45 - 2:00)
+
+1. Cliquer sur **Try this API**
+2. Selectionner `GET /pets`
+3. Cliquer **Send**
+4. Resultat : **200 OK**
+
+> "Test en live, directement depuis le portail. C'est notre premier clic."
+
+*Laisser le 200 OK visible a l'ecran.*
+
+**Checkpoint 2:00** — Si > 2:15, sauter le Try It (montrer juste le bouton).
+
+---
+
+## Acte 3 — APPROVAL (2:00 - 3:00)
+
+**[Onglet 2 : Console — https://console.gostoa.dev]**
+
+> "Maintenant, passons de l'autre cote. Je suis Parzival, API owner. C'est moi qui gere les acces."
+
+### 3.1 — Dashboard (2:00 - 2:15)
+
+1. Page Dashboard — montrer les indicateurs
+
+> "Vue d'ensemble en temps reel."
+
+### 3.2 — Approbation en 1 clic (2:15 - 2:50)
+
+1. Cliquer sur **Applications** dans la sidebar
+2. Pointer **Gunter Analytics Dashboard** — statut **Pending**
+
+> "Ici, une souscription en attente pour la Payments API. Dans un ESB classique, c'est 3 mails et une reunion. Ici..."
+
+3. Cliquer **Approve**
+
+> "Un clic. C'est notre deuxieme clic."
+
+### 3.3 — Monitoring (2:50 - 3:00)
+
+1. Cliquer sur **API Monitoring**
+2. Montrer le dashboard rapidement
+
+> "Chaque appel est trace et mesure. Plus de boite noire."
+
+**Checkpoint 3:00** — Si > 3:15, sauter le monitoring et passer a l'Acte 4.
+
+---
+
+## Acte 4 — API CALL (3:00 - 4:30)
+
+**[Onglet 3 : Terminal]**
+
+> "Maintenant, on va consommer l'API pour de vrai."
+
+### 4.1 — curl avec credentials (3:00 - 3:30)
+
+1. Dans le terminal, afficher la commande curl preparee :
+
+```bash
+curl -s -H "X-API-Key: <PASTE_KEY>" \
+  https://httpbin.org/anything/pets?status=available \
+  | python3 -m json.tool | head -20
+```
+
+2. Coller la cle API copiee a l'Acte 2
+3. Executer — reponse **200 OK** avec les donnees
+
+> "On a decouvert l'API, souscrit, teste, et maintenant on l'appelle en production. Le tout en moins de 5 minutes."
+
+### 4.2 — Dashboard metriques (3:30 - 4:15)
+
+**[Retour onglet 2 : Console]**
+
+1. Cliquer sur **API Monitoring**
+2. Montrer l'appel qui vient d'apparaitre dans les metriques
+
+> "L'appel qu'on vient de faire est deja visible ici. Le provider voit tout en temps reel."
+
+### 4.3 — Recapitulatif visuel (4:15 - 4:30)
+
+> "Recapitulons le parcours :"
+
+Pointer du doigt (ou montrer une slide) :
+
+> "1. Decouvrir l'API dans le catalogue — sans Excel.
+> 2. Souscrire en 1 clic — sans mail.
+> 3. Tester en live — sans attendre.
+> 4. Appeler en production — sans reunion.
+> 5. L'owner approuve ou monitore — sans bureaucratie."
+
+**Checkpoint 4:30** — Si > 4:40, passer directement a l'Outro.
+
+---
+
+## Acte 5 — OUTRO (4:30 - 5:00)
+
+**[Slide : "5-10 jours -> 2 minutes"]**
+
+> "Avec un ESB classique, obtenir un acces API prend 5 a 10 jours ouvrables. Avec STOA, ca prend 2 minutes."
+
+> "Un portail, 2 clics, zero mail."
+
+**[Slide : QR code + contact]**
+
+> "Scannez le QR code pour acceder a la documentation. Si vous voulez voir ca sur vos APIs, venez me voir apres."
+
+| | |
+|---|---|
+| Documentation | https://docs.gostoa.dev |
+| Contact | christophe@gostoa.dev |
+| Demo Portal | https://portal.gostoa.dev |
+
+> "Merci."
+
+---
+
+## Plan B — Si ca plante
+
+| Probleme | Action |
+|----------|--------|
+| Portal ne charge pas | Montrer screenshots dans le slide deck |
+| Login Keycloak echoue | Session pre-authentifiee (cookies en place) |
+| Subscribe echoue (409) | "Deja souscrit — c'est idempotent" -> My Subscriptions |
+| Test Sandbox erreur | Montrer le curl dans le terminal |
+| Console lente | Sauter le monitoring, aller au curl |
+| Reseau down | Basculer sur hotspot mobile, puis video backup |
+| Tout down | Lancer `backup-final.mp4` (offline) |
+
+### Commande curl de secours
+
+```bash
+# Fonctionne sans la plateforme STOA (httpbin toujours disponible)
+curl -s https://httpbin.org/anything/pets?status=available \
+  | python3 -m json.tool | head -20
+```
+
+---
+
+## Timing checkpoints
+
+| Temps | Checkpoint | Si en retard |
+|-------|-----------|-------------|
+| 0:30 | Intro finie | Couper la pause |
+| 2:00 | Discovery finie | Sauter Try It |
+| 3:00 | Approval fini | Sauter monitoring |
+| 4:30 | API Call fini | Sauter le recap visuel |
+| 5:00 | Fin | — |

--- a/docs/demo/DEMO-CHECKLIST.md
+++ b/docs/demo/DEMO-CHECKLIST.md
@@ -40,8 +40,14 @@ curl -s -o /dev/null -w "%{http_code}" https://auth.gostoa.dev       # Keycloak
 ### Seed Data
 
 ```bash
+# Obtenir un token (necessaire pour les endpoints portal)
+TOKEN=$(curl -s -X POST "https://auth.gostoa.dev/realms/stoa/protocol/openid-connect/token" \
+  -d "grant_type=password&client_id=control-plane-ui&username=anorak&password=demo" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))")
+
 # Verifier que les APIs demo sont dans le catalogue
-curl -s https://api.gostoa.dev/v1/portal/apis?search=petstore | python3 -m json.tool | head -5
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.gostoa.dev/v1/portal/apis?search=petstore" | python3 -m json.tool | head -5
 ```
 
 - [ ] Petstore API visible dans le catalogue
@@ -137,8 +143,8 @@ Si aucune souscription active n'existe pour la demo :
 ### Commande curl de secours
 
 ```bash
-# Test direct Petstore API (pas besoin de la plateforme)
-curl -s https://petstore3.swagger.io/api/v3/pet/findByStatus?status=available | python3 -m json.tool | head -20
+# Test direct via httpbin (toujours disponible, retourne 200)
+curl -s https://httpbin.org/anything/pets?status=available | python3 -m json.tool | head -20
 ```
 
 ---

--- a/docs/demo/DRY-RUN-1.md
+++ b/docs/demo/DRY-RUN-1.md
@@ -1,0 +1,151 @@
+# Dry-Run #1 Report — CAB-1062
+
+> **Date**: 2026-02-04
+> **Executor**: Claude Code (automated dry-run)
+> **Target demo**: "ESB is Dead" — 24 February 2026
+> **Verdict**: **FAIL** — 3 blockers to fix before next dry-run
+
+---
+
+## Timing Summary
+
+| Segment | Budget | Actual (API) | Status |
+|---------|--------|-------------|--------|
+| Pre-Auth (art3mis + parzival) | — | 0.9s | OK |
+| Hook (slides) | 0:00 - 0:30 | N/A (slides) | OK |
+| Problem (slides) | 0:30 - 1:30 | N/A (slides) | OK |
+| Solution LIVE — Portal | 1:30 - 3:30 | 4.7s (API calls) | BLOCKED |
+| Console — Admin View | 3:30 - 4:30 | 4.8s (API calls) | PARTIAL |
+| Close (slides) | 4:30 - 5:00 | N/A (slides) | OK |
+
+> API timings represent sequential curl calls, not browser rendering.
+> Real browser demo will feel faster with pre-loaded tabs and SSO sessions.
+
+---
+
+## T-30min Pre-Flight Checks
+
+| Service | URL | Status | Latency |
+|---------|-----|--------|---------|
+| Portal | https://portal.gostoa.dev | 200 | 0.20s |
+| Console | https://console.gostoa.dev | 200 | 0.28s |
+| API | https://api.gostoa.dev/health/ready | 200 | — |
+| Keycloak | https://auth.gostoa.dev | 302 (OK) | — |
+| Keycloak OIDC | /realms/stoa/.well-known/openid-configuration | 200 | — |
+
+**All services UP.**
+
+---
+
+## Blockers (Must Fix)
+
+### BLOCKER-1: Petstore API not in catalog
+
+- **Impact**: Demo script Step 3 ("Search petstore") returns 0 results
+- **Root cause**: `seed-demo-data.py` fails at Phase 1 — API creation returns `500: "GitLab not connected"`
+- **Details**: The `POST /v1/tenants/high-five/apis` endpoint requires GitLab integration (GitOps source of truth). The seed script cannot create APIs without this connection.
+- **Existing catalog**: 12 APIs exist from other seed runs (demo, high-five, oasis, ioi tenants) but none named "petstore"
+- **Fix options**:
+  1. **Connect GitLab** to the control-plane-api (requires GitLab token configuration)
+  2. **Add a direct SQL/API seed** that bypasses GitOps for demo data
+  3. **Pivot the demo** to use an existing API (e.g., "Account Management API" from demo tenant — found via search)
+  4. **Seed via K8s** — insert directly in the database or use a different admin endpoint
+
+### BLOCKER-2: Application creation fails (backend bug)
+
+- **Impact**: No "Gunter Analytics Dashboard" in pending state, no "OASIS Mobile App" — cannot demo approval flow
+- **Root cause**: `POST /v1/applications` returns `500: "'User' object has no attribute 'sub'"`
+- **Details**: The User model in control-plane-api is missing the `sub` attribute when creating applications via API (likely works differently from the UI flow)
+- **Fix**: Fix the `User` model or the application creation endpoint in `control-plane-api/`
+
+### BLOCKER-3: Petstore Swagger sandbox returns 500
+
+- **Impact**: Demo Step 6 ("Test live") — `GET /pet/findByStatus?status=available` at petstore3.swagger.io returns 500
+- **Details**: The external Petstore API (swagger.io) is unreliable. This is an external dependency outside our control.
+- **Fix options**:
+  1. **Use a STOA-hosted mock** instead of the external petstore3.swagger.io
+  2. **Prepare a curl backup** that works against a different endpoint
+  3. **Pre-record the sandbox response** as a video fallback
+
+---
+
+## Issues (Need Workaround)
+
+### ISSUE-1: Portal API requires authentication
+
+- **Impact**: DEMO-CHECKLIST.md curl examples (T-30min checks) fail without auth token
+- **Details**: `curl https://api.gostoa.dev/v1/portal/apis?search=petstore` returns `{"detail":"Not authenticated"}`
+- **Fix**: Update DEMO-CHECKLIST.md to include auth header, or make portal read endpoints public
+
+### ISSUE-2: Monitoring endpoint returns 404
+
+- **Impact**: Console Step 7 ("API Monitoring") — `GET /v1/monitoring/overview` returns 404
+- **Details**: The monitoring endpoint doesn't exist or has a different path
+- **Workaround**: The demo script says to "click API Monitoring in sidebar" — the UI page may exist even if this specific API endpoint doesn't. Verify in the browser.
+
+### ISSUE-3: Applications list is empty
+
+- **Impact**: Console Step 6 ("Applications list with Gunter Analytics Dashboard in Pending") — 0 applications returned
+- **Root cause**: Linked to BLOCKER-2 (app creation failed)
+- **Workaround**: None until BLOCKER-2 is fixed
+
+### ISSUE-4: Dashboard stats schema differs from script expectations
+
+- **Impact**: Minor — Dashboard returns `tools_available`, `active_subscriptions`, `api_calls_this_week`, `tools_trend` instead of expected "stats cards"
+- **Details**: The dashboard endpoint works but the data may not map to the visual described in the demo script
+- **Risk**: Low — the UI renders whatever the backend returns
+
+---
+
+## What Works
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Portal page load | OK | 0.20s, renders correctly |
+| Console page load | OK | 0.28s, renders correctly |
+| Keycloak SSO (art3mis) | OK | Token issued in 0.4s |
+| Keycloak SSO (parzival) | OK | Token issued in 0.5s |
+| API Catalog (12 APIs) | OK | Existing APIs visible, searchable |
+| Dashboard stats endpoint | OK | Returns data structure |
+| Subscribe endpoint | OK | Exists, returns validation errors as expected |
+| Metrics generation | OK | 33/33 API calls succeeded |
+| API detail page | OK | 200 in 0.83s for account-management-api |
+
+---
+
+## Seed Script Results
+
+```
+Phase 1 — APIs:       FAIL (3/3 failed — GitLab not connected)
+Phase 2 — Sync:       SKIPPED (no new APIs)
+Phase 3 — Apps:       FAIL (2/2 failed — User.sub bug)
+Phase 4 — Subs:       SKIPPED (no apps created)
+Phase 5 — Metrics:    OK (33 calls, 0 errors)
+```
+
+---
+
+## Recommended Fix Priority
+
+| Priority | Item | Owner | Effort |
+|----------|------|-------|--------|
+| P0 | BLOCKER-1: Seed Petstore API (fix GitLab or alt path) | Backend | Medium |
+| P0 | BLOCKER-2: Fix `User.sub` bug in app creation | Backend | Small |
+| P0 | BLOCKER-3: Host mock Petstore (don't depend on swagger.io) | Infra | Small |
+| P1 | ISSUE-1: Update checklist curl examples with auth | Docs | Trivial |
+| P1 | ISSUE-2: Verify monitoring page path in UI | Frontend | Trivial |
+| P2 | ISSUE-4: Validate dashboard card rendering | Frontend | Trivial |
+
+---
+
+## Next Steps
+
+1. Fix the 3 blockers
+2. Re-run seed-demo-data.py
+3. Schedule Dry-Run #2
+4. Browser-based walkthrough (not just API calls) to validate UI rendering
+5. Record video backup once dry-run passes
+
+---
+
+*Generated by Claude Code — CAB-1062 dry-run automation*

--- a/scripts/seed-demo-data.py
+++ b/scripts/seed-demo-data.py
@@ -65,7 +65,7 @@ PETSTORE_SPEC = json.dumps({
         "version": "1.0.0",
         "description": "Classic pet management API — browse, add, and manage pets in the store.",
     },
-    "servers": [{"url": "https://petstore3.swagger.io/api/v3"}],
+    "servers": [{"url": "https://httpbin.org/anything"}],
     "paths": {
         "/pets": {
             "get": {
@@ -510,7 +510,7 @@ DEMO_APIS = [
             "Classic pet management API \u2014 browse, add, and manage pets in the store. "
             "Ideal starter API for testing subscriptions and playground."
         ),
-        "backend_url": "https://petstore3.swagger.io/api/v3",
+        "backend_url": "https://httpbin.org/anything",
         "tags": ["portal:published", "rest", "demo", "public"],
         "openapi_spec": PETSTORE_SPEC,
     },
@@ -599,14 +599,12 @@ def create_client(token: str | None) -> httpx.Client:
 
 
 # =============================================================================
-# Phase 1: Seed APIs (via GitOps endpoint + catalog sync)
+# Phase 1: Seed APIs (GitOps first, offline fallback to catalog/seed)
 # =============================================================================
 
-def seed_apis(client: httpx.Client) -> dict[str, bool]:
-    """Create 3 demo APIs in the target tenant."""
+def seed_apis_via_gitops(client: httpx.Client) -> dict[str, bool]:
+    """Try creating APIs via GitOps endpoint. Returns {name: success}."""
     results = {}
-
-    print(f"\n=== Phase 1: Creating APIs in tenant '{DEMO_TENANT}' ===")
     for api in DEMO_APIS:
         name = api["name"]
         payload = {
@@ -621,19 +619,73 @@ def seed_apis(client: httpx.Client) -> dict[str, bool]:
         try:
             resp = client.post(f"/v1/tenants/{DEMO_TENANT}/apis", json=payload)
             if resp.status_code in (200, 201):
-                print(f"  [+] API '{name}' created")
+                print(f"  [+] API '{name}' created (GitOps)")
                 results[name] = True
             elif resp.status_code == 409:
                 print(f"  [=] API '{name}' already exists (idempotent)")
                 results[name] = True
             else:
-                print(f"  [-] API '{name}' failed: {resp.status_code} \u2014 {resp.text[:120]}")
+                print(f"  [-] API '{name}' failed: {resp.status_code} — {resp.text[:120]}")
                 results[name] = False
         except Exception as e:
             print(f"  [-] API '{name}' error: {e}")
             results[name] = False
-
     return results
+
+
+def seed_apis_offline(client: httpx.Client) -> dict[str, bool]:
+    """Seed APIs directly into catalog (bypasses GitLab). Offline mode."""
+    print("  [~] Switching to OFFLINE mode (direct catalog seed)...")
+    payload = {
+        "tenant_id": DEMO_TENANT,
+        "apis": [
+            {
+                "name": api["name"],
+                "display_name": api["display_name"],
+                "version": api["version"],
+                "description": api["description"],
+                "backend_url": api["backend_url"],
+                "tags": api["tags"],
+                "openapi_spec": api["openapi_spec"],
+                "category": "Demo",
+            }
+            for api in DEMO_APIS
+        ],
+    }
+    try:
+        resp = client.post("/v1/admin/catalog/seed", json=payload)
+        if resp.status_code in (200, 201):
+            data = resp.json()
+            seeded = data.get("seeded", 0)
+            failed = data.get("failed", 0)
+            results_map = data.get("results", {})
+            print(f"  [+] Offline seed: {seeded} seeded, {failed} failed")
+            return {name: (results_map.get(name, "") == "seeded") for name in results_map}
+        print(f"  [-] Offline seed failed: {resp.status_code} — {resp.text[:200]}")
+        return {api["name"]: False for api in DEMO_APIS}
+    except Exception as e:
+        print(f"  [-] Offline seed error: {e}")
+        return {api["name"]: False for api in DEMO_APIS}
+
+
+def seed_apis(client: httpx.Client) -> tuple[dict[str, bool], bool]:
+    """Create 3 demo APIs. Returns (results, used_offline_mode)."""
+    print(f"\n=== Phase 1: Creating APIs in tenant '{DEMO_TENANT}' ===")
+
+    # Try GitOps first
+    results = seed_apis_via_gitops(client)
+
+    # If any failed (likely "GitLab not connected"), fall back to offline seed
+    if not all(results.values()):
+        failed_names = [n for n, ok in results.items() if not ok]
+        print(f"  [!] {len(failed_names)} APIs failed via GitOps — trying offline seed")
+        offline_results = seed_apis_offline(client)
+        # Merge: keep GitOps successes, override failures with offline results
+        for name in failed_names:
+            results[name] = offline_results.get(name, False)
+        return results, True
+
+    return results, False
 
 
 def trigger_catalog_sync(client: httpx.Client) -> bool:
@@ -645,7 +697,7 @@ def trigger_catalog_sync(client: httpx.Client) -> bool:
             data = resp.json()
             print(f"  [+] Sync triggered: {data.get('message', 'OK')}")
             return True
-        print(f"  [-] Sync trigger failed: {resp.status_code} \u2014 {resp.text[:120]}")
+        print(f"  [-] Sync trigger failed: {resp.status_code} — {resp.text[:120]}")
         return False
     except Exception as e:
         print(f"  [-] Sync trigger error: {e}")
@@ -957,14 +1009,17 @@ def main() -> int:
 
     try:
         # Phase 1: APIs
-        apis = seed_apis(client)
+        apis, used_offline = seed_apis(client)
 
-        # Phase 2: Catalog sync
-        any_new = any(apis.values())
-        if any_new:
-            sync_ok = trigger_catalog_sync(client)
-            if sync_ok:
-                wait_for_sync(client)
+        # Phase 2: Catalog sync (skip if offline mode — data already in catalog)
+        if not used_offline:
+            any_new = any(apis.values())
+            if any_new:
+                sync_ok = trigger_catalog_sync(client)
+                if sync_ok:
+                    wait_for_sync(client)
+        else:
+            print("\n=== Phase 2: Catalog sync SKIPPED (offline mode — data is in catalog) ===")
 
         # Verify portal visibility
         portal_count = verify_portal_apis(client)


### PR DESCRIPTION
## Summary
- **demo/SCRIPT.md**: 5-act timed script — Intro (30s), Discovery (1m30), Approval (1m), API Call (1m30), Outro (30s)
- **demo/CHECKLIST-J1.md**: J-1 pre-flight checklist covering infra health, seed data, auth, dry runs, and material
- **docs/demo/DRY-RUN-1.md**: Dry-run #1 report identifying 3 blockers
- **Blocker fixes**: offline catalog seed endpoint, `user.sub` → `user.id` bug, petstore3.swagger.io → httpbin.org
- **seed-demo-data.py**: GitOps-first with automatic offline fallback

## Blockers fixed (from Dry-Run #1)
| Blocker | Fix |
|---------|-----|
| Petstore not in catalog (GitLab not connected) | New `POST /v1/admin/catalog/seed` endpoint + offline fallback in seed script |
| `User.sub` attribute error on app creation | `user.sub` → `user.id` in portal_applications.py |
| petstore3.swagger.io returns 500 | Switched to httpbin.org/anything |

## Test plan
- [ ] Run `seed-demo-data.py` against dev environment — verify 3 APIs seeded
- [ ] Verify `POST /v1/admin/catalog/seed` returns 200 with seeded count
- [ ] Verify `POST /v1/applications` no longer throws `User.sub` error
- [ ] Walk through SCRIPT.md acts 1-5 in browser
- [ ] Run CHECKLIST-J1.md health checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)