### PR TITLE
fix(ui): custom envsubst to protect nginx vars (CAB-1108)

### DIFF
--- a/.claude/rules/k8s-deploy.md
+++ b/.claude/rules/k8s-deploy.md
@@ -65,19 +65,28 @@ Always verify: `kubectl get svc -n stoa-system`
 Use the dedicated health endpoint, not `/` (which may return SPA HTML even when backend proxies are broken).
 
 ### 7. Runtime env vars for nginx proxy backends
-If the container uses `nginx.conf.template` with `proxy_pass` variables, the corresponding env vars MUST be in the deployment manifest AND in the Dockerfile's `NGINX_ENVSUBST_FILTER`.
+If the container uses `nginx.conf.template` with `proxy_pass` variables, the corresponding env vars MUST be in the deployment manifest.
 
-### 8. Nginx envsubst templates — use `$$` prefix for nginx variables (CRITICAL)
-Do NOT use `NGINX_ENVSUBST_FILTER` — the latest nginx Docker image's entrypoint uses awk to process it as a regex, and `${VAR}` syntax breaks awk. Also, Docker's `ENV` expands `${VAR}` at build time.
+### 8. Nginx envsubst — use custom script, NOT built-in (CRITICAL)
+Do NOT use `NGINX_ENVSUBST_FILTER` or the built-in `20-envsubst-on-templates.sh`:
+- `NGINX_ENVSUBST_FILTER`: latest nginx image uses awk to process it, `${VAR}` breaks awk regex
+- Docker `ENV` expands `${VAR}` at build time (single quotes don't prevent this)
+- Without filter, envsubst replaces ALL `$var` refs (including nginx `$uri`, `$host`) with empty strings
+- `$$` is NOT an escape in envsubst — `$$var` becomes `$` + empty string, not `$var`
 
-**Instead, use `$$` prefix** for all nginx variables in the template (envsubst converts `$$` → `$`):
-```nginx
-set $$api_backend "${API_BACKEND_URL}";     # envsubst: $$api_backend → $api_backend
-proxy_pass $$api_backend;                    # envsubst: leaves $api_backend
-proxy_set_header Host $$http_host;           # envsubst: $$http_host → $http_host
-resolver ${NGINX_LOCAL_RESOLVERS} valid=30s; # envsubst: substitutes the IP
+**Solution**: Custom entrypoint script with explicit filter + non-standard template dir:
+```dockerfile
+# Template in custom dir (NOT /etc/nginx/templates/) so built-in script skips it
+COPY 19-envsubst-custom.sh /docker-entrypoint.d/19-envsubst-custom.sh
+COPY nginx.conf.template /etc/nginx/custom-templates/default.conf.template
 ```
-Use `NGINX_LOCAL_RESOLVERS` (built-in from nginx image's `15-local-resolvers.envsh`) instead of a custom DNS resolver script.
+```bash
+#!/bin/sh
+# 19-envsubst-custom.sh — only substitute our 4 variables
+envsubst '${API_BACKEND_URL} ${LOGS_BACKEND_URL} ${GRAFANA_BACKEND_URL} ${DNS_RESOLVER}' \
+  < /etc/nginx/custom-templates/default.conf.template \
+  > /etc/nginx/conf.d/default.conf
+```
 
 ## CI Workflow (`*-ci.yml`)
 

--- a/control-plane-ui/Dockerfile
+++ b/control-plane-ui/Dockerfile
@@ -90,18 +90,19 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:alpine
 
 # Default backend URLs (overridable via K8s env vars)
-# Template uses $$ prefix for nginx variables so envsubst leaves them alone
 ENV API_BACKEND_URL=http://control-plane-api:8000 \
     LOGS_BACKEND_URL=http://opensearch-dashboards:5601 \
     GRAFANA_BACKEND_URL=http://grafana:3000
 
-# Extract DNS resolver from /etc/resolv.conf at startup (before envsubst)
-# Must use our own script because nginx's built-in 15-local-resolvers.envsh
-# does not export NGINX_LOCAL_RESOLVERS to subprocesses (envsubst can't see it)
+# Entrypoint scripts (run in alphabetical order at container startup):
+# 15-extract-dns-resolver.envsh — exports DNS_RESOLVER from /etc/resolv.conf
+# 19-envsubst-custom.sh — runs envsubst with explicit filter (only our 4 vars)
+# The template is in /etc/nginx/custom-templates/ (NOT /etc/nginx/templates/)
+# so the built-in 20-envsubst-on-templates.sh has nothing to process and
+# won't clobber nginx variables like $uri, $host, $http_upgrade, etc.
 COPY control-plane-ui/docker-entrypoint.d/15-extract-dns-resolver.envsh /docker-entrypoint.d/15-extract-dns-resolver.envsh
-
-# Copy nginx template (processed by built-in 20-envsubst-on-templates.sh at startup)
-COPY control-plane-ui/nginx.conf.template /etc/nginx/templates/default.conf.template
+COPY control-plane-ui/docker-entrypoint.d/19-envsubst-custom.sh /docker-entrypoint.d/19-envsubst-custom.sh
+COPY control-plane-ui/nginx.conf.template /etc/nginx/custom-templates/default.conf.template
 
 # Copy built app
 COPY --from=builder /app/control-plane-ui/dist /usr/share/nginx/html

--- a/control-plane-ui/docker-entrypoint.d/19-envsubst-custom.sh
+++ b/control-plane-ui/docker-entrypoint.d/19-envsubst-custom.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Custom envsubst that only substitutes our variables (not nginx $uri, $host, etc.)
+# Runs BEFORE the built-in 20-envsubst-on-templates.sh (which has nothing to process).
+# Template is in /etc/nginx/custom-templates/ (not /etc/nginx/templates/).
+set -e
+envsubst '${API_BACKEND_URL} ${LOGS_BACKEND_URL} ${GRAFANA_BACKEND_URL} ${DNS_RESOLVER}' \
+  < /etc/nginx/custom-templates/default.conf.template \
+  > /etc/nginx/conf.d/default.conf

--- a/control-plane-ui/nginx.conf.template
+++ b/control-plane-ui/nginx.conf.template
@@ -9,29 +9,28 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
 
     # DNS resolver for dynamic proxy_pass (K8s CoreDNS or Docker DNS)
-    # DNS_RESOLVER is exported by our 15-extract-dns-resolver.envsh (reads /etc/resolv.conf)
+    # DNS_RESOLVER is exported by 15-extract-dns-resolver.envsh (reads /etc/resolv.conf)
     resolver ${DNS_RESOLVER} valid=30s ipv6=off;
 
     # Backend URLs resolved at request time (not startup) via variables
     # NEVER use static proxy_pass hostnames — nginx crashes if DNS fails at startup
-    # NOTE: All nginx variables use $$ prefix so envsubst leaves them as literal $
-    set $$api_backend "${API_BACKEND_URL}";
-    set $$logs_backend "${LOGS_BACKEND_URL}";
-    set $$grafana_backend "${GRAFANA_BACKEND_URL}";
+    set $api_backend "${API_BACKEND_URL}";
+    set $logs_backend "${LOGS_BACKEND_URL}";
+    set $grafana_backend "${GRAFANA_BACKEND_URL}";
 
     # =========================================================================
     # OpenSearch Dashboards proxy (STOA Logs — CAB-1114)
     # Dashboards configured with server.basePath="/logs", rewriteBasePath=true
     # =========================================================================
     location /logs/ {
-        proxy_pass $$logs_backend;
+        proxy_pass $logs_backend;
         proxy_hide_header X-Frame-Options;
         add_header Content-Security-Policy "frame-ancestors 'self' https://console.gostoa.dev" always;
-        proxy_set_header Host $$http_host;
-        proxy_set_header X-Real-IP $$remote_addr;
-        proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $$scheme;
-        proxy_set_header Cookie $$http_cookie;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Cookie $http_cookie;
         proxy_buffer_size 128k;
         proxy_buffers 4 256k;
         proxy_busy_buffers_size 256k;
@@ -45,13 +44,13 @@ server {
     # Grafana configured with GF_SERVER_SERVE_FROM_SUB_PATH=true
     # =========================================================================
     location /grafana/ {
-        proxy_pass $$grafana_backend;
+        proxy_pass $grafana_backend;
         proxy_hide_header X-Frame-Options;
         add_header Content-Security-Policy "frame-ancestors 'self' https://console.gostoa.dev" always;
-        proxy_set_header Host $$http_host;
-        proxy_set_header X-Real-IP $$remote_addr;
-        proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $$scheme;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
@@ -59,34 +58,34 @@ server {
 
     # Grafana WebSocket for Live features
     location /grafana/api/live/ {
-        proxy_pass $$grafana_backend;
+        proxy_pass $grafana_backend;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $$http_upgrade;
+        proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $$http_host;
-        proxy_set_header X-Real-IP $$remote_addr;
-        proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $$scheme;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 86400s;
         proxy_send_timeout 86400s;
     }
 
     # SPA routing - serve index.html for all unmatched routes
     location / {
-        try_files $$uri $$uri/ /index.html;
+        try_files $uri $uri/ /index.html;
     }
 
     # API proxy (Swagger UI requires unsafe-eval + unsafe-inline for JS rendering)
     location /api/ {
-        proxy_pass $$api_backend/;
+        proxy_pass $api_backend/;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $$http_upgrade;
+        proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $$host;
-        proxy_set_header X-Real-IP $$remote_addr;
-        proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $$scheme;
-        proxy_cache_bypass $$http_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://fastapi.tiangolo.com; font-src 'self' data:; connect-src 'self'" always;
     }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `envsubst` does NOT support `$$` as escape — `$$var` becomes `$` + empty string (not `$var`). Without `NGINX_ENVSUBST_FILTER`, envsubst replaces ALL `$var` references including nginx variables (`$uri`, `$host`, `$http_upgrade`) with empty strings → `invalid variable name` crash.
- **Fix**: Custom `19-envsubst-custom.sh` with explicit filter that only substitutes our 4 env vars (`API_BACKEND_URL`, `LOGS_BACKEND_URL`, `GRAFANA_BACKEND_URL`, `DNS_RESOLVER`). Template moved to `/etc/nginx/custom-templates/` so the built-in `20-envsubst-on-templates.sh` has nothing to process.
- Template reverted to normal nginx `$var` syntax (no `$$`)

## Test plan

- [ ] CI builds Docker image successfully
- [ ] Deploy to EKS — control-plane-ui pod reaches `Running` status
- [ ] console.gostoa.dev returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)