### PR TITLE
fix(demo): add defaultClientScopes to stoa-observability for role mapping

### DIFF
--- a/deploy/docker-compose/init/keycloak-realm.json
+++ b/deploy/docker-compose/init/keycloak-realm.json
@@ -248,6 +248,13 @@
       "webOrigins": [
         "http://localhost"
       ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
       "protocolMappers": [
         {
           "name": "realm-roles",


### PR DESCRIPTION
## Summary
- Grafana SSO worked (PR #295) but all users got Viewer role — roles claim missing from userinfo
- Added `defaultClientScopes` with `roles` to `stoa-observability` client in realm seed
- Now: `cpi-admin` → Grafana Admin, others → Grafana Viewer

## Test plan
- [x] `docker compose down -v && docker compose up -d`
- [x] Login `halliday` (cpi-admin) → Org Role: **Admin**
- [x] Login `aech` (viewer) → Org Role: **Viewer**
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>