### PR TITLE
fix(ui): use $$ prefix for nginx envsubst template (CAB-1108)

### DIFF
--- a/.claude/rules/k8s-deploy.md
+++ b/.claude/rules/k8s-deploy.md
@@ -67,13 +67,17 @@ Use the dedicated health endpoint, not `/` (which may return SPA HTML even when 
 ### 7. Runtime env vars for nginx proxy backends
 If the container uses `nginx.conf.template` with `proxy_pass` variables, the corresponding env vars MUST be in the deployment manifest AND in the Dockerfile's `NGINX_ENVSUBST_FILTER`.
 
-### 8. Dockerfile `NGINX_ENVSUBST_FILTER` — escape `$` with `\$` (CRITICAL)
-Docker's `ENV` instruction expands `${VAR}` at build time — single quotes do NOT prevent expansion. If `NGINX_ENVSUBST_FILTER` uses `'${API_BACKEND_URL} ...'`, Docker substitutes the actual values, and envsubst at runtime does nothing (leaving template variables unresolved → nginx crash).
+### 8. Nginx envsubst templates — use `$$` prefix for nginx variables (CRITICAL)
+Do NOT use `NGINX_ENVSUBST_FILTER` — the latest nginx Docker image's entrypoint uses awk to process it as a regex, and `${VAR}` syntax breaks awk. Also, Docker's `ENV` expands `${VAR}` at build time.
 
-**Always escape `$` with `\$`:**
-```dockerfile
-ENV NGINX_ENVSUBST_FILTER="\${API_BACKEND_URL} \${LOGS_BACKEND_URL} \${DNS_RESOLVER}"
+**Instead, use `$$` prefix** for all nginx variables in the template (envsubst converts `$$` → `$`):
+```nginx
+set $$api_backend "${API_BACKEND_URL}";     # envsubst: $$api_backend → $api_backend
+proxy_pass $$api_backend;                    # envsubst: leaves $api_backend
+proxy_set_header Host $$http_host;           # envsubst: $$http_host → $http_host
+resolver ${NGINX_LOCAL_RESOLVERS} valid=30s; # envsubst: substitutes the IP
 ```
+Use `NGINX_LOCAL_RESOLVERS` (built-in from nginx image's `15-local-resolvers.envsh`) instead of a custom DNS resolver script.
 
 ## CI Workflow (`*-ci.yml`)
 

--- a/control-plane-ui/Dockerfile
+++ b/control-plane-ui/Dockerfile
@@ -90,16 +90,11 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:alpine
 
 # Default backend URLs (overridable via K8s env vars)
+# Template uses $$ prefix for nginx variables so envsubst leaves them alone
+# NGINX_LOCAL_RESOLVERS is provided by nginx image's built-in 15-local-resolvers.envsh
 ENV API_BACKEND_URL=http://control-plane-api:8000 \
     LOGS_BACKEND_URL=http://opensearch-dashboards:5601 \
     GRAFANA_BACKEND_URL=http://grafana:3000
-
-# Only substitute our custom vars (preserve nginx $uri, $host, etc.)
-# IMPORTANT: Use \$ to escape — Docker expands ${VAR} in ENV even inside single quotes
-ENV NGINX_ENVSUBST_FILTER="\${API_BACKEND_URL} \${LOGS_BACKEND_URL} \${GRAFANA_BACKEND_URL} \${DNS_RESOLVER}"
-
-# Extract DNS resolver from /etc/resolv.conf at startup (before envsubst)
-COPY control-plane-ui/docker-entrypoint.d/15-extract-dns-resolver.envsh /docker-entrypoint.d/15-extract-dns-resolver.envsh
 
 # Copy nginx template (processed by built-in 20-envsubst-on-templates.sh at startup)
 COPY control-plane-ui/nginx.conf.template /etc/nginx/templates/default.conf.template

--- a/control-plane-ui/nginx.conf.template
+++ b/control-plane-ui/nginx.conf.template
@@ -9,28 +9,29 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
 
     # DNS resolver for dynamic proxy_pass (K8s CoreDNS or Docker DNS)
-    # Extracted at startup from /etc/resolv.conf by 15-extract-dns-resolver.envsh
-    resolver ${DNS_RESOLVER} valid=30s ipv6=off;
+    # NGINX_LOCAL_RESOLVERS is provided by nginx image's built-in 15-local-resolvers.envsh
+    resolver ${NGINX_LOCAL_RESOLVERS} valid=30s ipv6=off;
 
     # Backend URLs resolved at request time (not startup) via variables
     # NEVER use static proxy_pass hostnames — nginx crashes if DNS fails at startup
-    set $api_backend "${API_BACKEND_URL}";
-    set $logs_backend "${LOGS_BACKEND_URL}";
-    set $grafana_backend "${GRAFANA_BACKEND_URL}";
+    # NOTE: All nginx variables use $$ prefix so envsubst leaves them as literal $
+    set $$api_backend "${API_BACKEND_URL}";
+    set $$logs_backend "${LOGS_BACKEND_URL}";
+    set $$grafana_backend "${GRAFANA_BACKEND_URL}";
 
     # =========================================================================
     # OpenSearch Dashboards proxy (STOA Logs — CAB-1114)
     # Dashboards configured with server.basePath="/logs", rewriteBasePath=true
     # =========================================================================
     location /logs/ {
-        proxy_pass $logs_backend;
+        proxy_pass $$logs_backend;
         proxy_hide_header X-Frame-Options;
         add_header Content-Security-Policy "frame-ancestors 'self' https://console.gostoa.dev" always;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Cookie $http_cookie;
+        proxy_set_header Host $$http_host;
+        proxy_set_header X-Real-IP $$remote_addr;
+        proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $$scheme;
+        proxy_set_header Cookie $$http_cookie;
         proxy_buffer_size 128k;
         proxy_buffers 4 256k;
         proxy_busy_buffers_size 256k;
@@ -44,13 +45,13 @@ server {
     # Grafana configured with GF_SERVER_SERVE_FROM_SUB_PATH=true
     # =========================================================================
     location /grafana/ {
-        proxy_pass $grafana_backend;
+        proxy_pass $$grafana_backend;
         proxy_hide_header X-Frame-Options;
         add_header Content-Security-Policy "frame-ancestors 'self' https://console.gostoa.dev" always;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $$http_host;
+        proxy_set_header X-Real-IP $$remote_addr;
+        proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $$scheme;
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
@@ -58,34 +59,34 @@ server {
 
     # Grafana WebSocket for Live features
     location /grafana/api/live/ {
-        proxy_pass $grafana_backend;
+        proxy_pass $$grafana_backend;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Upgrade $$http_upgrade;
         proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $$http_host;
+        proxy_set_header X-Real-IP $$remote_addr;
+        proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $$scheme;
         proxy_read_timeout 86400s;
         proxy_send_timeout 86400s;
     }
 
     # SPA routing - serve index.html for all unmatched routes
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $$uri $$uri/ /index.html;
     }
 
     # API proxy (Swagger UI requires unsafe-eval + unsafe-inline for JS rendering)
     location /api/ {
-        proxy_pass $api_backend/;
+        proxy_pass $$api_backend/;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Upgrade $$http_upgrade;
         proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass $http_upgrade;
+        proxy_set_header Host $$host;
+        proxy_set_header X-Real-IP $$remote_addr;
+        proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $$scheme;
+        proxy_cache_bypass $$http_upgrade;
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://fastapi.tiangolo.com; font-src 'self' data:; connect-src 'self'" always;
     }
 


### PR DESCRIPTION
## Summary

- **Root cause**: Latest `nginx-unprivileged:alpine` image has new `15-local-resolvers.envsh` + updated `20-envsubst-on-templates.sh` that uses awk to process `NGINX_ENVSUBST_FILTER` as a regex. The `${VAR}` syntax breaks awk regex parsing, envsubst fails silently, and `${DNS_RESOLVER}` stays literal in the nginx config → `[emerg] host not found in resolver "${DNS_RESOLVER}"` crash.
- **Fix**: Remove `NGINX_ENVSUBST_FILTER` entirely. Use canonical `$$` prefix for all nginx variables in the template (`envsubst` converts `$$` → literal `$`). Use built-in `NGINX_LOCAL_RESOLVERS` from the nginx image instead of custom `DNS_RESOLVER` script.
- Actual nginx error from `kubectl logs` (added in PR #164):
  ```
  awk: bad regex '${API_BACKEND_URL}...': Invalid contents of {}
  nginx: [emerg] host not found in resolver "${DNS_RESOLVER}" in /etc/nginx/conf.d/default.conf:13
  ```

## Test plan

- [ ] CI builds Docker image successfully
- [ ] Deploy to EKS — control-plane-ui pod reaches `Running` status
- [ ] console.gostoa.dev returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)