### PR TITLE
fix(ui): restore DNS_RESOLVER for envsubst (CAB-1108)

### DIFF
--- a/control-plane-ui/Dockerfile
+++ b/control-plane-ui/Dockerfile
@@ -91,10 +91,14 @@ FROM nginxinc/nginx-unprivileged:alpine
 
 # Default backend URLs (overridable via K8s env vars)
 # Template uses $$ prefix for nginx variables so envsubst leaves them alone
-# NGINX_LOCAL_RESOLVERS is provided by nginx image's built-in 15-local-resolvers.envsh
 ENV API_BACKEND_URL=http://control-plane-api:8000 \
     LOGS_BACKEND_URL=http://opensearch-dashboards:5601 \
     GRAFANA_BACKEND_URL=http://grafana:3000
+
+# Extract DNS resolver from /etc/resolv.conf at startup (before envsubst)
+# Must use our own script because nginx's built-in 15-local-resolvers.envsh
+# does not export NGINX_LOCAL_RESOLVERS to subprocesses (envsubst can't see it)
+COPY control-plane-ui/docker-entrypoint.d/15-extract-dns-resolver.envsh /docker-entrypoint.d/15-extract-dns-resolver.envsh
 
 # Copy nginx template (processed by built-in 20-envsubst-on-templates.sh at startup)
 COPY control-plane-ui/nginx.conf.template /etc/nginx/templates/default.conf.template

--- a/control-plane-ui/nginx.conf.template
+++ b/control-plane-ui/nginx.conf.template
@@ -9,8 +9,8 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
 
     # DNS resolver for dynamic proxy_pass (K8s CoreDNS or Docker DNS)
-    # NGINX_LOCAL_RESOLVERS is provided by nginx image's built-in 15-local-resolvers.envsh
-    resolver ${NGINX_LOCAL_RESOLVERS} valid=30s ipv6=off;
+    # DNS_RESOLVER is exported by our 15-extract-dns-resolver.envsh (reads /etc/resolv.conf)
+    resolver ${DNS_RESOLVER} valid=30s ipv6=off;
 
     # Backend URLs resolved at request time (not startup) via variables
     # NEVER use static proxy_pass hostnames — nginx crashes if DNS fails at startup


### PR DESCRIPTION
## Summary

- **Root cause**: nginx image's built-in `15-local-resolvers.envsh` does not `export NGINX_LOCAL_RESOLVERS`, so the subprocess running `envsubst` (in `20-envsubst-on-templates.sh`) cannot see it. The template `${NGINX_LOCAL_RESOLVERS}` stays literal → nginx crash.
- **Fix**: Restore our custom `15-extract-dns-resolver.envsh` which properly `export`s `DNS_RESOLVER`, and use `${DNS_RESOLVER}` in the template.

## Test plan

- [ ] CI builds Docker image successfully
- [ ] Deploy to EKS — control-plane-ui pod reaches `Running` status
- [ ] console.gostoa.dev returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)