### PR TITLE
feat(api): Consumer + Plan data model and CRUD APIs (CAB-1121 Phase 1)

### DIFF
--- a/control-plane-api/alembic/env.py
+++ b/control-plane-api/alembic/env.py
@@ -20,6 +20,8 @@ from src.database import Base
 from src.models.subscription import Subscription
 from src.models.mcp_subscription import MCPServer, MCPServerTool, MCPServerSubscription, MCPToolAccess
 from src.models.catalog import APICatalog, MCPToolsCatalog, CatalogSyncStatus
+from src.models.consumer import Consumer
+from src.models.plan import Plan
 
 # this is the Alembic Config object
 config = context.config

--- a/control-plane-api/alembic/versions/018_create_consumers_and_plans.py
+++ b/control-plane-api/alembic/versions/018_create_consumers_and_plans.py
@@ -1,0 +1,110 @@
+"""create consumers and plans tables, add consumer_id to subscriptions
+
+Revision ID: 018
+Revises: 017
+Create Date: 2026-02-09
+
+CAB-1121: Consumer Onboarding Phase 1 — Data Model Foundation
+- consumers table: external API consumers (company, partner, developer)
+- plans table: subscription plans with quota definitions
+- consumer_id column on subscriptions for linking consumers
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSON
+
+# revision identifiers, used by Alembic.
+revision: str = "018"
+down_revision: str | None = "017"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    consumer_status_enum = sa.Enum(
+        "active",
+        "suspended",
+        "blocked",
+        name="consumer_status_enum",
+    )
+    plan_status_enum = sa.Enum(
+        "active",
+        "deprecated",
+        "archived",
+        name="plan_status_enum",
+    )
+
+    # Create consumers table
+    op.create_table(
+        "consumers",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("external_id", sa.String(255), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("company", sa.String(255), nullable=True),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("tenant_id", sa.String(255), nullable=False),
+        sa.Column("keycloak_user_id", sa.String(255), nullable=True),
+        sa.Column("status", consumer_status_enum, nullable=False, server_default="active"),
+        sa.Column("consumer_metadata", JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column("created_by", sa.String(255), nullable=True),
+    )
+    op.create_index("ix_consumers_tenant_id", "consumers", ["tenant_id"])
+    op.create_index("ix_consumers_keycloak_user_id", "consumers", ["keycloak_user_id"])
+    op.create_index(
+        "ix_consumers_tenant_external", "consumers", ["tenant_id", "external_id"], unique=True
+    )
+    op.create_index("ix_consumers_tenant_status", "consumers", ["tenant_id", "status"])
+    op.create_index("ix_consumers_email", "consumers", ["email"])
+
+    # Create plans table
+    op.create_table(
+        "plans",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("slug", sa.String(100), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("tenant_id", sa.String(255), nullable=False),
+        sa.Column("rate_limit_per_second", sa.Integer, nullable=True),
+        sa.Column("rate_limit_per_minute", sa.Integer, nullable=True),
+        sa.Column("daily_request_limit", sa.Integer, nullable=True),
+        sa.Column("monthly_request_limit", sa.Integer, nullable=True),
+        sa.Column("burst_limit", sa.Integer, nullable=True),
+        sa.Column("requires_approval", sa.Boolean, nullable=False, server_default="false"),
+        sa.Column("auto_approve_roles", JSON, nullable=True),
+        sa.Column("status", plan_status_enum, nullable=False, server_default="active"),
+        sa.Column("pricing_metadata", JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column("created_by", sa.String(255), nullable=True),
+    )
+    op.create_index("ix_plans_tenant_id", "plans", ["tenant_id"])
+    op.create_index("ix_plans_tenant_slug", "plans", ["tenant_id", "slug"], unique=True)
+    op.create_index("ix_plans_tenant_status", "plans", ["tenant_id", "status"])
+
+    # Add consumer_id to subscriptions
+    op.add_column(
+        "subscriptions",
+        sa.Column("consumer_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_index("ix_subscriptions_consumer_id", "subscriptions", ["consumer_id"])
+
+
+def downgrade() -> None:
+    # Drop consumer_id from subscriptions
+    op.drop_index("ix_subscriptions_consumer_id", table_name="subscriptions")
+    op.drop_column("subscriptions", "consumer_id")
+
+    # Drop plans table
+    op.drop_table("plans")
+
+    # Drop consumers table
+    op.drop_table("consumers")
+
+    # Drop enums
+    sa.Enum(name="plan_status_enum").drop(op.get_bind(), checkfirst=True)
+    sa.Enum(name="consumer_status_enum").drop(op.get_bind(), checkfirst=True)

--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -1204,6 +1204,326 @@
         "title": "ComponentStatus",
         "type": "object"
       },
+      "ConsumerCreate": {
+        "description": "Schema for creating a new consumer.",
+        "example": {
+          "company": "ACME Corporation",
+          "description": "Strategic API partner",
+          "email": "api@acme.com",
+          "external_id": "partner-acme-001",
+          "name": "ACME Corp"
+        },
+        "properties": {
+          "company": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "consumer_metadata": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consumer Metadata"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "email": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Email",
+            "type": "string"
+          },
+          "external_id": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "External Id",
+            "type": "string"
+          },
+          "keycloak_user_id": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Keycloak User Id"
+          },
+          "name": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "external_id",
+          "name",
+          "email"
+        ],
+        "title": "ConsumerCreate",
+        "type": "object"
+      },
+      "ConsumerListResponse": {
+        "description": "Schema for paginated consumer list.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ConsumerResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "page": {
+            "title": "Page",
+            "type": "integer"
+          },
+          "page_size": {
+            "title": "Page Size",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          },
+          "total_pages": {
+            "title": "Total Pages",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "page_size",
+          "total_pages"
+        ],
+        "title": "ConsumerListResponse",
+        "type": "object"
+      },
+      "ConsumerResponse": {
+        "description": "Schema for consumer response.",
+        "properties": {
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "consumer_metadata": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consumer Metadata"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "external_id": {
+            "title": "External Id",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "keycloak_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Keycloak User Id"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ConsumerStatusEnum"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "external_id",
+          "name",
+          "email",
+          "company",
+          "description",
+          "tenant_id",
+          "keycloak_user_id",
+          "status",
+          "consumer_metadata",
+          "created_at",
+          "updated_at",
+          "created_by"
+        ],
+        "title": "ConsumerResponse",
+        "type": "object"
+      },
+      "ConsumerStatusEnum": {
+        "description": "Consumer status enum for API responses.",
+        "enum": [
+          "active",
+          "suspended",
+          "blocked"
+        ],
+        "title": "ConsumerStatusEnum",
+        "type": "string"
+      },
+      "ConsumerUpdate": {
+        "description": "Schema for updating an existing consumer.",
+        "properties": {
+          "company": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "consumer_metadata": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consumer Metadata"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "keycloak_user_id": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Keycloak User Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "title": "ConsumerUpdate",
+        "type": "object"
+      },
       "ContractCreate": {
         "description": "Request to create a new contract.",
         "example": {
@@ -2024,7 +2344,11 @@
         },
         "properties": {
           "protocol": {
-            "$ref": "#/components/schemas/ProtocolType",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProtocolType"
+              }
+            ],
             "description": "Protocol to enable"
           }
         },
@@ -2266,7 +2590,11 @@
             "title": "Trace Id"
           },
           "trigger": {
-            "$ref": "#/components/schemas/SnapshotTrigger",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SnapshotTrigger"
+              }
+            ],
             "default": "5xx"
           }
         },
@@ -2364,7 +2692,11 @@
         },
         "properties": {
           "auth_type": {
-            "$ref": "#/components/schemas/AuthTypeEnum",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AuthTypeEnum"
+              }
+            ],
             "default": "none",
             "description": "Authentication type"
           },
@@ -2450,7 +2782,11 @@
             "title": "Tool Prefix"
           },
           "transport": {
-            "$ref": "#/components/schemas/TransportTypeEnum",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransportTypeEnum"
+              }
+            ],
             "default": "sse",
             "description": "Transport protocol"
           }
@@ -2510,7 +2846,11 @@
             "type": "boolean"
           },
           "health_status": {
-            "$ref": "#/components/schemas/HealthStatusEnum",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HealthStatusEnum"
+              }
+            ],
             "default": "unknown"
           },
           "icon": {
@@ -2778,7 +3118,11 @@
             "type": "boolean"
           },
           "health_status": {
-            "$ref": "#/components/schemas/HealthStatusEnum",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HealthStatusEnum"
+              }
+            ],
             "default": "unknown"
           },
           "icon": {
@@ -4917,7 +5261,11 @@
             "title": "Auto Approve Roles"
           },
           "category": {
-            "$ref": "#/components/schemas/MCPServerCategoryEnum",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MCPServerCategoryEnum"
+              }
+            ],
             "default": "public"
           },
           "description": {
@@ -4991,7 +5339,11 @@
             "title": "Version"
           },
           "visibility": {
-            "$ref": "#/components/schemas/MCPServerVisibility",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MCPServerVisibility"
+              }
+            ],
             "default": {
               "public": true
             }
@@ -6578,6 +6930,487 @@
         "title": "PaginatedResponse[GatewayApplicationResponse]",
         "type": "object"
       },
+      "PlanCreate": {
+        "description": "Schema for creating a new subscription plan.",
+        "example": {
+          "daily_request_limit": 1000000,
+          "description": "High-volume plan for production workloads",
+          "monthly_request_limit": 30000000,
+          "name": "Gold Plan",
+          "rate_limit_per_minute": 5000,
+          "rate_limit_per_second": 100,
+          "requires_approval": true,
+          "slug": "gold"
+        },
+        "properties": {
+          "auto_approve_roles": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Auto Approve Roles"
+          },
+          "burst_limit": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Burst Limit"
+          },
+          "daily_request_limit": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Daily Request Limit"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "monthly_request_limit": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Monthly Request Limit"
+          },
+          "name": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "pricing_metadata": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pricing Metadata"
+          },
+          "rate_limit_per_minute": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Limit Per Minute"
+          },
+          "rate_limit_per_second": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Limit Per Second"
+          },
+          "requires_approval": {
+            "default": false,
+            "title": "Requires Approval",
+            "type": "boolean"
+          },
+          "slug": {
+            "maxLength": 100,
+            "minLength": 1,
+            "pattern": "^[a-z0-9-]+$",
+            "title": "Slug",
+            "type": "string"
+          }
+        },
+        "required": [
+          "slug",
+          "name"
+        ],
+        "title": "PlanCreate",
+        "type": "object"
+      },
+      "PlanListResponse": {
+        "description": "Schema for paginated plan list.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PlanResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "page": {
+            "title": "Page",
+            "type": "integer"
+          },
+          "page_size": {
+            "title": "Page Size",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          },
+          "total_pages": {
+            "title": "Total Pages",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "page_size",
+          "total_pages"
+        ],
+        "title": "PlanListResponse",
+        "type": "object"
+      },
+      "PlanResponse": {
+        "description": "Schema for plan response.",
+        "properties": {
+          "auto_approve_roles": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Auto Approve Roles"
+          },
+          "burst_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Burst Limit"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By"
+          },
+          "daily_request_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Daily Request Limit"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "monthly_request_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Monthly Request Limit"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "pricing_metadata": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pricing Metadata"
+          },
+          "rate_limit_per_minute": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Limit Per Minute"
+          },
+          "rate_limit_per_second": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Limit Per Second"
+          },
+          "requires_approval": {
+            "title": "Requires Approval",
+            "type": "boolean"
+          },
+          "slug": {
+            "title": "Slug",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/PlanStatusEnum"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "slug",
+          "name",
+          "description",
+          "tenant_id",
+          "rate_limit_per_second",
+          "rate_limit_per_minute",
+          "daily_request_limit",
+          "monthly_request_limit",
+          "burst_limit",
+          "requires_approval",
+          "auto_approve_roles",
+          "status",
+          "pricing_metadata",
+          "created_at",
+          "updated_at",
+          "created_by"
+        ],
+        "title": "PlanResponse",
+        "type": "object"
+      },
+      "PlanStatusEnum": {
+        "description": "Plan status enum for API responses.",
+        "enum": [
+          "active",
+          "deprecated",
+          "archived"
+        ],
+        "title": "PlanStatusEnum",
+        "type": "string"
+      },
+      "PlanUpdate": {
+        "description": "Schema for updating an existing plan.",
+        "properties": {
+          "auto_approve_roles": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Auto Approve Roles"
+          },
+          "burst_limit": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Burst Limit"
+          },
+          "daily_request_limit": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Daily Request Limit"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "monthly_request_limit": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Monthly Request Limit"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "pricing_metadata": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pricing Metadata"
+          },
+          "rate_limit_per_minute": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Limit Per Minute"
+          },
+          "rate_limit_per_second": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Limit Per Second"
+          },
+          "requires_approval": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Requires Approval"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PlanStatusEnum"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "title": "PlanUpdate",
+        "type": "object"
+      },
       "PlatformEvent": {
         "description": "Platform deployment event.",
         "properties": {
@@ -7825,7 +8658,11 @@
             "title": "Tool Name"
           },
           "type": {
-            "$ref": "#/components/schemas/ActivityType",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ActivityType"
+              }
+            ],
             "description": "Type of activity"
           }
         },
@@ -9642,7 +10479,11 @@
             "type": "integer"
           },
           "status": {
-            "$ref": "#/components/schemas/CallStatus",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CallStatus"
+              }
+            ],
             "description": "Call status"
           },
           "timestamp": {
@@ -9841,15 +10682,27 @@
             "type": "string"
           },
           "this_month": {
-            "$ref": "#/components/schemas/UsagePeriodStats",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UsagePeriodStats"
+              }
+            ],
             "description": "This month's statistics"
           },
           "this_week": {
-            "$ref": "#/components/schemas/UsagePeriodStats",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UsagePeriodStats"
+              }
+            ],
             "description": "This week's statistics"
           },
           "today": {
-            "$ref": "#/components/schemas/UsagePeriodStats",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UsagePeriodStats"
+              }
+            ],
             "description": "Today's statistics"
           },
           "top_tools": {
@@ -13640,7 +14493,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MCPSubscriptionApprove",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/MCPSubscriptionApprove"
+                  }
+                ],
                 "default": {},
                 "title": "Request"
               }
@@ -15128,6 +15985,513 @@
         ]
       }
     },
+    "/v1/consumers/{tenant_id}": {
+      "get": {
+        "description": "List consumers for a tenant with optional filtering.",
+        "operationId": "list_consumers_v1_consumers__tenant_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ConsumerStatusEnum"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 255,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsumerListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Consumers",
+        "tags": [
+          "Consumers"
+        ]
+      },
+      "post": {
+        "description": "Create a new consumer for a tenant.",
+        "operationId": "create_consumer_v1_consumers__tenant_id__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConsumerCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsumerResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Consumer",
+        "tags": [
+          "Consumers"
+        ]
+      }
+    },
+    "/v1/consumers/{tenant_id}/{consumer_id}": {
+      "delete": {
+        "description": "Delete a consumer.",
+        "operationId": "delete_consumer_v1_consumers__tenant_id___consumer_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "consumer_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Consumer Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete Consumer",
+        "tags": [
+          "Consumers"
+        ]
+      },
+      "get": {
+        "description": "Get consumer details by ID.",
+        "operationId": "get_consumer_v1_consumers__tenant_id___consumer_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "consumer_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Consumer Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsumerResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Consumer",
+        "tags": [
+          "Consumers"
+        ]
+      },
+      "put": {
+        "description": "Update consumer details.",
+        "operationId": "update_consumer_v1_consumers__tenant_id___consumer_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "consumer_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Consumer Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConsumerUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsumerResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Consumer",
+        "tags": [
+          "Consumers"
+        ]
+      }
+    },
+    "/v1/consumers/{tenant_id}/{consumer_id}/activate": {
+      "post": {
+        "description": "Reactivate a suspended consumer.",
+        "operationId": "activate_consumer_v1_consumers__tenant_id___consumer_id__activate_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "consumer_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Consumer Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsumerResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Activate Consumer",
+        "tags": [
+          "Consumers"
+        ]
+      }
+    },
+    "/v1/consumers/{tenant_id}/{consumer_id}/block": {
+      "post": {
+        "description": "Block a consumer (permanent until unblocked).",
+        "operationId": "block_consumer_v1_consumers__tenant_id___consumer_id__block_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "consumer_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Consumer Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsumerResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Block Consumer",
+        "tags": [
+          "Consumers"
+        ]
+      }
+    },
+    "/v1/consumers/{tenant_id}/{consumer_id}/suspend": {
+      "post": {
+        "description": "Suspend an active consumer.",
+        "operationId": "suspend_consumer_v1_consumers__tenant_id___consumer_id__suspend_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "consumer_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Consumer Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsumerResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Suspend Consumer",
+        "tags": [
+          "Consumers"
+        ]
+      }
+    },
     "/v1/contracts": {
       "get": {
         "description": "List contracts for the user's tenant (cached, TTL 60s).",
@@ -16610,7 +17974,11 @@
             "name": "status",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/LogStatus",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LogStatus"
+                }
+              ],
               "default": "all",
               "description": "Filter by status",
               "title": "Status"
@@ -16773,7 +18141,11 @@
             "name": "status",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/LogStatus",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LogStatus"
+                }
+              ],
               "default": "all",
               "description": "Filter by status",
               "title": "Status"
@@ -17595,7 +18967,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MCPKeyRotationRequest",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/MCPKeyRotationRequest"
+                  }
+                ],
                 "default": {
                   "grace_period_hours": 24
                 },
@@ -18256,6 +19632,379 @@
         "summary": "Get Operations Metrics",
         "tags": [
           "Operations"
+        ]
+      }
+    },
+    "/v1/plans/{tenant_id}": {
+      "get": {
+        "description": "List subscription plans for a tenant.",
+        "operationId": "list_plans_v1_plans__tenant_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/PlanStatusEnum"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Plans",
+        "tags": [
+          "Plans"
+        ]
+      },
+      "post": {
+        "description": "Create a new subscription plan for a tenant.",
+        "operationId": "create_plan_v1_plans__tenant_id__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Plan",
+        "tags": [
+          "Plans"
+        ]
+      }
+    },
+    "/v1/plans/{tenant_id}/by-slug/{slug}": {
+      "get": {
+        "description": "Get plan by slug within a tenant.",
+        "operationId": "get_plan_by_slug_v1_plans__tenant_id__by_slug__slug__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Plan By Slug",
+        "tags": [
+          "Plans"
+        ]
+      }
+    },
+    "/v1/plans/{tenant_id}/{plan_id}": {
+      "delete": {
+        "description": "Delete a plan.",
+        "operationId": "delete_plan_v1_plans__tenant_id___plan_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plan_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Plan Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete Plan",
+        "tags": [
+          "Plans"
+        ]
+      },
+      "get": {
+        "description": "Get plan details by ID.",
+        "operationId": "get_plan_v1_plans__tenant_id___plan_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plan_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Plan Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Plan",
+        "tags": [
+          "Plans"
+        ]
+      },
+      "put": {
+        "description": "Update plan details.",
+        "operationId": "update_plan_v1_plans__tenant_id___plan_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "plan_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Plan Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Plan",
+        "tags": [
+          "Plans"
         ]
       }
     },
@@ -19126,7 +20875,11 @@
             "name": "sort",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/SortOrder",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/SortOrder"
+                }
+              ],
               "default": "relevance",
               "description": "Sort order",
               "title": "Sort"
@@ -20421,7 +22174,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/KeyRotationRequest",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/KeyRotationRequest"
+                  }
+                ],
                 "default": {
                   "grace_period_hours": 24
                 },
@@ -23395,6 +25152,14 @@
     {
       "description": "Internal gateway auto-registration (ADR-028)",
       "name": "Gateway Internal"
+    },
+    {
+      "description": "Consumer onboarding and lifecycle management (CAB-1121)",
+      "name": "Consumers"
+    },
+    {
+      "description": "Subscription plan management with quotas (CAB-1121)",
+      "name": "Plans"
     }
   ]
 }

--- a/control-plane-api/src/main.py
+++ b/control-plane-api/src/main.py
@@ -29,6 +29,7 @@ from .routers import (
     business,
     catalog_admin,
     certificates,
+    consumers,
     contracts,
     deployments,
     events,
@@ -45,6 +46,7 @@ from .routers import (
     mcp_proxy,
     monitoring,
     operations,
+    plans,
     platform,
     portal,
     portal_applications,
@@ -328,6 +330,8 @@ app = FastAPI(
         {"name": "Gateway Policies", "description": "Gateway-agnostic policy management"},
         {"name": "Gateway Observability", "description": "Multi-gateway health and sync metrics"},
         {"name": "Gateway Internal", "description": "Internal gateway auto-registration (ADR-028)"},
+        {"name": "Consumers", "description": "Consumer onboarding and lifecycle management (CAB-1121)"},
+        {"name": "Plans", "description": "Subscription plan management with quotas (CAB-1121)"},
     ],
     contact={
         "name": "CAB Ingénierie",
@@ -450,6 +454,10 @@ app.include_router(gateway_deployments.router)
 app.include_router(gateway_policies.router)
 # Internal gateway registration API (ADR-028 auto-registration)
 app.include_router(gateway_internal.router)
+
+# Consumer Onboarding (CAB-1121)
+app.include_router(consumers.router)
+app.include_router(plans.router)
 
 
 # Legacy health endpoint - redirect to new /health/live

--- a/control-plane-api/src/models/__init__.py
+++ b/control-plane-api/src/models/__init__.py
@@ -5,6 +5,7 @@ from .catalog import (
     SyncStatus,
     SyncType,
 )
+from .consumer import Consumer, ConsumerStatus
 from .external_mcp_server import (
     ExternalMCPAuthType,
     ExternalMCPHealthStatus,
@@ -38,6 +39,7 @@ from .mcp_subscription import (
     MCPToolAccess,
     MCPToolAccessStatus,
 )
+from .plan import Plan, PlanStatus
 from .prospect_event import EventType, ProspectEvent
 from .prospect_feedback import ProspectFeedback
 from .subscription import Subscription, SubscriptionStatus

--- a/control-plane-api/src/models/consumer.py
+++ b/control-plane-api/src/models/consumer.py
@@ -1,0 +1,67 @@
+"""Consumer SQLAlchemy model for external API consumers."""
+
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Enum as SQLEnum, Index, String, Text
+from sqlalchemy.dialects.postgresql import JSON, UUID
+
+from src.database import Base
+
+
+class ConsumerStatus(enum.StrEnum):
+    """Consumer status enum."""
+
+    ACTIVE = "active"
+    SUSPENDED = "suspended"
+    BLOCKED = "blocked"
+
+
+class Consumer(Base):
+    """Consumer model - represents an external API consumer (company, partner, developer)."""
+
+    __tablename__ = "consumers"
+
+    # Primary key
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    # Identity
+    external_id = Column(String(255), nullable=False)
+    name = Column(String(255), nullable=False)
+    email = Column(String(255), nullable=False)
+    company = Column(String(255), nullable=True)
+    description = Column(Text, nullable=True)
+
+    # Tenant (the API provider)
+    tenant_id = Column(String(255), nullable=False, index=True)
+
+    # Optional Keycloak link
+    keycloak_user_id = Column(String(255), nullable=True, index=True)
+
+    # Status
+    status = Column(
+        SQLEnum(ConsumerStatus, values_callable=lambda x: [e.value for e in x]),
+        nullable=False,
+        default=ConsumerStatus.ACTIVE,
+    )
+
+    # Metadata (JSON for custom attributes)
+    consumer_metadata = Column(JSON, nullable=True)
+
+    # Timestamps
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    # Audit
+    created_by = Column(String(255), nullable=True)
+
+    # Indexes
+    __table_args__ = (
+        Index("ix_consumers_tenant_external", "tenant_id", "external_id", unique=True),
+        Index("ix_consumers_tenant_status", "tenant_id", "status"),
+        Index("ix_consumers_email", "email"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<Consumer {self.id} name={self.name} tenant={self.tenant_id}>"

--- a/control-plane-api/src/models/plan.py
+++ b/control-plane-api/src/models/plan.py
@@ -1,0 +1,72 @@
+"""Plan SQLAlchemy model for subscription plans with quota definitions."""
+
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, Enum as SQLEnum, Index, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSON, UUID
+
+from src.database import Base
+
+
+class PlanStatus(enum.StrEnum):
+    """Plan status enum."""
+
+    ACTIVE = "active"
+    DEPRECATED = "deprecated"
+    ARCHIVED = "archived"
+
+
+class Plan(Base):
+    """Plan model - defines subscription plans with quotas (Bronze/Silver/Gold)."""
+
+    __tablename__ = "plans"
+
+    # Primary key
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    # Identity
+    slug = Column(String(100), nullable=False)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+
+    # Tenant (the API provider who defines this plan)
+    tenant_id = Column(String(255), nullable=False, index=True)
+
+    # Quotas
+    rate_limit_per_second = Column(Integer, nullable=True)
+    rate_limit_per_minute = Column(Integer, nullable=True)
+    daily_request_limit = Column(Integer, nullable=True)
+    monthly_request_limit = Column(Integer, nullable=True)
+    burst_limit = Column(Integer, nullable=True)
+
+    # Approval workflow
+    requires_approval = Column(Boolean, nullable=False, default=False)
+    auto_approve_roles = Column(JSON, nullable=True)
+
+    # Status
+    status = Column(
+        SQLEnum(PlanStatus, values_callable=lambda x: [e.value for e in x]),
+        nullable=False,
+        default=PlanStatus.ACTIVE,
+    )
+
+    # Pricing (metadata, not enforced by platform)
+    pricing_metadata = Column(JSON, nullable=True)
+
+    # Timestamps
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    # Audit
+    created_by = Column(String(255), nullable=True)
+
+    # Indexes
+    __table_args__ = (
+        Index("ix_plans_tenant_slug", "tenant_id", "slug", unique=True),
+        Index("ix_plans_tenant_status", "tenant_id", "status"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<Plan {self.id} slug={self.slug} tenant={self.tenant_id}>"

--- a/control-plane-api/src/models/subscription.py
+++ b/control-plane-api/src/models/subscription.py
@@ -48,6 +48,9 @@ class Subscription(Base):
     api_version = Column(String(50), nullable=False)
     tenant_id = Column(String(255), nullable=False, index=True)
 
+    # Consumer reference (nullable for backward compatibility — CAB-1121)
+    consumer_id = Column(UUID(as_uuid=True), nullable=True, index=True)
+
     # Subscription plan
     plan_id = Column(String(255), nullable=True)
     plan_name = Column(String(255), nullable=True, default="default")

--- a/control-plane-api/src/repositories/consumer.py
+++ b/control-plane-api/src/repositories/consumer.py
@@ -1,0 +1,127 @@
+"""Repository for consumer CRUD operations (CAB-1121)."""
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.consumer import Consumer, ConsumerStatus
+
+
+class ConsumerRepository:
+    """Repository for consumer database operations."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(self, consumer: Consumer) -> Consumer:
+        """Create a new consumer."""
+        self.session.add(consumer)
+        await self.session.flush()
+        await self.session.refresh(consumer)
+        return consumer
+
+    async def get_by_id(self, consumer_id: UUID) -> Consumer | None:
+        """Get consumer by ID."""
+        result = await self.session.execute(select(Consumer).where(Consumer.id == consumer_id))
+        return result.scalar_one_or_none()
+
+    async def get_by_external_id(self, tenant_id: str, external_id: str) -> Consumer | None:
+        """Get consumer by tenant + external_id (unique pair)."""
+        result = await self.session.execute(
+            select(Consumer).where(
+                and_(
+                    Consumer.tenant_id == tenant_id,
+                    Consumer.external_id == external_id,
+                )
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def list_by_tenant(
+        self,
+        tenant_id: str,
+        status: ConsumerStatus | None = None,
+        search: str | None = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> tuple[list[Consumer], int]:
+        """List consumers for a tenant with pagination and optional filtering."""
+        query = select(Consumer).where(Consumer.tenant_id == tenant_id)
+
+        if status:
+            query = query.where(Consumer.status == status)
+
+        if search:
+            search_pattern = f"%{search}%"
+            query = query.where(
+                or_(
+                    Consumer.name.ilike(search_pattern),
+                    Consumer.email.ilike(search_pattern),
+                    Consumer.external_id.ilike(search_pattern),
+                    Consumer.company.ilike(search_pattern),
+                )
+            )
+
+        # Count total
+        count_query = select(func.count()).select_from(query.subquery())
+        total_result = await self.session.execute(count_query)
+        total = total_result.scalar_one()
+
+        # Paginate
+        query = query.order_by(Consumer.created_at.desc())
+        query = query.offset((page - 1) * page_size).limit(page_size)
+
+        result = await self.session.execute(query)
+        consumers = result.scalars().all()
+
+        return list(consumers), total
+
+    async def update(self, consumer: Consumer) -> Consumer:
+        """Update a consumer (caller sets fields before calling)."""
+        consumer.updated_at = datetime.utcnow()
+        await self.session.flush()
+        await self.session.refresh(consumer)
+        return consumer
+
+    async def update_status(
+        self,
+        consumer: Consumer,
+        new_status: ConsumerStatus,
+    ) -> Consumer:
+        """Update consumer status."""
+        consumer.status = new_status
+        consumer.updated_at = datetime.utcnow()
+        await self.session.flush()
+        await self.session.refresh(consumer)
+        return consumer
+
+    async def delete(self, consumer: Consumer) -> None:
+        """Delete a consumer (hard delete)."""
+        await self.session.delete(consumer)
+        await self.session.flush()
+
+    async def get_stats(self, tenant_id: str | None = None) -> dict:
+        """Get consumer statistics."""
+        base_query = select(Consumer)
+        if tenant_id:
+            base_query = base_query.where(Consumer.tenant_id == tenant_id)
+
+        # Total count
+        total_result = await self.session.execute(select(func.count()).select_from(base_query.subquery()))
+        total = total_result.scalar_one()
+
+        # Count by status
+        by_status = {}
+        for status in ConsumerStatus:
+            status_query = select(func.count()).where(Consumer.status == status)
+            if tenant_id:
+                status_query = status_query.where(Consumer.tenant_id == tenant_id)
+            result = await self.session.execute(status_query)
+            by_status[status.value] = result.scalar_one()
+
+        return {
+            "total": total,
+            "by_status": by_status,
+        }

--- a/control-plane-api/src/repositories/plan.py
+++ b/control-plane-api/src/repositories/plan.py
@@ -1,0 +1,79 @@
+"""Repository for plan CRUD operations (CAB-1121)."""
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.plan import Plan, PlanStatus
+
+
+class PlanRepository:
+    """Repository for plan database operations."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(self, plan: Plan) -> Plan:
+        """Create a new plan."""
+        self.session.add(plan)
+        await self.session.flush()
+        await self.session.refresh(plan)
+        return plan
+
+    async def get_by_id(self, plan_id: UUID) -> Plan | None:
+        """Get plan by ID."""
+        result = await self.session.execute(select(Plan).where(Plan.id == plan_id))
+        return result.scalar_one_or_none()
+
+    async def get_by_slug(self, tenant_id: str, slug: str) -> Plan | None:
+        """Get plan by tenant + slug (unique pair)."""
+        result = await self.session.execute(
+            select(Plan).where(
+                and_(
+                    Plan.tenant_id == tenant_id,
+                    Plan.slug == slug,
+                )
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def list_by_tenant(
+        self,
+        tenant_id: str,
+        status: PlanStatus | None = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> tuple[list[Plan], int]:
+        """List plans for a tenant with pagination."""
+        query = select(Plan).where(Plan.tenant_id == tenant_id)
+
+        if status:
+            query = query.where(Plan.status == status)
+
+        # Count total
+        count_query = select(func.count()).select_from(query.subquery())
+        total_result = await self.session.execute(count_query)
+        total = total_result.scalar_one()
+
+        # Paginate
+        query = query.order_by(Plan.created_at.desc())
+        query = query.offset((page - 1) * page_size).limit(page_size)
+
+        result = await self.session.execute(query)
+        plans = result.scalars().all()
+
+        return list(plans), total
+
+    async def update(self, plan: Plan) -> Plan:
+        """Update a plan (caller sets fields before calling)."""
+        plan.updated_at = datetime.utcnow()
+        await self.session.flush()
+        await self.session.refresh(plan)
+        return plan
+
+    async def delete(self, plan: Plan) -> None:
+        """Delete a plan (hard delete)."""
+        await self.session.delete(plan)
+        await self.session.flush()

--- a/control-plane-api/src/routers/consumers.py
+++ b/control-plane-api/src/routers/consumers.py
@@ -1,0 +1,291 @@
+"""Consumers router - External API consumer management (CAB-1121)."""
+
+import logging
+import math
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth import User, get_current_user
+from ..database import get_db
+from ..models.consumer import Consumer, ConsumerStatus
+from ..repositories.consumer import ConsumerRepository
+from ..schemas.consumer import (
+    ConsumerCreate,
+    ConsumerListResponse,
+    ConsumerResponse,
+    ConsumerStatusEnum,
+    ConsumerUpdate,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/consumers", tags=["Consumers"])
+
+
+def _has_tenant_access(user: User, tenant_id: str) -> bool:
+    """Check if user has access to a tenant."""
+    if "cpi-admin" in user.roles:
+        return True
+    return user.tenant_id == tenant_id
+
+
+# ============== CRUD Endpoints ==============
+
+
+@router.post("/{tenant_id}", response_model=ConsumerResponse, status_code=201)
+async def create_consumer(
+    tenant_id: str,
+    request: ConsumerCreate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new consumer for a tenant."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    repo = ConsumerRepository(db)
+
+    # Check for duplicate external_id
+    existing = await repo.get_by_external_id(tenant_id, request.external_id)
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Consumer with external_id '{request.external_id}' already exists in this tenant",
+        )
+
+    consumer = Consumer(
+        external_id=request.external_id,
+        name=request.name,
+        email=request.email,
+        company=request.company,
+        description=request.description,
+        tenant_id=tenant_id,
+        keycloak_user_id=request.keycloak_user_id,
+        status=ConsumerStatus.ACTIVE,
+        consumer_metadata=request.consumer_metadata,
+        created_by=user.id,
+    )
+
+    try:
+        consumer = await repo.create(consumer)
+        logger.info(
+            f"Created consumer {consumer.id} external_id={request.external_id} " f"tenant={tenant_id} by={user.email}"
+        )
+    except Exception as e:
+        logger.error(f"Failed to create consumer: {e}")
+        raise HTTPException(status_code=500, detail="Failed to create consumer")
+
+    return ConsumerResponse.model_validate(consumer)
+
+
+@router.get("/{tenant_id}", response_model=ConsumerListResponse)
+async def list_consumers(
+    tenant_id: str,
+    status: ConsumerStatusEnum | None = None,
+    search: str | None = Query(None, max_length=255),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List consumers for a tenant with optional filtering."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    repo = ConsumerRepository(db)
+
+    db_status = ConsumerStatus(status.value) if status else None
+    consumers, total = await repo.list_by_tenant(
+        tenant_id=tenant_id,
+        status=db_status,
+        search=search,
+        page=page,
+        page_size=page_size,
+    )
+
+    return ConsumerListResponse(
+        items=[ConsumerResponse.model_validate(c) for c in consumers],
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=math.ceil(total / page_size) if total > 0 else 1,
+    )
+
+
+@router.get("/{tenant_id}/{consumer_id}", response_model=ConsumerResponse)
+async def get_consumer(
+    tenant_id: str,
+    consumer_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get consumer details by ID."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    repo = ConsumerRepository(db)
+    consumer = await repo.get_by_id(consumer_id)
+
+    if not consumer:
+        raise HTTPException(status_code=404, detail="Consumer not found")
+
+    if consumer.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Consumer not found")
+
+    return ConsumerResponse.model_validate(consumer)
+
+
+@router.put("/{tenant_id}/{consumer_id}", response_model=ConsumerResponse)
+async def update_consumer(
+    tenant_id: str,
+    consumer_id: UUID,
+    request: ConsumerUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update consumer details."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    repo = ConsumerRepository(db)
+    consumer = await repo.get_by_id(consumer_id)
+
+    if not consumer:
+        raise HTTPException(status_code=404, detail="Consumer not found")
+
+    if consumer.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Consumer not found")
+
+    # Apply updates
+    update_data = request.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(consumer, field, value)
+
+    consumer = await repo.update(consumer)
+
+    logger.info(f"Updated consumer {consumer_id} by {user.email}")
+
+    return ConsumerResponse.model_validate(consumer)
+
+
+@router.delete("/{tenant_id}/{consumer_id}", status_code=204)
+async def delete_consumer(
+    tenant_id: str,
+    consumer_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a consumer."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    repo = ConsumerRepository(db)
+    consumer = await repo.get_by_id(consumer_id)
+
+    if not consumer:
+        raise HTTPException(status_code=404, detail="Consumer not found")
+
+    if consumer.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Consumer not found")
+
+    await repo.delete(consumer)
+
+    logger.info(f"Deleted consumer {consumer_id} by {user.email}")
+
+
+# ============== Status Management Endpoints ==============
+
+
+@router.post("/{tenant_id}/{consumer_id}/suspend", response_model=ConsumerResponse)
+async def suspend_consumer(
+    tenant_id: str,
+    consumer_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Suspend an active consumer."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    repo = ConsumerRepository(db)
+    consumer = await repo.get_by_id(consumer_id)
+
+    if not consumer:
+        raise HTTPException(status_code=404, detail="Consumer not found")
+
+    if consumer.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Consumer not found")
+
+    if consumer.status != ConsumerStatus.ACTIVE:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot suspend consumer in {consumer.status.value} status",
+        )
+
+    consumer = await repo.update_status(consumer, ConsumerStatus.SUSPENDED)
+    logger.info(f"Consumer {consumer_id} suspended by {user.email}")
+
+    return ConsumerResponse.model_validate(consumer)
+
+
+@router.post("/{tenant_id}/{consumer_id}/activate", response_model=ConsumerResponse)
+async def activate_consumer(
+    tenant_id: str,
+    consumer_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Reactivate a suspended consumer."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    repo = ConsumerRepository(db)
+    consumer = await repo.get_by_id(consumer_id)
+
+    if not consumer:
+        raise HTTPException(status_code=404, detail="Consumer not found")
+
+    if consumer.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Consumer not found")
+
+    if consumer.status != ConsumerStatus.SUSPENDED:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot activate consumer in {consumer.status.value} status",
+        )
+
+    consumer = await repo.update_status(consumer, ConsumerStatus.ACTIVE)
+    logger.info(f"Consumer {consumer_id} activated by {user.email}")
+
+    return ConsumerResponse.model_validate(consumer)
+
+
+@router.post("/{tenant_id}/{consumer_id}/block", response_model=ConsumerResponse)
+async def block_consumer(
+    tenant_id: str,
+    consumer_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Block a consumer (permanent until unblocked)."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    repo = ConsumerRepository(db)
+    consumer = await repo.get_by_id(consumer_id)
+
+    if not consumer:
+        raise HTTPException(status_code=404, detail="Consumer not found")
+
+    if consumer.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Consumer not found")
+
+    if consumer.status == ConsumerStatus.BLOCKED:
+        raise HTTPException(status_code=400, detail="Consumer is already blocked")
+
+    consumer = await repo.update_status(consumer, ConsumerStatus.BLOCKED)
+    logger.info(f"Consumer {consumer_id} blocked by {user.email}")
+
+    return ConsumerResponse.model_validate(consumer)

--- a/control-plane-api/src/routers/plans.py
+++ b/control-plane-api/src/routers/plans.py
@@ -1,0 +1,217 @@
+"""Plans router - Subscription plan management (CAB-1121)."""
+
+import logging
+import math
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth import User, get_current_user
+from ..database import get_db
+from ..models.plan import Plan, PlanStatus
+from ..repositories.plan import PlanRepository
+from ..schemas.plan import (
+    PlanCreate,
+    PlanListResponse,
+    PlanResponse,
+    PlanStatusEnum,
+    PlanUpdate,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/plans", tags=["Plans"])
+
+
+def _has_tenant_access(user: User, tenant_id: str) -> bool:
+    """Check if user has access to a tenant."""
+    if "cpi-admin" in user.roles:
+        return True
+    return user.tenant_id == tenant_id
+
+
+# ============== CRUD Endpoints ==============
+
+
+@router.post("/{tenant_id}", response_model=PlanResponse, status_code=201)
+async def create_plan(
+    tenant_id: str,
+    request: PlanCreate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new subscription plan for a tenant."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    repo = PlanRepository(db)
+
+    # Check for duplicate slug
+    existing = await repo.get_by_slug(tenant_id, request.slug)
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Plan with slug '{request.slug}' already exists in this tenant",
+        )
+
+    plan = Plan(
+        slug=request.slug,
+        name=request.name,
+        description=request.description,
+        tenant_id=tenant_id,
+        rate_limit_per_second=request.rate_limit_per_second,
+        rate_limit_per_minute=request.rate_limit_per_minute,
+        daily_request_limit=request.daily_request_limit,
+        monthly_request_limit=request.monthly_request_limit,
+        burst_limit=request.burst_limit,
+        requires_approval=request.requires_approval,
+        auto_approve_roles=request.auto_approve_roles,
+        status=PlanStatus.ACTIVE,
+        pricing_metadata=request.pricing_metadata,
+        created_by=user.id,
+    )
+
+    try:
+        plan = await repo.create(plan)
+        logger.info(f"Created plan {plan.id} slug={request.slug} tenant={tenant_id} by={user.email}")
+    except Exception as e:
+        logger.error(f"Failed to create plan: {e}")
+        raise HTTPException(status_code=500, detail="Failed to create plan")
+
+    return PlanResponse.model_validate(plan)
+
+
+@router.get("/{tenant_id}", response_model=PlanListResponse)
+async def list_plans(
+    tenant_id: str,
+    status: PlanStatusEnum | None = None,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List subscription plans for a tenant."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    repo = PlanRepository(db)
+
+    db_status = PlanStatus(status.value) if status else None
+    plans, total = await repo.list_by_tenant(
+        tenant_id=tenant_id,
+        status=db_status,
+        page=page,
+        page_size=page_size,
+    )
+
+    return PlanListResponse(
+        items=[PlanResponse.model_validate(p) for p in plans],
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=math.ceil(total / page_size) if total > 0 else 1,
+    )
+
+
+@router.get("/{tenant_id}/by-slug/{slug}", response_model=PlanResponse)
+async def get_plan_by_slug(
+    tenant_id: str,
+    slug: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get plan by slug within a tenant."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    repo = PlanRepository(db)
+    plan = await repo.get_by_slug(tenant_id, slug)
+
+    if not plan:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    return PlanResponse.model_validate(plan)
+
+
+@router.get("/{tenant_id}/{plan_id}", response_model=PlanResponse)
+async def get_plan(
+    tenant_id: str,
+    plan_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get plan details by ID."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    repo = PlanRepository(db)
+    plan = await repo.get_by_id(plan_id)
+
+    if not plan:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    if plan.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    return PlanResponse.model_validate(plan)
+
+
+@router.put("/{tenant_id}/{plan_id}", response_model=PlanResponse)
+async def update_plan(
+    tenant_id: str,
+    plan_id: UUID,
+    request: PlanUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update plan details."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    repo = PlanRepository(db)
+    plan = await repo.get_by_id(plan_id)
+
+    if not plan:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    if plan.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    # Apply updates
+    update_data = request.model_dump(exclude_unset=True)
+    if "status" in update_data:
+        update_data["status"] = PlanStatus(update_data["status"])
+    for field, value in update_data.items():
+        setattr(plan, field, value)
+
+    plan = await repo.update(plan)
+
+    logger.info(f"Updated plan {plan_id} by {user.email}")
+
+    return PlanResponse.model_validate(plan)
+
+
+@router.delete("/{tenant_id}/{plan_id}", status_code=204)
+async def delete_plan(
+    tenant_id: str,
+    plan_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a plan."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    repo = PlanRepository(db)
+    plan = await repo.get_by_id(plan_id)
+
+    if not plan:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    if plan.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    await repo.delete(plan)
+
+    logger.info(f"Deleted plan {plan_id} by {user.email}")

--- a/control-plane-api/src/schemas/consumer.py
+++ b/control-plane-api/src/schemas/consumer.py
@@ -1,0 +1,80 @@
+"""Pydantic schemas for consumer endpoints (CAB-1121)."""
+
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ConsumerStatusEnum(StrEnum):
+    """Consumer status enum for API responses."""
+
+    ACTIVE = "active"
+    SUSPENDED = "suspended"
+    BLOCKED = "blocked"
+
+
+class ConsumerCreate(BaseModel):
+    """Schema for creating a new consumer."""
+
+    external_id: str = Field(..., min_length=1, max_length=255)
+    name: str = Field(..., min_length=1, max_length=255)
+    email: str = Field(..., min_length=1, max_length=255)
+    company: str | None = Field(None, max_length=255)
+    description: str | None = None
+    keycloak_user_id: str | None = Field(None, max_length=255)
+    consumer_metadata: dict | None = None
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "external_id": "partner-acme-001",
+                "name": "ACME Corp",
+                "email": "api@acme.com",
+                "company": "ACME Corporation",
+                "description": "Strategic API partner",
+            }
+        }
+    )
+
+
+class ConsumerUpdate(BaseModel):
+    """Schema for updating an existing consumer."""
+
+    name: str | None = Field(None, min_length=1, max_length=255)
+    email: str | None = Field(None, min_length=1, max_length=255)
+    company: str | None = Field(None, max_length=255)
+    description: str | None = None
+    keycloak_user_id: str | None = Field(None, max_length=255)
+    consumer_metadata: dict | None = None
+
+
+class ConsumerResponse(BaseModel):
+    """Schema for consumer response."""
+
+    id: UUID
+    external_id: str
+    name: str
+    email: str
+    company: str | None
+    description: str | None
+    tenant_id: str
+    keycloak_user_id: str | None
+    status: ConsumerStatusEnum
+    consumer_metadata: dict | None
+    created_at: datetime
+    updated_at: datetime
+    created_by: str | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ConsumerListResponse(BaseModel):
+    """Schema for paginated consumer list."""
+
+    items: list[ConsumerResponse]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int

--- a/control-plane-api/src/schemas/plan.py
+++ b/control-plane-api/src/schemas/plan.py
@@ -1,0 +1,96 @@
+"""Pydantic schemas for plan endpoints (CAB-1121)."""
+
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PlanStatusEnum(StrEnum):
+    """Plan status enum for API responses."""
+
+    ACTIVE = "active"
+    DEPRECATED = "deprecated"
+    ARCHIVED = "archived"
+
+
+class PlanCreate(BaseModel):
+    """Schema for creating a new subscription plan."""
+
+    slug: str = Field(..., min_length=1, max_length=100, pattern=r"^[a-z0-9-]+$")
+    name: str = Field(..., min_length=1, max_length=255)
+    description: str | None = None
+    rate_limit_per_second: int | None = Field(None, ge=0)
+    rate_limit_per_minute: int | None = Field(None, ge=0)
+    daily_request_limit: int | None = Field(None, ge=0)
+    monthly_request_limit: int | None = Field(None, ge=0)
+    burst_limit: int | None = Field(None, ge=0)
+    requires_approval: bool = False
+    auto_approve_roles: list[str] | None = None
+    pricing_metadata: dict | None = None
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "slug": "gold",
+                "name": "Gold Plan",
+                "description": "High-volume plan for production workloads",
+                "rate_limit_per_second": 100,
+                "rate_limit_per_minute": 5000,
+                "daily_request_limit": 1000000,
+                "monthly_request_limit": 30000000,
+                "requires_approval": True,
+            }
+        }
+    )
+
+
+class PlanUpdate(BaseModel):
+    """Schema for updating an existing plan."""
+
+    name: str | None = Field(None, min_length=1, max_length=255)
+    description: str | None = None
+    rate_limit_per_second: int | None = Field(None, ge=0)
+    rate_limit_per_minute: int | None = Field(None, ge=0)
+    daily_request_limit: int | None = Field(None, ge=0)
+    monthly_request_limit: int | None = Field(None, ge=0)
+    burst_limit: int | None = Field(None, ge=0)
+    requires_approval: bool | None = None
+    auto_approve_roles: list[str] | None = None
+    pricing_metadata: dict | None = None
+    status: PlanStatusEnum | None = None
+
+
+class PlanResponse(BaseModel):
+    """Schema for plan response."""
+
+    id: UUID
+    slug: str
+    name: str
+    description: str | None
+    tenant_id: str
+    rate_limit_per_second: int | None
+    rate_limit_per_minute: int | None
+    daily_request_limit: int | None
+    monthly_request_limit: int | None
+    burst_limit: int | None
+    requires_approval: bool
+    auto_approve_roles: list[str] | None
+    status: PlanStatusEnum
+    pricing_metadata: dict | None
+    created_at: datetime
+    updated_at: datetime
+    created_by: str | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PlanListResponse(BaseModel):
+    """Schema for paginated plan list."""
+
+    items: list[PlanResponse]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int

--- a/control-plane-api/tests/conftest.py
+++ b/control-plane-api/tests/conftest.py
@@ -334,6 +334,65 @@ def sample_tenant_data():
     }
 
 
+# ============== Consumer & Plan Fixtures (CAB-1121) ==============
+
+
+@pytest.fixture
+def sample_consumer_id():
+    """Generate a consistent consumer ID for tests."""
+    return uuid4()
+
+
+@pytest.fixture
+def sample_consumer_data(sample_consumer_id):
+    """Sample consumer data for testing."""
+    return {
+        "id": sample_consumer_id,
+        "external_id": "partner-acme-001",
+        "name": "ACME Corp",
+        "email": "api@acme.com",
+        "company": "ACME Corporation",
+        "description": "Strategic API partner",
+        "tenant_id": "acme",
+        "keycloak_user_id": None,
+        "status": "active",
+        "consumer_metadata": None,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+        "created_by": "tenant-admin-user-id",
+    }
+
+
+@pytest.fixture
+def sample_plan_id():
+    """Generate a consistent plan ID for tests."""
+    return uuid4()
+
+
+@pytest.fixture
+def sample_plan_data(sample_plan_id):
+    """Sample plan data for testing."""
+    return {
+        "id": sample_plan_id,
+        "slug": "gold",
+        "name": "Gold Plan",
+        "description": "High-volume plan for production",
+        "tenant_id": "acme",
+        "rate_limit_per_second": 100,
+        "rate_limit_per_minute": 5000,
+        "daily_request_limit": 1000000,
+        "monthly_request_limit": 30000000,
+        "burst_limit": 200,
+        "requires_approval": True,
+        "auto_approve_roles": None,
+        "status": "active",
+        "pricing_metadata": None,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+        "created_by": "tenant-admin-user-id",
+    }
+
+
 # ============== App & Client Fixtures ==============
 
 @pytest.fixture

--- a/control-plane-api/tests/test_consumers.py
+++ b/control-plane-api/tests/test_consumers.py
@@ -1,0 +1,293 @@
+"""
+Tests for Consumers Router - CAB-1121
+
+Target: Consumer CRUD + status management + tenant isolation
+Tests: 12 test cases
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+
+class TestConsumersRouter:
+    """Test suite for Consumers Router endpoints."""
+
+    # ============== Helper Methods ==============
+
+    def _create_mock_consumer(self, data: dict) -> MagicMock:
+        """Create a mock Consumer object from data dict."""
+        mock = MagicMock()
+        for key, value in data.items():
+            setattr(mock, key, value)
+        return mock
+
+    # ============== Create Consumer Tests ==============
+
+    def test_create_consumer_success(
+        self, app_with_tenant_admin, mock_db_session, sample_consumer_data
+    ):
+        """Test successful consumer creation returns 201."""
+        mock_consumer = self._create_mock_consumer(sample_consumer_data)
+
+        with patch("src.routers.consumers.ConsumerRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_external_id = AsyncMock(return_value=None)
+            mock_repo_instance.create = AsyncMock(return_value=mock_consumer)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.post(
+                    "/v1/consumers/acme",
+                    json={
+                        "external_id": "partner-acme-001",
+                        "name": "ACME Corp",
+                        "email": "api@acme.com",
+                        "company": "ACME Corporation",
+                        "description": "Strategic API partner",
+                    },
+                )
+
+            assert response.status_code == 201
+            data = response.json()
+            assert data["external_id"] == "partner-acme-001"
+            assert data["name"] == "ACME Corp"
+            assert data["tenant_id"] == "acme"
+            assert data["status"] == "active"
+
+    def test_create_consumer_duplicate_409(
+        self, app_with_tenant_admin, mock_db_session, sample_consumer_data
+    ):
+        """Test duplicate external_id returns 409."""
+        mock_existing = self._create_mock_consumer(sample_consumer_data)
+
+        with patch("src.routers.consumers.ConsumerRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_external_id = AsyncMock(return_value=mock_existing)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.post(
+                    "/v1/consumers/acme",
+                    json={
+                        "external_id": "partner-acme-001",
+                        "name": "Duplicate",
+                        "email": "dup@acme.com",
+                    },
+                )
+
+            assert response.status_code == 409
+            assert "already exists" in response.json()["detail"]
+
+    def test_create_consumer_403_wrong_tenant(
+        self, app_with_other_tenant, mock_db_session
+    ):
+        """Test tenant isolation - cannot create consumer in another tenant."""
+        with TestClient(app_with_other_tenant) as client:
+            response = client.post(
+                "/v1/consumers/acme",
+                json={
+                    "external_id": "partner-001",
+                    "name": "Test",
+                    "email": "test@test.com",
+                },
+            )
+
+        assert response.status_code == 403
+
+    # ============== List Consumer Tests ==============
+
+    def test_list_consumers_success(
+        self, app_with_tenant_admin, mock_db_session, sample_consumer_data
+    ):
+        """Test listing consumers with pagination."""
+        mock_consumer = self._create_mock_consumer(sample_consumer_data)
+
+        with patch("src.routers.consumers.ConsumerRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.list_by_tenant = AsyncMock(
+                return_value=([mock_consumer], 1)
+            )
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.get("/v1/consumers/acme")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["total"] == 1
+            assert len(data["items"]) == 1
+            assert data["items"][0]["external_id"] == "partner-acme-001"
+
+    def test_list_consumers_empty(self, app_with_tenant_admin, mock_db_session):
+        """Test listing consumers when none exist."""
+        with patch("src.routers.consumers.ConsumerRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.list_by_tenant = AsyncMock(return_value=([], 0))
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.get("/v1/consumers/acme")
+
+            assert response.status_code == 200
+            assert response.json()["total"] == 0
+            assert response.json()["items"] == []
+
+    # ============== Get Consumer Tests ==============
+
+    def test_get_consumer_success(
+        self, app_with_tenant_admin, mock_db_session, sample_consumer_data
+    ):
+        """Test getting a consumer by ID."""
+        mock_consumer = self._create_mock_consumer(sample_consumer_data)
+
+        with patch("src.routers.consumers.ConsumerRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_id = AsyncMock(return_value=mock_consumer)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.get(
+                    f"/v1/consumers/acme/{sample_consumer_data['id']}"
+                )
+
+            assert response.status_code == 200
+            assert response.json()["name"] == "ACME Corp"
+
+    def test_get_consumer_404(self, app_with_tenant_admin, mock_db_session):
+        """Test 404 when consumer not found."""
+        with patch("src.routers.consumers.ConsumerRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_id = AsyncMock(return_value=None)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.get(f"/v1/consumers/acme/{uuid4()}")
+
+            assert response.status_code == 404
+
+    # ============== Update Consumer Tests ==============
+
+    def test_update_consumer_success(
+        self, app_with_tenant_admin, mock_db_session, sample_consumer_data
+    ):
+        """Test updating a consumer."""
+        mock_consumer = self._create_mock_consumer(sample_consumer_data)
+        updated_consumer = self._create_mock_consumer(
+            {**sample_consumer_data, "name": "ACME Updated"}
+        )
+
+        with patch("src.routers.consumers.ConsumerRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_id = AsyncMock(return_value=mock_consumer)
+            mock_repo_instance.update = AsyncMock(return_value=updated_consumer)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.put(
+                    f"/v1/consumers/acme/{sample_consumer_data['id']}",
+                    json={"name": "ACME Updated"},
+                )
+
+            assert response.status_code == 200
+            assert response.json()["name"] == "ACME Updated"
+
+    # ============== Delete Consumer Tests ==============
+
+    def test_delete_consumer_success(
+        self, app_with_tenant_admin, mock_db_session, sample_consumer_data
+    ):
+        """Test deleting a consumer."""
+        mock_consumer = self._create_mock_consumer(sample_consumer_data)
+
+        with patch("src.routers.consumers.ConsumerRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_id = AsyncMock(return_value=mock_consumer)
+            mock_repo_instance.delete = AsyncMock()
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.delete(
+                    f"/v1/consumers/acme/{sample_consumer_data['id']}"
+                )
+
+            assert response.status_code == 204
+
+    # ============== Status Management Tests ==============
+
+    def test_suspend_consumer_success(
+        self, app_with_tenant_admin, mock_db_session, sample_consumer_data
+    ):
+        """Test suspending an active consumer."""
+        mock_consumer = self._create_mock_consumer(sample_consumer_data)
+        mock_consumer.status = "active"
+        # ConsumerStatus comparison — mock the enum value
+        mock_consumer.status = MagicMock()
+        mock_consumer.status.__eq__ = lambda _self, other: str(other) == "active"
+        mock_consumer.status.value = "active"
+        mock_consumer.status.__ne__ = lambda _self, other: str(other) != "active"
+
+        suspended_consumer = self._create_mock_consumer(
+            {**sample_consumer_data, "status": "suspended"}
+        )
+
+        with patch("src.routers.consumers.ConsumerRepository") as MockRepo, \
+             patch("src.routers.consumers.ConsumerStatus") as MockStatus:
+            MockStatus.ACTIVE = "active"
+            MockStatus.SUSPENDED = "suspended"
+            MockStatus.BLOCKED = "blocked"
+
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_id = AsyncMock(return_value=mock_consumer)
+            mock_repo_instance.update_status = AsyncMock(return_value=suspended_consumer)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.post(
+                    f"/v1/consumers/acme/{sample_consumer_data['id']}/suspend"
+                )
+
+            assert response.status_code == 200
+
+    def test_activate_consumer_success(
+        self, app_with_tenant_admin, mock_db_session, sample_consumer_data
+    ):
+        """Test reactivating a suspended consumer."""
+        mock_consumer = self._create_mock_consumer(
+            {**sample_consumer_data, "status": "suspended"}
+        )
+        mock_consumer.status = MagicMock()
+        mock_consumer.status.__eq__ = lambda _self, other: str(other) == "suspended"
+        mock_consumer.status.value = "suspended"
+        mock_consumer.status.__ne__ = lambda _self, other: str(other) != "suspended"
+
+        activated_consumer = self._create_mock_consumer(
+            {**sample_consumer_data, "status": "active"}
+        )
+
+        with patch("src.routers.consumers.ConsumerRepository") as MockRepo, \
+             patch("src.routers.consumers.ConsumerStatus") as MockStatus:
+            MockStatus.ACTIVE = "active"
+            MockStatus.SUSPENDED = "suspended"
+            MockStatus.BLOCKED = "blocked"
+
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_id = AsyncMock(return_value=mock_consumer)
+            mock_repo_instance.update_status = AsyncMock(return_value=activated_consumer)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.post(
+                    f"/v1/consumers/acme/{sample_consumer_data['id']}/activate"
+                )
+
+            assert response.status_code == 200
+
+    def test_cpi_admin_cross_tenant_access(
+        self, app_with_cpi_admin, mock_db_session, sample_consumer_data
+    ):
+        """Test CPI admin can access any tenant's consumers."""
+        mock_consumer = self._create_mock_consumer(sample_consumer_data)
+
+        with patch("src.routers.consumers.ConsumerRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.list_by_tenant = AsyncMock(
+                return_value=([mock_consumer], 1)
+            )
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/consumers/acme")
+
+            assert response.status_code == 200
+            assert response.json()["total"] == 1

--- a/control-plane-api/tests/test_plans.py
+++ b/control-plane-api/tests/test_plans.py
@@ -1,0 +1,238 @@
+"""
+Tests for Plans Router - CAB-1121
+
+Target: Plan CRUD + tenant isolation
+Tests: 10 test cases
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+
+class TestPlansRouter:
+    """Test suite for Plans Router endpoints."""
+
+    # ============== Helper Methods ==============
+
+    def _create_mock_plan(self, data: dict) -> MagicMock:
+        """Create a mock Plan object from data dict."""
+        mock = MagicMock()
+        for key, value in data.items():
+            setattr(mock, key, value)
+        return mock
+
+    # ============== Create Plan Tests ==============
+
+    def test_create_plan_success(
+        self, app_with_tenant_admin, mock_db_session, sample_plan_data
+    ):
+        """Test successful plan creation returns 201."""
+        mock_plan = self._create_mock_plan(sample_plan_data)
+
+        with patch("src.routers.plans.PlanRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_slug = AsyncMock(return_value=None)
+            mock_repo_instance.create = AsyncMock(return_value=mock_plan)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.post(
+                    "/v1/plans/acme",
+                    json={
+                        "slug": "gold",
+                        "name": "Gold Plan",
+                        "description": "High-volume plan",
+                        "rate_limit_per_second": 100,
+                        "rate_limit_per_minute": 5000,
+                        "requires_approval": True,
+                    },
+                )
+
+            assert response.status_code == 201
+            data = response.json()
+            assert data["slug"] == "gold"
+            assert data["name"] == "Gold Plan"
+            assert data["tenant_id"] == "acme"
+            assert data["requires_approval"] is True
+
+    def test_create_plan_duplicate_slug_409(
+        self, app_with_tenant_admin, mock_db_session, sample_plan_data
+    ):
+        """Test duplicate slug returns 409."""
+        mock_existing = self._create_mock_plan(sample_plan_data)
+
+        with patch("src.routers.plans.PlanRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_slug = AsyncMock(return_value=mock_existing)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.post(
+                    "/v1/plans/acme",
+                    json={
+                        "slug": "gold",
+                        "name": "Duplicate Gold",
+                    },
+                )
+
+            assert response.status_code == 409
+            assert "already exists" in response.json()["detail"]
+
+    def test_create_plan_invalid_slug_422(
+        self, app_with_tenant_admin, mock_db_session
+    ):
+        """Test invalid slug format returns 422."""
+        with TestClient(app_with_tenant_admin) as client:
+            response = client.post(
+                "/v1/plans/acme",
+                json={
+                    "slug": "Gold Plan!",  # Invalid: uppercase + special chars
+                    "name": "Gold Plan",
+                },
+            )
+
+        assert response.status_code == 422
+
+    # ============== List Plans Tests ==============
+
+    def test_list_plans_success(
+        self, app_with_tenant_admin, mock_db_session, sample_plan_data
+    ):
+        """Test listing plans with pagination."""
+        mock_plan = self._create_mock_plan(sample_plan_data)
+
+        with patch("src.routers.plans.PlanRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.list_by_tenant = AsyncMock(
+                return_value=([mock_plan], 1)
+            )
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.get("/v1/plans/acme")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["total"] == 1
+            assert len(data["items"]) == 1
+            assert data["items"][0]["slug"] == "gold"
+
+    # ============== Get Plan Tests ==============
+
+    def test_get_plan_by_id_success(
+        self, app_with_tenant_admin, mock_db_session, sample_plan_data
+    ):
+        """Test getting a plan by UUID."""
+        mock_plan = self._create_mock_plan(sample_plan_data)
+
+        with patch("src.routers.plans.PlanRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_id = AsyncMock(return_value=mock_plan)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.get(
+                    f"/v1/plans/acme/{sample_plan_data['id']}"
+                )
+
+            assert response.status_code == 200
+            assert response.json()["slug"] == "gold"
+
+    def test_get_plan_by_slug_success(
+        self, app_with_tenant_admin, mock_db_session, sample_plan_data
+    ):
+        """Test getting a plan by slug."""
+        mock_plan = self._create_mock_plan(sample_plan_data)
+
+        with patch("src.routers.plans.PlanRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_slug = AsyncMock(return_value=mock_plan)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.get("/v1/plans/acme/by-slug/gold")
+
+            assert response.status_code == 200
+            assert response.json()["name"] == "Gold Plan"
+
+    def test_get_plan_404(self, app_with_tenant_admin, mock_db_session):
+        """Test 404 when plan not found."""
+        with patch("src.routers.plans.PlanRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_id = AsyncMock(return_value=None)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.get(f"/v1/plans/acme/{uuid4()}")
+
+            assert response.status_code == 404
+
+    # ============== Update Plan Tests ==============
+
+    def test_update_plan_success(
+        self, app_with_tenant_admin, mock_db_session, sample_plan_data
+    ):
+        """Test updating a plan."""
+        mock_plan = self._create_mock_plan(sample_plan_data)
+        updated_plan = self._create_mock_plan(
+            {**sample_plan_data, "name": "Gold Plan V2"}
+        )
+
+        with patch("src.routers.plans.PlanRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_id = AsyncMock(return_value=mock_plan)
+            mock_repo_instance.update = AsyncMock(return_value=updated_plan)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.put(
+                    f"/v1/plans/acme/{sample_plan_data['id']}",
+                    json={"name": "Gold Plan V2"},
+                )
+
+            assert response.status_code == 200
+            assert response.json()["name"] == "Gold Plan V2"
+
+    # ============== Delete Plan Tests ==============
+
+    def test_delete_plan_success(
+        self, app_with_tenant_admin, mock_db_session, sample_plan_data
+    ):
+        """Test deleting a plan."""
+        mock_plan = self._create_mock_plan(sample_plan_data)
+
+        with patch("src.routers.plans.PlanRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_id = AsyncMock(return_value=mock_plan)
+            mock_repo_instance.delete = AsyncMock()
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.delete(
+                    f"/v1/plans/acme/{sample_plan_data['id']}"
+                )
+
+            assert response.status_code == 204
+
+    # ============== Authorization Tests ==============
+
+    def test_plan_403_wrong_tenant(
+        self, app_with_other_tenant, mock_db_session
+    ):
+        """Test tenant isolation - cannot access plans in another tenant."""
+        with TestClient(app_with_other_tenant) as client:
+            response = client.get("/v1/plans/acme")
+
+        assert response.status_code == 403
+
+    def test_cpi_admin_cross_tenant_access(
+        self, app_with_cpi_admin, mock_db_session, sample_plan_data
+    ):
+        """Test CPI admin can access any tenant's plans."""
+        mock_plan = self._create_mock_plan(sample_plan_data)
+
+        with patch("src.routers.plans.PlanRepository") as MockRepo:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.list_by_tenant = AsyncMock(
+                return_value=([mock_plan], 1)
+            )
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/plans/acme")
+
+            assert response.status_code == 200
+            assert response.json()["total"] == 1


### PR DESCRIPTION
## Summary

CAB-1121 Phase 1 — Consumer Onboarding: Data Model + API Foundation

- **Consumer model** (`consumers` table): external API consumers with status lifecycle (active/suspended/blocked), tenant-scoped with `external_id` uniqueness
- **Plan model** (`plans` table): subscription plans with quota definitions (rate limits, request limits, burst), slug-based lookup, approval workflow support
- **14 REST endpoints**: full CRUD + status management for Consumers (8) and Plans (6), with tenant isolation and RBAC
- **Alembic migration 018**: creates both tables with indexes, adds nullable `consumer_id` to `subscriptions` for future linking
- **OpenAPI snapshot** updated to include new routes

### New files (11)
| File | Purpose |
|------|---------|
| `src/models/consumer.py` | Consumer SQLAlchemy model |
| `src/models/plan.py` | Plan SQLAlchemy model |
| `src/schemas/consumer.py` | Consumer Pydantic schemas |
| `src/schemas/plan.py` | Plan Pydantic schemas |
| `src/repositories/consumer.py` | Consumer repository (CRUD + search + stats) |
| `src/repositories/plan.py` | Plan repository (CRUD + slug lookup) |
| `src/routers/consumers.py` | Consumer endpoints (create/list/get/update/delete/suspend/activate/block) |
| `src/routers/plans.py` | Plan endpoints (create/list/get-by-id/get-by-slug/update/delete) |
| `alembic/versions/018_*.py` | Migration: consumers + plans tables |
| `tests/test_consumers.py` | 12 consumer tests |
| `tests/test_plans.py` | 11 plan tests |

### Modified files (6)
- `src/models/subscription.py` — added `consumer_id` column (nullable)
- `src/models/__init__.py` — registered Consumer + Plan models
- `alembic/env.py` — added model imports for autogenerate
- `src/main.py` — registered routers + OpenAPI tags
- `tests/conftest.py` — added test fixtures
- `openapi-snapshot.json` — updated with new routes/schemas

## Test plan

- [x] 23 new tests pass (12 consumer + 11 plan)
- [x] Full suite: 452 passed, 0 failed, coverage 54% (> 53% threshold)
- [x] OpenAPI contract tests pass (snapshot updated)
- [x] Ruff lint clean on all new/modified source files
- [x] Black formatting verified
- [x] Pre-commit hooks pass
- [ ] CI pipeline green (security-scan + control-plane-api CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)