### PR TITLE
fix(portal): update App.test.tsx for new LoginScreen component

### DIFF
--- a/portal/src/App.test.tsx
+++ b/portal/src/App.test.tsx
@@ -96,7 +96,11 @@ vi.mock('./pages/Unauthorized', () => ({
 
 vi.mock('./config', () => ({
   config: {
-    services: { console: { url: 'https://console.gostoa.dev' } },
+    api: { baseUrl: 'https://api.gostoa.dev' },
+    services: {
+      console: { url: 'https://console.gostoa.dev' },
+      docs: { url: 'https://docs.gostoa.dev' },
+    },
   },
 }));
 
@@ -139,7 +143,9 @@ describe('App', () => {
 
       renderApp('/');
 
-      expect(screen.getByText('Sign in with SSO')).toBeInTheDocument();
+      expect(screen.getByText('Discover AI-powered APIs')).toBeInTheDocument();
+      expect(screen.getByText('Request Access')).toBeInTheDocument();
+      expect(screen.getByText('Sign In')).toBeInTheDocument();
     });
 
     it('should show loading screen while authenticating', () => {


### PR DESCRIPTION
## Summary
- Fix broken `App.test.tsx` test caused by PR #351 (email capture LoginScreen redesign)
- Config mock was missing `api.baseUrl` and `services.docs.url` — caused `TypeError: Cannot read properties of undefined`
- Test assertion updated: "Sign in with SSO" is now inside the Sign In tab (not default), so check for "Discover AI-powered APIs" + tab labels instead

## Test plan
- [x] `npx vitest run src/App.test.tsx` — 15/15 pass
- [x] `npm run lint` — 14 warnings (under 20 threshold)
- [x] `npm run format:check` — clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>