### PR TITLE
fix(api): live validation bugs in Kong + Gravitee adapters

### DIFF
--- a/control-plane-api/src/adapters/gravitee/adapter.py
+++ b/control-plane-api/src/adapters/gravitee/adapter.py
@@ -271,8 +271,8 @@ class GraviteeGatewayAdapter(GatewayAdapterInterface):
                     continue
                 plans = await self._list_api_plans(api_id)
                 for plan in plans:
-                    tags = plan.get("tags", [])
-                    if any(isinstance(t, str) and t.startswith("stoa-policy-") for t in tags):
+                    name = plan.get("name", "")
+                    if name.startswith("stoa-"):
                         result.append(mappers.map_gravitee_plan_to_policy(plan))
             return result
         except Exception:
@@ -438,13 +438,13 @@ class GraviteeGatewayAdapter(GatewayAdapterInterface):
         return []
 
     async def _find_plan_by_stoa_id(self, api_id: str, stoa_policy_id: str) -> str | None:
-        """Find a plan by its stoa-policy tag."""
+        """Find a plan by its STOA name pattern (stoa-*-{policy_id})."""
         plans = await self._list_api_plans(api_id)
-        tag = f"stoa-policy-{stoa_policy_id}"
+        suffix = f"-{stoa_policy_id}"
         if isinstance(plans, list):
             for plan in plans:
-                tags = plan.get("tags", [])
-                if tag in tags:
+                name = plan.get("name", "")
+                if name.startswith("stoa-") and name.endswith(suffix):
                     return plan.get("id")
         return None
 

--- a/control-plane-api/src/adapters/gravitee/mappers.py
+++ b/control-plane-api/src/adapters/gravitee/mappers.py
@@ -75,10 +75,12 @@ def map_policy_to_gravitee_plan(policy_spec: dict, api_name: str) -> dict:
             period_time, period_unit = interval // 60, "MINUTES"
 
         return {
+            "definitionVersion": "V4",
             "name": f"stoa-rate-limit-{policy_id}",
             "description": f"STOA rate-limit policy {policy_id} for {api_name}",
-            "validation": "AUTO",
+            "mode": "STANDARD",
             "security": {"type": "KEY_LESS"},
+            "characteristics": [],
             "flows": [
                 {
                     "name": "rate-limit-flow",
@@ -98,15 +100,16 @@ def map_policy_to_gravitee_plan(policy_spec: dict, api_name: str) -> dict:
                     ],
                 }
             ],
-            "tags": [f"stoa-policy-{policy_id}"],
         }
 
     # Generic policy fallback
     return {
+        "definitionVersion": "V4",
         "name": f"stoa-{policy_type}-{policy_id}",
         "description": f"STOA {policy_type} policy {policy_id}",
-        "validation": "AUTO",
+        "mode": "STANDARD",
         "security": {"type": "KEY_LESS"},
+        "characteristics": [],
         "flows": [
             {
                 "name": f"{policy_type}-flow",
@@ -120,18 +123,23 @@ def map_policy_to_gravitee_plan(policy_spec: dict, api_name: str) -> dict:
                 ],
             }
         ],
-        "tags": [f"stoa-policy-{policy_id}"],
     }
 
 
 def map_gravitee_plan_to_policy(plan: dict) -> dict:
     """Map a Gravitee Plan to CP-normalized policy dict."""
-    tags = plan.get("tags", [])
+    # Extract STOA ID from plan name (e.g. "stoa-rate-limit-{id}" → "{id}")
+    plan_name = plan.get("name", "")
     stoa_id = ""
-    for tag in tags:
-        if isinstance(tag, str) and tag.startswith("stoa-policy-"):
-            stoa_id = tag.removeprefix("stoa-policy-")
-            break
+    if plan_name.startswith("stoa-"):
+        # Name pattern: stoa-{type}-{id}  →  extract last segment as ID
+        parts = plan_name.split("-", 2)  # ["stoa", "rate", "limit-{id}"] or ["stoa", "type", "{id}"]
+        if len(parts) >= 3:
+            # For "stoa-rate-limit-xxx" → everything after "stoa-rate-limit-"
+            prefix_len = (
+                len("stoa-rate-limit-") if plan_name.startswith("stoa-rate-limit-") else len(f"stoa-{parts[1]}-")
+            )
+            stoa_id = plan_name[prefix_len:] if len(plan_name) > prefix_len else ""
 
     # Extract rate-limit config from flows
     flows = plan.get("flows", [])

--- a/control-plane-api/src/adapters/kong/adapter.py
+++ b/control-plane-api/src/adapters/kong/adapter.py
@@ -212,7 +212,7 @@ class KongGatewayAdapter(GatewayAdapterInterface):
                 plugins = data.get("data", [])
                 result = []
                 for p in plugins:
-                    tags = p.get("tags", [])
+                    tags = p.get("tags") or []
                     if any(t.startswith("stoa-policy-") for t in tags):
                         result.append(mappers.map_kong_plugin_to_policy(p))
                 return result
@@ -281,7 +281,7 @@ class KongGatewayAdapter(GatewayAdapterInterface):
                 consumers = data.get("data", [])
                 result = []
                 for c in consumers:
-                    tags = c.get("tags", [])
+                    tags = c.get("tags") or []
                     if any(t.startswith("stoa-consumer-") for t in tags):
                         result.append(mappers.map_kong_consumer_to_cp(c))
                 return result
@@ -339,7 +339,7 @@ class KongGatewayAdapter(GatewayAdapterInterface):
                 for svc in data.get("data", []):
                     service_entry = {
                         "name": svc.get("name", ""),
-                        "url": f"{svc.get('protocol', 'http')}://{svc.get('host', '')}:{svc.get('port', 80)}{svc.get('path', '')}",
+                        "url": f"{svc.get('protocol', 'http')}://{svc.get('host', '')}:{svc.get('port', 80)}{svc.get('path') or ''}",
                     }
                     # Fetch routes for this service
                     routes_resp = await self._client.get(f"/services/{svc['id']}/routes")
@@ -376,7 +376,7 @@ class KongGatewayAdapter(GatewayAdapterInterface):
                             "name": p.get("name", ""),
                             "service": service_name,
                             "config": p.get("config", {}),
-                            "tags": p.get("tags", []),
+                            "tags": p.get("tags") or [],
                         }
                     )
         except Exception as e:
@@ -389,7 +389,7 @@ class KongGatewayAdapter(GatewayAdapterInterface):
                 consumers = [
                     {
                         "username": c.get("username", ""),
-                        "tags": c.get("tags", []),
+                        "tags": c.get("tags") or [],
                     }
                     for c in data.get("data", [])
                 ]

--- a/control-plane-api/src/adapters/kong/mappers.py
+++ b/control-plane-api/src/adapters/kong/mappers.py
@@ -103,7 +103,7 @@ def map_kong_plugin_to_policy(plugin: dict) -> dict:
         cp_config = kong_config
         policy_type = plugin_name.replace("-", "_")
 
-    tags = plugin.get("tags", [])
+    tags = plugin.get("tags") or []
     stoa_id = ""
     for tag in tags:
         if tag.startswith("stoa-policy-"):
@@ -150,7 +150,7 @@ def map_app_spec_to_kong_consumer(app_spec: dict) -> dict:
 
 def map_kong_consumer_to_cp(consumer: dict) -> dict:
     """Map a Kong consumer object to CP-normalized application dict."""
-    tags = consumer.get("tags", [])
+    tags = consumer.get("tags") or []
     subscription_id = ""
     for tag in tags:
         if tag.startswith("stoa-consumer-"):
@@ -159,6 +159,7 @@ def map_kong_consumer_to_cp(consumer: dict) -> dict:
 
     return {
         "id": consumer.get("id", ""),
+        "name": consumer.get("username", ""),
         "username": consumer.get("username", ""),
         "subscription_id": subscription_id,
         "created_at": consumer.get("created_at"),

--- a/control-plane-api/tests/test_gravitee_adapter.py
+++ b/control-plane-api/tests/test_gravitee_adapter.py
@@ -66,14 +66,16 @@ class TestGraviteeMappers:
         result = map_policy_to_gravitee_plan(policy, "acme-api")
 
         assert result["name"] == "stoa-rate-limit-pol-1"
-        assert result["validation"] == "AUTO"
+        assert result["definitionVersion"] == "V4"
+        assert result["mode"] == "STANDARD"
         assert result["security"]["type"] == "KEY_LESS"
         flow = result["flows"][0]
         assert flow["request"][0]["policy"] == "rate-limit"
         rate_config = flow["request"][0]["configuration"]["rate"]
         assert rate_config["limit"] == 100
         assert rate_config["periodTimeUnit"] == "MINUTES"
-        assert "stoa-policy-pol-1" in result["tags"]
+        assert result["definitionVersion"] == "V4"
+        assert result["mode"] == "STANDARD"
 
     def test_map_policy_to_gravitee_plan_per_second(self):
         policy = {
@@ -100,7 +102,6 @@ class TestGraviteeMappers:
         plan = {
             "id": "plan-123",
             "name": "stoa-rate-limit-pol-1",
-            "tags": ["stoa-policy-pol-1"],
             "flows": [
                 {
                     "request": [
@@ -470,7 +471,7 @@ class TestGraviteeAdapterPolicies:
         # _find_plan_by_stoa_id returns existing plan
         plans_resp = MagicMock()
         plans_resp.status_code = 200
-        plans_resp.json.return_value = {"data": [{"id": "plan-existing", "tags": ["stoa-policy-pol-1"]}]}
+        plans_resp.json.return_value = {"data": [{"id": "plan-existing", "name": "stoa-rate-limit-pol-1"}]}
 
         update_resp = MagicMock()
         update_resp.status_code = 200
@@ -517,7 +518,7 @@ class TestGraviteeAdapterPolicies:
         # _find_plan_by_stoa_id returns a plan
         plans_resp = MagicMock()
         plans_resp.status_code = 200
-        plans_resp.json.return_value = {"data": [{"id": "plan-1", "tags": ["stoa-policy-pol-1"]}]}
+        plans_resp.json.return_value = {"data": [{"id": "plan-1", "name": "stoa-rate-limit-pol-1"}]}
 
         close_resp = MagicMock()
         close_resp.status_code = 200
@@ -552,7 +553,6 @@ class TestGraviteeAdapterPolicies:
                 {
                     "id": "plan-1",
                     "name": "stoa-rate-limit-pol-1",
-                    "tags": ["stoa-policy-pol-1"],
                     "flows": [
                         {
                             "request": [
@@ -569,7 +569,6 @@ class TestGraviteeAdapterPolicies:
                 {
                     "id": "plan-2",
                     "name": "non-stoa-plan",
-                    "tags": [],
                     "flows": [],
                 },
             ]

--- a/control-plane-api/tests/test_kong_adapter.py
+++ b/control-plane-api/tests/test_kong_adapter.py
@@ -156,6 +156,7 @@ class TestKongMappers:
         result = map_kong_consumer_to_cp(consumer)
 
         assert result["id"] == "k-consumer-1"
+        assert result["name"] == "consumer-42"
         assert result["username"] == "consumer-42"
         assert result["subscription_id"] == "sub-1"
 


### PR DESCRIPTION
## Summary
- Fix 5 bugs found during Phase 4 live validation against OVH VPS (Kong + Gravitee)
- **20/20 PASS** on live validation after fixes

## Bugs Fixed

| Bug | Root Cause | Fix |
|-----|-----------|-----|
| Kong `POST /config` fails with "expected integer" for port | `path=None` → URL becomes `https://host:443None` | `svc.get('path') or ''` |
| Kong "NoneType is not iterable" on policy/consumer filtering | Kong returns `tags: null` (not `[]`) | `get("tags") or []` |
| Kong `list_applications` missing `name` field | Mapper returns `username` but not `name` | Add `name` = `username` |
| Gravitee Plan creation 400 "must not be null" | V4 Plans require `definitionVersion`, `mode`, `characteristics` | Add required fields |
| Gravitee Plan tags rejected "mismatch API tags" | Plan tags must match API tags | Use name-based identification instead |

## Test plan
- [x] 73 unit tests pass (38 Kong + 35 Gravitee)
- [x] Live validation: 20/20 PASS (Kong <KONG_VPS_IP> + Gravitee <GRAVITEE_VPS_IP>)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
