### PR TITLE
fix(ci): stop hook sub-item detection + metrics rotation (CAB-1169)

### DIFF
--- a/.claude/hooks/stop-state-lint.sh
+++ b/.claude/hooks/stop-state-lint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Stop hook: warn Claude when memory.md has DONE items stuck in active sections.
 # Runs on every Stop event. Warn-only (exit 0 always).
+#
+# Heading format dependency: expects "## " (H2) headings containing the section
+# keywords "IN PROGRESS", "NEXT", "DONE". If memory.md heading format changes
+# (e.g., different emoji, heading level, or wording), update extract_section().
 
 MEMORY="$CLAUDE_PROJECT_DIR/memory.md"
 [ ! -f "$MEMORY" ] && exit 0
@@ -8,20 +12,57 @@ MEMORY="$CLAUDE_PROJECT_DIR/memory.md"
 METRICS_LOG="$HOME/.claude/projects/-Users-torpedo-CabIngenierie-Dropbox-Christophe-ABOULICAM--PERSO-stoa-platform-stoa/memory/metrics.log"
 VIOLATIONS=0
 
-# Extract section between a heading and the next same-level heading
+# Extract section between an H2 heading containing $1 and the next H2 heading.
+# Depends on memory.md using "## " prefix for section headings.
 extract_section() {
   local heading="$1"
   sed -n "/^## .*${heading}/,/^## /{ /^## .*${heading}/d; /^## /d; p; }" "$MEMORY"
 }
 
+# Detect items where all sub-items are ✅ with zero [ ] remaining (implicit DONE).
+# Scans multi-line blocks: a parent line followed by "- ✅" lines with no "- [ ]" lines.
+count_all_done_subitems() {
+  local section="$1"
+  local count=0
+  local has_check=0 has_open=0 in_block=0
+  while IFS= read -r line; do
+    # New top-level item starts a block
+    if echo "$line" | grep -qE '^- '; then
+      # Close previous block
+      if [ "$in_block" -eq 1 ] && [ "$has_check" -gt 0 ] && [ "$has_open" -eq 0 ]; then
+        count=$((count + 1))
+      fi
+      in_block=1; has_check=0; has_open=0
+    fi
+    # Sub-item with ✅
+    if echo "$line" | grep -qE '^\s+- ✅'; then
+      has_check=$((has_check + 1))
+    fi
+    # Sub-item with [ ] (still open)
+    if echo "$line" | grep -qE '^\s+- \[ \]'; then
+      has_open=$((has_open + 1))
+    fi
+  done <<< "$section"
+  # Close last block
+  if [ "$in_block" -eq 1 ] && [ "$has_check" -gt 0 ] && [ "$has_open" -eq 0 ]; then
+    count=$((count + 1))
+  fi
+  echo "$count"
+}
+
 # Check IN PROGRESS section for DONE items
 IN_PROGRESS=$(extract_section "IN PROGRESS")
 if [ -n "$IN_PROGRESS" ]; then
+  # Pattern 1: explicit DONE markers
   HITS=$(echo "$IN_PROGRESS" | grep -cE '\*\*DONE\*\*|— DONE' || true)
-  if [ "$HITS" -gt 0 ]; then
-    echo "STATE LINT WARNING: $HITS item(s) marked DONE still in IN PROGRESS section of memory.md"
+  # Pattern 2: all sub-items ✅ with no [ ] remaining
+  IMPLICIT=$(count_all_done_subitems "$IN_PROGRESS")
+  TOTAL=$((HITS + IMPLICIT))
+  if [ "$TOTAL" -gt 0 ]; then
+    echo "STATE LINT WARNING: $TOTAL item(s) marked DONE still in IN PROGRESS section of memory.md"
+    [ "$IMPLICIT" -gt 0 ] && echo "  ($IMPLICIT item(s) have all sub-items checked with no open items remaining)"
     echo "  Move them to the DONE section before ending this session."
-    VIOLATIONS=$((VIOLATIONS + HITS))
+    VIOLATIONS=$((VIOLATIONS + TOTAL))
   fi
 fi
 
@@ -29,10 +70,13 @@ fi
 NEXT=$(extract_section "NEXT")
 if [ -n "$NEXT" ]; then
   HITS=$(echo "$NEXT" | grep -cE '\*\*DONE\*\*|— DONE|~~.*~~' || true)
-  if [ "$HITS" -gt 0 ]; then
-    echo "STATE LINT WARNING: $HITS item(s) marked DONE or struck-through in NEXT section of memory.md"
+  IMPLICIT=$(count_all_done_subitems "$NEXT")
+  TOTAL=$((HITS + IMPLICIT))
+  if [ "$TOTAL" -gt 0 ]; then
+    echo "STATE LINT WARNING: $TOTAL item(s) marked DONE or struck-through in NEXT section of memory.md"
+    [ "$IMPLICIT" -gt 0 ] && echo "  ($IMPLICIT item(s) have all sub-items checked with no open items remaining)"
     echo "  Move completed items to DONE section, remove strikethroughs."
-    VIOLATIONS=$((VIOLATIONS + HITS))
+    VIOLATIONS=$((VIOLATIONS + TOTAL))
   fi
 fi
 

--- a/.claude/rules/ai-workflow.md
+++ b/.claude/rules/ai-workflow.md
@@ -189,6 +189,12 @@ Same as operations.log: `YYYY-MM-DDTHH:MM | EVENT | key=value ...`
 - **CI fix** — `/ci-fix` skill appends `CI-FIX` automatically (see skill prompt)
 - **State drift** — `stop-state-lint.sh` hook appends `STATE-DRIFT` automatically
 
+### Log Rotation
+- Keep `metrics.log` under **500 lines** (same policy as operations.log)
+- When over 500 lines: move oldest entries to `metrics.log.1`
+- Keep `metrics.log.1` for 90 days, then delete
+- Clean up during session-end (Step 8 of session-startup.md)
+
 ### Usage
 Periodically review `metrics.log` to identify:
 - Average branch lifetime (PR-MERGED entries)


### PR DESCRIPTION
## Summary
- **Sub-item detection**: stop hook now catches implicit DONE — items where all sub-items are ✅ with zero `[ ]` remaining (was only catching explicit `**DONE**`/`— DONE` text)
- **Heading format docs**: added comment documenting the `## ` H2 heading format dependency in the hook script
- **Metrics rotation**: added 500-line rotation policy for `metrics.log` (same as `operations.log`)

Council adjustments from retroactive 8.00/10 validation on PR #474.

## Test plan
- [x] Hook syntax validated (`bash -n`)
- [x] Smoke test against real `memory.md` (zero violations = clean run)
- [ ] CI green (3 required checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>