### PR TITLE
fix(api): add email-validator dependency for Pydantic EmailStr

### DIFF
--- a/control-plane-api/requirements.txt
+++ b/control-plane-api/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.109.1
 uvicorn[standard]==0.27.0
 python-keycloak==3.9.0
-pydantic==2.12.5
+pydantic[email]==2.12.5
 pydantic-settings==2.1.0
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4


### PR DESCRIPTION
## Summary
- Add `pydantic[email]` extra to install `email-validator` (required by `EmailStr` in access request schema from PR #351)
- Without it, CP API pytest fails with `ImportError: email-validator is not installed` at import time
- This blocked the Docker build + deploy pipeline on main

## Test plan
- [ ] CP API CI passes (pytest no longer fails on EmailStr import)
- [ ] Docker build + deploy unblocked on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)