### PR TITLE
fix(api): sort imports in contracts router (ruff I001)

### DIFF
--- a/control-plane-api/src/routers/contracts.py
+++ b/control-plane-api/src/routers/contracts.py
@@ -16,7 +16,6 @@ from src.config import settings
 from src.database import get_db
 from src.logging_config import get_logger
 from src.models.contract import Contract, ProtocolBinding, ProtocolType
-from src.services.cache_service import contract_cache
 from src.schemas.contract import (
     BindingsListResponse,
     ContractCreate,
@@ -28,6 +27,7 @@ from src.schemas.contract import (
     EnableBindingResponse,
     ProtocolBindingResponse,
 )
+from src.services.cache_service import contract_cache
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- Fix pre-existing ruff I001 import ordering error in `contracts.py` — `src.schemas` before `src.services`
- Unblocks Control Plane API CI/CD pipeline (Docker build + EKS deploy)

## Test plan
- [ ] `ruff check src/routers/contracts.py` passes
- [ ] Control Plane API CI lint step passes
- [ ] Docker build + EKS deploy triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)