### PR TITLE
feat(api): environment write guards for read-only mode (ADR-040 Phase 5.3)

### DIFF
--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -24112,6 +24112,24 @@
               "title": "Tenant Id",
               "type": "string"
             }
+          },
+          {
+            "description": "Target environment",
+            "in": "query",
+            "name": "environment",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Target environment",
+              "title": "Environment"
+            }
           }
         ],
         "requestBody": {
@@ -24178,6 +24196,24 @@
             "schema": {
               "title": "Api Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "Target environment",
+            "in": "query",
+            "name": "environment",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Target environment",
+              "title": "Environment"
             }
           }
         ],
@@ -24286,6 +24322,24 @@
             "schema": {
               "title": "Api Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "Target environment",
+            "in": "query",
+            "name": "environment",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Target environment",
+              "title": "Environment"
             }
           }
         ],

--- a/control-plane-api/src/auth/__init__.py
+++ b/control-plane-api/src/auth/__init__.py
@@ -1,4 +1,5 @@
 from .dependencies import User, get_current_user
+from .environment_guard import require_writable_environment
 from .rbac import Permission, Role, require_permission, require_tenant_access
 
 __all__ = [
@@ -8,4 +9,5 @@ __all__ = [
     "get_current_user",
     "require_permission",
     "require_tenant_access",
+    "require_writable_environment",
 ]

--- a/control-plane-api/src/auth/environment_guard.py
+++ b/control-plane-api/src/auth/environment_guard.py
@@ -1,0 +1,52 @@
+"""Environment write guard — ADR-040 Born GitOps
+
+Blocks write operations (POST/PUT/DELETE) in read-only environments.
+cpi-admin can override for emergency hotfixes.
+"""
+
+import logging
+from typing import Literal
+
+from fastapi import Depends, HTTPException, Query
+
+from .dependencies import User, get_current_user
+
+logger = logging.getLogger(__name__)
+
+# Environment modes — mirrors environments.py defaults
+ENVIRONMENT_MODES: dict[str, Literal["full", "read-only", "promote-only"]] = {
+    "dev": "full",
+    "staging": "full",
+    "prod": "read-only",
+}
+
+
+def require_writable_environment(
+    environment: str | None = Query(default=None, description="Target environment"),
+    user: User = Depends(get_current_user),
+) -> User:
+    """FastAPI dependency that blocks writes in read-only environments.
+
+    Usage:
+        @router.post("")
+        async def create_api(user: User = Depends(require_writable_environment)):
+            ...
+    """
+    if not environment:
+        return user
+
+    mode = ENVIRONMENT_MODES.get(environment, "full")
+
+    if mode == "read-only" and "cpi-admin" not in user.roles:
+        logger.warning(
+            "Write blocked in read-only environment",
+            environment=environment,
+            user_id=user.id,
+            username=user.username,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Environment '{environment}' is read-only. Only cpi-admin can perform writes.",
+        )
+
+    return user

--- a/control-plane-api/src/routers/apis.py
+++ b/control-plane-api/src/routers/apis.py
@@ -6,7 +6,14 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
-from ..auth import Permission, User, get_current_user, require_permission, require_tenant_access
+from ..auth import (
+    Permission,
+    User,
+    get_current_user,
+    require_permission,
+    require_tenant_access,
+    require_writable_environment,
+)
 from ..schemas.pagination import PaginatedResponse
 from ..services.git_service import git_service
 from ..services.kafka_service import kafka_service
@@ -124,7 +131,7 @@ async def get_api(tenant_id: str, api_id: str, user: User = Depends(get_current_
         raise HTTPException(status_code=500, detail="Failed to retrieve API")
 
 
-@router.post("", response_model=APIResponse)
+@router.post("", response_model=APIResponse, dependencies=[Depends(require_writable_environment)])
 @require_permission(Permission.APIS_CREATE)
 @require_tenant_access
 async def create_api(tenant_id: str, api: APICreate, user: User = Depends(get_current_user)):
@@ -204,7 +211,7 @@ async def create_api(tenant_id: str, api: APICreate, user: User = Depends(get_cu
         raise HTTPException(status_code=500, detail=f"Failed to create API: {e!s}")
 
 
-@router.put("/{api_id}", response_model=APIResponse)
+@router.put("/{api_id}", response_model=APIResponse, dependencies=[Depends(require_writable_environment)])
 @require_permission(Permission.APIS_UPDATE)
 @require_tenant_access
 async def update_api(tenant_id: str, api_id: str, api: APIUpdate, user: User = Depends(get_current_user)):
@@ -254,7 +261,7 @@ async def update_api(tenant_id: str, api_id: str, api: APIUpdate, user: User = D
         raise HTTPException(status_code=500, detail=f"Failed to update API: {e!s}")
 
 
-@router.delete("/{api_id}")
+@router.delete("/{api_id}", dependencies=[Depends(require_writable_environment)])
 @require_permission(Permission.APIS_DELETE)
 @require_tenant_access
 async def delete_api(tenant_id: str, api_id: str, user: User = Depends(get_current_user)):


### PR DESCRIPTION
## Summary
- Add `require_writable_environment` FastAPI dependency in `auth/environment_guard.py`
- Blocks POST/PUT/DELETE on APIs when `environment=prod` (read-only mode)
- `cpi-admin` role can override read-only for emergency hotfixes
- Applied to create, update, and delete API endpoints via `dependencies=[Depends(...)]`
- Regenerated OpenAPI snapshot (54 new lines for environment query params)

## New files
- `control-plane-api/src/auth/environment_guard.py` — Environment write guard dependency

## Test plan
- [x] `ruff check` on modified files — clean
- [x] `black --check` on modified files — clean
- [x] OpenAPI contract tests — 6 passed
- [x] Snapshot regenerated and committed

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>