### PR TITLE
fix(ui): use FQDN for prometheus backend URL in k8s manifest

### DIFF
--- a/control-plane-ui/k8s/deployment.yaml
+++ b/control-plane-ui/k8s/deployment.yaml
@@ -70,7 +70,7 @@ spec:
             - name: GRAFANA_BACKEND_URL
               value: "http://grafana.stoa-system.svc:3000"
             - name: PROMETHEUS_BACKEND_URL
-              value: "http://prometheus-kube-prometheus-prometheus.monitoring.svc:9090"
+              value: "http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090"
           securityContext:
             privileged: false
             runAsNonRoot: true


### PR DESCRIPTION
## Summary
- nginx `resolver` directive does NOT use `/etc/resolv.conf` search domains
- Cross-namespace service names (monitoring → stoa-system) need the full `.svc.cluster.local` suffix
- Without it, nginx returns 502 with "Host not found" error

## Validated
- Deployed to Hetzner staging, confirmed 26 Prometheus targets returned successfully
- `/observability` page shows real metrics instead of "Prometheus is not reachable"

## Test plan
- [x] Staging deployment verified (Hetzner K3s)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>