### PR TITLE
feat(api): full-feature Kong + Gravitee adapters with policies and consumers

### DIFF
--- a/control-plane-api/src/adapters/gravitee/adapter.py
+++ b/control-plane-api/src/adapters/gravitee/adapter.py
@@ -29,6 +29,9 @@ class GraviteeGatewayAdapter(GatewayAdapterInterface):
 
     Communicates with the Gravitee Management API (default port 8083).
     Uses HTTP Basic authentication.
+
+    API lifecycle: create → start → deploy. Deletion: stop → delete.
+    Policies are managed via Plans with flows.
     """
 
     def __init__(self, config: dict | None = None):
@@ -88,26 +91,71 @@ class GraviteeGatewayAdapter(GatewayAdapterInterface):
     # --- APIs ---
 
     async def sync_api(self, api_spec: dict, tenant_id: str, auth_token: str | None = None) -> AdapterResult:
+        """Sync an API with full lifecycle: create/update → start → deploy.
+
+        1. Check if API exists by name
+        2. Create (POST) or update (PUT)
+        3. Start the API (POST /_start)
+        4. Deploy the API (POST /_deploy)
+        """
         try:
             payload = mappers.map_api_spec_to_gravitee_v4(api_spec, tenant_id)
-            resp = await self._client.post(f"{_MGMT_V2}/apis", json=payload)
+            api_name = payload["name"]
 
-            if resp.status_code in (200, 201):
+            # Check if API already exists
+            existing_id = await self._find_api_by_name(api_name)
+
+            if existing_id:
+                # Update existing API
+                resp = await self._client.put(f"{_MGMT_V2}/apis/{existing_id}", json=payload)
+                if resp.status_code not in (200, 201):
+                    return AdapterResult(
+                        success=False,
+                        error=f"Gravitee update API failed: HTTP {resp.status_code} — {resp.text}",
+                    )
+                api_id = existing_id
+            else:
+                # Create new API
+                resp = await self._client.post(f"{_MGMT_V2}/apis", json=payload)
+                if resp.status_code not in (200, 201):
+                    return AdapterResult(
+                        success=False,
+                        error=f"Gravitee create API failed: HTTP {resp.status_code} — {resp.text}",
+                    )
                 data = resp.json()
-                return AdapterResult(
-                    success=True,
-                    resource_id=data.get("id", ""),
-                    data={"name": payload["name"]},
-                )
+                api_id = data.get("id", "")
+
+            # Start the API
+            start_resp = await self._client.post(f"{_MGMT_V2}/apis/{api_id}/_start")
+            if start_resp.status_code not in (200, 204, 409):
+                # 409 = already started, which is fine
+                logger.warning("Gravitee _start returned %d for %s", start_resp.status_code, api_id)
+
+            # Deploy the API
+            deploy_resp = await self._client.post(f"{_MGMT_V2}/apis/{api_id}/deployments")
+            if deploy_resp.status_code not in (200, 202, 204):
+                logger.warning("Gravitee deploy returned %d for %s", deploy_resp.status_code, api_id)
+
             return AdapterResult(
-                success=False,
-                error=f"Gravitee sync_api failed: HTTP {resp.status_code} — {resp.text}",
+                success=True,
+                resource_id=api_id,
+                data={"name": api_name, "started": True},
             )
         except Exception as e:
             return AdapterResult(success=False, error=str(e))
 
     async def delete_api(self, api_id: str, auth_token: str | None = None) -> AdapterResult:
+        """Delete an API with lifecycle: stop → close plans → delete."""
         try:
+            # Stop the API first
+            stop_resp = await self._client.post(f"{_MGMT_V2}/apis/{api_id}/_stop")
+            if stop_resp.status_code not in (200, 204, 404, 409):
+                logger.warning("Gravitee _stop returned %d for %s", stop_resp.status_code, api_id)
+
+            # Close all plans before deletion
+            await self._close_all_plans(api_id)
+
+            # Delete the API
             resp = await self._client.delete(f"{_MGMT_V2}/apis/{api_id}")
             if resp.status_code in (200, 204):
                 return AdapterResult(success=True, resource_id=api_id)
@@ -132,27 +180,201 @@ class GraviteeGatewayAdapter(GatewayAdapterInterface):
         except Exception:
             return []
 
-    # --- Policies ---
+    # --- Policies (via Plans) ---
 
     async def upsert_policy(self, policy_spec: dict, auth_token: str | None = None) -> AdapterResult:
-        return AdapterResult(success=False, error=_NOT_SUPPORTED)
+        """Upsert a policy by creating/updating a Gravitee Plan on the target API."""
+        try:
+            api_id = policy_spec.get("api_id", "")
+            if not api_id:
+                return AdapterResult(success=False, error="api_id required for Gravitee policy")
+
+            api_name = policy_spec.get("api_name", api_id)
+            plan_payload = mappers.map_policy_to_gravitee_plan(policy_spec, api_name)
+            policy_id = policy_spec.get("id", "")
+
+            # Check if plan already exists with this stoa tag
+            existing_plan_id = await self._find_plan_by_stoa_id(api_id, policy_id)
+
+            if existing_plan_id:
+                resp = await self._client.put(
+                    f"{_MGMT_V2}/apis/{api_id}/plans/{existing_plan_id}",
+                    json=plan_payload,
+                )
+            else:
+                resp = await self._client.post(
+                    f"{_MGMT_V2}/apis/{api_id}/plans",
+                    json=plan_payload,
+                )
+
+            if resp.status_code in (200, 201):
+                data = resp.json()
+                plan_id = data.get("id", existing_plan_id or "")
+
+                # Publish the plan
+                pub_resp = await self._client.post(f"{_MGMT_V2}/apis/{api_id}/plans/{plan_id}/_publish")
+                if pub_resp.status_code not in (200, 204, 409):
+                    logger.warning("Plan publish returned %d", pub_resp.status_code)
+
+                return AdapterResult(
+                    success=True,
+                    resource_id=policy_id,
+                    data={"plan_id": plan_id},
+                )
+            return AdapterResult(
+                success=False,
+                error=f"Gravitee upsert_policy failed: HTTP {resp.status_code} — {resp.text}",
+            )
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
 
     async def delete_policy(self, policy_id: str, auth_token: str | None = None) -> AdapterResult:
-        return AdapterResult(success=False, error=_NOT_SUPPORTED)
+        """Delete a policy by closing and removing its Gravitee Plan.
+
+        Requires the api_id to be encoded in the policy_id as 'api_id:policy_id',
+        or searches all APIs.
+        """
+        try:
+            # policy_id format: "api_id:stoa_policy_id" or just "stoa_policy_id"
+            if ":" in policy_id:
+                api_id, stoa_id = policy_id.split(":", 1)
+            else:
+                stoa_id = policy_id
+                api_id = ""
+
+            if api_id:
+                plan_id = await self._find_plan_by_stoa_id(api_id, stoa_id)
+                if plan_id:
+                    await self._close_and_delete_plan(api_id, plan_id)
+            else:
+                # Search all APIs for this policy
+                apis = await self.list_apis()
+                for api in apis:
+                    aid = api.get("id", "")
+                    plan_id = await self._find_plan_by_stoa_id(aid, stoa_id)
+                    if plan_id:
+                        await self._close_and_delete_plan(aid, plan_id)
+                        break
+
+            return AdapterResult(success=True, resource_id=policy_id)
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
 
     async def list_policies(self, auth_token: str | None = None) -> list[dict]:
-        return []
+        """List all STOA-managed plans across all APIs."""
+        try:
+            result: list[dict] = []
+            apis = await self.list_apis()
+            for api in apis:
+                api_id = api.get("id", "")
+                if not api_id:
+                    continue
+                plans = await self._list_api_plans(api_id)
+                for plan in plans:
+                    tags = plan.get("tags", [])
+                    if any(isinstance(t, str) and t.startswith("stoa-policy-") for t in tags):
+                        result.append(mappers.map_gravitee_plan_to_policy(plan))
+            return result
+        except Exception:
+            return []
 
     # --- Applications ---
 
     async def provision_application(self, app_spec: dict, auth_token: str | None = None) -> AdapterResult:
-        return AdapterResult(success=False, error=_NOT_SUPPORTED)
+        """Provision a consumer application on Gravitee.
+
+        1. Create Application
+        2. Ensure a Plan exists on the target API
+        3. Subscribe the application to the plan
+        """
+        try:
+            app_payload = mappers.map_app_spec_to_gravitee_app(app_spec)
+            api_id = app_spec.get("api_id", "")
+
+            # Create application
+            resp = await self._client.post(f"{_MGMT_V1}/applications", json=app_payload)
+            if resp.status_code not in (200, 201):
+                return AdapterResult(
+                    success=False,
+                    error=f"Gravitee create app failed: HTTP {resp.status_code} — {resp.text}",
+                )
+            app_data = resp.json()
+            app_id = app_data.get("id", "")
+
+            # Find or create a rate-limit plan on the API
+            if api_id:
+                plan_id = await self._ensure_rate_limit_plan(api_id, app_spec)
+                if plan_id:
+                    # Subscribe app to plan
+                    sub_resp = await self._client.post(
+                        f"{_MGMT_V2}/apis/{api_id}/subscriptions",
+                        json={"planId": plan_id, "applicationId": app_id},
+                    )
+                    if sub_resp.status_code in (200, 201):
+                        sub_data = sub_resp.json()
+                        return AdapterResult(
+                            success=True,
+                            resource_id=app_id,
+                            data={
+                                "application_id": app_id,
+                                "subscription_id": sub_data.get("id", ""),
+                                "plan_id": plan_id,
+                            },
+                        )
+                    logger.warning(
+                        "Gravitee subscription failed: %d — %s",
+                        sub_resp.status_code,
+                        sub_resp.text,
+                    )
+
+            return AdapterResult(
+                success=True,
+                resource_id=app_id,
+                data={"application_id": app_id},
+            )
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
 
     async def deprovision_application(self, app_id: str, auth_token: str | None = None) -> AdapterResult:
-        return AdapterResult(success=False, error=_NOT_SUPPORTED)
+        """Remove an application: close subscriptions → delete app."""
+        try:
+            # Close active subscriptions for this app
+            subs_resp = await self._client.get(
+                f"{_MGMT_V1}/applications/{app_id}/subscriptions",
+                params={"status": "ACCEPTED"},
+            )
+            if subs_resp.status_code == 200:
+                subs = subs_resp.json()
+                sub_list = subs.get("data", subs) if isinstance(subs, dict) else subs
+                if isinstance(sub_list, list):
+                    for sub in sub_list:
+                        sub_id = sub.get("id", "")
+                        if sub_id:
+                            await self._client.post(f"{_MGMT_V1}/applications/{app_id}/subscriptions/{sub_id}/_close")
+
+            # Delete the application
+            resp = await self._client.delete(f"{_MGMT_V1}/applications/{app_id}")
+            if resp.status_code in (200, 204, 404):
+                return AdapterResult(success=True, resource_id=app_id)
+            return AdapterResult(
+                success=False,
+                error=f"Gravitee delete app failed: HTTP {resp.status_code}",
+            )
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
 
     async def list_applications(self, auth_token: str | None = None) -> list[dict]:
-        return []
+        """List all applications."""
+        try:
+            resp = await self._client.get(f"{_MGMT_V1}/applications")
+            if resp.status_code == 200:
+                data = resp.json()
+                apps = data.get("data", data) if isinstance(data, dict) else data
+                if isinstance(apps, list):
+                    return [mappers.map_gravitee_app_to_cp(a) for a in apps]
+            return []
+        except Exception:
+            return []
 
     # --- Auth / OIDC ---
 
@@ -188,3 +410,81 @@ class GraviteeGatewayAdapter(GatewayAdapterInterface):
             "Authorization": f"Basic {credentials}",
             "Content-Type": "application/json",
         }
+
+    async def _find_api_by_name(self, name: str) -> str | None:
+        """Find an API by name, return its ID or None."""
+        try:
+            resp = await self._client.get(f"{_MGMT_V2}/apis", params={"q": name})
+            if resp.status_code == 200:
+                data = resp.json()
+                apis = data.get("data", data) if isinstance(data, dict) else data
+                if isinstance(apis, list):
+                    for api in apis:
+                        if api.get("name") == name:
+                            return api.get("id")
+        except Exception as e:
+            logger.warning("Failed to search Gravitee APIs: %s", e)
+        return None
+
+    async def _list_api_plans(self, api_id: str) -> list[dict]:
+        """List all plans for a given API."""
+        try:
+            resp = await self._client.get(f"{_MGMT_V2}/apis/{api_id}/plans")
+            if resp.status_code == 200:
+                data = resp.json()
+                return data.get("data", data) if isinstance(data, (dict, list)) else []
+        except Exception as e:
+            logger.warning("Failed to list plans for %s: %s", api_id, e)
+        return []
+
+    async def _find_plan_by_stoa_id(self, api_id: str, stoa_policy_id: str) -> str | None:
+        """Find a plan by its stoa-policy tag."""
+        plans = await self._list_api_plans(api_id)
+        tag = f"stoa-policy-{stoa_policy_id}"
+        if isinstance(plans, list):
+            for plan in plans:
+                tags = plan.get("tags", [])
+                if tag in tags:
+                    return plan.get("id")
+        return None
+
+    async def _close_all_plans(self, api_id: str) -> None:
+        """Close all plans for an API (required before deletion)."""
+        plans = await self._list_api_plans(api_id)
+        if isinstance(plans, list):
+            for plan in plans:
+                plan_id = plan.get("id", "")
+                status = plan.get("status", "")
+                if plan_id and status != "CLOSED":
+                    await self._client.post(f"{_MGMT_V2}/apis/{api_id}/plans/{plan_id}/_close")
+
+    async def _close_and_delete_plan(self, api_id: str, plan_id: str) -> None:
+        """Close and delete a specific plan."""
+        await self._client.post(f"{_MGMT_V2}/apis/{api_id}/plans/{plan_id}/_close")
+        await self._client.delete(f"{_MGMT_V2}/apis/{api_id}/plans/{plan_id}")
+
+    async def _ensure_rate_limit_plan(self, api_id: str, app_spec: dict) -> str | None:
+        """Ensure a rate-limit plan exists on the API, create if needed."""
+        subscription_id = app_spec.get("subscription_id", "default")
+        rate_per_minute = app_spec.get("rate_limit_per_minute")
+        rate_per_second = app_spec.get("rate_limit_per_second")
+
+        if not rate_per_minute and not rate_per_second:
+            # Check for existing open plans
+            plans = await self._list_api_plans(api_id)
+            if isinstance(plans, list):
+                for plan in plans:
+                    if plan.get("status") in ("PUBLISHED", "STAGING"):
+                        return plan.get("id")
+            return None
+
+        max_requests = rate_per_minute or (rate_per_second * 60 if rate_per_second else 100)
+        policy_spec = {
+            "id": f"quota-{subscription_id}",
+            "type": "rate_limit",
+            "config": {"maxRequests": max_requests, "intervalSeconds": 60},
+        }
+        result = await self.upsert_policy({**policy_spec, "api_id": api_id})
+        if result.success and result.data:
+            return result.data.get("plan_id")
+        return None

--- a/control-plane-api/src/adapters/gravitee/mappers.py
+++ b/control-plane-api/src/adapters/gravitee/mappers.py
@@ -8,6 +8,7 @@ def map_api_spec_to_gravitee_v4(api_spec: dict, tenant_id: str) -> dict:
     """
     api_name = api_spec.get("api_name", api_spec.get("apiName", "unknown"))
     backend_url = api_spec.get("backend_url", api_spec.get("url", ""))
+    methods = api_spec.get("methods", ["GET", "POST", "PUT", "DELETE"])
 
     return {
         "name": f"{tenant_id}-{api_name}",
@@ -19,6 +20,7 @@ def map_api_spec_to_gravitee_v4(api_spec: dict, tenant_id: str) -> dict:
                 "type": "HTTP",
                 "paths": [{"path": f"/apis/{tenant_id}/{api_name}"}],
                 "entrypoints": [{"type": "http-proxy"}],
+                "methods": methods,
             }
         ],
         "endpointGroups": [
@@ -48,4 +50,139 @@ def map_gravitee_api_to_cp(api: dict) -> dict:
         "visibility": api.get("visibility", ""),
         "definition_version": api.get("definitionVersion", ""),
         "deployed_at": api.get("deployedAt"),
+    }
+
+
+def map_policy_to_gravitee_plan(policy_spec: dict, api_name: str) -> dict:
+    """Map STOA policy spec to a Gravitee Plan with rate-limit flow.
+
+    Gravitee uses Plans to enforce policies like rate-limiting.
+    Each plan has flows with policy steps.
+    """
+    policy_type = policy_spec.get("type", "")
+    config = policy_spec.get("config", {})
+    policy_id = policy_spec.get("id", "")
+
+    if policy_type == "rate_limit":
+        max_requests = config.get("maxRequests", 100)
+        interval = config.get("intervalSeconds", 60)
+        # Gravitee rate-limit uses "limit" and "periodTime" + "periodTimeUnit"
+        if interval <= 1:
+            period_time, period_unit = 1, "SECONDS"
+        elif interval <= 60:
+            period_time, period_unit = 1, "MINUTES"
+        else:
+            period_time, period_unit = interval // 60, "MINUTES"
+
+        return {
+            "name": f"stoa-rate-limit-{policy_id}",
+            "description": f"STOA rate-limit policy {policy_id} for {api_name}",
+            "validation": "AUTO",
+            "security": {"type": "KEY_LESS"},
+            "flows": [
+                {
+                    "name": "rate-limit-flow",
+                    "enabled": True,
+                    "request": [
+                        {
+                            "name": "Rate Limiting",
+                            "policy": "rate-limit",
+                            "configuration": {
+                                "rate": {
+                                    "limit": max_requests,
+                                    "periodTime": period_time,
+                                    "periodTimeUnit": period_unit,
+                                }
+                            },
+                        }
+                    ],
+                }
+            ],
+            "tags": [f"stoa-policy-{policy_id}"],
+        }
+
+    # Generic policy fallback
+    return {
+        "name": f"stoa-{policy_type}-{policy_id}",
+        "description": f"STOA {policy_type} policy {policy_id}",
+        "validation": "AUTO",
+        "security": {"type": "KEY_LESS"},
+        "flows": [
+            {
+                "name": f"{policy_type}-flow",
+                "enabled": True,
+                "request": [
+                    {
+                        "name": policy_type,
+                        "policy": policy_type.replace("_", "-"),
+                        "configuration": config,
+                    }
+                ],
+            }
+        ],
+        "tags": [f"stoa-policy-{policy_id}"],
+    }
+
+
+def map_gravitee_plan_to_policy(plan: dict) -> dict:
+    """Map a Gravitee Plan to CP-normalized policy dict."""
+    tags = plan.get("tags", [])
+    stoa_id = ""
+    for tag in tags:
+        if isinstance(tag, str) and tag.startswith("stoa-policy-"):
+            stoa_id = tag.removeprefix("stoa-policy-")
+            break
+
+    # Extract rate-limit config from flows
+    flows = plan.get("flows", [])
+    policy_type = "unknown"
+    cp_config: dict = {}
+
+    for flow in flows:
+        for step in flow.get("request", []):
+            policy_name = step.get("policy", "")
+            if policy_name == "rate-limit":
+                policy_type = "rate_limit"
+                rate_cfg = step.get("configuration", {}).get("rate", {})
+                limit = rate_cfg.get("limit", 100)
+                period_unit = rate_cfg.get("periodTimeUnit", "MINUTES")
+                period_time = rate_cfg.get("periodTime", 1)
+                interval = period_time if period_unit == "SECONDS" else period_time * 60
+                cp_config = {"maxRequests": limit, "intervalSeconds": interval}
+                break
+            else:
+                policy_type = policy_name.replace("-", "_")
+                cp_config = step.get("configuration", {})
+                break
+
+    return {
+        "id": stoa_id or plan.get("id", ""),
+        "name": plan.get("name", ""),
+        "type": policy_type,
+        "config": cp_config,
+        "plan_id": plan.get("id", ""),
+    }
+
+
+def map_app_spec_to_gravitee_app(app_spec: dict) -> dict:
+    """Map CP app_spec to a Gravitee Application creation payload."""
+    consumer_id = app_spec.get("consumer_external_id", app_spec.get("application_name", "unknown"))
+    return {
+        "name": consumer_id,
+        "description": f"STOA consumer {consumer_id}",
+        "settings": {
+            "app": {
+                "type": "SIMPLE",
+            }
+        },
+    }
+
+
+def map_gravitee_app_to_cp(app: dict) -> dict:
+    """Map a Gravitee Application object to CP-normalized dict."""
+    return {
+        "id": app.get("id", ""),
+        "name": app.get("name", ""),
+        "status": app.get("status", ""),
+        "created_at": app.get("created_at"),
     }

--- a/control-plane-api/src/adapters/kong/adapter.py
+++ b/control-plane-api/src/adapters/kong/adapter.py
@@ -24,6 +24,11 @@ class KongGatewayAdapter(GatewayAdapterInterface):
 
     Communicates with the Kong Admin API (default port 8001).
     DB-less mode: ``GET`` endpoints work, mutations via ``POST /config``.
+
+    State management: all mutations follow the pattern:
+    1. Fetch current entities via GET
+    2. Merge desired change
+    3. POST full declarative config to /config (atomic reload)
     """
 
     def __init__(self, config: dict | None = None):
@@ -78,44 +83,60 @@ class KongGatewayAdapter(GatewayAdapterInterface):
     # --- APIs ---
 
     async def sync_api(self, api_spec: dict, tenant_id: str, auth_token: str | None = None) -> AdapterResult:
-        """Sync an API by posting a full declarative config reload.
+        """Sync an API using state management: fetch → merge → reload.
 
-        In DB-less mode, individual service creation is not supported.
-        We build a minimal declarative config with the requested service
-        and POST it to ``/config``.
+        1. GET /services to read current services
+        2. Upsert our service by name (replace if exists, add if new)
+        3. Collect existing plugins
+        4. POST /config with the full merged config
         """
         try:
             service = mappers.map_api_spec_to_kong_service(api_spec, tenant_id)
-            config_payload = {
-                "_format_version": "3.0",
-                "services": [service],
-            }
-            resp = await self._client.post("/config", json=config_payload)
+            current_config = await self._fetch_current_config()
+            services = current_config.get("services", [])
 
-            if resp.status_code in (200, 201):
+            # Upsert: replace existing service by name, or append
+            services = [s for s in services if s.get("name") != service["name"]]
+            services.append(service)
+
+            config_payload = self._build_config(
+                services=services,
+                plugins=current_config.get("plugins", []),
+                consumers=current_config.get("consumers", []),
+            )
+            result = await self._reload_config(config_payload)
+            if result.success:
                 return AdapterResult(
                     success=True,
                     resource_id=service["name"],
                     data={"service_name": service["name"]},
                 )
-            return AdapterResult(
-                success=False,
-                error=f"Kong sync_api failed: HTTP {resp.status_code} — {resp.text}",
-            )
+            return result
         except Exception as e:
             return AdapterResult(success=False, error=str(e))
 
     async def delete_api(self, api_id: str, auth_token: str | None = None) -> AdapterResult:
-        """Delete not directly supported in DB-less — returns success (idempotent).
+        """Delete an API: fetch state → remove service → reload config."""
+        try:
+            current_config = await self._fetch_current_config()
+            services = current_config.get("services", [])
+            plugins = current_config.get("plugins", [])
 
-        In production, the declarative config would be regenerated without
-        this service and reloaded via ``POST /config``.
-        """
-        return AdapterResult(
-            success=True,
-            resource_id=api_id,
-            data={"detail": "DB-less mode: service removed from declarative config"},
-        )
+            # Remove service and its associated plugins
+            services = [s for s in services if s.get("name") != api_id]
+            plugins = [p for p in plugins if p.get("service") != api_id]
+
+            config_payload = self._build_config(
+                services=services,
+                plugins=plugins,
+                consumers=current_config.get("consumers", []),
+            )
+            result = await self._reload_config(config_payload)
+            if result.success:
+                return AdapterResult(success=True, resource_id=api_id)
+            return result
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
 
     async def list_apis(self, auth_token: str | None = None) -> list[dict]:
         try:
@@ -128,27 +149,145 @@ class KongGatewayAdapter(GatewayAdapterInterface):
         except Exception:
             return []
 
-    # --- Policies (not supported in DB-less) ---
+    # --- Policies ---
 
     async def upsert_policy(self, policy_spec: dict, auth_token: str | None = None) -> AdapterResult:
-        return AdapterResult(success=False, error=_NOT_SUPPORTED)
+        """Upsert a policy via declarative config: fetch → merge plugin → reload."""
+        try:
+            service_name = policy_spec.get("api_id", "")
+            plugin = mappers.map_policy_to_kong_plugin(policy_spec, service_name)
+            policy_id = policy_spec.get("id", "")
+
+            current_config = await self._fetch_current_config()
+            plugins = current_config.get("plugins", [])
+
+            # Remove existing plugin with same stoa-policy tag
+            tag = f"stoa-policy-{policy_id}"
+            plugins = [p for p in plugins if tag not in p.get("tags", [])]
+            plugins.append(plugin)
+
+            config_payload = self._build_config(
+                services=current_config.get("services", []),
+                plugins=plugins,
+                consumers=current_config.get("consumers", []),
+            )
+            result = await self._reload_config(config_payload)
+            if result.success:
+                return AdapterResult(
+                    success=True,
+                    resource_id=policy_id,
+                    data={"plugin_name": plugin["name"], "service": service_name},
+                )
+            return result
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
 
     async def delete_policy(self, policy_id: str, auth_token: str | None = None) -> AdapterResult:
-        return AdapterResult(success=False, error=_NOT_SUPPORTED)
+        """Delete a policy: fetch → remove plugin by stoa tag → reload."""
+        try:
+            current_config = await self._fetch_current_config()
+            plugins = current_config.get("plugins", [])
+
+            tag = f"stoa-policy-{policy_id}"
+            plugins = [p for p in plugins if tag not in p.get("tags", [])]
+
+            config_payload = self._build_config(
+                services=current_config.get("services", []),
+                plugins=plugins,
+                consumers=current_config.get("consumers", []),
+            )
+            result = await self._reload_config(config_payload)
+            if result.success:
+                return AdapterResult(success=True, resource_id=policy_id)
+            return result
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
 
     async def list_policies(self, auth_token: str | None = None) -> list[dict]:
-        return []
+        """List all plugins managed by STOA (identified by stoa-policy-* tags)."""
+        try:
+            resp = await self._client.get("/plugins")
+            if resp.status_code == 200:
+                data = resp.json()
+                plugins = data.get("data", [])
+                result = []
+                for p in plugins:
+                    tags = p.get("tags", [])
+                    if any(t.startswith("stoa-policy-") for t in tags):
+                        result.append(mappers.map_kong_plugin_to_policy(p))
+                return result
+            return []
+        except Exception:
+            return []
 
     # --- Applications ---
 
     async def provision_application(self, app_spec: dict, auth_token: str | None = None) -> AdapterResult:
-        return AdapterResult(success=False, error=_NOT_SUPPORTED)
+        """Provision a consumer in Kong declarative config.
+
+        Adds a consumer with key-auth credentials and optional rate-limiting.
+        """
+        try:
+            consumer = mappers.map_app_spec_to_kong_consumer(app_spec)
+            current_config = await self._fetch_current_config()
+            consumers = current_config.get("consumers", [])
+
+            # Upsert: replace existing consumer by username
+            consumers = [c for c in consumers if c.get("username") != consumer["username"]]
+            consumers.append(consumer)
+
+            config_payload = self._build_config(
+                services=current_config.get("services", []),
+                plugins=current_config.get("plugins", []),
+                consumers=consumers,
+            )
+            result = await self._reload_config(config_payload)
+            if result.success:
+                return AdapterResult(
+                    success=True,
+                    resource_id=consumer["username"],
+                    data={"consumer": consumer["username"]},
+                )
+            return result
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
 
     async def deprovision_application(self, app_id: str, auth_token: str | None = None) -> AdapterResult:
-        return AdapterResult(success=False, error=_NOT_SUPPORTED)
+        """Remove a consumer from Kong declarative config."""
+        try:
+            current_config = await self._fetch_current_config()
+            consumers = current_config.get("consumers", [])
+
+            consumers = [c for c in consumers if c.get("username") != app_id]
+
+            config_payload = self._build_config(
+                services=current_config.get("services", []),
+                plugins=current_config.get("plugins", []),
+                consumers=consumers,
+            )
+            result = await self._reload_config(config_payload)
+            if result.success:
+                return AdapterResult(success=True, resource_id=app_id)
+            return result
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
 
     async def list_applications(self, auth_token: str | None = None) -> list[dict]:
-        return []
+        """List consumers managed by STOA (identified by stoa-consumer-* tags)."""
+        try:
+            resp = await self._client.get("/consumers")
+            if resp.status_code == 200:
+                data = resp.json()
+                consumers = data.get("data", [])
+                result = []
+                for c in consumers:
+                    tags = c.get("tags", [])
+                    if any(t.startswith("stoa-consumer-") for t in tags):
+                        result.append(mappers.map_kong_consumer_to_cp(c))
+                return result
+            return []
+        except Exception:
+            return []
 
     # --- Auth / OIDC ---
 
@@ -183,3 +322,115 @@ class KongGatewayAdapter(GatewayAdapterInterface):
         if self._api_key:
             headers["Kong-Admin-Token"] = self._api_key
         return headers
+
+    async def _fetch_current_config(self) -> dict:
+        """Fetch current Kong state via GET endpoints.
+
+        Returns a dict with services, plugins, and consumers arrays.
+        """
+        services: list[dict] = []
+        plugins: list[dict] = []
+        consumers: list[dict] = []
+
+        try:
+            resp = await self._client.get("/services")
+            if resp.status_code == 200:
+                data = resp.json()
+                for svc in data.get("data", []):
+                    service_entry = {
+                        "name": svc.get("name", ""),
+                        "url": f"{svc.get('protocol', 'http')}://{svc.get('host', '')}:{svc.get('port', 80)}{svc.get('path', '')}",
+                    }
+                    # Fetch routes for this service
+                    routes_resp = await self._client.get(f"/services/{svc['id']}/routes")
+                    if routes_resp.status_code == 200:
+                        routes_data = routes_resp.json()
+                        service_entry["routes"] = [
+                            {
+                                "name": r.get("name", ""),
+                                "paths": r.get("paths", []),
+                                "methods": r.get("methods"),
+                                "strip_path": r.get("strip_path", True),
+                            }
+                            for r in routes_data.get("data", [])
+                        ]
+                    services.append(service_entry)
+        except Exception as e:
+            logger.warning("Failed to fetch Kong services: %s", e)
+
+        try:
+            resp = await self._client.get("/plugins")
+            if resp.status_code == 200:
+                data = resp.json()
+                for p in data.get("data", []):
+                    # Resolve service name from service.id
+                    service_id = ""
+                    svc_ref = p.get("service")
+                    if isinstance(svc_ref, dict):
+                        service_id = svc_ref.get("id", "")
+                    elif isinstance(svc_ref, str):
+                        service_id = svc_ref
+                    service_name = self._resolve_service_name(services, service_id)
+                    plugins.append(
+                        {
+                            "name": p.get("name", ""),
+                            "service": service_name,
+                            "config": p.get("config", {}),
+                            "tags": p.get("tags", []),
+                        }
+                    )
+        except Exception as e:
+            logger.warning("Failed to fetch Kong plugins: %s", e)
+
+        try:
+            resp = await self._client.get("/consumers")
+            if resp.status_code == 200:
+                data = resp.json()
+                consumers = [
+                    {
+                        "username": c.get("username", ""),
+                        "tags": c.get("tags", []),
+                    }
+                    for c in data.get("data", [])
+                ]
+        except Exception as e:
+            logger.warning("Failed to fetch Kong consumers: %s", e)
+
+        return {"services": services, "plugins": plugins, "consumers": consumers}
+
+    @staticmethod
+    def _resolve_service_name(services: list[dict], service_id: str) -> str:
+        """Resolve a service ID to its name (best-effort)."""
+        # In declarative config, service reference is by name
+        # This is a fallback; in practice the service_id might be the name
+        for svc in services:
+            if svc.get("id") == service_id or svc.get("name") == service_id:
+                return svc.get("name", "")
+        return service_id
+
+    @staticmethod
+    def _build_config(
+        services: list[dict],
+        plugins: list[dict],
+        consumers: list[dict],
+    ) -> dict:
+        """Build a full Kong declarative config payload."""
+        config: dict = {"_format_version": "3.0", "services": services}
+        if plugins:
+            config["plugins"] = plugins
+        if consumers:
+            config["consumers"] = consumers
+        return config
+
+    async def _reload_config(self, config_payload: dict) -> AdapterResult:
+        """POST /config to atomically reload the full Kong declarative config."""
+        try:
+            resp = await self._client.post("/config", json=config_payload)
+            if resp.status_code in (200, 201):
+                return AdapterResult(success=True)
+            return AdapterResult(
+                success=False,
+                error=f"Kong config reload failed: HTTP {resp.status_code} — {resp.text}",
+            )
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))

--- a/control-plane-api/src/adapters/kong/mappers.py
+++ b/control-plane-api/src/adapters/kong/mappers.py
@@ -35,3 +35,131 @@ def map_kong_service_to_cp(service: dict) -> dict:
         "protocol": service.get("protocol", "http"),
         "enabled": service.get("enabled", True),
     }
+
+
+def map_policy_to_kong_plugin(policy_spec: dict, service_name: str) -> dict:
+    """Map STOA policy spec to a Kong plugin in declarative config format.
+
+    Supported policy types:
+    - rate_limit → rate-limiting plugin
+    - cors → cors plugin
+    """
+    policy_type = policy_spec.get("type", "")
+    config = policy_spec.get("config", {})
+
+    if policy_type == "rate_limit":
+        max_requests = config.get("maxRequests", 100)
+        interval = config.get("intervalSeconds", 60)
+        plugin_config = {"minute": max_requests} if interval == 60 else {"second": max_requests}
+        return {
+            "name": "rate-limiting",
+            "service": service_name,
+            "config": plugin_config,
+            "tags": [f"stoa-policy-{policy_spec.get('id', '')}"],
+        }
+
+    if policy_type == "cors":
+        return {
+            "name": "cors",
+            "service": service_name,
+            "config": {
+                "origins": config.get("origins", ["*"]),
+                "methods": config.get("methods", ["GET", "POST", "PUT", "DELETE"]),
+                "headers": config.get("headers", ["Content-Type", "Authorization"]),
+                "max_age": config.get("max_age", 3600),
+            },
+            "tags": [f"stoa-policy-{policy_spec.get('id', '')}"],
+        }
+
+    return {
+        "name": policy_type.replace("_", "-"),
+        "service": service_name,
+        "config": config,
+        "tags": [f"stoa-policy-{policy_spec.get('id', '')}"],
+    }
+
+
+def map_kong_plugin_to_policy(plugin: dict) -> dict:
+    """Map a Kong plugin object to CP-normalized policy dict."""
+    plugin_name = plugin.get("name", "")
+    kong_config = plugin.get("config", {})
+
+    if plugin_name == "rate-limiting":
+        minute = kong_config.get("minute", 0)
+        second = kong_config.get("second", 0)
+        max_requests = minute or (second * 60) or 100
+        interval = 60 if minute else 1
+        cp_config = {"maxRequests": max_requests, "intervalSeconds": interval}
+        policy_type = "rate_limit"
+    elif plugin_name == "cors":
+        cp_config = {
+            "origins": kong_config.get("origins", []),
+            "methods": kong_config.get("methods", []),
+            "headers": kong_config.get("headers", []),
+            "max_age": kong_config.get("max_age", 3600),
+        }
+        policy_type = "cors"
+    else:
+        cp_config = kong_config
+        policy_type = plugin_name.replace("-", "_")
+
+    tags = plugin.get("tags", [])
+    stoa_id = ""
+    for tag in tags:
+        if tag.startswith("stoa-policy-"):
+            stoa_id = tag.removeprefix("stoa-policy-")
+            break
+
+    return {
+        "id": stoa_id or plugin.get("id", ""),
+        "name": plugin_name,
+        "type": policy_type,
+        "config": cp_config,
+        "service": plugin.get("service", ""),
+    }
+
+
+def map_app_spec_to_kong_consumer(app_spec: dict) -> dict:
+    """Map CP app_spec to a Kong consumer entry for declarative config.
+
+    Returns a consumer dict with username, key-auth credentials, and
+    optional rate-limiting plugin scoped to the consumer.
+    """
+    consumer_id = app_spec.get("consumer_external_id", app_spec.get("application_name", "unknown"))
+    api_key = app_spec.get("api_key", f"key-{consumer_id}")
+
+    consumer: dict = {
+        "username": consumer_id,
+        "keyauth_credentials": [{"key": api_key}],
+        "tags": [f"stoa-consumer-{app_spec.get('subscription_id', '')}"],
+    }
+
+    rate_per_minute = app_spec.get("rate_limit_per_minute")
+    rate_per_second = app_spec.get("rate_limit_per_second")
+    if rate_per_minute or rate_per_second:
+        rate = rate_per_minute or (rate_per_second * 60 if rate_per_second else 100)
+        consumer["plugins"] = [
+            {
+                "name": "rate-limiting",
+                "config": {"minute": rate},
+            }
+        ]
+
+    return consumer
+
+
+def map_kong_consumer_to_cp(consumer: dict) -> dict:
+    """Map a Kong consumer object to CP-normalized application dict."""
+    tags = consumer.get("tags", [])
+    subscription_id = ""
+    for tag in tags:
+        if tag.startswith("stoa-consumer-"):
+            subscription_id = tag.removeprefix("stoa-consumer-")
+            break
+
+    return {
+        "id": consumer.get("id", ""),
+        "username": consumer.get("username", ""),
+        "subscription_id": subscription_id,
+        "created_at": consumer.get("created_at"),
+    }

--- a/control-plane-api/tests/test_gravitee_adapter.py
+++ b/control-plane-api/tests/test_gravitee_adapter.py
@@ -5,7 +5,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.adapters.gravitee.adapter import GraviteeGatewayAdapter
-from src.adapters.gravitee.mappers import map_api_spec_to_gravitee_v4, map_gravitee_api_to_cp
+from src.adapters.gravitee.mappers import (
+    map_api_spec_to_gravitee_v4,
+    map_app_spec_to_gravitee_app,
+    map_gravitee_api_to_cp,
+    map_gravitee_app_to_cp,
+    map_gravitee_plan_to_policy,
+    map_policy_to_gravitee_plan,
+)
 
 # --- Mapper tests ---
 
@@ -25,6 +32,15 @@ class TestGraviteeMappers:
         target = result["endpointGroups"][0]["endpoints"][0]["configuration"]["target"]
         assert target == "https://payments.example.com"
 
+    def test_map_api_spec_includes_methods(self):
+        spec = {
+            "api_name": "orders",
+            "backend_url": "http://backend",
+            "methods": ["GET", "POST"],
+        }
+        result = map_api_spec_to_gravitee_v4(spec, "t1")
+        assert result["listeners"][0]["methods"] == ["GET", "POST"]
+
     def test_map_gravitee_api_to_cp(self):
         api = {
             "id": "grav-123",
@@ -40,6 +56,90 @@ class TestGraviteeMappers:
         assert result["name"] == "acme-api"
         assert result["state"] == "STARTED"
         assert result["definition_version"] == "V4"
+
+    def test_map_policy_to_gravitee_plan_rate_limit(self):
+        policy = {
+            "id": "pol-1",
+            "type": "rate_limit",
+            "config": {"maxRequests": 100, "intervalSeconds": 60},
+        }
+        result = map_policy_to_gravitee_plan(policy, "acme-api")
+
+        assert result["name"] == "stoa-rate-limit-pol-1"
+        assert result["validation"] == "AUTO"
+        assert result["security"]["type"] == "KEY_LESS"
+        flow = result["flows"][0]
+        assert flow["request"][0]["policy"] == "rate-limit"
+        rate_config = flow["request"][0]["configuration"]["rate"]
+        assert rate_config["limit"] == 100
+        assert rate_config["periodTimeUnit"] == "MINUTES"
+        assert "stoa-policy-pol-1" in result["tags"]
+
+    def test_map_policy_to_gravitee_plan_per_second(self):
+        policy = {
+            "id": "pol-2",
+            "type": "rate_limit",
+            "config": {"maxRequests": 10, "intervalSeconds": 1},
+        }
+        result = map_policy_to_gravitee_plan(policy, "api")
+        rate_config = result["flows"][0]["request"][0]["configuration"]["rate"]
+        assert rate_config["periodTimeUnit"] == "SECONDS"
+
+    def test_map_policy_to_gravitee_plan_generic(self):
+        policy = {
+            "id": "pol-gen",
+            "type": "ip_restriction",
+            "config": {"allow": ["10.0.0.0/8"]},
+        }
+        result = map_policy_to_gravitee_plan(policy, "api")
+
+        assert result["name"] == "stoa-ip_restriction-pol-gen"
+        assert result["flows"][0]["request"][0]["policy"] == "ip-restriction"
+
+    def test_map_gravitee_plan_to_policy(self):
+        plan = {
+            "id": "plan-123",
+            "name": "stoa-rate-limit-pol-1",
+            "tags": ["stoa-policy-pol-1"],
+            "flows": [
+                {
+                    "request": [
+                        {
+                            "policy": "rate-limit",
+                            "configuration": {
+                                "rate": {
+                                    "limit": 200,
+                                    "periodTime": 1,
+                                    "periodTimeUnit": "MINUTES",
+                                }
+                            },
+                        }
+                    ]
+                }
+            ],
+        }
+        result = map_gravitee_plan_to_policy(plan)
+
+        assert result["id"] == "pol-1"
+        assert result["type"] == "rate_limit"
+        assert result["config"]["maxRequests"] == 200
+        assert result["config"]["intervalSeconds"] == 60
+        assert result["plan_id"] == "plan-123"
+
+    def test_map_app_spec_to_gravitee_app(self):
+        spec = {
+            "consumer_external_id": "consumer-42",
+        }
+        result = map_app_spec_to_gravitee_app(spec)
+        assert result["name"] == "consumer-42"
+        assert result["settings"]["app"]["type"] == "SIMPLE"
+
+    def test_map_gravitee_app_to_cp(self):
+        app = {"id": "app-1", "name": "consumer-42", "status": "ACTIVE"}
+        result = map_gravitee_app_to_cp(app)
+        assert result["id"] == "app-1"
+        assert result["name"] == "consumer-42"
+        assert result["status"] == "ACTIVE"
 
 
 # --- Adapter tests ---
@@ -153,12 +253,26 @@ class TestGraviteeAdapterAPIs:
         return adapter, mock_client
 
     @pytest.mark.asyncio
-    async def test_sync_api_success(self):
+    async def test_sync_api_creates_new(self):
         adapter, client = self._make_adapter()
-        mock_resp = MagicMock()
-        mock_resp.status_code = 201
-        mock_resp.json.return_value = {"id": "new-api-id", "name": "acme-test"}
-        client.post = AsyncMock(return_value=mock_resp)
+
+        # _find_api_by_name returns None (new API)
+        search_resp = MagicMock()
+        search_resp.status_code = 200
+        search_resp.json.return_value = {"data": []}
+
+        create_resp = MagicMock()
+        create_resp.status_code = 201
+        create_resp.json.return_value = {"id": "new-api-id", "name": "acme-test"}
+
+        start_resp = MagicMock()
+        start_resp.status_code = 200
+
+        deploy_resp = MagicMock()
+        deploy_resp.status_code = 202
+
+        client.get = AsyncMock(return_value=search_resp)
+        client.post = AsyncMock(side_effect=[create_resp, start_resp, deploy_resp])
 
         result = await adapter.sync_api(
             {"api_name": "test", "backend_url": "http://backend"},
@@ -167,15 +281,55 @@ class TestGraviteeAdapterAPIs:
 
         assert result.success is True
         assert result.resource_id == "new-api-id"
-        client.post.assert_awaited_once()
+        assert result.data["started"] is True
+        # Verify lifecycle: POST (create) + POST (_start) + POST (deploy)
+        assert client.post.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_sync_api_updates_existing(self):
+        adapter, client = self._make_adapter()
+
+        # _find_api_by_name returns an existing ID
+        search_resp = MagicMock()
+        search_resp.status_code = 200
+        search_resp.json.return_value = {"data": [{"id": "existing-id", "name": "acme-test"}]}
+
+        update_resp = MagicMock()
+        update_resp.status_code = 200
+
+        start_resp = MagicMock()
+        start_resp.status_code = 409  # Already started
+
+        deploy_resp = MagicMock()
+        deploy_resp.status_code = 200
+
+        client.get = AsyncMock(return_value=search_resp)
+        client.put = AsyncMock(return_value=update_resp)
+        client.post = AsyncMock(side_effect=[start_resp, deploy_resp])
+
+        result = await adapter.sync_api(
+            {"api_name": "test", "backend_url": "http://backend"},
+            tenant_id="acme",
+        )
+
+        assert result.success is True
+        assert result.resource_id == "existing-id"
+        client.put.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_sync_api_failure(self):
         adapter, client = self._make_adapter()
-        mock_resp = MagicMock()
-        mock_resp.status_code = 400
-        mock_resp.text = "bad request"
-        client.post = AsyncMock(return_value=mock_resp)
+
+        search_resp = MagicMock()
+        search_resp.status_code = 200
+        search_resp.json.return_value = {"data": []}
+
+        create_resp = MagicMock()
+        create_resp.status_code = 400
+        create_resp.text = "bad request"
+
+        client.get = AsyncMock(return_value=search_resp)
+        client.post = AsyncMock(return_value=create_resp)
 
         result = await adapter.sync_api(
             {"api_name": "test", "backend_url": "http://backend"},
@@ -186,26 +340,53 @@ class TestGraviteeAdapterAPIs:
         assert "400" in result.error
 
     @pytest.mark.asyncio
-    async def test_delete_api_success(self):
+    async def test_delete_api_with_lifecycle(self):
         adapter, client = self._make_adapter()
-        mock_resp = MagicMock()
-        mock_resp.status_code = 204
-        client.delete = AsyncMock(return_value=mock_resp)
+
+        stop_resp = MagicMock()
+        stop_resp.status_code = 200
+
+        # Plans list for _close_all_plans
+        plans_resp = MagicMock()
+        plans_resp.status_code = 200
+        plans_resp.json.return_value = {"data": [{"id": "plan-1", "status": "PUBLISHED"}]}
+
+        close_resp = MagicMock()
+        close_resp.status_code = 200
+
+        delete_resp = MagicMock()
+        delete_resp.status_code = 204
+
+        client.post = AsyncMock(side_effect=[stop_resp, close_resp])
+        client.get = AsyncMock(return_value=plans_resp)
+        client.delete = AsyncMock(return_value=delete_resp)
 
         result = await adapter.delete_api("api-123")
 
         assert result.success is True
         assert result.resource_id == "api-123"
+        # Verify lifecycle: POST _stop + POST _close(plan) + DELETE
+        assert client.post.await_count == 2
 
     @pytest.mark.asyncio
     async def test_delete_api_not_found_idempotent(self):
         adapter, client = self._make_adapter()
-        mock_resp = MagicMock()
-        mock_resp.status_code = 404
-        client.delete = AsyncMock(return_value=mock_resp)
+
+        stop_resp = MagicMock()
+        stop_resp.status_code = 404
+
+        plans_resp = MagicMock()
+        plans_resp.status_code = 200
+        plans_resp.json.return_value = {"data": []}
+
+        delete_resp = MagicMock()
+        delete_resp.status_code = 404
+
+        client.post = AsyncMock(return_value=stop_resp)
+        client.get = AsyncMock(return_value=plans_resp)
+        client.delete = AsyncMock(return_value=delete_resp)
 
         result = await adapter.delete_api("gone")
-
         assert result.success is True
 
     @pytest.mark.asyncio
@@ -243,26 +424,283 @@ class TestGraviteeAdapterAPIs:
         assert apis == []
 
 
+class TestGraviteeAdapterPolicies:
+    def _make_adapter(self):
+        adapter = GraviteeGatewayAdapter(config={"base_url": "http://gravitee:8083"})
+        mock_client = AsyncMock()
+        adapter._client = mock_client
+        return adapter, mock_client
+
+    @pytest.mark.asyncio
+    async def test_upsert_policy_creates_plan(self):
+        adapter, client = self._make_adapter()
+
+        # _find_plan_by_stoa_id returns None (new plan)
+        plans_resp = MagicMock()
+        plans_resp.status_code = 200
+        plans_resp.json.return_value = {"data": []}
+
+        create_resp = MagicMock()
+        create_resp.status_code = 201
+        create_resp.json.return_value = {"id": "plan-new"}
+
+        publish_resp = MagicMock()
+        publish_resp.status_code = 200
+
+        client.get = AsyncMock(return_value=plans_resp)
+        client.post = AsyncMock(side_effect=[create_resp, publish_resp])
+
+        result = await adapter.upsert_policy(
+            {
+                "id": "pol-1",
+                "type": "rate_limit",
+                "config": {"maxRequests": 100, "intervalSeconds": 60},
+                "api_id": "api-123",
+            }
+        )
+
+        assert result.success is True
+        assert result.resource_id == "pol-1"
+        assert result.data["plan_id"] == "plan-new"
+
+    @pytest.mark.asyncio
+    async def test_upsert_policy_updates_existing(self):
+        adapter, client = self._make_adapter()
+
+        # _find_plan_by_stoa_id returns existing plan
+        plans_resp = MagicMock()
+        plans_resp.status_code = 200
+        plans_resp.json.return_value = {"data": [{"id": "plan-existing", "tags": ["stoa-policy-pol-1"]}]}
+
+        update_resp = MagicMock()
+        update_resp.status_code = 200
+        update_resp.json.return_value = {"id": "plan-existing"}
+
+        publish_resp = MagicMock()
+        publish_resp.status_code = 200
+
+        client.get = AsyncMock(return_value=plans_resp)
+        client.put = AsyncMock(return_value=update_resp)
+        client.post = AsyncMock(return_value=publish_resp)
+
+        result = await adapter.upsert_policy(
+            {
+                "id": "pol-1",
+                "type": "rate_limit",
+                "config": {"maxRequests": 200, "intervalSeconds": 60},
+                "api_id": "api-123",
+            }
+        )
+
+        assert result.success is True
+        client.put.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_upsert_policy_requires_api_id(self):
+        adapter, _client = self._make_adapter()
+
+        result = await adapter.upsert_policy(
+            {
+                "id": "pol-1",
+                "type": "rate_limit",
+                "config": {},
+            }
+        )
+
+        assert result.success is False
+        assert "api_id" in result.error
+
+    @pytest.mark.asyncio
+    async def test_delete_policy_with_api_id(self):
+        adapter, client = self._make_adapter()
+
+        # _find_plan_by_stoa_id returns a plan
+        plans_resp = MagicMock()
+        plans_resp.status_code = 200
+        plans_resp.json.return_value = {"data": [{"id": "plan-1", "tags": ["stoa-policy-pol-1"]}]}
+
+        close_resp = MagicMock()
+        close_resp.status_code = 200
+
+        delete_resp = MagicMock()
+        delete_resp.status_code = 204
+
+        client.get = AsyncMock(return_value=plans_resp)
+        client.post = AsyncMock(return_value=close_resp)
+        client.delete = AsyncMock(return_value=delete_resp)
+
+        result = await adapter.delete_policy("api-123:pol-1")
+
+        assert result.success is True
+        assert result.resource_id == "api-123:pol-1"
+
+    @pytest.mark.asyncio
+    async def test_list_policies(self):
+        adapter, client = self._make_adapter()
+
+        # Mock list_apis
+        apis_resp = MagicMock()
+        apis_resp.status_code = 200
+        apis_resp.json.return_value = {
+            "data": [{"id": "api-1", "name": "test", "state": "STARTED", "visibility": "", "definitionVersion": "V4"}]
+        }
+
+        plans_resp = MagicMock()
+        plans_resp.status_code = 200
+        plans_resp.json.return_value = {
+            "data": [
+                {
+                    "id": "plan-1",
+                    "name": "stoa-rate-limit-pol-1",
+                    "tags": ["stoa-policy-pol-1"],
+                    "flows": [
+                        {
+                            "request": [
+                                {
+                                    "policy": "rate-limit",
+                                    "configuration": {
+                                        "rate": {"limit": 100, "periodTime": 1, "periodTimeUnit": "MINUTES"}
+                                    },
+                                }
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "id": "plan-2",
+                    "name": "non-stoa-plan",
+                    "tags": [],
+                    "flows": [],
+                },
+            ]
+        }
+
+        client.get = AsyncMock(side_effect=[apis_resp, plans_resp])
+
+        policies = await adapter.list_policies()
+
+        assert len(policies) == 1
+        assert policies[0]["type"] == "rate_limit"
+        assert policies[0]["id"] == "pol-1"
+
+
+class TestGraviteeAdapterApplications:
+    def _make_adapter(self):
+        adapter = GraviteeGatewayAdapter(config={"base_url": "http://gravitee:8083"})
+        mock_client = AsyncMock()
+        adapter._client = mock_client
+        return adapter, mock_client
+
+    @pytest.mark.asyncio
+    async def test_provision_application(self):
+        adapter, client = self._make_adapter()
+
+        # Create app
+        create_resp = MagicMock()
+        create_resp.status_code = 201
+        create_resp.json.return_value = {"id": "app-new"}
+
+        # _ensure_rate_limit_plan: list plans returns empty, then upsert creates
+        plans_resp = MagicMock()
+        plans_resp.status_code = 200
+        plans_resp.json.return_value = {"data": []}
+
+        plan_create_resp = MagicMock()
+        plan_create_resp.status_code = 201
+        plan_create_resp.json.return_value = {"id": "plan-rl"}
+
+        publish_resp = MagicMock()
+        publish_resp.status_code = 200
+
+        sub_resp = MagicMock()
+        sub_resp.status_code = 201
+        sub_resp.json.return_value = {"id": "sub-1"}
+
+        client.get = AsyncMock(return_value=plans_resp)
+        client.post = AsyncMock(side_effect=[create_resp, plan_create_resp, publish_resp, sub_resp])
+
+        result = await adapter.provision_application(
+            {
+                "consumer_external_id": "consumer-42",
+                "api_id": "api-123",
+                "subscription_id": "sub-1",
+                "rate_limit_per_minute": 100,
+            }
+        )
+
+        assert result.success is True
+        assert result.resource_id == "app-new"
+        assert result.data["subscription_id"] == "sub-1"
+
+    @pytest.mark.asyncio
+    async def test_provision_application_no_api_id(self):
+        adapter, client = self._make_adapter()
+
+        create_resp = MagicMock()
+        create_resp.status_code = 201
+        create_resp.json.return_value = {"id": "app-new"}
+
+        client.post = AsyncMock(return_value=create_resp)
+
+        result = await adapter.provision_application(
+            {
+                "consumer_external_id": "consumer-42",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["application_id"] == "app-new"
+
+    @pytest.mark.asyncio
+    async def test_deprovision_application(self):
+        adapter, client = self._make_adapter()
+
+        # List subscriptions
+        subs_resp = MagicMock()
+        subs_resp.status_code = 200
+        subs_resp.json.return_value = {"data": [{"id": "sub-1"}, {"id": "sub-2"}]}
+
+        close_resp = MagicMock()
+        close_resp.status_code = 200
+
+        delete_resp = MagicMock()
+        delete_resp.status_code = 204
+
+        client.get = AsyncMock(return_value=subs_resp)
+        client.post = AsyncMock(return_value=close_resp)
+        client.delete = AsyncMock(return_value=delete_resp)
+
+        result = await adapter.deprovision_application("app-1")
+
+        assert result.success is True
+        assert result.resource_id == "app-1"
+        # Should close 2 subscriptions
+        assert client.post.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_list_applications(self):
+        adapter, client = self._make_adapter()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "data": [
+                {"id": "app-1", "name": "consumer-42", "status": "ACTIVE"},
+                {"id": "app-2", "name": "consumer-99", "status": "ACTIVE"},
+            ]
+        }
+        client.get = AsyncMock(return_value=mock_resp)
+
+        apps = await adapter.list_applications()
+
+        assert len(apps) == 2
+        assert apps[0]["name"] == "consumer-42"
+        assert apps[1]["name"] == "consumer-99"
+
+
 class TestGraviteeAdapterUnsupported:
     @pytest.mark.asyncio
     async def test_unsupported_methods(self):
         adapter = GraviteeGatewayAdapter()
-
-        r = await adapter.upsert_policy({})
-        assert r.success is False
-
-        r = await adapter.delete_policy("p1")
-        assert r.success is False
-
-        assert await adapter.list_policies() == []
-
-        r = await adapter.provision_application({})
-        assert r.success is False
-
-        r = await adapter.deprovision_application("a1")
-        assert r.success is False
-
-        assert await adapter.list_applications() == []
 
         r = await adapter.upsert_auth_server({})
         assert r.success is False

--- a/control-plane-api/tests/test_kong_adapter.py
+++ b/control-plane-api/tests/test_kong_adapter.py
@@ -5,7 +5,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.adapters.kong.adapter import KongGatewayAdapter
-from src.adapters.kong.mappers import map_api_spec_to_kong_service, map_kong_service_to_cp
+from src.adapters.kong.mappers import (
+    map_api_spec_to_kong_service,
+    map_app_spec_to_kong_consumer,
+    map_kong_consumer_to_cp,
+    map_kong_plugin_to_policy,
+    map_kong_service_to_cp,
+    map_policy_to_kong_plugin,
+)
 
 # --- Mapper tests ---
 
@@ -48,6 +55,109 @@ class TestKongMappers:
         assert result["name"] == "acme-orders-api"
         assert result["host"] == "api.example.com"
         assert result["port"] == 443
+
+    def test_map_policy_to_kong_plugin_rate_limit(self):
+        policy = {
+            "id": "pol-1",
+            "type": "rate_limit",
+            "config": {"maxRequests": 100, "intervalSeconds": 60},
+        }
+        result = map_policy_to_kong_plugin(policy, "acme-api")
+
+        assert result["name"] == "rate-limiting"
+        assert result["service"] == "acme-api"
+        assert result["config"]["minute"] == 100
+        assert "stoa-policy-pol-1" in result["tags"]
+
+    def test_map_policy_to_kong_plugin_rate_limit_per_second(self):
+        policy = {
+            "id": "pol-2",
+            "type": "rate_limit",
+            "config": {"maxRequests": 10, "intervalSeconds": 1},
+        }
+        result = map_policy_to_kong_plugin(policy, "svc")
+
+        assert result["config"]["second"] == 10
+
+    def test_map_policy_to_kong_plugin_cors(self):
+        policy = {
+            "id": "pol-cors",
+            "type": "cors",
+            "config": {"origins": ["https://example.com"]},
+        }
+        result = map_policy_to_kong_plugin(policy, "svc")
+
+        assert result["name"] == "cors"
+        assert result["config"]["origins"] == ["https://example.com"]
+
+    def test_map_policy_to_kong_plugin_generic(self):
+        policy = {
+            "id": "pol-custom",
+            "type": "ip_restriction",
+            "config": {"allow": ["10.0.0.0/8"]},
+        }
+        result = map_policy_to_kong_plugin(policy, "svc")
+
+        assert result["name"] == "ip-restriction"
+        assert result["config"]["allow"] == ["10.0.0.0/8"]
+
+    def test_map_kong_plugin_to_policy_rate_limit(self):
+        plugin = {
+            "id": "k-plugin-1",
+            "name": "rate-limiting",
+            "config": {"minute": 200},
+            "service": "acme-api",
+            "tags": ["stoa-policy-pol-1"],
+        }
+        result = map_kong_plugin_to_policy(plugin)
+
+        assert result["id"] == "pol-1"
+        assert result["type"] == "rate_limit"
+        assert result["config"]["maxRequests"] == 200
+        assert result["config"]["intervalSeconds"] == 60
+
+    def test_map_kong_plugin_to_policy_cors(self):
+        plugin = {
+            "name": "cors",
+            "config": {"origins": ["*"], "methods": ["GET"]},
+            "tags": [],
+        }
+        result = map_kong_plugin_to_policy(plugin)
+        assert result["type"] == "cors"
+
+    def test_map_app_spec_to_kong_consumer(self):
+        spec = {
+            "consumer_external_id": "consumer-42",
+            "api_key": "my-secret-key",
+            "subscription_id": "sub-1",
+            "rate_limit_per_minute": 500,
+        }
+        result = map_app_spec_to_kong_consumer(spec)
+
+        assert result["username"] == "consumer-42"
+        assert result["keyauth_credentials"][0]["key"] == "my-secret-key"
+        assert "stoa-consumer-sub-1" in result["tags"]
+        assert result["plugins"][0]["config"]["minute"] == 500
+
+    def test_map_app_spec_to_kong_consumer_no_rate_limit(self):
+        spec = {"consumer_external_id": "consumer-no-rl", "subscription_id": "sub-2"}
+        result = map_app_spec_to_kong_consumer(spec)
+
+        assert result["username"] == "consumer-no-rl"
+        assert "plugins" not in result
+
+    def test_map_kong_consumer_to_cp(self):
+        consumer = {
+            "id": "k-consumer-1",
+            "username": "consumer-42",
+            "tags": ["stoa-consumer-sub-1"],
+            "created_at": 1234567890,
+        }
+        result = map_kong_consumer_to_cp(consumer)
+
+        assert result["id"] == "k-consumer-1"
+        assert result["username"] == "consumer-42"
+        assert result["subscription_id"] == "sub-1"
 
 
 # --- Adapter tests ---
@@ -169,13 +279,22 @@ class TestKongAdapterAPIs:
         adapter._client = mock_client
         return adapter, mock_client
 
+    def _mock_empty_state(self, client):
+        """Mock GET endpoints to return empty state."""
+        empty_resp = MagicMock()
+        empty_resp.status_code = 200
+        empty_resp.json.return_value = {"data": []}
+        client.get = AsyncMock(return_value=empty_resp)
+
     @pytest.mark.asyncio
-    async def test_sync_api_success(self):
+    async def test_sync_api_with_state_management(self):
         adapter, client = self._make_adapter()
-        mock_resp = MagicMock()
-        mock_resp.status_code = 201
-        mock_resp.json.return_value = {}
-        client.post = AsyncMock(return_value=mock_resp)
+        self._mock_empty_state(client)
+
+        # POST /config succeeds
+        config_resp = MagicMock()
+        config_resp.status_code = 200
+        client.post = AsyncMock(return_value=config_resp)
 
         result = await adapter.sync_api(
             {"api_name": "test", "backend_url": "http://backend"},
@@ -184,13 +303,54 @@ class TestKongAdapterAPIs:
 
         assert result.success is True
         assert result.resource_id == "acme-test"
+        # Verify POST /config was called
         client.post.assert_awaited_once()
         call_args = client.post.call_args
         assert call_args[0][0] == "/config"
+        config = call_args[1]["json"]
+        assert config["_format_version"] == "3.0"
+        assert len(config["services"]) == 1
+        assert config["services"][0]["name"] == "acme-test"
+
+    @pytest.mark.asyncio
+    async def test_sync_api_upserts_existing(self):
+        adapter, client = self._make_adapter()
+
+        # Mock existing service in state
+        svc_resp = MagicMock()
+        svc_resp.status_code = 200
+        svc_resp.json.return_value = {
+            "data": [{"id": "s1", "name": "acme-test", "host": "old", "port": 80, "protocol": "http", "path": ""}]
+        }
+        routes_resp = MagicMock()
+        routes_resp.status_code = 200
+        routes_resp.json.return_value = {"data": []}
+        empty_resp = MagicMock()
+        empty_resp.status_code = 200
+        empty_resp.json.return_value = {"data": []}
+
+        client.get = AsyncMock(side_effect=[svc_resp, routes_resp, empty_resp, empty_resp])
+
+        config_resp = MagicMock()
+        config_resp.status_code = 200
+        client.post = AsyncMock(return_value=config_resp)
+
+        result = await adapter.sync_api(
+            {"api_name": "test", "backend_url": "http://new-backend"},
+            tenant_id="acme",
+        )
+
+        assert result.success is True
+        config = client.post.call_args[1]["json"]
+        # Should have exactly 1 service (replaced, not duplicated)
+        assert len(config["services"]) == 1
+        assert config["services"][0]["url"] == "http://new-backend"
 
     @pytest.mark.asyncio
     async def test_sync_api_failure(self):
         adapter, client = self._make_adapter()
+        self._mock_empty_state(client)
+
         mock_resp = MagicMock()
         mock_resp.status_code = 400
         mock_resp.text = "bad config"
@@ -203,6 +363,41 @@ class TestKongAdapterAPIs:
 
         assert result.success is False
         assert "400" in result.error
+
+    @pytest.mark.asyncio
+    async def test_delete_api_with_state_management(self):
+        adapter, client = self._make_adapter()
+
+        # Mock existing service
+        svc_resp = MagicMock()
+        svc_resp.status_code = 200
+        svc_resp.json.return_value = {
+            "data": [
+                {"id": "s1", "name": "acme-test", "host": "h", "port": 80, "protocol": "http", "path": ""},
+                {"id": "s2", "name": "acme-other", "host": "h2", "port": 80, "protocol": "http", "path": ""},
+            ]
+        }
+        routes_resp = MagicMock()
+        routes_resp.status_code = 200
+        routes_resp.json.return_value = {"data": []}
+        empty_resp = MagicMock()
+        empty_resp.status_code = 200
+        empty_resp.json.return_value = {"data": []}
+
+        client.get = AsyncMock(side_effect=[svc_resp, routes_resp, routes_resp, empty_resp, empty_resp])
+
+        config_resp = MagicMock()
+        config_resp.status_code = 200
+        client.post = AsyncMock(return_value=config_resp)
+
+        result = await adapter.delete_api("acme-test")
+
+        assert result.success is True
+        assert result.resource_id == "acme-test"
+        config = client.post.call_args[1]["json"]
+        # Should have only 1 service remaining
+        assert len(config["services"]) == 1
+        assert config["services"][0]["name"] == "acme-other"
 
     @pytest.mark.asyncio
     async def test_list_apis(self):
@@ -223,34 +418,237 @@ class TestKongAdapterAPIs:
         assert apis[0]["name"] == "svc1"
         assert apis[1]["port"] == 443
 
+
+class TestKongAdapterPolicies:
+    def _make_adapter(self):
+        adapter = KongGatewayAdapter(config={"base_url": "http://kong:8001"})
+        mock_client = AsyncMock()
+        adapter._client = mock_client
+        return adapter, mock_client
+
+    def _mock_empty_state(self, client):
+        empty_resp = MagicMock()
+        empty_resp.status_code = 200
+        empty_resp.json.return_value = {"data": []}
+        client.get = AsyncMock(return_value=empty_resp)
+
     @pytest.mark.asyncio
-    async def test_delete_api_dbless(self):
-        adapter = KongGatewayAdapter()
-        result = await adapter.delete_api("some-id")
+    async def test_upsert_policy(self):
+        adapter, client = self._make_adapter()
+        self._mock_empty_state(client)
+
+        config_resp = MagicMock()
+        config_resp.status_code = 200
+        client.post = AsyncMock(return_value=config_resp)
+
+        result = await adapter.upsert_policy(
+            {
+                "id": "pol-1",
+                "type": "rate_limit",
+                "config": {"maxRequests": 100, "intervalSeconds": 60},
+                "api_id": "acme-api",
+            }
+        )
+
         assert result.success is True
-        assert result.resource_id == "some-id"
+        assert result.resource_id == "pol-1"
+        config = client.post.call_args[1]["json"]
+        assert len(config["plugins"]) == 1
+        assert config["plugins"][0]["name"] == "rate-limiting"
+
+    @pytest.mark.asyncio
+    async def test_upsert_policy_replaces_existing(self):
+        adapter, client = self._make_adapter()
+
+        # Mock existing plugin with same tag
+        svc_resp = MagicMock()
+        svc_resp.status_code = 200
+        svc_resp.json.return_value = {"data": []}
+        plugin_resp = MagicMock()
+        plugin_resp.status_code = 200
+        plugin_resp.json.return_value = {
+            "data": [
+                {
+                    "name": "rate-limiting",
+                    "service": "acme-api",
+                    "config": {"minute": 50},
+                    "tags": ["stoa-policy-pol-1"],
+                }
+            ]
+        }
+        consumer_resp = MagicMock()
+        consumer_resp.status_code = 200
+        consumer_resp.json.return_value = {"data": []}
+
+        client.get = AsyncMock(side_effect=[svc_resp, plugin_resp, consumer_resp])
+
+        config_resp = MagicMock()
+        config_resp.status_code = 200
+        client.post = AsyncMock(return_value=config_resp)
+
+        result = await adapter.upsert_policy(
+            {
+                "id": "pol-1",
+                "type": "rate_limit",
+                "config": {"maxRequests": 200, "intervalSeconds": 60},
+                "api_id": "acme-api",
+            }
+        )
+
+        assert result.success is True
+        config = client.post.call_args[1]["json"]
+        # Should have exactly 1 plugin (replaced)
+        assert len(config["plugins"]) == 1
+        assert config["plugins"][0]["config"]["minute"] == 200
+
+    @pytest.mark.asyncio
+    async def test_delete_policy(self):
+        adapter, client = self._make_adapter()
+
+        svc_resp = MagicMock()
+        svc_resp.status_code = 200
+        svc_resp.json.return_value = {"data": []}
+        plugin_resp = MagicMock()
+        plugin_resp.status_code = 200
+        plugin_resp.json.return_value = {
+            "data": [
+                {"name": "rate-limiting", "tags": ["stoa-policy-pol-1"], "config": {}, "service": ""},
+                {"name": "cors", "tags": ["stoa-policy-pol-2"], "config": {}, "service": ""},
+            ]
+        }
+        consumer_resp = MagicMock()
+        consumer_resp.status_code = 200
+        consumer_resp.json.return_value = {"data": []}
+
+        client.get = AsyncMock(side_effect=[svc_resp, plugin_resp, consumer_resp])
+
+        config_resp = MagicMock()
+        config_resp.status_code = 200
+        client.post = AsyncMock(return_value=config_resp)
+
+        result = await adapter.delete_policy("pol-1")
+
+        assert result.success is True
+        config = client.post.call_args[1]["json"]
+        # Should have only 1 plugin remaining (cors)
+        assert len(config["plugins"]) == 1
+        assert config["plugins"][0]["name"] == "cors"
+
+    @pytest.mark.asyncio
+    async def test_list_policies(self):
+        adapter, client = self._make_adapter()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "data": [
+                {"name": "rate-limiting", "config": {"minute": 100}, "tags": ["stoa-policy-pol-1"], "service": "svc"},
+                {"name": "cors", "config": {}, "tags": ["some-other-tag"]},  # Not STOA-managed
+                {"name": "cors", "config": {}, "tags": ["stoa-policy-pol-2"], "service": "svc2"},
+            ]
+        }
+        client.get = AsyncMock(return_value=mock_resp)
+
+        policies = await adapter.list_policies()
+
+        assert len(policies) == 2
+        assert policies[0]["type"] == "rate_limit"
+        assert policies[1]["type"] == "cors"
+
+
+class TestKongAdapterApplications:
+    def _make_adapter(self):
+        adapter = KongGatewayAdapter(config={"base_url": "http://kong:8001"})
+        mock_client = AsyncMock()
+        adapter._client = mock_client
+        return adapter, mock_client
+
+    def _mock_empty_state(self, client):
+        empty_resp = MagicMock()
+        empty_resp.status_code = 200
+        empty_resp.json.return_value = {"data": []}
+        client.get = AsyncMock(return_value=empty_resp)
+
+    @pytest.mark.asyncio
+    async def test_provision_application(self):
+        adapter, client = self._make_adapter()
+        self._mock_empty_state(client)
+
+        config_resp = MagicMock()
+        config_resp.status_code = 200
+        client.post = AsyncMock(return_value=config_resp)
+
+        result = await adapter.provision_application(
+            {
+                "consumer_external_id": "consumer-42",
+                "api_key": "secret-key",
+                "subscription_id": "sub-1",
+                "rate_limit_per_minute": 500,
+            }
+        )
+
+        assert result.success is True
+        assert result.resource_id == "consumer-42"
+        config = client.post.call_args[1]["json"]
+        assert len(config["consumers"]) == 1
+        assert config["consumers"][0]["username"] == "consumer-42"
+
+    @pytest.mark.asyncio
+    async def test_deprovision_application(self):
+        adapter, client = self._make_adapter()
+
+        svc_resp = MagicMock()
+        svc_resp.status_code = 200
+        svc_resp.json.return_value = {"data": []}
+        plugin_resp = MagicMock()
+        plugin_resp.status_code = 200
+        plugin_resp.json.return_value = {"data": []}
+        consumer_resp = MagicMock()
+        consumer_resp.status_code = 200
+        consumer_resp.json.return_value = {
+            "data": [
+                {"username": "consumer-42", "tags": ["stoa-consumer-sub-1"]},
+                {"username": "consumer-99", "tags": ["stoa-consumer-sub-2"]},
+            ]
+        }
+
+        client.get = AsyncMock(side_effect=[svc_resp, plugin_resp, consumer_resp])
+
+        config_resp = MagicMock()
+        config_resp.status_code = 200
+        client.post = AsyncMock(return_value=config_resp)
+
+        result = await adapter.deprovision_application("consumer-42")
+
+        assert result.success is True
+        config = client.post.call_args[1]["json"]
+        assert len(config["consumers"]) == 1
+        assert config["consumers"][0]["username"] == "consumer-99"
+
+    @pytest.mark.asyncio
+    async def test_list_applications(self):
+        adapter, client = self._make_adapter()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "data": [
+                {"id": "c1", "username": "consumer-42", "tags": ["stoa-consumer-sub-1"]},
+                {"id": "c2", "username": "non-stoa-consumer", "tags": []},
+                {"id": "c3", "username": "consumer-99", "tags": ["stoa-consumer-sub-2"]},
+            ]
+        }
+        client.get = AsyncMock(return_value=mock_resp)
+
+        apps = await adapter.list_applications()
+
+        assert len(apps) == 2
+        assert apps[0]["username"] == "consumer-42"
+        assert apps[1]["username"] == "consumer-99"
 
 
 class TestKongAdapterUnsupported:
     @pytest.mark.asyncio
     async def test_unsupported_methods(self):
         adapter = KongGatewayAdapter()
-
-        r = await adapter.upsert_policy({})
-        assert r.success is False
-
-        r = await adapter.delete_policy("p1")
-        assert r.success is False
-
-        assert await adapter.list_policies() == []
-
-        r = await adapter.provision_application({})
-        assert r.success is False
-
-        r = await adapter.deprovision_application("a1")
-        assert r.success is False
-
-        assert await adapter.list_applications() == []
 
         r = await adapter.upsert_auth_server({})
         assert r.success is False
@@ -277,3 +675,25 @@ class TestKongRegistration:
         assert AdapterRegistry.has_type("kong") is True
         adapter = AdapterRegistry.create("kong", config={"base_url": "http://test:8001"})
         assert isinstance(adapter, KongGatewayAdapter)
+
+
+class TestKongBuildConfig:
+    def test_build_config_all_entities(self):
+        config = KongGatewayAdapter._build_config(
+            services=[{"name": "svc"}],
+            plugins=[{"name": "rate-limiting"}],
+            consumers=[{"username": "user1"}],
+        )
+        assert config["_format_version"] == "3.0"
+        assert len(config["services"]) == 1
+        assert len(config["plugins"]) == 1
+        assert len(config["consumers"]) == 1
+
+    def test_build_config_empty_optional(self):
+        config = KongGatewayAdapter._build_config(
+            services=[{"name": "svc"}],
+            plugins=[],
+            consumers=[],
+        )
+        assert "plugins" not in config
+        assert "consumers" not in config


### PR DESCRIPTION
## Summary
- **Kong adapter**: Full API lifecycle via declarative config (fetch → merge → POST /config), rate-limit policies via plugins, consumer provisioning with keyauth credentials
- **Gravitee adapter**: Full API lifecycle with start/deploy, policies via Plans with flows, application provisioning with subscriptions
- **73 tests** (38 Kong + 35 Gravitee) covering mappers, adapters, state management, lifecycle, and error paths

## Details

Brings Kong (DB-less) and Gravitee (APIM v4) adapters to feature parity with the STOA adapter:

| Method | Kong | Gravitee |
|--------|------|----------|
| `sync_api` | State mgmt: GET → merge → POST /config | Create/update → _start → deploy |
| `delete_api` | State mgmt: GET → remove → POST /config | _stop → close plans → DELETE |
| `upsert_policy` | Plugin merge via stoa-policy tags | Plan with rate-limit flow |
| `delete_policy` | Plugin removal by tag | Plan close + delete |
| `list_policies` | GET /plugins filtered by tags | Iterate APIs → list Plans |
| `provision_application` | Consumer + keyauth + rate-limiting | Application + Plan + Subscription |
| `deprovision_application` | Consumer removal | Close subscriptions + delete app |
| `list_applications` | GET /consumers filtered by tags | GET /applications |

## Test plan
- [x] `pytest tests/test_kong_adapter.py` — 38 tests pass
- [x] `pytest tests/test_gravitee_adapter.py` — 35 tests pass
- [x] `ruff check . && black --check .` — clean
- [ ] Live validation on OVH VPS (Phase 4, separate ops task)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>