### PR TITLE
perf(api,ui,portal): CAB-1113 Phases 4-6 — performance optimization

### DIFF
--- a/control-plane-api/src/routers/apis.py
+++ b/control-plane-api/src/routers/apis.py
@@ -2,10 +2,11 @@
 import logging
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from ..auth import Permission, User, get_current_user, require_permission, require_tenant_access
+from ..schemas.pagination import PaginatedResponse
 from ..services.git_service import git_service
 from ..services.kafka_service import kafka_service
 
@@ -72,16 +73,25 @@ def _api_from_yaml(tenant_id: str, api_data: dict) -> APIResponse:
     )
 
 
-@router.get("", response_model=list[APIResponse])
+@router.get("", response_model=PaginatedResponse[APIResponse])
 @require_tenant_access
-async def list_apis(tenant_id: str, user: User = Depends(get_current_user)):
-    """List all APIs for a tenant from GitLab"""
+async def list_apis(
+    tenant_id: str,
+    page: int = Query(default=1, ge=1, description="Page number"),
+    page_size: int = Query(default=20, ge=1, le=100, description="Items per page"),
+    user: User = Depends(get_current_user),
+):
+    """List APIs for a tenant from GitLab (paginated)."""
     try:
         apis = await git_service.list_apis(tenant_id)
-        return [_api_from_yaml(tenant_id, api) for api in apis]
+        all_items = [_api_from_yaml(tenant_id, api) for api in apis]
+        total = len(all_items)
+        start = (page - 1) * page_size
+        items = all_items[start : start + page_size]
+        return PaginatedResponse(items=items, total=total, page=page, page_size=page_size)
     except Exception as e:
         logger.error(f"Failed to list APIs for tenant {tenant_id}: {e}")
-        return []
+        return PaginatedResponse(items=[], total=0, page=page, page_size=page_size)
 
 
 @router.get("/{api_id}", response_model=APIResponse)

--- a/control-plane-api/src/routers/applications.py
+++ b/control-plane-api/src/routers/applications.py
@@ -1,9 +1,10 @@
 """Applications router - Consumer applications management"""
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from ..auth import Permission, User, get_current_user, require_permission, require_tenant_access
+from ..schemas.pagination import PaginatedResponse
 
 router = APIRouter(prefix="/v1/tenants/{tenant_id}/applications", tags=["Applications"])
 
@@ -30,12 +31,17 @@ class ApplicationCredentials(BaseModel):
     client_id: str
     client_secret: str
 
-@router.get("", response_model=list[ApplicationResponse])
+@router.get("", response_model=PaginatedResponse[ApplicationResponse])
 @require_tenant_access
-async def list_applications(tenant_id: str, user: User = Depends(get_current_user)):
-    """List all applications for a tenant"""
+async def list_applications(
+    tenant_id: str,
+    page: int = Query(default=1, ge=1, description="Page number"),
+    page_size: int = Query(default=20, ge=1, le=100, description="Items per page"),
+    user: User = Depends(get_current_user),
+):
+    """List all applications for a tenant (paginated)."""
     # TODO: Implement with Keycloak service
-    return []
+    return PaginatedResponse(items=[], total=0, page=page, page_size=page_size)
 
 @router.get("/{app_id}", response_model=ApplicationResponse)
 @require_tenant_access

--- a/control-plane-api/src/routers/contracts.py
+++ b/control-plane-api/src/routers/contracts.py
@@ -16,6 +16,7 @@ from src.config import settings
 from src.database import get_db
 from src.logging_config import get_logger
 from src.models.contract import Contract, ProtocolBinding, ProtocolType
+from src.services.cache_service import contract_cache
 from src.schemas.contract import (
     BindingsListResponse,
     ContractCreate,
@@ -191,6 +192,9 @@ async def create_contract(
     # Create default bindings (all disabled)
     bindings = await _get_or_create_default_bindings(db, contract)
 
+    # Invalidate contract list cache for this tenant
+    await contract_cache.delete_by_prefix(f"contracts:{tenant_id}")
+
     logger.info(
         "Contract created",
         contract_id=str(contract.id),
@@ -223,16 +227,23 @@ async def list_contracts(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """List contracts for the user's tenant."""
+    """List contracts for the user's tenant (cached, TTL 60s)."""
     tenant_id = user.tenant_id
     if not tenant_id and "cpi-admin" not in (user.roles or []):
         raise HTTPException(status_code=400, detail="User must belong to a tenant")
+
+    # Check cache
+    is_admin = "cpi-admin" in (user.roles or [])
+    cache_key = f"contracts:{tenant_id}:{is_admin}:{page}:{page_size}:{status}"
+    cached = await contract_cache.get(cache_key)
+    if cached is not None:
+        return cached
 
     query = select(Contract)
     count_query = select(func.count(Contract.id))
 
     # Filter by tenant unless admin
-    if "cpi-admin" not in (user.roles or []):
+    if not is_admin:
         query = query.where(Contract.tenant_id == tenant_id)
         count_query = count_query.where(Contract.tenant_id == tenant_id)
 
@@ -271,7 +282,9 @@ async def list_contracts(
             )
         )
 
-    return ContractListResponse(items=items, total=total, page=page, page_size=page_size)
+    response = ContractListResponse(items=items, total=total, page=page, page_size=page_size)
+    await contract_cache.set(cache_key, response)
+    return response
 
 
 @router.get("/{contract_id}", response_model=ContractResponse)
@@ -343,6 +356,9 @@ async def update_contract(
 
     await db.flush()
 
+    # Invalidate contract list cache for this tenant
+    await contract_cache.delete_by_prefix(f"contracts:{contract.tenant_id}")
+
     bindings = await _get_or_create_default_bindings(db, contract)
 
     logger.info(
@@ -383,12 +399,16 @@ async def delete_contract(
     if not _has_tenant_access(user, contract.tenant_id):
         raise HTTPException(status_code=403, detail="Access denied to this contract")
 
+    tenant_id = contract.tenant_id
     await db.delete(contract)  # Cascade deletes bindings
+
+    # Invalidate contract list cache for this tenant
+    await contract_cache.delete_by_prefix(f"contracts:{tenant_id}")
 
     logger.info(
         "Contract deleted",
         contract_id=str(contract_id),
-        tenant_id=contract.tenant_id,
+        tenant_id=tenant_id,
         user_id=user.id,
     )
 

--- a/control-plane-api/src/routers/gateway.py
+++ b/control-plane-api/src/routers/gateway.py
@@ -12,12 +12,13 @@ Benefits:
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
 from ..auth import Permission, User, get_current_user, require_permission
 from ..config import settings
+from ..schemas.pagination import PaginatedResponse
 from ..services.gateway_service import gateway_service
 
 logger = logging.getLogger(__name__)
@@ -107,19 +108,21 @@ async def get_auth_token(
 # API Operations
 # ============================================================================
 
-@router.get("/apis", response_model=list[GatewayAPIResponse])
+@router.get("/apis", response_model=PaginatedResponse[GatewayAPIResponse])
 @require_permission(Permission.APIS_READ)
 async def list_gateway_apis(
+    page: int = Query(default=1, ge=1, description="Page number"),
+    page_size: int = Query(default=20, ge=1, le=100, description="Items per page"),
     user: User = Depends(get_current_user),
-    token: str = Depends(get_auth_token)
+    token: str = Depends(get_auth_token),
 ):
-    """List all APIs registered in the Gateway.
+    """List APIs registered in the Gateway (paginated).
 
     Requires: cpi-admin or devops role
     """
     try:
         apis = await gateway_service.list_apis(auth_token=token)
-        return [
+        all_items = [
             GatewayAPIResponse(
                 id=api.get("api", {}).get("id", api.get("id", "")),
                 apiName=api.get("api", {}).get("apiName", api.get("apiName", "")),
@@ -130,9 +133,13 @@ async def list_gateway_apis(
             )
             for api in apis
         ]
+        total = len(all_items)
+        start = (page - 1) * page_size
+        items = all_items[start : start + page_size]
+        return PaginatedResponse(items=items, total=total, page=page, page_size=page_size)
     except Exception as e:
         logger.error(f"Failed to list Gateway APIs: {e}")
-        return []
+        return PaginatedResponse(items=[], total=0, page=page, page_size=page_size)
 
 
 @router.post("/apis", response_model=ImportAPIResponse)
@@ -274,19 +281,21 @@ async def delete_gateway_api(
 # Application Operations
 # ============================================================================
 
-@router.get("/applications", response_model=list[GatewayApplicationResponse])
+@router.get("/applications", response_model=PaginatedResponse[GatewayApplicationResponse])
 @require_permission(Permission.APIS_READ)
 async def list_gateway_applications(
+    page: int = Query(default=1, ge=1, description="Page number"),
+    page_size: int = Query(default=20, ge=1, le=100, description="Items per page"),
     user: User = Depends(get_current_user),
-    token: str = Depends(get_auth_token)
+    token: str = Depends(get_auth_token),
 ):
-    """List all applications registered in the Gateway.
+    """List applications registered in the Gateway (paginated).
 
     Requires: cpi-admin or tenant-admin role
     """
     try:
         apps = await gateway_service.list_applications(auth_token=token)
-        return [
+        all_items = [
             GatewayApplicationResponse(
                 id=app.get("id", ""),
                 name=app.get("name", ""),
@@ -295,9 +304,13 @@ async def list_gateway_applications(
             )
             for app in apps
         ]
+        total = len(all_items)
+        start = (page - 1) * page_size
+        items = all_items[start : start + page_size]
+        return PaginatedResponse(items=items, total=total, page=page, page_size=page_size)
     except Exception as e:
         logger.error(f"Failed to list Gateway applications: {e}")
-        return []
+        return PaginatedResponse(items=[], total=0, page=page, page_size=page_size)
 
 
 # ============================================================================

--- a/control-plane-api/src/routers/portal.py
+++ b/control-plane-api/src/routers/portal.py
@@ -8,19 +8,21 @@ PERFORMANCE OPTIMIZATION (CAB-682):
 - Latency reduced from 2-5 seconds to <200ms
 - Cache is synced from GitLab via the catalog sync service
 """
+
 import logging
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import func, select
+from sqlalchemy import String, bindparam, func, or_, select, text
+from sqlalchemy.dialects.postgresql import ARRAY as PgARRAY
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from ..auth.dependencies import User, get_current_user
 from ..database import get_db as get_async_db
-from ..models.mcp_subscription import MCPServer, MCPServerStatus
-from ..repositories.catalog import CatalogRepository
+from ..models.mcp_subscription import MCPServer, MCPServerCategory, MCPServerStatus, MCPServerTool
+from ..repositories.catalog import CatalogRepository, escape_like
+from ..schemas.portal import APIListItem, MCPServerListItem
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/portal", tags=["Portal"])
@@ -44,8 +46,10 @@ UNIVERSE_LABELS = {
 # Response Models
 # ============================================================================
 
+
 class PortalAPIResponse(BaseModel):
     """API response for Portal catalog."""
+
     id: str
     name: str
     display_name: str
@@ -68,7 +72,8 @@ class PortalAPIResponse(BaseModel):
 
 class PortalAPIsResponse(BaseModel):
     """Paginated API list response."""
-    apis: list[PortalAPIResponse]
+
+    apis: list[APIListItem]
     total: int
     page: int
     page_size: int
@@ -76,6 +81,7 @@ class PortalAPIsResponse(BaseModel):
 
 class PortalMCPServerResponse(BaseModel):
     """MCP Server response for Portal catalog."""
+
     id: str
     name: str
     display_name: str
@@ -96,7 +102,8 @@ class PortalMCPServerResponse(BaseModel):
 
 class PortalMCPServersResponse(BaseModel):
     """Paginated MCP servers list response."""
-    servers: list[PortalMCPServerResponse]
+
+    servers: list[MCPServerListItem]
     total: int
     page: int
     page_size: int
@@ -106,6 +113,7 @@ class PortalMCPServersResponse(BaseModel):
 # ============================================================================
 # API Catalog Endpoints (CAB-682: Now using PostgreSQL cache)
 # ============================================================================
+
 
 @router.get("/apis", response_model=PortalAPIsResponse)
 async def list_portal_apis(
@@ -146,7 +154,7 @@ async def list_portal_apis(
 
         return PortalAPIsResponse(
             apis=[
-                PortalAPIResponse(
+                APIListItem(
                     id=api.api_id,
                     name=api.api_name or api.api_id,
                     display_name=(api.api_metadata or {}).get("display_name", api.api_name or api.api_id),
@@ -155,10 +163,8 @@ async def list_portal_apis(
                     tenant_id=api.tenant_id,
                     tenant_name=api.tenant_id,
                     status=api.status or "draft",
-                    backend_url=(api.api_metadata or {}).get("backend_url"),
                     category=api.category,
                     tags=api.tags or [],
-                    deployments=(api.api_metadata or {}).get("deployments", {}),
                     is_promoted=api.portal_published,
                 )
                 for api in apis
@@ -254,11 +260,8 @@ async def get_portal_api_openapi(
             # Return minimal spec if not available
             return {
                 "openapi": "3.0.0",
-                "info": {
-                    "title": api.api_name or api.api_id,
-                    "version": api.version or "1.0.0"
-                },
-                "paths": {}
+                "info": {"title": api.api_name or api.api_id, "version": api.version or "1.0.0"},
+                "paths": {},
             }
 
         return api.openapi_spec
@@ -273,6 +276,36 @@ async def get_portal_api_openapi(
 # ============================================================================
 # MCP Server Catalog Endpoints
 # ============================================================================
+
+
+def _build_visibility_filter(user_roles: list[str]) -> text:
+    """Build SQL WHERE clause for MCP server visibility.
+
+    Translates the JSONB visibility rules to SQL:
+    - NULL or missing 'public' key → visible (default public=True)
+    - public=true → visible
+    - public=false → check roles/excludeRoles
+
+    Uses ::jsonb cast because the column is JSON type (not JSONB),
+    and ?/? | operators require JSONB.
+    """
+    return text(
+        "(visibility IS NULL"
+        " OR (visibility->>'public') IS NULL"
+        " OR (visibility->>'public') = 'true'"
+        " OR ("
+        "   (visibility->>'public') = 'false'"
+        "   AND ("
+        "     NOT ((visibility)::jsonb ? 'excludeRoles')"
+        "     OR NOT ((visibility)::jsonb -> 'excludeRoles' ?| :user_roles)"
+        "   )"
+        "   AND ("
+        "     NOT ((visibility)::jsonb ? 'roles')"
+        "     OR (visibility)::jsonb -> 'roles' ?| :user_roles"
+        "   )"
+        " ))"
+    ).bindparams(bindparam("user_roles", value=user_roles, type_=PgARRAY(String)))
+
 
 @router.get("/mcp-servers", response_model=PortalMCPServersResponse)
 async def list_portal_mcp_servers(
@@ -289,18 +322,37 @@ async def list_portal_mcp_servers(
     Source: PostgreSQL cache (synced from GitLab via GitOps — CAB-689)
 
     Returns only active servers that the user can see based on visibility rules.
+    All filtering, sorting, and pagination is done in SQL.
     Includes synced_at timestamp for cache freshness tracking.
     Falls back to Git sync if cache is empty (Obligation #3).
     """
     try:
-        # Build query
-        query = select(MCPServer).where(
-            MCPServer.status == MCPServerStatus.ACTIVE
-        ).options(selectinload(MCPServer.tools))
+        user_roles = list(user.roles or [])
 
-        # Filter by category if specified
+        # Subquery: count enabled tools per server (no relationship loading)
+        tools_count_subq = (
+            select(func.count(MCPServerTool.id))
+            .where(MCPServerTool.server_id == MCPServer.id)
+            .where(MCPServerTool.enabled.is_(True))
+            .correlate(MCPServer)
+            .scalar_subquery()
+            .label("tools_count")
+        )
+
+        # Build query: active servers + visibility filter + window count
+        visibility_filter = _build_visibility_filter(user_roles)
+        query = (
+            select(
+                MCPServer,
+                tools_count_subq,
+                func.count().over().label("total_count"),
+            )
+            .where(MCPServer.status == MCPServerStatus.ACTIVE)
+            .where(visibility_filter)
+        )
+
+        # Category filter (SQL)
         if category:
-            from ..models.mcp_subscription import MCPServerCategory
             cat_map = {
                 "platform": MCPServerCategory.PLATFORM,
                 "tenant": MCPServerCategory.TENANT,
@@ -309,97 +361,77 @@ async def list_portal_mcp_servers(
             if category in cat_map:
                 query = query.where(MCPServer.category == cat_map[category])
 
+        # Search filter (SQL ILIKE)
+        if search and search.strip():
+            search_term = escape_like(search.strip().lower())
+            search_pattern = f"%{search_term}%"
+            query = query.where(
+                or_(
+                    func.lower(MCPServer.name).like(search_pattern, escape="\\"),
+                    func.lower(MCPServer.display_name).like(search_pattern, escape="\\"),
+                    func.lower(func.coalesce(MCPServer.description, "")).like(search_pattern, escape="\\"),
+                )
+            )
+
+        # Sort + paginate in SQL
+        query = query.order_by(func.coalesce(MCPServer.display_name, MCPServer.name))
+        query = query.offset((page - 1) * page_size).limit(page_size)
+
         result = await db.execute(query)
-        all_servers = result.scalars().all()
+        rows = result.all()
 
         # CAB-689 Obligation #3: Fallback if cache is empty
-        if not all_servers:
-            logger.warning("MCP servers cache empty, falling back to Git sync")
-            try:
-                from ..services.catalog_sync_service import CatalogSyncService
-                from ..services.git_service import git_service
-                sync_service = CatalogSyncService(db, git_service)
-                await sync_service.sync_mcp_servers()
-                await db.commit()
+        if not rows:
+            count_result = await db.execute(
+                select(func.count(MCPServer.id)).where(MCPServer.status == MCPServerStatus.ACTIVE)
+            )
+            if count_result.scalar_one() == 0:
+                logger.warning("MCP servers cache empty, falling back to Git sync")
+                try:
+                    from ..services.catalog_sync_service import CatalogSyncService
+                    from ..services.git_service import git_service
 
-                # Re-query after sync
-                result = await db.execute(query)
-                all_servers = result.scalars().all()
-            except Exception as sync_err:
-                logger.error(f"Fallback Git sync failed: {sync_err}")
+                    sync_service = CatalogSyncService(db, git_service)
+                    await sync_service.sync_mcp_servers()
+                    await db.commit()
 
-        # Filter by visibility (Obligation #6)
-        visible_servers = []
-        user_roles = set(user.roles or [])
+                    # Re-query after sync
+                    result = await db.execute(query)
+                    rows = result.all()
+                except Exception as sync_err:
+                    logger.error(f"Fallback Git sync failed: {sync_err}")
 
-        for server in all_servers:
-            visibility = server.visibility or {"public": True}
-
-            # Check if server is public
-            if visibility.get("public", True):
-                visible_servers.append(server)
-                continue
-
-            # Check role-based visibility
-            required_roles = visibility.get("roles", [])
-            exclude_roles = visibility.get("excludeRoles", [])
-
-            # If user has any excluded role, skip
-            if any(role in user_roles for role in exclude_roles):
-                continue
-
-            # If roles specified, user must have at least one
-            if required_roles:
-                if any(role in user_roles for role in required_roles):
-                    visible_servers.append(server)
-            else:
-                # No specific roles required, visible to all
-                visible_servers.append(server)
-
-        # Apply search filter
-        if search:
-            search_lower = search.lower()
-            visible_servers = [
-                s for s in visible_servers
-                if search_lower in s.name.lower()
-                or search_lower in s.display_name.lower()
-                or search_lower in (s.description or "").lower()
+        # Extract results from single query
+        if rows:
+            total = rows[0].total_count
+            servers = [
+                MCPServerListItem(
+                    id=str(row.MCPServer.id),
+                    name=row.MCPServer.name,
+                    display_name=row.MCPServer.display_name,
+                    description=row.MCPServer.description or "",
+                    icon=row.MCPServer.icon,
+                    category=row.MCPServer.category.value,
+                    tenant_id=row.MCPServer.tenant_id,
+                    status=row.MCPServer.status.value,
+                    version=row.MCPServer.version,
+                    documentation_url=row.MCPServer.documentation_url,
+                    requires_approval=row.MCPServer.requires_approval,
+                    tools_count=row.tools_count or 0,
+                    created_at=row.MCPServer.created_at,
+                )
+                for row in rows
             ]
-
-        # Sort by name
-        visible_servers.sort(key=lambda s: s.display_name or s.name)
+        else:
+            total = 0
+            servers = []
 
         # CAB-689 Obligation #4: Get last synced_at
-        synced_at_result = await db.execute(
-            select(func.max(MCPServer.last_synced_at))
-        )
+        synced_at_result = await db.execute(select(func.max(MCPServer.last_synced_at)))
         last_synced_at = synced_at_result.scalar_one_or_none()
 
-        # Paginate
-        total = len(visible_servers)
-        start = (page - 1) * page_size
-        end = start + page_size
-        paginated_servers = visible_servers[start:end]
-
         return PortalMCPServersResponse(
-            servers=[
-                PortalMCPServerResponse(
-                    id=str(server.id),
-                    name=server.name,
-                    display_name=server.display_name,
-                    description=server.description or "",
-                    icon=server.icon,
-                    category=server.category.value,
-                    tenant_id=server.tenant_id,
-                    status=server.status.value,
-                    version=server.version,
-                    documentation_url=server.documentation_url,
-                    requires_approval=server.requires_approval,
-                    tools_count=len([t for t in server.tools if t.enabled]),
-                    created_at=server.created_at,
-                )
-                for server in paginated_servers
-            ],
+            servers=servers,
             total=total,
             page=page,
             page_size=page_size,
@@ -414,6 +446,7 @@ async def list_portal_mcp_servers(
 # ============================================================================
 # Categories and Tags (CAB-682: Now from database)
 # ============================================================================
+
 
 @router.get("/api-categories", response_model=list[str])
 async def get_api_categories(
@@ -435,6 +468,7 @@ async def get_api_categories(
 
 class UniverseResponse(BaseModel):
     """Universe metadata for Portal filtering (CAB-848)."""
+
     id: str
     label: str
 
@@ -444,10 +478,7 @@ async def get_api_universes(
     user: User = Depends(get_current_user),
 ):
     """Get available API universes for filtering (CAB-848)."""
-    return [
-        UniverseResponse(id=uid, label=label)
-        for uid, label in UNIVERSE_LABELS.items()
-    ]
+    return [UniverseResponse(id=uid, label=label) for uid, label in UNIVERSE_LABELS.items()]
 
 
 @router.get("/api-tags", response_model=list[str])

--- a/control-plane-api/src/routers/tenants.py
+++ b/control-plane-api/src/routers/tenants.py
@@ -9,6 +9,7 @@ from ..auth import Permission, Role, User, get_current_user, require_permission
 from ..database import get_db
 from ..models.tenant import Tenant, TenantStatus
 from ..repositories.tenant import TenantRepository
+from ..services.cache_service import tenant_cache
 from ..services.kafka_service import Topics, kafka_service
 from ..services.keycloak_service import keycloak_service
 
@@ -93,10 +94,16 @@ async def get_tenant(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db)
 ):
-    """Get tenant by ID from database"""
+    """Get tenant by ID from database (cached, TTL 30s)."""
     # Check access
     if Role.CPI_ADMIN not in user.roles and user.tenant_id != tenant_id:
         raise HTTPException(status_code=403, detail="Access denied")
+
+    # Check cache first
+    cache_key = f"tenant:{tenant_id}"
+    cached = await tenant_cache.get(cache_key)
+    if cached is not None:
+        return cached
 
     try:
         repo = TenantRepository(db)
@@ -105,7 +112,9 @@ async def get_tenant(
         if not tenant:
             raise HTTPException(status_code=404, detail="Tenant not found")
 
-        return _tenant_to_response(tenant)
+        response = _tenant_to_response(tenant)
+        await tenant_cache.set(cache_key, response)
+        return response
 
     except HTTPException:
         raise
@@ -226,6 +235,9 @@ async def update_tenant(
 
         tenant = await repo.update(tenant)
 
+        # Invalidate cache
+        await tenant_cache.delete(f"tenant:{tenant_id}")
+
         # Emit audit event
         await kafka_service.emit_audit_event(
             tenant_id=tenant_id,
@@ -270,6 +282,9 @@ async def delete_tenant(
         # Soft delete - set status to archived
         tenant.status = TenantStatus.ARCHIVED.value
         await repo.update(tenant)
+
+        # Invalidate cache
+        await tenant_cache.delete(f"tenant:{tenant_id}")
 
         # Emit Kafka event
         await kafka_service.publish(

--- a/control-plane-api/src/schemas/pagination.py
+++ b/control-plane-api/src/schemas/pagination.py
@@ -1,0 +1,20 @@
+"""Generic pagination schema for list endpoints."""
+
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel
+
+T = TypeVar("T")
+
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    """Paginated response wrapper.
+
+    Usage:
+        PaginatedResponse[APIResponse]
+    """
+
+    items: list[T]
+    total: int
+    page: int
+    page_size: int

--- a/control-plane-api/src/schemas/portal.py
+++ b/control-plane-api/src/schemas/portal.py
@@ -1,0 +1,46 @@
+"""Lightweight DTOs for Portal list endpoints (CAB-1113 Phase 5).
+
+List endpoints use these minimal schemas to avoid loading relationships
+and reduce payload size. Detail endpoints keep full response models.
+"""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class MCPServerListItem(BaseModel):
+    """Lightweight MCP server for list views — no relations loaded.
+
+    tools_count is computed via SQL subquery instead of loading the tools relationship.
+    """
+
+    id: str
+    name: str
+    display_name: str
+    status: str
+    tools_count: int = 0
+    category: str | None = None
+    icon: str | None = None
+    description: str = ""
+    tenant_id: str | None = None
+    version: str | None = None
+    documentation_url: str | None = None
+    requires_approval: bool = False
+    created_at: datetime | None = None
+
+
+class APIListItem(BaseModel):
+    """Lightweight API for list views — no deployments/backend_url."""
+
+    id: str
+    name: str
+    display_name: str
+    version: str
+    status: str
+    description: str = ""
+    tenant_id: str
+    tenant_name: str | None = None
+    category: str | None = None
+    tags: list[str] = []
+    is_promoted: bool = True

--- a/control-plane-api/src/services/cache_service.py
+++ b/control-plane-api/src/services/cache_service.py
@@ -85,6 +85,14 @@ class TTLCache:
             del self._cache[k]
         return len(expired_keys)
 
+    async def delete_by_prefix(self, prefix: str) -> int:
+        """Delete all keys matching a prefix."""
+        async with self._lock:
+            keys_to_delete = [k for k in self._cache if k.startswith(prefix)]
+            for k in keys_to_delete:
+                del self._cache[k]
+            return len(keys_to_delete)
+
     async def clear(self) -> None:
         """Clear all entries from cache."""
         async with self._lock:
@@ -101,6 +109,8 @@ class TTLCache:
 
 # Global cache instances
 api_key_cache = TTLCache(default_ttl_seconds=10, max_size=10000)
+tenant_cache = TTLCache(default_ttl_seconds=30, max_size=1000)
+contract_cache = TTLCache(default_ttl_seconds=60, max_size=5000)
 
 
 def cached(cache: TTLCache, key_prefix: str, ttl_seconds: int | None = None):

--- a/control-plane-api/tests/test_mcp_sync.py
+++ b/control-plane-api/tests/test_mcp_sync.py
@@ -154,14 +154,17 @@ def test_portal_response_includes_synced_at():
 # ============================================================
 
 def test_portal_mcp_endpoint_has_visibility_filtering():
-    """Verify visibility filtering is in the portal endpoint."""
+    """Verify visibility filtering is in the portal endpoint (via SQL helper)."""
     import inspect
-    from src.routers.portal import list_portal_mcp_servers
-    source = inspect.getsource(list_portal_mcp_servers)
+    from src.routers.portal import _build_visibility_filter, list_portal_mcp_servers
 
-    assert "visibility" in source
-    assert "public" in source
-    assert "excludeRoles" in source or "exclude_roles" in source
+    endpoint_source = inspect.getsource(list_portal_mcp_servers)
+    helper_source = inspect.getsource(_build_visibility_filter)
+
+    assert "visibility_filter" in endpoint_source
+    assert "visibility" in helper_source
+    assert "public" in helper_source
+    assert "excludeRoles" in helper_source or "exclude_roles" in helper_source
 
 
 # ============================================================

--- a/control-plane-ui/package-lock.json
+++ b/control-plane-ui/package-lock.json
@@ -20,6 +20,7 @@
         "react-oidc-context": "^2.3.1",
         "react-router-dom": "^6.21.2",
         "tailwind-merge": "^2.2.0",
+        "web-vitals": "^5.1.0",
         "zustand": "^4.4.7"
       },
       "devDependencies": {
@@ -6851,6 +6852,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/control-plane-ui/package.json
+++ b/control-plane-ui/package.json
@@ -25,6 +25,7 @@
     "react-oidc-context": "^2.3.1",
     "react-router-dom": "^6.21.2",
     "tailwind-merge": "^2.2.0",
+    "web-vitals": "^5.1.0",
     "zustand": "^4.4.7"
   },
   "devDependencies": {

--- a/control-plane-ui/src/main.tsx
+++ b/control-plane-ui/src/main.tsx
@@ -2,10 +2,19 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider as OidcProvider } from 'react-oidc-context';
+import { WebStorageStateStore } from 'oidc-client-ts';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { onCLS, onLCP, onINP } from 'web-vitals';
 import App from './App';
 import { config } from './config';
 import './index.css';
+
+// Log Core Web Vitals in dev mode
+if (config.app.isDev) {
+  onLCP(({ value }) => console.log('[WebVitals] LCP:', value, 'ms'));
+  onINP(({ value }) => console.log('[WebVitals] INP:', value, 'ms'));
+  onCLS(({ value }) => console.log('[WebVitals] CLS:', value));
+}
 
 // Create a client for React Query
 const queryClient = new QueryClient({
@@ -31,6 +40,8 @@ const oidcConfig = {
   // Explicitly require PKCE (S256 is the only secure option)
   // This ensures code_challenge and code_challenge_method are sent
   pkce_method: 'S256',
+  // Persist tokens in localStorage for cross-tab session and faster boot
+  userStore: new WebStorageStateStore({ store: window.localStorage }),
   onSigninCallback: () => {
     // Remove OIDC params from URL after successful login
     window.history.replaceState({}, document.title, window.location.pathname);

--- a/control-plane-ui/src/pages/APIs.tsx
+++ b/control-plane-ui/src/pages/APIs.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiService } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
-import type { API, APICreate, Tenant } from '../types';
+import type { API, APICreate } from '../types';
 import yaml from 'js-yaml';
 import { useToastActions } from '@stoa/shared/components/Toast';
 import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
@@ -40,16 +41,12 @@ const statusColors: Record<string, string> = {
 export function APIs() {
   const { isReady } = useAuth();
   const toast = useToastActions();
+  const queryClient = useQueryClient();
   const [confirm, ConfirmDialog] = useConfirm();
   const { celebrate } = useCelebration();
-  const [apis, setApis] = useState<API[]>([]);
-  const [tenants, setTenants] = useState<Tenant[]>([]);
   const [selectedTenant, setSelectedTenant] = useState<string>('');
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingApi, setEditingApi] = useState<API | null>(null);
-  const [isFirstApi, setIsFirstApi] = useState(false);
 
   // Search and pagination state
   const [searchQuery, setSearchQuery] = useState('');
@@ -59,58 +56,35 @@ export function APIs() {
   // Debounce search for performance (300ms delay)
   const debouncedSearch = useDebounce(searchQuery, 300);
 
-  useEffect(() => {
-    console.log('[APIs] isReady changed:', isReady);
-    if (isReady) {
-      loadTenants();
-    }
-  }, [isReady]);
+  // Fetch tenants via React Query
+  const { data: tenants = [], isLoading: tenantsLoading, error: tenantsError } = useQuery({
+    queryKey: ['tenants'],
+    queryFn: () => apiService.getTenants(),
+    enabled: isReady,
+  });
 
+  // Auto-select first tenant when tenants load
   useEffect(() => {
-    if (selectedTenant) {
-      loadApis(selectedTenant);
+    if (tenants.length > 0 && !selectedTenant) {
+      setSelectedTenant(tenants[0].id);
     }
-  }, [selectedTenant]);
+  }, [tenants, selectedTenant]);
+
+  // Fetch APIs for selected tenant via React Query
+  const { data: apis = [], isLoading: apisLoading, error: apisError } = useQuery({
+    queryKey: ['apis', selectedTenant],
+    queryFn: () => apiService.getApis(selectedTenant),
+    enabled: !!selectedTenant,
+  });
+
+  const isFirstApi = apis.length === 0 && !apisLoading;
+  const loading = tenantsLoading || apisLoading;
+  const error = tenantsError || apisError;
 
   // Reset pagination when filters change
   useEffect(() => {
     setCurrentPage(1);
   }, [debouncedSearch, statusFilter, selectedTenant]);
-
-  async function loadTenants() {
-    try {
-      console.log('[APIs] Loading tenants...');
-      const data = await apiService.getTenants();
-      console.log('[APIs] Loaded tenants:', data);
-      setTenants(data);
-      if (data.length > 0) {
-        setSelectedTenant(data[0].id);
-      }
-      setLoading(false);
-    } catch (err: any) {
-      console.error('[APIs] Failed to load tenants:', err);
-      setError(err.message || 'Failed to load tenants');
-      setLoading(false);
-    }
-  }
-
-  async function loadApis(tenantId: string) {
-    try {
-      setLoading(true);
-      console.log('[APIs] Loading APIs for tenant:', tenantId);
-      const data = await apiService.getApis(tenantId);
-      console.log('[APIs] Loaded APIs:', data);
-      setIsFirstApi(data.length === 0);
-      setApis(data);
-      setError(null);
-    } catch (err: any) {
-      console.error('[APIs] Failed to load APIs:', err);
-      setError(err.message || 'Failed to load APIs');
-      setApis([]);
-    } finally {
-      setLoading(false);
-    }
-  }
 
   // Client-side filtering and pagination (memoized for performance)
   const filteredApis = useMemo(() => {
@@ -143,6 +117,10 @@ export function APIs() {
 
   const totalPages = Math.ceil(filteredApis.length / PAGE_SIZE);
 
+  const invalidateApis = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['apis', selectedTenant] });
+  }, [queryClient, selectedTenant]);
+
   // Memoized handlers to prevent unnecessary re-renders
   const handleCreate = useCallback(async (api: APICreate, deployToDev: boolean) => {
     try {
@@ -159,7 +137,7 @@ export function APIs() {
       }
 
       setShowCreateModal(false);
-      await loadApis(selectedTenant);
+      invalidateApis();
 
       // Celebrate first API creation
       if (wasFirstApi) {
@@ -171,17 +149,17 @@ export function APIs() {
     } catch (err: any) {
       toast.error('Creation failed', err.message || 'Failed to create API');
     }
-  }, [selectedTenant, isFirstApi, celebrate, toast]);
+  }, [selectedTenant, isFirstApi, celebrate, toast, invalidateApis]);
 
   const handleUpdate = useCallback(async (apiId: string, api: Partial<APICreate>) => {
     try {
       await apiService.updateApi(selectedTenant, apiId, api);
       setEditingApi(null);
-      loadApis(selectedTenant);
+      invalidateApis();
     } catch (err: any) {
-      setError(err.message || 'Failed to update API');
+      toast.error('Update failed', err.message || 'Failed to update API');
     }
-  }, [selectedTenant]);
+  }, [selectedTenant, invalidateApis, toast]);
 
   const handleDelete = useCallback(async (apiId: string, apiName: string) => {
     const confirmed = await confirm({
@@ -196,11 +174,11 @@ export function APIs() {
     try {
       await apiService.deleteApi(selectedTenant, apiId);
       toast.success('API deleted', `${apiName} has been removed`);
-      loadApis(selectedTenant);
+      invalidateApis();
     } catch (err: any) {
       toast.error('Delete failed', err.message || 'Failed to delete API');
     }
-  }, [selectedTenant, confirm, toast]);
+  }, [selectedTenant, confirm, toast, invalidateApis]);
 
   const handleDeploy = useCallback(async (api: API, environment: 'dev' | 'staging') => {
     try {
@@ -213,11 +191,11 @@ export function APIs() {
         `Deployment started`,
         `${api.name} is being deployed to ${environment.toUpperCase()}`
       );
-      loadApis(selectedTenant);
+      invalidateApis();
     } catch (err: any) {
       toast.error('Deployment failed', err.message || 'Failed to deploy API');
     }
-  }, [selectedTenant, toast]);
+  }, [selectedTenant, toast, invalidateApis]);
 
   // Memoized filter clear handler
   const clearFilters = useCallback(() => {
@@ -326,8 +304,7 @@ export function APIs() {
 
       {error && (
         <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
-          {error}
-          <button onClick={() => setError(null)} className="float-right font-bold">&times;</button>
+          {error.message || 'An error occurred'}
         </div>
       )}
 

--- a/control-plane-ui/src/pages/Tenants.tsx
+++ b/control-plane-ui/src/pages/Tenants.tsx
@@ -1,40 +1,18 @@
-import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { apiService } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
-import type { Tenant } from '../types';
 import { EmptyState } from '@stoa/shared/components/EmptyState';
 import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 import { Users } from 'lucide-react';
 
 export function Tenants() {
   const { isReady } = useAuth();
-  const [tenants, setTenants] = useState<Tenant[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    // Only load tenants when token is ready
-    console.log('[Tenants] isReady changed:', isReady);
-    if (isReady) {
-      loadTenants();
-    }
-  }, [isReady]);
-
-  async function loadTenants() {
-    try {
-      setLoading(true);
-      console.log('[Tenants] Loading tenants...');
-      const data = await apiService.getTenants();
-      console.log('[Tenants] Loaded tenants:', data);
-      setTenants(data);
-      setError(null);
-    } catch (err: any) {
-      console.error('[Tenants] Failed to load tenants:', err);
-      setError(err.message || 'Failed to load tenants');
-    } finally {
-      setLoading(false);
-    }
-  }
+  const { data: tenants = [], isLoading: loading, error } = useQuery({
+    queryKey: ['tenants'],
+    queryFn: () => apiService.getTenants(),
+    enabled: isReady,
+  });
 
   const statusColors: Record<string, string> = {
     active: 'bg-green-100 text-green-800',
@@ -68,8 +46,7 @@ export function Tenants() {
 
       {error && (
         <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
-          {error}
-          <button onClick={() => setError(null)} className="float-right font-bold">&times;</button>
+          {error.message || 'Failed to load tenants'}
         </div>
       )}
 

--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -100,8 +100,10 @@ class ApiService {
 
   // APIs
   async getApis(tenantId: string): Promise<API[]> {
-    const { data } = await this.client.get(`/v1/tenants/${tenantId}/apis`);
-    return data;
+    const { data } = await this.client.get(`/v1/tenants/${tenantId}/apis`, {
+      params: { page: 1, page_size: 100 },
+    });
+    return data.items ?? data;
   }
 
   async getApi(tenantId: string, apiId: string): Promise<API> {
@@ -125,8 +127,10 @@ class ApiService {
 
   // Applications
   async getApplications(tenantId: string): Promise<Application[]> {
-    const { data } = await this.client.get(`/v1/tenants/${tenantId}/applications`);
-    return data;
+    const { data } = await this.client.get(`/v1/tenants/${tenantId}/applications`, {
+      params: { page: 1, page_size: 100 },
+    });
+    return data.items ?? data;
   }
 
   async getApplication(tenantId: string, appId: string): Promise<Application> {

--- a/portal/package-lock.json
+++ b/portal/package-lock.json
@@ -17,7 +17,8 @@
         "react-dom": "^18.2.0",
         "react-oidc-context": "^2.3.1",
         "react-router-dom": "^6.21.2",
-        "tailwind-merge": "^2.2.0"
+        "tailwind-merge": "^2.2.0",
+        "web-vitals": "^5.1.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -7746,6 +7747,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/portal/package.json
+++ b/portal/package.json
@@ -26,7 +26,8 @@
     "react-dom": "^18.2.0",
     "react-oidc-context": "^2.3.1",
     "react-router-dom": "^6.21.2",
-    "tailwind-merge": "^2.2.0"
+    "tailwind-merge": "^2.2.0",
+    "web-vitals": "^5.1.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/portal/src/components/usage/CallsTable.tsx
+++ b/portal/src/components/usage/CallsTable.tsx
@@ -3,7 +3,7 @@
  * Table des derniers appels MCP avec filtres
  */
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, memo } from 'react';
 import { Check, X, Clock } from 'lucide-react';
 import type { UsageCall, UsageCallStatus } from '../../types';
 import { formatLatency } from '../../services/usage';
@@ -86,7 +86,7 @@ function TableSkeleton() {
 
 const PAGE_SIZE = 25;
 
-export function CallsTable({ calls, isLoading = false, onFilterChange }: CallsTableProps) {
+export const CallsTable = memo(function CallsTable({ calls, isLoading = false, onFilterChange }: CallsTableProps) {
   const [selectedStatus, setSelectedStatus] = useState<UsageCallStatus | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -222,4 +222,4 @@ export function CallsTable({ calls, isLoading = false, onFilterChange }: CallsTa
       </div>
     </div>
   );
-}
+});

--- a/portal/src/components/usage/TopTools.tsx
+++ b/portal/src/components/usage/TopTools.tsx
@@ -3,7 +3,7 @@
  * Top 5 tools les plus utilisés
  */
 
-import { useMemo } from 'react';
+import { useMemo, memo } from 'react';
 import { Wrench } from 'lucide-react';
 import type { ToolUsageStat } from '../../types';
 import { formatLatency } from '../../services/usage';
@@ -30,7 +30,7 @@ function ToolsSkeleton() {
   );
 }
 
-export function TopTools({ tools, isLoading = false }: TopToolsProps) {
+export const TopTools = memo(function TopTools({ tools, isLoading = false }: TopToolsProps) {
   // Memoize maxCalls for performance - only recalculate when tools change
   // Note: Must be called before any early returns to satisfy React Hooks rules
   const maxCalls = useMemo(
@@ -101,4 +101,4 @@ export function TopTools({ tools, isLoading = false }: TopToolsProps) {
       )}
     </div>
   );
-}
+});

--- a/portal/src/components/usage/UsageChart.tsx
+++ b/portal/src/components/usage/UsageChart.tsx
@@ -3,6 +3,7 @@
  * Graphique d'évolution des appels sur 7 jours
  */
 
+import { memo } from 'react';
 import type { DailyCallStat } from '../../types';
 
 interface UsageChartProps {
@@ -26,7 +27,7 @@ function ChartSkeleton() {
   );
 }
 
-export function UsageChart({ data, isLoading = false }: UsageChartProps) {
+export const UsageChart = memo(function UsageChart({ data, isLoading = false }: UsageChartProps) {
   if (isLoading) {
     return (
       <div className="rounded-xl border border-gray-200 bg-white p-6">
@@ -96,4 +97,4 @@ export function UsageChart({ data, isLoading = false }: UsageChartProps) {
       </div>
     </div>
   );
-}
+});

--- a/portal/src/main.tsx
+++ b/portal/src/main.tsx
@@ -3,11 +3,20 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider as OidcProvider } from 'react-oidc-context';
+import { WebStorageStateStore } from 'oidc-client-ts';
 import { ThemeProvider } from '@stoa/shared/contexts';
 import { ToastProvider } from '@stoa/shared/components/Toast';
+import { onCLS, onLCP, onINP } from 'web-vitals';
 import App from './App';
 import { config } from './config';
 import './index.css';
+
+// Log Core Web Vitals in dev mode
+if (config.app.isDev) {
+  onLCP(({ value }) => console.log('[WebVitals] LCP:', value, 'ms'));
+  onINP(({ value }) => console.log('[WebVitals] INP:', value, 'ms'));
+  onCLS(({ value }) => console.log('[WebVitals] CLS:', value));
+}
 
 // React Query client configuration
 const queryClient = new QueryClient({
@@ -31,6 +40,8 @@ const oidcConfig = {
   // PKCE configuration - required by Keycloak 25+
   response_type: 'code',
   pkce_method: 'S256',
+  // Persist tokens in localStorage for cross-tab session and faster boot
+  userStore: new WebStorageStateStore({ store: window.localStorage }),
   onSigninCallback: () => {
     // Remove OIDC params from URL after successful login
     window.history.replaceState({}, document.title, window.location.pathname);

--- a/portal/src/pages/subscriptions/MySubscriptions.tsx
+++ b/portal/src/pages/subscriptions/MySubscriptions.tsx
@@ -7,8 +7,9 @@
  * Reference: Linear CAB-247
  */
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   TrendingUp,
   AlertCircle,
@@ -35,7 +36,7 @@ import { ExportConfigModal } from '../../components/subscriptions/ExportConfigMo
 import { mcpServersService } from '../../services/mcpServers';
 import { useAuth } from '../../contexts/AuthContext';
 import { StatCardWithIconSkeleton, ServerCardSkeletonGrid } from '../../components/skeletons';
-import type { MCPSubscription, MCPServerSubscription } from '../../types';
+import type { MCPSubscription } from '../../types';
 
 type StatusFilter = 'all' | 'active' | 'expired' | 'revoked' | 'pending' | 'suspended';
 type TabType = 'servers' | 'tools';
@@ -53,84 +54,76 @@ const statusConfig: Record<string, {
   suspended: { label: 'Suspended', color: 'text-orange-700', bgColor: 'bg-orange-100', icon: AlertCircle },
 };
 
+type ModalState = {
+  type: 'reveal' | 'rotate' | 'export';
+  subscription: MCPSubscription;
+} | null;
+
+type RevokeState = {
+  confirmId: string | null;
+  revokingId: string | null;
+};
+
 export function MySubscriptions() {
   const { isAuthenticated, accessToken } = useAuth();
   const toast = useToastActions();
+  const queryClient = useQueryClient();
+
+  // 5 useState total (was 11)
   const [activeTab, setActiveTab] = useState<TabType>('servers');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [searchQuery, setSearchQuery] = useState('');
-  const [revokingId, setRevokingId] = useState<string | null>(null);
-  const [confirmRevokeId, setConfirmRevokeId] = useState<string | null>(null);
-  const [revealModalSubscription, setRevealModalSubscription] = useState<MCPSubscription | null>(null);
-  const [rotateModalSubscription, setRotateModalSubscription] = useState<MCPSubscription | null>(null);
-  const [exportModalSubscription, setExportModalSubscription] = useState<MCPSubscription | null>(null);
+  const [activeModal, setActiveModal] = useState<ModalState>(null);
+  const [revokeState, setRevokeState] = useState<RevokeState>({ confirmId: null, revokingId: null });
 
-  // Server subscriptions state
-  const [serverSubscriptions, setServerSubscriptions] = useState<MCPServerSubscription[]>([]);
-  const [serverSubsLoading, setServerSubsLoading] = useState(false);
-  const [serverSubsError, setServerSubsError] = useState<string | null>(null);
+  const isReady = isAuthenticated && !!accessToken;
 
-  // Tool subscriptions (legacy)
+  // Server subscriptions via React Query (replaces 3 useState + 1 useEffect)
+  const {
+    data: serverSubscriptions = [],
+    isLoading: serverSubsLoading,
+    error: serverSubsErrorObj,
+  } = useQuery({
+    queryKey: ['server-subscriptions'],
+    queryFn: () => mcpServersService.getMyServerSubscriptions(),
+    enabled: isReady,
+  });
+
+  const serverSubsError = serverSubsErrorObj
+    ? (serverSubsErrorObj instanceof Error ? serverSubsErrorObj.message : 'Failed to load server subscriptions')
+    : null;
+
+  // Tool subscriptions (legacy) — already React Query
   const {
     data: subscriptionsData,
     isLoading: toolSubsLoading,
     isError: toolSubsError,
     error: toolError,
-    refetch: refetchToolSubs,
   } = useSubscriptions();
 
   const revokeMutation = useRevokeSubscription();
   const rotateKeyMutation = useRotateApiKey();
 
-  // Load server subscriptions
-  useEffect(() => {
-    if (!isAuthenticated || !accessToken) return;
-
-    async function loadServerSubscriptions() {
-      setServerSubsLoading(true);
-      setServerSubsError(null);
-      try {
-        const subs = await mcpServersService.getMyServerSubscriptions();
-        setServerSubscriptions(subs);
-      } catch (err) {
-        setServerSubsError(err instanceof Error ? err.message : 'Failed to load server subscriptions');
-        setServerSubscriptions([]);
-      } finally {
-        setServerSubsLoading(false);
-      }
-    }
-
-    loadServerSubscriptions();
-  }, [isAuthenticated, accessToken]);
-
   const handleRevokeSubscription = (subscriptionId: string) => {
-    setConfirmRevokeId(subscriptionId);
+    setRevokeState(prev => ({ ...prev, confirmId: subscriptionId }));
   };
 
   const confirmRevoke = async () => {
-    if (!confirmRevokeId) return;
-    setRevokingId(confirmRevokeId);
+    if (!revokeState.confirmId) return;
+    setRevokeState(prev => ({ ...prev, revokingId: prev.confirmId }));
     try {
-      await revokeMutation.mutateAsync(confirmRevokeId);
+      await revokeMutation.mutateAsync(revokeState.confirmId);
       toast.success('Subscription revoked', 'Your API key has been invalidated.');
-    } catch (error) {
-      toast.error('Failed to revoke subscription', error instanceof Error ? error.message : 'An error occurred');
+    } catch (err) {
+      toast.error('Failed to revoke subscription', err instanceof Error ? err.message : 'An error occurred');
     } finally {
-      setRevokingId(null);
-      setConfirmRevokeId(null);
+      setRevokeState({ confirmId: null, revokingId: null });
     }
   };
 
   const refetchAll = () => {
-    refetchToolSubs();
-    // Reload server subscriptions
-    if (isAuthenticated && accessToken) {
-      setServerSubsLoading(true);
-      mcpServersService.getMyServerSubscriptions()
-        .then(setServerSubscriptions)
-        .catch(() => setServerSubscriptions([]))
-        .finally(() => setServerSubsLoading(false));
-    }
+    queryClient.invalidateQueries({ queryKey: ['server-subscriptions'] });
+    queryClient.invalidateQueries({ queryKey: ['subscriptions'] });
   };
 
   // Get tool subscriptions array
@@ -512,14 +505,14 @@ export function MySubscriptions() {
                     {subscription.status === 'active' && (
                       <div className="mt-4 pt-4 border-t border-gray-100 flex items-center justify-between">
                         <button
-                          onClick={() => setRevealModalSubscription(subscription)}
+                          onClick={() => setActiveModal({ type: 'reveal', subscription })}
                           className="inline-flex items-center gap-1 text-sm text-primary-600 hover:text-primary-700 font-medium"
                         >
                           <Eye className="h-3 w-3" />
                           Reveal Key
                         </button>
                         <button
-                          onClick={() => setExportModalSubscription(subscription)}
+                          onClick={() => setActiveModal({ type: 'export', subscription })}
                           className="inline-flex items-center gap-1 text-sm text-green-600 hover:text-green-700 font-medium"
                         >
                           <Download className="h-3 w-3" />
@@ -527,7 +520,7 @@ export function MySubscriptions() {
                         </button>
                         <button
                           onClick={() => handleRevokeSubscription(subscription.id)}
-                          disabled={revokingId === subscription.id}
+                          disabled={revokeState.revokingId === subscription.id}
                           className="text-sm text-red-600 hover:text-red-700 font-medium disabled:opacity-50"
                         >
                           Revoke
@@ -543,23 +536,23 @@ export function MySubscriptions() {
       )}
 
       {/* Reveal Key Modal */}
-      {revealModalSubscription && (
+      {activeModal?.type === 'reveal' && (
         <RevealKeyModal
-          subscription={revealModalSubscription}
+          subscription={activeModal.subscription}
           isOpen={true}
-          onClose={() => setRevealModalSubscription(null)}
+          onClose={() => setActiveModal(null)}
         />
       )}
 
       {/* Rotate Key Modal */}
-      {rotateModalSubscription && (
+      {activeModal?.type === 'rotate' && (
         <RotateKeyModal
-          subscription={rotateModalSubscription}
+          subscription={activeModal.subscription}
           isOpen={true}
-          onClose={() => setRotateModalSubscription(null)}
+          onClose={() => setActiveModal(null)}
           onRotate={async (gracePeriodHours) => {
             const result = await rotateKeyMutation.mutateAsync({
-              id: rotateModalSubscription.id,
+              id: activeModal.subscription.id,
               gracePeriodHours,
             });
             return result;
@@ -569,24 +562,24 @@ export function MySubscriptions() {
       )}
 
       {/* Export Config Modal */}
-      {exportModalSubscription && (
+      {activeModal?.type === 'export' && (
         <ExportConfigModal
-          subscription={exportModalSubscription}
+          subscription={activeModal.subscription}
           isOpen={true}
-          onClose={() => setExportModalSubscription(null)}
+          onClose={() => setActiveModal(null)}
         />
       )}
 
       {/* Revoke Confirmation Dialog */}
       <ConfirmDialog
-        open={!!confirmRevokeId}
+        open={!!revokeState.confirmId}
         title="Revoke Subscription"
         message="Are you sure you want to revoke this subscription? Your API key will be invalidated immediately."
         confirmLabel="Revoke"
         variant="danger"
         onConfirm={confirmRevoke}
-        onCancel={() => setConfirmRevokeId(null)}
-        loading={revokingId === confirmRevokeId}
+        onCancel={() => setRevokeState({ confirmId: null, revokingId: null })}
+        loading={revokeState.revokingId === revokeState.confirmId}
       />
     </div>
   );

--- a/portal/src/pages/usage/UsagePage.tsx
+++ b/portal/src/pages/usage/UsagePage.tsx
@@ -5,74 +5,50 @@
  * Page principale /usage dans le Portal STOA
  */
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Activity, CheckCircle, Clock, AlertTriangle, RefreshCw } from 'lucide-react';
 import { StatCard, CallsTable, UsageChart, TopTools, SubscriptionsList } from '../../components/usage';
 import { usageService, formatLatency } from '../../services/usage';
 import { useAuth } from '../../contexts/AuthContext';
-import type { UsageSummary, UsageCallsResponse, ActiveSubscription } from '../../types';
 
 type Period = 'today' | 'week' | 'month';
 
 export function UsagePage() {
   const { isAuthenticated, isLoading: authLoading, accessToken } = useAuth();
-
-  const [summary, setSummary] = useState<UsageSummary | null>(null);
-  const [callsResponse, setCallsResponse] = useState<UsageCallsResponse | null>(null);
-  const [subscriptions, setSubscriptions] = useState<ActiveSubscription[]>([]);
-
-  const [summaryLoading, setSummaryLoading] = useState(true);
-  const [callsLoading, setCallsLoading] = useState(true);
-  const [subsLoading, setSubsLoading] = useState(true);
+  const queryClient = useQueryClient();
 
   const [selectedPeriod, setSelectedPeriod] = useState<Period>('today');
-  const [error, setError] = useState<string | null>(null);
 
-  // Fetch data
-  const fetchData = async () => {
-    setError(null);
+  const isReady = isAuthenticated && !authLoading && !!accessToken;
 
-    // Fetch summary
-    setSummaryLoading(true);
-    try {
-      const summaryData = await usageService.getSummary();
-      setSummary(summaryData);
-    } catch (err) {
-      console.error('Failed to fetch usage summary:', err);
-      setError('Failed to load usage data');
-    } finally {
-      setSummaryLoading(false);
-    }
+  // 3 parallel queries — no waterfall
+  const { data: summary = null, isLoading: summaryLoading, error: summaryError } = useQuery({
+    queryKey: ['usage', 'summary'],
+    queryFn: () => usageService.getSummary(),
+    enabled: isReady,
+    staleTime: 30_000,
+  });
 
-    // Fetch calls
-    setCallsLoading(true);
-    try {
-      const callsData = await usageService.getCalls({ limit: 20 });
-      setCallsResponse(callsData);
-    } catch (err) {
-      console.error('Failed to fetch calls:', err);
-    } finally {
-      setCallsLoading(false);
-    }
+  const { data: callsResponse = null, isLoading: callsLoading } = useQuery({
+    queryKey: ['usage', 'calls'],
+    queryFn: () => usageService.getCalls({ limit: 20 }),
+    enabled: isReady,
+    staleTime: 30_000,
+  });
 
-    // Fetch subscriptions
-    setSubsLoading(true);
-    try {
-      const subsData = await usageService.getActiveSubscriptions();
-      setSubscriptions(subsData);
-    } catch (err) {
-      console.error('Failed to fetch subscriptions:', err);
-    } finally {
-      setSubsLoading(false);
-    }
+  const { data: subscriptions = [], isLoading: subsLoading } = useQuery({
+    queryKey: ['usage', 'subscriptions'],
+    queryFn: () => usageService.getActiveSubscriptions(),
+    enabled: isReady,
+    staleTime: 30_000,
+  });
+
+  const error = summaryError ? (summaryError.message || 'Failed to load usage data') : null;
+
+  const refetchAll = () => {
+    queryClient.invalidateQueries({ queryKey: ['usage'] });
   };
-
-  useEffect(() => {
-    // Only fetch data when authenticated, auth is not loading, and token is available
-    if (isAuthenticated && !authLoading && accessToken) {
-      fetchData();
-    }
-  }, [isAuthenticated, authLoading, accessToken]);
 
   // Get stats for selected period
   const getPeriodStats = () => {
@@ -104,7 +80,7 @@ export function UsagePage() {
           </div>
 
           <button
-            onClick={fetchData}
+            onClick={refetchAll}
             className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-neutral-200 bg-white dark:bg-neutral-800 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
           >
             <RefreshCw className="w-4 h-4" />


### PR DESCRIPTION
## Summary

- **Phase 4**: Backend pagination on 4 list endpoints (`page`/`page_size` params, `PaginatedResponse` generic schema, default 20, max 100)
- **Phase 5**: SQL optimization in `portal.py` — replace Python-side filtering with SQL `WHERE`, `OFFSET/LIMIT`, `COUNT(*) OVER()` + lightweight DTOs (`MCPServerListItem`, `APIListItem`)
- **Phase 6**: In-memory TTL cache on `GET /tenants/{id}` (30s) and `GET /contracts` (60s) with mutation invalidation; Keycloak `localStorage` for cross-tab persistence; `web-vitals` v5.1.0 (LCP/INP/CLS dev logging)

## Test plan

- [x] `pytest` — 302 passed, 0 failed (pre-existing `test_opensearch` excluded)
- [x] `npm run build` — Console UI (2.31s) + Portal (2.24s)
- [ ] CI pipeline green
- [ ] Verify cache TTL behavior on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)