### PR TITLE
feat(ui): read-only mode for production environment (ADR-040 Phase 5)

### DIFF
--- a/control-plane-ui/src/hooks/useEnvironmentMode.test.ts
+++ b/control-plane-ui/src/hooks/useEnvironmentMode.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useEnvironmentMode } from './useEnvironmentMode';
+
+const mockUseEnvironment = vi.fn();
+const mockUseAuth = vi.fn();
+
+vi.mock('../contexts/EnvironmentContext', () => ({
+  useEnvironment: () => mockUseEnvironment(),
+}));
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+function setupMocks(mode: string, role: string) {
+  mockUseEnvironment.mockReturnValue({
+    activeEnvironment: mode === 'full' ? 'dev' : mode === 'read-only' ? 'prod' : 'staging',
+    activeConfig: { name: 'env', label: 'Env', mode, color: 'green' },
+    environments: [],
+    switchEnvironment: vi.fn(),
+  });
+  mockUseAuth.mockReturnValue({
+    user: { id: 'u1', roles: [role] },
+    hasRole: vi.fn((r: string) => r === role),
+  });
+}
+
+describe('useEnvironmentMode', () => {
+  it('returns all permissions in full mode', () => {
+    setupMocks('full', 'viewer');
+    const { result } = renderHook(() => useEnvironmentMode());
+    expect(result.current).toEqual({
+      canCreate: true,
+      canEdit: true,
+      canDelete: true,
+      canDeploy: true,
+      isReadOnly: false,
+    });
+  });
+
+  it('blocks writes in read-only mode for non-admin', () => {
+    setupMocks('read-only', 'viewer');
+    const { result } = renderHook(() => useEnvironmentMode());
+    expect(result.current).toEqual({
+      canCreate: false,
+      canEdit: false,
+      canDelete: false,
+      canDeploy: false,
+      isReadOnly: true,
+    });
+  });
+
+  it('allows writes in read-only mode for cpi-admin', () => {
+    setupMocks('read-only', 'cpi-admin');
+    const { result } = renderHook(() => useEnvironmentMode());
+    expect(result.current).toEqual({
+      canCreate: true,
+      canEdit: true,
+      canDelete: true,
+      canDeploy: true,
+      isReadOnly: false,
+    });
+  });
+
+  it('allows only deploy in promote-only mode', () => {
+    setupMocks('promote-only', 'devops');
+    const { result } = renderHook(() => useEnvironmentMode());
+    expect(result.current).toEqual({
+      canCreate: false,
+      canEdit: false,
+      canDelete: false,
+      canDeploy: true,
+      isReadOnly: false,
+    });
+  });
+});

--- a/control-plane-ui/src/hooks/useEnvironmentMode.ts
+++ b/control-plane-ui/src/hooks/useEnvironmentMode.ts
@@ -1,0 +1,66 @@
+import { useMemo } from 'react';
+import { useEnvironment } from '../contexts/EnvironmentContext';
+import { useAuth } from '../contexts/AuthContext';
+
+export interface EnvironmentPermissions {
+  canCreate: boolean;
+  canEdit: boolean;
+  canDelete: boolean;
+  canDeploy: boolean;
+  isReadOnly: boolean;
+}
+
+/**
+ * Returns write permissions based on the active environment mode.
+ * - `full` mode: all writes allowed
+ * - `read-only` mode: writes blocked (unless cpi-admin override)
+ * - `promote-only` mode: only deploy/promote allowed
+ */
+export function useEnvironmentMode(): EnvironmentPermissions {
+  const { activeConfig } = useEnvironment();
+  const { hasRole } = useAuth();
+
+  return useMemo(() => {
+    const mode = activeConfig.mode;
+    const isAdmin = hasRole('cpi-admin');
+
+    if (mode === 'full') {
+      return {
+        canCreate: true,
+        canEdit: true,
+        canDelete: true,
+        canDeploy: true,
+        isReadOnly: false,
+      };
+    }
+
+    if (mode === 'read-only') {
+      // cpi-admin can override read-only for emergency hotfixes
+      if (isAdmin) {
+        return {
+          canCreate: true,
+          canEdit: true,
+          canDelete: true,
+          canDeploy: true,
+          isReadOnly: false,
+        };
+      }
+      return {
+        canCreate: false,
+        canEdit: false,
+        canDelete: false,
+        canDeploy: false,
+        isReadOnly: true,
+      };
+    }
+
+    // promote-only: can deploy but not create/edit/delete
+    return {
+      canCreate: false,
+      canEdit: false,
+      canDelete: false,
+      canDeploy: true,
+      isReadOnly: false,
+    };
+  }, [activeConfig.mode, hasRole]);
+}

--- a/control-plane-ui/src/pages/APIs.test.tsx
+++ b/control-plane-ui/src/pages/APIs.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -131,7 +131,27 @@ vi.mock('@stoa/shared/components/Collapsible', () => ({
   Collapsible: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
+const mockUseEnvironmentMode = vi.fn(() => ({
+  canCreate: true,
+  canEdit: true,
+  canDelete: true,
+  canDeploy: true,
+  isReadOnly: false,
+}));
+
+vi.mock('../hooks/useEnvironmentMode', () => ({
+  useEnvironmentMode: () => mockUseEnvironmentMode(),
+}));
+
 import { APIs } from './APIs';
+
+const READ_ONLY_MODE = {
+  canCreate: false,
+  canEdit: false,
+  canDelete: false,
+  canDeploy: false,
+  isReadOnly: true,
+};
 
 function renderAPIs() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -145,6 +165,16 @@ function renderAPIs() {
 }
 
 describe('APIs', () => {
+  afterEach(() => {
+    mockUseEnvironmentMode.mockReturnValue({
+      canCreate: true,
+      canEdit: true,
+      canDelete: true,
+      canDeploy: true,
+      isReadOnly: false,
+    });
+  });
+
   it('renders the page heading', async () => {
     renderAPIs();
     expect(await screen.findByText('Manage API definitions and deployments')).toBeInTheDocument();
@@ -189,5 +219,34 @@ describe('APIs', () => {
     renderAPIs();
     expect(await screen.findByText('https://payments.example.com')).toBeInTheDocument();
     expect(screen.getByText('https://users.example.com')).toBeInTheDocument();
+  });
+
+  it('hides Create API button in read-only mode', async () => {
+    mockUseEnvironmentMode.mockReturnValue(READ_ONLY_MODE);
+    renderAPIs();
+    await screen.findByText('Payment API');
+    expect(screen.queryByText('Create API')).not.toBeInTheDocument();
+  });
+
+  it('shows read-only banner in read-only mode', async () => {
+    mockUseEnvironmentMode.mockReturnValue(READ_ONLY_MODE);
+    renderAPIs();
+    expect(await screen.findByText(/Production environment — read-only/)).toBeInTheDocument();
+  });
+
+  it('hides Edit and Delete buttons in read-only mode', async () => {
+    mockUseEnvironmentMode.mockReturnValue(READ_ONLY_MODE);
+    renderAPIs();
+    await screen.findByText('Payment API');
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+  });
+
+  it('hides Deploy buttons in read-only mode', async () => {
+    mockUseEnvironmentMode.mockReturnValue(READ_ONLY_MODE);
+    renderAPIs();
+    await screen.findByText('Payment API');
+    expect(screen.queryByText('Deploy DEV')).not.toBeInTheDocument();
+    expect(screen.queryByText('Deploy STG')).not.toBeInTheDocument();
   });
 });

--- a/control-plane-ui/src/pages/APIs.tsx
+++ b/control-plane-ui/src/pages/APIs.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiService } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
 import { useEnvironment } from '../contexts/EnvironmentContext';
+import { useEnvironmentMode } from '../hooks/useEnvironmentMode';
 import { useDebounce } from '../hooks/useDebounce';
 import type { API, APICreate } from '../types';
 import yaml from 'js-yaml';
@@ -26,6 +27,7 @@ const statusColors: Record<string, string> = {
 export function APIs() {
   const { isReady } = useAuth();
   const { activeEnvironment } = useEnvironment();
+  const { canCreate, canEdit, canDelete, canDeploy, isReadOnly } = useEnvironmentMode();
   const toast = useToastActions();
   const queryClient = useQueryClient();
   const [confirm, ConfirmDialog] = useConfirm();
@@ -232,17 +234,43 @@ export function APIs() {
             Manage API definitions and deployments
           </p>
         </div>
-        <button
-          onClick={() => setShowCreateModal(true)}
-          disabled={!selectedTenant}
-          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-        >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-          Create API
-        </button>
+        {canCreate && (
+          <button
+            onClick={() => setShowCreateModal(true)}
+            disabled={!selectedTenant}
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            Create API
+          </button>
+        )}
       </div>
+
+      {isReadOnly && (
+        <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-amber-700 dark:text-amber-400 px-4 py-3 rounded-lg text-sm flex items-center gap-2">
+          <svg
+            className="w-5 h-5 flex-shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+            />
+          </svg>
+          Production environment — read-only. Use Promote from staging to deploy changes.
+        </div>
+      )}
 
       {/* Filters */}
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
@@ -444,32 +472,40 @@ export function APIs() {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm">
                     <div className="flex gap-2">
-                      <button
-                        onClick={() => handleDeploy(api, 'dev')}
-                        className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300"
-                        title="Deploy to DEV"
-                      >
-                        Deploy DEV
-                      </button>
-                      <button
-                        onClick={() => handleDeploy(api, 'staging')}
-                        className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-                        title="Deploy to Staging"
-                      >
-                        Deploy STG
-                      </button>
-                      <button
-                        onClick={() => setEditingApi(api)}
-                        className="text-gray-600 hover:text-gray-800 dark:text-neutral-400 dark:hover:text-white"
-                      >
-                        Edit
-                      </button>
-                      <button
-                        onClick={() => handleDelete(api.id, api.display_name || api.name)}
-                        className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
-                      >
-                        Delete
-                      </button>
+                      {canDeploy && (
+                        <>
+                          <button
+                            onClick={() => handleDeploy(api, 'dev')}
+                            className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300"
+                            title="Deploy to DEV"
+                          >
+                            Deploy DEV
+                          </button>
+                          <button
+                            onClick={() => handleDeploy(api, 'staging')}
+                            className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                            title="Deploy to Staging"
+                          >
+                            Deploy STG
+                          </button>
+                        </>
+                      )}
+                      {canEdit && (
+                        <button
+                          onClick={() => setEditingApi(api)}
+                          className="text-gray-600 hover:text-gray-800 dark:text-neutral-400 dark:hover:text-white"
+                        >
+                          Edit
+                        </button>
+                      )}
+                      {canDelete && (
+                        <button
+                          onClick={() => handleDelete(api.id, api.display_name || api.name)}
+                          className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
+                        >
+                          Delete
+                        </button>
+                      )}
                     </div>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- Add `useEnvironmentMode` hook — derives write permissions from active environment config
- `full` mode: all actions allowed (dev, staging)
- `read-only` mode: all writes blocked, amber banner shown (prod for non-admin)
- `promote-only` mode: only deploy/promote allowed
- `cpi-admin` can override read-only mode for emergency hotfixes
- Applied to APIs page: Create/Edit/Delete/Deploy buttons conditionally rendered

## New files
- `control-plane-ui/src/hooks/useEnvironmentMode.ts` — permission hook
- `control-plane-ui/src/hooks/useEnvironmentMode.test.ts` — 4 tests (full, read-only, admin override, promote-only)

## Test plan
- [x] `npx tsc -p tsconfig.app.json --noEmit` — clean
- [x] `npm run lint` — 94 warnings (within max 94)
- [x] `npm run format:check` — clean
- [x] `npm run test -- --run` — 423 passed (415 + 8 new)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>