### PR TITLE
test(gateway): Phase 1 P0 unit tests — 63 new tests

### DIFF
--- a/stoa-gateway/Cargo.toml
+++ b/stoa-gateway/Cargo.toml
@@ -79,4 +79,5 @@ k8s = ["kube", "k8s-openapi", "schemars"]  # K8s CRD watcher (Phase 7)
 criterion = "0.5"
 tokio-test = "0.4"
 tower = { version = "0.5", features = ["util"] }
+wiremock = "0.6"
 

--- a/stoa-gateway/src/config.rs
+++ b/stoa-gateway/src/config.rs
@@ -605,4 +605,89 @@ mod tests {
         let config = Config::load().expect("Should load defaults");
         assert_eq!(config.port, 8080);
     }
+
+    #[test]
+    fn test_default_gateway_mode() {
+        let config = Config::default();
+        assert_eq!(config.gateway_mode, GatewayMode::default());
+    }
+
+    #[test]
+    fn test_default_rate_limits() {
+        let config = Config::default();
+        assert_eq!(config.rate_limit_default, Some(1000));
+        assert_eq!(config.rate_limit_window_seconds, Some(60));
+    }
+
+    #[test]
+    fn test_default_kafka_disabled() {
+        let config = Config::default();
+        assert!(!config.kafka_enabled);
+        assert_eq!(config.kafka_brokers, "redpanda:9092");
+        assert_eq!(config.kafka_metering_topic, "stoa.metering");
+        assert_eq!(config.kafka_errors_topic, "stoa.errors");
+    }
+
+    #[test]
+    fn test_default_mtls_disabled() {
+        let config = Config::default();
+        assert!(!config.mtls.enabled);
+        assert!(config.mtls.require_binding);
+        assert!(config.mtls.trusted_proxies.is_empty());
+        assert!(config.mtls.allowed_issuers.is_empty());
+    }
+
+    #[test]
+    fn test_default_mtls_headers() {
+        let mtls = MtlsConfig::default();
+        assert_eq!(mtls.header_verify, "X-SSL-Client-Verify");
+        assert_eq!(mtls.header_fingerprint, "X-SSL-Client-Fingerprint");
+        assert_eq!(mtls.header_subject_dn, "X-SSL-Client-S-DN");
+        assert_eq!(mtls.header_issuer_dn, "X-SSL-Client-I-DN");
+        assert_eq!(mtls.header_serial, "X-SSL-Client-Serial");
+        assert_eq!(mtls.header_not_before, "X-SSL-Client-NotBefore");
+        assert_eq!(mtls.header_not_after, "X-SSL-Client-NotAfter");
+        assert_eq!(mtls.header_cert, "X-SSL-Client-Cert");
+    }
+
+    #[test]
+    fn test_default_quota_settings() {
+        let config = Config::default();
+        assert!(!config.quota_enforcement_enabled);
+        assert_eq!(config.quota_sync_interval_secs, 60);
+        assert_eq!(config.quota_default_rate_per_minute, 60);
+        assert_eq!(config.quota_default_daily_limit, 10_000);
+    }
+
+    #[test]
+    fn test_default_circuit_breaker_settings() {
+        let config = Config::default();
+        assert_eq!(config.cb_failure_threshold, 5);
+        assert_eq!(config.cb_reset_timeout_secs, 30);
+        assert_eq!(config.cb_success_threshold, 2);
+    }
+
+    #[test]
+    fn test_default_governance_settings() {
+        let config = Config::default();
+        assert!(config.zombie_detection_enabled);
+        assert_eq!(config.agent_session_ttl_secs, 600);
+        assert_eq!(config.attestation_interval, 100);
+    }
+
+    #[test]
+    fn test_default_gateway_external_url() {
+        let config = Config::default();
+        assert_eq!(
+            config.gateway_external_url,
+            Some("http://localhost:8080".to_string())
+        );
+    }
+
+    #[test]
+    fn test_validate_warns_but_succeeds() {
+        let config = Config::default();
+        // Default config has no CP URL and no JWT — validate should still succeed
+        assert!(config.validate().is_ok());
+    }
 }

--- a/stoa-gateway/src/handlers/admin.rs
+++ b/stoa-gateway/src/handlers/admin.rs
@@ -529,6 +529,320 @@ mod tests {
         assert_eq!(data[0]["name"], "payments");
     }
 
+    fn build_full_admin_router(state: AppState) -> Router {
+        Router::new()
+            .route("/health", get(admin_health))
+            .route("/apis", get(list_apis).post(upsert_api))
+            .route("/apis/:id", get(get_api).delete(delete_api))
+            .route("/policies", get(list_policies).post(upsert_policy))
+            .route("/policies/:id", delete(delete_policy))
+            .route("/circuit-breaker/stats", get(circuit_breaker_stats))
+            .route(
+                "/circuit-breaker/reset",
+                axum::routing::post(circuit_breaker_reset),
+            )
+            .route("/cache/stats", get(cache_stats))
+            .route("/cache/clear", axum::routing::post(cache_clear))
+            .route("/sessions/stats", get(session_stats))
+            .route("/circuit-breakers", get(circuit_breakers_list))
+            .route(
+                "/circuit-breakers/:name/reset",
+                axum::routing::post(circuit_breaker_reset_by_name),
+            )
+            .route("/quotas", get(list_quotas))
+            .route("/quotas/:consumer_id", get(get_consumer_quota))
+            .route(
+                "/quotas/:consumer_id/reset",
+                axum::routing::post(reset_consumer_quota),
+            )
+            .route("/mtls/config", get(mtls_config))
+            .route("/mtls/stats", get(mtls_stats))
+            .layer(middleware::from_fn_with_state(state.clone(), admin_auth))
+            .with_state(state)
+    }
+
+    fn auth_req(method: &str, uri: &str) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("Authorization", "Bearer secret")
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    fn auth_json_req(method: &str, uri: &str, body: serde_json::Value) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("Authorization", "Bearer secret")
+            .header("Content-Type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_admin_auth_missing_header() {
+        let state = create_test_state(Some("secret"));
+        let app = build_admin_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_admin_auth_empty_configured_token() {
+        let state = create_test_state(Some(""));
+        let app = build_admin_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .header("Authorization", "Bearer ")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Empty token = disabled
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn test_get_api_not_found() {
+        let state = create_test_state(Some("secret"));
+        let app = build_admin_router(state);
+        let response = app
+            .oneshot(auth_req("GET", "/apis/nonexistent"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_upsert_update_existing_returns_200() {
+        let state = create_test_state(Some("secret"));
+        let app = build_admin_router(state);
+        let route = serde_json::json!({
+            "id": "r1", "name": "payments", "tenant_id": "acme",
+            "path_prefix": "/apis/acme/payments", "backend_url": "https://backend.test",
+            "methods": ["GET"], "spec_hash": "abc", "activated": true
+        });
+        // First insert → CREATED
+        let _ = app
+            .clone()
+            .oneshot(auth_json_req("POST", "/apis", route.clone()))
+            .await
+            .unwrap();
+        // Second insert (update) → OK
+        let response = app
+            .oneshot(auth_json_req("POST", "/apis", route))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_delete_api_not_found() {
+        let state = create_test_state(Some("secret"));
+        let app = build_admin_router(state);
+        let response = app
+            .oneshot(auth_req("DELETE", "/apis/ghost"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_upsert_and_list_policies() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let policy = serde_json::json!({
+            "id": "p1", "name": "rate-limit",
+            "policy_type": "rate_limit", "config": {"limit": 100},
+            "priority": 1, "api_id": "r1"
+        });
+        let response = app
+            .clone()
+            .oneshot(auth_json_req("POST", "/policies", policy))
+            .await
+            .unwrap();
+        assert!(response.status() == StatusCode::CREATED || response.status() == StatusCode::OK);
+        let response = app.oneshot(auth_req("GET", "/policies")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_delete_policy_not_found() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app
+            .oneshot(auth_req("DELETE", "/policies/ghost"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_circuit_breaker_stats() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app
+            .oneshot(auth_req("GET", "/circuit-breaker/stats"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["state"], "closed");
+        assert_eq!(data["success_count"], 0);
+    }
+
+    #[tokio::test]
+    async fn test_circuit_breaker_reset() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app
+            .oneshot(auth_req("POST", "/circuit-breaker/reset"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["status"], "ok");
+    }
+
+    #[tokio::test]
+    async fn test_cache_stats() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app.oneshot(auth_req("GET", "/cache/stats")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["hits"], 0);
+        assert_eq!(data["misses"], 0);
+    }
+
+    #[tokio::test]
+    async fn test_cache_clear() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app.oneshot(auth_req("POST", "/cache/clear")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_session_stats() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app
+            .oneshot(auth_req("GET", "/sessions/stats"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["active_sessions"], 0);
+    }
+
+    #[tokio::test]
+    async fn test_circuit_breakers_list_empty() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app
+            .oneshot(auth_req("GET", "/circuit-breakers"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert!(data.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_circuit_breaker_reset_by_name_not_found() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app
+            .oneshot(auth_req("POST", "/circuit-breakers/unknown/reset"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_list_quotas_empty() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app.oneshot(auth_req("GET", "/quotas")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert!(data.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_consumer_quota_not_found() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app
+            .oneshot(auth_req("GET", "/quotas/unknown-consumer"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_reset_consumer_quota_not_found() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app
+            .oneshot(auth_req("POST", "/quotas/unknown-consumer/reset"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_mtls_config_endpoint() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app.oneshot(auth_req("GET", "/mtls/config")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_mtls_stats_endpoint() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app.oneshot(auth_req("GET", "/mtls/stats")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
     #[tokio::test]
     async fn test_delete_api() {
         let state = create_test_state(Some("secret"));

--- a/stoa-gateway/src/mcp/handlers.rs
+++ b/stoa-gateway/src/mcp/handlers.rs
@@ -675,3 +675,211 @@ fn extract_user(headers: &HeaderMap) -> Option<String> {
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    // === expand_role_scopes ===
+
+    #[test]
+    fn test_expand_cpi_admin_all_scopes() {
+        let roles = vec!["cpi-admin".to_string()];
+        let mut scopes = vec![];
+        expand_role_scopes(&roles, &mut scopes);
+        assert_eq!(scopes.len(), 6);
+        assert!(scopes.contains(&"stoa:admin".to_string()));
+        assert!(scopes.contains(&"stoa:read".to_string()));
+        assert!(scopes.contains(&"stoa:write".to_string()));
+        assert!(scopes.contains(&"stoa:execute".to_string()));
+        assert!(scopes.contains(&"stoa:deploy".to_string()));
+        assert!(scopes.contains(&"stoa:audit".to_string()));
+    }
+
+    #[test]
+    fn test_expand_cpi_admin_underscore_variant() {
+        let roles = vec!["cpi_admin".to_string()];
+        let mut scopes = vec![];
+        expand_role_scopes(&roles, &mut scopes);
+        assert_eq!(scopes.len(), 6);
+    }
+
+    #[test]
+    fn test_expand_admin_role() {
+        let roles = vec!["admin".to_string()];
+        let mut scopes = vec![];
+        expand_role_scopes(&roles, &mut scopes);
+        assert_eq!(scopes.len(), 6);
+    }
+
+    #[test]
+    fn test_expand_tenant_admin() {
+        let roles = vec!["tenant-admin".to_string()];
+        let mut scopes = vec![];
+        expand_role_scopes(&roles, &mut scopes);
+        assert_eq!(scopes.len(), 3);
+        assert!(scopes.contains(&"stoa:read".to_string()));
+        assert!(scopes.contains(&"stoa:write".to_string()));
+        assert!(scopes.contains(&"stoa:execute".to_string()));
+    }
+
+    #[test]
+    fn test_expand_tenant_admin_underscore() {
+        let roles = vec!["tenant_admin".to_string()];
+        let mut scopes = vec![];
+        expand_role_scopes(&roles, &mut scopes);
+        assert_eq!(scopes.len(), 3);
+    }
+
+    #[test]
+    fn test_expand_devops() {
+        let roles = vec!["devops".to_string()];
+        let mut scopes = vec![];
+        expand_role_scopes(&roles, &mut scopes);
+        assert_eq!(scopes.len(), 3);
+        assert!(scopes.contains(&"stoa:read".to_string()));
+        assert!(scopes.contains(&"stoa:write".to_string()));
+        assert!(scopes.contains(&"stoa:deploy".to_string()));
+    }
+
+    #[test]
+    fn test_expand_dev_ops_hyphen() {
+        let roles = vec!["dev-ops".to_string()];
+        let mut scopes = vec![];
+        expand_role_scopes(&roles, &mut scopes);
+        assert_eq!(scopes.len(), 3);
+        assert!(scopes.contains(&"stoa:deploy".to_string()));
+    }
+
+    #[test]
+    fn test_expand_viewer() {
+        let roles = vec!["viewer".to_string()];
+        let mut scopes = vec![];
+        expand_role_scopes(&roles, &mut scopes);
+        assert_eq!(scopes.len(), 1);
+        assert!(scopes.contains(&"stoa:read".to_string()));
+    }
+
+    #[test]
+    fn test_expand_readonly_variants() {
+        for role in &["read-only", "readonly"] {
+            let roles = vec![role.to_string()];
+            let mut scopes = vec![];
+            expand_role_scopes(&roles, &mut scopes);
+            assert_eq!(scopes.len(), 1, "Failed for role: {}", role);
+            assert!(scopes.contains(&"stoa:read".to_string()));
+        }
+    }
+
+    #[test]
+    fn test_expand_unknown_role_adds_nothing() {
+        let roles = vec!["unknown-role".to_string()];
+        let mut scopes = vec![];
+        expand_role_scopes(&roles, &mut scopes);
+        assert!(scopes.is_empty());
+    }
+
+    #[test]
+    fn test_expand_no_duplicates() {
+        let roles = vec!["cpi-admin".to_string()];
+        let mut scopes = vec!["stoa:read".to_string(), "stoa:admin".to_string()];
+        expand_role_scopes(&roles, &mut scopes);
+        // Should still have 6 unique scopes, not 8
+        assert_eq!(scopes.len(), 6);
+    }
+
+    #[test]
+    fn test_expand_multiple_roles_combined() {
+        let roles = vec!["viewer".to_string(), "devops".to_string()];
+        let mut scopes = vec![];
+        expand_role_scopes(&roles, &mut scopes);
+        // viewer: read, devops: read+write+deploy → 3 unique
+        assert_eq!(scopes.len(), 3);
+        assert!(scopes.contains(&"stoa:read".to_string()));
+        assert!(scopes.contains(&"stoa:write".to_string()));
+        assert!(scopes.contains(&"stoa:deploy".to_string()));
+    }
+
+    #[test]
+    fn test_expand_empty_roles() {
+        let roles: Vec<String> = vec![];
+        let mut scopes = vec![];
+        expand_role_scopes(&roles, &mut scopes);
+        assert!(scopes.is_empty());
+    }
+
+    // === extract_tenant ===
+
+    #[test]
+    fn test_extract_tenant_present() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Tenant-ID", HeaderValue::from_static("acme-corp"));
+        assert_eq!(extract_tenant(&headers), Some("acme-corp".to_string()));
+    }
+
+    #[test]
+    fn test_extract_tenant_missing() {
+        let headers = HeaderMap::new();
+        assert_eq!(extract_tenant(&headers), None);
+    }
+
+    // === extract_user ===
+
+    #[test]
+    fn test_extract_user_present() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-User-ID", HeaderValue::from_static("user-42"));
+        assert_eq!(extract_user(&headers), Some("user-42".to_string()));
+    }
+
+    #[test]
+    fn test_extract_user_missing() {
+        let headers = HeaderMap::new();
+        assert_eq!(extract_user(&headers), None);
+    }
+
+    // === extract_optimization_level ===
+
+    #[test]
+    fn test_optimization_level_none_when_missing() {
+        let headers = HeaderMap::new();
+        assert_eq!(
+            extract_optimization_level(&headers),
+            OptimizationLevel::None
+        );
+    }
+
+    #[test]
+    fn test_optimization_level_moderate() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Token-Optimization", HeaderValue::from_static("moderate"));
+        assert_eq!(
+            extract_optimization_level(&headers),
+            OptimizationLevel::Moderate
+        );
+    }
+
+    #[test]
+    fn test_optimization_level_aggressive() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Token-Optimization",
+            HeaderValue::from_static("aggressive"),
+        );
+        assert_eq!(
+            extract_optimization_level(&headers),
+            OptimizationLevel::Aggressive
+        );
+    }
+
+    #[test]
+    fn test_optimization_level_unknown_defaults_to_none() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Token-Optimization", HeaderValue::from_static("turbo"));
+        assert_eq!(
+            extract_optimization_level(&headers),
+            OptimizationLevel::None
+        );
+    }
+}

--- a/stoa-gateway/src/oauth/discovery.rs
+++ b/stoa-gateway/src/oauth/discovery.rs
@@ -162,3 +162,97 @@ pub async fn openid_configuration(
 
     Ok(Json(oidc_config))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+
+    fn test_state(keycloak_url: Option<&str>, gateway_url: Option<&str>) -> AppState {
+        let config = Config {
+            keycloak_url: keycloak_url.map(|s| s.to_string()),
+            keycloak_realm: Some("test-realm".to_string()),
+            gateway_external_url: gateway_url.map(|s| s.to_string()),
+            ..Config::default()
+        };
+        AppState::new(config)
+    }
+
+    #[tokio::test]
+    async fn test_protected_resource_metadata_defaults() {
+        let state = test_state(None, None);
+        let Json(meta) = protected_resource_metadata(State(state)).await;
+        assert_eq!(meta["resource"], "http://localhost:8080");
+        assert!(meta["authorization_servers"].is_array());
+        assert!(meta["scopes_supported"].is_array());
+        assert_eq!(meta["bearer_methods_supported"][0], "header");
+    }
+
+    #[tokio::test]
+    async fn test_protected_resource_metadata_custom_urls() {
+        let state = test_state(
+            Some("https://auth.gostoa.dev"),
+            Some("https://mcp.gostoa.dev"),
+        );
+        let Json(meta) = protected_resource_metadata(State(state)).await;
+        assert_eq!(meta["resource"], "https://mcp.gostoa.dev");
+        assert_eq!(
+            meta["authorization_servers"][0],
+            "https://auth.gostoa.dev/realms/test-realm"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_authorization_server_metadata_defaults() {
+        let state = test_state(None, None);
+        let Json(meta) = authorization_server_metadata(State(state)).await;
+        assert_eq!(meta["token_endpoint"], "http://localhost:8080/oauth/token");
+        assert_eq!(
+            meta["registration_endpoint"],
+            "http://localhost:8080/oauth/register"
+        );
+        assert!(meta["scopes_supported"].is_array());
+        assert!(meta["grant_types_supported"].is_array());
+    }
+
+    #[tokio::test]
+    async fn test_authorization_server_metadata_custom_urls() {
+        let state = test_state(
+            Some("https://auth.gostoa.dev"),
+            Some("https://mcp.gostoa.dev"),
+        );
+        let Json(meta) = authorization_server_metadata(State(state)).await;
+        assert_eq!(meta["issuer"], "https://auth.gostoa.dev/realms/test-realm");
+        assert_eq!(meta["token_endpoint"], "https://mcp.gostoa.dev/oauth/token");
+        assert_eq!(
+            meta["authorization_endpoint"],
+            "https://auth.gostoa.dev/realms/test-realm/protocol/openid-connect/auth"
+        );
+        assert_eq!(
+            meta["jwks_uri"],
+            "https://auth.gostoa.dev/realms/test-realm/protocol/openid-connect/certs"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_authorization_server_metadata_has_required_fields() {
+        let state = test_state(Some("https://kc.test"), Some("https://gw.test"));
+        let Json(meta) = authorization_server_metadata(State(state)).await;
+        // RFC 8414 required fields
+        assert!(meta.get("issuer").is_some());
+        assert!(meta.get("authorization_endpoint").is_some());
+        assert!(meta.get("token_endpoint").is_some());
+        assert!(meta.get("response_types_supported").is_some());
+        assert_eq!(meta["response_types_supported"][0], "code");
+        assert_eq!(meta["code_challenge_methods_supported"][0], "S256");
+        assert_eq!(meta["subject_types_supported"][0], "public");
+    }
+
+    #[tokio::test]
+    async fn test_openid_configuration_no_keycloak_returns_503() {
+        let state = test_state(None, None);
+        let result = openid_configuration(State(state)).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/stoa-gateway/src/oauth/proxy.rs
+++ b/stoa-gateway/src/oauth/proxy.rs
@@ -312,3 +312,268 @@ async fn patch_public_client(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use axum::{body::Body, http::Request, routing::post, Router};
+    use tower::ServiceExt;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_state_with_keycloak(keycloak_url: Option<&str>) -> AppState {
+        let config = Config {
+            keycloak_url: keycloak_url.map(|s| s.to_string()),
+            keycloak_realm: Some("stoa".to_string()),
+            keycloak_admin_password: Some("admin-pass".to_string()),
+            ..Config::default()
+        };
+        AppState::new(config)
+    }
+
+    fn build_oauth_router(state: AppState) -> Router {
+        Router::new()
+            .route("/oauth/token", post(token_proxy))
+            .route("/oauth/register", post(register_proxy))
+            .with_state(state)
+    }
+
+    // === token_proxy tests ===
+
+    #[tokio::test]
+    async fn test_token_proxy_no_keycloak_url() {
+        let state = test_state_with_keycloak(None);
+        let app = build_oauth_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/token")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("grant_type=client_credentials"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "server_error");
+    }
+
+    #[tokio::test]
+    async fn test_token_proxy_success() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/realms/stoa/protocol/openid-connect/token"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"access_token": "test-token", "token_type": "Bearer"})),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let state = test_state_with_keycloak(Some(&mock_server.uri()));
+        let app = build_oauth_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/token")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("grant_type=client_credentials&client_id=test"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["access_token"], "test-token");
+    }
+
+    #[tokio::test]
+    async fn test_token_proxy_keycloak_error() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/realms/stoa/protocol/openid-connect/token"))
+            .respond_with(
+                ResponseTemplate::new(401).set_body_json(json!({"error": "invalid_client"})),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let state = test_state_with_keycloak(Some(&mock_server.uri()));
+        let app = build_oauth_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/token")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("grant_type=client_credentials"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_token_proxy_keycloak_unreachable() {
+        // Point to a non-existent server
+        let state = test_state_with_keycloak(Some("http://127.0.0.1:1"));
+        let app = build_oauth_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/token")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("grant_type=client_credentials"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    // === register_proxy tests ===
+
+    #[tokio::test]
+    async fn test_register_proxy_no_keycloak_url() {
+        let state = test_state_with_keycloak(None);
+        let app = build_oauth_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&json!({"client_name": "test"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn test_register_proxy_dcr_success() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/realms/stoa/clients-registrations/openid-connect"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+                "client_id": "new-client-abc",
+                "client_secret": "secret-123",
+                "registration_access_token": "rat-xyz"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Admin token for public client patch
+        Mock::given(method("POST"))
+            .and(path("/realms/master/protocol/openid-connect/token"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({"access_token": "admin-jwt"})),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // Client lookup
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/stoa/clients"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "id": "internal-uuid",
+                "clientId": "new-client-abc"
+            }])))
+            .mount(&mock_server)
+            .await;
+
+        // Client update (PKCE patch)
+        Mock::given(method("PUT"))
+            .and(path("/admin/realms/stoa/clients/internal-uuid"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&mock_server)
+            .await;
+
+        let state = test_state_with_keycloak(Some(&mock_server.uri()));
+        let app = build_oauth_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&json!({"client_name": "claude-mcp"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["client_id"], "new-client-abc");
+    }
+
+    #[tokio::test]
+    async fn test_register_proxy_dcr_keycloak_error() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/realms/stoa/clients-registrations/openid-connect"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(json!({
+                "error": "forbidden",
+                "error_description": "DCR disabled"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let state = test_state_with_keycloak(Some(&mock_server.uri()));
+        let app = build_oauth_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&json!({"client_name": "test"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_register_proxy_keycloak_unreachable() {
+        let state = test_state_with_keycloak(Some("http://127.0.0.1:1"));
+        let app = build_oauth_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&json!({"client_name": "test"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    }
+}


### PR DESCRIPTION
## Summary
- Add 63 new unit tests across 5 files for Phase 1 P0 coverage
- `mcp/handlers.rs`: 21 tests — RBAC scope expansion (ADR-012), header extraction, optimization levels
- `oauth/discovery.rs`: 6 tests — RFC 9728/8414 metadata, OIDC discovery fallback
- `oauth/proxy.rs`: 8 tests — token proxy + DCR proxy with wiremock (success, error, unreachable, not-configured)
- `handlers/admin.rs`: +18 tests — policies CRUD, circuit breakers, cache, sessions, quotas, mTLS endpoints
- `config.rs`: +10 tests — defaults for all config sections (governance, quota, CB, mTLS, Kafka)
- Added `wiremock 0.6` dev-dependency for OAuth proxy integration tests
- Total: 396 tests (332 baseline + 64 new), clippy clean, fmt clean

## Test plan
- [x] `cargo fmt --check` — zero diffs
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo test` — 396 passed, 0 failed
- [x] No new `todo!()` or `dbg!()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>