### PR TITLE
fix(gateway): add /health/ready and /health/live K8s probe routes

### DIFF
--- a/stoa-gateway/src/access_log.rs
+++ b/stoa-gateway/src/access_log.rs
@@ -11,7 +11,13 @@ use axum::{extract::Request, middleware::Next, response::Response};
 use std::time::Instant;
 
 /// Paths to skip from access logging (noisy health/metrics endpoints).
-const SKIP_PATHS: &[&str] = &["/health", "/ready", "/metrics"];
+const SKIP_PATHS: &[&str] = &[
+    "/health",
+    "/health/ready",
+    "/health/live",
+    "/ready",
+    "/metrics",
+];
 
 /// Access log middleware — emits structured JSON for each request.
 ///

--- a/stoa-gateway/src/lib.rs
+++ b/stoa-gateway/src/lib.rs
@@ -98,6 +98,8 @@ pub fn build_router(state: AppState) -> Router {
     // Common routes for all modes: health, metrics, admin
     let base = Router::new()
         .route("/health", get(health))
+        .route("/health/ready", get(ready))
+        .route("/health/live", get(health))
         .route("/ready", get(ready))
         .route("/metrics", get(prometheus_metrics))
         .nest("/admin", admin_router)


### PR DESCRIPTION
## Summary
- Add `/health/ready` and `/health/live` routes as aliases for existing `ready()` and `health()` handlers
- Fixes the post-deploy smoke test which checks `/health/ready` (K8s standard convention)
- Update access_log `SKIP_PATHS` to exclude the new probe paths from logging

## Root Cause
The gateway registered `/health` and `/ready` as separate top-level routes, but the reusable smoke test (`reusable-health-smoke.yml:60`) checks `/health/ready` — the K8s-standard nested probe path. This returned 404 and failed every gateway CI run on main.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` zero warnings
- [x] `cargo test` — 22 passed
- [x] `/health/ready` now maps to `ready()` handler
- [x] `/health/live` now maps to `health()` handler

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>