### PR TITLE
chore: add /council and /sync-plan AI Factory skills

### DIFF
--- a/.claude/skills/council.md
+++ b/.claude/skills/council.md
@@ -1,0 +1,181 @@
+# Skill: /council — Validate & Create Ticket
+
+## When to Use
+
+When user describes a feature, ADR, or architectural decision that needs validation before implementation. Automatically creates a Linear ticket if the Council score is >= 8/10.
+
+**Invoke**: `/council <description of what to build>`
+
+## The Council — 4 Personas
+
+### 1. Chucky (Devil's Advocate) — Score /10
+- Challenges assumptions and finds weaknesses
+- Questions: Is this really needed? What could go wrong? What's the hidden complexity?
+- Red flags: scope creep, over-engineering, unclear requirements
+- Focus: risk assessment, edge cases, failure modes
+
+### 2. OSS Killer (VC Skeptique) — Score /10
+- Evaluates market viability, competitive moat, user value
+- Questions: Does this differentiate STOA? Would a user pay for this? Is this a feature or a product?
+- Red flags: me-too features, no measurable impact, building for nobody
+- Focus: competitive advantage, adoption potential, ROI
+
+### 3. Archi 50x50 (Architecte Veteran) — Score /10
+- Evaluates architectural quality, technical debt, scalability
+- Questions: Does this follow existing patterns? Is the complexity justified? Will this age well?
+- Red flags: wrong abstraction level, coupling, breaking existing contracts
+- Focus: technical excellence, maintainability, performance
+
+### 4. Better Call Saul (Legal/IP) — Score /10
+- Evaluates legal risks, compliance, IP protection, content safety
+- Questions: Any license issues? GDPR/DORA compliance? Competitive claims risks?
+- Red flags: hardcoded secrets, unverified competitive claims, missing disclaimers
+- Focus: legal safety, regulatory alignment, IP protection
+
+## Workflow
+
+### Step 1: Analyze the Request
+
+Read and understand the user's feature/ADR/change description. Gather context from:
+- `memory.md` — current sprint, related work
+- `plan.md` — where this fits in priorities
+- Relevant code files if technical
+
+### Step 2: Run the Council
+
+Present each persona's evaluation in this format:
+
+```
+## Council Validation
+
+### Chucky (Devil's Advocate) — X/10
+**Verdict**: Go | Fix | Redo
+<2-3 sentences: key concerns or approval>
+**Adjustments**: <specific changes required, or "None">
+
+### OSS Killer (VC Skeptique) — X/10
+**Verdict**: Go | Fix | Redo
+<2-3 sentences>
+**Adjustments**: <specific changes required, or "None">
+
+### Archi 50x50 (Architecte Veteran) — X/10
+**Verdict**: Go | Fix | Redo
+<2-3 sentences>
+**Adjustments**: <specific changes required, or "None">
+
+### Better Call Saul (Legal/IP) — X/10
+**Verdict**: Go | Fix | Redo
+<2-3 sentences>
+**Adjustments**: <specific changes required, or "None">
+
+---
+**Average**: X.XX/10
+**Global Verdict**: Go | Fix | Redo
+**Adjustments to apply**: <numbered list of all adjustments from all personas>
+```
+
+### Step 3: Decision Gate
+
+| Average Score | Action |
+|---------------|--------|
+| >= 8.0 | **Go** — Auto-create Linear ticket (Step 4) |
+| 6.0 - 7.9 | **Fix** — List adjustments, ask user to confirm, then create ticket |
+| < 6.0 | **Redo** — Fundamental issues, do NOT create ticket. Propose alternatives. |
+
+### Step 4: Auto-Create Linear Ticket
+
+If Council passes (Go or Fix-then-confirmed), create the ticket:
+
+```
+linear.create_issue(
+  title: "<type>(scope): <short description>",
+  description: <see template below>,
+  team: "624a9948-a160-4e47-aba5-7f9404d23506",  # CAB-ING
+  project: "227427af-6844-484d-bb4a-dedeffc68825",  # STOA Platform
+  assignee: "0543749d-ecde-4edf-aec1-6f372aafafce",  # Christophe
+  estimate: <fibonacci points based on complexity>,
+  priority: <1=Urgent, 2=High, 3=Normal, 4=Low>,
+  labels: [<type label>, <priority label>, "hlfh:validated" if applicable],
+  state: "Todo"
+)
+```
+
+#### Issue Description Template
+
+```markdown
+## Context
+<1-2 paragraphs: what and why>
+
+## Council Validation — X.XX/10 {Go|Fix}
+
+| Persona | Score | Verdict |
+|---------|-------|---------|
+| Chucky (Devil's Advocate) | X/10 | Go |
+| OSS Killer (VC Skeptique) | X/10 | Go |
+| Archi 50x50 (Architecte Veteran) | X/10 | Go |
+| Better Call Saul (Legal/IP) | X/10 | Go |
+
+### Adjustments Applied
+1. <adjustment 1>
+2. <adjustment 2>
+...
+
+## Scope
+<Bullet list of what's in/out of scope>
+
+## Implementation Phases
+<Numbered list of phases with estimated LOC>
+
+## DoD
+- [ ] <acceptance criteria 1>
+- [ ] <acceptance criteria 2>
+- [ ] State files updated (memory.md, plan.md)
+- [ ] CI green
+```
+
+#### Estimate Guide
+
+| Complexity | Points | Examples |
+|------------|--------|---------|
+| Trivial | 1-2 | Config change, docs update, single-file fix |
+| Small | 3-5 | Single component, <150 LOC, clear scope |
+| Medium | 8-13 | Multi-component, <300 LOC, needs design |
+| Large | 21-34 | Cross-cutting, >300 LOC, multiple PRs |
+| Epic | 55+ | Multi-sprint, architectural change |
+
+#### Priority Mapping
+
+| Signal | Priority | Linear Label |
+|--------|----------|-------------|
+| Demo blocker, production down | 1 (Urgent) | `P0-Urgent` |
+| This week, user-facing | 2 (High) | `P1-High` |
+| This sprint | 3 (Normal) | `P2-Medium` |
+| Backlog, nice-to-have | 4 (Low) | `P3-Low` |
+
+### Step 5: Update plan.md
+
+After ticket creation, append to the appropriate section in `plan.md`:
+
+```markdown
+- [ ] CAB-XXXX: <title> (<points> pts) — Council X.XX/10
+```
+
+### Step 6: Report to User
+
+```
+Council: X.XX/10 — Go
+Ticket: CAB-XXXX (<points> pts)
+Linear: <URL>
+plan.md: updated
+Next: say "go" to start implementation, or "adjust <feedback>" to revise
+```
+
+## Rules
+
+- **Never skip the Council** for features >= 5 pts
+- **Always include DoD** in the Linear ticket
+- **Adjustments are mandatory** — if a persona says Fix, the adjustment must be in the DoD
+- **One ticket per feature** — don't create sub-tasks (those come during implementation)
+- **Score honestly** — don't inflate scores to pass the gate
+- For **ADRs**: use `/create-adr` skill after Council passes (ADR lives in stoa-docs)
+- For **mega-tickets** (>= 30 pts): add `mega-ticket` label automatically

--- a/.claude/skills/sync-plan.md
+++ b/.claude/skills/sync-plan.md
@@ -1,0 +1,118 @@
+# Skill: /sync-plan — Bidirectional plan.md ↔ Linear Sync
+
+## When to Use
+
+Synchronize `plan.md` with Linear ticket statuses. Can be run at session start, after merging PRs, or on-demand.
+
+**Invoke**: `/sync-plan` (full sync) or `/sync-plan CAB-XXXX` (single ticket)
+
+## Workflow
+
+### Step 1: Parse plan.md
+
+Read `plan.md` and extract all `CAB-XXXX` references with their current markers:
+
+| Marker | Meaning |
+|--------|---------|
+| `- [x]` | Done locally |
+| `- [~]` | Partially done |
+| `- [ ]` | Not started or pending |
+| `**DONE**` | Completed (in memory.md style) |
+
+Extract ticket IDs using pattern: `CAB-\d{3,4}`
+
+### Step 2: Fetch Linear Statuses
+
+For each extracted `CAB-XXXX`, fetch current status from Linear:
+
+```
+linear.get_issue("CAB-XXXX") → status, priority, estimate, assignee
+```
+
+**Batch optimization**: Use `list_issues` with project filter if >5 tickets to sync:
+```
+linear.list_issues(
+  project: "227427af-6844-484d-bb4a-dedeffc68825",
+  first: 50
+)
+```
+
+### Step 3: Detect Drift
+
+Compare plan.md markers vs Linear statuses:
+
+| plan.md | Linear | Drift? | Action |
+|---------|--------|--------|--------|
+| `[x]` | Done | No | Skip |
+| `[x]` | In Progress | Yes | **Warning**: plan.md says done but Linear disagrees |
+| `[ ]` | Done | Yes | Update plan.md → `[x]` |
+| `[ ]` | In Progress | Yes | Update plan.md → `[~]` |
+| `[~]` | Done | Yes | Update plan.md → `[x]` |
+| `[~]` | Todo | Yes | Update Linear → In Progress |
+| Not in plan | Exists in Linear | — | Report: "CAB-XXXX exists in Linear but not in plan.md" |
+
+### Step 4: Apply Updates
+
+#### Direction: Linear → plan.md (default)
+
+Update plan.md markers to match Linear reality:
+- `Done` in Linear → `[x]` in plan.md
+- `In Progress` in Linear → `[~]` in plan.md
+- `Canceled` in Linear → strikethrough in plan.md
+
+#### Direction: plan.md → Linear (on explicit request)
+
+When user says `/sync-plan --push`:
+- `[x]` in plan.md → `linear.update_issue(status="Done")`
+- `[~]` in plan.md → `linear.update_issue(status="In Progress")`
+- `[ ]` with priority change → `linear.update_issue(priority=N)`
+
+### Step 5: Priority Reorder
+
+After sync, reorder plan.md sections by Linear priority:
+1. P0 (Urgent) items first
+2. P1 (High) second
+3. P2 (Normal) third
+4. P3 (Low) last
+
+Only reorder within the same section (don't move items between sections).
+
+### Step 6: Report
+
+Present sync results:
+
+```
+Sync Results:
+- Tickets scanned: N
+- Updates applied (Linear → plan.md): N
+- Updates applied (plan.md → Linear): N
+- Drift detected: N items
+- New in Linear (not in plan): N items
+
+Changes:
+  CAB-XXXX: [ ] → [x] (Linear: Done)
+  CAB-YYYY: [~] → [x] (Linear: Done)
+  CAB-ZZZZ: Not in plan (Linear: Todo, 8 pts, P2)
+
+plan.md updated. Review changes with `git diff plan.md`.
+```
+
+## Single Ticket Mode
+
+`/sync-plan CAB-XXXX` — sync only one ticket:
+
+1. `linear.get_issue("CAB-XXXX")` → fetch full details
+2. Find `CAB-XXXX` in plan.md
+3. If not found → ask user where to add it (which section)
+4. If found → update marker to match Linear status
+5. Report the single change
+
+## Rules
+
+- **Never delete lines** from plan.md — only update markers and add new entries
+- **Preserve formatting** — keep existing indentation, bullet style, section headers
+- **Log sync** in operations.log: `MCP-CALL | service=linear action=sync-plan tickets=N`
+- **Conflict resolution**: if plan.md and Linear disagree, **Linear wins** by default (source of truth for status)
+- **Rate limiting**: max 20 `get_issue` calls per sync (use `list_issues` batch for larger sets)
+- **No auto-commit** — show diff to user, let them decide whether to commit
+- **Cycle awareness**: when listing issues, filter by current cycle if available


### PR DESCRIPTION
## Summary
- `/council` skill: 4-persona validation (Chucky, OSS Killer, Archi 50x50, Better Call Saul) with auto-create Linear ticket on score >= 8/10
- `/sync-plan` skill: bidirectional plan.md ↔ Linear sync with drift detection, priority reorder, and batch optimization
- Both skills leverage Claude.ai native MCP integrations (Linear)

## Test plan
- [ ] `/council <feature description>` runs 4 personas, scores, creates Linear ticket
- [ ] `/sync-plan` detects drift between plan.md and Linear statuses
- [ ] `/sync-plan CAB-XXXX` syncs a single ticket

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>