### PR TITLE
fix(ui,portal): add Cache-Control no-cache on index.html

### DIFF
--- a/control-plane-ui/nginx.conf.template
+++ b/control-plane-ui/nginx.conf.template
@@ -71,8 +71,11 @@ server {
     }
 
     # SPA routing - serve index.html for all unmatched routes
+    # no-cache ensures browser revalidates index.html on every load
+    # (hashed JS/CSS assets still cached 1y via location block below)
     location / {
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache" always;
     }
 
     # API proxy (Swagger UI requires unsafe-eval + unsafe-inline for JS rendering)

--- a/portal/nginx.conf
+++ b/portal/nginx.conf
@@ -16,8 +16,11 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
     # SPA routing - always serve index.html for client-side routes
+    # no-cache ensures browser revalidates index.html on every load
+    # (hashed JS/CSS assets still cached 1y via location block below)
     location / {
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache" always;
     }
 
     # Cache static assets


### PR DESCRIPTION
## Summary
- Add `Cache-Control: no-cache` header to `location /` block in both Console UI and Portal nginx configs
- Ensures browsers revalidate `index.html` on every load, so new deployments are picked up immediately
- Hashed static assets (JS/CSS) still cached for 1 year via the `location ~* \.(js|css|...)$` block

## Context
After deploying PR #226 (skeleton dark mode fix), users still saw the old version because `index.html` was served without cache control headers. Browsers cached the stale HTML indefinitely, preventing new asset bundles from loading.

## Test plan
- [ ] CI green
- [ ] After deploy, verify `curl -I https://portal.gostoa.dev/ | grep Cache-Control` returns `no-cache`
- [ ] New deployments are picked up without hard refresh

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>