### PR TITLE
fix(api): correct import for gateway health worker

### DIFF
--- a/control-plane-api/src/workers/gateway_health_worker.py
+++ b/control-plane-api/src/workers/gateway_health_worker.py
@@ -15,7 +15,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import settings
-from ..database import get_session_factory
+from ..database import _get_session_factory
 from ..models.gateway_instance import GatewayInstance, GatewayInstanceStatus, GatewayType
 
 logger = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ class GatewayHealthWorker:
 
     async def _check_gateway_health(self):
         """Check all gateways for stale heartbeats."""
-        session_factory = get_session_factory()
+        session_factory = _get_session_factory()
         async with session_factory() as session:
             await self._mark_stale_gateways_offline(session)
             await session.commit()


### PR DESCRIPTION
## Summary

Fix ImportError in gateway_health_worker.py that was causing control-plane-api pods to crash.

## Problem

The worker was importing `get_session_factory` but the function in `src/database.py` is actually named `_get_session_factory` (with underscore prefix for internal use).

## Solution

- Change `from ..database import get_session_factory` to `from ..database import _get_session_factory`
- Change `session_factory = get_session_factory()` to `session_factory = _get_session_factory()`

## Test Plan

- [ ] control-plane-api pods start without ImportError
- [ ] Gateway health worker logs appear on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)