### PR TITLE
feat(ui): environment-scoped queries for APIs page (ADR-040 Phase 3)

### DIFF
--- a/control-plane-ui/src/pages/APIs.test.tsx
+++ b/control-plane-ui/src/pages/APIs.test.tsx
@@ -7,6 +7,19 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 // Mocks
 // ---------------------------------------------------------------------------
 
+vi.mock('../contexts/EnvironmentContext', () => ({
+  useEnvironment: vi.fn(() => ({
+    activeEnvironment: 'dev',
+    activeConfig: { name: 'dev', label: 'Development', mode: 'full', color: 'green' },
+    environments: [
+      { name: 'dev', label: 'Development', mode: 'full', color: 'green' },
+      { name: 'staging', label: 'Staging', mode: 'full', color: 'amber' },
+      { name: 'prod', label: 'Production', mode: 'read-only', color: 'red' },
+    ],
+    switchEnvironment: vi.fn(),
+  })),
+}));
+
 vi.mock('../contexts/AuthContext', () => ({
   useAuth: vi.fn(() => ({
     user: {

--- a/control-plane-ui/src/pages/APIs.tsx
+++ b/control-plane-ui/src/pages/APIs.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiService } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
+import { useEnvironment } from '../contexts/EnvironmentContext';
 import { useDebounce } from '../hooks/useDebounce';
 import type { API, APICreate } from '../types';
 import yaml from 'js-yaml';
@@ -24,6 +25,7 @@ const statusColors: Record<string, string> = {
 
 export function APIs() {
   const { isReady } = useAuth();
+  const { activeEnvironment } = useEnvironment();
   const toast = useToastActions();
   const queryClient = useQueryClient();
   const [confirm, ConfirmDialog] = useConfirm();
@@ -65,8 +67,8 @@ export function APIs() {
     isLoading: apisLoading,
     error: apisError,
   } = useQuery({
-    queryKey: ['apis', selectedTenant],
-    queryFn: () => apiService.getApis(selectedTenant),
+    queryKey: ['apis', selectedTenant, activeEnvironment],
+    queryFn: () => apiService.getApis(selectedTenant, activeEnvironment),
     enabled: !!selectedTenant,
   });
 
@@ -112,8 +114,8 @@ export function APIs() {
   const totalPages = Math.ceil(filteredApis.length / PAGE_SIZE);
 
   const invalidateApis = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: ['apis', selectedTenant] });
-  }, [queryClient, selectedTenant]);
+    queryClient.invalidateQueries({ queryKey: ['apis', selectedTenant, activeEnvironment] });
+  }, [queryClient, selectedTenant, activeEnvironment]);
 
   // Memoized handlers to prevent unnecessary re-renders
   const handleCreate = useCallback(

--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -18,6 +18,8 @@ import type {
   ProspectListResponse,
   ProspectsMetricsResponse,
   ProspectDetail,
+  Environment,
+  EnvironmentConfig,
 } from '../types';
 
 const API_BASE_URL = config.api.baseUrl;
@@ -163,11 +165,17 @@ class ApiService {
     await this.client.delete(`/v1/tenants/${tenantId}`);
   }
 
+  // Environments (ADR-040)
+  async getEnvironments(): Promise<EnvironmentConfig[]> {
+    const { data } = await this.client.get('/v1/environments');
+    return data.environments;
+  }
+
   // APIs
-  async getApis(tenantId: string): Promise<API[]> {
-    const { data } = await this.client.get(`/v1/tenants/${tenantId}/apis`, {
-      params: { page: 1, page_size: 100 },
-    });
+  async getApis(tenantId: string, environment?: Environment): Promise<API[]> {
+    const params: Record<string, unknown> = { page: 1, page_size: 100 };
+    if (environment) params.environment = environment;
+    const { data } = await this.client.get(`/v1/tenants/${tenantId}/apis`, { params });
     return data.items ?? data;
   }
 
@@ -222,8 +230,14 @@ class ApiService {
   }
 
   // Deployments
-  async getDeployments(tenantId: string, apiId?: string): Promise<Deployment[]> {
-    const params = apiId ? { api_id: apiId } : {};
+  async getDeployments(
+    tenantId: string,
+    apiId?: string,
+    environment?: Environment
+  ): Promise<Deployment[]> {
+    const params: Record<string, string> = {};
+    if (apiId) params.api_id = apiId;
+    if (environment) params.environment = environment;
     const { data } = await this.client.get(`/v1/tenants/${tenantId}/deployments`, { params });
     return data;
   }


### PR DESCRIPTION
## Summary
- Add `getEnvironments()`, optional `environment` param to `getApis()` and `getDeployments()` in API service
- Compose React Query keys with `activeEnvironment`: `['apis', tenant, env]`
- Update invalidation callback with environment dependency
- Add `EnvironmentContext` mock to APIs tests — all 415 tests pass

## Context
ADR-040 Phase 3.1 + 3.2 — Environment-scoped queries. When the user switches environment via the selector (PR #331), the APIs page now fetches data for that specific environment.

## Test plan
- [x] `npx tsc -p tsconfig.app.json --noEmit` — clean
- [x] `npm run lint` — 94 warnings (within max 94)
- [x] `npm run format:check` — clean
- [x] `npm run test -- --run` — 415 passed

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>