### PR TITLE
feat(gateway): circuit breaker registry + zombie session reaper (CAB-362)

### DIFF
--- a/stoa-gateway/src/config.rs
+++ b/stoa-gateway/src/config.rs
@@ -200,6 +200,22 @@ pub struct Config {
     /// Env: STOA_K8S_ENABLED (default: false — explicit opt-in)
     #[serde(default)]
     pub k8s_enabled: bool,
+
+    // === Per-Upstream Circuit Breaker (CAB-362) ===
+    /// Failure threshold before opening circuit (default: 5)
+    /// Env: STOA_CB_FAILURE_THRESHOLD
+    #[serde(default = "default_cb_failure_threshold")]
+    pub cb_failure_threshold: u32,
+
+    /// Reset timeout in seconds before trying half-open (default: 30)
+    /// Env: STOA_CB_RESET_TIMEOUT_SECS
+    #[serde(default = "default_cb_reset_timeout_secs")]
+    pub cb_reset_timeout_secs: u64,
+
+    /// Successes needed in half-open to close circuit (default: 2)
+    /// Env: STOA_CB_SUCCESS_THRESHOLD
+    #[serde(default = "default_cb_success_threshold")]
+    pub cb_success_threshold: u32,
 }
 
 fn default_port() -> u16 {
@@ -266,6 +282,18 @@ fn default_kafka_errors_topic() -> String {
     "stoa.errors".to_string()
 }
 
+fn default_cb_failure_threshold() -> u32 {
+    5
+}
+
+fn default_cb_reset_timeout_secs() -> u64 {
+    30
+}
+
+fn default_cb_success_threshold() -> u32 {
+    2
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -310,6 +338,9 @@ impl Default for Config {
             kafka_metering_topic: default_kafka_metering_topic(),
             kafka_errors_topic: default_kafka_errors_topic(),
             k8s_enabled: false,
+            cb_failure_threshold: default_cb_failure_threshold(),
+            cb_reset_timeout_secs: default_cb_reset_timeout_secs(),
+            cb_success_threshold: default_cb_success_threshold(),
         }
     }
 }

--- a/stoa-gateway/src/governance/zombie.rs
+++ b/stoa-gateway/src/governance/zombie.rs
@@ -370,6 +370,27 @@ impl ZombieDetector {
         }
     }
 
+    /// Reap dead sessions (Revoked + Zombie) from the tracked map.
+    /// Returns the IDs of reaped sessions for cross-removal from SessionManager.
+    pub async fn reap_dead_sessions(&self) -> Vec<String> {
+        let mut sessions = self.sessions.write().await;
+        let reaped: Vec<String> = sessions
+            .iter()
+            .filter(|(_, s)| matches!(s.health, SessionHealth::Revoked | SessionHealth::Zombie))
+            .map(|(id, _)| id.clone())
+            .collect();
+        for id in &reaped {
+            sessions.remove(id);
+        }
+        if !reaped.is_empty() {
+            info!(
+                count = reaped.len(),
+                "Reaped dead sessions (zombie/revoked)"
+            );
+        }
+        reaped
+    }
+
     /// End a session (normal termination)
     pub async fn end_session(&self, session_id: &str) {
         let mut sessions = self.sessions.write().await;

--- a/stoa-gateway/src/handlers/admin.rs
+++ b/stoa-gateway/src/handlers/admin.rs
@@ -231,6 +231,68 @@ pub async fn cache_clear(State(state): State<AppState>) -> impl IntoResponse {
 }
 
 // =============================================================================
+// Session Stats (CAB-362)
+// =============================================================================
+
+#[derive(Serialize)]
+pub struct SessionStatsResponse {
+    pub active_sessions: usize,
+    pub zombie_count: usize,
+    pub tracked_sessions: usize,
+}
+
+/// GET /admin/sessions/stats
+pub async fn session_stats(State(state): State<AppState>) -> Json<SessionStatsResponse> {
+    if let Some(ref zd) = state.zombie_detector {
+        let stats = zd.stats().await;
+        Json(SessionStatsResponse {
+            active_sessions: stats.healthy + stats.warning,
+            zombie_count: stats.zombie,
+            tracked_sessions: stats.total_sessions,
+        })
+    } else {
+        Json(SessionStatsResponse {
+            active_sessions: state.session_manager.count(),
+            zombie_count: 0,
+            tracked_sessions: 0,
+        })
+    }
+}
+
+// =============================================================================
+// Per-Upstream Circuit Breakers (CAB-362)
+// =============================================================================
+
+/// GET /admin/circuit-breakers
+pub async fn circuit_breakers_list(
+    State(state): State<AppState>,
+) -> Json<Vec<crate::resilience::CircuitBreakerStatsEntry>> {
+    Json(state.circuit_breakers.stats_all())
+}
+
+/// POST /admin/circuit-breakers/:name/reset
+pub async fn circuit_breaker_reset_by_name(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    if state.circuit_breakers.reset(&name) {
+        (
+            StatusCode::OK,
+            Json(
+                serde_json::json!({"status": "ok", "message": format!("Circuit breaker '{}' reset", name)}),
+            ),
+        )
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(
+                serde_json::json!({"status": "error", "message": format!("Circuit breaker '{}' not found", name)}),
+            ),
+        )
+    }
+}
+
+// =============================================================================
 // Tests
 // =============================================================================
 

--- a/stoa-gateway/src/main.rs
+++ b/stoa-gateway/src/main.rs
@@ -202,6 +202,13 @@ fn build_router(state: AppState) -> Router {
         // Phase 6: Cache admin
         .route("/cache/stats", get(admin::cache_stats))
         .route("/cache/clear", post(admin::cache_clear))
+        // CAB-362: Session stats + per-upstream circuit breakers
+        .route("/sessions/stats", get(admin::session_stats))
+        .route("/circuit-breakers", get(admin::circuit_breakers_list))
+        .route(
+            "/circuit-breakers/:name/reset",
+            post(admin::circuit_breaker_reset_by_name),
+        )
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             admin::admin_auth,

--- a/stoa-gateway/src/proxy/dynamic.rs
+++ b/stoa-gateway/src/proxy/dynamic.rs
@@ -60,6 +60,21 @@ pub async fn dynamic_proxy(State(state): State<AppState>, request: Request<Body>
             .into_response();
     }
 
+    // Per-upstream circuit breaker (CAB-362)
+    let cb = state.circuit_breakers.get_or_create(&route.id);
+    if !cb.allow_request() {
+        warn!(
+            route_id = %route.id,
+            route_name = %route.name,
+            "Circuit breaker open for upstream"
+        );
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("Circuit breaker open for upstream: {}", route.name),
+        )
+            .into_response();
+    }
+
     // Build target URL: replace path_prefix with backend_url
     let remaining_path = path.strip_prefix(&route.path_prefix).unwrap_or("");
     let target_url = format!(
@@ -82,7 +97,16 @@ pub async fn dynamic_proxy(State(state): State<AppState>, request: Request<Body>
         "Dynamic proxy: forwarding request"
     );
 
-    forward_request(request, &method, &target_url).await
+    let response = forward_request(request, &method, &target_url).await;
+
+    // Record success/failure for circuit breaker
+    if response.status().is_server_error() {
+        cb.record_failure();
+    } else {
+        cb.record_success();
+    }
+
+    response
 }
 
 /// Forward request to the backend, reusing the webMethods proxy pattern.

--- a/stoa-gateway/src/resilience/circuit_breaker.rs
+++ b/stoa-gateway/src/resilience/circuit_breaker.rs
@@ -10,6 +10,8 @@
 #![allow(dead_code)]
 
 use parking_lot::RwLock;
+use serde::Serialize;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -304,6 +306,95 @@ impl CircuitBreaker {
     pub fn name(&self) -> &str {
         &self.name
     }
+}
+
+// =============================================================================
+// Circuit Breaker Registry (CAB-362)
+// =============================================================================
+
+/// Thread-safe registry of per-upstream circuit breakers.
+///
+/// Each upstream backend gets its own circuit breaker, created lazily on first
+/// request. This prevents a single unhealthy upstream from cascading failures
+/// to all other upstreams routed through the dynamic proxy.
+pub struct CircuitBreakerRegistry {
+    breakers: RwLock<HashMap<String, Arc<CircuitBreaker>>>,
+    default_config: CircuitBreakerConfig,
+}
+
+impl CircuitBreakerRegistry {
+    /// Create a new registry with the given default config for new circuit breakers.
+    pub fn new(default_config: CircuitBreakerConfig) -> Self {
+        Self {
+            breakers: RwLock::new(HashMap::new()),
+            default_config,
+        }
+    }
+
+    /// Get an existing circuit breaker or create a new one for the given upstream name.
+    pub fn get_or_create(&self, name: &str) -> Arc<CircuitBreaker> {
+        // Fast path: read lock
+        {
+            let breakers = self.breakers.read();
+            if let Some(cb) = breakers.get(name) {
+                return cb.clone();
+            }
+        }
+
+        // Slow path: write lock to insert
+        let mut breakers = self.breakers.write();
+        // Double-check after acquiring write lock
+        if let Some(cb) = breakers.get(name) {
+            return cb.clone();
+        }
+
+        let cb = CircuitBreaker::new(name, self.default_config.clone());
+        breakers.insert(name.to_string(), cb.clone());
+        cb
+    }
+
+    /// Get stats for all circuit breakers.
+    pub fn stats_all(&self) -> Vec<CircuitBreakerStatsEntry> {
+        let breakers = self.breakers.read();
+        breakers
+            .iter()
+            .map(|(name, cb)| {
+                let stats = cb.stats();
+                CircuitBreakerStatsEntry {
+                    name: name.clone(),
+                    state: stats.state.to_string(),
+                    success_count: stats.success_count,
+                    failure_count: stats.failure_count,
+                    consecutive_failures: stats.consecutive_failures,
+                    open_count: stats.open_count,
+                    rejected_count: stats.rejected_count,
+                }
+            })
+            .collect()
+    }
+
+    /// Reset a specific circuit breaker by name.
+    pub fn reset(&self, name: &str) -> bool {
+        let breakers = self.breakers.read();
+        if let Some(cb) = breakers.get(name) {
+            cb.reset();
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Stats entry for a single circuit breaker in the registry.
+#[derive(Debug, Clone, Serialize)]
+pub struct CircuitBreakerStatsEntry {
+    pub name: String,
+    pub state: String,
+    pub success_count: u64,
+    pub failure_count: u64,
+    pub consecutive_failures: u32,
+    pub open_count: u64,
+    pub rejected_count: u64,
 }
 
 /// Circuit breaker error

--- a/stoa-gateway/src/resilience/mod.rs
+++ b/stoa-gateway/src/resilience/mod.rs
@@ -22,6 +22,7 @@ mod circuit_breaker;
 mod retry;
 
 pub use circuit_breaker::{CircuitBreaker, CircuitBreakerConfig, CircuitBreakerError};
+pub use circuit_breaker::{CircuitBreakerRegistry, CircuitBreakerStatsEntry};
 #[allow(unused_imports)]
 pub use circuit_breaker::{CircuitBreakerStats, CircuitState};
 pub use retry::{retry_with_backoff, RetryConfig};

--- a/stoa-gateway/src/state.rs
+++ b/stoa-gateway/src/state.rs
@@ -10,12 +10,13 @@ use crate::auth::oidc::{OidcProvider, OidcProviderConfig};
 use crate::cache::{SemanticCache, SemanticCacheConfig};
 use crate::config::Config;
 use crate::control_plane::{OidcConfig, ToolProxyClient};
+use crate::governance::zombie::{ZombieConfig, ZombieDetector};
 use crate::mcp::session::SessionManager;
 use crate::mcp::tools::ToolRegistry;
 use crate::metering::{KafkaConfig, MeteringProducer, MeteringProducerConfig};
 use crate::policy::{PolicyDecision, PolicyEngine, PolicyEngineConfig, PolicyInput};
 use crate::rate_limit::RateLimiter;
-use crate::resilience::{CircuitBreaker, CircuitBreakerConfig};
+use crate::resilience::{CircuitBreaker, CircuitBreakerConfig, CircuitBreakerRegistry};
 use crate::routes::{PolicyRegistry, RouteRegistry};
 use crate::uac::Action;
 
@@ -41,6 +42,11 @@ pub struct AppState {
     /// Kafka metering producer (Phase 3: CAB-1105)
     /// None if Kafka metering is disabled or unavailable.
     pub metering_producer: Option<Arc<MeteringProducer>>,
+    /// Zombie session detector (CAB-362)
+    /// None if zombie detection is disabled.
+    pub zombie_detector: Option<Arc<ZombieDetector>>,
+    /// Per-upstream circuit breaker registry (CAB-362)
+    pub circuit_breakers: Arc<CircuitBreakerRegistry>,
 }
 
 impl AppState {
@@ -142,6 +148,30 @@ impl AppState {
         let cp_circuit_breaker = CircuitBreaker::new("cp-api", CircuitBreakerConfig::default());
         tracing::info!("Circuit breaker initialized for CP API");
 
+        // Initialize zombie detector (CAB-362)
+        let zombie_detector = if config.zombie_detection_enabled {
+            let zd = Arc::new(ZombieDetector::new(ZombieConfig {
+                session_ttl_secs: config.agent_session_ttl_secs,
+                attestation_interval: config.attestation_interval,
+                ..ZombieConfig::default()
+            }));
+            tracing::info!("Zombie session detector initialized");
+            Some(zd)
+        } else {
+            tracing::info!("Zombie detection disabled");
+            None
+        };
+
+        // Initialize per-upstream circuit breaker registry (CAB-362)
+        let cb_config = CircuitBreakerConfig {
+            failure_threshold: config.cb_failure_threshold,
+            reset_timeout: std::time::Duration::from_secs(config.cb_reset_timeout_secs),
+            success_threshold: config.cb_success_threshold,
+            ..CircuitBreakerConfig::default()
+        };
+        let circuit_breakers = Arc::new(CircuitBreakerRegistry::new(cb_config));
+        tracing::info!("Per-upstream circuit breaker registry initialized");
+
         // Initialize Kafka metering producer (Phase 3: CAB-1105)
         let metering_producer = if config.kafka_enabled {
             let kafka_config = KafkaConfig {
@@ -183,6 +213,8 @@ impl AppState {
             semantic_cache,
             cp_circuit_breaker,
             metering_producer,
+            zombie_detector,
+            circuit_breakers,
         }
     }
 
@@ -193,6 +225,26 @@ impl AppState {
 
         // Start rate limiter cleanup
         self.rate_limiter.clone().start_cleanup_task();
+
+        // Start zombie reaper (CAB-362)
+        if let Some(ref zd) = self.zombie_detector {
+            let zombie_detector = zd.clone();
+            let session_manager = self.session_manager.clone();
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
+                loop {
+                    interval.tick().await;
+                    // Mark zombies first
+                    zombie_detector.check_zombies().await;
+                    // Reap dead sessions and cross-remove from SessionManager
+                    let reaped = zombie_detector.reap_dead_sessions().await;
+                    for id in &reaped {
+                        session_manager.remove(id).await;
+                    }
+                }
+            });
+            tracing::info!("Zombie reaper background task started (60s interval)");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- **Per-upstream circuit breaker registry**: each backend gets its own CB via `CircuitBreakerRegistry` (thread-safe `RwLock<HashMap>`), preventing cascading failures across upstreams in the dynamic proxy
- **Zombie session reaper**: `ZombieDetector` wired into `AppState` with 60s background task that marks zombies via `check_zombies()` then reaps dead sessions (Revoked + Zombie) and cross-removes from `SessionManager`
- **3 new admin endpoints**: `GET /admin/sessions/stats`, `GET /admin/circuit-breakers`, `POST /admin/circuit-breakers/:name/reset`
- **Config**: `cb_failure_threshold` (5), `cb_reset_timeout_secs` (30), `cb_success_threshold` (2)

## Files changed (8)
| File | Changes |
|------|---------|
| `config.rs` | CB config fields + defaults |
| `governance/zombie.rs` | `reap_dead_sessions()` method |
| `resilience/circuit_breaker.rs` | `CircuitBreakerRegistry` struct |
| `resilience/mod.rs` | Export registry |
| `state.rs` | Wire ZombieDetector + CircuitBreakerRegistry, reaper task |
| `proxy/dynamic.rs` | Per-route CB check + record success/failure |
| `handlers/admin.rs` | Session stats + multi-CB admin endpoints |
| `main.rs` | Wire 3 new admin routes |

## Test plan
- [x] `cargo check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] `cargo test` — 267 tests pass (0 failures)
- [ ] CI green (security-scan: License Compliance, SBOM, Signed Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)