### PR TITLE
test(gateway): Phase 2 unit tests — modes + control plane (96 new)

### DIFF
--- a/stoa-gateway/src/control_plane/registration.rs
+++ b/stoa-gateway/src/control_plane/registration.rs
@@ -333,6 +333,10 @@ impl GatewayRegistrar {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Config;
+    use crate::mode::GatewayMode;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn test_registration_payload_serialization() {
@@ -353,6 +357,23 @@ mod tests {
     }
 
     #[test]
+    fn test_registration_payload_with_tenant() {
+        let payload = RegistrationPayload {
+            hostname: "gw-1".to_string(),
+            mode: "sidecar".to_string(),
+            version: "0.1.0".to_string(),
+            environment: "staging".to_string(),
+            capabilities: vec!["rest".to_string()],
+            admin_url: "http://gw-1:8081".to_string(),
+            tenant_id: Some("acme".to_string()),
+        };
+
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("tenant_id"));
+        assert!(json.contains("acme"));
+    }
+
+    #[test]
     fn test_heartbeat_payload_serialization() {
         let payload = HeartbeatPayload {
             uptime_seconds: 3600,
@@ -369,6 +390,21 @@ mod tests {
     }
 
     #[test]
+    fn test_heartbeat_payload_full() {
+        let payload = HeartbeatPayload {
+            uptime_seconds: 7200,
+            routes_count: 5,
+            policies_count: 3,
+            requests_total: Some(5000),
+            error_rate: Some(0.02),
+        };
+
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("error_rate"));
+        assert!(json.contains("0.02"));
+    }
+
+    #[test]
     fn test_registrar_creation() {
         let registrar = GatewayRegistrar::new(
             "https://api.example.com".to_string(),
@@ -377,5 +413,246 @@ mod tests {
 
         assert_eq!(registrar.cp_url, "https://api.example.com");
         assert_eq!(registrar.api_key, "test-key");
+    }
+
+    #[test]
+    fn test_registration_response_deserialize() {
+        let json = r#"{
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "name": "gw-edge-dev",
+            "status": "active"
+        }"#;
+
+        let resp: RegistrationResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.name, "gw-edge-dev");
+        assert_eq!(resp.status, "active");
+    }
+
+    #[test]
+    fn test_registration_error_display() {
+        let e = RegistrationError::InvalidApiKey;
+        assert_eq!(e.to_string(), "Invalid API key");
+
+        let e = RegistrationError::Unreachable("timeout".to_string());
+        assert!(e.to_string().contains("timeout"));
+
+        let e = RegistrationError::Rejected("duplicate".to_string());
+        assert!(e.to_string().contains("duplicate"));
+
+        let e = RegistrationError::HostnameError("no hostname".to_string());
+        assert!(e.to_string().contains("no hostname"));
+    }
+
+    #[test]
+    fn test_detect_capabilities_edge_mcp() {
+        let registrar = GatewayRegistrar::new("http://cp".to_string(), "key".to_string());
+        let config = Config {
+            gateway_mode: GatewayMode::EdgeMcp,
+            policy_enabled: true,
+            ..Config::default()
+        };
+
+        let caps = registrar.detect_capabilities(&config);
+        assert!(caps.contains(&"rest".to_string()));
+        assert!(caps.contains(&"oidc".to_string()));
+        assert!(caps.contains(&"metering".to_string()));
+        assert!(caps.contains(&"mcp".to_string()));
+        assert!(caps.contains(&"sse".to_string()));
+        assert!(caps.contains(&"policy".to_string()));
+    }
+
+    #[test]
+    fn test_detect_capabilities_sidecar() {
+        let registrar = GatewayRegistrar::new("http://cp".to_string(), "key".to_string());
+        let config = Config {
+            gateway_mode: GatewayMode::Sidecar,
+            policy_enabled: false,
+            ..Config::default()
+        };
+
+        let caps = registrar.detect_capabilities(&config);
+        assert!(caps.contains(&"ext_authz".to_string()));
+        assert!(!caps.contains(&"mcp".to_string()));
+        assert!(!caps.contains(&"policy".to_string()));
+    }
+
+    #[test]
+    fn test_detect_capabilities_proxy_with_rate_limit() {
+        let registrar = GatewayRegistrar::new("http://cp".to_string(), "key".to_string());
+        let config = Config {
+            gateway_mode: GatewayMode::Proxy,
+            rate_limit_default: Some(1000),
+            policy_enabled: false,
+            ..Config::default()
+        };
+
+        let caps = registrar.detect_capabilities(&config);
+        assert!(caps.contains(&"rate_limiting".to_string()));
+    }
+
+    #[test]
+    fn test_detect_capabilities_shadow() {
+        let registrar = GatewayRegistrar::new("http://cp".to_string(), "key".to_string());
+        let config = Config {
+            gateway_mode: GatewayMode::Shadow,
+            policy_enabled: false,
+            ..Config::default()
+        };
+
+        let caps = registrar.detect_capabilities(&config);
+        assert!(caps.contains(&"traffic_capture".to_string()));
+        assert!(!caps.contains(&"mcp".to_string()));
+    }
+
+    #[test]
+    fn test_get_hostname() {
+        let registrar = GatewayRegistrar::new("http://cp".to_string(), "key".to_string());
+        let hostname = registrar.get_hostname();
+        assert!(hostname.is_ok());
+        assert!(!hostname.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_gateway_id_initially_none() {
+        let registrar = GatewayRegistrar::new("http://cp".to_string(), "key".to_string());
+        assert!(registrar.gateway_id().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_register_success() {
+        let mock_server = MockServer::start().await;
+
+        let gw_id = Uuid::new_v4();
+        Mock::given(method("POST"))
+            .and(path("/v1/internal/gateways/register"))
+            .and(header("X-Gateway-Key", "test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": gw_id.to_string(),
+                "name": "gw-edge-dev",
+                "status": "active"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let registrar = GatewayRegistrar::new(mock_server.uri(), "test-key".to_string());
+        let config = Config::default();
+
+        let result = registrar.register(&config).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), gw_id);
+        assert_eq!(registrar.gateway_id().await, Some(gw_id));
+    }
+
+    #[tokio::test]
+    async fn test_register_unauthorized() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/internal/gateways/register"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&mock_server)
+            .await;
+
+        let registrar = GatewayRegistrar::new(mock_server.uri(), "bad-key".to_string());
+        let config = Config::default();
+
+        let result = registrar.register(&config).await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            RegistrationError::InvalidApiKey
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_register_forbidden() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/internal/gateways/register"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&mock_server)
+            .await;
+
+        let registrar = GatewayRegistrar::new(mock_server.uri(), "key".to_string());
+        let config = Config::default();
+
+        let result = registrar.register(&config).await;
+        assert!(matches!(
+            result.unwrap_err(),
+            RegistrationError::InvalidApiKey
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_register_server_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/internal/gateways/register"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+            .mount(&mock_server)
+            .await;
+
+        let registrar = GatewayRegistrar::new(mock_server.uri(), "key".to_string());
+        let config = Config::default();
+
+        let result = registrar.register(&config).await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            RegistrationError::Rejected(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_send_heartbeat_success() {
+        let mock_server = MockServer::start().await;
+        let gw_id = Uuid::new_v4();
+
+        Mock::given(method("POST"))
+            .and(path(format!("/v1/internal/gateways/{}/heartbeat", gw_id)))
+            .and(header("X-Gateway-Key", "key"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&mock_server)
+            .await;
+
+        let registrar = GatewayRegistrar::new(mock_server.uri(), "key".to_string());
+
+        let payload = HeartbeatPayload {
+            uptime_seconds: 60,
+            routes_count: 5,
+            policies_count: 2,
+            requests_total: None,
+            error_rate: None,
+        };
+
+        let result = registrar.send_heartbeat(gw_id, payload).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_send_heartbeat_failure() {
+        let mock_server = MockServer::start().await;
+        let gw_id = Uuid::new_v4();
+
+        Mock::given(method("POST"))
+            .and(path(format!("/v1/internal/gateways/{}/heartbeat", gw_id)))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&mock_server)
+            .await;
+
+        let registrar = GatewayRegistrar::new(mock_server.uri(), "key".to_string());
+
+        let payload = HeartbeatPayload {
+            uptime_seconds: 60,
+            routes_count: 0,
+            policies_count: 0,
+            requests_total: None,
+            error_rate: None,
+        };
+
+        let result = registrar.send_heartbeat(gw_id, payload).await;
+        assert!(result.is_err());
     }
 }

--- a/stoa-gateway/src/control_plane/tool_proxy.rs
+++ b/stoa-gateway/src/control_plane/tool_proxy.rs
@@ -345,3 +345,304 @@ impl ToolProxyClient {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn make_tool_context() -> ToolContext {
+        ToolContext {
+            tenant_id: "acme".to_string(),
+            user_id: Some("uid-1".to_string()),
+            user_email: Some("user@test.com".to_string()),
+            request_id: "req-1".to_string(),
+            roles: vec!["admin".to_string()],
+            scopes: vec!["stoa:read".to_string()],
+            raw_token: None,
+        }
+    }
+
+    #[test]
+    fn test_tool_proxy_client_new_no_oidc() {
+        let client = ToolProxyClient::new("http://localhost:8000", None);
+        assert_eq!(client.base_url(), "http://localhost:8000");
+        assert!(client.oidc.is_none());
+    }
+
+    #[test]
+    fn test_tool_proxy_client_new_with_oidc() {
+        let oidc = OidcConfig {
+            token_url: "http://kc/token".to_string(),
+            client_id: "gw".to_string(),
+            client_secret: "secret".to_string(),
+        };
+        let client = ToolProxyClient::new("http://localhost:8000/", Some(oidc));
+        // Trailing slash stripped
+        assert_eq!(client.base_url(), "http://localhost:8000");
+        assert!(client.oidc.is_some());
+    }
+
+    #[test]
+    fn test_remote_tool_def_deserialize() {
+        let json = r#"{
+            "name": "list_users",
+            "description": "List all users",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"page": {"type": "integer"}},
+                "required": ["page"]
+            }
+        }"#;
+
+        let tool: RemoteToolDef = serde_json::from_str(json).unwrap();
+        assert_eq!(tool.name, "list_users");
+        assert_eq!(tool.description, "List all users");
+        assert_eq!(tool.input_schema.schema_type, "object");
+        assert!(tool.input_schema.properties.contains_key("page"));
+        assert_eq!(tool.input_schema.required, vec!["page"]);
+    }
+
+    #[test]
+    fn test_remote_tool_def_deserialize_minimal() {
+        let json = r#"{
+            "name": "health",
+            "description": "Check health",
+            "inputSchema": {}
+        }"#;
+
+        let tool: RemoteToolDef = serde_json::from_str(json).unwrap();
+        assert_eq!(tool.name, "health");
+        // default_object() should provide "object"
+        assert_eq!(tool.input_schema.schema_type, "object");
+        assert!(tool.input_schema.properties.is_empty());
+        assert!(tool.input_schema.required.is_empty());
+    }
+
+    #[test]
+    fn test_tools_list_response_deserialize() {
+        let json = r#"{"tools": [
+            {"name": "t1", "description": "d1", "inputSchema": {}},
+            {"name": "t2", "description": "d2", "inputSchema": {"type": "object"}}
+        ]}"#;
+
+        let resp: ToolsListResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.tools.len(), 2);
+        assert_eq!(resp.tools[0].name, "t1");
+        assert_eq!(resp.tools[1].name, "t2");
+    }
+
+    #[tokio::test]
+    async fn test_discover_tools_unauthenticated() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/mcp/tools"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "tools": [
+                    {"name": "tool_a", "description": "A", "inputSchema": {}},
+                    {"name": "tool_b", "description": "B", "inputSchema": {}}
+                ]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = ToolProxyClient::new(&mock_server.uri(), None);
+        let tools = client.discover_tools().await.unwrap();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].name, "tool_a");
+    }
+
+    #[tokio::test]
+    async fn test_discover_tools_server_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/mcp/tools"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("Internal error"))
+            .mount(&mock_server)
+            .await;
+
+        let client = ToolProxyClient::new(&mock_server.uri(), None);
+        let result = client.discover_tools().await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("500"));
+    }
+
+    #[tokio::test]
+    async fn test_discover_tools_authenticated_with_fallback() {
+        let mock_server = MockServer::start().await;
+
+        // Token endpoint
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "test-token",
+                "expires_in": 300,
+                "token_type": "Bearer"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Authenticated endpoint returns 401 → triggers fallback
+        Mock::given(method("GET"))
+            .and(path("/v1/mcp/tools"))
+            .and(header("Authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&mock_server)
+            .await;
+
+        // Unauthenticated fallback works
+        Mock::given(method("GET"))
+            .and(path("/v1/mcp/tools"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "tools": [{"name": "fallback_tool", "description": "ok", "inputSchema": {}}]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let oidc = OidcConfig {
+            token_url: format!("{}/token", mock_server.uri()),
+            client_id: "gw".to_string(),
+            client_secret: "secret".to_string(),
+        };
+
+        let client = ToolProxyClient::new(&mock_server.uri(), Some(oidc));
+        let tools = client.discover_tools().await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "fallback_tool");
+    }
+
+    #[tokio::test]
+    async fn test_call_tool_unauthenticated() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/mcp/tools/list_users/invoke"))
+            .and(header("X-Tenant-ID", "acme"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"result": "ok", "users": []})),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = ToolProxyClient::new(&mock_server.uri(), None);
+        let ctx = make_tool_context();
+        let args = serde_json::json!({"page": 1});
+
+        let result = client.call_tool("list_users", args, &ctx).await.unwrap();
+        assert_eq!(result["result"], "ok");
+    }
+
+    #[tokio::test]
+    async fn test_call_tool_with_user_token() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/mcp/tools/my_tool/invoke"))
+            .and(header("Authorization", "Bearer user-jwt-token"))
+            .and(header("X-User-Id", "uid-1"))
+            .and(header("X-User-Email", "user@test.com"))
+            .and(header("X-User-Roles", "admin"))
+            .and(header("X-Tenant-ID", "acme"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": "done"})),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = ToolProxyClient::new(&mock_server.uri(), None);
+        let mut ctx = make_tool_context();
+        ctx.raw_token = Some("user-jwt-token".to_string());
+
+        let result = client
+            .call_tool("my_tool", serde_json::json!({}), &ctx)
+            .await
+            .unwrap();
+        assert_eq!(result["status"], "done");
+    }
+
+    #[tokio::test]
+    async fn test_call_tool_server_error_fallback() {
+        let mock_server = MockServer::start().await;
+
+        // All calls fail
+        Mock::given(method("POST"))
+            .and(path("/v1/mcp/tools/bad_tool/invoke"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&mock_server)
+            .await;
+
+        let client = ToolProxyClient::new(&mock_server.uri(), None);
+        let ctx = make_tool_context();
+        let result = client
+            .call_tool("bad_tool", serde_json::json!({}), &ctx)
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("500"));
+    }
+
+    #[tokio::test]
+    async fn test_get_token_no_oidc() {
+        let client = ToolProxyClient::new("http://localhost:8000", None);
+        let result = client.get_token().await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("OIDC not configured"));
+    }
+
+    #[tokio::test]
+    async fn test_get_token_success_and_cache() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "fresh-token",
+                "expires_in": 3600,
+                "token_type": "Bearer"
+            })))
+            .expect(1) // Should only be called once due to caching
+            .mount(&mock_server)
+            .await;
+
+        let oidc = OidcConfig {
+            token_url: format!("{}/token", mock_server.uri()),
+            client_id: "gw".to_string(),
+            client_secret: "s3cret".to_string(),
+        };
+
+        let client = ToolProxyClient::new(&mock_server.uri(), Some(oidc));
+
+        // First call - fetches token
+        let token1 = client.get_token().await.unwrap();
+        assert_eq!(token1, "fresh-token");
+
+        // Second call - should use cache (mock expects exactly 1 call)
+        let token2 = client.get_token().await.unwrap();
+        assert_eq!(token2, "fresh-token");
+    }
+
+    #[tokio::test]
+    async fn test_get_token_error_response() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("bad credentials"))
+            .mount(&mock_server)
+            .await;
+
+        let oidc = OidcConfig {
+            token_url: format!("{}/token", mock_server.uri()),
+            client_id: "gw".to_string(),
+            client_secret: "wrong".to_string(),
+        };
+
+        let client = ToolProxyClient::new(&mock_server.uri(), Some(oidc));
+        let result = client.get_token().await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("401"));
+    }
+}

--- a/stoa-gateway/src/mode/mod.rs
+++ b/stoa-gateway/src/mode/mod.rs
@@ -488,4 +488,109 @@ mod tests {
         assert_eq!(GatewayMode::Proxy.default_port(), 8082);
         assert_eq!(GatewayMode::Shadow.default_port(), 8083);
     }
+
+    #[test]
+    fn test_requires_upstream() {
+        assert!(!GatewayMode::EdgeMcp.requires_upstream());
+        assert!(!GatewayMode::Sidecar.requires_upstream());
+        assert!(GatewayMode::Proxy.requires_upstream());
+        assert!(GatewayMode::Shadow.requires_upstream());
+    }
+
+    #[test]
+    fn test_supports_transformation() {
+        assert!(!GatewayMode::EdgeMcp.supports_transformation());
+        assert!(!GatewayMode::Sidecar.supports_transformation());
+        assert!(GatewayMode::Proxy.supports_transformation());
+        assert!(!GatewayMode::Shadow.supports_transformation());
+    }
+
+    #[test]
+    fn test_description_not_empty() {
+        for mode in GatewayMode::all() {
+            assert!(!mode.description().is_empty());
+        }
+    }
+
+    #[test]
+    fn test_all_modes_count() {
+        assert_eq!(GatewayMode::all().len(), 4);
+    }
+
+    #[test]
+    fn test_mode_parse_variants() {
+        // edge-mcp has multiple aliases
+        assert_eq!(
+            "edge_mcp".parse::<GatewayMode>().unwrap(),
+            GatewayMode::EdgeMcp
+        );
+        assert_eq!(
+            "edgemcp".parse::<GatewayMode>().unwrap(),
+            GatewayMode::EdgeMcp
+        );
+        assert_eq!("MCP".parse::<GatewayMode>().unwrap(), GatewayMode::EdgeMcp);
+        assert_eq!(
+            "SIDECAR".parse::<GatewayMode>().unwrap(),
+            GatewayMode::Sidecar
+        );
+        assert_eq!("PROXY".parse::<GatewayMode>().unwrap(), GatewayMode::Proxy);
+        assert_eq!(
+            "SHADOW".parse::<GatewayMode>().unwrap(),
+            GatewayMode::Shadow
+        );
+    }
+
+    #[test]
+    fn test_mode_parse_error_message() {
+        let err = "foobar".parse::<GatewayMode>().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("foobar"));
+        assert!(msg.contains("edge-mcp"));
+    }
+
+    #[test]
+    fn test_mode_serde_roundtrip() {
+        let mode = GatewayMode::EdgeMcp;
+        let json = serde_json::to_string(&mode).unwrap();
+        assert_eq!(json, "\"edge-mcp\"");
+        let deserialized: GatewayMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, GatewayMode::EdgeMcp);
+    }
+
+    #[test]
+    fn test_mode_serde_all_variants() {
+        for mode in GatewayMode::all() {
+            let json = serde_json::to_string(mode).unwrap();
+            let back: GatewayMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(&back, mode);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Not in sidecar mode")]
+    fn test_mode_config_wrong_accessor_sidecar() {
+        let config = ModeConfig::from_env(); // defaults to EdgeMcp
+        let _ = config.sidecar();
+    }
+
+    #[test]
+    #[should_panic(expected = "Not in proxy mode")]
+    fn test_mode_config_wrong_accessor_proxy() {
+        let config = ModeConfig::from_env();
+        let _ = config.proxy();
+    }
+
+    #[test]
+    #[should_panic(expected = "Not in shadow mode")]
+    fn test_mode_config_wrong_accessor_shadow() {
+        let config = ModeConfig::from_env();
+        let _ = config.shadow();
+    }
+
+    #[test]
+    fn test_mode_config_edge_mcp_accessor() {
+        let config = ModeConfig::from_env(); // defaults to EdgeMcp
+        let settings = config.edge_mcp();
+        assert!(settings.sse_keepalive); // default is true
+    }
 }

--- a/stoa-gateway/src/mode/proxy.rs
+++ b/stoa-gateway/src/mode/proxy.rs
@@ -557,31 +557,32 @@ pub async fn handle_proxy(
 mod tests {
     use super::*;
 
+    fn make_route(prefix: &str, upstream: &str) -> RouteConfig {
+        RouteConfig {
+            path_prefix: prefix.to_string(),
+            upstream_url: upstream.to_string(),
+            strip_prefix: false,
+            rewrite_path: None,
+            timeout_secs: 30,
+            headers_to_add: HashMap::new(),
+            headers_to_remove: Vec::new(),
+            load_balance: false,
+            upstream_endpoints: Vec::new(),
+        }
+    }
+
+    fn make_route_strip(prefix: &str, upstream: &str) -> RouteConfig {
+        RouteConfig {
+            strip_prefix: true,
+            ..make_route(prefix, upstream)
+        }
+    }
+
     #[test]
     fn test_route_registry_find() {
         let mut registry = RouteRegistry::new();
-        registry.add_route(RouteConfig {
-            path_prefix: "/api/v1".to_string(),
-            upstream_url: "http://backend:8080".to_string(),
-            strip_prefix: true,
-            rewrite_path: None,
-            timeout_secs: 30,
-            headers_to_add: HashMap::new(),
-            headers_to_remove: Vec::new(),
-            load_balance: false,
-            upstream_endpoints: Vec::new(),
-        });
-        registry.add_route(RouteConfig {
-            path_prefix: "/api/v1/users".to_string(),
-            upstream_url: "http://users:8080".to_string(),
-            strip_prefix: true,
-            rewrite_path: None,
-            timeout_secs: 30,
-            headers_to_add: HashMap::new(),
-            headers_to_remove: Vec::new(),
-            load_balance: false,
-            upstream_endpoints: Vec::new(),
-        });
+        registry.add_route(make_route_strip("/api/v1", "http://backend:8080"));
+        registry.add_route(make_route_strip("/api/v1/users", "http://users:8080"));
 
         // Should match longest prefix
         let route = registry.find_route("/api/v1/users/123").unwrap();
@@ -596,17 +597,50 @@ mod tests {
     }
 
     #[test]
+    fn test_route_registry_empty() {
+        let registry = RouteRegistry::new();
+        assert!(registry.find_route("/anything").is_none());
+    }
+
+    #[test]
+    fn test_route_registry_default() {
+        let registry = RouteRegistry::default();
+        assert!(registry.find_route("/anything").is_none());
+    }
+
+    #[test]
+    fn test_route_registry_exact_match() {
+        let mut registry = RouteRegistry::new();
+        registry.add_route(make_route("/api/v1/health", "http://health:8080"));
+
+        let route = registry.find_route("/api/v1/health").unwrap();
+        assert_eq!(route.upstream_url, "http://health:8080");
+    }
+
+    #[test]
     fn test_hop_by_hop_headers() {
         assert!(is_hop_by_hop_header(&HeaderName::from_static("connection")));
         assert!(is_hop_by_hop_header(&HeaderName::from_static(
             "transfer-encoding"
         )));
+        assert!(is_hop_by_hop_header(&HeaderName::from_static("upgrade")));
+        assert!(is_hop_by_hop_header(&HeaderName::from_static("keep-alive")));
+        assert!(is_hop_by_hop_header(&HeaderName::from_static("te")));
+        assert!(is_hop_by_hop_header(&HeaderName::from_static("trailers")));
+        assert!(is_hop_by_hop_header(&HeaderName::from_static(
+            "proxy-authenticate"
+        )));
+        assert!(is_hop_by_hop_header(&HeaderName::from_static(
+            "proxy-authorization"
+        )));
+        // Non hop-by-hop
         assert!(!is_hop_by_hop_header(&HeaderName::from_static(
             "content-type"
         )));
         assert!(!is_hop_by_hop_header(&HeaderName::from_static(
             "authorization"
         )));
+        assert!(!is_hop_by_hop_header(&HeaderName::from_static("x-custom")));
     }
 
     #[test]
@@ -615,6 +649,7 @@ mod tests {
         headers.insert("X-Custom".to_string(), "value".to_string());
 
         let injector = HeaderInjector::new(headers);
+        assert_eq!(injector.name(), "header_injector");
 
         let mut request = ProxyRequest {
             method: Method::GET,
@@ -629,5 +664,184 @@ mod tests {
         injector.transform(&mut request).unwrap();
 
         assert!(request.headers.contains_key("x-custom"));
+    }
+
+    #[test]
+    fn test_header_injector_multiple() {
+        let mut headers = HashMap::new();
+        headers.insert("X-Tenant".to_string(), "acme".to_string());
+        headers.insert("X-Request-ID".to_string(), "req-123".to_string());
+
+        let injector = HeaderInjector::new(headers);
+
+        let mut request = ProxyRequest {
+            method: Method::POST,
+            uri: "/api".parse().unwrap(),
+            headers: HeaderMap::new(),
+            body: Vec::new(),
+            upstream_url: None,
+            route: None,
+            metadata: RequestMetadata::default(),
+        };
+
+        injector.transform(&mut request).unwrap();
+
+        assert_eq!(
+            request.headers.get("x-tenant").unwrap().to_str().unwrap(),
+            "acme"
+        );
+        assert_eq!(
+            request
+                .headers
+                .get("x-request-id")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "req-123"
+        );
+    }
+
+    #[test]
+    fn test_build_upstream_url_no_strip() {
+        let service = ProxyService::new(ProxySettings::default(), RouteRegistry::new());
+        let route = make_route("/api/v1", "http://backend:8080");
+        let uri: Uri = "/api/v1/users?page=1".parse().unwrap();
+
+        let url = service.build_upstream_url(&route, &uri).unwrap();
+        assert_eq!(url, "http://backend:8080/api/v1/users?page=1");
+    }
+
+    #[test]
+    fn test_build_upstream_url_strip_prefix() {
+        let service = ProxyService::new(ProxySettings::default(), RouteRegistry::new());
+        let route = make_route_strip("/api/v1", "http://backend:8080");
+        let uri: Uri = "/api/v1/users".parse().unwrap();
+
+        let url = service.build_upstream_url(&route, &uri).unwrap();
+        assert_eq!(url, "http://backend:8080/users");
+    }
+
+    #[test]
+    fn test_build_upstream_url_no_query() {
+        let service = ProxyService::new(ProxySettings::default(), RouteRegistry::new());
+        let route = make_route("/api", "http://backend:8080");
+        let uri: Uri = "/api/health".parse().unwrap();
+
+        let url = service.build_upstream_url(&route, &uri).unwrap();
+        assert_eq!(url, "http://backend:8080/api/health");
+    }
+
+    #[test]
+    fn test_default_timeout() {
+        assert_eq!(default_timeout(), 30);
+    }
+
+    #[test]
+    fn test_route_config_serde_defaults() {
+        let json = r#"{"path_prefix":"/api","upstream_url":"http://up:80"}"#;
+        let config: RouteConfig = serde_json::from_str(json).unwrap();
+
+        assert_eq!(config.path_prefix, "/api");
+        assert_eq!(config.upstream_url, "http://up:80");
+        assert!(!config.strip_prefix);
+        assert!(config.rewrite_path.is_none());
+        assert_eq!(config.timeout_secs, 30); // default_timeout()
+        assert!(config.headers_to_add.is_empty());
+        assert!(config.headers_to_remove.is_empty());
+        assert!(!config.load_balance);
+        assert!(config.upstream_endpoints.is_empty());
+    }
+
+    #[test]
+    fn test_proxy_error_display() {
+        let e = ProxyError::Connection("refused".to_string());
+        assert!(e.to_string().contains("refused"));
+
+        let e = ProxyError::Timeout;
+        assert_eq!(e.to_string(), "Upstream timeout");
+
+        let e = ProxyError::NoRoute("/unknown".to_string());
+        assert!(e.to_string().contains("/unknown"));
+
+        let e = ProxyError::RateLimited;
+        assert_eq!(e.to_string(), "Rate limited");
+
+        let e = ProxyError::PolicyDenied("blocked".to_string());
+        assert!(e.to_string().contains("blocked"));
+
+        let e = ProxyError::InvalidRequest("bad".to_string());
+        assert!(e.to_string().contains("bad"));
+
+        let e = ProxyError::Transformation("failed".to_string());
+        assert!(e.to_string().contains("failed"));
+    }
+
+    #[test]
+    fn test_proxy_service_add_transformer() {
+        let mut service = ProxyService::new(ProxySettings::default(), RouteRegistry::new());
+
+        let injector = Arc::new(HeaderInjector::new(HashMap::new()));
+        service.add_transformer(injector);
+
+        assert_eq!(service.transformers.len(), 1);
+    }
+
+    #[test]
+    fn test_proxy_service_add_response_transformer() {
+        struct NoopResponseTransformer;
+        impl ResponseTransformer for NoopResponseTransformer {
+            fn transform(&self, _response: &mut ProxyResponse) -> Result<(), ProxyError> {
+                Ok(())
+            }
+            fn name(&self) -> &str {
+                "noop"
+            }
+        }
+
+        let mut service = ProxyService::new(ProxySettings::default(), RouteRegistry::new());
+        service.add_response_transformer(Arc::new(NoopResponseTransformer));
+
+        assert_eq!(service.response_transformers.len(), 1);
+    }
+
+    #[test]
+    fn test_convert_response_ok() {
+        let service = ProxyService::new(ProxySettings::default(), RouteRegistry::new());
+        let response = ProxyResponse {
+            status: StatusCode::OK,
+            headers: HeaderMap::new(),
+            body: b"hello".to_vec(),
+            upstream_time_ms: 42,
+        };
+
+        let result = service.convert_response(response).unwrap();
+        assert_eq!(result.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn test_convert_response_with_headers() {
+        let service = ProxyService::new(ProxySettings::default(), RouteRegistry::new());
+        let mut headers = HeaderMap::new();
+        headers.insert("x-custom", HeaderValue::from_static("test"));
+
+        let response = ProxyResponse {
+            status: StatusCode::CREATED,
+            headers,
+            body: Vec::new(),
+            upstream_time_ms: 10,
+        };
+
+        let result = service.convert_response(response).unwrap();
+        assert_eq!(result.status(), StatusCode::CREATED);
+        assert_eq!(result.headers().get("x-custom").unwrap(), "test");
+    }
+
+    #[test]
+    fn test_request_metadata_default() {
+        let metadata = RequestMetadata::default();
+        assert!(metadata.request_id.is_empty());
+        assert!(metadata.tenant_id.is_none());
+        assert!(metadata.user_id.is_none());
+        assert!(metadata.start_time.is_none());
     }
 }

--- a/stoa-gateway/src/mode/shadow.rs
+++ b/stoa-gateway/src/mode/shadow.rs
@@ -821,10 +821,77 @@ pub struct ShadowStatus {
 mod tests {
     use super::*;
 
+    fn make_service(min_requests: u64) -> ShadowService {
+        ShadowService::new(ShadowSettings {
+            min_requests_for_uac: min_requests,
+            analysis_window_hours: 24,
+            ..Default::default()
+        })
+    }
+
+    fn make_tx(
+        id: &str,
+        method: &str,
+        path: &str,
+        status: u16,
+        latency: u64,
+    ) -> CapturedTransaction {
+        CapturedTransaction {
+            id: id.to_string(),
+            timestamp: chrono::Utc::now(),
+            request: CapturedRequest {
+                method: method.to_string(),
+                path: path.to_string(),
+                query_params: HashMap::new(),
+                headers: HashMap::new(),
+                content_type: Some("application/json".to_string()),
+                body: None,
+                body_size: 0,
+            },
+            response: CapturedResponse {
+                status_code: status,
+                headers: HashMap::new(),
+                content_type: Some("application/json".to_string()),
+                body: Some(serde_json::json!({"ok": true})),
+                body_size: 10,
+            },
+            latency_ms: latency,
+            source: "test".to_string(),
+        }
+    }
+
+    fn make_tx_with_auth(id: &str, auth_header: &str) -> CapturedTransaction {
+        let mut headers = HashMap::new();
+        headers.insert("authorization".to_string(), auth_header.to_string());
+        CapturedTransaction {
+            id: id.to_string(),
+            timestamp: chrono::Utc::now(),
+            request: CapturedRequest {
+                method: "GET".to_string(),
+                path: "/api/v1/data".to_string(),
+                query_params: HashMap::new(),
+                headers,
+                content_type: None,
+                body: None,
+                body_size: 0,
+            },
+            response: CapturedResponse {
+                status_code: 200,
+                headers: HashMap::new(),
+                content_type: None,
+                body: None,
+                body_size: 0,
+            },
+            latency_ms: 10,
+            source: "test".to_string(),
+        }
+    }
+
+    // === Existing tests ===
+
     #[test]
     fn test_normalize_path() {
-        let settings = ShadowSettings::default();
-        let service = ShadowService::new(settings);
+        let service = make_service(100);
 
         assert_eq!(
             service.normalize_path("GET", "/api/v1/users/123"),
@@ -839,9 +906,32 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_path_no_ids() {
+        let service = make_service(100);
+        assert_eq!(
+            service.normalize_path("POST", "/api/v1/users"),
+            "POST /api/v1/users"
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_multiple_ids() {
+        let service = make_service(100);
+        assert_eq!(
+            service.normalize_path("GET", "/api/v1/tenants/42/users/99"),
+            "GET /api/v1/tenants/{id}/users/{id}"
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_root() {
+        let service = make_service(100);
+        assert_eq!(service.normalize_path("GET", "/"), "GET /");
+    }
+
+    #[test]
     fn test_infer_schema() {
-        let settings = ShadowSettings::default();
-        let service = ShadowService::new(settings);
+        let service = make_service(100);
 
         let value = serde_json::json!({
             "name": "test",
@@ -859,9 +949,30 @@ mod tests {
     }
 
     #[test]
+    fn test_infer_schema_null() {
+        let service = make_service(100);
+        let schema = service.infer_schema(&serde_json::Value::Null);
+        assert_eq!(schema["type"], "null");
+    }
+
+    #[test]
+    fn test_infer_schema_number() {
+        let service = make_service(100);
+        let schema = service.infer_schema(&serde_json::json!(9.99));
+        assert_eq!(schema["type"], "number");
+    }
+
+    #[test]
+    fn test_infer_schema_empty_array() {
+        let service = make_service(100);
+        let schema = service.infer_schema(&serde_json::json!([]));
+        assert_eq!(schema["type"], "array");
+        assert!(schema["items"].is_null());
+    }
+
+    #[test]
     fn test_generate_operation_id() {
-        let settings = ShadowSettings::default();
-        let service = ShadowService::new(settings);
+        let service = make_service(100);
 
         assert_eq!(
             service.generate_operation_id("GET", "/api/v1/users"),
@@ -875,43 +986,264 @@ mod tests {
             service.generate_operation_id("GET", "/api/v1/users/{id}"),
             "get_api_v1_users"
         );
+        assert_eq!(
+            service.generate_operation_id("PUT", "/api/v1/users/{id}"),
+            "update_api_v1_users"
+        );
+        assert_eq!(
+            service.generate_operation_id("PATCH", "/api/v1/items/{id}"),
+            "patch_api_v1_items"
+        );
+        assert_eq!(
+            service.generate_operation_id("DELETE", "/api/v1/users/{id}"),
+            "delete_api_v1_users"
+        );
+    }
+
+    #[test]
+    fn test_generate_operation_id_root() {
+        let service = make_service(100);
+        assert_eq!(service.generate_operation_id("GET", "/"), "get");
+    }
+
+    #[test]
+    fn test_generate_operation_id_unknown_method() {
+        let service = make_service(100);
+        assert_eq!(
+            service.generate_operation_id("OPTIONS", "/api/v1/test"),
+            "options_api_v1_test"
+        );
     }
 
     #[tokio::test]
     async fn test_shadow_service_capture() {
-        let settings = ShadowSettings {
-            min_requests_for_uac: 10,
-            ..Default::default()
-        };
-        let service = ShadowService::new(settings);
+        let service = make_service(10);
 
-        let tx = CapturedTransaction {
-            id: "tx-1".to_string(),
-            timestamp: chrono::Utc::now(),
-            request: CapturedRequest {
-                method: "GET".to_string(),
-                path: "/api/v1/users".to_string(),
-                query_params: HashMap::new(),
-                headers: HashMap::new(),
-                content_type: None,
-                body: None,
-                body_size: 0,
-            },
-            response: CapturedResponse {
-                status_code: 200,
-                headers: HashMap::new(),
-                content_type: Some("application/json".to_string()),
-                body: Some(serde_json::json!({"users": []})),
-                body_size: 20,
-            },
-            latency_ms: 50,
-            source: "test".to_string(),
-        };
-
+        let tx = make_tx("tx-1", "GET", "/api/v1/users", 200, 50);
         service.capture(tx).await;
 
         let status = service.status().await;
         assert_eq!(status.transactions_captured, 1);
         assert!(!status.ready_for_generation);
+        assert_eq!(status.min_requests_threshold, 10);
+    }
+
+    #[tokio::test]
+    async fn test_shadow_service_status_ready() {
+        let service = make_service(2);
+
+        service
+            .capture(make_tx("tx-1", "GET", "/api/v1/a", 200, 10))
+            .await;
+        service
+            .capture(make_tx("tx-2", "GET", "/api/v1/b", 200, 20))
+            .await;
+
+        let status = service.status().await;
+        assert_eq!(status.transactions_captured, 2);
+        assert!(status.ready_for_generation);
+    }
+
+    // === Build endpoint pattern tests ===
+
+    #[test]
+    fn test_build_endpoint_pattern_empty() {
+        let service = make_service(100);
+        let txs: Vec<&CapturedTransaction> = vec![];
+        assert!(service.build_endpoint_pattern("GET /api", &txs).is_none());
+    }
+
+    #[test]
+    fn test_build_endpoint_pattern_invalid_key() {
+        let service = make_service(100);
+        let tx = make_tx("tx-1", "GET", "/api", 200, 10);
+        let txs = vec![&tx];
+        // Key without space separator
+        assert!(service.build_endpoint_pattern("invalid", &txs).is_none());
+    }
+
+    #[test]
+    fn test_build_endpoint_pattern_basic() {
+        let service = make_service(100);
+        let tx1 = make_tx("tx-1", "GET", "/api/v1/users", 200, 10);
+        let tx2 = make_tx("tx-2", "GET", "/api/v1/users", 200, 30);
+        let tx3 = make_tx("tx-3", "GET", "/api/v1/users", 500, 50);
+        let txs = vec![&tx1, &tx2, &tx3];
+
+        let pattern = service
+            .build_endpoint_pattern("GET /api/v1/users", &txs)
+            .unwrap();
+
+        assert_eq!(pattern.method, "GET");
+        assert_eq!(pattern.path_pattern, "/api/v1/users");
+        assert_eq!(pattern.sample_count, 3);
+        assert_eq!(pattern.avg_latency_ms, 30); // (10+30+50)/3
+                                                // Error rate: 1 out of 3 is >= 400
+        assert!((pattern.error_rate - 1.0 / 3.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_build_endpoint_pattern_detects_bearer_auth() {
+        let service = make_service(100);
+        let tx = make_tx_with_auth("tx-1", "Bearer eyJhbGciOi...");
+        let txs = vec![&tx];
+
+        let pattern = service
+            .build_endpoint_pattern("GET /api/v1/data", &txs)
+            .unwrap();
+        assert_eq!(pattern.auth_type, Some("bearer".to_string()));
+    }
+
+    #[test]
+    fn test_build_endpoint_pattern_detects_basic_auth() {
+        let service = make_service(100);
+        let tx = make_tx_with_auth("tx-1", "Basic dXNlcjpwYXNz");
+        let txs = vec![&tx];
+
+        let pattern = service
+            .build_endpoint_pattern("GET /api/v1/data", &txs)
+            .unwrap();
+        assert_eq!(pattern.auth_type, Some("basic".to_string()));
+    }
+
+    #[test]
+    fn test_build_endpoint_pattern_detects_api_key() {
+        let service = make_service(100);
+        let mut tx = make_tx("tx-1", "GET", "/api/v1/data", 200, 10);
+        tx.request
+            .headers
+            .insert("x-api-key".to_string(), "sk-test-123".to_string());
+        let txs = vec![&tx];
+
+        let pattern = service
+            .build_endpoint_pattern("GET /api/v1/data", &txs)
+            .unwrap();
+        assert_eq!(pattern.auth_type, Some("api_key".to_string()));
+    }
+
+    #[test]
+    fn test_build_endpoint_pattern_response_schema() {
+        let service = make_service(100);
+        let mut tx = make_tx("tx-1", "GET", "/api", 200, 10);
+        tx.response.body = Some(serde_json::json!({"users": [{"id": 1}]}));
+        let txs = vec![&tx];
+
+        let pattern = service.build_endpoint_pattern("GET /api", &txs).unwrap();
+        assert!(pattern.response_schemas.contains_key(&200));
+        assert_eq!(pattern.response_schemas[&200]["type"], "object");
+    }
+
+    // === Analyze patterns tests ===
+
+    #[tokio::test]
+    async fn test_analyze_patterns_groups_by_path() {
+        let service = make_service(100);
+        let txs = vec![
+            make_tx("tx-1", "GET", "/api/v1/users", 200, 10),
+            make_tx("tx-2", "GET", "/api/v1/users", 200, 20),
+            make_tx("tx-3", "POST", "/api/v1/users", 201, 30),
+        ];
+
+        let patterns = service.analyze_patterns(&txs).await;
+        assert_eq!(patterns.len(), 2); // GET + POST
+        assert!(patterns.contains_key("GET /api/v1/users"));
+        assert!(patterns.contains_key("POST /api/v1/users"));
+        assert_eq!(patterns["GET /api/v1/users"].sample_count, 2);
+        assert_eq!(patterns["POST /api/v1/users"].sample_count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_analyze_patterns_normalizes_ids() {
+        let service = make_service(100);
+        let txs = vec![
+            make_tx("tx-1", "GET", "/api/v1/users/1", 200, 10),
+            make_tx("tx-2", "GET", "/api/v1/users/2", 200, 20),
+            make_tx("tx-3", "GET", "/api/v1/users/99", 200, 30),
+        ];
+
+        let patterns = service.analyze_patterns(&txs).await;
+        // All should be grouped under GET /api/v1/users/{id}
+        assert_eq!(patterns.len(), 1);
+        assert!(patterns.contains_key("GET /api/v1/users/{id}"));
+        assert_eq!(patterns["GET /api/v1/users/{id}"].sample_count, 3);
+    }
+
+    // === Generate UAC tests ===
+
+    #[tokio::test]
+    async fn test_generate_uac_no_patterns() {
+        let service = make_service(100);
+        let uac = service.generate_uac("test-api", "http://test.com").await;
+        assert!(uac.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_generate_uac_success() {
+        let service = make_service(2);
+
+        // Capture enough transactions to trigger analysis
+        service
+            .capture(make_tx("tx-1", "GET", "/api/v1/users", 200, 10))
+            .await;
+        service
+            .capture(make_tx("tx-2", "POST", "/api/v1/users", 201, 20))
+            .await;
+
+        let uac = service.generate_uac("User API", "http://users.local").await;
+        assert!(uac.is_some());
+
+        let uac = uac.unwrap();
+        assert_eq!(uac.api_id, "user-api-api");
+        assert_eq!(uac.api_name, "User API");
+        assert_eq!(uac.base_url, "http://users.local");
+        assert_eq!(uac.version, "v1");
+        assert!(!uac.endpoints.is_empty());
+        assert!(!uac.rate_limits.is_empty());
+        assert_eq!(uac.rate_limits[0].endpoint, "*");
+        assert_eq!(uac.rate_limits[0].limit, 1000);
+        assert!(uac.metadata.confidence > 0.0);
+        assert!(uac.metadata.transactions_analyzed >= 2);
+
+        // Check it's stored
+        let status = service.status().await;
+        assert_eq!(status.uacs_generated, 1);
+    }
+
+    // === Export YAML test ===
+
+    #[tokio::test]
+    async fn test_export_uac_yaml() {
+        let service = make_service(2);
+        service
+            .capture(make_tx("tx-1", "GET", "/api", 200, 10))
+            .await;
+        service
+            .capture(make_tx("tx-2", "GET", "/api", 200, 20))
+            .await;
+
+        let uac = service
+            .generate_uac("Test", "http://test.com")
+            .await
+            .unwrap();
+        let yaml = service.export_uac_yaml(&uac).await;
+        assert!(yaml.contains("api_name: Test"));
+        assert!(yaml.contains("base_url: http://test.com"));
+    }
+
+    // === Content type collection test ===
+
+    #[test]
+    fn test_build_endpoint_pattern_content_types() {
+        let service = make_service(100);
+        let mut tx1 = make_tx("tx-1", "POST", "/api/v1/data", 200, 10);
+        tx1.request.content_type = Some("application/json".to_string());
+        let mut tx2 = make_tx("tx-2", "POST", "/api/v1/data", 200, 20);
+        tx2.request.content_type = Some("application/xml".to_string());
+        let txs = vec![&tx1, &tx2];
+
+        let pattern = service
+            .build_endpoint_pattern("POST /api/v1/data", &txs)
+            .unwrap();
+        assert!(!pattern.content_types.is_empty()); // at least one content type
     }
 }

--- a/stoa-gateway/src/mode/sidecar.rs
+++ b/stoa-gateway/src/mode/sidecar.rs
@@ -451,6 +451,37 @@ pub async fn health() -> &'static str {
 mod tests {
     use super::*;
 
+    fn make_sidecar(format: DecisionFormat) -> SidecarService {
+        SidecarService::new(SidecarSettings {
+            decision_format: format,
+            ..Default::default()
+        })
+    }
+
+    fn make_authz_request(user: Option<UserInfo>, tenant_id: Option<&str>) -> AuthzRequest {
+        AuthzRequest {
+            method: "GET".to_string(),
+            path: "/api/v1/users".to_string(),
+            headers: std::collections::HashMap::new(),
+            source_ip: None,
+            user,
+            tenant_id: tenant_id.map(|s| s.to_string()),
+            context: serde_json::Value::Null,
+        }
+    }
+
+    fn make_user(roles: Vec<&str>, scopes: Vec<&str>) -> UserInfo {
+        UserInfo {
+            id: "user-456".to_string(),
+            email: Some("user@example.com".to_string()),
+            roles: roles.into_iter().map(|s| s.to_string()).collect(),
+            scopes: scopes.into_iter().map(|s| s.to_string()).collect(),
+            claims: std::collections::HashMap::new(),
+        }
+    }
+
+    // === Existing tests ===
+
     #[test]
     fn test_authz_response_allow() {
         let response = AuthzResponse::allow();
@@ -485,6 +516,16 @@ mod tests {
         assert!(!response.allowed);
         assert_eq!(response.status_code, Some(429));
         assert!(response.headers_to_add.contains_key("X-RateLimit-Limit"));
+        assert!(response
+            .headers_to_add
+            .contains_key("X-RateLimit-Remaining"));
+        assert!(response.headers_to_add.contains_key("X-RateLimit-Reset"));
+        assert_eq!(
+            response.denial_reason,
+            Some("Rate limit exceeded".to_string())
+        );
+        assert_eq!(response.denied_by_policy, Some("rate_limit".to_string()));
+        assert!(response.metadata.is_some());
     }
 
     #[test]
@@ -502,6 +543,28 @@ mod tests {
             response.headers_to_add.get("X-Another"),
             Some(&"test".to_string())
         );
+    }
+
+    #[test]
+    fn test_authz_response_with_policy() {
+        let response = AuthzResponse::deny("forbidden").with_policy("rate_limit_policy");
+        assert_eq!(
+            response.denied_by_policy,
+            Some("rate_limit_policy".to_string())
+        );
+    }
+
+    #[test]
+    fn test_authz_response_with_metadata() {
+        let metadata = RequestMetadata {
+            request_id: "req-1".to_string(),
+            policies_evaluated: vec!["default".to_string()],
+            evaluation_time_us: 100,
+            rate_limit: None,
+        };
+        let response = AuthzResponse::allow().with_metadata(metadata);
+        assert!(response.metadata.is_some());
+        assert_eq!(response.metadata.unwrap().request_id, "req-1");
     }
 
     #[test]
@@ -525,5 +588,172 @@ mod tests {
         assert_eq!(request.tenant_id, Some("tenant-123".to_string()));
         assert!(request.user.is_some());
         assert_eq!(request.user.unwrap().id, "user-456");
+    }
+
+    #[test]
+    fn test_authz_request_deserialize_minimal() {
+        let json = r#"{"method":"POST","path":"/api"}"#;
+        let request: AuthzRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.path, "/api");
+        assert!(request.user.is_none());
+        assert!(request.tenant_id.is_none());
+        assert!(request.headers.is_empty());
+    }
+
+    // === Authorize flow tests ===
+
+    #[tokio::test]
+    async fn test_authorize_no_user_returns_unauthorized() {
+        let service = make_sidecar(DecisionFormat::JsonBody);
+        let request = make_authz_request(None, Some("tenant-1"));
+
+        let response = service.authorize(request).await;
+        assert!(!response.allowed);
+        assert_eq!(response.status_code, Some(401));
+        assert!(response
+            .denial_reason
+            .as_ref()
+            .unwrap()
+            .contains("Missing user"));
+    }
+
+    #[tokio::test]
+    async fn test_authorize_no_tenant_returns_deny() {
+        let service = make_sidecar(DecisionFormat::JsonBody);
+        let user = make_user(vec!["admin"], vec!["read"]);
+        let request = make_authz_request(Some(user), None);
+
+        let response = service.authorize(request).await;
+        assert!(!response.allowed);
+        assert_eq!(response.status_code, Some(403));
+        assert!(response
+            .denial_reason
+            .as_ref()
+            .unwrap()
+            .contains("Missing tenant"));
+    }
+
+    #[tokio::test]
+    async fn test_authorize_success_with_enrichment() {
+        let service = make_sidecar(DecisionFormat::JsonBody);
+        let user = make_user(vec!["admin", "devops"], vec!["read", "write"]);
+        let request = make_authz_request(Some(user), Some("acme"));
+
+        let response = service.authorize(request).await;
+        assert!(response.allowed);
+        assert_eq!(
+            response.headers_to_add.get("X-User-ID"),
+            Some(&"user-456".to_string())
+        );
+        assert_eq!(
+            response.headers_to_add.get("X-Tenant-ID"),
+            Some(&"acme".to_string())
+        );
+        assert!(response.headers_to_add.contains_key("X-Request-ID"));
+        assert_eq!(
+            response.headers_to_add.get("X-User-Scopes"),
+            Some(&"read,write".to_string())
+        );
+        assert_eq!(
+            response.headers_to_add.get("X-User-Roles"),
+            Some(&"admin,devops".to_string())
+        );
+        assert!(response.metadata.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_authorize_no_scopes_no_roles() {
+        let service = make_sidecar(DecisionFormat::JsonBody);
+        let user = make_user(vec![], vec![]);
+        let request = make_authz_request(Some(user), Some("acme"));
+
+        let response = service.authorize(request).await;
+        assert!(response.allowed);
+        assert!(!response.headers_to_add.contains_key("X-User-Scopes"));
+        assert!(!response.headers_to_add.contains_key("X-User-Roles"));
+    }
+
+    // === Format response tests ===
+
+    #[test]
+    fn test_format_status_code_allow() {
+        let service = make_sidecar(DecisionFormat::StatusCode);
+        let response = AuthzResponse::allow();
+        let http_resp = service.format_response(response);
+        assert_eq!(http_resp.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn test_format_status_code_deny() {
+        let service = make_sidecar(DecisionFormat::StatusCode);
+        let response = AuthzResponse::deny("forbidden");
+        let http_resp = service.format_response(response);
+        assert_eq!(http_resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_format_status_code_unauthorized() {
+        let service = make_sidecar(DecisionFormat::StatusCode);
+        let response = AuthzResponse::unauthorized("no token");
+        let http_resp = service.format_response(response);
+        assert_eq!(http_resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn test_format_json_body_allow() {
+        let service = make_sidecar(DecisionFormat::JsonBody);
+        let response = AuthzResponse::allow();
+        let http_resp = service.format_response(response);
+        assert_eq!(http_resp.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn test_format_json_body_deny() {
+        let service = make_sidecar(DecisionFormat::JsonBody);
+        let response = AuthzResponse::deny("blocked");
+        let http_resp = service.format_response(response);
+        assert_eq!(http_resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_format_envoy_allow() {
+        let service = make_sidecar(DecisionFormat::EnvoyExtAuthz);
+        let response = AuthzResponse::allow().with_header("X-User-ID", "uid-1");
+        let http_resp = service.format_response(response);
+        assert_eq!(http_resp.status(), StatusCode::OK);
+        // Envoy headers should be prefixed with x-ext-authz-
+        assert!(http_resp.headers().get("x-ext-authz-x-user-id").is_some());
+    }
+
+    #[test]
+    fn test_format_envoy_deny() {
+        let service = make_sidecar(DecisionFormat::EnvoyExtAuthz);
+        let response = AuthzResponse::deny("policy violation").with_policy("rbac");
+        let http_resp = service.format_response(response);
+        assert_eq!(http_resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_format_kong_allow() {
+        let service = make_sidecar(DecisionFormat::KongPlugin);
+        let response = AuthzResponse::allow().with_header("X-Tenant", "acme");
+        let http_resp = service.format_response(response);
+        assert_eq!(http_resp.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn test_format_kong_deny() {
+        let service = make_sidecar(DecisionFormat::KongPlugin);
+        let response = AuthzResponse::deny("rate exceeded");
+        let http_resp = service.format_response(response);
+        assert_eq!(http_resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_health_endpoint() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(health());
+        assert_eq!(result, "OK");
     }
 }


### PR DESCRIPTION
## Summary
- **Phase 2** of stoa-gateway test plan: unit tests for P1 modules (modes + control plane)
- **+96 new tests** (396 → 492 total), covering 6 source files
- All wiremock-based HTTP mocking for control_plane + OAuth proxy tests
- Clippy clean, fmt clean, zero failures

### Test Breakdown

| Module | New Tests | Coverage |
|--------|-----------|----------|
| `mode/proxy.rs` | +15 | build_upstream_url, route registry, transformers, ProxyError |
| `mode/sidecar.rs` | +17 | authorize flow (4 paths), format responses (4 formats x 2 outcomes) |
| `mode/shadow.rs` | +22 | endpoint patterns, auth detection, analyze, UAC generation, YAML export |
| `mode/mod.rs` | +12 | mode parsing, serde roundtrip, accessor panics, capabilities |
| `control_plane/tool_proxy.rs` | +14 | discover tools, call tool, OIDC token caching, user token forwarding |
| `control_plane/registration.rs` | +16 | register, heartbeat, detect_capabilities (4 modes), error variants |

## Test plan
- [x] `cargo test` — 492 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — zero warnings
- [x] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>