### PR TITLE
feat(ui): deep-link external service links to iframe views (CAB-1108)

### DIFF
--- a/control-plane-ui/src/components/PlatformStatus.tsx
+++ b/control-plane-ui/src/components/PlatformStatus.tsx
@@ -5,8 +5,10 @@
  * Shows sync status, health, recent deployment events, and external links.
  */
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { usePlatformStatus, useSyncComponent } from '../hooks/usePlatformStatus';
 import { ComponentStatus } from '../services/api';
+import { observabilityPath, logsPath } from '../utils/navigation';
 
 // Status color mappings
 const syncStatusColors: Record<string, string> = {
@@ -80,6 +82,7 @@ interface PlatformStatusProps {
 }
 
 export function PlatformStatus({ compact = false, onStatusChange }: PlatformStatusProps) {
+  const navigate = useNavigate();
   const { data: status, isLoading, error, refetch } = usePlatformStatus({
     refetchInterval: 30000, // Refresh every 30 seconds
   });
@@ -247,33 +250,27 @@ export function PlatformStatus({ compact = false, onStatusChange }: PlatformStat
                 <ExternalLinkIcon className="w-4 h-4" />
                 ArgoCD
               </a>
-              <a
-                href={status.external_links.grafana}
-                target="_blank"
-                rel="noopener noreferrer"
+              <button
+                onClick={() => navigate(observabilityPath(status.external_links.grafana))}
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
               >
                 <ExternalLinkIcon className="w-4 h-4" />
                 Grafana
-              </a>
-              <a
-                href={status.external_links.prometheus}
-                target="_blank"
-                rel="noopener noreferrer"
+              </button>
+              <button
+                onClick={() => navigate(observabilityPath(status.external_links.prometheus))}
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
               >
                 <ExternalLinkIcon className="w-4 h-4" />
                 Prometheus
-              </a>
-              <a
-                href={status.external_links.logs}
-                target="_blank"
-                rel="noopener noreferrer"
+              </button>
+              <button
+                onClick={() => navigate(logsPath(status.external_links.logs))}
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
               >
                 <ExternalLinkIcon className="w-4 h-4" />
                 Logs
-              </a>
+              </button>
             </div>
           </div>
         )}

--- a/control-plane-ui/src/pages/APIMonitoring.tsx
+++ b/control-plane-ui/src/pages/APIMonitoring.tsx
@@ -29,7 +29,9 @@ import {
   ExternalLink,
   Gauge,
 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { config } from '../config';
+import { observabilityPath } from '../utils/navigation';
 import { clsx } from 'clsx';
 
 // =============================================================================
@@ -499,6 +501,7 @@ function generateDemoTransaction(id: string): APITransaction {
 // =============================================================================
 
 export function APIMonitoring() {
+  const navigate = useNavigate();
   const [transactions, setTransactions] = useState<APITransactionSummary[]>([]);
   const [stats, setStats] = useState<APITransactionStats | null>(null);
   const [loading, setLoading] = useState(true);
@@ -574,15 +577,13 @@ export function APIMonitoring() {
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <a
-            href={`${config.services.grafana.url}/d/stoa-incident-response`}
-            target="_blank"
-            rel="noopener noreferrer"
+          <button
+            onClick={() => navigate(observabilityPath(`${config.services.grafana.url}/d/stoa-incident-response`))}
             className="flex items-center gap-2 bg-orange-500 text-white px-3 py-2 rounded-lg text-sm font-medium hover:bg-orange-600 transition-colors"
           >
             <ExternalLink className="h-4 w-4" />
             Open in Grafana
-          </a>
+          </button>
           <button
             onClick={() => setAutoRefresh(!autoRefresh)}
             className={clsx(

--- a/control-plane-ui/src/pages/Business/BusinessDashboard.tsx
+++ b/control-plane-ui/src/pages/Business/BusinessDashboard.tsx
@@ -10,10 +10,12 @@ import {
   BarChart2,
   ExternalLink,
 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { apiService } from '../../services/api';
 import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 import { config } from '../../config';
+import { observabilityPath } from '../../utils/navigation';
 
 const AUTO_REFRESH_INTERVAL = 60_000; // 1 minute for business metrics
 
@@ -212,6 +214,7 @@ function TopAPIItem({ api, rank, maxCalls }: { api: TopAPI; rank: number; maxCal
 }
 
 export function BusinessDashboard() {
+  const navigate = useNavigate();
   const { isReady, hasPermission } = useAuth();
   const [metrics, setMetrics] = useState<BusinessMetrics | null>(null);
   const [modeAdoption, setModeAdoption] = useState<GatewayModeAdoption[]>([]);
@@ -339,16 +342,14 @@ export function BusinessDashboard() {
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <a
-            href={grafanaUrl}
-            target="_blank"
-            rel="noopener noreferrer"
+          <button
+            onClick={() => navigate(observabilityPath(grafanaUrl))}
             className="flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400 hover:underline"
           >
             <BarChart2 className="h-4 w-4" />
             Advanced Analytics
             <ExternalLink className="h-3 w-3" />
-          </a>
+          </button>
           <button
             onClick={loadData}
             disabled={loading}
@@ -516,15 +517,13 @@ export function BusinessDashboard() {
                   <span className="font-semibold text-green-600">156%</span>, indicating strong demand for
                   AI-powered development tools.
                 </p>
-                <a
-                  href={grafanaUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <button
+                  onClick={() => navigate(observabilityPath(grafanaUrl))}
                   className="inline-flex items-center gap-1 mt-3 text-sm text-blue-600 dark:text-blue-400 hover:underline"
                 >
                   View detailed analytics in Grafana
                   <ExternalLink className="h-3 w-3" />
-                </a>
+                </button>
               </div>
             </div>
           </div>

--- a/control-plane-ui/src/pages/GatewayObservability/GatewayObservabilityDashboard.tsx
+++ b/control-plane-ui/src/pages/GatewayObservability/GatewayObservabilityDashboard.tsx
@@ -3,7 +3,9 @@ import { RefreshCw, ExternalLink, Gauge } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { apiService } from '../../services/api';
 import { CardSkeleton } from '@stoa/shared/components/Skeleton';
+import { useNavigate } from 'react-router-dom';
 import { config } from '../../config';
+import { observabilityPath } from '../../utils/navigation';
 import type { AggregatedMetrics } from '../../types';
 
 const AUTO_REFRESH_INTERVAL = 30_000;
@@ -94,6 +96,7 @@ function APDEXGauge({ score }: { score: number }) {
 
 
 export function GatewayObservabilityDashboard() {
+  const navigate = useNavigate();
   const { isReady } = useAuth();
   const [metrics, setMetrics] = useState<AggregatedMetrics | null>(null);
   const [apdexScore, setApdexScore] = useState(0.92); // Default fallback
@@ -147,15 +150,13 @@ export function GatewayObservabilityDashboard() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <a
-            href={`${config.services.grafana.url}/d/stoa-gateway-overview`}
-            target="_blank"
-            rel="noopener noreferrer"
+          <button
+            onClick={() => navigate(observabilityPath(`${config.services.grafana.url}/d/stoa-gateway-overview`))}
             className="flex items-center gap-2 bg-orange-500 text-white px-3 py-2 rounded-lg text-sm hover:bg-orange-600 transition-colors"
           >
             <ExternalLink className="h-4 w-4" />
             Open in Grafana
-          </a>
+          </button>
           <button
             onClick={loadData}
             className="flex items-center gap-2 border border-gray-300 text-gray-700 px-3 py-2 rounded-lg text-sm hover:bg-gray-50"

--- a/control-plane-ui/src/pages/GatewayStatus.tsx
+++ b/control-plane-ui/src/pages/GatewayStatus.tsx
@@ -1,6 +1,8 @@
 import { memo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useGatewayStatus, useGatewayPlatformInfo } from '../hooks/useGatewayStatus';
 import { config } from '../config';
+import { observabilityPath, logsPath } from '../utils/navigation';
 import {
   Server,
   Activity,
@@ -103,6 +105,7 @@ function HealthBadge({ status }: { status: string }) {
 }
 
 export default function GatewayStatus() {
+  const navigate = useNavigate();
   const { data, isLoading, error, refetch, dataUpdatedAt } = useGatewayStatus();
   const platform = useGatewayPlatformInfo();
 
@@ -403,36 +406,27 @@ export default function GatewayStatus() {
           </div>
           <p className="text-xs text-gray-500 mb-3">Metrics, dashboards &amp; logs</p>
           <div className="space-y-2">
-            <a
-              href={config.services.grafana.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center p-2 rounded-md hover:bg-gray-50 text-sm text-gray-700"
+            <button
+              onClick={() => navigate(observabilityPath())}
+              className="flex items-center w-full p-2 rounded-md hover:bg-gray-50 text-sm text-gray-700 text-left"
             >
               <BarChart3 className="w-4 h-4 mr-2 text-orange-500" />
               Grafana Dashboards
-              <ExternalLink className="w-3 h-3 ml-auto text-gray-400" />
-            </a>
-            <a
-              href={config.services.prometheus.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center p-2 rounded-md hover:bg-gray-50 text-sm text-gray-700"
+            </button>
+            <button
+              onClick={() => navigate(observabilityPath(config.services.prometheus.url))}
+              className="flex items-center w-full p-2 rounded-md hover:bg-gray-50 text-sm text-gray-700 text-left"
             >
               <Search className="w-4 h-4 mr-2 text-red-500" />
               Prometheus
-              <ExternalLink className="w-3 h-3 ml-auto text-gray-400" />
-            </a>
-            <a
-              href={config.services.logs.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center p-2 rounded-md hover:bg-gray-50 text-sm text-gray-700"
+            </button>
+            <button
+              onClick={() => navigate(logsPath())}
+              className="flex items-center w-full p-2 rounded-md hover:bg-gray-50 text-sm text-gray-700 text-left"
             >
               <Activity className="w-4 h-4 mr-2 text-green-500" />
               Logs Explorer
-              <ExternalLink className="w-3 h-3 ml-auto text-gray-400" />
-            </a>
+            </button>
           </div>
         </div>
 
@@ -472,14 +466,12 @@ export default function GatewayStatus() {
               </p>
             </div>
           ) : null}
-          <a
-            href={`${config.services.prometheus.url}/alerts`}
-            target="_blank"
-            rel="noopener noreferrer"
+          <button
+            onClick={() => navigate(observabilityPath(`${config.services.prometheus.url}/alerts`))}
             className="mt-3 inline-flex items-center text-xs text-indigo-600 hover:text-indigo-800"
           >
-            View Alerts <ExternalLink className="w-3 h-3 ml-1" />
-          </a>
+            View Alerts
+          </button>
         </div>
       </div>
 

--- a/control-plane-ui/src/pages/GrafanaEmbed.tsx
+++ b/control-plane-ui/src/pages/GrafanaEmbed.tsx
@@ -1,18 +1,29 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { config } from '../config';
+import { isAllowedEmbedUrl } from '../utils/navigation';
 import { ExternalLink, RefreshCw, Maximize2, Minimize2 } from 'lucide-react';
 
 /**
- * GrafanaEmbed - Embedded Grafana dashboard view
+ * GrafanaEmbed - Embedded Grafana / Prometheus dashboard view
  * Part of CAB-1108 Phase 2: Console Integration
+ *
+ * Supports deep-linking via ?url= query parameter.
+ * Example: /observability?url=https://grafana.gostoa.dev/d/stoa-gateway-overview
  */
 export function GrafanaEmbed() {
+  const [searchParams] = useSearchParams();
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [key, setKey] = useState(0); // For forcing iframe reload
+  const [key, setKey] = useState(0);
 
-  const grafanaUrl = config.services.grafana.url;
+  const targetUrl = searchParams.get('url');
+  const iframeUrl =
+    targetUrl && isAllowedEmbedUrl(targetUrl) ? targetUrl : config.services.grafana.url;
+
+  const isPrometheus = iframeUrl.includes('prometheus');
+  const serviceLabel = isPrometheus ? 'Prometheus' : 'Grafana';
 
   const handleIframeLoad = () => {
     setIsLoading(false);
@@ -21,23 +32,27 @@ export function GrafanaEmbed() {
 
   const handleIframeError = () => {
     setIsLoading(false);
-    setError('Failed to load Grafana. Please check your connection.');
+    setError(`Failed to load ${serviceLabel}. Please check your connection.`);
   };
 
   const handleRefresh = () => {
     setIsLoading(true);
     setError(null);
-    setKey(prev => prev + 1);
+    setKey((prev) => prev + 1);
   };
 
   const handleOpenExternal = () => {
-    window.open(grafanaUrl, '_blank', 'noopener,noreferrer');
+    window.open(iframeUrl, '_blank', 'noopener,noreferrer');
   };
 
   return (
-    <div className={`${isFullscreen ? 'fixed inset-0 z-50 bg-white dark:bg-neutral-900' : 'space-y-4'}`}>
+    <div
+      className={`${isFullscreen ? 'fixed inset-0 z-50 bg-white dark:bg-neutral-900' : 'space-y-4'}`}
+    >
       {/* Header */}
-      <div className={`flex items-center justify-between ${isFullscreen ? 'p-4 border-b border-gray-200 dark:border-neutral-700' : ''}`}>
+      <div
+        className={`flex items-center justify-between ${isFullscreen ? 'p-4 border-b border-gray-200 dark:border-neutral-700' : ''}`}
+      >
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
             STOA Observability
@@ -73,7 +88,7 @@ export function GrafanaEmbed() {
             title="Open in new tab"
           >
             <ExternalLink className="h-4 w-4" />
-            <span className="hidden sm:inline">Open in Grafana</span>
+            <span className="hidden sm:inline">Open in {serviceLabel}</span>
           </button>
         </div>
       </div>
@@ -90,7 +105,7 @@ export function GrafanaEmbed() {
           <div className="absolute inset-0 flex items-center justify-center bg-gray-50 dark:bg-neutral-900 z-10">
             <div className="text-center">
               <div className="w-12 h-12 border-4 border-primary-600 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
-              <p className="text-gray-500 dark:text-neutral-400">Loading Grafana...</p>
+              <p className="text-gray-500 dark:text-neutral-400">Loading {serviceLabel}...</p>
             </div>
           </div>
         )}
@@ -103,7 +118,7 @@ export function GrafanaEmbed() {
                 <span className="text-2xl">⚠️</span>
               </div>
               <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-                Unable to Load Grafana
+                Unable to Load {serviceLabel}
               </h3>
               <p className="text-gray-500 dark:text-neutral-400 mb-4">{error}</p>
               <div className="flex gap-2 justify-center">
@@ -124,11 +139,11 @@ export function GrafanaEmbed() {
           </div>
         )}
 
-        {/* Grafana Iframe */}
+        {/* Iframe */}
         <iframe
           key={key}
-          src={grafanaUrl}
-          title="STOA Observability - Grafana"
+          src={iframeUrl}
+          title={`STOA Observability - ${serviceLabel}`}
           className="w-full h-full border-0"
           onLoad={handleIframeLoad}
           onError={handleIframeError}

--- a/control-plane-ui/src/pages/Operations/OperationsDashboard.tsx
+++ b/control-plane-ui/src/pages/Operations/OperationsDashboard.tsx
@@ -12,11 +12,13 @@ import {
   Zap,
   Shield,
 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { apiService } from '../../services/api';
 import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 import type { AggregatedMetrics, PlatformStatusResponse } from '../../types';
 import { config } from '../../config';
+import { observabilityPath } from '../../utils/navigation';
 
 const AUTO_REFRESH_INTERVAL = 15_000; // 15 seconds for operations
 
@@ -123,6 +125,7 @@ function DeploymentItem({ deployment }: { deployment: RecentDeployment }) {
 }
 
 export function OperationsDashboard() {
+  const navigate = useNavigate();
   const { isReady } = useAuth();
   const [gatewayMetrics, setGatewayMetrics] = useState<AggregatedMetrics | null>(null);
   const [platformStatus, setPlatformStatus] = useState<PlatformStatusResponse | null>(null);
@@ -379,15 +382,13 @@ export function OperationsDashboard() {
                 <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase">
                   Active Incidents
                 </h2>
-                <a
-                  href={grafanaUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <button
+                  onClick={() => navigate(observabilityPath(grafanaUrl))}
                   className="text-xs text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1"
                 >
                   Open Grafana
                   <ExternalLink className="h-3 w-3" />
-                </a>
+                </button>
               </div>
               {operationsMetrics?.activeAlerts === 0 ? (
                 <div className="flex flex-col items-center justify-center py-8">
@@ -424,11 +425,9 @@ export function OperationsDashboard() {
               Observability Tools
             </h2>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <a
-                href={grafanaUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-neutral-700 hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
+              <button
+                onClick={() => navigate(observabilityPath(grafanaUrl))}
+                className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-neutral-700 hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors text-left"
               >
                 <div className="w-10 h-10 bg-orange-100 dark:bg-orange-900/30 rounded-lg flex items-center justify-center">
                   <Activity className="h-5 w-5 text-orange-600" />
@@ -438,12 +437,10 @@ export function OperationsDashboard() {
                   <p className="text-xs text-gray-500 dark:text-gray-400">Dashboards</p>
                 </div>
                 <ExternalLink className="h-4 w-4 text-gray-400 ml-auto" />
-              </a>
-              <a
-                href={prometheusUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-neutral-700 hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
+              </button>
+              <button
+                onClick={() => navigate(observabilityPath(prometheusUrl))}
+                className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-neutral-700 hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors text-left"
               >
                 <div className="w-10 h-10 bg-red-100 dark:bg-red-900/30 rounded-lg flex items-center justify-center">
                   <TrendingUp className="h-5 w-5 text-red-600" />
@@ -453,7 +450,7 @@ export function OperationsDashboard() {
                   <p className="text-xs text-gray-500 dark:text-gray-400">Metrics</p>
                 </div>
                 <ExternalLink className="h-4 w-4 text-gray-400 ml-auto" />
-              </a>
+              </button>
               <a
                 href="/monitoring"
                 className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-neutral-700 hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"

--- a/control-plane-ui/src/utils/navigation.ts
+++ b/control-plane-ui/src/utils/navigation.ts
@@ -1,0 +1,32 @@
+/**
+ * Navigation helpers for embedded service views (CAB-1108).
+ * Converts external links into internal iframe routes with deep-link support.
+ */
+
+/** Build a path to the Observability iframe, optionally with a target URL. */
+export function observabilityPath(targetUrl?: string): string {
+  if (!targetUrl) return '/observability';
+  return `/observability?url=${encodeURIComponent(targetUrl)}`;
+}
+
+/** Build a path to the Logs iframe, optionally with a target URL. */
+export function logsPath(targetUrl?: string): string {
+  if (!targetUrl) return '/logs';
+  return `/logs?url=${encodeURIComponent(targetUrl)}`;
+}
+
+/** Allowed hostnames for embedded iframe URLs. */
+const ALLOWED_HOSTS = ['grafana.gostoa.dev', 'prometheus.gostoa.dev', 'localhost'];
+
+/** Validate that a URL is safe to embed in an iframe (no open redirect). */
+export function isAllowedEmbedUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return ALLOWED_HOSTS.some(
+      (host) => parsed.hostname === host || parsed.hostname.endsWith(`.${host}`)
+    );
+  } catch {
+    // Relative URL or invalid — allow relative paths
+    return url.startsWith('/');
+  }
+}


### PR DESCRIPTION
## Summary
- Convert 13 external `<a href target="_blank">` links to internal iframe navigation with `?url=` deep-link support
- Add `useSearchParams` to `GrafanaEmbed` to load a custom URL in the iframe via `?url=` query param
- New `navigation.ts` helper with `observabilityPath()`, `logsPath()`, and `isAllowedEmbedUrl()` (domain allowlist security)
- ArgoCD links remain external (no iframe embed for ArgoCD)

## Files changed
| File | Changes |
|------|---------|
| `GrafanaEmbed.tsx` | Support `?url=` query param for deep-linking |
| `navigation.ts` | New helper file with embed URL builders |
| `GatewayStatus.tsx` | 4 links → `navigate(observabilityPath/logsPath)` |
| `PlatformStatus.tsx` | 3 links → `navigate(observabilityPath/logsPath)` |
| `OperationsDashboard.tsx` | 3 links → `navigate(observabilityPath)` |
| `APIMonitoring.tsx` | 1 link → `navigate(observabilityPath)` |
| `BusinessDashboard.tsx` | 2 links → `navigate(observabilityPath)` |
| `GatewayObservabilityDashboard.tsx` | 1 link → `navigate(observabilityPath)` |

## Test plan
- [ ] Click "Grafana" on GatewayStatus → opens `/observability?url=...` iframe
- [ ] Click "Prometheus" → opens `/observability?url=...` iframe with Prometheus
- [ ] Click "Logs" → opens `/logs?url=...` iframe with OpenSearch Dashboards
- [ ] Click "ArgoCD" → still opens external tab (no iframe)
- [ ] Direct navigation to `/observability` → loads default Grafana URL
- [ ] `npm run lint` passes (0 errors)
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)