### PR TITLE
feat(gateway): add gateway modes dashboard and statistics (CAB-1101)

### DIFF
--- a/control-plane-api/alembic/versions/017_add_gateway_mode_column.py
+++ b/control-plane-api/alembic/versions/017_add_gateway_mode_column.py
@@ -1,0 +1,42 @@
+"""add gateway mode column and STOA mode enum values
+
+Revision ID: 017
+Revises: 016
+Create Date: 2026-02-06
+
+Adds:
+- mode column to gateway_instances for STOA 4-mode architecture (ADR-024)
+- New gateway_type_enum values: stoa_edge_mcp, stoa_sidecar, stoa_proxy, stoa_shadow
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '017'
+down_revision: Union[str, None] = '016'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add mode column
+    op.add_column(
+        'gateway_instances',
+        sa.Column('mode', sa.String(50), nullable=True),
+    )
+    op.create_index('ix_gw_instances_mode', 'gateway_instances', ['mode'])
+
+    # Add new enum values for STOA modes (ADR-024)
+    # Using raw SQL since Alembic doesn't have direct enum value addition
+    op.execute("ALTER TYPE gateway_type_enum ADD VALUE IF NOT EXISTS 'stoa_edge_mcp'")
+    op.execute("ALTER TYPE gateway_type_enum ADD VALUE IF NOT EXISTS 'stoa_sidecar'")
+    op.execute("ALTER TYPE gateway_type_enum ADD VALUE IF NOT EXISTS 'stoa_proxy'")
+    op.execute("ALTER TYPE gateway_type_enum ADD VALUE IF NOT EXISTS 'stoa_shadow'")
+
+
+def downgrade() -> None:
+    op.drop_index('ix_gw_instances_mode', 'gateway_instances')
+    op.drop_column('gateway_instances', 'mode')
+    # Note: PostgreSQL doesn't support removing enum values, so we leave them

--- a/control-plane-api/src/models/gateway_instance.py
+++ b/control-plane-api/src/models/gateway_instance.py
@@ -20,7 +20,11 @@ class GatewayType(enum.StrEnum):
     APIGEE = "apigee"
     AWS_APIGATEWAY = "aws_apigateway"
     STOA = "stoa"
-    STOA_SIDECAR = "stoa_sidecar"  # STOA in sidecar mode (ADR-028)
+    # STOA Gateway modes (ADR-024) — for filtering/grouping
+    STOA_EDGE_MCP = "stoa_edge_mcp"
+    STOA_SIDECAR = "stoa_sidecar"
+    STOA_PROXY = "stoa_proxy"
+    STOA_SHADOW = "stoa_shadow"
 
 
 class GatewayInstanceStatus(enum.StrEnum):
@@ -81,6 +85,9 @@ class GatewayInstance(Base):
     # Capabilities
     capabilities = Column(JSONB, nullable=False, default=list)
     # e.g. ["rest", "graphql", "websocket", "oidc", "rate_limiting", "mcp"]
+
+    # STOA Gateway mode (ADR-024)
+    mode = Column(String(50), nullable=True, index=True)  # edge-mcp, sidecar, proxy, shadow
 
     # Metadata
     version = Column(String(50), nullable=True)     # Gateway software version

--- a/control-plane-api/src/routers/gateway_instances.py
+++ b/control-plane-api/src/routers/gateway_instances.py
@@ -3,15 +3,19 @@ import logging
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.auth.rbac import require_role
 from src.database import get_db
+from src.models.gateway_instance import GatewayInstance
 from src.schemas.gateway import (
     GatewayHealthCheckResponse,
     GatewayInstanceCreate,
     GatewayInstanceResponse,
     GatewayInstanceUpdate,
+    GatewayModeStats,
+    ModeStatItem,
     PaginatedGatewayInstances,
 )
 from src.schemas.gateway_import import ImportPreviewResponse, ImportResultResponse
@@ -62,6 +66,62 @@ async def list_gateways(
         page_size=page_size,
     )
     return PaginatedGatewayInstances(items=items, total=total, page=page, page_size=page_size)
+
+
+@router.get("/modes/stats", response_model=GatewayModeStats)
+async def get_gateway_mode_stats(
+    db: AsyncSession = Depends(get_db),
+    _user=Depends(require_role(["cpi-admin", "tenant-admin"])),
+):
+    """Get gateway statistics grouped by mode (ADR-024).
+
+    Returns counts of online/offline/degraded gateways for each STOA mode:
+    - edge-mcp: MCP protocol with SSE transport
+    - sidecar: Policy enforcement behind existing gateway
+    - proxy: Inline request/response transformation
+    - shadow: Passive traffic capture and analysis
+    """
+    # Query aggregated stats by mode for STOA gateways
+    stmt = (
+        select(
+            GatewayInstance.mode,
+            func.count(GatewayInstance.id).label("total"),
+            func.count(case((GatewayInstance.status == "online", 1))).label("online"),
+            func.count(case((GatewayInstance.status == "offline", 1))).label("offline"),
+            func.count(case((GatewayInstance.status == "degraded", 1))).label("degraded"),
+        )
+        .where(GatewayInstance.gateway_type.like("stoa%"))
+        .group_by(GatewayInstance.mode)
+    )
+
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    # Build response with all 4 modes (even if count is 0)
+    mode_data = {row.mode: row for row in rows if row.mode}
+    all_modes = ["edge-mcp", "sidecar", "proxy", "shadow"]
+
+    modes = []
+    total_gateways = 0
+    for mode in all_modes:
+        if mode in mode_data:
+            row = mode_data[mode]
+            modes.append(
+                ModeStatItem(
+                    mode=mode,
+                    total=row.total,
+                    online=row.online,
+                    offline=row.offline,
+                    degraded=row.degraded,
+                )
+            )
+            total_gateways += row.total
+        else:
+            modes.append(
+                ModeStatItem(mode=mode, total=0, online=0, offline=0, degraded=0)
+            )
+
+    return GatewayModeStats(modes=modes, total_gateways=total_gateways)
 
 
 @router.get("/{gateway_id}", response_model=GatewayInstanceResponse)

--- a/control-plane-api/src/routers/gateway_internal.py
+++ b/control-plane-api/src/routers/gateway_internal.py
@@ -81,12 +81,32 @@ def _derive_instance_name(hostname: str, mode: str, environment: str) -> str:
 
 
 def _mode_to_gateway_type(mode: str) -> GatewayType:
-    """Map gateway mode to GatewayType enum."""
-    mode_lower = mode.lower().replace("_", "").replace("-", "")
-    if mode_lower == "sidecar":
-        return GatewayType.STOA_SIDECAR
-    # All other modes (edge_mcp, proxy, shadow) are full STOA gateways
-    return GatewayType.STOA
+    """Map gateway mode to GatewayType enum (ADR-024)."""
+    mode_lower = mode.lower().replace("_", "-")
+    mode_map = {
+        "edge-mcp": GatewayType.STOA_EDGE_MCP,
+        "edgemcp": GatewayType.STOA_EDGE_MCP,
+        "mcp": GatewayType.STOA_EDGE_MCP,
+        "sidecar": GatewayType.STOA_SIDECAR,
+        "proxy": GatewayType.STOA_PROXY,
+        "shadow": GatewayType.STOA_SHADOW,
+    }
+    return mode_map.get(mode_lower, GatewayType.STOA)
+
+
+def _normalize_mode(mode: str) -> str:
+    """Normalize mode string to canonical form (ADR-024)."""
+    mode_lower = mode.lower().replace("_", "-")
+    mode_map = {
+        "edge-mcp": "edge-mcp",
+        "edgemcp": "edge-mcp",
+        "edge_mcp": "edge-mcp",
+        "mcp": "edge-mcp",
+        "sidecar": "sidecar",
+        "proxy": "proxy",
+        "shadow": "shadow",
+    }
+    return mode_map.get(mode_lower, "edge-mcp")
 
 
 # --- Endpoints ---
@@ -109,9 +129,10 @@ async def register_gateway(
 
     repo = GatewayInstanceRepository(db)
 
-    # Derive deterministic instance name
+    # Derive deterministic instance name and normalize mode
     instance_name = _derive_instance_name(payload.hostname, payload.mode, payload.environment)
     gateway_type = _mode_to_gateway_type(payload.mode)
+    normalized_mode = _normalize_mode(payload.mode)
 
     logger.info(
         "Gateway registration request: name=%s, type=%s, version=%s, capabilities=%s",
@@ -132,9 +153,10 @@ async def register_gateway(
         existing.base_url = payload.admin_url
         existing.status = GatewayInstanceStatus.ONLINE
         existing.last_health_check = now
+        existing.mode = normalized_mode  # ADR-024
         existing.health_details = {
             "registered_at": now.isoformat(),
-            "mode": payload.mode,
+            "mode": normalized_mode,
             "hostname": payload.hostname,
         }
         instance = await repo.update(existing)
@@ -144,7 +166,7 @@ async def register_gateway(
         # Create new registration
         instance = GatewayInstance(
             name=instance_name,
-            display_name=f"STOA Gateway ({payload.mode})",
+            display_name=f"STOA Gateway ({normalized_mode})",
             gateway_type=gateway_type,
             environment=payload.environment,
             tenant_id=payload.tenant_id,
@@ -152,14 +174,15 @@ async def register_gateway(
             auth_config={"type": "gateway_key"},  # Internal auth via heartbeat
             status=GatewayInstanceStatus.ONLINE,
             last_health_check=now,
+            mode=normalized_mode,  # ADR-024
             health_details={
                 "registered_at": now.isoformat(),
-                "mode": payload.mode,
+                "mode": normalized_mode,
                 "hostname": payload.hostname,
             },
             capabilities=payload.capabilities,
             version=payload.version,
-            tags=[f"mode:{payload.mode}", "auto-registered"],
+            tags=[f"mode:{normalized_mode}", "auto-registered"],
         )
         instance = await repo.create(instance)
         await db.commit()

--- a/control-plane-api/src/schemas/gateway.py
+++ b/control-plane-api/src/schemas/gateway.py
@@ -48,6 +48,7 @@ class GatewayInstanceResponse(BaseModel):
     capabilities: list[str]
     version: str | None
     tags: list[str]
+    mode: str | None = Field(None, description="STOA Gateway mode: edge-mcp, sidecar, proxy, shadow")
     created_at: datetime
     updated_at: datetime
 
@@ -60,6 +61,26 @@ class GatewayHealthCheckResponse(BaseModel):
     details: dict | None = None
     gateway_name: str
     gateway_type: str
+
+
+# =========================================================================
+# Gateway Mode Statistics (ADR-024)
+# =========================================================================
+
+
+class ModeStatItem(BaseModel):
+    """Statistics for a single gateway mode."""
+    mode: str
+    total: int
+    online: int
+    offline: int
+    degraded: int
+
+
+class GatewayModeStats(BaseModel):
+    """Gateway statistics grouped by mode."""
+    modes: list[ModeStatItem]
+    total_gateways: int
 
 
 # =========================================================================

--- a/control-plane-ui/src/App.tsx
+++ b/control-plane-ui/src/App.tsx
@@ -24,6 +24,7 @@ const ExternalMCPServerDetail = lazy(() => import('./pages/ExternalMCPServers').
 const AdminProspects = lazy(() => import('./pages/AdminProspects').then(m => ({ default: m.AdminProspects })));
 const GatewayStatus = lazy(() => import('./pages/GatewayStatus'));
 const GatewayRegistry = lazy(() => import('./pages/Gateways').then(m => ({ default: m.GatewayList })));
+const GatewayModes = lazy(() => import('./pages/Gateways').then(m => ({ default: m.GatewayModesDashboard })));
 const GatewayDeployments = lazy(() => import('./pages/GatewayDeployments').then(m => ({ default: m.GatewayDeploymentsDashboard })));
 const GatewayObservability = lazy(() => import('./pages/GatewayObservability').then(m => ({ default: m.GatewayObservabilityDashboard })));
 
@@ -224,6 +225,7 @@ function ProtectedRoutes() {
             <Route path="/external-mcp-servers" element={<ExternalMCPServersList />} />
             <Route path="/external-mcp-servers/:id" element={<ExternalMCPServerDetail />} />
             <Route path="/gateway" element={<GatewayStatus />} />
+            <Route path="/gateways/modes" element={<GatewayModes />} />
             <Route path="/gateways" element={<GatewayRegistry />} />
             <Route path="/gateway-deployments" element={<GatewayDeployments />} />
             <Route path="/gateway-observability" element={<GatewayObservability />} />

--- a/control-plane-ui/src/pages/Gateways/GatewayList.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayList.tsx
@@ -10,6 +10,7 @@ import type {
   GatewayInstance,
   GatewayType,
   GatewayInstanceStatus,
+  GatewayMode,
 } from '../../types';
 
 const statusColors: Record<GatewayInstanceStatus, string> = {
@@ -19,12 +20,30 @@ const statusColors: Record<GatewayInstanceStatus, string> = {
   maintenance: 'bg-blue-100 text-blue-800',
 };
 
+const modeColors: Record<GatewayMode, string> = {
+  'edge-mcp': 'bg-blue-100 text-blue-800 border-blue-200',
+  sidecar: 'bg-emerald-100 text-emerald-800 border-emerald-200',
+  proxy: 'bg-purple-100 text-purple-800 border-purple-200',
+  shadow: 'bg-orange-100 text-orange-800 border-orange-200',
+};
+
+const modeLabels: Record<GatewayMode, string> = {
+  'edge-mcp': 'Edge MCP',
+  sidecar: 'Sidecar',
+  proxy: 'Proxy',
+  shadow: 'Shadow',
+};
+
 const typeLabels: Record<GatewayType, string> = {
   webmethods: 'webMethods',
   kong: 'Kong',
   apigee: 'Apigee',
   aws_apigateway: 'AWS API Gateway',
   stoa: 'STOA',
+  stoa_edge_mcp: 'STOA Edge MCP',
+  stoa_sidecar: 'STOA Sidecar',
+  stoa_proxy: 'STOA Proxy',
+  stoa_shadow: 'STOA Shadow',
 };
 
 export function GatewayList() {
@@ -36,6 +55,23 @@ export function GatewayList() {
   const [error, setError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [healthChecking, setHealthChecking] = useState<string | null>(null);
+  const [modeFilter, setModeFilter] = useState<GatewayMode | ''>('');
+
+  // Filter gateways by mode
+  const filteredGateways = modeFilter
+    ? gateways.filter((gw) => gw.mode === modeFilter)
+    : gateways;
+
+  // Count STOA gateways by mode for the filter dropdown
+  const modeCounts = gateways.reduce(
+    (acc, gw) => {
+      if (gw.mode) {
+        acc[gw.mode] = (acc[gw.mode] || 0) + 1;
+      }
+      return acc;
+    },
+    {} as Record<string, number>,
+  );
 
   const loadGateways = useCallback(async () => {
     try {
@@ -68,23 +104,26 @@ export function GatewayList() {
     }
   };
 
-  const handleDelete = useCallback(async (id: string, name: string) => {
-    const confirmed = await confirm({
-      title: 'Delete Gateway',
-      message: `Are you sure you want to delete "${name}"? This cannot be undone.`,
-      confirmLabel: 'Delete',
-      variant: 'danger',
-    });
-    if (!confirmed) return;
+  const handleDelete = useCallback(
+    async (id: string, name: string) => {
+      const confirmed = await confirm({
+        title: 'Delete Gateway',
+        message: `Are you sure you want to delete "${name}"? This cannot be undone.`,
+        confirmLabel: 'Delete',
+        variant: 'danger',
+      });
+      if (!confirmed) return;
 
-    try {
-      await apiService.deleteGatewayInstance(id);
-      toast.success(`Gateway "${name}" deleted successfully`);
-      await loadGateways();
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to delete gateway');
-    }
-  }, [confirm, toast, loadGateways]);
+      try {
+        await apiService.deleteGatewayInstance(id);
+        toast.success(`Gateway "${name}" deleted successfully`);
+        await loadGateways();
+      } catch (err: any) {
+        toast.error(err.response?.data?.detail || 'Failed to delete gateway');
+      }
+    },
+    [confirm, toast, loadGateways],
+  );
 
   const handleCreated = () => {
     setShowForm(false);
@@ -117,12 +156,31 @@ export function GatewayList() {
             Manage registered gateway instances across all environments
           </p>
         </div>
-        <button
-          onClick={() => setShowForm(!showForm)}
-          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
-        >
-          {showForm ? 'Cancel' : '+ Register Gateway'}
-        </button>
+        <div className="flex items-center gap-3">
+          {/* Mode Filter */}
+          {Object.keys(modeCounts).length > 0 && (
+            <select
+              value={modeFilter}
+              onChange={(e) => setModeFilter(e.target.value as GatewayMode | '')}
+              className="text-sm border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            >
+              <option value="">All Modes ({gateways.length})</option>
+              {(['edge-mcp', 'sidecar', 'proxy', 'shadow'] as GatewayMode[]).map((mode) =>
+                modeCounts[mode] ? (
+                  <option key={mode} value={mode}>
+                    {modeLabels[mode]} ({modeCounts[mode]})
+                  </option>
+                ) : null,
+              )}
+            </select>
+          )}
+          <button
+            onClick={() => setShowForm(!showForm)}
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+          >
+            {showForm ? 'Cancel' : '+ Register Gateway'}
+          </button>
+        </div>
       </div>
 
       {/* Error Banner */}
@@ -137,32 +195,44 @@ export function GatewayList() {
 
       {/* Registration Form */}
       {showForm && (
-        <GatewayRegistrationForm
-          onCreated={handleCreated}
-          onCancel={() => setShowForm(false)}
-        />
+        <GatewayRegistrationForm onCreated={handleCreated} onCancel={() => setShowForm(false)} />
       )}
 
       {/* Gateway Cards */}
-      {gateways.length === 0 ? (
+      {filteredGateways.length === 0 ? (
         <div className="bg-white rounded-lg shadow">
           <EmptyState
             variant="servers"
-            title="No gateways registered"
-            description="Register your first gateway instance to start multi-gateway orchestration."
+            title={modeFilter ? `No ${modeLabels[modeFilter]} gateways` : 'No gateways registered'}
+            description={
+              modeFilter
+                ? 'Try clearing the filter or register a new gateway.'
+                : 'Register your first gateway instance to start multi-gateway orchestration.'
+            }
             action={{ label: 'Register Gateway', onClick: () => setShowForm(true) }}
           />
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {gateways.map((gw) => (
+          {filteredGateways.map((gw) => (
             <div key={gw.id} className="bg-white rounded-lg shadow hover:shadow-md transition-shadow">
               <div className="p-6">
                 {/* Header row */}
                 <div className="flex items-center justify-between mb-3">
-                  <span className={`px-2 py-1 text-xs font-medium rounded-full ${statusColors[gw.status]}`}>
-                    {gw.status}
-                  </span>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`px-2 py-1 text-xs font-medium rounded-full ${statusColors[gw.status]}`}
+                    >
+                      {gw.status}
+                    </span>
+                    {gw.mode && (
+                      <span
+                        className={`px-2 py-1 text-xs font-medium rounded-full border ${modeColors[gw.mode]}`}
+                      >
+                        {modeLabels[gw.mode]}
+                      </span>
+                    )}
+                  </div>
                   <span className="text-xs text-gray-400 font-mono">
                     {typeLabels[gw.gateway_type] || gw.gateway_type}
                   </span>
@@ -184,7 +254,10 @@ export function GatewayList() {
                   </div>
                   <div className="flex justify-between">
                     <span className="text-gray-500">Base URL</span>
-                    <span className="font-mono text-xs text-gray-700 truncate ml-2 max-w-[180px]" title={gw.base_url}>
+                    <span
+                      className="font-mono text-xs text-gray-700 truncate ml-2 max-w-[180px]"
+                      title={gw.base_url}
+                    >
                       {gw.base_url}
                     </span>
                   </div>

--- a/control-plane-ui/src/pages/Gateways/GatewayModesDashboard.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayModesDashboard.tsx
@@ -1,0 +1,224 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import { apiService } from '../../services/api';
+import { CardSkeleton } from '@stoa/shared/components/Skeleton';
+import type { GatewayMode } from '../../types';
+
+interface ModeConfig {
+  id: GatewayMode;
+  name: string;
+  description: string;
+  icon: string;
+  color: string;
+  bgColor: string;
+  borderColor: string;
+}
+
+const modeConfigs: ModeConfig[] = [
+  {
+    id: 'edge-mcp',
+    name: 'Edge MCP',
+    description: 'MCP protocol with SSE transport for AI-native API access',
+    icon: 'M13 10V3L4 14h7v7l9-11h-7z', // Lightning bolt
+    color: 'text-blue-600',
+    bgColor: 'bg-blue-50',
+    borderColor: 'border-blue-200',
+  },
+  {
+    id: 'sidecar',
+    name: 'Sidecar',
+    description: 'Policy enforcement behind existing gateway (Kong, Envoy, Apigee)',
+    icon: 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z', // Shield
+    color: 'text-emerald-600',
+    bgColor: 'bg-emerald-50',
+    borderColor: 'border-emerald-200',
+  },
+  {
+    id: 'proxy',
+    name: 'Proxy',
+    description: 'Inline request/response transformation with rate limiting',
+    icon: 'M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4', // Arrows right-left
+    color: 'text-purple-600',
+    bgColor: 'bg-purple-50',
+    borderColor: 'border-purple-200',
+  },
+  {
+    id: 'shadow',
+    name: 'Shadow',
+    description: 'Passive traffic capture and UAC contract auto-generation',
+    icon: 'M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z', // Eye
+    color: 'text-orange-600',
+    bgColor: 'bg-orange-50',
+    borderColor: 'border-orange-200',
+  },
+];
+
+interface ModeStats {
+  mode: string;
+  total: number;
+  online: number;
+  offline: number;
+  degraded: number;
+}
+
+export function GatewayModesDashboard() {
+  const { isReady } = useAuth();
+  const [stats, setStats] = useState<{ modes: ModeStats[]; total_gateways: number } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isReady) {
+      loadStats();
+    }
+  }, [isReady]);
+
+  const loadStats = async () => {
+    try {
+      setLoading(true);
+      const data = await apiService.getGatewayModeStats();
+      setStats(data);
+      setError(null);
+    } catch (err: any) {
+      setError(err.response?.data?.detail || err.message || 'Failed to load gateway mode stats');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getModeStat = (modeId: string): ModeStats => {
+    const found = stats?.modes.find((m) => m.mode === modeId);
+    return found || { mode: modeId, total: 0, online: 0, offline: 0, degraded: 0 };
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="h-8 w-64 bg-gray-200 rounded animate-pulse" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          {[1, 2, 3, 4].map((i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Gateway Modes</h1>
+        <p className="text-gray-500 mt-1">
+          STOA Gateway deployment modes across your infrastructure (ADR-024)
+        </p>
+      </div>
+
+      {/* Error Banner */}
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
+          {error}
+        </div>
+      )}
+
+      {/* Total Summary */}
+      <div className="bg-gradient-to-r from-indigo-500 to-purple-600 rounded-xl p-6 text-white">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-indigo-100 text-sm font-medium">Total STOA Gateways</p>
+            <p className="text-4xl font-bold mt-1">{stats?.total_gateways || 0}</p>
+          </div>
+          <div className="text-right">
+            <p className="text-indigo-100 text-sm">Unified Architecture</p>
+            <p className="text-lg font-medium mt-1">4 Deployment Modes</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Mode Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {modeConfigs.map((mode) => {
+          const stat = getModeStat(mode.id);
+          return (
+            <div
+              key={mode.id}
+              className={`${mode.bgColor} ${mode.borderColor} border-2 rounded-xl overflow-hidden hover:shadow-lg transition-shadow`}
+            >
+              <div className="p-6">
+                {/* Icon + Name */}
+                <div className="flex items-center gap-3 mb-4">
+                  <div className={`p-2 rounded-lg bg-white shadow-sm ${mode.color}`}>
+                    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={mode.icon} />
+                    </svg>
+                  </div>
+                  <h3 className="text-lg font-semibold text-gray-900">{mode.name}</h3>
+                </div>
+
+                {/* Description */}
+                <p className="text-sm text-gray-600 mb-4 min-h-[40px]">{mode.description}</p>
+
+                {/* Stats */}
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-2xl font-bold text-gray-900">{stat.total}</span>
+                    <span className="text-sm text-gray-500">instances</span>
+                  </div>
+
+                  <div className="grid grid-cols-3 gap-2 text-center">
+                    <div className="bg-white rounded-lg px-2 py-1.5 shadow-sm">
+                      <div className="text-green-600 font-semibold">{stat.online}</div>
+                      <div className="text-xs text-gray-500">online</div>
+                    </div>
+                    <div className="bg-white rounded-lg px-2 py-1.5 shadow-sm">
+                      <div className="text-yellow-600 font-semibold">{stat.degraded}</div>
+                      <div className="text-xs text-gray-500">degraded</div>
+                    </div>
+                    <div className="bg-white rounded-lg px-2 py-1.5 shadow-sm">
+                      <div className="text-gray-600 font-semibold">{stat.offline}</div>
+                      <div className="text-xs text-gray-500">offline</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Footer */}
+              <div className="px-6 py-3 bg-white/50 border-t border-white/20">
+                <a
+                  href={`/admin/gateways?mode=${mode.id}`}
+                  className={`text-sm font-medium ${mode.color} hover:underline`}
+                >
+                  View {mode.name} gateways &rarr;
+                </a>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Architecture Info */}
+      <div className="bg-white rounded-xl border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">STOA Gateway Architecture (ADR-024)</h2>
+        <div className="prose prose-sm text-gray-600">
+          <p>
+            The STOA Gateway uses a unified architecture with 4 deployment modes, all from a single Rust binary:
+          </p>
+          <ul className="mt-2 space-y-1">
+            <li>
+              <strong>Edge MCP:</strong> Native MCP protocol with SSE transport for AI agents (Claude, GPT, etc.)
+            </li>
+            <li>
+              <strong>Sidecar:</strong> Policy enforcement deployed alongside existing gateways
+            </li>
+            <li>
+              <strong>Proxy:</strong> Full inline proxy with request/response transformation
+            </li>
+            <li>
+              <strong>Shadow:</strong> Passive traffic observation for auto-generating API contracts
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/control-plane-ui/src/pages/Gateways/index.tsx
+++ b/control-plane-ui/src/pages/Gateways/index.tsx
@@ -1,2 +1,3 @@
 export { GatewayList } from './GatewayList';
+export { GatewayModesDashboard } from './GatewayModesDashboard';
 export { GatewayRegistrationForm } from './GatewayRegistrationForm';

--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -326,6 +326,20 @@ class ApiService {
     return data;
   }
 
+  async getGatewayModeStats(): Promise<{
+    modes: Array<{
+      mode: string;
+      total: number;
+      online: number;
+      offline: number;
+      degraded: number;
+    }>;
+    total_gateways: number;
+  }> {
+    const { data } = await this.client.get('/v1/admin/gateways/modes/stats');
+    return data;
+  }
+
   // Gateway Deployments
   async getDeploymentStatusSummary(): Promise<any> {
     const { data } = await this.client.get('/v1/admin/deployments/status');

--- a/control-plane-ui/src/types/index.ts
+++ b/control-plane-ui/src/types/index.ts
@@ -825,7 +825,17 @@ export interface ProspectsFilters {
 // Gateway Instance Types (Control Plane Agnostique)
 // =============================================================================
 
-export type GatewayType = 'webmethods' | 'kong' | 'apigee' | 'aws_apigateway' | 'stoa';
+export type GatewayType =
+  | 'webmethods'
+  | 'kong'
+  | 'apigee'
+  | 'aws_apigateway'
+  | 'stoa'
+  | 'stoa_edge_mcp'
+  | 'stoa_sidecar'
+  | 'stoa_proxy'
+  | 'stoa_shadow';
+export type GatewayMode = 'edge-mcp' | 'sidecar' | 'proxy' | 'shadow';
 export type GatewayInstanceStatus = 'online' | 'offline' | 'degraded' | 'maintenance';
 export type DeploymentSyncStatus = 'pending' | 'syncing' | 'synced' | 'drifted' | 'error' | 'deleting';
 
@@ -844,6 +854,7 @@ export interface GatewayInstance {
   capabilities: string[];
   version?: string;
   tags: string[];
+  mode?: GatewayMode;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- Add mode column to gateway_instances table with Alembic migration (017)
- Add STOA gateway mode enum values: `edge-mcp`, `sidecar`, `proxy`, `shadow`
- Add `/v1/admin/gateways/modes/stats` endpoint for aggregated mode statistics
- Add GatewayModesDashboard page showing all 4 modes with online/offline/degraded counts
- Update GatewayList with mode badges and filter dropdown

## Test plan
- [ ] Run Alembic migration: `alembic upgrade head`
- [ ] Verify `/v1/admin/gateways/modes/stats` returns stats for all 4 modes
- [ ] Verify GatewayList shows mode badges for STOA gateways
- [ ] Verify mode filter dropdown filters gateways by mode
- [ ] Verify GatewayModesDashboard shows 4 mode cards with statistics
- [ ] Run E2E tests for gateway flows

## Related
- Phase 9 of Rust Gateway Plan (ADR-024: 4-Mode Architecture)
- Ticket: CAB-1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)