### PR TITLE
feat(gateway): quota enforcement + per-upstream circuit breaker (CAB-1121 P4, CAB-362)

### DIFF
--- a/stoa-gateway/src/config.rs
+++ b/stoa-gateway/src/config.rs
@@ -119,6 +119,27 @@ pub struct Config {
     #[serde(default)]
     pub gateway_mode: GatewayMode,
 
+    // === Circuit Breaker (CAB-362) ===
+    /// Failure count before opening circuit breaker
+    /// Env: STOA_CIRCUIT_BREAKER_FAILURE_THRESHOLD (default: 5)
+    #[serde(default = "default_cb_failure_threshold")]
+    pub circuit_breaker_failure_threshold: u32,
+
+    /// Seconds to wait before transitioning from open to half-open
+    /// Env: STOA_CIRCUIT_BREAKER_RESET_TIMEOUT_SECS (default: 30)
+    #[serde(default = "default_cb_reset_timeout_secs")]
+    pub circuit_breaker_reset_timeout_secs: u64,
+
+    /// Successes needed in half-open to close the circuit
+    /// Env: STOA_CIRCUIT_BREAKER_SUCCESS_THRESHOLD (default: 3)
+    #[serde(default = "default_cb_success_threshold")]
+    pub circuit_breaker_success_threshold: u32,
+
+    /// Enable per-upstream circuit breakers (vs single global)
+    /// Env: STOA_CIRCUIT_BREAKER_PER_UPSTREAM (default: true)
+    #[serde(default = "default_cb_per_upstream")]
+    pub circuit_breaker_per_upstream: bool,
+
     // === Governance (ADR-012) ===
     /// Enable anti-zombie agent detection
     /// Env: STOA_ZOMBIE_DETECTION_ENABLED (default: true)
@@ -134,6 +155,16 @@ pub struct Config {
     /// Env: STOA_ATTESTATION_INTERVAL
     #[serde(default = "default_attestation_interval")]
     pub attestation_interval: u64,
+
+    /// Zombie reaper sweep interval in seconds
+    /// Env: STOA_ZOMBIE_REAPER_INTERVAL_SECS (default: 60)
+    #[serde(default = "default_zombie_reaper_interval")]
+    pub zombie_reaper_interval_secs: u64,
+
+    /// Enable automatic session revocation for zombie sessions
+    /// Env: STOA_ZOMBIE_AUTO_REVOKE (default: false)
+    #[serde(default)]
+    pub zombie_auto_revoke: bool,
 
     // === Shadow Mode ===
     /// Traffic capture source for shadow mode
@@ -200,6 +231,27 @@ pub struct Config {
     /// Env: STOA_K8S_ENABLED (default: false — explicit opt-in)
     #[serde(default)]
     pub k8s_enabled: bool,
+
+    // === Quota Enforcement (Phase 4: CAB-1121) ===
+    /// Enable per-consumer quota enforcement (default: false — feature flag)
+    /// Env: STOA_QUOTA_ENFORCEMENT_ENABLED
+    #[serde(default)]
+    pub quota_enforcement_enabled: bool,
+
+    /// Interval in seconds for syncing quota state (default: 300)
+    /// Env: STOA_QUOTA_SYNC_INTERVAL_SECS
+    #[serde(default = "default_quota_sync_interval")]
+    pub quota_sync_interval_secs: u64,
+
+    /// Default rate per minute for consumers without a plan (default: 60)
+    /// Env: STOA_QUOTA_DEFAULT_RATE_PER_MINUTE
+    #[serde(default = "default_quota_rate_per_minute")]
+    pub quota_default_rate_per_minute: u32,
+
+    /// Default daily request limit for consumers without a plan (default: 10000)
+    /// Env: STOA_QUOTA_DEFAULT_DAILY_LIMIT
+    #[serde(default = "default_quota_daily_limit")]
+    pub quota_default_daily_limit: u32,
 }
 
 fn default_port() -> u16 {
@@ -222,8 +274,28 @@ fn default_policy_enabled() -> bool {
     true
 }
 
+fn default_cb_failure_threshold() -> u32 {
+    5
+}
+
+fn default_cb_reset_timeout_secs() -> u64 {
+    30
+}
+
+fn default_cb_success_threshold() -> u32 {
+    3
+}
+
+fn default_cb_per_upstream() -> bool {
+    true
+}
+
 fn default_zombie_detection() -> bool {
     true
+}
+
+fn default_zombie_reaper_interval() -> u64 {
+    60
 }
 
 fn default_agent_session_ttl() -> u64 {
@@ -266,6 +338,18 @@ fn default_kafka_errors_topic() -> String {
     "stoa.errors".to_string()
 }
 
+fn default_quota_sync_interval() -> u64 {
+    300 // 5 minutes
+}
+
+fn default_quota_rate_per_minute() -> u32 {
+    60
+}
+
+fn default_quota_daily_limit() -> u32 {
+    10_000
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -295,9 +379,15 @@ impl Default for Config {
             log_format: Some("json".to_string()),
             otel_endpoint: None,
             gateway_mode: GatewayMode::default(),
+            circuit_breaker_failure_threshold: default_cb_failure_threshold(),
+            circuit_breaker_reset_timeout_secs: default_cb_reset_timeout_secs(),
+            circuit_breaker_success_threshold: default_cb_success_threshold(),
+            circuit_breaker_per_upstream: default_cb_per_upstream(),
             zombie_detection_enabled: default_zombie_detection(),
             agent_session_ttl_secs: default_agent_session_ttl(),
             attestation_interval: default_attestation_interval(),
+            zombie_reaper_interval_secs: default_zombie_reaper_interval(),
+            zombie_auto_revoke: false,
             shadow_capture_source: None,
             shadow_min_samples: default_shadow_min_samples(),
             shadow_gitlab_project: None,
@@ -310,6 +400,10 @@ impl Default for Config {
             kafka_metering_topic: default_kafka_metering_topic(),
             kafka_errors_topic: default_kafka_errors_topic(),
             k8s_enabled: false,
+            quota_enforcement_enabled: false,
+            quota_sync_interval_secs: default_quota_sync_interval(),
+            quota_default_rate_per_minute: default_quota_rate_per_minute(),
+            quota_default_daily_limit: default_quota_daily_limit(),
         }
     }
 }

--- a/stoa-gateway/src/handlers/admin.rs
+++ b/stoa-gateway/src/handlers/admin.rs
@@ -33,18 +33,22 @@ use crate::state::AppState;
 /// Bearer token authentication for admin API.
 ///
 /// Validates the `Authorization: Bearer <token>` header against
-/// `config.admin_api_token`. If no token is configured, returns 403
-/// (admin API disabled).
+/// `config.admin_api_token`. If no token is configured, returns 503
+/// (admin API disabled — no token configured).
 pub async fn admin_auth(
     State(state): State<AppState>,
     request: Request<Body>,
     next: Next,
-) -> Result<Response, StatusCode> {
+) -> Result<Response, Response> {
     let expected = match state.config.admin_api_token.as_deref() {
         Some(token) if !token.is_empty() => token,
         _ => {
             warn!("Admin API request rejected: no admin_api_token configured");
-            return Err(StatusCode::FORBIDDEN);
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Admin API disabled — no admin_api_token configured",
+            )
+                .into_response());
         }
     };
 
@@ -59,7 +63,7 @@ pub async fn admin_auth(
         Ok(next.run(request).await)
     } else {
         warn!("Admin API request rejected: invalid bearer token");
-        Err(StatusCode::UNAUTHORIZED)
+        Err(StatusCode::UNAUTHORIZED.into_response())
     }
 }
 
@@ -156,7 +160,7 @@ pub async fn delete_policy(
 }
 
 // =============================================================================
-// Circuit Breaker (Phase 6)
+// Circuit Breaker (Phase 6 + CAB-362 per-upstream)
 // =============================================================================
 
 #[derive(Serialize)]
@@ -170,13 +174,14 @@ pub struct CircuitBreakerStatsResponse {
     pub rejected_count: u64,
 }
 
-/// GET /admin/circuit-breaker/stats
+/// GET /admin/circuit-breaker/stats — backward compat (returns "cp-api" CB stats)
 pub async fn circuit_breaker_stats(
     State(state): State<AppState>,
 ) -> Json<CircuitBreakerStatsResponse> {
-    let stats = state.cp_circuit_breaker.stats();
+    let cb = state.get_or_create_cb("cp-api");
+    let stats = cb.stats();
     Json(CircuitBreakerStatsResponse {
-        name: state.cp_circuit_breaker.name().to_string(),
+        name: cb.name().to_string(),
         state: stats.state.to_string(),
         success_count: stats.success_count,
         failure_count: stats.failure_count,
@@ -186,13 +191,101 @@ pub async fn circuit_breaker_stats(
     })
 }
 
-/// POST /admin/circuit-breaker/reset
+/// POST /admin/circuit-breaker/reset — backward compat (resets "cp-api" CB)
 pub async fn circuit_breaker_reset(State(state): State<AppState>) -> impl IntoResponse {
-    state.cp_circuit_breaker.reset();
+    let cb = state.get_or_create_cb("cp-api");
+    cb.reset();
     (
         StatusCode::OK,
         Json(serde_json::json!({"status": "ok", "message": "Circuit breaker reset to closed"})),
     )
+}
+
+/// GET /admin/circuit-breakers — list all per-upstream circuit breakers
+pub async fn list_circuit_breakers(
+    State(state): State<AppState>,
+) -> Json<Vec<CircuitBreakerStatsResponse>> {
+    let breakers = state.circuit_breakers.read();
+    let mut results: Vec<CircuitBreakerStatsResponse> = breakers
+        .values()
+        .map(|cb| {
+            let stats = cb.stats();
+            CircuitBreakerStatsResponse {
+                name: cb.name().to_string(),
+                state: stats.state.to_string(),
+                success_count: stats.success_count,
+                failure_count: stats.failure_count,
+                consecutive_failures: stats.consecutive_failures,
+                open_count: stats.open_count,
+                rejected_count: stats.rejected_count,
+            }
+        })
+        .collect();
+    // Sort by name for deterministic output
+    results.sort_by(|a, b| a.name.cmp(&b.name));
+    Json(results)
+}
+
+/// POST /admin/circuit-breakers/:upstream_id/reset — reset a specific upstream CB
+pub async fn reset_upstream_circuit_breaker(
+    State(state): State<AppState>,
+    Path(upstream_id): Path<String>,
+) -> impl IntoResponse {
+    let breakers = state.circuit_breakers.read();
+    if let Some(cb) = breakers.get(&upstream_id) {
+        cb.reset();
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "status": "ok",
+                "message": format!("Circuit breaker '{}' reset to closed", upstream_id)
+            })),
+        )
+            .into_response()
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "status": "error",
+                "message": format!("Circuit breaker '{}' not found", upstream_id)
+            })),
+        )
+            .into_response()
+    }
+}
+
+// =============================================================================
+// Zombie Detector (CAB-362, ADR-012)
+// =============================================================================
+
+/// GET /admin/zombies/stats
+pub async fn zombie_stats(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let stats = state.zombie_detector.stats().await;
+    Json(serde_json::json!({
+        "total_sessions": stats.total_sessions,
+        "healthy": stats.healthy,
+        "warning": stats.warning,
+        "expired": stats.expired,
+        "zombie": stats.zombie,
+        "revoked": stats.revoked,
+        "alerts_total": stats.alerts_total,
+    }))
+}
+
+/// GET /admin/zombies/alerts
+pub async fn zombie_alerts(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> Json<serde_json::Value> {
+    let limit: usize = params
+        .get("limit")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(50);
+    let alerts = state.zombie_detector.recent_alerts(limit).await;
+    Json(serde_json::json!({
+        "count": alerts.len(),
+        "alerts": alerts,
+    }))
 }
 
 // =============================================================================
@@ -228,6 +321,76 @@ pub async fn cache_clear(State(state): State<AppState>) -> impl IntoResponse {
 }
 
 // =============================================================================
+// Quota Admin (Phase 4: CAB-1121)
+// =============================================================================
+
+/// GET /admin/quotas — list all consumer quota states
+pub async fn list_quotas(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let stats = state.quota_manager.list_all_stats();
+    Json(serde_json::json!({
+        "count": stats.len(),
+        "consumers": stats,
+        "rate_limiter_buckets": state.consumer_rate_limiter.bucket_count(),
+        "quota_enforcement_enabled": state.config.quota_enforcement_enabled,
+    }))
+}
+
+/// GET /admin/quotas/:consumer_id — specific consumer quota stats
+pub async fn get_consumer_quota(
+    State(state): State<AppState>,
+    Path(consumer_id): Path<String>,
+) -> impl IntoResponse {
+    match state.quota_manager.get_stats(&consumer_id) {
+        Some(stats) => {
+            let rate_info = state
+                .consumer_rate_limiter
+                .get_rate_limit_info(&consumer_id);
+            Json(serde_json::json!({
+                "consumer_id": consumer_id,
+                "quota": stats,
+                "rate_limit": {
+                    "limit": rate_info.limit,
+                    "remaining": rate_info.remaining,
+                    "reset_epoch": rate_info.reset_epoch,
+                },
+            }))
+            .into_response()
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "Consumer not found"})),
+        )
+            .into_response(),
+    }
+}
+
+/// POST /admin/quotas/:consumer_id/reset — reset quota counters
+pub async fn reset_consumer_quota(
+    State(state): State<AppState>,
+    Path(consumer_id): Path<String>,
+) -> impl IntoResponse {
+    if state.quota_manager.reset_consumer(&consumer_id) {
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "status": "ok",
+                "message": format!("Quota counters reset for consumer '{}'", consumer_id),
+            })),
+        )
+            .into_response()
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "status": "error",
+                "message": format!("Consumer '{}' not found", consumer_id),
+            })),
+        )
+            .into_response()
+    }
+}
+
+// =============================================================================
 // Tests
 // =============================================================================
 
@@ -253,12 +416,25 @@ mod tests {
     }
 
     fn build_admin_router(state: AppState) -> Router {
+        use axum::routing::post;
+
         Router::new()
             .route("/health", get(admin_health))
             .route("/apis", get(list_apis).post(upsert_api))
             .route("/apis/:id", get(get_api).delete(delete_api))
             .route("/policies", get(list_policies).post(upsert_policy))
             .route("/policies/:id", delete(delete_policy))
+            // Circuit breaker endpoints (backward compat + per-upstream)
+            .route("/circuit-breaker/stats", get(circuit_breaker_stats))
+            .route("/circuit-breaker/reset", post(circuit_breaker_reset))
+            .route("/circuit-breakers", get(list_circuit_breakers))
+            .route(
+                "/circuit-breakers/:upstream_id/reset",
+                post(reset_upstream_circuit_breaker),
+            )
+            // Zombie endpoints
+            .route("/zombies/stats", get(zombie_stats))
+            .route("/zombies/alerts", get(zombie_alerts))
             .layer(middleware::from_fn_with_state(state.clone(), admin_auth))
             .with_state(state)
     }
@@ -317,7 +493,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]
@@ -465,5 +641,182 @@ mod tests {
             .unwrap();
         let data: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
         assert_eq!(data.len(), 0);
+    }
+
+    // =========================================================================
+    // Circuit Breaker Admin Tests (CAB-362)
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_circuit_breaker_stats_backward_compat() {
+        let state = create_test_state(Some("secret"));
+        let app = build_admin_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/circuit-breaker/stats")
+                    .header("Authorization", "Bearer secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["name"], "cp-api");
+        assert_eq!(data["state"], "closed");
+    }
+
+    #[tokio::test]
+    async fn test_list_circuit_breakers() {
+        let state = create_test_state(Some("secret"));
+
+        // Create a second CB for upstream-payments
+        state.get_or_create_cb("upstream-payments");
+
+        let app = build_admin_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/circuit-breakers")
+                    .header("Authorization", "Bearer secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert!(data.len() >= 2); // cp-api + upstream-payments
+
+        // Sorted by name — cp-api first
+        assert_eq!(data[0]["name"], "cp-api");
+        assert_eq!(data[1]["name"], "upstream-payments");
+    }
+
+    #[tokio::test]
+    async fn test_reset_upstream_circuit_breaker() {
+        let state = create_test_state(Some("secret"));
+
+        // Create and trip a CB
+        let cb = state.get_or_create_cb("test-upstream");
+        for _ in 0..5 {
+            cb.record_failure();
+        }
+        assert_eq!(cb.stats().state.to_string(), "open");
+
+        let app = build_admin_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/circuit-breakers/test-upstream/reset")
+                    .header("Authorization", "Bearer secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Verify it's now closed
+        assert_eq!(cb.stats().state.to_string(), "closed");
+    }
+
+    #[tokio::test]
+    async fn test_reset_upstream_circuit_breaker_not_found() {
+        let state = create_test_state(Some("secret"));
+        let app = build_admin_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/circuit-breakers/nonexistent/reset")
+                    .header("Authorization", "Bearer secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    // =========================================================================
+    // Zombie Admin Tests (CAB-362)
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_zombie_stats_endpoint() {
+        let state = create_test_state(Some("secret"));
+
+        // Start some sessions via zombie detector
+        state
+            .zombie_detector
+            .start_session("sess-1", Some("user-1".to_string()), None)
+            .await;
+        state
+            .zombie_detector
+            .start_session("sess-2", Some("user-2".to_string()), None)
+            .await;
+
+        let app = build_admin_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/zombies/stats")
+                    .header("Authorization", "Bearer secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["total_sessions"], 2);
+        assert_eq!(data["healthy"], 2);
+    }
+
+    #[tokio::test]
+    async fn test_zombie_alerts_endpoint() {
+        let state = create_test_state(Some("secret"));
+        let app = build_admin_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/zombies/alerts?limit=10")
+                    .header("Authorization", "Bearer secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["count"], 0); // No alerts initially
+        assert!(data["alerts"].is_array());
     }
 }

--- a/stoa-gateway/src/main.rs
+++ b/stoa-gateway/src/main.rs
@@ -28,6 +28,7 @@ mod oauth;
 mod optimization;
 mod policy;
 mod proxy;
+mod quota;
 mod rate_limit;
 mod resilience;
 mod routes;
@@ -196,9 +197,25 @@ fn build_router(state: AppState) -> Router {
             get(admin::list_policies).post(admin::upsert_policy),
         )
         .route("/policies/:id", delete(admin::delete_policy))
-        // Phase 6: Circuit Breaker admin
+        // Phase 6: Circuit Breaker admin (backward compat)
         .route("/circuit-breaker/stats", get(admin::circuit_breaker_stats))
         .route("/circuit-breaker/reset", post(admin::circuit_breaker_reset))
+        // CAB-362: Per-upstream circuit breakers
+        .route("/circuit-breakers", get(admin::list_circuit_breakers))
+        .route(
+            "/circuit-breakers/:upstream_id/reset",
+            post(admin::reset_upstream_circuit_breaker),
+        )
+        // CAB-362: Zombie detector
+        .route("/zombies/stats", get(admin::zombie_stats))
+        .route("/zombies/alerts", get(admin::zombie_alerts))
+        // Phase 4 CAB-1121: Quota admin
+        .route("/quotas", get(admin::list_quotas))
+        .route("/quotas/:consumer_id", get(admin::get_consumer_quota))
+        .route(
+            "/quotas/:consumer_id/reset",
+            post(admin::reset_consumer_quota),
+        )
         // Phase 6: Cache admin
         .route("/cache/stats", get(admin::cache_stats))
         .route("/cache/clear", post(admin::cache_clear))
@@ -249,6 +266,12 @@ fn build_router(state: AppState) -> Router {
                 )
                 // Dynamic proxy fallback — must be LAST
                 .fallback(dynamic_proxy)
+                // Quota enforcement middleware (Phase 4: CAB-1121)
+                // Runs after auth, checks per-consumer rate limits + daily/monthly quotas
+                .layer(axum::middleware::from_fn_with_state(
+                    state.clone(),
+                    quota::quota_middleware,
+                ))
                 .with_state(state)
         }
         GatewayMode::Sidecar => {
@@ -406,7 +429,7 @@ async fn register_tools(state: &AppState) {
         match stoa_tools::discover_and_register(
             state.tool_registry.clone(),
             &state.control_plane,
-            state.cp_circuit_breaker.clone(),
+            state.get_or_create_cb("cp-api"),
         )
         .await
         {
@@ -426,7 +449,7 @@ async fn register_tools(state: &AppState) {
     stoa_tools::start_tool_refresh_task(
         state.tool_registry.clone(),
         state.control_plane.clone(),
-        state.cp_circuit_breaker.clone(),
+        state.get_or_create_cb("cp-api"),
     );
 }
 

--- a/stoa-gateway/src/mcp/session.rs
+++ b/stoa-gateway/src/mcp/session.rs
@@ -1,13 +1,16 @@
 //! MCP Session Manager
 //!
 //! Manages stateful SSE sessions with automatic TTL expiration.
+//! CAB-362: Integrates with ZombieDetector for session governance.
 
 use chrono::{DateTime, Duration, Utc};
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::time::{interval, Duration as TokioDuration};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
+
+use crate::governance::zombie::{SessionHealth, ZombieDetector};
 
 /// MCP Session
 #[derive(Debug, Clone)]
@@ -47,6 +50,8 @@ impl Session {
 pub struct SessionManager {
     sessions: Arc<RwLock<HashMap<String, Session>>>,
     ttl: Duration,
+    /// Optional zombie detector for session governance (CAB-362)
+    zombie_detector: Option<Arc<ZombieDetector>>,
 }
 
 impl SessionManager {
@@ -54,18 +59,55 @@ impl SessionManager {
         Self {
             sessions: Arc::new(RwLock::new(HashMap::new())),
             ttl: Duration::minutes(ttl_minutes),
+            zombie_detector: None,
         }
     }
 
-    /// Create a new session
+    /// Set the zombie detector for session governance (CAB-362)
+    pub fn set_zombie_detector(&mut self, detector: Arc<ZombieDetector>) {
+        self.zombie_detector = Some(detector);
+    }
+
+    /// Create a new session (CAB-362: also starts zombie tracking)
     pub async fn create(&self, session: Session) {
         let id = session.id.clone();
+        let tenant_id = session.tenant_id.clone();
         self.sessions.write().insert(id.clone(), session);
         debug!(session_id = %id, "Session created");
+
+        // Register with zombie detector for tracking
+        if let Some(ref detector) = self.zombie_detector {
+            detector.start_session(&id, None, Some(tenant_id)).await;
+        }
     }
 
     /// Get session by ID (and touch it)
+    /// CAB-362: Also records activity with zombie detector.
+    /// Returns None if session is zombie/revoked.
     pub async fn get(&self, id: &str) -> Option<Session> {
+        // Check zombie health first
+        if let Some(ref detector) = self.zombie_detector {
+            match detector.record_activity(id).await {
+                Ok(SessionHealth::Zombie) => {
+                    warn!(session_id = %id, "Session is zombie — removing");
+                    self.sessions.write().remove(id);
+                    return None;
+                }
+                Ok(SessionHealth::Revoked) => {
+                    warn!(session_id = %id, "Session is revoked — removing");
+                    self.sessions.write().remove(id);
+                    return None;
+                }
+                Err(crate::governance::zombie::ZombieError::SessionRevoked) => {
+                    warn!(session_id = %id, "Session revoked by zombie detector");
+                    self.sessions.write().remove(id);
+                    return None;
+                }
+                // AttestationRequired and SessionNotFound are non-fatal for get()
+                _ => {}
+            }
+        }
+
         let mut sessions = self.sessions.write();
         if let Some(session) = sessions.get_mut(id) {
             session.touch();
@@ -75,9 +117,15 @@ impl SessionManager {
         }
     }
 
-    /// Remove session
+    /// Remove session (CAB-362: also ends zombie tracking)
     pub async fn remove(&self, id: &str) -> bool {
-        self.sessions.write().remove(id).is_some()
+        let removed = self.sessions.write().remove(id).is_some();
+        if removed {
+            if let Some(ref detector) = self.zombie_detector {
+                detector.end_session(id).await;
+            }
+        }
+        removed
     }
 
     /// Update session metadata
@@ -155,6 +203,7 @@ impl Clone for SessionManager {
         Self {
             sessions: self.sessions.clone(),
             ttl: self.ttl,
+            zombie_detector: self.zombie_detector.clone(),
         }
     }
 }
@@ -195,5 +244,75 @@ mod tests {
         // Simulate old activity
         session.last_activity = Utc::now() - Duration::seconds(10);
         assert!(session.is_expired(short_ttl));
+    }
+
+    // =========================================================================
+    // Zombie Integration Tests (CAB-362)
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_session_create_registers_with_zombie_detector() {
+        use crate::governance::zombie::{ZombieConfig, ZombieDetector};
+
+        let detector = Arc::new(ZombieDetector::new(ZombieConfig::default()));
+        let mut manager = SessionManager::new(30);
+        manager.set_zombie_detector(detector.clone());
+
+        let session = Session::new("test-z1".into(), "tenant-1".into());
+        manager.create(session).await;
+
+        // Zombie detector should track the session
+        let stats = detector.stats().await;
+        assert_eq!(stats.total_sessions, 1);
+    }
+
+    #[tokio::test]
+    async fn test_session_remove_ends_zombie_tracking() {
+        use crate::governance::zombie::{ZombieConfig, ZombieDetector};
+
+        let detector = Arc::new(ZombieDetector::new(ZombieConfig::default()));
+        let mut manager = SessionManager::new(30);
+        manager.set_zombie_detector(detector.clone());
+
+        let session = Session::new("test-z2".into(), "tenant-1".into());
+        manager.create(session).await;
+
+        assert!(manager.remove("test-z2").await);
+
+        // Zombie detector should no longer track the session
+        let session_info = detector.get_session("test-z2").await;
+        assert!(session_info.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_session_get_checks_zombie_health() {
+        use crate::governance::zombie::{ZombieConfig, ZombieDetector};
+
+        let detector = Arc::new(ZombieDetector::new(ZombieConfig {
+            session_ttl_secs: 1,
+            zombie_factor: 1.0,
+            auto_revoke: true,
+            ..ZombieConfig::default()
+        }));
+        let mut manager = SessionManager::new(30);
+        manager.set_zombie_detector(detector.clone());
+
+        let session = Session::new("test-z3".into(), "tenant-1".into());
+        manager.create(session).await;
+
+        // Wait for zombie threshold (1s * 1.0 = 1s), then run check + revoke
+        // (simulates the background reaper task)
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+        let alerts = detector.check_zombies().await;
+        assert!(!alerts.is_empty());
+
+        // Explicitly revoke (as the background sweep would do for Critical + auto_revoke)
+        for alert in &alerts {
+            let _ = detector.revoke_session(&alert.session_id).await;
+        }
+
+        // Now get() should detect the revoked session and remove it
+        let result = manager.get("test-z3").await;
+        assert!(result.is_none());
     }
 }

--- a/stoa-gateway/src/quota/middleware.rs
+++ b/stoa-gateway/src/quota/middleware.rs
@@ -1,0 +1,358 @@
+//! Quota Enforcement Middleware (Phase 4: CAB-1121)
+//!
+//! Axum middleware that runs AFTER auth but BEFORE handlers.
+//! Checks both rate limits and daily/monthly quotas per consumer.
+//!
+//! Consumer identification:
+//! - From `AuthenticatedUser` request extension (JWT auth) — uses `user_id`
+//! - Fallback to API key consumer if no JWT
+//! - Skipped entirely if quota enforcement is disabled
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Serialize;
+use tracing::{debug, warn};
+
+use crate::auth::middleware::AuthenticatedUser;
+use crate::state::AppState;
+
+use super::QuotaError;
+
+/// Quota exceeded error response body.
+#[derive(Debug, Serialize)]
+struct QuotaExceededResponse {
+    error: String,
+    message: String,
+    retry_after_secs: Option<u64>,
+}
+
+/// Quota enforcement middleware.
+///
+/// Runs after auth middleware. Extracts consumer_id from request extensions
+/// and checks rate limits + daily/monthly quotas.
+///
+/// On success, adds rate limit headers to the response.
+/// On failure, returns 429 Too Many Requests.
+pub async fn quota_middleware(
+    State(state): State<AppState>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    // Skip if quota enforcement is disabled
+    if !state.config.quota_enforcement_enabled {
+        return next.run(request).await;
+    }
+
+    // Extract consumer_id from auth context
+    let consumer_id = extract_consumer_id(&request);
+
+    let consumer_id = match consumer_id {
+        Some(id) => id,
+        None => {
+            // No consumer identified — skip quota enforcement
+            // (anonymous requests are handled by the existing tenant rate limiter)
+            debug!("No consumer_id found, skipping quota enforcement");
+            return next.run(request).await;
+        }
+    };
+
+    // 1. Check rate limit (per-second / per-minute)
+    let rate_limit_info = match state.consumer_rate_limiter.check_rate_limit(&consumer_id) {
+        Ok(info) => info,
+        Err(quota_error) => {
+            warn!(
+                consumer_id = %consumer_id,
+                error = %quota_error,
+                "Rate limit exceeded"
+            );
+            return quota_error_response(&quota_error);
+        }
+    };
+
+    // 2. Check daily/monthly quota
+    if let Err(quota_error) = state.quota_manager.check_quota(&consumer_id) {
+        warn!(
+            consumer_id = %consumer_id,
+            error = %quota_error,
+            "Quota exceeded"
+        );
+        return quota_error_response(&quota_error);
+    }
+
+    // 3. Execute the handler
+    let mut response = next.run(request).await;
+
+    // 4. Record the request (only on success path)
+    state.quota_manager.record_request(&consumer_id);
+
+    // 5. Add rate limit headers to response
+    if rate_limit_info.limit > 0 {
+        let headers = response.headers_mut();
+        if let Ok(val) = rate_limit_info.limit.to_string().parse() {
+            headers.insert("X-RateLimit-Limit", val);
+        }
+        if let Ok(val) = rate_limit_info.remaining.to_string().parse() {
+            headers.insert("X-RateLimit-Remaining", val);
+        }
+        if let Ok(val) = rate_limit_info.reset_epoch.to_string().parse() {
+            headers.insert("X-RateLimit-Reset", val);
+        }
+    }
+
+    response
+}
+
+/// Extract consumer_id from request extensions.
+///
+/// Priority:
+/// 1. AuthenticatedUser.user_id (from JWT)
+/// 2. None (anonymous — skip quota)
+fn extract_consumer_id(request: &Request<Body>) -> Option<String> {
+    // Try JWT auth user
+    if let Some(user) = request.extensions().get::<AuthenticatedUser>() {
+        return Some(user.user_id.clone());
+    }
+
+    None
+}
+
+/// Build a 429 response from a QuotaError.
+fn quota_error_response(error: &QuotaError) -> Response {
+    let (retry_after, message) = match error {
+        QuotaError::RateLimit {
+            retry_after_secs,
+            limit_type,
+            limit,
+        } => (
+            Some(*retry_after_secs),
+            format!(
+                "Rate limit exceeded: {} limit of {} requests reached",
+                limit_type, limit
+            ),
+        ),
+        QuotaError::DailyQuota { used, limit } => (
+            None,
+            format!(
+                "Daily quota exceeded: {}/{} requests used. Resets at midnight UTC.",
+                used, limit
+            ),
+        ),
+        QuotaError::MonthlyQuota { used, limit } => (
+            None,
+            format!(
+                "Monthly quota exceeded: {}/{} requests used. Resets at month start.",
+                used, limit
+            ),
+        ),
+    };
+
+    let body = QuotaExceededResponse {
+        error: "quota_exceeded".to_string(),
+        message,
+        retry_after_secs: retry_after,
+    };
+
+    let mut response = (StatusCode::TOO_MANY_REQUESTS, Json(body)).into_response();
+
+    // Add Retry-After header if applicable
+    if let Some(secs) = retry_after {
+        if let Ok(val) = secs.to_string().parse() {
+            response.headers_mut().insert("Retry-After", val);
+        }
+    }
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::quota::rate_limiter::PlanQuota;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        middleware,
+        routing::get,
+        Router,
+    };
+    use tower::ServiceExt;
+
+    async fn echo_handler() -> &'static str {
+        "OK"
+    }
+
+    fn create_test_state(enabled: bool) -> AppState {
+        let config = Config {
+            quota_enforcement_enabled: enabled,
+            quota_default_rate_per_minute: 5,
+            quota_default_daily_limit: 100,
+            ..Config::default()
+        };
+        AppState::new(config)
+    }
+
+    fn build_test_router(state: AppState) -> Router {
+        Router::new()
+            .route("/test", get(echo_handler))
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                quota_middleware,
+            ))
+            .with_state(state)
+    }
+
+    #[tokio::test]
+    async fn test_quota_disabled_passes_through() {
+        let state = create_test_state(false);
+        let app = build_test_router(state);
+
+        let response = app
+            .oneshot(Request::builder().uri("/test").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_no_consumer_passes_through() {
+        let state = create_test_state(true);
+        let app = build_test_router(state);
+
+        // No auth headers = no consumer_id = skip quota
+        let response = app
+            .oneshot(Request::builder().uri("/test").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_headers_present() {
+        let state = create_test_state(true);
+
+        // Set a quota for consumer
+        state.consumer_rate_limiter.set_plan_quota(
+            "user-123",
+            PlanQuota {
+                rate_limit_per_minute: 10,
+                rate_limit_per_second: 0,
+                ..Default::default()
+            },
+        );
+        state.quota_manager.set_plan_quota(
+            "user-123",
+            PlanQuota {
+                daily_request_limit: 1000,
+                ..Default::default()
+            },
+        );
+
+        let app = build_test_router(state);
+
+        // Build request with AuthenticatedUser in extensions
+        let mut request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+        request.extensions_mut().insert(AuthenticatedUser {
+            user_id: "user-123".to_string(),
+            username: Some("test".to_string()),
+            email: None,
+            tenant_id: Some("acme".to_string()),
+            claims: test_claims(),
+            raw_token: "token".to_string(),
+        });
+
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().contains_key("X-RateLimit-Limit"));
+        assert!(response.headers().contains_key("X-RateLimit-Remaining"));
+        assert!(response.headers().contains_key("X-RateLimit-Reset"));
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_exceeded_returns_429() {
+        let state = create_test_state(true);
+
+        // Set a very low quota
+        state.consumer_rate_limiter.set_plan_quota(
+            "user-123",
+            PlanQuota {
+                rate_limit_per_minute: 2,
+                rate_limit_per_second: 0,
+                daily_request_limit: 0,
+                monthly_request_limit: 0,
+                ..Default::default()
+            },
+        );
+        state.quota_manager.set_plan_quota(
+            "user-123",
+            PlanQuota {
+                daily_request_limit: 0,
+                monthly_request_limit: 0,
+                ..Default::default()
+            },
+        );
+
+        let app = build_test_router(state);
+
+        // First 2 requests should succeed
+        for _ in 0..2 {
+            let mut request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+            request.extensions_mut().insert(test_auth_user());
+            let response = app.clone().oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        // 3rd request should be rate limited
+        let mut request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+        request.extensions_mut().insert(test_auth_user());
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(response.headers().contains_key("Retry-After"));
+    }
+
+    fn test_claims() -> crate::auth::claims::Claims {
+        use crate::auth::claims::{Audience, Claims, RealmAccess};
+        Claims {
+            sub: "user-123".to_string(),
+            exp: chrono::Utc::now().timestamp() + 3600,
+            iat: chrono::Utc::now().timestamp(),
+            iss: "https://auth.gostoa.dev/realms/stoa".to_string(),
+            aud: Audience::Single("stoa-mcp".to_string()),
+            azp: Some("stoa-mcp".to_string()),
+            preferred_username: Some("test".to_string()),
+            email: None,
+            email_verified: None,
+            name: None,
+            given_name: None,
+            family_name: None,
+            tenant: Some("acme".to_string()),
+            realm_access: Some(RealmAccess {
+                roles: vec!["tenant-admin".to_string()],
+            }),
+            resource_access: None,
+            sid: None,
+            typ: None,
+            scope: Some("openid stoa:read".to_string()),
+        }
+    }
+
+    fn test_auth_user() -> AuthenticatedUser {
+        AuthenticatedUser {
+            user_id: "user-123".to_string(),
+            username: Some("test".to_string()),
+            email: None,
+            tenant_id: Some("acme".to_string()),
+            claims: test_claims(),
+            raw_token: "token".to_string(),
+        }
+    }
+}

--- a/stoa-gateway/src/quota/mod.rs
+++ b/stoa-gateway/src/quota/mod.rs
@@ -1,0 +1,55 @@
+//! Quota Enforcement Module (Phase 4: CAB-1121)
+//!
+//! Per-consumer rate limiting and quota tracking for plan-based API access.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Request → Auth → QuotaMiddleware → Handler
+//!                       │
+//!              ┌────────┴────────┐
+//!              │                 │
+//!         RateLimiter      QuotaManager
+//!        (token bucket)   (daily/monthly)
+//!              │                 │
+//!         per-second/min   daily/monthly
+//!         burst limit      request limits
+//! ```
+//!
+//! Both components use in-memory state with `parking_lot::RwLock` for
+//! thread-safe access without poisoning risk.
+
+mod middleware;
+mod quota_manager;
+mod rate_limiter;
+
+pub use middleware::quota_middleware;
+pub use quota_manager::{QuotaManager, QuotaManagerConfig};
+#[allow(unused_imports)]
+pub use quota_manager::{QuotaState, QuotaStats};
+#[allow(unused_imports)]
+pub use rate_limiter::PlanQuota;
+pub use rate_limiter::{ConsumerRateLimiter, RateLimiterConfig};
+
+/// Errors returned by quota enforcement.
+///
+/// Variant naming avoids the "Exceeded" postfix to satisfy clippy::enum_variant_names.
+/// The error context (rate limit vs quota) is clear from the variant name + fields.
+#[derive(Debug, thiserror::Error)]
+pub enum QuotaError {
+    /// Per-second or per-minute rate limit exceeded.
+    #[error("rate limit exceeded: {limit_type} limit of {limit} reached")]
+    RateLimit {
+        limit_type: String,
+        limit: u32,
+        retry_after_secs: u64,
+    },
+
+    /// Daily request quota exhausted.
+    #[error("daily quota exceeded: {used}/{limit} requests used")]
+    DailyQuota { used: u64, limit: u32 },
+
+    /// Monthly request quota exhausted.
+    #[error("monthly quota exceeded: {used}/{limit} requests used")]
+    MonthlyQuota { used: u64, limit: u32 },
+}

--- a/stoa-gateway/src/quota/quota_manager.rs
+++ b/stoa-gateway/src/quota/quota_manager.rs
@@ -1,0 +1,592 @@
+//! Daily/Monthly Quota Manager (Phase 4: CAB-1121)
+//!
+//! Tracks per-consumer request counts against daily and monthly limits.
+//! Counters reset automatically at midnight (daily) and month start (monthly).
+//!
+//! Thread-safe via `parking_lot::RwLock` (non-poisoning).
+
+use chrono::{Datelike, Utc};
+use parking_lot::RwLock;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::time::{interval, Duration as TokioDuration};
+use tracing::{debug, info};
+
+use super::rate_limiter::PlanQuota;
+use super::QuotaError;
+
+/// Configuration for the quota manager.
+#[derive(Debug, Clone)]
+pub struct QuotaManagerConfig {
+    /// Default daily request limit when no plan quota is set.
+    pub default_daily_limit: u32,
+
+    /// Background reset check interval in seconds.
+    pub reset_check_interval_secs: u64,
+}
+
+impl Default for QuotaManagerConfig {
+    fn default() -> Self {
+        Self {
+            default_daily_limit: 10_000,
+            reset_check_interval_secs: 60,
+        }
+    }
+}
+
+/// Per-consumer quota state.
+#[derive(Debug, Clone, Serialize)]
+pub struct QuotaState {
+    /// Number of requests today.
+    pub daily_count: u64,
+    /// Number of requests this month.
+    pub monthly_count: u64,
+    /// Day of year when daily counter was last reset.
+    pub last_reset_day: u32,
+    /// Month when monthly counter was last reset.
+    pub last_reset_month: u32,
+    /// Year of last reset (to handle year transitions).
+    pub last_reset_year: i32,
+}
+
+impl QuotaState {
+    fn new() -> Self {
+        let now = Utc::now();
+        Self {
+            daily_count: 0,
+            monthly_count: 0,
+            last_reset_day: now.ordinal(),
+            last_reset_month: now.month(),
+            last_reset_year: now.year(),
+        }
+    }
+
+    /// Check if daily counter needs reset.
+    fn maybe_reset_daily(&mut self) {
+        let now = Utc::now();
+        if now.ordinal() != self.last_reset_day || now.year() != self.last_reset_year {
+            debug!(
+                old_day = self.last_reset_day,
+                new_day = now.ordinal(),
+                count = self.daily_count,
+                "Resetting daily quota counter"
+            );
+            self.daily_count = 0;
+            self.last_reset_day = now.ordinal();
+            self.last_reset_year = now.year();
+        }
+    }
+
+    /// Check if monthly counter needs reset.
+    fn maybe_reset_monthly(&mut self) {
+        let now = Utc::now();
+        if now.month() != self.last_reset_month || now.year() != self.last_reset_year {
+            debug!(
+                old_month = self.last_reset_month,
+                new_month = now.month(),
+                count = self.monthly_count,
+                "Resetting monthly quota counter"
+            );
+            self.monthly_count = 0;
+            self.last_reset_month = now.month();
+            self.last_reset_year = now.year();
+        }
+    }
+}
+
+/// Aggregated quota statistics for a consumer.
+#[derive(Debug, Clone, Serialize)]
+pub struct QuotaStats {
+    pub consumer_id: String,
+    pub daily_count: u64,
+    pub daily_limit: u32,
+    pub monthly_count: u64,
+    pub monthly_limit: u32,
+    pub daily_remaining: u64,
+    pub monthly_remaining: u64,
+}
+
+/// Manages daily and monthly request quotas per consumer.
+pub struct QuotaManager {
+    states: Arc<RwLock<HashMap<String, QuotaState>>>,
+    plan_quotas: Arc<RwLock<HashMap<String, PlanQuota>>>,
+    config: QuotaManagerConfig,
+}
+
+impl QuotaManager {
+    /// Create a new quota manager.
+    pub fn new(config: QuotaManagerConfig) -> Self {
+        Self {
+            states: Arc::new(RwLock::new(HashMap::new())),
+            plan_quotas: Arc::new(RwLock::new(HashMap::new())),
+            config,
+        }
+    }
+
+    /// Set the plan quota for a consumer (shared with rate limiter).
+    /// Called by admin API when CP pushes plan context via `upsert_policy`.
+    #[allow(dead_code)]
+    pub fn set_plan_quota(&self, consumer_id: &str, quota: PlanQuota) {
+        self.plan_quotas
+            .write()
+            .insert(consumer_id.to_string(), quota);
+    }
+
+    /// Check if the consumer has remaining quota.
+    ///
+    /// Does NOT increment the counter — call `record_request` after the
+    /// request succeeds to avoid counting failed requests.
+    pub fn check_quota(&self, consumer_id: &str) -> Result<(), QuotaError> {
+        let quotas = self.plan_quotas.read();
+        let default_quota = PlanQuota {
+            daily_request_limit: self.config.default_daily_limit,
+            ..PlanQuota::default()
+        };
+        let quota = quotas.get(consumer_id).unwrap_or(&default_quota);
+
+        let mut states = self.states.write();
+        let state = states
+            .entry(consumer_id.to_string())
+            .or_insert_with(QuotaState::new);
+
+        // Auto-reset if day/month changed
+        state.maybe_reset_daily();
+        state.maybe_reset_monthly();
+
+        // Check daily limit
+        if quota.daily_request_limit > 0 && state.daily_count >= quota.daily_request_limit as u64 {
+            return Err(QuotaError::DailyQuota {
+                used: state.daily_count,
+                limit: quota.daily_request_limit,
+            });
+        }
+
+        // Check monthly limit
+        if quota.monthly_request_limit > 0
+            && state.monthly_count >= quota.monthly_request_limit as u64
+        {
+            return Err(QuotaError::MonthlyQuota {
+                used: state.monthly_count,
+                limit: quota.monthly_request_limit,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Record a successful request (increment counters).
+    pub fn record_request(&self, consumer_id: &str) {
+        let mut states = self.states.write();
+        let state = states
+            .entry(consumer_id.to_string())
+            .or_insert_with(QuotaState::new);
+
+        state.maybe_reset_daily();
+        state.maybe_reset_monthly();
+
+        state.daily_count += 1;
+        state.monthly_count += 1;
+    }
+
+    /// Get quota stats for a specific consumer.
+    pub fn get_stats(&self, consumer_id: &str) -> Option<QuotaStats> {
+        let quotas = self.plan_quotas.read();
+        let default_quota = PlanQuota {
+            daily_request_limit: self.config.default_daily_limit,
+            ..PlanQuota::default()
+        };
+        let quota = quotas.get(consumer_id).unwrap_or(&default_quota);
+
+        let mut states = self.states.write();
+        let state = states.get_mut(consumer_id)?;
+
+        state.maybe_reset_daily();
+        state.maybe_reset_monthly();
+
+        let daily_remaining = if quota.daily_request_limit > 0 {
+            (quota.daily_request_limit as u64).saturating_sub(state.daily_count)
+        } else {
+            u64::MAX
+        };
+        let monthly_remaining = if quota.monthly_request_limit > 0 {
+            (quota.monthly_request_limit as u64).saturating_sub(state.monthly_count)
+        } else {
+            u64::MAX
+        };
+
+        Some(QuotaStats {
+            consumer_id: consumer_id.to_string(),
+            daily_count: state.daily_count,
+            daily_limit: quota.daily_request_limit,
+            monthly_count: state.monthly_count,
+            monthly_limit: quota.monthly_request_limit,
+            daily_remaining,
+            monthly_remaining,
+        })
+    }
+
+    /// List all consumer quota states.
+    pub fn list_all_stats(&self) -> Vec<QuotaStats> {
+        let quotas = self.plan_quotas.read();
+        let default_quota = PlanQuota {
+            daily_request_limit: self.config.default_daily_limit,
+            ..PlanQuota::default()
+        };
+
+        let mut states = self.states.write();
+        states
+            .iter_mut()
+            .map(|(consumer_id, state)| {
+                state.maybe_reset_daily();
+                state.maybe_reset_monthly();
+
+                let quota = quotas.get(consumer_id).unwrap_or(&default_quota);
+                let daily_remaining = if quota.daily_request_limit > 0 {
+                    (quota.daily_request_limit as u64).saturating_sub(state.daily_count)
+                } else {
+                    u64::MAX
+                };
+                let monthly_remaining = if quota.monthly_request_limit > 0 {
+                    (quota.monthly_request_limit as u64).saturating_sub(state.monthly_count)
+                } else {
+                    u64::MAX
+                };
+
+                QuotaStats {
+                    consumer_id: consumer_id.clone(),
+                    daily_count: state.daily_count,
+                    daily_limit: quota.daily_request_limit,
+                    monthly_count: state.monthly_count,
+                    monthly_limit: quota.monthly_request_limit,
+                    daily_remaining,
+                    monthly_remaining,
+                }
+            })
+            .collect()
+    }
+
+    /// Reset quota counters for a consumer.
+    pub fn reset_consumer(&self, consumer_id: &str) -> bool {
+        let mut states = self.states.write();
+        if let Some(state) = states.get_mut(consumer_id) {
+            state.daily_count = 0;
+            state.monthly_count = 0;
+            let now = Utc::now();
+            state.last_reset_day = now.ordinal();
+            state.last_reset_month = now.month();
+            state.last_reset_year = now.year();
+            info!(consumer_id = %consumer_id, "Quota counters reset");
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Run periodic reset check (called by background task).
+    pub fn check_and_reset_expired(&self) {
+        let mut states = self.states.write();
+        for (consumer_id, state) in states.iter_mut() {
+            let old_daily = state.daily_count;
+            let old_monthly = state.monthly_count;
+            state.maybe_reset_daily();
+            state.maybe_reset_monthly();
+            if state.daily_count != old_daily || state.monthly_count != old_monthly {
+                debug!(
+                    consumer_id = %consumer_id,
+                    "Quota counters auto-reset by background task"
+                );
+            }
+        }
+    }
+
+    /// Start background reset check task.
+    pub fn start_reset_task(self: Arc<Self>) {
+        let manager = self.clone();
+        let interval_secs = self.config.reset_check_interval_secs;
+        tokio::spawn(async move {
+            let mut check_interval = interval(TokioDuration::from_secs(interval_secs));
+            loop {
+                check_interval.tick().await;
+                manager.check_and_reset_expired();
+            }
+        });
+        info!(
+            interval_secs = interval_secs,
+            "Quota manager reset task started"
+        );
+    }
+
+    /// Get consumer count (for metrics).
+    #[allow(dead_code)]
+    pub fn consumer_count(&self) -> usize {
+        self.states.read().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> QuotaManagerConfig {
+        QuotaManagerConfig {
+            default_daily_limit: 100,
+            reset_check_interval_secs: 60,
+        }
+    }
+
+    #[test]
+    fn test_quota_allows_within_limit() {
+        let manager = QuotaManager::new(test_config());
+        manager.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                daily_request_limit: 5,
+                monthly_request_limit: 100,
+                ..Default::default()
+            },
+        );
+
+        for _ in 0..5 {
+            assert!(manager.check_quota("consumer-1").is_ok());
+            manager.record_request("consumer-1");
+        }
+    }
+
+    #[test]
+    fn test_daily_quota_exceeded() {
+        let manager = QuotaManager::new(test_config());
+        manager.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                daily_request_limit: 3,
+                monthly_request_limit: 0,
+                ..Default::default()
+            },
+        );
+
+        for _ in 0..3 {
+            assert!(manager.check_quota("consumer-1").is_ok());
+            manager.record_request("consumer-1");
+        }
+
+        let result = manager.check_quota("consumer-1");
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            QuotaError::DailyQuota { used, limit } => {
+                assert_eq!(used, 3);
+                assert_eq!(limit, 3);
+            }
+            other => panic!("Expected DailyQuota, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_monthly_quota_exceeded() {
+        let manager = QuotaManager::new(test_config());
+        manager.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                daily_request_limit: 0,
+                monthly_request_limit: 2,
+                ..Default::default()
+            },
+        );
+
+        for _ in 0..2 {
+            assert!(manager.check_quota("consumer-1").is_ok());
+            manager.record_request("consumer-1");
+        }
+
+        let result = manager.check_quota("consumer-1");
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            QuotaError::MonthlyQuota { used, limit } => {
+                assert_eq!(used, 2);
+                assert_eq!(limit, 2);
+            }
+            other => panic!("Expected MonthlyQuota, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_separate_consumers() {
+        let manager = QuotaManager::new(test_config());
+        manager.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                daily_request_limit: 2,
+                ..Default::default()
+            },
+        );
+        manager.set_plan_quota(
+            "consumer-2",
+            PlanQuota {
+                daily_request_limit: 2,
+                ..Default::default()
+            },
+        );
+
+        // Exhaust consumer-1
+        for _ in 0..2 {
+            manager.check_quota("consumer-1").unwrap();
+            manager.record_request("consumer-1");
+        }
+        assert!(manager.check_quota("consumer-1").is_err());
+
+        // consumer-2 should still be fine
+        assert!(manager.check_quota("consumer-2").is_ok());
+    }
+
+    #[test]
+    fn test_reset_consumer() {
+        let manager = QuotaManager::new(test_config());
+        manager.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                daily_request_limit: 2,
+                ..Default::default()
+            },
+        );
+
+        // Exhaust quota
+        for _ in 0..2 {
+            manager.check_quota("consumer-1").unwrap();
+            manager.record_request("consumer-1");
+        }
+        assert!(manager.check_quota("consumer-1").is_err());
+
+        // Reset
+        assert!(manager.reset_consumer("consumer-1"));
+
+        // Should be allowed again
+        assert!(manager.check_quota("consumer-1").is_ok());
+    }
+
+    #[test]
+    fn test_reset_nonexistent_consumer() {
+        let manager = QuotaManager::new(test_config());
+        assert!(!manager.reset_consumer("nonexistent"));
+    }
+
+    #[test]
+    fn test_get_stats() {
+        let manager = QuotaManager::new(test_config());
+        manager.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                daily_request_limit: 100,
+                monthly_request_limit: 1000,
+                ..Default::default()
+            },
+        );
+
+        // Record some requests
+        for _ in 0..5 {
+            manager.check_quota("consumer-1").unwrap();
+            manager.record_request("consumer-1");
+        }
+
+        let stats = manager.get_stats("consumer-1").unwrap();
+        assert_eq!(stats.consumer_id, "consumer-1");
+        assert_eq!(stats.daily_count, 5);
+        assert_eq!(stats.daily_limit, 100);
+        assert_eq!(stats.daily_remaining, 95);
+        assert_eq!(stats.monthly_count, 5);
+        assert_eq!(stats.monthly_limit, 1000);
+        assert_eq!(stats.monthly_remaining, 995);
+    }
+
+    #[test]
+    fn test_list_all_stats() {
+        let manager = QuotaManager::new(test_config());
+        manager.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                daily_request_limit: 100,
+                ..Default::default()
+            },
+        );
+        manager.set_plan_quota(
+            "consumer-2",
+            PlanQuota {
+                daily_request_limit: 200,
+                ..Default::default()
+            },
+        );
+
+        manager.record_request("consumer-1");
+        manager.record_request("consumer-2");
+        manager.record_request("consumer-2");
+
+        let stats = manager.list_all_stats();
+        assert_eq!(stats.len(), 2);
+    }
+
+    #[test]
+    fn test_unlimited_quota() {
+        let manager = QuotaManager::new(test_config());
+        manager.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                daily_request_limit: 0,
+                monthly_request_limit: 0,
+                ..Default::default()
+            },
+        );
+
+        // Should always pass
+        for _ in 0..100 {
+            assert!(manager.check_quota("consumer-1").is_ok());
+            manager.record_request("consumer-1");
+        }
+    }
+
+    #[test]
+    fn test_default_quota_for_unknown_consumer() {
+        let config = QuotaManagerConfig {
+            default_daily_limit: 5,
+            ..Default::default()
+        };
+        let manager = QuotaManager::new(config);
+
+        // No explicit quota — uses default daily limit
+        for _ in 0..5 {
+            assert!(manager.check_quota("unknown").is_ok());
+            manager.record_request("unknown");
+        }
+        assert!(manager.check_quota("unknown").is_err());
+    }
+
+    #[test]
+    fn test_consumer_count() {
+        let manager = QuotaManager::new(test_config());
+        assert_eq!(manager.consumer_count(), 0);
+
+        manager.record_request("consumer-1");
+        assert_eq!(manager.consumer_count(), 1);
+
+        manager.record_request("consumer-2");
+        assert_eq!(manager.consumer_count(), 2);
+    }
+
+    #[test]
+    fn test_check_and_reset_expired() {
+        let manager = QuotaManager::new(test_config());
+        manager.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                daily_request_limit: 100,
+                ..Default::default()
+            },
+        );
+
+        manager.record_request("consumer-1");
+
+        // Running check — nothing should be reset (same day)
+        manager.check_and_reset_expired();
+
+        let stats = manager.get_stats("consumer-1").unwrap();
+        assert_eq!(stats.daily_count, 1);
+    }
+}

--- a/stoa-gateway/src/quota/rate_limiter.rs
+++ b/stoa-gateway/src/quota/rate_limiter.rs
@@ -1,0 +1,640 @@
+//! Token Bucket Rate Limiter (Phase 4: CAB-1121)
+//!
+//! Per-consumer rate limiting based on plan quota fields.
+//! Uses a token bucket algorithm with per-second and per-minute windows.
+//!
+//! Thread-safe via `parking_lot::RwLock` (non-poisoning).
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::time::{interval, Duration as TokioDuration};
+use tracing::{debug, info};
+
+use super::QuotaError;
+
+/// Plan-level quota configuration pushed from Control Plane.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanQuota {
+    /// Maximum requests per second (0 = unlimited).
+    #[serde(default)]
+    pub rate_limit_per_second: u32,
+
+    /// Maximum requests per minute (0 = unlimited).
+    #[serde(default)]
+    pub rate_limit_per_minute: u32,
+
+    /// Maximum burst size (0 = use rate_limit_per_second).
+    #[serde(default)]
+    pub burst_limit: u32,
+
+    /// Maximum requests per day (0 = unlimited).
+    #[serde(default)]
+    pub daily_request_limit: u32,
+
+    /// Maximum requests per month (0 = unlimited).
+    #[serde(default)]
+    pub monthly_request_limit: u32,
+}
+
+impl Default for PlanQuota {
+    fn default() -> Self {
+        Self {
+            rate_limit_per_second: 0,
+            rate_limit_per_minute: 60,
+            burst_limit: 0,
+            daily_request_limit: 10_000,
+            monthly_request_limit: 0,
+        }
+    }
+}
+
+/// Configuration for the consumer rate limiter.
+#[derive(Debug, Clone)]
+pub struct RateLimiterConfig {
+    /// Default rate per minute when no plan quota is set.
+    pub default_rate_per_minute: u32,
+
+    /// Cleanup interval for stale buckets in seconds.
+    pub cleanup_interval_secs: u64,
+
+    /// How long before a bucket is considered stale (seconds).
+    pub stale_threshold_secs: u64,
+}
+
+impl Default for RateLimiterConfig {
+    fn default() -> Self {
+        Self {
+            default_rate_per_minute: 60,
+            cleanup_interval_secs: 120,
+            stale_threshold_secs: 3600,
+        }
+    }
+}
+
+/// Internal token bucket state for a single consumer.
+#[derive(Debug)]
+struct TokenBucket {
+    /// Available tokens for per-second limiting.
+    second_tokens: f64,
+    /// Maximum tokens for per-second bucket.
+    second_max: f64,
+    /// Last refill time for per-second bucket.
+    second_last_refill: Instant,
+
+    /// Available tokens for per-minute limiting.
+    minute_tokens: f64,
+    /// Maximum tokens for per-minute bucket.
+    minute_max: f64,
+    /// Last refill time for per-minute bucket.
+    minute_last_refill: Instant,
+
+    /// Last activity time (for stale cleanup).
+    last_activity: Instant,
+}
+
+impl TokenBucket {
+    fn new(quota: &PlanQuota) -> Self {
+        let now = Instant::now();
+        let second_max = if quota.burst_limit > 0 {
+            quota.burst_limit as f64
+        } else if quota.rate_limit_per_second > 0 {
+            quota.rate_limit_per_second as f64
+        } else {
+            f64::MAX
+        };
+        let minute_max = if quota.rate_limit_per_minute > 0 {
+            quota.rate_limit_per_minute as f64
+        } else {
+            f64::MAX
+        };
+
+        Self {
+            second_tokens: second_max,
+            second_max,
+            second_last_refill: now,
+            minute_tokens: minute_max,
+            minute_max,
+            minute_last_refill: now,
+            last_activity: now,
+        }
+    }
+
+    /// Refill tokens based on elapsed time.
+    fn refill(&mut self, quota: &PlanQuota) {
+        let now = Instant::now();
+
+        // Per-second refill
+        if quota.rate_limit_per_second > 0 {
+            let elapsed = now.duration_since(self.second_last_refill).as_secs_f64();
+            let new_tokens = elapsed * quota.rate_limit_per_second as f64;
+            self.second_tokens = (self.second_tokens + new_tokens).min(self.second_max);
+            self.second_last_refill = now;
+        }
+
+        // Per-minute refill
+        if quota.rate_limit_per_minute > 0 {
+            let elapsed = now.duration_since(self.minute_last_refill).as_secs_f64();
+            let refill_rate = quota.rate_limit_per_minute as f64 / 60.0;
+            let new_tokens = elapsed * refill_rate;
+            self.minute_tokens = (self.minute_tokens + new_tokens).min(self.minute_max);
+            self.minute_last_refill = now;
+        }
+    }
+
+    /// Try to consume one token. Returns Ok(()) or Err with the violated limit.
+    fn try_consume(&mut self, quota: &PlanQuota) -> Result<(), QuotaError> {
+        self.refill(quota);
+        self.last_activity = Instant::now();
+
+        // Check per-second limit
+        if quota.rate_limit_per_second > 0 && self.second_tokens < 1.0 {
+            return Err(QuotaError::RateLimit {
+                limit_type: "per_second".to_string(),
+                limit: quota.rate_limit_per_second,
+                retry_after_secs: 1, // Retry after 1 second for per-second limits
+            });
+        }
+
+        // Check per-minute limit
+        if quota.rate_limit_per_minute > 0 && self.minute_tokens < 1.0 {
+            let retry_after = 60 / quota.rate_limit_per_minute.max(1) as u64;
+            return Err(QuotaError::RateLimit {
+                limit_type: "per_minute".to_string(),
+                limit: quota.rate_limit_per_minute,
+                retry_after_secs: retry_after.max(1),
+            });
+        }
+
+        // Consume tokens
+        if quota.rate_limit_per_second > 0 {
+            self.second_tokens -= 1.0;
+        }
+        if quota.rate_limit_per_minute > 0 {
+            self.minute_tokens -= 1.0;
+        }
+
+        Ok(())
+    }
+
+    /// Get remaining tokens for the most restrictive limit.
+    fn remaining(&self, quota: &PlanQuota) -> u32 {
+        let second_remaining = if quota.rate_limit_per_second > 0 {
+            self.second_tokens.max(0.0) as u32
+        } else {
+            u32::MAX
+        };
+        let minute_remaining = if quota.rate_limit_per_minute > 0 {
+            self.minute_tokens.max(0.0) as u32
+        } else {
+            u32::MAX
+        };
+        second_remaining.min(minute_remaining)
+    }
+
+    /// Get the effective limit (most restrictive).
+    fn effective_limit(&self, quota: &PlanQuota) -> u32 {
+        if quota.rate_limit_per_second > 0 {
+            let burst = if quota.burst_limit > 0 {
+                quota.burst_limit
+            } else {
+                quota.rate_limit_per_second
+            };
+            if quota.rate_limit_per_minute > 0 {
+                burst.min(quota.rate_limit_per_minute)
+            } else {
+                burst
+            }
+        } else if quota.rate_limit_per_minute > 0 {
+            quota.rate_limit_per_minute
+        } else {
+            0 // unlimited
+        }
+    }
+
+    /// Get reset time in epoch seconds for the most restrictive limit.
+    fn reset_epoch(&self, quota: &PlanQuota) -> i64 {
+        let now = chrono::Utc::now().timestamp();
+        if quota.rate_limit_per_second > 0 && self.second_tokens < 1.0 {
+            return now + 1;
+        }
+        if quota.rate_limit_per_minute > 0 && self.minute_tokens < 1.0 {
+            let secs_per_token = 60.0 / quota.rate_limit_per_minute.max(1) as f64;
+            return now + secs_per_token.ceil() as i64;
+        }
+        now + 60 // Default: next minute
+    }
+}
+
+/// Result of a rate limit check with header information.
+#[derive(Debug, Clone)]
+pub struct RateLimitInfo {
+    /// Maximum requests in the current window.
+    pub limit: u32,
+    /// Remaining requests in the current window.
+    pub remaining: u32,
+    /// Unix timestamp when the rate limit resets.
+    pub reset_epoch: i64,
+}
+
+/// Per-consumer rate limiter using token bucket algorithm.
+///
+/// Manages separate token buckets for each consumer, keyed by consumer_id.
+/// Plan quotas are looked up from an in-memory cache.
+pub struct ConsumerRateLimiter {
+    buckets: Arc<RwLock<HashMap<String, TokenBucket>>>,
+    plan_quotas: Arc<RwLock<HashMap<String, PlanQuota>>>,
+    config: RateLimiterConfig,
+}
+
+impl ConsumerRateLimiter {
+    /// Create a new consumer rate limiter.
+    pub fn new(config: RateLimiterConfig) -> Self {
+        Self {
+            buckets: Arc::new(RwLock::new(HashMap::new())),
+            plan_quotas: Arc::new(RwLock::new(HashMap::new())),
+            config,
+        }
+    }
+
+    /// Set the plan quota for a consumer.
+    /// Called by admin API when CP pushes plan context via `upsert_policy`.
+    #[allow(dead_code)]
+    pub fn set_plan_quota(&self, consumer_id: &str, quota: PlanQuota) {
+        self.plan_quotas
+            .write()
+            .insert(consumer_id.to_string(), quota);
+    }
+
+    /// Remove plan quota for a consumer.
+    #[allow(dead_code)]
+    pub fn remove_plan_quota(&self, consumer_id: &str) {
+        self.plan_quotas.write().remove(consumer_id);
+        self.buckets.write().remove(consumer_id);
+    }
+
+    /// Check rate limit for a consumer. Returns rate limit info on success.
+    pub fn check_rate_limit(&self, consumer_id: &str) -> Result<RateLimitInfo, QuotaError> {
+        let quotas = self.plan_quotas.read();
+        let default_quota = PlanQuota {
+            rate_limit_per_minute: self.config.default_rate_per_minute,
+            ..PlanQuota::default()
+        };
+        let quota = quotas.get(consumer_id).unwrap_or(&default_quota);
+
+        // Skip if unlimited
+        if quota.rate_limit_per_second == 0 && quota.rate_limit_per_minute == 0 {
+            return Ok(RateLimitInfo {
+                limit: 0,
+                remaining: 0,
+                reset_epoch: 0,
+            });
+        }
+
+        let mut buckets = self.buckets.write();
+        let bucket = buckets
+            .entry(consumer_id.to_string())
+            .or_insert_with(|| TokenBucket::new(quota));
+
+        // Try to consume a token
+        bucket.try_consume(quota)?;
+
+        Ok(RateLimitInfo {
+            limit: bucket.effective_limit(quota),
+            remaining: bucket.remaining(quota),
+            reset_epoch: bucket.reset_epoch(quota),
+        })
+    }
+
+    /// Get rate limit info without consuming a token (for headers on already-checked requests).
+    pub fn get_rate_limit_info(&self, consumer_id: &str) -> RateLimitInfo {
+        let quotas = self.plan_quotas.read();
+        let default_quota = PlanQuota {
+            rate_limit_per_minute: self.config.default_rate_per_minute,
+            ..PlanQuota::default()
+        };
+        let quota = quotas.get(consumer_id).unwrap_or(&default_quota);
+
+        let buckets = self.buckets.read();
+        match buckets.get(consumer_id) {
+            Some(bucket) => RateLimitInfo {
+                limit: bucket.effective_limit(quota),
+                remaining: bucket.remaining(quota),
+                reset_epoch: bucket.reset_epoch(quota),
+            },
+            None => RateLimitInfo {
+                limit: bucket_effective_limit_from_quota(quota),
+                remaining: bucket_effective_limit_from_quota(quota),
+                reset_epoch: chrono::Utc::now().timestamp() + 60,
+            },
+        }
+    }
+
+    /// Cleanup stale consumer buckets.
+    pub fn cleanup_stale_buckets(&self) {
+        let stale_threshold = std::time::Duration::from_secs(self.config.stale_threshold_secs);
+        let mut buckets = self.buckets.write();
+
+        let before = buckets.len();
+        buckets.retain(|consumer_id, bucket| {
+            let keep = bucket.last_activity.elapsed() < stale_threshold;
+            if !keep {
+                debug!(consumer_id = %consumer_id, "Removing stale consumer rate limit bucket");
+            }
+            keep
+        });
+
+        let removed = before - buckets.len();
+        if removed > 0 {
+            info!(
+                removed = removed,
+                remaining = buckets.len(),
+                "Cleaned up stale consumer rate limit buckets"
+            );
+        }
+    }
+
+    /// Start background cleanup task.
+    pub fn start_cleanup_task(self: Arc<Self>) {
+        let limiter = self.clone();
+        let interval_secs = self.config.cleanup_interval_secs;
+        tokio::spawn(async move {
+            let mut cleanup_interval = interval(TokioDuration::from_secs(interval_secs));
+            loop {
+                cleanup_interval.tick().await;
+                limiter.cleanup_stale_buckets();
+            }
+        });
+        info!(
+            interval_secs = interval_secs,
+            "Consumer rate limiter cleanup task started"
+        );
+    }
+
+    /// Get current bucket count (for metrics/admin).
+    pub fn bucket_count(&self) -> usize {
+        self.buckets.read().len()
+    }
+
+    /// Get quota count (for metrics/admin).
+    #[allow(dead_code)]
+    pub fn quota_count(&self) -> usize {
+        self.plan_quotas.read().len()
+    }
+}
+
+/// Helper to compute effective limit from a quota without a bucket.
+fn bucket_effective_limit_from_quota(quota: &PlanQuota) -> u32 {
+    if quota.rate_limit_per_second > 0 {
+        let burst = if quota.burst_limit > 0 {
+            quota.burst_limit
+        } else {
+            quota.rate_limit_per_second
+        };
+        if quota.rate_limit_per_minute > 0 {
+            burst.min(quota.rate_limit_per_minute)
+        } else {
+            burst
+        }
+    } else if quota.rate_limit_per_minute > 0 {
+        quota.rate_limit_per_minute
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> RateLimiterConfig {
+        RateLimiterConfig {
+            default_rate_per_minute: 60,
+            cleanup_interval_secs: 60,
+            stale_threshold_secs: 3600,
+        }
+    }
+
+    #[test]
+    fn test_rate_limiter_allows_within_limit() {
+        let limiter = ConsumerRateLimiter::new(test_config());
+        limiter.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                rate_limit_per_minute: 5,
+                ..Default::default()
+            },
+        );
+
+        for i in 0..5 {
+            let result = limiter.check_rate_limit("consumer-1");
+            assert!(
+                result.is_ok(),
+                "Request {} should be allowed, got {:?}",
+                i + 1,
+                result
+            );
+        }
+    }
+
+    #[test]
+    fn test_rate_limiter_blocks_over_limit() {
+        let limiter = ConsumerRateLimiter::new(test_config());
+        limiter.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                rate_limit_per_minute: 3,
+                rate_limit_per_second: 0,
+                ..Default::default()
+            },
+        );
+
+        // Exhaust limit
+        for _ in 0..3 {
+            let result = limiter.check_rate_limit("consumer-1");
+            assert!(result.is_ok());
+        }
+
+        // Should be blocked
+        let result = limiter.check_rate_limit("consumer-1");
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            QuotaError::RateLimit { limit_type, .. } => {
+                assert_eq!(limit_type, "per_minute");
+            }
+            other => panic!("Expected RateLimit, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_separate_consumer_buckets() {
+        let limiter = ConsumerRateLimiter::new(test_config());
+        limiter.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                rate_limit_per_minute: 2,
+                rate_limit_per_second: 0,
+                ..Default::default()
+            },
+        );
+        limiter.set_plan_quota(
+            "consumer-2",
+            PlanQuota {
+                rate_limit_per_minute: 2,
+                rate_limit_per_second: 0,
+                ..Default::default()
+            },
+        );
+
+        // Exhaust consumer-1
+        for _ in 0..2 {
+            limiter.check_rate_limit("consumer-1").unwrap();
+        }
+        assert!(limiter.check_rate_limit("consumer-1").is_err());
+
+        // consumer-2 should still be allowed
+        assert!(limiter.check_rate_limit("consumer-2").is_ok());
+    }
+
+    #[test]
+    fn test_per_second_limit() {
+        let limiter = ConsumerRateLimiter::new(test_config());
+        limiter.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                rate_limit_per_second: 2,
+                rate_limit_per_minute: 0,
+                burst_limit: 2,
+                ..Default::default()
+            },
+        );
+
+        // Allow 2 (burst)
+        assert!(limiter.check_rate_limit("consumer-1").is_ok());
+        assert!(limiter.check_rate_limit("consumer-1").is_ok());
+
+        // Block 3rd
+        let result = limiter.check_rate_limit("consumer-1");
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            QuotaError::RateLimit { limit_type, .. } => {
+                assert_eq!(limit_type, "per_second");
+            }
+            other => panic!("Expected RateLimit, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_unlimited_quota() {
+        let limiter = ConsumerRateLimiter::new(test_config());
+        limiter.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                rate_limit_per_second: 0,
+                rate_limit_per_minute: 0,
+                ..Default::default()
+            },
+        );
+
+        // Should always pass
+        for _ in 0..100 {
+            assert!(limiter.check_rate_limit("consumer-1").is_ok());
+        }
+    }
+
+    #[test]
+    fn test_default_quota_for_unknown_consumer() {
+        let config = RateLimiterConfig {
+            default_rate_per_minute: 5,
+            ..Default::default()
+        };
+        let limiter = ConsumerRateLimiter::new(config);
+
+        // No explicit quota set — uses default
+        for _ in 0..5 {
+            assert!(limiter.check_rate_limit("unknown-consumer").is_ok());
+        }
+        assert!(limiter.check_rate_limit("unknown-consumer").is_err());
+    }
+
+    #[test]
+    fn test_rate_limit_info_headers() {
+        let limiter = ConsumerRateLimiter::new(test_config());
+        limiter.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                rate_limit_per_minute: 10,
+                rate_limit_per_second: 0,
+                ..Default::default()
+            },
+        );
+
+        let info = limiter.check_rate_limit("consumer-1").unwrap();
+        assert_eq!(info.limit, 10);
+        assert_eq!(info.remaining, 9);
+        assert!(info.reset_epoch > 0);
+    }
+
+    #[test]
+    fn test_cleanup_stale_buckets() {
+        let limiter = ConsumerRateLimiter::new(test_config());
+        limiter.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                rate_limit_per_minute: 100,
+                ..Default::default()
+            },
+        );
+
+        // Create some buckets
+        limiter.check_rate_limit("consumer-1").unwrap();
+
+        assert_eq!(limiter.bucket_count(), 1);
+
+        // Cleanup (none should be removed — not stale yet)
+        limiter.cleanup_stale_buckets();
+        assert_eq!(limiter.bucket_count(), 1);
+    }
+
+    #[test]
+    fn test_set_and_remove_quota() {
+        let limiter = ConsumerRateLimiter::new(test_config());
+        limiter.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                rate_limit_per_minute: 5,
+                ..Default::default()
+            },
+        );
+        assert_eq!(limiter.quota_count(), 1);
+
+        // Create a bucket by checking
+        limiter.check_rate_limit("consumer-1").unwrap();
+        assert_eq!(limiter.bucket_count(), 1);
+
+        // Remove
+        limiter.remove_plan_quota("consumer-1");
+        assert_eq!(limiter.quota_count(), 0);
+        assert_eq!(limiter.bucket_count(), 0);
+    }
+
+    #[test]
+    fn test_get_rate_limit_info_no_bucket() {
+        let limiter = ConsumerRateLimiter::new(test_config());
+        limiter.set_plan_quota(
+            "consumer-1",
+            PlanQuota {
+                rate_limit_per_minute: 100,
+                rate_limit_per_second: 0,
+                ..Default::default()
+            },
+        );
+
+        // No bucket yet — should return full quota
+        let info = limiter.get_rate_limit_info("consumer-1");
+        assert_eq!(info.limit, 100);
+        assert_eq!(info.remaining, 100);
+    }
+}

--- a/stoa-gateway/src/state.rs
+++ b/stoa-gateway/src/state.rs
@@ -2,7 +2,12 @@
 //!
 //! Shared state across all handlers.
 
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::RwLock;
+use tracing::info;
 
 use crate::auth::api_key::ApiKeyValidator;
 use crate::auth::jwt::{JwtValidator, JwtValidatorConfig};
@@ -10,10 +15,12 @@ use crate::auth::oidc::{OidcProvider, OidcProviderConfig};
 use crate::cache::{SemanticCache, SemanticCacheConfig};
 use crate::config::Config;
 use crate::control_plane::{OidcConfig, ToolProxyClient};
+use crate::governance::zombie::{ZombieConfig, ZombieDetector};
 use crate::mcp::session::SessionManager;
 use crate::mcp::tools::ToolRegistry;
 use crate::metering::{KafkaConfig, MeteringProducer, MeteringProducerConfig};
 use crate::policy::{PolicyDecision, PolicyEngine, PolicyEngineConfig, PolicyInput};
+use crate::quota::{ConsumerRateLimiter, QuotaManager, QuotaManagerConfig, RateLimiterConfig};
 use crate::rate_limit::RateLimiter;
 use crate::resilience::{CircuitBreaker, CircuitBreakerConfig};
 use crate::routes::{PolicyRegistry, RouteRegistry};
@@ -36,17 +43,27 @@ pub struct AppState {
     pub jwt_validator: Option<Arc<JwtValidator>>,
     /// Semantic cache for read-only tool responses (Phase 6)
     pub semantic_cache: Arc<SemanticCache>,
-    /// Circuit breaker for Control Plane API calls (Phase 6)
-    pub cp_circuit_breaker: Arc<CircuitBreaker>,
+    /// Per-upstream circuit breakers (CAB-362). Key = upstream ID.
+    /// The "cp-api" entry is the default for Control Plane API calls.
+    pub circuit_breakers: Arc<RwLock<HashMap<String, Arc<CircuitBreaker>>>>,
+    /// Circuit breaker config used when creating new per-upstream CBs
+    pub cb_config: CircuitBreakerConfig,
     /// Kafka metering producer (Phase 3: CAB-1105)
     /// None if Kafka metering is disabled or unavailable.
     pub metering_producer: Option<Arc<MeteringProducer>>,
+    /// Zombie session detector (CAB-362, ADR-012)
+    pub zombie_detector: Arc<ZombieDetector>,
+    /// Per-consumer rate limiter based on plan quotas (Phase 4: CAB-1121)
+    pub consumer_rate_limiter: Arc<ConsumerRateLimiter>,
+    /// Daily/monthly quota manager (Phase 4: CAB-1121)
+    pub quota_manager: Arc<QuotaManager>,
 }
 
 impl AppState {
     pub fn new(config: Config) -> Self {
         let tool_registry = Arc::new(ToolRegistry::new());
-        let session_manager = Arc::new(SessionManager::new(config.mcp_session_ttl_minutes));
+        let mut session_mgr = SessionManager::new(config.mcp_session_ttl_minutes);
+        // Zombie detector is set below after initialization
         let rate_limiter = Arc::new(RateLimiter::new(&config));
         let api_key_validator = Arc::new(ApiKeyValidator::new(&config));
 
@@ -138,9 +155,44 @@ impl AppState {
         let semantic_cache = Arc::new(SemanticCache::new(SemanticCacheConfig::default()));
         tracing::info!("Semantic cache initialized");
 
-        // Initialize circuit breaker for CP API (Phase 6)
-        let cp_circuit_breaker = CircuitBreaker::new("cp-api", CircuitBreakerConfig::default());
-        tracing::info!("Circuit breaker initialized for CP API");
+        // Initialize per-upstream circuit breakers (CAB-362)
+        let cb_config = CircuitBreakerConfig {
+            failure_threshold: config.circuit_breaker_failure_threshold,
+            reset_timeout: Duration::from_secs(config.circuit_breaker_reset_timeout_secs),
+            success_threshold: config.circuit_breaker_success_threshold,
+            window_size: Duration::from_secs(60),
+        };
+        let cp_circuit_breaker = CircuitBreaker::new("cp-api", cb_config.clone());
+        let mut breakers = HashMap::new();
+        breakers.insert("cp-api".to_string(), cp_circuit_breaker);
+        let circuit_breakers = Arc::new(RwLock::new(breakers));
+        info!(
+            per_upstream = config.circuit_breaker_per_upstream,
+            failure_threshold = config.circuit_breaker_failure_threshold,
+            "Circuit breakers initialized (CAB-362)"
+        );
+
+        // Initialize zombie detector (CAB-362, ADR-012)
+        let zombie_config = ZombieConfig {
+            session_ttl_secs: config.agent_session_ttl_secs,
+            zombie_factor: 2.0,
+            attestation_interval: config.attestation_interval,
+            auto_revoke: config.zombie_auto_revoke,
+            alert_threshold: 10,
+            cleanup_interval_secs: config.zombie_reaper_interval_secs,
+        };
+        let zombie_detector = Arc::new(ZombieDetector::new(zombie_config));
+        if config.zombie_detection_enabled {
+            // Wire zombie detector into session manager (CAB-362)
+            session_mgr.set_zombie_detector(zombie_detector.clone());
+            info!(
+                ttl_secs = config.agent_session_ttl_secs,
+                auto_revoke = config.zombie_auto_revoke,
+                reaper_interval = config.zombie_reaper_interval_secs,
+                "Zombie detector initialized (CAB-362)"
+            );
+        }
+        let session_manager = Arc::new(session_mgr);
 
         // Initialize Kafka metering producer (Phase 3: CAB-1105)
         let metering_producer = if config.kafka_enabled {
@@ -169,6 +221,29 @@ impl AppState {
             None
         };
 
+        // Initialize per-consumer quota enforcement (Phase 4: CAB-1121)
+        let rate_limiter_config = RateLimiterConfig {
+            default_rate_per_minute: config.quota_default_rate_per_minute,
+            ..RateLimiterConfig::default()
+        };
+        let consumer_rate_limiter = Arc::new(ConsumerRateLimiter::new(rate_limiter_config));
+
+        let quota_manager_config = QuotaManagerConfig {
+            default_daily_limit: config.quota_default_daily_limit,
+            ..QuotaManagerConfig::default()
+        };
+        let quota_manager = Arc::new(QuotaManager::new(quota_manager_config));
+
+        if config.quota_enforcement_enabled {
+            info!(
+                default_rate_per_minute = config.quota_default_rate_per_minute,
+                default_daily_limit = config.quota_default_daily_limit,
+                "Quota enforcement enabled (CAB-1121)"
+            );
+        } else {
+            info!("Quota enforcement disabled (STOA_QUOTA_ENFORCEMENT_ENABLED=false)");
+        }
+
         Self {
             config,
             tool_registry,
@@ -181,9 +256,46 @@ impl AppState {
             policy_registry,
             jwt_validator,
             semantic_cache,
-            cp_circuit_breaker,
+            circuit_breakers,
+            cb_config,
             metering_producer,
+            zombie_detector,
+            consumer_rate_limiter,
+            quota_manager,
         }
+    }
+
+    /// Get or create a circuit breaker for the given upstream ID.
+    ///
+    /// When `circuit_breaker_per_upstream` is true, each upstream gets its own CB.
+    /// When false, all upstreams share the "cp-api" global CB.
+    pub fn get_or_create_cb(&self, upstream_id: &str) -> Arc<CircuitBreaker> {
+        // If per-upstream is disabled, always return the global "cp-api" CB
+        let key = if self.config.circuit_breaker_per_upstream {
+            upstream_id
+        } else {
+            "cp-api"
+        };
+
+        // Fast path: check if CB already exists (read lock)
+        {
+            let breakers = self.circuit_breakers.read();
+            if let Some(cb) = breakers.get(key) {
+                return cb.clone();
+            }
+        }
+
+        // Slow path: create new CB (write lock)
+        let mut breakers = self.circuit_breakers.write();
+        // Double-check after acquiring write lock
+        if let Some(cb) = breakers.get(key) {
+            return cb.clone();
+        }
+
+        let cb = CircuitBreaker::new(key, self.cb_config.clone());
+        breakers.insert(key.to_string(), cb.clone());
+        tracing::debug!(upstream = %key, "Created new per-upstream circuit breaker");
+        cb
     }
 
     /// Start background tasks
@@ -193,6 +305,60 @@ impl AppState {
 
         // Start rate limiter cleanup
         self.rate_limiter.clone().start_cleanup_task();
+
+        // Start consumer rate limiter cleanup (Phase 4: CAB-1121)
+        if self.config.quota_enforcement_enabled {
+            self.consumer_rate_limiter.clone().start_cleanup_task();
+            self.quota_manager.clone().start_reset_task();
+        }
+
+        // Start zombie reaper sweep (CAB-362)
+        if self.config.zombie_detection_enabled {
+            let detector = self.zombie_detector.clone();
+            let session_manager = self.session_manager.clone();
+            let interval_secs = self.config.zombie_reaper_interval_secs;
+            let auto_revoke = self.config.zombie_auto_revoke;
+
+            tokio::spawn(async move {
+                let mut interval =
+                    tokio::time::interval(tokio::time::Duration::from_secs(interval_secs));
+                loop {
+                    interval.tick().await;
+
+                    let alerts = detector.check_zombies().await;
+                    for alert in &alerts {
+                        if alert.severity == crate::governance::zombie::AlertSeverity::Critical
+                            && auto_revoke
+                        {
+                            // Revoke zombie session and remove from session manager
+                            if let Err(e) = detector.revoke_session(&alert.session_id).await {
+                                tracing::warn!(
+                                    session_id = %alert.session_id,
+                                    error = %e,
+                                    "Failed to revoke zombie session"
+                                );
+                            } else {
+                                session_manager.remove(&alert.session_id).await;
+                                tracing::info!(
+                                    session_id = %alert.session_id,
+                                    "Zombie session revoked and removed"
+                                );
+                            }
+                        }
+                    }
+
+                    // Cleanup very old sessions from zombie detector
+                    let cleaned = detector.cleanup().await;
+                    if cleaned > 0 {
+                        tracing::debug!(cleaned, "Zombie detector cleanup completed");
+                    }
+                }
+            });
+            info!(
+                interval_secs,
+                "Zombie reaper background task started (CAB-362)"
+            );
+        }
     }
 }
 
@@ -260,5 +426,121 @@ impl UacEnforcer {
             PolicyDecision::Allow => Ok(()),
             PolicyDecision::Deny { reason } => Err(reason),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resilience::CircuitState;
+
+    fn test_state() -> AppState {
+        AppState::new(Config::default())
+    }
+
+    fn test_state_global_cb() -> AppState {
+        let config = Config {
+            circuit_breaker_per_upstream: false,
+            ..Config::default()
+        };
+        AppState::new(config)
+    }
+
+    #[test]
+    fn test_get_or_create_cb_returns_existing() {
+        let state = test_state();
+        // "cp-api" is created during AppState::new
+        let cb1 = state.get_or_create_cb("cp-api");
+        let cb2 = state.get_or_create_cb("cp-api");
+        assert_eq!(cb1.name(), cb2.name());
+        assert_eq!(cb1.name(), "cp-api");
+    }
+
+    #[test]
+    fn test_get_or_create_cb_creates_new() {
+        let state = test_state();
+        let cb = state.get_or_create_cb("upstream-payments");
+        assert_eq!(cb.name(), "upstream-payments");
+        assert_eq!(cb.state(), CircuitState::Closed);
+
+        // Verify it's now in the map
+        let breakers = state.circuit_breakers.read();
+        assert!(breakers.contains_key("upstream-payments"));
+    }
+
+    #[test]
+    fn test_per_upstream_isolation() {
+        let state = test_state();
+
+        let cb_a = state.get_or_create_cb("upstream-A");
+        let cb_b = state.get_or_create_cb("upstream-B");
+
+        // Trip upstream-A
+        for _ in 0..5 {
+            cb_a.record_failure();
+        }
+
+        // upstream-A should be open, upstream-B still closed
+        assert_eq!(cb_a.state(), CircuitState::Open);
+        assert_eq!(cb_b.state(), CircuitState::Closed);
+        assert!(cb_b.allow_request());
+        assert!(!cb_a.allow_request());
+    }
+
+    #[test]
+    fn test_global_cb_mode_shares_single_cb() {
+        let state = test_state_global_cb();
+
+        let cb_a = state.get_or_create_cb("upstream-A");
+        let cb_b = state.get_or_create_cb("upstream-B");
+
+        // Both should be the same "cp-api" CB
+        assert_eq!(cb_a.name(), "cp-api");
+        assert_eq!(cb_b.name(), "cp-api");
+
+        // Trip via cb_a, cb_b should also see it
+        for _ in 0..5 {
+            cb_a.record_failure();
+        }
+        assert_eq!(cb_b.state(), CircuitState::Open);
+    }
+
+    #[test]
+    fn test_cb_uses_config_thresholds() {
+        let config = Config {
+            circuit_breaker_failure_threshold: 2,
+            circuit_breaker_success_threshold: 1,
+            ..Config::default()
+        };
+        let state = AppState::new(config);
+
+        let cb = state.get_or_create_cb("test-upstream");
+
+        // Should trip after 2 failures (not default 5)
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Closed);
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+    }
+
+    #[test]
+    fn test_zombie_detector_initialized() {
+        let state = test_state();
+        // zombie_detector should be set
+        assert!(Arc::strong_count(&state.zombie_detector) >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_zombie_detector_tracks_sessions() {
+        let state = test_state();
+
+        state
+            .zombie_detector
+            .start_session("sess-1", Some("user-1".to_string()), None)
+            .await;
+
+        let stats = state.zombie_detector.stats().await;
+        assert_eq!(stats.total_sessions, 1);
+        assert_eq!(stats.healthy, 1);
     }
 }


### PR DESCRIPTION
## Summary

- **Token bucket rate limiter** — per-consumer, per-second + per-minute with burst support
- **Daily/monthly request quota tracking** — auto-reset, persistent counters in QuotaManager
- **Axum middleware** — wired after auth, before handlers; injects X-RateLimit-* headers + 429 with Retry-After
- **Admin endpoints** — GET/POST /admin/quotas, per-consumer stats + reset
- **Per-upstream circuit breakers** (CAB-362) — HashMap<String, Arc<CircuitBreaker>> with get_or_create_cb()
- **Zombie session reaper** (CAB-362) — ZombieDetector in AppState, background sweep every 60s, auto-revoke on Critical
- **Config** — 8 new STOA_ env vars (quota + CB + zombie)

## Files Changed (9 files, +2,542 lines)

- `stoa-gateway/src/quota/` — new module: mod.rs, rate_limiter.rs, quota_manager.rs, middleware.rs
- `stoa-gateway/src/config.rs` — 8 new config fields
- `stoa-gateway/src/state.rs` — QuotaManager + per-upstream CBs + ZombieDetector in AppState
- `stoa-gateway/src/handlers/admin.rs` — 10 new admin endpoints
- `stoa-gateway/src/mcp/session.rs` — zombie detector hooks on create/get/remove
- `stoa-gateway/src/main.rs` — quota middleware + zombie background task

## Test plan

- [x] 42 new tests (309 total), cargo test --all-features passes
- [x] cargo clippy --all-targets --all-features — zero warnings
- [x] cargo fmt --check — clean
- [ ] CI green on PR
- [ ] Merge + deploy + verify pod updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)