### PR TITLE
fix(ci): emit HELP/TYPE lines only once per metric in arena script

### DIFF
--- a/scripts/traffic/gateway-arena.py
+++ b/scripts/traffic/gateway-arena.py
@@ -76,22 +76,24 @@ class MetricStore:
 
     def __init__(self):
         self.lines = []
+        self._declared = set()
+
+    def _declare(self, name, metric_type, help_text=""):
+        """Emit HELP/TYPE lines only once per metric name."""
+        if name not in self._declared:
+            self._declared.add(name)
+            if help_text:
+                self.lines.append(f"# HELP {name} {help_text}")
+            self.lines.append(f"# TYPE {name} {metric_type}")
 
     def histogram(self, name, labels, values, help_text=""):
         """Add histogram metric from a list of observed values."""
         if not values:
             return
+        self._declare(name, "histogram", help_text)
         label_str = ",".join(f'{k}="{v}"' for k, v in labels.items())
         buckets = [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0]
-        if help_text:
-            self.lines.append(f"# HELP {name} {help_text}")
-            self.lines.append(f"# TYPE {name} histogram")
-        cumulative = 0
         for b in buckets:
-            cumulative += sum(1 for v in values if v <= b) - sum(
-                1 for v in values if v <= (buckets[buckets.index(b) - 1] if buckets.index(b) > 0 else 0)
-            )
-            # Simpler: just count all values <= b
             count_le = sum(1 for v in values if v <= b)
             self.lines.append(f'{name}_bucket{{{label_str},le="{b}"}} {count_le}')
         self.lines.append(f'{name}_bucket{{{label_str},le="+Inf"}} {len(values)}')
@@ -99,17 +101,13 @@ class MetricStore:
         self.lines.append(f"{name}_count{{{label_str}}} {len(values)}")
 
     def counter(self, name, labels, value, help_text=""):
+        self._declare(name, "counter", help_text)
         label_str = ",".join(f'{k}="{v}"' for k, v in labels.items())
-        if help_text:
-            self.lines.append(f"# HELP {name} {help_text}")
-            self.lines.append(f"# TYPE {name} counter")
         self.lines.append(f"{name}{{{label_str}}} {value}")
 
     def gauge(self, name, labels, value, help_text=""):
+        self._declare(name, "gauge", help_text)
         label_str = ",".join(f'{k}="{v}"' for k, v in labels.items())
-        if help_text:
-            self.lines.append(f"# HELP {name} {help_text}")
-            self.lines.append(f"# TYPE {name} gauge")
         self.lines.append(f"{name}{{{label_str}}} {value:.2f}")
 
     def push(self, url, job="gateway_arena"):


### PR DESCRIPTION
## Summary
- Pushgateway rejects duplicate HELP lines for the same metric name
- Track declared metrics in a `_declared` set and only emit HELP/TYPE headers on first use
- Fixes 400 error from Pushgateway on arena benchmark runs

## Test plan
- [ ] CI green
- [ ] Manual arena job pushes metrics without 400 error

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>