### PR TITLE
chore: add /decompose skill for component-scoped ticket splitting

### DIFF
--- a/.claude/rules/ai-factory.md
+++ b/.claude/rules/ai-factory.md
@@ -313,6 +313,45 @@ Usage: tout contenu public avec mentions concurrents, reglementations ou clients
 ```
 Usage: all new features. Objective: test-first + quality parity with human code.
 
+### Pattern 8: Decompose + Parallel Instances (multi-Claude)
+
+Prerequis: MEGA ticket (>= 21 pts) touching >= 2 components.
+Trigger: `/decompose CAB-XXXX` skill.
+
+```
+1.  [Inline] /decompose CAB-XXXX → creates N component-scoped sub-issues on Linear
+2.  [Inline] Review the DAG and execution plan
+3.  User launches N Claude Code instances (terminals or worktrees)
+
+    Phase 1 (parallel — no dependencies):
+4a. [Instance 1] CAB-XXXX-API: branch → code → tests → PR → merge
+4b. [Instance 2] CAB-XXXX-GW:  branch → code → tests → PR → merge
+4c. [Instance 3] CAB-XXXX-DOCS: branch → write → PR → merge (stoa-docs repo)
+
+    Phase 2 (parallel — after Phase 1 merges):
+5a. [Instance 1] CAB-XXXX-UI:    branch → code → tests → PR → merge
+5b. [Instance 2] CAB-XXXX-PORTAL: branch → code → tests → PR → merge
+
+    Phase 3 (sequential — after Phase 2):
+6.  [Instance 1] CAB-XXXX-E2E:   branch → tests → PR → merge
+
+7.  [Inline] Update parent ticket on Linear (Done)
+8.  [Inline] Update state files (memory.md, plan.md)
+```
+
+Key rules:
+- Each instance works in its own worktree: `git worktree add ../<name> feat/<branch>`
+- Each sub-issue = 1 PR, < 300 LOC, independently deployable
+- API always Phase 1 (upstream data provider)
+- UI always Phase 2 (depends on API endpoints)
+- E2E always last (needs all components)
+- docs always Phase 1 (separate repo, zero code coupling)
+- Worktrees share git history but isolate file changes
+- **Dropbox gotcha**: create worktrees OUTSIDE Dropbox folder to avoid sync conflicts
+
+Usage: MEGA features (>= 21 pts), cross-component work. Gain: 1.5-2x speedup.
+See `/decompose` skill for full DAG generation and Linear integration.
+
 ## Contraintes
 
 - **Maximum 3-4 subagents actifs simultanement** (au-dela, le cout explose et le temps de review aussi)

--- a/.claude/skills/decompose/SKILL.md
+++ b/.claude/skills/decompose/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: decompose
+description: Decompose a MEGA ticket into component-scoped sub-issues on Linear, with dependency DAG and parallel execution plan.
+argument-hint: "<CAB-XXXX or feature description>"
+---
+
+# Decompose — Component-Scoped Ticket Splitter
+
+Target: $ARGUMENTS
+
+## Purpose
+
+Split a MEGA ticket (or feature description) into independent, component-scoped sub-issues
+optimized for parallel execution by multiple Claude Code instances.
+
+## Step 1: Gather Source Material
+
+### If $ARGUMENTS is a CAB-XXXX ticket ID:
+
+```
+linear.get_issue("CAB-XXXX", includeRelations=true)
+```
+
+Extract: title, description, DoD, estimate, labels, parent.
+
+### If $ARGUMENTS is a feature description:
+
+Use the description directly. Proceed without Linear context.
+
+### Always read:
+
+- `memory.md` — current sprint context
+- Relevant source files — to understand which components are impacted
+
+## Step 2: Identify Affected Components
+
+Analyze the feature and map to STOA components:
+
+| Component | Path | Linear Label ID | Tech |
+|-----------|------|-----------------|------|
+| **cp-api** | `control-plane-api/` | `3d9dcfcc-2578-447f-ab94-0b00b73022f0` | Python, FastAPI |
+| **cp-ui** | `control-plane-ui/` | `1c4d11ff-da26-466d-a2ac-e49786bac927` | React, Console |
+| **portal** | `portal/` | `df33f1d3-bb93-463d-bf60-7d602a6add10` | React, Portal |
+| **gateway** | `stoa-gateway/` | `b14f839d-cde8-4fee-9f1c-894431143b35` | Rust, axum |
+| **operator** | `stoa-operator/` | _(create if needed)_ | Python, kopf |
+| **e2e** | `e2e/` | _(create if needed)_ | Playwright |
+| **docs** | `stoa-docs` (separate repo) | `8a23f909-d1fb-45be-9516-4e33a72998e1` | Docusaurus |
+| **infra** | `charts/`, `k8s/` | `ad81cb7f-31a7-4b9c-ac1f-fe0827bfea03` | Helm, K8s |
+
+For each component, check:
+1. Does this feature require changes in this component?
+2. What is the scope? (model, endpoint, page, route, config, test)
+3. Estimated LOC for this component slice?
+
+## Step 3: Build the Dependency DAG
+
+Classify each component-issue into phases based on data flow:
+
+```
+Phase 1 (no dependencies — fully parallel):
+  ├── cp-api    — models, schemas, endpoints (upstream data provider)
+  ├── gateway   — routing rules, middleware (independent data plane)
+  ├── docs      — ADR, guide (separate repo, zero code dependency)
+  └── infra     — Helm values, CRDs (independent)
+
+Phase 2 (depends on Phase 1 — parallel within phase):
+  ├── cp-ui     — Console pages (needs API endpoints from cp-api)
+  ├── portal    — Portal pages (needs API endpoints from cp-api)
+  └── operator  — CRD reconciler (needs CRDs from infra)
+
+Phase 3 (depends on Phase 2 — sequential):
+  └── e2e       — Integration tests (needs UI + API + Gateway running)
+```
+
+### Dependency Rules
+
+| Component | Typical Dependencies | Can Run Parallel With |
+|-----------|---------------------|----------------------|
+| cp-api | None (data source) | gateway, docs, infra |
+| gateway | None (data plane) | cp-api, docs, infra |
+| docs | None (separate repo) | Everything |
+| infra | None (config) | Everything |
+| cp-ui | cp-api (needs endpoints) | portal, operator |
+| portal | cp-api (needs endpoints) | cp-ui, operator |
+| operator | infra (needs CRDs) | cp-ui, portal |
+| e2e | cp-ui OR portal + cp-api | Nothing (last) |
+
+### Override Rules
+
+- If the feature has **shared types** (`shared/` directory): cp-ui and portal MUST be sequential (same shared/ changes)
+- If the feature has **API contract changes**: cp-api MUST complete and merge before cp-ui/portal start
+- If the feature is **UI-only** (no API changes): cp-ui and portal can start immediately (Phase 1)
+
+## Step 4: Estimate Points Per Component
+
+Use historical velocity data:
+
+| Component | Typical Points | LOC Range | Session Duration |
+|-----------|---------------|-----------|-----------------|
+| cp-api (model + endpoints + tests) | 8-13 pts | 100-300 LOC | 1-2 sessions |
+| cp-ui (pages + tests) | 8-13 pts | 100-250 LOC | 1-2 sessions |
+| portal (pages + tests) | 5-8 pts | 80-200 LOC | 1 session |
+| gateway (route + middleware) | 5-8 pts | 50-150 LOC | 1 session |
+| operator (reconciler) | 5-8 pts | 80-200 LOC | 1 session |
+| e2e (integration tests) | 3-5 pts | 50-150 LOC | 1 session |
+| docs (ADR + guide) | 3-5 pts | 200-500 words | 1 session |
+| infra (Helm + k8s) | 2-3 pts | 20-80 LOC | <1 session |
+
+Total sub-issue points should approximately equal the parent MEGA ticket estimate.
+
+## Step 5: Create Sub-Issues on Linear
+
+For each component-issue, create a Linear sub-issue:
+
+```
+linear.create_issue(
+  title: "[<component>] <action verb> <what> (<parent-ticket-id>)",
+  description: <see template below>,
+  team: "624a9948-a160-4e47-aba5-7f9404d23506",
+  project: "227427af-6844-484d-bb4a-dedeffc68825",
+  assignee: "0543749d-ecde-4edf-aec1-6f372aafafce",
+  parentId: "<parent-issue-id>",
+  estimate: <component-specific points>,
+  priority: <inherit from parent>,
+  labels: [<component label>, <type label>, "flow-ready"],
+  state: "Todo"
+)
+```
+
+### Sub-Issue Title Convention
+
+```
+[cp-api] Add consumer model + endpoints (CAB-XXXX)
+[portal] Consumer registration page (CAB-XXXX)
+[cp-ui]  Consumer management table (CAB-XXXX)
+[gateway] Consumer ID propagation (CAB-XXXX)
+[e2e]    Consumer flow integration test (CAB-XXXX)
+[docs]   Consumer onboarding guide (CAB-XXXX)
+```
+
+### Sub-Issue Description Template
+
+```markdown
+## Parent
+CAB-XXXX — <parent title>
+
+## Scope
+**Component**: `<path>/`
+**Phase**: <1|2|3> (parallel|depends on CAB-YYYY)
+**Estimated LOC**: ~<N>
+
+## What to Build
+- <bullet 1: specific deliverable>
+- <bullet 2: specific deliverable>
+- <bullet 3: specific deliverable>
+
+## Files to Touch
+- `<path/to/file1>` — <what changes>
+- `<path/to/file2>` — <what changes>
+
+## DoD (component-scoped)
+- [ ] Code compiles (`<build command>`)
+- [ ] Tests pass (`<test command>`)
+- [ ] Lint clean (`<lint command>`)
+- [ ] PR created with < 300 LOC
+- [ ] CI green
+
+## Parallel Execution Notes
+- **Can start immediately**: Yes | No (blocked by CAB-YYYY)
+- **Worktree command**: `git worktree add ../<project>-<component> feat/<branch>`
+- **Isolation**: No shared state with other sub-issues
+```
+
+## Step 6: Set Up Relations
+
+After all sub-issues are created, establish blocking relations:
+
+```
+# Phase 2 issues are blocked by Phase 1 issues
+linear.update_issue(phase2_issue_id, relation: { type: "blocks", relatedId: phase1_issue_id })
+```
+
+Use Linear's native `blocks` / `blockedBy` relations so the dependency graph is visible in Linear UI.
+
+## Step 7: Generate Execution Plan
+
+Present the DAG visually:
+
+```
+Execution Plan for CAB-XXXX — <Feature Name>
+═══════════════════════════════════════════════
+
+Phase 1 (parallel — start immediately):
+  ┌─────────────────────────────────────────┐
+  │ CAB-AAAA [cp-api]  8 pts  ~200 LOC     │ → Agent 1 (main worktree)
+  │ CAB-BBBB [gateway] 5 pts  ~100 LOC     │ → Agent 2 (worktree)
+  │ CAB-CCCC [docs]    3 pts  ~400 words   │ → Agent 3 (stoa-docs repo)
+  └─────────────────────────────────────────┘
+  ⏱ Estimated: 1-2 sessions (~45 min)
+
+Phase 2 (parallel — after Phase 1 merges):
+  ┌─────────────────────────────────────────┐
+  │ CAB-DDDD [portal]  8 pts  ~180 LOC     │ → Agent 1
+  │ CAB-EEEE [cp-ui]   8 pts  ~200 LOC     │ → Agent 2
+  └─────────────────────────────────────────┘
+  ⏱ Estimated: 1 session (~30 min)
+
+Phase 3 (sequential — after Phase 2 merges):
+  ┌─────────────────────────────────────────┐
+  │ CAB-FFFF [e2e]     3 pts  ~100 LOC     │ → Agent 1
+  └─────────────────────────────────────────┘
+  ⏱ Estimated: 1 session (~20 min)
+
+───────────────────────────────────────────
+Total: 35 pts │ 6 sub-issues │ 3 phases
+Sequential time: ~6 sessions
+Parallel time:   ~3 sessions (2x speedup)
+Max agents needed: 3 (Phase 1)
+
+Worktree Setup:
+  git worktree add ../stoa-portal feat/CAB-XXXX-portal
+  git worktree add ../stoa-gateway feat/CAB-XXXX-gateway
+```
+
+## Step 8: Update Parent Ticket
+
+Add a comment to the parent MEGA ticket with the decomposition summary:
+
+```
+linear.create_comment(
+  issueId: "<parent-id>",
+  body: "## Decomposed into N sub-issues\n\n<execution plan table>\n\nPhase 1 (parallel): CAB-AAAA, CAB-BBBB, CAB-CCCC\nPhase 2 (after API merge): CAB-DDDD, CAB-EEEE\nPhase 3 (after UI merge): CAB-FFFF\n\nMax parallelism: 3 agents"
+)
+```
+
+Add `needs-split` label removal if it was present:
+```
+linear.update_issue(parentId, removeLabelIds: ["768f96b2-69f0-4ed3-83de-538f657dd001"])
+```
+
+## Step 9: Report to User
+
+```
+Decomposition Complete: CAB-XXXX — <Feature Name>
+══════════════════════════════════════════════════
+
+Created N sub-issues:
+
+| # | Ticket | Component | Phase | Points | Parallel? |
+|---|--------|-----------|-------|--------|-----------|
+| 1 | CAB-AAAA | [cp-api] | 1 | 8 | Yes |
+| 2 | CAB-BBBB | [gateway] | 1 | 5 | Yes |
+| 3 | CAB-CCCC | [docs] | 1 | 3 | Yes |
+| 4 | CAB-DDDD | [portal] | 2 | 8 | After CAB-AAAA |
+| 5 | CAB-EEEE | [cp-ui] | 2 | 8 | After CAB-AAAA |
+| 6 | CAB-FFFF | [e2e] | 3 | 3 | After CAB-DDDD, CAB-EEEE |
+
+Speedup: 2x (3 phases instead of 6 sequential sessions)
+Max concurrent agents: 3
+
+Parent ticket CAB-XXXX updated with decomposition comment.
+
+Next steps:
+  1. "go phase 1" → start all Phase 1 sub-issues
+  2. Pick a specific sub-issue: "go CAB-AAAA"
+  3. Adjust: "move [docs] to Phase 2" or "merge [portal] and [cp-ui]"
+```
+
+## Rules
+
+- **Never create sub-issues for single-component features** — if only 1 component is affected, don't decompose
+- **Minimum 2 components** to justify decomposition (otherwise it's overhead)
+- **Maximum 8 sub-issues** per decomposition (more = over-engineering the split)
+- **Each sub-issue MUST be independently deployable** — no broken intermediate state
+- **Each sub-issue < 300 LOC** — if a component slice is larger, split further
+- **API always Phase 1** — UI components never start before their API dependency is merged
+- **E2E always last phase** — integration tests need all components running
+- **docs can always run in parallel** — separate repo, zero code coupling
+- **shared/ directory is a coupling signal** — if both cp-ui and portal touch `shared/`, they must be sequential
+- **Preserve parent estimate** — sum of sub-issue points should equal parent (redistribute, don't inflate)
+- **Label with `flow-ready`** — all sub-issues start as flow-ready since they come from a validated MEGA
+- **Inherit parent priority** — sub-issues get the same priority as the parent ticket
+
+## Component Label IDs (cached)
+
+| Component | Label ID |
+|-----------|----------|
+| cp-api | `3d9dcfcc-2578-447f-ab94-0b00b73022f0` |
+| cp-ui | `1c4d11ff-da26-466d-a2ac-e49786bac927` |
+| portal (ui) | `df33f1d3-bb93-463d-bf60-7d602a6add10` |
+| gateway | `b14f839d-cde8-4fee-9f1c-894431143b35` |
+| docs | `8a23f909-d1fb-45be-9516-4e33a72998e1` |
+| infra | `ad81cb7f-31a7-4b9c-ac1f-fe0827bfea03` |
+| flow-ready | `6692a52b-126d-4fce-b480-3fac19751ecb` |
+| mega-ticket | `97f7371c-8ac3-44e6-a0a0-412e81bc959e` |
+| needs-split | `768f96b2-69f0-4ed3-83de-538f657dd001` |
+
+## Linear IDs (cached)
+
+| Entity | ID |
+|--------|----|
+| Team (CAB-ING) | `624a9948-a160-4e47-aba5-7f9404d23506` |
+| Project (STOA Platform) | `227427af-6844-484d-bb4a-dedeffc68825` |
+| Assignee (Christophe) | `0543749d-ecde-4edf-aec1-6f372aafafce` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Key rules for AI Factory workflow:
 ### Skills (`.claude/skills/`)
 - 8 legacy: `implement-feature`, `fix-bug`, `review-pr`, `audit-component`, `create-adr`, `e2e-test`, `refactor`, `update-memory`
 - 2 modernes: `/ci-debug [PR|run-url]` (fork), `/parallel-review [PR|path]` (inline)
+- 3 MCP-powered: `/council` (4-persona validation → Linear), `/sync-plan` (plan.md ↔ Linear), `/decompose` (MEGA → component-scoped sub-issues + DAG)
 
 ### Agent Teams (experimental)
 Prerequis: `brew install tmux` + `export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`


### PR DESCRIPTION
## Summary
- New `/decompose CAB-XXXX` AI Factory skill that splits MEGA tickets into component-scoped sub-issues on Linear
- Phase-based DAG with dependency tracking (API → UI → E2E)
- Enables 1.5-2x speedup via parallel Claude Code instances + git worktrees
- Pattern 8 added to `ai-factory.md` documenting the multi-instance workflow

## Files
- `.claude/skills/decompose/SKILL.md` — 9-step decomposition workflow
- `.claude/rules/ai-factory.md` — Pattern 8 (decompose + parallel instances)
- `CLAUDE.md` — 3 MCP-powered skills reference

## Test plan
- [ ] Skill visible in Claude Code (`/decompose` appears in skill list)
- [ ] Manual test: `/decompose CAB-1133` creates component-scoped sub-issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>