### PR TITLE
fix(ci): add id-token permission to smoke-test jobs for Vault OIDC

### DIFF
--- a/.github/workflows/control-plane-api-ci.yml
+++ b/.github/workflows/control-plane-api-ci.yml
@@ -104,6 +104,7 @@ jobs:
       component: control-plane-api
     permissions:
       contents: read
+      id-token: write
     secrets: inherit
 
   # === Notify: Slack ===

--- a/.github/workflows/control-plane-ui-ci.yml
+++ b/.github/workflows/control-plane-ui-ci.yml
@@ -113,6 +113,7 @@ jobs:
       component: control-plane-ui
     permissions:
       contents: read
+      id-token: write
     secrets: inherit
 
   # === Notify: Slack ===

--- a/.github/workflows/stoa-portal-ci.yml
+++ b/.github/workflows/stoa-portal-ci.yml
@@ -114,6 +114,7 @@ jobs:
       component: stoa-portal
     permissions:
       contents: read
+      id-token: write
     secrets: inherit
 
   # === Notify: Slack ===


### PR DESCRIPTION
## Summary

- **Root cause**: Commit `0d51917` added `id-token: write` to `reusable-smoke-test.yml` for Vault OIDC authentication, but the three caller workflows still restricted the smoke-test job to `permissions: contents: read` only
- **Impact**: GitHub Actions validates permission compatibility at startup — the mismatch caused `startup_failure` on **every** Control Plane API, Console UI, and Portal CI/CD run since the Vault integration was merged
- **Fix**: Grant `id-token: write` to the `smoke-test` job in all three orchestrator workflows

### Affected workflows
| Workflow | Status before fix |
|----------|-------------------|
| `control-plane-api-ci.yml` | startup_failure |
| `control-plane-ui-ci.yml` | startup_failure |
| `stoa-portal-ci.yml` | startup_failure |

### Not affected (no smoke-test job)
- `mcp-gateway-ci.yml` ✅
- `stoa-gateway-ci.yml` ✅

## Test plan

- [ ] CI pipeline starts successfully (no more `startup_failure`)
- [ ] Smoke-test job can authenticate to Vault via OIDC
- [ ] Dependabot PRs for control-plane-ui unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)