### PR TITLE
feat(ui): add Drift Detection page (CAB-1138 P6)

### DIFF
--- a/control-plane-ui/src/App.tsx
+++ b/control-plane-ui/src/App.tsx
@@ -53,6 +53,9 @@ const GatewayModes = lazy(() =>
 const GatewayDeployments = lazy(() =>
   import('./pages/GatewayDeployments').then((m) => ({ default: m.GatewayDeploymentsDashboard }))
 );
+const DriftDetection = lazy(() =>
+  import('./pages/DriftDetection').then((m) => ({ default: m.DriftDetection }))
+);
 const GatewayObservability = lazy(() =>
   import('./pages/GatewayObservability').then((m) => ({ default: m.GatewayObservabilityDashboard }))
 );
@@ -354,6 +357,7 @@ function ProtectedRoutes() {
                 <Route path="/gateways/modes" element={<GatewayModes />} />
                 <Route path="/gateways" element={<GatewayRegistry />} />
                 <Route path="/gateway-deployments" element={<GatewayDeployments />} />
+                <Route path="/drift" element={<DriftDetection />} />
                 <Route path="/gateway-observability" element={<GatewayObservability />} />
                 <Route path="/operations" element={<OperationsDashboard />} />
                 <Route path="/my-usage" element={<TenantDashboard />} />

--- a/control-plane-ui/src/components/Layout.tsx
+++ b/control-plane-ui/src/components/Layout.tsx
@@ -157,6 +157,12 @@ const navigationSections: NavSection[] = [
         permission: 'tenants:read',
       },
       {
+        name: 'Drift',
+        href: '/drift',
+        icon: AlertTriangle,
+        permission: 'tenants:read',
+      },
+      {
         name: 'Metrics',
         href: '/gateway-observability',
         icon: BarChart3,

--- a/control-plane-ui/src/hooks/useBreadcrumbs.ts
+++ b/control-plane-ui/src/hooks/useBreadcrumbs.ts
@@ -18,6 +18,7 @@ const routeLabels: Record<string, string> = {
   gateway: 'Gateway',
   gateways: 'Gateway Registry',
   'gateway-deployments': 'Gateway Deployments',
+  drift: 'Drift Detection',
   'gateway-observability': 'Observability',
   applications: 'Applications',
   deployments: 'Deployments',

--- a/control-plane-ui/src/pages/DriftDetection/DriftDetection.test.tsx
+++ b/control-plane-ui/src/pages/DriftDetection/DriftDetection.test.tsx
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createAuthMock, renderWithProviders, mockGatewayInstance } from '../../test/helpers';
+import { useAuth } from '../../contexts/AuthContext';
+import type { PersonaRole } from '../../test/helpers';
+
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+
+const mockGetGatewayInstances = vi.fn().mockResolvedValue({ items: [], total: 0 });
+const mockGetGatewayDeployments = vi.fn().mockResolvedValue({ items: [], total: 0 });
+const mockGetDeploymentStatusSummary = vi.fn().mockResolvedValue({
+  synced: 5,
+  pending: 1,
+  drifted: 2,
+  error: 1,
+  syncing: 0,
+  deleting: 0,
+  total: 9,
+});
+const mockCheckGatewayHealth = vi.fn().mockResolvedValue({ status: 'healthy' });
+const mockForceSyncDeployment = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../services/api', () => ({
+  apiService: {
+    getGatewayInstances: (...args: unknown[]) => mockGetGatewayInstances(...args),
+    getGatewayDeployments: (...args: unknown[]) => mockGetGatewayDeployments(...args),
+    getDeploymentStatusSummary: (...args: unknown[]) => mockGetDeploymentStatusSummary(...args),
+    checkGatewayHealth: (...args: unknown[]) => mockCheckGatewayHealth(...args),
+    forceSyncDeployment: (...args: unknown[]) => mockForceSyncDeployment(...args),
+    setAuthToken: vi.fn(),
+    clearAuthToken: vi.fn(),
+  },
+}));
+
+vi.mock('../../components/SyncStatusBadge', () => ({
+  SyncStatusBadge: ({ status }: { status: string }) => <span>{status}</span>,
+}));
+
+vi.mock('@stoa/shared/components/Toast', () => ({
+  useToastActions: () => ({ success: vi.fn(), error: vi.fn(), info: vi.fn() }),
+}));
+
+vi.mock('@stoa/shared/components/ConfirmDialog', () => ({
+  useConfirm: () => [vi.fn().mockResolvedValue(true), null],
+}));
+
+vi.mock('@stoa/shared/components/EmptyState', () => ({
+  EmptyState: ({ title }: { title?: string }) => <div data-testid="empty-state">{title}</div>,
+}));
+
+vi.mock('@stoa/shared/components/Skeleton', () => ({
+  TableSkeleton: () => <div data-testid="table-skeleton" />,
+}));
+
+import { DriftDetection } from './DriftDetection';
+
+describe('DriftDetection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+    mockGetGatewayInstances.mockResolvedValue({ items: [], total: 0 });
+    mockGetGatewayDeployments.mockResolvedValue({ items: [], total: 0 });
+    mockGetDeploymentStatusSummary.mockResolvedValue({
+      synced: 5,
+      pending: 1,
+      drifted: 2,
+      error: 1,
+      syncing: 0,
+      deleting: 0,
+      total: 9,
+    });
+  });
+
+  it('renders the heading', async () => {
+    renderWithProviders(<DriftDetection />);
+    expect(await screen.findByRole('heading', { name: /Drift Detection/ })).toBeInTheDocument();
+  });
+
+  it('renders summary cards with correct counts', async () => {
+    mockGetGatewayInstances.mockResolvedValue({
+      items: [
+        mockGatewayInstance({ id: 'gw-1', status: 'online' }),
+        mockGatewayInstance({ id: 'gw-2', status: 'online' }),
+        mockGatewayInstance({ id: 'gw-3', status: 'online' }),
+        mockGatewayInstance({ id: 'gw-4', status: 'offline' }),
+      ],
+      total: 4,
+    });
+    mockGetDeploymentStatusSummary.mockResolvedValue({
+      synced: 5,
+      pending: 0,
+      drifted: 2,
+      error: 0,
+      syncing: 0,
+      deleting: 0,
+      total: 7,
+    });
+
+    renderWithProviders(<DriftDetection />);
+    await waitFor(() => {
+      expect(screen.getByText('4')).toBeInTheDocument(); // Total Gateways
+      expect(screen.getByText('3')).toBeInTheDocument(); // Healthy (3 online)
+      expect(screen.getByText('2')).toBeInTheDocument(); // Drifted
+    });
+  });
+
+  it('renders gateway health grid with gateway names', async () => {
+    mockGetGatewayInstances.mockResolvedValue({
+      items: [
+        mockGatewayInstance({ id: 'gw-1', display_name: 'STOA Gateway', status: 'online' }),
+        mockGatewayInstance({ id: 'gw-2', display_name: 'Kong Gateway', status: 'degraded' }),
+      ],
+      total: 2,
+    });
+
+    renderWithProviders(<DriftDetection />);
+    expect(await screen.findByText('STOA Gateway')).toBeInTheDocument();
+    expect(screen.getByText('Kong Gateway')).toBeInTheDocument();
+    expect(screen.getByText('Online')).toBeInTheDocument();
+    expect(screen.getByText('Degraded')).toBeInTheDocument();
+  });
+
+  it('shows All Clear when no drift', async () => {
+    renderWithProviders(<DriftDetection />);
+    expect(await screen.findByText('All Clear')).toBeInTheDocument();
+  });
+
+  it('renders drifted deployments table', async () => {
+    mockGetGatewayDeployments.mockImplementation((params: { sync_status?: string }) => {
+      if (params?.sync_status === 'drifted') {
+        return Promise.resolve({
+          items: [
+            {
+              id: 'dep-1',
+              api_catalog_id: 'api-1',
+              gateway_instance_id: 'gw-1',
+              sync_status: 'drifted',
+              sync_error: 'Config mismatch',
+              desired_state: { api_name: 'Payment API' },
+              desired_at: '2026-02-01T00:00:00Z',
+              sync_attempts: 3,
+              last_sync_attempt: '2026-02-15T10:00:00Z',
+              created_at: '2026-01-15T00:00:00Z',
+              updated_at: '2026-02-15T10:00:00Z',
+            },
+          ],
+          total: 1,
+        });
+      }
+      return Promise.resolve({ items: [], total: 0 });
+    });
+
+    renderWithProviders(<DriftDetection />);
+    expect(await screen.findByText('Payment API')).toBeInTheDocument();
+    expect(screen.getByText('drifted')).toBeInTheDocument();
+    expect(screen.getByText('Config mismatch')).toBeInTheDocument();
+  });
+
+  it('calls forceSyncDeployment when Force Sync is clicked', async () => {
+    const user = userEvent.setup();
+
+    mockGetGatewayDeployments.mockImplementation((params: { sync_status?: string }) => {
+      if (params?.sync_status === 'drifted') {
+        return Promise.resolve({
+          items: [
+            {
+              id: 'dep-1',
+              api_catalog_id: 'api-1',
+              gateway_instance_id: 'gw-1',
+              sync_status: 'drifted',
+              desired_state: {},
+              desired_at: '2026-02-01T00:00:00Z',
+              sync_attempts: 1,
+              created_at: '2026-01-15T00:00:00Z',
+              updated_at: '2026-02-15T10:00:00Z',
+            },
+          ],
+          total: 1,
+        });
+      }
+      return Promise.resolve({ items: [], total: 0 });
+    });
+
+    renderWithProviders(<DriftDetection />);
+    const syncBtn = await screen.findByText('Force Sync');
+    await user.click(syncBtn);
+
+    await waitFor(() => {
+      expect(mockForceSyncDeployment).toHaveBeenCalledWith('dep-1');
+    });
+  });
+
+  it('calls checkGatewayHealth when Check Health is clicked', async () => {
+    const user = userEvent.setup();
+
+    mockGetGatewayInstances.mockResolvedValue({
+      items: [mockGatewayInstance({ id: 'gw-1', display_name: 'Test GW', status: 'online' })],
+      total: 1,
+    });
+
+    renderWithProviders(<DriftDetection />);
+    const healthBtn = await screen.findByText('Check Health');
+    await user.click(healthBtn);
+
+    await waitFor(() => {
+      expect(mockCheckGatewayHealth).toHaveBeenCalledWith('gw-1');
+    });
+  });
+
+  it('hides action buttons for non-admin users', async () => {
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('viewer'));
+
+    mockGetGatewayInstances.mockResolvedValue({
+      items: [mockGatewayInstance({ id: 'gw-1', status: 'online' })],
+      total: 1,
+    });
+
+    mockGetGatewayDeployments.mockImplementation((params: { sync_status?: string }) => {
+      if (params?.sync_status === 'drifted') {
+        return Promise.resolve({
+          items: [
+            {
+              id: 'dep-1',
+              api_catalog_id: 'api-1',
+              gateway_instance_id: 'gw-1',
+              sync_status: 'drifted',
+              desired_state: {},
+              desired_at: '2026-02-01T00:00:00Z',
+              sync_attempts: 1,
+              created_at: '2026-01-15T00:00:00Z',
+              updated_at: '2026-02-15T10:00:00Z',
+            },
+          ],
+          total: 1,
+        });
+      }
+      return Promise.resolve({ items: [], total: 0 });
+    });
+
+    renderWithProviders(<DriftDetection />);
+    await screen.findByRole('heading', { name: /Drift Detection/ });
+
+    expect(screen.queryByText('Check Health')).not.toBeInTheDocument();
+    expect(screen.queryByText('Force Sync')).not.toBeInTheDocument();
+  });
+
+  it('shows error state with retry button', async () => {
+    const networkError = { response: { data: { detail: 'Service unavailable' } } };
+    mockGetGatewayInstances.mockRejectedValue(networkError);
+    mockGetGatewayDeployments.mockRejectedValue(networkError);
+    mockGetDeploymentStatusSummary.mockRejectedValue(networkError);
+
+    renderWithProviders(<DriftDetection />);
+    expect(await screen.findByRole('button', { name: /Retry/ })).toBeInTheDocument();
+    expect(screen.getByText('Service unavailable')).toBeInTheDocument();
+  });
+
+  describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
+    '%s persona',
+    (role) => {
+      it('renders the page', async () => {
+        vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
+        renderWithProviders(<DriftDetection />);
+        expect(await screen.findByRole('heading', { name: /Drift Detection/ })).toBeInTheDocument();
+      });
+    }
+  );
+});

--- a/control-plane-ui/src/pages/DriftDetection/DriftDetection.tsx
+++ b/control-plane-ui/src/pages/DriftDetection/DriftDetection.tsx
@@ -1,0 +1,373 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  RefreshCw,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Activity,
+  Server,
+  RotateCcw,
+} from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext';
+import { apiService } from '../../services/api';
+import { SyncStatusBadge } from '../../components/SyncStatusBadge';
+import { useToastActions } from '@stoa/shared/components/Toast';
+import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
+import { EmptyState } from '@stoa/shared/components/EmptyState';
+import { TableSkeleton } from '@stoa/shared/components/Skeleton';
+import type {
+  GatewayInstance,
+  GatewayInstanceStatus,
+  GatewayDeployment,
+  DeploymentStatusSummary,
+} from '../../types';
+
+const AUTO_REFRESH_INTERVAL = 30_000;
+
+const gatewayStatusConfig: Record<
+  GatewayInstanceStatus,
+  { icon: typeof CheckCircle2; color: string; bg: string; label: string }
+> = {
+  online: {
+    icon: CheckCircle2,
+    color: 'text-green-600 dark:text-green-400',
+    bg: 'bg-green-100 dark:bg-green-900/30',
+    label: 'Online',
+  },
+  offline: {
+    icon: XCircle,
+    color: 'text-red-600 dark:text-red-400',
+    bg: 'bg-red-100 dark:bg-red-900/30',
+    label: 'Offline',
+  },
+  degraded: {
+    icon: AlertTriangle,
+    color: 'text-orange-600 dark:text-orange-400',
+    bg: 'bg-orange-100 dark:bg-orange-900/30',
+    label: 'Degraded',
+  },
+  maintenance: {
+    icon: Activity,
+    color: 'text-blue-600 dark:text-blue-400',
+    bg: 'bg-blue-100 dark:bg-blue-900/30',
+    label: 'Maintenance',
+  },
+};
+
+const fallbackStatus = {
+  icon: AlertTriangle,
+  color: 'text-gray-600 dark:text-gray-400',
+  bg: 'bg-gray-100 dark:bg-neutral-700',
+  label: 'Unknown',
+};
+
+function SummaryCard({ label, value, color }: { label: string; value: number; color: string }) {
+  return (
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 px-4 py-3">
+      <p className="text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">{label}</p>
+      <p className={`text-2xl font-bold ${color}`}>{value}</p>
+    </div>
+  );
+}
+
+export function DriftDetection() {
+  const { isReady, hasRole } = useAuth();
+  const toast = useToastActions();
+  const [confirm, ConfirmDialog] = useConfirm();
+
+  const [gateways, setGateways] = useState<GatewayInstance[]>([]);
+  const [driftedDeployments, setDriftedDeployments] = useState<GatewayDeployment[]>([]);
+  const [summary, setSummary] = useState<DeploymentStatusSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  const isAdmin = hasRole('cpi-admin');
+
+  const loadData = useCallback(async () => {
+    try {
+      const [gatewaysResult, driftedResult, errorResult, summaryResult] = await Promise.all([
+        apiService.getGatewayInstances({ page_size: 100 }),
+        apiService.getGatewayDeployments({ sync_status: 'drifted', page_size: 100 }),
+        apiService.getGatewayDeployments({ sync_status: 'error', page_size: 100 }),
+        apiService.getDeploymentStatusSummary(),
+      ]);
+
+      setGateways(gatewaysResult.items);
+      setDriftedDeployments([...driftedResult.items, ...errorResult.items]);
+      setSummary(summaryResult);
+      setError(null);
+    } catch (err: unknown) {
+      const msg =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail ||
+        'Failed to load drift data';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isReady) loadData();
+  }, [isReady, loadData]);
+
+  useEffect(() => {
+    if (!isReady) return;
+    const interval = setInterval(loadData, AUTO_REFRESH_INTERVAL);
+    return () => clearInterval(interval);
+  }, [isReady, loadData]);
+
+  const handleHealthCheck = async (id: string, name: string) => {
+    setActionLoading(id);
+    try {
+      await apiService.checkGatewayHealth(id);
+      toast.success(`Health check triggered for ${name}`);
+      await loadData();
+    } catch {
+      toast.error(`Failed to check health for ${name}`);
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleForceSync = async (id: string) => {
+    const confirmed = await confirm({
+      title: 'Force Sync Deployment',
+      message: 'This will force re-sync the deployment to the gateway. Continue?',
+      confirmLabel: 'Force Sync',
+      variant: 'warning',
+    });
+    if (!confirmed) return;
+
+    setActionLoading(id);
+    try {
+      await apiService.forceSyncDeployment(id);
+      toast.success('Force sync triggered successfully');
+      await loadData();
+    } catch {
+      toast.error('Failed to force sync deployment');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="h-8 bg-gray-200 dark:bg-neutral-700 rounded w-1/4 animate-pulse" />
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-20 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+          ))}
+        </div>
+        <TableSkeleton />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6">
+        <div className="flex items-center mb-2">
+          <XCircle className="w-5 h-5 text-red-500 dark:text-red-400 mr-2" />
+          <span className="text-red-800 dark:text-red-300 font-medium">
+            Failed to load drift data
+          </span>
+        </div>
+        <p className="text-sm text-red-600 dark:text-red-400 mb-3">{error}</p>
+        <button
+          onClick={() => {
+            setLoading(true);
+            loadData();
+          }}
+          className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-red-700 dark:text-red-300 bg-white dark:bg-neutral-800 border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const healthyGateways = gateways.filter((g) => g.status === 'online').length;
+  const driftedCount = summary?.drifted ?? 0;
+  const errorCount = summary?.error ?? 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Drift Detection</h1>
+          <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
+            Monitor gateway health and deployment sync across all gateways
+          </p>
+        </div>
+        <button
+          onClick={loadData}
+          className="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-neutral-600 rounded-md text-sm font-medium text-gray-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 hover:bg-gray-50 dark:hover:bg-neutral-700"
+        >
+          <RefreshCw className="w-4 h-4 mr-2" />
+          Refresh
+        </button>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <SummaryCard
+          label="Total Gateways"
+          value={gateways.length}
+          color="text-gray-900 dark:text-white"
+        />
+        <SummaryCard label="Healthy" value={healthyGateways} color="text-green-600" />
+        <SummaryCard
+          label="Drifted"
+          value={driftedCount}
+          color={driftedCount > 0 ? 'text-orange-600' : 'text-gray-900 dark:text-white'}
+        />
+        <SummaryCard
+          label="Errors"
+          value={errorCount}
+          color={errorCount > 0 ? 'text-red-600' : 'text-gray-900 dark:text-white'}
+        />
+      </div>
+
+      {/* Gateway Health Grid */}
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">Gateway Health</h2>
+        {gateways.length === 0 ? (
+          <EmptyState
+            title="No gateways registered"
+            description="Register a gateway to start monitoring."
+          />
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {gateways.map((gw) => {
+              const cfg = gatewayStatusConfig[gw.status] || fallbackStatus;
+              const StatusIcon = cfg.icon;
+              return (
+                <div
+                  key={gw.id}
+                  className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4"
+                >
+                  <div className="flex items-center justify-between mb-3">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <Server className="w-4 h-4 text-gray-400 flex-shrink-0" />
+                      <span className="font-medium text-gray-900 dark:text-white text-sm truncate">
+                        {gw.display_name || gw.name}
+                      </span>
+                    </div>
+                    <span
+                      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0 ${cfg.bg} ${cfg.color}`}
+                    >
+                      <StatusIcon className="w-3 h-3" />
+                      {cfg.label}
+                    </span>
+                  </div>
+                  <div className="text-xs text-gray-500 dark:text-neutral-400 space-y-1">
+                    <p>Type: {gw.gateway_type}</p>
+                    {gw.last_health_check && (
+                      <p>Last check: {new Date(gw.last_health_check).toLocaleString()}</p>
+                    )}
+                  </div>
+                  {isAdmin && (
+                    <button
+                      onClick={() => handleHealthCheck(gw.id, gw.display_name || gw.name)}
+                      disabled={actionLoading === gw.id}
+                      className="mt-3 inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/20 rounded-md hover:bg-indigo-100 dark:hover:bg-indigo-900/40 disabled:opacity-50 transition-colors"
+                    >
+                      <Activity className="w-3 h-3" />
+                      {actionLoading === gw.id ? 'Checking...' : 'Check Health'}
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Drifted Deployments */}
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
+          Drifted Deployments
+        </h2>
+        {driftedDeployments.length === 0 ? (
+          <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-6 text-center">
+            <CheckCircle2 className="w-8 h-8 text-green-500 mx-auto mb-2" />
+            <p className="text-green-800 dark:text-green-300 font-medium">All Clear</p>
+            <p className="text-sm text-green-600 dark:text-green-400">
+              No drifted or errored deployments detected.
+            </p>
+          </div>
+        ) : (
+          <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 overflow-hidden">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
+              <thead className="bg-gray-50 dark:bg-neutral-900">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                    API
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                    Gateway
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                    Status
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                    Error
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                    Last Sync
+                  </th>
+                  {isAdmin && (
+                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                      Actions
+                    </th>
+                  )}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
+                {driftedDeployments.map((dep) => (
+                  <tr key={dep.id}>
+                    <td className="px-4 py-3 text-sm text-gray-900 dark:text-white">
+                      {String(dep.desired_state?.['api_name'] ?? dep.api_catalog_id)}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-500 dark:text-neutral-400">
+                      {dep.gateway_instance_id}
+                    </td>
+                    <td className="px-4 py-3">
+                      <SyncStatusBadge status={dep.sync_status} />
+                    </td>
+                    <td className="px-4 py-3 text-sm text-red-600 dark:text-red-400 max-w-xs truncate">
+                      {dep.sync_error || '\u2014'}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-500 dark:text-neutral-400">
+                      {dep.last_sync_attempt
+                        ? new Date(dep.last_sync_attempt).toLocaleString()
+                        : '\u2014'}
+                    </td>
+                    {isAdmin && (
+                      <td className="px-4 py-3 text-right">
+                        <button
+                          onClick={() => handleForceSync(dep.id)}
+                          disabled={actionLoading === dep.id}
+                          className="inline-flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium text-orange-700 dark:text-orange-400 bg-orange-50 dark:bg-orange-900/20 rounded-md hover:bg-orange-100 dark:hover:bg-orange-900/40 disabled:opacity-50 transition-colors"
+                        >
+                          <RotateCcw className="w-3 h-3" />
+                          {actionLoading === dep.id ? 'Syncing...' : 'Force Sync'}
+                        </button>
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {ConfirmDialog}
+    </div>
+  );
+}

--- a/control-plane-ui/src/pages/DriftDetection/index.tsx
+++ b/control-plane-ui/src/pages/DriftDetection/index.tsx
@@ -1,0 +1,1 @@
+export { DriftDetection } from './DriftDetection';


### PR DESCRIPTION
## Summary
- New `/drift` page in Console for multi-gateway health monitoring and drift remediation
- Summary cards (Total Gateways, Healthy, Drifted, Errors), gateway health grid with status badges, drifted deployments table with Force Sync action
- RBAC: action buttons (Check Health, Force Sync) gated to `cpi-admin` only
- Auto-refresh every 30s, confirmation dialog on Force Sync, error state with retry
- 13 tests covering rendering, actions, RBAC, error state, and all 4 personas

## Files
- `DriftDetection.tsx` — Page component (~370 LOC)
- `DriftDetection.test.tsx` — Tests (~270 LOC)
- `App.tsx` — Lazy route `/drift`
- `Layout.tsx` — Nav item in Gateway section
- `useBreadcrumbs.ts` — Breadcrumb label

## Test plan
- [x] TypeScript: `tsc -p tsconfig.app.json --noEmit` clean
- [x] ESLint: 105 warnings (matches max-warnings), 0 errors
- [x] Prettier: all files formatted
- [x] Tests: 49 files, 480 tests, 0 failures
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>