### PR TITLE
docs(gateway): add auto-registration documentation (ADR-028)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,17 @@ Welcome to the STOA Platform documentation. STOA is a multi-tenant API managemen
 - **[MCP Subscriptions](./MCP-SUBSCRIPTIONS.md)** - MCP Gateway subscriptions
 - **[MCP Claude AI Integration](./MCP-CLAUDEAI-INTEGRATION.md)** - Claude AI integration
 
+### Gateway
+
+- **[Gateway Auto-Registration](./guides/gateway-auto-registration.md)** - Zero-config gateway deployment (ADR-028)
+- **[WebMethods Sidecar Integration](./integrations/webmethods-sidecar-integration.md)** - STOA sidecar with WebMethods
+
+### Architecture Decisions (ADRs)
+
+- **[ADR-024: Gateway Unified Modes](https://docs.gostoa.dev/architecture/adr/adr-024-gateway-unified-modes)** - edge-mcp, sidecar, proxy, shadow
+- **[ADR-027: Gateway Adapter Pattern](./architecture/adr/adr-027-gateway-adapter-pattern.md)** - Multi-gateway orchestration
+- **[ADR-028: Gateway Auto-Registration](./architecture/adr/adr-028-gateway-auto-registration.md)** - Apple-style gateway onboarding
+
 ### Operations
 
 - **[Observability](./OBSERVABILITY.md)** - Monitoring and logging
@@ -45,6 +56,7 @@ Operational runbooks organized by severity:
 ### Integrations
 
 - **[IBM webMethods Gateway API](./ibm/webmethods-gateway-api.md)** - Gateway integration
+- **[WebMethods + STOA Sidecar](./integrations/webmethods-sidecar-integration.md)** - Policy enforcement via sidecar
 
 ## Getting Help
 

--- a/docs/architecture/adr/adr-028-gateway-auto-registration.md
+++ b/docs/architecture/adr/adr-028-gateway-auto-registration.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+**Accepted** — Implemented 2026-02-06
 
 ## Date
 

--- a/docs/integrations/webmethods-sidecar-integration.md
+++ b/docs/integrations/webmethods-sidecar-integration.md
@@ -256,6 +256,8 @@ If the gateway shows OFFLINE in Console but is running:
 
 ## Related Documentation
 
-- [ADR-028: Gateway Auto-Registration](../architecture/adr/adr-028-gateway-auto-registration.md)
-- [ADR-024: Gateway Unified Modes](https://docs.gostoa.dev/architecture/adr/adr-024-gateway-unified-modes)
+- [ADR-028: Gateway Auto-Registration](../architecture/adr/adr-028-gateway-auto-registration.md) — Zero-config gateway onboarding
+- [ADR-024: Gateway Unified Modes](https://docs.gostoa.dev/architecture/adr/adr-024-gateway-unified-modes) — Gateway modes architecture
+- [Gateway Auto-Registration Guide](../guides/gateway-auto-registration.md) — Practical operations guide
+- [Gateway Registration Runbook](../runbooks/high/gateway-registration-failed.md) — Troubleshooting registration issues
 - [Control Plane Agnostique Plan](../plans/control-plane-agnostique.md)

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -25,6 +25,7 @@ This directory contains operational procedures for incident management on the ST
 | Runbook | Description | Impact |
 |---------|-------------|--------|
 | [Gateway High Latency](high/gateway-high-latency.md) | High latency on Gateway | Latency SLA compromised |
+| [Gateway Registration Failed](high/gateway-registration-failed.md) | Gateway auto-registration issues | Gateway not orchestrated by CP |
 | [Kafka Lag](high/kafka-lag.md) | High consumer lag on Redpanda | Deployments delayed |
 | [Certificate Expiration](high/certificate-expiration.md) | TLS certificates expiring/expired | HTTPS services inaccessible |
 
@@ -140,3 +141,4 @@ To add or modify a runbook:
 | Date | Modification |
 |------|--------------|
 | 2024-12-28 | Initial creation - 9 runbooks |
+| 2026-02-06 | Added Gateway Registration Failed runbook (ADR-028) |


### PR DESCRIPTION
## Summary
- Updates ADR-028 status from **Proposed** to **Accepted** (implemented 2026-02-06)
- Adds Gateway section and Architecture Decisions (ADR) index to docs README
- Adds gateway registration runbook to high-priority runbooks index
- Adds cross-references between webMethods sidecar integration, operations guide, and runbook

## Context
Gateway auto-registration (ADR-028) was implemented in PRs #121 and #122. This PR completes the documentation:
- [Operations guide](docs/guides/gateway-auto-registration.md) — Covers Tier 1 (native) and Tier 2 (sidecar) deployment
- [Runbook](docs/runbooks/high/gateway-registration-failed.md) — Troubleshooting 503/401/404 registration failures
- Updated cross-references across all related docs

## Test plan
- [ ] Verify all markdown links resolve correctly
- [ ] Verify docs render properly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)