### PR TITLE
fix(gateway): drop protobuf dep to fix RUSTSEC-2024-0437

### DIFF
--- a/stoa-gateway/Cargo.toml
+++ b/stoa-gateway/Cargo.toml
@@ -21,7 +21,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 thiserror = "1"
 chrono = { version = "0.4", features = ["serde"] }
-prometheus = "0.13"
+prometheus = { version = "0.13", default-features = false }  # no protobuf (RUSTSEC-2024-0437)
 jsonwebtoken = "9"
 reqwest = { version = "0.11", features = ["json"] }
 async-trait = "0.1"


### PR DESCRIPTION
## Summary
- Disable `default-features` on `prometheus` 0.13 to remove `protobuf` 2.28.0 transitive dependency
- Fixes RUSTSEC-2024-0437 (crash due to uncontrolled recursion in protobuf crate)
- Gateway only uses `TextEncoder` + basic counters/gauges — no protobuf encoding needed

## Context
PR #75 merged with `cargo audit` failing due to this vulnerability. This is the follow-up fix.

## Test plan
- [x] `cargo check` passes (prometheus recompiles without protobuf feature)
- [x] `cargo tree -i protobuf` confirms protobuf is no longer in dependency tree
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets --all-features` passes
- [x] `RUSTFLAGS="-Dwarnings" cargo test --all-features` — 82/82 tests pass
- [ ] CI `cargo audit` should pass (no more RUSTSEC-2024-0437)

🤖 Generated with [Claude Code](https://claude.com/claude-code)