### PR TITLE
fix(gateway): collapse nested if in watcher.rs (clippy 1.93)

### DIFF
--- a/stoa-gateway/src/k8s/watcher.rs
+++ b/stoa-gateway/src/k8s/watcher.rs
@@ -294,10 +294,8 @@ impl CrdWatcher {
         let mut removed = 0;
 
         for tool_name in &names {
-            if tool_name.starts_with(&tool_prefix) {
-                if self.tool_registry.unregister(tool_name) {
-                    removed += 1;
-                }
+            if tool_name.starts_with(&tool_prefix) && self.tool_registry.unregister(tool_name) {
+                removed += 1;
             }
         }
 


### PR DESCRIPTION
## Summary
- Fix last remaining clippy error: collapsible nested `if` in `watcher.rs:297`
- Follows PR #191 which fixed 59/60 clippy errors

## Test plan
- [x] `cargo clippy -- -D warnings` passes locally (0 warnings)
- [ ] Gateway CI Clippy lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)