### PR TITLE
fix: convert /council and /sync-plan to SKILL.md format

### DIFF
--- a/.claude/rules/mcp-integrations.md
+++ b/.claude/rules/mcp-integrations.md
@@ -32,6 +32,8 @@ Connected via Claude.ai account settings (not local `.claude/settings.json`).
 | **Sub-task discovered** | Create child issue | `create_issue(title, parentId, team)` |
 | **Need cycle context** | Get current sprint issues | `list_cycles(teamId, type="current")` + `list_issues` |
 | **DoD verification** | Read issue description for acceptance criteria | `get_issue(id)` |
+| **Council validation** | Auto-create ticket on score >= 8/10 | `/council` skill → `create_issue` |
+| **Plan sync** | Drift detection plan.md ↔ Linear | `/sync-plan` skill → batch `get_issue` |
 
 ### When NOT to Use Linear MCP
 

--- a/.claude/skills/council/SKILL.md
+++ b/.claude/skills/council/SKILL.md
@@ -1,12 +1,21 @@
-# Skill: /council — Validate & Create Ticket
+---
+name: council
+description: Run 4-persona Council validation on a feature/ADR, then auto-create a Linear ticket if score >= 8/10.
+argument-hint: "<description of what to build>"
+---
 
-## When to Use
+# Council Validation — $ARGUMENTS
 
-When user describes a feature, ADR, or architectural decision that needs validation before implementation. Automatically creates a Linear ticket if the Council score is >= 8/10.
+## Step 1: Gather Context
 
-**Invoke**: `/council <description of what to build>`
+Read and understand the feature/ADR/change description. Gather context from:
+- `memory.md` — current sprint, related work
+- `plan.md` — where this fits in priorities
+- Relevant code files if technical
 
-## The Council — 4 Personas
+## Step 2: Run the Council — 4 Personas
+
+Evaluate $ARGUMENTS through each persona:
 
 ### 1. Chucky (Devil's Advocate) — Score /10
 - Challenges assumptions and finds weaknesses
@@ -32,18 +41,7 @@ When user describes a feature, ADR, or architectural decision that needs validat
 - Red flags: hardcoded secrets, unverified competitive claims, missing disclaimers
 - Focus: legal safety, regulatory alignment, IP protection
 
-## Workflow
-
-### Step 1: Analyze the Request
-
-Read and understand the user's feature/ADR/change description. Gather context from:
-- `memory.md` — current sprint, related work
-- `plan.md` — where this fits in priorities
-- Relevant code files if technical
-
-### Step 2: Run the Council
-
-Present each persona's evaluation in this format:
+Present each persona's evaluation:
 
 ```
 ## Council Validation
@@ -74,7 +72,7 @@ Present each persona's evaluation in this format:
 **Adjustments to apply**: <numbered list of all adjustments from all personas>
 ```
 
-### Step 3: Decision Gate
+## Step 3: Decision Gate
 
 | Average Score | Action |
 |---------------|--------|
@@ -82,25 +80,25 @@ Present each persona's evaluation in this format:
 | 6.0 - 7.9 | **Fix** — List adjustments, ask user to confirm, then create ticket |
 | < 6.0 | **Redo** — Fundamental issues, do NOT create ticket. Propose alternatives. |
 
-### Step 4: Auto-Create Linear Ticket
+## Step 4: Auto-Create Linear Ticket
 
-If Council passes (Go or Fix-then-confirmed), create the ticket:
+If Council passes (Go or Fix-then-confirmed), create the ticket using Linear MCP:
 
 ```
 linear.create_issue(
   title: "<type>(scope): <short description>",
   description: <see template below>,
-  team: "624a9948-a160-4e47-aba5-7f9404d23506",  # CAB-ING
-  project: "227427af-6844-484d-bb4a-dedeffc68825",  # STOA Platform
-  assignee: "0543749d-ecde-4edf-aec1-6f372aafafce",  # Christophe
-  estimate: <fibonacci points based on complexity>,
+  team: "624a9948-a160-4e47-aba5-7f9404d23506",
+  project: "227427af-6844-484d-bb4a-dedeffc68825",
+  assignee: "0543749d-ecde-4edf-aec1-6f372aafafce",
+  estimate: <fibonacci points>,
   priority: <1=Urgent, 2=High, 3=Normal, 4=Low>,
   labels: [<type label>, <priority label>, "hlfh:validated" if applicable],
   state: "Todo"
 )
 ```
 
-#### Issue Description Template
+### Issue Description Template
 
 ```markdown
 ## Context
@@ -118,7 +116,6 @@ linear.create_issue(
 ### Adjustments Applied
 1. <adjustment 1>
 2. <adjustment 2>
-...
 
 ## Scope
 <Bullet list of what's in/out of scope>
@@ -133,7 +130,7 @@ linear.create_issue(
 - [ ] CI green
 ```
 
-#### Estimate Guide
+### Estimate Guide
 
 | Complexity | Points | Examples |
 |------------|--------|---------|
@@ -143,7 +140,7 @@ linear.create_issue(
 | Large | 21-34 | Cross-cutting, >300 LOC, multiple PRs |
 | Epic | 55+ | Multi-sprint, architectural change |
 
-#### Priority Mapping
+### Priority Mapping
 
 | Signal | Priority | Linear Label |
 |--------|----------|-------------|
@@ -152,7 +149,7 @@ linear.create_issue(
 | This sprint | 3 (Normal) | `P2-Medium` |
 | Backlog, nice-to-have | 4 (Low) | `P3-Low` |
 
-### Step 5: Update plan.md
+## Step 5: Update plan.md
 
 After ticket creation, append to the appropriate section in `plan.md`:
 
@@ -160,7 +157,7 @@ After ticket creation, append to the appropriate section in `plan.md`:
 - [ ] CAB-XXXX: <title> (<points> pts) — Council X.XX/10
 ```
 
-### Step 6: Report to User
+## Step 6: Report to User
 
 ```
 Council: X.XX/10 — Go

--- a/.claude/skills/sync-plan/SKILL.md
+++ b/.claude/skills/sync-plan/SKILL.md
@@ -1,14 +1,16 @@
-# Skill: /sync-plan — Bidirectional plan.md ↔ Linear Sync
+---
+name: sync-plan
+description: Bidirectional sync between plan.md and Linear tickets. Detects drift, updates markers, reorders by priority.
+argument-hint: "[CAB-XXXX for single ticket, or empty for full sync]"
+---
 
-## When to Use
+# Plan ↔ Linear Sync
 
-Synchronize `plan.md` with Linear ticket statuses. Can be run at session start, after merging PRs, or on-demand.
+Synchronize plan.md with Linear ticket statuses.
 
-**Invoke**: `/sync-plan` (full sync) or `/sync-plan CAB-XXXX` (single ticket)
+Target: $ARGUMENTS
 
-## Workflow
-
-### Step 1: Parse plan.md
+## Step 1: Parse plan.md
 
 Read `plan.md` and extract all `CAB-XXXX` references with their current markers:
 
@@ -21,15 +23,14 @@ Read `plan.md` and extract all `CAB-XXXX` references with their current markers:
 
 Extract ticket IDs using pattern: `CAB-\d{3,4}`
 
-### Step 2: Fetch Linear Statuses
+## Step 2: Fetch Linear Statuses
 
-For each extracted `CAB-XXXX`, fetch current status from Linear:
-
+If single ticket ($ARGUMENTS = CAB-XXXX):
 ```
 linear.get_issue("CAB-XXXX") → status, priority, estimate, assignee
 ```
 
-**Batch optimization**: Use `list_issues` with project filter if >5 tickets to sync:
+If full sync (no argument or >5 tickets):
 ```
 linear.list_issues(
   project: "227427af-6844-484d-bb4a-dedeffc68825",
@@ -37,7 +38,9 @@ linear.list_issues(
 )
 ```
 
-### Step 3: Detect Drift
+For <= 5 tickets, use individual `get_issue` calls.
+
+## Step 3: Detect Drift
 
 Compare plan.md markers vs Linear statuses:
 
@@ -51,23 +54,22 @@ Compare plan.md markers vs Linear statuses:
 | `[~]` | Todo | Yes | Update Linear → In Progress |
 | Not in plan | Exists in Linear | — | Report: "CAB-XXXX exists in Linear but not in plan.md" |
 
-### Step 4: Apply Updates
+## Step 4: Apply Updates
 
-#### Direction: Linear → plan.md (default)
+### Direction: Linear → plan.md (default)
 
 Update plan.md markers to match Linear reality:
 - `Done` in Linear → `[x]` in plan.md
 - `In Progress` in Linear → `[~]` in plan.md
 - `Canceled` in Linear → strikethrough in plan.md
 
-#### Direction: plan.md → Linear (on explicit request)
+### Direction: plan.md → Linear (when user says `--push`)
 
-When user says `/sync-plan --push`:
 - `[x]` in plan.md → `linear.update_issue(status="Done")`
 - `[~]` in plan.md → `linear.update_issue(status="In Progress")`
 - `[ ]` with priority change → `linear.update_issue(priority=N)`
 
-### Step 5: Priority Reorder
+## Step 5: Priority Reorder
 
 After sync, reorder plan.md sections by Linear priority:
 1. P0 (Urgent) items first
@@ -77,9 +79,7 @@ After sync, reorder plan.md sections by Linear priority:
 
 Only reorder within the same section (don't move items between sections).
 
-### Step 6: Report
-
-Present sync results:
+## Step 6: Report
 
 ```
 Sync Results:
@@ -97,22 +97,12 @@ Changes:
 plan.md updated. Review changes with `git diff plan.md`.
 ```
 
-## Single Ticket Mode
-
-`/sync-plan CAB-XXXX` — sync only one ticket:
-
-1. `linear.get_issue("CAB-XXXX")` → fetch full details
-2. Find `CAB-XXXX` in plan.md
-3. If not found → ask user where to add it (which section)
-4. If found → update marker to match Linear status
-5. Report the single change
-
 ## Rules
 
 - **Never delete lines** from plan.md — only update markers and add new entries
 - **Preserve formatting** — keep existing indentation, bullet style, section headers
 - **Log sync** in operations.log: `MCP-CALL | service=linear action=sync-plan tickets=N`
-- **Conflict resolution**: if plan.md and Linear disagree, **Linear wins** by default (source of truth for status)
+- **Conflict resolution**: if plan.md and Linear disagree, **Linear wins** by default
 - **Rate limiting**: max 20 `get_issue` calls per sync (use `list_issues` batch for larger sets)
 - **No auto-commit** — show diff to user, let them decide whether to commit
 - **Cycle awareness**: when listing issues, filter by current cycle if available


### PR DESCRIPTION
## Summary
- Skills require `directory/SKILL.md` with YAML frontmatter to be user-invocable via `/command`
- Converted flat `.md` files to proper `SKILL.md` format with `name`, `description`, `argument-hint`
- Added Council + sync-plan triggers to `mcp-integrations.md`

## Test plan
- [x] `/council` appears in skill list after conversion
- [x] `/sync-plan` appears in skill list after conversion

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>