### PR TITLE
chore(security): add Machine Identity auth to secrets-management rule

### DIFF
--- a/.claude/rules/secrets-management.md
+++ b/.claude/rules/secrets-management.md
@@ -19,7 +19,7 @@ Infisical (self-hosted, source of truth — all environments)
 - **Self-hosted** on Hetzner (Docker Compose: infisical + postgres + redis)
 - **URL**: `https://vault.gostoa.dev`
 - **Admin**: `admin@gostoa.dev` (superAdmin)
-- **Org ID**: `d8d519fa-0e82-47e7-b914-bab341c9bbf2`
+- **Org ID**: `0c9506ce-668c-4ecd-8e6f-5845952eeb50`
 - **Project**: `stoa-infra` (`97972ffc-990b-4d28-9c4d-0664d217f03b`)
 
 ## Secret Inventory
@@ -34,6 +34,46 @@ Infisical (self-hosted, source of truth — all environments)
 | `prod` | `/ovh` | `OVH_CLOUD_PROJECT_ID` | OVH project ID |
 | `prod` | `/ovh` | `OVH_OPENSTACK_PASSWORD` | OVH OpenStack password |
 
+## Authentication
+
+Two methods available — Machine Identity (recommended) and browser login (fallback).
+
+### Machine Identity (Universal Auth) — Recommended
+
+Like AWS IAM roles: Client ID + Client Secret → short-lived access token (24h), auto-renewable.
+
+| Component | Value |
+|-----------|-------|
+| Identity | `stoa-cli-local` (`597c4a1e-ee10-44f7-8654-3b3cb4d01d84`) |
+| Client ID | `91417b6e-d6fd-424f-a9f0-b5e3ba063e2f` (non-sensitive, in `~/.zprofile`) |
+| Client Secret | Stored in macOS Keychain (`infisical-client-secret`) |
+| Access Token TTL | 24h (auto-renewable, max 30 days) |
+| Project Role | `admin` on `stoa-infra` |
+
+#### Get a token
+
+```bash
+# Quick — sets INFISICAL_TOKEN in current shell
+eval $(infisical-token)
+
+# Raw token for scripts
+export INFISICAL_TOKEN=$(infisical-token --raw)
+```
+
+#### How it works
+
+1. `infisical-token` reads Client Secret from macOS Keychain
+2. Calls `POST /api/v1/auth/universal-auth/login` with Client ID + Secret
+3. Returns a 24h access token (no browser needed)
+
+### Browser Login (Fallback)
+
+```bash
+infisical login --domain=https://vault.gostoa.dev/api
+```
+
+Opens browser for authentication. Session token stored in `~/.infisical/`. Expires in 10 days.
+
 ## CLI Setup
 
 ### Prerequisites
@@ -41,14 +81,6 @@ Infisical (self-hosted, source of truth — all environments)
 ```bash
 brew install infisical
 ```
-
-### One-time login
-
-```bash
-infisical login --domain=https://vault.gostoa.dev/api
-```
-
-Opens browser for authentication. Session token stored in `~/.infisical/`.
 
 ### Project init (per-repo, one-time)
 
@@ -63,6 +95,9 @@ Creates `.infisical.json` in repo root (gitignored).
 ### Retrieve secrets
 
 ```bash
+# Ensure you have a token first
+eval $(infisical-token)
+
 # Single secret
 infisical secrets get API_TOKEN --env=prod --path=/cloudflare
 
@@ -71,6 +106,10 @@ infisical secrets --env=prod --path=/cloudflare
 
 # Inject into command
 infisical run --env=prod --path=/cloudflare -- curl -H "Authorization: Bearer $API_TOKEN" ...
+
+# Direct API call (without CLI)
+curl -s "https://vault.gostoa.dev/api/v3/secrets/raw?workspaceId=97972ffc-990b-4d28-9c4d-0664d217f03b&environment=prod&secretPath=/cloudflare" \
+  -H "Authorization: Bearer $INFISICAL_TOKEN"
 ```
 
 ### Add a new secret
@@ -103,16 +142,48 @@ When touching secrets, env vars, or credentials:
 | `.env` file committed | Plaintext in repo history forever | `.gitignore` + `infisical run` for shared secrets |
 | Token in MEMORY.md / rules | AI context = potential leak | Reference path only, never values |
 
-## Rotation Procedure
+## Rotation Procedures
 
+### Rotate Application Secrets (Cloudflare, Hetzner, OVH)
+
+```bash
+# 1. Update secret value in Infisical
+infisical secrets set API_TOKEN=new-value --env=prod --path=/cloudflare
+
+# 2. Trigger pod restart to pick up new value
+kubectl rollout restart deployment/<name> -n stoa-system
+
+# 3. Verify pod is running with new secret
+kubectl logs deployment/<name> -n stoa-system --tail=10
 ```
-1. Update secret value in Infisical (UI or CLI)
-   infisical secrets set API_TOKEN=new-value --env=prod --path=/cloudflare
-2. Trigger pod restart to pick up new value:
-   kubectl rollout restart deployment/<name> -n stoa-system
-3. Verify pod is running with new secret:
-   kubectl logs deployment/<name> -n stoa-system --tail=10
+
+### Rotate Machine Identity Client Secret
+
+```bash
+# Automated: generates new secret, updates Keychain, verifies
+infisical-rotate-secret
+
+# Dry run (shows what would happen)
+infisical-rotate-secret --dry-run
 ```
+
+The rotation script (`~/.local/bin/infisical-rotate-secret`):
+1. Authenticates with current credentials
+2. Generates a new client secret via Infisical API
+3. Updates macOS Keychain with new secret
+4. Verifies new credentials work
+5. Old secrets remain active (revoke manually in UI if needed)
+
+**Recommended cadence**: Rotate every 90 days or after team member departure.
+
+### Helper Scripts
+
+| Script | Location | Purpose |
+|--------|----------|---------|
+| `infisical-token` | `~/.local/bin/` | Get fresh access token (24h TTL) |
+| `infisical-rotate-secret` | `~/.local/bin/` | Rotate Machine Identity client secret |
+
+Both scripts use macOS Keychain for secure secret storage — no plaintext files.
 
 ## GitHub Actions Secrets (CI/CD)
 
@@ -139,11 +210,6 @@ When touching secrets, env vars, or credentials:
 
 ## Auth Gotcha
 
-Infisical API requires org-scoped token:
-```bash
-# After initial auth, select organization:
-POST /api/v3/auth/select-organization
-Body: { "organizationId": "d8d519fa-0e82-47e7-b914-bab341c9bbf2" }
-```
-
-The CLI handles this automatically after `infisical login`.
+- **Machine Identity tokens** (from Universal Auth login) are already org-scoped — no extra step needed
+- **Browser login tokens** require org selection: the CLI handles this automatically after `infisical login`
+- **API tokens are JWT**: decode with `python3 -c "import base64,json; print(json.loads(base64.urlsafe_b64decode(token.split('.')[1]+'==')))"` to check expiry/org


### PR DESCRIPTION
## Summary
- Add Universal Auth (Machine Identity) as primary Infisical auth method — like AWS IAM roles
- Document Client ID, access token TTL (24h), rotation procedure, helper scripts (`infisical-token`, `infisical-rotate-secret`)
- Fix Org ID (was stale from old organization)
- Add direct API call examples alongside CLI usage

## Test plan
- [x] Machine Identity created and tested (all 7 secrets accessible)
- [x] `infisical-token` script verified (token + secret access)
- [x] Client secret stored in macOS Keychain (not plaintext)

🤖 Generated with [Claude Code](https://claude.com/claude-code)