### PR TITLE
docs: update state files — post docs-v1, countdown demo 24/02

### DIFF
--- a/memory.md
+++ b/memory.md
@@ -1,170 +1,72 @@
 # STOA Memory
 
-> Last updated: 2026-02-12 (Gateway Arena deployed on OVH — PR #374, full pipeline live)
+> Dernière MAJ: 2026-02-13
 
-## Active Sprint
-- **Goal**: Revenue-ready demo by Feb 24, 2026
-- **Branch**: main
-- **Focus**: Demo prep (dry-runs, email), remaining tickets
-- **Latest**: OVH prod LIVE (12/12 HTTPS). Hetzner staging LIVE (6/6 HTTPS). Portal tests: 427 total (PR #308)
+## ✅ DONE (cette semaine)
 
-## Session State
+### Docs v1.0 — COMPLET 107/107 pts
+- CAB-1139: MCP Documentation Complete (13 pts) — PR #36
+- CAB-1140: Developer Guides: Subscription, Consumer, Keys, Environments (21 pts) — PR #37
+- CAB-1141: API & Security References: RBAC, Gateway Admin, Quotas, OAuth (19 pts) — PR #37
+- CAB-1142: Admin Guide Phase 1: Installation, Keycloak, Monitoring (13 pts) — PR #39
+- CAB-1143: Multi-Gateway Orchestration & Gateway Modes (13 pts) — PR #39
+- CAB-1144: P2 Bundle: Admin Phase 2, OpenAPI Ref, Exit Strategy, Cleanup (28 pts) — PR #40
 
-| Status | Ticket | Description | Evidence |
-|--------|--------|-------------|----------|
-| DONE | — | Plan restructure: binary DoD + AI Factory execution | commit c8e74a38 |
-|--------|--------|-------------|----------|
-| DONE | CAB-1044 | API Search HTTP 500 fix | commit 2c5672d8 |
-| DONE | CAB-1040 | Gateway Routes HTTP 404 fix | commit 0c33e21d |
-| DONE | CAB-1042 | Vault sealed fix | commit 8bbf71b9 |
-| DONE | CAB-1041 | E2E BDD auth fix | commit 248f9d29 |
-| DONE | — | CLI stoa v0.1.0 (5 commands, 55 tests, 84% coverage) | Session 2 |
-| DONE | — | E2E tests 24/24 pass | Session 3 |
-| DONE | CAB-1061 | Demo data seed script | Session 4 |
-| DONE | CAB-1060 | Docs 20 pages (Docusaurus) | Session 5 |
-| DONE | CAB-1062 | Docker image + CI deploy | PR #74, Session 6 |
-| DONE | ADR-030 | AI context management architecture | Session 7 |
-| DONE | — | Context refactor: CLAUDE.md 11KB→3KB + 8 rules + 8 component docs + 8 skills + hooks | Session 7 |
-| DONE | CAB-CD-001 | Enterprise CD Architecture deployed on EKS | Session 8, commit 46401a3b |
-| DONE | CAB-1113 | Performance Phase 5+6: SQL filtering + DTOs + Cache + Keycloak Boot + Web Vitals | PRs #139, Session 9-10 |
-| DONE | CAB-1114 | OpenSearch all 4 phases: Deploy + RGPD + Multi-Tenant OIDC + Console Integration | Sessions 11-14 |
-| DONE | CAB-1115 | Console UI Performance Optimization | PR #148, Hotfix PR #150 |
-| DONE | CAB-1108 | Iframe Embed Fix — Logs + Grafana (nginx reverse proxy) | PRs #153, #155, #164-167 |
-| DONE | — | EKS Deploy Fixes — All 4 components running | PRs #149, #152, #154, #157 |
-| DONE | — | AI Factory Setup (5 agents, 2 skills, 14 rules) | Session 16 |
-| DONE | CAB-1116 | Test Automation — all 5 phases (Console 257, Portal 236, API 103, E2E 81) | PRs #168-178 |
-| DONE | CAB-1103 | Control Plane Agnostique — all 7 phases | PR #184 |
-| DONE | CAB-1105 | Kill Python — all 9 phases (222 tests, clippy clean) | PRs #180, #181 |
-| DONE | CAB-1109 | GitOps Pipeline — Helm + ArgoCD + CI migration | PRs #188, #193, stoa-infra PR #7 |
-| DONE | CAB-1119 | Brand Unification — all 5 phases (493 tests) | PRs #194, #198 |
-| DONE | — | PR cleanup: 39 PRs → 0 open | Session 20 |
-| DONE | CAB-1120 | Content Compliance (content-reviewer agent + rule) | PR #203 |
-| DONE | CAB-1121 | P1 Data Model + CRUD APIs (17 files, 23 tests) | PR #204 |
-| DONE | CAB-1121 | P2 Keycloak Integration | PR #208 |
-| DONE | CAB-1121 | P3 Gateway Propagation | PR #211 |
-| DONE | CAB-1121 | P5 Portal Consumer UI (16 files, 267 tests) | PR #220 |
-| DONE | CAB-1122 | Zero Errors — all 6 phases across all components | PR #215 |
-| DONE | CAB-362 | Circuit Breaker + Session Management (8 files) | PR #218 |
-| DONE | CAB-864 | P1 mTLS Design Doc + ADR-039 | PR #221 |
-| DONE | — | Ship/Show/Ask Git Workflow for AI Factory | PR #222 |
-| DONE | — | AI Factory modernization + state files refresh | Session 21 |
-| DONE | CAB-864 | P2 mTLS Gateway Module (Rust, 870 lines, 299 tests) | PR #224 |
-| DONE | CAB-864 | P3 Bulk Onboarding + Registry (Alembic 020) | PR #230 |
-| DONE | CAB-1121 | P4 Quota Enforcement (rate limiting, 27 tests) | PR #229 |
-| DONE | CAB-1121 | P6 E2E Tests full flow | PR #233 |
-| DONE | — | Console dark mode batch 1-4 | PRs #234, #235, #240, #241, #243 |
-| DONE | — | Console dark mode batch 5 (External MCP Servers) | PR #246 |
-| DONE | — | Console dark mode batch 6 (APIMonitoring + ErrorSnapshots) | PR #247 |
-| DONE | — | Console dark mode COMPLETE — all pages verified | All pages have dark: variants |
-| DONE | — | Dark mode tools components (ToolCard, UsageChart, QuickStartGuide, ToolSchemaViewer) | PR #286 |
-| DONE | D1 | Rust GW basic mode (compile fix + docker-compose) | PRs #242, #244 |
-| DONE | D2 | Keycloak federation cross-tenant (5 realms, OpenLDAP) | PR #248, #282 (live demo) |
-| DONE | D3 | OpenSearch error snapshots dashboard + seed script | PR #249 |
-| DONE | D4 | Gateway metrics dashboard + 9 analytics dashboards | PR #249 |
-| DONE | D5 | Master seed orchestration script (seed-all.sh) | PR #249 |
-| DONE | D6 | Docker-compose demo final (health checks, nginx routes, check-health.sh) | PR #250 |
-| DONE | D7 | Demo script 8-act presentation + pre-flight checklist | PR #257 |
-| DONE | D8 | README rewrite for public launch (4100→185 lines) | PR #280 |
-| DONE | D10 | Dry-run #2 — 7/8 acts PASS, federation fixed, seed fixed | PR #284 |
-| DONE | D11 | From-scratch validation — LDAP auto-seed, Keycloak SSL, 7/7+9/9 | PRs #287, #288 |
-| DONE | R1 | MCP v1 REST endpoints + API-to-Tool bridge (Act 7) | PR #290 |
-| DONE | R1-fix | API bridge: internal endpoint + docker-compose local build | PR #291 |
-| DONE | — | OpSec: dual-repo setup (stoa-strategy private), .gitignore enhanced, plan.md sanitized | commit aa629732 |
-| DONE | — | Fix /apis crash: CelebrationProvider missing in App.tsx | PR #293 |
-| DONE | — | Fix Grafana SSO: add stoa-observability Keycloak client + role mapping | PR #295 |
-| DONE | — | Demo Phase 1-2: Email + Script + Slides + Staging + MOU (5 livrables, français, Q1/Q2 resolved) | stoa-strategy 2bf8dbf |
-| DONE | — | Native Platform Metrics dashboard (replace Grafana iframe on /observability) | PR #299 |
-| DONE | — | Native Request Explorer dashboard (replace OpenSearch iframe on /logs) | PR #300 |
-| DONE | — | Docker-compose Console local build + Grafana auto-login + state files | PR #301 |
-| DONE | CAB-1133 | Portal Functional Test Suite — 164 tests, 13 pages × 4 personas | PR #308 |
-| DONE | — | Email Capture Phase 1 — Portal login redesign + access_requests endpoint + Alembic 023 | PRs #351, #354, #356, #361 |
-| DONE | CAB-911 | Admin Prospects Dashboard — conversion cockpit (API + Console UI, 11 tests) | commit f60b79fa |
-| DONE | — | Website Analysis + Content Roadmap — 4 docs (1483 lines), 3 segments, 24 content pieces | untracked in docs/ |
-| DONE | — | Hardware Requirements + Perf Benchmarks + Blog — hey benchmark script, 2 reference pages, 1 blog post | stoa PR #370, stoa-docs PR #29 |
-| DONE | — | Gateway Arena deployed on OVH — ServiceMonitor + deploy script + Grafana dashboard imported | PR #374, CronJob every 30m |
-| IN PROGRESS | ADR-040 | Born GitOps: Multi-Environment Promotion Architecture | stoa-docs ADR |
-| IN PROGRESS | — | Email Capture Phase 2 — Stripe-inspired conversion funnel (content expansion, pricing, community) | docs/CONTENT-ROADMAP.md |
-| NEXT | CAB-1130 | Email Khalil (send 14 fev EOD, wait feedback 15-16 fev) | — |
-| NEXT | CAB-1131 | Dry-runs 3x (18-23 fev, chrono < 5min) | — |
-| NEXT | CAB-1066 | Landing gostoa.dev + Stripe (stoa-web) | — |
-| NEXT | CAB-1035 | Persona Alex Test (manual) | — |
+### Infra & Code (semaines précédentes)
+- CAB-1099: Rust Gateway World-Class MCP (50 pts)
+- CAB-1105: Kill Python Dependency (34 pts)
+- CAB-1106: CD Enterprise ArgoCD + AWX + Kyverno (34 pts)
+- CAB-1086: Observability Full LGTM Stack (26 pts)
+- CAB-1116: Test Automation Strategy (21 pts)
+- CAB-1114: OpenSearch Multi-Tenant RGPD (21 pts)
+- CAB-1122: Zero 404/500 Audit & Fix (13 pts)
+- CAB-1115: Console UI Perf < 1s LCP (13 pts)
+- CAB-1113: Responsivité TTI < 1.5s (13 pts)
+- CAB-1108: Console Branding Unification (8 pts)
+- CAB-1117: Sidecar Deployment VM Docker Compose (8 pts)
+- CAB-1074: Demo Script 5 min (8 pts)
+- CAB-1073: Demo Flow Bulletproof Portal→Subscribe→Call (8 pts)
 
-## CI Pipeline Status (2026-02-11) — ALL GREEN THROUGH DEPLOY
+## 🔴 IN PROGRESS — Chemin critique démo 24/02
 
-| Component | CI | Docker | Apply | Deploy | Notes |
-|-----------|-----|--------|-------|--------|-------|
-| control-plane-ui | GREEN | GREEN | GREEN | GREEN | Coverage + formatting enforced |
-| portal | GREEN | GREEN | GREEN | GREEN | Coverage + formatting enforced |
-| control-plane-api | GREEN | GREEN | — | GREEN | Coverage 53%, ruff lint |
-| stoa-gateway | GREEN | GREEN | GREEN | GREEN | ArgoCD-managed, 267 tests |
+### P0 — Code (doit être fini semaine 7-8)
+CAB-1121: Consumer Onboarding & Token Exchange (35 pts) — MEGA, In Progress
+- Identity flow Portal → Keycloak → Gateway
+- Token Exchange RFC 8693
+- C'est LE flow qu'on démo
 
-## Quality Gates (CAB-1116 Phase 5)
-- **Coverage enforced in CI** via `run-coverage: true` in reusable workflow
-- **Pre-commit hooks**: lint-staged (eslint + prettier + ruff) via husky
-- **Prettier**: blocking in CI via `--if-present`
-- **ESLint ratchet**: console-ui max-warnings=93 (down from 100)
-- **Python fail_under**: aligned to 53 in pyproject.toml
-- **commitlint**: added `e2e` scope
+CAB-1137: OpenAPI → MCP Auto-Bridge stoactl (8 pts) — In Progress
+- stoactl bridge openapi.yaml → MCP tools auto-générés
+- Différenciateur critique vs Kong/Gravitee
 
-## Decisions This Sprint
-- 2026-02-04: Use column refs in SQLAlchemy upsert (not string keys)
-- 2026-02-04: E2E auth requires dual OIDC client tokens (portal + console)
-- 2026-02-05: ADRs live in stoa-docs, not stoa (ADR-030)
-- 2026-02-05: CLAUDE.md hierarchy: root (compact) + .claude/rules/ (modular)
-- 2026-02-06: Kyverno policies in Audit mode first, Enforce after validation
-- 2026-02-06: ArgoCD ApplicationSet uses goTemplate mode for multi-env
-- 2026-02-07: Custom nginx envsubst script — see `.claude/rules/k8s-deploy.md`
-- 2026-02-07: `tsconfig.app.json` pattern to exclude test files from Docker builds
-- 2026-02-08: ESLint ratchet (93 warnings) — blocks new warnings, allows gradual cleanup
-- 2026-02-08: `@wip` tag + `tags: 'not @wip'` for BDD features without steps
-- 2026-02-08: Weekly audit cron + smoke tests as post-deploy jobs
-- 2026-02-09: Ship/Show/Ask model for AI Factory (PR #222) — Claude determines review level
-- 2026-02-09: AI Factory modernization — state files auto-update protocol in ai-workflow.md
-- 2026-02-10: Replace iframe embeds (Grafana, OpenSearch) with native React dashboards querying Prometheus
-- 2026-02-10: Docker-compose Console switched to local build (always latest code)
-- 2026-02-11: Portal test helpers pattern — shared `test/helpers.tsx` with persona factories, mock data factories, `renderWithProviders` wrapper
-- 2026-02-11: ADR-040 Born GitOps — Console multi-env, Git=Control Plane, UAC as promotion unit, directory-per-env
-- 2026-02-11: Email capture Phase 1 — two-panel Portal login (request access + SSO), public endpoint, Alembic 023
-- 2026-02-11: Website analysis (4 docs) — 3 audience gaps (freelancers, SMBs, security), 24 content pieces planned, ~€5K budget for €68-150K ROI
-- 2026-02-12: Hardware/perf docs OpSec review — no production topology, no exact costs, no provider mapping in public docs (generic profiles only)
-- 2026-02-12: Gateway Arena deployed on OVH — CronJob→Pushgateway→Prometheus→Grafana, first leaderboard: STOA 58.45, Kong 56.58, Gravitee 53.05
+### P0 — Préparation démo (semaine du 17-23 fév)
+CAB-864: mTLS + OAuth2 Certificate Binding 100+ clients (34 pts) — Todo, due 26/02
+- Use case client principal
+- F5 → RI SAG → webMethods → Backend
 
-## Known Issues
-- E2E smoke tests fail on live infra (timeouts, missing UI elements)
-- Dependency Review fails: GitHub Advanced Security not enabled
-- Container Scan / CodeQL: intermittent failures, non-blocking
-- DCO Check: fails on squash-merged commits (expected, non-blocking)
-- `strict: true` branch protection: PR must be up-to-date before merge (see MEMORY.md for workaround)
-- control-plane-api still OutOfSync in ArgoCD (drift)
-- mcp-gateway Degraded in ArgoCD (residual from selector fix)
+CAB-802: Dry Run + Script + Video Backup (3 pts) — Todo, due 23/02
+CAB-550: Error Snapshot Demo Scenario (3 pts) — Todo, due 23/02
+CAB-872: mTLS Integration E2E + Script Démo (3 pts) — Todo
+CAB-1075: Demo Day Ready — Freeze + Dry Run Témoin + Plan B/C (5 pts) — Backlog
 
-## Security / OpSec (2026-02-10)
-- **Dual-repo**: stoa (public) + PotoMitan/stoa-strategy (private, GitHub)
-- **Private repo**: client mapping, pricing, legal, demo scripts, sensitive prompts
-- **.gitignore**: 72 patterns added (strategy, clients, pricing, slides, legal, prompts/*.txt)
-- **plan.md**: sanitized (no client names), full version in stoa-strategy
-- **Sensitive prompts**: moved from .claude/prompts/*.txt to stoa-strategy
-- **Legal templates**: OK public (use [COMPANY_NAME] placeholders)
+### P0 — Strategy (livrable de la démo, pas prérequis technique)
+CAB-1031: Plan d'Action SI Post-Démo — Arbre de Décision (21 pts) — Todo
 
-## Notes
-- Demo: mardi 24 fevrier 2026
-- Presentation "ESB is Dead" same day
-- Stack = Python (not Node)
-- Console tenants: "oasis", "oasis-gunters"
-- Portal OIDC client: stoa-portal; Console OIDC client: control-plane-ui
-- Demo seed: `./scripts/demo/seed-all.sh` (master orchestrator) or individual scripts
-- Demo sprint: D1-D11 COMPLETE (PRs #242-#288), R1: MCP REST endpoints (PRs #290, #291)
-- D11 from-scratch: `down -v` → `up -d` → `seed-all.sh` = 7/7 PASS + 9/9 federation
-- R1 validated: Act 7 works end-to-end (15 tools: 3 API + 12 native, invoke proxies to httpbin)
-- R1: GET /mcp/v1/tools + POST /mcp/v1/tools/invoke + api_bridge catalog discovery
-- Fixes: LDAP auto-seed (PR #287), Keycloak SSL auto-disable (PR #288), DEMO-SCRIPT.md updated
-- Fix: /apis page crash — CelebrationProvider added to App.tsx (PR #293)
-- EKS Console status: /apis ✅, /observability ✅ native (PR #299), /logs ✅ native (PR #300) — no Grafana/OpenSearch needed
-- Docker-compose: Console builds from source (PR #301), Prometheus proxy at /prometheus/, Grafana OIDC auto-login
-- Prometheus scrape: gateway UP (only stoa_rate_limit_buckets metric), CP API DOWN (no /metrics). HTTP request counters not yet instrumented.
-- Act 7 MCP: KNOWN limitation (Rust GW, fallback in demo script)
-- Console dark mode: 100% coverage (last 4 tools components fixed in PR #286)
-- Docs site: stoa-docs/ (Docusaurus 3.9), 20 pages
-- Vault v1.20.4 running, unsealed. ESO not yet deployed.
-- Portal test suite: 427 tests (37 files), 164 new in PR #308. 13 pages × 4 personas. Shared helpers at `portal/src/test/helpers.tsx`.
-- Not yet tested: APITestingSandbox, ApplicationDetail, Navigation routing (Phase 3 of CAB-1133)
+## 📋 NEXT (post-démo ou si le temps le permet)
+
+CAB-1133: Portal Functional Test Suite 17 routes × 4 personas (34 pts) — In Progress
+CAB-1134: ADR-040 Born GitOps Multi-Env (5 pts) — In Progress
+CAB-1138: GitOps Reconciliation Operator AWX → K8s (21 pts) — Backlog
+CAB-1030: Admin Guide Onboarding Ops Cédric (13 pts) — Todo (docs publiques faites, reste kit privé)
+CAB-1035: DX Persona Alex test onboarding MCP (2 pts) — Todo
+CAB-353: Go/No-Go Checklist 3 Months — Todo
+
+## 🚫 BLOCKED
+(rien)
+
+## 📝 NOTES
+- Demo MVP: mardi 24 février 2026
+- Présentation "ESB is Dead" même jour
+- docs.gostoa.dev = complet, 0 "Coming Soon", build green
+- Velocity avec Claude: estimation ÷10, 107 pts docs en 1 soirée
+- Chemin critique: CAB-1121 (35pts) + CAB-864 (34pts) = 69 pts code en 10 jours

--- a/plan.md
+++ b/plan.md
@@ -1,112 +1,79 @@
-# Plan: Demo Design Partner (24 fev 2026)
+# Sprint Plan — Countdown Démo 24 Février 2026
 
-> **Last updated:** 2026-02-11 (CAB-1133 Portal tests merged — PR #308)
-> **Status:** Phase 1+2 DONE — 5/5 livrables. OVH + Hetzner: ✅ COMPLETE. Portal tests: 427 (PR #308)
-> **Next action:** Dry-runs (Phase 4), Demo Day 24 fev
-> **Full plan:** [stoa-strategy/execution/plan-demo-partner.md](private repo)
+## 🎯 KPIs Démo
+| Métrique | Cible | Status |
+|----------|-------|--------|
+| Consumer flow E2E | Portal→Subscribe→Token→Call | 🔴 CAB-1121 |
+| mTLS use case client | 100+ certs, RFC 8705 | 🔴 CAB-864 |
+| OpenAPI→MCP bridge | stoactl bridge demo | 🟡 CAB-1137 |
+| Error Snapshot | Provoquer + investiguer en live | 🔴 CAB-550 |
+| Dry run 2x sans bug | 5 min chrono | 🔴 CAB-802 |
+| Plan SI post-démo | Arbre décision + roadmap | 🔴 CAB-1031 |
+| Docs site | Complet, 0 placeholder | ✅ DONE |
 
----
+## Semaine 7 (13-16 fév) — CODE CRITIQUE
+Focus: Finir les 2 gros MEGAs code
 
-## Executive Summary
+- [ ] CAB-1121: Consumer Onboarding & Token Exchange (35 pts)
+  - Session 1: Identity model + Keycloak clients + DB schema
+  - Session 2: Portal UI consumer registration + approval flow
+  - Session 3: Token Exchange endpoint + gateway enforcement
+  - Session 4: E2E test Portal→Subscribe→Token→API call
+  ⚠️ C'est LE parcours démo. Doit être bulletproof.
 
-**Mission:** Prepare 5-min "Design Partner" presentation for enterprise prospect (DSI + senior architects)
-**Deadline:** Vendredi 14 fev EOD (urgent track), 24 fev (demo day)
-**Livrables:** Email + Script verbal 5min + Slides presentation + Staging guide + MOU draft — ALL DONE
+- [ ] CAB-1137: OpenAPI → MCP Auto-Bridge (8 pts)
+  - Session unique: Parser OpenAPI 3.0/3.1 → génère MCP tool definitions
+  - Démo: `stoactl bridge petstore.yaml` → 5 tools créés en 3 secondes
 
----
+- [ ] CAB-864: mTLS + OAuth2 Certificate Binding (34 pts)
+  - Session 1: Certificate management API + Keycloak cert-bound tokens
+  - Session 2: F5/Gateway integration + rotation automatique
+  - Session 3: Bulk onboarding 100+ consumers script
+  - Session 4: E2E test cert→token→API avec mTLS enforced
 
-## Livrables Prioritaires
+## Semaine 8 (17-21 fév) — POLISH + DRY RUN
+Focus: Intégration, script démo, répétitions
 
-| # | Livrable | Deadline | Status |
-|---|----------|----------|--------|
-| 1 | Script verbal 5min | 14 fev | ✅ DONE |
-| 2 | Slides presentation (6+4 backup) | 14 fev | ✅ DONE |
-| 3 | Email design partner contact | 14 fev EOD | ✅ DONE (ready to send) |
-| 4 | Staging preview guide | 16 fev | ✅ DONE |
-| 5 | MOU draft 2 pages | 21 fev | ✅ DONE |
-| 6 | Dry-run 3x | 23 fev | PENDING |
+- [ ] CAB-1031: Plan d'Action SI Post-Démo (21 pts)
+  - Arbre de décision (3 scénarios: Go/Pivot/Stop)
+  - Roadmap conditionnelle Q2-Q4
+  - Budget et planning équipe élargie (Cédric + indépendants)
 
----
+- [ ] CAB-550: Error Snapshot Scenario (3 pts)
+  - Setup données démo: 3 erreurs pré-générées
+  - Script: provoquer timeout → snapshot → investigation dashboard
 
-## Execution Phases
+- [ ] CAB-872: mTLS Integration E2E (3 pts)
+  - Assembler les composants CAB-864
+  - Flow complet sans friction
 
-| Phase | Timeline | Deliverables | Status |
-|-------|----------|--------------|--------|
-| Phase 1 | 10 fev | Email + Script + Slides | DONE |
-| Phase 2 | 10 fev | Staging + MOU | DONE |
-| Phase 3 | 14-17 fev | Feedback loop (send email, collect feedback) | PENDING |
-| Phase 4 | 18-23 fev | Dry-runs 3x (Human + Claude adjustments) | PENDING |
-| Phase 5 | 24 fev | Demo Day | PENDING |
+- [ ] CAB-802: Dry Run + Script + Video (3 pts)
+  - Répétition #1 (mercredi 19) — timer 5 min
+  - Répétition #2 (vendredi 21) — avec Cédric comme témoin
+  - Video backup filmée
 
----
+## Dimanche 23 fév — FREEZE
+- [ ] CAB-1075: Demo Day Ready (5 pts)
+  - Code freeze 18h
+  - Full E2E suite → 100% PASS
+  - Infra health check (Vault, Keycloak, DB, Grafana)
+  - Plan B (video) et Plan C (slides statiques) prêts
 
-## Ship/Show/Ask
+## Mardi 24 fév — DÉMO 🎯
+- 5 min démo live
+- Présentation "ESB is Dead"
+- Plan d'Action SI distribué
 
-**Mode:** Ship (all deliverables — internal docs, zero risk, zero code change)
-**Confidence:** [High] — detailed context, binary DoD per deliverable
+## Post-démo (semaine 9+)
+- [ ] CAB-1133: Portal Test Suite (34 pts)
+- [ ] CAB-1134: ADR-040 Born GitOps (5 pts)
+- [ ] CAB-1138: GitOps Operator (21 pts)
+- [ ] CAB-1030: Kit onboarding Cédric (privé)
+- [ ] CAB-353: Go/No-Go Checklist
 
----
-
-## Security Note
-
-Sensitive details (client identity, contact names, pricing, internal strategy) are in the
-private `stoa-strategy` repository. This file contains only the execution structure.
-
----
-
-## OVH Production Migration (11 fev 2026)
-
-| Phase | Status |
-|-------|--------|
-| Phase 0: OVH Manager (cluster + DB + PAT) | ✅ DONE |
-| Phase 1: Bootstrap (nginx-ingress, cert-manager) | ✅ DONE |
-| Phase 2: Deploy (6 apps, 9 pods, K8s secrets) | ✅ DONE |
-| Phase 3: DNS Switch (prod→OVH, staging→Hetzner) | ✅ DONE |
-| Phase 4: CI/CD (KUBECONFIG_B64 secret) | ✅ DONE |
-| Phase 5: Verify (12/12 endpoints HTTPS OK) | ✅ DONE |
-
-**Architecture:** OVH MKS GRA9 (3x B2-15) + Managed PostgreSQL 16 + K8s Secrets
-**LB IP:** `5.196.236.53` (prod) / `46.225.38.168` (staging)
-**Cost:** ~€135/mois OVH + ~€45/mois Hetzner staging = ~€180/mois total
-**Vault/ESO:** deferred (manifests ready at `~/ovh-production/k8s/vault/` + `eso/`)
-
----
-
-## Hetzner Staging — K3s Standalone Migration (11 fev 2026)
-
-**Goal:** Passer de K3s HA (2 masters + 2 workers) a K3s standalone (1 server + 3 agents) pour liberer de la capacite et pouvoir deployer l'observability stack sur 5 serveurs.
-
-**Architecture:**
-| Serveur | IP | Hostname | Role |
-|---------|-----|----------|------|
-| server | 46.225.112.68 | stoa-staging-server | K3s standalone (control-plane + worker) |
-| agent-1 | 159.69.109.5 | stoa-staging-agent-1 | K3s agent |
-| agent-2 | 167.235.22.166 | stoa-staging-agent-2 | K3s agent |
-| agent-3 | 46.225.103.50 | stoa-staging-agent-3 | K3s agent |
-| postgres | 46.225.118.41 | — | PostgreSQL 16 |
-
-**Capacite:** 4 nodes K8s (16 vCPU, 32 GB) — suffisant pour 6 core apps + Prometheus + Grafana + OpenSearch
-
-| Phase | Description | Status |
-|-------|-------------|--------|
-| Phase 0 | Backup (pg_dump, manifests, kubeconfig) | ✅ DONE |
-| Phase 1 | Teardown K3s HA (uninstall sur 4 nodes) | ✅ DONE |
-| Phase 2 | Install K3s standalone sur server (SQLite) | ✅ DONE |
-| Phase 3 | Join 3 agents (staging names) | ✅ DONE |
-| Phase 4 | Redeploy apps (secrets, configmaps, 6 apps, staging ingress) | ✅ DONE |
-| Phase 5 | Verify (6/6 pods Ready, 6 TLS certs, 6/6 HTTPS OK) | ✅ DONE |
-| Phase 6 | Prometheus + Grafana (Helm kube-prometheus-stack) | ✅ DONE |
-| Phase 7 | DNS records staging-grafana/prometheus (Cloudflare) | PENDING |
-| Phase 8 | OpenSearch (optional) | DEFERRED |
-
----
-
-## Archive: Cycle 7 Scoreboard
-
-> Cycle 7 complete: 225 pts / 22 PRs (9-10 fev 2026)
-> Demo Sprint D1-D11 complete + R1 MCP endpoints
-> Native Observability: PRs #299 (Platform Metrics) + #300 (Request Explorer) — replaced iframe embeds with native React dashboards querying Prometheus. 68 tests, coverage >50%.
-> Docker-compose: PR #301 — Console local build + Grafana OIDC auto-login + nginx Prometheus proxy
-> Total PRs this session: #299, #300, #301 (3 PRs, ~700 LOC new code + 68 tests)
-> Remaining: CAB-1035 (2 pts manual), CAB-1066 (34 pts stoa-web, stretch)
-> CAB-1133 Portal Test Suite: PR #308 merged (164 new tests, 13 pages × 4 personas, 427 total)
+## Règles Countdown
+1. ZERO nouveau ticket jusqu'au 24/02
+2. Si bloqué > 1h → contourner, noter, avancer
+3. Priorité absolue: CAB-1121 > CAB-864 > CAB-1031 > reste
+4. Code freeze dimanche 23 à 18h — AUCUNE EXCEPTION
+5. Chaque session Claude Code = 1 sous-tâche d'1 MEGA, pas plus


### PR DESCRIPTION
## Summary
- Reset `memory.md` and `plan.md` for demo countdown (24 Feb 2026)
- Docs v1 complete (107/107 pts, 6 MEGAs, PRs #36-#40)
- Focus now on CAB-1121 (Consumer Onboarding) + CAB-864 (mTLS)

## Test plan
- [x] Docs-only change (`.md` files), no component CI triggered

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>