### PR TITLE
feat(portal): consumer registration + subscription workflow UI (CAB-1121 P5)

### DIFF
--- a/portal/src/App.tsx
+++ b/portal/src/App.tsx
@@ -43,6 +43,12 @@ const ServiceAccountsPage = lazy(() =>
 const WorkspacePage = lazy(() =>
   import('./pages/workspace').then((m) => ({ default: m.WorkspacePage }))
 );
+const ConsumerDetailPage = lazy(() =>
+  import('./pages/consumers').then((m) => ({ default: m.ConsumerDetailPage }))
+);
+const ConsumerRegistrationPage = lazy(() =>
+  import('./pages/consumers').then((m) => ({ default: m.ConsumerRegistrationPage }))
+);
 const UnauthorizedPage = lazy(() =>
   import('./pages/Unauthorized').then((m) => ({ default: m.UnauthorizedPage }))
 );
@@ -292,6 +298,25 @@ function AppContent() {
               element={
                 <ProtectedRoute scope="stoa:catalog:read">
                   <ContractDetailPage />
+                </ProtectedRoute>
+              }
+            />
+
+            {/* Consumer Management - requires tenant admin */}
+            <Route path="/consumers" element={<Navigate to="/workspace?tab=consumers" replace />} />
+            <Route
+              path="/consumers/register"
+              element={
+                <ProtectedRoute permission="apps:read">
+                  <ConsumerRegistrationPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/consumers/:id"
+              element={
+                <ProtectedRoute permission="apps:read">
+                  <ConsumerDetailPage />
                 </ProtectedRoute>
               }
             />

--- a/portal/src/components/consumers/ConsumerCard.test.tsx
+++ b/portal/src/components/consumers/ConsumerCard.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Tests for ConsumerCard component (CAB-1121)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ConsumerCard } from './ConsumerCard';
+import type { Consumer } from '../../types';
+
+const mockConsumer: Consumer = {
+  id: 'c1',
+  name: 'ACME Corp',
+  external_id: 'acme-001',
+  email: 'api@acme.com',
+  company: 'ACME Corporation',
+  description: 'Strategic API partner',
+  status: 'active',
+  tenant_id: 'tenant-1',
+  created_at: '2026-02-01T10:00:00Z',
+  updated_at: '2026-02-01T10:00:00Z',
+};
+
+describe('ConsumerCard', () => {
+  it('should render consumer name', () => {
+    render(
+      <MemoryRouter>
+        <ConsumerCard consumer={mockConsumer} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('ACME Corp')).toBeInTheDocument();
+  });
+
+  it('should render external_id', () => {
+    render(
+      <MemoryRouter>
+        <ConsumerCard consumer={mockConsumer} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('acme-001')).toBeInTheDocument();
+  });
+
+  it('should render status badge as Active', () => {
+    render(
+      <MemoryRouter>
+        <ConsumerCard consumer={mockConsumer} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  it('should render email', () => {
+    render(
+      <MemoryRouter>
+        <ConsumerCard consumer={mockConsumer} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('api@acme.com')).toBeInTheDocument();
+  });
+
+  it('should render company when provided', () => {
+    render(
+      <MemoryRouter>
+        <ConsumerCard consumer={mockConsumer} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('ACME Corporation')).toBeInTheDocument();
+  });
+
+  it('should render description', () => {
+    render(
+      <MemoryRouter>
+        <ConsumerCard consumer={mockConsumer} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Strategic API partner')).toBeInTheDocument();
+  });
+
+  it('should render suspended status correctly', () => {
+    const suspendedConsumer = { ...mockConsumer, status: 'suspended' as const };
+    render(
+      <MemoryRouter>
+        <ConsumerCard consumer={suspendedConsumer} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Suspended')).toBeInTheDocument();
+  });
+
+  it('should render blocked status correctly', () => {
+    const blockedConsumer = { ...mockConsumer, status: 'blocked' as const };
+    render(
+      <MemoryRouter>
+        <ConsumerCard consumer={blockedConsumer} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Blocked')).toBeInTheDocument();
+  });
+
+  it('should show default description when none provided', () => {
+    const noDescConsumer = { ...mockConsumer, description: null };
+    render(
+      <MemoryRouter>
+        <ConsumerCard consumer={noDescConsumer} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('No description provided')).toBeInTheDocument();
+  });
+
+  it('should link to consumer detail page', () => {
+    render(
+      <MemoryRouter>
+        <ConsumerCard consumer={mockConsumer} />
+      </MemoryRouter>
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/consumers/c1');
+  });
+
+  it('should render formatted date', () => {
+    render(
+      <MemoryRouter>
+        <ConsumerCard consumer={mockConsumer} />
+      </MemoryRouter>
+    );
+
+    // "Created Feb 1, 2026" or similar format
+    expect(screen.getByText(/Created/)).toBeInTheDocument();
+  });
+});

--- a/portal/src/components/consumers/ConsumerCard.tsx
+++ b/portal/src/components/consumers/ConsumerCard.tsx
@@ -1,0 +1,120 @@
+/**
+ * Consumer Card Component
+ *
+ * Displays an external API consumer in the consumers list.
+ * Optimized with React.memo to prevent unnecessary re-renders.
+ */
+
+import { memo, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  ArrowRight,
+  Clock,
+  CheckCircle,
+  PauseCircle,
+  ShieldOff,
+  Mail,
+  Building2,
+  Hash,
+} from 'lucide-react';
+import type { Consumer } from '../../types';
+
+interface ConsumerCardProps {
+  consumer: Consumer;
+}
+
+const statusConfig = {
+  active: {
+    icon: CheckCircle,
+    color: 'text-green-500',
+    bg: 'bg-green-100 dark:bg-green-900/30',
+    text: 'text-green-800 dark:text-green-300',
+    label: 'Active',
+  },
+  suspended: {
+    icon: PauseCircle,
+    color: 'text-amber-500',
+    bg: 'bg-amber-100 dark:bg-amber-900/30',
+    text: 'text-amber-800 dark:text-amber-300',
+    label: 'Suspended',
+  },
+  blocked: {
+    icon: ShieldOff,
+    color: 'text-red-500',
+    bg: 'bg-red-100 dark:bg-red-900/30',
+    text: 'text-red-800 dark:text-red-300',
+    label: 'Blocked',
+  },
+} as const;
+
+const dateFormatOptions: Intl.DateTimeFormatOptions = {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+};
+
+export const ConsumerCard = memo(function ConsumerCard({ consumer }: ConsumerCardProps) {
+  const status = statusConfig[consumer.status] || statusConfig.active;
+  const StatusIcon = status.icon;
+
+  const formattedDate = useMemo(() => {
+    return new Date(consumer.created_at).toLocaleDateString('en-US', dateFormatOptions);
+  }, [consumer.created_at]);
+
+  return (
+    <Link
+      to={`/consumers/${consumer.id}`}
+      className="group bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6 hover:border-primary-300 dark:hover:border-primary-600 hover:shadow-md transition-all"
+    >
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex-1 min-w-0">
+          <h3 className="font-semibold text-gray-900 dark:text-white group-hover:text-primary-700 dark:group-hover:text-primary-400 transition-colors truncate">
+            {consumer.name}
+          </h3>
+          <div className="flex items-center gap-2 mt-1">
+            <Hash className="h-3 w-3 text-gray-400 dark:text-neutral-500" />
+            <span className="text-xs font-mono text-gray-500 dark:text-neutral-400 truncate">
+              {consumer.external_id}
+            </span>
+          </div>
+        </div>
+        <span
+          className={`inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full ${status.bg} ${status.text}`}
+        >
+          <StatusIcon className={`h-3 w-3 ${status.color}`} />
+          {status.label}
+        </span>
+      </div>
+
+      <p className="text-sm text-gray-600 dark:text-neutral-300 line-clamp-2 mb-4 min-h-[40px]">
+        {consumer.description || 'No description provided'}
+      </p>
+
+      <div className="flex flex-wrap gap-3 mb-4">
+        <div className="flex items-center gap-1 text-sm text-gray-500 dark:text-neutral-400">
+          <Mail className="h-3.5 w-3.5" />
+          <span className="truncate max-w-[180px]">{consumer.email}</span>
+        </div>
+        {consumer.company && (
+          <div className="flex items-center gap-1 text-sm text-gray-500 dark:text-neutral-400">
+            <Building2 className="h-3.5 w-3.5" />
+            <span className="truncate max-w-[120px]">{consumer.company}</span>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between pt-3 border-t border-gray-100 dark:border-neutral-700">
+        <div className="flex items-center text-xs text-gray-500 dark:text-neutral-400">
+          <Clock className="h-3 w-3 mr-1" />
+          Created {formattedDate}
+        </div>
+        <span className="inline-flex items-center text-sm font-medium text-primary-600 dark:text-primary-400 group-hover:text-primary-700 dark:group-hover:text-primary-300">
+          View
+          <ArrowRight className="h-4 w-4 ml-1 group-hover:translate-x-1 transition-transform" />
+        </span>
+      </div>
+    </Link>
+  );
+});
+
+export default ConsumerCard;

--- a/portal/src/components/consumers/CreateConsumerModal.test.tsx
+++ b/portal/src/components/consumers/CreateConsumerModal.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Tests for CreateConsumerModal component (CAB-1121)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { CreateConsumerModal } from './CreateConsumerModal';
+
+describe('CreateConsumerModal', () => {
+  const mockOnClose = vi.fn();
+  const mockOnSubmit = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOnSubmit.mockResolvedValue(undefined);
+  });
+
+  it('should not render when isOpen is false', () => {
+    render(<CreateConsumerModal isOpen={false} onClose={mockOnClose} onSubmit={mockOnSubmit} />);
+
+    expect(screen.queryByText('Register New Consumer')).not.toBeInTheDocument();
+  });
+
+  it('should render when isOpen is true', () => {
+    render(<CreateConsumerModal isOpen={true} onClose={mockOnClose} onSubmit={mockOnSubmit} />);
+
+    expect(screen.getByText('Register New Consumer')).toBeInTheDocument();
+  });
+
+  it('should render all form fields', () => {
+    render(<CreateConsumerModal isOpen={true} onClose={mockOnClose} onSubmit={mockOnSubmit} />);
+
+    expect(screen.getByLabelText(/Consumer Name/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/External ID/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Contact Email/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Company/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Description/)).toBeInTheDocument();
+  });
+
+  it('should disable submit when name is empty', () => {
+    render(<CreateConsumerModal isOpen={true} onClose={mockOnClose} onSubmit={mockOnSubmit} />);
+
+    const submitButton = screen.getByText('Register Consumer');
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('should call onSubmit with form data', async () => {
+    render(<CreateConsumerModal isOpen={true} onClose={mockOnClose} onSubmit={mockOnSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(/Consumer Name/), {
+      target: { value: 'ACME Corp' },
+    });
+    fireEvent.change(screen.getByLabelText(/External ID/), {
+      target: { value: 'acme-001' },
+    });
+    fireEvent.change(screen.getByLabelText(/Contact Email/), {
+      target: { value: 'api@acme.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/Company/), {
+      target: { value: 'ACME Corporation' },
+    });
+
+    const submitButton = screen.getByText('Register Consumer');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        name: 'ACME Corp',
+        external_id: 'acme-001',
+        email: 'api@acme.com',
+        company: 'ACME Corporation',
+        description: undefined,
+      });
+    });
+  });
+
+  it('should show email validation error for invalid email', () => {
+    render(<CreateConsumerModal isOpen={true} onClose={mockOnClose} onSubmit={mockOnSubmit} />);
+
+    const emailInput = screen.getByLabelText(/Contact Email/);
+    fireEvent.change(emailInput, { target: { value: 'not-an-email' } });
+    fireEvent.blur(emailInput);
+
+    expect(screen.getByText('Please enter a valid email address')).toBeInTheDocument();
+  });
+
+  it('should display error message when error prop is provided', () => {
+    render(
+      <CreateConsumerModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onSubmit={mockOnSubmit}
+        error="Something went wrong"
+      />
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('should show loading state when isLoading is true', () => {
+    render(
+      <CreateConsumerModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onSubmit={mockOnSubmit}
+        isLoading={true}
+      />
+    );
+
+    expect(screen.getByText('Creating...')).toBeInTheDocument();
+  });
+
+  it('should call onClose when Cancel is clicked', () => {
+    render(<CreateConsumerModal isOpen={true} onClose={mockOnClose} onSubmit={mockOnSubmit} />);
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});

--- a/portal/src/components/consumers/CreateConsumerModal.tsx
+++ b/portal/src/components/consumers/CreateConsumerModal.tsx
@@ -1,0 +1,266 @@
+/**
+ * Create Consumer Modal Component
+ *
+ * Modal form for creating a new external API consumer (CAB-1121).
+ */
+
+import { useState } from 'react';
+import { X, Loader2, AlertCircle } from 'lucide-react';
+import type { ConsumerCreateRequest } from '../../types';
+
+interface CreateConsumerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: ConsumerCreateRequest) => Promise<void>;
+  isLoading?: boolean;
+  error?: string | null;
+}
+
+export function CreateConsumerModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  isLoading = false,
+  error = null,
+}: CreateConsumerModalProps) {
+  const [name, setName] = useState('');
+  const [externalId, setExternalId] = useState('');
+  const [email, setEmail] = useState('');
+  const [company, setCompany] = useState('');
+  const [description, setDescription] = useState('');
+  const [emailError, setEmailError] = useState<string | null>(null);
+
+  const validateEmail = (value: string): boolean => {
+    if (!value.trim()) {
+      setEmailError('Email is required');
+      return false;
+    }
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailPattern.test(value)) {
+      setEmailError('Please enter a valid email address');
+      return false;
+    }
+    setEmailError(null);
+    return true;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateEmail(email)) {
+      return;
+    }
+
+    await onSubmit({
+      name: name.trim(),
+      external_id: externalId.trim(),
+      email: email.trim(),
+      company: company.trim() || undefined,
+      description: description.trim() || undefined,
+    });
+  };
+
+  const resetForm = () => {
+    setName('');
+    setExternalId('');
+    setEmail('');
+    setCompany('');
+    setDescription('');
+    setEmailError(null);
+  };
+
+  const handleClose = () => {
+    if (!isLoading) {
+      resetForm();
+      onClose();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 transition-opacity"
+        onClick={handleClose}
+        onKeyDown={(e) => e.key === 'Escape' && handleClose()}
+        role="button"
+        aria-label="Close modal"
+        tabIndex={0}
+      />
+
+      {/* Modal */}
+      <div className="flex min-h-full items-center justify-center p-4">
+        <div className="relative bg-white dark:bg-neutral-800 rounded-xl shadow-xl max-w-lg w-full">
+          {/* Header */}
+          <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-neutral-700">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+              Register New Consumer
+            </h2>
+            <button
+              onClick={handleClose}
+              disabled={isLoading}
+              className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg transition-colors disabled:opacity-50"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          {/* Form */}
+          <form onSubmit={handleSubmit}>
+            <div className="p-6 space-y-4">
+              {/* Error message */}
+              {error && (
+                <div className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+                  <AlertCircle className="h-5 w-5 text-red-500 mt-0.5" />
+                  <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+                </div>
+              )}
+
+              {/* Name */}
+              <div>
+                <label
+                  htmlFor="consumer-name"
+                  className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
+                >
+                  Consumer Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  id="consumer-name"
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="ACME Corp"
+                  required
+                  disabled={isLoading}
+                  className="w-full px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:bg-gray-100 dark:disabled:bg-neutral-600 disabled:cursor-not-allowed"
+                />
+              </div>
+
+              {/* External ID */}
+              <div>
+                <label
+                  htmlFor="consumer-external-id"
+                  className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
+                >
+                  External ID <span className="text-red-500">*</span>
+                </label>
+                <input
+                  id="consumer-external-id"
+                  type="text"
+                  value={externalId}
+                  onChange={(e) => setExternalId(e.target.value)}
+                  placeholder="partner-acme-001"
+                  required
+                  disabled={isLoading}
+                  className="w-full px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white font-mono text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:bg-gray-100 dark:disabled:bg-neutral-600 disabled:cursor-not-allowed"
+                />
+                <p className="mt-1 text-xs text-gray-500 dark:text-neutral-400">
+                  Unique identifier for this consumer within your tenant
+                </p>
+              </div>
+
+              {/* Email */}
+              <div>
+                <label
+                  htmlFor="consumer-email"
+                  className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
+                >
+                  Contact Email <span className="text-red-500">*</span>
+                </label>
+                <input
+                  id="consumer-email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => {
+                    setEmail(e.target.value);
+                    if (emailError) validateEmail(e.target.value);
+                  }}
+                  onBlur={() => email && validateEmail(email)}
+                  placeholder="api@acme.com"
+                  required
+                  disabled={isLoading}
+                  className={`w-full px-4 py-2 border rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:bg-gray-100 dark:disabled:bg-neutral-600 disabled:cursor-not-allowed ${
+                    emailError
+                      ? 'border-red-300 dark:border-red-600'
+                      : 'border-gray-300 dark:border-neutral-600'
+                  }`}
+                />
+                {emailError && (
+                  <p className="mt-1 text-xs text-red-600 dark:text-red-400">{emailError}</p>
+                )}
+              </div>
+
+              {/* Company */}
+              <div>
+                <label
+                  htmlFor="consumer-company"
+                  className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
+                >
+                  Company
+                </label>
+                <input
+                  id="consumer-company"
+                  type="text"
+                  value={company}
+                  onChange={(e) => setCompany(e.target.value)}
+                  placeholder="ACME Corporation"
+                  disabled={isLoading}
+                  className="w-full px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:bg-gray-100 dark:disabled:bg-neutral-600 disabled:cursor-not-allowed"
+                />
+              </div>
+
+              {/* Description */}
+              <div>
+                <label
+                  htmlFor="consumer-description"
+                  className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
+                >
+                  Description
+                </label>
+                <textarea
+                  id="consumer-description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Brief description of this API consumer..."
+                  rows={3}
+                  disabled={isLoading}
+                  className="w-full px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:bg-gray-100 dark:disabled:bg-neutral-600 disabled:cursor-not-allowed resize-none"
+                />
+              </div>
+            </div>
+
+            {/* Footer */}
+            <div className="flex items-center justify-end gap-3 p-6 border-t border-gray-200 dark:border-neutral-700">
+              <button
+                type="button"
+                onClick={handleClose}
+                disabled={isLoading}
+                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-neutral-300 hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg transition-colors disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={isLoading || !name.trim() || !externalId.trim() || !email.trim()}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white text-sm font-medium rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Creating...
+                  </>
+                ) : (
+                  'Register Consumer'
+                )}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CreateConsumerModal;

--- a/portal/src/components/consumers/CredentialsDisplay.test.tsx
+++ b/portal/src/components/consumers/CredentialsDisplay.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Tests for CredentialsDisplay component (CAB-1121)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CredentialsDisplay } from './CredentialsDisplay';
+import type { ConsumerCredentials } from '../../types';
+
+const mockCredentials: ConsumerCredentials = {
+  consumer_id: 'c1',
+  client_id: 'stoa-client-acme-001',
+  client_secret: 'super-secret-value-12345',
+  token_endpoint: 'https://auth.gostoa.dev/realms/stoa/protocol/openid-connect/token',
+  grant_type: 'client_credentials',
+};
+
+describe('CredentialsDisplay', () => {
+  beforeEach(() => {
+    // Mock clipboard API
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it('should render client_id', () => {
+    render(<CredentialsDisplay credentials={mockCredentials} />);
+
+    expect(screen.getByText('stoa-client-acme-001')).toBeInTheDocument();
+  });
+
+  it('should render client_secret visible by default', () => {
+    render(<CredentialsDisplay credentials={mockCredentials} />);
+
+    expect(screen.getByText('super-secret-value-12345')).toBeInTheDocument();
+  });
+
+  it('should render token endpoint', () => {
+    render(<CredentialsDisplay credentials={mockCredentials} />);
+
+    expect(
+      screen.getByText('https://auth.gostoa.dev/realms/stoa/protocol/openid-connect/token')
+    ).toBeInTheDocument();
+  });
+
+  it('should render grant type', () => {
+    render(<CredentialsDisplay credentials={mockCredentials} />);
+
+    expect(screen.getByText('client_credentials')).toBeInTheDocument();
+  });
+
+  it('should show one-time warning', () => {
+    render(<CredentialsDisplay credentials={mockCredentials} />);
+
+    expect(screen.getByText(/The client secret is only shown once/)).toBeInTheDocument();
+  });
+
+  it('should toggle secret visibility', () => {
+    render(<CredentialsDisplay credentials={mockCredentials} />);
+
+    // Initially visible
+    expect(screen.getByText('super-secret-value-12345')).toBeInTheDocument();
+
+    // Click hide button
+    const hideButton = screen.getByTitle('Hide secret');
+    fireEvent.click(hideButton);
+
+    // Should be masked now
+    expect(screen.queryByText('super-secret-value-12345')).not.toBeInTheDocument();
+
+    // Click show button
+    const showButton = screen.getByTitle('Show secret');
+    fireEvent.click(showButton);
+
+    // Should be visible again
+    expect(screen.getByText('super-secret-value-12345')).toBeInTheDocument();
+  });
+
+  it('should copy client_id to clipboard', async () => {
+    render(<CredentialsDisplay credentials={mockCredentials} />);
+
+    const copyButton = screen.getByTitle('Copy Client ID');
+    fireEvent.click(copyButton);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('stoa-client-acme-001');
+  });
+
+  it('should copy client_secret to clipboard', async () => {
+    render(<CredentialsDisplay credentials={mockCredentials} />);
+
+    const copyButton = screen.getByTitle('Copy Client Secret');
+    fireEvent.click(copyButton);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('super-secret-value-12345');
+  });
+
+  it('should copy token endpoint to clipboard', async () => {
+    render(<CredentialsDisplay credentials={mockCredentials} />);
+
+    const copyButton = screen.getByTitle('Copy Token Endpoint');
+    fireEvent.click(copyButton);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'https://auth.gostoa.dev/realms/stoa/protocol/openid-connect/token'
+    );
+  });
+
+  it('should render all field labels', () => {
+    render(<CredentialsDisplay credentials={mockCredentials} />);
+
+    expect(screen.getByText('Client ID')).toBeInTheDocument();
+    expect(screen.getByText('Client Secret')).toBeInTheDocument();
+    expect(screen.getByText('Token Endpoint')).toBeInTheDocument();
+  });
+});

--- a/portal/src/components/consumers/CredentialsDisplay.tsx
+++ b/portal/src/components/consumers/CredentialsDisplay.tsx
@@ -1,0 +1,128 @@
+/**
+ * Credentials Display Component
+ *
+ * Displays consumer OAuth credentials after activation (CAB-1121).
+ * Shows client_id, client_secret (one-time), and token endpoint.
+ */
+
+import { useState } from 'react';
+import { Copy, Check, Eye, EyeOff, AlertTriangle, Key, Globe } from 'lucide-react';
+import type { ConsumerCredentials } from '../../types';
+
+interface CredentialsDisplayProps {
+  credentials: ConsumerCredentials;
+}
+
+export function CredentialsDisplay({ credentials }: CredentialsDisplayProps) {
+  const [showSecret, setShowSecret] = useState(true);
+  const [copiedField, setCopiedField] = useState<string | null>(null);
+
+  const copyToClipboard = async (value: string, field: string) => {
+    await navigator.clipboard.writeText(value);
+    setCopiedField(field);
+    setTimeout(() => setCopiedField(null), 2000);
+  };
+
+  const maskedSecret = credentials.client_secret.replace(/./g, '*');
+
+  return (
+    <div className="space-y-4">
+      {/* One-time warning */}
+      <div className="flex items-start gap-2 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+        <AlertTriangle className="h-5 w-5 text-amber-500 mt-0.5 flex-shrink-0" />
+        <div className="text-sm text-amber-700 dark:text-amber-300">
+          <strong>Important:</strong> The client secret is only shown once. Copy and store it
+          securely now. You will not be able to retrieve it again.
+        </div>
+      </div>
+
+      {/* Client ID */}
+      <div>
+        <span className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+          Client ID
+        </span>
+        <div className="flex items-center gap-2">
+          <div className="flex-1 flex items-center gap-2 px-4 py-2 bg-gray-50 dark:bg-neutral-700 border border-gray-200 dark:border-neutral-600 rounded-lg font-mono text-sm text-gray-900 dark:text-white">
+            <Key className="h-4 w-4 text-gray-400 dark:text-neutral-500 flex-shrink-0" />
+            <span className="flex-1 truncate">{credentials.client_id}</span>
+          </div>
+          <button
+            onClick={() => copyToClipboard(credentials.client_id, 'client_id')}
+            className="p-2 text-gray-500 hover:text-gray-700 dark:hover:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
+            title="Copy Client ID"
+          >
+            {copiedField === 'client_id' ? (
+              <Check className="h-5 w-5 text-green-500" />
+            ) : (
+              <Copy className="h-5 w-5" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Client Secret */}
+      <div>
+        <span className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+          Client Secret
+        </span>
+        <div className="flex items-center gap-2">
+          <div className="flex-1 flex items-center gap-2 px-4 py-2 bg-gray-50 dark:bg-neutral-700 border border-gray-200 dark:border-neutral-600 rounded-lg font-mono text-sm text-gray-900 dark:text-white">
+            <Key className="h-4 w-4 text-gray-400 dark:text-neutral-500 flex-shrink-0" />
+            <span className="flex-1 truncate">
+              {showSecret ? credentials.client_secret : maskedSecret}
+            </span>
+          </div>
+          <button
+            onClick={() => setShowSecret(!showSecret)}
+            className="p-2 text-gray-500 hover:text-gray-700 dark:hover:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
+            title={showSecret ? 'Hide secret' : 'Show secret'}
+          >
+            {showSecret ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+          </button>
+          <button
+            onClick={() => copyToClipboard(credentials.client_secret, 'client_secret')}
+            className="p-2 text-gray-500 hover:text-gray-700 dark:hover:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
+            title="Copy Client Secret"
+          >
+            {copiedField === 'client_secret' ? (
+              <Check className="h-5 w-5 text-green-500" />
+            ) : (
+              <Copy className="h-5 w-5" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Token Endpoint */}
+      <div>
+        <span className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+          Token Endpoint
+        </span>
+        <div className="flex items-center gap-2">
+          <div className="flex-1 flex items-center gap-2 px-4 py-2 bg-gray-50 dark:bg-neutral-700 border border-gray-200 dark:border-neutral-600 rounded-lg font-mono text-sm text-gray-900 dark:text-white">
+            <Globe className="h-4 w-4 text-gray-400 dark:text-neutral-500 flex-shrink-0" />
+            <span className="flex-1 truncate">{credentials.token_endpoint}</span>
+          </div>
+          <button
+            onClick={() => copyToClipboard(credentials.token_endpoint, 'token_endpoint')}
+            className="p-2 text-gray-500 hover:text-gray-700 dark:hover:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
+            title="Copy Token Endpoint"
+          >
+            {copiedField === 'token_endpoint' ? (
+              <Check className="h-5 w-5 text-green-500" />
+            ) : (
+              <Copy className="h-5 w-5" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Grant Type */}
+      <div className="text-sm text-gray-500 dark:text-neutral-400">
+        Grant Type: <span className="font-mono">{credentials.grant_type}</span>
+      </div>
+    </div>
+  );
+}
+
+export default CredentialsDisplay;

--- a/portal/src/components/consumers/PlanSelector.test.tsx
+++ b/portal/src/components/consumers/PlanSelector.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Tests for PlanSelector component (CAB-1121)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PlanSelector } from './PlanSelector';
+import type { Plan } from '../../types';
+
+const mockPlans: Plan[] = [
+  {
+    id: 'p1',
+    slug: 'free',
+    name: 'Free Plan',
+    description: 'Basic access for evaluation',
+    tenant_id: 'tenant-1',
+    rate_limit_per_second: 10,
+    rate_limit_per_minute: null,
+    daily_request_limit: 1000,
+    monthly_request_limit: null,
+    burst_limit: null,
+    requires_approval: false,
+    status: 'active',
+    created_at: '2026-02-01T10:00:00Z',
+    updated_at: '2026-02-01T10:00:00Z',
+  },
+  {
+    id: 'p2',
+    slug: 'gold',
+    name: 'Gold Plan',
+    description: 'Production-grade access',
+    tenant_id: 'tenant-1',
+    rate_limit_per_second: 100,
+    rate_limit_per_minute: null,
+    daily_request_limit: 1000000,
+    monthly_request_limit: 30000000,
+    burst_limit: null,
+    requires_approval: true,
+    status: 'active',
+    created_at: '2026-02-01T10:00:00Z',
+    updated_at: '2026-02-01T10:00:00Z',
+  },
+  {
+    id: 'p3',
+    slug: 'deprecated',
+    name: 'Old Plan',
+    description: 'No longer available',
+    tenant_id: 'tenant-1',
+    rate_limit_per_second: null,
+    rate_limit_per_minute: null,
+    daily_request_limit: null,
+    monthly_request_limit: null,
+    burst_limit: null,
+    requires_approval: false,
+    status: 'deprecated',
+    created_at: '2026-02-01T10:00:00Z',
+    updated_at: '2026-02-01T10:00:00Z',
+  },
+];
+
+describe('PlanSelector', () => {
+  it('should render active plans only', () => {
+    const onSelect = vi.fn();
+    render(<PlanSelector plans={mockPlans} onSelect={onSelect} />);
+
+    expect(screen.getByText('Free Plan')).toBeInTheDocument();
+    expect(screen.getByText('Gold Plan')).toBeInTheDocument();
+    expect(screen.queryByText('Old Plan')).not.toBeInTheDocument();
+  });
+
+  it('should render plan descriptions', () => {
+    const onSelect = vi.fn();
+    render(<PlanSelector plans={mockPlans} onSelect={onSelect} />);
+
+    expect(screen.getByText('Basic access for evaluation')).toBeInTheDocument();
+    expect(screen.getByText('Production-grade access')).toBeInTheDocument();
+  });
+
+  it('should call onSelect when a plan is clicked', () => {
+    const onSelect = vi.fn();
+    render(<PlanSelector plans={mockPlans} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByText('Free Plan'));
+    expect(onSelect).toHaveBeenCalledWith(mockPlans[0]);
+  });
+
+  it('should show selected state for selected plan', () => {
+    const onSelect = vi.fn();
+    render(<PlanSelector plans={mockPlans} selectedPlanId="p1" onSelect={onSelect} />);
+
+    // The selected plan should have a check icon (visible by its container)
+    const buttons = screen.getAllByRole('button');
+    // First button should be selected (Free Plan)
+    expect(buttons[0].className).toContain('border-primary-500');
+  });
+
+  it('should show "Requires approval" badge', () => {
+    const onSelect = vi.fn();
+    render(<PlanSelector plans={mockPlans} onSelect={onSelect} />);
+
+    expect(screen.getByText('Requires approval')).toBeInTheDocument();
+  });
+
+  it('should format rate limits correctly', () => {
+    const onSelect = vi.fn();
+    render(<PlanSelector plans={mockPlans} onSelect={onSelect} />);
+
+    // Free plan: 10/s
+    expect(screen.getByText('10/s')).toBeInTheDocument();
+    // Gold plan: 100/s
+    expect(screen.getByText('100/s')).toBeInTheDocument();
+  });
+
+  it('should show empty state when no active plans', () => {
+    const onSelect = vi.fn();
+    render(<PlanSelector plans={[]} onSelect={onSelect} />);
+
+    expect(screen.getByText('No plans available')).toBeInTheDocument();
+  });
+
+  it('should show loading skeleton when isLoading', () => {
+    const onSelect = vi.fn();
+    const { container } = render(<PlanSelector plans={[]} onSelect={onSelect} isLoading={true} />);
+
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('should format large numbers with K/M suffixes', () => {
+    const onSelect = vi.fn();
+    render(<PlanSelector plans={mockPlans} onSelect={onSelect} />);
+
+    // Gold plan: 1M/day, 30M/month
+    expect(screen.getByText('1M/day')).toBeInTheDocument();
+    expect(screen.getByText('30M/month')).toBeInTheDocument();
+  });
+});

--- a/portal/src/components/consumers/PlanSelector.tsx
+++ b/portal/src/components/consumers/PlanSelector.tsx
@@ -1,0 +1,124 @@
+/**
+ * Plan Selector Component
+ *
+ * Grid of available subscription plans for selection (CAB-1121).
+ */
+
+import { memo } from 'react';
+import { Check, Zap, Clock, Calendar, Sparkles } from 'lucide-react';
+import type { Plan } from '../../types';
+
+interface PlanSelectorProps {
+  plans: Plan[];
+  selectedPlanId?: string | null;
+  onSelect: (plan: Plan) => void;
+  isLoading?: boolean;
+}
+
+function formatLimit(value: number | null | undefined): string {
+  if (value === null || value === undefined) return 'Unlimited';
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(0)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K`;
+  return value.toString();
+}
+
+export const PlanSelector = memo(function PlanSelector({
+  plans,
+  selectedPlanId,
+  onSelect,
+  isLoading = false,
+}: PlanSelectorProps) {
+  const activePlans = plans.filter((p) => p.status === 'active');
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="animate-pulse bg-gray-100 dark:bg-neutral-700 rounded-lg h-48" />
+        ))}
+      </div>
+    );
+  }
+
+  if (activePlans.length === 0) {
+    return (
+      <div className="text-center py-8 text-gray-500 dark:text-neutral-400">
+        <Sparkles className="h-8 w-8 mx-auto mb-3 text-gray-300 dark:text-neutral-600" />
+        <p className="font-medium">No plans available</p>
+        <p className="text-sm mt-1">Contact your administrator to set up subscription plans.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {activePlans.map((plan) => {
+        const isSelected = selectedPlanId === plan.id;
+        return (
+          <button
+            key={plan.id}
+            type="button"
+            onClick={() => onSelect(plan)}
+            className={`relative text-left p-5 rounded-lg border-2 transition-all ${
+              isSelected
+                ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20 ring-1 ring-primary-500'
+                : 'border-gray-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 hover:border-primary-300 dark:hover:border-primary-600'
+            }`}
+          >
+            {/* Selected indicator */}
+            {isSelected && (
+              <div className="absolute top-3 right-3">
+                <div className="bg-primary-500 text-white rounded-full p-1">
+                  <Check className="h-3 w-3" />
+                </div>
+              </div>
+            )}
+
+            {/* Plan name and description */}
+            <h4 className="font-semibold text-gray-900 dark:text-white mb-1">{plan.name}</h4>
+            {plan.description && (
+              <p className="text-sm text-gray-500 dark:text-neutral-400 mb-4 line-clamp-2">
+                {plan.description}
+              </p>
+            )}
+
+            {/* Rate limits */}
+            <div className="space-y-2 text-sm">
+              {(plan.rate_limit_per_second !== null || plan.rate_limit_per_minute !== null) && (
+                <div className="flex items-center gap-2 text-gray-600 dark:text-neutral-300">
+                  <Zap className="h-3.5 w-3.5 text-amber-500" />
+                  <span>
+                    {plan.rate_limit_per_second !== null && plan.rate_limit_per_second !== undefined
+                      ? `${formatLimit(plan.rate_limit_per_second)}/s`
+                      : `${formatLimit(plan.rate_limit_per_minute)}/min`}
+                  </span>
+                </div>
+              )}
+              {plan.daily_request_limit !== null && plan.daily_request_limit !== undefined && (
+                <div className="flex items-center gap-2 text-gray-600 dark:text-neutral-300">
+                  <Clock className="h-3.5 w-3.5 text-blue-500" />
+                  <span>{formatLimit(plan.daily_request_limit)}/day</span>
+                </div>
+              )}
+              {plan.monthly_request_limit !== null && plan.monthly_request_limit !== undefined && (
+                <div className="flex items-center gap-2 text-gray-600 dark:text-neutral-300">
+                  <Calendar className="h-3.5 w-3.5 text-violet-500" />
+                  <span>{formatLimit(plan.monthly_request_limit)}/month</span>
+                </div>
+              )}
+            </div>
+
+            {/* Approval badge */}
+            {plan.requires_approval && (
+              <div className="mt-3 inline-flex items-center px-2 py-1 text-xs font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300 rounded-full">
+                Requires approval
+              </div>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+});
+
+export default PlanSelector;

--- a/portal/src/hooks/useConsumers.ts
+++ b/portal/src/hooks/useConsumers.ts
@@ -1,0 +1,142 @@
+/**
+ * STOA Developer Portal - Consumer Hooks
+ *
+ * React Query hooks for consumer operations (CAB-1121).
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { consumersService, ListConsumersParams } from '../services/consumers';
+import type {
+  Consumer,
+  ConsumerCreateRequest,
+  ConsumerUpdateRequest,
+  ConsumerCredentials,
+  PaginatedResponse,
+} from '../types';
+
+/**
+ * Hook to list consumers for a tenant
+ */
+export function useConsumers(tenantId: string | undefined, params?: ListConsumersParams) {
+  return useQuery<PaginatedResponse<Consumer>>({
+    queryKey: ['consumers', tenantId, params],
+    queryFn: () => consumersService.listConsumers(tenantId!, params),
+    enabled: !!tenantId,
+    staleTime: 30 * 1000, // 30 seconds
+  });
+}
+
+/**
+ * Hook to get a single consumer by ID
+ */
+export function useConsumer(tenantId: string | undefined, consumerId: string | undefined) {
+  return useQuery<Consumer>({
+    queryKey: ['consumer', tenantId, consumerId],
+    queryFn: () => consumersService.getConsumer(tenantId!, consumerId!),
+    enabled: !!tenantId && !!consumerId,
+    staleTime: 60 * 1000, // 1 minute
+  });
+}
+
+/**
+ * Hook to create a new consumer
+ */
+export function useCreateConsumer(tenantId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<Consumer, Error, ConsumerCreateRequest>({
+    mutationFn: (data) => consumersService.createConsumer(tenantId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['consumers', tenantId] });
+    },
+  });
+}
+
+/**
+ * Hook to update a consumer
+ */
+export function useUpdateConsumer(tenantId: string, consumerId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<Consumer, Error, ConsumerUpdateRequest>({
+    mutationFn: (data) => consumersService.updateConsumer(tenantId, consumerId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['consumers', tenantId] });
+      queryClient.invalidateQueries({ queryKey: ['consumer', tenantId, consumerId] });
+    },
+  });
+}
+
+/**
+ * Hook to delete a consumer
+ */
+export function useDeleteConsumer(tenantId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string>({
+    mutationFn: (consumerId) => consumersService.deleteConsumer(tenantId, consumerId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['consumers', tenantId] });
+    },
+  });
+}
+
+/**
+ * Hook to suspend a consumer
+ */
+export function useSuspendConsumer(tenantId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<Consumer, Error, string>({
+    mutationFn: (consumerId) => consumersService.suspendConsumer(tenantId, consumerId),
+    onSuccess: (_, consumerId) => {
+      queryClient.invalidateQueries({ queryKey: ['consumers', tenantId] });
+      queryClient.invalidateQueries({ queryKey: ['consumer', tenantId, consumerId] });
+    },
+  });
+}
+
+/**
+ * Hook to activate a consumer
+ */
+export function useActivateConsumer(tenantId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<Consumer, Error, string>({
+    mutationFn: (consumerId) => consumersService.activateConsumer(tenantId, consumerId),
+    onSuccess: (_, consumerId) => {
+      queryClient.invalidateQueries({ queryKey: ['consumers', tenantId] });
+      queryClient.invalidateQueries({ queryKey: ['consumer', tenantId, consumerId] });
+    },
+  });
+}
+
+/**
+ * Hook to block a consumer
+ */
+export function useBlockConsumer(tenantId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<Consumer, Error, string>({
+    mutationFn: (consumerId) => consumersService.blockConsumer(tenantId, consumerId),
+    onSuccess: (_, consumerId) => {
+      queryClient.invalidateQueries({ queryKey: ['consumers', tenantId] });
+      queryClient.invalidateQueries({ queryKey: ['consumer', tenantId, consumerId] });
+    },
+  });
+}
+
+/**
+ * Hook to get consumer credentials
+ */
+export function useConsumerCredentials(
+  tenantId: string | undefined,
+  consumerId: string | undefined
+) {
+  return useQuery<ConsumerCredentials>({
+    queryKey: ['consumer-credentials', tenantId, consumerId],
+    queryFn: () => consumersService.getCredentials(tenantId!, consumerId!),
+    enabled: false, // Only fetch on demand
+    staleTime: 0, // Never cache credentials
+  });
+}

--- a/portal/src/hooks/usePlans.ts
+++ b/portal/src/hooks/usePlans.ts
@@ -1,0 +1,45 @@
+/**
+ * STOA Developer Portal - Plan Hooks
+ *
+ * React Query hooks for subscription plan operations (CAB-1121).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { plansService, ListPlansParams } from '../services/plans';
+import type { Plan, PaginatedResponse } from '../types';
+
+/**
+ * Hook to list plans for a tenant
+ */
+export function usePlans(tenantId: string | undefined, params?: ListPlansParams) {
+  return useQuery<PaginatedResponse<Plan>>({
+    queryKey: ['plans', tenantId, params],
+    queryFn: () => plansService.listPlans(tenantId!, params),
+    enabled: !!tenantId,
+    staleTime: 60 * 1000, // 1 minute - plans don't change often
+  });
+}
+
+/**
+ * Hook to get a single plan by ID
+ */
+export function usePlan(tenantId: string | undefined, planId: string | undefined) {
+  return useQuery<Plan>({
+    queryKey: ['plan', tenantId, planId],
+    queryFn: () => plansService.getPlan(tenantId!, planId!),
+    enabled: !!tenantId && !!planId,
+    staleTime: 60 * 1000, // 1 minute
+  });
+}
+
+/**
+ * Hook to get a plan by slug
+ */
+export function usePlanBySlug(tenantId: string | undefined, slug: string | undefined) {
+  return useQuery<Plan>({
+    queryKey: ['plan', tenantId, 'slug', slug],
+    queryFn: () => plansService.getPlanBySlug(tenantId!, slug!),
+    enabled: !!tenantId && !!slug,
+    staleTime: 60 * 1000, // 1 minute
+  });
+}

--- a/portal/src/pages/consumers/ConsumerDetailPage.tsx
+++ b/portal/src/pages/consumers/ConsumerDetailPage.tsx
@@ -1,0 +1,376 @@
+/**
+ * Consumer Detail Page
+ *
+ * Displays and manages a single external API consumer (CAB-1121).
+ */
+
+import { useState } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import {
+  ArrowLeft,
+  Users,
+  Loader2,
+  AlertCircle,
+  CheckCircle,
+  PauseCircle,
+  ShieldOff,
+  Clock,
+  Mail,
+  Building2,
+  Hash,
+  Key,
+  Play,
+  Pause,
+  Ban,
+  Trash2,
+} from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext';
+import {
+  useConsumer,
+  useDeleteConsumer,
+  useSuspendConsumer,
+  useActivateConsumer,
+  useBlockConsumer,
+} from '../../hooks/useConsumers';
+import { CredentialsDisplay } from '../../components/consumers/CredentialsDisplay';
+import type { ConsumerCredentials } from '../../types';
+
+const statusConfig = {
+  active: {
+    icon: CheckCircle,
+    color: 'text-green-500',
+    bg: 'bg-green-100 dark:bg-green-900/30',
+    text: 'text-green-800 dark:text-green-300',
+    label: 'Active',
+  },
+  suspended: {
+    icon: PauseCircle,
+    color: 'text-amber-500',
+    bg: 'bg-amber-100 dark:bg-amber-900/30',
+    text: 'text-amber-800 dark:text-amber-300',
+    label: 'Suspended',
+  },
+  blocked: {
+    icon: ShieldOff,
+    color: 'text-red-500',
+    bg: 'bg-red-100 dark:bg-red-900/30',
+    text: 'text-red-800 dark:text-red-300',
+    label: 'Blocked',
+  },
+};
+
+const formatDate = (dateString: string) => {
+  return new Date(dateString).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+export function ConsumerDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const tenantId = user?.tenant_id || '';
+
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [credentials, setCredentials] = useState<ConsumerCredentials | null>(null);
+
+  const { data: consumer, isLoading, isError, error } = useConsumer(tenantId || undefined, id);
+
+  const deleteMutation = useDeleteConsumer(tenantId);
+  const suspendMutation = useSuspendConsumer(tenantId);
+  const activateMutation = useActivateConsumer(tenantId);
+  const blockMutation = useBlockConsumer(tenantId);
+
+  const handleDelete = async () => {
+    if (id) {
+      await deleteMutation.mutateAsync(id);
+      navigate('/workspace?tab=consumers');
+    }
+  };
+
+  const handleSuspend = async () => {
+    if (id) await suspendMutation.mutateAsync(id);
+  };
+
+  const handleActivate = async () => {
+    if (id) {
+      const result = await activateMutation.mutateAsync(id);
+      // If the activation returns credentials, display them
+      if (result.keycloak_client_id) {
+        // Credentials would come from the credentials endpoint
+        // For now, we show that the consumer is activated
+      }
+    }
+  };
+
+  const handleBlock = async () => {
+    if (id) await blockMutation.mutateAsync(id);
+  };
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center">
+          <Loader2 className="h-8 w-8 text-primary-600 animate-spin mx-auto mb-4" />
+          <p className="text-gray-500 dark:text-neutral-400">Loading consumer...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (isError || !consumer) {
+    return (
+      <div className="space-y-6">
+        <Link
+          to="/workspace?tab=consumers"
+          className="inline-flex items-center text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" />
+          Back to Consumers
+        </Link>
+
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="h-5 w-5 text-red-500 mt-0.5" />
+            <div>
+              <h3 className="font-medium text-red-800 dark:text-red-300">
+                Failed to load consumer
+              </h3>
+              <p className="text-sm text-red-600 dark:text-red-400 mt-1">
+                {(error as Error)?.message || 'The consumer could not be found.'}
+              </p>
+              <Link
+                to="/workspace?tab=consumers"
+                className="mt-3 inline-block px-4 py-2 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-lg hover:bg-red-200 dark:hover:bg-red-900/50 text-sm font-medium transition-colors"
+              >
+                Return to Consumers
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const status = statusConfig[consumer.status] || statusConfig.active;
+  const StatusIcon = status.icon;
+  const isActionPending =
+    suspendMutation.isPending ||
+    activateMutation.isPending ||
+    blockMutation.isPending ||
+    deleteMutation.isPending;
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        to="/workspace?tab=consumers"
+        className="inline-flex items-center text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white"
+      >
+        <ArrowLeft className="h-4 w-4 mr-1" />
+        Back to Consumers
+      </Link>
+
+      {/* Header */}
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
+        <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+          <div className="flex-1">
+            <div className="flex items-center gap-3 mb-2">
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{consumer.name}</h1>
+              <span
+                className={`inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full ${status.bg} ${status.text}`}
+              >
+                <StatusIcon className={`h-3 w-3 ${status.color}`} />
+                {status.label}
+              </span>
+            </div>
+            <p className="text-gray-600 dark:text-neutral-300">
+              {consumer.description || 'No description provided'}
+            </p>
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center gap-2">
+            {consumer.status === 'suspended' && (
+              <button
+                onClick={handleActivate}
+                disabled={isActionPending}
+                className="inline-flex items-center gap-2 px-4 py-2 border border-green-300 dark:border-green-700 text-green-700 dark:text-green-400 rounded-lg hover:bg-green-50 dark:hover:bg-green-900/20 transition-colors disabled:opacity-50"
+              >
+                <Play className="h-4 w-4" />
+                Activate
+              </button>
+            )}
+            {consumer.status === 'active' && (
+              <button
+                onClick={handleSuspend}
+                disabled={isActionPending}
+                className="inline-flex items-center gap-2 px-4 py-2 border border-amber-300 dark:border-amber-700 text-amber-700 dark:text-amber-400 rounded-lg hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors disabled:opacity-50"
+              >
+                <Pause className="h-4 w-4" />
+                Suspend
+              </button>
+            )}
+            {consumer.status !== 'blocked' && (
+              <button
+                onClick={handleBlock}
+                disabled={isActionPending}
+                className="inline-flex items-center gap-2 px-4 py-2 border border-red-300 dark:border-red-700 text-red-700 dark:text-red-400 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-50"
+              >
+                <Ban className="h-4 w-4" />
+                Block
+              </button>
+            )}
+            <button
+              onClick={() => setShowDeleteConfirm(true)}
+              disabled={isActionPending}
+              className="inline-flex items-center gap-2 px-4 py-2 border border-red-300 dark:border-red-700 text-red-700 dark:text-red-400 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-50"
+            >
+              <Trash2 className="h-4 w-4" />
+              Delete
+            </button>
+          </div>
+        </div>
+
+        {/* Metadata */}
+        <div className="flex flex-wrap items-center gap-6 mt-6 pt-6 border-t border-gray-100 dark:border-neutral-700 text-sm text-gray-500 dark:text-neutral-400">
+          <div className="flex items-center gap-1">
+            <Clock className="h-4 w-4" />
+            Created {formatDate(consumer.created_at)}
+          </div>
+          {consumer.updated_at !== consumer.created_at && (
+            <div>Updated {formatDate(consumer.updated_at)}</div>
+          )}
+        </div>
+      </div>
+
+      {/* Details */}
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          Consumer Details
+        </h3>
+        <dl className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <dt className="text-sm font-medium text-gray-500 dark:text-neutral-400 flex items-center gap-1">
+              <Hash className="h-3.5 w-3.5" /> External ID
+            </dt>
+            <dd className="mt-1 text-sm text-gray-900 dark:text-white font-mono">
+              {consumer.external_id}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-sm font-medium text-gray-500 dark:text-neutral-400 flex items-center gap-1">
+              <Mail className="h-3.5 w-3.5" /> Email
+            </dt>
+            <dd className="mt-1 text-sm text-gray-900 dark:text-white">{consumer.email}</dd>
+          </div>
+          {consumer.company && (
+            <div>
+              <dt className="text-sm font-medium text-gray-500 dark:text-neutral-400 flex items-center gap-1">
+                <Building2 className="h-3.5 w-3.5" /> Company
+              </dt>
+              <dd className="mt-1 text-sm text-gray-900 dark:text-white">{consumer.company}</dd>
+            </div>
+          )}
+          {consumer.keycloak_client_id && (
+            <div>
+              <dt className="text-sm font-medium text-gray-500 dark:text-neutral-400 flex items-center gap-1">
+                <Key className="h-3.5 w-3.5" /> OAuth Client ID
+              </dt>
+              <dd className="mt-1 text-sm text-gray-900 dark:text-white font-mono">
+                {consumer.keycloak_client_id}
+              </dd>
+            </div>
+          )}
+          <div className="md:col-span-2">
+            <dt className="text-sm font-medium text-gray-500 dark:text-neutral-400 flex items-center gap-1">
+              <Users className="h-3.5 w-3.5" /> Description
+            </dt>
+            <dd className="mt-1 text-sm text-gray-900 dark:text-white">
+              {consumer.description || 'No description provided'}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* Credentials (if available) */}
+      {credentials && (
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+            OAuth Credentials
+          </h3>
+          <CredentialsDisplay credentials={credentials} />
+          <button
+            onClick={() => setCredentials(null)}
+            className="mt-4 text-sm text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-200"
+          >
+            Dismiss credentials
+          </button>
+        </div>
+      )}
+
+      {/* Delete Confirmation Modal */}
+      {showDeleteConfirm && (
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div
+            className="fixed inset-0 bg-black/50"
+            onClick={() => setShowDeleteConfirm(false)}
+            onKeyDown={(e) => e.key === 'Escape' && setShowDeleteConfirm(false)}
+            role="button"
+            aria-label="Close modal"
+            tabIndex={0}
+          />
+          <div className="flex min-h-full items-center justify-center p-4">
+            <div className="relative bg-white dark:bg-neutral-800 rounded-xl shadow-xl max-w-md w-full p-6">
+              <div className="flex items-start gap-4">
+                <div className="p-3 bg-red-100 dark:bg-red-900/30 rounded-full">
+                  <Trash2 className="h-6 w-6 text-red-600 dark:text-red-400" />
+                </div>
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                    Delete Consumer
+                  </h3>
+                  <p className="text-sm text-gray-600 dark:text-neutral-300 mt-2">
+                    Are you sure you want to delete &quot;{consumer.name}&quot;? This action cannot
+                    be undone and will revoke all OAuth credentials.
+                  </p>
+                </div>
+              </div>
+              <div className="flex justify-end gap-3 mt-6">
+                <button
+                  onClick={() => setShowDeleteConfirm(false)}
+                  disabled={deleteMutation.isPending}
+                  className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-neutral-300 hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg transition-colors disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleDelete}
+                  disabled={deleteMutation.isPending}
+                  className="inline-flex items-center gap-2 px-4 py-2 bg-red-600 text-white text-sm font-medium rounded-lg hover:bg-red-700 transition-colors disabled:opacity-50"
+                >
+                  {deleteMutation.isPending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Deleting...
+                    </>
+                  ) : (
+                    'Delete Consumer'
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ConsumerDetailPage;

--- a/portal/src/pages/consumers/ConsumerRegistrationPage.tsx
+++ b/portal/src/pages/consumers/ConsumerRegistrationPage.tsx
@@ -1,0 +1,273 @@
+/**
+ * Consumer Registration Page
+ *
+ * Full-page form to register a new consumer with plan selection (CAB-1121).
+ */
+
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowLeft, Loader2, AlertCircle, CheckCircle } from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext';
+import { useCreateConsumer } from '../../hooks/useConsumers';
+import { usePlans } from '../../hooks/usePlans';
+import { PlanSelector } from '../../components/consumers/PlanSelector';
+import type { ConsumerCreateRequest, Plan } from '../../types';
+
+export function ConsumerRegistrationPage() {
+  const { user } = useAuth();
+  const tenantId = user?.tenant_id || '';
+
+  const [name, setName] = useState('');
+  const [externalId, setExternalId] = useState('');
+  const [email, setEmail] = useState('');
+  const [company, setCompany] = useState('');
+  const [description, setDescription] = useState('');
+  const [selectedPlan, setSelectedPlan] = useState<Plan | null>(null);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const createMutation = useCreateConsumer(tenantId);
+  const { data: plansData, isLoading: plansLoading } = usePlans(tenantId || undefined, {
+    status: 'active',
+  });
+
+  const plans = plansData?.items || [];
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setCreateError(null);
+
+    const data: ConsumerCreateRequest = {
+      name: name.trim(),
+      external_id: externalId.trim(),
+      email: email.trim(),
+      company: company.trim() || undefined,
+      description: description.trim() || undefined,
+    };
+
+    try {
+      await createMutation.mutateAsync(data);
+      setIsSuccess(true);
+    } catch (err) {
+      setCreateError((err as Error)?.message || 'Failed to register consumer');
+    }
+  };
+
+  // Success state
+  if (isSuccess) {
+    return (
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-8 text-center">
+          <div className="inline-flex p-4 bg-green-100 dark:bg-green-900/30 rounded-full mb-4">
+            <CheckCircle className="h-8 w-8 text-green-500" />
+          </div>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+            Consumer Registered Successfully
+          </h2>
+          <p className="text-gray-500 dark:text-neutral-400 mb-6">
+            The consumer &quot;{name}&quot; has been registered. You can now manage their API access
+            from the consumers list.
+          </p>
+          <div className="flex items-center justify-center gap-3">
+            <Link
+              to="/workspace?tab=consumers"
+              className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
+            >
+              View Consumers
+            </Link>
+            <button
+              onClick={() => {
+                setName('');
+                setExternalId('');
+                setEmail('');
+                setCompany('');
+                setDescription('');
+                setSelectedPlan(null);
+                setIsSuccess(false);
+              }}
+              className="px-4 py-2 border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-neutral-300 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
+            >
+              Register Another
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      {/* Back link */}
+      <Link
+        to="/workspace?tab=consumers"
+        className="inline-flex items-center text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white"
+      >
+        <ArrowLeft className="h-4 w-4 mr-1" />
+        Back to Consumers
+      </Link>
+
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Register New Consumer</h1>
+        <p className="text-gray-500 dark:text-neutral-400 mt-1">
+          Register an external API consumer with OAuth credentials
+        </p>
+      </div>
+
+      {/* Form */}
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* Error */}
+        {createError && (
+          <div className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+            <AlertCircle className="h-5 w-5 text-red-500 mt-0.5" />
+            <p className="text-sm text-red-700 dark:text-red-300">{createError}</p>
+          </div>
+        )}
+
+        {/* Consumer Details */}
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6 space-y-4">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Consumer Details</h3>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label
+                htmlFor="reg-name"
+                className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
+              >
+                Name <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="reg-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="ACME Corp"
+                required
+                disabled={createMutation.isPending}
+                className="w-full px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:opacity-50"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="reg-external-id"
+                className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
+              >
+                External ID <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="reg-external-id"
+                type="text"
+                value={externalId}
+                onChange={(e) => setExternalId(e.target.value)}
+                placeholder="partner-acme-001"
+                required
+                disabled={createMutation.isPending}
+                className="w-full px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white font-mono text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:opacity-50"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="reg-email"
+                className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
+              >
+                Contact Email <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="reg-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="api@acme.com"
+                required
+                disabled={createMutation.isPending}
+                className="w-full px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:opacity-50"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="reg-company"
+                className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
+              >
+                Company
+              </label>
+              <input
+                id="reg-company"
+                type="text"
+                value={company}
+                onChange={(e) => setCompany(e.target.value)}
+                placeholder="ACME Corporation"
+                disabled={createMutation.isPending}
+                className="w-full px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:opacity-50"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label
+              htmlFor="reg-description"
+              className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
+            >
+              Description
+            </label>
+            <textarea
+              id="reg-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Brief description of this API consumer..."
+              rows={3}
+              disabled={createMutation.isPending}
+              className="w-full px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:opacity-50 resize-none"
+            />
+          </div>
+        </div>
+
+        {/* Plan Selection */}
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
+            Select a Plan
+          </h3>
+          <p className="text-sm text-gray-500 dark:text-neutral-400 mb-4">
+            Choose a subscription plan for this consumer (optional)
+          </p>
+          <PlanSelector
+            plans={plans}
+            selectedPlanId={selectedPlan?.id}
+            onSelect={setSelectedPlan}
+            isLoading={plansLoading}
+          />
+        </div>
+
+        {/* Submit */}
+        <div className="flex items-center justify-end gap-3">
+          <Link
+            to="/workspace?tab=consumers"
+            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-neutral-300 hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
+          >
+            Cancel
+          </Link>
+          <button
+            type="submit"
+            disabled={
+              createMutation.isPending || !name.trim() || !externalId.trim() || !email.trim()
+            }
+            className="inline-flex items-center gap-2 px-6 py-2 bg-primary-600 text-white text-sm font-medium rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {createMutation.isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Registering...
+              </>
+            ) : (
+              'Register Consumer'
+            )}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default ConsumerRegistrationPage;

--- a/portal/src/pages/consumers/ConsumersPage.test.tsx
+++ b/portal/src/pages/consumers/ConsumersPage.test.tsx
@@ -1,0 +1,163 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Tests for ConsumersPage (CAB-1121)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ConsumersPage } from './ConsumersPage';
+
+// Mock AuthContext
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'user-1', name: 'Test User', tenant_id: 'tenant-1', roles: ['tenant-admin'] },
+    isAuthenticated: true,
+    isReady: true,
+  }),
+}));
+
+// Mock consumer data
+const mockConsumers = [
+  {
+    id: 'c1',
+    name: 'ACME Corp',
+    external_id: 'acme-001',
+    email: 'api@acme.com',
+    company: 'ACME Corporation',
+    description: 'Strategic partner',
+    status: 'active',
+    tenant_id: 'tenant-1',
+    created_at: '2026-02-01T10:00:00Z',
+    updated_at: '2026-02-01T10:00:00Z',
+  },
+  {
+    id: 'c2',
+    name: 'Beta Inc',
+    external_id: 'beta-001',
+    email: 'dev@beta.com',
+    status: 'suspended',
+    tenant_id: 'tenant-1',
+    created_at: '2026-02-02T10:00:00Z',
+    updated_at: '2026-02-02T10:00:00Z',
+  },
+];
+
+const mockRefetch = vi.fn();
+const mockMutateAsync = vi.fn();
+
+// Mock hooks
+vi.mock('../../hooks/useConsumers', () => ({
+  useConsumers: () => ({
+    data: { items: mockConsumers, total: 2, page: 1, pageSize: 20, totalPages: 1 },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: mockRefetch,
+  }),
+  useCreateConsumer: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+}));
+
+// Mock ConsumerCard
+vi.mock('../../components/consumers/ConsumerCard', () => ({
+  ConsumerCard: ({ consumer }: { consumer: any }) => (
+    <div data-testid={`consumer-card-${consumer.id}`}>{consumer.name}</div>
+  ),
+}));
+
+// Mock CreateConsumerModal
+vi.mock('../../components/consumers/CreateConsumerModal', () => ({
+  CreateConsumerModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="create-modal">Create Modal</div> : null,
+}));
+
+describe('ConsumersPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the page title and description', () => {
+    render(
+      <MemoryRouter>
+        <ConsumersPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Consumers')).toBeInTheDocument();
+    expect(screen.getByText('Manage your external API consumers')).toBeInTheDocument();
+  });
+
+  it('should render consumer cards', () => {
+    render(
+      <MemoryRouter>
+        <ConsumersPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('consumer-card-c1')).toHaveTextContent('ACME Corp');
+    expect(screen.getByTestId('consumer-card-c2')).toHaveTextContent('Beta Inc');
+  });
+
+  it('should render stats cards', () => {
+    render(
+      <MemoryRouter>
+        <ConsumersPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Total')).toBeInTheDocument();
+    // "Active" appears in both stats card and filter dropdown, check for multiple
+    expect(screen.getAllByText('Active').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Suspended').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should render search input', () => {
+    render(
+      <MemoryRouter>
+        <ConsumersPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByPlaceholderText('Search by name, ID, or email...')).toBeInTheDocument();
+  });
+
+  it('should filter consumers by search query', () => {
+    render(
+      <MemoryRouter>
+        <ConsumersPage />
+      </MemoryRouter>
+    );
+
+    const searchInput = screen.getByPlaceholderText('Search by name, ID, or email...');
+    fireEvent.change(searchInput, { target: { value: 'ACME' } });
+
+    expect(screen.getByTestId('consumer-card-c1')).toBeInTheDocument();
+    expect(screen.queryByTestId('consumer-card-c2')).not.toBeInTheDocument();
+  });
+
+  it('should open create modal when Register Consumer button is clicked', () => {
+    render(
+      <MemoryRouter>
+        <ConsumersPage />
+      </MemoryRouter>
+    );
+
+    const button = screen.getByText('Register Consumer');
+    fireEvent.click(button);
+
+    expect(screen.getByTestId('create-modal')).toBeInTheDocument();
+  });
+
+  it('should display consumer count', () => {
+    render(
+      <MemoryRouter>
+        <ConsumersPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('2 consumers')).toBeInTheDocument();
+  });
+});

--- a/portal/src/pages/consumers/ConsumersPage.tsx
+++ b/portal/src/pages/consumers/ConsumersPage.tsx
@@ -1,0 +1,265 @@
+/**
+ * Consumers Page
+ *
+ * Lists external API consumers with stats, search, and creation modal (CAB-1121).
+ */
+
+import { useState, useMemo } from 'react';
+import {
+  Plus,
+  Users,
+  Loader2,
+  AlertCircle,
+  RefreshCw,
+  Search,
+  CheckCircle,
+  PauseCircle,
+  ShieldOff,
+} from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext';
+import { useConsumers, useCreateConsumer } from '../../hooks/useConsumers';
+import { ConsumerCard } from '../../components/consumers/ConsumerCard';
+import { CreateConsumerModal } from '../../components/consumers/CreateConsumerModal';
+import type { Consumer, ConsumerCreateRequest } from '../../types';
+
+export function ConsumersPage() {
+  const { user } = useAuth();
+  const tenantId = user?.tenant_id || '';
+
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+
+  const {
+    data: consumersData,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useConsumers(tenantId || undefined);
+  const createMutation = useCreateConsumer(tenantId);
+
+  const consumers = useMemo(() => consumersData?.items || [], [consumersData?.items]);
+
+  // Filter consumers by search and status
+  const filteredConsumers = useMemo(() => {
+    return consumers.filter((c: Consumer) => {
+      const matchesSearch =
+        !searchQuery ||
+        c.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        c.external_id.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        c.email.toLowerCase().includes(searchQuery.toLowerCase());
+      const matchesStatus = statusFilter === 'all' || c.status === statusFilter;
+      return matchesSearch && matchesStatus;
+    });
+  }, [consumers, searchQuery, statusFilter]);
+
+  // Stats
+  const stats = useMemo(() => {
+    const total = consumers.length;
+    const active = consumers.filter((c: Consumer) => c.status === 'active').length;
+    const suspended = consumers.filter((c: Consumer) => c.status === 'suspended').length;
+    const blocked = consumers.filter((c: Consumer) => c.status === 'blocked').length;
+    return { total, active, suspended, blocked };
+  }, [consumers]);
+
+  const handleCreateConsumer = async (data: ConsumerCreateRequest) => {
+    setCreateError(null);
+    try {
+      await createMutation.mutateAsync(data);
+      setIsCreateModalOpen(false);
+    } catch (err) {
+      setCreateError((err as Error)?.message || 'Failed to create consumer');
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Consumers</h1>
+          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+            Manage your external API consumers
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => refetch()}
+            disabled={isLoading}
+            className="p-2 text-gray-500 hover:text-gray-700 dark:hover:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg transition-colors disabled:opacity-50"
+            title="Refresh"
+          >
+            <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+          </button>
+          <button
+            onClick={() => setIsCreateModalOpen(true)}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
+          >
+            <Plus className="h-4 w-4" />
+            Register Consumer
+          </button>
+        </div>
+      </div>
+
+      {/* Stats Cards */}
+      {!isLoading && !isError && consumers.length > 0 && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4">
+            <div className="flex items-center gap-2 mb-1">
+              <Users className="h-4 w-4 text-gray-400" />
+              <span className="text-sm text-gray-500 dark:text-neutral-400">Total</span>
+            </div>
+            <p className="text-2xl font-bold text-gray-900 dark:text-white">{stats.total}</p>
+          </div>
+          <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4">
+            <div className="flex items-center gap-2 mb-1">
+              <CheckCircle className="h-4 w-4 text-green-500" />
+              <span className="text-sm text-gray-500 dark:text-neutral-400">Active</span>
+            </div>
+            <p className="text-2xl font-bold text-green-600 dark:text-green-400">{stats.active}</p>
+          </div>
+          <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4">
+            <div className="flex items-center gap-2 mb-1">
+              <PauseCircle className="h-4 w-4 text-amber-500" />
+              <span className="text-sm text-gray-500 dark:text-neutral-400">Suspended</span>
+            </div>
+            <p className="text-2xl font-bold text-amber-600 dark:text-amber-400">
+              {stats.suspended}
+            </p>
+          </div>
+          <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4">
+            <div className="flex items-center gap-2 mb-1">
+              <ShieldOff className="h-4 w-4 text-red-500" />
+              <span className="text-sm text-gray-500 dark:text-neutral-400">Blocked</span>
+            </div>
+            <p className="text-2xl font-bold text-red-600 dark:text-red-400">{stats.blocked}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Search & Filters */}
+      {!isLoading && !isError && consumers.length > 0 && (
+        <div className="flex flex-col sm:flex-row gap-3">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search by name, ID, or email..."
+              className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            />
+          </div>
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          >
+            <option value="all">All statuses</option>
+            <option value="active">Active</option>
+            <option value="suspended">Suspended</option>
+            <option value="blocked">Blocked</option>
+          </select>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {isLoading && (
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-12 text-center">
+          <Loader2 className="h-8 w-8 text-primary-600 animate-spin mx-auto mb-4" />
+          <p className="text-gray-500 dark:text-neutral-400">Loading consumers...</p>
+        </div>
+      )}
+
+      {/* Error state */}
+      {isError && (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="h-5 w-5 text-red-500 mt-0.5" />
+            <div>
+              <h3 className="font-medium text-red-800 dark:text-red-300">
+                Failed to load consumers
+              </h3>
+              <p className="text-sm text-red-600 dark:text-red-400 mt-1">
+                {(error as Error)?.message || 'An unexpected error occurred'}
+              </p>
+              <button
+                onClick={() => refetch()}
+                className="mt-3 px-4 py-2 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-lg hover:bg-red-200 dark:hover:bg-red-900/50 text-sm font-medium transition-colors"
+              >
+                Try Again
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && !isError && consumers.length === 0 && (
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-12 text-center">
+          <div className="inline-flex p-4 bg-gray-100 dark:bg-neutral-700 rounded-full mb-4">
+            <Users className="h-8 w-8 text-gray-400 dark:text-neutral-500" />
+          </div>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+            No Consumers Yet
+          </h2>
+          <p className="text-gray-500 dark:text-neutral-400 max-w-md mx-auto mb-6">
+            Register your first API consumer to start managing external access to your APIs. Each
+            consumer gets their own OAuth credentials.
+          </p>
+          <button
+            onClick={() => setIsCreateModalOpen(true)}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
+          >
+            <Plus className="h-4 w-4" />
+            Register Your First Consumer
+          </button>
+        </div>
+      )}
+
+      {/* Filtered empty state */}
+      {!isLoading && !isError && consumers.length > 0 && filteredConsumers.length === 0 && (
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-8 text-center">
+          <Search className="h-8 w-8 text-gray-300 dark:text-neutral-600 mx-auto mb-3" />
+          <p className="text-gray-500 dark:text-neutral-400">
+            No consumers match your search criteria
+          </p>
+        </div>
+      )}
+
+      {/* Consumers grid */}
+      {!isLoading && !isError && filteredConsumers.length > 0 && (
+        <>
+          <div className="text-sm text-gray-500 dark:text-neutral-400">
+            {filteredConsumers.length === 1
+              ? '1 consumer'
+              : `${filteredConsumers.length} consumers`}
+            {filteredConsumers.length !== consumers.length &&
+              ` (filtered from ${consumers.length})`}
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filteredConsumers.map((consumer: Consumer) => (
+              <ConsumerCard key={consumer.id} consumer={consumer} />
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Create Modal */}
+      <CreateConsumerModal
+        isOpen={isCreateModalOpen}
+        onClose={() => {
+          setIsCreateModalOpen(false);
+          setCreateError(null);
+        }}
+        onSubmit={handleCreateConsumer}
+        isLoading={createMutation.isPending}
+        error={createError}
+      />
+    </div>
+  );
+}
+
+export default ConsumersPage;

--- a/portal/src/pages/consumers/index.ts
+++ b/portal/src/pages/consumers/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Consumer Pages - Index
+ *
+ * Export all consumer-related pages for easy imports (CAB-1121).
+ */
+
+export { ConsumersPage } from './ConsumersPage';
+export { ConsumerDetailPage } from './ConsumerDetailPage';
+export { ConsumerRegistrationPage } from './ConsumerRegistrationPage';

--- a/portal/src/pages/workspace/WorkspacePage.tsx
+++ b/portal/src/pages/workspace/WorkspacePage.tsx
@@ -1,6 +1,6 @@
 import { useSearchParams } from 'react-router-dom';
 import { Suspense, lazy } from 'react';
-import { AppWindow, CreditCard, FileCode2 } from 'lucide-react';
+import { AppWindow, CreditCard, FileCode2, Users } from 'lucide-react';
 
 const MyApplications = lazy(() => import('../apps').then((m) => ({ default: m.MyApplications })));
 const MySubscriptions = lazy(() =>
@@ -9,11 +9,15 @@ const MySubscriptions = lazy(() =>
 const ContractListPage = lazy(() =>
   import('../contracts').then((m) => ({ default: m.ContractListPage }))
 );
+const ConsumersPage = lazy(() =>
+  import('../consumers').then((m) => ({ default: m.ConsumersPage }))
+);
 
 const tabs = [
   { id: 'apps', label: 'Apps', icon: AppWindow },
   { id: 'subscriptions', label: 'Subscriptions', icon: CreditCard },
   { id: 'contracts', label: 'Contracts', icon: FileCode2 },
+  { id: 'consumers', label: 'Consumers', icon: Users },
 ] as const;
 
 type TabId = (typeof tabs)[number]['id'];
@@ -41,7 +45,7 @@ export function WorkspacePage() {
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-white">My Workspace</h1>
         <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
-          Manage your apps, subscriptions, and contracts
+          Manage your apps, subscriptions, contracts, and consumers
         </p>
       </div>
 
@@ -73,6 +77,7 @@ export function WorkspacePage() {
         {activeTab === 'apps' && <MyApplications />}
         {activeTab === 'subscriptions' && <MySubscriptions />}
         {activeTab === 'contracts' && <ContractListPage />}
+        {activeTab === 'consumers' && <ConsumersPage />}
       </Suspense>
     </div>
   );

--- a/portal/src/services/consumers.ts
+++ b/portal/src/services/consumers.ts
@@ -1,0 +1,118 @@
+/**
+ * STOA Developer Portal - Consumers Service
+ *
+ * Service for managing external API consumers (CAB-1121).
+ */
+
+import { apiClient } from './api';
+import type {
+  Consumer,
+  ConsumerCreateRequest,
+  ConsumerUpdateRequest,
+  ConsumerCredentials,
+  PaginatedResponse,
+} from '../types';
+
+export interface ListConsumersParams {
+  page?: number;
+  pageSize?: number;
+  status?: 'active' | 'suspended' | 'blocked';
+  search?: string;
+}
+
+export const consumersService = {
+  /**
+   * List consumers for a tenant
+   */
+  listConsumers: async (
+    tenantId: string,
+    params?: ListConsumersParams
+  ): Promise<PaginatedResponse<Consumer>> => {
+    const response = await apiClient.get<PaginatedResponse<Consumer>>(`/v1/consumers/${tenantId}`, {
+      params: {
+        page: params?.page || 1,
+        page_size: params?.pageSize || 20,
+        status: params?.status,
+        search: params?.search,
+      },
+    });
+    return response.data;
+  },
+
+  /**
+   * Get a single consumer by ID
+   */
+  getConsumer: async (tenantId: string, consumerId: string): Promise<Consumer> => {
+    const response = await apiClient.get<Consumer>(`/v1/consumers/${tenantId}/${consumerId}`);
+    return response.data;
+  },
+
+  /**
+   * Create a new consumer
+   */
+  createConsumer: async (tenantId: string, data: ConsumerCreateRequest): Promise<Consumer> => {
+    const response = await apiClient.post<Consumer>(`/v1/consumers/${tenantId}`, data);
+    return response.data;
+  },
+
+  /**
+   * Update an existing consumer
+   */
+  updateConsumer: async (
+    tenantId: string,
+    consumerId: string,
+    data: ConsumerUpdateRequest
+  ): Promise<Consumer> => {
+    const response = await apiClient.put<Consumer>(`/v1/consumers/${tenantId}/${consumerId}`, data);
+    return response.data;
+  },
+
+  /**
+   * Delete a consumer
+   */
+  deleteConsumer: async (tenantId: string, consumerId: string): Promise<void> => {
+    await apiClient.delete(`/v1/consumers/${tenantId}/${consumerId}`);
+  },
+
+  /**
+   * Suspend a consumer
+   */
+  suspendConsumer: async (tenantId: string, consumerId: string): Promise<Consumer> => {
+    const response = await apiClient.post<Consumer>(
+      `/v1/consumers/${tenantId}/${consumerId}/suspend`
+    );
+    return response.data;
+  },
+
+  /**
+   * Activate a consumer
+   */
+  activateConsumer: async (tenantId: string, consumerId: string): Promise<Consumer> => {
+    const response = await apiClient.post<Consumer>(
+      `/v1/consumers/${tenantId}/${consumerId}/activate`
+    );
+    return response.data;
+  },
+
+  /**
+   * Block a consumer
+   */
+  blockConsumer: async (tenantId: string, consumerId: string): Promise<Consumer> => {
+    const response = await apiClient.post<Consumer>(
+      `/v1/consumers/${tenantId}/${consumerId}/block`
+    );
+    return response.data;
+  },
+
+  /**
+   * Get consumer credentials (one-time display)
+   */
+  getCredentials: async (tenantId: string, consumerId: string): Promise<ConsumerCredentials> => {
+    const response = await apiClient.get<ConsumerCredentials>(
+      `/v1/consumers/${tenantId}/${consumerId}/credentials`
+    );
+    return response.data;
+  },
+};
+
+export default consumersService;

--- a/portal/src/services/plans.ts
+++ b/portal/src/services/plans.ts
@@ -1,0 +1,51 @@
+/**
+ * STOA Developer Portal - Plans Service
+ *
+ * Service for managing subscription plans (CAB-1121).
+ */
+
+import { apiClient } from './api';
+import type { Plan, PaginatedResponse } from '../types';
+
+export interface ListPlansParams {
+  page?: number;
+  pageSize?: number;
+  status?: 'active' | 'deprecated' | 'archived';
+}
+
+export const plansService = {
+  /**
+   * List plans for a tenant
+   */
+  listPlans: async (
+    tenantId: string,
+    params?: ListPlansParams
+  ): Promise<PaginatedResponse<Plan>> => {
+    const response = await apiClient.get<PaginatedResponse<Plan>>(`/v1/plans/${tenantId}`, {
+      params: {
+        page: params?.page || 1,
+        page_size: params?.pageSize || 20,
+        status: params?.status,
+      },
+    });
+    return response.data;
+  },
+
+  /**
+   * Get a single plan by ID
+   */
+  getPlan: async (tenantId: string, planId: string): Promise<Plan> => {
+    const response = await apiClient.get<Plan>(`/v1/plans/${tenantId}/${planId}`);
+    return response.data;
+  },
+
+  /**
+   * Get a plan by slug
+   */
+  getPlanBySlug: async (tenantId: string, slug: string): Promise<Plan> => {
+    const response = await apiClient.get<Plan>(`/v1/plans/${tenantId}/by-slug/${slug}`);
+    return response.data;
+  },
+};
+
+export default plansService;

--- a/portal/src/types/index.ts
+++ b/portal/src/types/index.ts
@@ -748,3 +748,65 @@ export interface PublishContractResponse {
   created_at: string;
   updated_at: string;
 }
+
+// ============ Consumer Types (CAB-1121) ============
+
+export interface Consumer {
+  id: string;
+  external_id: string;
+  name: string;
+  email: string;
+  company?: string | null;
+  description?: string | null;
+  tenant_id: string;
+  keycloak_user_id?: string | null;
+  keycloak_client_id?: string | null;
+  status: 'active' | 'suspended' | 'blocked';
+  consumer_metadata?: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+  created_by?: string | null;
+}
+
+export interface ConsumerCreateRequest {
+  external_id: string;
+  name: string;
+  email: string;
+  company?: string;
+  description?: string;
+}
+
+export interface ConsumerUpdateRequest {
+  name?: string;
+  email?: string;
+  company?: string;
+  description?: string;
+}
+
+export interface ConsumerCredentials {
+  consumer_id: string;
+  client_id: string;
+  client_secret: string;
+  token_endpoint: string;
+  grant_type: string;
+}
+
+export interface Plan {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string | null;
+  tenant_id: string;
+  rate_limit_per_second?: number | null;
+  rate_limit_per_minute?: number | null;
+  daily_request_limit?: number | null;
+  monthly_request_limit?: number | null;
+  burst_limit?: number | null;
+  requires_approval: boolean;
+  auto_approve_roles?: string[] | null;
+  status: 'active' | 'deprecated' | 'archived';
+  pricing_metadata?: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+  created_by?: string | null;
+}


### PR DESCRIPTION
## Summary

- **Types** — Consumer, Plan, ConsumerCreateRequest, ConsumerCredentials matching actual API schemas
- **Services** — consumers.ts (CRUD + suspend/activate/block/credentials), plans.ts (list + detail + by-slug)
- **React Query hooks** — useConsumers (8 hooks), usePlans (3 hooks) with cache invalidation
- **Components** — ConsumerCard, CreateConsumerModal (form validation), PlanSelector (quota display), CredentialsDisplay (one-time, copy-to-clipboard)
- **Pages** — ConsumersPage (stats cards, search, filter, grid), ConsumerDetailPage (status actions, delete), ConsumerRegistrationPage (form + plan selection)
- **Navigation** — Consumers tab in WorkspacePage, 3 routes in App.tsx with ProtectedRoute

## Files Changed (20 files, +2,686 lines)

- `portal/src/types/index.ts` — Consumer + Plan interfaces
- `portal/src/services/` — consumers.ts, plans.ts
- `portal/src/hooks/` — useConsumers.ts, usePlans.ts
- `portal/src/components/consumers/` — 4 components + 4 test files
- `portal/src/pages/consumers/` — 3 pages + 1 test + barrel index
- `portal/src/pages/workspace/WorkspacePage.tsx` — Consumers tab
- `portal/src/App.tsx` — lazy routes

## Test plan

- [x] 46 new tests (282 total), vitest passes
- [x] 0 TypeScript errors (tsc --noEmit)
- [x] 14 ESLint warnings (max 20)
- [x] Prettier clean
- [x] Pre-commit hooks pass (lint-staged)
- [ ] CI green on PR
- [ ] Merge + deploy + verify pod updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)