### PR TITLE
feat(ui): add Gateway Arena benchmark dashboard

### DIFF
--- a/control-plane-ui/src/App.tsx
+++ b/control-plane-ui/src/App.tsx
@@ -360,6 +360,7 @@ function ProtectedRoutes() {
                 {/* Native observability dashboards (replace iframe embeds) */}
                 <Route path="/observability" element={<PlatformMetrics />} />
                 <Route path="/observability/grafana" element={<GrafanaEmbed />} />
+                <Route path="/observability/benchmarks" element={<GrafanaEmbed />} />
                 <Route path="/identity" element={<IdentityEmbed />} />
                 {/* Native request explorer (replace OpenSearch iframe) */}
                 <Route path="/logs" element={<RequestExplorer />} />

--- a/control-plane-ui/src/config.ts
+++ b/control-plane-ui/src/config.ts
@@ -105,6 +105,9 @@ export const config = {
     },
     grafana: {
       url: import.meta.env.VITE_GRAFANA_URL || '/grafana/',
+      arenaDashboardUrl:
+        import.meta.env.VITE_ARENA_DASHBOARD_URL ||
+        '/grafana/d/gateway-arena/gateway-arena-leaderboard',
     },
     prometheus: {
       url: import.meta.env.VITE_PROMETHEUS_URL || `https://prometheus.${BASE_DOMAIN}`,

--- a/control-plane-ui/src/pages/GatewayStatus.tsx
+++ b/control-plane-ui/src/pages/GatewayStatus.tsx
@@ -557,6 +557,34 @@ export default function GatewayStatus() {
         </div>
       </div>
 
+      {/* Gateway Arena */}
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 shadow-sm p-5">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center">
+            <div className="p-2 bg-purple-50 dark:bg-purple-900/30 rounded-lg">
+              <Gauge className="w-5 h-5 text-purple-600 dark:text-purple-400" />
+            </div>
+            <div className="ml-3">
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Gateway Arena</h3>
+              <p className="text-xs text-gray-500 dark:text-neutral-400">
+                Continuous benchmark leaderboard — STOA vs Kong vs Gravitee
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={() =>
+              navigate(
+                `/observability/benchmarks?url=${encodeURIComponent(config.services.grafana.arenaDashboardUrl)}`
+              )
+            }
+            className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-white bg-purple-600 rounded-lg hover:bg-purple-700 transition-colors"
+          >
+            <BarChart3 className="w-4 h-4" />
+            View Benchmarks
+          </button>
+        </div>
+      </div>
+
       {/* Info Banner */}
       <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
         <div className="flex">


### PR DESCRIPTION
## Summary
- "Gateway Arena" card on `/gateway` page with Gauge icon and description
- Button navigates to `/observability/benchmarks` with Arena Grafana dashboard URL
- New route `/observability/benchmarks` reusing existing `GrafanaEmbed` component
- Config: `arenaDashboardUrl` pointing to `gateway-arena-leaderboard` Grafana dashboard

## Test plan
- [x] TypeScript clean (`tsc --noEmit`)
- [x] ESLint: 101 warnings (= max threshold)
- [x] Prettier: all files formatted
- [x] 3 files changed, ~32 LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>