### PR TITLE
fix(gateway): include tool name in CP invoke payload (CAB-1094)

### DIFF
--- a/stoa-gateway/src/control_plane/tool_proxy.rs
+++ b/stoa-gateway/src/control_plane/tool_proxy.rs
@@ -272,7 +272,7 @@ impl ToolProxyClient {
             self.get_token().await?
         };
 
-        let payload = serde_json::json!({ "arguments": args });
+        let payload = serde_json::json!({ "name": tool, "arguments": args });
 
         let mut req = self
             .client
@@ -312,7 +312,7 @@ impl ToolProxyClient {
         let url = format!("{}/v1/mcp/tools/{}/invoke", self.base_url, tool);
         debug!(tool, url = %url, "Proxying tool call (unauthenticated)");
 
-        let payload = serde_json::json!({ "arguments": args });
+        let payload = serde_json::json!({ "name": tool, "arguments": args });
 
         let resp = self
             .client


### PR DESCRIPTION
## Summary
- CP API `/v1/mcp/tools/{name}/invoke` expects `{"name": "tool_name", "arguments": {...}}` in the body
- Without `name`, CP returns 422 validation error, gateway falls back to unauthenticated, gets 403

## Test plan
- [x] 82 unit tests pass
- [ ] `tools/call stoa_platform_info` returns actual platform data

🤖 Generated with [Claude Code](https://claude.com/claude-code)