### PR TITLE
chore(ci): default environment staging, remove dev option

### DIFF
--- a/.github/workflows/control-plane-api-ci.yml
+++ b/.github/workflows/control-plane-api-ci.yml
@@ -32,10 +32,9 @@ on:
       environment:
         description: 'Target environment'
         required: true
-        default: 'dev'
+        default: 'staging'
         type: choice
         options:
-          - dev
           - staging
           - prod
 
@@ -110,7 +109,7 @@ jobs:
     with:
       component: control-plane-api
       image-name: control-plane-api
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ github.event.inputs.environment || 'staging' }}
       platforms: linux/amd64
     permissions:
       contents: read
@@ -127,7 +126,7 @@ jobs:
     with:
       component: control-plane-api
       image-tag: ${{ needs.docker.outputs.image-tag }}
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ github.event.inputs.environment || 'staging' }}
       environment-url: https://api.${{ (github.event.inputs.environment == 'staging' && 'staging.gostoa.dev') || 'gostoa.dev' }}
       verify-endpoint: https://api.${{ (github.event.inputs.environment == 'staging' && 'staging.gostoa.dev') || 'gostoa.dev' }}/health
       expected-status: '200'
@@ -154,7 +153,7 @@ jobs:
     uses: ./.github/workflows/reusable-notify.yml
     with:
       component: Control Plane API
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ github.event.inputs.environment || 'staging' }}
       ci-result: ${{ needs.ci.outputs.test-result }}
       deploy-result: ${{ needs.deploy.result }}
       smoke-result: ${{ needs.smoke-test.result }}

--- a/.github/workflows/control-plane-ui-ci.yml
+++ b/.github/workflows/control-plane-ui-ci.yml
@@ -34,10 +34,9 @@ on:
       environment:
         description: 'Target environment'
         required: true
-        default: 'dev'
+        default: 'staging'
         type: choice
         options:
-          - dev
           - staging
           - prod
 
@@ -73,12 +72,12 @@ jobs:
     with:
       component: control-plane-ui
       image-name: control-plane-ui
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ github.event.inputs.environment || 'staging' }}
       platforms: linux/amd64
       use-monorepo-context: true
       build-args: |
         VITE_BASE_DOMAIN=${{ (github.event.inputs.environment == 'staging' && 'staging.gostoa.dev') || 'gostoa.dev' }}
-        VITE_ENVIRONMENT=${{ github.event.inputs.environment || 'dev' }}
+        VITE_ENVIRONMENT=${{ github.event.inputs.environment || 'staging' }}
         VITE_KEYCLOAK_URL=https://auth.${{ (github.event.inputs.environment == 'staging' && 'staging.gostoa.dev') || 'gostoa.dev' }}
         VITE_KEYCLOAK_REALM=stoa
         VITE_KEYCLOAK_CLIENT_ID=control-plane-ui
@@ -99,7 +98,7 @@ jobs:
     permissions:
       contents: read
     environment:
-      name: ${{ github.event.inputs.environment || 'dev' }}
+      name: ${{ github.event.inputs.environment || 'staging' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Configure kubeconfig
@@ -123,7 +122,7 @@ jobs:
     with:
       component: control-plane-ui
       image-tag: ${{ needs.docker.outputs.image-tag }}
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ github.event.inputs.environment || 'staging' }}
       environment-url: https://console.${{ (github.event.inputs.environment == 'staging' && 'staging.gostoa.dev') || 'gostoa.dev' }}
     permissions:
       contents: read
@@ -148,7 +147,7 @@ jobs:
     uses: ./.github/workflows/reusable-notify.yml
     with:
       component: Control Plane UI
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ github.event.inputs.environment || 'staging' }}
       ci-result: ${{ needs.ci.outputs.test-result }}
       deploy-result: ${{ needs.deploy.result }}
       smoke-result: ${{ needs.smoke-test.result }}

--- a/.github/workflows/platform-config-ci.yml
+++ b/.github/workflows/platform-config-ci.yml
@@ -20,10 +20,9 @@ on:
       environment:
         description: 'Target environment'
         required: true
-        default: 'dev'
+        default: 'staging'
         type: choice
         options:
-          - dev
           - staging
           - prod
       dry_run:

--- a/.github/workflows/reusable-k8s-deploy.yml
+++ b/.github/workflows/reusable-k8s-deploy.yml
@@ -15,7 +15,7 @@ on:
         description: 'Target environment'
         required: false
         type: string
-        default: 'dev'
+        default: 'staging'
       namespace:
         description: 'Kubernetes namespace'
         required: false

--- a/.github/workflows/stoa-gateway-ci.yml
+++ b/.github/workflows/stoa-gateway-ci.yml
@@ -32,10 +32,9 @@ on:
       environment:
         description: 'Target environment'
         required: true
-        default: 'dev'
+        default: 'staging'
         type: choice
         options:
-          - dev
           - staging
           - prod
 
@@ -67,7 +66,7 @@ jobs:
     with:
       component: stoa-gateway
       image-name: stoa-gateway
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ github.event.inputs.environment || 'staging' }}
       platforms: linux/amd64
       build-args: |
         CACHEBUST=${{ github.sha }}
@@ -86,7 +85,7 @@ jobs:
     permissions:
       contents: read
     environment:
-      name: ${{ github.event.inputs.environment || 'dev' }}
+      name: ${{ github.event.inputs.environment || 'staging' }}
       url: https://mcp.${{ (github.event.inputs.environment == 'staging' && 'staging.gostoa.dev') || 'gostoa.dev' }}
     steps:
       - name: Configure kubeconfig
@@ -124,7 +123,7 @@ jobs:
     uses: ./.github/workflows/reusable-notify.yml
     with:
       component: STOA Gateway
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ github.event.inputs.environment || 'staging' }}
       ci-result: ${{ needs.ci.outputs.test-result }}
       deploy-result: ${{ needs.deploy.result }}
       smoke-result: ${{ needs.smoke-test.result }}

--- a/.github/workflows/stoa-portal-ci.yml
+++ b/.github/workflows/stoa-portal-ci.yml
@@ -34,10 +34,9 @@ on:
       environment:
         description: 'Target environment'
         required: true
-        default: 'dev'
+        default: 'staging'
         type: choice
         options:
-          - dev
           - staging
           - prod
 
@@ -73,12 +72,12 @@ jobs:
     with:
       component: portal
       image-name: portal
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ github.event.inputs.environment || 'staging' }}
       platforms: linux/amd64
       use-monorepo-context: true
       build-args: |
         VITE_BASE_DOMAIN=${{ (github.event.inputs.environment == 'staging' && 'staging.gostoa.dev') || 'gostoa.dev' }}
-        VITE_ENVIRONMENT=${{ github.event.inputs.environment || 'dev' }}
+        VITE_ENVIRONMENT=${{ github.event.inputs.environment || 'staging' }}
         VITE_KEYCLOAK_URL=https://auth.${{ (github.event.inputs.environment == 'staging' && 'staging.gostoa.dev') || 'gostoa.dev' }}
         VITE_KEYCLOAK_REALM=stoa
         VITE_KEYCLOAK_CLIENT_ID=stoa-portal
@@ -100,7 +99,7 @@ jobs:
     permissions:
       contents: read
     environment:
-      name: ${{ github.event.inputs.environment || 'dev' }}
+      name: ${{ github.event.inputs.environment || 'staging' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Configure kubeconfig
@@ -124,7 +123,7 @@ jobs:
     with:
       component: stoa-portal
       image-tag: ${{ needs.docker.outputs.image-tag }}
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ github.event.inputs.environment || 'staging' }}
       environment-url: https://portal.${{ (github.event.inputs.environment == 'staging' && 'staging.gostoa.dev') || 'gostoa.dev' }}
     permissions:
       contents: read
@@ -149,7 +148,7 @@ jobs:
     uses: ./.github/workflows/reusable-notify.yml
     with:
       component: STOA Portal
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ github.event.inputs.environment || 'staging' }}
       ci-result: ${{ needs.ci.outputs.test-result }}
       deploy-result: ${{ needs.deploy.result }}
       smoke-result: ${{ needs.smoke-test.result }}


### PR DESCRIPTION
## Summary
- Default deploy target changed from `dev` to `staging` (Hetzner K3s)
- `dev` option removed from workflow_dispatch choices (no dev cluster)
- Push to main now auto-deploys to staging environment

## Context
Only 2 environments available: staging (Hetzner) + prod (OVH). Dev will be re-added when business model funds a third cluster.

## Test plan
- [ ] CI green
- [ ] Next merge to main triggers deploy to staging (verify via Actions run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)