### PR TITLE
feat(mcp): deploy OpenSearch + Dashboards for STOA Logs (CAB-1114)

### DIFF
--- a/deploy/docker-compose/config/nginx/nginx.conf
+++ b/deploy/docker-compose/config/nginx/nginx.conf
@@ -1,11 +1,13 @@
 # =============================================================================
 # STOA Platform - Unified Reverse Proxy
 # =============================================================================
-# CAB-1108 Phase 3: Single entry point for Console, Grafana, Keycloak, API
+# CAB-1108 Phase 3 + CAB-1114 Phase 1
+# Single entry point for Console, Grafana, STOA Logs, Keycloak, API
 #
 # Routes:
 #   /           → Control Plane UI (port 3000)
 #   /grafana/*  → Grafana (port 3000 internal)
+#   /logs/*     → OpenSearch Dashboards (port 5601 internal)
 #   /auth/*     → Keycloak (port 8080 internal)
 #   /api/*      → Control Plane API (port 8000)
 # =============================================================================
@@ -53,6 +55,10 @@ http {
 
     upstream keycloak {
         server keycloak:8080;
+    }
+
+    upstream opensearch_dashboards {
+        server opensearch-dashboards:5601;
     }
 
     upstream api {
@@ -117,6 +123,39 @@ http {
             # WebSocket timeouts
             proxy_read_timeout 86400s;
             proxy_send_timeout 86400s;
+        }
+
+        # =====================================================================
+        # OpenSearch Dashboards (STOA Logs) - /logs/*
+        # Note: Dashboards is configured with server.basePath="/logs"
+        # and server.rewriteBasePath=true
+        # =====================================================================
+        location /logs/ {
+            proxy_pass http://opensearch_dashboards;
+
+            # Strip X-Frame-Options to allow iframe embedding
+            proxy_hide_header X-Frame-Options;
+
+            # Add permissive frame-ancestors for Console embedding
+            add_header Content-Security-Policy "frame-ancestors 'self' http://localhost:* https://console.gostoa.dev" always;
+
+            # Proxy headers
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Port $server_port;
+
+            # Buffer settings (Dashboards can have large responses)
+            proxy_buffer_size 128k;
+            proxy_buffers 4 256k;
+            proxy_busy_buffers_size 256k;
+
+            # Timeouts
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
         }
 
         # =====================================================================

--- a/deploy/docker-compose/config/opensearch-dashboards/img/stoa-favicon.svg
+++ b/deploy/docker-compose/config/opensearch-dashboards/img/stoa-favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="stoaGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1"/>
+      <stop offset="100%" style="stop-color:#8b5cf6"/>
+    </linearGradient>
+  </defs>
+  <!-- Background circle -->
+  <circle cx="16" cy="16" r="15" fill="url(#stoaGradient)"/>
+  <!-- S letter stylized as API flow -->
+  <path d="M10 11 Q10 8, 16 8 Q22 8, 22 11 Q22 14, 16 14 Q10 14, 10 17 Q10 20, 16 20 Q22 20, 22 24 Q22 27, 16 27"
+        stroke="white"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        fill="none"/>
+  <!-- API dots -->
+  <circle cx="8" cy="14" r="1.5" fill="white" opacity="0.8"/>
+  <circle cx="24" cy="14" r="1.5" fill="white" opacity="0.8"/>
+  <circle cx="8" cy="20" r="1.5" fill="white" opacity="0.8"/>
+  <circle cx="24" cy="20" r="1.5" fill="white" opacity="0.8"/>
+</svg>

--- a/deploy/docker-compose/config/opensearch-dashboards/img/stoa-logo-mark.svg
+++ b/deploy/docker-compose/config/opensearch-dashboards/img/stoa-logo-mark.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#8b5cf6;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Background circle -->
+  <circle cx="100" cy="100" r="90" fill="url(#grad1)" />
+  
+  <!-- STOA letters stylized -->
+  <text x="100" y="115" 
+        font-family="Arial, sans-serif" 
+        font-size="48" 
+        font-weight="bold" 
+        fill="white" 
+        text-anchor="middle">
+    STOA
+  </text>
+  
+  <!-- Decorative elements - API gateway symbol -->
+  <path d="M 60 145 L 100 160 L 140 145" 
+        stroke="white" 
+        stroke-width="3" 
+        fill="none" 
+        stroke-linecap="round"/>
+  <circle cx="60" cy="145" r="4" fill="white"/>
+  <circle cx="100" cy="160" r="4" fill="white"/>
+  <circle cx="140" cy="145" r="4" fill="white"/>
+  
+  <!-- Top decorative line -->
+  <path d="M 60 55 L 100 40 L 140 55" 
+        stroke="white" 
+        stroke-width="3" 
+        fill="none" 
+        stroke-linecap="round"/>
+  <circle cx="60" cy="55" r="4" fill="white"/>
+  <circle cx="100" cy="40" r="4" fill="white"/>
+  <circle cx="140" cy="55" r="4" fill="white"/>
+</svg>

--- a/deploy/docker-compose/config/opensearch-dashboards/opensearch_dashboards.yml
+++ b/deploy/docker-compose/config/opensearch-dashboards/opensearch_dashboards.yml
@@ -1,0 +1,23 @@
+# =============================================================================
+# STOA Logs - OpenSearch Dashboards Configuration
+# =============================================================================
+# CAB-1114 Phase 1: Branding + sub-path serving for reverse proxy
+# =============================================================================
+
+server.host: "0.0.0.0"
+server.port: 5601
+server.basePath: "/logs"
+server.rewriteBasePath: true
+
+opensearch.hosts: ["http://opensearch:9200"]
+
+# STOA Branding
+opensearchDashboards.branding:
+  applicationTitle: "STOA Logs"
+  mark:
+    defaultUrl: "/assets/stoa-logo-mark.svg"
+  logo:
+    defaultUrl: "/assets/stoa-logo-mark.svg"
+  faviconUrl: "/assets/stoa-favicon.svg"
+  loadingLogo:
+    defaultUrl: "/assets/stoa-logo-mark.svg"

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -14,8 +14,10 @@
 #   - console:     Console UI (port 3000)
 #   - prometheus:  Metrics (port 9090)
 #   - grafana:     Dashboards (port 3001)
+#   - opensearch:  Search engine (port 9200)
+#   - dashboards:  STOA Logs UI (port 5601, via /logs)
 #
-# Total RAM: ~1.5GB (works on 8GB machines)
+# Total RAM: ~2.5GB (works on 8GB machines)
 # =============================================================================
 
 services:
@@ -165,7 +167,7 @@ services:
     restart: unless-stopped
 
   # ==========================================================================
-  # Reverse Proxy (nginx) - CAB-1108 Phase 3
+  # Reverse Proxy (nginx) - CAB-1108 Phase 3 + CAB-1114
   # ==========================================================================
   nginx:
     image: nginx:1.25-alpine
@@ -179,6 +181,7 @@ services:
       - control-plane-api
       - grafana
       - keycloak
+      - opensearch-dashboards
     networks:
       - stoa-network
     healthcheck:
@@ -187,6 +190,84 @@ services:
       timeout: 5s
       retries: 3
     restart: unless-stopped
+
+  # ==========================================================================
+  # OpenSearch (Search Engine) - CAB-1114 Phase 1
+  # ==========================================================================
+  opensearch:
+    image: opensearchproject/opensearch:2.11.0
+    container_name: stoa-opensearch
+    ports:
+      - "${PORT_OPENSEARCH:-9200}:9200"
+    environment:
+      - cluster.name=stoa-cluster
+      - node.name=stoa-node-1
+      - discovery.type=single-node
+      - DISABLE_SECURITY_PLUGIN=true
+      - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
+      - bootstrap.memory_lock=true
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - opensearch-data:/usr/share/opensearch/data
+    networks:
+      - stoa-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+      start_period: 30s
+    restart: unless-stopped
+
+  # ==========================================================================
+  # OpenSearch Dashboards (STOA Logs UI) - CAB-1114 Phase 1
+  # ==========================================================================
+  opensearch-dashboards:
+    image: opensearchproject/opensearch-dashboards:2.11.0
+    container_name: stoa-opensearch-dashboards
+    ports:
+      - "${PORT_OPENSEARCH_DASHBOARDS:-5601}:5601"
+    environment:
+      - DISABLE_SECURITY_DASHBOARDS_PLUGIN=true
+      - OPENSEARCH_HOSTS=["http://opensearch:9200"]
+    volumes:
+      - ./config/opensearch-dashboards/opensearch_dashboards.yml:/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml:ro
+      - ./config/opensearch-dashboards/img/stoa-logo-mark.svg:/usr/share/opensearch-dashboards/assets/stoa-logo-mark.svg:ro
+      - ./config/opensearch-dashboards/img/stoa-favicon.svg:/usr/share/opensearch-dashboards/assets/stoa-favicon.svg:ro
+    depends_on:
+      opensearch:
+        condition: service_healthy
+    networks:
+      - stoa-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:5601/logs/api/status || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+
+  # ==========================================================================
+  # OpenSearch Init (one-shot) - CAB-1114 Phase 1
+  # ==========================================================================
+  opensearch-init:
+    image: curlimages/curl:8.5.0
+    container_name: stoa-opensearch-init
+    volumes:
+      - ./init/init-opensearch.sh:/init-opensearch.sh:ro
+    entrypoint: ["sh", "/init-opensearch.sh"]
+    depends_on:
+      opensearch:
+        condition: service_healthy
+    networks:
+      - stoa-network
+    restart: "no"
 
   # ==========================================================================
   # Prometheus (Metrics)
@@ -296,3 +377,4 @@ volumes:
   prometheus-data:
   grafana-data:
   loki-data:
+  opensearch-data:

--- a/deploy/docker-compose/init/init-opensearch.sh
+++ b/deploy/docker-compose/init/init-opensearch.sh
@@ -1,0 +1,225 @@
+#!/bin/sh
+# =============================================================================
+# STOA Platform - OpenSearch Init Script (CAB-1114 Phase 1)
+# =============================================================================
+# Creates index template, ISM policy, tenant indices, and seeds test data.
+# Runs as a one-shot container via curlimages/curl:8.5.0
+# =============================================================================
+
+set -e
+
+OS_HOST="http://opensearch:9200"
+
+log() { echo "[INIT] $1"; }
+
+# ---------------------------------------------------------------------------
+# 1. Wait for OpenSearch (belt-and-suspenders, depends_on already checks)
+# ---------------------------------------------------------------------------
+log "Waiting for OpenSearch..."
+for i in $(seq 1 30); do
+  if curl -sf "${OS_HOST}/_cluster/health" > /dev/null 2>&1; then
+    log "OpenSearch is ready"
+    break
+  fi
+  sleep 2
+done
+
+# ---------------------------------------------------------------------------
+# 2. Create ISM policy: stoa-logs-policy (14 days retention)
+# ---------------------------------------------------------------------------
+log "Creating ISM policy: stoa-logs-policy"
+curl -sf -X PUT "${OS_HOST}/_plugins/_ism/policies/stoa-logs-policy" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "policy": {
+    "description": "API call logs lifecycle - 14 days retention",
+    "default_state": "hot",
+    "states": [
+      {
+        "name": "hot",
+        "actions": [{ "rollover": { "min_size": "5gb", "min_index_age": "1d" } }],
+        "transitions": [{ "state_name": "warm", "conditions": { "min_index_age": "7d" } }]
+      },
+      {
+        "name": "warm",
+        "actions": [
+          { "replica_count": { "number_of_replicas": 0 } },
+          { "force_merge": { "max_num_segments": 1 } }
+        ],
+        "transitions": [{ "state_name": "delete", "conditions": { "min_index_age": "14d" } }]
+      },
+      {
+        "name": "delete",
+        "actions": [{ "delete": {} }],
+        "transitions": []
+      }
+    ],
+    "ism_template": [{ "index_patterns": ["stoa-logs-*"], "priority": 100 }]
+  }
+}' || log "ISM policy may already exist (OK)"
+
+# ---------------------------------------------------------------------------
+# 3. Create index template: stoa-logs
+# ---------------------------------------------------------------------------
+log "Creating index template: stoa-logs"
+curl -sf -X PUT "${OS_HOST}/_index_template/stoa-logs" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "index_patterns": ["stoa-logs-*"],
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0
+    },
+    "mappings": {
+      "properties": {
+        "@timestamp":         { "type": "date" },
+        "tenant_id":          { "type": "keyword" },
+        "correlation_id":     { "type": "keyword" },
+        "method":             { "type": "keyword" },
+        "path":               { "type": "keyword" },
+        "status":             { "type": "integer" },
+        "consumer_id":        { "type": "keyword" },
+        "consumer_name":      { "type": "keyword" },
+        "api_name":           { "type": "keyword" },
+        "api_version":        { "type": "keyword" },
+        "latency_ms":         { "type": "float" },
+        "request_size_bytes": { "type": "long" },
+        "response_size_bytes":{ "type": "long" },
+        "error_message":      { "type": "text" },
+        "error_code":         { "type": "keyword" },
+        "gateway_instance":   { "type": "keyword" },
+        "environment":        { "type": "keyword" },
+        "tags":               { "type": "keyword" }
+      }
+    }
+  },
+  "priority": 100
+}' || log "Index template may already exist (OK)"
+
+# ---------------------------------------------------------------------------
+# 4. Create per-tenant indices with write aliases
+# ---------------------------------------------------------------------------
+log "Creating tenant-alpha index..."
+curl -sf -X PUT "${OS_HOST}/stoa-logs-tenant-alpha-000001" \
+  -H "Content-Type: application/json" \
+  -d '{ "aliases": { "stoa-logs-tenant-alpha": { "is_write_index": true } } }' \
+  || log "tenant-alpha index may already exist (OK)"
+
+log "Creating tenant-beta index..."
+curl -sf -X PUT "${OS_HOST}/stoa-logs-tenant-beta-000001" \
+  -H "Content-Type: application/json" \
+  -d '{ "aliases": { "stoa-logs-tenant-beta": { "is_write_index": true } } }' \
+  || log "tenant-beta index may already exist (OK)"
+
+# ---------------------------------------------------------------------------
+# 5. Seed test data — tenant-alpha (~20 docs)
+# ---------------------------------------------------------------------------
+log "Injecting test data for tenant-alpha..."
+
+# Use current date components for realistic timestamps
+NOW=$(date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null || echo "2026-02-06T10:00:00.000Z")
+TODAY=$(echo "$NOW" | cut -c1-10)
+
+curl -sf -X POST "${OS_HOST}/_bulk" -H "Content-Type: application/x-ndjson" -d '
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T08:12:33.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a001","method":"GET","path":"/v1/apis","status":200,"consumer_id":"consumer-1","consumer_name":"AI Agent Alpha","api_name":"Catalog API","api_version":"v1","latency_ms":42.3,"request_size_bytes":256,"response_size_bytes":4820,"gateway_instance":"gw-edge-01","environment":"production","tags":["catalog","read"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T08:13:01.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a002","method":"GET","path":"/v1/apis","status":200,"consumer_id":"consumer-2","consumer_name":"Dashboard Bot","api_name":"Catalog API","api_version":"v1","latency_ms":38.7,"request_size_bytes":210,"response_size_bytes":4820,"gateway_instance":"gw-edge-01","environment":"production","tags":["catalog","read"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T08:15:22.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a003","method":"POST","path":"/v1/apis","status":201,"consumer_id":"consumer-1","consumer_name":"AI Agent Alpha","api_name":"Catalog API","api_version":"v1","latency_ms":156.2,"request_size_bytes":1480,"response_size_bytes":620,"gateway_instance":"gw-edge-01","environment":"production","tags":["catalog","write"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T08:17:45.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a004","method":"POST","path":"/v1/apis","status":400,"consumer_id":"consumer-1","consumer_name":"AI Agent Alpha","api_name":"Catalog API","api_version":"v1","latency_ms":12.1,"request_size_bytes":980,"response_size_bytes":340,"error_code":"VALIDATION_ERROR","error_message":"Field displayName is required","gateway_instance":"gw-edge-01","environment":"production","tags":["catalog","write","error"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T08:20:10.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a005","method":"GET","path":"/v1/apis/api-123","status":200,"consumer_id":"consumer-2","consumer_name":"Dashboard Bot","api_name":"Catalog API","api_version":"v1","latency_ms":28.5,"request_size_bytes":128,"response_size_bytes":2240,"gateway_instance":"gw-edge-01","environment":"production","tags":["catalog","read"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T08:22:55.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a006","method":"GET","path":"/v1/apis/api-999","status":404,"consumer_id":"consumer-1","consumer_name":"AI Agent Alpha","api_name":"Catalog API","api_version":"v1","latency_ms":8.3,"request_size_bytes":128,"response_size_bytes":180,"error_code":"NOT_FOUND","error_message":"API api-999 not found","gateway_instance":"gw-edge-01","environment":"production","tags":["catalog","read","error"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T08:25:30.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a007","method":"DELETE","path":"/v1/apis/api-456","status":401,"consumer_id":"consumer-3","consumer_name":"Rogue Client","api_name":"Catalog API","api_version":"v1","latency_ms":5.1,"request_size_bytes":128,"response_size_bytes":220,"error_code":"UNAUTHORIZED","error_message":"Missing or invalid bearer token","gateway_instance":"gw-edge-01","environment":"production","tags":["catalog","delete","error","security"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T08:30:00.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a008","method":"POST","path":"/v1/tools/invoke","status":200,"consumer_id":"consumer-1","consumer_name":"AI Agent Alpha","api_name":"Tool Invocation","api_version":"v1","latency_ms":1234.5,"request_size_bytes":2048,"response_size_bytes":8192,"gateway_instance":"gw-edge-01","environment":"production","tags":["tools","invoke"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T08:32:15.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a009","method":"POST","path":"/v1/tools/invoke","status":200,"consumer_id":"consumer-2","consumer_name":"Dashboard Bot","api_name":"Tool Invocation","api_version":"v1","latency_ms":890.2,"request_size_bytes":1536,"response_size_bytes":6144,"gateway_instance":"gw-edge-01","environment":"production","tags":["tools","invoke"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T08:35:42.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a010","method":"POST","path":"/v1/tools/invoke","status":500,"consumer_id":"consumer-1","consumer_name":"AI Agent Alpha","api_name":"Tool Invocation","api_version":"v1","latency_ms":2500.0,"request_size_bytes":2048,"response_size_bytes":512,"error_code":"INTERNAL_ERROR","error_message":"Upstream tool timed out after 2500ms","gateway_instance":"gw-edge-01","environment":"production","tags":["tools","invoke","error","timeout"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T09:00:05.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a011","method":"GET","path":"/v1/subscriptions","status":200,"consumer_id":"consumer-1","consumer_name":"AI Agent Alpha","api_name":"Subscription API","api_version":"v1","latency_ms":55.8,"request_size_bytes":180,"response_size_bytes":3200,"gateway_instance":"gw-edge-02","environment":"production","tags":["subscriptions","read"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T09:05:20.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a012","method":"POST","path":"/v1/subscriptions","status":201,"consumer_id":"consumer-2","consumer_name":"Dashboard Bot","api_name":"Subscription API","api_version":"v1","latency_ms":178.4,"request_size_bytes":920,"response_size_bytes":540,"gateway_instance":"gw-edge-02","environment":"production","tags":["subscriptions","write"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T09:10:33.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a013","method":"GET","path":"/v1/analytics/usage","status":200,"consumer_id":"consumer-1","consumer_name":"AI Agent Alpha","api_name":"Analytics API","api_version":"v1","latency_ms":320.6,"request_size_bytes":256,"response_size_bytes":12800,"gateway_instance":"gw-edge-02","environment":"production","tags":["analytics","read"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T09:15:00.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a014","method":"PUT","path":"/v1/apis/api-123","status":200,"consumer_id":"consumer-1","consumer_name":"AI Agent Alpha","api_name":"Catalog API","api_version":"v1","latency_ms":145.3,"request_size_bytes":1800,"response_size_bytes":620,"gateway_instance":"gw-edge-01","environment":"production","tags":["catalog","write"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T09:20:45.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a015","method":"GET","path":"/v1/apis","status":200,"consumer_id":"consumer-4","consumer_name":"Monitoring Agent","api_name":"Catalog API","api_version":"v1","latency_ms":35.2,"request_size_bytes":200,"response_size_bytes":4820,"gateway_instance":"gw-edge-01","environment":"production","tags":["catalog","read","monitoring"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T09:25:10.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a016","method":"POST","path":"/v1/tools/invoke","status":200,"consumer_id":"consumer-4","consumer_name":"Monitoring Agent","api_name":"Tool Invocation","api_version":"v1","latency_ms":456.7,"request_size_bytes":1024,"response_size_bytes":4096,"gateway_instance":"gw-edge-02","environment":"production","tags":["tools","invoke","monitoring"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T09:30:22.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a017","method":"DELETE","path":"/v1/apis/api-789","status":200,"consumer_id":"consumer-1","consumer_name":"AI Agent Alpha","api_name":"Catalog API","api_version":"v1","latency_ms":92.1,"request_size_bytes":128,"response_size_bytes":180,"gateway_instance":"gw-edge-01","environment":"production","tags":["catalog","delete"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T09:35:55.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a018","method":"POST","path":"/v1/tools/invoke","status":500,"consumer_id":"consumer-2","consumer_name":"Dashboard Bot","api_name":"Tool Invocation","api_version":"v1","latency_ms":1800.0,"request_size_bytes":2048,"response_size_bytes":480,"error_code":"UPSTREAM_ERROR","error_message":"Connection refused to backend service","gateway_instance":"gw-edge-02","environment":"production","tags":["tools","invoke","error"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T09:40:10.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a019","method":"GET","path":"/v1/health","status":200,"consumer_id":"consumer-4","consumer_name":"Monitoring Agent","api_name":"Health API","api_version":"v1","latency_ms":5.0,"request_size_bytes":64,"response_size_bytes":128,"gateway_instance":"gw-edge-01","environment":"production","tags":["health","monitoring"]}
+{"index":{"_index":"stoa-logs-tenant-alpha-000001"}}
+{"@timestamp":"'"${TODAY}"'T09:45:30.000Z","tenant_id":"tenant-alpha","correlation_id":"corr-a020","method":"POST","path":"/v1/apis","status":201,"consumer_id":"consumer-1","consumer_name":"AI Agent Alpha","api_name":"Catalog API","api_version":"v1","latency_ms":168.9,"request_size_bytes":1650,"response_size_bytes":640,"gateway_instance":"gw-edge-01","environment":"production","tags":["catalog","write"]}
+'
+
+# ---------------------------------------------------------------------------
+# 6. Seed test data — tenant-beta (~15 docs)
+# ---------------------------------------------------------------------------
+log "Injecting test data for tenant-beta..."
+
+curl -sf -X POST "${OS_HOST}/_bulk" -H "Content-Type: application/x-ndjson" -d '
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T07:00:12.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b001","method":"GET","path":"/v2/products","status":200,"consumer_id":"consumer-10","consumer_name":"E-Commerce Bot","api_name":"Product API","api_version":"v2","latency_ms":67.4,"request_size_bytes":300,"response_size_bytes":9600,"gateway_instance":"gw-edge-03","environment":"production","tags":["products","read"]}
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T07:05:45.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b002","method":"POST","path":"/v2/orders","status":201,"consumer_id":"consumer-10","consumer_name":"E-Commerce Bot","api_name":"Order API","api_version":"v2","latency_ms":234.8,"request_size_bytes":3200,"response_size_bytes":1024,"gateway_instance":"gw-edge-03","environment":"production","tags":["orders","write"]}
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T07:10:20.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b003","method":"GET","path":"/v2/products/prod-42","status":200,"consumer_id":"consumer-11","consumer_name":"Search Indexer","api_name":"Product API","api_version":"v2","latency_ms":22.1,"request_size_bytes":180,"response_size_bytes":2800,"gateway_instance":"gw-edge-03","environment":"production","tags":["products","read"]}
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T07:15:33.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b004","method":"PUT","path":"/v2/products/prod-42","status":400,"consumer_id":"consumer-10","consumer_name":"E-Commerce Bot","api_name":"Product API","api_version":"v2","latency_ms":15.3,"request_size_bytes":2100,"response_size_bytes":380,"error_code":"VALIDATION_ERROR","error_message":"Price must be a positive number","gateway_instance":"gw-edge-03","environment":"production","tags":["products","write","error"]}
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T07:20:00.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b005","method":"GET","path":"/v2/orders","status":403,"consumer_id":"consumer-12","consumer_name":"Unauthorized App","api_name":"Order API","api_version":"v2","latency_ms":6.8,"request_size_bytes":200,"response_size_bytes":280,"error_code":"FORBIDDEN","error_message":"Insufficient scope: orders:read required","gateway_instance":"gw-edge-03","environment":"production","tags":["orders","read","error","security"]}
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T07:25:15.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b006","method":"POST","path":"/v2/payments/charge","status":200,"consumer_id":"consumer-10","consumer_name":"E-Commerce Bot","api_name":"Payment API","api_version":"v2","latency_ms":890.5,"request_size_bytes":1500,"response_size_bytes":620,"gateway_instance":"gw-edge-04","environment":"production","tags":["payments","write"]}
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T07:30:42.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b007","method":"POST","path":"/v2/payments/charge","status":500,"consumer_id":"consumer-10","consumer_name":"E-Commerce Bot","api_name":"Payment API","api_version":"v2","latency_ms":2100.0,"request_size_bytes":1500,"response_size_bytes":420,"error_code":"GATEWAY_TIMEOUT","error_message":"Payment provider did not respond within 2000ms","gateway_instance":"gw-edge-04","environment":"production","tags":["payments","write","error","timeout"]}
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T07:35:10.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b008","method":"GET","path":"/v2/products","status":200,"consumer_id":"consumer-11","consumer_name":"Search Indexer","api_name":"Product API","api_version":"v2","latency_ms":78.9,"request_size_bytes":350,"response_size_bytes":15360,"gateway_instance":"gw-edge-03","environment":"production","tags":["products","read","bulk"]}
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T07:40:25.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b009","method":"DELETE","path":"/v2/orders/ord-101","status":200,"consumer_id":"consumer-10","consumer_name":"E-Commerce Bot","api_name":"Order API","api_version":"v2","latency_ms":110.4,"request_size_bytes":128,"response_size_bytes":200,"gateway_instance":"gw-edge-03","environment":"production","tags":["orders","delete"]}
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T07:45:55.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b010","method":"POST","path":"/v2/notifications/send","status":200,"consumer_id":"consumer-10","consumer_name":"E-Commerce Bot","api_name":"Notification API","api_version":"v2","latency_ms":145.6,"request_size_bytes":800,"response_size_bytes":320,"gateway_instance":"gw-edge-04","environment":"production","tags":["notifications","write"]}
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T07:50:30.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b011","method":"GET","path":"/v2/analytics/revenue","status":200,"consumer_id":"consumer-11","consumer_name":"Search Indexer","api_name":"Analytics API","api_version":"v2","latency_ms":445.2,"request_size_bytes":280,"response_size_bytes":18400,"gateway_instance":"gw-edge-04","environment":"production","tags":["analytics","read"]}
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T07:55:10.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b012","method":"POST","path":"/v2/orders","status":201,"consumer_id":"consumer-10","consumer_name":"E-Commerce Bot","api_name":"Order API","api_version":"v2","latency_ms":198.3,"request_size_bytes":2800,"response_size_bytes":980,"gateway_instance":"gw-edge-03","environment":"production","tags":["orders","write"]}
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T08:00:00.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b013","method":"GET","path":"/v2/health","status":200,"consumer_id":"consumer-13","consumer_name":"Health Monitor","api_name":"Health API","api_version":"v2","latency_ms":4.2,"request_size_bytes":64,"response_size_bytes":128,"gateway_instance":"gw-edge-03","environment":"production","tags":["health","monitoring"]}
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T08:05:22.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b014","method":"POST","path":"/v2/products","status":201,"consumer_id":"consumer-10","consumer_name":"E-Commerce Bot","api_name":"Product API","api_version":"v2","latency_ms":134.7,"request_size_bytes":2400,"response_size_bytes":680,"gateway_instance":"gw-edge-03","environment":"production","tags":["products","write"]}
+{"index":{"_index":"stoa-logs-tenant-beta-000001"}}
+{"@timestamp":"'"${TODAY}"'T08:10:45.000Z","tenant_id":"tenant-beta","correlation_id":"corr-b015","method":"POST","path":"/v2/payments/refund","status":200,"consumer_id":"consumer-10","consumer_name":"E-Commerce Bot","api_name":"Payment API","api_version":"v2","latency_ms":780.3,"request_size_bytes":1200,"response_size_bytes":540,"gateway_instance":"gw-edge-04","environment":"production","tags":["payments","write","refund"]}
+'
+
+# ---------------------------------------------------------------------------
+# 7. Refresh indices to make data searchable immediately
+# ---------------------------------------------------------------------------
+log "Refreshing indices..."
+curl -sf -X POST "${OS_HOST}/stoa-logs-tenant-alpha-*/_refresh" > /dev/null
+curl -sf -X POST "${OS_HOST}/stoa-logs-tenant-beta-*/_refresh" > /dev/null
+
+# ---------------------------------------------------------------------------
+# 8. DoD Summary
+# ---------------------------------------------------------------------------
+sleep 1
+echo ""
+echo "========================================="
+echo "CAB-1114 Phase 1 — Init Complete"
+echo "  Template: stoa-logs ✓"
+echo "  ISM Policy: stoa-logs-policy ✓"
+ALPHA_COUNT=$(curl -s "${OS_HOST}/stoa-logs-tenant-alpha-*/_count" | grep -o '"count":[0-9]*')
+BETA_COUNT=$(curl -s "${OS_HOST}/stoa-logs-tenant-beta-*/_count" | grep -o '"count":[0-9]*')
+echo "  tenant-alpha docs: ${ALPHA_COUNT}"
+echo "  tenant-beta docs: ${BETA_COUNT}"
+echo "========================================="

--- a/deploy/opensearch/index-templates/ism-policies.json
+++ b/deploy/opensearch/index-templates/ism-policies.json
@@ -79,6 +79,68 @@
       }
     },
     {
+      "policy_id": "stoa-logs-policy",
+      "description": "API call logs lifecycle - 14 days retention",
+      "default_state": "hot",
+      "states": [
+        {
+          "name": "hot",
+          "actions": [
+            {
+              "rollover": {
+                "min_size": "5gb",
+                "min_index_age": "1d"
+              }
+            }
+          ],
+          "transitions": [
+            {
+              "state_name": "warm",
+              "conditions": {
+                "min_index_age": "7d"
+              }
+            }
+          ]
+        },
+        {
+          "name": "warm",
+          "actions": [
+            {
+              "replica_count": {
+                "number_of_replicas": 0
+              }
+            },
+            {
+              "force_merge": {
+                "max_num_segments": 1
+              }
+            }
+          ],
+          "transitions": [
+            {
+              "state_name": "delete",
+              "conditions": {
+                "min_index_age": "14d"
+              }
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "actions": [
+            {
+              "delete": {}
+            }
+          ],
+          "transitions": []
+        }
+      ],
+      "ism_template": {
+        "index_patterns": ["stoa-logs-*"],
+        "priority": 100
+      }
+    },
+    {
       "policy_id": "analytics-policy",
       "description": "Analytics index lifecycle - 90 days retention",
       "default_state": "hot",

--- a/deploy/opensearch/index-templates/stoa-logs-template.json
+++ b/deploy/opensearch/index-templates/stoa-logs-template.json
@@ -1,0 +1,80 @@
+{
+  "index_patterns": ["stoa-logs-*"],
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1,
+      "index": {
+        "lifecycle": {
+          "name": "stoa-logs-policy",
+          "rollover_alias": "stoa-logs"
+        }
+      }
+    },
+    "mappings": {
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "tenant_id": {
+          "type": "keyword"
+        },
+        "correlation_id": {
+          "type": "keyword"
+        },
+        "method": {
+          "type": "keyword"
+        },
+        "path": {
+          "type": "keyword"
+        },
+        "status": {
+          "type": "integer"
+        },
+        "consumer_id": {
+          "type": "keyword"
+        },
+        "consumer_name": {
+          "type": "keyword"
+        },
+        "api_name": {
+          "type": "keyword"
+        },
+        "api_version": {
+          "type": "keyword"
+        },
+        "latency_ms": {
+          "type": "float"
+        },
+        "request_size_bytes": {
+          "type": "long"
+        },
+        "response_size_bytes": {
+          "type": "long"
+        },
+        "error_message": {
+          "type": "text"
+        },
+        "error_code": {
+          "type": "keyword"
+        },
+        "gateway_instance": {
+          "type": "keyword"
+        },
+        "environment": {
+          "type": "keyword"
+        },
+        "tags": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "priority": 100,
+  "version": 1,
+  "_meta": {
+    "description": "STOA Platform - API Call Logs Index (14 days retention, per-tenant)",
+    "managed_by": "stoa-logs-service",
+    "retention_days": 14
+  }
+}


### PR DESCRIPTION
## Summary
- Deploy OpenSearch 2.11.0 + Dashboards in docker-compose quickstart with STOA branding ("STOA Logs", logo, favicon)
- Add nginx `/logs/*` reverse proxy with X-Frame-Options strip + CSP for iframe embedding
- Create `stoa-logs-*` index template with ISM 14-day retention policy (hot → warm → delete)
- Init container seeds realistic API call traces for 2 tenants (`tenant-alpha`: 20 docs, `tenant-beta`: 15 docs)

## Test plan
- [x] `docker compose config` validates
- [x] `docker compose up -d opensearch opensearch-dashboards opensearch-init` — all healthy
- [x] `curl localhost:9200/_cluster/health` → green/yellow, version 2.11.0
- [x] `curl localhost:9200/_index_template/stoa-logs` → 200
- [x] `curl localhost:9200/_plugins/_ism/policies/stoa-logs-policy` → 200
- [x] `curl localhost:9200/stoa-logs-tenant-alpha-*/_search` → returns documents
- [x] `curl localhost:9200/stoa-logs-tenant-beta-*/_search` → returns different documents
- [x] `curl -I localhost/logs/app/home` → 200, no X-Frame-Options header
- [x] `curl -s localhost/logs/app/home | grep "STOA Logs"` → found
- [x] Init container logs show DoD summary with doc counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)