### PR TITLE
fix(portal): add dark mode support to Portal UI components

### DIFF
--- a/portal/src/components/apis/APICard.tsx
+++ b/portal/src/components/apis/APICard.tsx
@@ -16,9 +16,9 @@ interface APICardProps {
 
 // Move static objects outside component to prevent recreation on each render
 const statusColors = {
-  published: 'bg-green-100 text-green-800',
-  deprecated: 'bg-amber-100 text-amber-800',
-  draft: 'bg-gray-100 text-gray-800',
+  published: 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400',
+  deprecated: 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-400',
+  draft: 'bg-gray-100 dark:bg-neutral-700 text-gray-800 dark:text-neutral-200',
 } as const;
 
 // Date formatting options - created once
@@ -37,27 +37,27 @@ export const APICard = memo(function APICard({ api }: APICardProps) {
   return (
     <Link
       to={`/apis/${api.id}`}
-      className="group bg-white rounded-lg border border-gray-200 p-6 hover:border-primary-300 hover:shadow-md transition-all"
+      className="group bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6 hover:border-primary-300 dark:hover:border-primary-600 hover:shadow-md transition-all"
     >
       <div className="flex items-start justify-between mb-3">
         <div className="flex-1 min-w-0">
-          <h3 className="font-semibold text-gray-900 group-hover:text-primary-700 transition-colors truncate">
+          <h3 className="font-semibold text-gray-900 dark:text-white group-hover:text-primary-700 dark:group-hover:text-primary-400 transition-colors truncate">
             {api.name}
           </h3>
-          <p className="text-sm text-gray-500">v{api.version}</p>
+          <p className="text-sm text-gray-500 dark:text-neutral-400">v{api.version}</p>
         </div>
         <span className={`px-2 py-1 text-xs font-medium rounded-full ${statusColors[api.status]}`}>
           {api.status}
         </span>
       </div>
 
-      <p className="text-sm text-gray-600 line-clamp-2 mb-4 min-h-[40px]">
+      <p className="text-sm text-gray-600 dark:text-neutral-300 line-clamp-2 mb-4 min-h-[40px]">
         {api.description || 'No description available'}
       </p>
 
       <div className="flex flex-wrap gap-2 mb-4">
         {api.category && (
-          <span className="inline-flex items-center gap-1 px-2 py-1 bg-primary-50 text-primary-700 text-xs rounded-full">
+          <span className="inline-flex items-center gap-1 px-2 py-1 bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400 text-xs rounded-full">
             <Tag className="h-3 w-3" />
             {api.category}
           </span>
@@ -65,19 +65,19 @@ export const APICard = memo(function APICard({ api }: APICardProps) {
         {api.tags?.slice(0, 2).map((tag) => (
           <span
             key={tag}
-            className="px-2 py-1 bg-gray-100 text-gray-600 text-xs rounded-full"
+            className="px-2 py-1 bg-gray-100 dark:bg-neutral-700 text-gray-600 dark:text-neutral-300 text-xs rounded-full"
           >
             {tag}
           </span>
         ))}
         {api.tags && api.tags.length > 2 && (
-          <span className="px-2 py-1 bg-gray-100 text-gray-500 text-xs rounded-full">
+          <span className="px-2 py-1 bg-gray-100 dark:bg-neutral-700 text-gray-500 dark:text-neutral-400 text-xs rounded-full">
             +{api.tags.length - 2}
           </span>
         )}
       </div>
 
-      <div className="flex items-center justify-between pt-3 border-t border-gray-100">
+      <div className="flex items-center justify-between pt-3 border-t border-gray-100 dark:border-neutral-700">
         <div className="flex items-center text-xs text-gray-500">
           <Clock className="h-3 w-3 mr-1" />
           {formattedDate}

--- a/portal/src/components/usage/CallsTable.tsx
+++ b/portal/src/components/usage/CallsTable.tsx
@@ -18,20 +18,20 @@ function StatusBadge({ status }: { status: UsageCallStatus }) {
   const configs = {
     success: {
       icon: <Check className="w-3 h-3" />,
-      bg: 'bg-emerald-100',
-      text: 'text-emerald-700',
+      bg: 'bg-emerald-100 dark:bg-emerald-900/30',
+      text: 'text-emerald-700 dark:text-emerald-400',
       label: 'Success',
     },
     error: {
       icon: <X className="w-3 h-3" />,
-      bg: 'bg-red-100',
-      text: 'text-red-700',
+      bg: 'bg-red-100 dark:bg-red-900/30',
+      text: 'text-red-700 dark:text-red-400',
       label: 'Error',
     },
     timeout: {
       icon: <Clock className="w-3 h-3" />,
-      bg: 'bg-amber-100',
-      text: 'text-amber-700',
+      bg: 'bg-amber-100 dark:bg-amber-900/30',
+      text: 'text-amber-700 dark:text-amber-400',
       label: 'Timeout',
     },
   };
@@ -73,11 +73,11 @@ function TableSkeleton() {
   return (
     <div className="animate-pulse">
       {[...Array(5)].map((_, i) => (
-        <div key={i} className="flex items-center gap-4 p-4 border-b border-gray-100">
-          <div className="h-4 w-20 bg-gray-200 rounded" />
-          <div className="h-4 w-32 bg-gray-200 rounded flex-1" />
-          <div className="h-6 w-16 bg-gray-200 rounded-full" />
-          <div className="h-4 w-16 bg-gray-200 rounded" />
+        <div key={i} className="flex items-center gap-4 p-4 border-b border-gray-100 dark:border-neutral-700">
+          <div className="h-4 w-20 bg-gray-200 dark:bg-neutral-700 rounded" />
+          <div className="h-4 w-32 bg-gray-200 dark:bg-neutral-700 rounded flex-1" />
+          <div className="h-6 w-16 bg-gray-200 dark:bg-neutral-700 rounded-full" />
+          <div className="h-4 w-16 bg-gray-200 dark:bg-neutral-700 rounded" />
         </div>
       ))}
     </div>
@@ -97,13 +97,13 @@ export function CallsTable({ calls, isLoading = false, onFilterChange }: CallsTa
     : calls;
 
   return (
-    <div className="rounded-xl border border-gray-200 bg-white overflow-hidden">
+    <div className="rounded-xl border border-gray-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 overflow-hidden">
       {/* Header avec filtres */}
-      <div className="flex items-center justify-between p-4 border-b border-gray-100">
-        <h3 className="text-lg font-semibold text-gray-900">Recent Calls</h3>
+      <div className="flex items-center justify-between p-4 border-b border-gray-100 dark:border-neutral-700">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Recent Calls</h3>
 
         <div className="flex items-center gap-2">
-          <span className="text-sm text-gray-500 mr-2">Filter:</span>
+          <span className="text-sm text-gray-500 dark:text-neutral-400 mr-2">Filter:</span>
 
           {(['all', 'success', 'error', 'timeout'] as const).map((status) => (
             <button
@@ -112,8 +112,8 @@ export function CallsTable({ calls, isLoading = false, onFilterChange }: CallsTa
               className={`
                 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors
                 ${(status === 'all' && !selectedStatus) || selectedStatus === status
-                  ? 'bg-primary-100 text-primary-700 border border-primary-200'
-                  : 'bg-gray-50 text-gray-600 border border-transparent hover:bg-gray-100'
+                  ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 border border-primary-200 dark:border-primary-700'
+                  : 'bg-gray-50 dark:bg-neutral-700 text-gray-600 dark:text-neutral-300 border border-transparent hover:bg-gray-100 dark:hover:bg-neutral-600'
                 }
               `}
             >
@@ -130,7 +130,7 @@ export function CallsTable({ calls, isLoading = false, onFilterChange }: CallsTa
         <div className="overflow-x-auto">
           <table className="w-full">
             <thead>
-              <tr className="text-left text-xs font-medium text-gray-500 uppercase tracking-wider border-b border-gray-100 bg-gray-50">
+              <tr className="text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider border-b border-gray-100 dark:border-neutral-700 bg-gray-50 dark:bg-neutral-900">
                 <th className="px-4 py-3">Time</th>
                 <th className="px-4 py-3">Tool</th>
                 <th className="px-4 py-3">Status</th>
@@ -141,17 +141,17 @@ export function CallsTable({ calls, isLoading = false, onFilterChange }: CallsTa
               {filteredCalls.map((call) => (
                 <tr
                   key={call.id}
-                  className="border-b border-gray-50 hover:bg-gray-50 transition-colors"
+                  className="border-b border-gray-50 dark:border-neutral-700/50 hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
                 >
                   <td className="px-4 py-3">
-                    <span className="text-sm text-gray-500">
+                    <span className="text-sm text-gray-500 dark:text-neutral-400">
                       {formatTimestamp(call.timestamp)}
                     </span>
                   </td>
                   <td className="px-4 py-3">
                     <div>
-                      <div className="text-sm font-medium text-gray-900">{call.tool_name}</div>
-                      <div className="text-xs text-gray-400">{call.tool_id}</div>
+                      <div className="text-sm font-medium text-gray-900 dark:text-white">{call.tool_name}</div>
+                      <div className="text-xs text-gray-400 dark:text-neutral-500">{call.tool_id}</div>
                     </div>
                   </td>
                   <td className="px-4 py-3">
@@ -160,7 +160,7 @@ export function CallsTable({ calls, isLoading = false, onFilterChange }: CallsTa
                   <td className="px-4 py-3 text-right">
                     <span className={`
                       text-sm font-mono
-                      ${call.latency_ms > 500 ? 'text-amber-600' : 'text-gray-600'}
+                      ${call.latency_ms > 500 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-600 dark:text-neutral-300'}
                     `}>
                       {formatLatency(call.latency_ms)}
                     </span>
@@ -173,15 +173,15 @@ export function CallsTable({ calls, isLoading = false, onFilterChange }: CallsTa
           {/* Empty state */}
           {filteredCalls.length === 0 && (
             <div className="p-8 text-center">
-              <p className="text-gray-500">No calls found</p>
+              <p className="text-gray-500 dark:text-neutral-400">No calls found</p>
             </div>
           )}
         </div>
       )}
 
       {/* Footer */}
-      <div className="flex items-center justify-between px-4 py-3 border-t border-gray-100 bg-gray-50">
-        <span className="text-sm text-gray-500">
+      <div className="flex items-center justify-between px-4 py-3 border-t border-gray-100 dark:border-neutral-700 bg-gray-50 dark:bg-neutral-900">
+        <span className="text-sm text-gray-500 dark:text-neutral-400">
           Showing {filteredCalls.length} of {calls.length} calls
         </span>
         <button className="text-sm text-primary-600 hover:text-primary-700 font-medium transition-colors">

--- a/portal/src/components/usage/StatCard.tsx
+++ b/portal/src/components/usage/StatCard.tsx
@@ -21,34 +21,34 @@ interface StatCardProps {
 
 const colorClasses = {
   cyan: {
-    bg: 'bg-cyan-50',
-    border: 'border-cyan-200',
-    text: 'text-cyan-600',
-    icon: 'text-cyan-500',
+    bg: 'bg-cyan-50 dark:bg-cyan-900/20',
+    border: 'border-cyan-200 dark:border-cyan-800',
+    text: 'text-cyan-600 dark:text-cyan-400',
+    icon: 'text-cyan-500 dark:text-cyan-400',
   },
   emerald: {
-    bg: 'bg-emerald-50',
-    border: 'border-emerald-200',
-    text: 'text-emerald-600',
-    icon: 'text-emerald-500',
+    bg: 'bg-emerald-50 dark:bg-emerald-900/20',
+    border: 'border-emerald-200 dark:border-emerald-800',
+    text: 'text-emerald-600 dark:text-emerald-400',
+    icon: 'text-emerald-500 dark:text-emerald-400',
   },
   amber: {
-    bg: 'bg-amber-50',
-    border: 'border-amber-200',
-    text: 'text-amber-600',
-    icon: 'text-amber-500',
+    bg: 'bg-amber-50 dark:bg-amber-900/20',
+    border: 'border-amber-200 dark:border-amber-800',
+    text: 'text-amber-600 dark:text-amber-400',
+    icon: 'text-amber-500 dark:text-amber-400',
   },
   red: {
-    bg: 'bg-red-50',
-    border: 'border-red-200',
-    text: 'text-red-600',
-    icon: 'text-red-500',
+    bg: 'bg-red-50 dark:bg-red-900/20',
+    border: 'border-red-200 dark:border-red-800',
+    text: 'text-red-600 dark:text-red-400',
+    icon: 'text-red-500 dark:text-red-400',
   },
   purple: {
-    bg: 'bg-purple-50',
-    border: 'border-purple-200',
-    text: 'text-purple-600',
-    icon: 'text-purple-500',
+    bg: 'bg-purple-50 dark:bg-purple-900/20',
+    border: 'border-purple-200 dark:border-purple-800',
+    text: 'text-purple-600 dark:text-purple-400',
+    icon: 'text-purple-500 dark:text-purple-400',
   },
 };
 
@@ -66,9 +66,9 @@ export const StatCard = memo(function StatCard({
   if (isLoading) {
     return (
       <div className={`rounded-xl border ${colors.border} ${colors.bg} p-6 animate-pulse`}>
-        <div className="h-4 w-24 bg-gray-200 rounded mb-3" />
-        <div className="h-8 w-32 bg-gray-200 rounded mb-2" />
-        <div className="h-3 w-20 bg-gray-200 rounded" />
+        <div className="h-4 w-24 bg-gray-200 dark:bg-neutral-700 rounded mb-3" />
+        <div className="h-8 w-32 bg-gray-200 dark:bg-neutral-700 rounded mb-2" />
+        <div className="h-3 w-20 bg-gray-200 dark:bg-neutral-700 rounded" />
       </div>
     );
   }
@@ -76,7 +76,7 @@ export const StatCard = memo(function StatCard({
   return (
     <div className={`rounded-xl border ${colors.border} ${colors.bg} p-6 transition-shadow hover:shadow-md`}>
       <div className="flex items-center justify-between mb-3">
-        <span className="text-sm font-medium text-gray-500 uppercase tracking-wide">
+        <span className="text-sm font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wide">
           {title}
         </span>
         {icon && (
@@ -92,15 +92,15 @@ export const StatCard = memo(function StatCard({
 
       <div className="flex items-center gap-2">
         {subtitle && (
-          <span className="text-sm text-gray-500">{subtitle}</span>
+          <span className="text-sm text-gray-500 dark:text-neutral-400">{subtitle}</span>
         )}
 
         {trend && (
           <span className={`
             text-xs font-medium px-2 py-0.5 rounded-full
             ${trend.isPositive
-              ? 'bg-emerald-100 text-emerald-600'
-              : 'bg-red-100 text-red-600'
+              ? 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400'
+              : 'bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400'
             }
           `}>
             {trend.isPositive ? '↑' : '↓'} {Math.abs(trend.value)}%

--- a/portal/src/pages/apis/APICatalog.tsx
+++ b/portal/src/pages/apis/APICatalog.tsx
@@ -87,20 +87,20 @@ export function APICatalog() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">API Catalog</h1>
-          <p className="text-gray-500 mt-1">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">API Catalog</h1>
+          <p className="text-gray-500 dark:text-neutral-400 mt-1">
             Browse and discover available APIs
           </p>
         </div>
         <div className="flex items-center gap-2">
           {/* View mode toggle */}
-          <div className="flex items-center border border-gray-200 rounded-lg overflow-hidden">
+          <div className="flex items-center border border-gray-200 dark:border-neutral-700 rounded-lg overflow-hidden">
             <button
               onClick={() => setViewMode('grid')}
               className={`p-2 ${
                 viewMode === 'grid'
-                  ? 'bg-primary-50 text-primary-700'
-                  : 'bg-white text-gray-500 hover:bg-gray-50'
+                  ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400'
+                  : 'bg-white dark:bg-neutral-800 text-gray-500 dark:text-neutral-400 hover:bg-gray-50 dark:hover:bg-neutral-700'
               }`}
               title="Grid view"
             >
@@ -110,8 +110,8 @@ export function APICatalog() {
               onClick={() => setViewMode('list')}
               className={`p-2 ${
                 viewMode === 'list'
-                  ? 'bg-primary-50 text-primary-700'
-                  : 'bg-white text-gray-500 hover:bg-gray-50'
+                  ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400'
+                  : 'bg-white dark:bg-neutral-800 text-gray-500 dark:text-neutral-400 hover:bg-gray-50 dark:hover:bg-neutral-700'
               }`}
               title="List view"
             >
@@ -122,7 +122,7 @@ export function APICatalog() {
           <button
             onClick={() => refetchAPIs()}
             disabled={apisLoading}
-            className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors disabled:opacity-50"
+            className="p-2 text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg transition-colors disabled:opacity-50"
             title="Refresh"
           >
             <RefreshCw className={`h-4 w-4 ${apisLoading ? 'animate-spin' : ''}`} />
@@ -145,7 +145,7 @@ export function APICatalog() {
 
       {/* Results count */}
       {!apisLoading && !apisError && (
-        <div className="text-sm text-gray-500">
+        <div className="text-sm text-gray-500 dark:text-neutral-400">
           {totalCount === 0 ? (
             'No APIs found'
           ) : totalCount === 1 ? (
@@ -159,25 +159,25 @@ export function APICatalog() {
 
       {/* Loading state */}
       {apisLoading && (
-        <div className="bg-white rounded-lg border border-gray-200 p-12 text-center">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-12 text-center">
           <Loader2 className="h-8 w-8 text-primary-600 animate-spin mx-auto mb-4" />
-          <p className="text-gray-500">Loading APIs...</p>
+          <p className="text-gray-500 dark:text-neutral-400">Loading APIs...</p>
         </div>
       )}
 
       {/* Error state */}
       {apisError && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-6">
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6">
           <div className="flex items-start gap-3">
-            <AlertCircle className="h-5 w-5 text-red-500 mt-0.5" />
+            <AlertCircle className="h-5 w-5 text-red-500 dark:text-red-400 mt-0.5" />
             <div>
-              <h3 className="font-medium text-red-800">Failed to load APIs</h3>
-              <p className="text-sm text-red-600 mt-1">
+              <h3 className="font-medium text-red-800 dark:text-red-300">Failed to load APIs</h3>
+              <p className="text-sm text-red-600 dark:text-red-400 mt-1">
                 {(apisErrorDetails as Error)?.message || 'An unexpected error occurred'}
               </p>
               <button
                 onClick={() => refetchAPIs()}
-                className="mt-3 px-4 py-2 bg-red-100 text-red-700 rounded-lg hover:bg-red-200 text-sm font-medium transition-colors"
+                className="mt-3 px-4 py-2 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-lg hover:bg-red-200 dark:hover:bg-red-900/50 text-sm font-medium transition-colors"
               >
                 Try Again
               </button>
@@ -188,12 +188,12 @@ export function APICatalog() {
 
       {/* Empty state */}
       {!apisLoading && !apisError && apis.length === 0 && (
-        <div className="bg-white rounded-lg border border-gray-200 p-12 text-center">
-          <div className="inline-flex p-4 bg-gray-100 rounded-full mb-4">
-            <BookOpen className="h-8 w-8 text-gray-400" />
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-12 text-center">
+          <div className="inline-flex p-4 bg-gray-100 dark:bg-neutral-700 rounded-full mb-4">
+            <BookOpen className="h-8 w-8 text-gray-400 dark:text-neutral-500" />
           </div>
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">No APIs Found</h2>
-          <p className="text-gray-500 max-w-md mx-auto">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">No APIs Found</h2>
+          <p className="text-gray-500 dark:text-neutral-400 max-w-md mx-auto">
             {search || category || universe
               ? 'No APIs match your current filters. Try adjusting your search criteria.'
               : 'There are no published APIs available yet. Check back later!'}
@@ -232,22 +232,22 @@ export function APICatalog() {
 
           {/* Pagination */}
           {totalPages > 1 && (
-            <div className="flex items-center justify-between border-t border-gray-200 pt-4">
-              <div className="text-sm text-gray-500">
+            <div className="flex items-center justify-between border-t border-gray-200 dark:border-neutral-700 pt-4">
+              <div className="text-sm text-gray-500 dark:text-neutral-400">
                 Page {page} of {totalPages}
               </div>
               <div className="flex gap-2">
                 <button
                   onClick={() => setPage((p) => Math.max(1, p - 1))}
                   disabled={page === 1}
-                  className="px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg text-sm font-medium text-gray-700 dark:text-neutral-200 hover:bg-gray-50 dark:hover:bg-neutral-700 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Previous
                 </button>
                 <button
                   onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                   disabled={page === totalPages}
-                  className="px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg text-sm font-medium text-gray-700 dark:text-neutral-200 hover:bg-gray-50 dark:hover:bg-neutral-700 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Next
                 </button>

--- a/portal/src/pages/apis/APIDetail.tsx
+++ b/portal/src/pages/apis/APIDetail.tsx
@@ -33,11 +33,11 @@ import type { APIEndpoint } from '../../types';
 type TabType = 'overview' | 'endpoints' | 'openapi';
 
 const methodColors: Record<string, string> = {
-  GET: 'bg-green-100 text-green-800',
-  POST: 'bg-blue-100 text-blue-800',
-  PUT: 'bg-amber-100 text-amber-800',
-  PATCH: 'bg-orange-100 text-orange-800',
-  DELETE: 'bg-red-100 text-red-800',
+  GET: 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400',
+  POST: 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400',
+  PUT: 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-400',
+  PATCH: 'bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-400',
+  DELETE: 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400',
 };
 
 export function APIDetail() {
@@ -78,9 +78,9 @@ export function APIDetail() {
   };
 
   const statusColors = {
-    published: 'bg-green-100 text-green-800',
-    deprecated: 'bg-amber-100 text-amber-800',
-    draft: 'bg-gray-100 text-gray-800',
+    published: 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400',
+    deprecated: 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-400',
+    draft: 'bg-gray-100 dark:bg-neutral-700 text-gray-800 dark:text-neutral-200',
   };
 
   const formatDate = (dateString: string) => {
@@ -117,7 +117,7 @@ export function APIDetail() {
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="text-center">
           <Loader2 className="h-8 w-8 text-primary-600 animate-spin mx-auto mb-4" />
-          <p className="text-gray-500">Loading API details...</p>
+          <p className="text-gray-500 dark:text-neutral-400">Loading API details...</p>
         </div>
       </div>
     );
@@ -129,23 +129,23 @@ export function APIDetail() {
       <div className="space-y-6">
         <Link
           to="/apis"
-          className="inline-flex items-center text-sm text-gray-600 hover:text-gray-900"
+          className="inline-flex items-center text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white"
         >
           <ArrowLeft className="h-4 w-4 mr-1" />
           Back to API Catalog
         </Link>
 
-        <div className="bg-red-50 border border-red-200 rounded-lg p-6">
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6">
           <div className="flex items-start gap-3">
-            <AlertCircle className="h-5 w-5 text-red-500 mt-0.5" />
+            <AlertCircle className="h-5 w-5 text-red-500 dark:text-red-400 mt-0.5" />
             <div>
-              <h3 className="font-medium text-red-800">Failed to load API</h3>
-              <p className="text-sm text-red-600 mt-1">
+              <h3 className="font-medium text-red-800 dark:text-red-300">Failed to load API</h3>
+              <p className="text-sm text-red-600 dark:text-red-400 mt-1">
                 {(error as Error)?.message || 'The API could not be found or you do not have access to it.'}
               </p>
               <Link
                 to="/apis"
-                className="mt-3 inline-block px-4 py-2 bg-red-100 text-red-700 rounded-lg hover:bg-red-200 text-sm font-medium transition-colors"
+                className="mt-3 inline-block px-4 py-2 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-lg hover:bg-red-200 dark:hover:bg-red-900/50 text-sm font-medium transition-colors"
               >
                 Return to Catalog
               </Link>
@@ -167,29 +167,29 @@ export function APIDetail() {
       {/* Back link */}
       <Link
         to="/apis"
-        className="inline-flex items-center text-sm text-gray-600 hover:text-gray-900"
+        className="inline-flex items-center text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white"
       >
         <ArrowLeft className="h-4 w-4 mr-1" />
         Back to API Catalog
       </Link>
 
       {/* Header */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
         <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
           <div className="flex-1">
             <div className="flex items-center gap-3 mb-2">
-              <h1 className="text-2xl font-bold text-gray-900">{api.name}</h1>
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{api.name}</h1>
               <span className={`px-2 py-1 text-xs font-medium rounded-full ${statusColors[api.status]}`}>
                 {api.status}
               </span>
             </div>
-            <p className="text-gray-500 mb-4">Version {api.version}</p>
-            <p className="text-gray-700">{api.description || 'No description available'}</p>
+            <p className="text-gray-500 dark:text-neutral-400 mb-4">Version {api.version}</p>
+            <p className="text-gray-700 dark:text-neutral-300">{api.description || 'No description available'}</p>
 
             {/* Tags */}
             <div className="flex flex-wrap gap-2 mt-4">
               {api.category && (
-                <span className="inline-flex items-center gap-1 px-3 py-1 bg-primary-50 text-primary-700 text-sm rounded-full">
+                <span className="inline-flex items-center gap-1 px-3 py-1 bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400 text-sm rounded-full">
                   <Tag className="h-3 w-3" />
                   {api.category}
                 </span>
@@ -197,7 +197,7 @@ export function APIDetail() {
               {api.tags?.map((tag) => (
                 <span
                   key={tag}
-                  className="px-3 py-1 bg-gray-100 text-gray-600 text-sm rounded-full"
+                  className="px-3 py-1 bg-gray-100 dark:bg-neutral-700 text-gray-600 dark:text-neutral-300 text-sm rounded-full"
                 >
                   {tag}
                 </span>
@@ -219,7 +219,7 @@ export function APIDetail() {
             {config.features.enableAPITesting && (
               <Link
                 to={`/apis/${api.id}/test`}
-                className="inline-flex items-center justify-center gap-2 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                className="inline-flex items-center justify-center gap-2 px-4 py-2 border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-neutral-200 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
               >
                 <PlayCircle className="h-4 w-4" />
                 Try this API
@@ -230,7 +230,7 @@ export function APIDetail() {
                 href={api.documentation}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center justify-center gap-2 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                className="inline-flex items-center justify-center gap-2 px-4 py-2 border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-neutral-200 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
               >
                 <ExternalLink className="h-4 w-4" />
                 Documentation
@@ -240,26 +240,26 @@ export function APIDetail() {
         </div>
 
         {/* Metadata */}
-        <div className="flex items-center gap-6 mt-6 pt-6 border-t border-gray-100 text-sm text-gray-500">
+        <div className="flex items-center gap-6 mt-6 pt-6 border-t border-gray-100 dark:border-neutral-700 text-sm text-gray-500 dark:text-neutral-400">
           <div className="flex items-center gap-1">
             <Clock className="h-4 w-4" />
             Updated {formatDate(api.updatedAt)}
           </div>
           {api.tenantName && (
             <div>
-              Provider: <span className="text-gray-700">{api.tenantName}</span>
+              Provider: <span className="text-gray-700 dark:text-neutral-200">{api.tenantName}</span>
             </div>
           )}
           {api.endpoints && (
             <div>
-              <span className="text-gray-700">{api.endpoints.length}</span> endpoint{api.endpoints.length !== 1 ? 's' : ''}
+              <span className="text-gray-700 dark:text-neutral-200">{api.endpoints.length}</span> endpoint{api.endpoints.length !== 1 ? 's' : ''}
             </div>
           )}
         </div>
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-gray-200">
+      <div className="border-b border-gray-200 dark:border-neutral-700">
         <nav className="flex gap-8">
           {tabs.map((tab) => {
             const Icon = tab.icon;
@@ -269,8 +269,8 @@ export function APIDetail() {
                 onClick={() => setActiveTab(tab.id)}
                 className={`flex items-center gap-2 py-3 border-b-2 text-sm font-medium transition-colors ${
                   activeTab === tab.id
-                    ? 'border-primary-500 text-primary-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                    ? 'border-primary-500 text-primary-600 dark:text-primary-400'
+                    : 'border-transparent text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-200 hover:border-gray-300 dark:hover:border-neutral-600'
                 }`}
               >
                 <Icon className="h-4 w-4" />
@@ -282,23 +282,23 @@ export function APIDetail() {
       </div>
 
       {/* Tab Content */}
-      <div className="bg-white rounded-lg border border-gray-200">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700">
         {/* Overview Tab */}
         {activeTab === 'overview' && (
           <div className="p-6">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">About this API</h2>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">About this API</h2>
             <div className="prose prose-gray max-w-none">
               <p>{api.description || 'No detailed description available for this API.'}</p>
             </div>
 
             {/* Quick Start */}
             <div className="mt-8">
-              <h3 className="text-md font-semibold text-gray-900 mb-3">Quick Start</h3>
-              <div className="bg-gray-50 rounded-lg p-4">
-                <p className="text-sm text-gray-600 mb-3">
+              <h3 className="text-md font-semibold text-gray-900 dark:text-white mb-3">Quick Start</h3>
+              <div className="bg-gray-50 dark:bg-neutral-700 rounded-lg p-4">
+                <p className="text-sm text-gray-600 dark:text-neutral-300 mb-3">
                   To use this API, you'll need to:
                 </p>
-                <ol className="list-decimal list-inside space-y-2 text-sm text-gray-700">
+                <ol className="list-decimal list-inside space-y-2 text-sm text-gray-700 dark:text-neutral-200">
                   <li>Create an application to get client credentials</li>
                   <li>Subscribe your application to this API</li>
                   <li>Use your credentials to authenticate requests</li>
@@ -318,7 +318,7 @@ export function APIDetail() {
 
         {/* Endpoints Tab */}
         {activeTab === 'endpoints' && (
-          <div className="divide-y divide-gray-200">
+          <div className="divide-y divide-gray-200 dark:divide-neutral-700">
             {api.endpoints && api.endpoints.length > 0 ? (
               api.endpoints.map((endpoint: APIEndpoint, index: number) => {
                 const endpointId = `${endpoint.method}-${endpoint.path}-${index}`;
@@ -334,14 +334,14 @@ export function APIDetail() {
                         <span className={`px-2 py-1 text-xs font-mono font-semibold rounded ${methodColors[endpoint.method] || 'bg-gray-100 text-gray-800'}`}>
                           {endpoint.method}
                         </span>
-                        <span className="font-mono text-sm text-gray-700">{endpoint.path}</span>
+                        <span className="font-mono text-sm text-gray-700 dark:text-neutral-200">{endpoint.path}</span>
                       </div>
                       <div className="flex items-center gap-2">
-                        <span className="text-sm text-gray-500">{endpoint.summary}</span>
+                        <span className="text-sm text-gray-500 dark:text-neutral-400">{endpoint.summary}</span>
                         {isExpanded ? (
-                          <ChevronDown className="h-4 w-4 text-gray-400" />
+                          <ChevronDown className="h-4 w-4 text-gray-400 dark:text-neutral-500" />
                         ) : (
-                          <ChevronRight className="h-4 w-4 text-gray-400" />
+                          <ChevronRight className="h-4 w-4 text-gray-400 dark:text-neutral-500" />
                         )}
                       </div>
                     </button>
@@ -349,35 +349,35 @@ export function APIDetail() {
                     {isExpanded && (
                       <div className="mt-4 pl-16 space-y-4">
                         {endpoint.summary && (
-                          <p className="text-sm text-gray-600">{endpoint.summary}</p>
+                          <p className="text-sm text-gray-600 dark:text-neutral-300">{endpoint.summary}</p>
                         )}
 
                         {endpoint.parameters && endpoint.parameters.length > 0 && (
                           <div>
-                            <h4 className="text-sm font-medium text-gray-900 mb-2">Parameters</h4>
-                            <div className="bg-gray-50 rounded-lg overflow-hidden">
+                            <h4 className="text-sm font-medium text-gray-900 dark:text-white mb-2">Parameters</h4>
+                            <div className="bg-gray-50 dark:bg-neutral-700 rounded-lg overflow-hidden">
                               <table className="min-w-full text-sm">
                                 <thead>
-                                  <tr className="border-b border-gray-200">
-                                    <th className="px-3 py-2 text-left font-medium text-gray-500">Name</th>
-                                    <th className="px-3 py-2 text-left font-medium text-gray-500">Type</th>
-                                    <th className="px-3 py-2 text-left font-medium text-gray-500">Required</th>
-                                    <th className="px-3 py-2 text-left font-medium text-gray-500">Description</th>
+                                  <tr className="border-b border-gray-200 dark:border-neutral-600">
+                                    <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-neutral-400">Name</th>
+                                    <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-neutral-400">Type</th>
+                                    <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-neutral-400">Required</th>
+                                    <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-neutral-400">Description</th>
                                   </tr>
                                 </thead>
-                                <tbody className="divide-y divide-gray-200">
+                                <tbody className="divide-y divide-gray-200 dark:divide-neutral-600">
                                   {endpoint.parameters.map((param, pIndex) => (
                                     <tr key={pIndex}>
-                                      <td className="px-3 py-2 font-mono text-gray-700">{param.name}</td>
-                                      <td className="px-3 py-2 text-gray-500">{param.in}</td>
+                                      <td className="px-3 py-2 font-mono text-gray-700 dark:text-neutral-200">{param.name}</td>
+                                      <td className="px-3 py-2 text-gray-500 dark:text-neutral-400">{param.in}</td>
                                       <td className="px-3 py-2">
                                         {param.required ? (
-                                          <span className="text-red-600">Yes</span>
+                                          <span className="text-red-600 dark:text-red-400">Yes</span>
                                         ) : (
-                                          <span className="text-gray-400">No</span>
+                                          <span className="text-gray-400 dark:text-neutral-500">No</span>
                                         )}
                                       </td>
-                                      <td className="px-3 py-2 text-gray-600">{param.description || '-'}</td>
+                                      <td className="px-3 py-2 text-gray-600 dark:text-neutral-300">{param.description || '-'}</td>
                                     </tr>
                                   ))}
                                 </tbody>
@@ -388,19 +388,19 @@ export function APIDetail() {
 
                         {endpoint.responses && Object.keys(endpoint.responses).length > 0 && (
                           <div>
-                            <h4 className="text-sm font-medium text-gray-900 mb-2">Responses</h4>
+                            <h4 className="text-sm font-medium text-gray-900 dark:text-white mb-2">Responses</h4>
                             <div className="space-y-2">
                               {Object.entries(endpoint.responses).map(([code, response]) => (
                                 <div key={code} className="flex items-start gap-2 text-sm">
                                   <span className={`px-2 py-0.5 rounded font-mono text-xs ${
-                                    code.startsWith('2') ? 'bg-green-100 text-green-800' :
-                                    code.startsWith('4') ? 'bg-amber-100 text-amber-800' :
-                                    code.startsWith('5') ? 'bg-red-100 text-red-800' :
-                                    'bg-gray-100 text-gray-800'
+                                    code.startsWith('2') ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400' :
+                                    code.startsWith('4') ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-400' :
+                                    code.startsWith('5') ? 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400' :
+                                    'bg-gray-100 dark:bg-neutral-700 text-gray-800 dark:text-neutral-200'
                                   }`}>
                                     {code}
                                   </span>
-                                  <span className="text-gray-600">{response.description || 'No description'}</span>
+                                  <span className="text-gray-600 dark:text-neutral-300">{response.description || 'No description'}</span>
                                 </div>
                               ))}
                             </div>
@@ -413,9 +413,9 @@ export function APIDetail() {
               })
             ) : (
               <div className="p-12 text-center">
-                <Code2 className="h-8 w-8 text-gray-300 mx-auto mb-3" />
-                <p className="text-gray-500">No endpoint information available</p>
-                <p className="text-sm text-gray-400 mt-1">Check the OpenAPI spec tab for full API documentation</p>
+                <Code2 className="h-8 w-8 text-gray-300 dark:text-neutral-600 mx-auto mb-3" />
+                <p className="text-gray-500 dark:text-neutral-400">No endpoint information available</p>
+                <p className="text-sm text-gray-400 dark:text-neutral-500 mt-1">Check the OpenAPI spec tab for full API documentation</p>
               </div>
             )}
           </div>
@@ -431,10 +431,10 @@ export function APIDetail() {
             ) : openApiSpec ? (
               <div>
                 <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-lg font-semibold text-gray-900">OpenAPI Specification</h3>
+                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white">OpenAPI Specification</h3>
                   <button
                     onClick={copyOpenAPISpec}
-                    className="inline-flex items-center gap-2 px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors"
+                    className="inline-flex items-center gap-2 px-3 py-1.5 text-sm text-gray-600 dark:text-neutral-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
                   >
                     {copiedSpec ? (
                       <>
@@ -455,8 +455,8 @@ export function APIDetail() {
               </div>
             ) : (
               <div className="text-center py-12">
-                <FileJson className="h-8 w-8 text-gray-300 mx-auto mb-3" />
-                <p className="text-gray-500">No OpenAPI specification available</p>
+                <FileJson className="h-8 w-8 text-gray-300 dark:text-neutral-600 mx-auto mb-3" />
+                <p className="text-gray-500 dark:text-neutral-400">No OpenAPI specification available</p>
               </div>
             )}
           </div>
@@ -484,34 +484,34 @@ export function APIDetail() {
             onClick={() => setSubscriptionResult(null)}
           />
           <div className="flex min-h-full items-center justify-center p-4">
-            <div className="relative bg-white rounded-xl shadow-xl max-w-md w-full p-6">
+            <div className="relative bg-white dark:bg-neutral-800 rounded-xl shadow-xl max-w-md w-full p-6">
               <div className="text-center mb-6">
-                <div className="mx-auto w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mb-4">
-                  <Check className="h-6 w-6 text-green-600" />
+                <div className="mx-auto w-12 h-12 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mb-4">
+                  <Check className="h-6 w-6 text-green-600 dark:text-green-400" />
                 </div>
-                <h2 className="text-xl font-semibold text-gray-900">
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
                   Subscription Created!
                 </h2>
-                <p className="text-sm text-gray-500 mt-1">
+                <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
                   Your API key is shown below. Save it now - it won't be shown again.
                 </p>
               </div>
 
-              <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 mb-4">
+              <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3 mb-4">
                 <div className="flex items-start gap-2">
-                  <AlertCircle className="h-5 w-5 text-amber-600 flex-shrink-0 mt-0.5" />
-                  <p className="text-sm text-amber-800">
+                  <AlertCircle className="h-5 w-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+                  <p className="text-sm text-amber-800 dark:text-amber-300">
                     <strong>Important:</strong> Copy and save this API key now. For security reasons, it cannot be displayed again.
                   </p>
                 </div>
               </div>
 
               <div className="mb-6">
-                <span className="block text-sm font-medium text-gray-700 mb-2">
+                <span className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
                   Your API Key
                 </span>
                 <div className="flex items-center gap-2">
-                  <code className="flex-1 px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-sm font-mono break-all" aria-label="API Key">
+                  <code className="flex-1 px-3 py-2 bg-gray-100 dark:bg-neutral-700 border border-gray-300 dark:border-neutral-600 rounded-lg text-sm font-mono break-all text-gray-900 dark:text-white" aria-label="API Key">
                     {subscriptionResult.apiKey}
                   </code>
                   <button
@@ -520,7 +520,7 @@ export function APIDetail() {
                       setCopiedApiKey(true);
                       setTimeout(() => setCopiedApiKey(false), 2000);
                     }}
-                    className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg"
+                    className="p-2 text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg"
                   >
                     {copiedApiKey ? (
                       <Check className="h-5 w-5 text-green-500" />

--- a/portal/src/pages/contracts/CreateContractPage.tsx
+++ b/portal/src/pages/contracts/CreateContractPage.tsx
@@ -69,26 +69,26 @@ export const CreateContractPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-neutral-900">
       {/* Header */}
-      <header className="bg-white border-b border-gray-200">
+      <header className="bg-white dark:bg-neutral-800 border-b border-gray-200 dark:border-neutral-700">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex items-center gap-4">
             <button
               onClick={() => navigate('/contracts')}
-              className="text-gray-500 hover:text-gray-700 transition-colors"
+              className="text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-200 transition-colors"
             >
               <ArrowLeft className="h-5 w-5" />
             </button>
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-blue-100 flex items-center justify-center">
-                <FileCode className="h-5 w-5 text-blue-600" />
+              <div className="h-10 w-10 rounded-lg bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
+                <FileCode className="h-5 w-5 text-blue-600 dark:text-blue-400" />
               </div>
               <div>
-                <h1 className="text-xl font-semibold text-gray-900">
+                <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
                   Create Contract
                 </h1>
-                <p className="text-sm text-gray-500">
+                <p className="text-sm text-gray-500 dark:text-neutral-400">
                   Define once, expose via REST, MCP, GraphQL & more
                 </p>
               </div>
@@ -102,8 +102,8 @@ export const CreateContractPage: React.FC = () => {
         <form onSubmit={handleSubmit} className="space-y-6">
           {/* Error message */}
           {error && (
-            <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-              <p className="text-sm text-red-700">{error}</p>
+            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
+              <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
             </div>
           )}
 
@@ -111,7 +111,7 @@ export const CreateContractPage: React.FC = () => {
           <div>
             <label
               htmlFor="name"
-              className="block text-sm font-medium text-gray-700 mb-1"
+              className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
             >
               Contract Name <span className="text-red-500">*</span>
             </label>
@@ -123,9 +123,9 @@ export const CreateContractPage: React.FC = () => {
               value={formData.name}
               onChange={handleInputChange}
               placeholder="e.g., customer-api"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-neutral-400 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
-            <p className="mt-1 text-xs text-gray-500">
+            <p className="mt-1 text-xs text-gray-500 dark:text-neutral-400">
               Lowercase, hyphens allowed. Used in endpoints.
             </p>
           </div>
@@ -134,7 +134,7 @@ export const CreateContractPage: React.FC = () => {
           <div>
             <label
               htmlFor="display_name"
-              className="block text-sm font-medium text-gray-700 mb-1"
+              className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
             >
               Display Name
             </label>
@@ -145,7 +145,7 @@ export const CreateContractPage: React.FC = () => {
               value={formData.display_name || ''}
               onChange={handleInputChange}
               placeholder="e.g., Customer API"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-neutral-400 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
           </div>
 
@@ -153,7 +153,7 @@ export const CreateContractPage: React.FC = () => {
           <div>
             <label
               htmlFor="description"
-              className="block text-sm font-medium text-gray-700 mb-1"
+              className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
             >
               Description
             </label>
@@ -164,7 +164,7 @@ export const CreateContractPage: React.FC = () => {
               value={formData.description || ''}
               onChange={handleInputChange}
               placeholder="What does this API do?"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-neutral-400 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
           </div>
 
@@ -172,7 +172,7 @@ export const CreateContractPage: React.FC = () => {
           <div>
             <label
               htmlFor="version"
-              className="block text-sm font-medium text-gray-700 mb-1"
+              className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
             >
               Version
             </label>
@@ -183,7 +183,7 @@ export const CreateContractPage: React.FC = () => {
               value={formData.version || ''}
               onChange={handleInputChange}
               placeholder="1.0.0"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-neutral-400 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
           </div>
 
@@ -191,7 +191,7 @@ export const CreateContractPage: React.FC = () => {
           <div>
             <label
               htmlFor="openapi_spec_url"
-              className="block text-sm font-medium text-gray-700 mb-1"
+              className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
             >
               OpenAPI Spec URL
             </label>
@@ -202,22 +202,22 @@ export const CreateContractPage: React.FC = () => {
               value={formData.openapi_spec_url || ''}
               onChange={handleInputChange}
               placeholder="https://example.com/openapi.yaml"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-neutral-400 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
-            <p className="mt-1 text-xs text-gray-500">
+            <p className="mt-1 text-xs text-gray-500 dark:text-neutral-400">
               Optional. Link to your OpenAPI/Swagger specification.
             </p>
           </div>
 
           {/* Info box */}
-          <div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
+          <div className="bg-purple-50 dark:bg-purple-900/20 border border-purple-200 dark:border-purple-800 rounded-lg p-4">
             <div className="flex items-start gap-3">
               <span className="text-2xl">🤖</span>
               <div>
-                <p className="text-sm font-medium text-purple-800">
+                <p className="text-sm font-medium text-purple-800 dark:text-purple-300">
                   MCP binding auto-generated
                 </p>
-                <p className="text-sm text-purple-700 mt-1">
+                <p className="text-sm text-purple-700 dark:text-purple-400 mt-1">
                   When you publish this contract, STOA will automatically create
                   an MCP tool that AI agents can use. No extra configuration needed!
                 </p>
@@ -226,11 +226,11 @@ export const CreateContractPage: React.FC = () => {
           </div>
 
           {/* Submit button */}
-          <div className="flex justify-end gap-3 pt-4 border-t border-gray-200">
+          <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-neutral-700">
             <button
               type="button"
               onClick={() => navigate('/contracts')}
-              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-neutral-200 bg-white dark:bg-neutral-700 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-600 transition-colors"
             >
               Cancel
             </button>

--- a/portal/src/pages/profile/Profile.tsx
+++ b/portal/src/pages/profile/Profile.tsx
@@ -8,14 +8,14 @@ export function ProfilePage() {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">My Profile</h1>
-        <p className="text-gray-500 mt-1">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">My Profile</h1>
+        <p className="text-gray-500 dark:text-neutral-400 mt-1">
           View and manage your account settings
         </p>
       </div>
 
       {/* Profile Card */}
-      <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 overflow-hidden">
         {/* Header with avatar */}
         <div className="bg-gradient-to-r from-primary-600 to-accent-600 px-6 py-8">
           <div className="flex items-center gap-4">
@@ -33,63 +33,63 @@ export function ProfilePage() {
         <div className="p-6 space-y-6">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-4">
-              <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider">
+              <h3 className="text-sm font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                 Account Information
               </h3>
 
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-gray-100 rounded-lg">
-                  <User className="h-5 w-5 text-gray-600" />
+                <div className="p-2 bg-gray-100 dark:bg-neutral-700 rounded-lg">
+                  <User className="h-5 w-5 text-gray-600 dark:text-neutral-300" />
                 </div>
                 <div>
-                  <p className="text-sm text-gray-500">Full Name</p>
-                  <p className="font-medium text-gray-900">{user?.name || 'Not set'}</p>
+                  <p className="text-sm text-gray-500 dark:text-neutral-400">Full Name</p>
+                  <p className="font-medium text-gray-900 dark:text-white">{user?.name || 'Not set'}</p>
                 </div>
               </div>
 
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-gray-100 rounded-lg">
-                  <Mail className="h-5 w-5 text-gray-600" />
+                <div className="p-2 bg-gray-100 dark:bg-neutral-700 rounded-lg">
+                  <Mail className="h-5 w-5 text-gray-600 dark:text-neutral-300" />
                 </div>
                 <div>
-                  <p className="text-sm text-gray-500">Email</p>
-                  <p className="font-medium text-gray-900">{user?.email || 'Not set'}</p>
+                  <p className="text-sm text-gray-500 dark:text-neutral-400">Email</p>
+                  <p className="font-medium text-gray-900 dark:text-white">{user?.email || 'Not set'}</p>
                 </div>
               </div>
 
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-gray-100 rounded-lg">
-                  <Building className="h-5 w-5 text-gray-600" />
+                <div className="p-2 bg-gray-100 dark:bg-neutral-700 rounded-lg">
+                  <Building className="h-5 w-5 text-gray-600 dark:text-neutral-300" />
                 </div>
                 <div>
-                  <p className="text-sm text-gray-500">Organization</p>
-                  <p className="font-medium text-gray-900">{user?.organization || 'Not set'}</p>
+                  <p className="text-sm text-gray-500 dark:text-neutral-400">Organization</p>
+                  <p className="font-medium text-gray-900 dark:text-white">{user?.organization || 'Not set'}</p>
                 </div>
               </div>
             </div>
 
             <div className="space-y-4">
-              <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider">
+              <h3 className="text-sm font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                 Security
               </h3>
 
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-gray-100 rounded-lg">
-                  <Key className="h-5 w-5 text-gray-600" />
+                <div className="p-2 bg-gray-100 dark:bg-neutral-700 rounded-lg">
+                  <Key className="h-5 w-5 text-gray-600 dark:text-neutral-300" />
                 </div>
                 <div>
-                  <p className="text-sm text-gray-500">User ID</p>
-                  <p className="font-mono text-sm text-gray-900">{user?.id || 'Unknown'}</p>
+                  <p className="text-sm text-gray-500 dark:text-neutral-400">User ID</p>
+                  <p className="font-mono text-sm text-gray-900 dark:text-white">{user?.id || 'Unknown'}</p>
                 </div>
               </div>
 
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-gray-100 rounded-lg">
-                  <Shield className="h-5 w-5 text-gray-600" />
+                <div className="p-2 bg-gray-100 dark:bg-neutral-700 rounded-lg">
+                  <Shield className="h-5 w-5 text-gray-600 dark:text-neutral-300" />
                 </div>
                 <div>
-                  <p className="text-sm text-gray-500">Authentication</p>
-                  <p className="font-medium text-gray-900">OIDC (Keycloak)</p>
+                  <p className="text-sm text-gray-500 dark:text-neutral-400">Authentication</p>
+                  <p className="font-medium text-gray-900 dark:text-white">OIDC (Keycloak)</p>
                 </div>
               </div>
             </div>
@@ -98,9 +98,9 @@ export function ProfilePage() {
       </div>
 
       {/* API Keys Section (placeholder) */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">API Keys</h3>
-        <p className="text-gray-500">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">API Keys</h3>
+        <p className="text-gray-500 dark:text-neutral-400">
           API key management will be available soon. For now, use your OIDC access token
           for API authentication.
         </p>

--- a/portal/src/pages/servers/MCPServersPage.tsx
+++ b/portal/src/pages/servers/MCPServersPage.tsx
@@ -42,9 +42,9 @@ const categoryConfig: Record<ServerCategory, {
 };
 
 const statusColors: Record<string, { bg: string; text: string }> = {
-  active: { bg: 'bg-green-100', text: 'text-green-700' },
-  maintenance: { bg: 'bg-amber-100', text: 'text-amber-700' },
-  deprecated: { bg: 'bg-red-100', text: 'text-red-700' },
+  active: { bg: 'bg-green-100 dark:bg-green-900/30', text: 'text-green-700 dark:text-green-400' },
+  maintenance: { bg: 'bg-amber-100 dark:bg-amber-900/30', text: 'text-amber-700 dark:text-amber-400' },
+  deprecated: { bg: 'bg-red-100 dark:bg-red-900/30', text: 'text-red-700 dark:text-red-400' },
 };
 
 export function MCPServersPage() {
@@ -165,15 +165,15 @@ export function MCPServersPage() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">AI Tools</h1>
-          <p className="text-gray-500 mt-1">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">AI Tools</h1>
+          <p className="text-gray-500 dark:text-neutral-400 mt-1">
             Discover and subscribe to AI-powered tool collections
           </p>
         </div>
         <button
           onClick={handleRefresh}
           disabled={isLoading}
-          className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50"
+          className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-neutral-200 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors disabled:opacity-50"
         >
           <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
           Refresh
@@ -182,12 +182,12 @@ export function MCPServersPage() {
 
       {/* Admin Notice */}
       {isAdminUser && (
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
           <div className="flex items-start gap-3">
-            <Shield className="h-5 w-5 text-blue-600 mt-0.5" />
+            <Shield className="h-5 w-5 text-blue-600 dark:text-blue-400 mt-0.5" />
             <div>
-              <h3 className="font-medium text-blue-800">Admin Access</h3>
-              <p className="text-sm text-blue-600 mt-1">
+              <h3 className="font-medium text-blue-800 dark:text-blue-300">Admin Access</h3>
+              <p className="text-sm text-blue-600 dark:text-blue-400 mt-1">
                 You have access to Platform Tools (STOA administration) which are not visible to standard users.
               </p>
             </div>
@@ -204,13 +204,13 @@ export function MCPServersPage() {
             placeholder="Search AI tools..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-neutral-400 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
           />
         </div>
       </div>
 
       {/* Category Tabs */}
-      <div className="flex flex-wrap gap-2 border-b border-gray-200 pb-4">
+      <div className="flex flex-wrap gap-2 border-b border-gray-200 dark:border-neutral-700 pb-4">
         {availableCategories.map((cat) => {
           const config = categoryConfig[cat];
           const Icon = config.icon;
@@ -224,14 +224,14 @@ export function MCPServersPage() {
               onClick={() => setSelectedCategory(cat)}
               className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                 selectedCategory === cat
-                  ? 'bg-primary-100 text-primary-700 border border-primary-200'
-                  : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100'
+                  ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 border border-primary-200 dark:border-primary-700'
+                  : 'bg-gray-50 dark:bg-neutral-800 text-gray-600 dark:text-neutral-300 border border-gray-200 dark:border-neutral-700 hover:bg-gray-100 dark:hover:bg-neutral-700'
               }`}
             >
               <Icon className="h-4 w-4" />
               {config.label}
               <span className={`px-2 py-0.5 rounded-full text-xs ${
-                selectedCategory === cat ? 'bg-primary-200' : 'bg-gray-200'
+                selectedCategory === cat ? 'bg-primary-200 dark:bg-primary-800' : 'bg-gray-200 dark:bg-neutral-700'
               }`}>
                 {count}
               </span>
@@ -245,15 +245,15 @@ export function MCPServersPage() {
 
       {/* Error State */}
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-6">
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6">
           <div className="flex items-start gap-3">
-            <AlertCircle className="h-5 w-5 text-red-500 mt-0.5" />
+            <AlertCircle className="h-5 w-5 text-red-500 dark:text-red-400 mt-0.5" />
             <div>
-              <h3 className="font-medium text-red-800">Failed to load servers</h3>
-              <p className="text-sm text-red-600 mt-1">{error}</p>
+              <h3 className="font-medium text-red-800 dark:text-red-300">Failed to load servers</h3>
+              <p className="text-sm text-red-600 dark:text-red-400 mt-1">{error}</p>
               <button
                 onClick={handleRefresh}
-                className="mt-3 px-4 py-2 bg-red-100 text-red-700 rounded-lg hover:bg-red-200 text-sm font-medium transition-colors"
+                className="mt-3 px-4 py-2 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-lg hover:bg-red-200 dark:hover:bg-red-900/50 text-sm font-medium transition-colors"
               >
                 Try Again
               </button>
@@ -274,7 +274,7 @@ export function MCPServersPage() {
               <Link
                 key={server.id}
                 to={`/servers/${server.id}`}
-                className="bg-white rounded-lg border border-gray-200 p-5 hover:border-primary-300 hover:shadow-md transition-all group"
+                className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-5 hover:border-primary-300 dark:hover:border-primary-600 hover:shadow-md transition-all group"
               >
                 {/* Header */}
                 <div className="flex items-start justify-between mb-3">
@@ -302,21 +302,21 @@ export function MCPServersPage() {
                 </div>
 
                 {/* Title & Description */}
-                <h3 className="font-semibold text-gray-900 group-hover:text-primary-700 transition-colors">
+                <h3 className="font-semibold text-gray-900 dark:text-white group-hover:text-primary-700 dark:group-hover:text-primary-400 transition-colors">
                   {server.displayName}
                 </h3>
-                <p className="text-sm text-gray-500 mt-1 line-clamp-2">
+                <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1 line-clamp-2">
                   {server.description}
                 </p>
 
                 {/* Tools Count */}
-                <div className="flex items-center gap-4 mt-4 text-sm text-gray-500">
+                <div className="flex items-center gap-4 mt-4 text-sm text-gray-500 dark:text-neutral-400">
                   <div className="flex items-center gap-1">
                     <Wrench className="h-4 w-4" />
                     <span>{server.tools.length} tools</span>
                   </div>
                   {server.version && (
-                    <span className="text-gray-400">v{server.version}</span>
+                    <span className="text-gray-400 dark:text-neutral-500">v{server.version}</span>
                   )}
                 </div>
 
@@ -325,21 +325,21 @@ export function MCPServersPage() {
                   {server.tools.slice(0, 3).map((tool) => (
                     <span
                       key={tool.id}
-                      className="inline-flex items-center px-2 py-0.5 text-xs bg-gray-100 text-gray-600 rounded-full"
+                      className="inline-flex items-center px-2 py-0.5 text-xs bg-gray-100 dark:bg-neutral-700 text-gray-600 dark:text-neutral-300 rounded-full"
                     >
                       {tool.displayName}
                     </span>
                   ))}
                   {server.tools.length > 3 && (
-                    <span className="text-xs text-gray-400">
+                    <span className="text-xs text-gray-400 dark:text-neutral-500">
                       +{server.tools.length - 3} more
                     </span>
                   )}
                 </div>
 
                 {/* Footer */}
-                <div className="flex items-center justify-between mt-4 pt-4 border-t border-gray-100">
-                  <span className="text-xs font-medium text-gray-500 bg-gray-100 px-2 py-1 rounded capitalize">
+                <div className="flex items-center justify-between mt-4 pt-4 border-t border-gray-100 dark:border-neutral-700">
+                  <span className="text-xs font-medium text-gray-500 dark:text-neutral-400 bg-gray-100 dark:bg-neutral-700 px-2 py-1 rounded capitalize">
                     {server.category}
                   </span>
                   <span className="flex items-center gap-1 text-sm font-medium text-primary-600 group-hover:text-primary-700">
@@ -355,12 +355,12 @@ export function MCPServersPage() {
 
       {/* Empty State */}
       {!isLoading && !error && filteredServers.length === 0 && (
-        <div className="bg-white rounded-lg border border-gray-200 p-12 text-center">
-          <div className="inline-flex p-4 bg-gray-100 rounded-full mb-4">
-            <Wrench className="h-8 w-8 text-gray-400" />
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-12 text-center">
+          <div className="inline-flex p-4 bg-gray-100 dark:bg-neutral-700 rounded-full mb-4">
+            <Wrench className="h-8 w-8 text-gray-400 dark:text-neutral-500" />
           </div>
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">No AI Tools Found</h2>
-          <p className="text-gray-500 max-w-md mx-auto mb-6">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">No AI Tools Found</h2>
+          <p className="text-gray-500 dark:text-neutral-400 max-w-md mx-auto mb-6">
             {searchQuery || selectedCategory !== 'all'
               ? 'No tools match your current filters. Try adjusting your search or category.'
               : 'No AI tools are currently available for your account.'}

--- a/portal/src/pages/usage/UsagePage.tsx
+++ b/portal/src/pages/usage/UsagePage.tsx
@@ -90,22 +90,22 @@ export function UsagePage() {
   const periodStats = getPeriodStats();
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-neutral-900">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Header */}
         <div className="flex items-center justify-between mb-8">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
               Usage Dashboard
             </h1>
-            <p className="text-gray-500 mt-1">
+            <p className="text-gray-500 dark:text-neutral-400 mt-1">
               Monitor your MCP tool consumption and performance
             </p>
           </div>
 
           <button
             onClick={fetchData}
-            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-neutral-200 bg-white dark:bg-neutral-800 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
           >
             <RefreshCw className="w-4 h-4" />
             Refresh
@@ -114,9 +114,9 @@ export function UsagePage() {
 
         {/* Error banner */}
         {error && (
-          <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg flex items-center gap-3">
-            <AlertTriangle className="w-5 h-5 text-red-500" />
-            <span className="text-red-700">{error}</span>
+          <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-center gap-3">
+            <AlertTriangle className="w-5 h-5 text-red-500 dark:text-red-400" />
+            <span className="text-red-700 dark:text-red-300">{error}</span>
           </div>
         )}
 
@@ -195,7 +195,7 @@ export function UsagePage() {
 
         {/* Period Selector */}
         <div className="mt-8 flex items-center justify-center gap-2">
-          <span className="text-sm text-gray-500">View period:</span>
+          <span className="text-sm text-gray-500 dark:text-neutral-400">View period:</span>
           {(['today', 'week', 'month'] as const).map((period) => (
             <button
               key={period}
@@ -203,8 +203,8 @@ export function UsagePage() {
               className={`
                 px-4 py-2 rounded-lg text-sm font-medium transition-colors
                 ${selectedPeriod === period
-                  ? 'bg-primary-100 text-primary-700 border border-primary-200'
-                  : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+                  ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 border border-primary-200 dark:border-primary-700'
+                  : 'text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-700'
                 }
               `}
             >


### PR DESCRIPTION
## Summary

- Add dark mode variants (`dark:`) to all Portal UI components and pages
- Implemented consistent color mapping across components:
  - `bg-white` → `dark:bg-neutral-800`
  - `bg-gray-50` → `dark:bg-neutral-900`  
  - `bg-gray-100` → `dark:bg-neutral-700`
  - `text-gray-900` → `dark:text-white`
  - `text-gray-600` → `dark:text-neutral-300`
  - `border-gray-*` → `dark:border-neutral-*`

### Components updated:
- `APICard.tsx` - API catalog card with status badges
- `CallsTable.tsx` - Usage calls table with filters
- `StatCard.tsx` - Statistics card with trend indicators

### Pages updated:
- `APICatalog.tsx` - API catalog listing
- `APIDetail.tsx` - API detail with tabs, endpoints, OpenAPI spec
- `CreateContractPage.tsx` - Contract creation form
- `Profile.tsx` - User profile page
- `MCPServersPage.tsx` - MCP servers/AI tools listing  
- `UsagePage.tsx` - Usage dashboard

## Test plan

- [ ] Toggle dark mode in Portal and verify all pages render correctly
- [ ] Check text contrast on dark backgrounds
- [ ] Verify status badges, buttons, inputs have proper dark styling
- [ ] Test modals and overlays in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)