### PR TITLE
feat(operator): Prometheus metrics + /metrics endpoint (CAB-1138 P4)

### DIFF
--- a/stoa-operator/k8s/deployment.yaml
+++ b/stoa-operator/k8s/deployment.yaml
@@ -37,10 +37,25 @@ spec:
               value: "stoa-system"
             - name: STOA_OPERATOR_LOG_LEVEL
               value: "INFO"
+          ports:
+            - name: metrics
+              containerPort: 8000
           envFrom:
             - secretRef:
                 name: stoa-operator-secrets
                 optional: true
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
           resources:
             requests:
               memory: "64Mi"

--- a/stoa-operator/k8s/service.yaml
+++ b/stoa-operator/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: stoa-operator
+  namespace: stoa-system
+  labels:
+    app: stoa-operator
+    app.kubernetes.io/name: stoa-operator
+spec:
+  selector:
+    app: stoa-operator
+  ports:
+    - name: metrics
+      port: 8000
+      targetPort: 8000

--- a/stoa-operator/k8s/servicemonitor.yaml
+++ b/stoa-operator/k8s/servicemonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: stoa-operator
+  namespace: stoa-system
+  labels:
+    prometheus: kube-prometheus-stack
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: stoa-operator
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+  namespaceSelector:
+    matchNames:
+      - stoa-system

--- a/stoa-operator/requirements.txt
+++ b/stoa-operator/requirements.txt
@@ -1,3 +1,4 @@
 kopf>=1.37,<2.0
 httpx>=0.26,<1.0
 pydantic-settings>=2.1,<3.0
+prometheus_client>=0.21,<1.0

--- a/stoa-operator/src/config.py
+++ b/stoa-operator/src/config.py
@@ -12,6 +12,7 @@ class OperatorSettings(BaseSettings):
     LOG_LEVEL: str = "INFO"
     RECONCILE_INTERVAL_SECONDS: int = 60
     MAX_RETRIES: int = 3
+    METRICS_PORT: int = 8000
 
     model_config = {"env_prefix": "STOA_OPERATOR_"}
 

--- a/stoa-operator/src/cp_client.py
+++ b/stoa-operator/src/cp_client.py
@@ -1,11 +1,13 @@
 """Control Plane API client for the operator."""
 
 import logging
+import time
 from typing import Any
 
 import httpx
 
 from src.config import settings
+from src.metrics import record_cp_api_call
 
 logger = logging.getLogger(__name__)
 
@@ -42,37 +44,49 @@ class ControlPlaneClient:
             raise RuntimeError(msg)
         return self._client
 
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Send an HTTP request and record metrics."""
+        start = time.monotonic()
+        resp = await self.client.request(method, path, **kwargs)
+        record_cp_api_call(method, path, str(resp.status_code), time.monotonic() - start)
+        return resp
+
     # --- Gateway Instance methods ---
 
     async def register_gateway(self, data: dict[str, Any]) -> dict[str, Any]:
-        resp = await self.client.post("/v1/admin/gateways", json=data)
+        resp = await self._request("POST", "/v1/admin/gateways", json=data)
         resp.raise_for_status()
         return resp.json()
 
     async def get_gateway(self, gateway_id: str) -> dict[str, Any]:
-        resp = await self.client.get(f"/v1/admin/gateways/{gateway_id}")
+        resp = await self._request("GET", f"/v1/admin/gateways/{gateway_id}")
         resp.raise_for_status()
         return resp.json()
 
     async def update_gateway(self, gateway_id: str, data: dict[str, Any]) -> dict[str, Any]:
-        resp = await self.client.put(f"/v1/admin/gateways/{gateway_id}", json=data)
+        resp = await self._request("PUT", f"/v1/admin/gateways/{gateway_id}", json=data)
         resp.raise_for_status()
         return resp.json()
 
     async def delete_gateway(self, gateway_id: str) -> None:
-        resp = await self.client.delete(f"/v1/admin/gateways/{gateway_id}")
+        resp = await self._request("DELETE", f"/v1/admin/gateways/{gateway_id}")
         if resp.status_code == 404:
             logger.info("Gateway %s already deleted (404), treating as success", gateway_id)
             return
         resp.raise_for_status()
 
     async def list_gateways(self) -> list[dict[str, Any]]:
-        resp = await self.client.get("/v1/admin/gateways")
+        resp = await self._request("GET", "/v1/admin/gateways")
         resp.raise_for_status()
         return resp.json().get("items", [])
 
     async def health_check_gateway(self, gateway_id: str) -> dict[str, Any]:
-        resp = await self.client.post(f"/v1/admin/gateways/{gateway_id}/health")
+        resp = await self._request("POST", f"/v1/admin/gateways/{gateway_id}/health")
         resp.raise_for_status()
         return resp.json()
 
@@ -89,7 +103,8 @@ class ControlPlaneClient:
     async def create_deployment(
         self, api_catalog_id: str, gateway_instance_ids: list[str]
     ) -> list[dict[str, Any]]:
-        resp = await self.client.post(
+        resp = await self._request(
+            "POST",
             "/v1/admin/deployments",
             json={"api_catalog_id": api_catalog_id, "gateway_instance_ids": gateway_instance_ids},
         )
@@ -97,24 +112,24 @@ class ControlPlaneClient:
         return resp.json()
 
     async def get_deployment(self, deployment_id: str) -> dict[str, Any]:
-        resp = await self.client.get(f"/v1/admin/deployments/{deployment_id}")
+        resp = await self._request("GET", f"/v1/admin/deployments/{deployment_id}")
         resp.raise_for_status()
         return resp.json()
 
     async def delete_deployment(self, deployment_id: str) -> None:
-        resp = await self.client.delete(f"/v1/admin/deployments/{deployment_id}")
+        resp = await self._request("DELETE", f"/v1/admin/deployments/{deployment_id}")
         if resp.status_code == 404:
             logger.info("Deployment %s already deleted (404), treating as success", deployment_id)
             return
         resp.raise_for_status()
 
     async def force_sync_deployment(self, deployment_id: str) -> dict[str, Any]:
-        resp = await self.client.post(f"/v1/admin/deployments/{deployment_id}/sync")
+        resp = await self._request("POST", f"/v1/admin/deployments/{deployment_id}/sync")
         resp.raise_for_status()
         return resp.json()
 
     async def get_catalog_entries(self) -> list[dict[str, Any]]:
-        resp = await self.client.get("/v1/admin/deployments/catalog-entries")
+        resp = await self._request("GET", "/v1/admin/deployments/catalog-entries")
         resp.raise_for_status()
         return resp.json()
 

--- a/stoa-operator/src/handlers/gateway_binding.py
+++ b/stoa-operator/src/handlers/gateway_binding.py
@@ -1,12 +1,14 @@
 """kopf handlers for GatewayBinding CRD (gostoa.dev/v1alpha1)."""
 
 import logging
+import time
 from datetime import UTC, datetime
 
 import httpx
 import kopf
 
 from src.cp_client import cp_client
+from src.metrics import RESOURCES_MANAGED, record_reconciliation
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +46,7 @@ async def on_gwb_create(
     **_kwargs: object,
 ) -> dict:
     """Create deployment in CP API when a GatewayBinding is created."""
+    start = time.monotonic()
     api_name = spec.get("apiRef", {}).get("name", "unknown")
     gw_name = spec.get("gatewayRef", {}).get("name", "unknown")
     logger.info(
@@ -68,9 +71,12 @@ async def on_gwb_create(
         patch.status["syncAttempts"] = 1
         patch.status["lastSyncAttempt"] = datetime.now(UTC).isoformat()
         patch.status["syncError"] = ""
+        RESOURCES_MANAGED.labels(kind="gwb").inc()
+        record_reconciliation("gwb", "create", "success", time.monotonic() - start)
         return {"message": f"GatewayBinding {name} deployed (deployment={deployment_id})"}
 
     except (kopf.TemporaryError, kopf.PermanentError):
+        record_reconciliation("gwb", "create", "error", time.monotonic() - start)
         raise
     except httpx.HTTPStatusError as exc:
         msg = f"CP API error: {exc.response.status_code} — {exc.response.text}"
@@ -79,6 +85,7 @@ async def on_gwb_create(
         patch.status["syncError"] = msg
         patch.status["syncAttempts"] = (patch.status.get("syncAttempts") or 0) + 1
         patch.status["lastSyncAttempt"] = datetime.now(UTC).isoformat()
+        record_reconciliation("gwb", "create", "error", time.monotonic() - start)
         raise kopf.TemporaryError(msg, delay=30) from exc
     except httpx.RequestError as exc:
         msg = f"CP API unreachable: {exc}"
@@ -86,6 +93,7 @@ async def on_gwb_create(
         patch.status["syncStatus"] = "error"
         patch.status["syncError"] = msg
         patch.status["lastSyncAttempt"] = datetime.now(UTC).isoformat()
+        record_reconciliation("gwb", "create", "error", time.monotonic() - start)
         raise kopf.TemporaryError(msg, delay=60) from exc
     finally:
         await cp_client.close()
@@ -104,6 +112,7 @@ async def on_gwb_update(
     **_kwargs: object,
 ) -> dict:
     """Force re-sync deployment when GatewayBinding spec changes."""
+    start = time.monotonic()
     old_spec = old.get("spec", {})
     new_spec = new.get("spec", {})
     if old_spec == new_spec:
@@ -131,6 +140,7 @@ async def on_gwb_update(
         patch.status["syncAttempts"] = (status.get("syncAttempts") or 0) + 1
         patch.status["lastSyncAttempt"] = datetime.now(UTC).isoformat()
         patch.status["syncError"] = ""
+        record_reconciliation("gwb", "update", "success", time.monotonic() - start)
         return {"message": f"GatewayBinding {name} re-synced"}
 
     except httpx.HTTPStatusError as exc:
@@ -140,6 +150,7 @@ async def on_gwb_update(
         patch.status["syncError"] = msg
         patch.status["syncAttempts"] = (status.get("syncAttempts") or 0) + 1
         patch.status["lastSyncAttempt"] = datetime.now(UTC).isoformat()
+        record_reconciliation("gwb", "update", "error", time.monotonic() - start)
         raise kopf.TemporaryError(msg, delay=30) from exc
     except httpx.RequestError as exc:
         msg = f"CP API unreachable: {exc}"
@@ -147,6 +158,7 @@ async def on_gwb_update(
         patch.status["syncStatus"] = "error"
         patch.status["syncError"] = msg
         patch.status["lastSyncAttempt"] = datetime.now(UTC).isoformat()
+        record_reconciliation("gwb", "update", "error", time.monotonic() - start)
         raise kopf.TemporaryError(msg, delay=60) from exc
     finally:
         await cp_client.close()
@@ -161,6 +173,7 @@ async def on_gwb_delete(
     **_kwargs: object,
 ) -> None:
     """Delete deployment from CP API when CRD is deleted."""
+    start = time.monotonic()
     deployment_id = status.get("gatewayResourceId", "")
     api_name = spec.get("apiRef", {}).get("name", "unknown")
     gw_name = spec.get("gatewayRef", {}).get("name", "unknown")
@@ -181,13 +194,17 @@ async def on_gwb_delete(
         await cp_client.connect()
         await cp_client.delete_deployment(deployment_id)
         logger.info("Deployment %s deleted from CP API", deployment_id)
+        RESOURCES_MANAGED.labels(kind="gwb").dec()
+        record_reconciliation("gwb", "delete", "success", time.monotonic() - start)
     except httpx.HTTPStatusError as exc:
         msg = f"CP API error on delete: {exc.response.status_code}"
         logger.error("GWB delete failed for %s: %s", name, msg)
+        record_reconciliation("gwb", "delete", "error", time.monotonic() - start)
         raise kopf.TemporaryError(msg, delay=30) from exc
     except httpx.RequestError as exc:
         msg = f"CP API unreachable: {exc}"
         logger.error("GWB delete failed for %s: %s", name, msg)
+        record_reconciliation("gwb", "delete", "error", time.monotonic() - start)
         raise kopf.TemporaryError(msg, delay=60) from exc
     finally:
         await cp_client.close()
@@ -203,6 +220,7 @@ async def on_gwb_resume(
     **_kwargs: object,
 ) -> None:
     """Reconcile existing GatewayBindings on operator startup."""
+    start = time.monotonic()
     deployment_id = status.get("gatewayResourceId", "")
     sync_status = status.get("syncStatus", "unknown")
     api_name = spec.get("apiRef", {}).get("name", "unknown")
@@ -247,16 +265,21 @@ async def on_gwb_resume(
 
         patch.status["syncError"] = ""
         patch.status["lastSyncAttempt"] = datetime.now(UTC).isoformat()
+        RESOURCES_MANAGED.labels(kind="gwb").inc()
+        record_reconciliation("gwb", "resume", "success", time.monotonic() - start)
 
     except (kopf.TemporaryError, kopf.PermanentError):
+        record_reconciliation("gwb", "resume", "error", time.monotonic() - start)
         raise
     except httpx.HTTPStatusError as exc:
         msg = f"CP API error: {exc.response.status_code}"
         logger.error("GWB resume failed for %s: %s", name, msg)
         patch.status["syncError"] = msg
+        record_reconciliation("gwb", "resume", "error", time.monotonic() - start)
     except httpx.RequestError as exc:
         msg = f"CP API unreachable: {exc}"
         logger.error("GWB resume failed for %s: %s", name, msg)
         patch.status["syncError"] = msg
+        record_reconciliation("gwb", "resume", "error", time.monotonic() - start)
     finally:
         await cp_client.close()

--- a/stoa-operator/src/handlers/gateway_instance.py
+++ b/stoa-operator/src/handlers/gateway_instance.py
@@ -1,12 +1,14 @@
 """kopf handlers for GatewayInstance CRD (gostoa.dev/v1alpha1)."""
 
 import logging
+import time
 from datetime import UTC, datetime
 
 import httpx
 import kopf
 
 from src.cp_client import cp_client
+from src.metrics import RESOURCES_MANAGED, record_reconciliation
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +38,7 @@ async def on_gwi_create(
     **_kwargs: object,
 ) -> dict:
     """Register gateway in CP API when a GatewayInstance is created."""
+    start = time.monotonic()
     gw_type = spec.get("gatewayType", "unknown")
     base_url = spec.get("baseUrl", "")
     logger.info(
@@ -61,6 +64,8 @@ async def on_gwi_create(
         except httpx.HTTPStatusError:
             patch.status["phase"] = "offline"
 
+        RESOURCES_MANAGED.labels(kind="gwi").inc()
+        record_reconciliation("gwi", "create", "success", time.monotonic() - start)
         return {"message": f"GatewayInstance {name} registered (id={gw_id})"}
 
     except httpx.HTTPStatusError as exc:
@@ -68,12 +73,14 @@ async def on_gwi_create(
         logger.error("GWI create failed for %s: %s", name, msg)
         patch.status["phase"] = "error"
         patch.status["error"] = msg
+        record_reconciliation("gwi", "create", "error", time.monotonic() - start)
         raise kopf.TemporaryError(msg, delay=30) from exc
     except httpx.RequestError as exc:
         msg = f"CP API unreachable: {exc}"
         logger.error("GWI create failed for %s: %s", name, msg)
         patch.status["phase"] = "error"
         patch.status["error"] = msg
+        record_reconciliation("gwi", "create", "error", time.monotonic() - start)
         raise kopf.TemporaryError(msg, delay=60) from exc
     finally:
         await cp_client.close()
@@ -92,6 +99,7 @@ async def on_gwi_update(
     **_kwargs: object,
 ) -> dict:
     """Update gateway in CP API when spec changes."""
+    start = time.monotonic()
     old_spec = old.get("spec", {})
     new_spec = new.get("spec", {})
     if old_spec == new_spec:
@@ -118,17 +126,20 @@ async def on_gwi_update(
 
         patch.status["error"] = ""
         patch.status["lastHealthCheck"] = datetime.now(UTC).isoformat()
+        record_reconciliation("gwi", "update", "success", time.monotonic() - start)
         return {"message": f"GatewayInstance {name} updated in CP API"}
 
     except httpx.HTTPStatusError as exc:
         msg = f"CP API error: {exc.response.status_code} — {exc.response.text}"
         logger.error("GWI update failed for %s: %s", name, msg)
         patch.status["error"] = msg
+        record_reconciliation("gwi", "update", "error", time.monotonic() - start)
         raise kopf.TemporaryError(msg, delay=30) from exc
     except httpx.RequestError as exc:
         msg = f"CP API unreachable: {exc}"
         logger.error("GWI update failed for %s: %s", name, msg)
         patch.status["error"] = msg
+        record_reconciliation("gwi", "update", "error", time.monotonic() - start)
         raise kopf.TemporaryError(msg, delay=60) from exc
     finally:
         await cp_client.close()
@@ -143,6 +154,7 @@ async def on_gwi_delete(
     **_kwargs: object,
 ) -> None:
     """Delete gateway from CP API when CRD is deleted."""
+    start = time.monotonic()
     gw_id = status.get("cpGatewayId", "")
     logger.info("GatewayInstance deleted: %s/%s cpGatewayId=%s", namespace, name, gw_id)
 
@@ -154,13 +166,17 @@ async def on_gwi_delete(
         await cp_client.connect()
         await cp_client.delete_gateway(gw_id)
         logger.info("Gateway %s deleted from CP API", gw_id)
+        RESOURCES_MANAGED.labels(kind="gwi").dec()
+        record_reconciliation("gwi", "delete", "success", time.monotonic() - start)
     except httpx.HTTPStatusError as exc:
         msg = f"CP API error on delete: {exc.response.status_code}"
         logger.error("GWI delete failed for %s: %s", name, msg)
+        record_reconciliation("gwi", "delete", "error", time.monotonic() - start)
         raise kopf.TemporaryError(msg, delay=30) from exc
     except httpx.RequestError as exc:
         msg = f"CP API unreachable: {exc}"
         logger.error("GWI delete failed for %s: %s", name, msg)
+        record_reconciliation("gwi", "delete", "error", time.monotonic() - start)
         raise kopf.TemporaryError(msg, delay=60) from exc
     finally:
         await cp_client.close()
@@ -176,6 +192,7 @@ async def on_gwi_resume(
     **_kwargs: object,
 ) -> None:
     """Reconcile existing GatewayInstances on operator startup."""
+    start = time.monotonic()
     gw_id = status.get("cpGatewayId", "")
     phase = status.get("phase", "unknown")
     logger.info(
@@ -217,14 +234,18 @@ async def on_gwi_resume(
 
         patch.status["error"] = ""
         patch.status["lastHealthCheck"] = datetime.now(UTC).isoformat()
+        RESOURCES_MANAGED.labels(kind="gwi").inc()
+        record_reconciliation("gwi", "resume", "success", time.monotonic() - start)
 
     except httpx.HTTPStatusError as exc:
         msg = f"CP API error: {exc.response.status_code}"
         logger.error("GWI resume failed for %s: %s", name, msg)
         patch.status["error"] = msg
+        record_reconciliation("gwi", "resume", "error", time.monotonic() - start)
     except httpx.RequestError as exc:
         msg = f"CP API unreachable: {exc}"
         logger.error("GWI resume failed for %s: %s", name, msg)
         patch.status["error"] = msg
+        record_reconciliation("gwi", "resume", "error", time.monotonic() - start)
     finally:
         await cp_client.close()

--- a/stoa-operator/src/main.py
+++ b/stoa-operator/src/main.py
@@ -3,9 +3,11 @@
 import logging
 
 import kopf
+from prometheus_client import start_http_server
 
 from src.config import settings
 from src.cp_client import cp_client
+from src.metrics import OPERATOR_UP
 
 
 def configure_logging() -> None:
@@ -18,7 +20,7 @@ def configure_logging() -> None:
 
 @kopf.on.startup()
 async def on_startup(settings: kopf.OperatorSettings, **_kwargs: object) -> None:
-    """Configure operator and connect to CP API."""
+    """Configure operator, start metrics server, and connect to CP API."""
     # Use status subresource for progress storage — avoids update → handler loops
     settings.persistence.progress_storage = kopf.StatusProgressStorage(
         field="status.kopf",
@@ -26,14 +28,21 @@ async def on_startup(settings: kopf.OperatorSettings, **_kwargs: object) -> None
     # Import handlers to register them with kopf
     import src.handlers.gateway_binding  # noqa: F401
     import src.handlers.gateway_instance  # noqa: F401
+    from src.config import settings as op_settings
+
+    start_http_server(op_settings.METRICS_PORT)
+    OPERATOR_UP.set(1)
 
     await cp_client.connect()
-    logging.getLogger(__name__).info("STOA Operator started")
+    logging.getLogger(__name__).info(
+        "STOA Operator started (metrics on :%d)", op_settings.METRICS_PORT
+    )
 
 
 @kopf.on.cleanup()
 async def on_cleanup(**_kwargs: object) -> None:
     """Gracefully shut down the operator."""
+    OPERATOR_UP.set(0)
     await cp_client.close()
     logging.getLogger(__name__).info("STOA Operator stopped")
 

--- a/stoa-operator/src/metrics.py
+++ b/stoa-operator/src/metrics.py
@@ -1,0 +1,58 @@
+"""Prometheus metrics for the STOA operator."""
+
+from prometheus_client import Counter, Gauge, Histogram
+
+# --- Reconciliation metrics ---
+
+RECONCILIATIONS_TOTAL = Counter(
+    "stoa_operator_reconciliations_total",
+    "Total reconciliation handler calls",
+    ["kind", "action", "result"],
+)
+
+RECONCILIATION_DURATION = Histogram(
+    "stoa_operator_reconciliation_duration_seconds",
+    "Reconciliation handler execution time",
+    ["kind", "action"],
+    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+)
+
+# --- CP API client metrics ---
+
+CP_API_REQUESTS_TOTAL = Counter(
+    "stoa_operator_cp_api_requests_total",
+    "Total CP API HTTP calls",
+    ["method", "endpoint", "status"],
+)
+
+CP_API_DURATION = Histogram(
+    "stoa_operator_cp_api_duration_seconds",
+    "CP API call latency",
+    ["method", "endpoint"],
+    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+)
+
+# --- Operator health ---
+
+RESOURCES_MANAGED = Gauge(
+    "stoa_operator_resources_managed",
+    "Current count of managed resources",
+    ["kind"],
+)
+
+OPERATOR_UP = Gauge(
+    "stoa_operator_up",
+    "1 when operator is running",
+)
+
+
+def record_reconciliation(kind: str, action: str, result: str, duration: float) -> None:
+    """Record a reconciliation event with timing."""
+    RECONCILIATIONS_TOTAL.labels(kind=kind, action=action, result=result).inc()
+    RECONCILIATION_DURATION.labels(kind=kind, action=action).observe(duration)
+
+
+def record_cp_api_call(method: str, endpoint: str, status: str, duration: float) -> None:
+    """Record a CP API call with timing."""
+    CP_API_REQUESTS_TOTAL.labels(method=method, endpoint=endpoint, status=status).inc()
+    CP_API_DURATION.labels(method=method, endpoint=endpoint).observe(duration)

--- a/stoa-operator/tests/test_metrics.py
+++ b/stoa-operator/tests/test_metrics.py
@@ -1,0 +1,88 @@
+"""Tests for Prometheus metrics module."""
+
+from prometheus_client import REGISTRY
+from src.metrics import (
+    CP_API_DURATION,
+    CP_API_REQUESTS_TOTAL,
+    OPERATOR_UP,
+    RECONCILIATION_DURATION,
+    RECONCILIATIONS_TOTAL,
+    RESOURCES_MANAGED,
+    record_cp_api_call,
+    record_reconciliation,
+)
+
+
+def test_metrics_registered():
+    """All 6 metrics should be registered in the default registry."""
+    names = {m.name for m in REGISTRY.collect()}
+    # Counter names are registered without _total suffix in prometheus_client
+    assert "stoa_operator_reconciliations" in names
+    assert "stoa_operator_reconciliation_duration_seconds" in names
+    assert "stoa_operator_cp_api_requests" in names
+    assert "stoa_operator_cp_api_duration_seconds" in names
+    assert "stoa_operator_resources_managed" in names
+    assert "stoa_operator_up" in names
+
+
+def test_record_reconciliation_increments_counter():
+    """record_reconciliation should increment the counter and observe the histogram."""
+    labels = {"kind": "gwi", "action": "create", "result": "success"}
+    before = RECONCILIATIONS_TOTAL.labels(**labels)._value.get()
+    record_reconciliation("gwi", "create", "success", 0.05)
+    after = RECONCILIATIONS_TOTAL.labels(**labels)._value.get()
+    assert after == before + 1
+
+
+def test_record_reconciliation_observes_histogram():
+    """record_reconciliation should add a sample to the duration histogram."""
+    before = RECONCILIATION_DURATION.labels(kind="gwb", action="delete")._sum.get()
+    record_reconciliation("gwb", "delete", "success", 0.123)
+    after = RECONCILIATION_DURATION.labels(kind="gwb", action="delete")._sum.get()
+    assert after >= before + 0.12
+
+
+def test_record_cp_api_call_increments_counter():
+    """record_cp_api_call should increment the counter."""
+    before = CP_API_REQUESTS_TOTAL.labels(
+        method="POST", endpoint="/v1/admin/gateways", status="200"
+    )._value.get()
+    record_cp_api_call("POST", "/v1/admin/gateways", "200", 0.01)
+    after = CP_API_REQUESTS_TOTAL.labels(
+        method="POST", endpoint="/v1/admin/gateways", status="200"
+    )._value.get()
+    assert after == before + 1
+
+
+def test_record_cp_api_call_observes_histogram():
+    """record_cp_api_call should add a sample to the duration histogram."""
+    before = CP_API_DURATION.labels(method="GET", endpoint="/v1/admin/gateways")._sum.get()
+    record_cp_api_call("GET", "/v1/admin/gateways", "200", 0.456)
+    after = CP_API_DURATION.labels(method="GET", endpoint="/v1/admin/gateways")._sum.get()
+    assert after >= before + 0.45
+
+
+def test_operator_up_gauge():
+    """OPERATOR_UP should be settable to 1 and 0."""
+    OPERATOR_UP.set(1)
+    assert OPERATOR_UP._value.get() == 1.0
+    OPERATOR_UP.set(0)
+    assert OPERATOR_UP._value.get() == 0.0
+
+
+def test_resources_managed_gauge():
+    """RESOURCES_MANAGED should support inc/dec per kind."""
+    RESOURCES_MANAGED.labels(kind="gwi").set(0)
+    RESOURCES_MANAGED.labels(kind="gwi").inc()
+    RESOURCES_MANAGED.labels(kind="gwi").inc()
+    assert RESOURCES_MANAGED.labels(kind="gwi")._value.get() == 2.0
+    RESOURCES_MANAGED.labels(kind="gwi").dec()
+    assert RESOURCES_MANAGED.labels(kind="gwi")._value.get() == 1.0
+
+
+def test_record_reconciliation_error_result():
+    """Error results should be tracked separately from successes."""
+    before = RECONCILIATIONS_TOTAL.labels(kind="gwi", action="create", result="error")._value.get()
+    record_reconciliation("gwi", "create", "error", 0.5)
+    after = RECONCILIATIONS_TOTAL.labels(kind="gwi", action="create", result="error")._value.get()
+    assert after == before + 1


### PR DESCRIPTION
## Summary
- Add 6 Prometheus metrics: reconciliation counter/histogram, CP API counter/histogram, resources managed gauge, operator up gauge
- `/metrics` HTTP endpoint via `prometheus_client.start_http_server(8000)` — started in kopf startup handler
- K8s Service + ServiceMonitor for automatic Prometheus scraping
- Deployment updated: metrics port, liveness/readiness probes on `/metrics`
- Instrument all 8 handlers (gwi/gwb × create/update/delete/resume) with timing + result tracking
- Instrument `cp_client._request()` wrapper for automatic CP API call metrics
- 8 new tests (47 total), coverage 70.68%

## Test plan
- [x] `ruff check .` — zero errors
- [x] `black --check .` — clean
- [x] `pytest tests/ -v --cov=src --cov-fail-under=70` — 47 passed, 70.68% coverage
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)