### PR TITLE
fix(api): use enum values in gateway mode stats query (HTTP 500)

### DIFF
--- a/control-plane-api/src/routers/gateway_instances.py
+++ b/control-plane-api/src/routers/gateway_instances.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.auth.rbac import require_role
 from src.database import get_db
-from src.models.gateway_instance import GatewayInstance
+from src.models.gateway_instance import GatewayInstance, GatewayInstanceStatus
 from src.schemas.gateway import (
     GatewayHealthCheckResponse,
     GatewayInstanceCreate,
@@ -86,9 +86,15 @@ async def get_gateway_mode_stats(
         select(
             GatewayInstance.mode,
             func.count(GatewayInstance.id).label("total"),
-            func.count(case((GatewayInstance.status == "online", 1))).label("online"),
-            func.count(case((GatewayInstance.status == "offline", 1))).label("offline"),
-            func.count(case((GatewayInstance.status == "degraded", 1))).label("degraded"),
+            func.count(case((GatewayInstance.status == GatewayInstanceStatus.ONLINE, 1))).label(
+                "online"
+            ),
+            func.count(case((GatewayInstance.status == GatewayInstanceStatus.OFFLINE, 1))).label(
+                "offline"
+            ),
+            func.count(
+                case((GatewayInstance.status == GatewayInstanceStatus.DEGRADED, 1))
+            ).label("degraded"),
         )
         .where(GatewayInstance.gateway_type.like("stoa%"))
         .group_by(GatewayInstance.mode)


### PR DESCRIPTION
## Summary
- Fix HTTP 500 on `GET /v1/admin/gateways/modes/stats` — the SQLAlchemy `case()` expressions compared `GatewayInstance.status` (Enum column) with raw string literals (`"online"`, `"offline"`, `"degraded"`) instead of `GatewayInstanceStatus` enum values
- This broke the Console gateway dashboard (GatewayModesDashboard) and the business dashboard stats panel

## Root cause
```python
# BEFORE — HTTP 500:
func.count(case((GatewayInstance.status == "online", 1)))

# AFTER — fixed:
func.count(case((GatewayInstance.status == GatewayInstanceStatus.ONLINE, 1)))
```

## Test plan
- [ ] Merge and trigger control-plane-api CI
- [ ] Navigate to Console → Gateways page — no more 500 error
- [ ] Verify gateway mode stats dashboard loads (shows 0 for all modes if no STOA gateways registered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)