### PR TITLE
fix(gateway): fix type mismatch in mcp_tools_call handler

### DIFF
--- a/stoa-gateway/src/mcp/handlers.rs
+++ b/stoa-gateway/src/mcp/handlers.rs
@@ -10,8 +10,8 @@
 
 use axum::{
     extract::State,
-    http::{HeaderMap, StatusCode},
-    response::IntoResponse,
+    http::{HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
     Json,
 };
 use serde::{Deserialize, Serialize};
@@ -199,6 +199,24 @@ pub async fn mcp_tools_list(
     })
 }
 
+/// Helper to add rate limit headers to a response
+fn with_rate_limit_headers(
+    status: StatusCode,
+    body: Json<ToolsCallResponse>,
+    rate_result: &crate::rate_limit::RateLimitResult,
+) -> Response {
+    let mut response = (status, body).into_response();
+
+    // Add rate limit headers
+    for (key, value) in rate_result.headers() {
+        if let Ok(header_value) = HeaderValue::from_str(&value) {
+            response.headers_mut().insert(key, header_value);
+        }
+    }
+
+    response
+}
+
 /// POST /mcp/tools/call - Execute a tool
 ///
 /// Full execution pipeline (CAB-1105 Phases 1-4):
@@ -258,7 +276,8 @@ pub async fn mcp_tools_call(
                     }],
                     is_error: Some(true),
                 }),
-            );
+            )
+                .into_response();
         }
     };
 
@@ -286,7 +305,8 @@ pub async fn mcp_tools_call(
                 }],
                 is_error: Some(true),
             }),
-        );
+        )
+            .into_response();
     }
 
     // Build tool context with real JWT claims (Phase 1)
@@ -339,7 +359,8 @@ pub async fn mcp_tools_call(
                 }],
                 is_error: Some(true),
             }),
-        );
+        )
+            .into_response();
     }
     let t_policy = t_policy_start.elapsed();
 
@@ -382,7 +403,8 @@ pub async fn mcp_tools_call(
                     content: vec![ToolContent::Text { text }],
                     is_error: None,
                 }),
-            );
+            )
+                .into_response();
         }
     }
 
@@ -464,6 +486,7 @@ pub async fn mcp_tools_call(
                     is_error: result.is_error,
                 }),
             )
+                .into_response()
         }
         Err(e) => {
             let t_backend = t_backend_start.elapsed();
@@ -503,7 +526,7 @@ pub async fn mcp_tools_call(
                 t_backend_ms,
             );
 
-            (
+            with_rate_limit_headers(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ToolsCallResponse {
                     content: vec![ToolContent::Text {
@@ -511,6 +534,7 @@ pub async fn mcp_tools_call(
                     }],
                     is_error: Some(true),
                 }),
+                &rate_result,
             )
         }
     }

--- a/stoa-gateway/src/rate_limit.rs
+++ b/stoa-gateway/src/rate_limit.rs
@@ -146,7 +146,6 @@ impl RateLimiter {
 
 /// Result of a rate limit check
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct RateLimitResult {
     pub allowed: bool,
     pub limit: usize,
@@ -156,7 +155,6 @@ pub struct RateLimitResult {
 
 impl RateLimitResult {
     /// Generate X-RateLimit-* headers
-    #[allow(dead_code)]
     pub fn headers(&self) -> Vec<(&'static str, String)> {
         let mut headers = vec![
             ("X-RateLimit-Limit", self.limit.to_string()),


### PR DESCRIPTION
## Summary
- Fix compilation error in `stoa-gateway/src/mcp/handlers.rs`: all return branches in `mcp_tools_call` now consistently return `Response<Body>` via `.into_response()`
- Remove unused `#[allow(dead_code)]` on `RateLimitResult` and its `headers()` method (now actively used by the handler)

## Test plan
- [x] `cargo check` — zero errors
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — zero warnings (default features)
- [x] `cargo test` — 325 tests passed, 0 failed
- [x] SAST clippy rules — no `todo!()`, `unimplemented!()`, or `dbg!()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>