### PR TITLE
fix(ui): CAB-1108 post-audit branding corrections

### DIFF
--- a/.github/workflows/keycloak-theme.yml
+++ b/.github/workflows/keycloak-theme.yml
@@ -57,7 +57,7 @@ jobs:
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: keycloak
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:25.0-stoa

--- a/control-plane-ui/k8s/ingress.yaml
+++ b/control-plane-ui/k8s/ingress.yaml
@@ -8,6 +8,10 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    # CAB-1108: Allow iframe embedding of Grafana, Keycloak, OpenSearch Dashboards
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_hide_header X-Frame-Options;
+      add_header Content-Security-Policy "frame-ancestors 'self' https://console.gostoa.dev" always;
 spec:
   ingressClassName: nginx
   tls:

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -305,6 +305,7 @@ services:
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/stoa-overview.json
       # STOA Branding (CAB-1108)
       GF_APP_TITLE: "STOA Observability"
+      GF_USERS_HIDE_VERSION: "true"
       # Phase 2: Allow iframe embedding in Console
       GF_SECURITY_ALLOW_EMBEDDING: "true"
       # Phase 3: Sub-path serving for reverse proxy

--- a/deploy/observability/grafana-ingress.yaml
+++ b/deploy/observability/grafana-ingress.yaml
@@ -23,6 +23,10 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "50m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    # CAB-1108: Allow iframe embedding in Console
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_hide_header X-Frame-Options;
+      add_header Content-Security-Policy "frame-ancestors 'self' https://console.gostoa.dev" always;
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
## Summary

Post-audit corrective actions for CAB-1108 (Console Branding Unification). Audit identified 3 missing + 3 partial items out of 40 DoD criteria (85% coverage). These fixes bring coverage to **95%+**.

### Changes
- **Grafana**: add `GF_USERS_HIDE_VERSION: "true"` to hide version in footer
- **K8s Ingress (Console)**: add CSP `frame-ancestors` + strip `X-Frame-Options` for iframe embedding
- **K8s Ingress (Grafana)**: add CSP `frame-ancestors` + strip `X-Frame-Options` for iframe embedding
- **Keycloak CI**: enable multi-arch build (`linux/amd64` + `linux/arm64`)

### Files changed
| File | Change |
|------|--------|
| `deploy/docker-compose/docker-compose.yml` | `GF_USERS_HIDE_VERSION: "true"` |
| `control-plane-ui/k8s/ingress.yaml` | CSP + X-Frame-Options annotations |
| `deploy/observability/grafana-ingress.yaml` | CSP + X-Frame-Options annotations |
| `.github/workflows/keycloak-theme.yml` | `linux/amd64,linux/arm64` |

### Remaining gaps (deferred)
- Keycloak / OpenSearch Dashboards: no K8s Ingress files exist (docker-compose only, nginx.conf handles CSP)
- Helm Ingress templates: deferred until Helm chart refactor

## Test plan
- [x] `npm run build` passes (Console UI)
- [ ] CI green
- [ ] `docker compose up` → Grafana footer hides version
- [ ] K8s: verify CSP headers on `console.gostoa.dev` and `grafana.gostoa.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)