### PR TITLE
perf(gateway): add Kong + Gravitee in-cluster to Arena benchmark

### DIFF
--- a/.claude/rules/gateway-arena.md
+++ b/.claude/rules/gateway-arena.md
@@ -7,7 +7,7 @@ globs: "k8s/arena/**,scripts/traffic/**,docker/observability/grafana/**"
 
 ## Overview
 
-Continuous comparative benchmarking across STOA, Kong, and Gravitee gateways.
+Continuous comparative benchmarking: 6 gateways (3 K8s + 3 VPS) across STOA, Kong, and Gravitee.
 CronJob runs every 30 min on OVH K8s, pushes metrics to Pushgateway, visualized in Grafana.
 
 ## Adding a New Gateway
@@ -37,40 +37,51 @@ Consistency: IQR-based CV (robust to bimodal network latency).
 
 ## Fair Comparison — Local Echo Backend
 
-Arena uses a local nginx echo server (static JSON, <1ms) on each VPS so benchmarks
+Arena uses a local nginx echo server (static JSON, <1ms) so benchmarks
 measure pure gateway overhead, not backend/network latency.
+
+### In-Cluster (K8s — OVH MKS)
+
+| Gateway | Service | Health | Proxy | Backend |
+|---------|---------|--------|-------|---------|
+| stoa-k8s | `stoa-gateway.stoa-system.svc` | `/health` | `/echo/get` | echo-backend:8888 |
+| kong-k8s | `kong-arena.stoa-system.svc:8000` | `:8001/status` | `/echo/get` | echo-backend:8888 |
+| gravitee-k8s | `gravitee-arena-gw.stoa-system.svc:8082` | `:18082/_node/health` | `/echo/get` | echo-backend:8888 |
+
+### VPS (External)
 
 | Gateway | VPS IP | Health | Proxy | Backend |
 |---------|--------|--------|-------|---------|
-| STOA | `51.83.45.13:8080` | `/health` | `/echo/get` | echo-local:8888 (Docker) |
-| Kong | `51.83.45.13:8000` | `:8001/status` | `/echo/get` | echo-local:8888 (Docker) |
-| Gravitee | `54.36.209.237:8082` | `:8083/management/...` | `/echo/get` | echo-local:8888 (Docker) |
+| stoa-vps | `51.83.45.13:8080` | `/health` | `/echo/get` | echo-local:8888 (Docker) |
+| kong-vps | `51.83.45.13:8000` | `:8001/status` | `/echo/get` | echo-local:8888 (Docker) |
+| gravitee-vps | `54.36.209.237:8082` | `:8083/management/...` | `/echo/get` | echo-local:8888 (Docker) |
 
-### Docker Network Setup (critical)
+### Docker Network Setup (VPS only)
 
-All gateways run in Docker. The echo container MUST be on the same Docker network:
+VPS gateways run in Docker. The echo container MUST be on the same Docker network:
 - Kong VPS: `docker network connect kong_default echo-local && docker network connect stoa_default echo-local`
 - Gravitee VPS: `docker network connect gravitee_default echo-local`
 - Backend URL must be `http://echo-local:8888` (container name, NOT localhost)
 - STOA's SSRF blocklist blocks `localhost` — use container name or public IP
 
-### Deploy Echo + Configure Routes
+### Deploy
 
-```bash
-./deploy/vps/echo/deploy-all.sh
-```
+**K8s (all 3 gateways)**: `KUBECONFIG=~/.kube/config-stoa-ovh ./k8s/arena/deploy.sh`
 
-This script: deploys echo on both VPS, connects Docker networks, registers routes on all 3 gateways.
+**VPS echo + routes**: `./deploy/vps/echo/deploy-all.sh`
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
 | `scripts/traffic/gateway-arena.py` | Benchmark script (6 scenarios x N gateways) |
-| `k8s/arena/cronjob-prod.yaml` | CronJob manifest (every 30 min) |
+| `k8s/arena/cronjob-prod.yaml` | CronJob manifest (every 30 min, 6 gateways) |
+| `k8s/arena/kong.yaml` | Kong DB-less in-cluster (ConfigMap + Deploy + Svc) |
+| `k8s/arena/gravitee.yaml` | Gravitee APIM in-cluster (Mongo + Mgmt + GW + Init Job) |
+| `k8s/arena/echo-backend.yaml` | Shared echo backend (nginx, port 8888) |
 | `k8s/arena/pushgateway.yaml` | Pushgateway deployment + service |
 | `k8s/arena/pushgateway-servicemonitor.yaml` | Prometheus auto-discovery |
-| `k8s/arena/deploy.sh` | K8s deploy script (idempotent) |
+| `k8s/arena/deploy.sh` | K8s deploy script (idempotent, 9 steps) |
 | `docker/observability/grafana/dashboards/gateway-arena.json` | Grafana leaderboard dashboard |
 | `deploy/vps/echo/deploy-all.sh` | VPS echo + route setup |
 | `deploy/vps/echo/docker-compose.yml` | Echo server (nginx:alpine) |

--- a/k8s/arena/cronjob-prod.yaml
+++ b/k8s/arena/cronjob-prod.yaml
@@ -49,9 +49,11 @@ spec:
                   value: |
                     [
                       {"name":"stoa-k8s","health":"http://stoa-gateway.stoa-system.svc/health","proxy":"http://stoa-gateway.stoa-system.svc/echo/get"},
-                      {"name":"stoa","health":"http://51.83.45.13:8080/health","proxy":"http://51.83.45.13:8080/echo/get"},
-                      {"name":"kong","health":"http://51.83.45.13:8001/status","proxy":"http://51.83.45.13:8000/echo/get"},
-                      {"name":"gravitee","health":"http://54.36.209.237:8083/management/organizations/DEFAULT/environments/DEFAULT","proxy":"http://54.36.209.237:8082/echo/get"}
+                      {"name":"kong-k8s","health":"http://kong-arena.stoa-system.svc:8001/status","proxy":"http://kong-arena.stoa-system.svc:8000/echo/get"},
+                      {"name":"gravitee-k8s","health":"http://gravitee-arena-gw.stoa-system.svc:18082/_node/health","proxy":"http://gravitee-arena-gw.stoa-system.svc:8082/echo/get"},
+                      {"name":"stoa-vps","health":"http://51.83.45.13:8080/health","proxy":"http://51.83.45.13:8080/echo/get"},
+                      {"name":"kong-vps","health":"http://51.83.45.13:8001/status","proxy":"http://51.83.45.13:8000/echo/get"},
+                      {"name":"gravitee-vps","health":"http://54.36.209.237:8083/management/organizations/DEFAULT/environments/DEFAULT","proxy":"http://54.36.209.237:8082/echo/get"}
                     ]
               resources:
                 requests:

--- a/k8s/arena/deploy.sh
+++ b/k8s/arena/deploy.sh
@@ -5,19 +5,19 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOTAL=9
 
-echo "=== Gateway Arena Deploy ==="
+echo "=== Gateway Arena Deploy (6 gateways: 3 K8s + 3 VPS) ==="
 
 # 1. Echo backend (nginx returning static JSON — same as VPS echo)
-echo "[1/7] Applying echo backend..."
+echo "[1/$TOTAL] Applying echo backend..."
 kubectl apply -f "$SCRIPT_DIR/echo-backend.yaml"
 kubectl rollout status deploy/echo-backend -n stoa-system --timeout=60s
 
-# 2. Register echo route on K8s gateway
-echo "[2/7] Registering echo route on K8s STOA gateway..."
+# 2. Register echo route on K8s STOA gateway
+echo "[2/$TOTAL] Registering echo route on K8s STOA gateway..."
 ADMIN_TOKEN=$(kubectl get deploy stoa-gateway -n stoa-system -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="STOA_ADMIN_API_TOKEN")].value}')
 if [ -n "$ADMIN_TOKEN" ]; then
-  # Register via any gateway pod
   kubectl exec -n stoa-system deploy/stoa-gateway -- \
     curl -sf -X POST http://localhost:8080/admin/apis \
       -H "Authorization: Bearer $ADMIN_TOKEN" \
@@ -29,52 +29,82 @@ else
   echo "  WARNING: Could not read STOA_ADMIN_API_TOKEN from deployment. Register echo route manually."
 fi
 
-# 3. Pushgateway (Deployment + Service)
-echo "[3/7] Applying Pushgateway..."
+# 3. Kong DB-less (declarative config with echo route pre-configured)
+echo "[3/$TOTAL] Applying Kong Arena (DB-less)..."
+kubectl apply -f "$SCRIPT_DIR/kong.yaml"
+kubectl rollout status deploy/kong-arena -n stoa-system --timeout=120s
+echo "  Verifying Kong echo route..."
+kubectl exec -n stoa-system deploy/kong-arena -- \
+  curl -sf -o /dev/null -w "  Kong proxy echo: HTTP %{http_code}\n" http://localhost:8000/echo/get \
+  || echo "  WARNING: Kong echo route not ready yet"
+
+# 4. Gravitee APIM (MongoDB + Mgmt API + Gateway)
+echo "[4/$TOTAL] Applying Gravitee Arena stack..."
+kubectl apply -f "$SCRIPT_DIR/gravitee.yaml"
+echo "  Waiting for MongoDB..."
+kubectl rollout status deploy/gravitee-arena-mongo -n stoa-system --timeout=120s
+echo "  Waiting for Management API..."
+kubectl rollout status deploy/gravitee-arena-mgmt -n stoa-system --timeout=180s
+echo "  Waiting for Gateway..."
+kubectl rollout status deploy/gravitee-arena-gw -n stoa-system --timeout=180s
+
+# 5. Gravitee echo route init job
+echo "[5/$TOTAL] Running Gravitee echo route init job..."
+# Delete previous job if it exists (jobs are immutable)
+kubectl delete job gravitee-arena-init -n stoa-system --ignore-not-found
+kubectl apply -f "$SCRIPT_DIR/gravitee.yaml"
+echo "  Waiting for init job to complete..."
+if kubectl wait --for=condition=complete job/gravitee-arena-init -n stoa-system --timeout=300s 2>/dev/null; then
+  echo "  Gravitee echo route registered"
+  kubectl logs -n stoa-system job/gravitee-arena-init --tail=10
+else
+  echo "  WARNING: Gravitee init job did not complete. Check logs:"
+  echo "    kubectl logs -n stoa-system job/gravitee-arena-init"
+fi
+
+# 6. Pushgateway (Deployment + Service)
+echo "[6/$TOTAL] Applying Pushgateway..."
 kubectl apply -f "$SCRIPT_DIR/pushgateway.yaml"
 
-# 4. ConfigMap from arena script
-echo "[4/7] Creating ConfigMap from gateway-arena.py..."
+# 7. ConfigMap from arena script
+echo "[7/$TOTAL] Creating ConfigMap from gateway-arena.py..."
 kubectl create configmap gateway-arena-script \
   --from-file="$REPO_ROOT/scripts/traffic/gateway-arena.py" \
   -n stoa-system \
   --dry-run=client -o yaml | kubectl apply -f -
 
-# 5. ServiceMonitor for Prometheus auto-discovery
-echo "[5/7] Applying ServiceMonitor..."
+# 8. ServiceMonitor + CronJob
+echo "[8/$TOTAL] Applying ServiceMonitor + CronJob..."
 kubectl apply -f "$SCRIPT_DIR/pushgateway-servicemonitor.yaml"
-
-# 6. CronJob
-echo "[6/7] Applying CronJob..."
 kubectl apply -f "$SCRIPT_DIR/cronjob-prod.yaml"
 
-# 7. Smoke test — trigger one-off run
+# 9. Smoke test — trigger one-off run
 JOB_NAME="arena-smoke-$(date +%s)"
-echo "[7/7] Triggering smoke test job: $JOB_NAME"
+echo "[9/$TOTAL] Triggering smoke test job: $JOB_NAME"
 kubectl create job --from=cronjob/gateway-arena "$JOB_NAME" -n stoa-system
 
 echo ""
-echo "Waiting for job to complete (timeout 5m)..."
-if kubectl wait --for=condition=complete "job/$JOB_NAME" -n stoa-system --timeout=300s 2>/dev/null; then
+echo "Waiting for job to complete (timeout 10m)..."
+if kubectl wait --for=condition=complete "job/$JOB_NAME" -n stoa-system --timeout=600s 2>/dev/null; then
   echo ""
   echo "=== Smoke Test Logs ==="
-  kubectl logs -n stoa-system "job/$JOB_NAME" --tail=30
+  kubectl logs -n stoa-system "job/$JOB_NAME" --tail=50
   echo ""
   echo "=== Verification ==="
+  echo "Arena pods:"
+  kubectl get pods -n stoa-system -l 'app in (echo-backend,kong-arena,gravitee-arena-mongo,gravitee-arena-mgmt,gravitee-arena-gw)'
+  echo ""
   echo "Pushgateway pod:"
   kubectl get pods -n monitoring -l app=pushgateway
-  echo ""
-  echo "ServiceMonitor:"
-  kubectl get servicemonitor -n monitoring pushgateway
   echo ""
   echo "CronJob:"
   kubectl get cronjob -n stoa-system gateway-arena
   echo ""
   echo "Deploy complete. Next steps:"
-  echo "  1. Import Grafana dashboard: console.gostoa.dev/grafana -> Import -> paste docker/observability/grafana/dashboards/gateway-arena.json"
-  echo "  2. Verify Prometheus targets include pushgateway"
+  echo "  1. Verify 6 gateway scores in Pushgateway: curl http://pushgateway.monitoring.svc:9091/metrics"
+  echo "  2. Check Grafana dashboard for 6-gateway leaderboard"
   echo "  3. Clean up smoke job: kubectl delete job $JOB_NAME -n stoa-system"
 else
-  echo "Job did not complete in 5m. Check logs:"
+  echo "Job did not complete in 10m. Check logs:"
   echo "  kubectl logs -n stoa-system job/$JOB_NAME"
 fi

--- a/k8s/arena/gravitee.yaml
+++ b/k8s/arena/gravitee.yaml
@@ -1,0 +1,378 @@
+# Gravitee APIM for Arena benchmarks — minimal stack (MongoDB + Mgmt API + Gateway).
+# No persistence (emptyDir), no ingress — benchmark traffic only via ClusterIP.
+# Echo route registered via init Job after all components are ready.
+
+# --- MongoDB ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gravitee-arena-mongo
+  namespace: stoa-system
+  labels:
+    app: gravitee-arena-mongo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gravitee-arena-mongo
+  template:
+    metadata:
+      labels:
+        app: gravitee-arena-mongo
+    spec:
+      containers:
+        - name: mongo
+          image: mongo:7.0
+          ports:
+            - containerPort: 27017
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gravitee-arena-mongo
+  namespace: stoa-system
+  labels:
+    app: gravitee-arena-mongo
+spec:
+  selector:
+    app: gravitee-arena-mongo
+  ports:
+    - port: 27017
+      targetPort: 27017
+---
+# --- Management API ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gravitee-arena-mgmt
+  namespace: stoa-system
+  labels:
+    app: gravitee-arena-mgmt
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gravitee-arena-mgmt
+  template:
+    metadata:
+      labels:
+        app: gravitee-arena-mgmt
+    spec:
+      containers:
+        - name: mgmt-api
+          image: graviteeio/apim-management-api:4.6
+          ports:
+            - containerPort: 8083
+          env:
+            - name: gravitee_management_mongodb_uri
+              value: mongodb://gravitee-arena-mongo.stoa-system.svc:27017/gravitee
+            - name: gravitee_analytics_mongodb_uri
+              value: mongodb://gravitee-arena-mongo.stoa-system.svc:27017/gravitee
+            - name: gravitee_analytics_type
+              value: mongodb
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+          readinessProbe:
+            httpGet:
+              path: /_node/health
+              port: 8083
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /_node/health
+              port: 8083
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gravitee-arena-mgmt
+  namespace: stoa-system
+  labels:
+    app: gravitee-arena-mgmt
+spec:
+  selector:
+    app: gravitee-arena-mgmt
+  ports:
+    - port: 8083
+      targetPort: 8083
+---
+# --- Gateway ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gravitee-arena-gw
+  namespace: stoa-system
+  labels:
+    app: gravitee-arena-gw
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gravitee-arena-gw
+  template:
+    metadata:
+      labels:
+        app: gravitee-arena-gw
+    spec:
+      containers:
+        - name: gateway
+          image: graviteeio/apim-gateway:4.6
+          ports:
+            - containerPort: 8082
+              name: proxy
+            - containerPort: 18082
+              name: technical
+          env:
+            - name: gravitee_management_mongodb_uri
+              value: mongodb://gravitee-arena-mongo.stoa-system.svc:27017/gravitee
+            - name: gravitee_ratelimit_mongodb_uri
+              value: mongodb://gravitee-arena-mongo.stoa-system.svc:27017/gravitee
+            - name: gravitee_reporters_mongodb_uri
+              value: mongodb://gravitee-arena-mongo.stoa-system.svc:27017/gravitee
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+          readinessProbe:
+            httpGet:
+              path: /_node/health
+              port: 18082
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /_node/health
+              port: 18082
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gravitee-arena-gw
+  namespace: stoa-system
+  labels:
+    app: gravitee-arena-gw
+spec:
+  selector:
+    app: gravitee-arena-gw
+  ports:
+    - name: proxy
+      port: 8082
+      targetPort: 8082
+    - name: technical
+      port: 18082
+      targetPort: 18082
+---
+# --- Echo Route Init Job ---
+# Registers echo API on Gravitee after all components are ready.
+# Gravitee V4 lifecycle: create API → create plan → publish plan → deploy → start.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gravitee-arena-init
+  namespace: stoa-system
+  labels:
+    app: gravitee-arena-init
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        app: gravitee-arena-init
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: wait-mgmt
+          image: curlimages/curl:8.11.1
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for Gravitee Management API..."
+              for i in $(seq 1 60); do
+                if curl -sf http://gravitee-arena-mgmt.stoa-system.svc:8083/_node/health > /dev/null 2>&1; then
+                  echo "Management API is ready"
+                  exit 0
+                fi
+                echo "  attempt $i/60 — not ready yet"
+                sleep 5
+              done
+              echo "Management API did not become ready in 5 minutes"
+              exit 1
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+        - name: wait-gateway
+          image: curlimages/curl:8.11.1
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for Gravitee Gateway..."
+              for i in $(seq 1 60); do
+                if curl -sf http://gravitee-arena-gw.stoa-system.svc:18082/_node/health > /dev/null 2>&1; then
+                  echo "Gateway is ready"
+                  exit 0
+                fi
+                echo "  attempt $i/60 — not ready yet"
+                sleep 5
+              done
+              echo "Gateway did not become ready in 5 minutes"
+              exit 1
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: register-echo
+          image: curlimages/curl:8.11.1
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              MGMT="http://gravitee-arena-mgmt.stoa-system.svc:8083/management/v2/environments/DEFAULT"
+              AUTH="Basic YWRtaW46YWRtaW4="
+
+              # Check if echo API already exists
+              EXISTING=$(curl -sf "${MGMT}/apis?q=echo-arena" -H "Authorization: ${AUTH}" \
+                | sed -n 's/.*"id":"\([^"]*\)".*"name":"echo-arena".*/\1/p' \
+                || echo "")
+
+              if [ -n "$EXISTING" ]; then
+                echo "Echo API already exists: $EXISTING"
+              else
+                echo "Creating V4 echo API..."
+                API_RESPONSE=$(curl -sf -X POST "${MGMT}/apis" \
+                  -H "Authorization: ${AUTH}" \
+                  -H "Content-Type: application/json" \
+                  -d '{
+                    "name": "echo-arena",
+                    "apiVersion": "1.0",
+                    "description": "Echo backend for Arena benchmarks",
+                    "definitionVersion": "V4",
+                    "type": "PROXY",
+                    "listeners": [
+                      {
+                        "type": "HTTP",
+                        "paths": [{"path": "/echo"}],
+                        "entrypoints": [{"type": "http-proxy"}]
+                      }
+                    ],
+                    "endpointGroups": [
+                      {
+                        "name": "default",
+                        "type": "http-proxy",
+                        "endpoints": [
+                          {
+                            "name": "echo-backend",
+                            "type": "http-proxy",
+                            "configuration": {"target": "http://echo-backend.stoa-system.svc:8888"}
+                          }
+                        ]
+                      }
+                    ]
+                  }')
+                EXISTING=$(echo "$API_RESPONSE" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+                echo "API created: $EXISTING"
+
+                # Create KEY_LESS plan
+                echo "Creating KEY_LESS plan..."
+                PLAN_RESPONSE=$(curl -sf -X POST "${MGMT}/apis/${EXISTING}/plans" \
+                  -H "Authorization: ${AUTH}" \
+                  -H "Content-Type: application/json" \
+                  -d '{
+                    "name": "keyless",
+                    "description": "Open access for Arena",
+                    "definitionVersion": "V4",
+                    "mode": "STANDARD",
+                    "security": {"type": "KEY_LESS"},
+                    "characteristics": [],
+                    "status": "PUBLISHED"
+                  }')
+                PLAN_ID=$(echo "$PLAN_RESPONSE" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+                echo "Plan created: $PLAN_ID"
+
+                # Publish plan (Gravitee 4.6 may create in STAGING even with status=PUBLISHED)
+                echo "Publishing plan..."
+                curl -sf -X POST "${MGMT}/apis/${EXISTING}/plans/${PLAN_ID}/_publish" \
+                  -H "Authorization: ${AUTH}" > /dev/null 2>&1 || true
+
+                # Deploy
+                echo "Deploying API..."
+                curl -sf -X POST "${MGMT}/apis/${EXISTING}/deployments" \
+                  -H "Authorization: ${AUTH}" \
+                  -H "Content-Type: application/json" \
+                  -d '{"deploymentLabel":"arena-echo"}' > /dev/null 2>&1
+
+                # Start (may 400 on some V4 APIs — non-blocking)
+                echo "Starting API..."
+                curl -sf -X POST "${MGMT}/apis/${EXISTING}/_start" \
+                  -H "Authorization: ${AUTH}" > /dev/null 2>&1 || true
+
+                echo "Echo API deployed and started"
+              fi
+
+              # Verify echo route via gateway
+              echo "Verifying echo route..."
+              sleep 5
+              HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' http://gravitee-arena-gw.stoa-system.svc:8082/echo/get)
+              echo "Gravitee proxy echo: HTTP $HTTP_CODE"
+              if [ "$HTTP_CODE" = "200" ]; then
+                echo "SUCCESS: echo route is working"
+              else
+                echo "WARNING: echo route returned HTTP $HTTP_CODE (may need more time to sync)"
+              fi
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL

--- a/k8s/arena/kong.yaml
+++ b/k8s/arena/kong.yaml
@@ -1,0 +1,112 @@
+# Kong DB-less for Arena benchmarks — single pod, declarative config.
+# No persistence, no ingress — benchmark traffic only via ClusterIP.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kong-arena-config
+  namespace: stoa-system
+  labels:
+    app: kong-arena
+data:
+  kong.yml: |
+    _format_version: "3.0"
+    services:
+      - name: echo-local
+        url: http://echo-backend.stoa-system.svc:8888
+        routes:
+          - name: echo-route
+            paths:
+              - /echo
+            strip_path: true
+        tags:
+          - stoa-arena
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kong-arena
+  namespace: stoa-system
+  labels:
+    app: kong-arena
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kong-arena
+  template:
+    metadata:
+      labels:
+        app: kong-arena
+    spec:
+      containers:
+        - name: kong
+          image: kong:3.9-ubuntu
+          ports:
+            - containerPort: 8000
+              name: proxy
+            - containerPort: 8001
+              name: admin
+          env:
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_DECLARATIVE_CONFIG
+              value: /config/kong.yml
+            - name: KONG_PROXY_LISTEN
+              value: "0.0.0.0:8000"
+            - name: KONG_ADMIN_LISTEN
+              value: "0.0.0.0:8001"
+            - name: KONG_LOG_LEVEL
+              value: warn
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            runAsUser: 100
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: 8001
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8001
+            initialDelaySeconds: 15
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: kong-arena-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-arena
+  namespace: stoa-system
+  labels:
+    app: kong-arena
+spec:
+  selector:
+    app: kong-arena
+  ports:
+    - name: proxy
+      port: 8000
+      targetPort: 8000
+    - name: admin
+      port: 8001
+      targetPort: 8001


### PR DESCRIPTION
## Summary
- Deploy Kong DB-less + Gravitee APIM on OVH K8s for fair 6-gateway Arena comparison
- 3 K8s gateways (stoa-k8s, kong-k8s, gravitee-k8s) + 3 VPS gateways (stoa-vps, kong-vps, gravitee-vps)
- Kong: single pod, declarative config with echo route pre-configured (~150MB RAM)
- Gravitee: MongoDB + Management API + Gateway + Init Job (~1.2GB RAM total)
- No persistence, no ingress — benchmark-only deployments in `stoa-system`

## Files
- `k8s/arena/kong.yaml` — Kong DB-less (ConfigMap + Deploy + Svc)
- `k8s/arena/gravitee.yaml` — Gravitee stack (Mongo + Mgmt + GW + V4 Init Job)
- `k8s/arena/cronjob-prod.yaml` — 6 gateway entries (renamed existing with -vps suffix)
- `k8s/arena/deploy.sh` — 9-step idempotent deploy script
- `.claude/rules/gateway-arena.md` — updated docs for 6-gateway setup

## Test plan
- [x] `kubectl apply --dry-run=client` passes for all manifests
- [x] `bash -n deploy.sh` syntax valid
- [ ] Deploy to OVH K8s and verify all pods Running
- [ ] Manual benchmark job completes with 6 gateway scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>