### PR TITLE
fix(ci): update Docker build for monorepo shared dependencies (CAB-1100)

### DIFF
--- a/.github/workflows/control-plane-ui-ci.yml
+++ b/.github/workflows/control-plane-ui-ci.yml
@@ -12,6 +12,7 @@ on:
       - main
     paths:
       - 'control-plane-ui/**'
+      - 'shared/**'
       - '.github/workflows/control-plane-ui-ci.yml'
       - '.github/workflows/reusable-node-ci.yml'
       - '.github/workflows/reusable-docker-ecr.yml'
@@ -23,6 +24,7 @@ on:
       - main
     paths:
       - 'control-plane-ui/**'
+      - 'shared/**'
       - '.github/workflows/control-plane-ui-ci.yml'
       - '.github/workflows/reusable-node-ci.yml'
       - '.github/actions/**'
@@ -72,6 +74,7 @@ jobs:
       ecr-repository: apim/control-plane-ui
       environment: ${{ github.event.inputs.environment || 'dev' }}
       platforms: linux/amd64,linux/arm64
+      use-monorepo-context: true
       build-args: |
         VITE_BASE_DOMAIN=${{ (github.event.inputs.environment == 'staging' && 'staging.gostoa.dev') || 'gostoa.dev' }}
         VITE_ENVIRONMENT=${{ github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/reusable-docker-ecr.yml
+++ b/.github/workflows/reusable-docker-ecr.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: ''
+      use-monorepo-context:
+        description: 'Use repo root as build context (for shared/ dependencies)'
+        required: false
+        type: boolean
+        default: false
     outputs:
       image-tag:
         description: 'Full image tag (registry/repo:env-sha)'
@@ -68,7 +73,8 @@ jobs:
         id: build
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
-          context: ${{ inputs.component }}
+          context: ${{ inputs.use-monorepo-context && '.' || inputs.component }}
+          file: ${{ inputs.use-monorepo-context && format('{0}/Dockerfile', inputs.component) || format('{0}/Dockerfile', inputs.component) }}
           platforms: ${{ inputs.platforms }}
           push: true
           tags: |

--- a/control-plane-ui/Dockerfile
+++ b/control-plane-ui/Dockerfile
@@ -1,16 +1,27 @@
 # Build stage
+# NOTE: Build context must be repo root (not control-plane-ui/)
+# Use: docker build -f control-plane-ui/Dockerfile .
 FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+# Copy shared package first (monorepo dependency)
+COPY shared/package*.json ./shared/
+RUN cd shared && npm ci --ignore-scripts
+
+# Copy main package files
+COPY control-plane-ui/package*.json ./control-plane-ui/
 
 # Install dependencies
+WORKDIR /app/control-plane-ui
 RUN npm ci
 
-# Copy source
-COPY . .
+# Copy source files
+WORKDIR /app
+COPY shared/ ./shared/
+COPY control-plane-ui/ ./control-plane-ui/
+
+WORKDIR /app/control-plane-ui
 
 # Build arguments - Override with --build-arg during docker build
 # Example: docker build --build-arg VITE_BASE_DOMAIN=staging.example.com .
@@ -79,10 +90,10 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:alpine
 
 # Copy custom nginx config (nginx-unprivileged uses 8080 by default)
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY control-plane-ui/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Copy built app
-COPY --from=builder /app/dist /usr/share/nginx/html
+COPY --from=builder /app/control-plane-ui/dist /usr/share/nginx/html
 
 # nginx-unprivileged listens on 8080
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- Update Dockerfile to use repo root as build context for monorepo shared/ dependencies
- Add `use-monorepo-context` input to reusable-docker-ecr workflow
- Add `shared/**` to path triggers for control-plane-ui CI

## Context
The UX transformation PR #107 introduced a shared component library at `shared/`. The Docker build was failing because the build context was `control-plane-ui/` which doesn't include the `shared/` directory.

## Test plan
- [ ] CI passes for control-plane-ui
- [ ] Docker image builds successfully
- [ ] Deployment succeeds

Generated with [Claude Code](https://claude.com/claude-code)