### PR TITLE
docs: update state files for CAB-1138 P6 (#472)

### DIFF
--- a/memory.md
+++ b/memory.md
@@ -62,7 +62,7 @@ CAB-802: Dry Run + Script + Video Backup (3 pts)
 - CAB-1035: DX Persona Alex test onboarding MCP (2 pts)
 - CAB-353: Go/No-Go Checklist 3 Months
 - Arena k6 Migration L3: ramp-up + CI95 error bars + CPU pinning
-- CAB-1138 Phase 6: Console drift UI (stretch)
+- CAB-1138 Phase 6: Console drift UI — ✅ DONE PR #472 (6 files, 654 LOC, 13 tests)
 
 ## 🚫 BLOCKED
 

--- a/plan.md
+++ b/plan.md
@@ -68,7 +68,8 @@ Focus: Intégration, script démo, répétitions
 - [x] CAB-1066: Landing + Pricing refonte (21 pts) — DONE (stoa-web PRs #5, #6, #7)
 - [x] CAB-1133: Portal Test Suite (34 pts) — DONE (PR #461, 505 tests, 17 routes × 4 personas)
 - [x] CAB-1134: ADR-040 Born GitOps (5 pts) — DONE (stoa-docs PR #17, ADR published)
-- [x] CAB-1138: GitOps Operator P1-P5 (21 pts) — DONE (PRs #415, #418, #442-#446, #454, deployed 0.3.0)
+- [x] CAB-1138: GitOps Operator P1-P6 (21 pts) — DONE (PRs #415, #418, #442-#446, #454, #472, deployed 0.3.0)
+  - P6: Console Drift Detection UI — PR #472 merged (6 files, 13 tests, /drift page)
 - [ ] CAB-1030: Kit onboarding Cédric (privé)
 - [ ] CAB-353: Go/No-Go Checklist
 - [x] Arena k6 Migration L1+L2 (PRs #438, #444, #447, #449) — DONE


### PR DESCRIPTION
## Summary
- Mark CAB-1138 P6 (Console Drift Detection UI) as done in plan.md and memory.md
- PR #472 merged: /drift page, 6 files, 13 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)