### PR TITLE
fix(ci): resolve deploy CrashLoop + selector + env conflicts

### DIFF
--- a/.github/workflows/control-plane-ui-ci.yml
+++ b/.github/workflows/control-plane-ui-ci.yml
@@ -109,7 +109,12 @@ jobs:
       - name: Update kubeconfig
         run: aws eks update-kubeconfig --name apim-dev-cluster --region eu-west-1
       - name: Apply k8s manifest
-        run: kubectl apply --server-side --force-conflicts -f control-plane-ui/k8s/deployment.yaml
+        run: |
+          kubectl apply -f control-plane-ui/k8s/deployment.yaml 2>&1 || {
+            echo "Apply failed (likely immutable selector). Deleting and recreating..."
+            kubectl delete deployment control-plane-ui -n stoa-system --ignore-not-found
+            kubectl apply -f control-plane-ui/k8s/deployment.yaml
+          }
 
   # === Deploy: EKS rollout with auto-rollback ===
   deploy:

--- a/.github/workflows/stoa-gateway-ci.yml
+++ b/.github/workflows/stoa-gateway-ci.yml
@@ -97,7 +97,12 @@ jobs:
       - name: Update kubeconfig
         run: aws eks update-kubeconfig --name apim-dev-cluster --region eu-west-1
       - name: Apply k8s manifest
-        run: kubectl apply --server-side --force-conflicts -f stoa-gateway/k8s/deployment.yaml
+        run: |
+          kubectl apply -f stoa-gateway/k8s/deployment.yaml 2>&1 || {
+            echo "Apply failed (likely immutable selector). Deleting and recreating..."
+            kubectl delete deployment stoa-gateway -n stoa-system --ignore-not-found
+            kubectl apply -f stoa-gateway/k8s/deployment.yaml
+          }
 
   # === Deploy: EKS rollout with auto-rollback ===
   deploy:

--- a/.github/workflows/stoa-portal-ci.yml
+++ b/.github/workflows/stoa-portal-ci.yml
@@ -110,7 +110,12 @@ jobs:
       - name: Update kubeconfig
         run: aws eks update-kubeconfig --name apim-dev-cluster --region eu-west-1
       - name: Apply k8s manifest
-        run: kubectl apply --server-side --force-conflicts -f portal/k8s/deployment.yaml
+        run: |
+          kubectl apply -f portal/k8s/deployment.yaml 2>&1 || {
+            echo "Apply failed (likely immutable selector). Deleting and recreating..."
+            kubectl delete deployment stoa-portal -n stoa-system --ignore-not-found
+            kubectl apply -f portal/k8s/deployment.yaml
+          }
 
   # === Deploy: EKS rollout with auto-rollback ===
   deploy:

--- a/control-plane-ui/k8s/deployment.yaml
+++ b/control-plane-ui/k8s/deployment.yaml
@@ -72,7 +72,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 101
             runAsGroup: 101
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false
             allowPrivilegeEscalation: false
             capabilities:
               drop:

--- a/stoa-gateway/k8s/deployment.yaml
+++ b/stoa-gateway/k8s/deployment.yaml
@@ -49,11 +49,7 @@ spec:
             - name: STOA_LOG_FORMAT
               value: "json"
             - name: STOA_KEYCLOAK_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: stoa-gateway-config
-                  key: STOA_KEYCLOAK_URL
-                  optional: true
+              value: "https://auth.gostoa.dev"
             - name: STOA_KEYCLOAK_REALM
               value: "stoa"
             - name: STOA_KEYCLOAK_CLIENT_ID


### PR DESCRIPTION
## Summary
**HOTFIX** — Three issues blocking EKS deployment of all components:

1. **control-plane-ui CrashLoop**: `readOnlyRootFilesystem: true` blocks nginx envsubst startup writes → set to `false` temporarily
2. **stoa-gateway invalid env**: `valueFrom` configMapKeyRef for `STOA_KEYCLOAK_URL` conflicts with server-side apply merge → use plain `value`
3. **All 3 CIs**: immutable selector conflict (Helm vs standalone manifests) → apply-manifest falls back to `delete + recreate`

## Test plan
- [ ] CI passes
- [ ] control-plane-ui pod stops CrashLooping
- [ ] stoa-gateway apply-manifest succeeds
- [ ] stoa-portal deploy completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)