### PR TITLE
fix(ci): update STOA VPS IP in arena script defaults

### DIFF
--- a/scripts/traffic/gateway-arena.py
+++ b/scripts/traffic/gateway-arena.py
@@ -44,8 +44,8 @@ except ImportError:
 DEFAULT_GATEWAYS = json.dumps([
     {
         "name": "stoa",
-        "health": "http://TODO_STOA_VPS_IP:8080/health",
-        "proxy": "http://TODO_STOA_VPS_IP:8080/httpbin/get",
+        "health": "http://51.83.45.13:8080/health",
+        "proxy": "http://51.83.45.13:8080/httpbin/get",
     },
     {
         "name": "kong",


### PR DESCRIPTION
## Summary
- Replace `TODO_STOA_VPS_IP` with `<KONG_VPS_IP>` in `gateway-arena.py` DEFAULT_GATEWAYS
- CronJob env var already correct (PR #367), this fixes the script's fallback defaults

## Test plan
- [x] Manual Arena run on OVH K8s: all 3 gateways scored, metrics pushed to Pushgateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)
