### PR TITLE
feat(portal): add gateway instances page with Operations section

### DIFF
--- a/portal/src/App.tsx
+++ b/portal/src/App.tsx
@@ -47,6 +47,9 @@ const WorkspacePage = lazy(() =>
 const ConsumerRegistrationPage = lazy(() =>
   import('./pages/consumers').then((m) => ({ default: m.ConsumerRegistrationPage }))
 );
+const GatewaysPage = lazy(() =>
+  import('./pages/gateways').then((m) => ({ default: m.GatewaysPage }))
+);
 const UnauthorizedPage = lazy(() =>
   import('./pages/Unauthorized').then((m) => ({ default: m.UnauthorizedPage }))
 );
@@ -505,6 +508,16 @@ function AppContent() {
               element={
                 <ProtectedRoute scope="stoa:subscriptions:write">
                   <ConsumerRegistrationPage />
+                </ProtectedRoute>
+              }
+            />
+
+            {/* Gateway Instances (Operations) — admin only */}
+            <Route
+              path="/gateways"
+              element={
+                <ProtectedRoute scope="stoa:admin">
+                  <GatewaysPage />
                 </ProtectedRoute>
               }
             />

--- a/portal/src/components/layout/Sidebar.tsx
+++ b/portal/src/components/layout/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   Wrench,
   ExternalLink,
   Briefcase,
+  Server,
   LucideIcon,
 } from 'lucide-react';
 import { config } from '../../config';
@@ -83,6 +84,18 @@ const sections: NavSection[] = [
         icon: Webhook,
         enabled: config.features.enableSubscriptions,
         scope: 'stoa:subscriptions:write',
+      },
+    ],
+  },
+  {
+    title: 'Operations',
+    items: [
+      {
+        name: 'Gateways',
+        href: '/gateways',
+        icon: Server,
+        enabled: config.features.enableGateways,
+        scope: 'stoa:admin',
       },
     ],
   },

--- a/portal/src/config.ts
+++ b/portal/src/config.ts
@@ -72,6 +72,7 @@ export const config = {
     enableApplications: import.meta.env.VITE_ENABLE_APPLICATIONS !== 'false', // Consumer apps
     enableAPITesting: import.meta.env.VITE_ENABLE_API_TESTING !== 'false', // Sandbox testing
     enableDebug: import.meta.env.VITE_ENABLE_DEBUG === 'true',
+    enableGateways: import.meta.env.VITE_ENABLE_GATEWAYS !== 'false',
   },
 
   // API Testing Configuration

--- a/portal/src/pages/__tests__/GatewaysPage.test.tsx
+++ b/portal/src/pages/__tests__/GatewaysPage.test.tsx
@@ -1,0 +1,77 @@
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../test/helpers';
+import { GatewaysPage } from '../gateways/GatewaysPage';
+
+// Mock gatewaysService
+const mockListGateways = vi.fn();
+vi.mock('../../services/gateways', () => ({
+  gatewaysService: {
+    listGateways: (...args: unknown[]) => mockListGateways(...args),
+    triggerHealthCheck: vi.fn().mockResolvedValue(true),
+  },
+}));
+
+// Mock AuthContext
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+    isReady: true,
+    user: { id: '1', roles: ['cpi-admin'], permissions: [], effective_scopes: [] },
+    hasPermission: () => true,
+    hasRole: () => true,
+    hasScope: () => true,
+    hasAnyPermission: () => true,
+    hasAllPermissions: () => true,
+  }),
+}));
+
+describe('GatewaysPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders table when gateways exist', async () => {
+    mockListGateways.mockResolvedValue({
+      items: [
+        {
+          id: '1',
+          name: 'kong-gra',
+          display_name: 'Kong DB-less (GRA)',
+          gateway_type: 'kong',
+          base_url: 'https://kong.example.com',
+          environment: 'prod',
+          status: 'online',
+          last_health_check: '2026-02-12T10:00:00Z',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-02-12T10:00:00Z',
+        },
+      ],
+      total: 1,
+      page: 1,
+      page_size: 20,
+    });
+
+    renderWithProviders(<GatewaysPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Kong DB-less (GRA)')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Online')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no gateways', async () => {
+    mockListGateways.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      page_size: 20,
+    });
+
+    renderWithProviders(<GatewaysPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No gateways registered')).toBeInTheDocument();
+    });
+  });
+});

--- a/portal/src/pages/gateways/GatewaysPage.tsx
+++ b/portal/src/pages/gateways/GatewaysPage.tsx
@@ -1,0 +1,237 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Server, RefreshCw, Activity, Loader2 } from 'lucide-react';
+import { gatewaysService } from '../../services/gateways';
+import type { GatewayInstance, GatewayStatus, GatewayType } from '../../types';
+
+const statusConfig: Record<GatewayStatus, { bg: string; text: string; label: string }> = {
+  online: {
+    bg: 'bg-green-100 dark:bg-green-900/30',
+    text: 'text-green-800 dark:text-green-400',
+    label: 'Online',
+  },
+  offline: {
+    bg: 'bg-red-100 dark:bg-red-900/30',
+    text: 'text-red-800 dark:text-red-400',
+    label: 'Offline',
+  },
+  degraded: {
+    bg: 'bg-yellow-100 dark:bg-yellow-900/30',
+    text: 'text-yellow-800 dark:text-yellow-400',
+    label: 'Degraded',
+  },
+  maintenance: {
+    bg: 'bg-gray-100 dark:bg-neutral-700',
+    text: 'text-gray-800 dark:text-neutral-300',
+    label: 'Maintenance',
+  },
+};
+
+const gatewayTypeLabels: Partial<Record<GatewayType, string>> = {
+  stoa: 'STOA',
+  stoa_edge_mcp: 'STOA Edge-MCP',
+  stoa_sidecar: 'STOA Sidecar',
+  stoa_proxy: 'STOA Proxy',
+  stoa_shadow: 'STOA Shadow',
+  kong: 'Kong',
+  gravitee: 'Gravitee',
+  webmethods: 'webMethods',
+  apigee: 'Apigee',
+  aws_apigateway: 'AWS API GW',
+};
+
+function StatusBadge({ status }: { status: GatewayStatus }) {
+  const cfg = statusConfig[status] || statusConfig.offline;
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${cfg.bg} ${cfg.text}`}
+    >
+      {cfg.label}
+    </span>
+  );
+}
+
+function ModeBadge({ mode }: { mode: string }) {
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-400">
+      {mode}
+    </span>
+  );
+}
+
+export function GatewaysPage() {
+  const [gateways, setGateways] = useState<GatewayInstance[]>([]);
+  const [total, setTotal] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [typeFilter, setTypeFilter] = useState('');
+  const [envFilter, setEnvFilter] = useState('');
+  const [healthCheckingId, setHealthCheckingId] = useState<string | null>(null);
+
+  const fetchGateways = useCallback(async () => {
+    setIsLoading(true);
+    const data = await gatewaysService.listGateways({
+      gateway_type: typeFilter || undefined,
+      environment: envFilter || undefined,
+    });
+    setGateways(data.items);
+    setTotal(data.total);
+    setIsLoading(false);
+  }, [typeFilter, envFilter]);
+
+  useEffect(() => {
+    fetchGateways();
+  }, [fetchGateways]);
+
+  const handleHealthCheck = async (id: string) => {
+    setHealthCheckingId(id);
+    await gatewaysService.triggerHealthCheck(id);
+    await fetchGateways();
+    setHealthCheckingId(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Gateway Instances</h1>
+          <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
+            {total} gateway{total !== 1 ? 's' : ''} registered
+          </p>
+        </div>
+        <button
+          onClick={fetchGateways}
+          className="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-neutral-600 rounded-md text-sm font-medium text-gray-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
+        >
+          <RefreshCw className={`w-4 h-4 mr-2 ${isLoading ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      {/* Filters */}
+      <div className="flex gap-3">
+        <select
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+          className="px-3 py-2 border border-gray-300 dark:border-neutral-600 rounded-md text-sm bg-white dark:bg-neutral-800 text-gray-700 dark:text-neutral-300"
+        >
+          <option value="">All Types</option>
+          <option value="stoa">STOA</option>
+          <option value="kong">Kong</option>
+          <option value="gravitee">Gravitee</option>
+          <option value="webmethods">webMethods</option>
+        </select>
+        <select
+          value={envFilter}
+          onChange={(e) => setEnvFilter(e.target.value)}
+          className="px-3 py-2 border border-gray-300 dark:border-neutral-600 rounded-md text-sm bg-white dark:bg-neutral-800 text-gray-700 dark:text-neutral-300"
+        >
+          <option value="">All Environments</option>
+          <option value="dev">Development</option>
+          <option value="staging">Staging</option>
+          <option value="prod">Production</option>
+        </select>
+      </div>
+
+      {/* Table */}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="w-6 h-6 animate-spin text-gray-400" />
+        </div>
+      ) : gateways.length === 0 ? (
+        <div className="text-center py-12 bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700">
+          <Server className="w-12 h-12 text-gray-300 dark:text-neutral-600 mx-auto mb-3" />
+          <p className="text-gray-500 dark:text-neutral-400 font-medium">No gateways registered</p>
+          <p className="text-sm text-gray-400 dark:text-neutral-500 mt-1">
+            Gateway instances will appear here once registered via the Control Plane API.
+          </p>
+        </div>
+      ) : (
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 overflow-hidden">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
+            <thead className="bg-gray-50 dark:bg-neutral-900">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  Name
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  Type
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  Environment
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  Mode
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  Last Health Check
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
+              {gateways.map((gw) => (
+                <tr
+                  key={gw.id}
+                  className="hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-colors"
+                >
+                  <td className="px-4 py-3">
+                    <div className="flex items-center">
+                      <Server className="w-4 h-4 text-gray-400 dark:text-neutral-500 mr-2" />
+                      <div>
+                        <p className="text-sm font-medium text-gray-900 dark:text-white">
+                          {gw.display_name}
+                        </p>
+                        <p className="text-xs text-gray-500 dark:text-neutral-400">{gw.name}</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-700 dark:text-neutral-300">
+                    {gatewayTypeLabels[gw.gateway_type] || gw.gateway_type}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-700 dark:text-neutral-300 capitalize">
+                    {gw.environment}
+                  </td>
+                  <td className="px-4 py-3">
+                    <StatusBadge status={gw.status} />
+                  </td>
+                  <td className="px-4 py-3">
+                    {gw.mode ? (
+                      <ModeBadge mode={gw.mode} />
+                    ) : (
+                      <span className="text-gray-400 dark:text-neutral-500 text-sm">—</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500 dark:text-neutral-400">
+                    {gw.last_health_check
+                      ? new Date(gw.last_health_check).toLocaleString()
+                      : 'Never'}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => handleHealthCheck(gw.id)}
+                      disabled={healthCheckingId === gw.id}
+                      className="inline-flex items-center px-2 py-1 text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/30 rounded transition-colors disabled:opacity-50"
+                      title="Trigger health check"
+                    >
+                      {healthCheckingId === gw.id ? (
+                        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                      ) : (
+                        <Activity className="w-3.5 h-3.5" />
+                      )}
+                      <span className="ml-1">Check</span>
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/portal/src/pages/gateways/index.ts
+++ b/portal/src/pages/gateways/index.ts
@@ -1,0 +1,1 @@
+export { GatewaysPage } from './GatewaysPage';

--- a/portal/src/services/gateways.ts
+++ b/portal/src/services/gateways.ts
@@ -1,0 +1,69 @@
+/**
+ * STOA Developer Portal - Gateway Instances Service
+ *
+ * Service for browsing and monitoring gateway instances.
+ * Uses /v1/admin/gateways endpoints.
+ */
+
+import { apiClient } from './api';
+import type { GatewayInstance, GatewayInstancesResponse, GatewayModeStats } from '../types';
+
+export interface ListGatewaysParams {
+  page?: number;
+  pageSize?: number;
+  gateway_type?: string;
+  environment?: string;
+  status?: string;
+}
+
+export const gatewaysService = {
+  listGateways: async (params?: ListGatewaysParams): Promise<GatewayInstancesResponse> => {
+    try {
+      const response = await apiClient.get<GatewayInstancesResponse>('/v1/admin/gateways', {
+        params: {
+          page: params?.page || 1,
+          page_size: params?.pageSize || 20,
+          gateway_type: params?.gateway_type,
+          environment: params?.environment,
+          status: params?.status,
+        },
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Failed to fetch gateways:', error);
+      return { items: [], total: 0, page: 1, page_size: 20 };
+    }
+  },
+
+  getGateway: async (id: string): Promise<GatewayInstance | null> => {
+    try {
+      const response = await apiClient.get<GatewayInstance>(`/v1/admin/gateways/${id}`);
+      return response.data;
+    } catch (error) {
+      console.error(`Failed to fetch gateway ${id}:`, error);
+      return null;
+    }
+  },
+
+  getModeStats: async (): Promise<GatewayModeStats[]> => {
+    try {
+      const response = await apiClient.get<GatewayModeStats[]>('/v1/admin/gateways/modes/stats');
+      return response.data;
+    } catch (error) {
+      console.error('Failed to fetch mode stats:', error);
+      return [];
+    }
+  },
+
+  triggerHealthCheck: async (id: string): Promise<boolean> => {
+    try {
+      await apiClient.post(`/v1/admin/gateways/${id}/health`);
+      return true;
+    } catch (error) {
+      console.error(`Failed to trigger health check for gateway ${id}:`, error);
+      return false;
+    }
+  },
+};
+
+export default gatewaysService;

--- a/portal/src/types/index.ts
+++ b/portal/src/types/index.ts
@@ -801,6 +801,52 @@ export interface PlanListResponse {
   total_pages: number;
 }
 
+// ============ Gateway Instance Types ============
+
+export type GatewayStatus = 'online' | 'offline' | 'degraded' | 'maintenance';
+
+export type GatewayType =
+  | 'stoa'
+  | 'stoa_edge_mcp'
+  | 'stoa_sidecar'
+  | 'stoa_proxy'
+  | 'stoa_shadow'
+  | 'kong'
+  | 'gravitee'
+  | 'webmethods'
+  | 'apigee'
+  | 'aws_apigateway';
+
+export interface GatewayInstance {
+  id: string;
+  name: string;
+  display_name: string;
+  gateway_type: GatewayType;
+  base_url: string;
+  admin_url?: string;
+  environment: string;
+  status: GatewayStatus;
+  mode?: string;
+  last_health_check?: string;
+  api_count?: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GatewayInstancesResponse {
+  items: GatewayInstance[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+export interface GatewayModeStats {
+  mode: string;
+  count: number;
+  healthy: number;
+  unhealthy: number;
+}
+
 // ============ Publish Contract Response Types (CAB-560) ============
 
 /**


### PR DESCRIPTION
## Summary
- Add `/gateways` route with admin-only protection (`scope: stoa:admin`)
- Create GatewaysPage with status/mode badges, type+env filters, health check trigger
- Add `gatewaysService` for gateway CRUD + health check
- Add "Operations" sidebar section, `enableGateways` feature flag
- 2 unit tests (table render + empty state)

## Test plan
- [ ] Portal lint: 0 errors, 14 warnings (pre-existing)
- [ ] Portal tsc: clean
- [ ] Portal tests: 430 pass
- [ ] Navigate to `/gateways` as cpi-admin — see table
- [ ] Navigate to `/gateways` as viewer — redirected to /unauthorized

🤖 Generated with [Claude Code](https://claude.com/claude-code)