### PR TITLE
fix(k8s): add explicit privileged:false for Kyverno (CAB-1108)

### DIFF
--- a/control-plane-ui/k8s/deployment.yaml
+++ b/control-plane-ui/k8s/deployment.yaml
@@ -68,6 +68,7 @@ spec:
             - name: GRAFANA_BACKEND_URL
               value: "http://grafana.stoa-system.svc:3000"
           securityContext:
+            privileged: false
             runAsNonRoot: true
             runAsUser: 101
             runAsGroup: 101


### PR DESCRIPTION
## Summary
- **URGENT**: control-plane-ui deployment is DOWN — previous `replace --force` deleted the deployment but Kyverno blocked recreation
- Kyverno `restrict-privileged` policy requires `securityContext.privileged: false` explicitly
- Add `privileged: false` to container securityContext

## Test plan
- [ ] apply-manifest succeeds
- [ ] Pod is running on EKS

🤖 Generated with [Claude Code](https://claude.com/claude-code)