### PR TITLE
fix(operator): add imagePullSecrets for GHCR

### DIFF
--- a/stoa-operator/k8s/deployment.yaml
+++ b/stoa-operator/k8s/deployment.yaml
@@ -26,6 +26,8 @@ spec:
     spec:
       serviceAccountName: stoa-operator
       automountServiceAccountToken: true
+      imagePullSecrets:
+        - name: ghcr-pull-secret
       containers:
         - name: stoa-operator
           image: ghcr.io/stoa-platform/stoa-operator:latest


### PR DESCRIPTION
## Summary
- Add `imagePullSecrets` referencing `ghcr-pull-secret` to operator deployment manifest
- Fixes `ImagePullBackOff` on clusters where GHCR package is private

## Test plan
- [x] Deployed to staging — pod Running, `stoa_operator_up 1.0`
- [x] Deployed to prod — pod Running, `stoa_operator_up 1.0`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>