### PR TITLE
chore: add CS agent prompts for CAB-1103/CAB-1105

### DIFF
--- a/.claude/prompts/cab-1103-6a-ci-hardening.md
+++ b/.claude/prompts/cab-1103-6a-ci-hardening.md
@@ -1,0 +1,42 @@
+CAB-1103 Phase 6A: CI Hardening — zero tolerance sur les erreurs silencieuses.
+
+Branch: `feat/cab-1103-6a-ci-hardening` (creer depuis main)
+
+## Contexte
+Le CI a des `|| true` qui masquent des erreurs. Les charts Helm ne sont pas valides en CI. Les seuils de coverage ne sont pas enforces partout.
+
+## Taches
+
+### 1. Supprimer tous les `|| true` des workflows
+- Scanner `.github/workflows/*.yml` pour `|| true`, `|| echo`, `continue-on-error: true`
+- Supprimer chaque occurrence sauf si documentee comme intentionnelle (ex: `kubectl delete --ignore-not-found`)
+- Pour les steps qui echouent legitimement (dependency-review, container scan), utiliser `continue-on-error` avec un commentaire expliquant pourquoi
+
+### 2. Ajouter `helm lint` dans le CI
+- Creer ou modifier `.github/workflows/helm-ci.yml`
+- Step: `helm lint charts/stoa-platform/`
+- Trigger: push/PR qui modifie `charts/**`
+- S'assurer que le chart lint passe: `cd charts/stoa-platform && helm lint .`
+- Fixer les erreurs de lint si necessaire
+
+### 3. Enforcer les seuils de coverage
+- `control-plane-ui/`: verifier que `vitest.config.ts` a `coverage.thresholds` (doit etre ~50%)
+- `portal/`: verifier le seuil (doit etre ~70%)
+- `control-plane-api/`: verifier `pyproject.toml` `[tool.pytest.ini_options]` `--cov-fail-under` (doit etre 53)
+- S'assurer que les CI workflows utilisent `npm run test:coverage` (pas juste `npm test`)
+
+### 4. Valider
+- `grep -r '|| true' .github/workflows/` doit retourner 0 resultats (hors commentaires)
+- `helm lint charts/stoa-platform/` doit passer
+- Les 3 coverage thresholds sont configures et documentes
+
+## DoD
+- [ ] Zero `|| true` dans les workflow files (sauf exceptions documentees)
+- [ ] `helm lint charts/stoa-platform/` passe
+- [ ] Coverage thresholds enforces: console-ui 50%, portal 70%, api 53%
+- [ ] Commit: `ci: harden CI pipelines and enforce coverage thresholds (CAB-1103)`
+
+## Contraintes
+- Ne PAS toucher au code applicatif (src/)
+- Ne PAS modifier les seuils de coverage a la baisse
+- Ne PAS push

--- a/.claude/prompts/cab-1103-6b-monitoring-oidc.md
+++ b/.claude/prompts/cab-1103-6b-monitoring-oidc.md
@@ -1,0 +1,124 @@
+CAB-1103 Phase 6B: Monitoring OIDC — Grafana + Prometheus authentifies via Keycloak.
+
+Branch: `feat/cab-1103-6b-monitoring-oidc` (creer depuis main)
+
+## Contexte
+Grafana et Prometheus sont accessibles sans auth ou avec auth basique. On veut les proteger via OIDC (Keycloak).
+Keycloak admin: voir `.env` a la racine du repo pour les credentials (auth.gostoa.dev).
+
+## Architecture
+```
+Grafana   ──OIDC──→  Keycloak (auth.gostoa.dev, realm: stoa)
+Prometheus ──oauth2-proxy──→  Keycloak
+AlertManager → Slack webhooks (routing par severite)
+```
+
+## Taches
+
+### 1. Creer le client Keycloak `stoa-observability`
+Via l'Admin REST API de Keycloak:
+```bash
+# 1. Obtenir un token admin
+TOKEN=$(curl -s -X POST "https://auth.gostoa.dev/realms/master/protocol/openid-connect/token" \
+  -d "grant_type=password&client_id=admin-cli&username=admin&password=demo" | jq -r '.access_token')
+
+# 2. Creer le client
+curl -s -X POST "https://auth.gostoa.dev/admin/realms/stoa/clients" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "clientId": "stoa-observability",
+    "name": "STOA Observability",
+    "enabled": true,
+    "protocol": "openid-connect",
+    "publicClient": false,
+    "standardFlowEnabled": true,
+    "directAccessGrantsEnabled": false,
+    "redirectUris": [
+      "https://grafana.gostoa.dev/login/generic_oauth",
+      "https://grafana.gostoa.dev/*",
+      "http://localhost:3001/login/generic_oauth"
+    ],
+    "webOrigins": ["https://grafana.gostoa.dev", "http://localhost:3001"]
+  }'
+
+# 3. Recuperer le client secret
+CLIENT_ID=$(curl -s "https://auth.gostoa.dev/admin/realms/stoa/clients?clientId=stoa-observability" \
+  -H "Authorization: Bearer $TOKEN" | jq -r '.[0].id')
+curl -s "https://auth.gostoa.dev/admin/realms/stoa/clients/$CLIENT_ID/client-secret" \
+  -H "Authorization: Bearer $TOKEN" | jq -r '.value'
+```
+
+### 2. Configurer Grafana OIDC
+Fichier: `deploy/docker-compose/docker-compose.yml` (section grafana) ou `charts/stoa-platform/values.yaml`
+
+Variables d'environnement Grafana:
+```yaml
+GF_AUTH_GENERIC_OAUTH_ENABLED: "true"
+GF_AUTH_GENERIC_OAUTH_NAME: "STOA SSO"
+GF_AUTH_GENERIC_OAUTH_CLIENT_ID: "stoa-observability"
+GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: "<secret from step 1>"
+GF_AUTH_GENERIC_OAUTH_SCOPES: "openid profile email"
+GF_AUTH_GENERIC_OAUTH_AUTH_URL: "https://auth.gostoa.dev/realms/stoa/protocol/openid-connect/auth"
+GF_AUTH_GENERIC_OAUTH_TOKEN_URL: "https://auth.gostoa.dev/realms/stoa/protocol/openid-connect/token"
+GF_AUTH_GENERIC_OAUTH_API_URL: "https://auth.gostoa.dev/realms/stoa/protocol/openid-connect/userinfo"
+GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: "contains(roles[*], 'stoa:admin') && 'Admin' || 'Viewer'"
+GF_AUTH_GENERIC_OAUTH_ALLOW_ASSIGN_GRAFANA_ADMIN: "true"
+GF_SERVER_ROOT_URL: "https://grafana.gostoa.dev"
+GF_SERVER_SERVE_FROM_SUB_PATH: "true"
+GF_SECURITY_ALLOW_EMBEDDING: "true"
+```
+
+### 3. Configurer oauth2-proxy pour Prometheus
+Fichier: `deploy/docker-compose/docker-compose.yml` ou creer `deploy/docker-compose/oauth2-proxy.yml`
+- Image: `quay.io/oauth2-proxy/oauth2-proxy:v7.6.0`
+- Provider: `keycloak-oidc`
+- upstream: `http://prometheus:9090`
+- Ajouter dans Helm values si applicable
+
+### 4. AlertManager routing
+Fichier: `deploy/docker-compose/alertmanager/alertmanager.yml` ou `charts/stoa-platform/templates/alertmanager-config.yaml`
+
+```yaml
+route:
+  receiver: 'default'
+  routes:
+    - match:
+        severity: critical
+      receiver: 'slack-incidents'
+    - match:
+        severity: warning
+      receiver: 'slack-alerts'
+
+receivers:
+  - name: 'default'
+    slack_configs:
+      - api_url: '${SLACK_WEBHOOK_URL}'
+        channel: '#alerts'
+  - name: 'slack-incidents'
+    slack_configs:
+      - api_url: '${SLACK_WEBHOOK_URL}'
+        channel: '#incidents'
+        title: 'CRITICAL: {{ .GroupLabels.alertname }}'
+  - name: 'slack-alerts'
+    slack_configs:
+      - api_url: '${SLACK_WEBHOOK_URL}'
+        channel: '#alerts'
+```
+
+### 5. Mettre a jour Helm values
+- `charts/stoa-platform/values.yaml`: section grafana.oidc, prometheus.oauth2proxy, alertmanager
+- S'assurer que les secrets sont references via K8s Secrets (pas en dur)
+
+## DoD
+- [ ] Client `stoa-observability` cree dans Keycloak realm stoa
+- [ ] Grafana configuree pour OIDC (docker-compose + Helm values)
+- [ ] oauth2-proxy configure pour Prometheus
+- [ ] AlertManager routing: critical → #incidents, warning → #alerts
+- [ ] Commit: `feat(monitoring): OIDC auth for Grafana/Prometheus + AlertManager routing (CAB-1103)`
+
+## Contraintes
+- Stocker le client secret dans `.env` local (gitignore) + K8s Secret reference dans Helm
+- Ne PAS hardcoder de secrets dans les fichiers trackes
+- Ne PAS push
+- Credentials Keycloak admin: lire `.env` a la racine

--- a/.claude/prompts/cab-1103-6c-e2e-expansion.md
+++ b/.claude/prompts/cab-1103-6c-e2e-expansion.md
@@ -1,0 +1,131 @@
+CAB-1103 Phase 6C: E2E Expansion — 20+ nouveaux scenarios Playwright BDD.
+
+Branch: `feat/cab-1103-6c-e2e-expansion` (creer depuis main)
+
+## Contexte
+81 scenarios E2E existent (PR #175). 100% route coverage (Console 26/26, Portal 16/16).
+Il manque les scenarios fonctionnels: Gateway CRUD, deployment lifecycle, RBAC admin, portal consumer flow.
+
+## Architecture E2E existante
+```
+e2e/
+├── features/           # Fichiers .feature (Gherkin)
+│   ├── console/        # Scenarios Console UI
+│   └── portal/         # Scenarios Portal
+├── steps/              # Step definitions
+├── fixtures/           # Auth fixtures (storageState)
+│   └── .auth/          # Fichiers auth JSON par persona
+├── playwright.config.ts
+└── package.json
+```
+
+Personas disponibles (storageState pattern):
+- `parzival` = cpi-admin (stoa:admin)
+- `sorrento` = tenant-admin (stoa:write, stoa:read) — verifier si existe, sinon creer le fixture
+- `art3mis` = viewer (stoa:read) — verifier si existe, sinon creer le fixture
+
+## Taches
+
+### 1. Explorer l'existant
+- Lire `e2e/features/console/` et `e2e/features/portal/` pour comprendre les patterns
+- Lire `e2e/fixtures/` pour les auth fixtures
+- Lire `e2e/playwright.config.ts` pour les projects et la config BDD
+- Lire `e2e/steps/` pour les step definitions existantes
+
+### 2. Gateway CRUD (~6 scenarios)
+Fichier: `e2e/features/console/gateway-crud.feature`
+
+```gherkin
+Feature: Gateway CRUD
+  As a platform admin
+  I want to manage gateway instances
+  So that I can control the data plane
+
+  @console @gateway
+  Scenario: Admin creates a new gateway instance
+  Scenario: Admin lists all gateway instances
+  Scenario: Admin views gateway details with status badge
+  Scenario: Admin updates gateway configuration
+  Scenario: Admin deletes a gateway instance
+  Scenario: Viewer cannot create or delete gateways
+```
+
+### 3. Deployment Lifecycle (~5 scenarios)
+Fichier: `e2e/features/console/deployment-lifecycle.feature`
+
+```gherkin
+Feature: Deployment Lifecycle
+  As a devops user
+  I want to deploy APIs to gateways
+  So that they are available to consumers
+
+  @console @deployment
+  Scenario: Deploy an API to a gateway
+  Scenario: Verify deployment appears in gateway details
+  Scenario: Verify sync status is SYNCED
+  Scenario: Undeploy an API from a gateway
+  Scenario: Deployment list shows correct status badges
+```
+
+### 4. Admin RBAC (~5 scenarios)
+Fichier: `e2e/features/console/admin-rbac.feature`
+
+```gherkin
+Feature: Admin RBAC
+  As different role users
+  I want appropriate access to console features
+  So that the platform is secure
+
+  @console @rbac
+  Scenario: Admin (parzival) sees all menu items
+  Scenario: Tenant admin (sorrento) sees limited menu
+  Scenario: Viewer (art3mis) sees read-only interface
+  Scenario: Viewer cannot access admin pages
+  Scenario: Tenant admin cannot modify other tenants
+```
+
+### 5. Portal Consumer Flow (~6 scenarios)
+Fichier: `e2e/features/portal/consumer-flow.feature`
+
+```gherkin
+Feature: Portal Consumer Flow
+  As a developer
+  I want to discover and subscribe to APIs
+  So that I can integrate them in my applications
+
+  @portal @consumer
+  Scenario: Browse API catalog
+  Scenario: View API details and documentation
+  Scenario: Subscribe to an API
+  Scenario: View subscription with API key
+  Scenario: Select gateway for subscription
+  Scenario: Revoke a subscription
+```
+
+### 6. Creer les step definitions
+- `e2e/steps/gateway-crud.steps.ts`
+- `e2e/steps/deployment-lifecycle.steps.ts`
+- `e2e/steps/admin-rbac.steps.ts`
+- `e2e/steps/consumer-flow.steps.ts`
+
+Suivre le pattern existant: `Given/When/Then` avec `page.goto()`, `page.click()`, `expect(page.locator(...))`.
+Utiliser les soft assertions (`expect.soft()`) — documenter les frictions, ne jamais bloquer.
+
+### 7. Verifier
+- `npx playwright test --list` doit montrer >= 20 nouveaux scenarios
+- Les features sont syntaxiquement correctes
+- Les steps sont implementes (meme si certains utilisent `test.skip` pour les fonctionnalites non encore deployees)
+
+## DoD
+- [ ] >= 20 nouveaux scenarios Playwright BDD
+- [ ] 4 fichiers .feature (gateway-crud, deployment-lifecycle, admin-rbac, consumer-flow)
+- [ ] 4 fichiers step definitions correspondants
+- [ ] Auth fixtures pour sorrento et art3mis si manquants
+- [ ] Commit: `test(e2e): add 22 gateway/deployment/RBAC/consumer scenarios (CAB-1103)`
+
+## Contraintes
+- Utiliser le pattern BDD existant (playwright-bdd + Gherkin)
+- Utiliser storageState pour l'auth (pas de login dans les tests)
+- Soft assertions partout (`expect.soft()`)
+- Marquer `@wip` les scenarios qui dependent de features non deployees
+- Ne PAS push

--- a/.claude/prompts/cab-1103-6d-test-loop.md
+++ b/.claude/prompts/cab-1103-6d-test-loop.md
@@ -1,0 +1,158 @@
+CAB-1103 Phase 6D: Test Loop Automation — smoke tests en CI + audit hebdo.
+
+Branch: `feat/cab-1103-6d-test-loop` (creer depuis main)
+
+## Contexte
+Les smoke tests existent (`e2e/`) mais ne sont pas integres dans le CI post-deploy.
+Pas d'audit de securite automatise periodique.
+
+## Taches
+
+### 1. Smoke test integration dans CI
+Modifier les workflows de deploy pour ajouter un step post-deploy:
+
+Fichier: `.github/workflows/reusable-k8s-deploy.yml` (ou les workflows specifiques)
+
+Ajouter un job `smoke-test` apres le job `deploy`:
+```yaml
+smoke-test:
+  needs: deploy
+  runs-on: ubuntu-latest
+  if: success()
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - name: Install dependencies
+      run: cd e2e && npm ci
+    - name: Install Playwright browsers
+      run: cd e2e && npx playwright install chromium --with-deps
+    - name: Run smoke tests
+      run: cd e2e && npx playwright test --grep @smoke
+      env:
+        BASE_URL: https://console.gostoa.dev
+        PORTAL_URL: https://portal.gostoa.dev
+      continue-on-error: true  # Smoke tests are informational post-deploy
+    - name: Upload smoke test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: smoke-test-results
+        path: e2e/test-results/
+```
+
+### 2. Ajouter `npm run test:smoke` dans `e2e/package.json`
+```json
+{
+  "scripts": {
+    "test:smoke": "npx playwright test --grep @smoke"
+  }
+}
+```
+Verifier que le script existe deja ou le creer.
+
+### 3. Weekly audit workflow
+Fichier: `.github/workflows/weekly-audit.yml`
+
+```yaml
+name: Weekly Security Audit
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'  # Lundi 8h UTC
+  workflow_dispatch:       # Declenchement manuel
+
+jobs:
+  python-audit:
+    name: Python Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install pip-audit
+        run: pip install pip-audit
+      - name: Audit control-plane-api
+        run: cd control-plane-api && pip-audit -r requirements.txt
+      - name: Audit mcp-gateway
+        run: cd mcp-gateway && pip-audit -r requirements.txt
+
+  node-audit:
+    name: Node Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Audit control-plane-ui
+        run: cd control-plane-ui && npm audit --audit-level=high
+      - name: Audit portal
+        run: cd portal && npm audit --audit-level=high
+      - name: Audit e2e
+        run: cd e2e && npm audit --audit-level=high
+
+  rust-audit:
+    name: Rust Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+      - name: Audit stoa-gateway
+        run: cd stoa-gateway && cargo audit
+
+  gitleaks:
+    name: Secrets Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  helm-lint:
+    name: Helm Chart Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+      - name: Lint charts
+        run: helm lint charts/stoa-platform/
+
+  report:
+    name: Audit Summary
+    needs: [python-audit, node-audit, rust-audit, gitleaks, helm-lint]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Summary
+        run: |
+          echo "## Weekly Audit Results" >> $GITHUB_STEP_SUMMARY
+          echo "- Python: ${{ needs.python-audit.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Node: ${{ needs.node-audit.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Rust: ${{ needs.rust-audit.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Gitleaks: ${{ needs.gitleaks.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Helm: ${{ needs.helm-lint.result }}" >> $GITHUB_STEP_SUMMARY
+```
+
+### 4. Verifier
+- Le workflow `weekly-audit.yml` est syntaxiquement valide
+- Le smoke test step est correctement integre dans le deploy pipeline
+- `npm run test:smoke` fonctionne dans `e2e/`
+
+## DoD
+- [ ] `npm run test:smoke` defini dans `e2e/package.json`
+- [ ] Smoke test step integre dans le CI post-deploy
+- [ ] `.github/workflows/weekly-audit.yml` cree (Python + Node + Rust + gitleaks + Helm)
+- [ ] Commit: `ci: add smoke test integration and weekly audit workflow (CAB-1103)`
+
+## Contraintes
+- Smoke tests en `continue-on-error: true` (informatifs, ne bloquent pas le deploy)
+- Weekly audit: declenche aussi manuellement (`workflow_dispatch`)
+- Ne PAS push

--- a/.claude/prompts/cab-1105-phase8-gateway-modes.md
+++ b/.claude/prompts/cab-1105-phase8-gateway-modes.md
@@ -1,0 +1,136 @@
+CAB-1105 Phase 8: 4-Mode Architecture + Shadow Discovery — capstone feature.
+
+Branch: `feat/cab-1105-gateway-modes` (creer depuis main, APRES merge de feat/cab-1105-kill-python)
+
+## Contexte
+Le stoa-gateway Rust supporte actuellement un seul mode (edge-mcp). On veut 4 modes dans un seul binaire,
+selectionne a runtime via `STOA_GATEWAY_MODE`. Le mode Shadow est le killer feature (decouverte automatique d'APIs).
+
+Prerequis: les Phases 1-7 (feat/cab-1105-kill-python) doivent etre mergees dans main avant de commencer.
+Lire `stoa-gateway/src/` pour comprendre la structure actuelle.
+
+## Architecture
+
+```
+STOA_GATEWAY_MODE=edge_mcp (default)  → Full MCP: SSE + auth + tools + metrics
+STOA_GATEWAY_MODE=sidecar             → Lightweight: auth + rate limit + metrics only
+STOA_GATEWAY_MODE=proxy               → Reverse proxy: route + policies, no MCP
+STOA_GATEWAY_MODE=shadow              → Passive: observe traffic, generate UAC YAML
+```
+
+## Taches
+
+### 1. Mode Module Structure
+Creer `stoa-gateway/src/mode/`:
+```
+mode/
+├── mod.rs          # ModeConfig enum + factory
+├── edge_mcp.rs     # Refactor: extraire le comportement actuel de main.rs
+├── sidecar.rs      # Auth + rate limit + metrics endpoints
+├── proxy.rs        # HTTP reverse proxy + policies
+└── shadow.rs       # Passive observation + UAC generation
+```
+
+### 2. ModeConfig enum (`mode/mod.rs`)
+```rust
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum GatewayMode {
+    #[default]
+    EdgeMcp,
+    Sidecar,
+    Proxy,
+    Shadow,
+}
+
+impl GatewayMode {
+    pub fn from_env() -> Self {
+        std::env::var("STOA_GATEWAY_MODE")
+            .ok()
+            .and_then(|s| serde_json::from_str(&format!("\"{}\"", s)).ok())
+            .unwrap_or_default()
+    }
+}
+```
+
+### 3. EdgeMcp mode (`mode/edge_mcp.rs`)
+- Extraire le code actuel de `main.rs` dans une fonction `pub async fn start(config: &AppConfig) -> Result<()>`
+- C'est le mode par defaut, doit etre 100% backward compatible
+- Inclut: SSE transport, MCP protocol, auth, tools, metering, OPA
+
+### 4. Sidecar mode (`mode/sidecar.rs`)
+- Lightweight: pas de MCP protocol, pas de tools
+- Endpoints: `/auth/verify` (ext_authz compatible), `/metrics`, `/health`
+- Auth: JWT validation, scope checking via OPA
+- Rate limiting: per-client token bucket
+- Response format compatible ext_authz (200 = allow, 403 = deny)
+
+### 5. Proxy mode (`mode/proxy.rs`)
+- HTTP reverse proxy via `hyper` (deja dans les deps)
+- Route config via env ou fichier: `STOA_PROXY_UPSTREAM=http://backend:8080`
+- Apply policies: auth, rate limit, request transform
+- No MCP, no tools — classic API gateway behavior
+- Headers forwarding, path rewriting
+
+### 6. Shadow mode (`mode/shadow.rs`) — KILLER FEATURE
+- Passive traffic observation (read-only tap)
+- Auto-generate UAC YAML from observed API patterns:
+  - Detect endpoints (URL patterns)
+  - Detect HTTP methods
+  - Detect request/response schemas (sample-based)
+  - Detect auth patterns (Bearer, API key, etc.)
+- Output: `stoa-shadow-discovery.yaml` (importable into STOA)
+- Zero impact on existing traffic
+
+Creer `stoa-gateway/src/shadow/`:
+```
+shadow/
+├── discovery.rs       # Traffic analysis engine
+└── uac_generator.rs   # YAML output
+```
+
+### 7. Anti-Zombie Detection (`stoa-gateway/src/governance/zombie.rs`)
+- Tool registration TTL: 10 minutes
+- Tools must re-attest periodically
+- Expired tools removed from `tools/list`
+- Background task checking TTL every 30s
+
+### 8. Wire into main.rs
+```rust
+match GatewayMode::from_env() {
+    GatewayMode::EdgeMcp => mode::edge_mcp::start(&config).await?,
+    GatewayMode::Sidecar => mode::sidecar::start(&config).await?,
+    GatewayMode::Proxy => mode::proxy::start(&config).await?,
+    GatewayMode::Shadow => mode::shadow::start(&config).await?,
+}
+```
+
+### 9. Tests
+- Unit: mode parsing from env var
+- Unit: shadow discovery pattern detection
+- Unit: anti-zombie TTL expiration
+- Integration: each mode starts and responds to health check
+
+### 10. Verifier
+- `cargo test` vert
+- `cargo clippy -- -D warnings` propre
+- `cargo fmt --check` propre
+- `STOA_GATEWAY_MODE=edge_mcp cargo run` fonctionne (backward compatible)
+
+## DoD
+- [ ] `STOA_GATEWAY_MODE=edge_mcp` fonctionne (default, backward compatible)
+- [ ] `STOA_GATEWAY_MODE=sidecar` expose auth-only endpoints
+- [ ] `STOA_GATEWAY_MODE=proxy` route HTTP sans MCP
+- [ ] `STOA_GATEWAY_MODE=shadow` demarre en mode passif
+- [ ] Anti-zombie: tool expire disparait de tools/list
+- [ ] `cargo test` + `cargo clippy` clean
+- [ ] Commit: `feat(gateway): 4-mode architecture with shadow discovery (CAB-1105)`
+
+## Contraintes
+- EdgeMcp = 100% backward compatible (rien ne casse)
+- Shadow = read-only (zero ecriture vers un backend)
+- Single binary — mode selectionne a runtime, pas a la compilation
+- Feature flags: `STOA_SHADOW_ENABLED`, `STOA_ZOMBIE_TTL_SECONDS`
+- Ne PAS push

--- a/.claude/prompts/cab-1105-phase9-mode-dashboard.md
+++ b/.claude/prompts/cab-1105-phase9-mode-dashboard.md
@@ -1,0 +1,113 @@
+CAB-1105 Phase 9: Gateway Mode Dashboard — UI pour les 4 modes gateway.
+
+Branch: `feat/cab-1105-mode-dashboard` (creer depuis main, APRES merge de feat/cab-1105-kill-python)
+
+## Contexte
+Le control-plane-api et le control-plane-ui doivent supporter les 4 modes gateway (EdgeMcp, Sidecar, Proxy, Shadow).
+Le GatewayType enum dans l'API doit etre etendu. La Console UI doit afficher des badges de mode et une page dashboard.
+
+Stack: React 18, TypeScript, vitest, Keycloak-js. Lire CLAUDE.md pour les conventions.
+
+## Taches
+
+### 1. Explorer l'existant
+- Lire `control-plane-api/src/models/gateway.py` — modele GatewayInstance, GatewayType enum
+- Lire `control-plane-api/src/schemas/gateway.py` — schemas Pydantic
+- Lire `control-plane-api/src/routers/gateways.py` — endpoints CRUD
+- Lire `control-plane-ui/src/pages/Gateways/GatewayList.tsx` — liste actuelle
+- Lire `control-plane-ui/src/pages/Gateways/GatewayModesDashboard.tsx` si existe
+- Lire `control-plane-ui/src/types/index.ts` — types TypeScript
+
+### 2. API: Etendre GatewayType enum
+Fichier: `control-plane-api/src/models/gateway.py`
+
+Ajouter au GatewayType enum:
+```python
+class GatewayType(str, Enum):
+    STOA_NATIVE = "STOA_NATIVE"
+    STOA_SIDECAR = "STOA_SIDECAR"
+    STOA_PROXY = "STOA_PROXY"       # NEW
+    STOA_SHADOW = "STOA_SHADOW"     # NEW
+    KONG = "KONG"
+    ENVOY = "ENVOY"
+    NGINX = "NGINX"
+    CUSTOM = "CUSTOM"
+```
+
+### 3. API: Ajouter champ `mode` au schema
+Fichier: `control-plane-api/src/schemas/gateway.py`
+
+```python
+mode: Optional[str] = Field(None, description="Gateway operational mode: edge_mcp, sidecar, proxy, shadow")
+```
+
+### 4. UI: Types TypeScript
+Fichier: `control-plane-ui/src/types/index.ts`
+
+Mettre a jour le type GatewayType:
+```typescript
+export type GatewayType =
+  | 'STOA_NATIVE'
+  | 'STOA_SIDECAR'
+  | 'STOA_PROXY'
+  | 'STOA_SHADOW'
+  | 'KONG' | 'ENVOY' | 'NGINX' | 'CUSTOM';
+
+export type GatewayMode = 'edge_mcp' | 'sidecar' | 'proxy' | 'shadow';
+```
+
+### 5. UI: Mode badges dans GatewayList
+Fichier: `control-plane-ui/src/pages/Gateways/GatewayList.tsx`
+
+Badge couleurs:
+- EdgeMcp = blue (`bg-blue-100 text-blue-800`)
+- Sidecar = green (`bg-green-100 text-green-800`)
+- Proxy = yellow (`bg-yellow-100 text-yellow-800`)
+- Shadow = purple (`bg-purple-100 text-purple-800`)
+
+Ajouter une colonne "Mode" dans la table + un filtre par mode.
+
+### 6. UI: ModesDashboard page
+Creer: `control-plane-ui/src/pages/Gateways/GatewayModesDashboard.tsx`
+
+Contenu:
+- Pie chart: distribution des modes (combien de gateways par mode)
+- Stats cards: total par mode, online/offline par mode
+- Liste filtrable par mode
+- Lien depuis le sidebar ou la page GatewayList
+
+Si GatewayModesDashboard.tsx existe deja, l'enrichir avec les nouveaux modes.
+
+### 7. UI: Route + Sidebar
+- Ajouter la route `/gateways/modes` dans `App.tsx` (lazy-loaded)
+- Ajouter l'entree dans le sidebar si pas deja present
+- Raccourci clavier optionnel
+
+### 8. Tests
+- Unit test pour le composant ModeBadge
+- Unit test pour GatewayModesDashboard (mock data avec les 4 modes)
+- Mettre a jour les tests existants de GatewayList si les colonnes changent
+- Framework: vitest + React Testing Library (JAMAIS Jest)
+
+### 9. Verifier
+- `npm run lint` dans control-plane-ui/
+- `npm run format:check` dans control-plane-ui/
+- `npm run test` dans control-plane-ui/ — tous les tests passent
+- `npm run test:coverage` — pas de regression de coverage
+
+## DoD
+- [ ] GatewayType enum etendu avec STOA_PROXY et STOA_SHADOW
+- [ ] Mode badges (blue/green/yellow/purple) dans GatewayList
+- [ ] Filtre par mode dans GatewayList
+- [ ] Page GatewayModesDashboard avec pie chart + stats
+- [ ] Route `/gateways/modes` fonctionnelle
+- [ ] Tests unitaires pour les nouveaux composants
+- [ ] `npm run lint && npm run test` vert
+- [ ] Commit: `feat(ui): gateway mode dashboard with 4-mode badges (CAB-1105)`
+
+## Contraintes
+- Suivre les patterns UI existants (Tailwind, composants existants)
+- vitest (JAMAIS Jest), React Testing Library
+- Prettier: single quotes, semicolons, 100 chars
+- Ne PAS modifier le code Rust (stoa-gateway/)
+- Ne PAS push


### PR DESCRIPTION
## Summary
- 6 Claude Squad prompt files for parallel execution of CAB-1103 Phase 6 (4 sub-phases) and CAB-1105 Phases 8-9
- Required on main before CS agents can branch from it

## Files
- `.claude/prompts/cab-1103-6a-ci-hardening.md`
- `.claude/prompts/cab-1103-6b-monitoring-oidc.md`
- `.claude/prompts/cab-1103-6c-e2e-expansion.md`
- `.claude/prompts/cab-1103-6d-test-loop.md`
- `.claude/prompts/cab-1105-phase8-gateway-modes.md`
- `.claude/prompts/cab-1105-phase9-mode-dashboard.md`

## Test plan
- [x] No code changes, only `.md` prompt files
- [x] Files are in `.claude/prompts/` (no impact on build/CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)