### PR TITLE
fix(e2e): skip @wip features in bddgen to fix smoke test

### DIFF
--- a/e2e/features/demo-showcase.feature
+++ b/e2e/features/demo-showcase.feature
@@ -1,4 +1,4 @@
-@demo @showcase @critical
+@demo @showcase @critical @wip
 Feature: Demo Showcase - Ready Player One Demo Scenarios
 
   As a STOA Platform presenter

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -8,6 +8,7 @@ const testDir = defineBddConfig({
   features: 'features/**/*.feature',
   steps: 'steps/**/*.ts',
   importTestFrom: 'fixtures/test-base.ts',
+  tags: 'not @wip',
 });
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

- Smoke test fails at `bddgen` step with **75 missing step definitions** from `demo-showcase.feature`
- This feature file contains aspirational demo scenarios with no step implementations
- Fix: tag it `@wip` and add `tags: 'not @wip'` to `defineBddConfig` in `playwright.config.ts`
- `bddgen` now completes successfully, unblocking the smoke test pipeline

## Test plan

- [x] `npm run bddgen` passes locally (no missing step definitions)
- [ ] CI: smoke test should get past the `Setup E2E environment` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)