### PR TITLE
fix(api): use patch.object() to fix CI test import errors (CAB-1101)

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -38,6 +38,9 @@ runs:
         if [ -n "$INSTALL_CMD" ]; then
           eval "$INSTALL_CMD"
         elif [ -f "pyproject.toml" ]; then
+          # Install main dependencies from requirements.txt if it exists
+          [ -f "requirements.txt" ] && pip install -r requirements.txt
+          # Install dev dependencies from pyproject.toml
           pip install -e ".[dev,k8s]" 2>/dev/null || pip install -e ".[dev]" 2>/dev/null || pip install -e "."
         elif [ -f "requirements.txt" ]; then
           pip install -r requirements.txt

--- a/control-plane-api/tests/conftest.py
+++ b/control-plane-api/tests/conftest.py
@@ -64,16 +64,19 @@ _mock_metrics_service = MagicMock()
 _mock_metrics_service.connect = AsyncMock()
 _mock_metrics_service.disconnect = AsyncMock()
 
+# Import src.main explicitly before patching (fixes AttributeError in CI)
+# This ensures the submodule is properly loaded before patch() tries to access it
+import src.main as _main_module
+
 # Patch services in the main module where they're imported and used
-# These patches target 'src.main.<service>' because main.py does:
-#   from .services import kafka_service, git_service, ...
-patch('src.main.kafka_service', _mock_kafka_service).start()
-patch('src.main.git_service', _mock_git_service).start()
-patch('src.main.awx_service', _mock_awx_service).start()
-patch('src.main.keycloak_service', _mock_keycloak_service).start()
-patch('src.main.gateway_service', _mock_gateway_service).start()
-patch('src.main.argocd_service', _mock_argocd_service).start()
-patch('src.main.metrics_service', _mock_metrics_service).start()
+# Using patch.object() instead of string-based patching for reliability
+patch.object(_main_module, 'kafka_service', _mock_kafka_service).start()
+patch.object(_main_module, 'git_service', _mock_git_service).start()
+patch.object(_main_module, 'awx_service', _mock_awx_service).start()
+patch.object(_main_module, 'keycloak_service', _mock_keycloak_service).start()
+patch.object(_main_module, 'gateway_service', _mock_gateway_service).start()
+patch.object(_main_module, 'argocd_service', _mock_argocd_service).start()
+patch.object(_main_module, 'metrics_service', _mock_metrics_service).start()
 
 # Also patch at service module level for routers that import directly
 patch('src.services.kafka_service.kafka_service', _mock_kafka_service).start()
@@ -82,11 +85,11 @@ patch('src.services.keycloak_service.keycloak_service', _mock_keycloak_service).
 patch('src.services.metrics_service.metrics_service', _mock_metrics_service).start()
 
 # Patch OpenSearch setup
-patch('src.main.setup_opensearch', AsyncMock()).start()
+patch.object(_main_module, 'setup_opensearch', AsyncMock()).start()
 
 # Patch error snapshots
-patch('src.main.connect_error_snapshots', AsyncMock(return_value=None)).start()
-patch('src.main.add_error_snapshot_middleware', MagicMock()).start()
+patch.object(_main_module, 'connect_error_snapshots', AsyncMock(return_value=None)).start()
+patch.object(_main_module, 'add_error_snapshot_middleware', MagicMock()).start()
 
 import asyncio
 from collections.abc import AsyncGenerator, Generator


### PR DESCRIPTION
## Summary
- Fix conftest.py to use `patch.object()` instead of string-based `patch()` 
- Explicitly import `src.main` before patching to avoid AttributeError in CI

## Problem
CI tests were failing with:
```
AttributeError: module 'src' has no attribute 'main'
```

This happened because `patch('src.main.kafka_service', ...)` tries to resolve `src.main` as an attribute access, which requires the submodule to be already imported.

## Solution
- Import `src.main` explicitly: `import src.main as _main_module`
- Use `patch.object(_main_module, 'kafka_service', ...)` for reliable patching

## Test plan
- [x] Local tests pass (302 passed)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)