### PR TITLE
feat(gateway): wire CAB-1105 phases 1-4 into request pipeline

### DIFF
--- a/stoa-gateway/src/main.rs
+++ b/stoa-gateway/src/main.rs
@@ -99,8 +99,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Start background tasks
     state.start_background_tasks();
 
-    // Initialize Kafka metering (Phase 3: CAB-1105)
-    let _metering = init_metering(&config);
+    // Kafka metering is now initialized inside AppState::new() (Phase 3: CAB-1105)
 
     // Initialize K8s CRD watcher (Phase 7: CAB-1105)
     init_k8s_watcher(&config, &state).await;
@@ -341,44 +340,6 @@ async fn shutdown_signal() {
     tokio::select! {
         _ = ctrl_c => info!("Received Ctrl+C, initiating shutdown..."),
         _ = terminate => info!("Received SIGTERM, initiating shutdown..."),
-    }
-}
-
-// === Metering Initialization (Phase 3: CAB-1105) ===
-
-/// Initialize Kafka metering producer
-///
-/// Returns `Some(producer)` if metering is enabled and Kafka is reachable.
-/// Returns `None` if disabled or Kafka is unavailable (graceful degradation).
-fn init_metering(config: &Config) -> Option<std::sync::Arc<metering::MeteringProducer>> {
-    if !config.kafka_enabled {
-        info!("Kafka metering disabled (STOA_KAFKA_ENABLED=false)");
-        return None;
-    }
-
-    let kafka_config = metering::KafkaConfig {
-        brokers: config.kafka_brokers.clone(),
-        metering_topic: config.kafka_metering_topic.clone(),
-        errors_topic: config.kafka_errors_topic.clone(),
-        enabled: true,
-    };
-
-    let producer_config = metering::MeteringProducerConfig::from(&kafka_config);
-
-    match metering::MeteringProducer::new(producer_config) {
-        Ok(producer) => {
-            info!(
-                brokers = %config.kafka_brokers,
-                metering_topic = %config.kafka_metering_topic,
-                errors_topic = %config.kafka_errors_topic,
-                "Kafka metering enabled"
-            );
-            Some(std::sync::Arc::new(producer))
-        }
-        Err(e) => {
-            warn!(error = %e, "Kafka metering initialization failed — metering disabled");
-            None
-        }
     }
 }
 

--- a/stoa-gateway/src/mcp/handlers.rs
+++ b/stoa-gateway/src/mcp/handlers.rs
@@ -1,6 +1,12 @@
 //! MCP REST Handlers
 //!
-//! REST-style endpoints for MCP tools (backward compat with non-SSE clients)
+//! REST-style endpoints for MCP tools (backward compat with non-SSE clients).
+//!
+//! Integrates all 4 CAB-1105 phases:
+//! - Phase 1: JWT auth extraction → real user context flows to native tools
+//! - Phase 2: OPA policy evaluation with real scopes/roles
+//! - Phase 3: Kafka metering emission after every tool call
+//! - Phase 4: Token optimization on responses (via X-Token-Optimization header)
 
 use axum::{
     extract::State,
@@ -13,8 +19,13 @@ use serde_json::Value;
 use std::time::Instant;
 use tracing::{debug, error, instrument, warn};
 
+use crate::auth::jwt::JwtValidator;
 use crate::mcp::tools::{ToolContext, ToolDefinition};
+use crate::metering::{
+    ErrorSnapshot, EventStatus, GatewaySnapshot, MeteringProducerTrait, ToolCallEvent,
+};
 use crate::metrics;
+use crate::optimization::{OptimizationLevel, OptimizationSettings, TokenOptimizer};
 use crate::state::AppState;
 
 // === Request/Response Types ===
@@ -54,6 +65,119 @@ pub enum ToolContent {
     Text { text: String },
 }
 
+// === Authentication Context (Phase 1) ===
+
+/// Extracted authentication context from request headers
+struct AuthContext {
+    user_id: Option<String>,
+    user_email: Option<String>,
+    tenant_id: String,
+    roles: Vec<String>,
+    scopes: Vec<String>,
+    raw_token: Option<String>,
+}
+
+/// Extract and validate JWT from Authorization header (Phase 1: CAB-1105)
+///
+/// Flow:
+/// 1. Extract Bearer token from Authorization header
+/// 2. Validate JWT via Keycloak JWKS (RS256)
+/// 3. Extract claims (user_id, email, roles, scopes)
+/// 4. Expand role-based scopes (ADR-012)
+/// 5. Fallback to unauthenticated context if no JWT or validation fails
+async fn extract_auth_context(state: &AppState, headers: &HeaderMap) -> AuthContext {
+    let tenant_from_header = extract_tenant(headers);
+    let user_from_header = extract_user(headers);
+
+    // Try to extract and validate JWT
+    if let Some(auth_header) = headers.get("Authorization").and_then(|v| v.to_str().ok()) {
+        if let Some(validator) = &state.jwt_validator {
+            if let Ok(token_str) = JwtValidator::extract_token(auth_header) {
+                match validator.validate(token_str).await {
+                    Ok(claims) => {
+                        let roles: Vec<String> =
+                            claims.realm_roles().iter().map(|s| s.to_string()).collect();
+                        let mut scopes: Vec<String> =
+                            claims.scopes().iter().map(|s| s.to_string()).collect();
+
+                        // Expand role-based scopes (ADR-012 12-Scope Model)
+                        expand_role_scopes(&roles, &mut scopes);
+
+                        return AuthContext {
+                            user_id: Some(claims.sub.clone()),
+                            user_email: claims.email.clone(),
+                            tenant_id: claims
+                                .tenant_id()
+                                .map(|s| s.to_string())
+                                .or(tenant_from_header)
+                                .unwrap_or_else(|| "default".to_string()),
+                            roles,
+                            scopes,
+                            raw_token: Some(token_str.to_string()),
+                        };
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "JWT validation failed, using default context");
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback: unauthenticated with default read scope
+    AuthContext {
+        user_id: user_from_header,
+        user_email: None,
+        tenant_id: tenant_from_header.unwrap_or_else(|| "default".to_string()),
+        roles: vec![],
+        scopes: vec!["stoa:read".to_string()],
+        raw_token: None,
+    }
+}
+
+/// Expand STOA roles to OAuth scopes (ADR-012 12-Scope Model)
+///
+/// Maps Keycloak realm roles to granular STOA scopes:
+/// - cpi-admin → all 6 scopes (admin, read, write, execute, deploy, audit)
+/// - tenant-admin → read, write, execute
+/// - devops → read, write, deploy
+/// - viewer → read only
+fn expand_role_scopes(roles: &[String], scopes: &mut Vec<String>) {
+    for role in roles {
+        let extra = match role.as_str() {
+            "cpi-admin" | "cpi_admin" | "admin" => vec![
+                "stoa:admin",
+                "stoa:read",
+                "stoa:write",
+                "stoa:execute",
+                "stoa:deploy",
+                "stoa:audit",
+            ],
+            "tenant-admin" | "tenant_admin" => {
+                vec!["stoa:read", "stoa:write", "stoa:execute"]
+            }
+            "devops" | "dev-ops" => vec!["stoa:read", "stoa:write", "stoa:deploy"],
+            "viewer" | "read-only" | "readonly" => vec!["stoa:read"],
+            _ => vec![],
+        };
+        for s in extra {
+            let s = s.to_string();
+            if !scopes.contains(&s) {
+                scopes.push(s);
+            }
+        }
+    }
+}
+
+/// Extract token optimization level from request header (Phase 4)
+fn extract_optimization_level(headers: &HeaderMap) -> OptimizationLevel {
+    headers
+        .get("X-Token-Optimization")
+        .and_then(|v| v.to_str().ok())
+        .map(OptimizationLevel::from_str)
+        .unwrap_or(OptimizationLevel::None)
+}
+
 // === Handlers ===
 
 /// POST /mcp/tools/list - List available tools
@@ -63,43 +187,69 @@ pub async fn mcp_tools_list(
     headers: HeaderMap,
     Json(_request): Json<ToolsListRequest>,
 ) -> impl IntoResponse {
-    let tenant_id = extract_tenant(&headers).unwrap_or_else(|| "default".to_string());
+    let auth = extract_auth_context(&state, &headers).await;
 
-    debug!(tenant_id = %tenant_id, "Listing MCP tools");
+    debug!(tenant_id = %auth.tenant_id, "Listing MCP tools");
 
-    let tools = state.tool_registry.list(Some(&tenant_id));
+    let tools = state.tool_registry.list(Some(&auth.tenant_id));
 
     Json(ToolsListResponse {
         tools,
-        next_cursor: None, // Pagination not implemented yet
+        next_cursor: None,
     })
 }
 
 /// POST /mcp/tools/call - Execute a tool
+///
+/// Full execution pipeline (CAB-1105 Phases 1-4):
+/// 1. JWT auth extraction (Phase 1)
+/// 2. Rate limit check
+/// 3. OPA policy evaluation (Phase 2)
+/// 4. Tool execution
+/// 5. Metering emission (Phase 3)
+/// 6. Token optimization (Phase 4)
 #[instrument(name = "mcp.tools.call", skip(state, headers, request), fields(otel.kind = "server"))]
 pub async fn mcp_tools_call(
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(request): Json<ToolsCallRequest>,
 ) -> impl IntoResponse {
-    let tenant_id = extract_tenant(&headers).unwrap_or_else(|| "default".to_string());
+    let start = Instant::now();
     let request_id = uuid::Uuid::new_v4().to_string();
+    let request_size = serde_json::to_string(&request.arguments)
+        .map(|s| s.len() as u64)
+        .unwrap_or(0);
+
+    // Phase 1: Extract JWT auth context
+    let auth = extract_auth_context(&state, &headers).await;
+    let t_auth = start.elapsed();
 
     debug!(
-        tenant_id = %tenant_id,
+        tenant_id = %auth.tenant_id,
         tool = %request.name,
         request_id = %request_id,
+        user = ?auth.user_id,
+        scopes = ?auth.scopes,
         "Executing MCP tool"
     );
-
-    let start = Instant::now();
 
     // Get tool from registry
     let tool = match state.tool_registry.get(&request.name) {
         Some(t) => t,
         None => {
             warn!(tool = %request.name, "Tool not found");
-            metrics::record_tool_call(&request.name, &tenant_id, "not_found", 0.0);
+            metrics::record_tool_call(&request.name, &auth.tenant_id, "not_found", 0.0);
+            emit_metering_event(
+                &state,
+                &auth,
+                &request.name,
+                "Read",
+                EventStatus::NotFound,
+                start,
+                0,
+                request_size,
+                0,
+            );
             return (
                 StatusCode::NOT_FOUND,
                 Json(ToolsCallResponse {
@@ -113,10 +263,21 @@ pub async fn mcp_tools_call(
     };
 
     // Check rate limit
-    let rate_result = state.rate_limiter.check(&tenant_id);
+    let rate_result = state.rate_limiter.check(&auth.tenant_id);
     if !rate_result.allowed {
-        warn!(tenant_id = %tenant_id, "Rate limit exceeded");
-        metrics::record_rate_limit_hit(&tenant_id);
+        warn!(tenant_id = %auth.tenant_id, "Rate limit exceeded");
+        metrics::record_rate_limit_hit(&auth.tenant_id);
+        emit_metering_event(
+            &state,
+            &auth,
+            &request.name,
+            &format!("{:?}", tool.required_action()),
+            EventStatus::RateLimited,
+            start,
+            0,
+            request_size,
+            0,
+        );
         return (
             StatusCode::TOO_MANY_REQUESTS,
             Json(ToolsCallResponse {
@@ -128,19 +289,20 @@ pub async fn mcp_tools_call(
         );
     }
 
-    // Build context
+    // Build tool context with real JWT claims (Phase 1)
     let ctx = ToolContext {
-        tenant_id: tenant_id.clone(),
-        user_id: extract_user(&headers),
-        user_email: None,
+        tenant_id: auth.tenant_id.clone(),
+        user_id: auth.user_id.clone(),
+        user_email: auth.user_email.clone(),
         request_id,
-        roles: vec![],
-        scopes: vec!["stoa:read".to_string()], // Default scope for REST endpoints
-        raw_token: None,
+        roles: auth.roles.clone(),
+        scopes: auth.scopes.clone(),
+        raw_token: auth.raw_token.clone(),
     };
 
-    // Check UAC permission using OPA policy engine (Phase 2: CAB-1105)
+    // Phase 2: OPA policy evaluation with real scopes/roles
     let required_action = tool.required_action();
+    let t_policy_start = Instant::now();
     if let Err(e) = state.uac_enforcer.check_with_context(
         ctx.user_id.clone(),
         ctx.user_email.clone(),
@@ -150,12 +312,24 @@ pub async fn mcp_tools_call(
         ctx.scopes.clone(),
         ctx.roles.clone(),
     ) {
+        let t_gateway = start.elapsed().as_millis() as u64;
         warn!(
             tool = %request.name,
             action = ?required_action,
-            tenant = %tenant_id,
+            tenant = %auth.tenant_id,
             "UAC policy denied: {}",
             e
+        );
+        emit_metering_event(
+            &state,
+            &auth,
+            &request.name,
+            &format!("{:?}", required_action),
+            EventStatus::PolicyDenied,
+            start,
+            t_gateway,
+            request_size,
+            0,
         );
         return (
             StatusCode::FORBIDDEN,
@@ -167,36 +341,112 @@ pub async fn mcp_tools_call(
             }),
         );
     }
+    let t_policy = t_policy_start.elapsed();
 
-    // Execute tool
+    // Execute tool (measure backend time separately)
+    let t_backend_start = Instant::now();
     match tool.execute(request.arguments, &ctx).await {
         Ok(result) => {
-            let duration = start.elapsed().as_secs_f64();
-            metrics::record_tool_call(&request.name, &tenant_id, "success", duration);
+            let duration = start.elapsed();
+            let duration_secs = duration.as_secs_f64();
+            let t_gateway_ms = (t_auth + t_policy).as_millis() as u64;
+
+            metrics::record_tool_call(&request.name, &auth.tenant_id, "success", duration_secs);
+
+            // Build response content
+            let content: Vec<ToolContent> = result
+                .content
+                .into_iter()
+                .map(|c| match c {
+                    crate::mcp::tools::ToolContent::Text { text } => ToolContent::Text { text },
+                    _ => ToolContent::Text {
+                        text: "[unsupported content type]".to_string(),
+                    },
+                })
+                .collect();
+
+            // Phase 4: Apply token optimization if requested
+            let opt_level = extract_optimization_level(&headers);
+            let content = if opt_level != OptimizationLevel::None {
+                let optimizer = TokenOptimizer::new(OptimizationSettings {
+                    level: opt_level,
+                    ..Default::default()
+                });
+                content
+                    .into_iter()
+                    .map(|c| match c {
+                        ToolContent::Text { text } => {
+                            let (optimized, _stats) = optimizer.optimize_string(&text);
+                            ToolContent::Text { text: optimized }
+                        }
+                    })
+                    .collect()
+            } else {
+                content
+            };
+
+            let response_size = serde_json::to_string(&content)
+                .map(|s| s.len() as u64)
+                .unwrap_or(0);
+
+            // Phase 3: Emit metering event
+            emit_metering_event(
+                &state,
+                &auth,
+                &request.name,
+                &format!("{:?}", required_action),
+                EventStatus::Success,
+                start,
+                t_gateway_ms,
+                request_size,
+                response_size,
+            );
 
             (
                 StatusCode::OK,
                 Json(ToolsCallResponse {
-                    content: result
-                        .content
-                        .into_iter()
-                        .map(|c| match c {
-                            crate::mcp::tools::ToolContent::Text { text } => {
-                                ToolContent::Text { text }
-                            }
-                            _ => ToolContent::Text {
-                                text: "[unsupported content type]".to_string(),
-                            },
-                        })
-                        .collect(),
+                    content,
                     is_error: result.is_error,
                 }),
             )
         }
         Err(e) => {
-            let duration = start.elapsed().as_secs_f64();
+            let t_backend = t_backend_start.elapsed();
+            let duration = start.elapsed();
+            let t_gateway_ms = (t_auth + t_policy).as_millis() as u64;
+            let t_backend_ms = t_backend.as_millis() as u64;
+
             error!(tool = %request.name, error = %e, "Tool execution failed");
-            metrics::record_tool_call(&request.name, &tenant_id, "error", duration);
+            metrics::record_tool_call(
+                &request.name,
+                &auth.tenant_id,
+                "error",
+                duration.as_secs_f64(),
+            );
+
+            // Phase 3: Emit error metering event + error snapshot
+            emit_metering_event(
+                &state,
+                &auth,
+                &request.name,
+                &format!("{:?}", required_action),
+                EventStatus::Error,
+                start,
+                t_gateway_ms,
+                request_size,
+                0,
+            );
+            emit_error_snapshot(
+                &state,
+                &auth,
+                &request.name,
+                &format!("{:?}", required_action),
+                &e.to_string(),
+                500,
+                start,
+                t_gateway_ms,
+                t_backend_ms,
+            );
 
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -208,6 +458,83 @@ pub async fn mcp_tools_call(
                 }),
             )
         }
+    }
+}
+
+// === Phase 3: Metering Emission ===
+
+/// Emit a metering event (non-blocking, fire-and-forget)
+#[allow(clippy::too_many_arguments)]
+fn emit_metering_event(
+    state: &AppState,
+    auth: &AuthContext,
+    tool_name: &str,
+    action: &str,
+    status: EventStatus,
+    start: Instant,
+    t_gateway_ms: u64,
+    request_size: u64,
+    response_size: u64,
+) {
+    if let Some(ref producer) = state.metering_producer {
+        let latency_ms = start.elapsed().as_millis() as u64;
+        let t_backend_ms = latency_ms.saturating_sub(t_gateway_ms);
+
+        let event = ToolCallEvent::new(
+            auth.tenant_id.clone(),
+            tool_name.to_string(),
+            action.to_string(),
+        )
+        .with_user(auth.user_id.clone(), auth.user_email.clone())
+        .with_timing(latency_ms, t_gateway_ms, t_backend_ms)
+        .with_status(status)
+        .with_sizes(request_size, response_size)
+        .with_auth(auth.scopes.clone(), auth.roles.clone());
+
+        producer.send_metering_event(event);
+    }
+}
+
+/// Emit an error snapshot (non-blocking, fire-and-forget)
+#[allow(clippy::too_many_arguments)]
+fn emit_error_snapshot(
+    state: &AppState,
+    auth: &AuthContext,
+    tool_name: &str,
+    action: &str,
+    error_message: &str,
+    response_status: u16,
+    start: Instant,
+    t_gateway_ms: u64,
+    t_backend_ms: u64,
+) {
+    if let Some(ref producer) = state.metering_producer {
+        let latency_ms = start.elapsed().as_millis() as u64;
+
+        let event = ToolCallEvent::new(
+            auth.tenant_id.clone(),
+            tool_name.to_string(),
+            action.to_string(),
+        )
+        .with_user(auth.user_id.clone(), auth.user_email.clone())
+        .with_timing(latency_ms, t_gateway_ms, t_backend_ms)
+        .with_status(EventStatus::Error);
+
+        let snapshot = ErrorSnapshot::from_event(
+            event,
+            "ToolExecutionError".to_string(),
+            error_message.to_string(),
+            response_status,
+        )
+        .with_request("/mcp/tools/call".to_string(), "POST".to_string())
+        .with_gateway_state(GatewaySnapshot {
+            active_sessions: state.session_manager.count() as u64,
+            uptime_secs: 0, // TODO: track gateway uptime
+            rate_limit_buckets: 0,
+            memory_rss_bytes: None,
+        });
+
+        producer.send_error_snapshot(snapshot);
     }
 }
 

--- a/stoa-gateway/src/metering/mod.rs
+++ b/stoa-gateway/src/metering/mod.rs
@@ -25,7 +25,7 @@ mod events;
 mod producer;
 
 pub use events::{ErrorSnapshot, EventStatus, GatewaySnapshot, ToolCallEvent};
-pub use producer::{MeteringProducer, MeteringProducerConfig};
+pub use producer::{MeteringProducer, MeteringProducerConfig, MeteringProducerTrait};
 
 /// Kafka configuration for metering
 #[derive(Debug, Clone)]

--- a/stoa-gateway/src/state.rs
+++ b/stoa-gateway/src/state.rs
@@ -12,6 +12,7 @@ use crate::config::Config;
 use crate::control_plane::{OidcConfig, ToolProxyClient};
 use crate::mcp::session::SessionManager;
 use crate::mcp::tools::ToolRegistry;
+use crate::metering::{KafkaConfig, MeteringProducer, MeteringProducerConfig};
 use crate::policy::{PolicyDecision, PolicyEngine, PolicyEngineConfig, PolicyInput};
 use crate::rate_limit::RateLimiter;
 use crate::resilience::{CircuitBreaker, CircuitBreakerConfig};
@@ -37,6 +38,9 @@ pub struct AppState {
     pub semantic_cache: Arc<SemanticCache>,
     /// Circuit breaker for Control Plane API calls (Phase 6)
     pub cp_circuit_breaker: Arc<CircuitBreaker>,
+    /// Kafka metering producer (Phase 3: CAB-1105)
+    /// None if Kafka metering is disabled or unavailable.
+    pub metering_producer: Option<Arc<MeteringProducer>>,
 }
 
 impl AppState {
@@ -138,6 +142,33 @@ impl AppState {
         let cp_circuit_breaker = CircuitBreaker::new("cp-api", CircuitBreakerConfig::default());
         tracing::info!("Circuit breaker initialized for CP API");
 
+        // Initialize Kafka metering producer (Phase 3: CAB-1105)
+        let metering_producer = if config.kafka_enabled {
+            let kafka_config = KafkaConfig {
+                brokers: config.kafka_brokers.clone(),
+                metering_topic: config.kafka_metering_topic.clone(),
+                errors_topic: config.kafka_errors_topic.clone(),
+                enabled: true,
+            };
+            let producer_config = MeteringProducerConfig::from(&kafka_config);
+            match MeteringProducer::new(producer_config) {
+                Ok(producer) => {
+                    tracing::info!(
+                        brokers = %config.kafka_brokers,
+                        "Kafka metering producer initialized"
+                    );
+                    Some(Arc::new(producer))
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Kafka metering initialization failed");
+                    None
+                }
+            }
+        } else {
+            tracing::info!("Kafka metering disabled (STOA_KAFKA_ENABLED=false)");
+            None
+        };
+
         Self {
             config,
             tool_registry,
@@ -151,6 +182,7 @@ impl AppState {
             jwt_validator,
             semantic_cache,
             cp_circuit_breaker,
+            metering_producer,
         }
     }
 


### PR DESCRIPTION
## Summary

Wire all 4 CAB-1105 phases into the `mcp_tools_call` handler, connecting existing modules into the live request pipeline:

- **Phase 1 — JWT Auth → Native Tools**: Extract and validate JWT from `Authorization` header via JWKS, flow real user context (`user_id`, `email`, `tenant`, `roles`, `scopes`) into `ToolContext` for native tool execution
- **Phase 2 — OPA Policy Engine**: Evaluate OPA policy with real JWT claims and ADR-012 role-to-scope expansion (`cpi-admin` → all scopes, `tenant-admin` → read+write+execute). Enforce before tool execution
- **Phase 3 — Kafka Metering + Error Snapshots**: Emit `ToolCallEvent` on **every** outcome (success, error, rate_limited, policy_denied, not_found) with zero-blind-spot timing breakdown (`t_gateway_ms`, `t_backend_ms`). Emit `ErrorSnapshot` with `GatewaySnapshot` on errors
- **Phase 4 — Token Optimization**: Apply 4-stage pipeline (null removal, schema pruning, key shortening, pagination injection) on responses when `X-Token-Optimization: moderate|aggressive` header is present

### Files changed (4)

| File | Change |
|------|--------|
| `stoa-gateway/src/mcp/handlers.rs` | Main pipeline rewrite — `AuthContext`, `extract_auth_context()`, `expand_role_scopes()`, metering helpers |
| `stoa-gateway/src/state.rs` | Added `metering_producer: Option<Arc<MeteringProducer>>` field + initialization in `AppState::new()` |
| `stoa-gateway/src/main.rs` | Removed dead `init_metering()` function (now in AppState) |
| `stoa-gateway/src/metering/mod.rs` | Re-export `MeteringProducerTrait` for use outside module |

## Test plan

- [x] `cargo check` — clean compilation, 0 warnings
- [x] `cargo test` — 214 tests pass, 0 failures
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI pipeline (stoa-gateway-ci.yml)
- [ ] Integration test with Keycloak JWT (manual, EKS)
- [ ] Verify metering events in Kafka topic (manual, with `STOA_KAFKA_ENABLED=true`)
- [ ] Verify token optimization with `curl -H "X-Token-Optimization: aggressive"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)