### PR TITLE
fix(ci): correct service URLs in prod traffic generator CronJob

### DIFF
--- a/k8s/traffic/cronjob-prod.yaml
+++ b/k8s/traffic/cronjob-prod.yaml
@@ -34,11 +34,11 @@ spec:
                 - /app/heartbeat.py
               env:
                 - name: GATEWAY_URL
-                  value: "http://stoa-gateway:8080"
+                  value: "http://stoa-gateway.stoa-system.svc:80"
                 - name: API_URL
-                  value: "http://control-plane-api:8000"
+                  value: "http://stoa-control-plane-api.stoa-system.svc:80"
                 - name: PORTAL_URL
-                  value: "http://stoa-portal:8080"
+                  value: "http://stoa-portal.stoa-system.svc:80"
                 - name: DURATION
                   value: "300"
                 - name: RATE


### PR DESCRIPTION
## Summary
- Same fix as staging (#352): FQDN with port 80 instead of 8080/8000
- Verified live on OVH prod — status 200 on all endpoints

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>