### PR TITLE
fix(demo): correct credentials in demo scripts (CAB-802)

### DIFF
--- a/docs/demo/DEMO-SCRIPT.md
+++ b/docs/demo/DEMO-SCRIPT.md
@@ -563,7 +563,7 @@ git shortlog --since="2026-02-09" -sn
 | art3mis | Portal | samantha2045 | Developer |
 | admin | Grafana | admin / admin | Monitoring |
 | admin | OpenSearch | admin / StoaAdmin2026Prod | Logs |
-| admin | Keycloak | admin / admin | Auth Admin |
+| admin | Keycloak | admin / demo | Auth Admin |
 | demo-alpha | Federation (alpha) | demo | Demo Org Alpha user |
 | demo-beta | Federation (beta) | demo | Demo Org Beta user |
 

--- a/scripts/demo/demo-dry-run.sh
+++ b/scripts/demo/demo-dry-run.sh
@@ -157,7 +157,7 @@ fi
 # Token issuance (art3mis — used throughout)
 TOKEN_START=$(date +%s%N)
 TOKEN_RESPONSE=$(curl -s -X POST "${AUTH_URL}/realms/stoa/protocol/openid-connect/token" \
-    -d "grant_type=password&client_id=control-plane-ui&username=art3mis&password=demo" \
+    -d "grant_type=password&client_id=control-plane-ui&username=art3mis&password=samantha2045" \
     --max-time 10 2>/dev/null || echo '{}')
 TOKEN_END=$(date +%s%N)
 TOKEN_MS=$(( (TOKEN_END - TOKEN_START) / 1000000 ))


### PR DESCRIPTION
## Summary
- Fix art3mis password in `demo-dry-run.sh`: `demo` → `samantha2045` (matches production Keycloak)
- Fix Keycloak admin credentials in `DEMO-SCRIPT.md`: `admin/admin` → `admin/demo` (matches production)
- Discovered during full Acts 1-8 rehearsal against production

## Test plan
- [x] `demo-dry-run.sh` → 23/23 PASS, GO verdict
- [x] Manual rehearsal Acts 1-8 against production

🤖 Generated with [Claude Code](https://claude.com/claude-code)