### PR TITLE
fix(api): graceful degradation for error snapshots when storage unavailable

### DIFF
--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -22398,7 +22398,7 @@
     },
     "/v1/snapshots": {
       "get": {
-        "description": "List error snapshots for the user's tenant.\n\nSupports filtering by:\n- Date range (start_date, end_date)\n- HTTP status code\n- Trigger type (4xx, 5xx, timeout, manual)\n- Path substring\n- Gateway source\n- Resolution status\n\nResults are paginated and sorted by timestamp (newest first).",
+        "description": "List error snapshots for the user's tenant.\n\nReturns empty list when storage is unavailable.",
         "operationId": "list_snapshots_v1_snapshots_get",
         "parameters": [
           {
@@ -22592,7 +22592,7 @@
     },
     "/v1/snapshots/filters": {
       "get": {
-        "description": "Get available filter values for the UI.\n\nReturns distinct trigger types, sources, status codes,\nand resolution statuses from recent snapshots.",
+        "description": "Get available filter values for the UI.\n\nReturns empty filters when storage is unavailable.",
         "operationId": "get_available_filters_v1_snapshots_filters_get",
         "responses": {
           "200": {
@@ -22697,7 +22697,7 @@
     },
     "/v1/snapshots/stats/summary": {
       "get": {
-        "description": "Get snapshot statistics summary.\n\nReturns counts by trigger type, status code, and resolution status.",
+        "description": "Get snapshot statistics summary.",
         "operationId": "get_snapshot_stats_summary_v1_snapshots_stats_summary_get",
         "parameters": [
           {
@@ -22775,7 +22775,7 @@
     },
     "/v1/snapshots/{snapshot_id}": {
       "delete": {
-        "description": "Delete an error snapshot.\n\nPermanently removes the snapshot from storage.\nAccess is restricted to the user's tenant.",
+        "description": "Delete an error snapshot.",
         "operationId": "delete_snapshot_v1_snapshots__snapshot_id__delete",
         "parameters": [
           {
@@ -22814,7 +22814,7 @@
         ]
       },
       "get": {
-        "description": "Get detailed error snapshot by ID.\n\nReturns the complete snapshot including:\n- Request/response data (with PII masked)\n- Routing and policy information\n- Backend state\n- Captured logs\n- Environment information\n\nAccess is restricted to the user's tenant.",
+        "description": "Get detailed error snapshot by ID.",
         "operationId": "get_snapshot_v1_snapshots__snapshot_id__get",
         "parameters": [
           {
@@ -22860,7 +22860,7 @@
         ]
       },
       "patch": {
-        "description": "Update the resolution status of an error snapshot.\n\nAllows operators to mark snapshots as investigating, resolved, or ignored.",
+        "description": "Update the resolution status of an error snapshot.",
         "operationId": "update_snapshot_resolution_v1_snapshots__snapshot_id__patch",
         "parameters": [
           {
@@ -22918,7 +22918,7 @@
     },
     "/v1/snapshots/{snapshot_id}/replay": {
       "post": {
-        "description": "Generate cURL command to replay the captured request.\n\nReturns a cURL command that can be used to replay the original\nrequest. Note that sensitive data (Authorization headers, etc.)\nwill show as [REDACTED] in the generated command.\n\nAccess is restricted to the user's tenant.",
+        "description": "Generate cURL command to replay the captured request.",
         "operationId": "generate_replay_v1_snapshots__snapshot_id__replay_post",
         "parameters": [
           {

--- a/control-plane-api/src/features/error_snapshots/router.py
+++ b/control-plane-api/src/features/error_snapshots/router.py
@@ -3,8 +3,13 @@
 CAB-397: CRUD operations for viewing and managing error snapshots.
 Routes with fixed paths (/stats, /filters) MUST be defined BEFORE
 /{snapshot_id} to avoid path parameter capture.
+
+Graceful degradation: when MinIO/S3 storage is unavailable (e.g., not
+deployed), read endpoints return empty results instead of 500/503.
+Write endpoints return 503 to clearly signal the storage is down.
 """
 
+import logging
 from datetime import datetime
 from typing import Annotated
 
@@ -23,6 +28,8 @@ from .models import (
 )
 from .service import SnapshotService
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/v1/snapshots", tags=["Error Snapshots"])
 
 # Dependency for getting snapshot service
@@ -35,13 +42,12 @@ def set_snapshot_service(service: SnapshotService) -> None:
     _snapshot_service = service
 
 
-def get_snapshot_service() -> SnapshotService:
-    """Get snapshot service dependency."""
-    if _snapshot_service is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Error snapshot service not initialized",
-        )
+def get_snapshot_service() -> SnapshotService | None:
+    """Get snapshot service dependency.
+
+    Returns None when storage is unavailable — endpoints handle graceful
+    degradation by returning empty results for reads and 503 for writes.
+    """
     return _snapshot_service
 
 
@@ -51,45 +57,24 @@ def get_snapshot_service() -> SnapshotService:
 @router.get("", response_model=SnapshotListResponse)
 async def list_snapshots(
     page: Annotated[int, Query(ge=1, description="Page number")] = 1,
-    page_size: Annotated[
-        int, Query(ge=1, le=100, description="Items per page")
-    ] = 20,
-    start_date: Annotated[
-        datetime | None, Query(description="Filter: start date")
-    ] = None,
-    end_date: Annotated[
-        datetime | None, Query(description="Filter: end date")
-    ] = None,
-    status_code: Annotated[
-        int | None, Query(description="Filter: HTTP status code")
-    ] = None,
-    trigger: Annotated[
-        SnapshotTrigger | None, Query(description="Filter: trigger type")
-    ] = None,
-    path_contains: Annotated[
-        str | None, Query(description="Filter: path contains string")
-    ] = None,
-    source: Annotated[
-        str | None, Query(description="Filter: gateway source")
-    ] = None,
-    resolution_status: Annotated[
-        ResolutionStatus | None, Query(description="Filter: resolution status")
-    ] = None,
+    page_size: Annotated[int, Query(ge=1, le=100, description="Items per page")] = 20,
+    start_date: Annotated[datetime | None, Query(description="Filter: start date")] = None,
+    end_date: Annotated[datetime | None, Query(description="Filter: end date")] = None,
+    status_code: Annotated[int | None, Query(description="Filter: HTTP status code")] = None,
+    trigger: Annotated[SnapshotTrigger | None, Query(description="Filter: trigger type")] = None,
+    path_contains: Annotated[str | None, Query(description="Filter: path contains string")] = None,
+    source: Annotated[str | None, Query(description="Filter: gateway source")] = None,
+    resolution_status: Annotated[ResolutionStatus | None, Query(description="Filter: resolution status")] = None,
     user: User = Depends(get_current_user),
-    service: SnapshotService = Depends(get_snapshot_service),
+    service: SnapshotService | None = Depends(get_snapshot_service),
 ) -> SnapshotListResponse:
     """List error snapshots for the user's tenant.
 
-    Supports filtering by:
-    - Date range (start_date, end_date)
-    - HTTP status code
-    - Trigger type (4xx, 5xx, timeout, manual)
-    - Path substring
-    - Gateway source
-    - Resolution status
-
-    Results are paginated and sorted by timestamp (newest first).
+    Returns empty list when storage is unavailable.
     """
+    if service is None:
+        return _empty_list_response(page, page_size)
+
     tenant_id = user.tenant_id or "unknown"
 
     filters = SnapshotFilters(
@@ -102,42 +87,35 @@ async def list_snapshots(
         resolution_status=resolution_status,
     )
 
-    return await service.list(
-        tenant_id=tenant_id,
-        filters=filters,
-        page=page,
-        page_size=page_size,
-    )
+    try:
+        return await service.list(
+            tenant_id=tenant_id,
+            filters=filters,
+            page=page,
+            page_size=page_size,
+        )
+    except Exception as e:
+        logger.warning(f"snapshot_list_failed storage_error={e}")
+        return _empty_list_response(page, page_size)
 
 
 @router.get("/stats/summary")
 async def get_snapshot_stats_summary(
-    start_date: Annotated[
-        datetime | None, Query(description="Start date for stats")
-    ] = None,
-    end_date: Annotated[
-        datetime | None, Query(description="End date for stats")
-    ] = None,
+    start_date: Annotated[datetime | None, Query(description="Start date for stats")] = None,
+    end_date: Annotated[datetime | None, Query(description="End date for stats")] = None,
     user: User = Depends(get_current_user),
-    service: SnapshotService = Depends(get_snapshot_service),
+    service: SnapshotService | None = Depends(get_snapshot_service),
 ) -> dict:
-    """Get snapshot statistics summary.
-
-    Returns counts by trigger type, status code, and resolution status.
-    """
+    """Get snapshot statistics summary."""
     return await _compute_stats(start_date, end_date, user, service)
 
 
 @router.get("/stats")
 async def get_snapshot_stats(
-    start_date: Annotated[
-        datetime | None, Query(description="Start date for stats")
-    ] = None,
-    end_date: Annotated[
-        datetime | None, Query(description="End date for stats")
-    ] = None,
+    start_date: Annotated[datetime | None, Query(description="Start date for stats")] = None,
+    end_date: Annotated[datetime | None, Query(description="End date for stats")] = None,
     user: User = Depends(get_current_user),
-    service: SnapshotService = Depends(get_snapshot_service),
+    service: SnapshotService | None = Depends(get_snapshot_service),
 ) -> dict:
     """Get snapshot statistics (alias for /stats/summary)."""
     return await _compute_stats(start_date, end_date, user, service)
@@ -146,39 +124,45 @@ async def get_snapshot_stats(
 @router.get("/filters", response_model=SnapshotFiltersResponse)
 async def get_available_filters(
     user: User = Depends(get_current_user),
-    service: SnapshotService = Depends(get_snapshot_service),
+    service: SnapshotService | None = Depends(get_snapshot_service),
 ) -> SnapshotFiltersResponse:
     """Get available filter values for the UI.
 
-    Returns distinct trigger types, sources, status codes,
-    and resolution statuses from recent snapshots.
+    Returns empty filters when storage is unavailable.
     """
+    if service is None:
+        return _empty_filters_response()
+
     tenant_id = user.tenant_id or "unknown"
 
-    filters = SnapshotFilters()
-    result = await service.list(tenant_id, filters, page=1, page_size=1000)
+    try:
+        filters = SnapshotFilters()
+        result = await service.list(tenant_id, filters, page=1, page_size=1000)
 
-    triggers: set[str] = set()
-    sources: set[str] = set()
-    status_codes: set[int] = set()
-    resolution_statuses: set[str] = set()
+        triggers: set[str] = set()
+        sources: set[str] = set()
+        status_codes: set[int] = set()
+        resolution_statuses: set[str] = set()
 
-    for item in result.items:
-        triggers.add(item.trigger.value)
-        sources.add(item.source)
-        status_codes.add(item.status)
-        resolution_statuses.add(item.resolution_status.value)
+        for item in result.items:
+            triggers.add(item.trigger.value)
+            sources.add(item.source)
+            status_codes.add(item.status)
+            resolution_statuses.add(item.resolution_status.value)
 
-    # Always include all known resolution statuses
-    for rs in ResolutionStatus:
-        resolution_statuses.add(rs.value)
+        # Always include all known resolution statuses
+        for rs in ResolutionStatus:
+            resolution_statuses.add(rs.value)
 
-    return SnapshotFiltersResponse(
-        triggers=sorted(triggers),
-        sources=sorted(sources),
-        status_codes=sorted(status_codes),
-        resolution_statuses=sorted(resolution_statuses),
-    )
+        return SnapshotFiltersResponse(
+            triggers=sorted(triggers),
+            sources=sorted(sources),
+            status_codes=sorted(status_codes),
+            resolution_statuses=sorted(resolution_statuses),
+        )
+    except Exception as e:
+        logger.warning(f"snapshot_filters_failed storage_error={e}")
+        return _empty_filters_response()
 
 
 # ── Parameterized routes ──────────────────────────────────────────────
@@ -188,29 +172,19 @@ async def get_available_filters(
 async def get_snapshot(
     snapshot_id: str,
     user: User = Depends(get_current_user),
-    service: SnapshotService = Depends(get_snapshot_service),
+    service: SnapshotService | None = Depends(get_snapshot_service),
 ) -> ErrorSnapshot:
-    """Get detailed error snapshot by ID.
+    """Get detailed error snapshot by ID."""
+    _require_service(service)
 
-    Returns the complete snapshot including:
-    - Request/response data (with PII masked)
-    - Routing and policy information
-    - Backend state
-    - Captured logs
-    - Environment information
-
-    Access is restricted to the user's tenant.
-    """
     tenant_id = user.tenant_id or "unknown"
-
-    snapshot = await service.get(snapshot_id, tenant_id)
+    snapshot = await service.get(snapshot_id, tenant_id)  # type: ignore[union-attr]
 
     if not snapshot:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Snapshot {snapshot_id} not found",
         )
-
     return snapshot
 
 
@@ -219,15 +193,13 @@ async def update_snapshot_resolution(
     snapshot_id: str,
     body: ResolutionUpdate,
     user: User = Depends(get_current_user),
-    service: SnapshotService = Depends(get_snapshot_service),
+    service: SnapshotService | None = Depends(get_snapshot_service),
 ) -> ErrorSnapshot:
-    """Update the resolution status of an error snapshot.
+    """Update the resolution status of an error snapshot."""
+    _require_service(service)
 
-    Allows operators to mark snapshots as investigating, resolved, or ignored.
-    """
     tenant_id = user.tenant_id or "unknown"
-
-    snapshot = await service.get(snapshot_id, tenant_id)
+    snapshot = await service.get(snapshot_id, tenant_id)  # type: ignore[union-attr]
 
     if not snapshot:
         raise HTTPException(
@@ -239,8 +211,7 @@ async def update_snapshot_resolution(
     if body.resolution_notes is not None:
         snapshot.resolution_notes = body.resolution_notes
 
-    await service.save(snapshot)
-
+    await service.save(snapshot)  # type: ignore[union-attr]
     return snapshot
 
 
@@ -248,16 +219,13 @@ async def update_snapshot_resolution(
 async def delete_snapshot(
     snapshot_id: str,
     user: User = Depends(get_current_user),
-    service: SnapshotService = Depends(get_snapshot_service),
+    service: SnapshotService | None = Depends(get_snapshot_service),
 ) -> None:
-    """Delete an error snapshot.
+    """Delete an error snapshot."""
+    _require_service(service)
 
-    Permanently removes the snapshot from storage.
-    Access is restricted to the user's tenant.
-    """
     tenant_id = user.tenant_id or "unknown"
-
-    deleted = await service.delete(snapshot_id, tenant_id)
+    deleted = await service.delete(snapshot_id, tenant_id)  # type: ignore[union-attr]
 
     if not deleted:
         raise HTTPException(
@@ -270,19 +238,13 @@ async def delete_snapshot(
 async def generate_replay(
     snapshot_id: str,
     user: User = Depends(get_current_user),
-    service: SnapshotService = Depends(get_snapshot_service),
+    service: SnapshotService | None = Depends(get_snapshot_service),
 ) -> ReplayResponse:
-    """Generate cURL command to replay the captured request.
+    """Generate cURL command to replay the captured request."""
+    _require_service(service)
 
-    Returns a cURL command that can be used to replay the original
-    request. Note that sensitive data (Authorization headers, etc.)
-    will show as [REDACTED] in the generated command.
-
-    Access is restricted to the user's tenant.
-    """
     tenant_id = user.tenant_id or "unknown"
-
-    snapshot = await service.get(snapshot_id, tenant_id)
+    snapshot = await service.get(snapshot_id, tenant_id)  # type: ignore[union-attr]
 
     if not snapshot:
         raise HTTPException(
@@ -290,7 +252,7 @@ async def generate_replay(
             detail=f"Snapshot {snapshot_id} not found",
         )
 
-    curl_command = service.generate_replay_curl(snapshot)
+    curl_command = service.generate_replay_curl(snapshot)  # type: ignore[union-attr]
 
     return ReplayResponse(
         curl_command=curl_command,
@@ -306,17 +268,64 @@ async def generate_replay(
 # ── Helpers ───────────────────────────────────────────────────────────
 
 
+def _require_service(service: SnapshotService | None) -> None:
+    """Raise 503 if service is unavailable (for write endpoints)."""
+    if service is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Error snapshot storage not available",
+        )
+
+
+def _empty_list_response(page: int = 1, page_size: int = 20) -> SnapshotListResponse:
+    """Return an empty list response for graceful degradation."""
+    return SnapshotListResponse(items=[], total=0, page=page, page_size=page_size)
+
+
+def _empty_stats() -> dict:
+    """Return empty stats for graceful degradation."""
+    return {
+        "total": 0,
+        "by_trigger": {},
+        "by_status_code": {},
+        "resolution_stats": {
+            "unresolved": 0,
+            "investigating": 0,
+            "resolved": 0,
+            "ignored": 0,
+        },
+        "period": {"start": None, "end": None},
+    }
+
+
+def _empty_filters_response() -> SnapshotFiltersResponse:
+    """Return default filters for graceful degradation."""
+    return SnapshotFiltersResponse(
+        triggers=["4xx", "5xx", "timeout"],
+        sources=[],
+        status_codes=[],
+        resolution_statuses=sorted(rs.value for rs in ResolutionStatus),
+    )
+
+
 async def _compute_stats(
     start_date: datetime | None,
     end_date: datetime | None,
     user: User,
-    service: SnapshotService,
+    service: SnapshotService | None,
 ) -> dict:
     """Shared stats computation for /stats and /stats/summary."""
+    if service is None:
+        return _empty_stats()
+
     tenant_id = user.tenant_id or "unknown"
 
-    filters = SnapshotFilters(start_date=start_date, end_date=end_date)
-    result = await service.list(tenant_id, filters, page=1, page_size=1000)
+    try:
+        filters = SnapshotFilters(start_date=start_date, end_date=end_date)
+        result = await service.list(tenant_id, filters, page=1, page_size=1000)
+    except Exception as e:
+        logger.warning(f"snapshot_stats_failed storage_error={e}")
+        return _empty_stats()
 
     by_trigger: dict[str, int] = {}
     by_status: dict[int, int] = {}


### PR DESCRIPTION
## Summary
- Read endpoints (`GET /v1/snapshots`, `/stats`, `/filters`) return empty results instead of 500/503 when MinIO storage is unavailable
- Write endpoints (`PATCH`, `DELETE`, `POST /replay`) return 503 with clear error message
- Fixes production crash: OVH has no MinIO deployed, causing unhandled exceptions that bypass CORS middleware

## Context
PR #327 rewired Console error snapshots to call CP API. On OVH production, MinIO is not deployed, so the storage layer crashes with connection errors. This causes:
- 500 responses without CORS headers (browser blocks the response)
- Console page shows "Failed to load error snapshots" instead of an empty state

## Test plan
- [x] 563 CP API tests pass (557 + 6 contract)
- [x] Ruff + Black clean
- [x] OpenAPI snapshot updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>