### PR TITLE
fix(api): fix OpenSearch auth + audit middleware wiring

### DIFF
--- a/control-plane-api/k8s/configmap.yaml
+++ b/control-plane-api/k8s/configmap.yaml
@@ -74,7 +74,7 @@ data:
   DATABASE_MAX_OVERFLOW: "10"
 
   # OpenSearch (CAB-307: Audit Trail)
-  OPENSEARCH_HOST: "https://opensearch.opensearch.svc.cluster.local:9200"
+  OPENSEARCH_HOST: "http://opensearch.opensearch.svc.cluster.local:9200"
   OPENSEARCH_USER: "admin"
   OPENSEARCH_VERIFY_CERTS: "false"
   AUDIT_ENABLED: "true"

--- a/control-plane-api/src/main.py
+++ b/control-plane-api/src/main.py
@@ -25,6 +25,7 @@ from .middleware.http_logging import HTTPLoggingMiddleware
 from .middleware.metrics import MetricsMiddleware, get_metrics
 from .middleware.rate_limit import limiter, rate_limit_exceeded_handler
 from .opensearch import search_router, setup_opensearch
+from .opensearch.audit_middleware import AuditMiddleware
 from .routers import (
     access_requests,
     admin_prospects,
@@ -417,7 +418,8 @@ if settings.LOG_HTTP_MIDDLEWARE_ENABLED:
 # Must be added before app startup, connects to storage in lifespan
 add_error_snapshot_middleware(app)
 
-# Audit middleware (CAB-307) - AuditMiddleware added dynamically via setup_opensearch()
+# Audit middleware (CAB-307) - registered at init, lazy-connects to OpenSearch at request time
+app.add_middleware(AuditMiddleware)
 
 # Routers
 app.include_router(tenants.router)

--- a/control-plane-api/src/opensearch/audit_middleware.py
+++ b/control-plane-api/src/opensearch/audit_middleware.py
@@ -217,12 +217,24 @@ class AuditMiddleware(BaseHTTPMiddleware):
     def __init__(
         self,
         app,
-        audit_logger: AuditLogger,
+        audit_logger: AuditLogger | None = None,
         skip_paths: set[str] | None = None,
     ):
         super().__init__(app)
-        self.audit_logger = audit_logger
+        self._audit_logger = audit_logger
         self.skip_paths = skip_paths or self.SKIP_PATHS
+
+    @property
+    def audit_logger(self) -> AuditLogger | None:
+        """Lazy lookup: use provided logger or get from OpenSearchService singleton."""
+        if self._audit_logger:
+            return self._audit_logger
+        try:
+            from .opensearch_integration import OpenSearchService
+            service = OpenSearchService.get_instance()
+            return service.audit_logger
+        except Exception:
+            return None
 
     async def dispatch(
         self,
@@ -230,6 +242,10 @@ class AuditMiddleware(BaseHTTPMiddleware):
         call_next: RequestResponseEndpoint,
     ) -> Response:
         """Process request and log audit event."""
+
+        # Skip if audit logger not yet initialized (OpenSearch not connected)
+        if not self.audit_logger:
+            return await call_next(request)
 
         # Skip non-auditable paths
         if request.url.path in self.skip_paths:

--- a/control-plane-api/src/opensearch/opensearch_integration.py
+++ b/control-plane-api/src/opensearch/opensearch_integration.py
@@ -173,9 +173,5 @@ async def setup_opensearch(app: FastAPI) -> None:
     async def opensearch_health():
         return await service.health_check()
 
-    # Wire audit middleware (CAB-307) — logs all API requests to OpenSearch
     if service.audit_logger:
-        from .audit_middleware import AuditMiddleware
-
-        app.add_middleware(AuditMiddleware, audit_logger=service.audit_logger)
-        logger.info("Audit middleware attached — real audit logging enabled")
+        logger.info("Audit logger ready — middleware uses lazy lookup via OpenSearchService")

--- a/k8s/logging/fluent-bit-config.yaml
+++ b/k8s/logging/fluent-bit-config.yaml
@@ -49,8 +49,7 @@ data:
         HTTP_Passwd       ${OPENSEARCH_PASSWORD}
         Index             stoa-logs
         Type              _doc
-        tls               On
-        tls.verify        Off
+        tls               Off
         Suppress_Type_Name  On
         Logstash_Format   On
         Logstash_Prefix   stoa-logs


### PR DESCRIPTION
## Summary
- Switch OpenSearch internal K8s communication to HTTP (disable HTTP TLS) — fixes Python client 401 caused by demo cert TLS handshake incompatibility
- Register AuditMiddleware at init time with lazy logger lookup (Starlette forbids adding middleware after app startup)
- Update Fluent Bit config to use plain HTTP for OpenSearch output

## Root cause
OpenSearch demo certificates cause Python TLS libraries to fail auth (username shows as `null` in OpenSearch logs) while curl works fine. The actual stored password included a shell-escaped backslash (`StOa_Admin_2026\!`). Even with correct password, Python's TLS handshake with demo certs was unreliable. Disabling HTTP TLS for internal cluster communication is the cleanest fix (transport TLS between nodes remains enabled).

## Test plan
- [x] 599 tests pass, 6 OpenAPI contract tests pass
- [x] CP API connects to OpenSearch (status 200, cluster recognized)
- [x] Audit logger initializes successfully
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>