### PR TITLE
test(e2e): add Portal mTLS certificate upload E2E flow (CAB-872)

### DIFF
--- a/e2e/features/portal-mtls-flow.feature
+++ b/e2e/features/portal-mtls-flow.feature
@@ -1,0 +1,24 @@
+@portal @mtls @critical
+Feature: Portal - mTLS Certificate Upload & Token Exchange
+  # Tests the consumer-facing mTLS flow in the Developer Portal:
+  # subscribe to an API, upload a client certificate, verify cert details.
+  # Requires: running Portal + API + Keycloak + seed data.
+
+  Background:
+    Given I am logged in as "art3mis" from community "high-five"
+
+  @smoke @mtls
+  Scenario: Consumer uploads certificate during subscription
+    When I access the API catalog
+    And I click on the first API in the catalog
+    And I click the subscribe button
+    And I upload a test certificate file
+    And I confirm the subscription
+    Then the subscription is created with status "pending"
+
+  @mtls
+  Scenario: Consumer views certificate details after subscription
+    When I navigate to my subscriptions
+    And I click on the first subscription
+    Then I can see the certificate fingerprint
+    And the certificate status is "active"

--- a/e2e/steps/consumer-flow.steps.ts
+++ b/e2e/steps/consumer-flow.steps.ts
@@ -3,8 +3,13 @@
  * Steps for the API consumer journey: discover, subscribe, consume
  */
 
-import { createBdd } from 'playwright-bdd';
-import { test, expect } from '../fixtures/test-base';
+import { createBdd } from "playwright-bdd";
+import { test, expect } from "../fixtures/test-base";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const { When, Then } = createBdd(test);
 
@@ -12,25 +17,33 @@ const { When, Then } = createBdd(test);
 // API CATALOG DETAIL STEPS
 // ============================================================================
 
-When('I click on the first API in the catalog', async ({ page }) => {
+When("I click on the first API in the catalog", async ({ page }) => {
   const apiCard = page.locator('a[href^="/apis/"]').first();
   await expect.soft(apiCard).toBeVisible({ timeout: 10000 });
   await apiCard.click();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState("networkidle");
 });
 
-Then('the API detail page loads with description and endpoints', async ({ page }) => {
-  const url = page.url();
-  const heading = page.locator('h1, h2').first();
-  const description = page.locator('text=/description|overview|endpoint|version|base url/i');
+Then(
+  "the API detail page loads with description and endpoints",
+  async ({ page }) => {
+    const url = page.url();
+    const heading = page.locator("h1, h2").first();
+    const description = page.locator(
+      "text=/description|overview|endpoint|version|base url/i",
+    );
 
-  const loaded =
-    url.includes('/apis/') ||
-    (await heading.isVisible({ timeout: 10000 }).catch(() => false)) ||
-    (await description.first().isVisible({ timeout: 5000 }).catch(() => false));
+    const loaded =
+      url.includes("/apis/") ||
+      (await heading.isVisible({ timeout: 10000 }).catch(() => false)) ||
+      (await description
+        .first()
+        .isVisible({ timeout: 5000 })
+        .catch(() => false));
 
-  expect.soft(loaded).toBe(true);
-});
+    expect.soft(loaded).toBe(true);
+  },
+);
 
 // Note: application management steps (create, appears in list, click, detail page)
 // are defined in portal-advanced.steps.ts and portal-contracts.steps.ts
@@ -39,29 +52,31 @@ Then('the API detail page loads with description and endpoints', async ({ page }
 // SUBSCRIPTION FLOW STEPS
 // ============================================================================
 
-When('I click the subscribe button', async ({ page }) => {
+When("I click the subscribe button", async ({ page }) => {
   const subscribeButton = page.locator(
     'button:has-text("Subscribe"), button:has-text("Souscrire"), a:has-text("Subscribe")',
   );
   await expect.soft(subscribeButton.first()).toBeVisible({ timeout: 10000 });
   await subscribeButton.first().click();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState("networkidle");
 });
 
 When(
-  'I select application {string} for the subscription',
+  "I select application {string} for the subscription",
   async ({ page }, appName: string) => {
     const appSelect = page
-      .locator('select[name*="application"], select[name*="app"], [role="combobox"]')
+      .locator(
+        'select[name*="application"], select[name*="app"], [role="combobox"]',
+      )
       .first();
 
     if (await appSelect.isVisible({ timeout: 5000 }).catch(() => false)) {
-      const options = await appSelect.locator('option').all();
+      const options = await appSelect.locator("option").all();
       let matched = false;
       for (const opt of options) {
         const text = await opt.textContent();
         if (text && text.toLowerCase().includes(appName.toLowerCase())) {
-          const value = await opt.getAttribute('value');
+          const value = await opt.getAttribute("value");
           if (value) {
             await appSelect.selectOption(value);
             matched = true;
@@ -70,7 +85,7 @@ When(
         }
       }
       if (!matched && options.length > 1) {
-        const value = await options[1].getAttribute('value');
+        const value = await options[1].getAttribute("value");
         if (value) {
           await appSelect.selectOption(value);
         }
@@ -95,14 +110,19 @@ When(
 // APPLICATION DETAIL STEPS
 // ============================================================================
 
-Then('the API key section is visible', async ({ page }) => {
+Then("the API key section is visible", async ({ page }) => {
   const apiKeySection = page.locator(
-    'text=/api key|credentials|secret|token|cle|identifiant/i',
+    "text=/api key|credentials|secret|token|cle|identifiant/i",
   );
-  const isVisible = await apiKeySection.first().isVisible({ timeout: 10000 }).catch(() => false);
+  const isVisible = await apiKeySection
+    .first()
+    .isVisible({ timeout: 10000 })
+    .catch(() => false);
   expect
     .soft(
-      isVisible || page.url().includes('/apps/') || page.url().includes('/workspace/'),
+      isVisible ||
+        page.url().includes("/apps/") ||
+        page.url().includes("/workspace/"),
     )
     .toBe(true);
 });
@@ -114,14 +134,54 @@ Then('the API key section is visible', async ({ page }) => {
 // APPLICATION ISOLATION STEPS
 // ============================================================================
 
-Then('I do not see applications from tenant {string}', async ({ page }, tenantName: string) => {
-  await page.waitForLoadState('networkidle');
+Then(
+  "I do not see applications from tenant {string}",
+  async ({ page }, tenantName: string) => {
+    await page.waitForLoadState("networkidle");
 
-  const pageContent = await page.textContent('body');
-  const hasTenantContent =
-    pageContent?.toLowerCase().includes(tenantName.toLowerCase()) || false;
+    const pageContent = await page.textContent("body");
+    const hasTenantContent =
+      pageContent?.toLowerCase().includes(tenantName.toLowerCase()) || false;
 
-  expect
-    .soft(!hasTenantContent || page.url().includes('/workspace'))
-    .toBe(true);
+    expect
+      .soft(!hasTenantContent || page.url().includes("/workspace"))
+      .toBe(true);
+  },
+);
+
+// ============================================================================
+// mTLS CERTIFICATE STEPS (CAB-872)
+// ============================================================================
+
+const CERTS_DIR = path.resolve(__dirname, "../../scripts/demo/certs");
+
+When("I upload a test certificate file", async ({ page }) => {
+  // CertificateUploader has a hidden <input type="file"> — use setInputFiles
+  const fileInput = page.locator('input[type="file"][accept*=".pem"]');
+  const certPath = path.join(CERTS_DIR, "client-001.pem");
+  await fileInput.setInputFiles(certPath);
+  // Wait for the upload to be processed (fingerprint displayed)
+  await page.waitForTimeout(1000);
+});
+
+When("I click on the first subscription", async ({ page }) => {
+  const subCard = page
+    .locator(
+      '[class*="card"], [class*="rounded-lg"], tr, a[href*="/subscriptions/"]',
+    )
+    .first();
+  await expect.soft(subCard).toBeVisible({ timeout: 10000 });
+  await subCard.click();
+  await page.waitForLoadState("networkidle");
+});
+
+Then("I can see the certificate fingerprint", async ({ page }) => {
+  // Fingerprint is a SHA-256 hex string (64 hex chars) or displayed with colons
+  const fingerprint = page.locator("text=/[0-9a-fA-F]{64}|[0-9a-fA-F:]{95}/");
+  await expect.soft(fingerprint.first()).toBeVisible({ timeout: 10000 });
+});
+
+Then("the certificate status is {string}", async ({ page }, status: string) => {
+  const statusBadge = page.locator(`text=/${status}/i`);
+  await expect.soft(statusBadge.first()).toBeVisible({ timeout: 10000 });
 });


### PR DESCRIPTION
## Summary
- New feature file: `portal-mtls-flow.feature` (2 Gherkin scenarios for portal-chromium)
- Scenario 1: consumer uploads cert during subscription via CertificateUploader
- Scenario 2: consumer views cert fingerprint + status after subscription
- 4 new step definitions in `consumer-flow.steps.ts`: upload cert, click subscription, verify fingerprint, verify cert status
- Uses `page.setInputFiles()` for hidden file input (no drag-drop needed)

## Test plan
- [x] `npx bddgen` clean
- [x] `npx playwright test --list --project=portal-chromium` shows 2 mTLS scenarios
- [ ] CI green (3 required checks)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)