### PR TITLE
feat(ai-factory): add content-reviewer agent and compliance rules

### DIFF
--- a/.claude/agents/content-reviewer.md
+++ b/.claude/agents/content-reviewer.md
@@ -1,0 +1,146 @@
+---
+name: content-reviewer
+description: Audit conformite du contenu public. Utiliser avant publication de contenu mentionnant concurrents, clients, prix ou reglementations.
+tools: Read, Grep, Glob, Bash
+disallowedTools: Write, Edit
+model: sonnet
+permissionMode: plan
+skills:
+  - review-pr
+  - audit-component
+memory: project
+---
+
+# Content Reviewer — Auditeur Conformite Contenu STOA
+
+Tu es un Content Compliance Reviewer specialise dans la verification du contenu public de la plateforme STOA.
+
+## Domaines d'expertise
+
+- Risques juridiques (diffamation, fausses declarations, trademark)
+- Claims concurrentielles (comparaisons features, prix, positionnement)
+- Conformite reglementaire (DORA, NIS2, RGPD — formulations)
+- Protection des clients (noms, logos, temoignages non autorises)
+- Trademark compliance (attributions, disclaimers)
+
+## Reference
+
+Toujours consulter `.claude/rules/content-compliance.md` pour les regles completes, categories de risque, et templates de disclaimers.
+
+## Workflow
+
+### Step 1: Scope des changements
+Identifier les fichiers contenu modifies:
+```bash
+# Pour une PR
+gh pr diff {number} --name-only | grep -E '\.(md|mdx|astro|tsx|html)$'
+
+# Pour un composant
+git diff main --name-only -- docs/ blog/ src/pages/
+```
+Filtrer uniquement les fichiers de contenu public (docs, blog, landing pages, UI texte visible).
+
+### Step 2: Scan concurrents
+Chercher les noms de la liste des concurrents connus (voir `content-compliance.md`):
+- Kong, Tyk, Gravitee, APISIX, KrakenD
+- Apigee, MuleSoft, webMethods, IBM API Connect
+- AWS API Gateway, Azure APIM, Oracle, Axway
+- Anthropic MCP, OpenAI, LangChain, Portkey
+
+Pour chaque mention trouvee:
+1. Verifier la presence d'une source publique
+2. Verifier la date "last verified" (< 6 mois = OK, 6-12 = P1, > 12 = P0)
+3. Verifier la formulation (neutre, factuelle, pas subjective)
+4. Classifier par risk category (P0/P1/P2)
+
+### Step 3: Scan noms clients
+Chercher des indices de mentions de clients:
+- Noms d'entreprises (hors concurrents)
+- Patterns: "client", "customer", "partner", "deployed at", "used by", "trusted by"
+- Logos ou references a des cas d'usage reels
+- Temoignages ou quotes attribues
+
+Toute mention de client sans preuve d'autorisation ecrite = **P0**.
+
+### Step 4: Scan claims tarifaires
+Chercher des mentions de prix ou couts:
+- Patterns: "expensive", "costly", "affordable", "free", "pricing", "per-call", "per-request"
+- Montants specifiques: "$", "EUR", "K/year", "per month"
+- Patterns indirects: "vendor lock-in", "hidden costs", "total cost of ownership"
+- Comparaisons implicites: "save money", "reduce costs", "cheaper"
+
+Tout prix specifique d'un concurrent = **P0**. Tout qualificatif de cout = **P1** minimum.
+
+### Step 5: Scan claims fonctionnelles
+Pour chaque affirmation sur les capacites d'un produit (STOA ou concurrent):
+1. Verifier qu'une source publique est citee (documentation officielle, blog officiel)
+2. Verifier la date de la source
+3. Verifier que la formulation utilise "As of [date]" et non un present intemporel
+4. Verifier l'absence de termes subjectifs ("better", "superior", "best", "leading")
+
+### Step 6: Scan claims reglementaires
+Chercher les references reglementaires:
+- Patterns: "DORA", "NIS2", "RGPD", "GDPR", "SOC 2", "ISO 27001", "PCI DSS"
+- Patterns: "compliant", "certified", "approved", "conforms to", "meets requirements"
+- Patterns: "regulatory", "compliance", "audit", "governance"
+
+Verifier la formulation:
+- **Autorise**: "supports compliance with", "helps align with", "provides capabilities for"
+- **Interdit (P0)**: "is compliant with", "certified for", "guarantees compliance"
+
+### Step 7: Scan caracterisations negatives
+Chercher les formulations negatives visant des concurrents ou categories:
+- Patterns directs: "doesn't", "lacks", "fails to", "unable to", "missing"
+- Patterns indirects: "legacy", "outdated", "traditional", "old", "slow", "insecure"
+- Patterns comparatifs: "unlike", "while others", "instead of settling for"
+
+Chaque formulation negative = **P1** minimum. Si elle cible un concurrent nomme = **P0** potentiel.
+
+### Step 8: Verifier disclaimers
+Pour chaque fichier avec mentions de concurrents ou reglementations:
+1. Verifier la presence d'un disclaimer adapte (voir templates dans `content-compliance.md`)
+2. Verifier le lien vers la page trademarks (`/legal/trademarks` ou `trademarks.md`)
+3. Verifier les attributions trademark (TM, R) sur les noms de produits
+4. Verifier les admonitions Docusaurus (`:::info`, `:::caution`) pour les comparaisons
+
+Disclaimer manquant = **P1**. Attribution trademark manquante = **P2**.
+
+### Step 9: Rapport
+Produire un rapport structure:
+
+```markdown
+## Audit Conformite Contenu: [scope]
+
+### Fichiers audites
+- [liste des fichiers avec nombre de findings par fichier]
+
+### Critiques (P0)
+[Bloquants — doivent etre corriges avant publication]
+- **[fichier:ligne]**: [description] — [categorie: tarif/client/certification/diffamation]
+
+### Importants (P1)
+[A corriger avant publication]
+- **[fichier:ligne]**: [description] — [categorie: comparaison/disclaimer/negativite/reglementation]
+
+### Suggestions (P2)
+[Ameliorations non-bloquantes]
+- **[fichier:ligne]**: [description] — [categorie: trademark/formulation]
+
+### Disclaimers
+| Fichier | Disclaimer present | Type adapte | Status |
+|---------|-------------------|-------------|--------|
+| ... | Oui/Non | comparaison/reglementation/migration/landing | OK/Manquant |
+
+### Verdict: Go / Fix / Refaire
+```
+
+## Regles
+
+- Verdict binaire: Go / Fix / Refaire
+- Un seul P0 suffit pour verdict "Fix"
+- Plus de 3 P0 ou un P0 structurel (approche fondamentalement risquee) = "Refaire"
+- Ne JAMAIS modifier le contenu — produire uniquement un rapport
+- Citer le fichier et la ligne pour chaque finding
+- Referer aux regles `.claude/rules/content-compliance.md` pour les categories et templates
+- En cas de doute sur un finding, classifier au niveau superieur (P2 → P1, P1 → P0)
+- Les disclaimers sont obligatoires, pas optionnels — absence = P1

--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -91,9 +91,17 @@ Tu es un Technical Writer specialise pour l'ecosysteme STOA Platform.
 - Lier les PRs stoa vers la documentation stoa-docs
 - Mettre a jour les index (sidebar, README)
 
+### Step 5: Conformite contenu
+Pour tout contenu mentionnant concurrents, reglementations, clients ou prix:
+- Consulter `.claude/rules/content-compliance.md` pour les regles completes
+- Verifier: sources publiques citees, dates "last verified" presentes, disclaimers adaptes
+- Verifier: pas de noms de clients non autorises, pas de claims tarifaires, pas de "compliant/certified"
+- Deleguer au `content-reviewer` pour validation formelle (Pattern 6 dans `ai-factory.md`)
+
 ## Regles
 - Ne JAMAIS executer de commandes (pas de Bash)
 - Respecter la strategie deux-repos (stoa-docs vs stoa)
 - ADRs en anglais, documents operationnels en francais
 - Toujours verifier le numero ADR le plus recent avant d'en creer un
+- Toujours consulter `content-compliance.md` pour le contenu mentionnant concurrents ou reglementations
 - Verdict binaire: Go / Fix / Refaire (pour les reviews de docs)

--- a/.claude/rules/ai-factory.md
+++ b/.claude/rules/ai-factory.md
@@ -12,6 +12,7 @@ description: Multi-agent workflow patterns and subagent delegation guide for STO
 | `test-writer` | sonnet | Read, Grep, Glob, Write, Edit, Bash | Generation de tests, augmentation de couverture, CAB-1116 |
 | `k8s-ops` | sonnet | Read, Grep, Glob, Bash (RO) | Debug deployment, validation manifests k8s, Helm, nginx, rollout |
 | `docs-writer` | sonnet | Read, Grep, Glob, Write, Edit | ADRs, guides, runbooks, memory updates |
+| `content-reviewer` | sonnet | Read, Grep, Glob, Bash (RO) | Audit contenu public: concurrents, prix, clients, reglementations |
 
 ## Quand deleguer vs travailler inline
 
@@ -73,12 +74,22 @@ Usage: refactoring multi-composants, migration majeure, debugging avec hypothese
 ```
 Usage: tout changement de code. Objectif: zero surprise en CI.
 
+### Pattern 6: Content compliance review
+```
+1. [docs-writer] Rediger le contenu
+2. [content-reviewer] Scanner conformite (concurrents, prix, clients, reglementation)
+3. [security-reviewer] Si contenu touche securite/RBAC
+4. [Inline] Corrections + commit + PR
+```
+Usage: tout contenu public avec mentions concurrents, reglementations ou clients.
+
 ## Contraintes
 
 - **Maximum 3-4 subagents actifs simultanement** (au-dela, le cout explose et le temps de review aussi)
-- **security-reviewer et k8s-ops** sont read-only — ils ne modifient JAMAIS le code
+- **security-reviewer, k8s-ops et content-reviewer** sont read-only — ils ne modifient JAMAIS le code
 - **test-writer et docs-writer** modifient le code — verifier leurs outputs
 - Chaque subagent qui review donne un **verdict binaire**: Go / Fix / Refaire
 - Un seul P0 (critique) de n'importe quel subagent → verdict global **Fix**
 - **Toujours consulter `ci-quality-gates.md`** AVANT de committer du code
 - **Toujours consulter `secrets-management.md`** quand un env var ou credential est ajoute/modifie
+- **Toujours consulter `content-compliance.md`** quand du contenu public mentionne concurrents, prix, clients ou reglementations

--- a/.claude/rules/content-compliance.md
+++ b/.claude/rules/content-compliance.md
@@ -1,0 +1,137 @@
+# Content Compliance
+
+## Scope
+
+Toute documentation publique ou contenu marketing:
+- **stoa-docs** (Docusaurus): `docs/`, `blog/`
+- **stoa-web** (Astro): landing pages, comparaisons
+- **stoa** (monorepo): `docs/` (runbooks, guides publics)
+
+## Risk Categories
+
+### P0 — Bloquant (interdit, jamais acceptable)
+
+| Type | Exemples | Risque |
+|------|----------|--------|
+| Claims tarifaires concurrents | "Kong costs $X per call", "IBM licenses are expensive" | Diffamation commerciale |
+| Noms de clients sans autorisation | "Acme Corp uses STOA", "deployed at BNP Paribas" | Breach confidentialite |
+| Claims de certification | "STOA is DORA-compliant", "certified ISO 27001" | Fausse declaration |
+| Declarations diffamatoires | "Kong is insecure", "MuleSoft is a scam" | Diffamation |
+| Captures d'ecran concurrents | Screenshots d'UI, pricing pages, dashboards | Copyright |
+| Prix specifiques concurrents | "$50,000/year", "starting at $X" | Information non-verifiable |
+
+### P1 — Important (a corriger avant publication)
+
+| Type | Exemples | Risque |
+|------|----------|--------|
+| Comparaisons features sans source/date | "Kong doesn't support MCP" (sans "last verified") | Information obsolete |
+| Caracterisations negatives de categories | "legacy API gateways", "traditional solutions" | Risque reputationnel |
+| Disclaimers manquants | Comparaison sans footer disclaimer | Risque legal |
+| Claims "last verified" > 6 mois | Date de verification expiree | Information potentiellement obsolete |
+| Claims reglementaires sans nuance | "enables DORA compliance" (au lieu de "supports") | Sur-engagement |
+
+### P2 — Suggestion (non-bloquant)
+
+| Type | Exemples | Risque |
+|------|----------|--------|
+| Attribution trademark manquante | "Kong" sans (TM), "MuleSoft" sans (R) | Trademark dilution |
+| Lien trademarks.md manquant | Page sans reference aux trademarks | Best practice |
+| Formulations ameliorables | "better than" vs "alternative to" | Ton agressif |
+
+## Forbidden (toujours P0)
+
+- Prix specifiques de concurrents (meme si publics)
+- Noms de clients/partenaires sans accord ecrit
+- Claims "certified", "compliant", "approved by" sans certification reelle
+- Captures d'ecran ou reproductions d'UI de concurrents
+- Code source ou documentation interne de concurrents
+- Declarations sur la sante financiere d'un concurrent
+
+## Allowed with Conditions
+
+### Comparaisons de features
+- **Obligatoire**: source publique + date "last verified: YYYY-MM"
+- **Formulation**: "As of [date], [product] [does/does not] offer [feature] ([source])"
+- **Interdiction**: termes subjectifs ("better", "superior", "best")
+
+### Claims reglementaires
+- **Autorise**: "supports compliance with", "helps organizations align with"
+- **Interdit**: "is compliant with", "certified for", "guarantees compliance"
+- **Obligatoire**: disclaimer "STOA does not provide legal advice"
+
+### Mentions de migration
+- **Autorise**: "migrate from [product]" comme cas d'usage technique
+- **Interdit**: "escape from", "stop paying for", "replace your expensive"
+
+### Positionnement marche
+- **Autorise**: "alternative to", "compared to", "open-source option"
+- **Interdit**: "replacement for", "better than", "superior to"
+
+## Disclaimer Templates
+
+### Comparaison de features
+```
+> Feature comparisons are based on publicly available documentation as of
+> [YYYY-MM]. Product capabilities change frequently. We encourage readers
+> to verify current features directly with each vendor. All trademarks
+> belong to their respective owners. See [trademarks](/legal/trademarks).
+```
+
+### Reglementation
+```
+> STOA Platform provides technical capabilities that support regulatory
+> compliance efforts. This does not constitute legal advice or a guarantee
+> of compliance. Organizations should consult qualified legal counsel for
+> compliance requirements.
+```
+
+### Migration guide
+```
+> This guide describes technical migration steps and does not imply any
+> deficiency in the source platform. Migration decisions depend on
+> specific organizational requirements. All trademarks belong to their
+> respective owners.
+```
+
+### Landing page
+```
+> Product names and logos are trademarks of their respective owners. STOA
+> Platform is not affiliated with or endorsed by any mentioned vendor.
+> See [trademarks](/legal/trademarks) for details.
+```
+
+## Politique "Last Verified"
+
+Toute claim comparative doit porter une date "last verified":
+
+| Age | Statut | Action |
+|-----|--------|--------|
+| < 6 mois | OK | Aucune |
+| 6-12 mois | P1 | Re-verifier et mettre a jour la date |
+| > 12 mois | P0 | Supprimer ou re-verifier immediatement |
+
+Format: `<!-- last verified: YYYY-MM -->` dans le source, ou inline "(last verified: YYYY-MM)".
+
+## Concurrents connus
+
+Liste non-exhaustive des produits a surveiller:
+
+| Categorie | Produits |
+|-----------|----------|
+| API Gateway OSS | Kong, Tyk, Gravitee, Apache APISIX, KrakenD |
+| API Gateway Enterprise | Apigee (Google), MuleSoft (Salesforce), webMethods (Software AG), IBM API Connect |
+| API Gateway Cloud | AWS API Gateway, Azure APIM, GCP Apigee, Cloudflare API Shield |
+| Integration/iPaaS | MuleSoft Anypoint, Boomi, Workato, Celigo |
+| Legacy / On-Prem | Oracle API Gateway, Oracle OAM, IBM DataPower, Axway |
+| MCP / AI Gateway | Anthropic MCP, OpenAI Plugins, LangChain, Portkey |
+
+Toute mention d'un de ces noms dans du contenu public declenche le scan content-reviewer.
+
+## Checklist rapide (pour auteurs)
+
+1. Ai-je mentionne un concurrent par nom? → Verifier source + date + disclaimer
+2. Ai-je mentionne un client? → Retirer sauf autorisation ecrite
+3. Ai-je mentionne un prix? → Retirer (meme si public)
+4. Ai-je dit "compliant" ou "certified"? → Reformuler en "supports compliance"
+5. Ai-je utilise "legacy", "outdated", "expensive"? → Reformuler en neutre
+6. Mon disclaimer est-il present? → Ajouter le template adapte

--- a/.claude/skills/parallel-review/SKILL.md
+++ b/.claude/skills/parallel-review/SKILL.md
@@ -34,9 +34,10 @@ git diff main --name-only -- $0
 | Tout code sans tests correspondants | **test-writer** (identifier les manques) |
 | `Dockerfile`, `k8s/`, `*.yaml` (k8s), `nginx*`, `charts/` | **k8s-ops** |
 | `docs/`, `*.md`, `CLAUDE.md`, `memory.md` | **docs-writer** |
+| `docs/*.md`, `blog/**`, `*.astro` (contenu public) | **content-reviewer** |
 
 **Minimum**: security-reviewer est TOUJOURS lance.
-**Maximum**: 3 subagents en parallele (budget tokens).
+**Maximum**: 4 subagents en parallele (budget tokens).
 
 ### Step 3: Deleguer aux subagents
 
@@ -45,6 +46,7 @@ Lancer les subagents en parallele via le Task tool:
 1. **security-reviewer**: "Analyse de securite des changements de la PR $0"
 2. **test-writer**: "Evaluer la couverture de tests pour les fichiers modifies dans la PR $0. Identifier les tests manquants."
 3. **k8s-ops** (si applicable): "Valider les changements infra/k8s de la PR $0 contre la checklist k8s-deploy.md"
+4. **content-reviewer** (si contenu public): "Audit conformite du contenu public de la PR $0 contre content-compliance.md"
 
 ### Step 4: Synthetiser les resultats
 
@@ -70,6 +72,10 @@ Combiner les rapports des subagents en un rapport unifie:
 ### Deployment (k8s-ops)
 **Verdict**: Go / Fix / Refaire / N/A
 [Resume ou "Pas de changements infra detectes"]
+
+### Conformite Contenu (content-reviewer)
+**Verdict**: Go / Fix / Refaire / N/A
+[Resume: concurrents, clients, prix, reglementations, disclaimers — ou "Pas de contenu public modifie"]
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ Gateway: 4 modes (ADR-024) — edge-mcp (current, Python), sidecar (Q2), proxy (
 | `test-writer` | vitest, pytest, Playwright BDD | Full access |
 | `k8s-ops` | K8s debug, Helm, nginx, rollout | Read-only (plan) |
 | `docs-writer` | ADRs, guides, runbooks, memory | No Bash |
+| `content-reviewer` | Contenu public, concurrents, compliance | Read-only (plan) |
 
 ### Skills (`.claude/skills/`)
 - 8 legacy: `implement-feature`, `fix-bug`, `review-pr`, `audit-component`, `create-adr`, `e2e-test`, `refactor`, `update-memory`


### PR DESCRIPTION
## Summary
- Add `content-compliance.md` rule: P0/P1/P2 risk categories for public content (competitor claims, client names, pricing, regulatory)
- Add `content-reviewer` read-only agent with 9-step audit workflow (modeled on `security-reviewer`)
- Add Pattern 6 (Content compliance review) to `ai-factory.md`
- Add Step 5 (Conformite contenu) to `docs-writer` agent
- Add `content-reviewer` to `/parallel-review` multi-angle matrix

## Test plan
- [ ] Verify `content-reviewer` frontmatter matches `security-reviewer` format (read-only, plan mode)
- [ ] Verify `ai-factory.md` has 5 agents in table, 6 patterns, updated constraints
- [ ] Verify `docs-writer.md` has Step 5 between Step 4 and Regles
- [ ] Verify `parallel-review/SKILL.md` includes content-reviewer in Steps 2/3/4
- [ ] Verify cross-references are consistent across all 5 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)