### PR TITLE
fix(ci): auto-create ECR repository if missing

### DIFF
--- a/.github/workflows/stoa-gateway-ci.yml
+++ b/.github/workflows/stoa-gateway-ci.yml
@@ -169,6 +169,13 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Ensure ECR repository exists
+        run: |
+          aws ecr describe-repositories --repository-names ${{ env.ECR_REPOSITORY }} --region ${{ env.AWS_REGION }} 2>/dev/null || \
+          aws ecr create-repository --repository-name ${{ env.ECR_REPOSITORY }} --region ${{ env.AWS_REGION }} \
+            --image-scanning-configuration scanOnPush=true \
+            --image-tag-mutability MUTABLE
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Summary
- Add `Ensure ECR repository exists` step before Docker push
- Creates `apim/stoa-gateway` ECR repo with image scanning enabled if it doesn't exist
- Fixes the Docker push failure: `The repository with name 'apim/stoa-gateway' does not exist in the registry`

## Context
PR #79 optimized the CI pipeline, but the Docker push still failed because the ECR repository hasn't been created yet in the AWS account.

## Test plan
- [ ] CI creates the ECR repo on first push to main
- [ ] Subsequent pushes skip creation (repo already exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)