### PR TITLE
fix(api): cast gateway_type enum to text for LIKE query

### DIFF
--- a/control-plane-api/src/routers/gateway_instances.py
+++ b/control-plane-api/src/routers/gateway_instances.py
@@ -3,7 +3,7 @@ import logging
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import case, func, select
+from sqlalchemy import String, case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.auth.rbac import require_role
@@ -96,7 +96,7 @@ async def get_gateway_mode_stats(
                 case((GatewayInstance.status == GatewayInstanceStatus.DEGRADED, 1))
             ).label("degraded"),
         )
-        .where(GatewayInstance.gateway_type.like("stoa%"))
+        .where(GatewayInstance.gateway_type.cast(String).like("stoa%"))
         .group_by(GatewayInstance.mode)
     )
 


### PR DESCRIPTION
## Summary
- Fix 500 error on `/v1/admin/gateways/modes/stats` endpoint
- PostgreSQL enum types don't support `LIKE` operator — added `.cast(String)` before `.like("stoa%")`
- One-line fix in `gateway_instances.py`

## Test plan
- [x] Reproduced 500 on OVH production
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>