### PR TITLE
fix(ui): add dark mode to AI tools components

### DIFF
--- a/control-plane-ui/src/components/tools/QuickStartGuide.tsx
+++ b/control-plane-ui/src/components/tools/QuickStartGuide.tsx
@@ -138,17 +138,17 @@ curl -X POST "${mcpGatewayUrl}/mcp/tools/invoke" \\
   };
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700">
       {/* Tabs */}
-      <div className="flex border-b border-gray-200">
+      <div className="flex border-b border-gray-200 dark:border-neutral-700">
         {tabs.map((tab) => (
           <button
             key={tab.id}
             onClick={() => setActiveTab(tab.id)}
             className={`flex items-center gap-2 px-4 py-3 text-sm font-medium transition-colors ${
               activeTab === tab.id
-                ? 'text-blue-600 border-b-2 border-blue-600 -mb-px bg-blue-50'
-                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50'
+                ? 'text-blue-600 border-b-2 border-blue-600 -mb-px bg-blue-50 dark:bg-blue-950/30'
+                : 'text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-200 hover:bg-gray-50 dark:hover:bg-neutral-700'
             }`}
           >
             {tab.icon}
@@ -172,12 +172,12 @@ curl -X POST "${mcpGatewayUrl}/mcp/tools/invoke" \\
       </div>
 
       {/* Help Text */}
-      <div className="px-4 py-3 bg-gray-50 border-t border-gray-200 rounded-b-lg">
-        <p className="text-xs text-gray-500">
+      <div className="px-4 py-3 bg-gray-50 dark:bg-neutral-800/50 border-t border-gray-200 dark:border-neutral-700 rounded-b-lg">
+        <p className="text-xs text-gray-500 dark:text-neutral-400">
           {activeTab === 'claude-desktop' && (
             <>
               Add this configuration to your Claude Desktop config file at{' '}
-              <code className="bg-gray-200 px-1 rounded">
+              <code className="bg-gray-200 dark:bg-neutral-700 px-1 rounded">
                 ~/Library/Application Support/Claude/claude_desktop_config.json
               </code>
             </>
@@ -185,13 +185,16 @@ curl -X POST "${mcpGatewayUrl}/mcp/tools/invoke" \\
           {activeTab === 'python' && (
             <>
               Install the Anthropic SDK:{' '}
-              <code className="bg-gray-200 px-1 rounded">pip install anthropic</code>
+              <code className="bg-gray-200 dark:bg-neutral-700 px-1 rounded">
+                pip install anthropic
+              </code>
             </>
           )}
           {activeTab === 'curl' && (
             <>
-              Replace <code className="bg-gray-200 px-1 rounded">YOUR_TOKEN</code> with your
-              Keycloak access token.
+              Replace{' '}
+              <code className="bg-gray-200 dark:bg-neutral-700 px-1 rounded">YOUR_TOKEN</code> with
+              your Keycloak access token.
             </>
           )}
         </p>

--- a/control-plane-ui/src/components/tools/ToolCard.tsx
+++ b/control-plane-ui/src/components/tools/ToolCard.tsx
@@ -11,11 +11,11 @@ interface ToolCardProps {
 
 // Move static objects outside component to prevent recreation on each render
 const methodColors: Record<string, string> = {
-  GET: 'bg-green-100 text-green-800',
-  POST: 'bg-blue-100 text-blue-800',
-  PUT: 'bg-yellow-100 text-yellow-800',
-  PATCH: 'bg-orange-100 text-orange-800',
-  DELETE: 'bg-red-100 text-red-800',
+  GET: 'bg-green-100 text-green-800 dark:bg-green-950/30 dark:text-green-400',
+  POST: 'bg-blue-100 text-blue-800 dark:bg-blue-950/30 dark:text-blue-400',
+  PUT: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-950/30 dark:text-yellow-400',
+  PATCH: 'bg-orange-100 text-orange-800 dark:bg-orange-950/30 dark:text-orange-400',
+  DELETE: 'bg-red-100 text-red-800 dark:bg-red-950/30 dark:text-red-400',
 };
 
 export const ToolCard = memo(function ToolCard({
@@ -29,30 +29,32 @@ export const ToolCard = memo(function ToolCard({
 
   return (
     <div
-      className="bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md hover:border-blue-300 transition-all cursor-pointer"
+      className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-200 dark:border-neutral-700 hover:shadow-md hover:border-blue-300 dark:hover:border-blue-600 transition-all cursor-pointer"
       onClick={onClick}
     >
       <div className="p-5">
         {/* Header */}
         <div className="flex items-start justify-between mb-3">
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-blue-50 rounded-lg">
+            <div className="p-2 bg-blue-50 dark:bg-blue-950/30 rounded-lg">
               <Wrench className="h-5 w-5 text-blue-600" />
             </div>
             <div>
-              <h3 className="font-semibold text-gray-900 text-sm">{tool.name}</h3>
-              <span className="text-xs text-gray-500">v{tool.version}</span>
+              <h3 className="font-semibold text-gray-900 dark:text-white text-sm">{tool.name}</h3>
+              <span className="text-xs text-gray-500 dark:text-neutral-400">v{tool.version}</span>
             </div>
           </div>
           <span
-            className={`px-2 py-0.5 rounded text-xs font-medium ${methodColors[tool.method] || 'bg-gray-100 text-gray-800'}`}
+            className={`px-2 py-0.5 rounded text-xs font-medium ${methodColors[tool.method] || 'bg-gray-100 dark:bg-neutral-700 text-gray-800 dark:text-neutral-300'}`}
           >
             {tool.method}
           </span>
         </div>
 
         {/* Description */}
-        <p className="text-sm text-gray-600 mb-4 line-clamp-2">{tool.description}</p>
+        <p className="text-sm text-gray-600 dark:text-neutral-300 mb-4 line-clamp-2">
+          {tool.description}
+        </p>
 
         {/* Tags */}
         {tool.tags.length > 0 && (
@@ -60,20 +62,22 @@ export const ToolCard = memo(function ToolCard({
             {tool.tags.slice(0, 3).map((tag) => (
               <span
                 key={tag}
-                className="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 text-gray-600 rounded text-xs"
+                className="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 dark:bg-neutral-700 text-gray-600 dark:text-neutral-300 rounded text-xs"
               >
                 <Tag className="h-3 w-3" />
                 {tag}
               </span>
             ))}
             {tool.tags.length > 3 && (
-              <span className="text-xs text-gray-400">+{tool.tags.length - 3} more</span>
+              <span className="text-xs text-gray-400 dark:text-neutral-500">
+                +{tool.tags.length - 3} more
+              </span>
             )}
           </div>
         )}
 
         {/* Stats */}
-        <div className="flex items-center gap-4 text-xs text-gray-500 mb-4">
+        <div className="flex items-center gap-4 text-xs text-gray-500 dark:text-neutral-400 mb-4">
           <span className="flex items-center gap-1">
             <Zap className="h-3.5 w-3.5" />
             {paramCount} params
@@ -92,8 +96,12 @@ export const ToolCard = memo(function ToolCard({
         </div>
 
         {/* Actions */}
-        <div className="flex items-center justify-between pt-3 border-t border-gray-100">
-          {tool.tenantId && <span className="text-xs text-gray-400">Tenant: {tool.tenantId}</span>}
+        <div className="flex items-center justify-between pt-3 border-t border-gray-100 dark:border-neutral-700">
+          {tool.tenantId && (
+            <span className="text-xs text-gray-400 dark:text-neutral-500">
+              Tenant: {tool.tenantId}
+            </span>
+          )}
           {!tool.tenantId && <span />}
 
           {onSubscribe && (
@@ -104,7 +112,7 @@ export const ToolCard = memo(function ToolCard({
               }}
               className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
                 isSubscribed
-                  ? 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                  ? 'bg-gray-100 dark:bg-neutral-700 text-gray-600 dark:text-neutral-300 hover:bg-gray-200 dark:hover:bg-neutral-600'
                   : 'bg-blue-600 text-white hover:bg-blue-700'
               }`}
             >

--- a/control-plane-ui/src/components/tools/ToolSchemaViewer.tsx
+++ b/control-plane-ui/src/components/tools/ToolSchemaViewer.tsx
@@ -12,13 +12,17 @@ export function ToolSchemaViewer({ schema, title = 'Input Schema' }: ToolSchemaV
   const required = schema.required || [];
 
   if (Object.keys(properties).length === 0) {
-    return <div className="text-sm text-gray-500 italic">This tool has no input parameters.</div>;
+    return (
+      <div className="text-sm text-gray-500 dark:text-neutral-400 italic">
+        This tool has no input parameters.
+      </div>
+    );
   }
 
   return (
-    <div className="bg-gray-50 rounded-lg border border-gray-200">
-      <div className="px-4 py-3 border-b border-gray-200">
-        <h4 className="text-sm font-medium text-gray-700">{title}</h4>
+    <div className="bg-gray-50 dark:bg-neutral-900 rounded-lg border border-gray-200 dark:border-neutral-700">
+      <div className="px-4 py-3 border-b border-gray-200 dark:border-neutral-700">
+        <h4 className="text-sm font-medium text-gray-700 dark:text-neutral-300">{title}</h4>
       </div>
       <div className="p-4 space-y-2">
         {Object.entries(properties).map(([name, prop]) => (
@@ -65,51 +69,55 @@ function PropertyRow({ name, property, isRequired, depth = 0 }: PropertyRowProps
   return (
     <div className="text-sm" style={{ marginLeft: depth * 16 }}>
       <div
-        className={`flex items-start gap-2 py-1.5 ${hasNestedProperties || hasItems ? 'cursor-pointer hover:bg-gray-100 rounded' : ''}`}
+        className={`flex items-start gap-2 py-1.5 ${hasNestedProperties || hasItems ? 'cursor-pointer hover:bg-gray-100 dark:hover:bg-neutral-800 rounded' : ''}`}
         onClick={() => (hasNestedProperties || hasItems) && setIsExpanded(!isExpanded)}
       >
         {/* Expand/Collapse Icon */}
         {hasNestedProperties || hasItems ? (
           isExpanded ? (
-            <ChevronDown className="h-4 w-4 text-gray-400 mt-0.5 flex-shrink-0" />
+            <ChevronDown className="h-4 w-4 text-gray-400 dark:text-neutral-500 mt-0.5 flex-shrink-0" />
           ) : (
-            <ChevronRight className="h-4 w-4 text-gray-400 mt-0.5 flex-shrink-0" />
+            <ChevronRight className="h-4 w-4 text-gray-400 dark:text-neutral-500 mt-0.5 flex-shrink-0" />
           )
         ) : (
-          <Circle className="h-2 w-2 text-gray-300 mt-1.5 ml-1 mr-1 flex-shrink-0" />
+          <Circle className="h-2 w-2 text-gray-300 dark:text-neutral-600 mt-1.5 ml-1 mr-1 flex-shrink-0" />
         )}
 
         {/* Property Name */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <span className="font-mono font-medium text-gray-900">{name}</span>
+            <span className="font-mono font-medium text-gray-900 dark:text-white">{name}</span>
             <span className={`font-mono text-xs ${typeColors[property.type] || 'text-gray-500'}`}>
               {formatType(property)}
             </span>
             {isRequired && (
-              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 bg-red-50 text-red-600 text-xs rounded">
+              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 bg-red-50 dark:bg-red-950/30 text-red-600 dark:text-red-400 text-xs rounded">
                 <AlertCircle className="h-3 w-3" />
                 required
               </span>
             )}
             {property.enum && (
-              <span className="text-xs text-gray-400">enum: [{property.enum.join(', ')}]</span>
+              <span className="text-xs text-gray-400 dark:text-neutral-500">
+                enum: [{property.enum.join(', ')}]
+              </span>
             )}
             {property.default !== undefined && (
-              <span className="text-xs text-gray-400">
+              <span className="text-xs text-gray-400 dark:text-neutral-500">
                 default: {JSON.stringify(property.default)}
               </span>
             )}
           </div>
           {property.description && (
-            <p className="text-gray-500 text-xs mt-0.5">{property.description}</p>
+            <p className="text-gray-500 dark:text-neutral-400 text-xs mt-0.5">
+              {property.description}
+            </p>
           )}
         </div>
       </div>
 
       {/* Nested Properties */}
       {isExpanded && hasNestedProperties && (
-        <div className="mt-1 pl-2 border-l border-gray-200 ml-2">
+        <div className="mt-1 pl-2 border-l border-gray-200 dark:border-neutral-700 ml-2">
           {Object.entries(property.properties!).map(([nestedName, nestedProp]) => (
             <PropertyRow
               key={nestedName}
@@ -124,8 +132,8 @@ function PropertyRow({ name, property, isRequired, depth = 0 }: PropertyRowProps
 
       {/* Array Items */}
       {isExpanded && hasItems && property.items?.properties && (
-        <div className="mt-1 pl-2 border-l border-gray-200 ml-2">
-          <div className="text-xs text-gray-400 mb-1">Array items:</div>
+        <div className="mt-1 pl-2 border-l border-gray-200 dark:border-neutral-700 ml-2">
+          <div className="text-xs text-gray-400 dark:text-neutral-500 mb-1">Array items:</div>
           {Object.entries(property.items.properties).map(([itemName, itemProp]) => (
             <PropertyRow
               key={itemName}

--- a/control-plane-ui/src/components/tools/UsageChart.tsx
+++ b/control-plane-ui/src/components/tools/UsageChart.tsx
@@ -80,9 +80,12 @@ export function UsageChart({ data, metric, title, height = 200 }: UsageChartProp
 
   if (data.length === 0) {
     return (
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
-        <h3 className="text-sm font-medium text-gray-700 mb-4">{title}</h3>
-        <div className="flex items-center justify-center text-gray-400 text-sm" style={{ height }}>
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4">
+        <h3 className="text-sm font-medium text-gray-700 dark:text-neutral-300 mb-4">{title}</h3>
+        <div
+          className="flex items-center justify-center text-gray-400 dark:text-neutral-500 text-sm"
+          style={{ height }}
+        >
           No data available
         </div>
       </div>
@@ -90,10 +93,10 @@ export function UsageChart({ data, metric, title, height = 200 }: UsageChartProp
   }
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-4">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4">
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-sm font-medium text-gray-700">{title}</h3>
+        <h3 className="text-sm font-medium text-gray-700 dark:text-neutral-300">{title}</h3>
         <div className={`flex items-center gap-1 text-sm ${trendColor}`}>
           <TrendIcon className="h-4 w-4" />
           <span>{Math.abs(trend).toFixed(1)}%</span>
@@ -121,7 +124,7 @@ export function UsageChart({ data, metric, title, height = 200 }: UsageChartProp
         </div>
 
         {/* Y-axis labels */}
-        <div className="absolute left-0 top-0 bottom-0 flex flex-col justify-between text-xs text-gray-400 -ml-8 w-8 text-right">
+        <div className="absolute left-0 top-0 bottom-0 flex flex-col justify-between text-xs text-gray-400 dark:text-neutral-500 -ml-8 w-8 text-right">
           <span>
             {metric === 'successRate' ? `${(max * 100).toFixed(0)}%` : max.toLocaleString()}
           </span>
@@ -132,7 +135,7 @@ export function UsageChart({ data, metric, title, height = 200 }: UsageChartProp
       </div>
 
       {/* X-axis labels */}
-      <div className="flex justify-between mt-2 text-xs text-gray-400">
+      <div className="flex justify-between mt-2 text-xs text-gray-400 dark:text-neutral-500">
         <span>{data.length > 0 ? formatLabel(data[0].timestamp) : ''}</span>
         <span>{data.length > 0 ? formatLabel(data[data.length - 1].timestamp) : ''}</span>
       </div>
@@ -158,22 +161,24 @@ export function UsageStatsCard({
   color = 'blue',
 }: UsageStatsCardProps) {
   const colorClasses = {
-    blue: 'bg-blue-50 text-blue-600',
-    green: 'bg-green-50 text-green-600',
-    orange: 'bg-orange-50 text-orange-600',
-    purple: 'bg-purple-50 text-purple-600',
-    red: 'bg-red-50 text-red-600',
+    blue: 'bg-blue-50 dark:bg-blue-950/30 text-blue-600 dark:text-blue-400',
+    green: 'bg-green-50 dark:bg-green-950/30 text-green-600 dark:text-green-400',
+    orange: 'bg-orange-50 dark:bg-orange-950/30 text-orange-600 dark:text-orange-400',
+    purple: 'bg-purple-50 dark:bg-purple-950/30 text-purple-600 dark:text-purple-400',
+    red: 'bg-red-50 dark:bg-red-950/30 text-red-600 dark:text-red-400',
   };
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-4">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4">
       <div className="flex items-center justify-between mb-2">
-        <span className="text-sm text-gray-500">{title}</span>
+        <span className="text-sm text-gray-500 dark:text-neutral-400">{title}</span>
         {icon && <div className={`p-2 rounded-lg ${colorClasses[color]}`}>{icon}</div>}
       </div>
-      <div className="text-2xl font-bold text-gray-900">{value}</div>
+      <div className="text-2xl font-bold text-gray-900 dark:text-white">{value}</div>
       <div className="flex items-center justify-between mt-1">
-        {subtitle && <span className="text-xs text-gray-400">{subtitle}</span>}
+        {subtitle && (
+          <span className="text-xs text-gray-400 dark:text-neutral-500">{subtitle}</span>
+        )}
         {trend !== undefined && (
           <span
             className={`flex items-center gap-1 text-xs ${trend >= 0 ? 'text-green-600' : 'text-red-600'}`}


### PR DESCRIPTION
## Summary
- Add `dark:` Tailwind classes to 4 components in `control-plane-ui/src/components/tools/`: ToolCard, UsageChart, QuickStartGuide, ToolSchemaViewer
- These were the last components without dark mode coverage in the Console (~97% → 100%)
- Pattern follows GatewayModesDashboard reference: `dark:bg-neutral-800`, `dark:border-neutral-700`, `dark:text-white/neutral-300/400/500`

## Test plan
- [ ] Visual check: toggle dark mode in Console, navigate to Tools page — no white blocks
- [ ] Local quality gate passed (ESLint 93 warnings, Prettier clean, TSC clean)
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)