### PR TITLE
feat(ui): add dark mode and polish Console pages (CAB-1100)

### DIFF
--- a/control-plane-ui/src/App.tsx
+++ b/control-plane-ui/src/App.tsx
@@ -6,6 +6,7 @@ import { PlatformStatus } from './components/PlatformStatus';
 import { quickLinks } from './config';
 import { ToastProvider } from '@stoa/shared/components/Toast';
 import { CommandPaletteProvider } from '@stoa/shared/components/CommandPalette';
+import { ThemeProvider } from '@stoa/shared/contexts';
 
 // Lazy load pages for code splitting
 const Tenants = lazy(() => import('./pages/Tenants').then(m => ({ default: m.Tenants })));
@@ -275,14 +276,16 @@ function Login() {
 
 function App() {
   return (
-    <ToastProvider>
-      <AuthProvider>
-        <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route path="/*" element={<ProtectedRoutes />} />
-        </Routes>
-      </AuthProvider>
-    </ToastProvider>
+    <ThemeProvider>
+      <ToastProvider>
+        <AuthProvider>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route path="/*" element={<ProtectedRoutes />} />
+          </Routes>
+        </AuthProvider>
+      </ToastProvider>
+    </ThemeProvider>
   );
 }
 

--- a/control-plane-ui/src/components/Layout.tsx
+++ b/control-plane-ui/src/components/Layout.tsx
@@ -5,6 +5,8 @@ import { useBreadcrumbs } from '../hooks/useBreadcrumbs';
 import { Breadcrumb } from '@stoa/shared/components/Breadcrumb';
 import { useCommandPalette, type CommandItem } from '@stoa/shared/components/CommandPalette';
 import { useSequenceShortcuts } from '@stoa/shared/hooks';
+import { ThemeToggle } from '@stoa/shared/components/ThemeToggle';
+import { useTheme } from '@stoa/shared/contexts';
 import {
   LayoutDashboard,
   Building2,
@@ -25,6 +27,8 @@ import {
   X,
   Search,
   Plus,
+  Sun,
+  Moon,
 } from 'lucide-react';
 import { clsx } from 'clsx';
 
@@ -54,6 +58,7 @@ export function Layout({ children }: LayoutProps) {
   const navigate = useNavigate();
   const breadcrumbItems = useBreadcrumbs();
   const { setOpen: setCommandPaletteOpen, setItems: setCommandItems } = useCommandPalette();
+  const { resolvedTheme, toggleTheme } = useTheme();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const filteredNavigation = navigation.filter(
@@ -128,13 +133,23 @@ export function Layout({ children }: LayoutProps) {
         keywords: ['logout', 'sign out', 'exit'],
         onSelect: logout,
       },
+      // Theme toggle
+      {
+        id: 'toggle-theme',
+        label: resolvedTheme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode',
+        description: `Currently in ${resolvedTheme} mode`,
+        icon: resolvedTheme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />,
+        section: 'Settings',
+        keywords: ['theme', 'dark', 'light', 'mode', 'toggle'],
+        onSelect: toggleTheme,
+      },
     ];
 
     setCommandItems(commands);
-  }, [filteredNavigation, navigate, logout, setCommandItems]);
+  }, [filteredNavigation, navigate, logout, setCommandItems, resolvedTheme, toggleTheme]);
 
   return (
-    <div className="min-h-screen bg-gray-100">
+    <div className="min-h-screen bg-gray-100 dark:bg-neutral-900 transition-colors">
       {/* Mobile sidebar backdrop */}
       {sidebarOpen && (
         <div
@@ -146,16 +161,16 @@ export function Layout({ children }: LayoutProps) {
       {/* Sidebar */}
       <div
         className={clsx(
-          'fixed inset-y-0 left-0 z-50 w-64 bg-gray-900 transition-transform duration-300 ease-in-out lg:translate-x-0',
+          'fixed inset-y-0 left-0 z-50 w-64 bg-gray-900 dark:bg-neutral-950 transition-transform duration-300 ease-in-out lg:translate-x-0',
           sidebarOpen ? 'translate-x-0' : '-translate-x-full'
         )}
       >
         {/* Sidebar header */}
-        <div className="flex h-16 items-center justify-between border-b border-gray-800 px-4">
+        <div className="flex h-16 items-center justify-between border-b border-gray-800 dark:border-neutral-800 px-4">
           <h1 className="text-lg font-bold text-white">STOA Control Plane</h1>
           <button
             onClick={() => setSidebarOpen(false)}
-            className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-800 hover:text-white lg:hidden"
+            className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-800 dark:hover:bg-neutral-800 hover:text-white lg:hidden"
           >
             <X className="h-5 w-5" />
           </button>
@@ -175,7 +190,7 @@ export function Layout({ children }: LayoutProps) {
                       'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
                       isActive
                         ? 'bg-primary-600 text-white'
-                        : 'text-gray-300 hover:bg-gray-800 hover:text-white'
+                        : 'text-gray-300 hover:bg-gray-800 dark:hover:bg-neutral-800 hover:text-white'
                     )}
                   >
                     <item.icon className="h-5 w-5 flex-shrink-0" />
@@ -193,7 +208,7 @@ export function Layout({ children }: LayoutProps) {
         </nav>
 
         {/* User section */}
-        <div className="absolute bottom-0 left-0 right-0 border-t border-gray-800 p-4">
+        <div className="absolute bottom-0 left-0 right-0 border-t border-gray-800 dark:border-neutral-800 p-4">
           <div className="flex items-center gap-3">
             <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary-600 flex-shrink-0">
               <User className="h-5 w-5 text-white" />
@@ -204,7 +219,7 @@ export function Layout({ children }: LayoutProps) {
             </div>
             <button
               onClick={logout}
-              className="rounded-lg p-2 text-gray-400 hover:bg-gray-800 hover:text-white flex-shrink-0"
+              className="rounded-lg p-2 text-gray-400 hover:bg-gray-800 dark:hover:bg-neutral-800 hover:text-white flex-shrink-0"
               title="Logout"
             >
               <LogOut className="h-5 w-5" />
@@ -216,11 +231,11 @@ export function Layout({ children }: LayoutProps) {
       {/* Main content */}
       <div className="lg:pl-64">
         {/* Header */}
-        <header className="sticky top-0 z-40 flex h-16 items-center gap-4 border-b bg-white px-4 sm:px-6 shadow-sm">
+        <header className="sticky top-0 z-40 flex h-16 items-center gap-4 border-b bg-white dark:bg-neutral-900 dark:border-neutral-800 px-4 sm:px-6 shadow-sm dark:shadow-none">
           {/* Mobile menu button */}
           <button
             onClick={() => setSidebarOpen(true)}
-            className="rounded-lg p-2 text-gray-500 hover:bg-gray-100 lg:hidden"
+            className="rounded-lg p-2 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-neutral-800 lg:hidden"
           >
             <Menu className="h-5 w-5" />
           </button>
@@ -234,18 +249,18 @@ export function Layout({ children }: LayoutProps) {
           />
 
           {/* Mobile: Just show current page name */}
-          <span className="flex-1 font-medium text-gray-900 truncate sm:hidden">
+          <span className="flex-1 font-medium text-gray-900 dark:text-white truncate sm:hidden">
             {breadcrumbItems[breadcrumbItems.length - 1]?.label || 'Dashboard'}
           </span>
 
           {/* Command Palette trigger */}
           <button
             onClick={() => setCommandPaletteOpen(true)}
-            className="hidden sm:flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm text-gray-500 hover:bg-gray-100 hover:border-gray-300 transition-colors"
+            className="hidden sm:flex items-center gap-2 rounded-lg border border-gray-200 dark:border-neutral-700 bg-gray-50 dark:bg-neutral-800 px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-neutral-700 hover:border-gray-300 dark:hover:border-neutral-600 transition-colors"
           >
             <Search className="h-4 w-4" />
             <span className="hidden md:inline">Search...</span>
-            <kbd className="hidden md:flex items-center gap-0.5 rounded bg-white px-1.5 py-0.5 text-xs font-medium border border-gray-200">
+            <kbd className="hidden md:flex items-center gap-0.5 rounded bg-white dark:bg-neutral-700 px-1.5 py-0.5 text-xs font-medium border border-gray-200 dark:border-neutral-600">
               <span className="text-xs">⌘</span>K
             </kbd>
           </button>
@@ -253,16 +268,19 @@ export function Layout({ children }: LayoutProps) {
           {/* Mobile search button */}
           <button
             onClick={() => setCommandPaletteOpen(true)}
-            className="rounded-lg p-2 text-gray-500 hover:bg-gray-100 sm:hidden"
+            className="rounded-lg p-2 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-neutral-800 sm:hidden"
           >
             <Search className="h-5 w-5" />
           </button>
 
+          {/* Theme toggle */}
+          <ThemeToggle size="md" />
+
           {/* Tenant selector */}
           {user?.tenant_id && (
-            <div className="hidden sm:flex items-center gap-2 rounded-lg bg-neutral-100 px-3 py-1.5">
-              <Building2 className="h-4 w-4 text-neutral-500" />
-              <span className="text-sm font-medium text-neutral-700 max-w-[120px] truncate">{user.tenant_id}</span>
+            <div className="hidden sm:flex items-center gap-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 px-3 py-1.5">
+              <Building2 className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
+              <span className="text-sm font-medium text-neutral-700 dark:text-neutral-300 max-w-[120px] truncate">{user.tenant_id}</span>
               <ChevronDown className="h-4 w-4 text-neutral-400" />
             </div>
           )}

--- a/control-plane-ui/src/pages/AITools/MySubscriptions.tsx
+++ b/control-plane-ui/src/pages/AITools/MySubscriptions.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import {
-  Bell,
   Wrench,
   ExternalLink,
   AlertCircle,
@@ -11,6 +10,8 @@ import {
   Trash2,
 } from 'lucide-react';
 import { mcpGatewayService } from '../../services/mcpGatewayApi';
+import { EmptyState } from '@stoa/shared/components/EmptyState';
+import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 import type { ToolSubscription, MCPTool } from '../../types';
 
 export function MySubscriptions() {
@@ -78,8 +79,16 @@ export function MySubscriptions() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="h-8 w-48 bg-gray-200 rounded animate-pulse" />
+          <div className="h-10 w-32 bg-gray-200 rounded animate-pulse" />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {[1, 2, 3].map((i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
       </div>
     );
   }
@@ -211,19 +220,13 @@ export function MySubscriptions() {
           </table>
         </div>
       ) : (
-        <div className="text-center py-12 bg-white rounded-lg border border-gray-200">
-          <Bell className="h-12 w-12 text-gray-300 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-900 mb-2">No subscriptions yet</h3>
-          <p className="text-sm text-gray-500 mb-4">
-            Subscribe to AI tools from the catalog to start using them
-          </p>
-          <Link
-            to="/ai-tools"
-            className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700 transition-colors"
-          >
-            <Wrench className="h-4 w-4" />
-            Browse Tool Catalog
-          </Link>
+        <div className="bg-white rounded-lg border border-gray-200">
+          <EmptyState
+            variant="subscriptions"
+            title="No subscriptions yet"
+            description="Subscribe to AI tools from the catalog to start using them."
+            action={{ label: 'Browse Tool Catalog', onClick: () => navigate('/ai-tools') }}
+          />
         </div>
       )}
 

--- a/control-plane-ui/src/pages/AITools/ToolCatalog.tsx
+++ b/control-plane-ui/src/pages/AITools/ToolCatalog.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { Search, Filter, Tag, RefreshCw, Wrench, AlertCircle } from 'lucide-react';
+import { Search, Filter, Tag, RefreshCw, AlertCircle } from 'lucide-react';
 import { mcpGatewayService } from '../../services/mcpGatewayApi';
 import { ToolCard } from '../../components/tools';
 import type { MCPTool } from '../../types';
+import { EmptyState } from '@stoa/shared/components/EmptyState';
+import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 
 export function ToolCatalog() {
   const navigate = useNavigate();
@@ -184,8 +186,10 @@ export function ToolCatalog() {
 
       {/* Loading */}
       {loading && (
-        <div className="flex items-center justify-center py-12">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <CardSkeleton key={i} />
+          ))}
         </div>
       )}
 
@@ -211,22 +215,15 @@ export function ToolCatalog() {
               ))}
             </div>
           ) : (
-            <div className="text-center py-12 bg-white rounded-lg border border-gray-200">
-              <Wrench className="h-12 w-12 text-gray-300 mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-gray-900 mb-2">No tools found</h3>
-              <p className="text-sm text-gray-500">
-                {hasActiveFilters
-                  ? 'Try adjusting your search or filter criteria'
-                  : 'No tools are available at the moment'}
-              </p>
-              {hasActiveFilters && (
-                <button
-                  onClick={clearFilters}
-                  className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700 transition-colors"
-                >
-                  Clear all filters
-                </button>
-              )}
+            <div className="col-span-full bg-white rounded-lg border border-gray-200">
+              <EmptyState
+                variant={hasActiveFilters ? 'search' : 'tools'}
+                action={
+                  hasActiveFilters
+                    ? { label: 'Clear all filters', onClick: clearFilters }
+                    : undefined
+                }
+              />
             </div>
           )}
         </>

--- a/control-plane-ui/src/pages/AITools/ToolDetail.tsx
+++ b/control-plane-ui/src/pages/AITools/ToolDetail.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { mcpGatewayService } from '../../services/mcpGatewayApi';
 import { ToolSchemaViewer, SchemaJsonViewer, QuickStartGuide } from '../../components/tools';
+import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 import type { MCPTool, ToolUsageSummary } from '../../types';
 
 type TabType = 'overview' | 'schema' | 'quickstart' | 'usage';
@@ -72,8 +73,19 @@ export function ToolDetail() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+      <div className="space-y-6">
+        <div className="flex items-center gap-4">
+          <div className="h-4 w-4 bg-gray-200 rounded animate-pulse" />
+          <div className="h-4 w-24 bg-gray-200 rounded animate-pulse" />
+        </div>
+        <div className="flex items-center gap-6">
+          <div className="h-16 w-16 bg-gray-200 rounded-lg animate-pulse" />
+          <div className="space-y-2 flex-1">
+            <div className="h-8 w-64 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 w-96 bg-gray-200 rounded animate-pulse" />
+          </div>
+        </div>
+        <CardSkeleton className="h-64" />
       </div>
     );
   }

--- a/control-plane-ui/src/pages/AITools/UsageDashboard.tsx
+++ b/control-plane-ui/src/pages/AITools/UsageDashboard.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react';
 import { mcpGatewayService } from '../../services/mcpGatewayApi';
 import { UsageChart, UsageStatsCard } from '../../components/tools';
+import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 import type { ToolUsageSummary } from '../../types';
 
 type PeriodType = 'day' | 'week' | 'month';
@@ -66,8 +67,17 @@ export function UsageDashboard() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="h-8 w-48 bg-gray-200 rounded animate-pulse" />
+          <div className="h-10 w-36 bg-gray-200 rounded animate-pulse" />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {[1, 2, 3, 4].map((i) => (
+            <CardSkeleton key={i} className="h-24" />
+          ))}
+        </div>
+        <CardSkeleton className="h-80" />
       </div>
     );
   }

--- a/control-plane-ui/src/pages/APIs.tsx
+++ b/control-plane-ui/src/pages/APIs.tsx
@@ -5,6 +5,11 @@ import type { API, APICreate, Tenant } from '../types';
 import yaml from 'js-yaml';
 import { useToastActions } from '@stoa/shared/components/Toast';
 import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
+import { EmptyState } from '@stoa/shared/components/EmptyState';
+import { TableSkeleton } from '@stoa/shared/components/Skeleton';
+import { useCelebration } from '@stoa/shared/components/Celebration';
+import { Collapsible } from '@stoa/shared/components/Collapsible';
+import { FileText, Server, Code2, Settings } from 'lucide-react';
 
 // Debounce hook for search optimization
 function useDebounce<T>(value: T, delay: number): T {
@@ -36,6 +41,7 @@ export function APIs() {
   const { isReady } = useAuth();
   const toast = useToastActions();
   const [confirm, ConfirmDialog] = useConfirm();
+  const { celebrate } = useCelebration();
   const [apis, setApis] = useState<API[]>([]);
   const [tenants, setTenants] = useState<Tenant[]>([]);
   const [selectedTenant, setSelectedTenant] = useState<string>('');
@@ -43,6 +49,7 @@ export function APIs() {
   const [error, setError] = useState<string | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingApi, setEditingApi] = useState<API | null>(null);
+  const [isFirstApi, setIsFirstApi] = useState(false);
 
   // Search and pagination state
   const [searchQuery, setSearchQuery] = useState('');
@@ -93,6 +100,7 @@ export function APIs() {
       console.log('[APIs] Loading APIs for tenant:', tenantId);
       const data = await apiService.getApis(tenantId);
       console.log('[APIs] Loaded APIs:', data);
+      setIsFirstApi(data.length === 0);
       setApis(data);
       setError(null);
     } catch (err: any) {
@@ -138,6 +146,7 @@ export function APIs() {
   // Memoized handlers to prevent unnecessary re-renders
   const handleCreate = useCallback(async (api: APICreate, deployToDev: boolean) => {
     try {
+      const wasFirstApi = isFirstApi;
       const created = await apiService.createApi(selectedTenant, api);
 
       // Auto-deploy to DEV if requested
@@ -150,11 +159,19 @@ export function APIs() {
       }
 
       setShowCreateModal(false);
-      loadApis(selectedTenant);
+      await loadApis(selectedTenant);
+
+      // Celebrate first API creation
+      if (wasFirstApi) {
+        celebrate();
+        toast.success('Welcome!', 'You created your first API. Explore the Deploy options next.');
+      } else {
+        toast.success('API created', `${api.display_name || api.name} has been created`);
+      }
     } catch (err: any) {
-      setError(err.message || 'Failed to create API');
+      toast.error('Creation failed', err.message || 'Failed to create API');
     }
-  }, [selectedTenant]);
+  }, [selectedTenant, isFirstApi, celebrate, toast]);
 
   const handleUpdate = useCallback(async (apiId: string, api: Partial<APICreate>) => {
     try {
@@ -210,8 +227,12 @@ export function APIs() {
 
   if (loading && tenants.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      <div className="space-y-6">
+        <TableSkeleton
+          rows={5}
+          columns={6}
+          headers={['Name', 'Version', 'Status', 'Portal', 'Deployed', 'Actions']}
+        />
       </div>
     );
   }
@@ -313,35 +334,27 @@ export function APIs() {
       {/* APIs List */}
       <div className="bg-white rounded-lg shadow overflow-hidden">
         {loading ? (
-          <div className="flex items-center justify-center h-32">
-            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
-          </div>
+          <TableSkeleton
+            rows={5}
+            columns={6}
+            headers={['Name', 'Version', 'Status', 'Portal', 'Deployed', 'Actions']}
+          />
         ) : apis.length === 0 ? (
-          <div className="text-center py-12 text-gray-500">
-            <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-            </svg>
-            <p className="mt-2">No APIs found for this tenant</p>
-            <button
-              onClick={() => setShowCreateModal(true)}
-              className="mt-4 text-blue-600 hover:text-blue-700"
-            >
-              Create your first API
-            </button>
-          </div>
+          <EmptyState
+            variant="apis"
+            action={{
+              label: 'Create your first API',
+              onClick: () => setShowCreateModal(true),
+            }}
+          />
         ) : filteredApis.length === 0 ? (
-          <div className="text-center py-12 text-gray-500">
-            <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-            </svg>
-            <p className="mt-2">No APIs match your search criteria</p>
-            <button
-              onClick={clearFilters}
-              className="mt-4 text-blue-600 hover:text-blue-700"
-            >
-              Clear filters
-            </button>
-          </div>
+          <EmptyState
+            variant="search"
+            action={{
+              label: 'Clear filters',
+              onClick: clearFilters,
+            }}
+          />
         ) : (
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
@@ -709,121 +722,161 @@ paths:
             </div>
           )}
 
-          {/* Form Fields */}
-          <div className="grid grid-cols-2 gap-4">
+          {/* Basic Information Section */}
+          <Collapsible
+            title="Basic Information"
+            icon={<FileText className="h-4 w-4" />}
+            defaultExpanded={true}
+            variant="bordered"
+          >
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Name (slug)</label>
+                  <input
+                    type="text"
+                    value={formData.name}
+                    onChange={(e) => setFormData({ ...formData, name: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '-') })}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="payment-api"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Version</label>
+                  <input
+                    type="text"
+                    value={formData.version}
+                    onChange={(e) => setFormData({ ...formData, version: e.target.value })}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="1.0.0"
+                    required
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Display Name</label>
+                <input
+                  type="text"
+                  value={formData.display_name}
+                  onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  placeholder="Payment API"
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+                <textarea
+                  value={formData.description}
+                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  rows={2}
+                  placeholder="API for handling payments..."
+                />
+              </div>
+            </div>
+          </Collapsible>
+
+          {/* Endpoint Configuration Section */}
+          <Collapsible
+            title="Endpoint Configuration"
+            icon={<Server className="h-4 w-4" />}
+            defaultExpanded={true}
+            variant="bordered"
+          >
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Name (slug)</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Backend URL</label>
               <input
-                type="text"
-                value={formData.name}
-                onChange={(e) => setFormData({ ...formData, name: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '-') })}
+                type="url"
+                value={formData.backend_url}
+                onChange={(e) => setFormData({ ...formData, backend_url: e.target.value })}
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                placeholder="payment-api"
+                placeholder="https://backend.internal/api/v1"
                 required
               />
+              <p className="text-xs text-gray-500 mt-1">The backend service URL that the Gateway will proxy requests to</p>
             </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Version</label>
-              <input
-                type="text"
-                value={formData.version}
-                onChange={(e) => setFormData({ ...formData, version: e.target.value })}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                placeholder="1.0.0"
-                required
-              />
-            </div>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Display Name</label>
-            <input
-              type="text"
-              value={formData.display_name}
-              onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              placeholder="Payment API"
-              required
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
-            <textarea
-              value={formData.description}
-              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              rows={2}
-              placeholder="API for handling payments..."
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Backend URL</label>
-            <input
-              type="url"
-              value={formData.backend_url}
-              onChange={(e) => setFormData({ ...formData, backend_url: e.target.value })}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              placeholder="https://backend.internal/api/v1"
-              required
-            />
-            <p className="text-xs text-gray-500 mt-1">The backend service URL that the Gateway will proxy requests to</p>
-          </div>
+          </Collapsible>
 
           {/* OpenAPI Spec for manual mode */}
           {mode === 'manual' && (
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">OpenAPI Spec (optional)</label>
-              <textarea
-                value={formData.openapi_spec}
-                onChange={(e) => setFormData({ ...formData, openapi_spec: e.target.value })}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"
-                rows={4}
-                placeholder="Paste OpenAPI/Swagger spec here (YAML or JSON)..."
-              />
-            </div>
-          )}
-
-          {/* Portal Promotion Toggle */}
-          <div className="pt-4 border-t">
-            <div className="flex items-start gap-3">
-              <div className="flex items-center h-5">
-                <input
-                  type="checkbox"
-                  id="portalPromoted"
-                  checked={formData.portal_promoted}
-                  onChange={(e) => setFormData({ ...formData, portal_promoted: e.target.checked })}
-                  className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+            <Collapsible
+              title="OpenAPI Specification"
+              icon={<Code2 className="h-4 w-4" />}
+              badge="Optional"
+              defaultExpanded={false}
+              variant="bordered"
+            >
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">OpenAPI Spec</label>
+                <textarea
+                  value={formData.openapi_spec}
+                  onChange={(e) => setFormData({ ...formData, openapi_spec: e.target.value })}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"
+                  rows={6}
+                  placeholder="Paste OpenAPI/Swagger spec here (YAML or JSON)..."
                 />
+                <p className="text-xs text-gray-500 mt-1">Adding an OpenAPI spec enables API documentation and validation</p>
               </div>
-              <div className="flex-1">
-                <label htmlFor="portalPromoted" className="text-sm font-medium text-gray-700">
-                  Promote to Developer Portal
-                </label>
-                <p className="text-xs text-gray-500 mt-1">
-                  When enabled, this API will be visible in the Developer Portal for consumers to discover and subscribe.
-                  This adds the <code className="bg-gray-100 px-1 rounded">portal:published</code> tag.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Deploy to DEV checkbox */}
-          {!isEdit && (
-            <div className="flex items-center gap-2 pt-2">
-              <input
-                type="checkbox"
-                id="deployToDev"
-                checked={deployToDev}
-                onChange={(e) => setDeployToDev(e.target.checked)}
-                className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
-              />
-              <label htmlFor="deployToDev" className="text-sm text-gray-700">
-                Deploy to DEV environment after creation
-              </label>
-            </div>
+            </Collapsible>
           )}
+
+          {/* Portal & Deployment Settings */}
+          <Collapsible
+            title="Portal & Deployment"
+            icon={<Settings className="h-4 w-4" />}
+            defaultExpanded={!isEdit}
+            variant="bordered"
+          >
+            <div className="space-y-4">
+              {/* Portal Promotion Toggle */}
+              <div className="flex items-start gap-3">
+                <div className="flex items-center h-5">
+                  <input
+                    type="checkbox"
+                    id="portalPromoted"
+                    checked={formData.portal_promoted}
+                    onChange={(e) => setFormData({ ...formData, portal_promoted: e.target.checked })}
+                    className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                  />
+                </div>
+                <div className="flex-1">
+                  <label htmlFor="portalPromoted" className="text-sm font-medium text-gray-700">
+                    Promote to Developer Portal
+                  </label>
+                  <p className="text-xs text-gray-500 mt-1">
+                    When enabled, this API will be visible in the Developer Portal for consumers to discover and subscribe.
+                  </p>
+                </div>
+              </div>
+
+              {/* Deploy to DEV checkbox */}
+              {!isEdit && (
+                <div className="flex items-start gap-3 pt-3 border-t">
+                  <div className="flex items-center h-5">
+                    <input
+                      type="checkbox"
+                      id="deployToDev"
+                      checked={deployToDev}
+                      onChange={(e) => setDeployToDev(e.target.checked)}
+                      className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                    />
+                  </div>
+                  <div className="flex-1">
+                    <label htmlFor="deployToDev" className="text-sm font-medium text-gray-700">
+                      Deploy to DEV environment
+                    </label>
+                    <p className="text-xs text-gray-500 mt-1">
+                      Automatically deploy this API to the DEV environment after creation.
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </Collapsible>
 
           <div className="flex justify-end gap-3 pt-4 border-t mt-6">
             <button

--- a/control-plane-ui/src/pages/Applications.tsx
+++ b/control-plane-ui/src/pages/Applications.tsx
@@ -3,6 +3,8 @@ import { apiService } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
 import { useToastActions } from '@stoa/shared/components/Toast';
 import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
+import { EmptyState } from '@stoa/shared/components/EmptyState';
+import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 import type { Application, ApplicationCreate, Tenant, API } from '../types';
 
 // Debounce hook for search optimization
@@ -183,8 +185,16 @@ export function Applications() {
 
   if (loading && tenants.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      <div className="space-y-6">
+        <div className="flex justify-between items-center">
+          <div className="h-8 w-48 bg-gray-200 rounded animate-pulse" />
+          <div className="h-10 w-40 bg-gray-200 rounded animate-pulse" />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[1, 2, 3].map((i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
       </div>
     );
   }
@@ -286,34 +296,26 @@ export function Applications() {
       {/* Applications Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {loading ? (
-          <div className="col-span-full flex items-center justify-center h-32">
-            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
-          </div>
+          <>
+            {[1, 2, 3].map((i) => (
+              <CardSkeleton key={i} />
+            ))}
+          </>
         ) : applications.length === 0 ? (
-          <div className="col-span-full text-center py-12 text-gray-500 bg-white rounded-lg shadow">
-            <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z" />
-            </svg>
-            <p className="mt-2">No applications found for this tenant</p>
-            <button
-              onClick={() => setShowCreateModal(true)}
-              className="mt-4 text-blue-600 hover:text-blue-700"
-            >
-              Create your first application
-            </button>
+          <div className="col-span-full bg-white rounded-lg shadow">
+            <EmptyState
+              variant="default"
+              title="No applications found"
+              description="No applications found for this tenant. Create your first application to get started."
+              action={{ label: 'Create Application', onClick: () => setShowCreateModal(true) }}
+            />
           </div>
         ) : filteredApplications.length === 0 ? (
-          <div className="col-span-full text-center py-12 text-gray-500 bg-white rounded-lg shadow">
-            <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-            </svg>
-            <p className="mt-2">No applications match your search criteria</p>
-            <button
-              onClick={() => { setSearchQuery(''); setStatusFilter(''); }}
-              className="mt-4 text-blue-600 hover:text-blue-700"
-            >
-              Clear filters
-            </button>
+          <div className="col-span-full bg-white rounded-lg shadow">
+            <EmptyState
+              variant="search"
+              action={{ label: 'Clear filters', onClick: () => { setSearchQuery(''); setStatusFilter(''); } }}
+            />
           </div>
         ) : (
           paginatedApplications.map((app) => (

--- a/control-plane-ui/src/pages/Deployments.tsx
+++ b/control-plane-ui/src/pages/Deployments.tsx
@@ -4,6 +4,8 @@ import { useAuth } from '../contexts/AuthContext';
 import { config } from '../config';
 import { useToastActions } from '@stoa/shared/components/Toast';
 import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
+import { EmptyState } from '@stoa/shared/components/EmptyState';
+import { TableSkeleton } from '@stoa/shared/components/Skeleton';
 import type { Deployment, Tenant, API, TraceSummary, PipelineTrace, TraceStats, TraceStep, TraceStatus } from '../types';
 import {
   Activity,
@@ -494,8 +496,13 @@ function DeploymentHistoryTab() {
 
   if (loading && tenants.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      <div className="space-y-6">
+        <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-4">
+          <div className="h-10 w-48 bg-gray-200 rounded animate-pulse" />
+        </div>
+        <div className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden">
+          <TableSkeleton rows={5} columns={7} />
+        </div>
       </div>
     );
   }
@@ -550,15 +557,12 @@ function DeploymentHistoryTab() {
       {/* Deployments List */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden">
         {loading ? (
-          <div className="flex items-center justify-center h-32">
-            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
-          </div>
+          <TableSkeleton rows={5} columns={7} />
         ) : deployments.length === 0 ? (
-          <div className="text-center py-12 text-gray-500">
-            <Rocket className="mx-auto h-12 w-12 text-gray-400" />
-            <p className="mt-2">No deployments found</p>
-            <p className="text-sm text-gray-400">Deploy an API to see it here</p>
-          </div>
+          <EmptyState
+            variant="deployments"
+            description="Deploy an API to see it here."
+          />
         ) : (
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">

--- a/control-plane-ui/src/pages/ExternalMCPServers/ExternalMCPServerDetail.tsx
+++ b/control-plane-ui/src/pages/ExternalMCPServers/ExternalMCPServerDetail.tsx
@@ -12,13 +12,14 @@ import {
   Trash2,
   Play,
   ExternalLink,
-  Code,
 } from 'lucide-react';
 import { externalMcpServersService } from '../../services/externalMcpServersApi';
 import { useAuth } from '../../contexts/AuthContext';
 import { ExternalMCPServerModal } from './ExternalMCPServerModal';
 import { useToastActions } from '@stoa/shared/components/Toast';
 import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
+import { EmptyState } from '@stoa/shared/components/EmptyState';
+import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 import type {
   ExternalMCPServerDetail as ServerDetail,
   ExternalMCPServerUpdate,
@@ -159,8 +160,17 @@ export function ExternalMCPServerDetail() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      <div className="space-y-6">
+        <div className="flex items-center gap-4">
+          <div className="h-6 w-6 bg-gray-200 rounded animate-pulse" />
+          <div className="h-12 w-12 bg-gray-200 rounded-lg animate-pulse" />
+          <div className="space-y-2">
+            <div className="h-6 w-48 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 w-32 bg-gray-200 rounded animate-pulse" />
+          </div>
+        </div>
+        <CardSkeleton className="h-48" />
+        <CardSkeleton className="h-64" />
       </div>
     );
   }
@@ -334,11 +344,12 @@ export function ExternalMCPServerDetail() {
         </div>
 
         {server.tools.length === 0 ? (
-          <div className="p-12 text-center text-gray-500">
-            <Code className="h-12 w-12 mx-auto text-gray-400" />
-            <p className="mt-2">No tools synced yet</p>
-            <p className="text-sm text-gray-400">Click "Sync Tools" to discover available tools</p>
-          </div>
+          <EmptyState
+            variant="tools"
+            title="No tools synced yet"
+            description="Click 'Sync Tools' to discover available tools from this server."
+            action={{ label: 'Sync Tools', onClick: handleSyncTools }}
+          />
         ) : (
           <div className="divide-y">
             {server.tools.map((tool) => (

--- a/control-plane-ui/src/pages/ExternalMCPServers/ExternalMCPServersList.tsx
+++ b/control-plane-ui/src/pages/ExternalMCPServers/ExternalMCPServersList.tsx
@@ -6,6 +6,8 @@ import { useAuth } from '../../contexts/AuthContext';
 import { ExternalMCPServerModal } from './ExternalMCPServerModal';
 import { useToastActions } from '@stoa/shared/components/Toast';
 import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
+import { EmptyState } from '@stoa/shared/components/EmptyState';
+import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 import type { ExternalMCPServer, ExternalMCPServerCreate, ExternalMCPServerUpdate, ExternalMCPHealthStatus } from '../../types';
 
 const healthStatusConfig: Record<ExternalMCPHealthStatus, { color: string; icon: typeof CheckCircle; label: string }> = {
@@ -120,8 +122,19 @@ export function ExternalMCPServersList() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      <div className="space-y-6">
+        <div className="flex justify-between items-center">
+          <div className="h-8 w-64 bg-gray-200 rounded animate-pulse" />
+          <div className="flex gap-3">
+            <div className="h-10 w-24 bg-gray-200 rounded animate-pulse" />
+            <div className="h-10 w-28 bg-gray-200 rounded animate-pulse" />
+          </div>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[1, 2, 3].map((i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
       </div>
     );
   }
@@ -165,12 +178,13 @@ export function ExternalMCPServersList() {
       {/* Servers Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {servers.length === 0 ? (
-          <div className="col-span-full text-center py-12 text-gray-500 bg-white rounded-lg shadow">
-            <Server className="mx-auto h-12 w-12 text-gray-400" />
-            <p className="mt-2">No external MCP servers registered</p>
-            <p className="text-sm text-gray-400 mt-1">
-              Click "Add Server" to register an external MCP server like Linear or GitHub
-            </p>
+          <div className="col-span-full bg-white rounded-lg shadow">
+            <EmptyState
+              variant="servers"
+              title="No external MCP servers registered"
+              description="Register external MCP servers like Linear or GitHub to proxy through STOA with governance."
+              action={{ label: 'Add Server', onClick: () => setShowCreateModal(true) }}
+            />
           </div>
         ) : (
           servers.map((server) => {

--- a/control-plane-ui/src/pages/GatewayDeployments/DeployAPIDialog.tsx
+++ b/control-plane-ui/src/pages/GatewayDeployments/DeployAPIDialog.tsx
@@ -98,8 +98,15 @@ export function DeployAPIDialog({ onClose, onDeployed }: DeployAPIDialogProps) {
           )}
 
           {loading ? (
-            <div className="flex items-center justify-center py-8">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+            <div className="space-y-4 py-4">
+              <div className="space-y-2">
+                <div className="h-4 w-32 bg-gray-200 rounded animate-pulse" />
+                <div className="h-10 w-full bg-gray-200 rounded animate-pulse" />
+              </div>
+              <div className="space-y-2">
+                <div className="h-4 w-28 bg-gray-200 rounded animate-pulse" />
+                <div className="h-32 w-full bg-gray-200 rounded animate-pulse" />
+              </div>
             </div>
           ) : (
             <>

--- a/control-plane-ui/src/pages/GatewayDeployments/GatewayDeploymentsDashboard.tsx
+++ b/control-plane-ui/src/pages/GatewayDeployments/GatewayDeploymentsDashboard.tsx
@@ -6,6 +6,8 @@ import { SyncStatusBadge } from '../../components/SyncStatusBadge';
 import { DeployAPIDialog } from './DeployAPIDialog';
 import { useToastActions } from '@stoa/shared/components/Toast';
 import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
+import { EmptyState } from '@stoa/shared/components/EmptyState';
+import { TableSkeleton } from '@stoa/shared/components/Skeleton';
 import type { GatewayDeployment, DeploymentStatusSummary } from '../../types';
 
 const PAGE_SIZE = 20;
@@ -213,19 +215,14 @@ export function GatewayDeploymentsDashboard() {
       {/* Table */}
       <div className="bg-white rounded-lg shadow overflow-hidden">
         {loading ? (
-          <div className="flex items-center justify-center py-12">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
-          </div>
+          <TableSkeleton rows={5} columns={6} />
         ) : deployments.length === 0 ? (
-          <div className="text-center py-12">
-            <p className="text-gray-500">No deployments found.</p>
-            <button
-              onClick={() => setShowDeployDialog(true)}
-              className="mt-3 text-sm text-blue-600 hover:text-blue-800"
-            >
-              Deploy your first API
-            </button>
-          </div>
+          <EmptyState
+            variant="deployments"
+            title="No deployments found"
+            description="Deploy an API to a gateway to get started."
+            action={{ label: 'Deploy API', onClick: () => setShowDeployDialog(true) }}
+          />
         ) : (
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">

--- a/control-plane-ui/src/pages/GatewayObservability/GatewayObservabilityDashboard.tsx
+++ b/control-plane-ui/src/pages/GatewayObservability/GatewayObservabilityDashboard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { RefreshCw } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { apiService } from '../../services/api';
+import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 import type { AggregatedMetrics } from '../../types';
 
 const AUTO_REFRESH_INTERVAL = 30_000;
@@ -111,8 +112,24 @@ export function GatewayObservabilityDashboard() {
       )}
 
       {loading ? (
-        <div className="flex items-center justify-center py-12">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        <div className="space-y-6">
+          <div className="h-8 w-32 bg-gray-200 rounded-full animate-pulse" />
+          <div>
+            <div className="h-4 w-32 bg-gray-200 rounded animate-pulse mb-3" />
+            <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+              {[1, 2, 3, 4, 5].map((i) => (
+                <CardSkeleton key={i} className="h-20" />
+              ))}
+            </div>
+          </div>
+          <div>
+            <div className="h-4 w-24 bg-gray-200 rounded animate-pulse mb-3" />
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              {[1, 2, 3].map((i) => (
+                <CardSkeleton key={i} className="h-16" />
+              ))}
+            </div>
+          </div>
         </div>
       ) : metrics ? (
         <>

--- a/control-plane-ui/src/pages/Gateways/GatewayList.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayList.tsx
@@ -4,6 +4,8 @@ import { apiService } from '../../services/api';
 import { GatewayRegistrationForm } from './GatewayRegistrationForm';
 import { useToastActions } from '@stoa/shared/components/Toast';
 import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
+import { EmptyState } from '@stoa/shared/components/EmptyState';
+import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 import type {
   GatewayInstance,
   GatewayType,
@@ -91,8 +93,16 @@ export function GatewayList() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="h-8 w-48 bg-gray-200 rounded animate-pulse" />
+          <div className="h-10 w-40 bg-gray-200 rounded animate-pulse" />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[1, 2, 3].map((i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
       </div>
     );
   }
@@ -135,14 +145,13 @@ export function GatewayList() {
 
       {/* Gateway Cards */}
       {gateways.length === 0 ? (
-        <div className="bg-white rounded-lg shadow p-12 text-center">
-          <svg className="w-16 h-16 text-gray-300 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 12h14M12 5l7 7-7 7" />
-          </svg>
-          <h3 className="text-lg font-medium text-gray-900 mb-2">No gateways registered</h3>
-          <p className="text-gray-500">
-            Register your first gateway instance to start multi-gateway orchestration.
-          </p>
+        <div className="bg-white rounded-lg shadow">
+          <EmptyState
+            variant="servers"
+            title="No gateways registered"
+            description="Register your first gateway instance to start multi-gateway orchestration."
+            action={{ label: 'Register Gateway', onClick: () => setShowForm(true) }}
+          />
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/control-plane-ui/src/pages/Tenants.tsx
+++ b/control-plane-ui/src/pages/Tenants.tsx
@@ -2,6 +2,9 @@ import { useState, useEffect } from 'react';
 import { apiService } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
 import type { Tenant } from '../types';
+import { EmptyState } from '@stoa/shared/components/EmptyState';
+import { CardSkeleton } from '@stoa/shared/components/Skeleton';
+import { Users } from 'lucide-react';
 
 export function Tenants() {
   const { isReady } = useAuth();
@@ -41,8 +44,12 @@ export function Tenants() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      <div className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[1, 2, 3].map((i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
       </div>
     );
   }
@@ -69,12 +76,17 @@ export function Tenants() {
       {/* Tenants Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {tenants.length === 0 ? (
-          <div className="col-span-full text-center py-12 text-gray-500 bg-white rounded-lg shadow">
-            <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
-            </svg>
-            <p className="mt-2">No tenants found</p>
-            <p className="text-sm text-gray-400 mt-1">Tenants are managed via GitOps configuration</p>
+          <div className="col-span-full bg-white rounded-lg shadow">
+            <EmptyState
+              variant="users"
+              title="No tenants found"
+              description="Tenants are managed via GitOps configuration in the iam/tenants.yaml file."
+              illustration={
+                <div className="w-24 h-24 rounded-2xl bg-gradient-to-br from-purple-50 to-purple-100 flex items-center justify-center">
+                  <Users className="w-10 h-10 text-purple-500" />
+                </div>
+              }
+            />
           </div>
         ) : (
           tenants.map((tenant) => (

--- a/control-plane-ui/tailwind.config.js
+++ b/control-plane-ui/tailwind.config.js
@@ -7,7 +7,9 @@ export default {
     './src/**/*.{js,ts,jsx,tsx}',
     // Include shared components
     '../shared/components/**/*.{js,ts,jsx,tsx}',
+    '../shared/contexts/**/*.{js,ts,jsx,tsx}',
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       colors: tokens.colors,

--- a/shared/components/CommandPalette/CommandPalette.tsx
+++ b/shared/components/CommandPalette/CommandPalette.tsx
@@ -87,7 +87,7 @@ function ShortcutKey({ shortcut }: { shortcut: string[] }) {
       {shortcut.map((key, index) => (
         <kbd
           key={index}
-          className="px-1.5 py-0.5 text-xs font-medium text-neutral-500 bg-neutral-100 border border-neutral-200 rounded"
+          className="px-1.5 py-0.5 text-xs font-medium text-neutral-500 dark:text-neutral-400 bg-neutral-100 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded"
         >
           {key}
         </kbd>
@@ -192,11 +192,11 @@ export function CommandPalette({ items, placeholder = 'Search commands...', onCl
 
       {/* Dialog */}
       <div
-        className="relative bg-white rounded-xl shadow-2xl w-full max-w-lg mx-4 overflow-hidden animate-scale-in"
+        className="relative bg-white dark:bg-neutral-900 rounded-xl shadow-2xl w-full max-w-lg mx-4 overflow-hidden animate-scale-in"
         onKeyDown={handleKeyDown}
       >
         {/* Search Input */}
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-neutral-200">
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-neutral-200 dark:border-neutral-700">
           <Search className="h-5 w-5 text-neutral-400 flex-shrink-0" />
           <input
             ref={inputRef}
@@ -204,9 +204,9 @@ export function CommandPalette({ items, placeholder = 'Search commands...', onCl
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder={placeholder}
-            className="flex-1 text-base text-neutral-900 placeholder-neutral-400 outline-none bg-transparent"
+            className="flex-1 text-base text-neutral-900 dark:text-neutral-100 placeholder-neutral-400 dark:placeholder-neutral-500 outline-none bg-transparent"
           />
-          <kbd className="hidden sm:flex items-center gap-1 px-2 py-1 text-xs font-medium text-neutral-400 bg-neutral-100 border border-neutral-200 rounded">
+          <kbd className="hidden sm:flex items-center gap-1 px-2 py-1 text-xs font-medium text-neutral-400 bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
             esc
           </kbd>
         </div>
@@ -214,16 +214,16 @@ export function CommandPalette({ items, placeholder = 'Search commands...', onCl
         {/* Results */}
         <div ref={listRef} className="max-h-[60vh] overflow-y-auto">
           {flatItems.length === 0 ? (
-            <div className="px-4 py-12 text-center text-neutral-500">
-              <Command className="h-8 w-8 mx-auto mb-3 text-neutral-300" />
+            <div className="px-4 py-12 text-center text-neutral-500 dark:text-neutral-400">
+              <Command className="h-8 w-8 mx-auto mb-3 text-neutral-300 dark:text-neutral-600" />
               <p className="text-sm">No results found</p>
-              <p className="text-xs text-neutral-400 mt-1">Try a different search term</p>
+              <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1">Try a different search term</p>
             </div>
           ) : (
             Object.entries(groupedItems).map(([section, sectionItems]) => (
               <div key={section}>
                 {/* Section Header */}
-                <div className="px-4 py-2 text-xs font-medium text-neutral-500 uppercase tracking-wider bg-neutral-50">
+                <div className="px-4 py-2 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider bg-neutral-50 dark:bg-neutral-800">
                   {section}
                 </div>
 
@@ -242,23 +242,23 @@ export function CommandPalette({ items, placeholder = 'Search commands...', onCl
                       }}
                       onMouseEnter={() => setSelectedIndex(itemIndex)}
                       className={`w-full flex items-center gap-3 px-4 py-3 text-left transition-colors ${
-                        isSelected ? 'bg-primary-50' : 'hover:bg-neutral-50'
+                        isSelected ? 'bg-primary-50 dark:bg-primary-900/30' : 'hover:bg-neutral-50 dark:hover:bg-neutral-800'
                       }`}
                     >
                       {/* Icon */}
                       {item.icon && (
-                        <div className={`flex-shrink-0 ${isSelected ? 'text-primary-600' : 'text-neutral-400'}`}>
+                        <div className={`flex-shrink-0 ${isSelected ? 'text-primary-600 dark:text-primary-400' : 'text-neutral-400'}`}>
                           {item.icon}
                         </div>
                       )}
 
                       {/* Content */}
                       <div className="flex-1 min-w-0">
-                        <div className={`text-sm font-medium ${isSelected ? 'text-primary-700' : 'text-neutral-900'}`}>
+                        <div className={`text-sm font-medium ${isSelected ? 'text-primary-700 dark:text-primary-300' : 'text-neutral-900 dark:text-neutral-100'}`}>
                           {item.label}
                         </div>
                         {item.description && (
-                          <div className="text-xs text-neutral-500 truncate">
+                          <div className="text-xs text-neutral-500 dark:text-neutral-400 truncate">
                             {item.description}
                           </div>
                         )}
@@ -268,7 +268,7 @@ export function CommandPalette({ items, placeholder = 'Search commands...', onCl
                       {item.shortcut ? (
                         <ShortcutKey shortcut={item.shortcut} />
                       ) : isSelected ? (
-                        <ArrowRight className="h-4 w-4 text-primary-500" />
+                        <ArrowRight className="h-4 w-4 text-primary-500 dark:text-primary-400" />
                       ) : null}
                     </button>
                   );
@@ -279,20 +279,20 @@ export function CommandPalette({ items, placeholder = 'Search commands...', onCl
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between px-4 py-2 border-t border-neutral-200 bg-neutral-50 text-xs text-neutral-500">
+        <div className="flex items-center justify-between px-4 py-2 border-t border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800 text-xs text-neutral-500 dark:text-neutral-400">
           <div className="flex items-center gap-4">
             <span className="flex items-center gap-1">
-              <kbd className="px-1 py-0.5 bg-white border border-neutral-200 rounded text-[10px]">↑</kbd>
-              <kbd className="px-1 py-0.5 bg-white border border-neutral-200 rounded text-[10px]">↓</kbd>
+              <kbd className="px-1 py-0.5 bg-white dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded text-[10px]">↑</kbd>
+              <kbd className="px-1 py-0.5 bg-white dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded text-[10px]">↓</kbd>
               <span className="ml-1">navigate</span>
             </span>
             <span className="flex items-center gap-1">
-              <kbd className="px-1.5 py-0.5 bg-white border border-neutral-200 rounded text-[10px]">↵</kbd>
+              <kbd className="px-1.5 py-0.5 bg-white dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded text-[10px]">↵</kbd>
               <span className="ml-1">select</span>
             </span>
           </div>
           <span className="flex items-center gap-1">
-            <kbd className="px-1.5 py-0.5 bg-white border border-neutral-200 rounded text-[10px]">esc</kbd>
+            <kbd className="px-1.5 py-0.5 bg-white dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded text-[10px]">esc</kbd>
             <span className="ml-1">close</span>
           </span>
         </div>

--- a/shared/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/shared/components/ConfirmDialog/ConfirmDialog.tsx
@@ -42,21 +42,21 @@ const variantStyles: Record<ConfirmVariant, {
 }> = {
   default: {
     icon: <AlertTriangle className="h-6 w-6" />,
-    iconBg: 'bg-primary-100',
-    iconColor: 'text-primary-600',
-    confirmButton: 'bg-primary-600 hover:bg-primary-700 text-white',
+    iconBg: 'bg-primary-100 dark:bg-primary-900',
+    iconColor: 'text-primary-600 dark:text-primary-400',
+    confirmButton: 'bg-primary-600 hover:bg-primary-700 dark:bg-primary-500 dark:hover:bg-primary-600 text-white',
   },
   danger: {
     icon: <Trash2 className="h-6 w-6" />,
-    iconBg: 'bg-error-100',
-    iconColor: 'text-error-600',
-    confirmButton: 'bg-error-600 hover:bg-error-700 text-white',
+    iconBg: 'bg-error-100 dark:bg-error-900',
+    iconColor: 'text-error-600 dark:text-error-400',
+    confirmButton: 'bg-error-600 hover:bg-error-700 dark:bg-error-500 dark:hover:bg-error-600 text-white',
   },
   warning: {
     icon: <AlertTriangle className="h-6 w-6" />,
-    iconBg: 'bg-warning-100',
-    iconColor: 'text-warning-600',
-    confirmButton: 'bg-warning-600 hover:bg-warning-700 text-white',
+    iconBg: 'bg-warning-100 dark:bg-warning-900',
+    iconColor: 'text-warning-600 dark:text-warning-400',
+    confirmButton: 'bg-warning-600 hover:bg-warning-700 dark:bg-warning-500 dark:hover:bg-warning-600 text-white',
   },
 };
 
@@ -135,13 +135,13 @@ export function ConfirmDialog({
       {/* Dialog */}
       <div
         ref={dialogRef}
-        className="relative bg-white rounded-modal shadow-modal w-full max-w-md animate-scale-in"
+        className="relative bg-white dark:bg-neutral-900 rounded-modal shadow-modal w-full max-w-md animate-scale-in"
       >
         {/* Close button */}
         <button
           onClick={onCancel}
           disabled={loading}
-          className="absolute top-4 right-4 p-1 rounded-full text-neutral-400 hover:text-neutral-600 hover:bg-neutral-100 transition-colors disabled:opacity-50"
+          className="absolute top-4 right-4 p-1 rounded-full text-neutral-400 hover:text-neutral-600 dark:text-neutral-500 dark:hover:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors disabled:opacity-50"
           aria-label="Close dialog"
         >
           <X className="h-5 w-5" />
@@ -157,7 +157,7 @@ export function ConfirmDialog({
           {/* Title */}
           <h2
             id="confirm-dialog-title"
-            className="text-lg font-semibold text-neutral-900 text-center mb-2"
+            className="text-lg font-semibold text-neutral-900 dark:text-neutral-100 text-center mb-2"
           >
             {title}
           </h2>
@@ -165,7 +165,7 @@ export function ConfirmDialog({
           {/* Message */}
           <p
             id="confirm-dialog-description"
-            className="text-sm text-neutral-600 text-center"
+            className="text-sm text-neutral-600 dark:text-neutral-400 text-center"
           >
             {message}
           </p>
@@ -176,7 +176,7 @@ export function ConfirmDialog({
           <button
             onClick={onCancel}
             disabled={loading}
-            className="flex-1 px-4 py-2.5 text-sm font-medium text-neutral-700 bg-white border border-neutral-300 rounded-lg hover:bg-neutral-50 transition-colors disabled:opacity-50"
+            className="flex-1 px-4 py-2.5 text-sm font-medium text-neutral-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors disabled:opacity-50"
           >
             {cancelLabel}
           </button>

--- a/shared/components/EmptyState/EmptyState.tsx
+++ b/shared/components/EmptyState/EmptyState.tsx
@@ -48,11 +48,11 @@ export interface EmptyStateProps {
 function DefaultIllustration() {
   return (
     <div className="relative">
-      <div className="w-24 h-24 rounded-2xl bg-gradient-to-br from-neutral-100 to-neutral-200 flex items-center justify-center">
+      <div className="w-24 h-24 rounded-2xl bg-gradient-to-br from-neutral-100 to-neutral-200 dark:from-neutral-800 dark:to-neutral-700 flex items-center justify-center">
         <FileText className="w-10 h-10 text-neutral-400" />
       </div>
-      <div className="absolute -bottom-1 -right-1 w-8 h-8 rounded-lg bg-primary-100 flex items-center justify-center">
-        <Plus className="w-4 h-4 text-primary-600" />
+      <div className="absolute -bottom-1 -right-1 w-8 h-8 rounded-lg bg-primary-100 dark:bg-primary-900 flex items-center justify-center">
+        <Plus className="w-4 h-4 text-primary-600 dark:text-primary-400" />
       </div>
     </div>
   );
@@ -61,11 +61,11 @@ function DefaultIllustration() {
 function SearchIllustration() {
   return (
     <div className="relative">
-      <div className="w-24 h-24 rounded-full bg-gradient-to-br from-neutral-100 to-neutral-200 flex items-center justify-center">
+      <div className="w-24 h-24 rounded-full bg-gradient-to-br from-neutral-100 to-neutral-200 dark:from-neutral-800 dark:to-neutral-700 flex items-center justify-center">
         <Search className="w-10 h-10 text-neutral-400" />
       </div>
-      <div className="absolute top-0 right-0 w-6 h-6 rounded-full bg-warning-100 flex items-center justify-center">
-        <span className="text-warning-600 text-xs font-bold">?</span>
+      <div className="absolute top-0 right-0 w-6 h-6 rounded-full bg-warning-100 dark:bg-warning-900 flex items-center justify-center">
+        <span className="text-warning-600 dark:text-warning-400 text-xs font-bold">?</span>
       </div>
     </div>
   );
@@ -226,7 +226,7 @@ export function EmptyState({
 
       {/* Title */}
       <h3
-        className={`font-semibold text-neutral-900 ${
+        className={`font-semibold text-neutral-900 dark:text-neutral-100 ${
           compact ? 'text-base' : 'text-lg'
         }`}
       >
@@ -235,7 +235,7 @@ export function EmptyState({
 
       {/* Description */}
       <p
-        className={`text-neutral-500 max-w-sm ${
+        className={`text-neutral-500 dark:text-neutral-400 max-w-sm ${
           compact ? 'text-sm mt-1' : 'mt-2'
         }`}
       >
@@ -248,7 +248,7 @@ export function EmptyState({
           {action && (
             <button
               onClick={action.onClick}
-              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 transition-colors"
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 dark:bg-primary-500 dark:hover:bg-primary-600 transition-colors"
             >
               {action.icon || <Plus className="w-4 h-4" />}
               {action.label}
@@ -257,7 +257,7 @@ export function EmptyState({
           {secondaryAction && (
             <button
               onClick={secondaryAction.onClick}
-              className="text-sm text-primary-600 hover:text-primary-700 font-medium"
+              className="text-sm text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 font-medium"
             >
               {secondaryAction.label}
             </button>

--- a/shared/components/ThemeToggle/ThemeToggle.tsx
+++ b/shared/components/ThemeToggle/ThemeToggle.tsx
@@ -1,0 +1,163 @@
+import { Sun, Moon, Monitor } from 'lucide-react';
+import { useTheme, type Theme } from '../../contexts/ThemeContext';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ThemeToggleProps {
+  /** Show label text */
+  showLabel?: boolean;
+  /** Size variant */
+  size?: 'sm' | 'md' | 'lg';
+  /** Additional className */
+  className?: string;
+}
+
+// ============================================================================
+// Simple Toggle Button (Light/Dark only)
+// ============================================================================
+
+export function ThemeToggle({
+  showLabel = false,
+  size = 'md',
+  className = '',
+}: ThemeToggleProps) {
+  const { resolvedTheme, toggleTheme } = useTheme();
+
+  const sizeClasses = {
+    sm: 'p-1.5',
+    md: 'p-2',
+    lg: 'p-2.5',
+  };
+
+  const iconSizes = {
+    sm: 'h-4 w-4',
+    md: 'h-5 w-5',
+    lg: 'h-6 w-6',
+  };
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className={`
+        ${sizeClasses[size]}
+        rounded-lg
+        text-neutral-500 dark:text-neutral-400
+        hover:bg-neutral-100 dark:hover:bg-neutral-800
+        hover:text-neutral-700 dark:hover:text-neutral-200
+        transition-colors
+        ${showLabel ? 'flex items-center gap-2' : ''}
+        ${className}
+      `}
+      title={`Switch to ${resolvedTheme === 'dark' ? 'light' : 'dark'} mode`}
+    >
+      {resolvedTheme === 'dark' ? (
+        <Sun className={iconSizes[size]} />
+      ) : (
+        <Moon className={iconSizes[size]} />
+      )}
+      {showLabel && (
+        <span className="text-sm font-medium">
+          {resolvedTheme === 'dark' ? 'Light mode' : 'Dark mode'}
+        </span>
+      )}
+    </button>
+  );
+}
+
+// ============================================================================
+// Three-way Selector (Light/Dark/System)
+// ============================================================================
+
+export interface ThemeSelectorProps {
+  /** Additional className */
+  className?: string;
+}
+
+export function ThemeSelector({ className = '' }: ThemeSelectorProps) {
+  const { theme, setTheme } = useTheme();
+
+  const options: { value: Theme; icon: typeof Sun; label: string }[] = [
+    { value: 'light', icon: Sun, label: 'Light' },
+    { value: 'dark', icon: Moon, label: 'Dark' },
+    { value: 'system', icon: Monitor, label: 'System' },
+  ];
+
+  return (
+    <div
+      className={`
+        inline-flex items-center
+        p-1 rounded-lg
+        bg-neutral-100 dark:bg-neutral-800
+        ${className}
+      `}
+    >
+      {options.map(({ value, icon: Icon, label }) => (
+        <button
+          key={value}
+          onClick={() => setTheme(value)}
+          className={`
+            flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium
+            transition-colors
+            ${
+              theme === value
+                ? 'bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white shadow-sm'
+                : 'text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200'
+            }
+          `}
+          title={label}
+        >
+          <Icon className="h-4 w-4" />
+          <span className="hidden sm:inline">{label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ============================================================================
+// Dropdown Selector
+// ============================================================================
+
+export interface ThemeDropdownProps {
+  /** Additional className */
+  className?: string;
+}
+
+export function ThemeDropdown({ className = '' }: ThemeDropdownProps) {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+
+  const icons = {
+    light: Sun,
+    dark: Moon,
+    system: Monitor,
+  };
+
+  const CurrentIcon = theme === 'system' ? icons[resolvedTheme] : icons[theme];
+
+  return (
+    <div className={`relative ${className}`}>
+      <select
+        value={theme}
+        onChange={(e) => setTheme(e.target.value as Theme)}
+        className="
+          appearance-none
+          pl-9 pr-8 py-2
+          rounded-lg border border-neutral-200 dark:border-neutral-700
+          bg-white dark:bg-neutral-800
+          text-sm text-neutral-900 dark:text-neutral-100
+          focus:ring-2 focus:ring-primary-500 focus:border-transparent
+          cursor-pointer
+        "
+      >
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+        <option value="system">System</option>
+      </select>
+      <CurrentIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400 pointer-events-none" />
+    </div>
+  );
+}
+
+export default ThemeToggle;

--- a/shared/components/ThemeToggle/index.ts
+++ b/shared/components/ThemeToggle/index.ts
@@ -1,0 +1,2 @@
+export { ThemeToggle, ThemeSelector, ThemeDropdown } from './ThemeToggle';
+export type { ThemeToggleProps, ThemeSelectorProps, ThemeDropdownProps } from './ThemeToggle';

--- a/shared/components/Toast/Toast.tsx
+++ b/shared/components/Toast/Toast.tsx
@@ -137,24 +137,24 @@ const ICONS: Record<ToastType, React.ComponentType<{ className?: string }>> = {
 
 const STYLES: Record<ToastType, { bg: string; icon: string; border: string }> = {
   success: {
-    bg: 'bg-white',
+    bg: 'bg-white dark:bg-neutral-800',
     icon: 'text-success-500',
-    border: 'border-success-200',
+    border: 'border-success-200 dark:border-success-700',
   },
   error: {
-    bg: 'bg-white',
+    bg: 'bg-white dark:bg-neutral-800',
     icon: 'text-error-500',
-    border: 'border-error-200',
+    border: 'border-error-200 dark:border-error-700',
   },
   warning: {
-    bg: 'bg-white',
+    bg: 'bg-white dark:bg-neutral-800',
     icon: 'text-warning-500',
-    border: 'border-warning-200',
+    border: 'border-warning-200 dark:border-warning-700',
   },
   info: {
-    bg: 'bg-white',
+    bg: 'bg-white dark:bg-neutral-800',
     icon: 'text-primary-500',
-    border: 'border-primary-200',
+    border: 'border-primary-200 dark:border-primary-700',
   },
 };
 
@@ -197,14 +197,14 @@ function ToastItem({ toast, onDismiss }: ToastItemProps) {
       <div className="flex gap-3">
         <Icon className={`h-5 w-5 flex-shrink-0 ${styles.icon}`} />
         <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-neutral-900">{toast.title}</p>
+          <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100">{toast.title}</p>
           {toast.description && (
-            <p className="mt-1 text-sm text-neutral-600">{toast.description}</p>
+            <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">{toast.description}</p>
           )}
           {toast.action && (
             <button
               onClick={toast.action.onClick}
-              className="mt-2 text-sm font-medium text-primary-600 hover:text-primary-700 transition-colors"
+              className="mt-2 text-sm font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 transition-colors"
             >
               {toast.action.label}
             </button>
@@ -213,7 +213,7 @@ function ToastItem({ toast, onDismiss }: ToastItemProps) {
       </div>
       <button
         onClick={handleDismiss}
-        className="absolute top-3 right-3 p-1 rounded-full text-neutral-400 hover:text-neutral-600 hover:bg-neutral-100 transition-colors"
+        className="absolute top-3 right-3 p-1 rounded-full text-neutral-400 hover:text-neutral-600 dark:text-neutral-500 dark:hover:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
         aria-label="Dismiss notification"
       >
         <X className="h-4 w-4" />

--- a/shared/contexts/ThemeContext.tsx
+++ b/shared/contexts/ThemeContext.tsx
@@ -1,0 +1,105 @@
+import { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type Theme = 'light' | 'dark' | 'system';
+
+interface ThemeContextValue {
+  /** Current theme preference */
+  theme: Theme;
+  /** Resolved theme (always 'light' or 'dark') */
+  resolvedTheme: 'light' | 'dark';
+  /** Set theme preference */
+  setTheme: (theme: Theme) => void;
+  /** Toggle between light and dark */
+  toggleTheme: () => void;
+}
+
+// ============================================================================
+// Context
+// ============================================================================
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+const STORAGE_KEY = 'stoa-theme';
+
+// ============================================================================
+// Provider
+// ============================================================================
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    if (typeof window === 'undefined') return 'system';
+    return (localStorage.getItem(STORAGE_KEY) as Theme) || 'system';
+  });
+
+  const [systemTheme, setSystemTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window === 'undefined') return 'light';
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  // Listen for system theme changes
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setSystemTheme(e.matches ? 'dark' : 'light');
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  // Resolve the actual theme
+  const resolvedTheme = theme === 'system' ? systemTheme : theme;
+
+  // Apply theme to document
+  useEffect(() => {
+    const root = document.documentElement;
+
+    if (resolvedTheme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [resolvedTheme]);
+
+  // Set theme with persistence
+  const setTheme = useCallback((newTheme: Theme) => {
+    setThemeState(newTheme);
+    localStorage.setItem(STORAGE_KEY, newTheme);
+  }, []);
+
+  // Toggle between light and dark (or use system preference as base)
+  const toggleTheme = useCallback(() => {
+    const newTheme = resolvedTheme === 'dark' ? 'light' : 'dark';
+    setTheme(newTheme);
+  }, [resolvedTheme, setTheme]);
+
+  const value = useMemo(
+    () => ({ theme, resolvedTheme, setTheme, toggleTheme }),
+    [theme, resolvedTheme, setTheme, toggleTheme]
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}
+
+export default ThemeProvider;

--- a/shared/contexts/index.ts
+++ b/shared/contexts/index.ts
@@ -1,0 +1,2 @@
+export { ThemeProvider, useTheme } from './ThemeContext';
+export type { Theme } from './ThemeContext';


### PR DESCRIPTION
## Summary
- Add dark mode support with system preference detection and localStorage persistence
- Polish all Console pages with shared UX components (Skeleton, EmptyState, Collapsible)
- Update shared components (Toast, CommandPalette, ConfirmDialog, EmptyState) with dark mode styles

## Test plan
- [ ] Toggle dark mode via header button
- [ ] Toggle dark mode via Command Palette (⌘K → "dark mode")
- [ ] Verify system preference detection works
- [ ] Verify theme persists across page reloads
- [ ] Verify all pages render correctly in both light and dark modes
- [ ] Verify skeleton loaders display during data loading
- [ ] Verify empty states show appropriate illustrations and actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)