### PR TITLE
fix(ui,portal): dark mode support for skeleton loading states

### DIFF
--- a/portal/src/components/common/Skeleton.tsx
+++ b/portal/src/components/common/Skeleton.tsx
@@ -13,7 +13,12 @@ interface SkeletonProps {
  * ```
  */
 export function Skeleton({ className = '' }: SkeletonProps) {
-  return <div className={`animate-pulse rounded bg-gray-200 ${className}`} aria-hidden="true" />;
+  return (
+    <div
+      className={`animate-pulse rounded bg-gray-200 dark:bg-neutral-700 ${className}`}
+      aria-hidden="true"
+    />
+  );
 }
 
 /**

--- a/portal/src/components/skeletons/DashboardSkeleton.tsx
+++ b/portal/src/components/skeletons/DashboardSkeleton.tsx
@@ -51,7 +51,10 @@ export function HomePageSkeleton() {
       {/* Stats row */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="bg-white rounded-lg border border-gray-200 p-4">
+          <div
+            key={i}
+            className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4"
+          >
             <div className="flex items-center justify-between">
               <div>
                 <Skeleton className="h-3 w-20 mb-2" />
@@ -66,7 +69,7 @@ export function HomePageSkeleton() {
       {/* Two columns: Quick Actions + Recent */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Quick actions */}
-        <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
           <Skeleton className="h-6 w-32 mb-4" />
           <div className="grid grid-cols-2 gap-4">
             {Array.from({ length: 4 }).map((_, i) => (
@@ -76,7 +79,7 @@ export function HomePageSkeleton() {
         </div>
 
         {/* Recent activity */}
-        <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
           <Skeleton className="h-6 w-36 mb-4" />
           <div className="space-y-3">
             {Array.from({ length: 5 }).map((_, i) => (

--- a/portal/src/components/skeletons/ServerCardSkeleton.tsx
+++ b/portal/src/components/skeletons/ServerCardSkeleton.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from '../common/Skeleton';
  */
 export function ServerCardSkeleton() {
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
       {/* Icon */}
       <Skeleton className="h-12 w-12 rounded-lg mb-4" />
 
@@ -74,7 +74,10 @@ export function ServerDetailSkeleton() {
         <Skeleton className="h-6 w-32 mb-4" />
         <div className="space-y-3">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="bg-white rounded-lg border border-gray-200 p-4">
+            <div
+              key={i}
+              className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4"
+            >
               <div className="flex items-center gap-3">
                 <Skeleton className="h-8 w-8 rounded" />
                 <div className="flex-1">

--- a/portal/src/components/skeletons/StatCardSkeleton.tsx
+++ b/portal/src/components/skeletons/StatCardSkeleton.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from '../common/Skeleton';
  */
 export function StatCardSkeleton() {
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
       <Skeleton className="h-4 w-24 mb-2" />
       <Skeleton className="h-8 w-16 mb-1" />
       <Skeleton className="h-3 w-20" />
@@ -31,7 +31,7 @@ export function StatCardSkeletonRow({ count = 3 }: { count?: number }) {
  */
 export function StatCardWithIconSkeleton() {
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
       <div className="flex items-center justify-between mb-4">
         <Skeleton className="h-4 w-24" />
         <Skeleton className="h-10 w-10 rounded-lg" />
@@ -47,7 +47,7 @@ export function StatCardWithIconSkeleton() {
  */
 export function UsageStatSkeleton() {
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
       <div className="flex items-center gap-3 mb-4">
         <Skeleton className="h-12 w-12 rounded-lg" />
         <div>

--- a/portal/src/components/skeletons/TableSkeleton.tsx
+++ b/portal/src/components/skeletons/TableSkeleton.tsx
@@ -24,7 +24,7 @@ export function TableRowSkeleton({ columns = 5 }: TableRowSkeletonProps) {
  */
 export function TableSkeleton({ rows = 5, columns = 5 }: { rows?: number; columns?: number }) {
   return (
-    <tbody className="divide-y divide-gray-200">
+    <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
       {Array.from({ length: rows }).map((_, i) => (
         <TableRowSkeleton key={i} columns={columns} />
       ))}
@@ -47,14 +47,16 @@ export function FullTableSkeleton({
   const headerCount = headers?.length || columns;
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
-      <table className="min-w-full divide-y divide-gray-200">
-        <thead className="bg-gray-50">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 overflow-hidden">
+      <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
+        <thead className="bg-gray-50 dark:bg-neutral-800">
           <tr>
             {Array.from({ length: headerCount }).map((_, i) => (
               <th key={i} className="px-4 py-3 text-left">
                 {headers ? (
-                  <span className="text-xs font-medium text-gray-500 uppercase">{headers[i]}</span>
+                  <span className="text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                    {headers[i]}
+                  </span>
                 ) : (
                   <Skeleton className="h-4 w-20" />
                 )}
@@ -73,28 +75,28 @@ export function FullTableSkeleton({
  */
 export function SubscriptionTableSkeleton({ rows = 5 }: { rows?: number }) {
   return (
-    <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
-      <table className="min-w-full divide-y divide-gray-200">
-        <thead className="bg-gray-50">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 overflow-hidden">
+      <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
+        <thead className="bg-gray-50 dark:bg-neutral-800">
           <tr>
-            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
               Server
             </th>
-            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
               Status
             </th>
-            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
               API Key
             </th>
-            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
               Created
             </th>
-            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
               Actions
             </th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-200">
+        <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
           {Array.from({ length: rows }).map((_, i) => (
             <tr key={i}>
               <td className="px-4 py-3">

--- a/shared/components/Skeleton/Skeleton.tsx
+++ b/shared/components/Skeleton/Skeleton.tsx
@@ -13,7 +13,7 @@ interface SkeletonProps {
 export function Skeleton({ className = '' }: SkeletonProps) {
   return (
     <div
-      className={`animate-pulse rounded bg-neutral-200 ${className}`}
+      className={`animate-pulse rounded bg-neutral-200 dark:bg-neutral-700 ${className}`}
       aria-hidden="true"
     />
   );
@@ -84,7 +84,7 @@ export function ButtonSkeleton({
 
 export function CardSkeleton({ className = '' }: { className?: string }) {
   return (
-    <div className={`bg-white rounded-lg border border-neutral-200 p-6 ${className}`}>
+    <div className={`bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 p-6 ${className}`}>
       <div className="flex items-center gap-3 mb-4">
         <Skeleton className="h-10 w-10 rounded-lg" />
         <div className="flex-1">
@@ -125,7 +125,7 @@ export function TableBodySkeleton({
   columns?: number;
 }) {
   return (
-    <tbody className="divide-y divide-neutral-200">
+    <tbody className="divide-y divide-neutral-200 dark:divide-neutral-700">
       {Array.from({ length: rows }).map((_, i) => (
         <TableRowSkeleton key={i} columns={columns} />
       ))}
@@ -145,14 +145,14 @@ export function TableSkeleton({
   const headerCount = headers?.length || columns;
 
   return (
-    <div className="bg-white rounded-lg border border-neutral-200 overflow-hidden">
-      <table className="min-w-full divide-y divide-neutral-200">
-        <thead className="bg-neutral-50">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 overflow-hidden">
+      <table className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700">
+        <thead className="bg-neutral-50 dark:bg-neutral-800">
           <tr>
             {Array.from({ length: headerCount }).map((_, i) => (
               <th key={i} className="px-4 py-3 text-left">
                 {headers ? (
-                  <span className="text-xs font-medium text-neutral-500 uppercase">
+                  <span className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     {headers[i]}
                   </span>
                 ) : (
@@ -174,7 +174,7 @@ export function TableSkeleton({
 
 export function StatCardSkeleton() {
   return (
-    <div className="bg-white rounded-lg border border-neutral-200 p-6">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 p-6">
       <Skeleton className="h-4 w-24 mb-2" />
       <Skeleton className="h-8 w-16 mb-1" />
       <Skeleton className="h-3 w-20" />


### PR DESCRIPTION
## Summary
- All skeleton card containers (`ServerCardSkeleton`, `StatCardSkeleton`, `TableSkeleton`, `DashboardSkeleton`) used `bg-white` without `dark:` variant
- In dark mode, these appeared as bright white rectangles on dark background during data loading
- Added `dark:bg-neutral-800`, `dark:border-neutral-700`, `dark:divide-neutral-700` to all skeleton containers (shared + portal)
- Base `Skeleton` pulse blocks: `bg-gray-200 dark:bg-neutral-700`

## Test plan
- [x] Console: 282 tests, 93 warnings, prettier clean
- [x] Portal: 267 tests, 14 warnings, prettier clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>