### PR TITLE
perf(ui): optimize Console UI responsiveness — LCP <1s (CAB-1115)

### DIFF
--- a/control-plane-ui/src/App.tsx
+++ b/control-plane-ui/src/App.tsx
@@ -9,22 +9,27 @@ import { CommandPaletteProvider } from '@stoa/shared/components/CommandPalette';
 import { ThemeProvider } from '@stoa/shared/contexts';
 
 // Lazy load pages for code splitting
+// Consolidated imports — single module loader per multi-export file
+const aiToolsModule = () => import('./pages/AITools');
+const externalMcpModule = () => import('./pages/ExternalMCPServers');
+const gatewaysModule = () => import('./pages/Gateways');
+
 const Tenants = lazy(() => import('./pages/Tenants').then(m => ({ default: m.Tenants })));
 const APIs = lazy(() => import('./pages/APIs').then(m => ({ default: m.APIs })));
 const Applications = lazy(() => import('./pages/Applications').then(m => ({ default: m.Applications })));
 const Deployments = lazy(() => import('./pages/Deployments').then(m => ({ default: m.Deployments })));
 const APIMonitoring = lazy(() => import('./pages/APIMonitoring').then(m => ({ default: m.APIMonitoring })));
 const ErrorSnapshots = lazy(() => import('./pages/ErrorSnapshots').then(m => ({ default: m.ErrorSnapshots })));
-const ToolCatalog = lazy(() => import('./pages/AITools').then(m => ({ default: m.ToolCatalog })));
-const ToolDetail = lazy(() => import('./pages/AITools').then(m => ({ default: m.ToolDetail })));
-const MySubscriptions = lazy(() => import('./pages/AITools').then(m => ({ default: m.MySubscriptions })));
-const UsageDashboard = lazy(() => import('./pages/AITools').then(m => ({ default: m.UsageDashboard })));
-const ExternalMCPServersList = lazy(() => import('./pages/ExternalMCPServers').then(m => ({ default: m.ExternalMCPServersList })));
-const ExternalMCPServerDetail = lazy(() => import('./pages/ExternalMCPServers').then(m => ({ default: m.ExternalMCPServerDetail })));
+const ToolCatalog = lazy(() => aiToolsModule().then(m => ({ default: m.ToolCatalog })));
+const ToolDetail = lazy(() => aiToolsModule().then(m => ({ default: m.ToolDetail })));
+const MySubscriptions = lazy(() => aiToolsModule().then(m => ({ default: m.MySubscriptions })));
+const UsageDashboard = lazy(() => aiToolsModule().then(m => ({ default: m.UsageDashboard })));
+const ExternalMCPServersList = lazy(() => externalMcpModule().then(m => ({ default: m.ExternalMCPServersList })));
+const ExternalMCPServerDetail = lazy(() => externalMcpModule().then(m => ({ default: m.ExternalMCPServerDetail })));
 const AdminProspects = lazy(() => import('./pages/AdminProspects').then(m => ({ default: m.AdminProspects })));
 const GatewayStatus = lazy(() => import('./pages/GatewayStatus'));
-const GatewayRegistry = lazy(() => import('./pages/Gateways').then(m => ({ default: m.GatewayList })));
-const GatewayModes = lazy(() => import('./pages/Gateways').then(m => ({ default: m.GatewayModesDashboard })));
+const GatewayRegistry = lazy(() => gatewaysModule().then(m => ({ default: m.GatewayList })));
+const GatewayModes = lazy(() => gatewaysModule().then(m => ({ default: m.GatewayModesDashboard })));
 const GatewayDeployments = lazy(() => import('./pages/GatewayDeployments').then(m => ({ default: m.GatewayDeploymentsDashboard })));
 const GatewayObservability = lazy(() => import('./pages/GatewayObservability').then(m => ({ default: m.GatewayObservabilityDashboard })));
 const OperationsDashboard = lazy(() => import('./pages/Operations').then(m => ({ default: m.OperationsDashboard })));
@@ -37,21 +42,7 @@ const IdentityEmbed = lazy(() => import('./pages/IdentityEmbed'));
 // CAB-1114: OpenSearch Dashboards for API trace logs
 const LogsEmbed = lazy(() => import('./pages/LogsEmbed'));
 
-// Branded loading screen for auth init (similar to portal)
-function LoadingScreen() {
-  return (
-    <div className="min-h-screen bg-gray-50 dark:bg-neutral-900 flex items-center justify-center transition-colors">
-      <div className="text-center">
-        <div className="w-16 h-16 bg-blue-600 rounded-xl flex items-center justify-center mx-auto mb-4 animate-pulse">
-          <span className="text-white font-bold text-xl">SC</span>
-        </div>
-        <p className="text-gray-500 dark:text-neutral-400">Loading STOA Console...</p>
-      </div>
-    </div>
-  );
-}
-
-// Loading spinner for lazy-loaded pages
+// Loading spinner for lazy-loaded pages and auth init skeleton
 function PageLoader() {
   return (
     <div className="flex items-center justify-center min-h-[400px]">
@@ -71,21 +62,21 @@ function Dashboard() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-        <p className="text-gray-500 mt-2">Welcome to STOA Control Plane</p>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Dashboard</h1>
+        <p className="text-gray-500 dark:text-neutral-400 mt-2">Welcome to STOA Control Plane</p>
       </div>
 
       {/* Welcome Card */}
-      <div className="bg-white rounded-lg shadow p-6">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none p-6">
         <div className="flex items-center gap-4">
-          <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+          <div className="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-full flex items-center justify-center">
             <svg className="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
             </svg>
           </div>
           <div>
-            <h2 className="text-lg font-semibold text-gray-900">Hello, {user?.name || 'User'}!</h2>
-            <p className="text-sm text-gray-500">{user?.email}</p>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Hello, {user?.name || 'User'}!</h2>
+            <p className="text-sm text-gray-500 dark:text-neutral-400">{user?.email}</p>
           </div>
         </div>
       </div>
@@ -144,8 +135,8 @@ function Dashboard() {
 
       {/* Info Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div className="bg-white rounded-lg shadow p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">Quick Links</h3>
+        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none p-6">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Quick Links</h3>
           <ul className="space-y-3">
             {quickLinks.map((link) => (
               <li key={link.name}>
@@ -160,9 +151,9 @@ function Dashboard() {
           </ul>
         </div>
 
-        <div className="bg-white rounded-lg shadow p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">Getting Started</h3>
-          <ol className="space-y-3 text-sm text-gray-600">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none p-6">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Getting Started</h3>
+          <ol className="space-y-3 text-sm text-gray-600 dark:text-neutral-400">
             <li className="flex gap-2">
               <span className="font-bold text-blue-600">1.</span>
               <span>Go to <a href="/apis" className="text-blue-600 hover:underline">APIs</a> and create a new API</span>
@@ -223,7 +214,12 @@ function ProtectedRoutes() {
   const { isAuthenticated, isLoading } = useAuth();
 
   if (isLoading) {
-    return <LoadingScreen />;
+    // Show app shell (sidebar + header) immediately while auth initializes
+    return (
+      <Layout>
+        <PageLoader />
+      </Layout>
+    );
   }
 
   if (!isAuthenticated) {

--- a/control-plane-ui/src/components/Layout.tsx
+++ b/control-plane-ui/src/components/Layout.tsx
@@ -65,6 +65,16 @@ const navigation = [
   { name: 'Error Snapshots', href: '/mcp/errors', icon: AlertTriangle, permission: 'apis:read' },
 ];
 
+// Prefetch route chunks on hover — loads JS before click for instant navigation
+const routePrefetchMap: Record<string, () => Promise<unknown>> = {
+  '/apis': () => import('../pages/APIs'),
+  '/tenants': () => import('../pages/Tenants'),
+  '/ai-tools': () => import('../pages/AITools'),
+  '/applications': () => import('../pages/Applications'),
+  '/deployments': () => import('../pages/Deployments'),
+  '/monitoring': () => import('../pages/APIMonitoring'),
+};
+
 export function Layout({ children }: LayoutProps) {
   const { user, logout, hasPermission } = useAuth();
   const location = useLocation();
@@ -74,8 +84,9 @@ export function Layout({ children }: LayoutProps) {
   const { resolvedTheme, toggleTheme } = useTheme();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
-  const filteredNavigation = navigation.filter(
-    item => !item.permission || hasPermission(item.permission)
+  const filteredNavigation = useMemo(
+    () => navigation.filter(item => !item.permission || hasPermission(item.permission)),
+    [hasPermission]
   );
 
   // Close sidebar when route changes (mobile)
@@ -97,20 +108,25 @@ export function Layout({ children }: LayoutProps) {
 
   useSequenceShortcuts(sequenceShortcuts);
 
-  // Register command palette items
+  // Memoize navigation commands separately (only changes when nav items change)
+  const navigationCommands = useMemo(() =>
+    filteredNavigation.map(item => ({
+      id: `nav-${item.href}`,
+      label: item.name,
+      description: `Navigate to ${item.name}`,
+      icon: <item.icon className="h-4 w-4" />,
+      section: 'Navigation' as const,
+      shortcut: item.shortcut ? ['G', item.shortcut[1].toUpperCase()] : undefined,
+      keywords: [item.name.toLowerCase(), 'go', 'navigate'],
+      onSelect: () => navigate(item.href),
+    })),
+    [filteredNavigation, navigate]
+  );
+
+  // Register command palette items — only theme-dependent items rebuild on theme change
   useEffect(() => {
     const commands: CommandItem[] = [
-      // Navigation commands
-      ...filteredNavigation.map(item => ({
-        id: `nav-${item.href}`,
-        label: item.name,
-        description: `Navigate to ${item.name}`,
-        icon: <item.icon className="h-4 w-4" />,
-        section: 'Navigation',
-        shortcut: item.shortcut ? ['G', item.shortcut[1].toUpperCase()] : undefined,
-        keywords: [item.name.toLowerCase(), 'go', 'navigate'],
-        onSelect: () => navigate(item.href),
-      })),
+      ...navigationCommands,
       // Quick actions
       {
         id: 'action-new-api',
@@ -122,7 +138,6 @@ export function Layout({ children }: LayoutProps) {
         keywords: ['new', 'create', 'add', 'api'],
         onSelect: () => {
           navigate('/apis');
-          // The page will need to handle opening the create modal
         },
       },
       {
@@ -159,7 +174,7 @@ export function Layout({ children }: LayoutProps) {
     ];
 
     setCommandItems(commands);
-  }, [filteredNavigation, navigate, logout, setCommandItems, resolvedTheme, toggleTheme]);
+  }, [navigationCommands, navigate, logout, setCommandItems, resolvedTheme, toggleTheme]);
 
   return (
     <div className="min-h-screen bg-gray-100 dark:bg-neutral-900 transition-colors">
@@ -199,6 +214,7 @@ export function Layout({ children }: LayoutProps) {
                 <li key={item.name}>
                   <Link
                     to={item.href}
+                    onMouseEnter={() => routePrefetchMap[item.href]?.()}
                     className={clsx(
                       'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
                       isActive
@@ -227,16 +243,27 @@ export function Layout({ children }: LayoutProps) {
               <User className="h-5 w-5 text-white" />
             </div>
             <div className="flex-1 min-w-0">
-              <p className="truncate text-sm font-medium text-white">{user?.name}</p>
-              <p className="truncate text-xs text-gray-400">{user?.roles.join(', ')}</p>
+              {user ? (
+                <>
+                  <p className="truncate text-sm font-medium text-white">{user.name}</p>
+                  <p className="truncate text-xs text-gray-400">{user.roles.join(', ')}</p>
+                </>
+              ) : (
+                <>
+                  <div className="h-4 w-24 bg-gray-700 rounded animate-pulse" />
+                  <div className="h-3 w-16 bg-gray-700 rounded animate-pulse mt-1" />
+                </>
+              )}
             </div>
-            <button
-              onClick={logout}
-              className="rounded-lg p-2 text-gray-400 hover:bg-gray-800 dark:hover:bg-neutral-800 hover:text-white flex-shrink-0"
-              title="Logout"
-            >
-              <LogOut className="h-5 w-5" />
-            </button>
+            {user && (
+              <button
+                onClick={logout}
+                className="rounded-lg p-2 text-gray-400 hover:bg-gray-800 dark:hover:bg-neutral-800 hover:text-white flex-shrink-0"
+                title="Logout"
+              >
+                <LogOut className="h-5 w-5" />
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/control-plane-ui/src/components/PlatformStatus.tsx
+++ b/control-plane-ui/src/components/PlatformStatus.tsx
@@ -4,7 +4,7 @@
  * Displays GitOps sync status for platform components via Argo CD.
  * Shows sync status, health, recent deployment events, and external links.
  */
-import { useState } from 'react';
+import { useState, useEffect, useCallback, memo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { usePlatformStatus, useSyncComponent } from '../hooks/usePlatformStatus';
 import { ComponentStatus } from '../services/api';
@@ -89,36 +89,34 @@ export function PlatformStatus({ compact = false, onStatusChange }: PlatformStat
   const syncMutation = useSyncComponent();
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
-  // Update lastUpdated when data changes
-  if (status && !lastUpdated) {
-    setLastUpdated(new Date());
-  }
+  // Update lastUpdated and notify parent when status data changes
+  useEffect(() => {
+    if (status) {
+      setLastUpdated(new Date());
+      onStatusChange?.(status.gitops.status);
+    }
+  }, [status, onStatusChange]);
 
-  // Notify parent of status changes
-  if (status && onStatusChange) {
-    onStatusChange(status.gitops.status);
-  }
-
-  const handleRefresh = () => {
+  const handleRefresh = useCallback(() => {
     refetch();
     setLastUpdated(new Date());
-  };
+  }, [refetch]);
 
-  const handleSync = async (componentName: string) => {
+  const handleSync = useCallback(async (componentName: string) => {
     try {
       await syncMutation.mutateAsync(componentName);
       setLastUpdated(new Date());
     } catch (err) {
       console.error('Failed to sync component:', err);
     }
-  };
+  }, [syncMutation]);
 
   if (isLoading && !status) {
     return (
-      <div className="bg-white rounded-lg shadow p-6">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none p-6">
         <div className="flex items-center justify-center">
           <RefreshIcon className="w-5 h-5 animate-spin text-gray-400" />
-          <span className="ml-2 text-gray-500">Loading platform status...</span>
+          <span className="ml-2 text-gray-500 dark:text-neutral-400">Loading platform status...</span>
         </div>
       </div>
     );
@@ -126,7 +124,7 @@ export function PlatformStatus({ compact = false, onStatusChange }: PlatformStat
 
   if (error && !status) {
     return (
-      <div className="bg-white rounded-lg shadow p-6">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none p-6">
         <div className="flex items-center gap-2 text-red-600">
           <ExclamationCircleIcon className="w-5 h-5" />
           <span>Failed to load platform status</span>
@@ -173,13 +171,13 @@ export function PlatformStatus({ compact = false, onStatusChange }: PlatformStat
   }
 
   return (
-    <div className="bg-white rounded-lg shadow">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none">
       {/* Header */}
-      <div className="px-6 py-4 border-b border-gray-200">
+      <div className="px-6 py-4 border-b border-gray-200 dark:border-neutral-700">
         <div className="flex items-center justify-between">
           <div>
-            <h3 className="text-lg font-semibold text-gray-900">Platform Status</h3>
-            <p className="text-sm text-gray-500">GitOps sync status via Argo CD</p>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Platform Status</h3>
+            <p className="text-sm text-gray-500 dark:text-neutral-400">GitOps sync status via Argo CD</p>
           </div>
           <div className="flex items-center gap-3">
             <span className={`px-3 py-1 rounded-full text-sm font-medium ${overallConfig.bg} ${overallConfig.color}`}>
@@ -188,10 +186,10 @@ export function PlatformStatus({ compact = false, onStatusChange }: PlatformStat
             <button
               onClick={handleRefresh}
               disabled={isLoading}
-              className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+              className="p-2 hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
               title="Refresh status"
             >
-              <RefreshIcon className={`w-5 h-5 text-gray-600 ${isLoading ? 'animate-spin' : ''}`} />
+              <RefreshIcon className={`w-5 h-5 text-gray-600 dark:text-neutral-400 ${isLoading ? 'animate-spin' : ''}`} />
             </button>
           </div>
         </div>
@@ -292,17 +290,17 @@ interface ComponentCardProps {
   isSyncing: boolean;
 }
 
-function ComponentCard({ component, onSync, isSyncing }: ComponentCardProps) {
+const ComponentCard = memo(function ComponentCard({ component, onSync, isSyncing }: ComponentCardProps) {
   const syncColor = syncStatusColors[component.sync_status] || syncStatusColors.Unknown;
   const healthColor = healthStatusColors[component.health_status] || healthStatusColors.Unknown;
   const isOutOfSync = component.sync_status === 'OutOfSync';
 
   return (
-    <div className="border border-gray-200 rounded-lg p-4 hover:border-gray-300 transition-colors">
+    <div className="border border-gray-200 dark:border-neutral-700 rounded-lg p-4 hover:border-gray-300 dark:hover:border-neutral-600 transition-colors">
       <div className="flex items-start justify-between">
         <div>
-          <h4 className="font-medium text-gray-900">{component.display_name}</h4>
-          <p className="text-xs text-gray-500 mt-0.5">{component.name}</p>
+          <h4 className="font-medium text-gray-900 dark:text-white">{component.display_name}</h4>
+          <p className="text-xs text-gray-500 dark:text-neutral-400 mt-0.5">{component.name}</p>
         </div>
         <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${syncColor}`}>
           {component.sync_status}
@@ -352,7 +350,7 @@ function ComponentCard({ component, onSync, isSyncing }: ComponentCardProps) {
       </div>
     </div>
   );
-}
+});
 
 function formatRelativeTime(isoString: string): string {
   const date = new Date(isoString);

--- a/control-plane-ui/src/contexts/AuthContext.tsx
+++ b/control-plane-ui/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useEffect, useState, useCallback, useMemo, ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState, useCallback, useMemo, useRef, ReactNode } from 'react';
 import { useAuth as useOidcAuth, hasAuthParams } from 'react-oidc-context';
+import { useQueryClient } from '@tanstack/react-query';
 import type { User } from '../types';
 import { apiService } from '../services/api';
 import { mcpGatewayService } from '../services/mcpGatewayApi';
@@ -87,36 +88,45 @@ function extractUserFromToken(oidcUser: any): User | null {
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const oidc = useOidcAuth();
+  const queryClient = useQueryClient();
   const [user, setUser] = useState<User | null>(null);
   const [isReady, setIsReady] = useState(false);
+  const prevTokenRef = useRef<string | null>(null);
 
   useEffect(() => {
-    console.log('[AuthContext] useEffect triggered, oidc.user:', !!oidc.user);
     if (oidc.user) {
-      setUser(extractUserFromToken(oidc.user));
-      // Set the access token for API calls
-      if (oidc.user.access_token) {
-        console.log('[AuthContext] Setting auth token');
-        apiService.setAuthToken(oidc.user.access_token);
-        mcpGatewayService.setAuthToken(oidc.user.access_token);
-        setIsReady(true); // Token is now set
-      } else {
-        console.warn('[AuthContext] oidc.user exists but no access_token');
+      const token = oidc.user.access_token;
+      // Skip re-extraction if token hasn't changed (StrictMode + silent renew)
+      if (token && token !== prevTokenRef.current) {
+        prevTokenRef.current = token;
+        setUser(extractUserFromToken(oidc.user));
+        apiService.setAuthToken(token);
+        mcpGatewayService.setAuthToken(token);
+        setIsReady(true);
+        // Prefetch tenants immediately — most pages need this data
+        queryClient.prefetchQuery({
+          queryKey: ['tenants'],
+          queryFn: () => apiService.getTenants(),
+          staleTime: 5 * 60 * 1000, // 5 minutes
+        });
+      } else if (!token) {
+        setUser(extractUserFromToken(oidc.user));
       }
     } else {
+      prevTokenRef.current = null;
       setUser(null);
       apiService.clearAuthToken();
       mcpGatewayService.clearAuthToken();
       setIsReady(false);
     }
-  }, [oidc.user]);
+  }, [oidc.user, queryClient]);
 
   // Auto-login if we have auth params in URL (callback from Keycloak)
   useEffect(() => {
     if (!oidc.isAuthenticated && !oidc.isLoading && hasAuthParams()) {
       oidc.signinRedirect();
     }
-  }, [oidc.isAuthenticated, oidc.isLoading]);
+  }, [oidc.isAuthenticated, oidc.isLoading, oidc]);
 
   const hasPermission = useCallback((permission: string): boolean => {
     return user?.permissions.includes(permission) ?? false;

--- a/control-plane-ui/src/hooks/useDebounce.ts
+++ b/control-plane-ui/src/hooks/useDebounce.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Debounce a value by a given delay.
+ * Returns the debounced value that only updates after the delay has passed.
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/control-plane-ui/src/pages/APIs.tsx
+++ b/control-plane-ui/src/pages/APIs.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiService } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
+import { useDebounce } from '../hooks/useDebounce';
 import type { API, APICreate } from '../types';
 import yaml from 'js-yaml';
 import { useToastActions } from '@stoa/shared/components/Toast';
@@ -11,23 +12,6 @@ import { TableSkeleton } from '@stoa/shared/components/Skeleton';
 import { useCelebration } from '@stoa/shared/components/Celebration';
 import { Collapsible } from '@stoa/shared/components/Collapsible';
 import { FileText, Server, Code2, Settings } from 'lucide-react';
-
-// Debounce hook for search optimization
-function useDebounce<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState<T>(value);
-
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedValue(value);
-    }, delay);
-
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [value, delay]);
-
-  return debouncedValue;
-}
 
 const PAGE_SIZE = 20;
 
@@ -56,11 +40,12 @@ export function APIs() {
   // Debounce search for performance (300ms delay)
   const debouncedSearch = useDebounce(searchQuery, 300);
 
-  // Fetch tenants via React Query
+  // Fetch tenants via React Query (long staleTime — tenants rarely change)
   const { data: tenants = [], isLoading: tenantsLoading, error: tenantsError } = useQuery({
     queryKey: ['tenants'],
     queryFn: () => apiService.getTenants(),
     enabled: isReady,
+    staleTime: 5 * 60 * 1000, // 5 minutes
   });
 
   // Auto-select first tenant when tenants load

--- a/control-plane-ui/src/pages/AdminProspects.tsx
+++ b/control-plane-ui/src/pages/AdminProspects.tsx
@@ -6,6 +6,7 @@
  */
 import { useState, useCallback, useEffect } from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import { useDebounce } from '../hooks/useDebounce';
 import {
   useProspects,
   useProspectsMetrics,
@@ -35,18 +36,6 @@ import {
   Eye,
   MousePointerClick,
 } from 'lucide-react';
-
-// Debounce hook
-function useDebounce<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState<T>(value);
-
-  useEffect(() => {
-    const handler = setTimeout(() => setDebouncedValue(value), delay);
-    return () => clearTimeout(handler);
-  }, [value, delay]);
-
-  return debouncedValue;
-}
 
 const PAGE_SIZE = 25;
 

--- a/control-plane-ui/src/pages/Applications.tsx
+++ b/control-plane-ui/src/pages/Applications.tsx
@@ -1,28 +1,13 @@
 import { useState, useEffect, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { apiService } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
+import { useDebounce } from '../hooks/useDebounce';
 import { useToastActions } from '@stoa/shared/components/Toast';
 import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
 import { EmptyState } from '@stoa/shared/components/EmptyState';
 import { CardSkeleton } from '@stoa/shared/components/Skeleton';
-import type { Application, ApplicationCreate, Tenant, API } from '../types';
-
-// Debounce hook for search optimization
-function useDebounce<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState<T>(value);
-
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedValue(value);
-    }, delay);
-
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [value, delay]);
-
-  return debouncedValue;
-}
+import type { Application, ApplicationCreate, API } from '../types';
 
 const PAGE_SIZE = 12;
 
@@ -31,10 +16,9 @@ export function Applications() {
   const toast = useToastActions();
   const [confirm, ConfirmDialog] = useConfirm();
   const [applications, setApplications] = useState<Application[]>([]);
-  const [tenants, setTenants] = useState<Tenant[]>([]);
   const [apis, setApis] = useState<API[]>([]);
   const [selectedTenant, setSelectedTenant] = useState<string>('');
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingApp, setEditingApp] = useState<Application | null>(null);
@@ -47,11 +31,20 @@ export function Applications() {
   // Debounce search for performance (300ms delay)
   const debouncedSearch = useDebounce(searchQuery, 300);
 
+  // Fetch tenants via React Query (benefits from prefetch in AuthContext)
+  const { data: tenants = [], isLoading: tenantsLoading, error: tenantsError } = useQuery({
+    queryKey: ['tenants'],
+    queryFn: () => apiService.getTenants(),
+    enabled: isReady,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+
+  // Auto-select first tenant when tenants load
   useEffect(() => {
-    if (isReady) {
-      loadTenants();
+    if (tenants.length > 0 && !selectedTenant) {
+      setSelectedTenant(tenants[0].id);
     }
-  }, [isReady]);
+  }, [tenants, selectedTenant]);
 
   useEffect(() => {
     if (selectedTenant) {
@@ -64,20 +57,6 @@ export function Applications() {
   useEffect(() => {
     setCurrentPage(1);
   }, [debouncedSearch, statusFilter, selectedTenant]);
-
-  async function loadTenants() {
-    try {
-      const data = await apiService.getTenants();
-      setTenants(data);
-      if (data.length > 0) {
-        setSelectedTenant(data[0].id);
-      }
-      setLoading(false);
-    } catch (err: any) {
-      setError(err.message || 'Failed to load tenants');
-      setLoading(false);
-    }
-  }
 
   // Parallel loading of applications and APIs
   async function loadTenantData(tenantId: string) {
@@ -183,7 +162,7 @@ export function Applications() {
     suspended: 'bg-red-100 text-red-800',
   };
 
-  if (loading && tenants.length === 0) {
+  if ((tenantsLoading || loading) && tenants.length === 0) {
     return (
       <div className="space-y-6">
         <div className="flex justify-between items-center">
@@ -286,9 +265,9 @@ export function Applications() {
         </div>
       </div>
 
-      {error && (
+      {(error || tenantsError) && (
         <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
-          {error}
+          {error || 'Failed to load tenants'}
           <button onClick={() => setError(null)} className="float-right font-bold">&times;</button>
         </div>
       )}

--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -27,12 +27,8 @@ class ApiService {
     // Use request interceptor to ensure token is always attached
     this.client.interceptors.request.use(
       (config: InternalAxiosRequestConfig) => {
-        console.log('[ApiService] Interceptor called, authToken exists:', !!this.authToken);
         if (this.authToken) {
           config.headers.Authorization = `Bearer ${this.authToken}`;
-          console.log('[ApiService] Authorization header set');
-        } else {
-          console.warn('[ApiService] No auth token available for request to:', config.url);
         }
         return config;
       },
@@ -41,7 +37,6 @@ class ApiService {
   }
 
   setAuthToken(token: string) {
-    console.log('[ApiService] setAuthToken called');
     this.authToken = token;
     // Also set defaults for backwards compatibility
     this.client.defaults.headers.common['Authorization'] = `Bearer ${token}`;

--- a/control-plane-ui/vite.config.ts
+++ b/control-plane-ui/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
           'vendor-query': ['@tanstack/react-query'],
           'vendor-auth': ['react-oidc-context', 'oidc-client-ts'],
           'vendor-utils': ['axios', 'clsx', 'js-yaml'],
+          'vendor-icons': ['lucide-react'],
         },
       },
     },


### PR DESCRIPTION
## Summary

- **Phase 1** — Remove debug `console.log` from API interceptor and AuthContext hot path
- **Phase 2** — Render Layout shell (sidebar + header) during OIDC init instead of blank `LoadingScreen`
- **Phase 3** — Prefetch tenants in `AuthContext` after auth, add 5min `staleTime` to eliminate network waterfall
- **Phase 4** — `useMemo` for navigation/commands, `memo()` on `ComponentCard`, `useCallback` on handlers
- **Phase 5** — Extract shared `useDebounce` hook, consolidate duplicate lazy imports, fix dark mode on Dashboard & PlatformStatus
- **Phase 6** — Route prefetch on sidebar hover (`onMouseEnter`), `vendor-icons` Vite chunk for lucide-react

## Test plan

- [x] `npm run build` succeeds (2.36s)
- [x] `npm run test` — 23/23 tests pass
- [x] `npm run lint` — 0 errors (89 pre-existing warnings)
- [ ] Verify sidebar renders immediately during auth init (skeleton user section)
- [ ] Verify single `/v1/tenants` request across Dashboard → APIs → Applications navigation
- [ ] Verify `vendor-icons-*.js` chunk in Network tab
- [ ] Verify route chunk loads on sidebar hover before click

🤖 Generated with [Claude Code](https://claude.com/claude-code)