### PR TITLE
feat(api): gateway propagation on subscription approval (CAB-1121 Phase 3)

### DIFF
--- a/control-plane-api/src/adapters/stoa/adapter.py
+++ b/control-plane-api/src/adapters/stoa/adapter.py
@@ -51,9 +51,7 @@ class StoaGatewayAdapter(GatewayAdapterInterface):
             if resp.status_code == 200:
                 data = resp.json()
                 return AdapterResult(success=True, data=data)
-            return AdapterResult(
-                success=False, error=f"Health check failed: HTTP {resp.status_code}"
-            )
+            return AdapterResult(success=False, error=f"Health check failed: HTTP {resp.status_code}")
         except Exception as e:
             return AdapterResult(success=False, error=str(e))
 
@@ -71,9 +69,7 @@ class StoaGatewayAdapter(GatewayAdapterInterface):
 
     # --- APIs ---
 
-    async def sync_api(
-        self, api_spec: dict, tenant_id: str, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def sync_api(self, api_spec: dict, tenant_id: str, auth_token: str | None = None) -> AdapterResult:
         try:
             payload = mappers.map_api_spec_to_stoa(api_spec, tenant_id)
             resp = await self._client.post("/admin/apis", json=payload)
@@ -85,15 +81,11 @@ class StoaGatewayAdapter(GatewayAdapterInterface):
                     resource_id=data.get("id", payload.get("id", "")),
                     data={"spec_hash": payload.get("spec_hash", "")},
                 )
-            return AdapterResult(
-                success=False, error=f"sync_api failed: HTTP {resp.status_code} — {resp.text}"
-            )
+            return AdapterResult(success=False, error=f"sync_api failed: HTTP {resp.status_code} — {resp.text}")
         except Exception as e:
             return AdapterResult(success=False, error=str(e))
 
-    async def delete_api(
-        self, api_id: str, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def delete_api(self, api_id: str, auth_token: str | None = None) -> AdapterResult:
         try:
             resp = await self._client.delete(f"/admin/apis/{api_id}")
             if resp.status_code in (200, 204):
@@ -101,9 +93,7 @@ class StoaGatewayAdapter(GatewayAdapterInterface):
             if resp.status_code == 404:
                 # Already deleted — idempotent
                 return AdapterResult(success=True, resource_id=api_id)
-            return AdapterResult(
-                success=False, error=f"delete_api failed: HTTP {resp.status_code}"
-            )
+            return AdapterResult(success=False, error=f"delete_api failed: HTTP {resp.status_code}")
         except Exception as e:
             return AdapterResult(success=False, error=str(e))
 
@@ -118,9 +108,7 @@ class StoaGatewayAdapter(GatewayAdapterInterface):
 
     # --- Policies ---
 
-    async def upsert_policy(
-        self, policy_spec: dict, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def upsert_policy(self, policy_spec: dict, auth_token: str | None = None) -> AdapterResult:
         try:
             payload = mappers.map_policy_to_stoa(policy_spec)
             resp = await self._client.post("/admin/policies", json=payload)
@@ -139,18 +127,14 @@ class StoaGatewayAdapter(GatewayAdapterInterface):
         except Exception as e:
             return AdapterResult(success=False, error=str(e))
 
-    async def delete_policy(
-        self, policy_id: str, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def delete_policy(self, policy_id: str, auth_token: str | None = None) -> AdapterResult:
         try:
             resp = await self._client.delete(f"/admin/policies/{policy_id}")
             if resp.status_code in (200, 204):
                 return AdapterResult(success=True, resource_id=policy_id)
             if resp.status_code == 404:
                 return AdapterResult(success=True, resource_id=policy_id)
-            return AdapterResult(
-                success=False, error=f"delete_policy failed: HTTP {resp.status_code}"
-            )
+            return AdapterResult(success=False, error=f"delete_policy failed: HTTP {resp.status_code}")
         except Exception as e:
             return AdapterResult(success=False, error=str(e))
 
@@ -163,50 +147,82 @@ class StoaGatewayAdapter(GatewayAdapterInterface):
         except Exception:
             return []
 
-    # --- Applications (not supported by stoa-gateway) ---
+    # --- Applications (CAB-1121 Phase 3) ---
 
-    async def provision_application(
-        self, app_spec: dict, auth_token: str | None = None
-    ) -> AdapterResult:
-        return AdapterResult(success=False, error=_NOT_SUPPORTED)
+    async def provision_application(self, app_spec: dict, auth_token: str | None = None) -> AdapterResult:
+        """Provision a consumer application on stoa-gateway.
 
-    async def deprovision_application(
-        self, app_id: str, auth_token: str | None = None
-    ) -> AdapterResult:
-        return AdapterResult(success=False, error=_NOT_SUPPORTED)
+        1. Register/update the API route via sync_api
+        2. Push rate-limit policy if plan quotas are present
+        3. Return the API route ID as resource_id
+        """
+        try:
+            tenant_id = app_spec.get("tenant_id", "")
+
+            # Step 1: Register the API route
+            route_spec = mappers.map_app_spec_to_route(app_spec)
+            sync_result = await self.sync_api(route_spec, tenant_id, auth_token=auth_token)
+
+            if not sync_result.success:
+                return AdapterResult(
+                    success=False,
+                    error=f"sync_api failed: {sync_result.error}",
+                )
+
+            api_route_id = sync_result.resource_id or app_spec.get("api_id", "")
+
+            # Step 2: Push rate-limit policy if plan has quotas
+            policy_spec = mappers.map_quota_to_policy(app_spec, app_spec.get("subscription_id", ""))
+            if policy_spec:
+                policy_result = await self.upsert_policy(policy_spec, auth_token=auth_token)
+                if not policy_result.success:
+                    logger.warning(
+                        "Rate-limit policy push failed for %s: %s",
+                        app_spec.get("subscription_id"),
+                        policy_result.error,
+                    )
+
+            return AdapterResult(success=True, resource_id=api_route_id)
+
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
+
+    async def deprovision_application(self, app_id: str, auth_token: str | None = None) -> AdapterResult:
+        """Deprovision a consumer application from stoa-gateway.
+
+        1. Delete the rate-limit policy for this subscription
+        2. Return success (route is kept — other subscriptions may reference it)
+        """
+        try:
+            # The app_id for STOA adapter is the API route ID.
+            # Policy cleanup is handled by _cleanup_rate_limit_policy in provisioning_service.
+            # Here we just confirm the deprovision.
+            return AdapterResult(success=True, resource_id=app_id)
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
 
     async def list_applications(self, auth_token: str | None = None) -> list[dict]:
         return []
 
     # --- Auth / OIDC (not supported by stoa-gateway) ---
 
-    async def upsert_auth_server(
-        self, auth_spec: dict, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def upsert_auth_server(self, auth_spec: dict, auth_token: str | None = None) -> AdapterResult:
         return AdapterResult(success=False, error=_NOT_SUPPORTED)
 
-    async def upsert_strategy(
-        self, strategy_spec: dict, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def upsert_strategy(self, strategy_spec: dict, auth_token: str | None = None) -> AdapterResult:
         return AdapterResult(success=False, error=_NOT_SUPPORTED)
 
-    async def upsert_scope(
-        self, scope_spec: dict, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def upsert_scope(self, scope_spec: dict, auth_token: str | None = None) -> AdapterResult:
         return AdapterResult(success=False, error=_NOT_SUPPORTED)
 
     # --- Aliases (not supported by stoa-gateway) ---
 
-    async def upsert_alias(
-        self, alias_spec: dict, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def upsert_alias(self, alias_spec: dict, auth_token: str | None = None) -> AdapterResult:
         return AdapterResult(success=False, error=_NOT_SUPPORTED)
 
     # --- Configuration (not supported by stoa-gateway) ---
 
-    async def apply_config(
-        self, config_spec: dict, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def apply_config(self, config_spec: dict, auth_token: str | None = None) -> AdapterResult:
         return AdapterResult(success=False, error=_NOT_SUPPORTED)
 
     # --- Backup (not supported by stoa-gateway) ---

--- a/control-plane-api/src/adapters/stoa/mappers.py
+++ b/control-plane-api/src/adapters/stoa/mappers.py
@@ -34,3 +34,50 @@ def map_policy_to_stoa(policy_spec: dict) -> dict:
         "priority": policy_spec.get("priority", 100),
         "api_id": policy_spec.get("api_id", ""),
     }
+
+
+def map_app_spec_to_route(app_spec: dict) -> dict:
+    """Convert enriched app_spec to stoa-gateway sync_api format (CAB-1121 Phase 3).
+
+    Used by provision_application to register the API route on the gateway
+    before pushing the rate-limit policy.
+    """
+    api_id = app_spec.get("api_id", "")
+    tenant_id = app_spec.get("tenant_id", "")
+    app_name = app_spec.get("application_name", "unknown")
+    return {
+        "api_catalog_id": api_id,
+        "api_name": app_name,
+        "backend_url": app_spec.get("backend_url", ""),
+        "methods": app_spec.get("methods", ["GET", "POST", "PUT", "DELETE"]),
+        "spec_hash": "",
+        "activated": True,
+        "tenant_id": tenant_id,
+    }
+
+
+def map_quota_to_policy(app_spec: dict, subscription_id: str) -> dict | None:
+    """Convert plan quota fields from enriched app_spec to rate-limit policy (CAB-1121 Phase 3).
+
+    Returns None if no rate-limit quotas are defined.
+    """
+    rate_per_minute = app_spec.get("rate_limit_per_minute")
+    rate_per_second = app_spec.get("rate_limit_per_second")
+
+    if not rate_per_minute and not rate_per_second:
+        return None
+
+    consumer_ext_id = app_spec.get("consumer_external_id", "unknown")
+    plan_slug = app_spec.get("plan_slug", "default")
+
+    return {
+        "id": f"quota-{subscription_id}",
+        "name": f"rate-limit-{consumer_ext_id}-{plan_slug}",
+        "type": "rate_limit",
+        "api_id": app_spec.get("api_id", ""),
+        "config": {
+            "maxRequests": rate_per_minute or (rate_per_second * 60 if rate_per_second else 100),
+            "intervalSeconds": 60,
+        },
+        "priority": 50,
+    }

--- a/control-plane-api/src/adapters/webmethods/adapter.py
+++ b/control-plane-api/src/adapters/webmethods/adapter.py
@@ -51,9 +51,7 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
 
     # --- APIs ---
 
-    async def sync_api(
-        self, api_spec: dict, tenant_id: str, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def sync_api(self, api_spec: dict, tenant_id: str, auth_token: str | None = None) -> AdapterResult:
         try:
             result = await self._svc.import_api(
                 api_name=api_spec["apiName"],
@@ -63,16 +61,12 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
                 api_type=api_spec.get("type", "openapi"),
                 auth_token=auth_token,
             )
-            api_id = (
-                result.get("apiResponse", {}).get("api", {}).get("id", "")
-            )
+            api_id = result.get("apiResponse", {}).get("api", {}).get("id", "")
             return AdapterResult(success=True, resource_id=api_id, data=result)
         except Exception as e:
             return AdapterResult(success=False, error=str(e))
 
-    async def delete_api(
-        self, api_id: str, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def delete_api(self, api_id: str, auth_token: str | None = None) -> AdapterResult:
         try:
             await self._svc.delete_api(api_id, auth_token=auth_token)
             return AdapterResult(success=True, resource_id=api_id)
@@ -84,9 +78,7 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
 
     # --- Policies ---
 
-    async def upsert_policy(
-        self, policy_spec: dict, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def upsert_policy(self, policy_spec: dict, auth_token: str | None = None) -> AdapterResult:
         try:
             payload = mappers.map_policy_to_webmethods(policy_spec)
 
@@ -101,14 +93,16 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
             if existing_policy:
                 policy_id = existing_policy.get("id", "")
                 result = await self._svc._request(
-                    "PUT", f"/policyActions/{policy_id}",
+                    "PUT",
+                    f"/policyActions/{policy_id}",
                     auth_token=auth_token,
                     json=payload["policyAction"],
                 )
                 return AdapterResult(success=True, resource_id=policy_id, data=result)
             else:
                 result = await self._svc._request(
-                    "POST", "/policyActions",
+                    "POST",
+                    "/policyActions",
                     auth_token=auth_token,
                     json=payload["policyAction"],
                 )
@@ -117,13 +111,9 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
         except Exception as e:
             return AdapterResult(success=False, error=str(e))
 
-    async def delete_policy(
-        self, policy_id: str, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def delete_policy(self, policy_id: str, auth_token: str | None = None) -> AdapterResult:
         try:
-            await self._svc._request(
-                "DELETE", f"/policyActions/{policy_id}", auth_token=auth_token
-            )
+            await self._svc._request("DELETE", f"/policyActions/{policy_id}", auth_token=auth_token)
             return AdapterResult(success=True, resource_id=policy_id)
         except Exception as e:
             return AdapterResult(success=False, error=str(e))
@@ -134,10 +124,29 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
 
     # --- Applications ---
 
-    async def provision_application(
-        self, app_spec: dict, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def provision_application(self, app_spec: dict, auth_token: str | None = None) -> AdapterResult:
         try:
+            # Idempotency check: see if app already exists by name (CAB-1121 Phase 3)
+            app_name = app_spec["application_name"]
+            existing_apps = await self.list_applications(auth_token=auth_token)
+            existing = next(
+                (a for a in existing_apps if a.get("name") == app_name),
+                None,
+            )
+
+            if existing:
+                existing_id = existing.get("id", "")
+                logger.info(
+                    "Application '%s' already exists (id=%s), returning existing",
+                    app_name,
+                    existing_id,
+                )
+                return AdapterResult(
+                    success=True,
+                    resource_id=existing_id,
+                    data=existing,
+                )
+
             result = await self._svc.provision_application(
                 subscription_id=app_spec["subscription_id"],
                 application_name=app_spec["application_name"],
@@ -155,9 +164,7 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
         except Exception as e:
             return AdapterResult(success=False, error=str(e))
 
-    async def deprovision_application(
-        self, app_id: str, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def deprovision_application(self, app_id: str, auth_token: str | None = None) -> AdapterResult:
         try:
             await self._svc.deprovision_application(
                 app_id=app_id,
@@ -173,9 +180,7 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
 
     # --- Auth / OIDC ---
 
-    async def upsert_auth_server(
-        self, auth_spec: dict, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def upsert_auth_server(self, auth_spec: dict, auth_token: str | None = None) -> AdapterResult:
         try:
             payload = mappers.map_auth_server_to_webmethods(auth_spec)
 
@@ -188,28 +193,20 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
 
             if existing_alias:
                 alias_id = existing_alias.get("id", "")
-                result = await self._svc._request(
-                    "PUT", f"/alias/{alias_id}", auth_token=auth_token, json=payload
-                )
+                result = await self._svc._request("PUT", f"/alias/{alias_id}", auth_token=auth_token, json=payload)
                 return AdapterResult(success=True, resource_id=alias_id, data=result)
             else:
-                result = await self._svc._request(
-                    "POST", "/alias", auth_token=auth_token, json=payload
-                )
+                result = await self._svc._request("POST", "/alias", auth_token=auth_token, json=payload)
                 alias_id = result.get("alias", {}).get("id", "")
                 return AdapterResult(success=True, resource_id=alias_id, data=result)
         except Exception as e:
             return AdapterResult(success=False, error=str(e))
 
-    async def upsert_strategy(
-        self, strategy_spec: dict, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def upsert_strategy(self, strategy_spec: dict, auth_token: str | None = None) -> AdapterResult:
         try:
             existing = await self._svc.list_strategies(auth_token=auth_token)
             name = strategy_spec.get("name", "")
-            existing_strategy = next(
-                (s for s in existing if s.get("name") == name), None
-            )
+            existing_strategy = next((s for s in existing if s.get("name") == name), None)
 
             payload = {
                 "name": name,
@@ -227,17 +224,13 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
                 )
                 return AdapterResult(success=True, resource_id=strategy_id, data=result)
             else:
-                result = await self._svc._request(
-                    "POST", "/strategies", auth_token=auth_token, json=payload
-                )
+                result = await self._svc._request("POST", "/strategies", auth_token=auth_token, json=payload)
                 strategy_id = result.get("strategy", {}).get("id", "")
                 return AdapterResult(success=True, resource_id=strategy_id, data=result)
         except Exception as e:
             return AdapterResult(success=False, error=str(e))
 
-    async def upsert_scope(
-        self, scope_spec: dict, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def upsert_scope(self, scope_spec: dict, auth_token: str | None = None) -> AdapterResult:
         try:
             result = await self._svc.create_scope_mapping(
                 scope_name=scope_spec["scopeName"],
@@ -254,9 +247,7 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
 
     # --- Aliases ---
 
-    async def upsert_alias(
-        self, alias_spec: dict, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def upsert_alias(self, alias_spec: dict, auth_token: str | None = None) -> AdapterResult:
         try:
             payload = mappers.map_alias_to_webmethods(alias_spec)
 
@@ -268,14 +259,10 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
 
             if existing_alias:
                 alias_id = existing_alias.get("id", "")
-                result = await self._svc._request(
-                    "PUT", f"/alias/{alias_id}", auth_token=auth_token, json=payload
-                )
+                result = await self._svc._request("PUT", f"/alias/{alias_id}", auth_token=auth_token, json=payload)
                 return AdapterResult(success=True, resource_id=alias_id, data=result)
             else:
-                result = await self._svc._request(
-                    "POST", "/alias", auth_token=auth_token, json=payload
-                )
+                result = await self._svc._request("POST", "/alias", auth_token=auth_token, json=payload)
                 alias_id = result.get("alias", {}).get("id", "")
                 return AdapterResult(success=True, resource_id=alias_id, data=result)
         except Exception as e:
@@ -283,17 +270,17 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
 
     # --- Configuration ---
 
-    async def apply_config(
-        self, config_spec: dict, auth_token: str | None = None
-    ) -> AdapterResult:
+    async def apply_config(self, config_spec: dict, auth_token: str | None = None) -> AdapterResult:
         try:
             payloads = mappers.map_config_to_webmethods(config_spec)
             results = {}
 
             for config_key, payload in payloads.items():
                 result = await self._svc._request(
-                    "PUT", f"/configurations/{config_key}",
-                    auth_token=auth_token, json=payload,
+                    "PUT",
+                    f"/configurations/{config_key}",
+                    auth_token=auth_token,
+                    json=payload,
                 )
                 results[config_key] = result
 
@@ -306,7 +293,8 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
     async def export_archive(self, auth_token: str | None = None) -> bytes:
         async with self._svc._get_client(auth_token) as client:
             response = await client.request(
-                "GET", "/archive",
+                "GET",
+                "/archive",
                 params={"include": "api,application,alias,policy"},
             )
             response.raise_for_status()

--- a/control-plane-api/src/services/provisioning_service.py
+++ b/control-plane-api/src/services/provisioning_service.py
@@ -3,16 +3,23 @@
 Orchestrates application creation/deletion via the Gateway Adapter Pattern.
 Uses AdapterRegistry to resolve the correct gateway adapter per API deployment.
 Falls back to the default webMethods adapter when no gateway deployment exists.
+
+CAB-1121 Phase 3: Enriches app_spec with consumer/plan context and pushes
+rate-limit policies to the gateway on provision/deprovision.
 """
+
 import asyncio
 import logging
 from datetime import datetime
+from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..adapters import AdapterRegistry
 from ..adapters.gateway_adapter_interface import GatewayAdapterInterface
 from ..models.subscription import ProvisioningStatus, Subscription
+from ..repositories.consumer import ConsumerRepository
+from ..repositories.plan import PlanRepository
 
 logger = logging.getLogger(__name__)
 
@@ -27,9 +34,7 @@ _default_adapter = AdapterRegistry.create("webmethods")
 gateway_service = _default_adapter._svc
 
 
-async def _resolve_adapter(
-    db: AsyncSession, api_id: str, tenant_id: str
-) -> GatewayAdapterInterface:
+async def _resolve_adapter(db: AsyncSession, api_id: str, tenant_id: str) -> GatewayAdapterInterface:
     """Resolve the gateway adapter for an API.
 
     Looks up gateway_deployments to find which gateway the API is deployed to.
@@ -86,6 +91,7 @@ async def provision_on_approval(
 
     adapter = await _resolve_adapter(db, subscription.api_id, subscription.tenant_id)
 
+    # Build base app_spec
     app_spec = {
         "subscription_id": str(subscription.id),
         "application_name": subscription.application_name,
@@ -94,6 +100,41 @@ async def provision_on_approval(
         "subscriber_email": subscription.subscriber_email,
         "correlation_id": correlation_id,
     }
+
+    # Enrich with consumer context (CAB-1121 Phase 3)
+    consumer = None
+    if subscription.consumer_id:
+        try:
+            consumer_repo = ConsumerRepository(db)
+            consumer = await consumer_repo.get_by_id(
+                subscription.consumer_id
+                if isinstance(subscription.consumer_id, UUID)
+                else UUID(str(subscription.consumer_id))
+            )
+        except Exception as e:
+            logger.warning("Failed to load consumer %s: %s", subscription.consumer_id, e)
+
+    if consumer:
+        app_spec["consumer_id"] = str(consumer.id)
+        app_spec["consumer_external_id"] = consumer.external_id
+        app_spec["keycloak_client_id"] = consumer.keycloak_client_id or ""
+
+    # Enrich with plan context (CAB-1121 Phase 3)
+    plan = None
+    if subscription.plan_id:
+        try:
+            plan_repo = PlanRepository(db)
+            plan = await plan_repo.get_by_id(UUID(str(subscription.plan_id)))
+        except Exception as e:
+            logger.warning("Failed to load plan %s: %s", subscription.plan_id, e)
+
+    if plan:
+        app_spec["plan_slug"] = plan.slug
+        app_spec["rate_limit_per_second"] = plan.rate_limit_per_second
+        app_spec["rate_limit_per_minute"] = plan.rate_limit_per_minute
+        app_spec["daily_request_limit"] = plan.daily_request_limit
+        app_spec["monthly_request_limit"] = plan.monthly_request_limit
+        app_spec["burst_limit"] = plan.burst_limit
 
     last_error = None
 
@@ -110,6 +151,9 @@ async def provision_on_approval(
             subscription.provisioning_error = None
             await db.commit()
 
+            # Push rate-limit policy if plan has quotas (CAB-1121 Phase 3)
+            await _push_rate_limit_policy(adapter, subscription, plan, consumer, auth_token, correlation_id)
+
             logger.info(
                 f"Provisioned gateway app {result.resource_id} for subscription "
                 f"{subscription.id} (attempt {attempt})",
@@ -120,8 +164,7 @@ async def provision_on_approval(
         except Exception as e:
             last_error = str(e)
             logger.warning(
-                f"Provisioning attempt {attempt}/{MAX_RETRIES} failed for "
-                f"subscription {subscription.id}: {e}",
+                f"Provisioning attempt {attempt}/{MAX_RETRIES} failed for " f"subscription {subscription.id}: {e}",
                 extra={"correlation_id": correlation_id},
             )
 
@@ -135,10 +178,104 @@ async def provision_on_approval(
     await db.commit()
 
     logger.error(
-        f"Provisioning failed after {MAX_RETRIES} attempts for "
-        f"subscription {subscription.id}: {last_error}",
+        f"Provisioning failed after {MAX_RETRIES} attempts for " f"subscription {subscription.id}: {last_error}",
         extra={"correlation_id": correlation_id, "tenant_id": subscription.tenant_id},
     )
+
+
+async def _push_rate_limit_policy(
+    adapter: GatewayAdapterInterface,
+    subscription: Subscription,
+    plan: object | None,
+    consumer: object | None,
+    auth_token: str | None,
+    correlation_id: str,
+) -> None:
+    """Push a rate-limit policy to the gateway after successful provisioning.
+
+    Non-blocking: logs warnings on failure but does not raise.
+    """
+    if not plan:
+        return
+
+    rate_limit = getattr(plan, "rate_limit_per_minute", None) or getattr(plan, "rate_limit_per_second", None)
+    if not rate_limit:
+        return
+
+    consumer_ext_id = getattr(consumer, "external_id", "unknown") if consumer else "unknown"
+    plan_slug = getattr(plan, "slug", "default")
+
+    policy_spec = {
+        "id": f"quota-{subscription.id}",
+        "name": f"rate-limit-{consumer_ext_id}-{plan_slug}",
+        "type": "rate_limit",
+        "api_id": subscription.api_id,
+        "config": {
+            "maxRequests": getattr(plan, "rate_limit_per_minute", None) or 100,
+            "intervalSeconds": 60,
+        },
+        "priority": 50,
+    }
+
+    try:
+        result = await adapter.upsert_policy(policy_spec, auth_token=auth_token)
+        if result.success:
+            logger.info(
+                "Pushed rate-limit policy %s for subscription %s",
+                policy_spec["id"],
+                subscription.id,
+                extra={"correlation_id": correlation_id},
+            )
+        else:
+            logger.warning(
+                "Failed to push rate-limit policy for subscription %s: %s",
+                subscription.id,
+                result.error,
+                extra={"correlation_id": correlation_id},
+            )
+    except Exception as e:
+        logger.warning(
+            "Error pushing rate-limit policy for subscription %s: %s",
+            subscription.id,
+            e,
+            extra={"correlation_id": correlation_id},
+        )
+
+
+async def _cleanup_rate_limit_policy(
+    adapter: GatewayAdapterInterface,
+    subscription: Subscription,
+    auth_token: str | None,
+    correlation_id: str,
+) -> None:
+    """Remove the rate-limit policy from the gateway on deprovision.
+
+    Non-blocking: logs warnings on failure but does not raise.
+    """
+    policy_id = f"quota-{subscription.id}"
+    try:
+        result = await adapter.delete_policy(policy_id, auth_token=auth_token)
+        if result.success:
+            logger.info(
+                "Cleaned up rate-limit policy %s for subscription %s",
+                policy_id,
+                subscription.id,
+                extra={"correlation_id": correlation_id},
+            )
+        else:
+            logger.warning(
+                "Failed to clean up rate-limit policy %s: %s",
+                policy_id,
+                result.error,
+                extra={"correlation_id": correlation_id},
+            )
+    except Exception as e:
+        logger.warning(
+            "Error cleaning up rate-limit policy %s: %s",
+            policy_id,
+            e,
+            extra={"correlation_id": correlation_id},
+        )
 
 
 async def deprovision_on_revocation(
@@ -164,9 +301,10 @@ async def deprovision_on_revocation(
     adapter = await _resolve_adapter(db, subscription.api_id, subscription.tenant_id)
 
     try:
-        result = await adapter.deprovision_application(
-            subscription.gateway_app_id, auth_token=auth_token
-        )
+        # Clean up rate-limit policy first (CAB-1121 Phase 3)
+        await _cleanup_rate_limit_policy(adapter, subscription, auth_token, correlation_id)
+
+        result = await adapter.deprovision_application(subscription.gateway_app_id, auth_token=auth_token)
 
         if not result.success:
             raise RuntimeError(result.error or "Adapter returned failure")

--- a/control-plane-api/tests/test_provisioning.py
+++ b/control-plane-api/tests/test_provisioning.py
@@ -1,11 +1,17 @@
 """
-Tests for Gateway Provisioning Service - CAB-800
+Tests for Gateway Provisioning Service - CAB-800, CAB-1121 Phase 3
 
 Tests cover:
 - provision_on_approval: success, retry on failure, all retries exhausted
-- deprovision_on_revocation: success, failure, skip when no gateway_app_id
+- provision_on_approval: consumer/plan enrichment, rate-limit policy push (CAB-1121)
+- deprovision_on_revocation: success, failure, skip when no gateway_app_id, policy cleanup
+- _push_rate_limit_policy: success, no plan, no quotas, failure
+- _cleanup_rate_limit_policy: success, failure
 - _resolve_adapter: default fallback, gateway deployment resolution
 - GatewayAdminService.provision_application: success, cleanup on association failure
+- STOA adapter: provision_application, deprovision_application
+- webMethods adapter: idempotent provision_application
+- Mappers: map_app_spec_to_route, map_quota_to_policy
 """
 
 import pytest
@@ -45,6 +51,7 @@ def _make_subscription(**overrides):
         "api_name": "Weather API",
         "api_version": "1.0",
         "tenant_id": "acme",
+        "consumer_id": None,
         "plan_id": "basic",
         "plan_name": "Basic Plan",
         "api_key_hash": "hashed",
@@ -70,16 +77,63 @@ def _make_subscription(**overrides):
     return mock
 
 
-def _mock_adapter(provision_result=None, deprovision_result=None):
+def _make_consumer(**overrides):
+    """Create a mock consumer with default values."""
+    defaults = {
+        "id": uuid4(),
+        "external_id": "ext-consumer-001",
+        "name": "Acme Consumer",
+        "email": "consumer@acme.com",
+        "company": "Acme Corp",
+        "tenant_id": "acme",
+        "keycloak_client_id": "kc-client-acme-001",
+        "keycloak_user_id": None,
+        "status": "active",
+    }
+    defaults.update(overrides)
+    mock = MagicMock()
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _make_plan(**overrides):
+    """Create a mock plan with default values."""
+    defaults = {
+        "id": uuid4(),
+        "slug": "gold",
+        "name": "Gold Plan",
+        "tenant_id": "acme",
+        "rate_limit_per_second": None,
+        "rate_limit_per_minute": 600,
+        "daily_request_limit": 50000,
+        "monthly_request_limit": 1000000,
+        "burst_limit": 50,
+        "requires_approval": True,
+        "status": "active",
+    }
+    defaults.update(overrides)
+    mock = MagicMock()
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _mock_adapter(provision_result=None, deprovision_result=None, upsert_policy_result=None, delete_policy_result=None):
     """Create a mock adapter with default AdapterResult returns."""
     adapter = AsyncMock()
     adapter.provision_application = AsyncMock(
-        return_value=provision_result or AdapterResult(
-            success=True, resource_id="wm-app-001", data={"app_id": "wm-app-001"}
-        )
+        return_value=provision_result
+        or AdapterResult(success=True, resource_id="wm-app-001", data={"app_id": "wm-app-001"})
     )
     adapter.deprovision_application = AsyncMock(
         return_value=deprovision_result or AdapterResult(success=True, resource_id="wm-app-001")
+    )
+    adapter.upsert_policy = AsyncMock(
+        return_value=upsert_policy_result or AdapterResult(success=True, resource_id="quota-001")
+    )
+    adapter.delete_policy = AsyncMock(
+        return_value=delete_policy_result or AdapterResult(success=True, resource_id="quota-001")
     )
     return adapter
 
@@ -125,13 +179,16 @@ class TestProvisionOnApproval:
             ]
         )
 
-        with patch(
-            "src.services.provisioning_service._resolve_adapter",
-            new_callable=AsyncMock,
-            return_value=adapter,
-        ), patch(
-            "src.services.provisioning_service.asyncio.sleep",
-            new_callable=AsyncMock,
+        with (
+            patch(
+                "src.services.provisioning_service._resolve_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter,
+            ),
+            patch(
+                "src.services.provisioning_service.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
         ):
             from src.services.provisioning_service import provision_on_approval
 
@@ -148,17 +205,18 @@ class TestProvisionOnApproval:
         db = AsyncMock()
 
         adapter = AsyncMock()
-        adapter.provision_application = AsyncMock(
-            side_effect=RuntimeError("connection refused")
-        )
+        adapter.provision_application = AsyncMock(side_effect=RuntimeError("connection refused"))
 
-        with patch(
-            "src.services.provisioning_service._resolve_adapter",
-            new_callable=AsyncMock,
-            return_value=adapter,
-        ), patch(
-            "src.services.provisioning_service.asyncio.sleep",
-            new_callable=AsyncMock,
+        with (
+            patch(
+                "src.services.provisioning_service._resolve_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter,
+            ),
+            patch(
+                "src.services.provisioning_service.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
         ):
             from src.services.provisioning_service import provision_on_approval
 
@@ -177,17 +235,18 @@ class TestProvisionOnApproval:
         fail_result = AdapterResult(success=False, error="gateway 503")
         success_result = AdapterResult(success=True, resource_id="wm-app-003", data={})
         adapter = AsyncMock()
-        adapter.provision_application = AsyncMock(
-            side_effect=[fail_result, success_result]
-        )
+        adapter.provision_application = AsyncMock(side_effect=[fail_result, success_result])
 
-        with patch(
-            "src.services.provisioning_service._resolve_adapter",
-            new_callable=AsyncMock,
-            return_value=adapter,
-        ), patch(
-            "src.services.provisioning_service.asyncio.sleep",
-            new_callable=AsyncMock,
+        with (
+            patch(
+                "src.services.provisioning_service._resolve_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter,
+            ),
+            patch(
+                "src.services.provisioning_service.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
         ):
             from src.services.provisioning_service import provision_on_approval
 
@@ -251,9 +310,7 @@ class TestDeprovisionOnRevocation:
         db = AsyncMock()
 
         adapter = AsyncMock()
-        adapter.deprovision_application = AsyncMock(
-            side_effect=RuntimeError("not found")
-        )
+        adapter.deprovision_application = AsyncMock(side_effect=RuntimeError("not found"))
 
         with patch(
             "src.services.provisioning_service._resolve_adapter",
@@ -300,12 +357,15 @@ class TestResolveAdapter:
         """Falls back to default adapter when no gateway deployment exists."""
         db = AsyncMock()
 
-        with patch(
-            "src.services.provisioning_service.GatewayDeploymentRepository",
-            create=True,
-        ) as MockDeployRepo, patch(
-            "src.services.provisioning_service.GatewayInstanceRepository",
-            create=True,
+        with (
+            patch(
+                "src.services.provisioning_service.GatewayDeploymentRepository",
+                create=True,
+            ) as MockDeployRepo,
+            patch(
+                "src.services.provisioning_service.GatewayInstanceRepository",
+                create=True,
+            ),
         ):
             mock_deploy_repo = MockDeployRepo.return_value
             mock_deploy_repo.get_primary_for_api = AsyncMock(return_value=None)
@@ -325,9 +385,7 @@ class TestResolveAdapter:
             create=True,
         ) as MockDeployRepo:
             mock_deploy_repo = MockDeployRepo.return_value
-            mock_deploy_repo.get_primary_for_api = AsyncMock(
-                side_effect=Exception("DB error")
-            )
+            mock_deploy_repo.get_primary_for_api = AsyncMock(side_effect=Exception("DB error"))
 
             from src.services.provisioning_service import _resolve_adapter, _default_adapter
 
@@ -352,9 +410,7 @@ class TestGatewayAdminServiceProvisioning:
                 {},
             ]
         )
-        svc.create_application = AsyncMock(
-            return_value={"id": "wm-123", "name": "test-app"}
-        )
+        svc.create_application = AsyncMock(return_value={"id": "wm-123", "name": "test-app"})
 
         result = await svc.provision_application(
             subscription_id="sub-001",
@@ -383,6 +439,463 @@ class TestGatewayAdminServiceProvisioning:
         )
 
         assert result is True
-        svc._request.assert_awaited_once_with(
-            "DELETE", "/applications/wm-123", auth_token=None
+        svc._request.assert_awaited_once_with("DELETE", "/applications/wm-123", auth_token=None)
+
+
+# ──────────────────────────────────────────────────────────────
+# CAB-1121 Phase 3 — Consumer/Plan enrichment + policy push
+# ──────────────────────────────────────────────────────────────
+
+
+class TestProvisionWithConsumerPlanEnrichment:
+    """Tests for consumer/plan context enrichment in provision_on_approval."""
+
+    @pytest.mark.asyncio
+    async def test_provision_enriches_app_spec_with_consumer_and_plan(self):
+        """app_spec includes consumer and plan fields when both are present."""
+        consumer = _make_consumer()
+        plan = _make_plan()
+        sub = _make_subscription(consumer_id=consumer.id, plan_id=str(plan.id))
+        db = AsyncMock()
+
+        captured_spec = {}
+        adapter = _mock_adapter()
+
+        async def capture_app_spec(spec, auth_token=None):
+            captured_spec.update(spec)
+            return AdapterResult(success=True, resource_id="route-001")
+
+        adapter.provision_application = AsyncMock(side_effect=capture_app_spec)
+
+        with (
+            patch(
+                "src.services.provisioning_service._resolve_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter,
+            ),
+            patch(
+                "src.services.provisioning_service.ConsumerRepository",
+            ) as MockConsumerRepo,
+            patch(
+                "src.services.provisioning_service.PlanRepository",
+            ) as MockPlanRepo,
+        ):
+            mock_consumer_repo = MockConsumerRepo.return_value
+            mock_consumer_repo.get_by_id = AsyncMock(return_value=consumer)
+            mock_plan_repo = MockPlanRepo.return_value
+            mock_plan_repo.get_by_id = AsyncMock(return_value=plan)
+
+            from src.services.provisioning_service import provision_on_approval
+
+            await provision_on_approval(db, sub, "jwt-token", "corr-enrich")
+
+        assert captured_spec["consumer_id"] == str(consumer.id)
+        assert captured_spec["consumer_external_id"] == "ext-consumer-001"
+        assert captured_spec["keycloak_client_id"] == "kc-client-acme-001"
+        assert captured_spec["plan_slug"] == "gold"
+        assert captured_spec["rate_limit_per_minute"] == 600
+        assert captured_spec["daily_request_limit"] == 50000
+        assert sub.provisioning_status == ProvisioningStatus.READY
+
+    @pytest.mark.asyncio
+    async def test_provision_works_without_consumer(self):
+        """Provisioning succeeds even without consumer_id set."""
+        plan = _make_plan()
+        sub = _make_subscription(consumer_id=None, plan_id=str(plan.id))
+        db = AsyncMock()
+
+        adapter = _mock_adapter()
+
+        with (
+            patch(
+                "src.services.provisioning_service._resolve_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter,
+            ),
+            patch(
+                "src.services.provisioning_service.PlanRepository",
+            ) as MockPlanRepo,
+        ):
+            mock_plan_repo = MockPlanRepo.return_value
+            mock_plan_repo.get_by_id = AsyncMock(return_value=plan)
+
+            from src.services.provisioning_service import provision_on_approval
+
+            await provision_on_approval(db, sub, "jwt-token", "corr-no-consumer")
+
+        assert sub.provisioning_status == ProvisioningStatus.READY
+
+    @pytest.mark.asyncio
+    async def test_provision_works_without_plan(self):
+        """Provisioning succeeds even without plan_id set."""
+        sub = _make_subscription(consumer_id=None, plan_id=None)
+        db = AsyncMock()
+
+        adapter = _mock_adapter()
+
+        with patch(
+            "src.services.provisioning_service._resolve_adapter",
+            new_callable=AsyncMock,
+            return_value=adapter,
+        ):
+            from src.services.provisioning_service import provision_on_approval
+
+            await provision_on_approval(db, sub, "jwt-token", "corr-no-plan")
+
+        assert sub.provisioning_status == ProvisioningStatus.READY
+
+    @pytest.mark.asyncio
+    async def test_provision_continues_on_consumer_load_failure(self):
+        """Consumer load failure is non-blocking — provisioning continues."""
+        sub = _make_subscription(consumer_id=uuid4())
+        db = AsyncMock()
+
+        adapter = _mock_adapter()
+
+        with (
+            patch(
+                "src.services.provisioning_service._resolve_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter,
+            ),
+            patch(
+                "src.services.provisioning_service.ConsumerRepository",
+            ) as MockConsumerRepo,
+        ):
+            mock_consumer_repo = MockConsumerRepo.return_value
+            mock_consumer_repo.get_by_id = AsyncMock(side_effect=Exception("DB error"))
+
+            from src.services.provisioning_service import provision_on_approval
+
+            await provision_on_approval(db, sub, "jwt-token", "corr-consumer-fail")
+
+        assert sub.provisioning_status == ProvisioningStatus.READY
+
+
+class TestPushRateLimitPolicy:
+    """Tests for _push_rate_limit_policy helper."""
+
+    @pytest.mark.asyncio
+    async def test_push_policy_success(self):
+        """Rate-limit policy is pushed when plan has rate_limit_per_minute."""
+        plan = _make_plan(rate_limit_per_minute=600)
+        consumer = _make_consumer()
+        sub = _make_subscription()
+        adapter = _mock_adapter()
+
+        from src.services.provisioning_service import _push_rate_limit_policy
+
+        await _push_rate_limit_policy(adapter, sub, plan, consumer, "jwt", "corr-1")
+
+        adapter.upsert_policy.assert_awaited_once()
+        policy_arg = adapter.upsert_policy.call_args[0][0]
+        assert policy_arg["id"] == f"quota-{sub.id}"
+        assert policy_arg["type"] == "rate_limit"
+        assert policy_arg["config"]["maxRequests"] == 600
+        assert policy_arg["name"] == "rate-limit-ext-consumer-001-gold"
+
+    @pytest.mark.asyncio
+    async def test_push_policy_skips_when_no_plan(self):
+        """No policy push when plan is None."""
+        sub = _make_subscription()
+        adapter = _mock_adapter()
+
+        from src.services.provisioning_service import _push_rate_limit_policy
+
+        await _push_rate_limit_policy(adapter, sub, None, None, "jwt", "corr-2")
+
+        adapter.upsert_policy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_push_policy_skips_when_no_quotas(self):
+        """No policy push when plan has no rate limits."""
+        plan = _make_plan(rate_limit_per_minute=None, rate_limit_per_second=None)
+        sub = _make_subscription()
+        adapter = _mock_adapter()
+
+        from src.services.provisioning_service import _push_rate_limit_policy
+
+        await _push_rate_limit_policy(adapter, sub, plan, None, "jwt", "corr-3")
+
+        adapter.upsert_policy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_push_policy_non_blocking_on_failure(self):
+        """Policy push failure does not raise."""
+        plan = _make_plan(rate_limit_per_minute=100)
+        sub = _make_subscription()
+        adapter = _mock_adapter(upsert_policy_result=AdapterResult(success=False, error="gateway error"))
+
+        from src.services.provisioning_service import _push_rate_limit_policy
+
+        # Should not raise
+        await _push_rate_limit_policy(adapter, sub, plan, None, "jwt", "corr-4")
+
+    @pytest.mark.asyncio
+    async def test_push_policy_non_blocking_on_exception(self):
+        """Policy push exception does not raise."""
+        plan = _make_plan(rate_limit_per_minute=100)
+        sub = _make_subscription()
+        adapter = AsyncMock()
+        adapter.upsert_policy = AsyncMock(side_effect=Exception("network error"))
+
+        from src.services.provisioning_service import _push_rate_limit_policy
+
+        # Should not raise
+        await _push_rate_limit_policy(adapter, sub, plan, None, "jwt", "corr-5")
+
+
+class TestCleanupRateLimitPolicy:
+    """Tests for _cleanup_rate_limit_policy helper."""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_policy_success(self):
+        """Rate-limit policy is deleted on deprovision."""
+        sub = _make_subscription()
+        adapter = _mock_adapter()
+
+        from src.services.provisioning_service import _cleanup_rate_limit_policy
+
+        await _cleanup_rate_limit_policy(adapter, sub, "jwt", "corr-cleanup")
+
+        adapter.delete_policy.assert_awaited_once_with(f"quota-{sub.id}", auth_token="jwt")
+
+    @pytest.mark.asyncio
+    async def test_cleanup_policy_non_blocking_on_failure(self):
+        """Policy cleanup failure does not raise."""
+        sub = _make_subscription()
+        adapter = _mock_adapter(delete_policy_result=AdapterResult(success=False, error="not found"))
+
+        from src.services.provisioning_service import _cleanup_rate_limit_policy
+
+        # Should not raise
+        await _cleanup_rate_limit_policy(adapter, sub, "jwt", "corr-cleanup-fail")
+
+
+class TestDeprovisionWithPolicyCleanup:
+    """Tests for deprovision_on_revocation with rate-limit policy cleanup."""
+
+    @pytest.mark.asyncio
+    async def test_deprovision_cleans_up_policy(self):
+        """Deprovision calls delete_policy before deprovision_application."""
+        sub = _make_subscription(
+            gateway_app_id="wm-app-001",
+            provisioning_status=ProvisioningStatus.READY,
         )
+        db = AsyncMock()
+        adapter = _mock_adapter()
+
+        with patch(
+            "src.services.provisioning_service._resolve_adapter",
+            new_callable=AsyncMock,
+            return_value=adapter,
+        ):
+            from src.services.provisioning_service import deprovision_on_revocation
+
+            await deprovision_on_revocation(db, sub, "jwt-token", "corr-deprov")
+
+        # Both delete_policy and deprovision_application should be called
+        adapter.delete_policy.assert_awaited_once()
+        adapter.deprovision_application.assert_awaited_once()
+        assert sub.provisioning_status == ProvisioningStatus.DEPROVISIONED
+
+
+class TestStoaAdapterProvision:
+    """Tests for StoaGatewayAdapter.provision_application (CAB-1121 Phase 3)."""
+
+    @pytest.mark.asyncio
+    async def test_provision_calls_sync_api_and_upsert_policy(self):
+        """provision_application registers route and pushes rate-limit policy."""
+        from src.adapters.stoa.adapter import StoaGatewayAdapter
+
+        adapter = StoaGatewayAdapter(config={"base_url": "http://gw:8080"})
+
+        # Mock the internal methods
+        adapter.sync_api = AsyncMock(return_value=AdapterResult(success=True, resource_id="route-abc"))
+        adapter.upsert_policy = AsyncMock(return_value=AdapterResult(success=True, resource_id="quota-sub-1"))
+
+        app_spec = {
+            "subscription_id": "sub-1",
+            "application_name": "Test App",
+            "api_id": "api-123",
+            "tenant_id": "acme",
+            "rate_limit_per_minute": 600,
+            "plan_slug": "gold",
+            "consumer_external_id": "ext-001",
+        }
+
+        result = await adapter.provision_application(app_spec)
+
+        assert result.success is True
+        assert result.resource_id == "route-abc"
+        adapter.sync_api.assert_awaited_once()
+        adapter.upsert_policy.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_provision_without_quotas_skips_policy(self):
+        """provision_application skips policy push when no quotas in app_spec."""
+        from src.adapters.stoa.adapter import StoaGatewayAdapter
+
+        adapter = StoaGatewayAdapter(config={"base_url": "http://gw:8080"})
+        adapter.sync_api = AsyncMock(return_value=AdapterResult(success=True, resource_id="route-xyz"))
+        adapter.upsert_policy = AsyncMock()
+
+        app_spec = {
+            "subscription_id": "sub-2",
+            "application_name": "No Quota App",
+            "api_id": "api-456",
+            "tenant_id": "acme",
+        }
+
+        result = await adapter.provision_application(app_spec)
+
+        assert result.success is True
+        adapter.upsert_policy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_provision_fails_when_sync_api_fails(self):
+        """provision_application returns failure when sync_api fails."""
+        from src.adapters.stoa.adapter import StoaGatewayAdapter
+
+        adapter = StoaGatewayAdapter(config={"base_url": "http://gw:8080"})
+        adapter.sync_api = AsyncMock(return_value=AdapterResult(success=False, error="HTTP 500"))
+
+        result = await adapter.provision_application({"subscription_id": "s1", "tenant_id": "t"})
+
+        assert result.success is False
+        assert "sync_api failed" in result.error
+
+    @pytest.mark.asyncio
+    async def test_deprovision_returns_success(self):
+        """deprovision_application always returns success (route kept)."""
+        from src.adapters.stoa.adapter import StoaGatewayAdapter
+
+        adapter = StoaGatewayAdapter()
+        result = await adapter.deprovision_application("route-abc")
+
+        assert result.success is True
+        assert result.resource_id == "route-abc"
+
+
+class TestWebMethodsIdempotentProvision:
+    """Tests for webMethods adapter idempotent provision_application (CAB-1121 Phase 3)."""
+
+    @pytest.mark.asyncio
+    async def test_provision_returns_existing_app(self):
+        """provision_application returns existing app when name matches."""
+        from src.adapters.webmethods.adapter import WebMethodsGatewayAdapter
+
+        adapter = WebMethodsGatewayAdapter.__new__(WebMethodsGatewayAdapter)
+        adapter._config = {}
+        adapter._svc = AsyncMock()
+
+        # list_applications returns existing app
+        adapter.list_applications = AsyncMock(return_value=[{"id": "existing-app-001", "name": "Test App"}])
+
+        app_spec = {
+            "subscription_id": "sub-1",
+            "application_name": "Test App",
+            "api_id": "api-123",
+            "tenant_id": "acme",
+        }
+
+        result = await adapter.provision_application(app_spec)
+
+        assert result.success is True
+        assert result.resource_id == "existing-app-001"
+        # Should NOT call provision_application on the service
+        adapter._svc.provision_application.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_provision_creates_when_no_existing(self):
+        """provision_application creates new app when no match found."""
+        from src.adapters.webmethods.adapter import WebMethodsGatewayAdapter
+
+        adapter = WebMethodsGatewayAdapter.__new__(WebMethodsGatewayAdapter)
+        adapter._config = {}
+        adapter._svc = AsyncMock()
+        adapter._svc.provision_application = AsyncMock(return_value={"app_id": "new-app-002"})
+
+        # list_applications returns empty
+        adapter.list_applications = AsyncMock(return_value=[])
+
+        app_spec = {
+            "subscription_id": "sub-2",
+            "application_name": "New App",
+            "api_id": "api-456",
+            "tenant_id": "acme",
+        }
+
+        result = await adapter.provision_application(app_spec)
+
+        assert result.success is True
+        assert result.resource_id == "new-app-002"
+        adapter._svc.provision_application.assert_awaited_once()
+
+
+class TestMappers:
+    """Tests for stoa mapper functions (CAB-1121 Phase 3)."""
+
+    def test_map_app_spec_to_route(self):
+        """map_app_spec_to_route converts enriched app_spec to sync_api format."""
+        from src.adapters.stoa.mappers import map_app_spec_to_route
+
+        app_spec = {
+            "api_id": "api-123",
+            "tenant_id": "acme",
+            "application_name": "Weather App",
+            "backend_url": "https://api.weather.com",
+        }
+
+        route = map_app_spec_to_route(app_spec)
+
+        assert route["api_catalog_id"] == "api-123"
+        assert route["api_name"] == "Weather App"
+        assert route["tenant_id"] == "acme"
+        assert route["backend_url"] == "https://api.weather.com"
+        assert route["activated"] is True
+
+    def test_map_quota_to_policy_with_per_minute(self):
+        """map_quota_to_policy builds rate-limit policy from per-minute quota."""
+        from src.adapters.stoa.mappers import map_quota_to_policy
+
+        app_spec = {
+            "rate_limit_per_minute": 600,
+            "consumer_external_id": "ext-001",
+            "plan_slug": "gold",
+            "api_id": "api-123",
+        }
+
+        policy = map_quota_to_policy(app_spec, "sub-001")
+
+        assert policy is not None
+        assert policy["id"] == "quota-sub-001"
+        assert policy["name"] == "rate-limit-ext-001-gold"
+        assert policy["type"] == "rate_limit"
+        assert policy["config"]["maxRequests"] == 600
+        assert policy["config"]["intervalSeconds"] == 60
+
+    def test_map_quota_to_policy_with_per_second(self):
+        """map_quota_to_policy converts per-second to per-minute."""
+        from src.adapters.stoa.mappers import map_quota_to_policy
+
+        app_spec = {
+            "rate_limit_per_second": 10,
+            "rate_limit_per_minute": None,
+            "api_id": "api-456",
+        }
+
+        policy = map_quota_to_policy(app_spec, "sub-002")
+
+        assert policy is not None
+        assert policy["config"]["maxRequests"] == 600  # 10 * 60
+
+    def test_map_quota_to_policy_returns_none_when_no_quotas(self):
+        """map_quota_to_policy returns None when no rate limits defined."""
+        from src.adapters.stoa.mappers import map_quota_to_policy
+
+        app_spec = {"api_id": "api-789"}
+
+        policy = map_quota_to_policy(app_spec, "sub-003")
+
+        assert policy is None

--- a/control-plane-api/tests/test_stoa_adapter.py
+++ b/control-plane-api/tests/test_stoa_adapter.py
@@ -1,4 +1,5 @@
 """Tests for STOA Gateway Adapter — Python side (Sub-phase 4a)."""
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -13,10 +14,12 @@ class TestStoaAdapterLifecycle:
     @pytest.mark.asyncio
     async def test_connect_creates_client(self):
         """connect() initializes an httpx.AsyncClient."""
-        adapter = StoaGatewayAdapter(config={
-            "base_url": "http://localhost:8080",
-            "auth_config": {"admin_token": "test-token"},
-        })
+        adapter = StoaGatewayAdapter(
+            config={
+                "base_url": "http://localhost:8080",
+                "auth_config": {"admin_token": "test-token"},
+            }
+        )
         assert adapter._client is None
 
         with patch("src.adapters.stoa.adapter.httpx.AsyncClient") as mock_cls:
@@ -53,10 +56,12 @@ class TestStoaAdapterAPIs:
     """Tests for API sync/delete/list operations."""
 
     def _make_adapter(self):
-        adapter = StoaGatewayAdapter(config={
-            "base_url": "http://gw.test:8080",
-            "auth_config": {"admin_token": "secret"},
-        })
+        adapter = StoaGatewayAdapter(
+            config={
+                "base_url": "http://gw.test:8080",
+                "auth_config": {"admin_token": "secret"},
+            }
+        )
         mock_client = AsyncMock()
         adapter._client = mock_client
         return adapter, mock_client
@@ -150,10 +155,12 @@ class TestStoaAdapterPolicies:
     """Tests for policy upsert/delete/list operations."""
 
     def _make_adapter(self):
-        adapter = StoaGatewayAdapter(config={
-            "base_url": "http://gw.test:8080",
-            "auth_config": {"admin_token": "secret"},
-        })
+        adapter = StoaGatewayAdapter(
+            config={
+                "base_url": "http://gw.test:8080",
+                "auth_config": {"admin_token": "secret"},
+            }
+        )
         mock_client = AsyncMock()
         adapter._client = mock_client
         return adapter, mock_client
@@ -167,13 +174,15 @@ class TestStoaAdapterPolicies:
         mock_resp.json.return_value = {"id": "pol-1", "status": "ok"}
         client.post = AsyncMock(return_value=mock_resp)
 
-        result = await adapter.upsert_policy({
-            "name": "rate-limit-100",
-            "type": "rate_limit",
-            "config": {"rate": 100},
-            "priority": 50,
-            "api_id": "api-123",
-        })
+        result = await adapter.upsert_policy(
+            {
+                "name": "rate-limit-100",
+                "type": "rate_limit",
+                "config": {"rate": 100},
+                "priority": 50,
+                "api_id": "api-123",
+            }
+        )
 
         assert result.success is True
         assert result.resource_id == "pol-1"
@@ -187,13 +196,14 @@ class TestStoaAdapterUnsupported:
         """Methods not supported by stoa-gateway return failure."""
         adapter = StoaGatewayAdapter()
 
-        # Applications
-        result = await adapter.provision_application({"app": "test"})
-        assert result.success is False
-        assert "Not supported" in result.error
+        # Applications — provision_application now implemented (CAB-1121 Phase 3)
+        # Without a connected client, sync_api fails gracefully
+        result = await adapter.provision_application({"app": "test", "tenant_id": "t"})
+        assert result.success is False  # Fails because no client connected
 
+        # deprovision_application now returns success (route kept for other subs)
         result = await adapter.deprovision_application("app-1")
-        assert result.success is False
+        assert result.success is True
 
         apps = await adapter.list_applications()
         assert apps == []
@@ -256,14 +266,16 @@ class TestStoaMappers:
 
     def test_map_policy_to_stoa(self):
         """map_policy_to_stoa produces correct structure."""
-        result = map_policy_to_stoa({
-            "id": "pol-1",
-            "name": "rate-limit-100",
-            "type": "rate_limit",
-            "config": {"rate": 100, "window": "1m"},
-            "priority": 50,
-            "api_id": "api-123",
-        })
+        result = map_policy_to_stoa(
+            {
+                "id": "pol-1",
+                "name": "rate-limit-100",
+                "type": "rate_limit",
+                "config": {"rate": 100, "window": "1m"},
+                "priority": 50,
+                "api_id": "api-123",
+            }
+        )
 
         assert result["id"] == "pol-1"
         assert result["name"] == "rate-limit-100"
@@ -279,11 +291,13 @@ class TestStoaAdapterRegistry:
     def test_registry_has_stoa(self):
         """STOA adapter is registered in AdapterRegistry."""
         from src.adapters.registry import AdapterRegistry
+
         assert AdapterRegistry.has_type("stoa") is True
 
     def test_registry_create_stoa(self):
         """AdapterRegistry.create('stoa') returns StoaGatewayAdapter instance."""
         from src.adapters.registry import AdapterRegistry
+
         adapter = AdapterRegistry.create("stoa", config={"base_url": "http://test:8080"})
         assert isinstance(adapter, StoaGatewayAdapter)
         assert adapter._base_url == "http://test:8080"

--- a/plan.md
+++ b/plan.md
@@ -1,213 +1,260 @@
-# STOA Platform — Plan
+# 🚀 CYCLE 7 — Plan Claude Code (9-15 fév 2026)
 
-> Last updated: 2026-02-08 22:30 CET
-> Sprint goal: Revenue-ready demo by Feb 24, 2026
-
----
-
-## Active — In Progress
-
-### CAB-1112 — Kyverno: Switch Audit → Enforce (5 ClusterPolicies)
-
-**Status**: TODO | **Points**: 2 | **Labels**: mvp-critical | **Cycle**: 6
-**Parent**: CAB-1106
-
-**Prérequis**:
-- [x] CAB-1106 déployé
-- [ ] Minimum 3-5 jours en mode Audit sans faux positifs dans les PolicyReports
-
-**5 ClusterPolicies à basculer**:
-1. `disallow-latest-tag`
-2. `require-requests-limits`
-3. `disallow-privilege-escalation`
-4. `require-non-root`
-5. `restrict-image-registries`
-
-**DoD**:
-- [ ] 5/5 ClusterPolicies en mode `Enforce`
-- [ ] Aucun pod légitime bloqué
-- [ ] PolicyReports propres (0 FAIL sur resources STOA)
-
-**Exécution recommandée**: Claude CLI (ops sensible, feedback live kubectl)
+**Target: 300 pts** | Vélocité réelle: **~1 pt / 2 min** (5 pts SEO = 8 min) | Mode: FULL SEND
 
 ---
 
-## Completed — Cycle 6
+## 📊 SCOREBOARD (révisé — audit Claude Code + vélocité réelle)
 
-### CAB-1119 — Brand Unification: Logo S Émeraude + Design Tokens + Portal Menu Cleanup ✅
+> **Audit réalité:** 6 tickets avaient 70-100% du code déjà écrit (Cycle 6).
+> **Vélocité réelle:** Session 1 (5 pts) = 8 min. Ratio: ~1 pt / 2 min.
 
-**Status**: DONE | **PR**: #194 (phases 1-3) + #198 (phases 4-5) | **Points**: 13 | **Cycle**: 6
-
-| Phase | Sujet | Status | Result |
-|-------|-------|--------|--------|
-| Phase 1 | Design Tokens + Favicon Recolor | DONE | Emerald palette, 14 SVG recolors, 3 Keycloak theme files, CSS cleanup |
-| Phase 2 | StoaLogo Component + UI Integration | DONE | Inline SVG component, Console sidebar + Portal header/loading/login |
-| Phase 3 | Portal Menu Restructure | DONE | 3 sections (Discover/Workspace/Account), tabbed WorkspacePage, redirects |
-| Phase 4 | Console Sidebar Restructuration | DONE | 5 sections (Overview/Catalog/⚡Gateway/Insights/Governance), STOA badges, "Control Plane" subtitle |
-| Phase 5 | Dark/Light Mode Complet | DONE | Console sidebar light mode, Portal dashboard dark mode (6 components) |
-
-All tests pass (257 console, 236 portal). Both apps build clean. Prettier + ESLint green.
-
----
-
-### BDD Steps + Clippy Fixes ✅
-
-**Status**: DONE | **PRs**: #191, #192, #196 | **Cycle**: 6
-
-- **PR #191**: Removed 6 duplicate steps from `console-admin.steps.ts` + clippy errors + helm-lint notify
-- **PR #192**: Fix clippy `collapsible_if` in `watcher.rs` (clippy 1.93)
-- **PR #196**: Removed 12 more duplicate steps from `admin-rbac.steps.ts` (3) + `consumer-flow.steps.ts` (9)
-
-Root cause: PR #184 (CAB-1103) added new step files duplicating existing step definitions. `bddgen` now clean.
-
----
-
-### AI Factory Enhancement — CI-awareness, Secrets, Rust Gotchas ✅
-
-**Status**: DONE | **PRs**: #195 + #199 (merged) | **Cycle**: 6
-
-| Action | File | Description |
-|--------|------|-------------|
-| CREATE | `.claude/rules/ci-quality-gates.md` | Exact CI thresholds (Python 53%/40%, ESLint 93/20, Rust zero), 10 failure patterns, pre-commit checklists |
-| CREATE | `.claude/rules/secrets-management.md` | Vault/ESO/AWS SM architecture, paths, agent checklist, 6 anti-patterns, rotation |
-| UPDATE | `.claude/rules/code-style-rust.md` | 31→128 lines: CI commands, system deps, 7 clippy gotchas, SAST rules |
-| UPDATE | `.claude/agents/test-writer.md` | Real CI thresholds, ESLint ratchet, CI exact commands, 5 gotchas |
-| UPDATE | `.claude/agents/security-reviewer.md` | Vault/ESO compliance checks, authorized paths, anti-patterns |
-| UPDATE | `.claude/agents/k8s-ops.md` | ArgoCD section, ESO diagnostics, Helm nil pointer gotcha |
-| UPDATE | `.claude/rules/ai-factory.md` | Pattern 5 (CI-first development), cross-refs to new rules |
-
-13 rules total (11 original + 2 new). Goal: CI-green at first push for all agents.
+| # | Ticket | Pts | Durée réelle | Jour prévu |
+|---|--------|-----|-------------|------------|
+| 1 | CAB-1121 — Consumer Onboarding P1 (Data Model) | **55** | ✅ PR #204 merged | ✅ Lun |
+| 1b | CAB-1121 — Consumer Onboarding P2 (Keycloak) | **20** | ✅ PR #208 merged | ✅ Lun |
+| 1c | CAB-1121 — Consumer Onboarding P3 (Gateway) | **15** | ✅ Code done, PR pending | ✅ Lun |
+| 2 | CAB-1118 — Sidebar Redesign | **8** | ✅ PR #207 + #209 merged | ✅ Lun |
+| 3 | CAB-1117 — Sidecar Docker Compose | **8** | ✅ PR #206 merged | ✅ Lun |
+| 4 | CAB-1030 — Admin Guide + Onboarding | **13** | ~25 min | Mar |
+| 5 | CAB-1068 — AI Factory Setup | **3** | ~6 min | Mar |
+| 6 | CAB-1120 — SEO + Compliance | **5** | ✅ 8 min (done) | ✅ Lun |
+| 7 | CAB-550 — Error Snapshot Demo | **3** | ~6 min | Mar |
+| 8 | CAB-802 — Demo Dry Run Script | **3** | ~6 min | Mar |
+| 9 | CAB-1112 — Kyverno Enforce | **2** | ✅ PR #205 merged | ✅ Lun |
+| 10 | CAB-1035 — Persona Alex Test | **2** | ~15 min (manuel) | Mar |
+| 11 | CAB-1097 — ADR fix | **2** | ✅ PR #205 merged | ✅ Lun |
+| 12 | CAB-362 — Circuit Breaker + Session | **5** | ~10 min | Mar |
+| 13 | Content Compliance apply | **5** | ✅ PR #203 merged | ✅ Lun |
+| | | | | |
+| | **SUBTOTAL BASE** | **94** | **~3h** | **Lun-Mar** |
+| | **DONE Lun (P1+P2+P3+Sidebar+Sidecar+Kyverno+ADR+SEO+Compliance)** | **120** | | ✅ |
+| | | | | |
+| 14 | CAB-864 — mTLS Epic | **34** | ~70 min | Mar-Mer |
+| 15 | CAB-1121 P4 — Quota Enforcement | **15** | ~30 min | Mar |
+| 16 | CAB-1121 P5 — Portal Consumer UI | **21** | ~40 min | Mer |
+| 17 | CAB-1121 P6 — E2E Tests full flow | **13** | ~25 min | Mer |
+| 18 | CAB-1066 — Landing + Pricing | **34** | ~70 min | Mer-Jeu |
+| | | | | |
+| | **TOTAL PLANIFIÉ** | **196** | **~6h** | **Lun→Mer** |
+| | **AVEC mTLS + P4-P6** | **279** | **~9h** | **Lun→Mer** |
+| | **AVEC Landing** | **313** | **~11h** | **Lun→Jeu** |
 
 ---
 
-### CAB-1109 — GitOps Pipeline: Manifests, Helm, Policies-as-Code, Shadow→Git MR Loop ✅
+## 📅 PLANNING JOUR PAR JOUR
 
-**Status**: DONE | **PR**: #188 (merged) + stoa-infra | **Cycle**: 6 | **DoD**: 8/8
+### LUNDI 9 FÉV — "Sprint Day" (~130 pts, ~4h30)
 
-| Phase | Sujet | Status | Description |
-|-------|-------|--------|-------------|
-| 1 | Rego Policies as ConfigMap + SIGHUP | DONE | ConfigMap from `.Files.Glob`, Stakater Reloader, SIGHUP handler in main.rs |
-| 2 | Helm Chart Enhancement | DONE | Kyverno `privileged: false`, RBAC CRD watcher, Ingress, nil-safe conditionals, all env vars |
-| 3 | Tool/ToolSet CRD Manifests | DONE | `tools.gostoa.dev` + `toolsets.gostoa.dev` CRDs matching Rust structs + examples |
-| 4 | Gateway Config Values | DONE | `values-dev.yaml` (1 replica, debug), `values-staging.yaml` (2 replicas, kafka), `values-prod.yaml` (3 replicas, kafka, otel, ingress) |
-| 5 | Shadow → Git MR Loop | DONE | `POST /shadow/submit-uac` → GitClient → branch + commit + MR with review checklist |
+#### Session 1: CAB-1120 SEO + Compliance (5 pts) — ✅ DONE (8 min)
 
-**stoa-infra — 9 fichiers (7 créés, 2 modifiés):**
-- `values.yaml` + `deployment.yaml` modifiés (securityContext, probes, env vars, volumes)
-- Créés : `policy-configmap.yaml`, `default.rego`, `rbac.yaml`, `servicemonitor.yaml`, `externalsecret.yaml`, `argocd-application.yaml`, `argocd-crds-application.yaml`
+#### Session 1b: Content Compliance Agent (5 pts) — ✅ DONE (PR #203 merged)
 
-**stoa — 1 fichier modifié:**
-- `.github/workflows/stoa-gateway-ci.yml` → supprimé `apply-manifest`, remplacé par `rollout restart`
+#### Session 1c: CAB-1121 P1 — Data Model + CRUD APIs (55 pts) — ✅ DONE (PR #204 merged)
+- Consumer model + Plan model + Alembic migration 018
+- 14 REST endpoints (8 consumer + 6 plan) with tenant isolation
+- 23 tests, full suite 452 passed, coverage 54%
+- Full CI/CD green through deploy + smoke test
 
-267 Rust tests pass, clippy clean, fmt clean. Helm lint: 4 variantes pass.
+#### Session 2: CAB-1121 P2 — Keycloak + OAuth2 (20 pts) — ✅ DONE (PR #208 merged)
+- Consumer registration → auto-create OAuth2 client in Keycloak
+- client_id = `{tenant}-{consumer_external_id}`, client_secret auto-generated
+- Service account enabled for client_credentials grant
+- Failure mode: 503 + logged warning, non-blocking
+- 10 tests added, 485 total pass, coverage 54%
 
-**Prochaine étape opérationnelle (hors ticket):**
-1. `kubectl delete deployment stoa-gateway -n stoa-system` (selectors immutables)
-2. `kubectl apply -f charts/stoa-gateway/argocd-application.yaml`
-3. `kubectl apply -f charts/stoa-platform/argocd-crds-application.yaml`
+#### Session 3: CAB-1121 P3 — Gateway Propagation (15 pts) — ✅ DONE (code ready, PR pending)
+- Enriched app_spec with consumer + plan context on provision
+- STOA adapter: provision_application → sync_api + upsert_policy
+- webMethods adapter: idempotent provision (check existing by name)
+- Rate-limit policy push on approval, cleanup on deprovision
+- 22 new tests (485 total pass, coverage 54.22%)
 
----
+#### Session 4: CAB-1118 Sidebar finitions (8 pts) — ✅ DONE (PR #207 + #209 merged)
+- Collapsible sidebar sections, tenant dropdown, skeleton pages
+- Function coverage boost above 35%
 
-## Completed — Earlier Cycles
+#### Session 5: CAB-1117 Sidecar Docker Compose (8 pts) — ✅ DONE (PR #206 merged)
+- docker-compose.sidecar.yml demo scenario
 
-### CAB-1116 — Test Automation Strategy (21 SP, 5 phases) ✅
-
-| Phase | Sujet | Status | PR | Result |
-|-------|-------|--------|-----|--------|
-| Phase 1 | Console UI unit tests (MSW) | DONE | #168 | 25 files, 249 tests, 50.98% coverage |
-| Phase 2A | Portal unit tests | DONE | #169 | 20 files, 219 tests, 70% coverage |
-| Phase 2B | API unit tests | DONE | #171 | 6 routers, 103 tests, 48%->53% coverage |
-| Phase 3A | OpenAPI contract tests | DONE | #172 | 40 tests (6 pytest + 17 console-ui + 17 portal) |
-| Phase 3B | Integration tests | DONE | #173 | 20 tests with PostgreSQL 16 in CI |
-| Phase 4 | E2E completeness | DONE | #175 | 52->81 scenarios, 100% route coverage |
-| Phase 5 | Quality gates | DONE | #176 | CI coverage, pre-commit hooks, formatting |
-| Hotfix | Docker build (tsconfig.app.json) | DONE | #177 | Exclude test files from tsc build |
-| Hotfix | bddgen @wip tag | DONE | #178 | Skip unimplemented demo-showcase.feature |
-
-#### CI Pipeline Status (2026-02-08)
-
-| Component | CI | Docker | Deploy | Notes |
-|-----------|-----|--------|--------|-------|
-| control-plane-ui | GREEN | GREEN | GREEN | Coverage + formatting enforced |
-| portal | GREEN | GREEN | GREEN | Coverage + formatting enforced |
-| control-plane-api | GREEN | — | — | Coverage 53%, ruff lint |
-| stoa-gateway | GREEN | — | — | Rust cargo test |
+#### Session 6: CAB-1112 Kyverno (2 pts) + CAB-1097 ADR fix (2 pts) — ✅ DONE (PR #205 merged)
+- Kyverno: 5 ClusterPolicies Audit → Enforce
+- ADR-027→035, ADR-028→036, ADR-033→037 renumbered
 
 ---
 
-### CAB-1103 — Control Plane Agnostique (Phases 1-7) ✅
+### MARDI 10 FÉV — "Docs + Polish Day" (~80 pts, ~3h)
 
-| Phase | Sujet | Status | PR | Description |
-|-------|-------|--------|-----|-------------|
-| Phase 1-5 | Core implementation | DONE | — | Models, adapters, sync engine |
-| Phase 6 | Operational Readiness | DONE | #184 | CI hardening, monitoring OIDC, E2E expansion, test loop |
-| Phase 7 | Gateway Auto-Registration | DONE | #121, #122 | ADR-036 merged |
+#### Session 7: CAB-1030 Admin Guide (13 pts) — ~25 min
+```
+- [ ] /docs/admin/ 12 pages (overview→upgrade)
+- [ ] OpenShift delta (SCC, Routes, registry, non-root)
+- [ ] Onboarding Kit Cédric (privé)
+- [ ] Content Compliance scan: zéro client name
+```
 
-#### Phase 6 — Operational Readiness (4 sub-phases)
+#### Session 8: CAB-1068 AI Factory (3 pts) — ~6 min
+```
+- [ ] Templates: MEGA-TICKET.md, PHASE-PLAN.md
+- [ ] Scripts: run-phase.sh, slack-notify.sh
+```
 
-| Sub-phase | Sujet | Status | PR | Result |
-|-----------|-------|--------|-----|--------|
-| 6A | CI Hardening | DONE | #184 | 5 `|| true` bugs fixed in 7 workflows, 11 intentional documented |
-| 6B | Monitoring OIDC | DONE | #184 | Grafana OIDC, oauth2-proxy, AlertManager routing, setup script |
-| 6C | E2E Expansion | DONE | #184 | 22 new BDD scenarios (gateway CRUD, deployment lifecycle, admin RBAC, portal consumer) |
-| 6D | Test Loop Automation | DONE | #184 | weekly-audit.yml (6 jobs) + smoke tests in mcp-gateway-ci + stoa-gateway-ci |
+#### Session 9: CAB-550 Error Snapshot Demo (3 pts) — ~6 min
+```
+- [ ] Script démo 2 min + seed data generator
+```
 
-23 files changed, +1659 lines.
+#### Session 10: CAB-802 Demo Dry Run Script (3 pts) — ~6 min
+```
+- [ ] Script markdown avec timing par étape (aligné one-pager flow)
+- [ ] Checklist pré-démo + Plan B
+```
+
+#### Session 11: CAB-362 Circuit Breaker (5 pts) — ~10 min
+```
+- [ ] Session management: zombie detection + reaper
+- [ ] Per-upstream config (actuellement générique)
+```
+
+#### Session 12: CAB-1035 Persona Alex (2 pts) — ~15 min
+```
+- [ ] Parcours complet chronométré: signup → discover → first MCP call
+- [ ] Frictions documentées en tickets
+```
+
+#### Session 13: CAB-864 mTLS P1 — Design + ADR (8 pts) — ~15 min
+```
+- [ ] ADR: F5 mTLS termination → STOA → webMethods flow
+- [ ] RFC 8705 cert-bound tokens spec
+- [ ] Architecture diagram
+```
 
 ---
 
-### CAB-1105 — Kill Python + Production-Grade MCP Gateway (9 phases) ✅
+### MERCREDI 11 FÉV — "Stretch Day" (~90 pts, ~3h)
 
-| Phase | Sujet | Status | PR | Result |
-|-------|-------|--------|----|--------|
-| Phase 1 | Native Tool Execution | DONE | #180 | JWT auth, native tools, real user context in ToolContext |
-| Phase 2 | OPA Policy Engine | DONE | #180 | OPA eval with real JWT claims, ADR-012 role-to-scope |
-| Phase 3 | Kafka Metering + Error Snapshots | DONE | #180 | Metering emission, ErrorSnapshot, timing breakdown |
-| Phase 4 | Token Optimization Pipeline | DONE | #180 | X-Token-Optimization header, 4-stage pipeline |
-| Phase 5 | MCP 2025-03-26 Spec Compliance | DONE | #181 | outputSchema on NativeTool, annotations wired |
-| Phase 6 | Circuit Breaker + Cache + Retry | DONE | #181 | Semantic cache in pipeline, CB + retry on CP discovery |
-| Phase 7 | K8s CRD + MCP Federation | DONE | #181 | DynamicTool from CRDs, FederatedTool from ToolSets, watcher wired |
-| Phase 8 | 4-Mode Architecture | DONE | #181 | Mode-specific router (EdgeMcp/Sidecar/Proxy/Shadow) |
-| Phase 9 | Gateway Mode Dashboard | DONE | #181 | Sidebar entry + g+m shortcut |
+#### Session 14: CAB-864 mTLS P2-P3 — Implémentation (26 pts) — ~50 min
+```
+- [ ] F5 X.509 header extraction
+- [ ] Certificate-bound tokens implementation
+- [ ] 100-client bulk onboarding flow
+```
 
-222 tests pass, clippy clean, fmt clean.
+#### Session 15: CAB-1121 P5 — Portal Consumer UI (21 pts) — ~40 min
+```
+- [ ] Portal UI: consumer registration form
+- [ ] Subscription workflow UI: browse catalogue → select plan → request access
+- [ ] Owner approval UI: notification + approve/reject
+- [ ] Credentials display (one-time)
+```
+
+#### Session 16: CAB-1121 P6 — E2E Tests (13 pts) — ~25 min
+```
+- [ ] Full flow test: register → subscribe → approve → token exchange → API call
+- [ ] Contract tests JWT claims schema
+- [ ] Multi-tenant isolation tests
+```
 
 ---
 
-## Demo Readiness (Feb 24)
+### JEUDI 12 FÉV — "Bonus Day" (si avance, ~34 pts)
 
-| Priority | Ticket | Description | Status |
-|----------|--------|-------------|--------|
-| P0 | CAB-1066 | Landing page gostoa.dev + Stripe | NOT STARTED |
-| P0 | — | Browser-based demo walkthrough | NOT STARTED |
-| P1 | — | Record video backup for demo | NOT STARTED |
-| P1 | CAB-1112 | Kyverno policies: Audit → Enforce | NOT STARTED |
-| P1 | CAB-1119 | Brand Unification (all 5 phases) | ✅ DONE (#194 + #198) |
-| P1 | CAB-1109 | GitOps Pipeline (Helm, CRDs, ArgoCD) | ✅ DONE (#188 + #193) |
-| P2 | — | AI Factory CI-awareness + deployment lifecycle | ✅ DONE (#195 + #199) |
-| P2 | — | BDD steps + Clippy fixes | ✅ DONE (#191 + #192 + #196) |
+#### Session 17: CAB-1066 Landing + Pricing (34 pts) — ~70 min
+```
+- [ ] Repo stoa-web (Astro)
+- [ ] Landing page redesign avec comparison table révisée
+- [ ] Pricing page + Stripe integration
+- [ ] Content Compliance applied
+```
 
-### Demo Checklist
+---
 
-- [x] All 4 components deployed on EKS
-- [x] CI/CD pipeline green through deploy
-- [x] Test coverage enforced in CI
-- [x] Pre-commit hooks (lint-staged)
-- [x] Prettier formatting (console-ui + portal)
-- [x] OpenSearch logs + RGPD + multi-tenant OIDC
-- [x] Grafana + Logs iframe embed in console
-- [x] Rust gateway production-grade (9 phases, 222 tests)
-- [x] CI hardening (`|| true` audit)
-- [x] Monitoring OIDC (Grafana + Prometheus + AlertManager)
-- [x] E2E expansion (22 new BDD scenarios)
-- [x] Weekly audit + smoke tests post-deploy
-- [x] Brand Unification phases 1-3 (emerald palette, StoaLogo, Portal menu) — PR #194
-- [x] GitOps pipeline (Helm chart, CRDs, ArgoCD sync, CI migration) — PR #188 + stoa-infra
-- [x] AI Factory: CI quality gates, secrets mgmt rules, agent enhancements — PR #195
-- [x] Brand Unification phases 4-5 (Console sidebar restructure, dark/light mode complet) — PR #198
-- [x] Deployment lifecycle rule (PR→CI→Merge→CI→CD→Pod) — PR #199
-- [x] BDD duplicate steps + clippy fixes — PRs #191, #192, #196
-- [ ] Landing page (gostoa.dev) with Stripe
-- [ ] Demo walkthrough script
-- [ ] Video backup recording
-- [ ] Kyverno Enforce mode
+## 📊 RÉCAP SCORING (révisé — vélocité 1pt/2min)
+
+| Jour | Tickets | Points | Durée |
+|------|---------|--------|-------|
+| **Lundi** ✅ | S1 SEO ✅ + S1b Compliance ✅ + S1c P1 ✅ + S2 Keycloak ✅ + S3 Gateway ✅ + S4 Sidebar ✅ + S5 Sidecar ✅ + S6 Kyverno+ADR ✅ | **120** | done |
+| **Mardi** | S7 Admin Guide (13) + S8 Factory (3) + S9 Demo (3) + S10 Script (3) + S11 CB (5) + S12 Alex (2) + S13 mTLS design (8) + P4 Quota (15) | **52** | ~2h |
+| **Mercredi** | S14 mTLS impl (26) + S15 Portal UI (21) + S16 E2E (13) | **60** | ~2h |
+| **Jeudi** | S17 Landing (34) | **34** | ~1h10 |
+| | | | |
+| **DONE (Lundi)** | | **120** | |
+| **+ Mardi** | | **172** | |
+| **+ Mercredi** | | **232** | |
+| **+ Jeudi** | | **266** | |
+
+### Blockers identifiés
+1. **Keycloak Token Exchange SPI** — si config realm non-triviale, Session 2 peut glisser
+2. **Vault root token** — pas bloquant Cycle 7 (workaround K8s secrets)
+3. **CAB-1066** — context switch repo stoa-web, à ne prendre que si avance réelle
+
+---
+
+## ✅ DEFINITION OF DONE — Standard Marchemalo (tricouche)
+
+Chaque livrable de chaque session doit passer les 3 couches. Pas de "Done" si une couche manque.
+
+### Couche 1 — Local testé
+```
+- [ ] Code compile sans erreur
+- [ ] Tests unitaires passent (jest/vitest/go test)
+- [ ] Lint + format OK (eslint, prettier, golangci-lint)
+- [ ] Pas de regression sur tests existants
+- [ ] Review code: pas de secret, pas de TODO non-tracké
+```
+
+### Couche 2 — Live validé
+```
+- [ ] Déployé sur env dev/staging (ou docker-compose local pour sidecar)
+- [ ] Flow E2E testé manuellement: l'humain voit le résultat attendu
+- [ ] Pas d'erreur dans les logs (Loki/stdout)
+- [ ] Métriques Prometheus exposées et visibles dans Grafana
+- [ ] RBAC vérifié: chaque rôle voit/ne voit pas ce qu'il doit
+```
+
+### Couche 3 — Automatisé
+```
+- [ ] Tests d'intégration (testcontainers ou API tests)
+- [ ] CI pipeline vert (GitHub Actions / ArgoCD sync)
+- [ ] Si API: OpenAPI spec à jour + tests contract
+- [ ] Si UI: screenshot/snapshot tests ou test Cypress/Playwright minimal
+- [ ] Si infra: manifests K8s/Helm validés (helm template + kubeval)
+```
+
+### Matrice DoD par ticket
+
+| Ticket | Couche 1 (local) | Couche 2 (live) | Couche 3 (auto) |
+|--------|-------------------|-----------------|-----------------|
+| **CAB-1121** Consumer Onboarding | Unit tests API + DB migrations | Token Exchange flow E2E sur Keycloak dev | Integration tests + contract tests JWT claims |
+| **CAB-1118** Sidebar Redesign | Jest components + lint | Console dev: navigation par rôle testée manuellement | Snapshot tests composants sidebar + RBAC matrix |
+| **CAB-1117** Sidecar VM | docker-compose up OK | Traffic proxy → upstream, metrics dans Prometheus | CI: docker-compose build + healthcheck + traffic test |
+| **CAB-1030** Admin Guide | Build Docusaurus sans erreur | Pages rendues, navigation OK, liens valides | Linkcheck CI (broken links), grep zéro client name |
+| **CAB-1068** AI Factory | Scripts exécutables | Premier run-phase.sh réussi | Slack webhook test automatisé |
+| **CAB-550** Error Snapshot Demo | Script valide, seed data OK | Flow démo joué 1x complet chrono | Script génération erreurs idempotent |
+| **CAB-1112** Kyverno | Policies YAML valides | Pod non-conforme rejeté en live | PolicyReport clean (zéro FAIL légitime) |
+| **CAB-362** Circuit Breaker | Unit tests states machine | Simuler pool exhaustion → recovery auto | Integration test: failure injection + recovery |
+| **CAB-1120** SEO | Articles build OK | Pages indexables (GSC fetch) | Content Compliance grep (zéro P0 violation) |
+| **CAB-802** Demo Script | Markdown valide | Dry run 1x complet < 5min | Checklist pré-démo scriptée |
+| **CAB-1035** Persona Alex | N/A (test manuel) | Parcours complet chronométré | Frictions documentées en tickets |
+| **CAB-1097** ADR fix | Fichier migré, build OK | Page rendue dans Docusaurus | CI build pass |
+
+---
+
+## ⚡ RÈGLES CLAUDE CODE
+
+1. **Un MEGA par session** — `/clear` entre sessions
+2. **Audit avant code** — lire le code existant, conventions, ORM
+3. **Council 8/10** — MEGA-tickets seulement si Council GO
+4. **Content Compliance** — zéro nom client, zéro prix concurrent, disclaimers
+5. **DoD tricouche** — chaque livrable passe local + live + auto AVANT de marquer Done
+6. **State files** — memory.md update avant chaque `/clear`
+7. **Test "40-year architect"** — un architecte de 40 ans d'expérience comprend le ticket en 30 secondes
+
+---
+
+## 🔗 RÉFÉRENCES
+
+- One-pager: STOA-OnePager-Hybrid-v2 (démo 5 min = flow CAB-1121)
+- Content Compliance: document project (P0/P1/P2 rules)
+- Linear Cycle 7: 483a7848-51bb-4b7c-a4f6-dbad7a769d08
+- Démo target: 24 février 2026


### PR DESCRIPTION
## Summary
- **Enrich provisioning** with consumer + plan context (external_id, keycloak_client_id, plan quotas)
- **STOA adapter**: implement `provision_application()` via `sync_api` + `upsert_policy` (was "Not supported")
- **webMethods adapter**: idempotent `provision_application()` — returns existing app if name matches
- **Rate-limit policy push** on approval (non-blocking), cleanup on deprovision
- **22 new tests** (485 total pass, coverage 54.22% — above 53% threshold)

## Files changed (7)
| File | Change |
|------|--------|
| `src/services/provisioning_service.py` | Enrich app_spec + `_push_rate_limit_policy` + `_cleanup_rate_limit_policy` |
| `src/adapters/stoa/adapter.py` | Implement provision/deprovision (sync_api + policy) |
| `src/adapters/stoa/mappers.py` | Add `map_app_spec_to_route` + `map_quota_to_policy` |
| `src/adapters/webmethods/adapter.py` | Idempotent check in `provision_application` |
| `tests/test_provisioning.py` | 22 new tests for enrichment, policy, adapters, mappers |
| `tests/test_stoa_adapter.py` | Updated `test_unsupported_methods` for new behavior |
| `plan.md` | Updated scoreboard with completed items |

## Test plan
- [x] `ruff check` clean on all source files
- [x] `black --check` clean
- [x] 485 tests pass, 0 failures
- [x] Coverage 54.22% (above 53% threshold)
- [ ] CI green on PR
- [ ] CI green on main after merge
- [ ] CD deploy + pod updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)