### PR TITLE
feat(demo): add federation live demo script + Makefile targets (D2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # STOA Platform — Developer Makefile
 # Usage: make <target>
 
-.PHONY: seed-demo test-demo migrate-kong migrate-kong-dry-run test-migrate-kong test-migrate-kong-integration help
+.PHONY: seed-demo test-demo demo-federation-setup demo-federation-test demo-federation-live demo-federation-cleanup migrate-kong migrate-kong-dry-run test-migrate-kong test-migrate-kong-integration help
 
 # ── Demo Data ──────────────────────────────────────────────────────────────
 
@@ -12,6 +12,20 @@ seed-demo: ## Seed demo data (APIs, apps, metrics) — requires ANORAK_PASSWORD
 test-demo: ## Run E2E demo tests (@demo tag)
 	@echo "==> Running demo E2E tests..."
 	cd e2e && npm run test:demo
+
+# ── Federation Demo ──────────────────────────────────────────────────────
+
+demo-federation-setup: ## Start federation demo stack (Keycloak + LDAP + gateway + OPA)
+	@./scripts/demo-federation/00-setup.sh
+
+demo-federation-test: ## Run federation isolation test (9/9 must pass)
+	@./scripts/demo-federation/04-test-isolation.sh
+
+demo-federation-live: ## Run 2-min live presenter demo (colorful output)
+	@./scripts/demo-federation/06-live-demo.sh
+
+demo-federation-cleanup: ## Tear down federation demo stack
+	@./scripts/demo-federation/99-cleanup.sh
 
 # ── Kong Migration ────────────────────────────────────────────────────────
 

--- a/scripts/demo-federation/06-live-demo.sh
+++ b/scripts/demo-federation/06-live-demo.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# =============================================================================
+# STOA Federation Demo — Live Presenter Script (2 min)
+# "Un login, tous vos tenants — souverainete europeenne"
+#
+# Usage: ./06-live-demo.sh
+# Prerequisites: Federation stack running (./00-setup.sh)
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOKEN_DIR="${SCRIPT_DIR}/.tokens"
+mkdir -p "${TOKEN_DIR}"
+
+KEYCLOAK_URL="${KEYCLOAK_URL:-http://localhost:8080}"
+GATEWAY_URL="${GATEWAY_URL:-http://localhost:9000}"
+
+# Colors
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+DIM='\033[2m'
+NC='\033[0m'
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# Helpers
+banner() { echo -e "\n${BOLD}${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"; echo -e "${BOLD}${CYAN}  $1${NC}"; echo -e "${BOLD}${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"; }
+pause() { sleep "${1:-0.3}"; }
+
+login_silent() {
+  local REALM="$1" USER="$2" PASS="$3"
+  local REALM_NAME="demo-org-${REALM}"
+  local CLIENT_SECRET
+  case "${REALM}" in
+    alpha) CLIENT_SECRET="alpha-demo-secret" ;;
+    beta)  CLIENT_SECRET="beta-demo-secret" ;;
+    gamma) CLIENT_SECRET="gamma-demo-secret" ;;
+  esac
+  RESPONSE=$(curl -s -X POST "${KEYCLOAK_URL}/realms/${REALM_NAME}/protocol/openid-connect/token" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "grant_type=password" \
+    -d "client_id=federation-demo" \
+    -d "client_secret=${CLIENT_SECRET}" \
+    -d "username=${USER}" \
+    -d "password=${PASS}")
+  TOKEN=$(echo "${RESPONSE}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null || echo "")
+  if [ -z "${TOKEN}" ] || [ "${TOKEN}" = "None" ]; then
+    echo -e "  ${RED}FAIL${NC} Login failed for ${USER}@${REALM_NAME}"
+    return 1
+  fi
+  echo "${TOKEN}" > "${TOKEN_DIR}/${REALM}.token"
+  return 0
+}
+
+call_api() {
+  local DESCRIPTION="$1" TOKEN_REALM="$2" TARGET="$3" EXPECTED="$4"
+  local TOKEN_FILE="${TOKEN_DIR}/${TOKEN_REALM}.token"
+  local TOKEN
+  TOKEN=$(cat "${TOKEN_FILE}")
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    "${GATEWAY_URL}/api/${TARGET}/whoami")
+  if [ "${HTTP_CODE}" = "${EXPECTED}" ]; then
+    if [ "${EXPECTED}" = "200" ]; then
+      echo -e "  ${GREEN}✓${NC} ${DESCRIPTION}  ${DIM}→ ${HTTP_CODE}${NC}"
+    else
+      # Extract issuer mismatch reason
+      local BODY
+      BODY=$(curl -s -H "Authorization: Bearer ${TOKEN}" "${GATEWAY_URL}/api/${TARGET}/whoami")
+      local REASON
+      REASON=$(echo "${BODY}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('detail','issuer mismatch'))" 2>/dev/null || echo "issuer mismatch")
+      echo -e "  ${RED}✗${NC} ${DESCRIPTION}  ${DIM}→ ${HTTP_CODE} (${REASON})${NC}"
+    fi
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${YELLOW}?${NC} ${DESCRIPTION}  ${DIM}→ ${HTTP_CODE} (expected ${EXPECTED})${NC}"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# ─── Pre-flight check ───────────────────────────────────────────────────
+if ! curl -sf "${KEYCLOAK_URL}/health/ready" > /dev/null 2>&1; then
+  echo -e "${RED}Keycloak not ready at ${KEYCLOAK_URL}. Run ./00-setup.sh first.${NC}"
+  exit 1
+fi
+if ! curl -sf "${GATEWAY_URL}/health" > /dev/null 2>&1; then
+  echo -e "${RED}Gateway not ready at ${GATEWAY_URL}. Run ./00-setup.sh first.${NC}"
+  exit 1
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+# PHASE 1 — Silent authentication (15s)
+# ═══════════════════════════════════════════════════════════════════════════
+banner "PHASE 1 — Authenticating 3 Organizations"
+
+echo -e "  ${DIM}3 orgs, 3 protocols, 0 users stored centrally${NC}\n"
+
+echo -n "  Org Alpha (OIDC federation)...  "
+login_silent alpha demo-alpha demo && echo -e "${GREEN}OK${NC}" || true
+pause
+
+echo -n "  Org Beta  (SAML federation)...  "
+login_silent beta demo-beta demo && echo -e "${GREEN}OK${NC}" || true
+pause
+
+echo -n "  Org Gamma (LDAP federation)...  "
+login_silent gamma eve-gamma demo && echo -e "${GREEN}OK${NC}" || true
+pause 0.5
+
+# ═══════════════════════════════════════════════════════════════════════════
+# PHASE 2 — Same-realm access (20s)
+# ═══════════════════════════════════════════════════════════════════════════
+banner "PHASE 2 — Same-Realm Access (should succeed)"
+
+echo -e "  ${DIM}Each org accesses its own APIs${NC}\n"
+
+call_api "Alpha token → Alpha API" alpha alpha 200
+pause
+call_api "Beta token  → Beta API " beta  beta  200
+pause
+call_api "Gamma token → Gamma API" gamma gamma 200
+pause 0.5
+
+# ═══════════════════════════════════════════════════════════════════════════
+# PHASE 3 — Cross-realm denial (45s)
+# ═══════════════════════════════════════════════════════════════════════════
+banner "PHASE 3 — Cross-Realm Isolation (must be denied)"
+
+echo -e "  ${DIM}Proving that Org A cannot access Org B's APIs${NC}\n"
+
+call_api "Alpha token → Beta API  " alpha beta  403
+pause
+call_api "Alpha token → Gamma API " alpha gamma 403
+pause
+call_api "Beta token  → Alpha API " beta  alpha 403
+pause
+call_api "Beta token  → Gamma API " beta  gamma 403
+pause
+call_api "Gamma token → Alpha API " gamma alpha 403
+pause
+call_api "Gamma token → Beta API  " gamma beta  403
+pause 0.5
+
+# ═══════════════════════════════════════════════════════════════════════════
+# PHASE 4 — Verdict (10s)
+# ═══════════════════════════════════════════════════════════════════════════
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+
+echo ""
+echo -e "${BOLD}${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+if [ "${FAIL_COUNT}" -eq 0 ]; then
+  echo -e "${BOLD}${GREEN}"
+  echo "    ██╗███████╗ ██████╗ ██╗      █████╗ ████████╗██╗ ██████╗ ███╗   ██╗"
+  echo "    ██║██╔════╝██╔═══██╗██║     ██╔══██╗╚══██╔══╝██║██╔═══██╗████╗  ██║"
+  echo "    ██║███████╗██║   ██║██║     ███████║   ██║   ██║██║   ██║██╔██╗ ██║"
+  echo "    ██║╚════██║██║   ██║██║     ██╔══██║   ██║   ██║██║   ██║██║╚██╗██║"
+  echo "    ██║███████║╚██████╔╝███████╗██║  ██║   ██║   ██║╚██████╔╝██║ ╚████║"
+  echo "    ╚═╝╚══════╝ ╚═════╝ ╚══════╝╚═╝  ╚═╝   ╚═╝   ╚═╝ ╚═════╝ ╚═╝  ╚═══╝"
+  echo ""
+  echo "                ██╗   ██╗███████╗██████╗ ██╗███████╗██╗███████╗██████╗ "
+  echo "                ██║   ██║██╔════╝██╔══██╗██║██╔════╝██║██╔════╝██╔══██╗"
+  echo "                ██║   ██║█████╗  ██████╔╝██║█████╗  ██║█████╗  ██║  ██║"
+  echo "                ╚██╗ ██╔╝██╔══╝  ██╔══██╗██║██╔══╝  ██║██╔══╝  ██║  ██║"
+  echo "                 ╚████╔╝ ███████╗██║  ██║██║██║     ██║███████╗██████╔╝"
+  echo "                  ╚═══╝  ╚══════╝╚═╝  ╚═╝╚═╝╚═╝     ╚═╝╚══════╝╚═════╝ "
+  echo -e "${NC}"
+  echo -e "  ${BOLD}${PASS_COUNT}/${TOTAL} tests passed — Zero User Storage Federation works${NC}"
+  echo ""
+  echo -e "  ${CYAN}What this proves (ADR-026):${NC}"
+  echo "    1. 3 orgs, 3 protocols (OIDC, SAML, LDAP) — all federated"
+  echo "    2. 0 users stored in STOA — tokens from external IdPs"
+  echo "    3. Cross-realm access denied by gateway (issuer mismatch)"
+  echo "    4. European sovereignty: data stays with each organization"
+  echo ""
+  echo -e "  ${DIM}\"Un login, tous vos tenants — souverainete europeenne\"${NC}"
+else
+  echo -e "${BOLD}${RED}  ISOLATION BROKEN — ${FAIL_COUNT}/${TOTAL} test(s) failed!${NC}"
+fi
+
+echo -e "${BOLD}${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+[ "${FAIL_COUNT}" -eq 0 ] && exit 0 || exit 1

--- a/scripts/demo-federation/README.md
+++ b/scripts/demo-federation/README.md
@@ -169,6 +169,71 @@ Raw Keycloak gives you federation. STOA gives you **API-lifecycle-aware federati
 4. **MCP-Native** — AI agents inherit the same federation model
 5. **GitOps Realms** — Realm configs as code, applied via CI/CD
 
+## Live Demo (2 min — Act 5)
+
+### Pre-Flight Checklist
+
+```bash
+# 1. Start the stack (allow ~60s for Keycloak cold start)
+make demo-federation-setup
+
+# 2. Verify isolation works before going on stage
+make demo-federation-test
+
+# 3. Run the presenter script
+make demo-federation-live
+
+# 4. Cleanup after demo
+make demo-federation-cleanup
+```
+
+### Timing
+
+| Phase | Duration | What happens |
+|-------|----------|-------------|
+| 1. Auth | ~15s | Silent login for 3 orgs (OIDC, SAML, LDAP) |
+| 2. Same-realm | ~20s | 3 green checkmarks (each org accesses its own API) |
+| 3. Cross-realm | ~45s | 6 red X with issuer mismatch reasons |
+| 4. Verdict | ~10s | ASCII art "ISOLATION VERIFIED" banner |
+
+### Presenter Notes
+
+- Run `make demo-federation-setup` **before** going on stage (Keycloak takes ~45s to start)
+- The live demo script (`06-live-demo.sh`) is self-contained: authenticates, tests, and shows verdict
+- If a test fails, the script exits with code 1 and shows "ISOLATION BROKEN" — fix before presenting
+- Key message: *"Un login, tous vos tenants — souverainete europeenne"*
+
+## Known Issues
+
+| Issue | Symptom | Workaround |
+|-------|---------|------------|
+| LDAP seed flakiness | `ldapadd` fails on first attempt | Script retries 5 times with 2s delay |
+| Token exchange not active | Keycloak preview feature disabled | Script falls back to user token — isolation demo still works |
+| Port 8080 conflict | Keycloak fails to start | Stop other services on 8080, or set `KEYCLOAK_URL=http://localhost:8081` |
+| OPA AMD64 only | OPA container fails on Apple Silicon | OPA is optional — isolation test works without it (gateway-level validation) |
+| Keycloak cold start | First startup imports 5 realms (~45-60s) | Subsequent starts are faster (~15s); just wait |
+
+## Troubleshooting
+
+```bash
+# Check all containers are running
+docker compose -f deploy/demo-federation/docker-compose.yml ps
+
+# Check Keycloak logs (realm import issues)
+docker logs stoa-federation-keycloak 2>&1 | tail -20
+
+# Check gateway logs (JWT validation issues)
+docker logs stoa-federation-gateway 2>&1 | tail -20
+
+# Check LDAP is seeded
+docker exec stoa-federation-ldap ldapsearch -x -H ldap://localhost:389 \
+  -D "cn=admin,dc=demo,dc=stoa" -w "admin-password" -b "ou=users,dc=demo,dc=stoa"
+
+# Manual token test
+TOKEN=$(cat scripts/demo-federation/.tokens/alpha.token)
+curl -H "Authorization: Bearer $TOKEN" http://localhost:9000/api/alpha/whoami
+```
+
 ## File Structure
 
 ```
@@ -195,6 +260,7 @@ scripts/demo-federation/
 ├── 03-call-api.sh               # Call API
 ├── 04-test-isolation.sh         # Prove isolation
 ├── 05-stoa-integration.sh       # STOA value-add
+├── 06-live-demo.sh              # 2-min presenter script
 ├── 99-cleanup.sh                # Tear down
 └── README.md                    # This file
 ```


### PR DESCRIPTION
## Summary
- Add `06-live-demo.sh`: 2-min presenter script for Act 5 ("Un login, tous vos tenants") with 4 phases — silent auth, same-realm access (green checkmarks), cross-realm denial (red X + issuer mismatch), ASCII art verdict banner
- Add Makefile targets: `demo-federation-setup`, `demo-federation-test`, `demo-federation-live`, `demo-federation-cleanup`
- Update README with live demo checklist, timing table, known issues, and troubleshooting section

## Test plan
- [ ] `make demo-federation-setup` starts the stack
- [ ] `make demo-federation-test` passes 9/9
- [ ] `make demo-federation-live` completes in < 120s
- [ ] `make demo-federation-cleanup` tears down cleanly

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>