### PR TITLE
fix(ci): escape NGINX_ENVSUBST_FILTER dollar signs (CAB-1108)

### DIFF
--- a/.claude/rules/k8s-deploy.md
+++ b/.claude/rules/k8s-deploy.md
@@ -67,6 +67,14 @@ Use the dedicated health endpoint, not `/` (which may return SPA HTML even when 
 ### 7. Runtime env vars for nginx proxy backends
 If the container uses `nginx.conf.template` with `proxy_pass` variables, the corresponding env vars MUST be in the deployment manifest AND in the Dockerfile's `NGINX_ENVSUBST_FILTER`.
 
+### 8. Dockerfile `NGINX_ENVSUBST_FILTER` — escape `$` with `\$` (CRITICAL)
+Docker's `ENV` instruction expands `${VAR}` at build time — single quotes do NOT prevent expansion. If `NGINX_ENVSUBST_FILTER` uses `'${API_BACKEND_URL} ...'`, Docker substitutes the actual values, and envsubst at runtime does nothing (leaving template variables unresolved → nginx crash).
+
+**Always escape `$` with `\$`:**
+```dockerfile
+ENV NGINX_ENVSUBST_FILTER="\${API_BACKEND_URL} \${LOGS_BACKEND_URL} \${DNS_RESOLVER}"
+```
+
 ## CI Workflow (`*-ci.yml`)
 
 ### apply-manifest Job (CRITICAL)

--- a/.github/workflows/reusable-k8s-deploy.yml
+++ b/.github/workflows/reusable-k8s-deploy.yml
@@ -121,6 +121,16 @@ jobs:
           kubectl get pods -n ${{ inputs.namespace }} -l app=${{ inputs.component }} -o wide || \
             kubectl get pods -n ${{ inputs.namespace }} -l app.kubernetes.io/name=${{ inputs.component }} -o wide || true
           echo ""
+          echo "=== Container Logs (last 50 lines) ==="
+          POD=$(kubectl get pods -n ${{ inputs.namespace }} -l app=${{ inputs.component }} \
+            --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}' 2>/dev/null) || true
+          if [ -n "$POD" ]; then
+            kubectl logs "$POD" -n ${{ inputs.namespace }} --tail=50 2>&1 || true
+            echo ""
+            echo "=== Previous Container Logs ==="
+            kubectl logs "$POD" -n ${{ inputs.namespace }} --previous --tail=30 2>&1 || true
+          fi
+          echo ""
           echo "=== Recent Events (last 10 min) ==="
           kubectl get events -n ${{ inputs.namespace }} --sort-by='.lastTimestamp' | tail -30 || true
           echo ""

--- a/control-plane-ui/Dockerfile
+++ b/control-plane-ui/Dockerfile
@@ -95,7 +95,8 @@ ENV API_BACKEND_URL=http://control-plane-api:8000 \
     GRAFANA_BACKEND_URL=http://grafana:3000
 
 # Only substitute our custom vars (preserve nginx $uri, $host, etc.)
-ENV NGINX_ENVSUBST_FILTER='${API_BACKEND_URL} ${LOGS_BACKEND_URL} ${GRAFANA_BACKEND_URL} ${DNS_RESOLVER}'
+# IMPORTANT: Use \$ to escape — Docker expands ${VAR} in ENV even inside single quotes
+ENV NGINX_ENVSUBST_FILTER="\${API_BACKEND_URL} \${LOGS_BACKEND_URL} \${GRAFANA_BACKEND_URL} \${DNS_RESOLVER}"
 
 # Extract DNS resolver from /etc/resolv.conf at startup (before envsubst)
 COPY control-plane-ui/docker-entrypoint.d/15-extract-dns-resolver.envsh /docker-entrypoint.d/15-extract-dns-resolver.envsh


### PR DESCRIPTION
## Summary

- **Root cause**: Docker `ENV` expands `${VAR}` at build time — single quotes do NOT prevent this. `NGINX_ENVSUBST_FILTER` was getting URL values (`http://control-plane-api:8000 ...`) instead of variable references (`${API_BACKEND_URL} ...`), so `envsubst` at container startup did nothing. The nginx config template was left with unresolved `${DNS_RESOLVER}` etc., causing nginx to crash immediately.
- **Fix**: Use `\${VAR}` in the Dockerfile to produce literal `${VAR}` strings that `envsubst` can process at runtime
- **Bonus**: Added `kubectl logs` (current + previous container) to the reusable deploy workflow diagnostics for faster crash debugging

## Test plan

- [ ] CI builds Docker image successfully
- [ ] Deploy to EKS — control-plane-ui pod reaches `Running` status
- [ ] console.gostoa.dev returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)