### PR TITLE
fix(api): make Kafka publish no-op when KAFKA_ENABLED=false

### DIFF
--- a/control-plane-api/src/services/kafka_service.py
+++ b/control-plane-api/src/services/kafka_service.py
@@ -39,6 +39,10 @@ class KafkaService:
 
     async def connect(self):
         """Initialize Kafka producer with retry logic"""
+        if not settings.KAFKA_ENABLED:
+            logger.info("Kafka disabled — skipping producer initialization")
+            return
+
         import time
         max_retries = 5
         retry_delay = 2
@@ -116,6 +120,10 @@ class KafkaService:
         Returns:
             Event ID
         """
+        if not settings.KAFKA_ENABLED:
+            logger.debug(f"Kafka disabled — skipping {event_type} event to {topic}")
+            return str(uuid.uuid4())
+
         if not self._producer:
             raise RuntimeError("Kafka producer not initialized")
 

--- a/scripts/seed-demo-data.py
+++ b/scripts/seed-demo-data.py
@@ -27,7 +27,7 @@ Environment Variables:
     CONTROL_PLANE_URL   API base URL          (default: https://api.gostoa.dev)
     KEYCLOAK_URL        Keycloak base URL     (default: https://auth.gostoa.dev)
     KEYCLOAK_REALM      Keycloak realm        (default: stoa)
-    ANORAK_USER         Admin username         (default: anorak@gostoa.dev)
+    ANORAK_USER         Admin username         (default: anorak)
     ANORAK_PASSWORD     Admin password         (required)
     SEED_TENANT         Target tenant          (default: high-five)
 """
@@ -51,7 +51,7 @@ except ImportError:
 API_URL = os.getenv("CONTROL_PLANE_URL", "https://api.gostoa.dev")
 KEYCLOAK_URL = os.getenv("KEYCLOAK_URL", "https://auth.gostoa.dev")
 KEYCLOAK_REALM = os.getenv("KEYCLOAK_REALM", "stoa")
-SEED_USER = os.getenv("ANORAK_USER", "anorak@gostoa.dev")
+SEED_USER = os.getenv("ANORAK_USER", "anorak")
 SEED_PASSWORD = os.getenv("ANORAK_PASSWORD", "")
 DEMO_TENANT = os.getenv("SEED_TENANT", "high-five")
 


### PR DESCRIPTION
## Summary
- Guard `kafka_service.publish()` and `connect()` with `KAFKA_ENABLED` setting — returns dummy event ID when disabled instead of raising RuntimeError
- Fix `seed-demo-data.py` default username from `anorak@gostoa.dev` to `anorak` (matches actual Keycloak user)

## Context
PR #386 added `KAFKA_ENABLED` to guard the health check, but the actual `publish()` calls in routers (tenants, APIs, deployments) still raised `RuntimeError("Kafka producer not initialized")` when Kafka is not deployed. This blocked tenant/plan/consumer creation on OVH production.

## Test plan
- [x] `ruff check` clean
- [x] `py_compile` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>