### PR TITLE
feat(ui,portal): animated splash screen with theme-aware loading

### DIFF
--- a/control-plane-ui/index.html
+++ b/control-plane-ui/index.html
@@ -11,8 +11,42 @@
     <link rel="dns-prefetch" href="https://auth.gostoa.dev">
     <link rel="preconnect" href="https://api.gostoa.dev" crossorigin>
     <link rel="dns-prefetch" href="https://api.gostoa.dev">
+    <!-- Prevent flash of wrong theme — runs before first paint -->
+    <script>
+      (function(){var t=localStorage.getItem('stoa-theme');var d=t==='dark'||(t!=='light'&&window.matchMedia('(prefers-color-scheme:dark)').matches);if(d)document.documentElement.classList.add('dark')})()
+    </script>
+    <style>
+      #stoa-splash{position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;background:#f9fafb;transition:opacity .5s cubic-bezier(.4,0,.2,1)}
+      .dark #stoa-splash{background:#171717}
+      #stoa-splash.hide{opacity:0;pointer-events:none}
+      .stoa-sp-wrap{animation:stoa-breathe 2.5s ease-in-out infinite}
+      .stoa-sp-svg{animation:stoa-glow 2.5s ease-in-out infinite}
+      .stoa-sp-ring{animation:stoa-ring 2.5s linear infinite;transform-origin:16px 16px}
+      .stoa-sp-d1{animation:stoa-dot 1.6s ease-in-out 0s infinite}
+      .stoa-sp-d2{animation:stoa-dot 1.6s ease-in-out .2s infinite}
+      .stoa-sp-d3{animation:stoa-dot 1.6s ease-in-out .4s infinite}
+      .stoa-sp-d4{animation:stoa-dot 1.6s ease-in-out .6s infinite}
+      @keyframes stoa-breathe{0%,100%{transform:scale(1)}50%{transform:scale(1.06)}}
+      @keyframes stoa-glow{0%,100%{filter:drop-shadow(0 0 10px rgba(5,150,105,.2))}50%{filter:drop-shadow(0 0 28px rgba(5,150,105,.5))}}
+      @keyframes stoa-ring{from{transform:rotate(0)}to{transform:rotate(360deg)}}
+      @keyframes stoa-dot{0%,100%{opacity:.4}50%{opacity:1}}
+    </style>
   </head>
   <body>
+    <div id="stoa-splash" aria-live="polite" aria-label="Loading STOA Control Plane">
+      <div class="stoa-sp-wrap">
+        <svg viewBox="-2 -2 36 36" width="64" height="64" class="stoa-sp-svg" aria-hidden="true">
+          <circle cx="16" cy="16" r="17" fill="none" stroke="#059669" stroke-width="1.2" stroke-dasharray="27 80" stroke-linecap="round" class="stoa-sp-ring" opacity=".5"/>
+          <defs><linearGradient id="sg" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#047857"/><stop offset="100%" stop-color="#059669"/></linearGradient></defs>
+          <circle cx="16" cy="16" r="15" fill="url(#sg)"/>
+          <path d="M10 11 Q10 8,16 8 Q22 8,22 11 Q22 14,16 14 Q10 14,10 17 Q10 20,16 20 Q22 20,22 24 Q22 27,16 27" stroke="white" stroke-width="2.5" stroke-linecap="round" fill="none"/>
+          <circle cx="8" cy="14" r="1.5" fill="white" class="stoa-sp-d1"/>
+          <circle cx="24" cy="14" r="1.5" fill="white" class="stoa-sp-d2"/>
+          <circle cx="8" cy="20" r="1.5" fill="white" class="stoa-sp-d3"/>
+          <circle cx="24" cy="20" r="1.5" fill="white" class="stoa-sp-d4"/>
+        </svg>
+      </div>
+    </div>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/control-plane-ui/src/App.test.tsx
+++ b/control-plane-ui/src/App.test.tsx
@@ -163,6 +163,6 @@ describe('App', () => {
     });
 
     renderApp('/');
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Loading' })).toBeInTheDocument();
   });
 });

--- a/control-plane-ui/src/App.tsx
+++ b/control-plane-ui/src/App.tsx
@@ -7,6 +7,7 @@ import { quickLinks } from './config';
 import { ToastProvider } from '@stoa/shared/components/Toast';
 import { CommandPaletteProvider } from '@stoa/shared/components/CommandPalette';
 import { ThemeProvider } from '@stoa/shared/contexts';
+import { StoaLoader } from '@stoa/shared/components/StoaLoader';
 
 // Lazy load pages for code splitting
 // Consolidated imports — single module loader per multi-export file
@@ -78,18 +79,9 @@ const TokenOptimizer = lazy(() =>
 const Policies = lazy(() => import('./pages/Policies').then((m) => ({ default: m.Policies })));
 const AuditLog = lazy(() => import('./pages/AuditLog').then((m) => ({ default: m.AuditLog })));
 
-// Loading spinner for lazy-loaded pages and auth init skeleton
+// Loading indicator for lazy-loaded pages and auth init
 function PageLoader() {
-  return (
-    <div className="flex items-center justify-center min-h-[400px]">
-      <div className="text-center">
-        <div className="w-10 h-10 bg-blue-600 rounded-lg flex items-center justify-center mx-auto mb-3 animate-pulse">
-          <span className="text-white font-bold text-sm">SC</span>
-        </div>
-        <p className="text-gray-500 dark:text-neutral-400 text-sm">Loading...</p>
-      </div>
-    </div>
-  );
+  return <StoaLoader variant="inline" />;
 }
 
 function Dashboard() {

--- a/control-plane-ui/src/index.css
+++ b/control-plane-ui/src/index.css
@@ -9,3 +9,63 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+/* STOA Loader — animated loading indicator */
+.stoa-loader-breathe {
+  animation: stoa-breathe 2.5s ease-in-out infinite;
+}
+.stoa-loader-glow {
+  animation: stoa-glow 2.5s ease-in-out infinite;
+}
+.stoa-loader-ring {
+  animation: stoa-ring 2.5s linear infinite;
+  transform-origin: 16px 16px;
+}
+.stoa-loader-dot-1 {
+  animation: stoa-dot 1.6s ease-in-out 0s infinite;
+}
+.stoa-loader-dot-2 {
+  animation: stoa-dot 1.6s ease-in-out 0.2s infinite;
+}
+.stoa-loader-dot-3 {
+  animation: stoa-dot 1.6s ease-in-out 0.4s infinite;
+}
+.stoa-loader-dot-4 {
+  animation: stoa-dot 1.6s ease-in-out 0.6s infinite;
+}
+
+@keyframes stoa-breathe {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.06);
+  }
+}
+@keyframes stoa-glow {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 10px rgba(5, 150, 105, 0.2));
+  }
+  50% {
+    filter: drop-shadow(0 0 28px rgba(5, 150, 105, 0.5));
+  }
+}
+@keyframes stoa-ring {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+@keyframes stoa-dot {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 1;
+  }
+}

--- a/control-plane-ui/src/main.tsx
+++ b/control-plane-ui/src/main.tsx
@@ -59,3 +59,14 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     </QueryClientProvider>
   </React.StrictMode>
 );
+
+// Smooth handoff: HTML splash → React app (double-rAF ensures React has painted)
+requestAnimationFrame(() => {
+  requestAnimationFrame(() => {
+    const splash = document.getElementById('stoa-splash');
+    if (splash) {
+      splash.classList.add('hide');
+      splash.addEventListener('transitionend', () => splash.remove());
+    }
+  });
+});

--- a/portal/index.html
+++ b/portal/index.html
@@ -13,8 +13,42 @@
     <link rel="dns-prefetch" href="https://api.gostoa.dev">
     <link rel="preconnect" href="https://mcp.gostoa.dev" crossorigin>
     <link rel="dns-prefetch" href="https://mcp.gostoa.dev">
+    <!-- Prevent flash of wrong theme — runs before first paint -->
+    <script>
+      (function(){var t=localStorage.getItem('stoa-theme');var d=t==='dark'||(t!=='light'&&window.matchMedia('(prefers-color-scheme:dark)').matches);if(d)document.documentElement.classList.add('dark')})()
+    </script>
+    <style>
+      #stoa-splash{position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;background:#f9fafb;transition:opacity .5s cubic-bezier(.4,0,.2,1)}
+      .dark #stoa-splash{background:#171717}
+      #stoa-splash.hide{opacity:0;pointer-events:none}
+      .stoa-sp-wrap{animation:stoa-breathe 2.5s ease-in-out infinite}
+      .stoa-sp-svg{animation:stoa-glow 2.5s ease-in-out infinite}
+      .stoa-sp-ring{animation:stoa-ring 2.5s linear infinite;transform-origin:16px 16px}
+      .stoa-sp-d1{animation:stoa-dot 1.6s ease-in-out 0s infinite}
+      .stoa-sp-d2{animation:stoa-dot 1.6s ease-in-out .2s infinite}
+      .stoa-sp-d3{animation:stoa-dot 1.6s ease-in-out .4s infinite}
+      .stoa-sp-d4{animation:stoa-dot 1.6s ease-in-out .6s infinite}
+      @keyframes stoa-breathe{0%,100%{transform:scale(1)}50%{transform:scale(1.06)}}
+      @keyframes stoa-glow{0%,100%{filter:drop-shadow(0 0 10px rgba(5,150,105,.2))}50%{filter:drop-shadow(0 0 28px rgba(5,150,105,.5))}}
+      @keyframes stoa-ring{from{transform:rotate(0)}to{transform:rotate(360deg)}}
+      @keyframes stoa-dot{0%,100%{opacity:.4}50%{opacity:1}}
+    </style>
   </head>
   <body>
+    <div id="stoa-splash" aria-live="polite" aria-label="Loading STOA Developer Portal">
+      <div class="stoa-sp-wrap">
+        <svg viewBox="-2 -2 36 36" width="64" height="64" class="stoa-sp-svg" aria-hidden="true">
+          <circle cx="16" cy="16" r="17" fill="none" stroke="#059669" stroke-width="1.2" stroke-dasharray="27 80" stroke-linecap="round" class="stoa-sp-ring" opacity=".5"/>
+          <defs><linearGradient id="sg" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#047857"/><stop offset="100%" stop-color="#059669"/></linearGradient></defs>
+          <circle cx="16" cy="16" r="15" fill="url(#sg)"/>
+          <path d="M10 11 Q10 8,16 8 Q22 8,22 11 Q22 14,16 14 Q10 14,10 17 Q10 20,16 20 Q22 20,22 24 Q22 27,16 27" stroke="white" stroke-width="2.5" stroke-linecap="round" fill="none"/>
+          <circle cx="8" cy="14" r="1.5" fill="white" class="stoa-sp-d1"/>
+          <circle cx="24" cy="14" r="1.5" fill="white" class="stoa-sp-d2"/>
+          <circle cx="8" cy="20" r="1.5" fill="white" class="stoa-sp-d3"/>
+          <circle cx="24" cy="20" r="1.5" fill="white" class="stoa-sp-d4"/>
+        </svg>
+      </div>
+    </div>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/portal/src/App.test.tsx
+++ b/portal/src/App.test.tsx
@@ -147,7 +147,7 @@ describe('App', () => {
 
       renderApp('/');
 
-      expect(screen.getByText('Loading...')).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'Loading' })).toBeInTheDocument();
     });
   });
 
@@ -235,7 +235,7 @@ describe('App', () => {
 
       renderApp('/servers');
 
-      expect(screen.getByText('Loading...')).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'Loading' })).toBeInTheDocument();
     });
   });
 });

--- a/portal/src/App.tsx
+++ b/portal/src/App.tsx
@@ -4,6 +4,7 @@ import { Layout } from './components/layout';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { ErrorBoundary, SkipLink } from './components/common';
 import { StoaLogo } from '@stoa/shared/components/StoaLogo';
+import { StoaLoader } from '@stoa/shared/components/StoaLoader';
 import { config } from './config';
 
 // Lazy load pages for code splitting - reduces initial bundle by ~60%
@@ -50,32 +51,14 @@ const UnauthorizedPage = lazy(() =>
   import('./pages/Unauthorized').then((m) => ({ default: m.UnauthorizedPage }))
 );
 
-// Page loader skeleton for lazy-loaded pages
+// Loading indicator for lazy-loaded pages
 function PageLoader() {
-  return (
-    <div className="flex items-center justify-center min-h-[400px]">
-      <div className="text-center">
-        <div className="mx-auto mb-3 animate-pulse">
-          <StoaLogo size="md" />
-        </div>
-        <p className="text-gray-500 dark:text-neutral-400 text-sm">Loading...</p>
-      </div>
-    </div>
-  );
+  return <StoaLoader variant="inline" />;
 }
 
-// Loading screen
+// Full-screen loading during auth initialization
 function LoadingScreen() {
-  return (
-    <div className="min-h-screen bg-gray-50 dark:bg-neutral-900 flex items-center justify-center transition-colors">
-      <div className="text-center">
-        <div className="mx-auto mb-4 animate-pulse">
-          <StoaLogo size="lg" />
-        </div>
-        <p className="text-gray-500 dark:text-neutral-400">Loading...</p>
-      </div>
-    </div>
-  );
+  return <StoaLoader variant="fullscreen" />;
 }
 
 // Login screen

--- a/portal/src/index.css
+++ b/portal/src/index.css
@@ -68,3 +68,63 @@ body {
     text-wrap: balance;
   }
 }
+
+/* STOA Loader — animated loading indicator */
+.stoa-loader-breathe {
+  animation: stoa-breathe 2.5s ease-in-out infinite;
+}
+.stoa-loader-glow {
+  animation: stoa-glow 2.5s ease-in-out infinite;
+}
+.stoa-loader-ring {
+  animation: stoa-ring 2.5s linear infinite;
+  transform-origin: 16px 16px;
+}
+.stoa-loader-dot-1 {
+  animation: stoa-dot 1.6s ease-in-out 0s infinite;
+}
+.stoa-loader-dot-2 {
+  animation: stoa-dot 1.6s ease-in-out 0.2s infinite;
+}
+.stoa-loader-dot-3 {
+  animation: stoa-dot 1.6s ease-in-out 0.4s infinite;
+}
+.stoa-loader-dot-4 {
+  animation: stoa-dot 1.6s ease-in-out 0.6s infinite;
+}
+
+@keyframes stoa-breathe {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.06);
+  }
+}
+@keyframes stoa-glow {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 10px rgba(5, 150, 105, 0.2));
+  }
+  50% {
+    filter: drop-shadow(0 0 28px rgba(5, 150, 105, 0.5));
+  }
+}
+@keyframes stoa-ring {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+@keyframes stoa-dot {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 1;
+  }
+}

--- a/portal/src/main.tsx
+++ b/portal/src/main.tsx
@@ -63,3 +63,14 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     </ThemeProvider>
   </React.StrictMode>
 );
+
+// Smooth handoff: HTML splash → React app (double-rAF ensures React has painted)
+requestAnimationFrame(() => {
+  requestAnimationFrame(() => {
+    const splash = document.getElementById('stoa-splash');
+    if (splash) {
+      splash.classList.add('hide');
+      splash.addEventListener('transitionend', () => splash.remove());
+    }
+  });
+});

--- a/shared/components/StoaLoader/StoaLoader.tsx
+++ b/shared/components/StoaLoader/StoaLoader.tsx
@@ -1,0 +1,67 @@
+interface StoaLoaderProps {
+  /** Full screen overlay or inline content area */
+  variant?: 'fullscreen' | 'inline';
+  /** Override SVG size in px (default: 64 fullscreen, 48 inline) */
+  size?: number;
+}
+
+export function StoaLoader({ variant = 'inline', size }: StoaLoaderProps) {
+  const svgSize = size ?? (variant === 'fullscreen' ? 64 : 48);
+
+  const wrapperClass =
+    variant === 'fullscreen'
+      ? 'min-h-screen bg-gray-50 dark:bg-neutral-900 flex items-center justify-center transition-colors'
+      : 'flex items-center justify-center min-h-[400px]';
+
+  return (
+    <div className={wrapperClass}>
+      <div className="text-center">
+        <div className="stoa-loader-breathe mx-auto">
+          <svg
+            viewBox="-2 -2 36 36"
+            width={svgSize}
+            height={svgSize}
+            className="stoa-loader-glow"
+            role="img"
+            aria-label="Loading"
+          >
+            {/* Spinning ring */}
+            <circle
+              cx="16"
+              cy="16"
+              r="17"
+              fill="none"
+              stroke="#059669"
+              strokeWidth="1.2"
+              strokeDasharray="27 80"
+              strokeLinecap="round"
+              className="stoa-loader-ring"
+              opacity="0.5"
+            />
+            <defs>
+              <linearGradient id="stoaLoaderGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stopColor="#047857" />
+                <stop offset="100%" stopColor="#059669" />
+              </linearGradient>
+            </defs>
+            {/* Main circle */}
+            <circle cx="16" cy="16" r="15" fill="url(#stoaLoaderGrad)" />
+            {/* S path */}
+            <path
+              d="M10 11 Q10 8,16 8 Q22 8,22 11 Q22 14,16 14 Q10 14,10 17 Q10 20,16 20 Q22 20,22 24 Q22 27,16 27"
+              stroke="white"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              fill="none"
+            />
+            {/* Orbital dots */}
+            <circle cx="8" cy="14" r="1.5" fill="white" className="stoa-loader-dot-1" />
+            <circle cx="24" cy="14" r="1.5" fill="white" className="stoa-loader-dot-2" />
+            <circle cx="8" cy="20" r="1.5" fill="white" className="stoa-loader-dot-3" />
+            <circle cx="24" cy="20" r="1.5" fill="white" className="stoa-loader-dot-4" />
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/shared/components/StoaLoader/index.ts
+++ b/shared/components/StoaLoader/index.ts
@@ -1,0 +1,1 @@
+export { StoaLoader } from './StoaLoader';


### PR DESCRIPTION
## Summary
- Replace basic loading indicators (animate-pulse "SC" box / StoaLogo) with Discord-inspired animated splash screen
- Add inline theme detection script in `index.html` to prevent dark mode white flash — runs before any JS loads
- New shared `StoaLoader` component with 4 CSS animations: breathe, emerald glow, spinning ring, sequential dot pulse
- Smooth 0.5s CSS fade-out handoff from HTML splash to React app via double-rAF

## Test plan
- [x] Console UI: 282 tests pass, 93 warnings (max 93), prettier clean, tsc clean
- [x] Portal: 267 tests pass, 14 warnings (max 20), prettier clean, tsc clean
- [x] Dark mode: no white flash on load (theme detected from localStorage before first paint)
- [x] Light mode: gray-50 background with emerald glow animation
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>