### PR TITLE
feat(demo): add hero errors + validate flag for error snapshot (CAB-550)

### DIFF
--- a/scripts/demo/opensearch-live-demo.sh
+++ b/scripts/demo/opensearch-live-demo.sh
@@ -21,6 +21,7 @@ OPENSEARCH_AUTH="${OPENSEARCH_AUTH:-admin:admin}"
 GATEWAY_URL="${GATEWAY_URL:-https://mcp.gostoa.dev}"
 ERROR_COUNT="${ERROR_COUNT:-50}"
 CLEANUP=false
+VALIDATE=false
 
 # Parse flags
 for arg in "$@"; do
@@ -32,6 +33,9 @@ for arg in "$@"; do
       ;;
     --cleanup)
       CLEANUP=true
+      ;;
+    --validate)
+      VALIDATE=true
       ;;
   esac
 done
@@ -70,6 +74,57 @@ echo ""
 if ! curl $CURL_OPTS "${OPENSEARCH_URL}/_cluster/health" > /dev/null 2>&1; then
   echo -e "${RED}OpenSearch not ready at ${OPENSEARCH_URL}${NC}"
   exit 1
+fi
+
+# ─── Validate mode (pre-demo check) ─────────────────────────────────────
+if [ "$VALIDATE" = true ]; then
+  banner "Pre-Demo Validation"
+  PASS=0; FAIL=0
+
+  # 1. OpenSearch cluster health
+  OS_HEALTH=$(curl $CURL_OPTS "${OPENSEARCH_URL}/_cluster/health" 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])" 2>/dev/null || echo "unreachable")
+  if [ "$OS_HEALTH" = "green" ] || [ "$OS_HEALTH" = "yellow" ]; then
+    echo -e "  ${GREEN}PASS${NC} OpenSearch cluster: ${OS_HEALTH}"; PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC} OpenSearch cluster: ${OS_HEALTH}"; FAIL=$((FAIL+1))
+  fi
+
+  # 2. Gateway health
+  GW_STATUS=$(curl -sk -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || echo "000")
+  if [ "$GW_STATUS" = "200" ]; then
+    echo -e "  ${GREEN}PASS${NC} Gateway health: HTTP ${GW_STATUS}"; PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC} Gateway health: HTTP ${GW_STATUS}"; FAIL=$((FAIL+1))
+  fi
+
+  # 3. Document count in stoa-errors-*
+  DOC_CT=$(curl $CURL_OPTS "${OPENSEARCH_URL}/${INDEX_PATTERN}/_count" 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['count'])" 2>/dev/null || echo "0")
+  if [ "$DOC_CT" -gt 0 ] 2>/dev/null; then
+    echo -e "  ${GREEN}PASS${NC} Error documents: ${DOC_CT} in ${INDEX_PATTERN}"; PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC} No documents in ${INDEX_PATTERN}"; FAIL=$((FAIL+1))
+  fi
+
+  # 4. Hero errors present
+  HERO_CT=$(curl $CURL_OPTS -X POST "${OPENSEARCH_URL}/${INDEX_PATTERN}/_count" \
+    -H 'Content-Type: application/json' \
+    -d '{"query":{"wildcard":{"trace_id.keyword":"HERO-*"}}}' 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['count'])" 2>/dev/null || echo "0")
+  if [ "$HERO_CT" -ge 3 ] 2>/dev/null; then
+    echo -e "  ${GREEN}PASS${NC} Hero errors: ${HERO_CT} (expected >= 3)"; PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC} Hero errors: ${HERO_CT} (expected >= 3)"; FAIL=$((FAIL+1))
+  fi
+
+  echo ""
+  if [ "$FAIL" -eq 0 ]; then
+    echo -e "  ${GREEN}${BOLD}ALL ${PASS} CHECKS PASSED${NC} — ready for demo"
+  else
+    echo -e "  ${RED}${BOLD}${FAIL} CHECK(S) FAILED${NC} — run with --prod --cleanup first to seed data"
+  fi
+  exit "$FAIL"
 fi
 
 # ─── Cleanup (optional) ─────────────────────────────────────────────────
@@ -209,12 +264,12 @@ pause 1
 # ═════════════════════════════════════════════════════════════════════════
 banner "PHASE 5 — Live Trace Lookup"
 
-echo -e "  ${DIM}Pick a random error, trace it end-to-end${NC}\n"
+echo -e "  ${DIM}Search for a critical timeout error by HERO trace ID${NC}\n"
 
-# Get a random trace_id from indexed docs
+# Get the hero timeout error (deterministic — always findable)
 TRACE_DOC=$(curl $CURL_OPTS -X POST "${OPENSEARCH_URL}/${INDEX_PATTERN}/_search" \
   -H 'Content-Type: application/json' \
-  -d '{"size":1,"query":{"match_all":{}},"sort":[{"@timestamp":"desc"}]}' 2>/dev/null)
+  -d '{"size":1,"query":{"wildcard":{"trace_id.keyword":"HERO-TIMEOUT-*"}}}' 2>/dev/null)
 
 echo "$TRACE_DOC" | python3 -c "
 import sys, json

--- a/scripts/demo/seed-error-snapshot.py
+++ b/scripts/demo/seed-error-snapshot.py
@@ -122,10 +122,65 @@ def build_error_scenarios(api_url: str) -> list[dict]:
     ]
 
 
-def build_opensearch_documents(count: int = 50) -> list[dict]:
-    """Build sample error snapshot documents for OpenSearch indexing."""
+def build_hero_errors() -> list[dict]:
+    """Build 3 deterministic hero errors the presenter can search by HERO-* prefix."""
     now = datetime.now(timezone.utc)
-    docs = []
+    return [
+        {
+            "@timestamp": (now - timedelta(minutes=5)).isoformat(),
+            "trace_id": f"HERO-TIMEOUT-{uuid.uuid4().hex[:12]}",
+            "tenant_id": "oasis",
+            "error_type": "upstream_timeout",
+            "error_message": "Upstream did not respond within 30s for /mcp/v1/tools/invoke: connection to backend timed out after 30000ms",
+            "http_status": 504,
+            "method": "POST",
+            "endpoint": "/mcp/v1/tools/invoke",
+            "severity": "critical",
+            "resolution_status": "unresolved",
+            "user_agent": "Claude/3.5 (MCP Agent)",
+            "response_time_ms": 30000,
+            "request_id": str(uuid.uuid4()),
+        },
+        {
+            "@timestamp": (now - timedelta(minutes=10)).isoformat(),
+            "trace_id": f"HERO-AUTH-{uuid.uuid4().hex[:12]}",
+            "tenant_id": "acme-corp",
+            "error_type": "authentication_error",
+            "error_message": "JWT token expired at 2026-02-24T09:00:00Z, current time 2026-02-24T10:35:00Z — token lifetime exceeded by 95 minutes",
+            "http_status": 401,
+            "method": "GET",
+            "endpoint": "/v1/portal/apis",
+            "severity": "error",
+            "resolution_status": "unresolved",
+            "user_agent": "Mozilla/5.0 (Portal)",
+            "response_time_ms": 12,
+            "request_id": str(uuid.uuid4()),
+        },
+        {
+            "@timestamp": (now - timedelta(minutes=15)).isoformat(),
+            "trace_id": f"HERO-CONTRACT-{uuid.uuid4().hex[:12]}",
+            "tenant_id": "demo-org-alpha",
+            "error_type": "contract_violation",
+            "error_message": "Response does not match UAC contract schema for /v1/subscriptions: field 'quota_remaining' expected integer, got null — schema version v2.1.0",
+            "http_status": 422,
+            "method": "POST",
+            "endpoint": "/v1/subscriptions",
+            "severity": "error",
+            "resolution_status": "investigating",
+            "user_agent": "stoactl/1.0",
+            "response_time_ms": 145,
+            "request_id": str(uuid.uuid4()),
+        },
+    ]
+
+
+def build_opensearch_documents(count: int = 50) -> list[dict]:
+    """Build sample error snapshot documents for OpenSearch indexing.
+
+    Always prepends 3 deterministic hero errors for demo reliability.
+    """
+    now = datetime.now(timezone.utc)
+    docs = list(build_hero_errors())
 
     for i in range(count):
         # Spread errors over the last 24 hours
@@ -333,10 +388,13 @@ def main() -> None:
         print()
 
         docs = build_opensearch_documents(args.count)
+        hero_count = len(build_hero_errors())
 
-        # Show sample
-        print(f"Sample document:")
-        print(f"  {json.dumps(docs[0], indent=2)[:300]}...")
+        # Show hero errors
+        print(f"Hero errors ({hero_count} deterministic):")
+        for doc in docs[:hero_count]:
+            print(f"  {doc['trace_id']:<30} {doc['severity']:<10} {doc['error_type']}")
+        print(f"\n+ {len(docs) - hero_count} random error snapshots")
         print()
 
         indexed = index_to_opensearch(args.opensearch_url, docs, args.opensearch_auth)


### PR DESCRIPTION
## Summary
- 3 deterministic hero errors (`HERO-TIMEOUT`, `HERO-AUTH`, `HERO-CONTRACT`) prepended to seeded data — presenter can always search `HERO-*` in OpenSearch Discover
- `--validate` flag on live demo script: checks OpenSearch health, gateway health, doc count, and hero presence (4 pass/fail checks)
- Phase 5 now searches for the hero timeout error instead of a random doc — deterministic demo flow

## Test plan
- [x] `python3 scripts/demo/seed-error-snapshot.py --dry-run` — shows 3 scenarios
- [x] Python module test: `build_opensearch_documents(50)` returns 53 docs (3 hero + 50 random)
- [x] `bash -n scripts/demo/opensearch-live-demo.sh` — syntax OK
- [x] `--validate` with unreachable OpenSearch exits with code 1

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>