### PR TITLE
fix(ui): use service-level iframe config (CAB-1108)

### DIFF
--- a/control-plane-ui/k8s/ingress.yaml
+++ b/control-plane-ui/k8s/ingress.yaml
@@ -8,10 +8,9 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    # CAB-1108: Allow iframe embedding of Grafana, Keycloak, OpenSearch Dashboards
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_hide_header X-Frame-Options;
-      add_header Content-Security-Policy "frame-ancestors 'self' https://console.gostoa.dev" always;
+    # CAB-1108: iframe embedding handled at service level
+    # (Grafana: GF_SECURITY_ALLOW_EMBEDDING, Keycloak: X-Frame-Options config)
+    # Note: nginx configuration-snippet is blocked by ingress admission webhook
 spec:
   ingressClassName: nginx
   tls:

--- a/deploy/observability/grafana-ingress.yaml
+++ b/deploy/observability/grafana-ingress.yaml
@@ -23,10 +23,10 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "50m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
-    # CAB-1108: Allow iframe embedding in Console
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_hide_header X-Frame-Options;
-      add_header Content-Security-Policy "frame-ancestors 'self' https://console.gostoa.dev" always;
+    # CAB-1108: iframe embedding handled via Grafana env vars:
+    # GF_SECURITY_ALLOW_EMBEDDING=true (disables X-Frame-Options: deny)
+    # GF_AUTH_ANONYMOUS_ENABLED=true + GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+    # Note: nginx configuration-snippet is blocked by ingress admission webhook
 spec:
   ingressClassName: nginx
   tls:

--- a/deploy/observability/prometheus-ingress.yaml
+++ b/deploy/observability/prometheus-ingress.yaml
@@ -24,6 +24,9 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "10m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    # CAB-1108: Prometheus iframe embedding requires oauth2-proxy
+    # authentication. User must visit prometheus.gostoa.dev first.
+    # oauth2-proxy uses --cookie-samesite=none for cross-origin iframe support
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
## Summary
- Remove `nginx.ingress.kubernetes.io/configuration-snippet` annotations (blocked by nginx ingress admission webhook)
- Document service-level iframe configuration:
  - Grafana: `GF_SECURITY_ALLOW_EMBEDDING=true` + anonymous viewer access
  - Prometheus: `oauth2-proxy --cookie-samesite=none` for cross-origin iframe cookie support

## Applied on cluster (not in this PR)
- `kubectl set env` on Grafana deployment: `GF_SECURITY_ALLOW_EMBEDDING=true`, `GF_AUTH_ANONYMOUS_ENABLED=true`, `GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer`, `GF_SECURITY_X_FRAME_OPTIONS=""`
- Patched Grafana initContainers + containers with `privileged: false` for Kyverno compliance
- Patched oauth2-proxy-prometheus with `--cookie-samesite=none`

## Test plan
- [x] Grafana returns 200 (no redirect) with no X-Frame-Options header
- [x] Grafana iframe loads in Console `/observability` page
- [ ] Prometheus iframe loads after user authenticates at prometheus.gostoa.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)