### PR TITLE
docs(demo): rewrite demo script as 8-act presentation (D7)

### DIFF
--- a/docs/demo/DEMO-CHECKLIST.md
+++ b/docs/demo/DEMO-CHECKLIST.md
@@ -1,156 +1,219 @@
 # Demo Pre-Flight Checklist
 
-> **CAB-1061** | Run this checklist **30 minutes before** the presentation.
-> Target: 24 February 2026 | "ESB is Dead"
+> **Date**: 24 February 2026 | "ESB is Dead, AI Agents Are Here"
+> Run this checklist **30 minutes before** the presentation.
 
 ---
 
-## T-24h : Preparation
+## T-24h: Preparation
 
-- [ ] Dry-run complet fait (< 5 min)
-- [ ] Video backup enregistree et accessible offline
-- [ ] Slide deck export en PDF (backup si PowerPoint plante)
-- [ ] QR code genere et teste (pointe vers https://docs.gostoa.dev)
+- [ ] Full dry-run completed (< 20 min, all 8 acts)
+- [ ] Video backup recorded and accessible offline
+- [ ] Slide deck exported as PDF (backup)
+- [ ] QR code generated and tested (https://docs.gostoa.dev)
+- [ ] Terminal font size 18pt+ (readable from back of room)
 
-## T-30min : Infrastructure
+## T-30min: Infrastructure
+
+### Start Services
+
+```bash
+cd deploy/docker-compose
+
+# Start all services with federation
+docker compose --profile federation up -d
+
+# Wait for all healthy
+../../scripts/demo/check-health.sh --wait --federation
+
+# Seed demo data
+ANORAK_PASSWORD=readyplayerone ../../scripts/demo/seed-all.sh --federation
+```
+
+### Service Health
+
+```bash
+# Quick check all services
+../../scripts/demo/check-health.sh --federation
+```
+
+- [ ] All 16+ services: HEALTHY
+- [ ] One-shot services (db-migrate, opensearch-init): DONE (exited 0)
+
+### Individual Service Checks
+
+| Service | Check | Expected |
+|---------|-------|----------|
+| Console | `curl -s http://localhost` | 200 (HTML) |
+| Portal | `curl -s http://localhost:3002` | 200 (HTML) |
+| API | `curl -s http://localhost:8000/health` | 200 |
+| Gateway | `curl -s http://localhost:8081/health` | 200 JSON |
+| Keycloak | `curl -s http://localhost/auth/realms/stoa` | 200 JSON |
+| Grafana | `curl -s http://localhost/grafana/api/health` | 200 |
+| OpenSearch | `curl -sfk https://localhost:9200 -u admin:StOa_Admin_2026!` | 200 |
+| Federation GW | `curl -s http://localhost:9000/health` | 200 |
+
+- [ ] All services respond 200
 
 ### Connectivity
 
-- [ ] Wifi stable (tester avec speed test)
-- [ ] Hotspot mobile pret en backup
-- [ ] VPN deconnecte (eviter latence)
+- [ ] Wifi stable (speed test done)
+- [ ] Hotspot mobile ready as backup
+- [ ] VPN disconnected (avoid latency)
 
-### Services UP
+---
 
-Verifier que chaque service repond :
+## T-15min: Browser Setup
+
+### Open Tabs (Chrome, 125% zoom)
+
+| Tab | URL | Pre-condition |
+|-----|-----|---------------|
+| 1 | http://localhost | Logged in as **halliday** |
+| 2 | http://localhost/portal | NOT logged in (fresh) |
+| 3 | Terminal (full screen) | Font 18pt, dark background |
+| 4 | http://localhost/grafana | Logged in as **admin** |
+| 5 | http://localhost/logs | Logged in as **admin** |
+| 6 | http://localhost/auth | Logged in as **admin** |
+
+### Pre-Auth Sessions
+
+1. **Console (Tab 1)** — Login as halliday / readyplayerone
+   - [ ] Dashboard loads with stats
+   - [ ] Sidebar visible: APIs, Tenants, Consumers, Monitoring
+
+2. **Portal (Tab 2)** — Do NOT login (developer flow starts fresh)
+   - [ ] Landing page visible
+
+3. **Grafana (Tab 4)** — Login as admin / admin
+   - [ ] STOA Platform Overview dashboard loads
+   - [ ] Navigate to STOA Gateway Metrics — verify data exists
+
+4. **OpenSearch (Tab 5)** — Login as admin / StOa_Admin_2026!
+   - [ ] Discover page shows stoa-errors-* index
+
+5. **Keycloak (Tab 6)** — Login as admin / admin
+   - [ ] 6 realms visible (stoa + 5 federation)
+
+### Browser State
+
+- [ ] Notifications disabled
+- [ ] "Do Not Disturb" enabled (macOS)
+- [ ] History/favorites bar hidden
+- [ ] Zoom at 125%
+- [ ] Dark mode disabled (better for projector)
+- [ ] Personal tabs closed
+
+---
+
+## T-5min: Verify Each Act
+
+### Act 1 — Console
+
+- [ ] API Catalog page loads with APIs
+- [ ] Tenants page loads
+- [ ] Create Tenant form accessible
+
+### Act 2 — Portal
+
+- [ ] API Catalog loads with searchable APIs
+- [ ] "Payments" search returns results
+- [ ] Subscribe button visible on API detail page
+
+### Act 3 — Gateway
 
 ```bash
-# Health checks — tout doit retourner 200
-curl -s -o /dev/null -w "%{http_code}" https://portal.gostoa.dev     # Portal
-curl -s -o /dev/null -w "%{http_code}" https://console.gostoa.dev    # Console
-curl -s -o /dev/null -w "%{http_code}" https://api.gostoa.dev/health/ready  # API
-curl -s -o /dev/null -w "%{http_code}" https://auth.gostoa.dev       # Keycloak
+# Test gateway health
+curl -s http://localhost/gateway/health | python3 -m json.tool
 ```
+- [ ] Gateway health returns 200 with mode: "edge-mcp"
 
-- [ ] Portal : 200
-- [ ] Console : 200
-- [ ] API : 200
-- [ ] Keycloak : 200
+### Act 4 — Grafana
 
-### Seed Data
+- [ ] Gateway Metrics dashboard has data
+- [ ] Platform Overview dashboard has data
+
+### Act 5 — OpenSearch
+
+- [ ] Error Snapshots dashboard has data (from seed)
+- [ ] Recent Errors table shows entries
+
+### Act 6 — Federation
 
 ```bash
-# Obtenir un token (necessaire pour les endpoints portal)
-TOKEN=$(curl -s -X POST "https://auth.gostoa.dev/realms/stoa/protocol/openid-connect/token" \
-  -d "grant_type=password&client_id=control-plane-ui&username=anorak&password=demo" \
-  | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))")
-
-# Verifier que les APIs demo sont dans le catalogue
-curl -s -H "Authorization: Bearer $TOKEN" \
-  "https://api.gostoa.dev/v1/portal/apis?search=petstore" | python3 -m json.tool | head -5
+# Test federation token (org-alpha)
+curl -s -X POST "http://localhost:8080/realms/demo-org-alpha/protocol/openid-connect/token" \
+  -d "grant_type=password&client_id=demo-client&username=alice&password=alice123" | python3 -c "import sys,json; t=json.load(sys.stdin); print('OK' if 'access_token' in t else 'FAIL: ' + str(t))"
 ```
+- [ ] Token issued for alice in demo-org-alpha
 
-- [ ] Petstore API visible dans le catalogue
-- [ ] Account Management API visible
-- [ ] Payments API visible
-
-Si les APIs manquent, re-executer le seed :
+### Act 7 — MCP Bridge
 
 ```bash
-ANORAK_PASSWORD=<password> python scripts/seed-demo-data.py
+# Test MCP tool discovery
+curl -s http://localhost:8081/mcp/v1/tools | python3 -m json.tool | head -5
+```
+- [ ] MCP tools endpoint responds
+
+### Act 8 — Git Stats
+
+```bash
+git log --oneline --since="2026-02-09" | wc -l
+```
+- [ ] Shows 20+ PRs
+
+---
+
+## Terminal Commands (Pre-Typed)
+
+Prepare these in a script or terminal history:
+
+```bash
+# Act 3.1 — Gateway health
+curl http://localhost/gateway/health | python3 -m json.tool
+
+# Act 3.2 — Authenticated call (replace TOKEN)
+export TOKEN="<paste from Act 2>"
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8081/v1/proxy/payments/status
+
+# Act 3.3 — Rate limit burst
+for i in $(seq 1 20); do curl -s -o /dev/null -w "%{http_code} " -H "Authorization: Bearer $TOKEN" http://localhost:8081/v1/proxy/payments/status; done; echo
+
+# Act 6.2 — Federation token
+TOKEN_A=$(curl -s -X POST "http://localhost:8080/realms/demo-org-alpha/protocol/openid-connect/token" -d "grant_type=password&client_id=demo-client&username=alice&password=alice123" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+curl -H "Authorization: Bearer $TOKEN_A" http://localhost:9000/api/org-beta/resource
+
+# Act 7.1 — MCP tools
+curl http://localhost:8081/mcp/v1/tools | python3 -m json.tool
+
+# Act 7.2 — MCP invoke
+curl -X POST http://localhost:8081/mcp/v1/tools/invoke -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d '{"tool": "payments-api", "arguments": {"action": "get-status"}}'
+
+# Act 8 — Git stats
+git log --oneline --since="2026-02-09" | wc -l
 ```
 
 ---
 
-## T-15min : Navigateur
+## Plan B: If Something Breaks
 
-### Setup onglets
-
-Ouvrir dans cet ordre (Chrome recommande) :
-
-| Onglet | URL | Pre-condition |
-|--------|-----|---------------|
-| 1 | https://portal.gostoa.dev/apis | Logged in as **art3mis** |
-| 2 | https://console.gostoa.dev | Logged in as **parzival** |
-| 3 | Slide deck | Sur la slide titre |
-
-### Pre-auth sessions
-
-1. **Portal** — Se connecter en tant que art3mis
-   - Aller sur https://portal.gostoa.dev
-   - Login SSO avec credentials art3mis
-   - Verifier que le catalogue s'affiche
-   - **Ne pas fermer l'onglet** (la session Keycloak reste active)
-
-2. **Console** — Se connecter en tant que parzival
-   - Aller sur https://console.gostoa.dev
-   - Login Keycloak avec credentials parzival
-   - Verifier que le Dashboard s'affiche
-   - **Ne pas fermer l'onglet**
-
-### Etat du navigateur
-
-- [ ] Notifications navigateur desactivees
-- [ ] Mode "Ne pas deranger" active (macOS)
-- [ ] Historique/favoris barre masquee
-- [ ] Zoom navigateur a 125% (lisibilite salle)
-- [ ] Dark mode desactive (meilleure projection)
-- [ ] Onglets personnels fermes
-
----
-
-## T-5min : Verification scenario
-
-### Portal (onglet 1)
-
-- [ ] API Catalog charge avec les 3 APIs
-- [ ] Recherche "petstore" retourne un resultat
-- [ ] Page detail Petstore API s'ouvre
-- [ ] Onglets Endpoints et OpenAPI Spec fonctionnent
-- [ ] Bouton Subscribe visible
-
-### Console (onglet 2)
-
-- [ ] Dashboard affiche les stats
-- [ ] Page Applications montre "Gunter Analytics Dashboard" en Pending
-- [ ] API Monitoring accessible
-
-### Subscription test (optionnel)
-
-Si aucune souscription active n'existe pour la demo :
-
-1. Portal > Petstore API > Subscribe
-2. Selectionner "OASIS Mobile App" + "Standard Plan"
-3. Verifier que l'API Key est generee
-4. Tester dans le Sandbox : `GET /pets` → 200 OK
-
-> **Note** : Si la souscription existe deja (409), c'est normal et idempotent.
-> Aller dans My Subscriptions pour montrer la souscription existante.
-
----
-
-## Plan B : Si ca plante
-
-| Scenario | Action immediate |
+| Scenario | Immediate Action |
 |----------|-----------------|
-| Wifi down | Basculer sur hotspot mobile |
-| Portal down | Passer aux screenshots dans le slide deck |
-| Keycloak down | Mentionner "environnement en maintenance" et montrer la video backup |
-| Subscribe erreur | Montrer My Subscriptions (souscription existante) |
-| Test Sandbox 500 | Ouvrir terminal, faire un `curl` direct |
-| Tout down | Lancer la video backup (offline) |
-
-### Commande curl de secours
-
-```bash
-# Test direct via httpbin (toujours disponible, retourne 200)
-curl -s https://httpbin.org/anything/pets?status=available | python3 -m json.tool | head -20
-```
+| Wifi down | Switch to mobile hotspot |
+| Console down | Use Portal for admin demo |
+| Gateway 500 | Show pre-recorded terminal output |
+| Grafana empty | Show screenshot in slides |
+| OpenSearch down | "Indexing in progress" + show architecture slide |
+| Federation fails | Show Keycloak admin UI (6 realms visible) |
+| MCP endpoint missing | "Bridge is in development" + show architecture |
+| Everything down | Switch to video backup (offline) |
 
 ---
 
-## Post-demo
+## Post-Demo
 
-- [ ] Collecter contacts (cartes de visite / QR code LinkedIn)
-- [ ] Noter les questions posees
-- [ ] Screenshot du slide final avec QR code (partager sur LinkedIn)
+- [ ] Collect contacts (business cards / LinkedIn QR)
+- [ ] Note questions asked
+- [ ] Screenshot slide with QR code (share on LinkedIn)
+- [ ] Write down any bugs noticed during demo
+- [ ] Update DRY-RUN report with findings

--- a/docs/demo/DEMO-SCRIPT.md
+++ b/docs/demo/DEMO-SCRIPT.md
@@ -1,205 +1,361 @@
-# Demo Script — "ESB is Dead" (5 min)
+# Demo Script — "ESB is Dead, AI Agents Are Here"
 
-> **CAB-1061** | Presentation: 24 February 2026
-> Presenter: Christophe Aboulicam | Platform: STOA
+> **Date**: 24 February 2026 | **Duration**: ~20 min
+> **Presenter**: Christophe Aboulicam | **Platform**: STOA
+> **Setup**: Docker Compose local (17 services) or EKS production
 
 ---
 
 ## Overview
 
-| Segment | Time | What |
-|---------|------|------|
-| Hook | 0:00 - 0:30 | Question + pain point |
-| Problem | 0:30 - 1:30 | ESB world today |
-| Solution LIVE | 1:30 - 3:30 | Portal demo (developer flow) |
-| Console | 3:30 - 4:30 | Admin view (provider flow) |
-| Close | 4:30 - 5:00 | Punchline + CTA |
+| Act | Time | What | Key Moment |
+|-----|------|------|------------|
+| 1 | 0:00 - 3:00 | Console: create tenant + publish API | "Admin in 3 min" |
+| 2 | 3:00 - 6:00 | Portal: discover, subscribe, get token | "5 days → 5 minutes" |
+| 3 | 6:00 - 8:00 | Rust Gateway: API call, JWT, zero latency | "Sub-millisecond proxy" |
+| 4 | 8:00 - 10:00 | Grafana: live dashboards, real-time metrics | "Full observability" |
+| 5 | 10:00 - 12:00 | OpenSearch: error snapshots, trace search | "Every error, traced" |
+| 6 | 12:00 - 14:00 | Keycloak: federation login cross-tenant | "Zero trust, multi-org" |
+| 7 | 14:00 - 17:00 | MCP Bridge: legacy API → AI agent tool | "The paradigm shift" |
+| 8 | 17:00 - 19:00 | AI Factory: how this was built | "The bombshell" |
 
 ---
 
-## 0:00 - 0:30 | HOOK
+## Pre-Demo Setup
 
-**[Slide: titre "ESB is Dead"]**
+```bash
+# Start the platform
+cd deploy/docker-compose
+docker compose up -d
+# With federation for Act 6:
+docker compose --profile federation up -d
 
-> "Levez la main si vous avez deja attendu **5 jours** pour obtenir un acces API dans votre entreprise."
+# Wait for all services
+../../scripts/demo/check-health.sh --wait --federation
 
-*Pause 3 secondes. Laisser les mains se lever.*
+# Seed demo data
+ANORAK_PASSWORD=readyplayerone ../../scripts/demo/seed-all.sh --federation
+```
 
-> "5 jours. Pour un GET sur une API REST. Avec 3 mails, 2 reunions, et un ticket ServiceNow."
+### Browser Tabs (pre-authenticated)
 
-> "Aujourd'hui je vais vous montrer comment on fait la meme chose en **5 minutes**."
-
----
-
-## 0:30 - 1:30 | PROBLEM
-
-**[Slide: "The ESB World" — ou Portal ouvert sur un catalogue vide]**
-
-> "Voici ce que la plupart des equipes vivent aujourd'hui."
-
-Pointer les 3 douleurs :
-
-1. **Catalogue = fichier Excel**
-   > "Les APIs existent, mais personne ne sait ou elles sont. Un fichier Excel partage par mail, jamais a jour."
-
-2. **Acces = processus bureaucratique**
-   > "Pour consommer une API, il faut un mail a l'equipe API, une reunion de cadrage, un ticket, une validation manager. Minimum 5 jours ouvrables."
-
-3. **Gateway = boite noire**
-   > "webMethods, TIBCO, DataPower — des boites noires a 500K euros/an de licence. Personne ne sait ce qui transite. Pas de self-service, pas de visibilite."
-
-> "On a construit STOA pour eliminer ces 3 problemes. Je vais vous montrer — en live."
+| Tab | URL | User | Purpose |
+|-----|-----|------|---------|
+| 1 | http://localhost | halliday | Console (Platform Admin) |
+| 2 | http://localhost/portal | (not logged in) | Portal (developer flow) |
+| 3 | Terminal | — | Gateway + curl commands |
+| 4 | http://localhost/grafana | admin | Grafana dashboards |
+| 5 | http://localhost/logs | admin | OpenSearch Dashboards |
+| 6 | http://localhost/auth | admin | Keycloak admin |
 
 ---
 
-## 1:30 - 3:30 | SOLUTION LIVE — Developer Portal
+## Act 1 — Console: Create Tenant + Publish API (3 min)
 
-**[Switch: navigateur — https://portal.gostoa.dev]**
+**[Tab 1: Console — logged in as halliday]**
 
-> "Je suis Art3mis, developpeur dans l'equipe mobile. J'ai besoin d'integrer une API."
+> "I'm the platform admin. Let me show you how fast we can set up a new team."
 
-### Etape 1 — Catalogue (1:30 - 1:50)
+### 1.1 — Dashboard Overview (30s)
 
-1. Cliquer sur **API Catalog** dans la sidebar
-2. La page `/apis` affiche les APIs disponibles
+1. Show the Dashboard: tenant count, API count, active subscriptions
+2. Point out the sidebar: APIs, Tenants, Consumers, Monitoring
 
-> "Premier changement : un **catalogue en self-service**. Toutes les APIs de l'entreprise, cherchables, filtrees, avec leur documentation."
+> "Real-time overview. Every tenant, every API, every subscription — visible instantly."
 
-### Etape 2 — Recherche + Specification (1:50 - 2:15)
+### 1.2 — Create a Tenant (1 min)
 
-1. Taper `petstore` dans la barre de recherche
-2. Cliquer sur la carte **Petstore API**
-3. La page detail s'ouvre (`/apis/{id}`)
-4. Cliquer sur l'onglet **Endpoints** — les operations apparaissent
-5. Cliquer sur l'onglet **OpenAPI Spec** — le spec complet est visible
+1. Click **Tenants** in sidebar
+2. Click **Create Tenant**
+3. Fill in: Name = "Acme Corp", Slug = "acme-corp"
+4. Submit
 
-> "La spec OpenAPI complete, directement dans le portail. Plus besoin de chercher dans Confluence ou de demander au tech lead."
+> "New organization provisioned in seconds. Keycloak realm, RBAC roles, namespace — all automated."
 
-### Etape 3 — Souscription en 1 clic (2:15 - 2:45)
+### 1.3 — Publish an API (1:30 min)
 
-1. Cliquer sur le bouton **Subscribe**
-2. La modale `SubscribeModal` s'ouvre
-3. Selectionner l'application (ex: "OASIS Mobile App")
-4. Selectionner le plan (ex: "Standard Plan")
-5. Confirmer
+1. Click **API Catalog** in sidebar
+2. Click **Add API**
+3. Fill in:
+   - Name: "Payments API"
+   - Version: "v1"
+   - Backend URL: "https://httpbin.org/anything"
+   - Description: "Enterprise payment processing"
+4. Submit
+5. Show the API detail page with endpoints
 
-> "Un clic. Pas de mail, pas de reunion, pas de ticket."
-
-6. La modale de succes affiche **l'API Key generee**
-7. **IMPORTANT** : Montrer le message "Copy and save this API key now"
-
-> "Credentials generees **instantanement**. Pas dans 5 jours. Maintenant."
-
-### Etape 4 — Test live (2:45 - 3:30)
-
-1. Copier la cle API
-2. Cliquer sur **Try this API** (ou naviguer vers `/apis/{id}/test`)
-3. Dans le Testing Sandbox :
-   - Selectionner `GET /pets`
-   - Cliquer **Send**
-   - Le resultat affiche **200 OK** avec la liste de pets
-
-> "Test en live, directement depuis le portail. On vient de passer de 5 jours a... 2 minutes."
-
-*Laisser le `200 OK` visible a l'ecran pendant la transition.*
+> "API published to the catalog. Developers can discover it immediately — no email, no ticket, no Confluence page."
 
 ---
 
-## 3:30 - 4:30 | CONSOLE — Admin View
+## Act 2 — Portal: Discover, Subscribe, Get Token (3 min)
 
-**[Switch: nouvel onglet — https://console.gostoa.dev]**
+**[Tab 2: Portal — fresh browser, not logged in]**
 
-> "Maintenant, passons de l'autre cote. Je suis Parzival, tenant-admin. C'est moi qui gere les APIs et les acces."
+> "Now I switch sides. I'm a developer. I heard there's a Payments API available."
 
-### Etape 5 — Dashboard (3:30 - 3:50)
+### 2.1 — Self-Registration (30s)
 
-1. Page `/` — Dashboard
-2. Montrer les cartes de statut rapide
+1. Click **Sign Up**
+2. Fill registration form (or show it's pre-configured via Keycloak)
+3. Redirect to portal catalog
 
-> "Vue d'ensemble en temps reel. APIs, applications, deployments — tout est visible."
+> "Self-service registration. No ServiceNow ticket required."
 
-### Etape 6 — Approbation (3:50 - 4:10)
+### 2.2 — API Discovery (1 min)
 
-1. Cliquer sur **Applications** dans la sidebar
-2. Montrer la liste des applications
-3. Pointer **Gunter Analytics Dashboard** — statut **Pending** (jaune)
+1. Browse the API Catalog
+2. Search for "payments"
+3. Click on **Payments API**
+4. Show: description, endpoints, OpenAPI spec tab
 
-> "Ici une souscription en attente d'approbation pour la Payments API. Un clic pour approuver ou rejeter."
+> "Full API documentation, searchable, always up-to-date. Not a shared Excel file."
 
-4. *(Optionnel)* Approuver la demande en live
+### 2.3 — Subscribe + Get Token (1:30 min)
 
-> "Les equipes API gardent le controle — mais sans bureaucratie."
+1. Click **Subscribe**
+2. Select application and plan
+3. Confirm
+4. **Show the generated API key / JWT token**
 
-### Etape 7 — Monitoring (4:10 - 4:30)
+> "One click. Credentials generated instantly. Not in 5 days. Right now."
 
-1. Cliquer sur **API Monitoring** dans la sidebar
-2. Montrer le dashboard monitoring
-
-> "Monitoring en temps reel. Chaque appel API est trace, mesure, visible. Plus de boite noire."
-
----
-
-## 4:30 - 5:00 | CLOSE
-
-**[Slide: "5 jours -> 5 minutes"]**
-
-> "Recapitulons."
-
-> "Avec un ESB classique :
-> - 5 jours pour un acces API
-> - Un fichier Excel comme catalogue
-> - Zero visibilite sur le trafic"
-
-> "Avec STOA :
-> - **5 minutes** pour decouvrir, souscrire et tester une API
-> - Un catalogue self-service avec spec OpenAPI
-> - Un monitoring temps reel"
-
-**[Slide: QR code + contact]**
-
-> "Scannez le QR code pour acceder a la documentation. Et si vous voulez voir comment ca marche sur **vos** APIs, venez me voir apres."
-
-| | |
-|---|---|
-| Documentation | https://docs.gostoa.dev |
-| Contact | christophe@gostoa.dev |
-| Demo Portal | https://portal.gostoa.dev |
-
-> "Merci."
+5. Copy the token for Act 3
 
 ---
 
-## Notes pour le presentateur
+## Act 3 — Rust Gateway: API Call, JWT, Zero Latency (2 min)
 
-### Persona & credentials
+**[Tab 3: Terminal]**
 
-| Persona | URL | Role | Usage dans la demo |
-|---------|-----|------|--------------------|
-| art3mis | portal.gostoa.dev | devops | Portal: search, subscribe, test |
-| parzival | console.gostoa.dev | tenant-admin | Console: approve, monitor |
+> "Now let's use this token. The request goes through our Rust Gateway — built for zero-latency API management."
 
-### Raccourcis navigateur
+### 3.1 — Health Check (15s)
 
-- **Onglet 1** : Portal (pre-logged as art3mis)
-- **Onglet 2** : Console (pre-logged as parzival)
-- **Onglet 3** : Slide deck (backup)
+```bash
+curl http://localhost/gateway/health
+# → {"status":"healthy","mode":"edge-mcp","version":"0.1.0"}
+```
 
-### Si ca plante
+> "Gateway healthy. Rust. Sub-millisecond overhead."
 
-| Probleme | Action |
-|----------|--------|
-| Portal ne charge pas | Montrer screenshots dans le slide deck |
-| Login Keycloak echoue | Utiliser session pre-authentifiee (cookies en place) |
-| Subscribe echoue (409) | "L'API est deja souscrite — c'est idempotent" |
-| Test Sandbox erreur | Montrer le curl equivalent dans le terminal |
-| Reseau down | Basculer sur la video backup |
+### 3.2 — Authenticated API Call (45s)
 
-### Timing checkpoints
+```bash
+# Use the token from Act 2
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8081/v1/proxy/payments/status
+# → 200 OK with response
+```
 
-| Temps | Checkpoint | Si en retard |
-|-------|-----------|-------------|
-| 0:30 | Hook fini | Couper la pause |
-| 1:30 | Problem fini | Sauter la slide webMethods |
-| 2:30 | Subscribe fait | Sauter le test sandbox |
-| 3:30 | Portal fini | Raccourcir console a 30s |
-| 4:30 | Console fini | Aller droit au close |
+> "JWT validated, request proxied to backend, response in under 10ms. Try that with your ESB."
+
+### 3.3 — Rate Limiting Demo (1 min)
+
+```bash
+# Rapid-fire requests to trigger rate limit
+for i in $(seq 1 20); do
+  curl -s -o /dev/null -w "%{http_code} " \
+    -H "Authorization: Bearer $TOKEN" \
+    http://localhost:8081/v1/proxy/payments/status
+done
+# → 200 200 200 ... 429 429
+```
+
+> "Per-consumer rate limiting. The 429 means: 'slow down'. Automatic protection, per plan, per consumer. No configuration needed."
+
+---
+
+## Act 4 — Grafana: Live Dashboards (2 min)
+
+**[Tab 4: Grafana — http://localhost/grafana]**
+
+> "Every request we just made is already visible in real-time."
+
+### 4.1 — Gateway Metrics (1 min)
+
+1. Open **STOA Gateway Metrics** dashboard
+2. Point out:
+   - Tool calls/sec graph (shows the burst we just did)
+   - Latency percentiles: p50, p90, p99
+   - Rate limit hits (the 429s are visible)
+   - Active SSE connections
+
+> "Real-time gateway metrics. Every API call measured, every rate limit tracked."
+
+### 4.2 — Platform Overview (1 min)
+
+1. Open **STOA Platform Overview** dashboard
+2. Show:
+   - Total APIs, tenants, active subscriptions
+   - Request volume over time
+   - Error rate
+
+> "Platform-wide observability. Not a black box. Every metric, every tenant, every API."
+
+---
+
+## Act 5 — OpenSearch: Error Snapshots (2 min)
+
+**[Tab 5: OpenSearch Dashboards or Grafana Error Snapshots]**
+
+> "What happens when things go wrong? Let me show you our error tracking."
+
+### 5.1 — Error Snapshots Dashboard (1 min)
+
+1. Open **STOA Error Snapshots** dashboard in Grafana
+2. Point out:
+   - Total errors count
+   - Errors by status code (pie chart: 400, 401, 404, 429, 500, 504)
+   - Errors by tenant (pie chart)
+   - Error timeline (stacked bar chart)
+
+> "Every error captured with context: tenant, trace ID, status code, timestamp."
+
+### 5.2 — Trace ID Drill-Down (1 min)
+
+1. Scroll to **Recent Errors** table
+2. Click a trace ID → opens OpenSearch Dashboards
+3. Show the full error document: trace_id, error_message, endpoint, method
+
+> "Click any trace ID to get the full picture. From dashboard to root cause in one click."
+
+---
+
+## Act 6 — Keycloak: Federation Cross-Tenant (2 min)
+
+**[Tab 6: Keycloak Admin — http://localhost/auth]**
+
+> "Now the enterprise killer feature: identity federation."
+
+### 6.1 — Show Federation Architecture (45s)
+
+1. In Keycloak admin, show the 6 realms:
+   - `stoa` (main platform)
+   - `idp-source-alpha`, `idp-source-beta` (identity providers)
+   - `demo-org-alpha`, `demo-org-beta`, `demo-org-gamma` (tenant orgs)
+2. Click on `demo-org-gamma` → Identity Providers → show LDAP federation
+
+> "Six realms. Each organization keeps their own identity provider — Active Directory, LDAP, SAML, OIDC. STOA federates them all."
+
+### 6.2 — Cross-Realm Token Isolation (1:15 min)
+
+```bash
+# Get token from org-alpha
+TOKEN_A=$(curl -s -X POST "http://localhost:8080/realms/demo-org-alpha/protocol/openid-connect/token" \
+  -d "grant_type=password&client_id=demo-client&username=alice&password=alice123" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+# Try to access org-beta resources → REJECTED
+curl -H "Authorization: Bearer $TOKEN_A" http://localhost:9000/api/org-beta/resource
+# → 403 Forbidden: "Token issued by demo-org-alpha, not authorized for demo-org-beta"
+```
+
+> "Zero trust. A token from Organization A cannot access Organization B's resources. Enforced at the gateway level, not by convention."
+
+---
+
+## Act 7 — MCP Bridge: Legacy API → AI Agent (3 min)
+
+**[Tab 3: Terminal]**
+
+> "Here's the paradigm shift. Everything we've built — APIs, authentication, rate limiting — all of that becomes available to AI agents."
+
+### 7.1 — MCP Tool Discovery (1 min)
+
+```bash
+# List available MCP tools
+curl http://localhost:8081/mcp/v1/tools
+# → [{"name": "payments-api", "description": "Enterprise payment processing", ...}]
+```
+
+> "Every API in our catalog is automatically exposed as an MCP tool. Define Once, Expose Everywhere — that's our Universal API Contract."
+
+### 7.2 — AI Agent Call (2 min)
+
+```bash
+# An AI agent invokes the tool
+curl -X POST http://localhost:8081/mcp/v1/tools/invoke \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"tool": "payments-api", "arguments": {"action": "get-status"}}'
+# → {"result": {"status": "active", "last_transaction": "..."}}
+```
+
+> "A Claude agent, a GPT agent, any MCP-compatible agent — they can now call your enterprise APIs. With authentication, rate limiting, monitoring, and audit trail. All the governance you need, none of the friction."
+
+> "This is not an API gateway. This is a **bridge** between your legacy enterprise and the AI-native future."
+
+---
+
+## Act 8 — AI Factory: How This Was Built (2 min)
+
+**[Slide or terminal showing git log]**
+
+> "One last thing. Let me tell you how we built this platform."
+
+```bash
+# Show the velocity
+git log --oneline --since="2026-02-09" | wc -l
+# → 22 PRs in 2 days
+
+git shortlog --since="2026-02-09" -sn
+# → 225 points delivered
+```
+
+> "225 story points. 22 pull requests. 2 days."
+
+> "This entire platform — the Rust gateway, the React console, the developer portal, the federation system, the MCP bridge, the observability stack, the error tracking — all of it was built by a team of 10."
+
+> "10 people doing the work of 300+ developers. How?"
+
+> "AI Agents. Not as a feature of the product — as the DNA of how we build."
+
+> "We don't just sell an AI gateway. We are an AI-native company."
+
+**[Slide: "ESB is Dead. AI Agents Are Here."]**
+
+> "Thank you."
+
+---
+
+## Timing Checkpoints
+
+| Time | Checkpoint | If Behind |
+|------|-----------|-----------|
+| 3:00 | Act 1 done | Skip tenant creation, show existing |
+| 6:00 | Act 2 done | Skip registration, use pre-auth |
+| 8:00 | Act 3 done | Skip rate limit demo |
+| 10:00 | Act 4 done | Show 1 dashboard instead of 2 |
+| 12:00 | Act 5 done | Skip drill-down, show table only |
+| 14:00 | Act 6 done | Skip curl demo, show Keycloak realms only |
+| 17:00 | Act 7 done | Pre-record MCP call as video backup |
+| 19:00 | Act 8 done | Shorten to 30s git stats + punchline |
+
+## If Something Breaks
+
+| Problem | Immediate Action |
+|---------|-----------------|
+| Console won't load | Show Portal instead (Acts 1-2 combined) |
+| Gateway returns 500 | Show pre-recorded terminal output |
+| Grafana empty | Show screenshot in slides |
+| OpenSearch down | "Error tracking is indexing, let me show you the architecture" |
+| Federation token fails | Show Keycloak admin UI realms (visual proof) |
+| MCP endpoint missing | "The MCP bridge is in development — let me show you the architecture" |
+| Everything down | Switch to video backup (offline, pre-recorded) |
+
+## Personas & Credentials
+
+| Persona | URL | Credentials | Role |
+|---------|-----|-------------|------|
+| halliday | Console | readyplayerone | Platform Admin |
+| parzival | Console | copperkeystart | Tenant Admin (OASIS Gunters) |
+| art3mis | Portal | samantha2045 | Developer |
+| admin | Grafana | admin / admin | Monitoring |
+| admin | OpenSearch | admin / StOa_Admin_2026! | Logs |
+| admin | Keycloak | admin / admin | Auth Admin |
+| alice | Federation | alice123 | Demo Org Alpha user |
+
+---
+
+*Generated for the "ESB is Dead" demo — 24 February 2026*


### PR DESCRIPTION
## Summary
- Rewrite DEMO-SCRIPT.md from 5-min Portal-only to full 8-act, ~20-min presentation
- Acts: Console → Portal → Rust Gateway → Grafana → OpenSearch → Federation → MCP Bridge → AI Factory
- Update DEMO-CHECKLIST.md with pre-flight checks for all 8 acts
- Add pre-typed terminal commands section for live demo
- Include timing checkpoints and Plan B fallbacks for each act

## Test plan
- [ ] Demo script coherent with docker-compose services (D6)
- [ ] All curl commands use correct endpoints
- [ ] Credentials match actual Keycloak realm configuration
- [ ] Timing adds up to ~20 min total

🤖 Generated with [Claude Code](https://claude.com/claude-code)