### PR TITLE
fix(helm): nginx-conf emptyDir for readOnly FS (CAB-1108)

### DIFF
--- a/control-plane-ui/k8s/deployment.yaml
+++ b/control-plane-ui/k8s/deployment.yaml
@@ -82,6 +82,8 @@ spec:
           volumeMounts:
             - name: nginx-cache
               mountPath: /var/cache/nginx
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d
             - name: nginx-run
               mountPath: /var/run
             - name: tmp
@@ -91,6 +93,8 @@ spec:
         fsGroup: 101
       volumes:
         - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-conf
           emptyDir: {}
         - name: nginx-run
           emptyDir: {}


### PR DESCRIPTION
## Summary
- **URGENT**: control-plane-ui pod in CrashLoopBackOff — nginx entrypoint's `20-envsubst-on-templates.sh` fails to write rendered config to `/etc/nginx/conf.d/` because `readOnlyRootFilesystem: true`
- Add `nginx-conf` emptyDir volume mounted at `/etc/nginx/conf.d/`

## Test plan
- [ ] Pod starts successfully (no CrashLoopBackOff)
- [ ] Deploy completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)