### PR TITLE
chore: add tooling, templates, and scripts for demo and AI workflow

### DIFF
--- a/.claude/BOOTSTRAP-CLAUDE-CODE.md
+++ b/.claude/BOOTSTRAP-CLAUDE-CODE.md
@@ -1,0 +1,200 @@
+# BOOTSTRAP PROMPT — Session 1
+
+Copie ce prompt dans Claude Code (terminal ou VS Code).
+
+---
+
+## INSTRUCTIONS
+
+Tu es le dev principal de STOA Platform. Objectif: produit revenue-ready pour le **24 février 2026** (dans 20 jours).
+
+Tu travailles en **sessions isolées** avec état persistant via fichiers markdown.
+
+### ÉTAPE 1 : BACKUP + BRANCHE
+
+```bash
+git checkout main && git pull
+git checkout -b backup/pre-claude-$(date +%Y%m%d-%H%M%S)
+git push origin HEAD
+git checkout -b feat/claude-sprint-feb24
+```
+
+### ÉTAPE 2 : CRÉE LES FICHIERS DE CONTEXTE
+
+Crée ces 3 fichiers **à la racine du repo** :
+
+---
+
+**Fichier 1: CLAUDE.md**
+
+```markdown
+# STOA Platform — AI Dev Context
+
+## Mission
+Produit revenue-ready pour le **24 février 2026**.
+
+## Architecture
+- Control Plane: Python 3.11 + FastAPI + SQLAlchemy
+- MCP Gateway: Python 3.11 + FastAPI + OPA
+- Portal/Console: React + TypeScript + Vite
+- CLI stoa: Python + Typer + Rich
+- CLI stoactl: Go + Cobra (repo github.com/stoa-platform/stoactl)
+- Auth: Keycloak (OIDC, Token Exchange)
+- DB: PostgreSQL, OpenSearch
+- Secrets: HashiCorp Vault
+- Observability: Prometheus, Grafana, Loki
+
+## Stack Rules
+- Python partout côté backend — JAMAIS Node.js
+- Async par défaut
+- Pydantic v2 pour validation
+- Type hints obligatoires
+- pytest pour tests, coverage > 80%
+
+## Repos
+| Repo | Stack | URL |
+|------|-------|-----|
+| stoa | Python | github.com/stoa-platform/stoa |
+| stoactl | Go | github.com/stoa-platform/stoactl |
+| stoa-docs | Docusaurus | github.com/stoa-platform/stoa-docs |
+| stoa-web | Astro | github.com/stoa-platform/stoa-web |
+| stoa-quickstart | Docker Compose | github.com/stoa-platform/stoa-quickstart |
+
+## API Endpoints (Control Plane)
+Base: http://localhost:8000/v1
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /apis | List APIs |
+| POST | /apis | Create API |
+| GET | /apis/{id} | Get API |
+| GET | /tenants | List tenants |
+| POST | /tenants | Create tenant |
+| GET | /subscriptions | List subscriptions |
+| POST | /subscriptions | Create subscription |
+| GET | /mcp/tools | List MCP tools |
+| POST | /mcp/call | Call MCP tool |
+| GET | /health | Health check |
+
+## Commit Convention
+- feat: nouvelle feature + CAB-XXXX
+- fix: bug fix + CAB-XXXX  
+- docs: documentation
+- test: tests
+- refactor: refactoring
+
+## Session Rules
+1. Lis CLAUDE.md + memory.md + plan.md au début
+2. Focus sur UN seul MEGA-ticket par session
+3. Update memory.md à la fin avec ta progression
+4. Commit souvent, messages clairs
+5. /clear entre sessions pour contexte fresh
+```
+
+---
+
+**Fichier 2: memory.md**
+
+```markdown
+# STOA Memory
+
+> Dernière MAJ: 2026-02-04
+
+## ✅ DONE
+(vide)
+
+## 🔴 IN PROGRESS
+CAB-1052: Fix 4 bugs critiques
+- [ ] CAB-1044: API Search → HTTP 500
+- [ ] CAB-1040: Gateway Routes → HTTP 404  
+- [ ] CAB-1042: Vault sealed → credentials fail
+- [ ] CAB-1041: E2E BDD auth → tests fail
+
+## 📋 NEXT
+- CAB-1060: Docs 20 pages (docs.gostoa.dev)
+- CAB-1061: Demo script 5 min
+- CAB-1062: Final polish + dry-runs
+- CAB-1066: Landing gostoa.dev + Stripe
+
+## 🚫 BLOCKED
+(rien)
+
+## 📝 NOTES
+- Demo: mardi 24 février 2026
+- Présentation "ESB is Dead" même jour
+- 2 design partners à closer
+- Stack = Python (pas Node)
+```
+
+---
+
+**Fichier 3: plan.md**
+
+```markdown
+# Sprint Plan — 24 Février 2026
+
+## 🎯 KPIs
+| Métrique | Cible |
+|----------|-------|
+| Demo sans bug | ✅ |
+| Docs pages | 20+ |
+| Landing live | gostoa.dev |
+| Stripe checkout | Fonctionnel |
+| Design partners | 2 LOI |
+
+## Semaine 1 (4-7 fév) — STABILISATION
+- [ ] CAB-1052: Fix 4 bugs critiques
+- [ ] CLI stoa complète (login, get apis, apply)
+- [ ] E2E tests 100% pass
+- [ ] Loki: 0 errors sur 5 min
+
+## Semaine 2 (10-14 fév) — CONTENU  
+- [ ] CAB-1060: 20 pages docs Docusaurus
+- [ ] Getting Started < 5 min read
+- [ ] MCP Gateway deep-dive
+- [ ] API Reference complète
+- [ ] FAQ + Troubleshooting
+
+## Semaine 3 (17-21 fév) — GO TO MARKET
+- [ ] CAB-1066: Landing + Pricing + Stripe
+- [ ] CAB-1061: Demo script 5 min chronométré
+- [ ] CAB-1062: 2 dry-runs sans bug
+- [ ] Video backup (si réseau fail)
+- [ ] One-pager PDF final
+
+## Règles Anti-Dérive
+1. 1 MEGA par session — pas de scope creep
+2. Si bloqué > 30 min → note dans memory.md, passe au suivant
+3. Commit toutes les 30 min minimum
+4. Push avant /clear
+```
+
+---
+
+### ÉTAPE 3 : COMMIT LA STRUCTURE
+
+```bash
+git add CLAUDE.md memory.md plan.md
+git commit -m "feat: bootstrap AI dev context for sprint feb24"
+git push origin feat/claude-sprint-feb24
+```
+
+### ÉTAPE 4 : COMMENCE LE TRAVAIL
+
+**Focus: CAB-1052 — Fix les 4 bugs critiques**
+
+1. Explore le code, trouve les fichiers concernés
+2. Reproduis chaque bug localement (docker compose up ou pytest)
+3. Fix avec test qui prouve le fix
+4. Commit: `fix: CAB-XXXX description`
+5. Répète pour les 4 bugs
+6. Update memory.md avec ce qui est DONE
+
+**DoD Session 1:**
+- Zero HTTP 500 sur /apis/search
+- Zero HTTP 404 sur /mcp/routes  
+- Vault unsealed automatiquement
+- E2E auth tests passent
+- memory.md mis à jour
+
+Go.

--- a/.claude/skills/e2e-test.md
+++ b/.claude/skills/e2e-test.md
@@ -1,0 +1,276 @@
+# Skill: E2E Test (Playwright BDD)
+
+## Quand utiliser
+
+Quand on demande de creer, modifier ou debugger un test E2E dans `e2e/`.
+
+## Stack
+
+- **Playwright** + **playwright-bdd** (Gherkin)
+- TypeScript (ES2022, strict)
+- Authentification via Keycloak avec storage states par persona
+
+## Architecture des fichiers
+
+```
+e2e/
+├── features/<domain>.feature    # Scenarios Gherkin (source de verite)
+├── steps/<domain>.steps.ts      # Implementation des steps
+├── fixtures/
+│   ├── test-base.ts             # Fixtures Playwright custom (URLS, helpers)
+│   ├── personas.ts              # Personas + credentials
+│   ├── auth.setup.ts            # Auth Keycloak → storage states
+│   └── .auth/<persona>.json     # Storage states (gitignored)
+├── .features-gen/               # Genere par bddgen (gitignored)
+├── playwright.config.ts         # Config: projects, timeouts, reporters
+└── package.json                 # Scripts npm
+```
+
+## Pipeline: feature → steps → run
+
+1. Ecrire le `.feature` dans `features/`
+2. Implementer les steps dans `steps/` (reutiliser les steps existants)
+3. `bddgen` genere les specs dans `.features-gen/`
+4. Playwright execute les specs generees
+
+## Systeme de personas
+
+Toutes les personas sont definies dans `fixtures/personas.ts`. Theme: Ready Player One.
+
+| Persona    | Tenant    | Role         | defaultApp | Usage typique                    |
+|------------|-----------|--------------|------------|----------------------------------|
+| `parzival` | high-five | tenant-admin | console    | Admin tenant, tests isolation    |
+| `art3mis`  | high-five | devops       | portal     | Tests portal, search, subscribe  |
+| `aech`     | high-five | viewer       | portal     | Tests lecture seule              |
+| `sorrento` | ioi       | tenant-admin | console    | Tests cross-tenant, isolation    |
+| `i-r0k`    | ioi       | viewer       | portal     | Tests lecture tenant concurrent  |
+| `anorak`   | * (all)   | cpi-admin    | console    | Tests admin plateforme           |
+| `alex`     | oasis     | viewer       | portal     | TTFTC onboarding (fresh, no pre-auth) |
+
+### Credentials
+
+Via `.env` (copier `.env.example`). Format:
+```
+PARZIVAL_USER=parzival@high-five.io
+PARZIVAL_PASSWORD=secret
+```
+
+### Auth storage states
+
+`auth.setup.ts` boucle sur toutes les personas, se connecte via Keycloak, sauvegarde le state dans `fixtures/.auth/<persona>.json`.
+
+Les projets Playwright referencent ces states:
+```ts
+// portal-chromium utilise parzival par defaut
+storageState: 'fixtures/.auth/parzival.json',
+```
+
+Pour charger une persona dans un step:
+```ts
+import { PERSONAS, PersonaKey, getAuthStatePath } from '../fixtures/personas';
+
+const authStatePath = getAuthStatePath(personaName as PersonaKey);
+const storageState = JSON.parse(fs.readFileSync(authStatePath, 'utf-8'));
+await context.addCookies(storageState.cookies);
+```
+
+## Projets Playwright
+
+Definis dans `playwright.config.ts`. Chaque projet cible un domaine:
+
+| Projet            | baseURL                  | Auth              | testMatch     |
+|-------------------|--------------------------|-------------------|---------------|
+| `auth-setup`      | -                        | Keycloak login    | auth.setup.ts |
+| `portal-chromium` | `STOA_PORTAL_URL`        | parzival state    | /portal/      |
+| `console-chromium`| `STOA_CONSOLE_URL`       | parzival state    | /console/     |
+| `gateway`         | `STOA_GATEWAY_URL`       | aucune (API keys) | /gateway/     |
+| `ttftc`           | `STOA_PORTAL_URL`        | fresh (alex)      | /alex-ttftc/  |
+
+`auth-setup` est une dependance de portal/console/ttftc (s'execute en premier).
+
+## Tags / Markers
+
+Tags sur les features et scenarios Gherkin. Utilises pour le filtrage.
+
+| Tag          | Usage                                        |
+|--------------|----------------------------------------------|
+| `@portal`    | Tests Developer Portal                       |
+| `@console`   | Tests Console (API Provider)                 |
+| `@gateway`   | Tests Gateway API (HTTP, pas de browser)     |
+| `@smoke`     | Verification rapide, CI                      |
+| `@critical`  | Tests bloquants (isolation, securite)        |
+| `@rpo`       | Scenarios demo Ready Player One              |
+| `@ttftc`     | Time to First Tool Call (benchmark UX)       |
+| `@isolation` | Tests isolation multi-tenant                 |
+| `@security`  | Tests securite (cross-tenant, tokens)        |
+| `@high-five` | Specifique tenant High-Five                  |
+| `@ioi`       | Specifique tenant IOI                        |
+| `@filtering` | Tests recherche/filtres                      |
+| `@negative`  | Tests de cas d'erreur                        |
+
+Combiner les tags: `@portal @smoke` sur la Feature, `@rpo @high-five` sur le Scenario.
+
+## Commandes
+
+```bash
+cd e2e
+
+# Tous les tests
+npm run test:e2e
+
+# Par tag
+npm run test:smoke
+npm run test:critical
+npm run test:portal
+npm run test:console
+npm run test:gateway
+npm run test:rpo
+
+# Mode interactif
+npm run test:e2e:ui        # UI Playwright
+npm run test:e2e:headed    # Navigateur visible
+npm run test:e2e:debug     # Mode debug
+
+# Rapport HTML
+npm run report
+```
+
+## Comment creer un nouveau test
+
+### 1. Feature file
+
+Creer `features/<domain>-<subject>.feature`:
+
+```gherkin
+@portal @smoke
+Feature: Portal - <Description courte>
+
+  Background:
+    Given the STOA Portal is accessible
+
+  @rpo @high-five
+  Scenario: <Persona> does <action>
+    Given I am logged in as "<persona>" from community "<tenant>"
+    When I <action>
+    Then I <expected result>
+```
+
+Regles:
+- Tags Feature = domaine + importance (`@portal @smoke`)
+- Tags Scenario = contexte + tenant (`@rpo @high-five`)
+- Background pour les preconditions communes
+- Steps en anglais (malgre le README qui mentionne le francais, tous les tests existants sont en anglais)
+- Nommage fichier: `<domain>-<subject>.feature`
+
+### 2. Step definitions
+
+Ajouter dans le fichier steps existant ou creer `steps/<domain>.steps.ts`:
+
+```ts
+/**
+ * <Domain> step definitions for STOA E2E Tests
+ * <Description>
+ */
+
+import { createBdd } from 'playwright-bdd';
+import { test, expect, URLS } from '../fixtures/test-base';
+
+const { Given, When, Then } = createBdd(test);
+
+// ============================================================================
+// <SECTION NAME>
+// ============================================================================
+
+When('I <action with {string} params>', async ({ page }, param: string) => {
+  await page.goto(`${URLS.portal}/<path>`);
+  await page.waitForLoadState('networkidle');
+});
+
+Then('I <assertion>', async ({ page }) => {
+  await expect(page.locator('<selector>')).toBeVisible({ timeout: 10000 });
+});
+```
+
+Regles:
+- **Toujours** importer `test` depuis `../fixtures/test-base` (pas depuis `@playwright/test`)
+- **Toujours** `createBdd(test)` pour lier les steps aux fixtures custom
+- Utiliser `URLS.portal`, `URLS.console`, `URLS.gateway` (pas de URL en dur)
+- `page.waitForLoadState('networkidle')` apres chaque navigation
+- Timeouts explicites sur les `expect`: `{ timeout: 10000 }`
+- Sections separees par `// ====...` avec nom en majuscules
+- Reutiliser les steps de `common.steps.ts` avant d'en creer de nouveaux
+
+### 3. Steps existants reutilisables
+
+**common.steps.ts** (auth + navigation):
+- `Given I am logged in as {string}` — charge le storage state
+- `Given I am logged in as {string} from community {string}` — idem avec contexte tenant
+- `Given I am logged in to Console as {string} from team {string}` — Console + navigation
+- `Given the STOA Portal is accessible` / `Given the STOA Console is accessible` — health check
+- `When I navigate to page {string}` / `When I navigate to the subscriptions page`
+- `Then I receive an access denied error`
+
+**portal.steps.ts** (catalog + subscriptions):
+- `When I access the API catalog` / `Given I am on the API catalog page`
+- `When I search for {string}` / `Then the results contain {string}`
+- `When I filter by category {string}`
+- `When I click on {string}` — generic button click
+- `Then I see APIs in the catalog`
+- Steps de subscription (subscribe, confirm, revoke, view key)
+
+**console.steps.ts** (tenant isolation + API management):
+- `When I access the API list`
+- `Then I see only APIs from tenant {string}` / `Then I do not see APIs from tenant {string}`
+- `When I select tenant {string}` / `When I open the tenant selector`
+- `When I create an API named {string}`
+
+**gateway.steps.ts** (API calls HTTP):
+- `When I call {string}` — format: `"GET /api/v1/path"`
+- `Then I receive a {int} response` / `Then I receive a {int} error`
+- `Then the error message contains {string}`
+- Steps pour API keys (valid, invalid, expired)
+
+### 4. Generer et tester
+
+```bash
+cd e2e
+npm run bddgen                    # Genere les specs
+npx playwright test --grep @<tag> # Run par tag
+```
+
+## Exemple concret: portal-catalog.feature
+
+Le test le plus simple du projet:
+
+**Feature** (`features/portal-catalog.feature`):
+```gherkin
+@portal @smoke
+Feature: Portal - API Catalog visibility by community
+
+  Background:
+    Given the STOA Portal is accessible
+
+  @rpo @high-five
+  Scenario: Parzival sees all public OASIS APIs
+    Given I am logged in as "parzival" from community "high-five"
+    When I access the API catalog
+    Then I see APIs in the catalog
+```
+
+**Steps utilises** (deja existants):
+- `Given the STOA Portal is accessible` → `common.steps.ts` (line 89)
+- `Given I am logged in as {string} from community {string}` → `common.steps.ts` (line 41)
+- `When I access the API catalog` → `portal.steps.ts` (line 15)
+- `Then I see APIs in the catalog` → `portal.steps.ts` (line 45)
+
+Aucun nouveau step a ecrire. 3 fichiers impliques, 0 code nouveau.
+
+## Patterns a respecter
+
+1. **Pas de `@playwright/test` direct** — toujours passer par `fixtures/test-base.ts`
+2. **Pas de selectors fragiles** — preferer `text=`, `role=`, `[class*=]` aux selecteurs CSS specifiques
+3. **Pas de `page.waitForTimeout()`** sauf en dernier recours — preferer `waitForLoadState('networkidle')`
+4. **Pas de donnees en dur** — les URLs viennent de `URLS`, les credentials de `PERSONAS`
+5. **Gateway tests = HTTP pur** — pas de `page`, utiliser `request.fetch()` depuis le fixture
+6. **Un fichier steps par domaine** — ne pas melanger portal et console dans le meme fichier
+7. **Nommer les features `<domain>-<subject>.feature`** — le `testMatch` des projets Playwright filtre par nom

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,122 @@
+# Copyright 2026 STOA Platform Authors
+# SPDX-License-Identifier: Apache-2.0
+
+name: "\U0001F41B Bug Report"
+description: Report a bug to help us improve STOA
+title: "[Bug] "
+labels: ["type:bug", "status:triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which STOA component is affected?
+      options:
+        - control-plane-api (FastAPI backend)
+        - portal (Developer Portal)
+        - control-plane-ui (Console UI)
+        - mcp-gateway (MCP Gateway)
+        - helm (Charts / Kubernetes)
+        - e2e (End-to-End tests)
+        - docs (Documentation)
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+      placeholder: When I do X, I expect Y but Z happens instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the behavior.
+      value: |
+        1. Configure '...'
+        2. Send request to '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this bug?
+      options:
+        - "Critical: service down / data loss"
+        - "High: feature broken, no workaround"
+        - "Medium: feature broken, workaround exists"
+        - "Low: cosmetic / minor inconvenience"
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: STOA Version
+      description: Which version of STOA are you using?
+      placeholder: "e.g. 0.1.0 or commit SHA"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      description: How is STOA deployed?
+      options:
+        - Docker Compose (local)
+        - Kubernetes (Helm)
+        - EKS
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs
+      description: Paste any relevant log output (secrets will NOT be sanitized automatically - please remove them).
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: Relevant configuration (remove secrets!).
+      render: yaml
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues to ensure this bug hasn't been reported
+          required: true
+        - label: I have removed any sensitive information from logs and configs
+          required: true

--- a/.github/ISSUE_TEMPLATE/docs_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs_improvement.yml
@@ -1,0 +1,57 @@
+# Copyright 2026 STOA Platform Authors
+# SPDX-License-Identifier: Apache-2.0
+
+name: "\U0001F4DA Documentation Improvement"
+description: Suggest improvements or report issues in the documentation
+title: "[Docs] "
+labels: ["type:docs", "status:triage"]
+
+body:
+  - type: input
+    id: page_url
+    attributes:
+      label: Documentation Page
+      description: Link to the page or section that needs improvement.
+      placeholder: "https://docs.gostoa.dev/..."
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: issue_type
+    attributes:
+      label: What's the Issue?
+      options:
+        - label: Outdated information
+        - label: Missing information
+        - label: Unclear explanation
+        - label: Broken links
+        - label: Typo or grammar
+        - label: Code example doesn't work
+        - label: Other
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the Improvement
+      description: A clear description of what should be changed or added.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Content
+      description: If you have specific wording or content to suggest.
+      render: markdown
+    validations:
+      required: false
+
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Would you like to contribute this change?
+      options:
+        - "Yes, I'd like to submit a PR"
+        - "No, I'm just reporting the issue"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,97 @@
+# Copyright 2026 STOA Platform Authors
+# SPDX-License-Identifier: Apache-2.0
+
+name: "\u2728 Feature Request"
+description: Suggest a new feature or enhancement for STOA
+title: "[Feature] "
+labels: ["type:feature", "status:triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe the problem and your proposed solution.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which component would this feature affect?
+      options:
+        - control-plane-api (FastAPI backend)
+        - portal (Developer Portal)
+        - control-plane-ui (Console UI)
+        - mcp-gateway (MCP Gateway)
+        - stoa-gateway (Rust gateway)
+        - helm (Charts / Kubernetes)
+        - docs (Documentation)
+        - platform-wide
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve?
+      placeholder: "I'm always frustrated when... / Currently there's no way to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like to see implemented.
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example Usage
+      description: Show how this feature would be used (config snippet, API call, CLI command, etc.).
+      render: yaml
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What alternative solutions or workarounds have you considered?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Who Benefits
+      description: Who would primarily benefit from this feature?
+      options:
+        - API Providers (tenant admins)
+        - API Consumers (developers)
+        - Platform Operators (DevOps)
+        - AI Agents (MCP clients)
+        - Everyone
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Related issues, similar features in other tools, links, screenshots.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues to ensure this hasn't been requested
+          required: true
+        - label: This feature aligns with STOA's goals (cloud-native, open source, AI-native API management)
+          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,54 @@
+# Copyright 2026 STOA Platform Authors
+# SPDX-License-Identifier: Apache-2.0
+
+name: "\u2753 Question"
+description: Ask a question about STOA usage or configuration
+title: "[Question] "
+labels: ["type:question"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Tip**: For quicker responses, consider asking on our [Discord](https://discord.gg/j8tHSSes) where the community can help!
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of STOA is your question about?
+      options:
+        - control-plane-api (FastAPI backend)
+        - portal (Developer Portal)
+        - control-plane-ui (Console UI)
+        - mcp-gateway (MCP Gateway)
+        - helm (Charts / Kubernetes)
+        - deployment / infrastructure
+        - general / getting started
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What are you trying to achieve? What have you tried so far?
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: Relevant configuration or environment info (if applicable).
+      render: yaml
+    validations:
+      required: false

--- a/.stoa-ai/.env.example
+++ b/.stoa-ai/.env.example
@@ -1,0 +1,19 @@
+# STOA AI Factory Configuration
+# Copy this file to .env and fill in your values
+
+# Slack Integration
+# Get your webhook from https://api.slack.com/apps
+SLACK_WEBHOOK=https://hooks.slack.com/services/TXXXX/BXXXX/XXXXXXXX
+
+# Linear (optional, for API access)
+LINEAR_API_KEY=lin_api_XXXXXXXX
+
+# Claude Code (if using API mode)
+ANTHROPIC_API_KEY=sk-ant-XXXXXXXX
+
+# Paths
+STOA_REPO_PATH=/path/to/stoa
+PHASES_DIR=.stoa-ai/phases
+
+# n8n (if self-hosted)
+N8N_WEBHOOK_URL=https://your-n8n.example.com/webhook

--- a/.stoa-ai/CLAUDE.md
+++ b/.stoa-ai/CLAUDE.md
@@ -1,0 +1,137 @@
+# STOA Platform — Claude Code Context
+
+> Ce fichier est le contexte persistant pour Claude Code. À lire au début de chaque session.
+
+## 🎯 Projet
+
+**STOA Platform** — "The European Agent Gateway"
+- API Management AI-Native Open Source
+- Positioning: "Legacy-to-MCP Bridge" — Pont entre APIs legacy et AI agents
+- Kill feature: UAC (Universal API Contract) — "Define Once, Expose Everywhere"
+- Licence: Apache 2.0 + Trademark protection
+
+## 🏗️ Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      CONTROL PLANE (Cloud)                      │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐        │
+│  │  Portal  │  │ Console  │  │   API    │  │ Keycloak │        │
+│  │  (React) │  │  (React) │  │(FastAPI) │  │  (Auth)  │        │
+│  └──────────┘  └──────────┘  └──────────┘  └──────────┘        │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                    Config + Policies + Metrics
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                      DATA PLANE (On-Premise)                    │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐                      │
+│  │   MCP    │  │webMethods│  │  Kong/   │                      │
+│  │ Gateway  │  │ Gateway  │  │  Envoy   │                      │
+│  └──────────┘  └──────────┘  └──────────┘                      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## 📁 Structure Repo
+
+```
+stoa/
+├── backend/                 # FastAPI Control Plane API
+│   ├── app/
+│   │   ├── api/v1/         # Endpoints REST
+│   │   ├── core/           # Config, Security, Database
+│   │   ├── models/         # SQLAlchemy models
+│   │   ├── schemas/        # Pydantic schemas
+│   │   └── services/       # Business logic
+│   └── tests/
+├── frontend/
+│   ├── portal/             # React Portal (catalogue, souscriptions)
+│   └── console/            # React Console (admin, config)
+├── mcp-gateway/            # MCP Gateway (Rust/Python)
+├── infra/
+│   ├── kubernetes/         # K8s manifests
+│   ├── terraform/          # IaC
+│   └── docker/             # Dockerfiles
+└── docs/                   # Docusaurus documentation
+```
+
+## 🚫 Zones Interdites (NE PAS MODIFIER)
+
+Ces fichiers sont stables et critiques. Ne pas toucher sans validation explicite :
+
+- `backend/app/core/security.py` — Authentication/Authorization
+- `backend/app/core/config.py` — Configuration centrale
+- `infra/terraform/` — Infrastructure as Code
+- `infra/kubernetes/production/` — Configs prod
+- `.github/workflows/` — CI/CD pipelines
+
+## ✅ Conventions de Code
+
+### Python (Backend)
+- **Style**: Black + isort + ruff
+- **Types**: Toujours typer les fonctions
+- **Tests**: pytest, coverage > 80%
+- **Async**: Préférer async/await
+
+### TypeScript/React (Frontend)
+- **Style**: Prettier + ESLint
+- **Components**: Functional + hooks
+- **State**: Zustand ou React Query
+- **Tests**: Vitest + Testing Library
+
+### Commits
+```
+type(scope): description
+
+Types: feat, fix, docs, style, refactor, test, chore
+Scope: backend, portal, console, gateway, infra, docs
+```
+
+## 🔐 Sécurité
+
+- **Zero Trust**: Tout trafic authentifié
+- **RBAC**: Scopes OAuth2 granulaires
+- **Secrets**: Jamais en clair, toujours Vault/env
+- **Anonymisation**: Jamais de vrais noms clients dans le code/tickets
+
+## 📊 Observabilité
+
+- **Metrics**: Prometheus → Grafana
+- **Logs**: Loki (structured JSON)
+- **Traces**: OpenTelemetry (optionnel)
+- **Alerts**: Alertmanager → Slack
+
+## 🔄 Workflow Claude Code
+
+1. **Lire ce fichier** au début de chaque session
+2. **Lire plan.md** pour connaître la phase en cours
+3. **Lire memory.md** pour l'état de la session précédente
+4. **Coder → Tester → Commiter** en boucle
+5. **Mettre à jour memory.md** avant `/clear`
+6. **Notifier Slack** si bloqué ou phase terminée
+
+## 🏷️ Labels & Priorities
+
+| Priority | Signification |
+|----------|---------------|
+| P0 | Urgent — Cette semaine |
+| P1 | High — Ce cycle |
+| P2 | Medium — Ce mois |
+| P3 | Low — Backlog |
+
+## 📅 Dates Clés
+
+- **MVP Demo**: 24 février 2026
+- **"ESB is Dead" Presentation**: 24 février 2026
+- **Free Run Until**: ~11 février 2026
+
+# CLAUDE.md
+
+Webhook notifications: https://hlfh.app.n8n.cloud/webhook/stoa-notify
+
+Quand tu finis une tâche importante, notifie via:
+curl -X POST "URL_CI_DESSUS" -H "Content-Type: application/json" -d '{"message": "ton message"}'
+---
+
+*Dernière mise à jour: 2026-02-04*

--- a/.stoa-ai/README.md
+++ b/.stoa-ai/README.md
@@ -1,0 +1,179 @@
+# 🏭 STOA AI Factory
+
+> Claude Code H24 + Orchestration Humaine
+
+## 🎯 Concept
+
+**Tu n'es plus un Project Manager. Tu es un Architect qui supervise un AI Agent.**
+
+```
+┌─────────────────────────────────────────────────────────┐
+│              CHRISTOPHE = ARCHITECT                     │
+│  • Définit PHASEs (objectif + contraintes)              │
+│  • Valide PLANs avant GO                                │
+│  • Review checkpoints Slack                             │
+│  • Décision GO/NOGO sur PRs                             │
+└─────────────────────────────────────────────────────────┘
+                         │
+               Plan + Context + Rules
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────┐
+│              CLAUDE CODE = AI WORKER H24                │
+│                                                         │
+│   Code → Test → Verify → Commit → Loop                  │
+│                    │                                    │
+│          Si bloqué/checkpoint → SLACK                   │
+└─────────────────────────────────────────────────────────┘
+```
+
+## 📁 Structure
+
+```
+.stoa-ai/
+├── CLAUDE.md              # Contexte global (lire au début)
+├── memory.md              # État session courante
+├── templates/
+│   ├── MEGA-TICKET.md     # Template ticket Linear
+│   ├── PHASE-PLAN.md      # Template plan.md
+│   └── PROMPT-ENTRY.md    # Prompt d'entrée Claude Code
+├── phases/
+│   └── CAB-XXXX/          # Un dossier par phase
+│       ├── plan.md        # Plan détaillé de la phase
+│       ├── context.md     # Contexte spécifique (optionnel)
+│       └── logs/          # Logs des sessions
+├── scripts/
+│   ├── run-phase.sh       # Lancer une phase
+│   ├── slack-notify.sh    # Envoyer notification
+│   └── daily-digest.sh    # Résumé quotidien
+└── n8n/
+    └── ai-phase-runner.json  # Workflow n8n à importer
+```
+
+## 🚀 Quick Start
+
+### 1. Configuration
+
+```bash
+# Copier dans ton repo STOA
+cp -r .stoa-ai/ /path/to/stoa/
+
+# Rendre les scripts exécutables
+chmod +x .stoa-ai/scripts/*.sh
+
+# Configurer Slack webhook
+export SLACK_WEBHOOK="https://hooks.slack.com/services/XXX/YYY/ZZZ"
+```
+
+### 2. Créer une Phase
+
+```bash
+# Créer le dossier de phase
+mkdir -p .stoa-ai/phases/CAB-XXXX
+
+# Copier le template
+cp .stoa-ai/templates/PHASE-PLAN.md .stoa-ai/phases/CAB-XXXX/plan.md
+
+# Éditer le plan avec tes steps spécifiques
+vim .stoa-ai/phases/CAB-XXXX/plan.md
+```
+
+### 3. Lancer Claude Code
+
+```bash
+# Option A: Script automatique (tmux)
+./stoa-ai/scripts/run-phase.sh CAB-XXXX
+
+# Option B: Manuel avec prompt
+claude "Lis .stoa-ai/CLAUDE.md, memory.md, et phases/CAB-XXXX/plan.md. Exécute le plan."
+```
+
+### 4. Surveiller via Slack
+
+Les notifications arrivent automatiquement:
+- 🟢 Phase terminée
+- 🟡 Décision nécessaire
+- 🔴 Tests échoués
+
+## 🔄 Workflow Complet
+
+### Toi (5-10 min par phase)
+
+1. **Créer MEGA-ticket** dans Linear avec objectif clair
+2. **Rédiger plan.md** avec steps détaillés
+3. **Valider via Council** (score 8/10 minimum)
+4. **Lancer** `./run-phase.sh CAB-XXXX`
+5. **Attendre** notifications Slack
+6. **Review** et Approve/Request Changes
+
+### Claude Code (autonome)
+
+```
+loop:
+  1. Lire plan.md → identifier next step
+  2. Coder le step
+  3. Lancer tests
+  4. Si pass → commit + update plan.md + continue
+  5. Si fail → retry 2x → Slack alert
+  6. Si question → Slack alert + wait
+  7. Si phase done → Slack "Review needed" + stop
+```
+
+## 📱 Intégration Slack
+
+### Créer le Webhook
+
+1. Aller sur https://api.slack.com/apps
+2. Create New App → From scratch
+3. Incoming Webhooks → Activate
+4. Add New Webhook to Workspace
+5. Choisir le channel `#stoa-ai-worker`
+6. Copier l'URL du webhook
+
+### Test Manuel
+
+```bash
+export SLACK_WEBHOOK="https://hooks.slack.com/services/..."
+./.stoa-ai/scripts/slack-notify.sh done CAB-1068 "Test notification"
+```
+
+## ⚙️ Intégration n8n
+
+### Importer le Workflow
+
+1. Ouvrir n8n
+2. Workflows → Import from File
+3. Sélectionner `.stoa-ai/n8n/ai-phase-runner.json`
+4. Configurer les credentials:
+   - `SLACK_WEBHOOK` dans les variables d'environnement n8n
+   - Chemin vers le repo STOA
+
+### Configurer Linear Webhook
+
+1. Linear → Settings → Integrations → Webhooks
+2. Add Webhook
+3. URL: `https://your-n8n-instance/webhook/stoa-phase-trigger`
+4. Events: Issue updated
+
+## 📊 Daily Digest
+
+Configurer un cron pour le résumé quotidien:
+
+```bash
+# Éditer crontab
+crontab -e
+
+# Ajouter (tous les jours à 9h)
+0 9 * * * cd /path/to/stoa && ./.stoa-ai/scripts/daily-digest.sh
+```
+
+## 🏷️ Références
+
+- [Anthropic Claude Code Best Practices](https://www.anthropic.com/engineering/claude-code-best-practices)
+- [AWS AI-DLC](https://aws.amazon.com/blogs/devops/open-sourcing-adaptive-workflows-for-ai-driven-development-life-cycle-ai-dlc/)
+- CAB-1068 — Ticket de setup
+- CAB-1051 — Mode Phase concept
+
+---
+
+*"Claude Code ne dort jamais. Christophe orchestre et valide."*

--- a/.stoa-ai/memory.md
+++ b/.stoa-ai/memory.md
@@ -1,0 +1,45 @@
+# Session Memory
+
+> État actif de la session Claude Code. Mettre à jour AVANT chaque `/clear`.
+
+## 📅 Session Info
+
+- **Date**: 2026-02-04
+- **Phase en cours**: CAB-1068 (AI Factory Setup)
+- **Branche Git**: `christopheabcabi/cab-1068-mega-ai-factory-setup-claude-code-h24-orchestration`
+
+## ✅ Fait cette session
+
+- [ ] Structure `.stoa-ai/` créée
+- [ ] CLAUDE.md rédigé
+- [ ] Templates créés
+- [ ] Scripts créés
+
+## 🚧 En cours
+
+- Configuration initiale AI Factory
+
+## 🛑 Bloqué sur
+
+- (rien pour l'instant)
+
+## 💡 Décisions prises
+
+- Pattern 3 fichiers validé: CLAUDE.md + memory.md + plan.md
+- Notifications Slack pour checkpoints
+- n8n pour orchestration workflows
+
+## 📝 Notes pour prochaine session
+
+- Tester le script run-phase.sh avec un vrai MEGA
+- Configurer webhook Slack
+- Créer workflow n8n
+
+## 🔗 Liens utiles cette session
+
+- [CAB-1068](https://linear.app/hlfh-workspace/issue/CAB-1068) — Ticket principal
+- [CAB-1051](https://linear.app/hlfh-workspace/issue/CAB-1051) — Mode Phase concept
+
+---
+
+*Dernière update: 2026-02-04 12:16*

--- a/.stoa-ai/n8n/ai-phase-runner.json
+++ b/.stoa-ai/n8n/ai-phase-runner.json
@@ -1,0 +1,178 @@
+{
+  "name": "STOA AI Phase Runner",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "stoa-phase-trigger",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Linear Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "webhookId": "stoa-phase-trigger"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-status",
+              "leftValue": "={{ $json.data.status.name }}",
+              "rightValue": "In Progress",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "filter-status",
+      "name": "Check Status = In Progress",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [470, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.SLACK_WEBHOOK }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"text\": \"🚀 *{{ $json.data.identifier }}* — Phase starting\",\n  \"blocks\": [\n    {\n      \"type\": \"header\",\n      \"text\": {\n        \"type\": \"plain_text\",\n        \"text\": \"🚀 Phase Starting\",\n        \"emoji\": true\n      }\n    },\n    {\n      \"type\": \"section\",\n      \"fields\": [\n        {\"type\": \"mrkdwn\", \"text\": \"*Ticket*\\n{{ $json.data.identifier }}\"},\n        {\"type\": \"mrkdwn\", \"text\": \"*Title*\\n{{ $json.data.title }}\"}\n      ]\n    },\n    {\n      \"type\": \"actions\",\n      \"elements\": [\n        {\n          \"type\": \"button\",\n          \"text\": {\"type\": \"plain_text\", \"text\": \"View in Linear\"},\n          \"url\": \"{{ $json.data.url }}\"\n        }\n      ]\n    }\n  ]\n}",
+        "options": {}
+      },
+      "id": "slack-notify-start",
+      "name": "Slack: Phase Starting",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [690, 200]
+    },
+    {
+      "parameters": {
+        "command": "=cd /path/to/stoa && git fetch && git checkout {{ $json.data.branchName }} && git pull"
+      },
+      "id": "git-checkout",
+      "name": "Git Checkout Branch",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [910, 200]
+    },
+    {
+      "parameters": {
+        "command": "=cd /path/to/stoa && ./.stoa-ai/scripts/run-phase.sh {{ $json.data.identifier }}"
+      },
+      "id": "run-claude-code",
+      "name": "Run Claude Code",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [1130, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.SLACK_WEBHOOK }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"text\": \"{{ $json.stdout.includes('Phase complete') ? '🟢' : '🔴' }} *{{ $node['Linear Webhook'].json.data.identifier }}* — Phase {{ $json.stdout.includes('Phase complete') ? 'Complete' : 'Stopped' }}\",\n  \"blocks\": [\n    {\n      \"type\": \"header\",\n      \"text\": {\n        \"type\": \"plain_text\",\n        \"text\": \"{{ $json.stdout.includes('Phase complete') ? '🟢 Phase Complete' : '🔴 Phase Stopped' }}\",\n        \"emoji\": true\n      }\n    },\n    {\n      \"type\": \"section\",\n      \"text\": {\n        \"type\": \"mrkdwn\",\n        \"text\": \"*{{ $node['Linear Webhook'].json.data.identifier }}*: {{ $node['Linear Webhook'].json.data.title }}\"\n      }\n    },\n    {\n      \"type\": \"actions\",\n      \"elements\": [\n        {\n          \"type\": \"button\",\n          \"text\": {\"type\": \"plain_text\", \"text\": \"Review\"},\n          \"url\": \"{{ $node['Linear Webhook'].json.data.url }}\",\n          \"style\": \"primary\"\n        }\n      ]\n    }\n  ]\n}",
+        "options": {}
+      },
+      "id": "slack-notify-end",
+      "name": "Slack: Phase Result",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1350, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={\"status\": \"acknowledged\", \"ticket\": \"{{ $json.data.identifier }}\"}"
+      },
+      "id": "respond-webhook",
+      "name": "Respond OK",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [690, 400]
+    }
+  ],
+  "connections": {
+    "Linear Webhook": {
+      "main": [
+        [
+          {
+            "node": "Check Status = In Progress",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Status = In Progress": {
+      "main": [
+        [
+          {
+            "node": "Slack: Phase Starting",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond OK",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Slack: Phase Starting": {
+      "main": [
+        [
+          {
+            "node": "Git Checkout Branch",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Git Checkout Branch": {
+      "main": [
+        [
+          {
+            "node": "Run Claude Code",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Run Claude Code": {
+      "main": [
+        [
+          {
+            "node": "Slack: Phase Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": ["stoa", "ai-factory", "automation"]
+}

--- a/.stoa-ai/phases/CAB-1068/plan.md
+++ b/.stoa-ai/phases/CAB-1068/plan.md
@@ -1,0 +1,86 @@
+# Plan: CAB-1068 — AI Factory Setup
+
+> Ce fichier guide Claude Code. Mettre à jour les checkboxes au fur et à mesure.
+
+## 🎯 Objectif de cette Phase
+
+Mettre en place l'infrastructure AI Factory pour permettre à Claude Code de travailler H24 en autonomie supervisée.
+
+## 📋 Contexte
+
+- **MEGA parent**: CAB-1068
+- **Branche**: `christopheabcabi/cab-1068-mega-ai-factory-setup-claude-code-h24-orchestration`
+- **Fichiers principaux**: 
+  - `.stoa-ai/CLAUDE.md`
+  - `.stoa-ai/memory.md`
+  - `.stoa-ai/scripts/*.sh`
+
+## ✅ Steps
+
+### Step 1: Structure de base
+- [x] Créer `.stoa-ai/` directory
+- [x] Créer `CLAUDE.md` avec contexte projet
+- [x] Créer `memory.md` template
+- [ ] Valider structure dans le repo STOA
+
+### Step 2: Templates
+- [x] Créer `templates/MEGA-TICKET.md`
+- [x] Créer `templates/PHASE-PLAN.md`
+- [x] Créer `templates/PROMPT-ENTRY.md`
+
+### Step 3: Scripts d'automatisation
+- [x] Créer `scripts/run-phase.sh`
+- [x] Créer `scripts/slack-notify.sh`
+- [x] Créer `scripts/daily-digest.sh`
+- [ ] Rendre les scripts exécutables (`chmod +x`)
+- [ ] Tester localement
+
+### Step 4: Slack Integration
+- [ ] Créer channel `#stoa-ai-worker`
+- [ ] Créer Slack App avec Incoming Webhook
+- [ ] Configurer `SLACK_WEBHOOK` env var
+- [ ] Tester notification manuelle
+
+### Step 5: n8n Workflow
+- [ ] Créer workflow "AI Phase Runner"
+- [ ] Trigger: Linear webhook (status change)
+- [ ] Action: Clone + Run Claude Code
+- [ ] Action: Slack notify on completion
+- [ ] Tester E2E
+
+### Step 6: Premier test réel
+- [ ] Choisir un petit ticket existant
+- [ ] Créer sa phase dans `.stoa-ai/phases/`
+- [ ] Lancer `./run-phase.sh CAB-XXXX`
+- [ ] Observer le comportement
+- [ ] Documenter les learnings
+
+## 🚫 Ne PAS faire
+
+- Ne pas modifier l'architecture STOA existante
+- Ne pas créer de dépendances bloquantes
+- Ce setup doit être 100% optionnel
+
+## 🔔 Checkpoints Slack
+
+Envoyer notification si:
+- [x] Structure créée → `🟢 Structure ready`
+- [ ] Scripts testés → `🟢 Scripts ready`
+- [ ] Slack configuré → `🟢 Slack ready`
+- [ ] Premier test OK → `🟢 AI Factory operational`
+
+## 📊 Progression
+
+| Step | Status | Temps |
+|------|--------|-------|
+| Step 1: Structure | ✅ DONE | 10min |
+| Step 2: Templates | ✅ DONE | 15min |
+| Step 3: Scripts | 🔄 IN PROGRESS | - |
+| Step 4: Slack | ⬜ TODO | - |
+| Step 5: n8n | ⬜ TODO | - |
+| Step 6: Test | ⬜ TODO | - |
+
+---
+
+*Créé: 2026-02-04*
+*Dernière update: 2026-02-04 12:20*

--- a/.stoa-ai/scripts/daily-digest.sh
+++ b/.stoa-ai/scripts/daily-digest.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# daily-digest.sh — Génère et envoie un résumé quotidien d'activité
+# Usage: ./daily-digest.sh [date]
+# Peut être lancé via cron: 0 9 * * * /path/to/daily-digest.sh
+
+set -e
+
+DATE="${1:-$(date +%Y-%m-%d)}"
+SLACK_WEBHOOK="${SLACK_WEBHOOK:-}"
+PHASES_DIR=".stoa-ai/phases"
+
+echo "📊 Generating daily digest for $DATE..."
+
+# Compte les commits du jour
+COMMITS_TODAY=$(git log --oneline --since="$DATE 00:00" --until="$DATE 23:59" 2>/dev/null | wc -l || echo "0")
+
+# Compte les phases actives
+PHASES_ACTIVE=$(find "$PHASES_DIR" -name "plan.md" -exec grep -l "🔄 IN PROGRESS" {} \; 2>/dev/null | wc -l || echo "0")
+
+# Compte les phases terminées aujourd'hui (basé sur les logs)
+PHASES_DONE=$(find "$PHASES_DIR" -name "*.log" -newermt "$DATE" -exec grep -l "Phase complete" {} \; 2>/dev/null | wc -l || echo "0")
+
+# Tests status
+if [ -f "pytest.log" ]; then
+    TESTS_STATUS=$(tail -1 pytest.log 2>/dev/null || echo "Unknown")
+else
+    TESTS_STATUS="No test log found"
+fi
+
+# Build digest message
+DIGEST=$(cat <<EOF
+📊 *STOA AI Factory — Daily Digest*
+📅 Date: $DATE
+
+*Activity*
+• Commits: $COMMITS_TODAY
+• Phases active: $PHASES_ACTIVE
+• Phases completed: $PHASES_DONE
+
+*Tests*
+$TESTS_STATUS
+
+*Recent commits*
+$(git log --oneline -5 --since="$DATE 00:00" 2>/dev/null || echo "No commits today")
+EOF
+)
+
+echo "$DIGEST"
+
+# Send to Slack if webhook configured
+if [ -n "$SLACK_WEBHOOK" ]; then
+    PAYLOAD=$(cat <<EOF
+{
+    "blocks": [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "📊 STOA AI Factory — Daily Digest",
+                "emoji": true
+            }
+        },
+        {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": "*Date*\n$DATE"},
+                {"type": "mrkdwn", "text": "*Commits*\n$COMMITS_TODAY"}
+            ]
+        },
+        {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": "*Phases Active*\n$PHASES_ACTIVE"},
+                {"type": "mrkdwn", "text": "*Phases Done*\n$PHASES_DONE"}
+            ]
+        },
+        {
+            "type": "divider"
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Recent Commits*\n\`\`\`$(git log --oneline -5 --since="$DATE 00:00" 2>/dev/null | head -5 || echo "No commits")\`\`\`"
+            }
+        }
+    ]
+}
+EOF
+)
+
+    curl -s -X POST "$SLACK_WEBHOOK" \
+        -H 'Content-Type: application/json' \
+        -d "$PAYLOAD" > /dev/null
+    
+    echo "✅ Digest sent to Slack"
+else
+    echo "⚠️  SLACK_WEBHOOK not set. Digest printed above."
+fi

--- a/.stoa-ai/scripts/run-phase.sh
+++ b/.stoa-ai/scripts/run-phase.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# run-phase.sh — Lance une phase Claude Code en background
+# Usage: ./run-phase.sh CAB-XXXX
+
+set -e
+
+TICKET_ID="${1:-}"
+SLACK_WEBHOOK="${SLACK_WEBHOOK:-}"
+PHASE_DIR=".stoa-ai/phases/$TICKET_ID"
+
+# Couleurs
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Validation
+if [ -z "$TICKET_ID" ]; then
+    echo -e "${RED}Usage: ./run-phase.sh CAB-XXXX${NC}"
+    exit 1
+fi
+
+if [ ! -d "$PHASE_DIR" ]; then
+    echo -e "${RED}Phase directory not found: $PHASE_DIR${NC}"
+    echo -e "${YELLOW}Create it first with: mkdir -p $PHASE_DIR${NC}"
+    exit 1
+fi
+
+if [ ! -f "$PHASE_DIR/plan.md" ]; then
+    echo -e "${RED}plan.md not found in $PHASE_DIR${NC}"
+    echo -e "${YELLOW}Copy template: cp .stoa-ai/templates/PHASE-PLAN.md $PHASE_DIR/plan.md${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}🚀 Starting Claude Code for $TICKET_ID${NC}"
+echo "Phase dir: $PHASE_DIR"
+echo "Plan file: $PHASE_DIR/plan.md"
+
+# Notify Slack start
+if [ -n "$SLACK_WEBHOOK" ]; then
+    curl -s -X POST "$SLACK_WEBHOOK" \
+        -H 'Content-Type: application/json' \
+        -d "{\"text\":\"🚀 *$TICKET_ID* — Phase started\"}" > /dev/null
+fi
+
+# Create log directory
+mkdir -p "$PHASE_DIR/logs"
+LOG_FILE="$PHASE_DIR/logs/$(date +%Y%m%d-%H%M%S).log"
+
+# Option 1: tmux session (interactive)
+if command -v tmux &> /dev/null; then
+    SESSION_NAME="claude-$TICKET_ID"
+    
+    # Kill existing session if any
+    tmux kill-session -t "$SESSION_NAME" 2>/dev/null || true
+    
+    # Create new session
+    tmux new-session -d -s "$SESSION_NAME" -c "$(pwd)"
+    
+    # Build the prompt
+    PROMPT="Tu es Claude Code pour STOA. Lis .stoa-ai/CLAUDE.md, .stoa-ai/memory.md, et $PHASE_DIR/plan.md. Exécute le plan step by step. Code → Test → Commit. Update plan.md après chaque step. Notifie si bloqué ou terminé."
+    
+    # Send command to tmux
+    tmux send-keys -t "$SESSION_NAME" "claude \"$PROMPT\" 2>&1 | tee $LOG_FILE" Enter
+    
+    echo -e "${GREEN}✅ Claude Code running in tmux session: $SESSION_NAME${NC}"
+    echo -e "${YELLOW}Attach with: tmux attach -t $SESSION_NAME${NC}"
+    echo -e "${YELLOW}Detach with: Ctrl+B then D${NC}"
+    echo -e "${YELLOW}Log file: $LOG_FILE${NC}"
+    
+else
+    # Option 2: Direct execution (blocking)
+    echo -e "${YELLOW}tmux not found, running in foreground...${NC}"
+    
+    PROMPT="Tu es Claude Code pour STOA. Lis .stoa-ai/CLAUDE.md, .stoa-ai/memory.md, et $PHASE_DIR/plan.md. Exécute le plan step by step."
+    
+    claude "$PROMPT" 2>&1 | tee "$LOG_FILE"
+fi
+
+echo -e "${GREEN}Done.${NC}"

--- a/.stoa-ai/scripts/slack-notify.sh
+++ b/.stoa-ai/scripts/slack-notify.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# slack-notify.sh — Envoie une notification Slack structurée
+# Usage: ./slack-notify.sh <type> <ticket> <message> [url]
+# Types: done, blocked, failed, info
+
+set -e
+
+TYPE="${1:-info}"
+TICKET="${2:-UNKNOWN}"
+MESSAGE="${3:-No message}"
+URL="${4:-}"
+
+SLACK_WEBHOOK="${SLACK_WEBHOOK:-}"
+
+if [ -z "$SLACK_WEBHOOK" ]; then
+    echo "⚠️  SLACK_WEBHOOK not set. Message:"
+    echo "[$TYPE] $TICKET: $MESSAGE"
+    exit 0
+fi
+
+# Emoji et couleur selon le type
+case "$TYPE" in
+    done)
+        EMOJI="🟢"
+        COLOR="#36a64f"
+        TITLE="Phase Complete"
+        ;;
+    blocked)
+        EMOJI="🟡"
+        COLOR="#ffcc00"
+        TITLE="Decision Needed"
+        ;;
+    failed)
+        EMOJI="🔴"
+        COLOR="#ff0000"
+        TITLE="Tests Failed"
+        ;;
+    *)
+        EMOJI="ℹ️"
+        COLOR="#439FE0"
+        TITLE="Info"
+        ;;
+esac
+
+# Build JSON payload
+if [ -n "$URL" ]; then
+    ACTIONS=",\"actions\":[{\"type\":\"button\",\"text\":{\"type\":\"plain_text\",\"text\":\"View\"},\"url\":\"$URL\"}]"
+else
+    ACTIONS=""
+fi
+
+PAYLOAD=$(cat <<EOF
+{
+    "blocks": [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "$EMOJI $TITLE: $TICKET",
+                "emoji": true
+            }
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "$MESSAGE"
+            }
+        }
+    ],
+    "attachments": [
+        {
+            "color": "$COLOR"
+            $ACTIONS
+        }
+    ]
+}
+EOF
+)
+
+# Send to Slack
+curl -s -X POST "$SLACK_WEBHOOK" \
+    -H 'Content-Type: application/json' \
+    -d "$PAYLOAD" > /dev/null
+
+echo "✅ Notification sent: [$TYPE] $TICKET"

--- a/.stoa-ai/templates/MEGA-TICKET.md
+++ b/.stoa-ai/templates/MEGA-TICKET.md
@@ -1,0 +1,70 @@
+# [MEGA] {TITRE}
+
+## 🎯 Objectif
+
+**{Description claire en 1-2 phrases}**
+
+> "{Citation/North Star inspirante}"
+
+---
+
+## 📐 Why Now?
+
+- {Raison business 1}
+- {Raison business 2}
+- {Deadline ou opportunité}
+
+---
+
+## 🏗️ Scope
+
+### In Scope ✅
+- {Feature/composant 1}
+- {Feature/composant 2}
+
+### Out of Scope ❌
+- {Ce qu'on ne fait PAS}
+- {Pour éviter scope creep}
+
+---
+
+## ✅ Definition of Done
+
+- [ ] {Critère mesurable 1}
+- [ ] {Critère mesurable 2}
+- [ ] Tests passent (coverage > 80%)
+- [ ] Documentation mise à jour
+- [ ] Review Council 8/10
+
+---
+
+## 📦 Livrables
+
+1. **{Livrable 1}**: {Description}
+2. **{Livrable 2}**: {Description}
+
+---
+
+## 🔗 Dépendances
+
+- {Ticket ou système dont on dépend}
+- {API externe nécessaire}
+
+---
+
+## 📊 Estimation
+
+| Phase | Points | Temps estimé |
+|-------|--------|--------------|
+| Phase 1: {nom} | X | Xh |
+| Phase 2: {nom} | X | Xh |
+| **Total** | **X** | **Xh** |
+
+---
+
+## 🏷️ Metadata
+
+- **Type**: Feature / Infrastructure / Fix
+- **CIR Eligible**: Oui / Non
+- **Priorité**: P0 / P1 / P2
+- **Labels**: {labels pertinents}

--- a/.stoa-ai/templates/PHASE-PLAN.md
+++ b/.stoa-ai/templates/PHASE-PLAN.md
@@ -1,0 +1,68 @@
+# Plan: {TICKET_ID} — {TITRE}
+
+> Ce fichier guide Claude Code. Mettre à jour les checkboxes au fur et à mesure.
+
+## 🎯 Objectif de cette Phase
+
+{Description claire de ce qu'on veut accomplir}
+
+## 📋 Contexte
+
+- **MEGA parent**: {CAB-XXXX}
+- **Branche**: `{nom-branche}`
+- **Fichiers principaux**: 
+  - `{path/to/file1}`
+  - `{path/to/file2}`
+
+## ✅ Steps
+
+### Step 1: {Nom du step}
+- [ ] {Action 1.1}
+- [ ] {Action 1.2}
+- [ ] Tests: `pytest tests/test_xxx.py`
+
+### Step 2: {Nom du step}
+- [ ] {Action 2.1}
+- [ ] {Action 2.2}
+- [ ] Tests: `pytest tests/test_yyy.py`
+
+### Step 3: {Nom du step}
+- [ ] {Action 3.1}
+- [ ] {Action 3.2}
+- [ ] Tests: `pytest tests/test_zzz.py`
+
+### Step 4: Validation finale
+- [ ] Tous les tests passent
+- [ ] Linting OK (`ruff check .`)
+- [ ] Types OK (`mypy .`)
+- [ ] Commit avec message conventionnel
+- [ ] Push sur branche
+
+## 🚫 Ne PAS faire
+
+- {Chose à éviter 1}
+- {Chose à éviter 2}
+- Ne pas toucher aux zones interdites (voir CLAUDE.md)
+
+## 🔔 Checkpoints Slack
+
+Envoyer notification si:
+- [ ] Phase terminée → `🟢 Phase done`
+- [ ] Bloqué > 10 min → `🟡 Need decision`
+- [ ] Tests échouent 2x → `🔴 Tests failing`
+
+## 📊 Progression
+
+| Step | Status | Temps |
+|------|--------|-------|
+| Step 1 | ⬜ TODO | - |
+| Step 2 | ⬜ TODO | - |
+| Step 3 | ⬜ TODO | - |
+| Step 4 | ⬜ TODO | - |
+
+Status: ⬜ TODO | 🔄 IN PROGRESS | ✅ DONE | ❌ BLOCKED
+
+---
+
+*Créé: {DATE}*
+*Dernière update: {DATE}*

--- a/.stoa-ai/templates/PROMPT-ENTRY.md
+++ b/.stoa-ai/templates/PROMPT-ENTRY.md
@@ -1,0 +1,86 @@
+# Prompt d'Entrée Claude Code
+
+> Copier-coller ce prompt pour démarrer une session Claude Code sur une phase.
+
+---
+
+## Prompt Standard
+
+```
+Tu es Claude Code, AI Worker pour le projet STOA Platform.
+
+## Contexte
+Lis ces fichiers dans l'ordre:
+1. `.stoa-ai/CLAUDE.md` — Contexte projet global
+2. `.stoa-ai/memory.md` — État de la dernière session
+3. `.stoa-ai/phases/{TICKET_ID}/plan.md` — Plan de cette phase
+
+## Ta mission
+Exécuter le plan de la phase {TICKET_ID}: {TITRE}
+
+## Règles
+1. Suis les steps dans l'ordre
+2. Code → Test → Commit pour chaque step
+3. Met à jour plan.md après chaque step complété
+4. Si bloqué > 10 min → STOP et notifie
+5. Si tous les tests passent → Phase terminée, notifie
+6. Respecte les zones interdites dans CLAUDE.md
+
+## Workflow
+```
+loop:
+  read plan.md → find next unchecked step
+  implement step
+  run tests
+  if tests pass:
+    commit with conventional message
+    check step in plan.md
+    continue
+  else:
+    retry once
+    if still failing:
+      STOP and notify "Tests failing on step X"
+  
+  if all steps done:
+    STOP and notify "Phase complete. Ready for review."
+```
+
+## Notifications
+Quand tu dois notifier, écris:
+- 🟢 NOTIFY: Phase {TICKET_ID} complete. Ready for review.
+- 🟡 NOTIFY: Phase {TICKET_ID} blocked on step X. Decision needed: {question}
+- 🔴 NOTIFY: Phase {TICKET_ID} tests failing on step X. See output above.
+
+Commence maintenant. Lis les fichiers de contexte puis exécute le plan.
+```
+
+---
+
+## Variantes
+
+### Mode Audit (analyse sans coder)
+```
+Lis `.stoa-ai/CLAUDE.md` et analyse le codebase.
+Produis un audit de {COMPOSANT} avec:
+- État actuel
+- Problèmes identifiés
+- Recommandations
+Ne modifie aucun fichier.
+```
+
+### Mode Fix Rapide
+```
+Fix le bug suivant: {DESCRIPTION}
+Fichier concerné: {PATH}
+Tests à vérifier: {TEST_PATH}
+Commit message: fix({scope}): {description}
+```
+
+### Mode Refactor
+```
+Refactore {COMPOSANT} selon ces critères:
+- {Critère 1}
+- {Critère 2}
+Garde la même interface publique.
+Assure-toi que tous les tests passent.
+```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# STOA Platform — Developer Makefile
+# Usage: make <target>
+
+.PHONY: seed-demo test-demo migrate-kong migrate-kong-dry-run test-migrate-kong test-migrate-kong-integration help
+
+# ── Demo Data ──────────────────────────────────────────────────────────────
+
+seed-demo: ## Seed demo data (APIs, apps, metrics) — requires ANORAK_PASSWORD
+	@echo "==> Seeding demo data..."
+	python3 scripts/seed-demo-data.py
+
+test-demo: ## Run E2E demo tests (@demo tag)
+	@echo "==> Running demo E2E tests..."
+	cd e2e && npm run test:demo
+
+# ── Kong Migration ────────────────────────────────────────────────────────
+
+KONG_SOURCE ?= scripts/tests/fixtures/sample-kong.yaml
+STOA_OUTPUT ?= .stoa-migration
+
+migrate-kong: ## Migrate Kong config to STOA (KONG_SOURCE=kong.yaml STOA_OUTPUT=stoa/)
+	@python3 scripts/migrate-kong.py --from $(KONG_SOURCE) --to $(STOA_OUTPUT)
+
+migrate-kong-dry-run: ## Dry-run Kong migration (KONG_SOURCE=kong.yaml)
+	@python3 scripts/migrate-kong.py --from $(KONG_SOURCE) --dry-run
+
+test-migrate-kong: ## Run Kong migration unit tests
+	@echo "==> Running migrate-kong tests..."
+	cd scripts && python3 -m pytest tests/test_migrate_kong.py -v
+
+test-migrate-kong-integration: ## Run Kong migration integration tests (requires Docker)
+	@echo "==> Running migrate-kong integration tests (Docker required)..."
+	cd scripts && python3 -m pytest tests/test_migrate_kong_integration.py -v -m integration
+
+# ── Help ───────────────────────────────────────────────────────────────────
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help

--- a/scripts/migrate-kong.py
+++ b/scripts/migrate-kong.py
@@ -1,0 +1,835 @@
+#!/usr/bin/env python3
+"""
+Kong -> STOA Migration Adapter.
+
+Migrates Kong Gateway declarative config (kong.yaml) or Kong Admin API
+into STOA platform format.
+
+Mapping:
+  Kong service    -> STOA API
+  Kong route      -> STOA API endpoint (resource)
+  Kong plugin     -> STOA API policy
+  Kong consumer   -> STOA tenant / application
+  Kong upstream   -> STOA backend target
+
+Usage:
+  python migrate-kong.py --from kong.yaml --to stoa/
+  python migrate-kong.py --from http://localhost:8001 --to stoa/
+  python migrate-kong.py --from kong.yaml --dry-run
+  python migrate-kong.py --from kong.yaml --to stoa/ --verbose
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import yaml
+
+log = logging.getLogger("migrate-kong")
+
+
+# ---------------------------------------------------------------------------
+# UX helpers
+# ---------------------------------------------------------------------------
+
+
+class _UX:
+    """Structured terminal output with progress indicators."""
+
+    def __init__(self, *, verbose: bool = False, quiet: bool = False) -> None:
+        self.verbose = verbose
+        self.quiet = quiet
+
+    # -- public primitives --------------------------------------------------
+
+    def step(self, icon: str, msg: str) -> None:
+        if not self.quiet:
+            print(f"{icon} {msg}")
+
+    def detail(self, msg: str) -> None:
+        """Only printed in --verbose mode."""
+        if self.verbose:
+            print(f"  {msg}")
+
+    # -- semantic helpers ---------------------------------------------------
+
+    def connecting(self, source: str) -> None:
+        self.step("\U0001f50d", f"Loading Kong config from {source} ...")
+
+    def found(self, services: int, routes: int, plugins: int) -> None:
+        self.step(
+            "\u2714",
+            f"Found {services} service(s), {routes} route(s), {plugins} plugin(s)",
+        )
+
+    def migrating(self) -> None:
+        self.step("\U0001f4e6", "Migrating ...")
+
+    def migrated_api(self, kong_name: str, stoa_id: str) -> None:
+        self.step("\u2714", f"{kong_name} \u2192 API `{stoa_id}`")
+
+    def warning(self, msg: str) -> None:
+        self.step("\u26a0\ufe0f", msg)
+
+    def skipped(self, msg: str) -> None:
+        self.step("\u23ed", msg)
+
+    def manual(self, msg: str) -> None:
+        self.step("\u26a0\ufe0f", msg)
+
+    def output_files(self, yaml_path: Path, report_path: Path, stats: dict[str, int]) -> None:
+        print()
+        self.step("\U0001f4c4", "Output:")
+        api_count = stats.get("apis", 0)
+        tenant_count = stats.get("tenants", 0)
+        print(f"  \u2192 {yaml_path} ({api_count} APIs, {tenant_count} tenants)")
+        print(f"  \u2192 {report_path}")
+
+    def done(self) -> None:
+        print()
+        self.step("\u2705", "Migration complete. Run:  stoa apply -f <output>/stoa-apis.yaml")
+
+    def dry_run_banner(self) -> None:
+        print()
+        self.step("\U0001f4cb", "DRY-RUN \u2014 showing what WOULD be migrated (no files written)")
+        print()
+
+    def dry_run_summary(self, stats: dict[str, int]) -> None:
+        print()
+        self.step(
+            "\U0001f4cb",
+            f"Would produce: {stats.get('apis', 0)} APIs, "
+            f"{stats.get('policies', 0)} policies, "
+            f"{stats.get('tenants', 0)} tenants, "
+            f"{stats.get('applications', 0)} applications",
+        )
+        self.step(
+            "\u26a0\ufe0f",
+            f"{stats.get('manual', 0)} manual action(s), "
+            f"{stats.get('skipped', 0)} skipped",
+        )
+
+    def error_connection(self, url: str, err: str) -> None:
+        print(f"\u274c Cannot connect to Kong at {url}", file=sys.stderr)
+        print(f"  \u2192 {err}", file=sys.stderr)
+        if "localhost" in url or "127.0.0.1" in url:
+            print(
+                "  \u2192 Is Kong running? Try: docker-compose up -d kong",
+                file=sys.stderr,
+            )
+
+    def error_file(self, path: str, err: str) -> None:
+        print(f"\u274c Cannot read Kong config at {path}", file=sys.stderr)
+        print(f"  \u2192 {err}", file=sys.stderr)
+        print(
+            "  \u2192 Expected: kong.yaml (declarative config, _format_version: '3.0')",
+            file=sys.stderr,
+        )
+
+    def error_generic(self, err: str) -> None:
+        print(f"\u274c {err}", file=sys.stderr)
+
+
+ux = _UX()  # module-level singleton, reconfigured in main()
+
+
+# ---------------------------------------------------------------------------
+# Kong Config Loaders
+# ---------------------------------------------------------------------------
+
+
+def load_from_file(path: str) -> dict[str, Any]:
+    """Load Kong declarative config from a YAML file."""
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+    with p.open() as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid Kong config: expected mapping, got {type(data).__name__}")
+    return data
+
+
+def load_from_admin_api(url: str) -> dict[str, Any]:
+    """Load Kong config from Admin API (http://host:8001)."""
+    import urllib.error
+    import urllib.request
+
+    def _get(endpoint: str) -> dict[str, Any]:
+        full = f"{url.rstrip('/')}{endpoint}"
+        log.debug("GET %s", full)
+        resp = urllib.request.urlopen(full, timeout=10)  # noqa: S310
+        return json.loads(resp.read())
+
+    try:
+        _get("/")  # connectivity check
+    except (urllib.error.URLError, OSError) as exc:
+        raise ConnectionError(str(exc)) from exc
+
+    services_resp = _get("/services")
+    services_data = services_resp.get("data", [])
+
+    services = []
+    for svc in services_data:
+        svc_id = svc.get("id", svc.get("name"))
+
+        routes_resp = _get(f"/services/{svc_id}/routes")
+        svc["routes"] = routes_resp.get("data", [])
+
+        plugins_resp = _get(f"/services/{svc_id}/plugins")
+        svc["plugins"] = plugins_resp.get("data", [])
+
+        services.append(svc)
+
+    upstreams_resp = _get("/upstreams")
+    upstreams = upstreams_resp.get("data", [])
+    for ups in upstreams:
+        ups_name = ups.get("name") or ups.get("id")
+        targets_resp = _get(f"/upstreams/{ups_name}/targets")
+        ups["targets"] = targets_resp.get("data", [])
+
+    consumers_resp = _get("/consumers")
+    consumers = consumers_resp.get("data", [])
+    for consumer in consumers:
+        c_name = consumer.get("username") or consumer.get("id")
+        try:
+            cred_resp = _get(f"/consumers/{c_name}/key-auth")
+            consumer["keyauth_credentials"] = cred_resp.get("data", [])
+        except Exception:
+            consumer["keyauth_credentials"] = []
+        try:
+            plugins_resp = _get(f"/consumers/{c_name}/plugins")
+            consumer["plugins"] = plugins_resp.get("data", [])
+        except Exception:
+            consumer["plugins"] = []
+
+    global_plugins_resp = _get("/plugins")
+    global_plugins = [
+        p
+        for p in global_plugins_resp.get("data", [])
+        if not p.get("service") and not p.get("consumer")
+    ]
+
+    return {
+        "_format_version": "admin-api",
+        "services": services,
+        "upstreams": upstreams,
+        "consumers": consumers,
+        "plugins": global_plugins,
+    }
+
+
+def load_kong_config(source: str) -> dict[str, Any]:
+    """Load Kong config from file path or Admin API URL."""
+    if source.startswith("http://") or source.startswith("https://"):
+        return load_from_admin_api(source)
+    return load_from_file(source)
+
+
+# ---------------------------------------------------------------------------
+# Stats helper
+# ---------------------------------------------------------------------------
+
+
+def _count_kong_objects(cfg: dict[str, Any]) -> tuple[int, int, int]:
+    """Return (services, routes, plugins) counts from a Kong config."""
+    services = cfg.get("services", [])
+    routes = sum(len(s.get("routes", [])) for s in services)
+    plugins = sum(len(s.get("plugins", [])) for s in services) + len(cfg.get("plugins", []))
+    return len(services), routes, plugins
+
+
+# ---------------------------------------------------------------------------
+# Kong -> STOA Mappers
+# ---------------------------------------------------------------------------
+
+
+def _slugify(name: str) -> str:
+    """Convert a name to a URL-friendly slug."""
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower())
+    return slug.strip("-")
+
+
+def _map_rate_limit_plugin(config: dict[str, Any]) -> dict[str, Any]:
+    """Map Kong rate-limiting plugin config to STOA policy config."""
+    stoa_config: dict[str, Any] = {"by": "token"}
+    if "minute" in config:
+        stoa_config["requests"] = config["minute"]
+        stoa_config["window"] = 60
+    elif "hour" in config:
+        stoa_config["requests"] = config["hour"]
+        stoa_config["window"] = 3600
+    elif "second" in config:
+        stoa_config["requests"] = config["second"]
+        stoa_config["window"] = 1
+    return stoa_config
+
+
+def _map_cors_plugin(config: dict[str, Any]) -> dict[str, Any]:
+    """Map Kong cors plugin config to STOA policy config."""
+    return {
+        "allowOrigins": config.get("origins", ["*"]),
+        "allowMethods": config.get("methods", ["GET", "POST", "PUT", "DELETE", "OPTIONS"]),
+        "allowHeaders": config.get("headers", ["Authorization", "Content-Type"]),
+        "maxAge": config.get("max_age", 3600),
+    }
+
+
+# Plugins that map cleanly to STOA policies
+PLUGIN_MAPPERS: dict[str, tuple[str, Any]] = {
+    "rate-limiting": ("rate-limit", _map_rate_limit_plugin),
+    "rate-limiting-advanced": ("rate-limit", _map_rate_limit_plugin),
+    "cors": ("cors", _map_cors_plugin),
+}
+
+# Plugins that signal subscription requirement
+AUTH_PLUGINS = {"key-auth", "oauth2", "jwt", "basic-auth", "hmac-auth"}
+
+# Plugins that cannot be auto-migrated
+UNSUPPORTED_PLUGINS = {
+    "request-transformer",
+    "response-transformer",
+    "request-termination",
+    "ip-restriction",
+    "acl",
+    "bot-detection",
+    "ldap-auth",
+    "session",
+    "proxy-cache",
+    "grpc-gateway",
+    "grpc-web",
+    "aws-lambda",
+    "azure-functions",
+    "opentelemetry",
+    "zipkin",
+}
+
+
+class MigrationReport:
+    """Accumulates migration events for the final report."""
+
+    def __init__(self) -> None:
+        self.migrated: list[str] = []
+        self.warnings: list[str] = []
+        self.skipped: list[str] = []
+        self.manual_actions: list[str] = []
+
+    def add_migrated(self, msg: str) -> None:
+        self.migrated.append(msg)
+
+    def add_warning(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    def add_skipped(self, msg: str) -> None:
+        self.skipped.append(msg)
+
+    def add_manual(self, msg: str) -> None:
+        self.manual_actions.append(msg)
+
+    def render(self) -> str:
+        """Render the report as Markdown."""
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        lines = [
+            "# Kong \u2192 STOA Migration Report",
+            "",
+            f"**Generated**: {now}",
+            "",
+            "---",
+            "",
+        ]
+
+        lines.append(f"## Migrated ({len(self.migrated)})")
+        lines.append("")
+        for m in self.migrated:
+            lines.append(f"- {m}")
+        lines.append("")
+
+        if self.warnings:
+            lines.append(f"## Warnings ({len(self.warnings)})")
+            lines.append("")
+            for w in self.warnings:
+                lines.append(f"- \u26a0\ufe0f {w}")
+            lines.append("")
+
+        if self.skipped:
+            lines.append(f"## Skipped ({len(self.skipped)})")
+            lines.append("")
+            for s in self.skipped:
+                lines.append(f"- {s}")
+            lines.append("")
+
+        if self.manual_actions:
+            lines.append(f"## Manual Actions Required ({len(self.manual_actions)})")
+            lines.append("")
+            for a in self.manual_actions:
+                lines.append(f"- [ ] {a}")
+            lines.append("")
+
+        lines.append("---")
+        lines.append("")
+        lines.append("## Migration Summary")
+        lines.append("")
+        lines.append("| Metric | Count |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Migrated | {len(self.migrated)} |")
+        lines.append(f"| Warnings | {len(self.warnings)} |")
+        lines.append(f"| Skipped | {len(self.skipped)} |")
+        lines.append(f"| Manual actions | {len(self.manual_actions)} |")
+        lines.append("")
+
+        return "\n".join(lines)
+
+
+class KongToStoaMigrator:
+    """Converts Kong declarative config into STOA platform resources."""
+
+    def __init__(self, kong_config: dict[str, Any]) -> None:
+        self.kong = kong_config
+        self.report = MigrationReport()
+
+        # Collected STOA resources
+        self.apis: list[dict[str, Any]] = []
+        self.policies: list[dict[str, Any]] = []
+        self.tenants: list[dict[str, Any]] = []
+        self.applications: list[dict[str, Any]] = []
+        self.subscriptions: list[dict[str, Any]] = []
+
+        # Track upstreams by name for cross-reference
+        self._upstreams: dict[str, dict[str, Any]] = {}
+
+    # -- public ---------------------------------------------------------
+
+    def migrate(self) -> None:
+        """Run the full migration pipeline."""
+        self._index_upstreams()
+        self._migrate_services()
+        self._migrate_consumers()
+        self._migrate_global_plugins()
+
+    def stats(self) -> dict[str, int]:
+        """Return counts of migrated resources."""
+        return {
+            "apis": len(self.apis),
+            "policies": len(self.policies),
+            "tenants": len(self.tenants),
+            "applications": len(self.applications),
+            "migrated": len(self.report.migrated),
+            "warnings": len(self.report.warnings),
+            "skipped": len(self.report.skipped),
+            "manual": len(self.report.manual_actions),
+        }
+
+    def to_stoa_yaml(self) -> str:
+        """Serialize all collected resources into a single STOA YAML doc."""
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        doc: dict[str, Any] = {
+            "apiVersion": "stoa.io/v1",
+            "kind": "StoaExport",
+            "metadata": {
+                "name": "kong-migration",
+                "timestamp": now,
+                "source": "kong-declarative",
+            },
+        }
+
+        spec: dict[str, Any] = {}
+        if self.tenants:
+            spec["tenants"] = self.tenants
+        if self.apis:
+            spec["apis"] = self.apis
+        if self.policies:
+            spec["policies"] = self.policies
+        if self.applications:
+            spec["applications"] = self.applications
+        if self.subscriptions:
+            spec["subscriptions"] = self.subscriptions
+
+        doc["spec"] = spec
+        return yaml.dump(doc, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+    # -- internals ------------------------------------------------------
+
+    def _index_upstreams(self) -> None:
+        for ups in self.kong.get("upstreams", []):
+            name = ups.get("name", "")
+            self._upstreams[name] = ups
+
+    def _migrate_services(self) -> None:
+        for svc in self.kong.get("services", []):
+            self._migrate_one_service(svc)
+
+    def _migrate_one_service(self, svc: dict[str, Any]) -> None:
+        svc_name = svc.get("name", "unnamed-service")
+        slug = _slugify(svc_name)
+
+        # Determine backend URL
+        backend_url = svc.get("url", "")
+        if not backend_url:
+            proto = svc.get("protocol", "https")
+            host = svc.get("host", "localhost")
+            port = svc.get("port", 443)
+            path = svc.get("path", "")
+            backend_url = f"{proto}://{host}:{port}{path}"
+
+        # Check if there's a matching upstream
+        upstream_info = self._resolve_upstream(svc)
+
+        # Build resources (endpoints) from routes
+        resources = self._map_routes(svc.get("routes", []))
+
+        # Map plugins
+        plugins = svc.get("plugins", [])
+        policies, requires_subscription = self._map_plugins(plugins, context=svc_name)
+
+        tags = svc.get("tags", [])
+
+        api: dict[str, Any] = {
+            "id": slug,
+            "name": slug,
+            "displayName": svc_name.replace("-", " ").title(),
+            "version": "1.0.0",
+            "description": f"Migrated from Kong service: {svc_name}",
+            "backend_url": backend_url,
+            "status": "draft",
+            "tags": tags,
+        }
+
+        if resources:
+            api["resources"] = resources
+        if policies:
+            api["policies"] = [p["name"] for p in policies]
+        if requires_subscription:
+            api["auth"] = {"type": "api-key", "required": True}
+        if upstream_info:
+            api["backend"] = upstream_info
+
+        self.apis.append(api)
+        self.policies.extend(policies)
+        self.report.add_migrated(f"Service `{svc_name}` \u2192 API `{slug}`")
+
+        ux.migrated_api(svc_name, slug)
+        for route in svc.get("routes", []):
+            route_name = route.get("name", "unnamed-route")
+            self.report.add_migrated(f"Route `{route_name}` \u2192 resource in API `{slug}`")
+            ux.detail(f"route `{route_name}` \u2192 resource")
+
+    def _map_routes(self, routes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        resources = []
+        for route in routes:
+            paths = route.get("paths", ["/"])
+            methods = route.get("methods") or ["GET", "POST", "PUT", "DELETE"]
+            route_name = route.get("name", "")
+            for path in paths:
+                res: dict[str, Any] = {
+                    "path": path + "/*" if not path.endswith("*") else path,
+                    "methods": methods,
+                }
+                if route_name:
+                    res["description"] = f"From Kong route: {route_name}"
+                resources.append(res)
+        return resources
+
+    def _map_plugins(
+        self,
+        plugins: list[dict[str, Any]],
+        context: str = "",
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Map Kong plugins to STOA policies.
+
+        Returns (policies, requires_subscription).
+        """
+        policies: list[dict[str, Any]] = []
+        requires_subscription = False
+
+        for plugin in plugins:
+            plugin_name = plugin.get("name", "")
+            config = plugin.get("config", {})
+
+            if plugin_name in AUTH_PLUGINS:
+                requires_subscription = True
+                self.report.add_migrated(
+                    f"Plugin `{plugin_name}` on `{context}` \u2192 subscription required"
+                )
+                ux.detail(f"plugin `{plugin_name}` \u2192 subscription required")
+                continue
+
+            if plugin_name in PLUGIN_MAPPERS:
+                policy_type, mapper_fn = PLUGIN_MAPPERS[plugin_name]
+                policy_slug = _slugify(f"{context}-{policy_type}")
+                policy = {
+                    "apiVersion": "stoa.io/v1",
+                    "kind": "Policy",
+                    "name": policy_slug,
+                    "type": policy_type,
+                    "config": mapper_fn(config),
+                }
+                policies.append(policy)
+                self.report.add_migrated(
+                    f"Plugin `{plugin_name}` on `{context}` \u2192 policy `{policy_slug}`"
+                )
+                ux.detail(f"plugin `{plugin_name}` \u2192 policy `{policy_slug}`")
+            elif plugin_name in UNSUPPORTED_PLUGINS:
+                self.report.add_manual(
+                    f"Plugin `{plugin_name}` on `{context}` has no STOA equivalent \u2014 "
+                    f"configure manually. Config: {json.dumps(config, default=str)}"
+                )
+                ux.manual(f"`{plugin_name}` plugin on `{context}` \u2192 manual action required")
+            elif plugin_name in ("prometheus", "datadog", "statsd"):
+                self.report.add_skipped(
+                    f"Observability plugin `{plugin_name}` \u2014 "
+                    f"STOA uses built-in metering pipeline"
+                )
+                ux.skipped(f"`{plugin_name}` plugin \u2192 skipped (STOA built-in)")
+            elif plugin_name in ("file-log", "tcp-log", "http-log", "syslog", "udp-log"):
+                self.report.add_skipped(
+                    f"Logging plugin `{plugin_name}` \u2014 "
+                    f"STOA uses built-in logging policy"
+                )
+                ux.skipped(f"`{plugin_name}` plugin \u2192 skipped (STOA built-in)")
+            else:
+                self.report.add_warning(
+                    f"Unknown plugin `{plugin_name}` on `{context}` \u2014 skipped"
+                )
+                ux.warning(f"Unknown plugin `{plugin_name}` on `{context}` \u2014 skipped")
+
+        return policies, requires_subscription
+
+    def _resolve_upstream(self, svc: dict[str, Any]) -> dict[str, Any] | None:
+        """Check if a Kong upstream matches this service's host."""
+        host = svc.get("host", "")
+        ups = self._upstreams.get(host)
+        if not ups:
+            svc_name = svc.get("name", "")
+            for ups_name, ups_data in self._upstreams.items():
+                if svc_name in ups_name or ups_name in svc_name:
+                    ups = ups_data
+                    break
+        if not ups:
+            return None
+
+        targets = []
+        for t in ups.get("targets", []):
+            target_entry: dict[str, Any] = {"url": t.get("target", "")}
+            weight = t.get("weight")
+            if weight is not None:
+                target_entry["weight"] = weight
+            targets.append(target_entry)
+
+        result: dict[str, Any] = {
+            "algorithm": ups.get("algorithm", "round-robin"),
+            "targets": targets,
+        }
+
+        healthchecks = ups.get("healthchecks", {})
+        active = healthchecks.get("active", {})
+        if active.get("http_path"):
+            result["healthCheck"] = {
+                "path": active["http_path"],
+                "interval": active.get("healthy", {}).get("interval", 30),
+            }
+
+        ups_name = ups.get("name", "unnamed")
+        self.report.add_migrated(f"Upstream `{ups_name}` \u2192 backend targets in API")
+        ux.detail(f"upstream `{ups_name}` \u2192 backend targets")
+
+        return result
+
+    def _migrate_consumers(self) -> None:
+        for consumer in self.kong.get("consumers", []):
+            self._migrate_one_consumer(consumer)
+
+    def _migrate_one_consumer(self, consumer: dict[str, Any]) -> None:
+        username = consumer.get("username", "unnamed")
+        custom_id = consumer.get("custom_id", "")
+        tags = consumer.get("tags", [])
+
+        is_service_account = "service-account" in tags or custom_id.startswith("svc-")
+
+        if is_service_account:
+            app_slug = _slugify(username)
+            app: dict[str, Any] = {
+                "apiVersion": "stoa.io/v1",
+                "kind": "Application",
+                "id": app_slug,
+                "displayName": username.replace("-", " ").title(),
+                "type": "service",
+                "tags": tags,
+            }
+            self.applications.append(app)
+            self.report.add_migrated(
+                f"Consumer `{username}` (service) \u2192 application `{app_slug}`"
+            )
+            ux.detail(f"consumer `{username}` \u2192 application `{app_slug}`")
+        else:
+            tenant_slug = _slugify(custom_id or username)
+            tenant: dict[str, Any] = {
+                "apiVersion": "stoa.io/v1",
+                "kind": "Tenant",
+                "id": tenant_slug,
+                "displayName": username.replace("-", " ").title(),
+                "tags": tags,
+                "settings": {},
+            }
+
+            consumer_plugins = consumer.get("plugins", [])
+            for plugin in consumer_plugins:
+                if plugin.get("name") in ("rate-limiting", "rate-limiting-advanced"):
+                    cfg = plugin.get("config", {})
+                    tenant["settings"]["rateLimit"] = _map_rate_limit_plugin(cfg)
+                    self.report.add_migrated(
+                        f"Consumer rate-limit for `{username}` \u2192 tenant settings"
+                    )
+
+            self.tenants.append(tenant)
+            self.report.add_migrated(f"Consumer `{username}` \u2192 tenant `{tenant_slug}`")
+            ux.detail(f"consumer `{username}` \u2192 tenant `{tenant_slug}`")
+
+            if consumer.get("keyauth_credentials"):
+                self.report.add_manual(
+                    f"Consumer `{username}` has API keys \u2014 create STOA subscriptions "
+                    f"and issue new API keys via the portal"
+                )
+
+    def _migrate_global_plugins(self) -> None:
+        for plugin in self.kong.get("plugins", []):
+            plugin_name = plugin.get("name", "")
+            if plugin_name in ("prometheus", "datadog", "statsd"):
+                self.report.add_skipped(
+                    f"Global plugin `{plugin_name}` \u2014 STOA uses built-in metering"
+                )
+                ux.skipped(f"`{plugin_name}` global plugin \u2192 skipped (STOA built-in)")
+            elif plugin_name in ("file-log", "tcp-log", "http-log", "syslog", "udp-log"):
+                self.report.add_skipped(
+                    f"Global plugin `{plugin_name}` \u2014 STOA uses built-in logging"
+                )
+                ux.skipped(f"`{plugin_name}` global plugin \u2192 skipped (STOA built-in)")
+            else:
+                self.report.add_warning(
+                    f"Global plugin `{plugin_name}` \u2014 review for manual configuration"
+                )
+                ux.warning(
+                    f"Global plugin `{plugin_name}` \u2014 review for manual configuration"
+                )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    global ux
+
+    parser = argparse.ArgumentParser(
+        description="Kong \u2192 STOA Migration Adapter",
+        epilog=(
+            "Examples:\n"
+            "  python migrate-kong.py --from kong.yaml --to stoa/\n"
+            "  python migrate-kong.py --from http://localhost:8001 --to stoa/\n"
+            "  python migrate-kong.py --from kong.yaml --dry-run\n"
+            "  python migrate-kong.py --from kong.yaml --to stoa/ --verbose\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--from",
+        dest="source",
+        required=True,
+        help="Kong config source: path to kong.yaml or Admin API URL (http://host:8001)",
+    )
+    parser.add_argument(
+        "--to",
+        dest="output_dir",
+        default=None,
+        help="Output directory for STOA files (required unless --dry-run)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be migrated without writing files",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show detailed output for each migrated resource",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress progress output (only errors)",
+    )
+    args = parser.parse_args(argv)
+
+    source: str = args.source
+    dry_run: bool = args.dry_run
+    verbose: bool = args.verbose
+    quiet: bool = args.quiet
+
+    # Validate args
+    if not dry_run and not args.output_dir:
+        parser.error("--to is required unless --dry-run is set")
+
+    # Configure UX + logging
+    ux = _UX(verbose=verbose, quiet=quiet)
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG, format="  [debug] %(message)s")
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
+    if dry_run:
+        ux.dry_run_banner()
+
+    # Load Kong config
+    ux.connecting(source)
+    try:
+        kong_config = load_kong_config(source)
+    except ConnectionError as e:
+        ux.error_connection(source, str(e))
+        return 1
+    except FileNotFoundError as e:
+        ux.error_file(source, str(e))
+        return 1
+    except Exception as e:
+        ux.error_generic(str(e))
+        return 1
+
+    svc_count, route_count, plugin_count = _count_kong_objects(kong_config)
+    ux.found(svc_count, route_count, plugin_count)
+
+    # Run migration
+    ux.migrating()
+    migrator = KongToStoaMigrator(kong_config)
+    migrator.migrate()
+
+    st = migrator.stats()
+
+    if dry_run:
+        ux.dry_run_summary(st)
+        return 0
+
+    # Write outputs
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    stoa_yaml_path = output_dir / "stoa-apis.yaml"
+    stoa_yaml_path.write_text(migrator.to_stoa_yaml())
+
+    report_path = output_dir / "migration-report.md"
+    report_path.write_text(migrator.report.render())
+
+    ux.output_files(stoa_yaml_path, report_path, st)
+    ux.done()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/fixtures/sample-kong.yaml
+++ b/scripts/tests/fixtures/sample-kong.yaml
@@ -1,0 +1,198 @@
+_format_version: "3.0"
+
+services:
+  - name: petstore-service
+    url: https://petstore.swagger.io/v2
+    protocol: https
+    host: petstore-upstream
+    port: 443
+    path: /v2
+    retries: 5
+    connect_timeout: 60000
+    write_timeout: 60000
+    read_timeout: 60000
+    tags:
+      - petstore
+      - rest
+    routes:
+      - name: petstore-route
+        paths:
+          - /petstore
+        methods:
+          - GET
+          - POST
+          - PUT
+          - DELETE
+        strip_path: true
+        preserve_host: false
+        protocols:
+          - https
+        tags:
+          - petstore
+    plugins:
+      - name: rate-limiting
+        config:
+          minute: 100
+          hour: 5000
+          policy: local
+          fault_tolerant: true
+          hide_client_headers: false
+      - name: cors
+        config:
+          origins:
+            - "https://portal.example.com"
+            - "https://console.example.com"
+          methods:
+            - GET
+            - POST
+            - PUT
+            - DELETE
+            - OPTIONS
+          headers:
+            - Authorization
+            - Content-Type
+          max_age: 3600
+          credentials: true
+
+  - name: crm-api-service
+    url: https://crm.acme-corp.com/api/v2
+    protocol: https
+    host: crm.acme-corp.com
+    port: 443
+    path: /api/v2
+    tags:
+      - crm
+      - internal
+    routes:
+      - name: crm-api-route
+        paths:
+          - /crm/v2
+        methods:
+          - GET
+          - POST
+          - PUT
+          - PATCH
+        strip_path: true
+        protocols:
+          - https
+      - name: crm-search-route
+        paths:
+          - /crm/search
+        methods:
+          - GET
+          - POST
+        strip_path: true
+        protocols:
+          - https
+    plugins:
+      - name: key-auth
+        config:
+          key_names:
+            - apikey
+            - X-API-Key
+          hide_credentials: true
+      - name: rate-limiting
+        config:
+          minute: 60
+          hour: 2000
+          policy: local
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "X-Forwarded-By:kong"
+
+  - name: payment-gateway
+    url: https://payments.internal.com/api/v1
+    protocol: https
+    host: payments.internal.com
+    port: 443
+    path: /api/v1
+    tags:
+      - payments
+      - critical
+    routes:
+      - name: payment-route
+        paths:
+          - /payments
+        methods:
+          - POST
+        strip_path: true
+        protocols:
+          - https
+        tags:
+          - critical
+    plugins:
+      - name: key-auth
+        config:
+          key_names:
+            - Authorization
+      - name: rate-limiting
+        config:
+          minute: 30
+          hour: 500
+      - name: ip-restriction
+        config:
+          allow:
+            - 10.0.0.0/8
+            - 192.168.0.0/16
+
+upstreams:
+  - name: petstore-upstream
+    algorithm: round-robin
+    hash_on: none
+    healthchecks:
+      active:
+        healthy:
+          interval: 10
+          successes: 3
+        unhealthy:
+          interval: 10
+          http_failures: 3
+        http_path: /health
+    targets:
+      - target: petstore1.internal:8080
+        weight: 100
+      - target: petstore2.internal:8080
+        weight: 100
+
+  - name: crm-upstream
+    algorithm: least-connections
+    targets:
+      - target: crm1.internal:8080
+        weight: 70
+      - target: crm2.internal:8080
+        weight: 30
+
+consumers:
+  - username: acme-corp
+    custom_id: tenant-acme
+    tags:
+      - premium
+    keyauth_credentials:
+      - key: acme-api-key-001
+    plugins:
+      - name: rate-limiting
+        config:
+          minute: 500
+          hour: 20000
+
+  - username: beta-team
+    custom_id: tenant-beta
+    tags:
+      - standard
+    keyauth_credentials:
+      - key: beta-api-key-001
+
+  - username: monitoring-bot
+    custom_id: svc-monitoring
+    tags:
+      - service-account
+
+plugins:
+  - name: prometheus
+    config:
+      per_consumer: true
+  - name: file-log
+    config:
+      path: /var/log/kong/access.log

--- a/scripts/tests/test_migrate_kong.py
+++ b/scripts/tests/test_migrate_kong.py
@@ -1,0 +1,393 @@
+"""Tests for Kong -> STOA migration adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Allow importing the script (hyphenated filename) from parent dir
+import importlib
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+_mod = importlib.import_module("migrate-kong")
+KongToStoaMigrator = _mod.KongToStoaMigrator
+_slugify = _mod._slugify
+load_from_file = _mod.load_from_file
+_count_kong_objects = _mod._count_kong_objects
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+SAMPLE_KONG = FIXTURES / "sample-kong.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def kong_config() -> dict:
+    return load_from_file(str(SAMPLE_KONG))
+
+
+@pytest.fixture()
+def migrated(kong_config: dict) -> KongToStoaMigrator:
+    m = KongToStoaMigrator(kong_config)
+    m.migrate()
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Unit: slugify
+# ---------------------------------------------------------------------------
+
+
+class TestSlugify:
+    def test_basic(self):
+        assert _slugify("petstore-service") == "petstore-service"
+
+    def test_spaces_and_caps(self):
+        assert _slugify("My Cool Service") == "my-cool-service"
+
+    def test_special_chars(self):
+        assert _slugify("api@v2!") == "api-v2"
+
+    def test_leading_trailing(self):
+        assert _slugify("---hello---") == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Unit: load_from_file
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFromFile:
+    def test_loads_sample(self, kong_config: dict):
+        assert "_format_version" in kong_config
+        assert "services" in kong_config
+        assert len(kong_config["services"]) == 3
+
+    def test_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            load_from_file("/nonexistent/kong.yaml")
+
+    def test_has_upstreams(self, kong_config: dict):
+        assert "upstreams" in kong_config
+        assert len(kong_config["upstreams"]) == 2
+
+    def test_has_consumers(self, kong_config: dict):
+        assert "consumers" in kong_config
+        assert len(kong_config["consumers"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Unit: _count_kong_objects
+# ---------------------------------------------------------------------------
+
+
+class TestCountKongObjects:
+    def test_counts(self, kong_config: dict):
+        svc, routes, plugins = _count_kong_objects(kong_config)
+        assert svc == 3
+        assert routes == 4
+        assert plugins == 10  # 8 service plugins + 2 global
+
+
+# ---------------------------------------------------------------------------
+# Integration: service -> API mapping
+# ---------------------------------------------------------------------------
+
+
+class TestServiceMigration:
+    def test_all_services_migrated(self, migrated: KongToStoaMigrator):
+        assert len(migrated.apis) == 3
+
+    def test_petstore_api(self, migrated: KongToStoaMigrator):
+        pet = next(a for a in migrated.apis if a["id"] == "petstore-service")
+        assert pet["backend_url"] == "https://petstore.swagger.io/v2"
+        assert pet["status"] == "draft"
+        assert "petstore" in pet["tags"]
+
+    def test_crm_api_has_auth(self, migrated: KongToStoaMigrator):
+        crm = next(a for a in migrated.apis if a["id"] == "crm-api-service")
+        assert crm["auth"]["required"] is True
+
+    def test_payment_api_has_auth(self, migrated: KongToStoaMigrator):
+        pay = next(a for a in migrated.apis if a["id"] == "payment-gateway")
+        assert pay["auth"]["required"] is True
+
+
+# ---------------------------------------------------------------------------
+# Integration: route -> resource mapping
+# ---------------------------------------------------------------------------
+
+
+class TestRouteMigration:
+    def test_petstore_has_one_resource(self, migrated: KongToStoaMigrator):
+        pet = next(a for a in migrated.apis if a["id"] == "petstore-service")
+        assert len(pet["resources"]) == 1
+        assert pet["resources"][0]["path"] == "/petstore/*"
+
+    def test_crm_has_two_resources(self, migrated: KongToStoaMigrator):
+        crm = next(a for a in migrated.apis if a["id"] == "crm-api-service")
+        assert len(crm["resources"]) == 2
+        paths = {r["path"] for r in crm["resources"]}
+        assert "/crm/v2/*" in paths
+        assert "/crm/search/*" in paths
+
+    def test_route_methods(self, migrated: KongToStoaMigrator):
+        pay = next(a for a in migrated.apis if a["id"] == "payment-gateway")
+        assert pay["resources"][0]["methods"] == ["POST"]
+
+
+# ---------------------------------------------------------------------------
+# Integration: plugin -> policy mapping
+# ---------------------------------------------------------------------------
+
+
+class TestPluginMigration:
+    def test_rate_limit_policies_created(self, migrated: KongToStoaMigrator):
+        rl_policies = [p for p in migrated.policies if p["type"] == "rate-limit"]
+        assert len(rl_policies) >= 2  # petstore + crm + payment
+
+    def test_cors_policy_created(self, migrated: KongToStoaMigrator):
+        cors_policies = [p for p in migrated.policies if p["type"] == "cors"]
+        assert len(cors_policies) == 1
+        cfg = cors_policies[0]["config"]
+        assert "https://portal.example.com" in cfg["allowOrigins"]
+
+    def test_unsupported_plugin_in_manual_actions(self, migrated: KongToStoaMigrator):
+        manual = migrated.report.manual_actions
+        assert any("request-transformer" in a for a in manual)
+        assert any("ip-restriction" in a for a in manual)
+
+
+# ---------------------------------------------------------------------------
+# Integration: consumer -> tenant/application mapping
+# ---------------------------------------------------------------------------
+
+
+class TestConsumerMigration:
+    def test_tenants_created(self, migrated: KongToStoaMigrator):
+        assert len(migrated.tenants) == 2  # acme-corp, beta-team
+
+    def test_applications_created(self, migrated: KongToStoaMigrator):
+        assert len(migrated.applications) == 1  # monitoring-bot
+
+    def test_acme_tenant_has_rate_limit(self, migrated: KongToStoaMigrator):
+        acme = next(t for t in migrated.tenants if t["id"] == "tenant-acme")
+        assert "rateLimit" in acme["settings"]
+        assert acme["settings"]["rateLimit"]["requests"] == 500
+
+    def test_monitoring_bot_is_application(self, migrated: KongToStoaMigrator):
+        app = migrated.applications[0]
+        assert app["id"] == "monitoring-bot"
+        assert app["type"] == "service"
+
+
+# ---------------------------------------------------------------------------
+# Integration: upstream -> backend targets
+# ---------------------------------------------------------------------------
+
+
+class TestUpstreamMigration:
+    def test_petstore_has_upstream(self, migrated: KongToStoaMigrator):
+        pet = next(a for a in migrated.apis if a["id"] == "petstore-service")
+        assert "backend" in pet
+        assert pet["backend"]["algorithm"] == "round-robin"
+        assert len(pet["backend"]["targets"]) == 2
+
+    def test_upstream_healthcheck(self, migrated: KongToStoaMigrator):
+        pet = next(a for a in migrated.apis if a["id"] == "petstore-service")
+        assert "healthCheck" in pet["backend"]
+        assert pet["backend"]["healthCheck"]["path"] == "/health"
+
+
+# ---------------------------------------------------------------------------
+# Integration: stats
+# ---------------------------------------------------------------------------
+
+
+class TestStats:
+    def test_stats_keys(self, migrated: KongToStoaMigrator):
+        st = migrated.stats()
+        assert st["apis"] == 3
+        assert st["tenants"] == 2
+        assert st["applications"] == 1
+        assert st["policies"] == 4
+        assert st["migrated"] > 0
+        assert st["manual"] > 0
+
+    def test_skipped_count(self, migrated: KongToStoaMigrator):
+        st = migrated.stats()
+        assert st["skipped"] == 2  # prometheus + file-log
+
+
+# ---------------------------------------------------------------------------
+# Integration: YAML output
+# ---------------------------------------------------------------------------
+
+
+class TestYamlOutput:
+    def test_valid_yaml(self, migrated: KongToStoaMigrator):
+        output = migrated.to_stoa_yaml()
+        parsed = yaml.safe_load(output)
+        assert parsed["apiVersion"] == "stoa.io/v1"
+        assert parsed["kind"] == "StoaExport"
+
+    def test_has_all_sections(self, migrated: KongToStoaMigrator):
+        output = migrated.to_stoa_yaml()
+        parsed = yaml.safe_load(output)
+        spec = parsed["spec"]
+        assert "apis" in spec
+        assert "policies" in spec
+        assert "tenants" in spec
+        assert "applications" in spec
+
+    def test_apis_count(self, migrated: KongToStoaMigrator):
+        output = migrated.to_stoa_yaml()
+        parsed = yaml.safe_load(output)
+        assert len(parsed["spec"]["apis"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Integration: migration report
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationReport:
+    def test_report_is_markdown(self, migrated: KongToStoaMigrator):
+        report = migrated.report.render()
+        assert "# Kong" in report
+        assert "STOA Migration Report" in report
+
+    def test_report_has_migrated(self, migrated: KongToStoaMigrator):
+        report = migrated.report.render()
+        assert "## Migrated" in report
+        assert "petstore-service" in report
+
+    def test_report_has_manual_actions(self, migrated: KongToStoaMigrator):
+        report = migrated.report.render()
+        assert "## Manual Actions Required" in report
+
+    def test_report_has_summary_table(self, migrated: KongToStoaMigrator):
+        report = migrated.report.render()
+        assert "## Migration Summary" in report
+        assert "| Migrated |" in report
+
+
+# ---------------------------------------------------------------------------
+# Integration: CLI (main function)
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_main_file_input(self, tmp_path: Path):
+        main = _mod.main
+
+        out = tmp_path / "output"
+        rc = main(["--from", str(SAMPLE_KONG), "--to", str(out)])
+        assert rc == 0
+        assert (out / "stoa-apis.yaml").exists()
+        assert (out / "migration-report.md").exists()
+
+        # Validate output YAML
+        parsed = yaml.safe_load((out / "stoa-apis.yaml").read_text())
+        assert parsed["apiVersion"] == "stoa.io/v1"
+        assert len(parsed["spec"]["apis"]) == 3
+
+    def test_main_missing_source(self, tmp_path: Path):
+        main = _mod.main
+
+        rc = main(["--from", "/nonexistent.yaml", "--to", str(tmp_path)])
+        assert rc == 1
+
+    def test_main_verbose(self, tmp_path: Path, capsys):
+        main = _mod.main
+
+        out = tmp_path / "output"
+        rc = main(["--from", str(SAMPLE_KONG), "--to", str(out), "--verbose"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        # Verbose shows detail lines with indentation
+        assert "route" in captured.out
+        assert "plugin" in captured.out or "upstream" in captured.out
+
+    def test_main_quiet(self, tmp_path: Path, capsys):
+        main = _mod.main
+
+        out = tmp_path / "output"
+        rc = main(["--from", str(SAMPLE_KONG), "--to", str(out), "--quiet"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        # Quiet mode: no progress lines (but output_files still prints)
+        assert "Migrating" not in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Integration: dry-run mode
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    def test_dry_run_no_files(self, tmp_path: Path):
+        main = _mod.main
+
+        rc = main(["--from", str(SAMPLE_KONG), "--dry-run"])
+        assert rc == 0
+        # No files should be written anywhere
+        assert not (tmp_path / "stoa-apis.yaml").exists()
+
+    def test_dry_run_output(self, capsys):
+        main = _mod.main
+
+        rc = main(["--from", str(SAMPLE_KONG), "--dry-run"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "DRY-RUN" in captured.out
+        assert "Would produce" in captured.out
+        assert "3 APIs" in captured.out
+
+    def test_dry_run_with_to_still_no_files(self, tmp_path: Path):
+        """Even if --to is given with --dry-run, no files are written."""
+        main = _mod.main
+
+        out = tmp_path / "dry-output"
+        rc = main(["--from", str(SAMPLE_KONG), "--to", str(out), "--dry-run"])
+        assert rc == 0
+        assert not out.exists()
+
+    def test_no_to_without_dry_run(self):
+        """--to is required when --dry-run is not set."""
+        main = _mod.main
+
+        with pytest.raises(SystemExit):
+            main(["--from", str(SAMPLE_KONG)])
+
+
+# ---------------------------------------------------------------------------
+# Integration: error UX
+# ---------------------------------------------------------------------------
+
+
+class TestErrorUX:
+    def test_missing_file_error_message(self, capsys, tmp_path: Path):
+        main = _mod.main
+
+        rc = main(["--from", "/no/such/kong.yaml", "--to", str(tmp_path)])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "Cannot read Kong config" in captured.err
+        assert "Expected: kong.yaml" in captured.err
+
+    def test_connection_error_message(self, capsys, tmp_path: Path):
+        main = _mod.main
+
+        rc = main(["--from", "http://localhost:19999", "--to", str(tmp_path)])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "Cannot connect to Kong" in captured.err
+        assert "Is Kong running?" in captured.err

--- a/scripts/tests/test_migrate_kong_integration.py
+++ b/scripts/tests/test_migrate_kong_integration.py
@@ -1,0 +1,165 @@
+"""
+Integration test: Kong Docker -> migrate-kong.py -> STOA YAML.
+
+Requires Docker. Spins up Kong with declarative config, runs the migration
+against the Admin API, and validates the output.
+
+Run:
+  pytest tests/test_migrate_kong_integration.py -v -m integration
+
+Skip in CI without Docker:
+  pytest -m "not integration"
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+_mod = importlib.import_module("migrate-kong")
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+SAMPLE_KONG = FIXTURES / "sample-kong.yaml"
+
+KONG_IMAGE = "kong/kong:3.9"
+KONG_CONTAINER = "stoa-migrate-test-kong"
+KONG_ADMIN_PORT = 18001
+
+
+def _docker_available() -> bool:
+    try:
+        subprocess.run(["docker", "info"], capture_output=True, timeout=5, check=True)
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return False
+
+
+def _wait_for_kong(url: str, retries: int = 30, delay: float = 1.0) -> bool:
+    for _ in range(retries):
+        try:
+            resp = urlopen(url, timeout=2)  # noqa: S310
+            if resp.status == 200:
+                return True
+        except (URLError, OSError):
+            pass
+        time.sleep(delay)
+    return False
+
+
+@pytest.fixture(scope="module")
+def kong_admin_url():
+    """Start Kong in DB-less mode with sample config, yield admin URL, tear down."""
+    if not _docker_available():
+        pytest.skip("Docker not available")
+
+    # Stop any leftover container
+    subprocess.run(
+        ["docker", "rm", "-f", KONG_CONTAINER],
+        capture_output=True,
+    )
+
+    # Start Kong DB-less with declarative config
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            KONG_CONTAINER,
+            "-e",
+            "KONG_DATABASE=off",
+            "-e",
+            f"KONG_DECLARATIVE_CONFIG=/kong/kong.yaml",
+            "-e",
+            "KONG_ADMIN_LISTEN=0.0.0.0:8001",
+            "-e",
+            "KONG_PROXY_LISTEN=0.0.0.0:8000",
+            "-v",
+            f"{SAMPLE_KONG}:/kong/kong.yaml:ro",
+            "-p",
+            f"{KONG_ADMIN_PORT}:8001",
+            KONG_IMAGE,
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    url = f"http://localhost:{KONG_ADMIN_PORT}"
+
+    if not _wait_for_kong(url):
+        # Grab logs for debugging
+        logs = subprocess.run(
+            ["docker", "logs", KONG_CONTAINER],
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(["docker", "rm", "-f", KONG_CONTAINER], capture_output=True)
+        pytest.fail(f"Kong did not start.\nLogs:\n{logs.stdout}\n{logs.stderr}")
+
+    yield url
+
+    # Teardown
+    subprocess.run(["docker", "rm", "-f", KONG_CONTAINER], capture_output=True)
+
+
+@pytest.mark.integration
+class TestKongAdminAPIMigration:
+    """Full integration: Kong Docker -> Admin API -> migrate-kong.py -> STOA."""
+
+    def test_admin_api_accessible(self, kong_admin_url: str):
+        resp = urlopen(kong_admin_url, timeout=5)  # noqa: S310
+        data = json.loads(resp.read())
+        assert "version" in data
+
+    def test_services_loaded(self, kong_admin_url: str):
+        resp = urlopen(f"{kong_admin_url}/services", timeout=5)  # noqa: S310
+        data = json.loads(resp.read())
+        names = {s["name"] for s in data.get("data", [])}
+        assert "petstore-service" in names
+        assert "crm-api-service" in names
+        assert "payment-gateway" in names
+
+    def test_full_migration_from_admin_api(self, kong_admin_url: str, tmp_path: Path):
+        main = _mod.main
+
+        out = tmp_path / "stoa-output"
+        rc = main(["--from", kong_admin_url, "--to", str(out)])
+        assert rc == 0
+
+        # Validate output files exist
+        assert (out / "stoa-apis.yaml").exists()
+        assert (out / "migration-report.md").exists()
+
+        # Validate YAML structure
+        parsed = yaml.safe_load((out / "stoa-apis.yaml").read_text())
+        assert parsed["apiVersion"] == "stoa.io/v1"
+        assert parsed["kind"] == "StoaExport"
+        assert len(parsed["spec"]["apis"]) == 3
+
+    def test_dry_run_from_admin_api(self, kong_admin_url: str, capsys):
+        main = _mod.main
+
+        rc = main(["--from", kong_admin_url, "--dry-run"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "DRY-RUN" in captured.out
+        assert "3 APIs" in captured.out
+
+    def test_verbose_from_admin_api(self, kong_admin_url: str, tmp_path: Path, capsys):
+        main = _mod.main
+
+        out = tmp_path / "verbose-out"
+        rc = main(["--from", kong_admin_url, "--to", str(out), "--verbose"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "route" in captured.out


### PR DESCRIPTION
## Summary
- **Claude Code config**: bootstrap guide and e2e-test skill (`.claude/`)
- **GitHub issue templates**: bug report, feature request, docs improvement, question (`.github/ISSUE_TEMPLATE/`)
- **AI Factory**: config, n8n workflow, scripts, templates, phase plan (`.stoa-ai/`)
- **Makefile**: developer convenience targets (`seed-demo`, `migrate-kong`, `test-demo`)
- **Kong migration tool**: `scripts/migrate-kong.py` with unit and integration tests
- **Excluded**: `.stoa-ai/.env` (secrets), `cli/` (only bytecache), `stoa-docs/` (only build artifacts)

## Test plan
- [ ] Verify `.stoa-ai/.env` is NOT included in the diff
- [ ] Verify no `node_modules/`, `__pycache__/`, or build artifacts are committed
- [ ] Run `make test-migrate-kong` to validate migration tool tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)