### PR TITLE
fix(gateway): align k8s manifest with production

### DIFF
--- a/stoa-gateway/k8s/deployment.yaml
+++ b/stoa-gateway/k8s/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: stoa-gateway
-          image: ghcr.io/stoa-platform/stoa-gateway:dev-latest
+          image: ghcr.io/stoa-platform/stoa-gateway:latest
           imagePullPolicy: Always
           ports:
             - name: http
@@ -43,7 +43,7 @@ spec:
             - name: STOA_HOST
               value: "0.0.0.0"
             - name: STOA_CONTROL_PLANE_URL
-              value: "http://control-plane-api.stoa-system.svc.cluster.local:8000"
+              value: "http://stoa-control-plane-api.stoa-system.svc.cluster.local:80"
             - name: STOA_LOG_LEVEL
               value: "info"
             - name: STOA_LOG_FORMAT
@@ -54,6 +54,10 @@ spec:
               value: "stoa"
             - name: STOA_KEYCLOAK_CLIENT_ID
               value: "stoa-mcp-gateway"
+            - name: STOA_RATE_LIMIT_DEFAULT
+              value: "1000"
+            - name: STOA_GATEWAY_EXTERNAL_URL
+              value: "https://mcp.gostoa.dev"
             - name: STOA_KAFKA_ENABLED
               value: "true"
             - name: STOA_KAFKA_BROKERS


### PR DESCRIPTION
## Summary
- Image tag: `dev-latest` → `latest` (matches CI docker push + OVH production)
- CP URL: `control-plane-api:8000` → `stoa-control-plane-api:80` (matches Helm chart service name + port)
- Add missing env vars: `STOA_RATE_LIMIT_DEFAULT`, `STOA_GATEWAY_EXTERNAL_URL`

This standalone manifest was out of sync with the Helm-managed production deployment (ArgoCD sources from `stoa-infra/charts/stoa-gateway`). Applying it directly caused pod failures (CP API unreachable).

## Context
Part of the Gateway → Redpanda connection work. The drift was discovered when `kubectl apply -f deployment.yaml` broke OVH pods.

## Test plan
- [ ] CI green (security-scan only — no code changes)
- [ ] `kubectl diff` against live deployment shows alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>