### PR TITLE
fix(gateway): replace invalid unicode escape in admin_auth

### DIFF
--- a/stoa-gateway/src/handlers/admin.rs
+++ b/stoa-gateway/src/handlers/admin.rs
@@ -34,7 +34,7 @@ use crate::state::AppState;
 ///
 /// Validates the `Authorization: Bearer <token>` header against
 /// `config.admin_api_token`. If no token is configured, returns 503
-/// (admin API disabled \u2014 no token configured).
+/// (admin API disabled -- no token configured).
 pub async fn admin_auth(
     State(state): State<AppState>,
     request: Request<Body>,
@@ -44,10 +44,11 @@ pub async fn admin_auth(
         Some(token) if !token.is_empty() => token,
         _ => {
             warn!("Admin API request rejected: no admin_api_token configured");
-            return Err(
-                (StatusCode::SERVICE_UNAVAILABLE, "Admin API disabled \u2014 no admin_api_token configured")
-                    .into_response(),
-            );
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Admin API disabled - no admin_api_token configured",
+            )
+                .into_response());
         }
     };
 


### PR DESCRIPTION
## Summary
- Replace `\u2014` (invalid Rust unicode escape) with ASCII dash `-` in admin_auth error message
- Fixes gateway CI fmt/clippy failures blocking Docker build + deploy pipeline

## Context
CAB-1122 introduced `\u2014` em-dash in a string literal. Rust requires `\u{2014}` syntax with curly braces. This blocked all gateway CI runs since merge.

## Test plan
- [x] `cargo check` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)