### PR TITLE
fix(ui): dark mode for APIs, Tenants, Applications pages

### DIFF
--- a/control-plane-ui/src/pages/APIs.tsx
+++ b/control-plane-ui/src/pages/APIs.tsx
@@ -17,9 +17,9 @@ const PAGE_SIZE = 20;
 
 // Status colors moved outside component to prevent recreation
 const statusColors: Record<string, string> = {
-  draft: 'bg-gray-100 text-gray-800',
-  published: 'bg-green-100 text-green-800',
-  deprecated: 'bg-yellow-100 text-yellow-800',
+  draft: 'bg-gray-100 text-gray-800 dark:bg-neutral-700 dark:text-neutral-300',
+  published: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  deprecated: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
 };
 
 export function APIs() {
@@ -225,8 +225,10 @@ export function APIs() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">APIs</h1>
-          <p className="text-gray-500 mt-1">Manage API definitions and deployments</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">APIs</h1>
+          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+            Manage API definitions and deployments
+          </p>
         </div>
         <button
           onClick={() => setShowCreateModal(true)}
@@ -241,15 +243,17 @@ export function APIs() {
       </div>
 
       {/* Filters */}
-      <div className="bg-white rounded-lg shadow p-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
         <div className="flex flex-wrap gap-4 items-end">
           {/* Tenant Selector */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Tenant</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+              Tenant
+            </label>
             <select
               value={selectedTenant}
               onChange={(e) => setSelectedTenant(e.target.value)}
-              className="w-48 border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-48 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               {tenants.map((tenant) => (
                 <option key={tenant.id} value={tenant.id}>
@@ -261,14 +265,16 @@ export function APIs() {
 
           {/* Search Input */}
           <div className="flex-1 min-w-[200px]">
-            <label className="block text-sm font-medium text-gray-700 mb-2">Search</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+              Search
+            </label>
             <div className="relative">
               <input
                 type="text"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Search by name, description, URL..."
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 pl-10 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 pl-10 bg-white dark:bg-neutral-700 dark:text-white dark:placeholder-neutral-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
               <svg
                 className="absolute left-3 top-2.5 h-5 w-5 text-gray-400"
@@ -303,11 +309,13 @@ export function APIs() {
 
           {/* Status Filter */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Status</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+              Status
+            </label>
             <select
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
-              className="w-36 border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-36 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               <option value="">All Status</option>
               <option value="draft">Draft</option>
@@ -317,7 +325,7 @@ export function APIs() {
           </div>
 
           {/* Results count */}
-          <div className="text-sm text-gray-500 self-end pb-2">
+          <div className="text-sm text-gray-500 dark:text-neutral-400 self-end pb-2">
             {filteredApis.length} of {apis.length} APIs
           </div>
         </div>
@@ -330,7 +338,7 @@ export function APIs() {
       )}
 
       {/* APIs List */}
-      <div className="bg-white rounded-lg shadow overflow-hidden">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow overflow-hidden">
         {loading ? (
           <TableSkeleton
             rows={5}
@@ -354,41 +362,43 @@ export function APIs() {
             }}
           />
         ) : (
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
+            <thead className="bg-gray-50 dark:bg-neutral-700">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Name
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Version
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Status
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Portal
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Deployed
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
                   Actions
                 </th>
               </tr>
             </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
+            <tbody className="bg-white dark:bg-neutral-800 divide-y divide-gray-200 dark:divide-neutral-700">
               {paginatedApis.map((api) => (
-                <tr key={api.id} className="hover:bg-gray-50">
+                <tr key={api.id} className="hover:bg-gray-50 dark:hover:bg-neutral-700">
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div>
-                      <div className="text-sm font-medium text-gray-900">
+                      <div className="text-sm font-medium text-gray-900 dark:text-white">
                         {api.display_name || api.name}
                       </div>
-                      <div className="text-sm text-gray-500">{api.backend_url}</div>
+                      <div className="text-sm text-gray-500 dark:text-neutral-400">
+                        {api.backend_url}
+                      </div>
                     </div>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-neutral-400">
                     v{api.version}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
@@ -400,7 +410,7 @@ export function APIs() {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm">
                     {api.portal_promoted || api.tags?.includes('portal:published') ? (
-                      <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs bg-purple-100 text-purple-700">
+                      <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
                         <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
                           <path
                             fillRule="evenodd"
@@ -411,18 +421,20 @@ export function APIs() {
                         Published
                       </span>
                     ) : (
-                      <span className="text-gray-400 text-xs">Not promoted</span>
+                      <span className="text-gray-400 dark:text-neutral-500 text-xs">
+                        Not promoted
+                      </span>
                     )}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm">
                     <div className="flex gap-2">
                       <span
-                        className={`px-2 py-1 rounded text-xs ${api.deployed_dev ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}
+                        className={`px-2 py-1 rounded text-xs ${api.deployed_dev ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' : 'bg-gray-100 text-gray-500 dark:bg-neutral-700 dark:text-neutral-400'}`}
                       >
                         DEV
                       </span>
                       <span
-                        className={`px-2 py-1 rounded text-xs ${api.deployed_staging ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500'}`}
+                        className={`px-2 py-1 rounded text-xs ${api.deployed_staging ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' : 'bg-gray-100 text-gray-500 dark:bg-neutral-700 dark:text-neutral-400'}`}
                       >
                         STG
                       </span>
@@ -432,27 +444,27 @@ export function APIs() {
                     <div className="flex gap-2">
                       <button
                         onClick={() => handleDeploy(api, 'dev')}
-                        className="text-green-600 hover:text-green-800"
+                        className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300"
                         title="Deploy to DEV"
                       >
                         Deploy DEV
                       </button>
                       <button
                         onClick={() => handleDeploy(api, 'staging')}
-                        className="text-blue-600 hover:text-blue-800"
+                        className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
                         title="Deploy to Staging"
                       >
                         Deploy STG
                       </button>
                       <button
                         onClick={() => setEditingApi(api)}
-                        className="text-gray-600 hover:text-gray-800"
+                        className="text-gray-600 hover:text-gray-800 dark:text-neutral-400 dark:hover:text-white"
                       >
                         Edit
                       </button>
                       <button
                         onClick={() => handleDelete(api.id, api.display_name || api.name)}
-                        className="text-red-600 hover:text-red-800"
+                        className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
                       >
                         Delete
                       </button>
@@ -466,8 +478,8 @@ export function APIs() {
 
         {/* Pagination */}
         {!loading && filteredApis.length > 0 && totalPages > 1 && (
-          <div className="bg-gray-50 px-6 py-3 flex items-center justify-between border-t border-gray-200">
-            <div className="text-sm text-gray-500">
+          <div className="bg-gray-50 dark:bg-neutral-700 px-6 py-3 flex items-center justify-between border-t border-gray-200 dark:border-neutral-600">
+            <div className="text-sm text-gray-500 dark:text-neutral-400">
               Showing {(currentPage - 1) * PAGE_SIZE + 1} to{' '}
               {Math.min(currentPage * PAGE_SIZE, filteredApis.length)} of {filteredApis.length}{' '}
               results
@@ -476,17 +488,17 @@ export function APIs() {
               <button
                 onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
                 disabled={currentPage === 1}
-                className="px-3 py-1 text-sm border border-gray-300 rounded-lg hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-3 py-1 text-sm border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-600 dark:text-neutral-300 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Previous
               </button>
-              <span className="px-3 py-1 text-sm text-gray-700">
+              <span className="px-3 py-1 text-sm text-gray-700 dark:text-neutral-300">
                 Page {currentPage} of {totalPages}
               </span>
               <button
                 onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
                 disabled={currentPage === totalPages}
-                className="px-3 py-1 text-sm border border-gray-300 rounded-lg hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-3 py-1 text-sm border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-600 dark:text-neutral-300 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Next
               </button>
@@ -638,10 +650,13 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
-        <div className="flex justify-between items-center px-6 py-4 border-b">
-          <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="flex justify-between items-center px-6 py-4 border-b dark:border-neutral-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-neutral-300"
+          >
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
                 strokeLinecap="round"
@@ -656,14 +671,14 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
         {/* Mode Selector (only for create) */}
         {!isEdit && (
           <div className="px-6 pt-4">
-            <div className="flex rounded-lg bg-gray-100 p-1">
+            <div className="flex rounded-lg bg-gray-100 dark:bg-neutral-700 p-1">
               <button
                 type="button"
                 onClick={() => setMode('manual')}
                 className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors ${
                   mode === 'manual'
-                    ? 'bg-white text-gray-900 shadow'
-                    : 'text-gray-500 hover:text-gray-700'
+                    ? 'bg-white dark:bg-neutral-600 text-gray-900 dark:text-white shadow'
+                    : 'text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-300'
                 }`}
               >
                 Manual Entry
@@ -673,8 +688,8 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
                 onClick={() => setMode('openapi')}
                 className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors ${
                   mode === 'openapi'
-                    ? 'bg-white text-gray-900 shadow'
-                    : 'text-gray-500 hover:text-gray-700'
+                    ? 'bg-white dark:bg-neutral-600 text-gray-900 dark:text-white shadow'
+                    : 'text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-300'
                 }`}
               >
                 Import OpenAPI/Swagger
@@ -686,9 +701,9 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
         <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-6 space-y-4">
           {/* OpenAPI Import Section */}
           {mode === 'openapi' && !isEdit && (
-            <div className="space-y-4 pb-4 border-b">
+            <div className="space-y-4 pb-4 border-b dark:border-neutral-700">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
+                <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
                   Upload OpenAPI/Swagger File
                 </label>
                 <div className="flex gap-2">
@@ -702,7 +717,7 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
                   <button
                     type="button"
                     onClick={() => fileInputRef.current?.click()}
-                    className="flex items-center gap-2 px-4 py-2 border-2 border-dashed border-gray-300 rounded-lg hover:border-blue-400 hover:bg-blue-50 transition-colors"
+                    className="flex items-center gap-2 px-4 py-2 border-2 border-dashed border-gray-300 dark:border-neutral-600 rounded-lg hover:border-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors dark:text-neutral-300"
                   >
                     <svg
                       className="w-5 h-5 text-gray-400"
@@ -723,7 +738,7 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
+                <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
                   Or Paste OpenAPI/Swagger Content
                 </label>
                 <textarea
@@ -734,7 +749,7 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
                       parseOpenApiSpec(e.target.value);
                     }
                   }}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"
+                  className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"
                   rows={8}
                   placeholder={`openapi: "3.0.0"
 info:
@@ -751,13 +766,13 @@ paths:
               </div>
 
               {parseError && (
-                <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+                <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 px-4 py-3 rounded-lg text-sm">
                   {parseError}
                 </div>
               )}
 
               {formData.name && !parseError && formData.openapi_spec && (
-                <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg text-sm">
+                <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 text-green-700 dark:text-green-400 px-4 py-3 rounded-lg text-sm">
                   <strong>Parsed successfully!</strong> Found API: {formData.display_name} v
                   {formData.version}
                 </div>
@@ -775,7 +790,7 @@ paths:
             <div className="space-y-4">
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                  <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
                     Name (slug)
                   </label>
                   <input
@@ -787,18 +802,20 @@ paths:
                         name: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '-'),
                       })
                     }
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     placeholder="payment-api"
                     required
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Version</label>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+                    Version
+                  </label>
                   <input
                     type="text"
                     value={formData.version}
                     onChange={(e) => setFormData({ ...formData, version: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     placeholder="1.0.0"
                     required
                   />
@@ -838,16 +855,18 @@ paths:
             variant="bordered"
           >
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Backend URL</label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+                Backend URL
+              </label>
               <input
                 type="url"
                 value={formData.backend_url}
                 onChange={(e) => setFormData({ ...formData, backend_url: e.target.value })}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 placeholder="https://backend.internal/api/v1"
                 required
               />
-              <p className="text-xs text-gray-500 mt-1">
+              <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
                 The backend service URL that the Gateway will proxy requests to
               </p>
             </div>
@@ -863,15 +882,17 @@ paths:
               variant="bordered"
             >
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">OpenAPI Spec</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+                  OpenAPI Spec
+                </label>
                 <textarea
                   value={formData.openapi_spec}
                   onChange={(e) => setFormData({ ...formData, openapi_spec: e.target.value })}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"
+                  className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"
                   rows={6}
                   placeholder="Paste OpenAPI/Swagger spec here (YAML or JSON)..."
                 />
-                <p className="text-xs text-gray-500 mt-1">
+                <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
                   Adding an OpenAPI spec enables API documentation and validation
                 </p>
               </div>
@@ -900,10 +921,13 @@ paths:
                   />
                 </div>
                 <div className="flex-1">
-                  <label htmlFor="portalPromoted" className="text-sm font-medium text-gray-700">
+                  <label
+                    htmlFor="portalPromoted"
+                    className="text-sm font-medium text-gray-700 dark:text-neutral-300"
+                  >
                     Promote to Developer Portal
                   </label>
-                  <p className="text-xs text-gray-500 mt-1">
+                  <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
                     When enabled, this API will be visible in the Developer Portal for consumers to
                     discover and subscribe.
                   </p>
@@ -912,7 +936,7 @@ paths:
 
               {/* Deploy to DEV checkbox */}
               {!isEdit && (
-                <div className="flex items-start gap-3 pt-3 border-t">
+                <div className="flex items-start gap-3 pt-3 border-t dark:border-neutral-700">
                   <div className="flex items-center h-5">
                     <input
                       type="checkbox"
@@ -923,10 +947,13 @@ paths:
                     />
                   </div>
                   <div className="flex-1">
-                    <label htmlFor="deployToDev" className="text-sm font-medium text-gray-700">
+                    <label
+                      htmlFor="deployToDev"
+                      className="text-sm font-medium text-gray-700 dark:text-neutral-300"
+                    >
                       Deploy to DEV environment
                     </label>
-                    <p className="text-xs text-gray-500 mt-1">
+                    <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
                       Automatically deploy this API to the DEV environment after creation.
                     </p>
                   </div>
@@ -935,11 +962,11 @@ paths:
             </div>
           </Collapsible>
 
-          <div className="flex justify-end gap-3 pt-4 border-t mt-6">
+          <div className="flex justify-end gap-3 pt-4 border-t dark:border-neutral-700 mt-6">
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50"
+              className="px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg text-gray-700 dark:text-neutral-300 hover:bg-gray-50 dark:hover:bg-neutral-700"
             >
               Cancel
             </button>

--- a/control-plane-ui/src/pages/Applications.tsx
+++ b/control-plane-ui/src/pages/Applications.tsx
@@ -162,9 +162,9 @@ export function Applications() {
   }
 
   const statusColors: Record<string, string> = {
-    pending: 'bg-yellow-100 text-yellow-800',
-    approved: 'bg-green-100 text-green-800',
-    suspended: 'bg-red-100 text-red-800',
+    pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+    approved: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+    suspended: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
   };
 
   if ((tenantsLoading || loading) && tenants.length === 0) {
@@ -187,8 +187,10 @@ export function Applications() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Applications</h1>
-          <p className="text-gray-500 mt-1">Manage consumer applications and API subscriptions</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Applications</h1>
+          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+            Manage consumer applications and API subscriptions
+          </p>
         </div>
         <button
           onClick={() => setShowCreateModal(true)}
@@ -203,15 +205,17 @@ export function Applications() {
       </div>
 
       {/* Filters */}
-      <div className="bg-white rounded-lg shadow p-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
         <div className="flex flex-wrap gap-4 items-end">
           {/* Tenant Selector */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Tenant</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+              Tenant
+            </label>
             <select
               value={selectedTenant}
               onChange={(e) => setSelectedTenant(e.target.value)}
-              className="w-48 border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-48 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               {tenants.map((tenant) => (
                 <option key={tenant.id} value={tenant.id}>
@@ -223,14 +227,16 @@ export function Applications() {
 
           {/* Search Input */}
           <div className="flex-1 min-w-[200px]">
-            <label className="block text-sm font-medium text-gray-700 mb-2">Search</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+              Search
+            </label>
             <div className="relative">
               <input
                 type="text"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Search by name, description, client ID..."
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 pl-10 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 pl-10 bg-white dark:bg-neutral-700 dark:text-white dark:placeholder-neutral-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
               <svg
                 className="absolute left-3 top-2.5 h-5 w-5 text-gray-400"
@@ -265,11 +271,13 @@ export function Applications() {
 
           {/* Status Filter */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Status</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+              Status
+            </label>
             <select
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
-              className="w-36 border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-36 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               <option value="">All Status</option>
               <option value="pending">Pending</option>
@@ -279,14 +287,14 @@ export function Applications() {
           </div>
 
           {/* Results count */}
-          <div className="text-sm text-gray-500 self-end pb-2">
+          <div className="text-sm text-gray-500 dark:text-neutral-400 self-end pb-2">
             {filteredApplications.length} of {applications.length} applications
           </div>
         </div>
       </div>
 
       {(error || tenantsError) && (
-        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 px-4 py-3 rounded-lg">
           {error || 'Failed to load tenants'}
           <button onClick={() => setError(null)} className="float-right font-bold">
             &times;
@@ -303,7 +311,7 @@ export function Applications() {
             ))}
           </>
         ) : applications.length === 0 ? (
-          <div className="col-span-full bg-white rounded-lg shadow">
+          <div className="col-span-full bg-white dark:bg-neutral-800 rounded-lg shadow">
             <EmptyState
               variant="default"
               title="No applications found"
@@ -312,7 +320,7 @@ export function Applications() {
             />
           </div>
         ) : filteredApplications.length === 0 ? (
-          <div className="col-span-full bg-white rounded-lg shadow">
+          <div className="col-span-full bg-white dark:bg-neutral-800 rounded-lg shadow">
             <EmptyState
               variant="search"
               action={{
@@ -328,14 +336,14 @@ export function Applications() {
           paginatedApplications.map((app) => (
             <div
               key={app.id}
-              className="bg-white rounded-lg shadow p-6 hover:shadow-md transition-shadow"
+              className="bg-white dark:bg-neutral-800 rounded-lg shadow p-6 hover:shadow-md transition-shadow"
             >
               <div className="flex justify-between items-start mb-4">
                 <div>
-                  <h3 className="text-lg font-semibold text-gray-900">
+                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
                     {app.display_name || app.name}
                   </h3>
-                  <p className="text-sm text-gray-500">{app.name}</p>
+                  <p className="text-sm text-gray-500 dark:text-neutral-400">{app.name}</p>
                 </div>
                 <span
                   className={`px-2 py-1 text-xs font-medium rounded-full ${statusColors[app.status]}`}
@@ -344,14 +352,16 @@ export function Applications() {
                 </span>
               </div>
 
-              <p className="text-sm text-gray-600 mb-4 line-clamp-2">
+              <p className="text-sm text-gray-600 dark:text-neutral-300 mb-4 line-clamp-2">
                 {app.description || 'No description'}
               </p>
 
-              <div className="text-sm text-gray-600 mb-4">
+              <div className="text-sm text-gray-600 dark:text-neutral-300 mb-4">
                 <div className="flex items-center gap-2 mb-1">
                   <span className="font-medium">Client ID:</span>
-                  <code className="bg-gray-100 px-2 py-0.5 rounded text-xs">{app.client_id}</code>
+                  <code className="bg-gray-100 dark:bg-neutral-700 px-2 py-0.5 rounded text-xs">
+                    {app.client_id}
+                  </code>
                 </div>
                 <div className="flex items-center gap-2">
                   <span className="font-medium">Subscriptions:</span>
@@ -362,18 +372,20 @@ export function Applications() {
               {/* Subscribed APIs */}
               {app.api_subscriptions && app.api_subscriptions.length > 0 && (
                 <div className="mb-4">
-                  <p className="text-xs font-medium text-gray-500 mb-2">Subscribed APIs:</p>
+                  <p className="text-xs font-medium text-gray-500 dark:text-neutral-400 mb-2">
+                    Subscribed APIs:
+                  </p>
                   <div className="flex flex-wrap gap-1">
                     {app.api_subscriptions.slice(0, 3).map((apiId) => (
                       <span
                         key={apiId}
-                        className="px-2 py-0.5 bg-blue-50 text-blue-700 text-xs rounded"
+                        className="px-2 py-0.5 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 text-xs rounded"
                       >
                         {apiId}
                       </span>
                     ))}
                     {app.api_subscriptions.length > 3 && (
-                      <span className="px-2 py-0.5 bg-gray-100 text-gray-600 text-xs rounded">
+                      <span className="px-2 py-0.5 bg-gray-100 dark:bg-neutral-700 text-gray-600 dark:text-neutral-300 text-xs rounded">
                         +{app.api_subscriptions.length - 3} more
                       </span>
                     )}
@@ -381,16 +393,16 @@ export function Applications() {
                 </div>
               )}
 
-              <div className="flex gap-2 pt-4 border-t">
+              <div className="flex gap-2 pt-4 border-t dark:border-neutral-700">
                 <button
                   onClick={() => setEditingApp(app)}
-                  className="flex-1 px-3 py-2 text-sm text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-lg"
+                  className="flex-1 px-3 py-2 text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-800 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg"
                 >
                   Edit
                 </button>
                 <button
                   onClick={() => handleDelete(app.id, app.display_name || app.name)}
-                  className="flex-1 px-3 py-2 text-sm text-red-600 hover:text-red-800 hover:bg-red-50 rounded-lg"
+                  className="flex-1 px-3 py-2 text-sm text-red-600 dark:text-red-400 hover:text-red-800 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg"
                 >
                   Delete
                 </button>
@@ -402,8 +414,8 @@ export function Applications() {
 
       {/* Pagination */}
       {!loading && filteredApplications.length > 0 && totalPages > 1 && (
-        <div className="bg-white rounded-lg shadow px-6 py-3 flex items-center justify-between">
-          <div className="text-sm text-gray-500">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow px-6 py-3 flex items-center justify-between">
+          <div className="text-sm text-gray-500 dark:text-neutral-400">
             Showing {(currentPage - 1) * PAGE_SIZE + 1} to{' '}
             {Math.min(currentPage * PAGE_SIZE, filteredApplications.length)} of{' '}
             {filteredApplications.length} results
@@ -412,17 +424,17 @@ export function Applications() {
             <button
               onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
               disabled={currentPage === 1}
-              className="px-3 py-1 text-sm border border-gray-300 rounded-lg hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-3 py-1 text-sm border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-700 dark:text-neutral-300 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Previous
             </button>
-            <span className="px-3 py-1 text-sm text-gray-700">
+            <span className="px-3 py-1 text-sm text-gray-700 dark:text-neutral-300">
               Page {currentPage} of {totalPages}
             </span>
             <button
               onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
               disabled={currentPage === totalPages}
-              className="px-3 py-1 text-sm border border-gray-300 rounded-lg hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-3 py-1 text-sm border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-700 dark:text-neutral-300 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Next
             </button>
@@ -513,10 +525,13 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
-        <div className="flex justify-between items-center px-6 py-4 border-b">
-          <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="flex justify-between items-center px-6 py-4 border-b dark:border-neutral-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-neutral-300"
+          >
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
                 strokeLinecap="round"
@@ -530,7 +545,9 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
         <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-6 space-y-4">
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Name (slug)</label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+                Name (slug)
+              </label>
               <input
                 type="text"
                 value={formData.name}
@@ -540,18 +557,20 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
                     name: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '-'),
                   })
                 }
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 placeholder="my-mobile-app"
                 required
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Display Name</label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+                Display Name
+              </label>
               <input
                 type="text"
                 value={formData.display_name}
                 onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 placeholder="My Mobile App"
                 required
               />
@@ -571,19 +590,21 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
 
           {/* Redirect URIs */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Redirect URIs</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              Redirect URIs
+            </label>
             <div className="flex gap-2 mb-2">
               <input
                 type="url"
                 value={redirectUri}
                 onChange={(e) => setRedirectUri(e.target.value)}
-                className="flex-1 border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="flex-1 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 placeholder="https://myapp.example.com/callback"
               />
               <button
                 type="button"
                 onClick={addRedirectUri}
-                className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200"
+                className="px-4 py-2 bg-gray-100 dark:bg-neutral-700 text-gray-700 dark:text-neutral-300 rounded-lg hover:bg-gray-200 dark:hover:bg-neutral-600"
               >
                 Add
               </button>
@@ -593,7 +614,7 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
                 {formData.redirect_uris.map((uri) => (
                   <span
                     key={uri}
-                    className="inline-flex items-center gap-1 px-3 py-1 bg-gray-100 rounded-lg text-sm"
+                    className="inline-flex items-center gap-1 px-3 py-1 bg-gray-100 dark:bg-neutral-700 rounded-lg text-sm dark:text-neutral-300"
                   >
                     {uri}
                     <button
@@ -611,17 +632,19 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
 
           {/* API Subscriptions */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
               API Subscriptions
             </label>
             {apis.length === 0 ? (
-              <p className="text-sm text-gray-500 italic">No APIs available for subscription</p>
+              <p className="text-sm text-gray-500 dark:text-neutral-400 italic">
+                No APIs available for subscription
+              </p>
             ) : (
-              <div className="border border-gray-200 rounded-lg divide-y max-h-48 overflow-y-auto">
+              <div className="border border-gray-200 dark:border-neutral-600 rounded-lg divide-y dark:divide-neutral-700 max-h-48 overflow-y-auto">
                 {apis.map((api) => (
                   <label
                     key={api.id}
-                    className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 cursor-pointer"
+                    className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 dark:hover:bg-neutral-700 cursor-pointer"
                   >
                     <input
                       type="checkbox"
@@ -630,16 +653,16 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
                       className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
                     />
                     <div className="flex-1">
-                      <p className="text-sm font-medium text-gray-900">
+                      <p className="text-sm font-medium text-gray-900 dark:text-white">
                         {api.display_name || api.name}
                       </p>
-                      <p className="text-xs text-gray-500">v{api.version}</p>
+                      <p className="text-xs text-gray-500 dark:text-neutral-400">v{api.version}</p>
                     </div>
                     <span
                       className={`px-2 py-0.5 text-xs rounded ${
                         api.status === 'published'
-                          ? 'bg-green-100 text-green-700'
-                          : 'bg-gray-100 text-gray-600'
+                          ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                          : 'bg-gray-100 text-gray-600 dark:bg-neutral-700 dark:text-neutral-300'
                       }`}
                     >
                       {api.status}
@@ -650,11 +673,11 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
             )}
           </div>
 
-          <div className="flex justify-end gap-3 pt-4 border-t mt-6">
+          <div className="flex justify-end gap-3 pt-4 border-t dark:border-neutral-700 mt-6">
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50"
+              className="px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg text-gray-700 dark:text-neutral-300 hover:bg-gray-50 dark:hover:bg-neutral-700"
             >
               Cancel
             </button>

--- a/control-plane-ui/src/pages/Tenants.tsx
+++ b/control-plane-ui/src/pages/Tenants.tsx
@@ -19,9 +19,9 @@ export function Tenants() {
   });
 
   const statusColors: Record<string, string> = {
-    active: 'bg-green-100 text-green-800',
-    suspended: 'bg-red-100 text-red-800',
-    pending: 'bg-yellow-100 text-yellow-800',
+    active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+    suspended: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+    pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
   };
 
   if (loading) {
@@ -40,16 +40,16 @@ export function Tenants() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Tenants</h1>
-          <p className="text-gray-500 mt-1">View tenant organizations</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Tenants</h1>
+          <p className="text-gray-500 dark:text-neutral-400 mt-1">View tenant organizations</p>
         </div>
-        <div className="text-sm text-gray-500 bg-gray-100 px-3 py-2 rounded-lg">
+        <div className="text-sm text-gray-500 dark:text-neutral-400 bg-gray-100 dark:bg-neutral-700 px-3 py-2 rounded-lg">
           Tenant management via GitOps (Phase 2)
         </div>
       </div>
 
       {error && (
-        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 px-4 py-3 rounded-lg">
           {error.message || 'Failed to load tenants'}
         </div>
       )}
@@ -57,7 +57,7 @@ export function Tenants() {
       {/* Tenants Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {tenants.length === 0 ? (
-          <div className="col-span-full bg-white rounded-lg shadow">
+          <div className="col-span-full bg-white dark:bg-neutral-800 rounded-lg shadow">
             <EmptyState
               variant="users"
               title="No tenants found"
@@ -73,14 +73,16 @@ export function Tenants() {
           tenants.map((tenant) => (
             <div
               key={tenant.id}
-              className="bg-white rounded-lg shadow p-6 hover:shadow-md transition-shadow"
+              className="bg-white dark:bg-neutral-800 rounded-lg shadow p-6 hover:shadow-md transition-shadow"
             >
               <div className="flex justify-between items-start mb-4">
                 <div>
-                  <h3 className="text-lg font-semibold text-gray-900">
+                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
                     {tenant.display_name || tenant.name}
                   </h3>
-                  <p className="text-sm text-gray-500 font-mono">{tenant.name}</p>
+                  <p className="text-sm text-gray-500 dark:text-neutral-400 font-mono">
+                    {tenant.name}
+                  </p>
                 </div>
                 <span
                   className={`px-2 py-1 text-xs font-medium rounded-full ${statusColors[tenant.status]}`}
@@ -89,17 +91,17 @@ export function Tenants() {
                 </span>
               </div>
 
-              <div className="space-y-2 text-sm text-gray-600">
+              <div className="space-y-2 text-sm text-gray-600 dark:text-neutral-300">
                 <div className="flex justify-between">
-                  <span className="text-gray-500">Tenant ID:</span>
+                  <span className="text-gray-500 dark:text-neutral-400">Tenant ID:</span>
                   <span className="font-mono text-xs">{tenant.id}</span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-gray-500">Created:</span>
+                  <span className="text-gray-500 dark:text-neutral-400">Created:</span>
                   <span>{new Date(tenant.created_at).toLocaleDateString()}</span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-gray-500">Last Updated:</span>
+                  <span className="text-gray-500 dark:text-neutral-400">Last Updated:</span>
                   <span>{new Date(tenant.updated_at).toLocaleDateString()}</span>
                 </div>
               </div>
@@ -109,7 +111,7 @@ export function Tenants() {
       </div>
 
       {/* Info Banner */}
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+      <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
         <div className="flex gap-3">
           <svg
             className="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5"
@@ -125,11 +127,13 @@ export function Tenants() {
             />
           </svg>
           <div>
-            <h4 className="text-sm font-medium text-blue-800">Tenant Management</h4>
-            <p className="text-sm text-blue-700 mt-1">
+            <h4 className="text-sm font-medium text-blue-800 dark:text-blue-400">
+              Tenant Management
+            </h4>
+            <p className="text-sm text-blue-700 dark:text-blue-300 mt-1">
               Tenant creation and IAM configuration is managed via the GitOps repository. See the{' '}
-              <code className="bg-blue-100 px-1 rounded">iam/tenants.yaml</code> file for tenant
-              definitions.
+              <code className="bg-blue-100 dark:bg-blue-900/30 px-1 rounded">iam/tenants.yaml</code>{' '}
+              file for tenant definitions.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Redo of PR #239 which was empty due to Dropbox sync revert
- Adds `dark:` Tailwind classes to all elements in APIs.tsx, Applications.tsx, and Tenants.tsx
- Covers: filters, tables, cards, modals, pagination, status badges, form inputs, error/success banners

## Test plan
- [x] tsc clean
- [x] ESLint 93/93 (max-warnings)
- [x] Prettier clean
- [x] vitest 282/282 pass
- [x] lint-staged passed on commit

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>