### PR TITLE
fix(ui): align prometheus metric names with gateway exports

### DIFF
--- a/control-plane-ui/src/pages/PlatformMetrics/PlatformMetricsDashboard.tsx
+++ b/control-plane-ui/src/pages/PlatformMetrics/PlatformMetricsDashboard.tsx
@@ -98,28 +98,28 @@ export function PlatformMetricsDashboard() {
 
   // Prometheus queries
   const totalRequests = usePrometheusQuery(
-    `sum(increase(stoa_control_plane_http_requests_total[${timeRange}]))`,
+    `sum(increase(stoa_http_requests_total[${timeRange}]))`,
     AUTO_REFRESH_INTERVAL
   );
   const errorRate = usePrometheusQuery(
-    'sum(rate(stoa_control_plane_http_requests_total{status=~"5.."}[5m])) / sum(rate(stoa_control_plane_http_requests_total[5m]))',
+    'sum(rate(stoa_http_requests_total{status=~"5.."}[5m])) / sum(rate(stoa_http_requests_total[5m]))',
     AUTO_REFRESH_INTERVAL
   );
   const p95Latency = usePrometheusQuery(
-    'histogram_quantile(0.95, sum(rate(stoa_control_plane_http_request_duration_seconds_bucket[5m])) by (le))',
+    'histogram_quantile(0.95, sum(rate(stoa_http_request_duration_seconds_bucket[5m])) by (le))',
     AUTO_REFRESH_INTERVAL
   );
   const servicesUp = usePrometheusQuery('count(up == 1)', AUTO_REFRESH_INTERVAL);
 
   // Sparklines
   const requestRateSeries = usePrometheusRange(
-    'sum(rate(stoa_control_plane_http_requests_total[5m]))',
+    'sum(rate(stoa_http_requests_total[5m]))',
     rangeCfg.seconds,
     rangeCfg.step,
     AUTO_REFRESH_INTERVAL
   );
   const errorRateSeries = usePrometheusRange(
-    'sum(rate(stoa_control_plane_http_requests_total{status=~"5.."}[5m])) / sum(rate(stoa_control_plane_http_requests_total[5m]))',
+    'sum(rate(stoa_http_requests_total{status=~"5.."}[5m])) / sum(rate(stoa_http_requests_total[5m]))',
     rangeCfg.seconds,
     rangeCfg.step,
     AUTO_REFRESH_INTERVAL

--- a/control-plane-ui/src/pages/RequestExplorer/RequestExplorerDashboard.tsx
+++ b/control-plane-ui/src/pages/RequestExplorer/RequestExplorerDashboard.tsx
@@ -94,35 +94,35 @@ export function RequestExplorerDashboard() {
 
   // KPI queries
   const totalRequests = usePrometheusQuery(
-    `sum(increase(stoa_control_plane_http_requests_total[${timeRange}]))`,
+    `sum(increase(stoa_http_requests_total[${timeRange}]))`,
     AUTO_REFRESH_INTERVAL
   );
   const successRate = usePrometheusQuery(
-    `sum(rate(stoa_control_plane_http_requests_total{status=~"2.."}[5m])) / sum(rate(stoa_control_plane_http_requests_total[5m]))`,
+    `sum(rate(stoa_http_requests_total{status=~"2.."}[5m])) / sum(rate(stoa_http_requests_total[5m]))`,
     AUTO_REFRESH_INTERVAL
   );
   const avgLatency = usePrometheusQuery(
-    'sum(rate(stoa_control_plane_http_request_duration_seconds_sum[5m])) / sum(rate(stoa_control_plane_http_request_duration_seconds_count[5m]))',
+    'sum(rate(stoa_http_request_duration_seconds_sum[5m])) / sum(rate(stoa_http_request_duration_seconds_count[5m]))',
     AUTO_REFRESH_INTERVAL
   );
   const activeEndpoints = usePrometheusQuery(
-    `count(count by (path) (increase(stoa_control_plane_http_requests_total[${timeRange}]) > 0))`,
+    `count(count by (path) (increase(stoa_http_requests_total[${timeRange}]) > 0))`,
     AUTO_REFRESH_INTERVAL
   );
 
   // Status breakdown
   const statusBreakdown = usePrometheusQuery(
-    `sum by (status) (increase(stoa_control_plane_http_requests_total[${timeRange}]))`,
+    `sum by (status) (increase(stoa_http_requests_total[${timeRange}]))`,
     AUTO_REFRESH_INTERVAL
   );
 
   // Top endpoints
   const topEndpoints = usePrometheusQuery(
-    `topk(10, sum by (path, method) (increase(stoa_control_plane_http_requests_total[${timeRange}])))`,
+    `topk(10, sum by (path, method) (increase(stoa_http_requests_total[${timeRange}])))`,
     AUTO_REFRESH_INTERVAL
   );
   const topEndpointErrors = usePrometheusQuery(
-    `sum by (path, method) (increase(stoa_control_plane_http_requests_total{status=~"5.."}[${timeRange}]))`,
+    `sum by (path, method) (increase(stoa_http_requests_total{status=~"5.."}[${timeRange}]))`,
     AUTO_REFRESH_INTERVAL
   );
 


### PR DESCRIPTION
## Summary
- Dashboard queries used `stoa_control_plane_http_requests_total` but the Rust gateway exports `stoa_http_requests_total`
- This caused all Prometheus-powered widgets on /observability and /logs to show empty data
- Fixed in both `PlatformMetricsDashboard` and `RequestExplorerDashboard`

## Test plan
- [x] 415/415 tests pass
- [x] ESLint: 0 errors, 93 warnings (threshold)
- [x] Prettier clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>