### PR TITLE
fix(api): add values_callable to StrEnum SQLAlchemy columns (CAB-1094)

### DIFF
--- a/control-plane-api/alembic/versions/013_create_gateway_instances.py
+++ b/control-plane-api/alembic/versions/013_create_gateway_instances.py
@@ -21,16 +21,18 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # Create enum types
+    # Create enum types (create_type=False prevents double-creation in create_table)
     gateway_type_enum = sa.Enum(
         'webmethods', 'kong', 'apigee', 'aws_apigateway', 'stoa',
         name='gateway_type_enum',
+        create_type=False,
     )
     gateway_type_enum.create(op.get_bind(), checkfirst=True)
 
     gateway_status_enum = sa.Enum(
         'online', 'offline', 'degraded', 'maintenance',
         name='gateway_instance_status_enum',
+        create_type=False,
     )
     gateway_status_enum.create(op.get_bind(), checkfirst=True)
 

--- a/control-plane-api/alembic/versions/014_create_gateway_deployments.py
+++ b/control-plane-api/alembic/versions/014_create_gateway_deployments.py
@@ -21,10 +21,11 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # Create enum type
+    # Create enum type (create_type=False prevents double-creation in create_table)
     sync_status_enum = sa.Enum(
         'pending', 'syncing', 'synced', 'drifted', 'error', 'deleting',
         name='deployment_sync_status_enum',
+        create_type=False,
     )
     sync_status_enum.create(op.get_bind(), checkfirst=True)
 

--- a/control-plane-api/alembic/versions/016_create_gateway_policies.py
+++ b/control-plane-api/alembic/versions/016_create_gateway_policies.py
@@ -22,17 +22,19 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # Create enum types
+    # Create enum types (create_type=False prevents double-creation in create_table)
     policy_type_enum = sa.Enum(
         'cors', 'rate_limit', 'jwt_validation', 'ip_filter',
         'logging', 'caching', 'transform',
         name='policy_type_enum',
+        create_type=False,
     )
     policy_type_enum.create(op.get_bind(), checkfirst=True)
 
     policy_scope_enum = sa.Enum(
         'api', 'gateway', 'tenant',
         name='policy_scope_enum',
+        create_type=False,
     )
     policy_scope_enum.create(op.get_bind(), checkfirst=True)
 

--- a/control-plane-api/src/models/contract.py
+++ b/control-plane-api/src/models/contract.py
@@ -75,7 +75,10 @@ class ProtocolBinding(Base):
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     contract_id = Column(UUID(as_uuid=True), ForeignKey("contracts.id", ondelete="CASCADE"), nullable=False)
-    protocol = Column(SQLEnum(ProtocolType), nullable=False)
+    protocol = Column(
+        SQLEnum(ProtocolType, values_callable=lambda x: [e.value for e in x]),
+        nullable=False,
+    )
     enabled = Column(Boolean, default=False, nullable=False)
 
     # Protocol-specific endpoint info

--- a/control-plane-api/src/models/gateway_deployment.py
+++ b/control-plane-api/src/models/gateway_deployment.py
@@ -60,7 +60,11 @@ class GatewayDeployment(Base):
 
     # Sync tracking
     sync_status = Column(
-        SQLEnum(DeploymentSyncStatus, name="deployment_sync_status_enum"),
+        SQLEnum(
+            DeploymentSyncStatus,
+            name="deployment_sync_status_enum",
+            values_callable=lambda x: [e.value for e in x],
+        ),
         nullable=False,
         default=DeploymentSyncStatus.PENDING,
         server_default="pending",

--- a/control-plane-api/src/models/gateway_instance.py
+++ b/control-plane-api/src/models/gateway_instance.py
@@ -45,7 +45,11 @@ class GatewayInstance(Base):
     name = Column(String(255), unique=True, nullable=False)        # "webmethods-prod"
     display_name = Column(String(255), nullable=False)
     gateway_type = Column(
-        SQLEnum(GatewayType, name="gateway_type_enum"),
+        SQLEnum(
+            GatewayType,
+            name="gateway_type_enum",
+            values_callable=lambda x: [e.value for e in x],
+        ),
         nullable=False,
     )
     environment = Column(String(50), nullable=False, index=True)   # dev / staging / prod
@@ -61,7 +65,11 @@ class GatewayInstance(Base):
 
     # Health
     status = Column(
-        SQLEnum(GatewayInstanceStatus, name="gateway_instance_status_enum"),
+        SQLEnum(
+            GatewayInstanceStatus,
+            name="gateway_instance_status_enum",
+            values_callable=lambda x: [e.value for e in x],
+        ),
         nullable=False,
         default=GatewayInstanceStatus.OFFLINE,
         server_default="offline",

--- a/control-plane-api/src/models/gateway_policy.py
+++ b/control-plane-api/src/models/gateway_policy.py
@@ -56,12 +56,20 @@ class GatewayPolicy(Base):
     name = Column(String(255), nullable=False)
     description = Column(Text, nullable=True)
     policy_type = Column(
-        SQLEnum(PolicyType, name="policy_type_enum"),
+        SQLEnum(
+            PolicyType,
+            name="policy_type_enum",
+            values_callable=lambda x: [e.value for e in x],
+        ),
         nullable=False,
     )
     tenant_id = Column(String(255), nullable=True, index=True)
     scope = Column(
-        SQLEnum(PolicyScope, name="policy_scope_enum"),
+        SQLEnum(
+            PolicyScope,
+            name="policy_scope_enum",
+            values_callable=lambda x: [e.value for e in x],
+        ),
         nullable=False,
         default=PolicyScope.API,
         server_default="api",

--- a/control-plane-api/src/models/subscription.py
+++ b/control-plane-api/src/models/subscription.py
@@ -64,9 +64,9 @@ class Subscription(Base):
 
     # Status
     status = Column(
-        SQLEnum(SubscriptionStatus),
+        SQLEnum(SubscriptionStatus, values_callable=lambda x: [e.value for e in x]),
         nullable=False,
-        default=SubscriptionStatus.PENDING
+        default=SubscriptionStatus.PENDING,
     )
     status_reason = Column(Text, nullable=True)
 
@@ -83,7 +83,7 @@ class Subscription(Base):
 
     # Gateway provisioning (CAB-800)
     provisioning_status = Column(
-        SQLEnum(ProvisioningStatus),
+        SQLEnum(ProvisioningStatus, values_callable=lambda x: [e.value for e in x]),
         nullable=False,
         default=ProvisioningStatus.NONE,
         server_default="none",


### PR DESCRIPTION
## Summary

- Fix StrEnum + SQLAlchemy enum serialization bug introduced by PR #78 (ruff UP042 migration)
- SQLAlchemy's `Enum` type defaults to using member **names** (uppercase: `PENDING`, `SYNCING`) as DB values instead of member **values** (lowercase: `pending`, `syncing`)
- This caused `invalid input value for enum` errors when asyncpg sent uppercase values to PostgreSQL
- Also fix alembic migrations 013/014/016 with `create_type=False` to prevent double-creation of enum types during migration

## Changes

**Models** (5 files) — Add `values_callable=lambda x: [e.value for e in x]` to all `SQLEnum` columns using StrEnum:
- `gateway_deployment.py` — `DeploymentSyncStatus` (sync engine was crashing)
- `gateway_instance.py` — `GatewayType`, `GatewayInstanceStatus`
- `gateway_policy.py` — `PolicyType`, `PolicyScope`
- `subscription.py` — `SubscriptionStatus`, `ProvisioningStatus`
- `contract.py` — `ProtocolType`

**Migrations** (3 files) — Add `create_type=False` to enum definitions:
- `013_create_gateway_instances.py`
- `014_create_gateway_deployments.py`
- `016_create_gateway_policies.py`

## Test plan

- [x] All 302 existing tests pass (10 opensearch failures are pre-existing)
- [x] All 90 gateway-specific tests pass
- [x] Ruff lint clean on all modified files
- [ ] After merge + deploy: verify sync engine starts without enum errors
- [ ] Verify gateway API endpoints return 403 (auth) not 500 (crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)