### PR TITLE
fix(ui): add CelebrationProvider to fix /apis page crash

### DIFF
--- a/control-plane-ui/src/App.tsx
+++ b/control-plane-ui/src/App.tsx
@@ -7,6 +7,7 @@ import { quickLinks } from './config';
 import { ToastProvider } from '@stoa/shared/components/Toast';
 import { CommandPaletteProvider } from '@stoa/shared/components/CommandPalette';
 import { ThemeProvider } from '@stoa/shared/contexts';
+import { CelebrationProvider } from '@stoa/shared/components/Celebration';
 import { StoaLoader } from '@stoa/shared/components/StoaLoader';
 
 // Lazy load pages for code splitting
@@ -418,12 +419,14 @@ function App() {
   return (
     <ThemeProvider>
       <ToastProvider>
-        <AuthProvider>
-          <Routes>
-            <Route path="/login" element={<Login />} />
-            <Route path="/*" element={<ProtectedRoutes />} />
-          </Routes>
-        </AuthProvider>
+        <CelebrationProvider>
+          <AuthProvider>
+            <Routes>
+              <Route path="/login" element={<Login />} />
+              <Route path="/*" element={<ProtectedRoutes />} />
+            </Routes>
+          </AuthProvider>
+        </CelebrationProvider>
       </ToastProvider>
     </ThemeProvider>
   );


### PR DESCRIPTION
## Summary
- `/apis` page crashed with blank screen: `useCelebration must be used within a CelebrationProvider`
- Added `CelebrationProvider` to the App.tsx provider tree (between `ToastProvider` and `AuthProvider`)
- K8s deployment already has correct env vars (`API_BACKEND_URL`, `LOGS_BACKEND_URL`, `GRAFANA_BACKEND_URL`)

## Test plan
- [x] `npm run lint` — 0 errors, 93 warnings (matches threshold)
- [x] `npx tsc -p tsconfig.app.json --noEmit` — 0 errors
- [x] `npm run format:check` — all files formatted
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>