### PR TITLE
docs(docs): update arena rule with echo backend gotchas

### DIFF
--- a/.claude/rules/gateway-arena.md
+++ b/.claude/rules/gateway-arena.md
@@ -28,41 +28,52 @@ CronJob runs every 30 min on OVH K8s, pushes metrics to Pushgateway, visualized 
 | 60-80 | Acceptable | Normal for external gateways with network hop |
 | <60 | Investigate | Connection issues or high error rate |
 
-Score formula: `0.40 * Latency + 0.30 * Availability + 0.20 * ErrorRate + 0.10 * Consistency`
+Score formula: `0.15*Base + 0.25*Burst50 + 0.25*Burst100 + 0.15*Avail + 0.10*Error + 0.10*Consistency`
 
-## Fair Comparison — All Gateways on VPS
+6 scenarios: health, proxy_sequential(20), burst_10, burst_50, burst_100, sustained(100).
+Scoring caps: 500ms (sequential), 3s (burst_50), 5s (burst_100) — tuned for K8s→VPS remote benchmarking.
 
-Arena uses dedicated OVH VPS instances for each gateway to ensure fair comparison
-(same network conditions, same backend, no K8s/LB/TLS overhead):
+## Fair Comparison — Local Echo Backend
+
+Arena uses a local nginx echo server (static JSON, <1ms) on each VPS so benchmarks
+measure pure gateway overhead, not backend/network latency.
 
 | Gateway | VPS IP | Health | Proxy | Backend |
 |---------|--------|--------|-------|---------|
-| STOA | `51.83.45.13:8080` | `/health` | `/httpbin/get` | httpbin.org (colocated on Kong VPS) |
-| Kong | `51.83.45.13:8000` | `:8001/status` | `/httpbin/get` | httpbin.org |
-| Gravitee | `54.36.209.237:8082` | `:8083/management/...` | `/httpbin/get` | httpbin.org |
+| STOA | `51.83.45.13:8080` | `/health` | `/echo/get` | echo-local:8888 (Docker) |
+| Kong | `51.83.45.13:8000` | `:8001/status` | `/echo/get` | echo-local:8888 (Docker) |
+| Gravitee | `54.36.209.237:8082` | `:8083/management/...` | `/echo/get` | echo-local:8888 (Docker) |
 
-### STOA VPS Setup
+### Docker Network Setup (critical)
+
+All gateways run in Docker. The echo container MUST be on the same Docker network:
+- Kong VPS: `docker network connect kong_default echo-local && docker network connect stoa_default echo-local`
+- Gravitee VPS: `docker network connect gravitee_default echo-local`
+- Backend URL must be `http://echo-local:8888` (container name, NOT localhost)
+- STOA's SSRF blocklist blocks `localhost` — use container name or public IP
+
+### Deploy Echo + Configure Routes
 
 ```bash
-# Deploy (one-time)
-scp -i ~/.ssh/id_ed25519_stoa -r deploy/vps/stoa/ debian@51.83.45.13:~/stoa/
-ssh -i ~/.ssh/id_ed25519_stoa debian@51.83.45.13
-cd ~/stoa && docker compose up -d && ./setup.sh
+./deploy/vps/echo/deploy-all.sh
 ```
 
-Config: `deploy/vps/stoa/docker-compose.yml` (standalone mode, all optional features OFF).
-Route registration: `deploy/vps/stoa/setup.sh` (POST `/admin/apis` with httpbin route).
+This script: deploys echo on both VPS, connects Docker networks, registers routes on all 3 gateways.
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `scripts/traffic/gateway-arena.py` | Benchmark script (3 scenarios x N gateways) |
+| `scripts/traffic/gateway-arena.py` | Benchmark script (6 scenarios x N gateways) |
 | `k8s/arena/cronjob-prod.yaml` | CronJob manifest (every 30 min) |
 | `k8s/arena/pushgateway.yaml` | Pushgateway deployment + service |
+| `k8s/arena/pushgateway-servicemonitor.yaml` | Prometheus auto-discovery |
+| `k8s/arena/deploy.sh` | K8s deploy script (idempotent) |
 | `docker/observability/grafana/dashboards/gateway-arena.json` | Grafana leaderboard dashboard |
+| `deploy/vps/echo/deploy-all.sh` | VPS echo + route setup |
+| `deploy/vps/echo/docker-compose.yml` | Echo server (nginx:alpine) |
+| `deploy/vps/echo/nginx.conf` | Static JSON response config |
 | `deploy/vps/stoa/docker-compose.yml` | STOA VPS deployment (standalone) |
-| `deploy/vps/stoa/setup.sh` | Register httpbin proxy route on STOA VPS |
 
 ## Troubleshooting
 
@@ -73,6 +84,11 @@ Route registration: `deploy/vps/stoa/setup.sh` (POST `/admin/apis` with httpbin 
 | Pushgateway empty | Script not pushing or Pushgateway down | Verify pod: `kubectl get pods -n monitoring -l app=pushgateway` |
 | Metrics not in Prometheus | Scrape config missing | Verify Pushgateway target in Prometheus targets page |
 | Stale metrics | CronJob not running | Check: `kubectl get cronjob gateway-arena -n stoa-system` |
+| STOA 403 "Backend URL blocked" | SSRF blocklist blocks localhost | Use Docker container name (`echo-local`) or public IP as backend URL |
+| Kong 502 on echo | Kong container can't reach host localhost | Connect echo to Kong Docker network: `docker network connect kong_default echo-local` |
+| Gravitee "no published plan" | Plan created in STAGING status | Explicitly publish: `POST /apis/{id}/plans/{planId}/_publish` |
+| Gravitee 404 | API not started or not deployed | Lifecycle: create → plan → publish plan → deploy → start |
+| Staging ServiceMonitor not discovered | Wrong Prometheus selector labels | Staging uses `release: prometheus` (not `kube-prometheus-stack`) |
 
 ## Manual Run
 


### PR DESCRIPTION
## Summary
- Updated `.claude/rules/gateway-arena.md` with lessons learned from live Arena deployment
- Added Docker network setup section (critical for echo backend connectivity)
- Updated score formula, scenarios (6 instead of 3), and scoring caps (500ms/3s/5s)
- Added 5 new troubleshooting entries (SSRF, Docker networks, Gravitee lifecycle)
- Updated key files table with new echo deployment files

## Test plan
- [ ] Rule file is valid markdown
- [ ] CI green (docs-only, no component CI)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)