### PR TITLE
test(ui): boost function coverage above 35% (CAB-1118)

### DIFF
--- a/control-plane-ui/src/components/Layout.test.tsx
+++ b/control-plane-ui/src/components/Layout.test.tsx
@@ -1,8 +1,17 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Layout } from './Layout';
+
+vi.mock('../services/api', () => ({
+  apiService: {
+    getTenants: vi.fn().mockResolvedValue([
+      { id: 't1', name: 'oasis-gunters', display_name: 'Oasis Gunters' },
+      { id: 't2', name: 'sixers-corp', display_name: 'Sixers Corp' },
+    ]),
+  },
+}));
 
 const mockUseAuth = vi.fn(() => ({
   user: {
@@ -71,6 +80,10 @@ function renderLayout(children = <div>Page Content</div>) {
 }
 
 describe('Layout', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('renders sidebar with navigation items', () => {
     renderLayout();
     // Nav items render name in <span> + optional shortcut — check by text within the nav
@@ -137,6 +150,100 @@ describe('Layout', () => {
     renderLayout();
     const badges = screen.getAllByText('STOA');
     expect(badges.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('collapses section when header is clicked', () => {
+    renderLayout();
+    // Gateway section is open by default
+    const gatewayHeader = screen.getByText('\u26A1 Gateway');
+    expect(gatewayHeader).toBeInTheDocument();
+    // Click to collapse
+    fireEvent.click(gatewayHeader);
+    // Verify localStorage was updated
+    const stored = JSON.parse(localStorage.getItem('stoa-sidebar-sections') || '{}');
+    expect(stored['\u26A1 Gateway']).toBe(true);
+  });
+
+  it('expands collapsed section when header is clicked', () => {
+    renderLayout();
+    // Overview is collapsed by default — click to expand
+    const overviewHeader = screen.getByText('Overview');
+    fireEvent.click(overviewHeader);
+    const stored = JSON.parse(localStorage.getItem('stoa-sidebar-sections') || '{}');
+    expect(stored['Overview']).toBe(false);
+  });
+
+  it('persists section state to localStorage', () => {
+    // Pre-set localStorage
+    localStorage.setItem(
+      'stoa-sidebar-sections',
+      JSON.stringify({ Overview: false, Catalog: true })
+    );
+    renderLayout();
+    // Toggle Catalog to expand
+    const catalogHeader = screen.getByText('Catalog');
+    fireEvent.click(catalogHeader);
+    const stored = JSON.parse(localStorage.getItem('stoa-sidebar-sections') || '{}');
+    expect(stored['Catalog']).toBe(false);
+  });
+
+  it('renders tenant selector button', () => {
+    renderLayout();
+    // The tenant selector shows the user's tenant_id
+    expect(screen.getByText('oasis-gunters')).toBeInTheDocument();
+  });
+
+  it('opens tenant dropdown when clicked', () => {
+    renderLayout();
+    const tenantButton = screen.getByText('oasis-gunters');
+    fireEvent.click(tenantButton);
+    // Dropdown should be open (but no tenants loaded since API is mocked)
+    // The button should still be visible
+    expect(tenantButton).toBeInTheDocument();
+  });
+
+  it('renders new skeleton page nav items (CAB-1118)', () => {
+    renderLayout();
+    expect(screen.getByText('Shadow Discovery')).toBeInTheDocument();
+    expect(screen.getByText('Token Optimizer')).toBeInTheDocument();
+    expect(screen.getByText('Policies')).toBeInTheDocument();
+    expect(screen.getByText('Audit Log')).toBeInTheDocument();
+  });
+
+  it('shows tenant list in dropdown and switches tenant', async () => {
+    renderLayout();
+    // Wait for tenant query to resolve
+    await waitFor(() => {
+      expect(screen.getByText('Oasis Gunters')).toBeInTheDocument();
+    });
+    // Open dropdown
+    fireEvent.click(screen.getByText('Oasis Gunters'));
+    // Both tenants should appear in dropdown
+    expect(screen.getByText('Sixers Corp')).toBeInTheDocument();
+    // Switch to Sixers Corp
+    fireEvent.click(screen.getByText('Sixers Corp'));
+    // Active tenant should be stored
+    expect(localStorage.getItem('stoa-active-tenant')).toBe('t2');
+  });
+
+  it('closes tenant dropdown on outside click', async () => {
+    renderLayout();
+    await waitFor(() => {
+      expect(screen.getByText('Oasis Gunters')).toBeInTheDocument();
+    });
+    // Open dropdown
+    fireEvent.click(screen.getByText('Oasis Gunters'));
+    await waitFor(() => {
+      expect(screen.getByText('Sixers Corp')).toBeInTheDocument();
+    });
+    // Click outside
+    fireEvent.mouseDown(document.body);
+    // Dropdown should close — Sixers Corp option should disappear
+    await waitFor(() => {
+      // The tenant name in dropdown list should be gone (not the button)
+      const sixersElements = screen.queryAllByText('Sixers Corp');
+      expect(sixersElements).toHaveLength(0);
+    });
   });
 
   it('hides navigation items when user lacks permissions', () => {

--- a/control-plane-ui/src/hooks/useDebounce.test.ts
+++ b/control-plane-ui/src/hooks/useDebounce.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDebounce } from './useDebounce';
+
+describe('useDebounce', () => {
+  it('returns initial value immediately', () => {
+    const { result } = renderHook(() => useDebounce('hello', 300));
+    expect(result.current).toBe('hello');
+  });
+
+  it('debounces value updates', () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 300), {
+      initialProps: { value: 'hello' },
+    });
+
+    rerender({ value: 'world' });
+    // Not yet updated
+    expect(result.current).toBe('hello');
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current).toBe('world');
+
+    vi.useRealTimers();
+  });
+
+  it('resets timer on rapid changes', () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 300), {
+      initialProps: { value: 'a' },
+    });
+
+    rerender({ value: 'b' });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    rerender({ value: 'c' });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    // Still 'a' because timer reset
+    expect(result.current).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(result.current).toBe('c');
+
+    vi.useRealTimers();
+  });
+});

--- a/control-plane-ui/src/pages/AuditLog.test.tsx
+++ b/control-plane-ui/src/pages/AuditLog.test.tsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AuditLog } from './AuditLog';
+
+describe('AuditLog', () => {
+  it('renders title and coming soon card', () => {
+    render(<AuditLog />);
+    expect(screen.getByText('Audit Log')).toBeInTheDocument();
+    expect(screen.getByText('Coming Soon')).toBeInTheDocument();
+  });
+});

--- a/control-plane-ui/src/pages/Policies.test.tsx
+++ b/control-plane-ui/src/pages/Policies.test.tsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Policies } from './Policies';
+
+describe('Policies', () => {
+  it('renders title and coming soon card', () => {
+    render(<Policies />);
+    expect(screen.getByText('Policies')).toBeInTheDocument();
+    expect(screen.getByText('Coming Soon')).toBeInTheDocument();
+  });
+});

--- a/control-plane-ui/src/pages/ShadowDiscovery.test.tsx
+++ b/control-plane-ui/src/pages/ShadowDiscovery.test.tsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ShadowDiscovery } from './ShadowDiscovery';
+
+describe('ShadowDiscovery', () => {
+  it('renders title and coming soon card', () => {
+    render(<ShadowDiscovery />);
+    expect(screen.getByText('Shadow API Discovery')).toBeInTheDocument();
+    expect(screen.getByText('Coming Soon')).toBeInTheDocument();
+  });
+});

--- a/control-plane-ui/src/pages/TokenOptimizer.test.tsx
+++ b/control-plane-ui/src/pages/TokenOptimizer.test.tsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TokenOptimizer } from './TokenOptimizer';
+
+describe('TokenOptimizer', () => {
+  it('renders title and coming soon card', () => {
+    render(<TokenOptimizer />);
+    expect(screen.getByText('Token Optimizer')).toBeInTheDocument();
+    expect(screen.getByText('Coming Soon')).toBeInTheDocument();
+  });
+});

--- a/control-plane-ui/src/utils/navigation.test.ts
+++ b/control-plane-ui/src/utils/navigation.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { observabilityPath, logsPath, isAllowedEmbedUrl } from './navigation';
+
+describe('observabilityPath', () => {
+  it('returns base path without target URL', () => {
+    expect(observabilityPath()).toBe('/observability');
+  });
+
+  it('returns path with encoded target URL', () => {
+    expect(observabilityPath('https://grafana.gostoa.dev/d/abc')).toBe(
+      '/observability?url=https%3A%2F%2Fgrafana.gostoa.dev%2Fd%2Fabc'
+    );
+  });
+});
+
+describe('logsPath', () => {
+  it('returns base path without target URL', () => {
+    expect(logsPath()).toBe('/logs');
+  });
+
+  it('returns path with encoded target URL', () => {
+    expect(logsPath('https://grafana.gostoa.dev/explore')).toBe(
+      '/logs?url=https%3A%2F%2Fgrafana.gostoa.dev%2Fexplore'
+    );
+  });
+});
+
+describe('isAllowedEmbedUrl', () => {
+  it('allows grafana.gostoa.dev', () => {
+    expect(isAllowedEmbedUrl('https://grafana.gostoa.dev/d/abc')).toBe(true);
+  });
+
+  it('allows prometheus.gostoa.dev', () => {
+    expect(isAllowedEmbedUrl('https://prometheus.gostoa.dev/graph')).toBe(true);
+  });
+
+  it('allows localhost', () => {
+    expect(isAllowedEmbedUrl('http://localhost:3000/d/abc')).toBe(true);
+  });
+
+  it('rejects external URLs', () => {
+    expect(isAllowedEmbedUrl('https://evil.com/steal')).toBe(false);
+  });
+
+  it('allows relative paths', () => {
+    expect(isAllowedEmbedUrl('/d/dashboard')).toBe(true);
+  });
+
+  it('rejects non-relative invalid URLs', () => {
+    expect(isAllowedEmbedUrl('javascript:alert(1)')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `apiService` mock to Layout tests to cover tenant dropdown interaction (`handleTenantSwitch`, click-outside handler)
- Add test file for `navigation.ts` utilities (3 functions: `observabilityPath`, `logsPath`, `isAllowedEmbedUrl`)
- Add test file for `useDebounce` hook
- Add test files for 4 skeleton pages (ShadowDiscovery, TokenOptimizer, Policies, AuditLog)

Function coverage: 33.07% → 40.74% (threshold: 35%)

## Test plan
- [x] All 282 tests pass
- [x] Function coverage 40.74% > 35% threshold
- [x] ESLint: 0 errors, 93 warnings (pre-existing)
- [x] Prettier: all files clean
- [x] TypeScript: 0 new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)