### PR TITLE
fix(ci): correct service URLs in traffic generator CronJob

### DIFF
--- a/k8s/traffic/cronjob-staging.yaml
+++ b/k8s/traffic/cronjob-staging.yaml
@@ -34,11 +34,11 @@ spec:
                 - /app/heartbeat.py
               env:
                 - name: GATEWAY_URL
-                  value: "http://stoa-gateway:8080"
+                  value: "http://stoa-gateway.stoa-system.svc:80"
                 - name: API_URL
-                  value: "http://control-plane-api:8000"
+                  value: "http://stoa-control-plane-api.stoa-system.svc:80"
                 - name: PORTAL_URL
-                  value: "http://stoa-portal:8080"
+                  value: "http://stoa-portal.stoa-system.svc:80"
                 - name: DURATION
                   value: "600"
                 - name: RATE


### PR DESCRIPTION
## Summary
- Fix service names: `stoa-gateway.stoa-system.svc:80` (not `stoa-gateway:8080`)
- Fix API name: `stoa-control-plane-api` (not `control-plane-api`)
- Fix portal port: 80 (not 8080)

Verified live on staging — all endpoints return 200.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>