### PR TITLE
fix(ci): replace broken Vault smoke tests with two-tier verification

### DIFF
--- a/.github/workflows/control-plane-api-ci.yml
+++ b/.github/workflows/control-plane-api-ci.yml
@@ -135,17 +135,17 @@ jobs:
       contents: read
     secrets: inherit
 
-  # === Smoke Test: E2E @smoke after deploy ===
+  # === Smoke Test: health checks after deploy (Tier 1) ===
+  # Full E2E with personas runs nightly (e2e-nightly.yml)
   smoke-test:
     needs: deploy
     if: needs.deploy.result == 'success'
-    uses: ./.github/workflows/reusable-smoke-test.yml
+    uses: ./.github/workflows/reusable-health-smoke.yml
     with:
       component: control-plane-api
+      environment: ${{ github.event.inputs.environment || 'dev' }}
     permissions:
       contents: read
-      id-token: write
-    secrets: inherit
 
   # === Notify: Slack ===
   notify:

--- a/.github/workflows/control-plane-ui-ci.yml
+++ b/.github/workflows/control-plane-ui-ci.yml
@@ -129,17 +129,17 @@ jobs:
       contents: read
     secrets: inherit
 
-  # === Smoke Test: E2E @smoke after deploy ===
+  # === Smoke Test: health checks after deploy (Tier 1) ===
+  # Full E2E with personas runs nightly (e2e-nightly.yml)
   smoke-test:
     needs: deploy
     if: needs.deploy.result == 'success'
-    uses: ./.github/workflows/reusable-smoke-test.yml
+    uses: ./.github/workflows/reusable-health-smoke.yml
     with:
       component: control-plane-ui
+      environment: ${{ github.event.inputs.environment || 'dev' }}
     permissions:
       contents: read
-      id-token: write
-    secrets: inherit
 
   # === Notify: Slack ===
   notify:

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,35 @@
+# =============================================================================
+# E2E Nightly Tests — Tier 2 full verification
+# =============================================================================
+# Runs the full @smoke Playwright suite with persona auth against production.
+# Scheduled nightly at 6h UTC, or on-demand via workflow_dispatch.
+#
+# Requires GitHub Secrets for 7 personas (see scripts/dev/setup-e2e-secrets.sh).
+# For post-deploy health checks (Tier 1), see reusable-health-smoke.yml.
+# =============================================================================
+
+name: E2E Nightly Tests
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      test-grep:
+        description: 'Playwright grep pattern'
+        type: choice
+        options:
+          - '@smoke'
+          - '@critical'
+          - '@smoke|@critical'
+        default: '@smoke'
+
+jobs:
+  e2e:
+    uses: ./.github/workflows/reusable-smoke-test.yml
+    with:
+      component: nightly
+      test-grep: ${{ inputs.test-grep || '@smoke' }}
+    permissions:
+      contents: read
+    secrets: inherit

--- a/.github/workflows/reusable-health-smoke.yml
+++ b/.github/workflows/reusable-health-smoke.yml
@@ -1,0 +1,67 @@
+# =============================================================================
+# Reusable Health Smoke Test — Tier 1 post-deploy verification
+# =============================================================================
+# curl-based health checks against 5 production endpoints.
+# Zero auth required, runs in ~30s, catches real deploy failures:
+#   pod crash, ingress misconfiguration, Keycloak down, image pull error.
+#
+# For full E2E with Playwright + personas, see e2e-nightly.yml (Tier 2).
+# =============================================================================
+
+name: Reusable Health Smoke Test
+
+on:
+  workflow_call:
+    inputs:
+      component:
+        description: 'Component that was just deployed (for logging)'
+        required: true
+        type: string
+      environment:
+        description: 'Target environment (dev, staging, prod)'
+        required: false
+        type: string
+        default: 'dev'
+
+jobs:
+  health-check:
+    name: Health Smoke (${{ inputs.component }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Wait for rollout (30s)
+        run: sleep 30
+
+      - name: Health checks
+        env:
+          ENV_PREFIX: ${{ inputs.environment == 'staging' && 'staging-' || '' }}
+        run: |
+          set -euo pipefail
+          PASS=0; FAIL=0
+
+          check() {
+            local name="$1" url="$2" expected="${3:-200}"
+            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 --retry 2 --retry-delay 5 "$url") || status="000"
+            if [ "$status" = "$expected" ]; then
+              echo "  $name: $status"
+              PASS=$((PASS+1))
+            else
+              echo "  $name: $status (expected $expected)"
+              FAIL=$((FAIL+1))
+            fi
+          }
+
+          BASE="${ENV_PREFIX}gostoa.dev"
+          echo "Health checks for ${BASE} (after ${{ inputs.component }} deploy)"
+          echo "---"
+
+          check "API Health"      "https://${ENV_PREFIX}api.gostoa.dev/health"
+          check "Gateway Health"  "https://${ENV_PREFIX}mcp.gostoa.dev/health/ready"
+          check "Portal"          "https://${ENV_PREFIX}portal.gostoa.dev"
+          check "Console"         "https://${ENV_PREFIX}console.gostoa.dev"
+          check "Keycloak OIDC"   "https://${ENV_PREFIX}auth.gostoa.dev/realms/stoa/.well-known/openid-configuration"
+
+          echo "---"
+          echo "Results: $PASS passed, $FAIL failed (component: ${{ inputs.component }})"
+          [ "$FAIL" -eq 0 ] || exit 1

--- a/.github/workflows/reusable-smoke-test.yml
+++ b/.github/workflows/reusable-smoke-test.yml
@@ -12,13 +12,7 @@ on:
         required: false
         type: string
         default: '@smoke'
-      vault-enabled:
-        description: 'Whether to fetch secrets from Vault (requires Vault JWT auth configured)'
-        required: false
-        type: boolean
-        default: true
     secrets:
-      # Legacy secrets (used when vault-enabled=false or as fallback)
       E2E_PORTAL_URL:
         required: false
       E2E_CONSOLE_URL:
@@ -61,41 +55,10 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      id-token: write  # Required for Vault OIDC authentication
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Fetch E2E secrets from Vault
-        if: inputs.vault-enabled
-        id: vault-secrets
-        continue-on-error: true  # Gracefully fall back to GitHub secrets if Vault fails
-        uses: hashicorp/vault-action@v3
-        with:
-          url: https://vault.gostoa.dev
-          method: jwt
-          role: github-actions
-          jwtGithubAudience: sigstore
-          exportEnv: true
-          secrets: |
-            secret/data/e2e/urls PORTAL_URL | E2E_PORTAL_URL ;
-            secret/data/e2e/urls CONSOLE_URL | E2E_CONSOLE_URL ;
-            secret/data/e2e/urls GATEWAY_URL | E2E_GATEWAY_URL ;
-            secret/data/e2e/urls KEYCLOAK_URL | E2E_KEYCLOAK_URL ;
-            secret/data/e2e/personas/parzival username | PARZIVAL_USER ;
-            secret/data/e2e/personas/parzival password | PARZIVAL_PASSWORD ;
-            secret/data/e2e/personas/art3mis username | ART3MIS_USER ;
-            secret/data/e2e/personas/art3mis password | ART3MIS_PASSWORD ;
-            secret/data/e2e/personas/aech username | AECH_USER ;
-            secret/data/e2e/personas/aech password | AECH_PASSWORD ;
-            secret/data/e2e/personas/sorrento username | SORRENTO_USER ;
-            secret/data/e2e/personas/sorrento password | SORRENTO_PASSWORD ;
-            secret/data/e2e/personas/anorak username | ANORAK_USER ;
-            secret/data/e2e/personas/anorak password | ANORAK_PASSWORD ;
-            secret/data/e2e/personas/alex username | ALEX_USER ;
-            secret/data/e2e/personas/alex password | ALEX_PASSWORD ;
-            secret/data/e2e/api-keys test | TEST_API_KEY
 
       - name: Setup E2E environment
         uses: ./.github/actions/e2e-setup
@@ -103,26 +66,26 @@ jobs:
       - name: Run smoke tests
         working-directory: e2e
         env:
-          # URLs - Vault values take precedence, then secrets, then defaults
-          STOA_PORTAL_URL: ${{ env.E2E_PORTAL_URL || secrets.E2E_PORTAL_URL || 'https://portal.gostoa.dev' }}
-          STOA_CONSOLE_URL: ${{ env.E2E_CONSOLE_URL || secrets.E2E_CONSOLE_URL || 'https://console.gostoa.dev' }}
-          STOA_GATEWAY_URL: ${{ env.E2E_GATEWAY_URL || secrets.E2E_GATEWAY_URL || 'https://api.gostoa.dev' }}
-          KEYCLOAK_URL: ${{ env.E2E_KEYCLOAK_URL || secrets.E2E_KEYCLOAK_URL || 'https://auth.gostoa.dev' }}
+          # URLs — GitHub Secrets with sane defaults
+          STOA_PORTAL_URL: ${{ secrets.E2E_PORTAL_URL || 'https://portal.gostoa.dev' }}
+          STOA_CONSOLE_URL: ${{ secrets.E2E_CONSOLE_URL || 'https://console.gostoa.dev' }}
+          STOA_GATEWAY_URL: ${{ secrets.E2E_GATEWAY_URL || 'https://api.gostoa.dev' }}
+          KEYCLOAK_URL: ${{ secrets.E2E_KEYCLOAK_URL || 'https://auth.gostoa.dev' }}
           KEYCLOAK_REALM: stoa
-          # Personas - Vault values take precedence, then secrets
-          PARZIVAL_USER: ${{ env.PARZIVAL_USER || secrets.PARZIVAL_USER }}
-          PARZIVAL_PASSWORD: ${{ env.PARZIVAL_PASSWORD || secrets.PARZIVAL_PASSWORD }}
-          ART3MIS_USER: ${{ env.ART3MIS_USER || secrets.ART3MIS_USER }}
-          ART3MIS_PASSWORD: ${{ env.ART3MIS_PASSWORD || secrets.ART3MIS_PASSWORD }}
-          AECH_USER: ${{ env.AECH_USER || secrets.AECH_USER }}
-          AECH_PASSWORD: ${{ env.AECH_PASSWORD || secrets.AECH_PASSWORD }}
-          SORRENTO_USER: ${{ env.SORRENTO_USER || secrets.SORRENTO_USER }}
-          SORRENTO_PASSWORD: ${{ env.SORRENTO_PASSWORD || secrets.SORRENTO_PASSWORD }}
-          ANORAK_USER: ${{ env.ANORAK_USER || secrets.ANORAK_USER }}
-          ANORAK_PASSWORD: ${{ env.ANORAK_PASSWORD || secrets.ANORAK_PASSWORD }}
-          ALEX_USER: ${{ env.ALEX_USER || secrets.ALEX_USER }}
-          ALEX_PASSWORD: ${{ env.ALEX_PASSWORD || secrets.ALEX_PASSWORD }}
-          TEST_API_KEY: ${{ env.TEST_API_KEY || secrets.TEST_API_KEY }}
+          # Personas — from GitHub Secrets (see scripts/dev/setup-e2e-secrets.sh)
+          PARZIVAL_USER: ${{ secrets.PARZIVAL_USER }}
+          PARZIVAL_PASSWORD: ${{ secrets.PARZIVAL_PASSWORD }}
+          ART3MIS_USER: ${{ secrets.ART3MIS_USER }}
+          ART3MIS_PASSWORD: ${{ secrets.ART3MIS_PASSWORD }}
+          AECH_USER: ${{ secrets.AECH_USER }}
+          AECH_PASSWORD: ${{ secrets.AECH_PASSWORD }}
+          SORRENTO_USER: ${{ secrets.SORRENTO_USER }}
+          SORRENTO_PASSWORD: ${{ secrets.SORRENTO_PASSWORD }}
+          ANORAK_USER: ${{ secrets.ANORAK_USER }}
+          ANORAK_PASSWORD: ${{ secrets.ANORAK_PASSWORD }}
+          ALEX_USER: ${{ secrets.ALEX_USER }}
+          ALEX_PASSWORD: ${{ secrets.ALEX_PASSWORD }}
+          TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
         run: |
           npx playwright test --project=auth-setup || exit 1
           npx playwright test --grep ${{ inputs.test-grep }}

--- a/.github/workflows/stoa-gateway-ci.yml
+++ b/.github/workflows/stoa-gateway-ci.yml
@@ -107,17 +107,17 @@ jobs:
           kubectl rollout restart deployment/stoa-gateway -n stoa-system
           kubectl rollout status deployment/stoa-gateway -n stoa-system --timeout=300s
 
-  # === Smoke Test: E2E @smoke after deploy ===
+  # === Smoke Test: health checks after deploy (Tier 1) ===
+  # Full E2E with personas runs nightly (e2e-nightly.yml)
   smoke-test:
     needs: deploy
     if: needs.deploy.result == 'success'
-    uses: ./.github/workflows/reusable-smoke-test.yml
+    uses: ./.github/workflows/reusable-health-smoke.yml
     with:
       component: stoa-gateway
+      environment: ${{ github.event.inputs.environment || 'dev' }}
     permissions:
       contents: read
-      id-token: write
-    secrets: inherit
 
   # === Notify: Slack ===
   notify:

--- a/.github/workflows/stoa-portal-ci.yml
+++ b/.github/workflows/stoa-portal-ci.yml
@@ -130,17 +130,17 @@ jobs:
       contents: read
     secrets: inherit
 
-  # === Smoke Test: E2E @smoke after deploy ===
+  # === Smoke Test: health checks after deploy (Tier 1) ===
+  # Full E2E with personas runs nightly (e2e-nightly.yml)
   smoke-test:
     needs: deploy
     if: needs.deploy.result == 'success'
-    uses: ./.github/workflows/reusable-smoke-test.yml
+    uses: ./.github/workflows/reusable-health-smoke.yml
     with:
       component: stoa-portal
+      environment: ${{ github.event.inputs.environment || 'dev' }}
     permissions:
       contents: read
-      id-token: write
-    secrets: inherit
 
   # === Notify: Slack ===
   notify:

--- a/scripts/dev/setup-e2e-secrets.sh
+++ b/scripts/dev/setup-e2e-secrets.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Setup GitHub Secrets for E2E nightly tests
+# =============================================================================
+# Configures the 17 secrets required by reusable-smoke-test.yml (Tier 2).
+# Run once, then update when Keycloak passwords change.
+#
+# Prerequisites:
+#   - gh CLI authenticated (gh auth status)
+#   - Access to Keycloak admin (auth.gostoa.dev) for persona passwords
+#
+# Usage:
+#   ./scripts/dev/setup-e2e-secrets.sh
+# =============================================================================
+set -euo pipefail
+
+REPO="stoa-platform/stoa"
+
+echo "Setting up E2E GitHub Secrets for $REPO"
+echo "==========================================="
+echo ""
+echo "This script requires Keycloak persona passwords."
+echo "Get them from: https://auth.gostoa.dev/admin/master/console/#/stoa/users"
+echo ""
+
+# --- URLs (with defaults — optional, but explicit is better) ---
+gh secret set E2E_PORTAL_URL  --repo "$REPO" --body "https://portal.gostoa.dev"
+gh secret set E2E_CONSOLE_URL --repo "$REPO" --body "https://console.gostoa.dev"
+gh secret set E2E_GATEWAY_URL --repo "$REPO" --body "https://api.gostoa.dev"
+gh secret set E2E_KEYCLOAK_URL --repo "$REPO" --body "https://auth.gostoa.dev"
+echo "  URLs configured"
+
+# --- Personas (REQUIRED — prompt for passwords) ---
+personas=("PARZIVAL" "ART3MIS" "AECH" "SORRENTO" "ANORAK" "ALEX")
+usernames=("parzival" "art3mis" "aech" "sorrento" "anorak" "alex")
+
+for i in "${!personas[@]}"; do
+  name="${personas[$i]}"
+  user="${usernames[$i]}"
+  gh secret set "${name}_USER" --repo "$REPO" --body "$user"
+
+  read -rsp "  Enter password for $user: " password
+  echo ""
+  gh secret set "${name}_PASSWORD" --repo "$REPO" --body "$password"
+done
+echo "  Personas configured"
+
+# --- API Key ---
+read -rsp "  Enter TEST_API_KEY (gateway API key): " apikey
+echo ""
+gh secret set TEST_API_KEY --repo "$REPO" --body "$apikey"
+echo "  API key configured"
+
+echo ""
+echo "Done! 17 secrets configured for $REPO."
+echo "Verify with: gh secret list --repo $REPO"


### PR DESCRIPTION
## Summary

- **Problem**: Post-deploy smoke tests fail systematically — `reusable-smoke-test.yml` uses `hashicorp/vault-action` against Infisical (migrated Feb 2026), not HashiCorp Vault. JWT auth fails silently (`continue-on-error`), GitHub Secrets fallback also fails (secrets not configured). Result: all `@smoke` tests skip/fail after every deploy.

- **Solution**: Industry-standard two-tier post-deploy verification:

  | Tier | When | What | Duration | Auth needed |
  |------|------|------|----------|-------------|
  | **Tier 1** (health) | Every deploy | curl 5 endpoints (API, Gateway, Portal, Console, Keycloak) | ~30s | None |
  | **Tier 2** (E2E) | Nightly 6h UTC + on-demand | Full Playwright `@smoke` with 7 personas | 5-15 min | GitHub Secrets |

### Changes

1. **`reusable-health-smoke.yml`** (NEW) — Tier 1: curl-based health checks, zero auth, staging-aware
2. **`e2e-nightly.yml`** (NEW) — Tier 2: cron `0 6 * * *` + `workflow_dispatch` with test pattern choice
3. **`reusable-smoke-test.yml`** (EDIT) — Remove `hashicorp/vault-action`, use GitHub Secrets directly
4. **4 CI workflows** (EDIT) — Switch post-deploy from `reusable-smoke-test` to `reusable-health-smoke`
5. **`scripts/dev/setup-e2e-secrets.sh`** (NEW) — Helper to configure the 17 GitHub Secrets for E2E

### Manual TODO after merge

Run `./scripts/dev/setup-e2e-secrets.sh` to configure Keycloak persona passwords as GitHub Secrets (required for nightly E2E).

## Test plan

- [ ] Health smoke runs successfully after next deploy (curl checks)
- [ ] E2E nightly can be triggered manually via `workflow_dispatch`
- [ ] `scripts/dev/setup-e2e-secrets.sh` sets all 17 secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)