### PR TITLE
fix(gateway): correct heartbeat URL and add STOA_SIDECAR enum

### DIFF
--- a/control-plane-api/src/models/gateway_instance.py
+++ b/control-plane-api/src/models/gateway_instance.py
@@ -20,6 +20,7 @@ class GatewayType(enum.StrEnum):
     APIGEE = "apigee"
     AWS_APIGATEWAY = "aws_apigateway"
     STOA = "stoa"
+    STOA_SIDECAR = "stoa_sidecar"  # STOA in sidecar mode (ADR-028)
 
 
 class GatewayInstanceStatus(enum.StrEnum):

--- a/stoa-gateway/src/control_plane/registration.rs
+++ b/stoa-gateway/src/control_plane/registration.rs
@@ -255,7 +255,7 @@ impl GatewayRegistrar {
         payload: HeartbeatPayload,
     ) -> Result<(), RegistrationError> {
         let url = format!(
-            "{}/v1/internal/gateways/heartbeat/{}",
+            "{}/v1/internal/gateways/{}/heartbeat",
             self.cp_url, gateway_id
         );
 


### PR DESCRIPTION
## Summary

Fixes two issues with gateway auto-registration (ADR-028):

### 1. Heartbeat URL Path (Rust)

The Rust gateway was calling the wrong URL for heartbeat:
- **Before**: `POST /v1/internal/gateways/heartbeat/{gateway_id}`
- **After**: `POST /v1/internal/gateways/{gateway_id}/heartbeat`

This caused 404 errors in the heartbeat loop.

### 2. STOA_SIDECAR Enum (Python)

Added missing `STOA_SIDECAR` value to `GatewayType` enum. The health worker was crashing because it referenced this enum value which didn't exist.

## Test Plan

- [ ] Gateway heartbeat succeeds (no more 404)
- [ ] Gateway health worker runs without AttributeError
- [ ] Gateway shows ONLINE status after registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)