### PR TITLE
feat(gateway): add sidecar docker-compose demo (CAB-1117)

### DIFF
--- a/deploy/docker-compose/docker-compose.sidecar.yml
+++ b/deploy/docker-compose/docker-compose.sidecar.yml
@@ -1,0 +1,96 @@
+# =============================================================================
+# STOA Sidecar Mode — Docker Compose Demo
+# =============================================================================
+# Demonstrates the STOA Gateway in sidecar mode behind an NGINX reverse proxy.
+#
+# Architecture:
+#   Client → nginx-proxy (auth_request) → stoa-gateway /authz → allow/deny
+#                       ↓ (if allowed)
+#                 fake-webmethods (mock backend)
+#
+# Usage:
+#   cd deploy/docker-compose
+#   docker compose -f docker-compose.sidecar.yml up -d --build
+#   # or use the demo script:
+#   ./sidecar/demo.sh
+# =============================================================================
+
+services:
+  # ==========================================================================
+  # STOA Gateway — Sidecar Mode (policy enforcement)
+  # ==========================================================================
+  stoa-gateway:
+    build:
+      context: ../../stoa-gateway
+      dockerfile: Dockerfile
+    container_name: stoa-sidecar-gateway
+    environment:
+      STOA_GATEWAY_MODE: sidecar
+      STOA_PORT: "8081"
+      STOA_HOST: "0.0.0.0"
+      STOA_LOG_LEVEL: debug
+      STOA_UPSTREAM_TYPE: nginx
+      STOA_AUTO_REGISTER: "false"
+      STOA_K8S_ENABLED: "false"
+      STOA_KAFKA_ENABLED: "false"
+      STOA_POLICY_ENABLED: "false"
+      STOA_ZOMBIE_DETECTION_ENABLED: "false"
+    ports:
+      - "${PORT_GATEWAY:-8081}:8081"
+    networks:
+      - sidecar-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+    restart: unless-stopped
+
+  # ==========================================================================
+  # Fake webMethods — Mock backend with 3 JSON endpoints
+  # ==========================================================================
+  fake-webmethods:
+    image: nginx:1.25-alpine
+    container_name: stoa-sidecar-webmethods
+    volumes:
+      - ./sidecar/webmethods-mock/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    networks:
+      - sidecar-network
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  # ==========================================================================
+  # NGINX Reverse Proxy — auth_request to STOA Gateway
+  # ==========================================================================
+  nginx-proxy:
+    image: nginx:1.25-alpine
+    container_name: stoa-sidecar-proxy
+    ports:
+      - "${PORT_PROXY:-8080}:8080"
+    volumes:
+      - ./sidecar/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      stoa-gateway:
+        condition: service_healthy
+      fake-webmethods:
+        condition: service_healthy
+    networks:
+      - sidecar-network
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+# =============================================================================
+# Networks
+# =============================================================================
+networks:
+  sidecar-network:
+    driver: bridge

--- a/deploy/docker-compose/sidecar/.env.example
+++ b/deploy/docker-compose/sidecar/.env.example
@@ -1,0 +1,15 @@
+# =============================================================================
+# STOA Sidecar Demo — Environment Configuration
+# =============================================================================
+# Copy to deploy/docker-compose/.env before running:
+#   cp sidecar/.env.example .env
+# =============================================================================
+
+# Docker Compose project name
+COMPOSE_PROJECT_NAME=stoa-sidecar-demo
+
+# NGINX reverse proxy (entry point)
+PORT_PROXY=8080
+
+# STOA Gateway sidecar (direct access for debugging)
+PORT_GATEWAY=8081

--- a/deploy/docker-compose/sidecar/README.md
+++ b/deploy/docker-compose/sidecar/README.md
@@ -1,0 +1,156 @@
+# STOA Gateway — Sidecar Mode Demo
+
+Demonstrates the STOA Gateway running as a **sidecar** alongside an existing API gateway (NGINX), providing policy enforcement via the `ext_authz` pattern.
+
+## Architecture
+
+```
+                          ┌─────────────────────────────────────────────┐
+                          │              Docker Network                 │
+  Client                  │                                             │
+    │                     │  ┌────────────┐       ┌─────────────────┐  │
+    │  GET /api/customers │  │            │ POST  │  stoa-gateway   │  │
+    ├─────────────────────▸  │  nginx     │──────▸│  :8081          │  │
+    │                     │  │  proxy     │ /authz│                 │  │
+    │                     │  │  :8080     │◂──────│  Mode: sidecar  │  │
+    │                     │  │            │200/401│  DecisionFormat:│  │
+    │                     │  │            │       │    StatusCode   │  │
+    │                     │  │            │       └─────────────────┘  │
+    │                     │  │            │                            │
+    │                     │  │            │       ┌─────────────────┐  │
+    │                     │  │   if 200   │       │ fake-webmethods │  │
+    │  ◂──── response ────│  │   ───────▸ │──────▸│  :8080          │  │
+    │                     │  │ proxy_pass │       │                 │  │
+    │                     │  └────────────┘       │  Mock backend   │  │
+                          │                       └─────────────────┘  │
+                          └─────────────────────────────────────────────┘
+```
+
+### Flow
+
+1. **Client** sends `GET /api/customers` with `Authorization: Bearer <token>`
+2. **nginx-proxy** intercepts and issues an `auth_request` subrequest to `/_authz`
+3. `/_authz` constructs a JSON body from request metadata and POSTs to **stoa-gateway** `/authz`
+4. **stoa-gateway** evaluates the authorization request:
+   - No user info → `401 Unauthorized`
+   - No tenant ID → `403 Forbidden`
+   - User + tenant present → `200 OK` (allowed)
+5. nginx acts on the response:
+   - `200` → proxy the request to **fake-webmethods** backend
+   - `401/403` → return error to client
+
+## Quick Start
+
+```bash
+cd deploy/docker-compose
+
+# Run the full demo (start, test, cleanup)
+./sidecar/demo.sh
+
+# Or start manually
+docker compose -f docker-compose.sidecar.yml up -d --build
+
+# Test without token (expect 401)
+curl -i http://localhost:8080/api/customers
+
+# Test with token (expect 200)
+curl -i -H "Authorization: Bearer my-token" http://localhost:8080/api/customers
+
+# Direct authz call
+curl -X POST http://localhost:8081/authz \
+  -H "Content-Type: application/json" \
+  -d '{
+    "method": "GET",
+    "path": "/api/customers",
+    "headers": {},
+    "tenant_id": "demo-tenant",
+    "user": {"id": "user-1", "roles": ["admin"], "scopes": ["read"]}
+  }'
+
+# Gateway metrics
+curl http://localhost:8081/metrics
+
+# Stop
+docker compose -f docker-compose.sidecar.yml down
+```
+
+## Services
+
+| Service | Port | Description |
+|---------|------|-------------|
+| nginx-proxy | 8080 | Entry point, auth_request to gateway |
+| stoa-gateway | 8081 | Sidecar policy enforcement (POST /authz) |
+| fake-webmethods | internal | Mock backend (customers, orders APIs) |
+
+## Endpoints
+
+### Through nginx-proxy (:8080)
+
+| Method | Path | Auth Required | Description |
+|--------|------|---------------|-------------|
+| GET | `/api/customers` | Yes | List customers |
+| GET | `/api/orders` | Yes | List orders |
+| POST | `/api/orders` | Yes | Create order |
+| GET | `/health` | No | Proxy health |
+| GET | `/gateway/health` | No | Gateway health (proxied) |
+| GET | `/gateway/metrics` | No | Gateway metrics (proxied) |
+
+### Direct to stoa-gateway (:8081)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/authz` | Authorization decision endpoint |
+| GET | `/health` | Gateway health |
+| GET | `/metrics` | Prometheus metrics |
+
+## AuthzRequest / AuthzResponse
+
+The `/authz` endpoint accepts:
+
+```json
+{
+  "method": "GET",
+  "path": "/api/customers",
+  "headers": {"Authorization": "Bearer ..."},
+  "tenant_id": "demo-tenant",
+  "user": {
+    "id": "user-123",
+    "email": "user@example.com",
+    "roles": ["admin"],
+    "scopes": ["read", "write"]
+  }
+}
+```
+
+Responses:
+- **200 OK** — request allowed (with `StatusCode` decision format)
+- **401 Unauthorized** — missing user information
+- **403 Forbidden** — missing tenant ID or policy violation
+- **429 Too Many Requests** — rate limit exceeded
+
+## Environment Variables
+
+Copy `sidecar/.env.example` to `.env` to customize ports:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT_PROXY` | 8080 | nginx-proxy listen port |
+| `PORT_GATEWAY` | 8081 | stoa-gateway listen port |
+
+## Keep Services Running
+
+To keep services running after the demo script finishes:
+
+```bash
+KEEP_RUNNING=true ./sidecar/demo.sh
+```
+
+## Production Considerations
+
+This demo uses simplified authentication simulation. In production:
+
+- The **upstream gateway** (Kong, Envoy, Apigee) validates JWTs and extracts claims
+- User info and tenant ID are passed to STOA via headers configured in `SidecarSettings`
+- The `DecisionFormat` can be set to `EnvoyExtAuthz` or `KongPlugin` for native integration
+- OPA policies provide fine-grained access control
+- Kafka metering captures all authorization decisions

--- a/deploy/docker-compose/sidecar/demo.sh
+++ b/deploy/docker-compose/sidecar/demo.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# =============================================================================
+# STOA Sidecar Mode — Demo Script
+# =============================================================================
+# Starts the sidecar Docker Compose stack and runs through demo scenarios:
+#   1. Request without token → 401 Unauthorized
+#   2. Request with valid token → 200 OK (customers)
+#   3. Request with valid token → 200 OK (orders)
+#   4. POST with valid token → 201 Created
+#   5. Direct /authz call (no user) → 401
+#   6. Direct /authz call (with user) → 200
+#   7. Gateway Prometheus metrics
+#
+# Usage:
+#   cd deploy/docker-compose
+#   ./sidecar/demo.sh
+# =============================================================================
+
+set -euo pipefail
+
+# --- Colors ---
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# --- Config ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="docker-compose.sidecar.yml"
+PROXY_URL="http://localhost:${PORT_PROXY:-8080}"
+GATEWAY_URL="http://localhost:${PORT_GATEWAY:-8081}"
+DEMO_TOKEN="demo-token-valid"
+
+passed=0
+failed=0
+
+# --- Helpers ---
+banner() {
+    echo ""
+    echo -e "${BOLD}${BLUE}═══════════════════════════════════════════════════════════════${NC}"
+    echo -e "${BOLD}${BLUE}  $1${NC}"
+    echo -e "${BOLD}${BLUE}═══════════════════════════════════════════════════════════════${NC}"
+    echo ""
+}
+
+step() {
+    echo -e "${CYAN}▸ $1${NC}"
+}
+
+check() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+
+    if [ "$actual" = "$expected" ]; then
+        echo -e "  ${GREEN}✓ PASS${NC} — $description (HTTP $actual)"
+        ((passed++))
+    else
+        echo -e "  ${RED}✗ FAIL${NC} — $description (expected $expected, got $actual)"
+        ((failed++))
+    fi
+}
+
+wait_for_service() {
+    local name="$1"
+    local url="$2"
+    local max_retries=30
+    local i=0
+
+    printf "  Waiting for %s..." "$name"
+    while [ $i -lt $max_retries ]; do
+        if curl -sf "$url" > /dev/null 2>&1; then
+            echo -e " ${GREEN}ready${NC}"
+            return 0
+        fi
+        printf "."
+        sleep 2
+        ((i++))
+    done
+    echo -e " ${RED}TIMEOUT${NC}"
+    return 1
+}
+
+cleanup() {
+    if [ "${KEEP_RUNNING:-}" != "true" ]; then
+        banner "Cleanup"
+        step "Stopping services..."
+        cd "$COMPOSE_DIR"
+        docker compose -f "$COMPOSE_FILE" down --remove-orphans 2>/dev/null || true
+    else
+        echo ""
+        echo -e "${YELLOW}Services still running. Stop with:${NC}"
+        echo "  cd $COMPOSE_DIR && docker compose -f $COMPOSE_FILE down"
+    fi
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+banner "STOA Gateway — Sidecar Mode Demo"
+
+echo -e "${BOLD}Architecture:${NC}"
+echo ""
+echo "  Client Request"
+echo "       │"
+echo "       ▼"
+echo "  ┌─────────────┐    auth_request     ┌─────────────────┐"
+echo "  │ nginx-proxy  │ ─────────────────▸  │  stoa-gateway   │"
+echo "  │  :8080       │                     │  :8081 (sidecar)│"
+echo "  │              │  ◂── allow/deny ──  │  POST /authz    │"
+echo "  │              │                     └─────────────────┘"
+echo "  │              │    proxy_pass"
+echo "  │              │ ─────────────────▸  ┌─────────────────┐"
+echo "  │              │   (if allowed)      │ fake-webmethods │"
+echo "  └─────────────┘                     │  :8080 (mock)   │"
+echo "                                      └─────────────────┘"
+echo ""
+
+# --- Step 1: Start services ---
+banner "Step 1: Start Services"
+
+cd "$COMPOSE_DIR"
+step "Building and starting containers..."
+docker compose -f "$COMPOSE_FILE" up -d --build
+
+step "Waiting for services to be healthy..."
+wait_for_service "stoa-gateway" "$GATEWAY_URL/health"
+wait_for_service "nginx-proxy" "$PROXY_URL/health"
+
+echo ""
+step "All services ready."
+
+# --- Step 2: Test without token → 401 ---
+banner "Step 2: Request Without Token"
+
+step "GET $PROXY_URL/api/customers (no Authorization header)"
+HTTP_CODE=$(curl -s -o /tmp/sidecar-response.json -w "%{http_code}" "$PROXY_URL/api/customers")
+check "No token → 401 Unauthorized" "401" "$HTTP_CODE"
+echo -e "  ${YELLOW}Response:${NC}"
+cat /tmp/sidecar-response.json | python3 -m json.tool 2>/dev/null || cat /tmp/sidecar-response.json
+echo ""
+
+# --- Step 3: Request with valid token → 200 (customers) ---
+banner "Step 3: Authenticated Request — Customers"
+
+step "GET $PROXY_URL/api/customers (Bearer $DEMO_TOKEN)"
+HTTP_CODE=$(curl -s -o /tmp/sidecar-response.json -w "%{http_code}" \
+    -H "Authorization: Bearer $DEMO_TOKEN" \
+    "$PROXY_URL/api/customers")
+check "Valid token → 200 OK (customers)" "200" "$HTTP_CODE"
+echo -e "  ${YELLOW}Response:${NC}"
+cat /tmp/sidecar-response.json | python3 -m json.tool 2>/dev/null || cat /tmp/sidecar-response.json
+echo ""
+
+# --- Step 4: Request with valid token → 200 (orders) ---
+banner "Step 4: Authenticated Request — Orders"
+
+step "GET $PROXY_URL/api/orders (Bearer $DEMO_TOKEN)"
+HTTP_CODE=$(curl -s -o /tmp/sidecar-response.json -w "%{http_code}" \
+    -H "Authorization: Bearer $DEMO_TOKEN" \
+    "$PROXY_URL/api/orders")
+check "Valid token → 200 OK (orders)" "200" "$HTTP_CODE"
+echo -e "  ${YELLOW}Response (truncated):${NC}"
+cat /tmp/sidecar-response.json | python3 -m json.tool 2>/dev/null | head -20 || cat /tmp/sidecar-response.json | head -20
+echo "  ..."
+echo ""
+
+# --- Step 5: POST with valid token → 201 ---
+banner "Step 5: Create Order (POST)"
+
+step "POST $PROXY_URL/api/orders (Bearer $DEMO_TOKEN)"
+HTTP_CODE=$(curl -s -o /tmp/sidecar-response.json -w "%{http_code}" \
+    -X POST \
+    -H "Authorization: Bearer $DEMO_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"customer_id":"cust-001","items":[{"product":"API License","quantity":1}]}' \
+    "$PROXY_URL/api/orders")
+check "POST with token → 201 Created" "201" "$HTTP_CODE"
+echo -e "  ${YELLOW}Response:${NC}"
+cat /tmp/sidecar-response.json | python3 -m json.tool 2>/dev/null || cat /tmp/sidecar-response.json
+echo ""
+
+# --- Step 6: Direct /authz — no user → 401 ---
+banner "Step 6: Direct Gateway /authz — No User"
+
+step "POST $GATEWAY_URL/authz (no user in body)"
+HTTP_CODE=$(curl -s -o /tmp/sidecar-response.json -w "%{http_code}" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"method":"GET","path":"/api/customers","headers":{}}' \
+    "$GATEWAY_URL/authz")
+check "authz without user → 401" "401" "$HTTP_CODE"
+echo ""
+
+# --- Step 7: Direct /authz — with user → 200 ---
+banner "Step 7: Direct Gateway /authz — With User"
+
+step "POST $GATEWAY_URL/authz (user + tenant in body)"
+HTTP_CODE=$(curl -s -o /tmp/sidecar-response.json -w "%{http_code}" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{
+      "method": "GET",
+      "path": "/api/customers",
+      "headers": {"Authorization": "Bearer demo-token"},
+      "tenant_id": "demo-tenant",
+      "user": {
+        "id": "demo-user",
+        "email": "demo@stoa.dev",
+        "roles": ["admin"],
+        "scopes": ["read", "write"]
+      }
+    }' \
+    "$GATEWAY_URL/authz")
+check "authz with user → 200" "200" "$HTTP_CODE"
+echo ""
+
+# --- Step 8: Prometheus metrics ---
+banner "Step 8: Gateway Metrics"
+
+step "GET $GATEWAY_URL/metrics"
+echo ""
+METRICS=$(curl -s "$GATEWAY_URL/metrics")
+if [ -n "$METRICS" ]; then
+    echo -e "  ${GREEN}Metrics endpoint available${NC}"
+    echo "$METRICS" | head -20
+    TOTAL_LINES=$(echo "$METRICS" | wc -l)
+    echo -e "  ... ($TOTAL_LINES total metric lines)"
+else
+    echo -e "  ${YELLOW}No metrics available yet${NC}"
+fi
+echo ""
+
+# --- Summary ---
+banner "Results"
+
+TOTAL=$((passed + failed))
+echo -e "  ${GREEN}Passed: $passed${NC}"
+echo -e "  ${RED}Failed: $failed${NC}"
+echo -e "  ${BOLD}Total:  $TOTAL${NC}"
+echo ""
+
+if [ "$failed" -gt 0 ]; then
+    echo -e "  ${RED}Some tests failed. Check the gateway logs:${NC}"
+    echo "    docker compose -f $COMPOSE_FILE logs stoa-gateway"
+    echo ""
+fi
+
+echo -e "  ${BOLD}Useful commands:${NC}"
+echo "    docker compose -f $COMPOSE_FILE logs -f stoa-gateway  # Gateway logs"
+echo "    docker compose -f $COMPOSE_FILE logs -f nginx-proxy   # Proxy logs"
+echo "    curl $GATEWAY_URL/health                              # Health check"
+echo "    curl $GATEWAY_URL/metrics                             # Prometheus metrics"
+echo ""
+
+# --- Cleanup ---
+cleanup
+
+rm -f /tmp/sidecar-response.json
+
+exit $failed

--- a/deploy/docker-compose/sidecar/nginx.conf
+++ b/deploy/docker-compose/sidecar/nginx.conf
@@ -1,0 +1,94 @@
+# =============================================================================
+# NGINX Reverse Proxy — auth_request to STOA Gateway Sidecar
+# =============================================================================
+#
+# Flow:
+#   1. Client sends request to /api/*
+#   2. nginx issues auth_request subrequest to /_authz
+#   3. /_authz proxies POST to stoa-gateway:8081/authz with JSON body
+#   4. If gateway returns 200 → nginx proxies to fake-webmethods backend
+#   5. If gateway returns 401/403 → nginx returns error to client
+#
+# Auth simulation:
+#   - Request with "Authorization: Bearer <token>" → user info included → 200
+#   - Request without Authorization header → no user info → 401
+# =============================================================================
+
+server {
+    listen 8080;
+    server_name _;
+
+    # --------------------------------------------------------------------------
+    # Health check (for Docker healthcheck)
+    # --------------------------------------------------------------------------
+    location = /health {
+        access_log off;
+        default_type text/plain;
+        return 200 'OK';
+    }
+
+    # --------------------------------------------------------------------------
+    # Internal: auth subrequest to STOA Gateway sidecar
+    # --------------------------------------------------------------------------
+    location = /_authz {
+        internal;
+
+        # When Authorization header is present, include user info in the authz
+        # request body. This simulates the upstream gateway having already
+        # validated the JWT and extracted user claims.
+        set $authz_user '';
+        if ($http_authorization ~* "^Bearer (.+)$") {
+            set $authz_user ',"user":{"id":"demo-user","email":"demo@stoa.dev","roles":["admin"],"scopes":["read","write"]},"tenant_id":"demo-tenant"';
+        }
+
+        proxy_method POST;
+        proxy_set_header Content-Type application/json;
+        proxy_set_body '{"method":"$request_method","path":"$request_uri","headers":{"Host":"$host"}$authz_user}';
+        proxy_pass http://stoa-gateway:8081/authz;
+    }
+
+    # --------------------------------------------------------------------------
+    # Protected API endpoints — auth_request enforced
+    # --------------------------------------------------------------------------
+    location /api/ {
+        auth_request /_authz;
+
+        # Propagate enrichment headers from gateway response
+        auth_request_set $authz_x_user_id $upstream_http_x_user_id;
+        auth_request_set $authz_x_tenant_id $upstream_http_x_tenant_id;
+        auth_request_set $authz_x_request_id $upstream_http_x_request_id;
+
+        proxy_set_header X-User-ID $authz_x_user_id;
+        proxy_set_header X-Tenant-ID $authz_x_tenant_id;
+        proxy_set_header X-Request-ID $authz_x_request_id;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_pass http://fake-webmethods:8080;
+    }
+
+    # --------------------------------------------------------------------------
+    # Gateway direct access (metrics, health) — no auth required
+    # --------------------------------------------------------------------------
+    location /gateway/ {
+        rewrite ^/gateway/(.*) /$1 break;
+        proxy_pass http://stoa-gateway:8081;
+    }
+
+    # --------------------------------------------------------------------------
+    # Custom error responses for auth failures
+    # --------------------------------------------------------------------------
+    error_page 401 = @error401;
+    error_page 403 = @error403;
+
+    location @error401 {
+        default_type application/json;
+        return 401 '{"error":"unauthorized","message":"Missing or invalid authentication token. Use: Authorization: Bearer <token>"}';
+    }
+
+    location @error403 {
+        default_type application/json;
+        return 403 '{"error":"forbidden","message":"Access denied by STOA Gateway policy"}';
+    }
+}

--- a/deploy/docker-compose/sidecar/webmethods-mock/nginx.conf
+++ b/deploy/docker-compose/sidecar/webmethods-mock/nginx.conf
@@ -1,0 +1,103 @@
+# =============================================================================
+# Fake webMethods — Mock backend with 3 JSON endpoints
+# =============================================================================
+# Simulates a legacy webMethods Integration Server with REST APIs.
+# Used by the sidecar demo to demonstrate STOA Gateway policy enforcement.
+# =============================================================================
+
+server {
+    listen 8080;
+    server_name _;
+
+    default_type application/json;
+
+    # Health check
+    location = /health {
+        default_type text/plain;
+        return 200 'OK';
+    }
+
+    # GET /api/customers — list of mock customers
+    location = /api/customers {
+        return 200 '{
+  "customers": [
+    {
+      "id": "cust-001",
+      "name": "Acme Corporation",
+      "email": "contact@acme.example.com",
+      "plan": "enterprise",
+      "created_at": "2024-01-15T10:30:00Z"
+    },
+    {
+      "id": "cust-002",
+      "name": "Globex Industries",
+      "email": "info@globex.example.com",
+      "plan": "professional",
+      "created_at": "2024-03-22T14:15:00Z"
+    },
+    {
+      "id": "cust-003",
+      "name": "Initech Solutions",
+      "email": "support@initech.example.com",
+      "plan": "starter",
+      "created_at": "2024-06-01T08:00:00Z"
+    }
+  ],
+  "total": 3,
+  "_metadata": {
+    "source": "fake-webmethods",
+    "version": "1.0.0"
+  }
+}';
+    }
+
+    # GET /api/orders — list of mock orders
+    # POST /api/orders — create order (returns 201)
+    location = /api/orders {
+        if ($request_method = POST) {
+            return 201 '{
+  "id": "ord-789",
+  "status": "created",
+  "customer_id": "cust-001",
+  "items": [{"product": "API License", "quantity": 1, "price": 299.99}],
+  "total": 299.99,
+  "created_at": "2026-02-09T12:00:00Z",
+  "_metadata": {
+    "source": "fake-webmethods",
+    "version": "1.0.0"
+  }
+}';
+        }
+
+        return 200 '{
+  "orders": [
+    {
+      "id": "ord-001",
+      "customer_id": "cust-001",
+      "status": "delivered",
+      "total": 1250.00,
+      "created_at": "2024-11-10T09:30:00Z"
+    },
+    {
+      "id": "ord-002",
+      "customer_id": "cust-002",
+      "status": "processing",
+      "total": 499.99,
+      "created_at": "2025-01-05T16:45:00Z"
+    },
+    {
+      "id": "ord-003",
+      "customer_id": "cust-003",
+      "status": "pending",
+      "total": 89.99,
+      "created_at": "2025-02-01T11:20:00Z"
+    }
+  ],
+  "total": 3,
+  "_metadata": {
+    "source": "fake-webmethods",
+    "version": "1.0.0"
+  }
+}';
+    }
+}


### PR DESCRIPTION
## Summary

- Docker Compose setup demonstrating STOA Gateway **sidecar mode** behind NGINX reverse proxy
- NGINX `auth_request` → gateway `POST /authz` for policy enforcement before proxying to backend
- Fake webMethods mock backend with 3 JSON endpoints (customers GET, orders GET/POST)
- Automated `demo.sh` script with 7 test scenarios and pass/fail reporting
- README with ASCII architecture diagram, quick-start, and endpoint reference

## Architecture

```
Client → nginx-proxy (:8080) → auth_request → stoa-gateway (:8081) POST /authz
                ↓ (if 200)
         fake-webmethods (mock backend)
```

## Files

| File | Description |
|------|-------------|
| `deploy/docker-compose/docker-compose.sidecar.yml` | 3-service compose stack |
| `deploy/docker-compose/sidecar/nginx.conf` | Reverse proxy with auth_request |
| `deploy/docker-compose/sidecar/webmethods-mock/nginx.conf` | Mock webMethods backend |
| `deploy/docker-compose/sidecar/demo.sh` | Automated demo script |
| `deploy/docker-compose/sidecar/.env.example` | Port configuration |
| `deploy/docker-compose/sidecar/README.md` | Documentation + ASCII diagram |

## Test plan

- [ ] `docker compose -f docker-compose.sidecar.yml config` validates syntax
- [ ] Services start with `docker compose up -d --build`
- [ ] `curl /api/customers` without token → 401
- [ ] `curl -H "Authorization: Bearer token" /api/customers` → 200
- [ ] `POST /authz` without user → 401
- [ ] `POST /authz` with user+tenant → 200
- [ ] `./sidecar/demo.sh` runs all 7 scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)