### PR TITLE
chore(demo): docker-compose Console local build + Grafana auto-login

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -168,7 +168,10 @@ services:
   # Console UI
   # ==========================================================================
   control-plane-ui:
-    image: ghcr.io/stoa-platform/control-plane-ui:1.0.0
+    build:
+      context: ../../
+      dockerfile: control-plane-ui/Dockerfile
+    image: stoa-console:local
     container_name: stoa-console
     ports:
       - "${PORT_CONSOLE:-3000}:8080"
@@ -432,6 +435,8 @@ services:
       GF_AUTH_GENERIC_OAUTH_API_URL: "http://keycloak:8080/realms/stoa/protocol/openid-connect/userinfo"
       GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: "contains(roles[*], 'cpi-admin') && 'Admin' || 'Viewer'"
       GF_AUTH_GENERIC_OAUTH_ALLOW_ASSIGN_GRAFANA_ADMIN: "true"
+      GF_AUTH_GENERIC_OAUTH_AUTO_LOGIN: "true"
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
     volumes:
       - ./config/grafana/provisioning:/etc/grafana/provisioning:ro
       - ./config/grafana/dashboards:/var/lib/grafana/dashboards:ro

--- a/memory.md
+++ b/memory.md
@@ -1,6 +1,6 @@
 # STOA Memory
 
-> Last updated: 2026-02-10 (Demo Design Partner Phase 1-2 DONE)
+> Last updated: 2026-02-10 (Native Observability PRs #299, #300 merged)
 
 ## Active Sprint
 - **Goal**: Revenue-ready demo by Feb 24, 2026
@@ -72,6 +72,8 @@
 | DONE | — | Fix /apis crash: CelebrationProvider missing in App.tsx | PR #293 |
 | DONE | — | Fix Grafana SSO: add stoa-observability Keycloak client + role mapping | PR #295 |
 | DONE | — | Demo Phase 1-2: Email + Script + Slides + Staging + MOU (5 livrables, français, Q1/Q2 resolved) | stoa-strategy 2bf8dbf |
+| DONE | — | Native Platform Metrics dashboard (replace Grafana iframe on /observability) | PR #299 |
+| DONE | — | Native Request Explorer dashboard (replace OpenSearch iframe on /logs) | PR #300 |
 | NEXT | CAB-1130 | Email Khalil (send 14 fev EOD, wait feedback 15-16 fev) | — |
 | NEXT | CAB-1131 | Dry-runs 3x (18-23 fev, chrono < 5min) | — |
 | NEXT | CAB-1066 | Landing gostoa.dev + Stripe (stoa-web) | — |

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,6 @@
 # Plan: Demo Design Partner (24 fev 2026)
 
-> **Last updated:** 2026-02-10 (lundi soir)
+> **Last updated:** 2026-02-10 (lundi nuit)
 > **Status:** Phase 1+2 DONE — 5/5 livrables generated and pushed
 > **Next action:** Send email to Khalil (deadline 14 fev EOD) → collect feedback → dry-runs
 > **Full plan:** [stoa-strategy/execution/plan-demo-partner.md](private repo)
@@ -58,4 +58,5 @@ private `stoa-strategy` repository. This file contains only the execution struct
 
 > Cycle 7 complete: 225 pts / 22 PRs (9-10 fev 2026)
 > Demo Sprint D1-D11 complete + R1 MCP endpoints
+> Native Observability: PRs #299 (Platform Metrics) + #300 (Request Explorer) — replaced iframe embeds with native React dashboards querying Prometheus. 68 tests, coverage >50%.
 > Remaining: CAB-1035 (2 pts manual), CAB-1066 (34 pts stoa-web, stretch)


### PR DESCRIPTION
## Summary
- Console: build from source (`control-plane-ui/Dockerfile`) instead of pre-built `ghcr.io` image, so docker-compose always has latest code (native dashboards, dark mode fixes)
- Grafana: enable OIDC auto-login + disable login form for seamless SSO demo experience
- Update `memory.md` and `plan.md` with native observability PRs #299, #300

## Test plan
- [x] `docker compose build control-plane-ui` succeeds
- [x] `docker compose up -d` — Console serves native dashboards
- [x] Prometheus proxy reachable: `curl /prometheus/api/v1/query?query=up`
- [x] Grafana auto-login redirects to Keycloak OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>