### PR TITLE
fix(portal): use monorepo context for Docker build (CAB-1094)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -105,7 +105,9 @@ jobs:
         id: build
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
-          context: ./${{ matrix.service }}
+          # Use repo root context for UI apps that depend on shared/
+          context: ${{ (matrix.service == 'portal' || matrix.service == 'control-plane-ui') && '.' || format('./{0}', matrix.service) }}
+          file: ./${{ matrix.service }}/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/stoa-portal-ci.yml
+++ b/.github/workflows/stoa-portal-ci.yml
@@ -12,6 +12,7 @@ on:
       - main
     paths:
       - 'portal/**'
+      - 'shared/**'
       - '.github/workflows/stoa-portal-ci.yml'
       - '.github/workflows/reusable-node-ci.yml'
       - '.github/workflows/reusable-docker-ecr.yml'
@@ -23,6 +24,7 @@ on:
       - main
     paths:
       - 'portal/**'
+      - 'shared/**'
       - '.github/workflows/stoa-portal-ci.yml'
       - '.github/workflows/reusable-node-ci.yml'
       - '.github/actions/**'
@@ -72,6 +74,7 @@ jobs:
       ecr-repository: apim/stoa-portal
       environment: ${{ github.event.inputs.environment || 'dev' }}
       platforms: linux/amd64,linux/arm64
+      use-monorepo-context: true
       build-args: |
         VITE_BASE_DOMAIN=gostoa.dev
         VITE_ENVIRONMENT=${{ github.event.inputs.environment || 'dev' }}

--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -1,16 +1,27 @@
 # Build stage
+# NOTE: Build context must be repo root (not portal/)
+# Use: docker build -f portal/Dockerfile .
 FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+# Copy shared package first (monorepo dependency)
+COPY shared/package*.json ./shared/
+RUN cd shared && npm ci --ignore-scripts
+
+# Copy main package files
+COPY portal/package*.json ./portal/
 
 # Install dependencies
+WORKDIR /app/portal
 RUN npm ci
 
-# Copy source
-COPY . .
+# Copy source files
+WORKDIR /app
+COPY shared/ ./shared/
+COPY portal/ ./portal/
+
+WORKDIR /app/portal
 
 # Build arguments - Override with --build-arg during docker build
 # Example: docker build --build-arg VITE_BASE_DOMAIN=staging.example.com .
@@ -75,10 +86,10 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:alpine
 
 # Copy custom nginx config (nginx-unprivileged uses 8080 by default)
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY portal/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Copy built app
-COPY --from=builder /app/dist /usr/share/nginx/html
+COPY --from=builder /app/portal/dist /usr/share/nginx/html
 
 # nginx-unprivileged listens on 8080
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- Fix Portal Docker build failure caused by missing `@stoa/shared` module
- Portal now depends on shared components (Toast, ThemeToggle, ConfirmDialog)
- Update Dockerfile to use repo root as build context to include `shared/` folder

## Changes
- **portal/Dockerfile**: Use monorepo context pattern (copy shared/ before portal/)
- **stoa-portal-ci.yml**: Add `use-monorepo-context: true`, add `shared/**` to trigger paths
- **docker-publish.yml**: Use repo root context for portal and control-plane-ui

## Test plan
- [ ] Verify Portal Docker build succeeds in CI
- [ ] Verify Portal deployment completes
- [ ] Verify Portal loads correctly with dark mode toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)