### PR TITLE
fix(ci): exclude test files from tsc build for Docker

### DIFF
--- a/control-plane-ui/package.json
+++ b/control-plane-ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc -p tsconfig.app.json && vite build",
     "preview": "vite preview",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 93",
     "test": "vitest run",

--- a/control-plane-ui/tsconfig.app.json
+++ b/control-plane-ui/tsconfig.app.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/__tests__"]
+}

--- a/portal/package.json
+++ b/portal/package.json
@@ -6,7 +6,7 @@
   "description": "STOA Developer Portal - Self-service portal for API consumers",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc -p tsconfig.app.json && vite build",
     "preview": "vite preview",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 20",
     "lint:fix": "eslint src --ext ts,tsx --fix",

--- a/portal/tsconfig.app.json
+++ b/portal/tsconfig.app.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/__tests__"]
+}


### PR DESCRIPTION
## Summary

- Docker builds for **control-plane-ui** and **portal** fail because `tsc` compiles `contract.test.ts` which imports `../../../control-plane-api/openapi-snapshot.json` — a path outside the Docker build context
- Add `tsconfig.app.json` to both components that extends `tsconfig.json` but excludes test files (`*.test.ts`, `*.test.tsx`, `__tests__/`)
- Update build script from `tsc && vite build` to `tsc -p tsconfig.app.json && vite build`

## Test plan

- [x] `npm run build` passes locally for control-plane-ui
- [x] `npm run build` passes locally for portal
- [x] Tests still run (vitest uses its own TS handling, not tsconfig.app.json)
- [ ] CI: Docker build should now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)