### PR TITLE
fix(ui): set console replicas to 2 for zero-downtime deploys

### DIFF
--- a/control-plane-ui/k8s/deployment.yaml
+++ b/control-plane-ui/k8s/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: frontend
     app.kubernetes.io/part-of: stoa-platform
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
## Summary
- Console deployment had `replicas: 1` with `maxSurge: 0, maxUnavailable: 1`, causing **downtime on every deploy** (pod killed before new one starts)
- Bumps to `replicas: 2` to match portal and gateway, ensuring at least 1 pod serves traffic during rollout

## Test plan
- [ ] CI green (security-scan: License, SBOM, Signed Commits)
- [ ] After merge: verify `kubectl get pods -n stoa-system -l app=control-plane-ui` shows 2 pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)