### PR TITLE
test(gateway): add Phase 4 resilience tests (CB, fault injection, concurrency)

### DIFF
--- a/stoa-gateway/tests/resilience/circuit_breaker.rs
+++ b/stoa-gateway/tests/resilience/circuit_breaker.rs
@@ -1,0 +1,249 @@
+//! Circuit breaker integration tests via the full Axum router.
+//!
+//! Tests that the per-upstream circuit breaker in the dynamic proxy
+//! correctly opens after failures, rejects when open, recovers via
+//! half-open, and isolates per upstream.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use stoa_gateway::config::Config;
+use stoa_gateway::routes::ApiRoute;
+use stoa_gateway::state::AppState;
+
+/// Create a test route pointing to a backend that will fail (connection refused).
+fn failing_route(id: &str, prefix: &str) -> ApiRoute {
+    ApiRoute {
+        id: id.to_string(),
+        name: format!("failing-{}", id),
+        tenant_id: "acme".to_string(),
+        path_prefix: prefix.to_string(),
+        // Port 19999 should be closed → connection refused
+        backend_url: "http://127.0.0.1:19999".to_string(),
+        methods: vec![],
+        spec_hash: "abc".to_string(),
+        activated: true,
+    }
+}
+
+/// Build AppState with a low CB threshold for fast test cycles.
+fn state_with_low_cb_threshold() -> AppState {
+    let config = Config {
+        admin_api_token: Some("test-token".to_string()),
+        cb_failure_threshold: 5,
+        cb_reset_timeout_secs: 1,
+        cb_success_threshold: 1,
+        auto_register: false,
+        ..Config::default()
+    };
+    AppState::new(config)
+}
+
+/// Send a GET to the given URI through the router.
+async fn proxy_get(router: &axum::Router, uri: &str) -> (StatusCode, String) {
+    let request = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = router
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("router should not error");
+
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), 1_048_576)
+        .await
+        .expect("read body");
+    (status, String::from_utf8_lossy(&body).to_string())
+}
+
+/// DoD #4: Circuit breaker opens after 5 consecutive failures.
+#[tokio::test]
+async fn test_cb_opens_after_5_failures() {
+    let state = state_with_low_cb_threshold();
+    state
+        .route_registry
+        .upsert(failing_route("r1", "/apis/broken"));
+    let router = stoa_gateway::build_router(state.clone());
+
+    // Send 5 requests — all should fail with 502 (connection refused → Bad Gateway)
+    for i in 0..5 {
+        let (status, _) = proxy_get(&router, "/apis/broken/test").await;
+        assert!(
+            status == StatusCode::BAD_GATEWAY || status == StatusCode::GATEWAY_TIMEOUT,
+            "Request {} should fail with 502/504, got {}",
+            i,
+            status
+        );
+    }
+
+    // 6th request should be rejected by circuit breaker → 503
+    let (status, body) = proxy_get(&router, "/apis/broken/test").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(
+        body.contains("Circuit breaker open"),
+        "Expected CB open message, got: {}",
+        body
+    );
+}
+
+/// After CB opens, requests are fast-failed with 503.
+#[tokio::test]
+async fn test_cb_rejects_when_open() {
+    let state = state_with_low_cb_threshold();
+    state
+        .route_registry
+        .upsert(failing_route("r1", "/apis/broken"));
+    let router = stoa_gateway::build_router(state.clone());
+
+    // Open the CB
+    for _ in 0..5 {
+        proxy_get(&router, "/apis/broken/test").await;
+    }
+
+    // Multiple subsequent requests should all be 503 (fast-fail, no actual HTTP call)
+    for _ in 0..3 {
+        let (status, body) = proxy_get(&router, "/apis/broken/test").await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(body.contains("Circuit breaker open"));
+    }
+}
+
+/// After CB opens and reset_timeout passes, CB transitions to half-open.
+/// A success in half-open closes the circuit.
+#[tokio::test]
+async fn test_cb_half_open_recovery() {
+    let state = state_with_low_cb_threshold();
+    state
+        .route_registry
+        .upsert(failing_route("r1", "/apis/broken"));
+    let router = stoa_gateway::build_router(state.clone());
+
+    // Open the CB
+    for _ in 0..5 {
+        proxy_get(&router, "/apis/broken/test").await;
+    }
+
+    // Verify CB is open
+    let (status, _) = proxy_get(&router, "/apis/broken/test").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+    // Wait for reset_timeout (1s configured above)
+    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+
+    // CB should be half-open now — allows the request through (will still fail at backend)
+    let (status, _) = proxy_get(&router, "/apis/broken/test").await;
+    // Half-open allows the request but backend is still down → 502
+    assert!(
+        status == StatusCode::BAD_GATEWAY || status == StatusCode::GATEWAY_TIMEOUT,
+        "Half-open should allow request through, got {}",
+        status
+    );
+}
+
+/// Route A failures don't affect Route B's circuit breaker.
+#[tokio::test]
+async fn test_cb_per_upstream_isolation() {
+    let state = state_with_low_cb_threshold();
+    state
+        .route_registry
+        .upsert(failing_route("r1", "/apis/broken-a"));
+    state
+        .route_registry
+        .upsert(failing_route("r2", "/apis/broken-b"));
+    let router = stoa_gateway::build_router(state.clone());
+
+    // Trip CB for route A only
+    for _ in 0..5 {
+        proxy_get(&router, "/apis/broken-a/test").await;
+    }
+
+    // Route A should be CB-open → 503
+    let (status, _) = proxy_get(&router, "/apis/broken-a/test").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+    // Route B should still work (backend will fail with 502, but NOT CB-blocked)
+    let (status, _) = proxy_get(&router, "/apis/broken-b/test").await;
+    assert!(
+        status == StatusCode::BAD_GATEWAY || status == StatusCode::GATEWAY_TIMEOUT,
+        "Route B should not be CB-blocked, got {}",
+        status
+    );
+}
+
+/// Method not allowed returns 405, not CB trip.
+#[tokio::test]
+async fn test_method_not_allowed_does_not_trip_cb() {
+    let state = state_with_low_cb_threshold();
+    state.route_registry.upsert(ApiRoute {
+        id: "r1".to_string(),
+        name: "limited-api".to_string(),
+        tenant_id: "acme".to_string(),
+        path_prefix: "/apis/limited".to_string(),
+        backend_url: "http://127.0.0.1:19999".to_string(),
+        methods: vec!["POST".to_string()],
+        spec_hash: "abc".to_string(),
+        activated: true,
+    });
+    let router = stoa_gateway::build_router(state.clone());
+
+    // Send 10 GET requests to a POST-only route — should get 405, not trip CB
+    for _ in 0..10 {
+        let (status, _) = proxy_get(&router, "/apis/limited/test").await;
+        assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    // CB should still be closed (405 is handled before proxying)
+    let request = Request::builder()
+        .method("GET")
+        .uri("/admin/circuit-breakers")
+        .header("Authorization", "Bearer test-token")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = router.clone().oneshot(request).await.expect("ok");
+    let body = axum::body::to_bytes(response.into_body(), 1_048_576)
+        .await
+        .expect("read body");
+    let stats: Vec<serde_json::Value> = serde_json::from_slice(&body).expect("valid JSON");
+    // No CB entry created since method check happens before proxy
+    assert!(stats.is_empty(), "405 should not create a CB entry");
+}
+
+/// GET /admin/circuit-breakers returns stats for registered upstream CBs.
+#[tokio::test]
+async fn test_cb_stats_endpoint() {
+    let state = state_with_low_cb_threshold();
+    state
+        .route_registry
+        .upsert(failing_route("r1", "/apis/broken"));
+    let router = stoa_gateway::build_router(state.clone());
+
+    // Generate some failures to create a CB entry
+    for _ in 0..3 {
+        proxy_get(&router, "/apis/broken/test").await;
+    }
+
+    // Query admin endpoint
+    let request = Request::builder()
+        .method("GET")
+        .uri("/admin/circuit-breakers")
+        .header("Authorization", "Bearer test-token")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = router.clone().oneshot(request).await.expect("ok");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), 1_048_576)
+        .await
+        .expect("read body");
+    let stats: Vec<serde_json::Value> = serde_json::from_slice(&body).expect("valid JSON");
+    assert!(!stats.is_empty(), "Should have at least 1 CB entry");
+    assert_eq!(stats[0]["state"], "closed"); // 3 failures < threshold of 5
+    assert_eq!(stats[0]["failure_count"], 3);
+}

--- a/stoa-gateway/tests/resilience/common.rs
+++ b/stoa-gateway/tests/resilience/common.rs
@@ -1,0 +1,7 @@
+//! Shared helpers for resilience tests — reuses TestApp from integration tests.
+
+#[allow(dead_code)]
+#[path = "../integration/common.rs"]
+mod integration_common;
+
+pub use integration_common::TestApp;

--- a/stoa-gateway/tests/resilience/concurrency.rs
+++ b/stoa-gateway/tests/resilience/concurrency.rs
@@ -1,0 +1,168 @@
+//! Concurrency tests — verify gateway handles high concurrent load without deadlocks.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+use crate::common::TestApp;
+
+/// DoD #5: 1,000 concurrent tool list calls complete without deadlock (< 5s).
+#[tokio::test]
+async fn test_1000_concurrent_tool_calls() {
+    let app = TestApp::new();
+    let router = Arc::new(app);
+
+    let mut handles = Vec::with_capacity(1000);
+    for _ in 0..1000 {
+        let r = router.clone();
+        handles.push(tokio::spawn(async move {
+            let (status, _) = r
+                .post_json(
+                    "/mcp/tools/list",
+                    r#"{"jsonrpc":"2.0","method":"tools/list","id":1}"#,
+                )
+                .await;
+            status
+        }));
+    }
+
+    let deadline = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let mut results = Vec::with_capacity(1000);
+        for handle in handles {
+            results.push(handle.await.expect("task should not panic"));
+        }
+        results
+    })
+    .await;
+
+    let results = deadline.expect("1000 concurrent requests should complete within 5s");
+    assert_eq!(results.len(), 1000);
+
+    // All requests should get a response (not hang or crash)
+    for (i, status) in results.iter().enumerate() {
+        assert!(
+            status.is_success() || *status == StatusCode::BAD_REQUEST,
+            "Request {} unexpected status: {}",
+            i,
+            status
+        );
+    }
+}
+
+/// 100 concurrent GET /admin/health calls.
+#[tokio::test]
+async fn test_concurrent_admin_health() {
+    let config = stoa_gateway::config::Config {
+        admin_api_token: Some("test-token".to_string()),
+        auto_register: false,
+        ..stoa_gateway::config::Config::default()
+    };
+    let state = stoa_gateway::state::AppState::new(config);
+    let router = Arc::new(stoa_gateway::build_router(state));
+
+    let mut handles = Vec::with_capacity(100);
+    for _ in 0..100 {
+        let r = router.clone();
+        handles.push(tokio::spawn(async move {
+            let request = Request::builder()
+                .method("GET")
+                .uri("/admin/health")
+                .header("Authorization", "Bearer test-token")
+                .body(Body::empty())
+                .expect("valid request");
+
+            let response = (*r).clone().oneshot(request).await.expect("ok");
+            response.status()
+        }));
+    }
+
+    let deadline = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let mut results = Vec::with_capacity(100);
+        for handle in handles {
+            results.push(handle.await.expect("task should not panic"));
+        }
+        results
+    })
+    .await;
+
+    let results = deadline.expect("100 concurrent admin/health should complete within 5s");
+    assert_eq!(results.len(), 100);
+    for status in &results {
+        assert_eq!(*status, StatusCode::OK);
+    }
+}
+
+/// Mix of concurrent requests to different endpoints.
+#[tokio::test]
+async fn test_concurrent_mixed_endpoints() {
+    let config = stoa_gateway::config::Config {
+        admin_api_token: Some("test-token".to_string()),
+        auto_register: false,
+        ..stoa_gateway::config::Config::default()
+    };
+    let state = stoa_gateway::state::AppState::new(config);
+    let router = Arc::new(stoa_gateway::build_router(state));
+
+    let mut handles = Vec::with_capacity(300);
+
+    // 100 health checks
+    for _ in 0..100 {
+        let r = router.clone();
+        handles.push(tokio::spawn(async move {
+            let request = Request::builder()
+                .method("GET")
+                .uri("/health")
+                .body(Body::empty())
+                .expect("valid request");
+            let response = (*r).clone().oneshot(request).await.expect("ok");
+            response.status()
+        }));
+    }
+
+    // 100 MCP discovery
+    for _ in 0..100 {
+        let r = router.clone();
+        handles.push(tokio::spawn(async move {
+            let request = Request::builder()
+                .method("GET")
+                .uri("/mcp")
+                .body(Body::empty())
+                .expect("valid request");
+            let response = (*r).clone().oneshot(request).await.expect("ok");
+            response.status()
+        }));
+    }
+
+    // 100 admin health (authenticated)
+    for _ in 0..100 {
+        let r = router.clone();
+        handles.push(tokio::spawn(async move {
+            let request = Request::builder()
+                .method("GET")
+                .uri("/admin/health")
+                .header("Authorization", "Bearer test-token")
+                .body(Body::empty())
+                .expect("valid request");
+            let response = (*r).clone().oneshot(request).await.expect("ok");
+            response.status()
+        }));
+    }
+
+    let deadline = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let mut results = Vec::with_capacity(300);
+        for handle in handles {
+            results.push(handle.await.expect("task should not panic"));
+        }
+        results
+    })
+    .await;
+
+    let results = deadline.expect("300 concurrent mixed requests should complete within 5s");
+    assert_eq!(results.len(), 300);
+
+    // All should complete with some valid HTTP status
+    for status in &results {
+        assert!(status.as_u16() < 600, "Unexpected status code: {}", status);
+    }
+}

--- a/stoa-gateway/tests/resilience/fault_injection.rs
+++ b/stoa-gateway/tests/resilience/fault_injection.rs
@@ -1,0 +1,176 @@
+//! Fault injection tests — verify gateway behavior when dependencies are down.
+//!
+//! Tests that the gateway handles CP/Keycloak unavailability gracefully
+//! (no panics, correct status codes).
+
+use crate::common::TestApp;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use stoa_gateway::config::Config;
+use stoa_gateway::routes::ApiRoute;
+use stoa_gateway::state::AppState;
+use tower::ServiceExt;
+
+/// DoD #2: /health returns 200 even when CP is unreachable.
+///
+/// The health endpoint is a liveness probe — it should always return 200
+/// as long as the gateway process is running, regardless of backend health.
+#[tokio::test]
+async fn test_health_when_cp_down() {
+    // Default TestApp has no CP URL configured
+    let app = TestApp::new();
+    let (status, body) = app.get("/health").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, "OK");
+}
+
+/// DoD #3 (partial): /ready returns 503 when CP is unreachable.
+///
+/// The readiness probe checks CP connectivity. If CP is down,
+/// the gateway should report NOT READY (not crash).
+#[tokio::test]
+async fn test_ready_when_cp_down() {
+    // Point CP URL to a non-existent endpoint
+    let config = Config {
+        control_plane_url: Some("http://127.0.0.1:19998".to_string()),
+        auto_register: false,
+        ..Config::default()
+    };
+    let state = AppState::new(config);
+    let router = stoa_gateway::build_router(state);
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/ready")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = router.oneshot(request).await.expect("should not panic");
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let body = axum::body::to_bytes(response.into_body(), 1_048_576)
+        .await
+        .expect("read body");
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("NOT READY"),
+        "Expected NOT READY message, got: {}",
+        body_str
+    );
+}
+
+/// DoD #3 (partial): /ready returns 503 when Keycloak is unreachable.
+///
+/// If Keycloak OIDC discovery fails, the gateway should report NOT READY.
+#[tokio::test]
+async fn test_ready_when_keycloak_down() {
+    let config = Config {
+        // Point to unreachable Keycloak
+        keycloak_url: Some("http://127.0.0.1:19997".to_string()),
+        keycloak_realm: Some("stoa".to_string()),
+        keycloak_client_id: Some("test-client".to_string()),
+        keycloak_client_secret: Some("test-secret".to_string()),
+        auto_register: false,
+        ..Config::default()
+    };
+    let state = AppState::new(config);
+    let router = stoa_gateway::build_router(state);
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/ready")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = router.oneshot(request).await.expect("should not panic");
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let body = axum::body::to_bytes(response.into_body(), 1_048_576)
+        .await
+        .expect("read body");
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("NOT READY"),
+        "Expected NOT READY message, got: {}",
+        body_str
+    );
+}
+
+/// Dynamic proxy returns 504 when backend never responds (timeout).
+#[tokio::test]
+async fn test_proxy_timeout() {
+    // Register a route pointing to a host that accepts TCP but never responds.
+    // Using a non-routable IP (10.255.255.1) — connect_timeout will fire.
+    let config = Config {
+        admin_api_token: Some("test-token".to_string()),
+        auto_register: false,
+        ..Config::default()
+    };
+    let state = AppState::new(config);
+    state.route_registry.upsert(ApiRoute {
+        id: "timeout-route".to_string(),
+        name: "timeout-api".to_string(),
+        tenant_id: "acme".to_string(),
+        path_prefix: "/apis/timeout".to_string(),
+        backend_url: "http://10.255.255.1:9999".to_string(),
+        methods: vec![],
+        spec_hash: "abc".to_string(),
+        activated: true,
+    });
+    let router = stoa_gateway::build_router(state);
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/apis/timeout/test")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = router.oneshot(request).await.expect("should not panic");
+    // Connection timeout → 504 Gateway Timeout or 502 Bad Gateway
+    assert!(
+        response.status() == StatusCode::GATEWAY_TIMEOUT
+            || response.status() == StatusCode::BAD_GATEWAY,
+        "Expected 504/502, got {}",
+        response.status()
+    );
+}
+
+/// Dynamic proxy returns 503 for a deactivated route.
+#[tokio::test]
+async fn test_deactivated_route_returns_503() {
+    let config = Config {
+        auto_register: false,
+        ..Config::default()
+    };
+    let state = AppState::new(config);
+    state.route_registry.upsert(ApiRoute {
+        id: "inactive-route".to_string(),
+        name: "inactive-api".to_string(),
+        tenant_id: "acme".to_string(),
+        path_prefix: "/apis/inactive".to_string(),
+        backend_url: "http://127.0.0.1:19999".to_string(),
+        methods: vec![],
+        spec_hash: "abc".to_string(),
+        activated: false,
+    });
+    let router = stoa_gateway::build_router(state);
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/apis/inactive/test")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = router.oneshot(request).await.expect("should not panic");
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// Dynamic proxy returns 404 for unknown paths.
+#[tokio::test]
+async fn test_unknown_route_returns_404() {
+    let app = TestApp::new();
+    let (status, body) = app.get("/apis/nonexistent/test").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert!(body.contains("No matching API route"));
+}

--- a/stoa-gateway/tests/resilience/main.rs
+++ b/stoa-gateway/tests/resilience/main.rs
@@ -1,0 +1,11 @@
+//! Resilience tests for STOA Gateway
+//!
+//! Tests circuit breaker integration, fault injection (CP/Keycloak down),
+//! and concurrency under load via the full Axum router.
+//!
+//! Run: `cargo test --test resilience`
+
+mod circuit_breaker;
+mod common;
+mod concurrency;
+mod fault_injection;


### PR DESCRIPTION
## Summary
- 15 new resilience tests in `tests/resilience/` (circuit breaker integration, fault injection, concurrency)
- Circuit breaker: opens after failures, rejects when open, half-open recovery, per-upstream isolation, admin stats
- Fault injection: /health OK when CP down, /ready 503 when CP/Keycloak down, proxy timeout, deactivated routes
- Concurrency: 1,000 concurrent tool calls, 100 admin/health, 300 mixed endpoints — all within 5s deadline

## Test plan
- [x] `cargo test --test resilience` — 15/15 pass
- [x] `cargo test` — 552 total tests, 0 failures (no regressions)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] CI green

**Phase 4 DoD checks covered:** #1 (≥15 tests), #2 (CP down→health 200), #3 (KC down→ready 503), #4 (CB opens after 5 failures), #5 (1000 concurrent→no deadlock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)