### PR TITLE
fix(api): use column refs in catalog seed upsert

### DIFF
--- a/control-plane-api/src/routers/catalog_admin.py
+++ b/control-plane-api/src/routers/catalog_admin.py
@@ -391,16 +391,16 @@ async def seed_catalog_directly(
             ).on_conflict_do_update(
                 index_elements=["tenant_id", "api_id"],
                 set_={
-                    "api_name": api_entry.display_name,
-                    "version": api_entry.version,
-                    "status": "active",
-                    "category": api_entry.category,
-                    "tags": tags,
-                    "portal_published": portal_published,
-                    "api_metadata": api_metadata,
-                    "openapi_spec": openapi_spec,
-                    "synced_at": datetime.now(timezone.utc),
-                    "deleted_at": None,
+                    APICatalog.api_name: api_entry.display_name,
+                    APICatalog.version: api_entry.version,
+                    APICatalog.status: "active",
+                    APICatalog.category: api_entry.category,
+                    APICatalog.tags: tags,
+                    APICatalog.portal_published: portal_published,
+                    APICatalog.api_metadata: api_metadata,
+                    APICatalog.openapi_spec: openapi_spec,
+                    APICatalog.synced_at: datetime.now(timezone.utc),
+                    APICatalog.deleted_at: None,
                 },
             )
             await db.execute(stmt)


### PR DESCRIPTION
## Summary
- Replace string keys with `APICatalog.column` references in `on_conflict_do_update` `set_` clause
- Follows SQLAlchemy best practices and prevents silent failures on column name mismatches

## Test plan
- [ ] Verify `POST /v1/admin/catalog/seed` still works with demo data (`make seed-demo`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)