### PR TITLE
fix(ui): dark mode for Deployments and AITools pages

### DIFF
--- a/control-plane-ui/src/pages/AITools/MySubscriptions.tsx
+++ b/control-plane-ui/src/pages/AITools/MySubscriptions.tsx
@@ -72,9 +72,9 @@ export function MySubscriptions() {
   };
 
   const statusColors: Record<string, string> = {
-    active: 'bg-green-100 text-green-800',
-    suspended: 'bg-yellow-100 text-yellow-800',
-    pending: 'bg-gray-100 text-gray-800',
+    active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+    suspended: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+    pending: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300',
   };
 
   if (loading) {
@@ -98,8 +98,10 @@ export function MySubscriptions() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">My Subscriptions</h1>
-          <p className="text-sm text-gray-500 mt-1">Manage your subscribed AI tools</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">My Subscriptions</h1>
+          <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
+            Manage your subscribed AI tools
+          </p>
         </div>
         <Link
           to="/ai-tools"
@@ -112,7 +114,7 @@ export function MySubscriptions() {
 
       {/* Error */}
       {error && (
-        <div className="flex items-center gap-2 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
+        <div className="flex items-center gap-2 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-400">
           <AlertCircle className="h-5 w-5 flex-shrink-0" />
           <span className="text-sm">{error}</span>
         </div>
@@ -120,35 +122,35 @@ export function MySubscriptions() {
 
       {/* Subscriptions List */}
       {subscriptions.length > 0 ? (
-        <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 overflow-hidden">
           <table className="w-full">
-            <thead className="bg-gray-50 border-b border-gray-200">
+            <thead className="bg-gray-50 dark:bg-neutral-700 border-b border-gray-200 dark:border-neutral-600">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Tool
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Status
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Usage
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Subscribed
                 </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Actions
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200">
+            <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
               {subscriptions.map((sub) => {
                 const tool = tools.get(sub.toolName);
                 return (
-                  <tr key={sub.id} className="hover:bg-gray-50">
+                  <tr key={sub.id} className="hover:bg-gray-50 dark:hover:bg-neutral-700">
                     <td className="px-6 py-4">
                       <div className="flex items-center gap-3">
-                        <div className="p-2 bg-blue-50 rounded-lg">
+                        <div className="p-2 bg-blue-50 dark:bg-blue-900/30 rounded-lg">
                           <Wrench className="h-5 w-5 text-blue-600" />
                         </div>
                         <div>
@@ -156,12 +158,12 @@ export function MySubscriptions() {
                             onClick={() =>
                               navigate(`/ai-tools/${encodeURIComponent(sub.toolName)}`)
                             }
-                            className="font-medium text-gray-900 hover:text-blue-600"
+                            className="font-medium text-gray-900 dark:text-white hover:text-blue-600"
                           >
                             {sub.toolName}
                           </button>
                           {tool && (
-                            <p className="text-sm text-gray-500 line-clamp-1 max-w-xs">
+                            <p className="text-sm text-gray-500 dark:text-neutral-400 line-clamp-1 max-w-xs">
                               {tool.description}
                             </p>
                           )}
@@ -176,16 +178,18 @@ export function MySubscriptions() {
                       </span>
                     </td>
                     <td className="px-6 py-4">
-                      <div className="flex items-center gap-2 text-sm text-gray-600">
-                        <Activity className="h-4 w-4 text-gray-400" />
+                      <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-neutral-300">
+                        <Activity className="h-4 w-4 text-gray-400 dark:text-neutral-500" />
                         <span>{sub.usageCount} calls</span>
                         {sub.usageLimit && (
-                          <span className="text-gray-400">/ {sub.usageLimit} limit</span>
+                          <span className="text-gray-400 dark:text-neutral-500">
+                            / {sub.usageLimit} limit
+                          </span>
                         )}
                       </div>
                     </td>
                     <td className="px-6 py-4">
-                      <div className="flex items-center gap-2 text-sm text-gray-500">
+                      <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-neutral-400">
                         <Clock className="h-4 w-4" />
                         {new Date(sub.subscribedAt).toLocaleDateString()}
                       </div>
@@ -220,7 +224,7 @@ export function MySubscriptions() {
           </table>
         </div>
       ) : (
-        <div className="bg-white rounded-lg border border-gray-200">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700">
           <EmptyState
             variant="subscriptions"
             title="No subscriptions yet"
@@ -232,9 +236,11 @@ export function MySubscriptions() {
 
       {/* Help Section */}
       {subscriptions.length > 0 && (
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-          <h4 className="font-medium text-blue-900 mb-2">Using Subscribed Tools</h4>
-          <p className="text-sm text-blue-700">
+        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+          <h4 className="font-medium text-blue-900 dark:text-blue-400 mb-2">
+            Using Subscribed Tools
+          </h4>
+          <p className="text-sm text-blue-700 dark:text-blue-300">
             Subscribed tools are automatically available in your MCP client (Claude Desktop, Cursor,
             etc.). Configure your client to connect to the STOA MCP Gateway to start using these
             tools. Visit any tool's "Quick Start" tab for setup instructions.

--- a/control-plane-ui/src/pages/AITools/ToolCatalog.tsx
+++ b/control-plane-ui/src/pages/AITools/ToolCatalog.tsx
@@ -90,14 +90,14 @@ export function ToolCatalog() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">AI Tool Catalog</h1>
-          <p className="text-sm text-gray-500 mt-1">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">AI Tool Catalog</h1>
+          <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
             Browse MCP tools available for AI-powered API interactions
           </p>
         </div>
         <button
           onClick={loadTools}
-          className="flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+          className="flex items-center gap-2 px-4 py-2 bg-white dark:bg-neutral-700 border border-gray-300 dark:border-neutral-600 rounded-lg text-sm text-gray-700 dark:text-neutral-300 hover:bg-gray-50 dark:hover:bg-neutral-600 transition-colors"
         >
           <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
           Refresh
@@ -105,7 +105,7 @@ export function ToolCatalog() {
       </div>
 
       {/* Filters Bar */}
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4">
         <div className="flex flex-wrap items-center gap-4">
           {/* Search */}
           <div className="flex-1 min-w-[250px]">
@@ -116,7 +116,7 @@ export function ToolCatalog() {
                 placeholder="Search tools by name or description..."
                 value={searchQuery}
                 onChange={(e) => handleSearch(e.target.value)}
-                className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               />
             </div>
           </div>
@@ -126,7 +126,7 @@ export function ToolCatalog() {
             <select
               value={selectedTag}
               onChange={(e) => handleTagFilter(e.target.value)}
-              className="appearance-none pl-10 pr-8 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="appearance-none pl-10 pr-8 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               <option value="">All Tags</option>
               {tags.map((tag) => (
@@ -142,7 +142,7 @@ export function ToolCatalog() {
           {hasActiveFilters && (
             <button
               onClick={clearFilters}
-              className="flex items-center gap-1 px-3 py-2 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+              className="flex items-center gap-1 px-3 py-2 text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white transition-colors"
             >
               <Filter className="h-4 w-4" />
               Clear filters
@@ -152,9 +152,9 @@ export function ToolCatalog() {
 
         {/* Active Filters */}
         {hasActiveFilters && (
-          <div className="flex flex-wrap gap-2 mt-3 pt-3 border-t border-gray-100">
+          <div className="flex flex-wrap gap-2 mt-3 pt-3 border-t border-gray-100 dark:border-neutral-700">
             {searchQuery && (
-              <span className="inline-flex items-center gap-1 px-2 py-1 bg-blue-50 text-blue-700 rounded text-xs">
+              <span className="inline-flex items-center gap-1 px-2 py-1 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 rounded text-xs">
                 Search: {searchQuery}
                 <button onClick={() => handleSearch('')} className="hover:text-blue-900">
                   &times;
@@ -162,7 +162,7 @@ export function ToolCatalog() {
               </span>
             )}
             {selectedTag && (
-              <span className="inline-flex items-center gap-1 px-2 py-1 bg-green-50 text-green-700 rounded text-xs">
+              <span className="inline-flex items-center gap-1 px-2 py-1 bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-400 rounded text-xs">
                 Tag: {selectedTag}
                 <button onClick={() => handleTagFilter('')} className="hover:text-green-900">
                   &times;
@@ -175,7 +175,7 @@ export function ToolCatalog() {
 
       {/* Error */}
       {error && (
-        <div className="flex items-center gap-2 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
+        <div className="flex items-center gap-2 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-400">
           <AlertCircle className="h-5 w-5 flex-shrink-0" />
           <span className="text-sm">{error}</span>
           <button onClick={loadTools} className="ml-auto text-sm underline hover:no-underline">
@@ -197,7 +197,7 @@ export function ToolCatalog() {
       {!loading && !error && (
         <>
           {/* Results Count */}
-          <div className="flex items-center justify-between text-sm text-gray-500">
+          <div className="flex items-center justify-between text-sm text-gray-500 dark:text-neutral-400">
             <span>
               Showing {tools.length} of {totalCount} tools
             </span>
@@ -211,7 +211,7 @@ export function ToolCatalog() {
               ))}
             </div>
           ) : (
-            <div className="col-span-full bg-white rounded-lg border border-gray-200">
+            <div className="col-span-full bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700">
               <EmptyState
                 variant={hasActiveFilters ? 'search' : 'tools'}
                 action={

--- a/control-plane-ui/src/pages/AITools/ToolDetail.tsx
+++ b/control-plane-ui/src/pages/AITools/ToolDetail.tsx
@@ -57,11 +57,13 @@ export function ToolDetail() {
   }, [toolName]);
 
   const methodColors: Record<string, string> = {
-    GET: 'bg-green-100 text-green-800 border-green-200',
-    POST: 'bg-blue-100 text-blue-800 border-blue-200',
-    PUT: 'bg-yellow-100 text-yellow-800 border-yellow-200',
-    PATCH: 'bg-orange-100 text-orange-800 border-orange-200',
-    DELETE: 'bg-red-100 text-red-800 border-red-200',
+    GET: 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800',
+    POST: 'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-800',
+    PUT: 'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-800',
+    PATCH:
+      'bg-orange-100 text-orange-800 border-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:border-orange-800',
+    DELETE:
+      'bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800',
   };
 
   const tabs: { id: TabType; label: string; icon: React.ReactNode }[] = [
@@ -95,13 +97,13 @@ export function ToolDetail() {
       <div className="space-y-6">
         <button
           onClick={() => navigate('/ai-tools')}
-          className="flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900"
+          className="flex items-center gap-2 text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white"
         >
           <ArrowLeft className="h-4 w-4" />
           Back to catalog
         </button>
 
-        <div className="flex items-center gap-2 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
+        <div className="flex items-center gap-2 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-400">
           <AlertCircle className="h-5 w-5 flex-shrink-0" />
           <span className="text-sm">{error || 'Tool not found'}</span>
         </div>
@@ -113,23 +115,26 @@ export function ToolDetail() {
     <div className="space-y-6">
       {/* Breadcrumb */}
       <nav className="flex items-center gap-2 text-sm">
-        <Link to="/ai-tools" className="text-gray-500 hover:text-gray-700">
+        <Link
+          to="/ai-tools"
+          className="text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-300"
+        >
           AI Tools
         </Link>
-        <span className="text-gray-300">/</span>
-        <span className="text-gray-900 font-medium">{tool.name}</span>
+        <span className="text-gray-300 dark:text-neutral-600">/</span>
+        <span className="text-gray-900 dark:text-white font-medium">{tool.name}</span>
       </nav>
 
       {/* Header */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
         <div className="flex items-start justify-between">
           <div className="flex items-start gap-4">
-            <div className="p-3 bg-blue-50 rounded-lg">
+            <div className="p-3 bg-blue-50 dark:bg-blue-900/30 rounded-lg">
               <Wrench className="h-8 w-8 text-blue-600" />
             </div>
             <div>
               <div className="flex items-center gap-3 mb-1">
-                <h1 className="text-2xl font-bold text-gray-900">{tool.name}</h1>
+                <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{tool.name}</h1>
                 <span
                   className={`px-2.5 py-0.5 rounded border text-sm font-medium ${
                     methodColors[tool.method] || 'bg-gray-100 text-gray-800 border-gray-200'
@@ -137,9 +142,9 @@ export function ToolDetail() {
                 >
                   {tool.method}
                 </span>
-                <span className="text-sm text-gray-500">v{tool.version}</span>
+                <span className="text-sm text-gray-500 dark:text-neutral-400">v{tool.version}</span>
               </div>
-              <p className="text-gray-600 max-w-2xl">{tool.description}</p>
+              <p className="text-gray-600 dark:text-neutral-400 max-w-2xl">{tool.description}</p>
 
               {/* Metadata */}
               <div className="flex flex-wrap items-center gap-4 mt-4">
@@ -148,7 +153,7 @@ export function ToolDetail() {
                     {tool.tags.map((tag) => (
                       <span
                         key={tag}
-                        className="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 text-gray-600 rounded text-xs"
+                        className="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 dark:bg-neutral-700 text-gray-600 dark:text-neutral-300 rounded text-xs"
                       >
                         <Tag className="h-3 w-3" />
                         {tag}
@@ -157,10 +162,12 @@ export function ToolDetail() {
                   </div>
                 )}
                 {tool.tenantId && (
-                  <span className="text-xs text-gray-400">Tenant: {tool.tenantId}</span>
+                  <span className="text-xs text-gray-400 dark:text-neutral-500">
+                    Tenant: {tool.tenantId}
+                  </span>
                 )}
                 {tool.endpoint && (
-                  <span className="flex items-center gap-1 text-xs text-gray-400">
+                  <span className="flex items-center gap-1 text-xs text-gray-400 dark:text-neutral-500">
                     <ExternalLink className="h-3 w-3" />
                     API-backed
                   </span>
@@ -172,7 +179,7 @@ export function ToolDetail() {
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-gray-200">
+      <div className="border-b border-gray-200 dark:border-neutral-700">
         <nav className="flex gap-6">
           {tabs.map((tab) => (
             <button
@@ -181,7 +188,7 @@ export function ToolDetail() {
               className={`flex items-center gap-2 px-1 py-3 text-sm font-medium border-b-2 transition-colors ${
                 activeTab === tab.id
                   ? 'text-blue-600 border-blue-600'
-                  : 'text-gray-500 border-transparent hover:text-gray-700 hover:border-gray-300'
+                  : 'text-gray-500 dark:text-neutral-400 border-transparent hover:text-gray-700 dark:hover:text-neutral-300 hover:border-gray-300 dark:hover:border-neutral-500'
               }`}
             >
               {tab.icon}
@@ -192,23 +199,27 @@ export function ToolDetail() {
       </div>
 
       {/* Tab Content */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
         {activeTab === 'overview' && (
           <div className="space-y-6">
             <div>
-              <h3 className="text-lg font-medium text-gray-900 mb-2">Description</h3>
-              <p className="text-gray-600">{tool.description}</p>
+              <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+                Description
+              </h3>
+              <p className="text-gray-600 dark:text-neutral-400">{tool.description}</p>
             </div>
 
             <div>
-              <h3 className="text-lg font-medium text-gray-900 mb-3">Parameters</h3>
+              <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-3">Parameters</h3>
               <ToolSchemaViewer schema={tool.inputSchema} title="Input Parameters" />
             </div>
 
             {tool.endpoint && (
               <div>
-                <h3 className="text-lg font-medium text-gray-900 mb-2">Backend Endpoint</h3>
-                <code className="block px-4 py-3 bg-gray-100 rounded-lg text-sm font-mono text-gray-800">
+                <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+                  Backend Endpoint
+                </h3>
+                <code className="block px-4 py-3 bg-gray-100 dark:bg-neutral-900 rounded-lg text-sm font-mono text-gray-800 dark:text-neutral-300">
                   {tool.method} {tool.endpoint}
                 </code>
               </div>
@@ -219,12 +230,12 @@ export function ToolDetail() {
         {activeTab === 'schema' && (
           <div className="space-y-6">
             <div className="flex items-center justify-between">
-              <h3 className="text-lg font-medium text-gray-900">JSON Schema</h3>
+              <h3 className="text-lg font-medium text-gray-900 dark:text-white">JSON Schema</h3>
               <button
                 onClick={() =>
                   navigator.clipboard.writeText(JSON.stringify(tool.inputSchema, null, 2))
                 }
-                className="flex items-center gap-1 px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+                className="flex items-center gap-1 px-3 py-1.5 text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white transition-colors"
               >
                 <Code className="h-4 w-4" />
                 Copy JSON
@@ -241,39 +252,47 @@ export function ToolDetail() {
             {usage ? (
               <>
                 <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-                  <div className="p-4 bg-gray-50 rounded-lg">
-                    <div className="text-sm text-gray-500 mb-1">Total Calls</div>
-                    <div className="text-2xl font-bold text-gray-900">
+                  <div className="p-4 bg-gray-50 dark:bg-neutral-700 rounded-lg">
+                    <div className="text-sm text-gray-500 dark:text-neutral-400 mb-1">
+                      Total Calls
+                    </div>
+                    <div className="text-2xl font-bold text-gray-900 dark:text-white">
                       {usage.totalCalls.toLocaleString()}
                     </div>
                   </div>
-                  <div className="p-4 bg-gray-50 rounded-lg">
-                    <div className="text-sm text-gray-500 mb-1">Success Rate</div>
+                  <div className="p-4 bg-gray-50 dark:bg-neutral-700 rounded-lg">
+                    <div className="text-sm text-gray-500 dark:text-neutral-400 mb-1">
+                      Success Rate
+                    </div>
                     <div className="text-2xl font-bold text-green-600">
                       {(usage.successRate * 100).toFixed(1)}%
                     </div>
                   </div>
-                  <div className="p-4 bg-gray-50 rounded-lg">
-                    <div className="text-sm text-gray-500 mb-1">Avg Latency</div>
-                    <div className="text-2xl font-bold text-gray-900">
+                  <div className="p-4 bg-gray-50 dark:bg-neutral-700 rounded-lg">
+                    <div className="text-sm text-gray-500 dark:text-neutral-400 mb-1">
+                      Avg Latency
+                    </div>
+                    <div className="text-2xl font-bold text-gray-900 dark:text-white">
                       {usage.avgLatencyMs.toFixed(0)}ms
                     </div>
                   </div>
-                  <div className="p-4 bg-gray-50 rounded-lg">
-                    <div className="text-sm text-gray-500 mb-1">Cost Units</div>
+                  <div className="p-4 bg-gray-50 dark:bg-neutral-700 rounded-lg">
+                    <div className="text-sm text-gray-500 dark:text-neutral-400 mb-1">
+                      Cost Units
+                    </div>
                     <div className="text-2xl font-bold text-purple-600">
                       ${usage.totalCostUnits.toFixed(4)}
                     </div>
                   </div>
                 </div>
 
-                <div className="text-sm text-gray-500">
+                <div className="text-sm text-gray-500 dark:text-neutral-400">
                   Usage data for the last {usage.period} ({usage.startDate} - {usage.endDate})
                 </div>
               </>
             ) : (
-              <div className="text-center py-8 text-gray-500">
-                <Clock className="h-12 w-12 mx-auto mb-4 text-gray-300" />
+              <div className="text-center py-8 text-gray-500 dark:text-neutral-400">
+                <Clock className="h-12 w-12 mx-auto mb-4 text-gray-300 dark:text-neutral-600" />
                 <p>No usage data available yet.</p>
                 <p className="text-sm mt-1">Start using this tool to see usage statistics.</p>
               </div>

--- a/control-plane-ui/src/pages/AITools/UsageDashboard.tsx
+++ b/control-plane-ui/src/pages/AITools/UsageDashboard.tsx
@@ -87,8 +87,10 @@ export function UsageDashboard() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Usage Dashboard</h1>
-          <p className="text-sm text-gray-500 mt-1">Monitor your AI tool usage and costs</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Usage Dashboard</h1>
+          <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
+            Monitor your AI tool usage and costs
+          </p>
         </div>
         <div className="flex items-center gap-3">
           {/* Period Selector */}
@@ -97,7 +99,7 @@ export function UsageDashboard() {
             <select
               value={period}
               onChange={(e) => setPeriod(e.target.value as PeriodType)}
-              className="border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               {periodOptions.map((opt) => (
                 <option key={opt.value} value={opt.value}>
@@ -111,7 +113,7 @@ export function UsageDashboard() {
 
       {/* Error */}
       {error && (
-        <div className="flex items-center gap-2 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
+        <div className="flex items-center gap-2 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-400">
           <AlertCircle className="h-5 w-5 flex-shrink-0" />
           <span className="text-sm">{error}</span>
         </div>
@@ -168,41 +170,44 @@ export function UsageDashboard() {
 
           {/* Tool Breakdown */}
           {usage.toolBreakdown && usage.toolBreakdown.length > 0 && (
-            <div className="bg-white rounded-lg border border-gray-200">
-              <div className="px-6 py-4 border-b border-gray-200">
-                <h3 className="text-lg font-medium text-gray-900">Usage by Tool</h3>
+            <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700">
+              <div className="px-6 py-4 border-b border-gray-200 dark:border-neutral-700">
+                <h3 className="text-lg font-medium text-gray-900 dark:text-white">Usage by Tool</h3>
               </div>
               <div className="overflow-x-auto">
                 <table className="w-full">
-                  <thead className="bg-gray-50">
+                  <thead className="bg-gray-50 dark:bg-neutral-700">
                     <tr>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                         Tool
                       </th>
-                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                         Calls
                       </th>
-                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                         Success
                       </th>
-                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                         Errors
                       </th>
-                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                         Avg Latency
                       </th>
-                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                         Cost
                       </th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-200">
+                  <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
                     {usage.toolBreakdown.map((tool) => (
-                      <tr key={tool.toolName} className="hover:bg-gray-50">
-                        <td className="px-6 py-4 text-sm font-medium text-gray-900">
+                      <tr
+                        key={tool.toolName}
+                        className="hover:bg-gray-50 dark:hover:bg-neutral-700"
+                      >
+                        <td className="px-6 py-4 text-sm font-medium text-gray-900 dark:text-white">
                           {tool.toolName}
                         </td>
-                        <td className="px-6 py-4 text-sm text-gray-600 text-right">
+                        <td className="px-6 py-4 text-sm text-gray-600 dark:text-neutral-300 text-right">
                           {tool.totalCalls.toLocaleString()}
                         </td>
                         <td className="px-6 py-4 text-sm text-green-600 text-right">
@@ -211,7 +216,7 @@ export function UsageDashboard() {
                         <td className="px-6 py-4 text-sm text-red-600 text-right">
                           {tool.errorCount.toLocaleString()}
                         </td>
-                        <td className="px-6 py-4 text-sm text-gray-600 text-right">
+                        <td className="px-6 py-4 text-sm text-gray-600 dark:text-neutral-300 text-right">
                           {tool.avgLatencyMs.toFixed(0)}ms
                         </td>
                         <td className="px-6 py-4 text-sm text-purple-600 text-right">
@@ -226,16 +231,18 @@ export function UsageDashboard() {
           )}
 
           {/* Period Info */}
-          <div className="text-sm text-gray-500 text-center">
+          <div className="text-sm text-gray-500 dark:text-neutral-400 text-center">
             Showing data from {new Date(usage.startDate).toLocaleDateString()} to{' '}
             {new Date(usage.endDate).toLocaleDateString()}
           </div>
         </>
       ) : (
-        <div className="text-center py-12 bg-white rounded-lg border border-gray-200">
-          <BarChart3 className="h-12 w-12 text-gray-300 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-900 mb-2">No usage data yet</h3>
-          <p className="text-sm text-gray-500">
+        <div className="text-center py-12 bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700">
+          <BarChart3 className="h-12 w-12 text-gray-300 dark:text-neutral-600 mx-auto mb-4" />
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+            No usage data yet
+          </h3>
+          <p className="text-sm text-gray-500 dark:text-neutral-400">
             Start using AI tools to see your usage metrics here
           </p>
         </div>

--- a/control-plane-ui/src/pages/Deployments.tsx
+++ b/control-plane-ui/src/pages/Deployments.tsx
@@ -74,11 +74,19 @@ const tabs: Tab[] = [
 
 const statusConfig: Record<TraceStatus, { icon: typeof CheckCircle2; color: string; bg: string }> =
   {
-    pending: { icon: Clock, color: 'text-gray-500', bg: 'bg-gray-100' },
-    in_progress: { icon: Loader2, color: 'text-blue-500', bg: 'bg-blue-100' },
-    success: { icon: CheckCircle2, color: 'text-green-500', bg: 'bg-green-100' },
-    failed: { icon: XCircle, color: 'text-red-500', bg: 'bg-red-100' },
-    skipped: { icon: AlertCircle, color: 'text-yellow-500', bg: 'bg-yellow-100' },
+    pending: { icon: Clock, color: 'text-gray-500', bg: 'bg-gray-100 dark:bg-gray-800' },
+    in_progress: { icon: Loader2, color: 'text-blue-500', bg: 'bg-blue-100 dark:bg-blue-900/30' },
+    success: {
+      icon: CheckCircle2,
+      color: 'text-green-500',
+      bg: 'bg-green-100 dark:bg-green-900/30',
+    },
+    failed: { icon: XCircle, color: 'text-red-500', bg: 'bg-red-100 dark:bg-red-900/30' },
+    skipped: {
+      icon: AlertCircle,
+      color: 'text-yellow-500',
+      bg: 'bg-yellow-100 dark:bg-yellow-900/30',
+    },
   };
 
 const stepNames: Record<string, { label: string; icon: typeof Activity }> = {
@@ -120,15 +128,15 @@ function StatsCard({
   color: string;
 }) {
   return (
-    <div className="rounded-lg bg-white p-6 shadow-sm border border-gray-100">
+    <div className="rounded-lg bg-white dark:bg-neutral-800 p-6 shadow-sm border border-gray-100 dark:border-neutral-700">
       <div className="flex items-center gap-4">
         <div className={clsx('rounded-lg p-3', color)}>
           <Icon className="h-6 w-6 text-white" />
         </div>
         <div>
-          <p className="text-sm font-medium text-gray-500">{title}</p>
-          <p className="text-2xl font-bold text-gray-900">{value}</p>
-          {subtitle && <p className="text-xs text-gray-400">{subtitle}</p>}
+          <p className="text-sm font-medium text-gray-500 dark:text-neutral-400">{title}</p>
+          <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
+          {subtitle && <p className="text-xs text-gray-400 dark:text-neutral-500">{subtitle}</p>}
         </div>
       </div>
     </div>
@@ -147,7 +155,7 @@ function StepTimeline({ steps }: { steps: TraceStep[] }) {
         return (
           <div key={index} className="relative">
             {index < steps.length - 1 && (
-              <div className="absolute left-4 top-8 h-full w-0.5 bg-gray-200" />
+              <div className="absolute left-4 top-8 h-full w-0.5 bg-gray-200 dark:bg-neutral-600" />
             )}
             <div className={clsx('flex items-start gap-3 rounded-lg p-3', cfg.bg)}>
               <div className={clsx('rounded-full p-1', cfg.bg)}>
@@ -161,8 +169,10 @@ function StepTimeline({ steps }: { steps: TraceStep[] }) {
               </div>
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
-                  <StepTypeIcon className="h-4 w-4 text-gray-400" />
-                  <span className="font-medium text-gray-900">{stepInfo.label}</span>
+                  <StepTypeIcon className="h-4 w-4 text-gray-400 dark:text-neutral-500" />
+                  <span className="font-medium text-gray-900 dark:text-white">
+                    {stepInfo.label}
+                  </span>
                   {step.duration_ms && (
                     <span className="text-xs text-gray-500">
                       ({formatDuration(step.duration_ms)})
@@ -170,10 +180,10 @@ function StepTimeline({ steps }: { steps: TraceStep[] }) {
                   )}
                 </div>
                 {step.details && (
-                  <div className="mt-2 text-xs text-gray-600 font-mono bg-white/50 rounded p-2">
+                  <div className="mt-2 text-xs text-gray-600 dark:text-neutral-300 font-mono bg-white/50 dark:bg-neutral-800/50 rounded p-2">
                     {Object.entries(step.details).map(([key, value]) => (
                       <div key={key} className="flex gap-2">
-                        <span className="text-gray-400">{key}:</span>
+                        <span className="text-gray-400 dark:text-neutral-500">{key}:</span>
                         <span className="truncate">
                           {typeof value === 'object' ? JSON.stringify(value) : String(value)}
                         </span>
@@ -182,7 +192,7 @@ function StepTimeline({ steps }: { steps: TraceStep[] }) {
                   </div>
                 )}
                 {step.error && (
-                  <div className="mt-2 text-xs text-red-600 bg-red-50 rounded p-2">
+                  <div className="mt-2 text-xs text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 rounded p-2">
                     {step.error}
                   </div>
                 )}
@@ -225,12 +235,12 @@ function TraceRow({
   }, [isExpanded, trace.id, details]);
 
   return (
-    <div className="border-b border-gray-100 last:border-0">
+    <div className="border-b border-gray-100 dark:border-neutral-700 last:border-0">
       <div
-        className="flex items-center gap-4 p-4 hover:bg-gray-50 cursor-pointer"
+        className="flex items-center gap-4 p-4 hover:bg-gray-50 dark:hover:bg-neutral-700 cursor-pointer"
         onClick={onToggle}
       >
-        <button className="text-gray-400">
+        <button className="text-gray-400 dark:text-neutral-500">
           {isExpanded ? <ChevronDown className="h-5 w-5" /> : <ChevronRight className="h-5 w-5" />}
         </button>
         <div className={clsx('rounded-full p-1.5', cfg.bg)}>
@@ -240,46 +250,50 @@ function TraceRow({
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <GitBranch className="h-4 w-4 text-gray-400" />
-            <span className="font-medium text-gray-900">{trace.trigger_type}</span>
+            <GitBranch className="h-4 w-4 text-gray-400 dark:text-neutral-500" />
+            <span className="font-medium text-gray-900 dark:text-white">{trace.trigger_type}</span>
             {trace.api_name && (
               <>
-                <span className="text-gray-400">→</span>
+                <span className="text-gray-400 dark:text-neutral-500">→</span>
                 <span className="text-blue-600">{trace.api_name}</span>
               </>
             )}
           </div>
           {trace.git_commit_message && (
-            <p className="text-sm text-gray-500 truncate mt-1">{trace.git_commit_message}</p>
+            <p className="text-sm text-gray-500 dark:text-neutral-400 truncate mt-1">
+              {trace.git_commit_message}
+            </p>
           )}
         </div>
-        <div className="flex items-center gap-2 text-sm text-gray-500">
+        <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-neutral-400">
           <User className="h-4 w-4" />
           <span>{trace.git_author || 'unknown'}</span>
         </div>
         {trace.git_commit_sha && (
-          <div className="flex items-center gap-1 text-sm text-gray-400 font-mono">
+          <div className="flex items-center gap-1 text-sm text-gray-400 dark:text-neutral-500 font-mono">
             <GitCommit className="h-4 w-4" />
             <span>{trace.git_commit_sha}</span>
           </div>
         )}
-        <div className="flex items-center gap-1 text-sm text-gray-500 w-20 justify-end">
+        <div className="flex items-center gap-1 text-sm text-gray-500 dark:text-neutral-400 w-20 justify-end">
           <Clock className="h-4 w-4" />
           <span>{formatDuration(trace.total_duration_ms)}</span>
         </div>
         <div className="flex items-center gap-1 text-sm w-16">
           <span className="text-green-600">{trace.steps_completed}</span>
-          <span className="text-gray-400">/</span>
-          <span className="text-gray-600">{trace.steps_count}</span>
+          <span className="text-gray-400 dark:text-neutral-500">/</span>
+          <span className="text-gray-600 dark:text-neutral-300">{trace.steps_count}</span>
           {trace.steps_failed > 0 && (
             <span className="text-red-500 ml-1">({trace.steps_failed})</span>
           )}
         </div>
-        <div className="text-sm text-gray-400 w-24 text-right">{formatTime(trace.created_at)}</div>
+        <div className="text-sm text-gray-400 dark:text-neutral-500 w-24 text-right">
+          {formatTime(trace.created_at)}
+        </div>
       </div>
 
       {isExpanded && (
-        <div className="bg-gray-50 p-4 border-t border-gray-100">
+        <div className="bg-gray-50 dark:bg-neutral-800 p-4 border-t border-gray-100 dark:border-neutral-700">
           {loading ? (
             <div className="flex items-center justify-center py-8">
               <Loader2 className="h-6 w-6 animate-spin text-blue-500" />
@@ -287,31 +301,37 @@ function TraceRow({
           ) : details ? (
             <div className="grid grid-cols-2 gap-6">
               <div className="space-y-4">
-                <h4 className="font-medium text-gray-900">Git Information</h4>
-                <div className="bg-white rounded-lg p-4 space-y-2 text-sm">
+                <h4 className="font-medium text-gray-900 dark:text-white">Git Information</h4>
+                <div className="bg-white dark:bg-neutral-700 rounded-lg p-4 space-y-2 text-sm">
                   <div className="flex justify-between">
-                    <span className="text-gray-500">Project:</span>
-                    <span className="font-mono">{details.git_project || '-'}</span>
+                    <span className="text-gray-500 dark:text-neutral-400">Project:</span>
+                    <span className="font-mono dark:text-neutral-200">
+                      {details.git_project || '-'}
+                    </span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-gray-500">Branch:</span>
-                    <span className="font-mono">{details.git_branch || '-'}</span>
+                    <span className="text-gray-500 dark:text-neutral-400">Branch:</span>
+                    <span className="font-mono dark:text-neutral-200">
+                      {details.git_branch || '-'}
+                    </span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-gray-500">Author:</span>
+                    <span className="text-gray-500 dark:text-neutral-400">Author:</span>
                     <span>
                       {details.git_author}{' '}
                       {details.git_author_email && `<${details.git_author_email}>`}
                     </span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-gray-500">Commit:</span>
-                    <span className="font-mono">{details.git_commit_sha || '-'}</span>
+                    <span className="text-gray-500 dark:text-neutral-400">Commit:</span>
+                    <span className="font-mono dark:text-neutral-200">
+                      {details.git_commit_sha || '-'}
+                    </span>
                   </div>
                   {details.git_files_changed && details.git_files_changed.length > 0 && (
                     <div>
-                      <span className="text-gray-500">Files changed:</span>
-                      <ul className="mt-1 text-xs font-mono text-gray-600 max-h-32 overflow-auto">
+                      <span className="text-gray-500 dark:text-neutral-400">Files changed:</span>
+                      <ul className="mt-1 text-xs font-mono text-gray-600 dark:text-neutral-300 max-h-32 overflow-auto">
                         {details.git_files_changed.map((file, i) => (
                           <li key={i} className="truncate">
                             {file}
@@ -322,19 +342,23 @@ function TraceRow({
                   )}
                 </div>
                 {details.error_summary && (
-                  <div className="bg-red-50 rounded-lg p-4">
-                    <h5 className="font-medium text-red-800 mb-2">Error</h5>
-                    <p className="text-sm text-red-600">{details.error_summary}</p>
+                  <div className="bg-red-50 dark:bg-red-900/20 rounded-lg p-4">
+                    <h5 className="font-medium text-red-800 dark:text-red-400 mb-2">Error</h5>
+                    <p className="text-sm text-red-600 dark:text-red-300">
+                      {details.error_summary}
+                    </p>
                   </div>
                 )}
               </div>
               <div className="space-y-4">
-                <h4 className="font-medium text-gray-900">Pipeline Steps</h4>
+                <h4 className="font-medium text-gray-900 dark:text-white">Pipeline Steps</h4>
                 <StepTimeline steps={details.steps} />
               </div>
             </div>
           ) : (
-            <p className="text-center text-gray-500 py-4">Failed to load details</p>
+            <p className="text-center text-gray-500 dark:text-neutral-400 py-4">
+              Failed to load details
+            </p>
           )}
         </div>
       )}
@@ -385,9 +409,11 @@ function PipelineTracesTab() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <p className="text-gray-500">End-to-end tracing of GitLab → Kafka → AWX pipeline</p>
+        <p className="text-gray-500 dark:text-neutral-400">
+          End-to-end tracing of GitLab → Kafka → AWX pipeline
+        </p>
         <div className="flex items-center gap-4">
-          <label className="flex items-center gap-2 text-sm text-gray-600">
+          <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-neutral-400">
             <input
               type="checkbox"
               checked={autoRefresh}
@@ -436,13 +462,13 @@ function PipelineTracesTab() {
         </div>
       )}
 
-      <div className="rounded-lg bg-white shadow-sm border border-gray-100">
-        <div className="border-b border-gray-100 px-4 py-3">
-          <h2 className="font-medium text-gray-900">Recent Pipeline Executions</h2>
+      <div className="rounded-lg bg-white dark:bg-neutral-800 shadow-sm border border-gray-100 dark:border-neutral-700">
+        <div className="border-b border-gray-100 dark:border-neutral-700 px-4 py-3">
+          <h2 className="font-medium text-gray-900 dark:text-white">Recent Pipeline Executions</h2>
         </div>
         {traces.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-12 text-gray-500">
-            <Activity className="h-12 w-12 mb-4 text-gray-300" />
+          <div className="flex flex-col items-center justify-center py-12 text-gray-500 dark:text-neutral-400">
+            <Activity className="h-12 w-12 mb-4 text-gray-300 dark:text-neutral-600" />
             <p>No pipeline traces yet</p>
             <p className="text-sm">Push to GitLab to trigger a pipeline</p>
           </div>
@@ -553,20 +579,20 @@ function DeploymentHistoryTab() {
   );
 
   const statusColors: Record<string, string> = {
-    pending: 'bg-yellow-100 text-yellow-800',
-    in_progress: 'bg-blue-100 text-blue-800',
-    success: 'bg-green-100 text-green-800',
-    failed: 'bg-red-100 text-red-800',
-    rolled_back: 'bg-gray-100 text-gray-800',
+    pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+    in_progress: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+    success: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+    failed: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+    rolled_back: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300',
   };
 
   if (loading && tenants.length === 0) {
     return (
       <div className="space-y-6">
-        <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-4">
-          <div className="h-10 w-48 bg-gray-200 rounded animate-pulse" />
+        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 p-4">
+          <div className="h-10 w-48 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
         </div>
-        <div className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 overflow-hidden">
           <TableSkeleton rows={5} columns={7} />
         </div>
       </div>
@@ -576,17 +602,19 @@ function DeploymentHistoryTab() {
   return (
     <div className="space-y-6">
       {/* Filters */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 p-4">
         <div className="flex flex-wrap gap-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Tenant</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              Tenant
+            </label>
             <select
               value={selectedTenant}
               onChange={(e) => {
                 setSelectedTenant(e.target.value);
                 setSelectedApi('');
               }}
-              className="w-48 border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-48 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               {tenants.map((tenant) => (
                 <option key={tenant.id} value={tenant.id}>
@@ -596,11 +624,13 @@ function DeploymentHistoryTab() {
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">API (optional)</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              API (optional)
+            </label>
             <select
               value={selectedApi}
               onChange={(e) => setSelectedApi(e.target.value)}
-              className="w-48 border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-48 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               <option value="">All APIs</option>
               {apis.map((api) => (
@@ -614,7 +644,7 @@ function DeploymentHistoryTab() {
       </div>
 
       {error && (
-        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 px-4 py-3 rounded-lg">
           {error}
           <button onClick={() => setError(null)} className="float-right font-bold">
             &times;
@@ -623,57 +653,61 @@ function DeploymentHistoryTab() {
       )}
 
       {/* Deployments List */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 overflow-hidden">
         {loading ? (
           <TableSkeleton rows={5} columns={7} />
         ) : deployments.length === 0 ? (
           <EmptyState variant="deployments" description="Deploy an API to see it here." />
         ) : (
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
+            <thead className="bg-gray-50 dark:bg-neutral-700">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   API
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Environment
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Version
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Status
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Started
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Deployed By
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Actions
                 </th>
               </tr>
             </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
+            <tbody className="bg-white dark:bg-neutral-800 divide-y divide-gray-200 dark:divide-neutral-700">
               {deployments.map((deployment) => (
-                <tr key={deployment.id} className="hover:bg-gray-50">
+                <tr key={deployment.id} className="hover:bg-gray-50 dark:hover:bg-neutral-700">
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm font-medium text-gray-900">{deployment.api_name}</div>
-                    <div className="text-xs text-gray-500 font-mono">{deployment.api_id}</div>
+                    <div className="text-sm font-medium text-gray-900 dark:text-white">
+                      {deployment.api_name}
+                    </div>
+                    <div className="text-xs text-gray-500 dark:text-neutral-400 font-mono">
+                      {deployment.api_id}
+                    </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <span
                       className={`px-2 py-1 text-xs font-medium rounded ${
                         deployment.environment === 'dev'
-                          ? 'bg-green-100 text-green-700'
-                          : 'bg-blue-100 text-blue-700'
+                          ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                          : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
                       }`}
                     >
                       {deployment.environment.toUpperCase()}
                     </span>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-neutral-400">
                     v{deployment.version}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
@@ -691,10 +725,10 @@ function DeploymentHistoryTab() {
                       </p>
                     )}
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-neutral-400">
                     {new Date(deployment.started_at).toLocaleString()}
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-neutral-400">
                     {deployment.deployed_by}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm">
@@ -739,14 +773,16 @@ function GitLabConfigTab() {
   return (
     <div className="space-y-6">
       {/* GitOps Overview */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">GitOps Integration</h3>
-        <p className="text-gray-600 mb-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          GitOps Integration
+        </h3>
+        <p className="text-gray-600 dark:text-neutral-400 mb-4">
           API definitions are managed through Git. When you commit changes to the repository,
           webhooks automatically trigger the deployment pipeline.
         </p>
-        <div className="bg-gray-50 rounded-lg p-4 font-mono text-sm">
-          <div className="text-gray-500 mb-2"># Pipeline flow</div>
+        <div className="bg-gray-50 dark:bg-neutral-900 rounded-lg p-4 font-mono text-sm">
+          <div className="text-gray-500 dark:text-neutral-400 mb-2"># Pipeline flow</div>
           <div className="text-blue-600">GitLab Push</div>
           <div className="text-gray-400 ml-4">↓ webhook</div>
           <div className="text-green-600 ml-4">Control-Plane-API</div>
@@ -760,10 +796,12 @@ function GitLabConfigTab() {
       </div>
 
       {/* Repository Structure */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">Repository Structure</h3>
-        <div className="bg-gray-50 rounded-lg p-4 font-mono text-sm">
-          <pre className="text-gray-700">{`stoa-api-definitions/
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          Repository Structure
+        </h3>
+        <div className="bg-gray-50 dark:bg-neutral-900 rounded-lg p-4 font-mono text-sm">
+          <pre className="text-gray-700 dark:text-neutral-300">{`stoa-api-definitions/
 ├── tenants/
 │   ├── tenant-acme/
 │   │   ├── apis/
@@ -787,8 +825,10 @@ function GitLabConfigTab() {
       </div>
 
       {/* External Links */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">External Resources</h3>
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          External Resources
+        </h3>
         <div className="flex flex-wrap gap-4">
           <a
             href={config.services.gitlab.url}
@@ -814,23 +854,27 @@ function GitLabConfigTab() {
       </div>
 
       {/* Webhook Status */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">Webhook Configuration</h3>
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          Webhook Configuration
+        </h3>
         <div className="space-y-3">
-          <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+          <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-neutral-900 rounded-lg">
             <div>
-              <p className="font-medium text-gray-900">GitLab Webhook</p>
-              <p className="text-sm text-gray-500">Receives push and merge request events</p>
+              <p className="font-medium text-gray-900 dark:text-white">GitLab Webhook</p>
+              <p className="text-sm text-gray-500 dark:text-neutral-400">
+                Receives push and merge request events
+              </p>
             </div>
-            <span className="flex items-center gap-2 px-3 py-1 bg-green-100 text-green-800 rounded-full text-sm">
+            <span className="flex items-center gap-2 px-3 py-1 bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400 rounded-full text-sm">
               <CheckCircle2 className="h-4 w-4" />
               Active
             </span>
           </div>
-          <div className="text-sm text-gray-500">
+          <div className="text-sm text-gray-500 dark:text-neutral-400">
             <p>
               <strong>Endpoint:</strong>{' '}
-              <code className="bg-gray-100 px-2 py-0.5 rounded">
+              <code className="bg-gray-100 dark:bg-neutral-700 px-2 py-0.5 rounded">
                 {config.api.baseUrl}/webhooks/gitlab
               </code>
             </p>
@@ -855,12 +899,14 @@ export function Deployments() {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Deployments</h1>
-        <p className="text-gray-500 mt-1">GitOps pipeline monitoring and deployment history</p>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Deployments</h1>
+        <p className="text-gray-500 dark:text-neutral-400 mt-1">
+          GitOps pipeline monitoring and deployment history
+        </p>
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-gray-200">
+      <div className="border-b border-gray-200 dark:border-neutral-700">
         <nav className="flex gap-8">
           {tabs.map((tab) => (
             <button
@@ -870,7 +916,7 @@ export function Deployments() {
                 'flex items-center gap-2 py-4 px-1 border-b-2 font-medium text-sm transition-colors',
                 activeTab === tab.id
                   ? 'border-blue-500 text-blue-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                  : 'border-transparent text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-300 hover:border-gray-300 dark:hover:border-neutral-500'
               )}
             >
               <tab.icon className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- Add dark mode support to `Deployments.tsx` (Pipeline Traces, Deployment History, GitLab Config tabs)
- Add dark mode support to `AITools/ToolCatalog.tsx`, `AITools/ToolDetail.tsx`, `AITools/MySubscriptions.tsx`, `AITools/UsageDashboard.tsx`
- Follows established dark mode pattern: `dark:bg-neutral-800` (cards), `dark:text-white` (headings), `dark:text-neutral-400` (secondary text), `dark:border-neutral-700` (borders)

## Test plan
- [x] Local quality gate passed (tsc, eslint 93/93, prettier, vitest 282/282)
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>