### PR TITLE
chore(deps): update k8s-openapi from 0.23 to 0.27 in /stoa-gateway

### DIFF
--- a/stoa-gateway/Cargo.toml
+++ b/stoa-gateway/Cargo.toml
@@ -59,7 +59,7 @@ rdkafka = { version = "0.39", features = ["cmake-build"], optional = true }
 
 # === Phase 7: K8s CRD + Federation (CAB-1105) ===
 kube = { version = "3.0", features = ["runtime", "derive"], optional = true }
-k8s-openapi = { version = "0.23", features = ["latest"], optional = true }
+k8s-openapi = { version = "0.27", features = ["latest"], optional = true }
 schemars = { version = "0.8", optional = true }
 
 [features]


### PR DESCRIPTION
## Summary
- Bumps k8s-openapi from 0.23 to 0.27 (replaces Dependabot PR #279 which had merge conflicts)
- Breaking change: chrono→jiff for DateTime types, but STOA gateway uses strings for timestamps in CRDs — no code changes needed
- Companion to kube 3.0 upgrade (PR #278)

## Test plan
- [ ] CI green (cargo check with k8s feature)

Closes #279

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>