### PR TITLE
perf(ci): switch docker builds to amd64-only for faster deploys

### DIFF
--- a/.github/actions/docker-metadata/action.yml
+++ b/.github/actions/docker-metadata/action.yml
@@ -22,7 +22,7 @@ inputs:
   platforms:
     description: 'Docker target platforms'
     required: false
-    default: 'linux/amd64,linux/arm64'
+    default: 'linux/amd64'
 
 outputs:
   tags:

--- a/.github/workflows/control-plane-api-ci.yml
+++ b/.github/workflows/control-plane-api-ci.yml
@@ -71,7 +71,7 @@ jobs:
       component: control-plane-api
       ecr-repository: apim/control-plane-api
       environment: ${{ github.event.inputs.environment || 'dev' }}
-      platforms: linux/amd64,linux/arm64
+      platforms: linux/amd64
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/control-plane-ui-ci.yml
+++ b/.github/workflows/control-plane-ui-ci.yml
@@ -73,7 +73,7 @@ jobs:
       component: control-plane-ui
       ecr-repository: apim/control-plane-ui
       environment: ${{ github.event.inputs.environment || 'dev' }}
-      platforms: linux/amd64,linux/arm64
+      platforms: linux/amd64
       use-monorepo-context: true
       build-args: |
         VITE_BASE_DOMAIN=${{ (github.event.inputs.environment == 'staging' && 'staging.gostoa.dev') || 'gostoa.dev' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -108,7 +108,7 @@ jobs:
           # Use repo root context for UI apps that depend on shared/
           context: ${{ (matrix.service == 'portal' || matrix.service == 'control-plane-ui') && '.' || format('./{0}', matrix.service) }}
           file: ./${{ matrix.service }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/keycloak-theme.yml
+++ b/.github/workflows/keycloak-theme.yml
@@ -57,7 +57,7 @@ jobs:
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: keycloak
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:25.0-stoa

--- a/.github/workflows/mcp-gateway-ci.yml
+++ b/.github/workflows/mcp-gateway-ci.yml
@@ -70,7 +70,7 @@ jobs:
       component: mcp-gateway
       ecr-repository: apim/mcp-gateway
       environment: ${{ github.event.inputs.environment || 'dev' }}
-      platforms: linux/amd64,linux/arm64
+      platforms: linux/amd64
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/reusable-docker-ecr.yml
+++ b/.github/workflows/reusable-docker-ecr.yml
@@ -20,7 +20,7 @@ on:
         description: 'Docker target platforms'
         required: false
         type: string
-        default: 'linux/amd64,linux/arm64'
+        default: 'linux/amd64'
       build-args:
         description: 'Docker build-args (newline-separated KEY=VALUE)'
         required: false

--- a/.github/workflows/stoa-portal-ci.yml
+++ b/.github/workflows/stoa-portal-ci.yml
@@ -73,7 +73,7 @@ jobs:
       component: portal
       ecr-repository: apim/stoa-portal
       environment: ${{ github.event.inputs.environment || 'dev' }}
-      platforms: linux/amd64,linux/arm64
+      platforms: linux/amd64
       use-monorepo-context: true
       build-args: |
         VITE_BASE_DOMAIN=gostoa.dev


### PR DESCRIPTION
## Summary
- Switch all Docker builds from multi-arch (amd64+arm64) to amd64-only
- EKS runs amd64 exclusively — arm64 cross-compilation was doubling build times (~20min) with no benefit
- 8 files updated: reusable workflow, composite action, and 6 component workflows

## Test plan
- [ ] CI triggers and Docker builds complete in ~5min instead of ~20min
- [ ] EKS pods pull amd64 images successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)