### PR TITLE
fix(ui): add dark mode variants to SyncStatusBadge

### DIFF
--- a/control-plane-ui/src/components/SyncStatusBadge.tsx
+++ b/control-plane-ui/src/components/SyncStatusBadge.tsx
@@ -2,12 +2,30 @@ import { clsx } from 'clsx';
 import type { DeploymentSyncStatus } from '../types';
 
 const statusConfig: Record<DeploymentSyncStatus, { label: string; classes: string }> = {
-  pending: { label: 'Pending', classes: 'bg-yellow-100 text-yellow-800' },
-  syncing: { label: 'Syncing', classes: 'bg-blue-100 text-blue-800 animate-pulse' },
-  synced: { label: 'Synced', classes: 'bg-green-100 text-green-800' },
-  drifted: { label: 'Drifted', classes: 'bg-orange-100 text-orange-800' },
-  error: { label: 'Error', classes: 'bg-red-100 text-red-800' },
-  deleting: { label: 'Deleting', classes: 'bg-gray-100 text-gray-800' },
+  pending: {
+    label: 'Pending',
+    classes: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+  },
+  syncing: {
+    label: 'Syncing',
+    classes: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 animate-pulse',
+  },
+  synced: {
+    label: 'Synced',
+    classes: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  },
+  drifted: {
+    label: 'Drifted',
+    classes: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400',
+  },
+  error: {
+    label: 'Error',
+    classes: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+  },
+  deleting: {
+    label: 'Deleting',
+    classes: 'bg-gray-100 text-gray-800 dark:bg-neutral-800 dark:text-neutral-400',
+  },
 };
 
 interface SyncStatusBadgeProps {
@@ -16,7 +34,10 @@ interface SyncStatusBadgeProps {
 }
 
 export function SyncStatusBadge({ status, className }: SyncStatusBadgeProps) {
-  const config = statusConfig[status] || { label: status, classes: 'bg-gray-100 text-gray-800' };
+  const config = statusConfig[status] || {
+    label: status,
+    classes: 'bg-gray-100 text-gray-800 dark:bg-neutral-800 dark:text-neutral-400',
+  };
 
   return (
     <span


### PR DESCRIPTION
## Summary
- Add `dark:` Tailwind variants to all 6 deployment sync status badges (pending, syncing, synced, drifted, error, deleting)
- Uses semi-transparent backgrounds (`dark:bg-{color}-900/30`) and lighter text (`dark:text-{color}-400`) for proper dark mode contrast
- Fixes the last component missing dark mode support in the Console UI (100% coverage)

## Test plan
- [ ] Toggle dark mode in Console header → verify SyncStatusBadge renders correctly on Gateway Deployments page
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)