### PR TITLE
ci: disable CodeQL workflow (GHAS not enabled)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,12 +9,13 @@
 name: CodeQL Analysis
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  schedule:
-    - cron: '0 4 * * 1'  # Weekly Monday 4 AM UTC
+  workflow_dispatch: # Disabled: GHAS not enabled on this repo (paid feature for private repos)
+  # push:
+  #   branches: [main]
+  # pull_request:
+  #   branches: [main]
+  # schedule:
+  #   - cron: '0 4 * * 1'  # Weekly Monday 4 AM UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- Disable CodeQL Analysis automatic triggers (push/PR/schedule) since GitHub Advanced Security is not enabled on this private repo
- Changed to `workflow_dispatch` only so it can be re-enabled when GHAS is purchased
- Eliminates systematic CI failure noise on every merge to main

## Test plan
- [ ] Security Scan (3 required checks) still passes
- [ ] CodeQL no longer triggers on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)