### PR TITLE
feat(portal): add dark mode, toasts, and modern dialogs (CAB-1100)

### DIFF
--- a/portal/src/App.tsx
+++ b/portal/src/App.tsx
@@ -32,7 +32,7 @@ function PageLoader() {
         <div className="w-10 h-10 bg-primary-600 rounded-lg flex items-center justify-center mx-auto mb-3 animate-pulse">
           <span className="text-white font-bold text-sm">SP</span>
         </div>
-        <p className="text-gray-500 text-sm">Loading...</p>
+        <p className="text-gray-500 dark:text-neutral-400 text-sm">Loading...</p>
       </div>
     </div>
   );
@@ -41,12 +41,12 @@ function PageLoader() {
 // Loading screen
 function LoadingScreen() {
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+    <div className="min-h-screen bg-gray-50 dark:bg-neutral-900 flex items-center justify-center transition-colors">
       <div className="text-center">
         <div className="w-16 h-16 bg-primary-600 rounded-xl flex items-center justify-center mx-auto mb-4 animate-pulse">
           <span className="text-white font-bold text-xl">SP</span>
         </div>
-        <p className="text-gray-500">Loading...</p>
+        <p className="text-gray-500 dark:text-neutral-400">Loading...</p>
       </div>
     </div>
   );
@@ -57,14 +57,14 @@ function LoginScreen() {
   const { login } = useAuth();
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-primary-600 to-accent-600 flex items-center justify-center p-4">
-      <div className="bg-white rounded-xl shadow-2xl p-8 max-w-md w-full">
+    <div className="min-h-screen bg-gradient-to-br from-primary-600 to-accent-600 dark:from-primary-900 dark:to-accent-900 flex items-center justify-center p-4 transition-colors">
+      <div className="bg-white dark:bg-neutral-800 rounded-xl shadow-2xl p-8 max-w-md w-full">
         <div className="text-center mb-8">
           <div className="w-16 h-16 bg-primary-600 rounded-xl flex items-center justify-center mx-auto mb-4">
             <span className="text-white font-bold text-xl">SP</span>
           </div>
-          <h1 className="text-2xl font-bold text-gray-900">STOA Developer Portal</h1>
-          <p className="text-gray-500 mt-2">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">STOA Developer Portal</h1>
+          <p className="text-gray-500 dark:text-neutral-400 mt-2">
             Sign in to access tools and APIs
           </p>
         </div>
@@ -76,9 +76,9 @@ function LoginScreen() {
           Sign in with SSO
         </button>
 
-        <p className="text-center text-sm text-gray-500 mt-6">
+        <p className="text-center text-sm text-gray-500 dark:text-neutral-400 mt-6">
           Don't have an account?{' '}
-          <a href={`${config.services.console.url}/register`} className="text-primary-600 hover:underline">
+          <a href={`${config.services.console.url}/register`} className="text-primary-600 dark:text-primary-400 hover:underline">
             Contact your administrator
           </a>
         </p>

--- a/portal/src/components/layout/Footer.tsx
+++ b/portal/src/components/layout/Footer.tsx
@@ -2,8 +2,8 @@ import { config } from '../../config';
 
 export function Footer() {
   return (
-    <footer className="bg-white border-t border-gray-200 py-4 px-6">
-      <div className="flex flex-col sm:flex-row justify-between items-center gap-2 text-sm text-gray-500">
+    <footer className="bg-white dark:bg-neutral-900 border-t border-gray-200 dark:border-neutral-800 py-4 px-6 transition-colors">
+      <div className="flex flex-col sm:flex-row justify-between items-center gap-2 text-sm text-gray-500 dark:text-neutral-400">
         <div>
           &copy; {new Date().getFullYear()} STOA Platform. All rights reserved.
         </div>
@@ -12,7 +12,7 @@ export function Footer() {
             href={config.services.docs.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="hover:text-gray-700"
+            className="hover:text-gray-700 dark:hover:text-neutral-200 transition-colors"
           >
             Documentation
           </a>

--- a/portal/src/components/layout/Header.tsx
+++ b/portal/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Menu, Bell, User, LogOut, ExternalLink } from 'lucide-react';
+import { ThemeToggle } from '@stoa/shared/components/ThemeToggle';
 import { useAuth } from '../../contexts/AuthContext';
 import { config } from '../../config';
 
@@ -11,13 +12,13 @@ export function Header({ onMenuClick }: HeaderProps) {
   const { user, logout } = useAuth();
 
   return (
-    <header className="bg-white border-b border-gray-200 sticky top-0 z-30">
+    <header className="bg-white dark:bg-neutral-900 border-b border-gray-200 dark:border-neutral-800 sticky top-0 z-30 transition-colors">
       <div className="flex items-center justify-between h-16 px-4 sm:px-6 lg:px-8">
         {/* Left: Menu button + Logo */}
         <div className="flex items-center gap-4">
           <button
             onClick={onMenuClick}
-            className="lg:hidden p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-md"
+            className="lg:hidden p-2 text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-800 rounded-md transition-colors"
             aria-label="Open menu"
           >
             <Menu className="h-6 w-6" aria-hidden="true" />
@@ -28,8 +29,8 @@ export function Header({ onMenuClick }: HeaderProps) {
               <span className="text-white font-bold text-sm">SP</span>
             </div>
             <div className="hidden sm:block">
-              <h1 className="text-lg font-semibold text-gray-900">STOA</h1>
-              <p className="text-xs text-gray-500 -mt-1">Developer Portal</p>
+              <h1 className="text-lg font-semibold text-gray-900 dark:text-white">STOA</h1>
+              <p className="text-xs text-gray-500 dark:text-neutral-400 -mt-1">Developer Portal</p>
             </div>
           </Link>
         </div>
@@ -46,16 +47,19 @@ export function Header({ onMenuClick }: HeaderProps) {
             href={config.services.console.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="hidden sm:flex items-center gap-1 px-3 py-2 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-md"
+            className="hidden sm:flex items-center gap-1 px-3 py-2 text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-neutral-100 hover:bg-gray-100 dark:hover:bg-neutral-800 rounded-md transition-colors"
           >
             <span>Console</span>
             <ExternalLink className="h-3 w-3" aria-hidden="true" />
             <span className="sr-only">(opens in new tab)</span>
           </a>
 
+          {/* Theme toggle */}
+          <ThemeToggle size="md" />
+
           {/* Notifications */}
           <button
-            className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-md relative"
+            className="p-2 text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-800 rounded-md relative transition-colors"
             aria-label="Notifications"
           >
             <Bell className="h-5 w-5" aria-hidden="true" />
@@ -66,35 +70,35 @@ export function Header({ onMenuClick }: HeaderProps) {
           {/* User menu */}
           <div className="relative group">
             <button
-              className="flex items-center gap-2 p-2 hover:bg-gray-100 rounded-md"
+              className="flex items-center gap-2 p-2 hover:bg-gray-100 dark:hover:bg-neutral-800 rounded-md transition-colors"
               aria-label="User menu"
               aria-haspopup="true"
             >
-              <div className="w-8 h-8 bg-primary-100 rounded-full flex items-center justify-center">
-                <User className="h-4 w-4 text-primary-600" aria-hidden="true" />
+              <div className="w-8 h-8 bg-primary-100 dark:bg-primary-900/30 rounded-full flex items-center justify-center">
+                <User className="h-4 w-4 text-primary-600 dark:text-primary-400" aria-hidden="true" />
               </div>
-              <span className="hidden sm:block text-sm font-medium text-gray-700">
+              <span className="hidden sm:block text-sm font-medium text-gray-700 dark:text-neutral-300">
                 {user?.name || 'User'}
               </span>
             </button>
 
             {/* Dropdown */}
-            <div className="absolute right-0 mt-1 w-56 bg-white rounded-md shadow-lg border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-150">
-              <div className="px-4 py-3 border-b border-gray-100">
-                <p className="text-sm font-medium text-gray-900">{user?.name}</p>
-                <p className="text-xs text-gray-500 truncate">{user?.email}</p>
+            <div className="absolute right-0 mt-1 w-56 bg-white dark:bg-neutral-800 rounded-md shadow-lg border border-gray-200 dark:border-neutral-700 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-150">
+              <div className="px-4 py-3 border-b border-gray-100 dark:border-neutral-700">
+                <p className="text-sm font-medium text-gray-900 dark:text-white">{user?.name}</p>
+                <p className="text-xs text-gray-500 dark:text-neutral-400 truncate">{user?.email}</p>
               </div>
               <div className="py-1">
                 <Link
                   to="/profile"
-                  className="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                  className="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-neutral-300 hover:bg-gray-100 dark:hover:bg-neutral-700"
                 >
                   <User className="h-4 w-4" aria-hidden="true" />
                   My Profile
                 </Link>
                 <button
                   onClick={logout}
-                  className="w-full flex items-center gap-2 px-4 py-2 text-sm text-red-600 hover:bg-red-50"
+                  className="w-full flex items-center gap-2 px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20"
                 >
                   <LogOut className="h-4 w-4" aria-hidden="true" />
                   Sign out

--- a/portal/src/components/layout/Layout.tsx
+++ b/portal/src/components/layout/Layout.tsx
@@ -13,7 +13,7 @@ export function Layout({ children }: LayoutProps) {
   const { showSpotlight, dismissSpotlight } = useUACSpotlight();
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col">
+    <div className="min-h-screen bg-gray-50 dark:bg-neutral-900 flex flex-col transition-colors">
       <Header onMenuClick={() => setSidebarOpen(true)} />
 
       <div className="flex flex-1">

--- a/portal/src/components/layout/Sidebar.tsx
+++ b/portal/src/components/layout/Sidebar.tsx
@@ -74,7 +74,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
       {/* Mobile overlay */}
       {isOpen && (
         <div
-          className="fixed inset-0 bg-gray-600 bg-opacity-50 z-40 lg:hidden"
+          className="fixed inset-0 bg-gray-600/50 dark:bg-black/60 z-40 lg:hidden"
           onClick={onClose}
           aria-hidden="true"
         />
@@ -83,7 +83,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
       {/* Sidebar */}
       <aside
         className={`
-          fixed top-0 left-0 z-50 h-full w-64 bg-white border-r border-gray-200
+          fixed top-0 left-0 z-50 h-full w-64 bg-white dark:bg-neutral-900 border-r border-gray-200 dark:border-neutral-800
           transform transition-transform duration-200 ease-in-out
           lg:translate-x-0 lg:static lg:z-auto lg:h-auto lg:min-h-full
           flex flex-col
@@ -91,11 +91,11 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         `}
       >
         {/* Mobile close button */}
-        <div className="flex items-center justify-between h-16 px-4 border-b border-gray-200 lg:hidden">
-          <span className="text-lg font-semibold text-gray-900">Menu</span>
+        <div className="flex items-center justify-between h-16 px-4 border-b border-gray-200 dark:border-neutral-800 lg:hidden">
+          <span className="text-lg font-semibold text-gray-900 dark:text-white">Menu</span>
           <button
             onClick={onClose}
-            className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+            className="p-2 text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-800 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors"
             aria-label="Close menu"
           >
             <X className="h-5 w-5" aria-hidden="true" />
@@ -112,8 +112,8 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               className={({ isActive }) =>
                 `flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors cursor-pointer ${
                   isActive
-                    ? 'bg-primary-50 text-primary-700'
-                    : 'text-gray-700 hover:bg-gray-100'
+                    ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400'
+                    : 'text-gray-700 dark:text-neutral-300 hover:bg-gray-100 dark:hover:bg-neutral-800'
                 }`
               }
             >
@@ -124,27 +124,27 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         </nav>
 
         {/* Footer info */}
-        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200 bg-white">
+        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
           <a
             href={`https://api.${config.baseDomain}/docs`}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2 text-xs text-primary-600 hover:text-primary-700 mb-2 transition-colors"
+            className="flex items-center gap-2 text-xs text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 mb-2 transition-colors"
           >
             <BookOpen className="h-3.5 w-3.5" aria-hidden="true" />
             API Documentation
             <ExternalLink className="h-3 w-3" aria-hidden="true" />
             <span className="sr-only">(opens in new tab)</span>
           </a>
-          <div className="text-xs text-gray-500">
+          <div className="text-xs text-gray-500 dark:text-neutral-400">
             <p>STOA Developer Portal</p>
             <p>v{config.app.version}</p>
           </div>
 
           {/* Debug: show user roles in development */}
           {import.meta.env.DEV && user && (
-            <div className="mt-2 pt-2 border-t border-gray-100">
-              <p className="text-xs text-gray-400">
+            <div className="mt-2 pt-2 border-t border-gray-100 dark:border-neutral-800">
+              <p className="text-xs text-gray-400 dark:text-neutral-500">
                 Roles: {user.roles.join(', ') || 'none'}
               </p>
             </div>

--- a/portal/src/main.tsx
+++ b/portal/src/main.tsx
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider as OidcProvider } from 'react-oidc-context';
+import { ThemeProvider } from '@stoa/shared/contexts';
+import { ToastProvider } from '@stoa/shared/components/Toast';
 import App from './App';
 import { config } from './config';
 import './index.css';
@@ -37,12 +39,16 @@ const oidcConfig = {
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <OidcProvider {...oidcConfig}>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </OidcProvider>
-    </QueryClientProvider>
+    <ThemeProvider>
+      <ToastProvider>
+        <QueryClientProvider client={queryClient}>
+          <OidcProvider {...oidcConfig}>
+            <BrowserRouter>
+              <App />
+            </BrowserRouter>
+          </OidcProvider>
+        </QueryClientProvider>
+      </ToastProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/portal/src/pages/subscriptions/MySubscriptions.tsx
+++ b/portal/src/pages/subscriptions/MySubscriptions.tsx
@@ -26,6 +26,8 @@ import {
   Wrench,
   ExternalLink,
 } from 'lucide-react';
+import { ConfirmDialog } from '@stoa/shared/components/ConfirmDialog';
+import { useToastActions } from '@stoa/shared/components/Toast';
 import { useSubscriptions, useRevokeSubscription, useRotateApiKey } from '../../hooks/useSubscriptions';
 import { RevealKeyModal } from '../../components/subscriptions/RevealKeyModal';
 import { RotateKeyModal } from '../../components/subscriptions/RotateKeyModal';
@@ -53,10 +55,12 @@ const statusConfig: Record<string, {
 
 export function MySubscriptions() {
   const { isAuthenticated, accessToken } = useAuth();
+  const toast = useToastActions();
   const [activeTab, setActiveTab] = useState<TabType>('servers');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [confirmRevokeId, setConfirmRevokeId] = useState<string | null>(null);
   const [revealModalSubscription, setRevealModalSubscription] = useState<MCPSubscription | null>(null);
   const [rotateModalSubscription, setRotateModalSubscription] = useState<MCPSubscription | null>(null);
   const [exportModalSubscription, setExportModalSubscription] = useState<MCPSubscription | null>(null);
@@ -99,14 +103,21 @@ export function MySubscriptions() {
     loadServerSubscriptions();
   }, [isAuthenticated, accessToken]);
 
-  const handleRevokeSubscription = async (subscriptionId: string) => {
-    if (confirm('Are you sure you want to revoke this subscription? Your API key will be invalidated immediately.')) {
-      setRevokingId(subscriptionId);
-      try {
-        await revokeMutation.mutateAsync(subscriptionId);
-      } finally {
-        setRevokingId(null);
-      }
+  const handleRevokeSubscription = (subscriptionId: string) => {
+    setConfirmRevokeId(subscriptionId);
+  };
+
+  const confirmRevoke = async () => {
+    if (!confirmRevokeId) return;
+    setRevokingId(confirmRevokeId);
+    try {
+      await revokeMutation.mutateAsync(confirmRevokeId);
+      toast.success('Subscription revoked', 'Your API key has been invalidated.');
+    } catch (error) {
+      toast.error('Failed to revoke subscription', error instanceof Error ? error.message : 'An error occurred');
+    } finally {
+      setRevokingId(null);
+      setConfirmRevokeId(null);
     }
   };
 
@@ -565,6 +576,18 @@ export function MySubscriptions() {
           onClose={() => setExportModalSubscription(null)}
         />
       )}
+
+      {/* Revoke Confirmation Dialog */}
+      <ConfirmDialog
+        open={!!confirmRevokeId}
+        title="Revoke Subscription"
+        message="Are you sure you want to revoke this subscription? Your API key will be invalidated immediately."
+        confirmLabel="Revoke"
+        variant="danger"
+        onConfirm={confirmRevoke}
+        onCancel={() => setConfirmRevokeId(null)}
+        loading={revokingId === confirmRevokeId}
+      />
     </div>
   );
 }

--- a/portal/src/pages/webhooks/WebhooksPage.tsx
+++ b/portal/src/pages/webhooks/WebhooksPage.tsx
@@ -21,6 +21,8 @@ import {
   ToggleRight,
   ExternalLink,
 } from 'lucide-react';
+import { ConfirmDialog } from '@stoa/shared/components/ConfirmDialog';
+import { useToastActions } from '@stoa/shared/components/Toast';
 import { useAuth } from '../../contexts/AuthContext';
 import {
   useWebhooks,
@@ -52,6 +54,7 @@ const statusConfig: Record<string, { label: string; color: string; icon: typeof 
 
 export function WebhooksPage() {
   const { user } = useAuth();
+  const toast = useToastActions();
   const [selectedTenantId, setSelectedTenantId] = useState<string>('');
 
   // Use user's tenant_id if available, otherwise allow admin to select
@@ -63,6 +66,7 @@ export function WebhooksPage() {
   const [viewingDeliveries, setViewingDeliveries] = useState<string | null>(null);
   const [testingWebhook, setTestingWebhook] = useState<string | null>(null);
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [deleteWebhookId, setDeleteWebhookId] = useState<string | null>(null);
 
   const { data: webhooksData, isLoading, isError, refetch } = useWebhooks(tenantId);
   const createMutation = useCreateWebhook();
@@ -73,29 +77,36 @@ export function WebhooksPage() {
   const handleCreate = async (data: WebhookCreate) => {
     try {
       await createMutation.mutateAsync({ tenantId, data });
+      toast.success('Webhook created', 'Your webhook has been created successfully.');
       setShowCreateModal(false);
     } catch (error) {
-      console.error('Failed to create webhook:', error);
+      toast.error('Failed to create webhook', error instanceof Error ? error.message : 'An error occurred');
     }
   };
 
   const handleUpdate = async (webhookId: string, data: Partial<WebhookCreate>) => {
     try {
       await updateMutation.mutateAsync({ tenantId, webhookId, data });
+      toast.success('Webhook updated', 'Your changes have been saved.');
       setEditingWebhook(null);
     } catch (error) {
-      console.error('Failed to update webhook:', error);
+      toast.error('Failed to update webhook', error instanceof Error ? error.message : 'An error occurred');
     }
   };
 
-  const handleDelete = async (webhookId: string) => {
-    if (!confirm('Are you sure you want to delete this webhook? This action cannot be undone.')) {
-      return;
-    }
+  const handleDelete = (webhookId: string) => {
+    setDeleteWebhookId(webhookId);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteWebhookId) return;
     try {
-      await deleteMutation.mutateAsync({ tenantId, webhookId });
+      await deleteMutation.mutateAsync({ tenantId, webhookId: deleteWebhookId });
+      toast.success('Webhook deleted', 'The webhook has been removed.');
     } catch (error) {
-      console.error('Failed to delete webhook:', error);
+      toast.error('Failed to delete webhook', error instanceof Error ? error.message : 'An error occurred');
+    } finally {
+      setDeleteWebhookId(null);
     }
   };
 
@@ -106,8 +117,12 @@ export function WebhooksPage() {
         webhookId: webhook.id,
         data: { enabled: !webhook.enabled },
       });
+      toast.success(
+        webhook.enabled ? 'Webhook disabled' : 'Webhook enabled',
+        `The webhook is now ${webhook.enabled ? 'disabled' : 'active'}.`
+      );
     } catch (error) {
-      console.error('Failed to toggle webhook:', error);
+      toast.error('Failed to toggle webhook', error instanceof Error ? error.message : 'An error occurred');
     }
   };
 
@@ -308,6 +323,18 @@ export function WebhooksPage() {
           onClose={() => setViewingDeliveries(null)}
         />
       )}
+
+      {/* Delete Confirmation Dialog */}
+      <ConfirmDialog
+        open={!!deleteWebhookId}
+        title="Delete Webhook"
+        message="Are you sure you want to delete this webhook? This action cannot be undone."
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteWebhookId(null)}
+        loading={deleteMutation.isPending}
+      />
     </div>
   );
 }

--- a/portal/tailwind.config.js
+++ b/portal/tailwind.config.js
@@ -1,38 +1,24 @@
+// Import shared design tokens
+const tokens = require('../shared/tailwind/tokens.js');
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
+    // Shared components for dark mode classes
+    '../shared/components/**/*.{js,ts,jsx,tsx}',
+    '../shared/contexts/**/*.{js,ts,jsx,tsx}',
   ],
+  darkMode: 'class',
   theme: {
     extend: {
-      colors: {
-        // Developer Portal uses teal/cyan theme to differentiate from Console (blue)
-        primary: {
-          50: '#f0fdfa',
-          100: '#ccfbf1',
-          200: '#99f6e4',
-          300: '#5eead4',
-          400: '#2dd4bf',
-          500: '#14b8a6',
-          600: '#0d9488',
-          700: '#0f766e',
-          800: '#115e59',
-          900: '#134e4a',
-        },
-        accent: {
-          50: '#ecfeff',
-          100: '#cffafe',
-          200: '#a5f3fc',
-          300: '#67e8f9',
-          400: '#22d3ee',
-          500: '#06b6d4',
-          600: '#0891b2',
-          700: '#0e7490',
-          800: '#155e75',
-          900: '#164e63',
-        },
-      },
+      colors: tokens.colors,
+      animation: tokens.animation,
+      keyframes: tokens.keyframes,
+      boxShadow: tokens.boxShadow,
+      borderRadius: tokens.borderRadius,
+      transitionTimingFunction: tokens.transitionTimingFunction,
     },
   },
   plugins: [],

--- a/portal/tsconfig.json
+++ b/portal/tsconfig.json
@@ -17,9 +17,10 @@
     "noFallthroughCasesInSwitch": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@stoa/shared/*": ["../shared/*"]
     }
   },
-  "include": ["src"],
+  "include": ["src", "../shared"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/portal/vite.config.ts
+++ b/portal/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@stoa/shared': path.resolve(__dirname, '../shared'),
+    },
+  },
   server: {
     port: 3001, // Different port from Console (3000)
     proxy: {


### PR DESCRIPTION
## Summary

- Add dark mode support with ThemeProvider and ThemeToggle to Portal
- Add ToastProvider for toast notifications on mutations
- Replace browser `confirm()` with ConfirmDialog component
- Update Layout, Header, Sidebar, Footer with dark mode styles
- Configure Tailwind with shared design tokens
- Add `@stoa/shared` path alias in Vite and TypeScript config

This brings the Portal UX in line with the Console's Apple-like polish implemented in #112.

## Changes

### Dark Mode Support
- `portal/tailwind.config.js` - Added `darkMode: 'class'` and shared tokens
- `portal/src/main.tsx` - Wrapped app with ThemeProvider and ToastProvider
- `portal/src/components/layout/*` - Full dark mode support for all layout components
- `portal/src/App.tsx` - Dark mode for loading/login screens

### Modern Dialogs & Toasts
- `portal/src/pages/subscriptions/MySubscriptions.tsx` - ConfirmDialog for revoke, toast on success/error
- `portal/src/pages/webhooks/WebhooksPage.tsx` - ConfirmDialog for delete, toasts on all mutations

### Configuration
- `portal/vite.config.ts` - Added `@stoa/shared` path alias
- `portal/tsconfig.json` - Added path mapping for shared components

## Test plan

- [ ] Verify dark mode toggle works in Portal header
- [ ] Verify theme persists across page refreshes
- [ ] Verify ConfirmDialog appears for subscription revoke
- [ ] Verify ConfirmDialog appears for webhook delete
- [ ] Verify toast notifications on webhook CRUD operations
- [ ] Verify toast notification on subscription revoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)