### PR TITLE
chore(deps): bump fastapi from 0.109.1 to 0.128.6

### DIFF
--- a/control-plane-api/requirements.txt
+++ b/control-plane-api/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.109.1
+fastapi==0.128.6
 uvicorn[standard]==0.40.0
 python-keycloak==3.9.0
 pydantic[email]==2.12.5


### PR DESCRIPTION
## Summary
- Bumps fastapi from 0.109.1 to 0.128.6 in control-plane-api
- Resolves Dependabot PR #253 which had merge conflicts after other pip bumps

## Test plan
- [x] CI required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)