### PR TITLE
fix(ci): handle immutable selector in apply-manifest (CAB-1108)

### DIFF
--- a/.claude/rules/k8s-deploy.md
+++ b/.claude/rules/k8s-deploy.md
@@ -58,8 +58,12 @@ apply-manifest:
     - name: Update kubeconfig
       run: aws eks update-kubeconfig --name apim-dev-cluster --region eu-west-1
     - name: Apply k8s manifest
-      run: kubectl apply -f <component>/k8s/deployment.yaml
+      run: |
+        kubectl apply -f <component>/k8s/deployment.yaml 2>/dev/null \
+          || kubectl replace --force -f <component>/k8s/deployment.yaml
 ```
+
+**Gotcha**: `kubectl apply` fails with "spec.selector: field is immutable" if the deployment was originally created by Helm (different selector labels). The `replace --force` fallback deletes and recreates the deployment, which handles selector mismatches.
 
 And the deploy job must depend on it:
 ```yaml

--- a/.github/workflows/control-plane-ui-ci.yml
+++ b/.github/workflows/control-plane-ui-ci.yml
@@ -109,7 +109,9 @@ jobs:
       - name: Update kubeconfig
         run: aws eks update-kubeconfig --name apim-dev-cluster --region eu-west-1
       - name: Apply k8s manifest
-        run: kubectl apply -f control-plane-ui/k8s/deployment.yaml
+        run: |
+          kubectl apply -f control-plane-ui/k8s/deployment.yaml 2>/dev/null \
+            || kubectl replace --force -f control-plane-ui/k8s/deployment.yaml
 
   # === Deploy: EKS rollout with auto-rollback ===
   deploy:


### PR DESCRIPTION
## Summary
- `kubectl apply` fails with `spec.selector: field is immutable` when the deployment was originally created by Helm (different selector labels)
- Add `replace --force` fallback to delete and recreate the deployment when selector mismatch occurs
- Update `.claude/rules/k8s-deploy.md` with the gotcha

## Test plan
- [ ] apply-manifest job succeeds on next merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)