### PR TITLE
fix(api): widen api_key_prefix column from 10 to 20 chars

### DIFF
--- a/control-plane-api/src/models/subscription.py
+++ b/control-plane-api/src/models/subscription.py
@@ -57,7 +57,7 @@ class Subscription(Base):
 
     # API Key (hashed for security)
     api_key_hash = Column(String(512), nullable=False, unique=True)
-    api_key_prefix = Column(String(10), nullable=False)  # First 8 chars for display
+    api_key_prefix = Column(String(20), nullable=False)  # Prefix: stoa_sk_ + 4 hex
 
     # Key rotation with grace period (CAB-314)
     previous_api_key_hash = Column(String(512), nullable=True, index=True)  # Old key during grace period


### PR DESCRIPTION
## Summary
- Widen `api_key_prefix` in Subscription model from `String(10)` to `String(20)` to match the generated prefix format (`stoa_sk_` + 4 hex = 12 chars)

## Context
The `APIKeyService.generate_key()` creates prefixes like `stoa_sk_xxxx` which are 12 characters, exceeding the `varchar(10)` constraint. DB column already widened on OVH production via ALTER TABLE.

## Test plan
- [x] `ruff check` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>