### PR TITLE
fix(gateway): apply cargo fmt and clippy fixes for phase 8 (CAB-1096)

### DIFF
--- a/stoa-gateway/src/governance/mod.rs
+++ b/stoa-gateway/src/governance/mod.rs
@@ -22,6 +22,3 @@
 #![allow(dead_code)]
 
 pub mod zombie;
-
-// Re-exports
-pub use zombie::{ZombieDetector, ZombieConfig, ZombieAlert, SessionHealth};

--- a/stoa-gateway/src/governance/zombie.rs
+++ b/stoa-gateway/src/governance/zombie.rs
@@ -193,7 +193,12 @@ impl ZombieDetector {
     }
 
     /// Start a new session
-    pub async fn start_session(&self, session_id: &str, user_id: Option<String>, tenant_id: Option<String>) {
+    pub async fn start_session(
+        &self,
+        session_id: &str,
+        user_id: Option<String>,
+        tenant_id: Option<String>,
+    ) {
         let mut session = TrackedSession::new(session_id.to_string());
         session.user_id = user_id.clone();
         session.tenant_id = tenant_id.clone();
@@ -274,7 +279,10 @@ impl ZombieDetector {
             let idle_secs = session.idle_duration().num_seconds();
 
             // Check for zombie state
-            if idle_secs >= zombie_threshold && session.health != SessionHealth::Zombie && session.health != SessionHealth::Revoked {
+            if idle_secs >= zombie_threshold
+                && session.health != SessionHealth::Zombie
+                && session.health != SessionHealth::Revoked
+            {
                 session.health = SessionHealth::Zombie;
 
                 let alert = ZombieAlert {
@@ -387,7 +395,8 @@ impl ZombieDetector {
     /// Cleanup expired sessions
     pub async fn cleanup(&self) -> usize {
         let mut sessions = self.sessions.write().await;
-        let zombie_threshold = (self.config.session_ttl_secs as f64 * self.config.zombie_factor * 2.0) as i64;
+        let zombie_threshold =
+            (self.config.session_ttl_secs as f64 * self.config.zombie_factor * 2.0) as i64;
 
         let before = sessions.len();
         sessions.retain(|_, session| {
@@ -408,22 +417,31 @@ impl ZombieDetector {
     pub async fn stats(&self) -> ZombieStats {
         let sessions = self.sessions.read().await;
 
-        let mut stats = ZombieStats::default();
-        stats.total_sessions = sessions.len();
+        let mut healthy = 0;
+        let mut warning = 0;
+        let mut expired = 0;
+        let mut zombie = 0;
+        let mut revoked = 0;
 
         for session in sessions.values() {
             match session.health {
-                SessionHealth::Healthy => stats.healthy += 1,
-                SessionHealth::Warning => stats.warning += 1,
-                SessionHealth::Expired => stats.expired += 1,
-                SessionHealth::Zombie => stats.zombie += 1,
-                SessionHealth::Revoked => stats.revoked += 1,
+                SessionHealth::Healthy => healthy += 1,
+                SessionHealth::Warning => warning += 1,
+                SessionHealth::Expired => expired += 1,
+                SessionHealth::Zombie => zombie += 1,
+                SessionHealth::Revoked => revoked += 1,
             }
         }
 
-        stats.alerts_total = self.alerts.read().await.len();
-
-        stats
+        ZombieStats {
+            total_sessions: sessions.len(),
+            healthy,
+            warning,
+            expired,
+            zombie,
+            revoked,
+            alerts_total: self.alerts.read().await.len(),
+        }
     }
 
     /// Get recent alerts
@@ -435,7 +453,10 @@ impl ZombieDetector {
     /// Check if zombie threshold is exceeded
     pub async fn is_alert_threshold_exceeded(&self) -> bool {
         let sessions = self.sessions.read().await;
-        let zombie_count = sessions.values().filter(|s| s.health == SessionHealth::Zombie).count();
+        let zombie_count = sessions
+            .values()
+            .filter(|s| s.health == SessionHealth::Zombie)
+            .count();
         zombie_count >= self.config.alert_threshold
     }
 }
@@ -492,7 +513,9 @@ mod tests {
         let detector = ZombieDetector::new(ZombieConfig::default());
 
         // Start session
-        detector.start_session("test-session", Some("user-1".to_string()), None).await;
+        detector
+            .start_session("test-session", Some("user-1".to_string()), None)
+            .await;
 
         // Record activity
         let health = detector.record_activity("test-session").await.unwrap();
@@ -557,9 +580,9 @@ mod tests {
     #[tokio::test]
     async fn test_zombie_detection() {
         let detector = ZombieDetector::new(ZombieConfig {
-            session_ttl_secs: 1,  // 1 second TTL for testing
-            zombie_factor: 2.0,   // 2 seconds to zombie
-            auto_revoke: false,   // Don't auto-revoke for this test
+            session_ttl_secs: 1, // 1 second TTL for testing
+            zombie_factor: 2.0,  // 2 seconds to zombie
+            auto_revoke: false,  // Don't auto-revoke for this test
             ..Default::default()
         });
 

--- a/stoa-gateway/src/mode/mod.rs
+++ b/stoa-gateway/src/mode/mod.rs
@@ -370,7 +370,8 @@ impl EdgeMcpSettings {
 impl SidecarSettings {
     fn from_env() -> Self {
         Self {
-            upstream_type: std::env::var("STOA_UPSTREAM_TYPE").unwrap_or_else(|_| "generic".to_string()),
+            upstream_type: std::env::var("STOA_UPSTREAM_TYPE")
+                .unwrap_or_else(|_| "generic".to_string()),
             user_info_header: std::env::var("STOA_USER_INFO_HEADER")
                 .unwrap_or_else(|_| "X-User-Info".to_string()),
             tenant_id_header: std::env::var("STOA_TENANT_ID_HEADER")
@@ -431,11 +432,20 @@ mod tests {
 
     #[test]
     fn test_gateway_mode_parse() {
-        assert_eq!("edge-mcp".parse::<GatewayMode>().unwrap(), GatewayMode::EdgeMcp);
+        assert_eq!(
+            "edge-mcp".parse::<GatewayMode>().unwrap(),
+            GatewayMode::EdgeMcp
+        );
         assert_eq!("mcp".parse::<GatewayMode>().unwrap(), GatewayMode::EdgeMcp);
-        assert_eq!("sidecar".parse::<GatewayMode>().unwrap(), GatewayMode::Sidecar);
+        assert_eq!(
+            "sidecar".parse::<GatewayMode>().unwrap(),
+            GatewayMode::Sidecar
+        );
         assert_eq!("proxy".parse::<GatewayMode>().unwrap(), GatewayMode::Proxy);
-        assert_eq!("shadow".parse::<GatewayMode>().unwrap(), GatewayMode::Shadow);
+        assert_eq!(
+            "shadow".parse::<GatewayMode>().unwrap(),
+            GatewayMode::Shadow
+        );
         assert!("invalid".parse::<GatewayMode>().is_err());
     }
 

--- a/stoa-gateway/src/mode/proxy.rs
+++ b/stoa-gateway/src/mode/proxy.rs
@@ -49,7 +49,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, instrument};
 
 /// Proxy errors
 #[derive(Error, Debug)]
@@ -303,7 +303,10 @@ impl ProxyService {
 
         // Apply request transformers
         for transformer in &self.transformers {
-            debug!(transformer = transformer.name(), "Applying request transformer");
+            debug!(
+                transformer = transformer.name(),
+                "Applying request transformer"
+            );
             transformer.transform(&mut proxy_request)?;
         }
 
@@ -312,7 +315,10 @@ impl ProxyService {
 
         // Apply response transformers
         for transformer in &self.response_transformers {
-            debug!(transformer = transformer.name(), "Applying response transformer");
+            debug!(
+                transformer = transformer.name(),
+                "Applying response transformer"
+            );
             transformer.transform(&mut proxy_response)?;
         }
 
@@ -417,16 +423,13 @@ impl ProxyService {
         req_builder = req_builder.timeout(Duration::from_secs(route.timeout_secs));
 
         // Send request
-        let response = req_builder
-            .send()
-            .await
-            .map_err(|e| {
-                if e.is_timeout() {
-                    ProxyError::Timeout
-                } else {
-                    ProxyError::Connection(e.to_string())
-                }
-            })?;
+        let response = req_builder.send().await.map_err(|e| {
+            if e.is_timeout() {
+                ProxyError::Timeout
+            } else {
+                ProxyError::Connection(e.to_string())
+            }
+        })?;
 
         let upstream_time = start.elapsed().as_millis() as u64;
 
@@ -595,9 +598,15 @@ mod tests {
     #[test]
     fn test_hop_by_hop_headers() {
         assert!(is_hop_by_hop_header(&HeaderName::from_static("connection")));
-        assert!(is_hop_by_hop_header(&HeaderName::from_static("transfer-encoding")));
-        assert!(!is_hop_by_hop_header(&HeaderName::from_static("content-type")));
-        assert!(!is_hop_by_hop_header(&HeaderName::from_static("authorization")));
+        assert!(is_hop_by_hop_header(&HeaderName::from_static(
+            "transfer-encoding"
+        )));
+        assert!(!is_hop_by_hop_header(&HeaderName::from_static(
+            "content-type"
+        )));
+        assert!(!is_hop_by_hop_header(&HeaderName::from_static(
+            "authorization"
+        )));
     }
 
     #[test]

--- a/stoa-gateway/src/mode/shadow.rs
+++ b/stoa-gateway/src/mode/shadow.rs
@@ -50,7 +50,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 /// Captured HTTP transaction
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -468,24 +468,22 @@ impl ShadowService {
         let error_rate = errors as f64 / transactions.len() as f64;
 
         // Detect auth type
-        let auth_type = transactions
-            .iter()
-            .find_map(|t| {
-                if t.request.headers.contains_key("authorization") {
-                    let auth = t.request.headers.get("authorization")?;
-                    if auth.to_lowercase().starts_with("bearer") {
-                        Some("bearer".to_string())
-                    } else if auth.to_lowercase().starts_with("basic") {
-                        Some("basic".to_string())
-                    } else {
-                        Some("unknown".to_string())
-                    }
-                } else if t.request.headers.contains_key("x-api-key") {
-                    Some("api_key".to_string())
+        let auth_type = transactions.iter().find_map(|t| {
+            if t.request.headers.contains_key("authorization") {
+                let auth = t.request.headers.get("authorization")?;
+                if auth.to_lowercase().starts_with("bearer") {
+                    Some("bearer".to_string())
+                } else if auth.to_lowercase().starts_with("basic") {
+                    Some("basic".to_string())
                 } else {
-                    None
+                    Some("unknown".to_string())
                 }
-            });
+            } else if t.request.headers.contains_key("x-api-key") {
+                Some("api_key".to_string())
+            } else {
+                None
+            }
+        });
 
         // Collect content types
         let content_types: Vec<String> = transactions
@@ -602,7 +600,8 @@ impl ShadowService {
             }],
             metadata: UacMetadata {
                 generated_at: now,
-                analysis_start: now - chrono::Duration::hours(self.settings.analysis_window_hours as i64),
+                analysis_start: now
+                    - chrono::Duration::hours(self.settings.analysis_window_hours as i64),
                 analysis_end: now,
                 transactions_analyzed: self.transactions.read().await.len() as u64,
                 endpoints_detected: endpoints.len() as u64,

--- a/stoa-gateway/src/mode/sidecar.rs
+++ b/stoa-gateway/src/mode/sidecar.rs
@@ -40,13 +40,13 @@ use super::{DecisionFormat, SidecarSettings};
 use axum::{
     body::Body,
     extract::State,
-    http::{HeaderMap, Request, StatusCode},
+    http::StatusCode,
     response::{IntoResponse, Response},
     Json,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 /// Sidecar authorization request (from upstream gateway)
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -212,7 +212,10 @@ impl AuthzResponse {
             status_code: Some(429),
             headers_to_add: [
                 ("X-RateLimit-Limit".to_string(), state.limit.to_string()),
-                ("X-RateLimit-Remaining".to_string(), state.remaining.to_string()),
+                (
+                    "X-RateLimit-Remaining".to_string(),
+                    state.remaining.to_string(),
+                ),
                 ("X-RateLimit-Reset".to_string(), state.reset_at.to_string()),
             ]
             .into_iter()
@@ -491,8 +494,14 @@ mod tests {
             .with_header("X-Another", "test");
 
         assert!(response.allowed);
-        assert_eq!(response.headers_to_add.get("X-Custom"), Some(&"value".to_string()));
-        assert_eq!(response.headers_to_add.get("X-Another"), Some(&"test".to_string()));
+        assert_eq!(
+            response.headers_to_add.get("X-Custom"),
+            Some(&"value".to_string())
+        );
+        assert_eq!(
+            response.headers_to_add.get("X-Another"),
+            Some(&"test".to_string())
+        );
     }
 
     #[test]

--- a/stoa-gateway/src/shadow/capture.rs
+++ b/stoa-gateway/src/shadow/capture.rs
@@ -55,7 +55,10 @@ pub struct TrafficCapture {
 
 impl TrafficCapture {
     /// Create a new traffic capture service
-    pub fn new(source: CaptureSource, buffer_size: usize) -> (Self, mpsc::Receiver<CapturedTransaction>) {
+    pub fn new(
+        source: CaptureSource,
+        buffer_size: usize,
+    ) -> (Self, mpsc::Receiver<CapturedTransaction>) {
         let (tx, rx) = mpsc::channel(buffer_size);
         let capture = Self {
             source,
@@ -67,7 +70,8 @@ impl TrafficCapture {
 
     /// Start capturing traffic
     pub async fn start(&self) {
-        self.running.store(true, std::sync::atomic::Ordering::SeqCst);
+        self.running
+            .store(true, std::sync::atomic::Ordering::SeqCst);
         info!(source = ?self.source, "Starting traffic capture");
 
         match &self.source {
@@ -81,7 +85,11 @@ impl TrafficCapture {
                 // Inline capture is handled by the proxy middleware
                 info!("Inline capture mode - traffic captured via proxy");
             }
-            CaptureSource::KafkaReplay { brokers, topic, group_id } => {
+            CaptureSource::KafkaReplay {
+                brokers,
+                topic,
+                group_id,
+            } => {
                 self.capture_kafka_replay(brokers, topic, group_id).await;
             }
         }
@@ -89,7 +97,8 @@ impl TrafficCapture {
 
     /// Stop capturing
     pub fn stop(&self) {
-        self.running.store(false, std::sync::atomic::Ordering::SeqCst);
+        self.running
+            .store(false, std::sync::atomic::Ordering::SeqCst);
         info!("Stopping traffic capture");
     }
 
@@ -169,7 +178,9 @@ impl TrafficCapture {
 
         for line in lines {
             if line.is_empty() {
-                body_start = text.find("\r\n\r\n").map(|i| i + 4)
+                body_start = text
+                    .find("\r\n\r\n")
+                    .map(|i| i + 4)
                     .or_else(|| text.find("\n\n").map(|i| i + 2))
                     .unwrap_or(raw.len());
                 break;
@@ -191,7 +202,8 @@ impl TrafficCapture {
         }
 
         // Parse body if JSON
-        let body = if body_start < raw.len() && content_type.as_deref() == Some("application/json") {
+        let body = if body_start < raw.len() && content_type.as_deref() == Some("application/json")
+        {
             serde_json::from_slice(&raw[body_start..]).ok()
         } else {
             None
@@ -229,7 +241,9 @@ impl TrafficCapture {
 
         for line in lines {
             if line.is_empty() {
-                body_start = text.find("\r\n\r\n").map(|i| i + 4)
+                body_start = text
+                    .find("\r\n\r\n")
+                    .map(|i| i + 4)
                     .or_else(|| text.find("\n\n").map(|i| i + 2))
                     .unwrap_or(raw.len());
                 break;
@@ -248,7 +262,12 @@ impl TrafficCapture {
         }
 
         // Parse body if JSON
-        let body = if body_start < raw.len() && content_type.as_deref().map(|ct| ct.contains("json")).unwrap_or(false) {
+        let body = if body_start < raw.len()
+            && content_type
+                .as_deref()
+                .map(|ct| ct.contains("json"))
+                .unwrap_or(false)
+        {
             serde_json::from_slice(&raw[body_start..]).ok()
         } else {
             None

--- a/stoa-gateway/src/shadow/mod.rs
+++ b/stoa-gateway/src/shadow/mod.rs
@@ -19,17 +19,3 @@
 #![allow(dead_code)]
 
 pub mod capture;
-
-// Re-export capture utilities
-pub use capture::{CaptureSource, TrafficCapture};
-
-// Re-export types from mode::shadow for convenience
-pub use crate::mode::shadow::{
-    CapturedRequest,
-    CapturedResponse,
-    CapturedTransaction,
-    EndpointPattern,
-    GeneratedUac,
-    ShadowService,
-    ShadowStatus,
-};


### PR DESCRIPTION
## Summary

- Fix formatting issues (line length, import ordering) introduced in Phase 8
- Remove unused imports (ZombieDetector re-exports, warn, error, etc.)
- Fix `field_reassign_with_default` clippy warning in `zombie.rs stats()`

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features` has no warnings
- [x] `cargo test` - all 121 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)