### PR TITLE
feat(helm): add STOA sidecar for 3rd-party gateways (ADR-028)

### DIFF
--- a/charts/stoa-platform/templates/stoa-sidecar-deployment.yaml
+++ b/charts/stoa-platform/templates/stoa-sidecar-deployment.yaml
@@ -1,0 +1,176 @@
+{{- if .Values.stoaSidecar.enabled }}
+---
+# ==============================================================================
+# STOA Sidecar Deployment
+# ==============================================================================
+# Deploys STOA Gateway in sidecar mode alongside third-party gateways
+# (WebMethods, Kong, Envoy, etc.). The sidecar provides:
+# - ext_authz endpoint for policy enforcement
+# - Rate limiting
+# - Usage metering (Kafka pipeline)
+# - OIDC token validation
+#
+# Third-party gateway configures ext_authz to point to the sidecar:
+#   ext_authz_url: http://localhost:8081/authz
+# ==============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.stoaSidecar.targetGateway | default "third-party" }}-with-stoa-sidecar
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: stoa-sidecar
+    app.kubernetes.io/component: sidecar
+    stoa.io/target-gateway: {{ .Values.stoaSidecar.targetGateway | default "generic" }}
+    {{- include "stoa-platform.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.stoaSidecar.replicas | default 2 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: stoa-sidecar
+      stoa.io/target-gateway: {{ .Values.stoaSidecar.targetGateway | default "generic" }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: stoa-sidecar
+        app.kubernetes.io/component: sidecar
+        stoa.io/target-gateway: {{ .Values.stoaSidecar.targetGateway | default "generic" }}
+        {{- include "stoa-platform.labels" . | nindent 8 }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8081"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: {{ .Values.stoaSidecar.serviceAccount | default "default" }}
+      containers:
+        # --- Main Gateway Container (third-party: WebMethods, Kong, etc.) ---
+        {{- if .Values.stoaSidecar.mainGateway.enabled }}
+        - name: {{ .Values.stoaSidecar.targetGateway | default "gateway" }}
+          image: "{{ .Values.stoaSidecar.mainGateway.image.repository }}:{{ .Values.stoaSidecar.mainGateway.image.tag }}"
+          imagePullPolicy: {{ .Values.stoaSidecar.mainGateway.image.pullPolicy | default "Always" }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.stoaSidecar.mainGateway.port | default 8080 }}
+              protocol: TCP
+          env:
+            {{- with .Values.stoaSidecar.mainGateway.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            # Configure ext_authz to point to STOA sidecar
+            - name: EXT_AUTHZ_URL
+              value: "http://localhost:8081/authz"
+          resources:
+            {{- toYaml .Values.stoaSidecar.mainGateway.resources | nindent 12 }}
+        {{- end }}
+
+        # --- STOA Sidecar Container ---
+        - name: stoa-sidecar
+          image: "{{ .Values.stoaSidecar.image.repository }}:{{ .Values.stoaSidecar.image.tag }}"
+          imagePullPolicy: {{ .Values.stoaSidecar.image.pullPolicy | default "Always" }}
+          ports:
+            - name: authz
+              containerPort: 8081
+              protocol: TCP
+          env:
+            # Sidecar mode configuration
+            - name: STOA_GATEWAY_MODE
+              value: "sidecar"
+            - name: STOA_PORT
+              value: "8081"
+            - name: STOA_HOST
+              value: "127.0.0.1"  # Only accessible from localhost (within pod)
+            - name: STOA_AUTO_REGISTER
+              value: "true"
+            - name: STOA_ENVIRONMENT
+              value: {{ .Values.stoaSidecar.environment | default "dev" | quote }}
+
+            # Control Plane connection
+            - name: STOA_CONTROL_PLANE_URL
+              value: {{ .Values.stoaSidecar.controlPlaneUrl | default "http://control-plane-api.stoa-system.svc.cluster.local:8000" | quote }}
+            {{- if .Values.stoaSidecar.secretName }}
+            - name: STOA_CONTROL_PLANE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.stoaSidecar.secretName }}
+                  key: control-plane-api-key
+                  optional: true
+            {{- end }}
+
+            # OIDC configuration (for token validation)
+            - name: STOA_KEYCLOAK_URL
+              value: {{ .Values.stoaSidecar.keycloakUrl | default "" | quote }}
+            - name: STOA_KEYCLOAK_REALM
+              value: {{ .Values.stoaSidecar.keycloakRealm | default "stoa" | quote }}
+            - name: STOA_KEYCLOAK_CLIENT_ID
+              value: {{ .Values.stoaSidecar.keycloakClientId | default "stoa-sidecar" | quote }}
+            {{- if .Values.stoaSidecar.secretName }}
+            - name: STOA_KEYCLOAK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.stoaSidecar.secretName }}
+                  key: keycloak-client-secret
+                  optional: true
+            {{- end }}
+
+            # Policy engine
+            - name: STOA_POLICY_ENABLED
+              value: {{ .Values.stoaSidecar.policyEnabled | default "true" | quote }}
+
+            # Logging
+            - name: STOA_LOG_LEVEL
+              value: {{ .Values.stoaSidecar.logLevel | default "info" | quote }}
+            - name: STOA_LOG_FORMAT
+              value: {{ .Values.stoaSidecar.logFormat | default "json" | quote }}
+
+            {{- with .Values.stoaSidecar.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: authz
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: authz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.stoaSidecar.resources | nindent 12 }}
+      {{- with .Values.stoaSidecar.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.stoaSidecar.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+---
+# Service for exposing the main gateway (external traffic)
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.stoaSidecar.targetGateway | default "third-party" }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: stoa-sidecar
+    stoa.io/target-gateway: {{ .Values.stoaSidecar.targetGateway | default "generic" }}
+    {{- include "stoa-platform.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.stoaSidecar.service.type | default "ClusterIP" }}
+  ports:
+    - name: http
+      port: {{ .Values.stoaSidecar.service.port | default 80 }}
+      targetPort: {{ .Values.stoaSidecar.mainGateway.port | default 8080 }}
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: stoa-sidecar
+    stoa.io/target-gateway: {{ .Values.stoaSidecar.targetGateway | default "generic" }}
+{{- end }}

--- a/charts/stoa-platform/values.yaml
+++ b/charts/stoa-platform/values.yaml
@@ -94,6 +94,104 @@ stoaGateway:
   tolerations: []
   extraEnv: []
 
+# ==============================================================================
+# STOA Sidecar Configuration (ADR-028: Tier 2 - Third-Party Gateway Integration)
+# ==============================================================================
+# Deploy STOA Gateway in sidecar mode alongside third-party gateways
+# (WebMethods, Kong, Envoy, Apigee). Provides:
+# - ext_authz endpoint for policy enforcement
+# - Rate limiting
+# - Usage metering via Kafka
+# - OIDC token validation
+#
+# Example usage for WebMethods:
+#   stoaSidecar:
+#     enabled: true
+#     targetGateway: webmethods
+#     mainGateway:
+#       enabled: true
+#       image:
+#         repository: softwareag/webmethods-api-gateway
+#         tag: "10.15"
+#       port: 9072
+#       env:
+#         - name: EXT_AUTHZ_URL
+#           value: "http://localhost:8081/authz"
+# ==============================================================================
+stoaSidecar:
+  enabled: false
+  # Target gateway type (for labeling/identification)
+  targetGateway: webmethods  # webmethods | kong | envoy | apigee | generic
+
+  # STOA Sidecar image (Rust gateway in sidecar mode)
+  image:
+    repository: 848853684735.dkr.ecr.eu-west-1.amazonaws.com/apim/stoa-gateway
+    tag: latest
+    pullPolicy: Always
+
+  replicas: 2
+  serviceAccount: default
+  environment: dev  # dev | staging | prod
+
+  # Control Plane connection (for auto-registration)
+  controlPlaneUrl: "http://control-plane-api.stoa-system.svc.cluster.local:8000"
+
+  # Keycloak OIDC (for token validation)
+  keycloakUrl: ""
+  keycloakRealm: stoa
+  keycloakClientId: stoa-sidecar
+
+  # Secret containing credentials
+  secretName: stoa-sidecar-secrets
+
+  # Policy enforcement
+  policyEnabled: true
+
+  # Logging
+  logLevel: info
+  logFormat: json
+
+  # Service configuration
+  service:
+    type: ClusterIP
+    port: 80
+
+  # Main gateway container (third-party gateway running alongside)
+  mainGateway:
+    enabled: true
+    image:
+      repository: softwareag/webmethods-api-gateway
+      tag: "10.15"
+      pullPolicy: IfNotPresent
+    port: 9072
+    env:
+      # WebMethods-specific environment variables
+      - name: JAVA_OPTS
+        value: "-Xms512m -Xmx1g"
+      # Configure ext_authz to point to STOA sidecar
+      - name: EXT_AUTHZ_ENABLED
+        value: "true"
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: 2000m
+        memory: 4Gi
+
+  # STOA sidecar resources (minimal footprint)
+  resources:
+    requests:
+      cpu: 50m
+      memory: 32Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  extraEnv: []
+
 # Gateway OpenAPI Sync Configuration
 # Automatically syncs OpenAPI spec from Control-Plane-API to webMethods Gateway
 gatewaySync:

--- a/docs/integrations/webmethods-sidecar-integration.md
+++ b/docs/integrations/webmethods-sidecar-integration.md
@@ -1,0 +1,261 @@
+# WebMethods Gateway + STOA Sidecar Integration
+
+This guide explains how to deploy Software AG webMethods API Gateway with STOA sidecar for policy enforcement, rate limiting, and usage metering.
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Kubernetes Pod                           │
+│  ┌──────────────────────┐    ┌───────────────────────────────┐  │
+│  │   webMethods API     │    │      STOA Sidecar             │  │
+│  │      Gateway         │    │    (sidecar mode)             │  │
+│  │                      │    │                               │  │
+│  │  ┌────────────────┐  │    │  ┌─────────────────────────┐  │  │
+│  │  │   ext_authz    │──┼────┼──│  /authz endpoint       │  │  │
+│  │  │   filter       │  │    │  │  - OPA policies        │  │  │
+│  │  └────────────────┘  │    │  │  - Rate limiting       │  │  │
+│  │                      │    │  │  - Token validation    │  │  │
+│  │  Port: 9072          │    │  └─────────────────────────┘  │  │
+│  │  (API traffic)       │    │                               │  │
+│  └──────────────────────┘    │  Port: 8081                   │  │
+│                              │  (internal only)              │  │
+│                              │                               │  │
+│                              │  ┌─────────────────────────┐  │  │
+│                              │  │  Auto-registration      │  │  │
+│                              │  │  → Control Plane        │  │  │
+│                              │  └─────────────────────────┘  │  │
+│                              └───────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Prerequisites
+
+1. STOA Control Plane deployed and accessible
+2. Keycloak realm `stoa` configured
+3. Gateway API keys configured in Control Plane
+
+## Deployment
+
+### 1. Create Secrets
+
+```bash
+kubectl create secret generic stoa-sidecar-secrets \
+  --namespace stoa-system \
+  --from-literal=control-plane-api-key="gw_your_api_key_here" \
+  --from-literal=keycloak-client-secret="your_keycloak_secret"
+```
+
+### 2. Configure Helm Values
+
+Create a `values-webmethods.yaml` file:
+
+```yaml
+stoaSidecar:
+  enabled: true
+  targetGateway: webmethods
+
+  # STOA Sidecar configuration
+  image:
+    repository: 848853684735.dkr.ecr.eu-west-1.amazonaws.com/apim/stoa-gateway
+    tag: latest
+
+  environment: prod
+  controlPlaneUrl: "https://api.gostoa.dev"
+  keycloakUrl: "https://auth.gostoa.dev"
+  keycloakRealm: stoa
+  keycloakClientId: stoa-sidecar
+  secretName: stoa-sidecar-secrets
+
+  # webMethods Gateway configuration
+  mainGateway:
+    enabled: true
+    image:
+      repository: softwareag/webmethods-api-gateway
+      tag: "10.15"
+    port: 9072
+    env:
+      - name: JAVA_OPTS
+        value: "-Xms1g -Xmx2g"
+      - name: SAG_IS_LICENSE_KEY
+        valueFrom:
+          secretKeyRef:
+            name: webmethods-license
+            key: license-key
+      # Enable ext_authz to point to STOA sidecar
+      - name: apigw_ext_authz_enabled
+        value: "true"
+      - name: apigw_ext_authz_url
+        value: "http://127.0.0.1:8081/authz"
+    resources:
+      requests:
+        cpu: 1000m
+        memory: 2Gi
+      limits:
+        cpu: 4000m
+        memory: 8Gi
+```
+
+### 3. Deploy
+
+```bash
+helm upgrade --install stoa-webmethods ./charts/stoa-platform \
+  --namespace stoa-system \
+  --values values-webmethods.yaml
+```
+
+## How It Works
+
+### 1. Auto-Registration
+
+When the pod starts, the STOA sidecar automatically registers with the Control Plane:
+
+```json
+POST /v1/internal/gateways/register
+{
+  "hostname": "webmethods-with-stoa-sidecar-xyz",
+  "mode": "sidecar",
+  "version": "0.1.0",
+  "environment": "prod",
+  "capabilities": ["ext_authz", "rate_limiting", "metering", "oidc"],
+  "admin_url": "http://10.0.1.50:8081"
+}
+```
+
+### 2. Request Flow
+
+1. **Client** → webMethods Gateway (port 9072)
+2. webMethods → **ext_authz** → STOA sidecar (port 8081)
+3. STOA sidecar evaluates:
+   - OPA policies (loaded from Control Plane)
+   - Rate limits (per tenant/API/user)
+   - JWT token validation (via Keycloak)
+4. **Decision** returned to webMethods (allow/deny)
+5. If allowed, webMethods → **Backend API**
+6. STOA sidecar → **Kafka** (usage metrics)
+
+### 3. Heartbeat
+
+The sidecar sends heartbeats every 30 seconds:
+
+```json
+POST /v1/internal/gateways/heartbeat/{gateway_id}
+{
+  "uptime_seconds": 3600,
+  "routes_count": 0,
+  "policies_count": 5,
+  "requests_total": 10000,
+  "error_rate": 0.01
+}
+```
+
+## Monitoring
+
+### Console View
+
+The webMethods + STOA sidecar appears in the STOA Console at `/gateways`:
+
+| Name | Type | Status | Environment |
+|------|------|--------|-------------|
+| webmethods-prod-abc123 | stoa_sidecar | ONLINE | prod |
+
+### Observability Dashboard
+
+View aggregated metrics at `/gateway-observability`:
+- Gateway health (online/offline/degraded)
+- Request throughput
+- Error rates
+- Policy enforcement stats
+
+### Prometheus Metrics
+
+The sidecar exposes Prometheus metrics at `http://localhost:8081/metrics`:
+
+```prometheus
+stoa_sidecar_requests_total{tenant="acme",api="billing",status="allowed"} 9500
+stoa_sidecar_requests_total{tenant="acme",api="billing",status="denied"} 500
+stoa_sidecar_policy_evaluation_duration_seconds_bucket{le="0.01"} 9800
+stoa_sidecar_rate_limit_hits_total{tenant="acme"} 150
+```
+
+## Policies
+
+### Creating a Rate Limit Policy
+
+```bash
+curl -X POST https://api.gostoa.dev/v1/admin/policies \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "rate-limit-100rpm",
+    "policy_type": "rate_limit",
+    "scope": "api",
+    "config": {
+      "requests_per_minute": 100,
+      "burst_size": 10
+    },
+    "priority": 100
+  }'
+```
+
+### Binding Policy to Gateway
+
+```bash
+curl -X POST https://api.gostoa.dev/v1/admin/policies/bindings \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "policy_id": "UUID_FROM_ABOVE",
+    "gateway_instance_id": "UUID_OF_WEBMETHODS_SIDECAR"
+  }'
+```
+
+## Troubleshooting
+
+### Sidecar Not Registering
+
+Check logs:
+```bash
+kubectl logs -n stoa-system deployment/webmethods-with-stoa-sidecar -c stoa-sidecar
+```
+
+Verify Control Plane URL is reachable:
+```bash
+kubectl exec -n stoa-system deployment/webmethods-with-stoa-sidecar -c stoa-sidecar -- \
+  curl -s http://control-plane-api.stoa-system.svc.cluster.local:8000/health
+```
+
+### ext_authz Errors
+
+Check webMethods logs for ext_authz connection issues:
+```bash
+kubectl logs -n stoa-system deployment/webmethods-with-stoa-sidecar -c webmethods
+```
+
+Test ext_authz endpoint directly:
+```bash
+kubectl exec -n stoa-system deployment/webmethods-with-stoa-sidecar -c webmethods -- \
+  curl -s http://127.0.0.1:8081/authz -X POST -H "Content-Type: application/json" -d '{}'
+```
+
+### Gateway Shows OFFLINE
+
+If the gateway shows OFFLINE in Console but is running:
+
+1. Check heartbeat is being sent:
+   ```bash
+   kubectl logs -n stoa-system deployment/webmethods-with-stoa-sidecar -c stoa-sidecar | grep heartbeat
+   ```
+
+2. Verify Control Plane API key:
+   ```bash
+   kubectl get secret stoa-sidecar-secrets -n stoa-system -o jsonpath='{.data.control-plane-api-key}' | base64 -d
+   ```
+
+3. Ensure the API key is in the `GATEWAY_API_KEYS` list in Control Plane config.
+
+## Related Documentation
+
+- [ADR-028: Gateway Auto-Registration](../architecture/adr/adr-028-gateway-auto-registration.md)
+- [ADR-024: Gateway Unified Modes](https://docs.gostoa.dev/architecture/adr/adr-024-gateway-unified-modes)
+- [Control Plane Agnostique Plan](../plans/control-plane-agnostique.md)


### PR DESCRIPTION
## Summary
- Add Helm template for STOA sidecar deployment alongside third-party gateways
- Add values.yaml configuration for sidecar pattern (WebMethods, Kong, Envoy, Apigee)
- Add comprehensive integration documentation

## What This Enables
Organizations using third-party API gateways (WebMethods, Kong, Envoy, Apigee) can now integrate STOA's:
- Policy enforcement via ext_authz
- Rate limiting
- Usage metering (Kafka pipeline)
- OIDC token validation

Without replacing their existing infrastructure.

## Files Changed
- `charts/stoa-platform/templates/stoa-sidecar-deployment.yaml` - NEW
- `charts/stoa-platform/values.yaml` - Add stoaSidecar configuration
- `docs/integrations/webmethods-sidecar-integration.md` - NEW

## Architecture
```
┌─────────────────────────────────────────┐
│            Kubernetes Pod               │
│  ┌─────────────┐    ┌────────────────┐  │
│  │  webMethods │    │  STOA Sidecar  │  │
│  │  (or Kong)  │────│  - ext_authz   │  │
│  │  Port: 9072 │    │  - rate limit  │  │
│  └─────────────┘    │  - metering    │  │
│                     │  Port: 8081    │  │
│                     └────────────────┘  │
└─────────────────────────────────────────┘
```

## Test plan
- [ ] `helm lint charts/stoa-platform` passes
- [ ] `helm template` renders correctly with sidecar enabled
- [ ] Values documentation is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)