### PR TITLE
fix(api): align SQLAlchemy enum names with Alembic migration 018

### DIFF
--- a/control-plane-api/src/models/consumer.py
+++ b/control-plane-api/src/models/consumer.py
@@ -51,7 +51,7 @@ class Consumer(Base):
 
     # Status
     status = Column(
-        SQLEnum(ConsumerStatus, values_callable=lambda x: [e.value for e in x]),
+        SQLEnum(ConsumerStatus, values_callable=lambda x: [e.value for e in x], name="consumer_status_enum"),
         nullable=False,
         default=ConsumerStatus.ACTIVE,
     )

--- a/control-plane-api/src/models/plan.py
+++ b/control-plane-api/src/models/plan.py
@@ -47,7 +47,7 @@ class Plan(Base):
 
     # Status
     status = Column(
-        SQLEnum(PlanStatus, values_callable=lambda x: [e.value for e in x]),
+        SQLEnum(PlanStatus, values_callable=lambda x: [e.value for e in x], name="plan_status_enum"),
         nullable=False,
         default=PlanStatus.ACTIVE,
     )


### PR DESCRIPTION
## Summary
- Add `name="plan_status_enum"` to Plan model's status column
- Add `name="consumer_status_enum"` to Consumer model's status column

## Context
Alembic migration 018 created enum types as `plan_status_enum` and `consumer_status_enum`, but SQLAlchemy's default naming (lowercase class name) generated `planstatus` and `consumerstatus`. This caused `DatatypeMismatchError` on every INSERT to plans/consumers.

## Test plan
- [x] `ruff check` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>