### PR TITLE
fix(ui): dynamic DNS resolver for nginx proxy backends (CAB-1108)

### DIFF
--- a/control-plane-ui/Dockerfile
+++ b/control-plane-ui/Dockerfile
@@ -94,7 +94,10 @@ ENV LOGS_BACKEND_URL=http://opensearch-dashboards:5601 \
     GRAFANA_BACKEND_URL=http://grafana:3000
 
 # Only substitute our custom vars (preserve nginx $uri, $host, etc.)
-ENV NGINX_ENVSUBST_FILTER='${LOGS_BACKEND_URL} ${GRAFANA_BACKEND_URL}'
+ENV NGINX_ENVSUBST_FILTER='${LOGS_BACKEND_URL} ${GRAFANA_BACKEND_URL} ${DNS_RESOLVER}'
+
+# Extract DNS resolver from /etc/resolv.conf at startup (before envsubst)
+COPY control-plane-ui/docker-entrypoint.d/15-extract-dns-resolver.envsh /docker-entrypoint.d/15-extract-dns-resolver.envsh
 
 # Copy nginx template (processed by built-in 20-envsubst-on-templates.sh at startup)
 COPY control-plane-ui/nginx.conf.template /etc/nginx/templates/default.conf.template

--- a/control-plane-ui/docker-entrypoint.d/15-extract-dns-resolver.envsh
+++ b/control-plane-ui/docker-entrypoint.d/15-extract-dns-resolver.envsh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Extract DNS resolver from /etc/resolv.conf for nginx reverse proxy.
+# Sourced by docker-entrypoint.sh BEFORE 20-envsubst-on-templates.sh,
+# so $DNS_RESOLVER is available for template substitution.
+#
+# K8s: CoreDNS IP (e.g. 10.96.0.10)
+# Docker: embedded DNS (127.0.0.11)
+DNS_RESOLVER=$(awk '/^nameserver/{print $2; exit}' /etc/resolv.conf)
+export DNS_RESOLVER="${DNS_RESOLVER:-127.0.0.11}"

--- a/control-plane-ui/nginx.conf.template
+++ b/control-plane-ui/nginx.conf.template
@@ -8,12 +8,20 @@ server {
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
 
+    # DNS resolver for dynamic proxy_pass (K8s CoreDNS or Docker DNS)
+    # Extracted at startup from /etc/resolv.conf by 15-extract-dns-resolver.envsh
+    resolver ${DNS_RESOLVER} valid=30s ipv6=off;
+
+    # Backend URLs resolved at request time (not startup) via variables
+    set $logs_backend "${LOGS_BACKEND_URL}";
+    set $grafana_backend "${GRAFANA_BACKEND_URL}";
+
     # =========================================================================
     # OpenSearch Dashboards proxy (STOA Logs — CAB-1114)
     # Dashboards configured with server.basePath="/logs", rewriteBasePath=true
     # =========================================================================
     location /logs/ {
-        proxy_pass ${LOGS_BACKEND_URL};
+        proxy_pass $logs_backend;
         proxy_hide_header X-Frame-Options;
         add_header Content-Security-Policy "frame-ancestors 'self' https://console.gostoa.dev" always;
         proxy_set_header Host $http_host;
@@ -34,7 +42,7 @@ server {
     # Grafana configured with GF_SERVER_SERVE_FROM_SUB_PATH=true
     # =========================================================================
     location /grafana/ {
-        proxy_pass ${GRAFANA_BACKEND_URL};
+        proxy_pass $grafana_backend;
         proxy_hide_header X-Frame-Options;
         add_header Content-Security-Policy "frame-ancestors 'self' https://console.gostoa.dev" always;
         proxy_set_header Host $http_host;
@@ -48,7 +56,7 @@ server {
 
     # Grafana WebSocket for Live features
     location /grafana/api/live/ {
-        proxy_pass ${GRAFANA_BACKEND_URL};
+        proxy_pass $grafana_backend;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
## Summary
- Fixes deploy rollout failure from PR #153 — nginx failed to start because backend hostnames (`opensearch-dashboards`, `grafana`) couldn't be resolved at startup
- Switches `proxy_pass` from static hostnames to nginx variables + `resolver` directive → DNS resolved at request time, not startup
- Adds `15-extract-dns-resolver.envsh` entrypoint script that reads DNS resolver IP from `/etc/resolv.conf` (K8s CoreDNS or Docker DNS)

## Root Cause
nginx resolves static `proxy_pass` hostnames at startup. If the backend services are unavailable (different namespace, not yet deployed), nginx refuses to start → readiness probe fails → rollout times out → automatic rollback.

## Fix
| Change | Purpose |
|--------|---------|
| `nginx.conf.template`: `set $logs_backend` + `resolver` | DNS at request time, not startup |
| `15-extract-dns-resolver.envsh` | Extract DNS IP from `/etc/resolv.conf` (K8s/Docker agnostic) |
| `Dockerfile`: add `${DNS_RESOLVER}` to envsubst filter | Template substitution for resolver IP |

## Test plan
- [ ] CI build passes
- [ ] Pod starts even if backends are unavailable (nginx starts, `/` serves SPA)
- [ ] `/logs/` and `/grafana/` proxy to backends when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)