### PR TITLE
docs(ci): cycle-driven plan.md + /sync-plan v2

### DIFF
--- a/.claude/rules/ai-workflow.md
+++ b/.claude/rules/ai-workflow.md
@@ -47,7 +47,7 @@ description: AI-native development workflow, session management, context managem
 
 ### What Are State Files
 - `memory.md` (repo root) — session state, ticket tracker, CI status, decisions, known issues
-- `plan.md` (repo root) — sprint scoreboard, remaining tasks, DoD matrix
+- `plan.md` (repo root) — cycle-driven sprint view (synced from Linear via `/sync-plan`)
 - `~/.claude/projects/.../memory/MEMORY.md` — private persistent memory across conversations
 - `~/.claude/projects/.../memory/operations.log` — append-only session traceability log
 
@@ -62,9 +62,37 @@ Update `memory.md` when:
 6. **Before session end** — always, even if no trigger above
 
 Update `plan.md` when:
-1. **PR merged** — mark as merged in scoreboard
-2. **New task added to sprint** — add row to scoreboard
-3. **Task blocked/unblocked** — update blocker column
+1. **PR merged** — mark ticket as `[x]` in the correct cycle section
+2. **`/sync-plan` run** — cycle-driven sync from Linear (adds missing tickets, updates markers)
+3. **Task blocked/unblocked** — update marker `[~]` ↔ `[!]`
+4. **Cycle rollover** — when a new cycle starts, current becomes historical, next becomes current
+
+### plan.md Structure (Cycle-Driven)
+
+plan.md is a **view** of Linear cycles, NOT a manually curated document. Structure:
+
+```
+# Sprint Plan — STOA Platform
+> Last sync: YYYY-MM-DD
+
+## Cycle N (dates) — CURRENT
+### In Progress    → [~] tickets with sub-items
+### Todo           → [ ] tickets ordered by priority
+### Done (N)       → [x] tickets with PR references
+
+## Cycle N+1 (dates) — NEXT
+### Todo           → [ ] planned tickets
+### Backlog        → parked items (no checkbox)
+
+## Milestones      → manually maintained
+## KPIs Demo       → manually maintained
+## Regles          → manually maintained
+```
+
+**Key rules**:
+- Linear is source of truth; plan.md is a read-only view (except sub-items under `[~]` which are manual)
+- `/sync-plan` discovers ALL tickets in a cycle — tickets added in Linear appear automatically
+- Milestones, KPIs, Regles sections are preserved across syncs (not from Linear)
 
 Update private `MEMORY.md` when:
 1. **New ticket completed** — add to relevant section

--- a/.claude/rules/session-startup.md
+++ b/.claude/rules/session-startup.md
@@ -30,14 +30,14 @@ Before reading state files, check for crashed sessions and log this session:
 Read these 2 files **in this order** to understand current context:
 
 1. **`memory.md`** (repo root) — active sprint, CI status, decisions, known issues
-2. **`plan.md`** (repo root) — deliverables, execution phases, task status
+2. **`plan.md`** (repo root) — cycle-driven sprint view (synced from Linear via `/sync-plan`)
 
 Private memory (`~/.claude/projects/.../memory/MEMORY.md`) is auto-loaded by Claude Code.
 
 ## Step 2 — Pick Your Task
 
 1. Check **Active Tickets** in `MEMORY.md` → pick highest priority unclaimed task
-2. If no active tickets → check `plan.md` for NEXT/PENDING items
+2. If no active tickets → check `plan.md` current cycle "In Progress" and "Todo" sections
 3. If user says "what next?" → summarize what's available, recommend highest priority
 4. If user gives a specific task → use that (skip queue)
 5. If task has **CAB-XXXX** ID → fetch from Linear MCP for full DoD + description:

--- a/.claude/skills/sync-plan/SKILL.md
+++ b/.claude/skills/sync-plan/SKILL.md
@@ -1,16 +1,59 @@
 ---
 name: sync-plan
-description: Bidirectional sync between plan.md and Linear tickets. Detects drift, updates markers, reorders by priority.
-argument-hint: "[CAB-XXXX for single ticket, or empty for full sync]"
+description: "Cycle-aware bidirectional sync between plan.md and Linear. Discovers all cycle tickets, detects drift, updates markers."
+argument-hint: "[CAB-XXXX | --push | --cycles | empty for full sync]"
 ---
 
-# Plan ↔ Linear Sync
+# Plan ↔ Linear Sync (Cycle-Aware)
 
-Synchronize plan.md with Linear ticket statuses.
+Synchronize plan.md with Linear ticket statuses using cycle-driven discovery.
 
 Target: $ARGUMENTS
 
-## Step 1: Parse plan.md
+## Step 0: Determine Sync Mode
+
+| Argument | Mode | Description |
+|----------|------|-------------|
+| (empty) | **Full sync** | Fetch current + next cycle, detect all drift |
+| `CAB-XXXX` | **Single ticket** | Fetch one ticket, update plan.md marker |
+| `--push` | **Push to Linear** | Push plan.md markers → Linear statuses |
+| `--cycles` | **Cycle discovery** | Show current + next cycle summary only |
+
+## Step 1: Fetch Linear Cycles
+
+Always start by discovering the active cycles:
+
+```
+linear.list_cycles(teamId: "624a9948-a160-4e47-aba5-7f9404d23506")
+```
+
+Identify:
+- **Current cycle**: `type: "current"` or dates containing today
+- **Next cycle**: `type: "upcoming"` or starts after current ends
+
+Extract: cycle ID, name, start date, end date, scope (total issues), completed count.
+
+## Step 2: Fetch Cycle Issues
+
+For each active cycle (current + next):
+
+```
+linear.list_issues(
+  team: "624a9948-a160-4e47-aba5-7f9404d23506",
+  cycle: "<cycle_id>",
+  first: 50
+)
+```
+
+For each issue, extract: `identifier`, `title`, `status`, `priority` (value + name), `estimate` (value), `cycleId`, `completedAt`.
+
+**Important**: The `status` field is a string ("Done", "In Progress", "Todo", "Backlog", "Canceled", "Duplicate"), NOT a nested object.
+
+**Priority mapping**: `priority` is `{value: N, name: "..."}` where 1=Urgent, 2=High, 3=Normal, 4=Low.
+
+**Estimate mapping**: `estimate` is `{value: N, name: "..."}` where N is fibonacci points (1,2,3,5,8,13,21,34,55).
+
+## Step 3: Parse plan.md
 
 Read `plan.md` and extract all `CAB-XXXX` references with their current markers:
 
@@ -19,30 +62,14 @@ Read `plan.md` and extract all `CAB-XXXX` references with their current markers:
 | `- [x]` | Done locally |
 | `- [~]` | Partially done |
 | `- [ ]` | Not started or pending |
-| `**DONE**` | Completed (in memory.md style) |
 
 Extract ticket IDs using pattern: `CAB-\d{3,4}`
 
-## Step 2: Fetch Linear Statuses
+Also identify which **cycle section** each ticket is in (e.g., "Cycle 7 — CURRENT" vs "Cycle 8 — NEXT").
 
-If single ticket ($ARGUMENTS = CAB-XXXX):
-```
-linear.get_issue("CAB-XXXX") → status, priority, estimate, assignee
-```
+## Step 4: Detect Drift (3 categories)
 
-If full sync (no argument or >5 tickets):
-```
-linear.list_issues(
-  project: "227427af-6844-484d-bb4a-dedeffc68825",
-  first: 50
-)
-```
-
-For <= 5 tickets, use individual `get_issue` calls.
-
-## Step 3: Detect Drift
-
-Compare plan.md markers vs Linear statuses:
+### 4a. Marker Drift (ticket in both plan.md and Linear)
 
 | plan.md | Linear | Drift? | Action |
 |---------|--------|--------|--------|
@@ -52,16 +79,30 @@ Compare plan.md markers vs Linear statuses:
 | `[ ]` | In Progress | Yes | Update plan.md → `[~]` |
 | `[~]` | Done | Yes | Update plan.md → `[x]` |
 | `[~]` | Todo | Yes | Update Linear → In Progress |
-| Not in plan | Exists in Linear | — | Report: "CAB-XXXX exists in Linear but not in plan.md" |
+| any | Canceled/Duplicate | Yes | Strikethrough in plan.md |
 
-## Step 4: Apply Updates
+### 4b. Missing from plan.md (ticket in Linear cycle but NOT in plan.md)
+
+This is the **most critical** category — the root cause of past drift.
+
+For each issue in the cycle that has NO matching `CAB-XXXX` in plan.md:
+- Report: `CAB-XXXX: NOT IN PLAN (Linear: <status>, <points> pts, <priority>)`
+- Propose: add to the appropriate cycle section in plan.md
+
+### 4c. Orphan in plan.md (ticket in plan.md but NOT in any active cycle)
+
+For each `CAB-XXXX` in plan.md that isn't in current or next cycle:
+- If status is Done → keep in Done section (historical)
+- If status is Todo/In Progress → **Warning**: ticket not assigned to any cycle
+
+## Step 5: Apply Updates
 
 ### Direction: Linear → plan.md (default)
 
-Update plan.md markers to match Linear reality:
-- `Done` in Linear → `[x]` in plan.md
-- `In Progress` in Linear → `[~]` in plan.md
-- `Canceled` in Linear → strikethrough in plan.md
+1. Update markers for existing tickets (4a)
+2. **Add missing tickets** from cycle to plan.md (4b) — in the correct cycle section
+3. Move tickets between cycle sections if `cycleId` changed
+4. Reorder within each section by priority (P1 first, P4 last)
 
 ### Direction: plan.md → Linear (when user says `--push`)
 
@@ -69,30 +110,94 @@ Update plan.md markers to match Linear reality:
 - `[~]` in plan.md → `linear.update_issue(status="In Progress")`
 - `[ ]` with priority change → `linear.update_issue(priority=N)`
 
-## Step 5: Priority Reorder
+## Step 6: Regenerate plan.md Structure
 
-After sync, reorder plan.md sections by Linear priority:
-1. P0 (Urgent) items first
-2. P1 (High) second
-3. P2 (Normal) third
-4. P3 (Low) last
+plan.md follows this exact structure:
 
-Only reorder within the same section (don't move items between sections).
+```markdown
+# Sprint Plan — STOA Platform
 
-## Step 6: Report
+> Auto-synced with Linear via `/sync-plan`. Source of truth: Linear cycles.
+> Last sync: YYYY-MM-DD
+
+## Cycle N (dates) — CURRENT
+
+**Scope**: X pts | **Done**: Y pts | **Velocity**: Z issues closed
+**Theme**: <from cycle description or memory.md>
+
+### In Progress
+- [~] CAB-XXXX: Title (N pts, PN)
+  - ✅ completed sub-item
+  - [ ] remaining sub-item
+
+### Todo
+- [ ] CAB-XXXX: Title (N pts, PN)
+
+### Done (N issues)
+- [x] CAB-XXXX: Title (N pts) — PR #N
+
+---
+
+## Cycle N+1 (dates) — NEXT
+
+**Theme**: <description>
+
+### Todo
+- [ ] CAB-XXXX: Title (N pts, PN)
+
+### Backlog (parked in cycle, not committed)
+- CAB-XXXX: Title (PN)
+
+---
+
+## Milestones
+(preserved from existing plan.md)
+
+## KPIs Demo
+(preserved from existing plan.md)
+
+## Regles
+1. **Linear is source of truth** — plan.md is a view, not the master
+2-N. (preserved from existing plan.md)
+```
+
+**Preservation rules**:
+- NEVER delete sub-items under `[~]` tickets (they contain PR references and manual progress)
+- NEVER delete the Milestones, KPIs Demo, or Regles sections
+- When adding a new ticket, format: `- [ ] CAB-XXXX: <title> (<estimate> pts, P<priority>)`
+- Done tickets with PR references: preserve the `— PR #N` suffix
+
+## Step 7: Compute Metrics
+
+Calculate and display:
+- **Scope**: sum of all estimates in current cycle
+- **Done**: sum of estimates for Done issues
+- **Velocity**: count of Done issues
+- **Completion %**: Done / Scope
+- **Burn rate**: issues completed per day (based on cycle start date)
+
+## Step 8: Report
 
 ```
-Sync Results:
-- Tickets scanned: N
-- Updates applied (Linear → plan.md): N
-- Updates applied (plan.md → Linear): N
-- Drift detected: N items
-- New in Linear (not in plan): N items
+Sync Results (YYYY-MM-DD):
+━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Changes:
+Cycle N (current): X/Y pts done (Z%)
+Cycle N+1 (next): A issues planned
+
+Drift detected: N items
   CAB-XXXX: [ ] → [x] (Linear: Done)
   CAB-YYYY: [~] → [x] (Linear: Done)
-  CAB-ZZZZ: Not in plan (Linear: Todo, 8 pts, P2)
+
+Missing from plan.md: N items
+  CAB-ZZZZ: Added (Linear: Todo, 8 pts, P2)
+  CAB-WWWW: Added (Linear: In Progress, 3 pts, P1)
+
+Orphans (in plan, not in cycle): N items
+  CAB-VVVV: In Done section (OK — historical)
+
+Updates applied: N (Linear → plan.md)
+Updates pushed: N (plan.md → Linear) [only if --push]
 
 plan.md updated. Review changes with `git diff plan.md`.
 ```
@@ -100,9 +205,12 @@ plan.md updated. Review changes with `git diff plan.md`.
 ## Rules
 
 - **Never delete lines** from plan.md — only update markers and add new entries
-- **Preserve formatting** — keep existing indentation, bullet style, section headers
-- **Log sync** in operations.log: `MCP-CALL | service=linear action=sync-plan tickets=N`
-- **Conflict resolution**: if plan.md and Linear disagree, **Linear wins** by default
-- **Rate limiting**: max 20 `get_issue` calls per sync (use `list_issues` batch for larger sets)
+- **Preserve sub-items** — manual progress notes under `[~]` tickets are sacred
+- **Preserve sections** — Milestones, KPIs, Regles sections are manually maintained
+- **Log sync** in operations.log: `MCP-CALL | service=linear action=sync-plan tickets=N cycles=current+next`
+- **Conflict resolution**: Linear wins by default (plan.md is a view)
+- **Rate limiting**: max 20 `get_issue` calls per sync (use `list_issues` batch)
 - **No auto-commit** — show diff to user, let them decide whether to commit
-- **Cycle awareness**: when listing issues, filter by current cycle if available
+- **Cycle-first discovery** — always fetch by cycle, not just by project. This ensures tickets added to a cycle in Linear automatically appear in plan.md
+- **Backlog/Duplicate/Canceled**: skip these statuses when adding to plan.md Todo section. Only include in Backlog subsection of next cycle (without checkbox).
+- **Last sync timestamp**: always update the `> Last sync:` line in plan.md header

--- a/memory.md
+++ b/memory.md
@@ -43,7 +43,7 @@
 - CAB-1138: GitOps Operator P1-P5 (21 pts) — PRs #415-#446, #454, deployed 0.3.0
 - CAB-1066: Landing + Pricing (34 pts) — stoa-web PRs #5, #6, #7
 - Portal mTLS Self-Service — PRs #426-#429
-- Arena k6 Migration L1+L2 — PRs #438, #444, #447, #449
+- Arena k6 Migration L1+L2+L3 — PRs #438, #444, #447, #449, #480 (ramp-up + CI95 bars)
 - SEO Batch 6: 5 articles (O2, A2, D1, O4, M6) — stoa-docs PR #41, 32 total published
 - CAB-1138 Phase 6: Console drift UI — PR #472 (654 LOC, 13 tests)
 - CAB-1169: AI Factory v2 — PRs #474, #476 (stop hook, /ci-fix skill, metrics.log, Council 8.00/10)
@@ -66,7 +66,7 @@ CAB-802: Dry Run + Script + Video Backup (3 pts)
 - CAB-1075: Demo Day Ready — Freeze + Dry Run Témoin + Plan B/C (5 pts)
 - CAB-1035: DX Persona Alex test onboarding MCP (2 pts)
 - CAB-353: Go/No-Go Checklist 3 Months
-- Arena k6 Migration L3: ramp-up + CI95 error bars + CPU pinning
+- Arena k6 L3 CPU pinning VPS (deferred post-demo)
 - SEO adjustments Council: D1 Early Access disclaimer, relecture humaine, endpoints quickstart
 
 ## 🚫 BLOCKED

--- a/plan.md
+++ b/plan.md
@@ -1,87 +1,104 @@
-# Sprint Plan — Countdown Démo 24 Février 2026
+# Sprint Plan — STOA Platform
 
-## 🎯 KPIs Démo
-| Métrique | Cible | Status |
-|----------|-------|--------|
-| Consumer flow E2E | Portal→Subscribe→Token→Call | ✅ CAB-1121 (PR #423 + E2E #450) |
-| mTLS use case client | 100+ certs, RFC 8705 | ✅ CAB-864 + CAB-872 (PR #453) |
-| OpenAPI→MCP bridge | stoactl bridge demo | ✅ CAB-1137 (stoactl PR #6, stoa PR #436) |
-| Error Snapshot | Provoquer + investiguer en live | ✅ CAB-550 (PR #448) |
-| Dry run 2x sans bug | 5 min chrono | 🟡 CAB-802 (script done PR #456, rehearsals pending) |
-| Plan SI post-démo | Arbre décision + roadmap | ✅ CAB-1031 |
-| Docs site | Complet, 0 placeholder | ✅ DONE |
+> Auto-synced with Linear via `/sync-plan`. Source of truth: Linear cycles.
+> Last sync: 2026-02-15
 
-## Semaine 7 (13-16 fév) — CODE CRITIQUE
-Focus: Finir les 2 gros MEGAs code
+## Cycle 7 (Feb 9–15) — CURRENT
 
-- [x] CAB-1121: Consumer Onboarding & Token Exchange (35 pts) — DONE (PR #423 + E2E PR #450)
-- [x] CAB-1137: OpenAPI → MCP Auto-Bridge (8 pts) — DONE (stoactl PR #6, stoa PR #436)
+**Scope**: 445 pts | **Done**: 330+ pts | **Velocity**: ~28 issues closed
+**Theme**: Code critique + Polish + AI Factory v2
 
-- [x] CAB-864: mTLS + OAuth2 Certificate Binding (34 pts) — DONE (PRs #425-#429, #453)
-  - ✅ Session 1: Certificate management API + Keycloak cert-bound tokens (already implemented)
-  - ✅ Session 2: F5/Gateway integration + rotation automatique (already implemented)
-  - ✅ Session 3: Demo scenario scripts (generate-mtls-certs.sh, seed-mtls-demo.py, mtls-demo-commands.sh, DEMO-SCRIPT Act 3b, seed-all.sh integration) — Done 13/02
-  - ✅ Session 4: Phase 2 Self-Service (13/02) — 4 micro-PRs #426-#429 merged:
-    - PR #426: Console Consumers page (table, search, RBAC, mobile)
-    - PR #427: Portal CertificateUploader → SubscribeModal wiring
-    - PR #428: Gateway mTLS Prometheus metrics (3 counters/gauges)
-    - PR #429: Grafana mTLS dashboard (7 panels) + 3 alerting rules
-  - [x] Session 5: E2E validation script + @wip tags (→ CAB-872, PR #453)
+### In Progress
 
-## Semaine 8 (17-21 fév) — POLISH + DRY RUN
-Focus: Intégration, script démo, répétitions
-
-- [x] CAB-1031: Plan d'Action SI Post-Démo (21 pts) — Done 13/02
-  - ✅ Arbre de décision (3 gates: J+7 Design Partner, J+30 Community, J+90 Revenue)
-  - ✅ 3 scénarios: Go Full (roadmap Q2-Q4), Pivot Lean (3 options), Stop/Park
-  - ✅ Budget progressif (3.7K→8.7K→15.7K EUR/mois) + onboarding Cédric
-  - ✅ Council 8.5/10 — 3 adjustments applied
-  - Document: stoa-strategy/execution/PLAN-ACTION-SI-POST-DEMO.md (private)
-
-- [x] CAB-550: Error Snapshot Scenario (3 pts) — DONE (PR #448)
-
-- [x] CAB-872: mTLS Integration E2E (3 pts) — DONE (PR #453)
-  - validate-mtls-flow.sh: automated pre-flight (token + cnf + 3 scenarios)
-  - mtls-demo-commands.sh --validate flag
-  - DEMO-SCRIPT.md updated with mTLS pre-flight step
-
-- [~] CAB-802: Dry Run + Script + Video (3 pts)
+- [~] CAB-802: Dry Run + Script + Video (3 pts, P1)
   - ✅ demo-dry-run.sh rewritten: 8 acts, 23 checks, GO/NO-GO (PR #456)
   - ✅ 7 production fixes: 23/23 PASS, GO in 3.5s (PR #463)
-  - [ ] Répétition #1 (mercredi 19) — timer 5 min
-  - [ ] Répétition #2 (vendredi 21) — avec Cédric comme témoin
-  - [ ] Video backup filmée
+  - ✅ Credential fixes (PR #469)
+  - [ ] Repetition #1 (mercredi 19) — timer 5 min
+  - [ ] Repetition #2 (vendredi 21) — avec Cedric comme temoin
+  - [ ] Video backup filmee
 
-## Dimanche 23 fév — FREEZE
-- [ ] CAB-1075: Demo Day Ready (5 pts)
-  - Code freeze 18h
-  - Full E2E suite → 100% PASS
-  - Infra health check (Vault, Keycloak, DB, Grafana)
-  - Plan B (video) et Plan C (slides statiques) prêts
+### Todo
 
-## Mardi 24 fév — DÉMO 🎯
-- 5 min démo live
-- Présentation "ESB is Dead"
-- Plan d'Action SI distribué
+- [ ] CAB-1075: Demo Day Ready — Freeze + Dry Run Temoin + Plan B/C (5 pts, P1)
+- [ ] CAB-1145: Smoke test complet parcours demo PROD (3 pts, P1)
+- [ ] CAB-1146: Baseline PROD — Documenter etat de reference avant freeze (2 pts, P1)
+- [ ] CAB-1147: Benchmarks Freeze — Capturer resultats STOA vs Kong vs Gravitee (2 pts, P2)
+- [ ] CAB-1129: Demo Script — Design Partner Pitch 5min (P2)
+- [ ] CAB-1128: Design Partner Communication — Client A Beta Access (P2)
+- [ ] CAB-1130: Demo Slides — Design Partner Presentation (P2)
+- [ ] CAB-1035: Persona Alex — Test manuel onboarding MCP Gateway (2 pts, P2)
+- [ ] CAB-362: GW2-10 Circuit Breaker + Session Management (5 pts, P2) — deferred post-demo
 
-## Pre-démo — Manuel
-- [ ] CAB-1035: Persona Alex — Test manuel onboarding MCP Gateway (2 pts, 1h chrono)
+### Done (24+ issues)
 
-## Post-démo (semaine 9+)
-- [x] CAB-1066: Landing + Pricing refonte (21 pts) — DONE (stoa-web PRs #5, #6, #7)
-- [x] CAB-1133: Portal Test Suite (34 pts) — DONE (PR #461, 505 tests, 17 routes × 4 personas)
-- [x] CAB-1134: ADR-040 Born GitOps (5 pts) — DONE (stoa-docs PR #17, ADR published)
-- [x] CAB-1138: GitOps Operator P1-P6 (21 pts) — DONE (PRs #415, #418, #442-#446, #454, #472, deployed 0.3.0)
-  - P6: Console Drift Detection UI — PR #472 merged (6 files, 13 tests, /drift page)
-- [x] CAB-1030: Admin Guide & Onboarding Ops Ready (13 pts) — DONE (stoa PR #475, stoa-strategy PR #1)
-- [ ] CAB-353: Go/No-Go Checklist
-- [x] Arena k6 Migration L1+L2 (PRs #438, #444, #447, #449) — DONE
-- [ ] Arena k6 Migration L3: ramp-up + CI95 error bars + CPU pinning
-- [x] CAB-1169: AI Factory v2 — hooks, /ci-fix, observability (13 pts) — DONE (PRs #474, #476, Council 8.00/10)
+- [x] CAB-1121: Consumer Onboarding & Token Exchange (35 pts) — PR #423 + E2E PR #450
+- [x] CAB-1137: OpenAPI → MCP Auto-Bridge (8 pts) — stoactl PR #6, stoa PR #436
+- [x] CAB-864: mTLS + OAuth2 Certificate Binding (34 pts) — PRs #425-#429, #453
+- [x] CAB-1031: Plan d'Action SI Post-Demo (21 pts) — stoa-strategy
+- [x] CAB-550: Error Snapshot Scenario (3 pts) — PR #448
+- [x] CAB-872: mTLS Integration E2E (3 pts) — PR #453
+- [x] CAB-1066: Landing + Pricing refonte (21 pts) — stoa-web PRs #5, #6, #7
+- [x] CAB-1133: Portal Test Suite (34 pts) — PR #461, 505 tests
+- [x] CAB-1134: ADR-040 Born GitOps (5 pts) — stoa-docs PR #17
+- [x] CAB-1138: GitOps Operator P1-P6 (21 pts) — PRs #415-#472, deployed 0.3.0
+- [x] CAB-1030: Admin Guide & Onboarding Ops Ready (13 pts) — PR #475
+- [x] CAB-1169: AI Factory v2 (13 pts) — PRs #474, #476
+- [x] CAB-1135: AWS Decommissioning (P2) — OVH+Hetzner live, 92% cost reduction
+- [x] CAB-1166: 4-Persona Test Parity (29 pts) — PRs #467, #468
+- [x] Arena k6 Migration L1+L2+L3 — PRs #438, #444, #447, #449, #480 (ramp-up + CI95 bars)
 
-## Règles Countdown
-1. ZERO nouveau ticket jusqu'au 24/02
-2. Si bloqué > 1h → contourner, noter, avancer
-3. Priorité absolue: CAB-1121 > CAB-864 > CAB-1031 > reste
-4. Code freeze dimanche 23 à 18h — AUCUNE EXCEPTION
-5. Chaque session Claude Code = 1 sous-tâche d'1 MEGA, pas plus
+---
+
+## Cycle 8 (Feb 15–22) — NEXT
+
+**Theme**: Demo prep, staging freerun, narrative
+
+### Todo
+
+- [ ] CAB-1150: Preparation Demo 24/02 — narrative + speaker notes (P1)
+- [ ] CAB-1151: Dress Rehearsal — Smoke test final PROD (P1)
+- [ ] CAB-1148: Staging Freerun — Features V1++ lundi (P3)
+- [ ] CAB-1149: Staging Freerun — V1++ suite mardi-mercredi (P3)
+- [ ] CAB-1162: SEO Tracking — Looker Studio + Search Console archive (3 pts, P3)
+
+### Backlog (parked in cycle, not committed)
+
+- CAB-601: Status Page (P2)
+- CAB-571: Error Snapshot Network/TLS (P2)
+- CAB-252: Gateway v2 Linux Native
+- CAB-392: Community Contrib Value Program
+- _+ 8 Duplicate/Canceled items (old UAC/AWX tickets)_
+
+---
+
+## Milestones
+
+| Date | Event | Gate |
+|------|-------|------|
+| Dim 15 fev | Cycle 7 ends, PROD freeze | CAB-1145 + CAB-1146 |
+| Lun-Mer 16-19 | Staging freerun V1++ | CAB-1148 + CAB-1149 |
+| Jeu-Sam 20-22 | Off — narrative prep | CAB-1150 |
+| Dim 22 fev | Dress rehearsal | CAB-1151 |
+| Mar 24 fev | DEMO DAY | 5 min live + "ESB is Dead" |
+
+## KPIs Demo
+
+| Metrique | Cible | Status |
+|----------|-------|--------|
+| Consumer flow E2E | Portal→Subscribe→Token→Call | ✅ CAB-1121 |
+| mTLS use case client | 100+ certs, RFC 8705 | ✅ CAB-864 + CAB-872 |
+| OpenAPI→MCP bridge | stoactl bridge demo | ✅ CAB-1137 |
+| Error Snapshot | Provoquer + investiguer en live | ✅ CAB-550 |
+| Dry run 2x sans bug | 5 min chrono | 🟡 CAB-802 (script done, rehearsals pending) |
+| Plan SI post-demo | Arbre decision + roadmap | ✅ CAB-1031 |
+| Docs site | Complet, 0 placeholder | ✅ 107 pts, 6 MEGAs |
+
+## Regles
+
+1. **Linear is source of truth** — plan.md is a view, not the master
+2. Si bloque > 1h → contourner, noter, avancer
+3. Code freeze PROD dimanche 15 a 18h
+4. Staging freerun lundi-mercredi (no PROD changes)
+5. Chaque session Claude Code = 1 sous-tache, pas plus
+6. `/sync-plan` before and after each session


### PR DESCRIPTION
## Summary
- Rewrite plan.md to be cycle-driven (Linear cycles → plan.md sections)
- Upgrade `/sync-plan` skill to discover ALL tickets from Linear cycles (not just those already in plan.md)
- Update ai-workflow.md and session-startup.md for cycle-driven state file protocol

## Changes
- **plan.md**: Cycle 7 (CURRENT) + Cycle 8 (NEXT) structure, 7 missing tickets added
- **sync-plan/SKILL.md**: v2 with `list_cycles` + `list_issues(cycle=N)`, 3-category drift detection, metrics
- **ai-workflow.md**: cycle-driven plan.md structure documented
- **session-startup.md**: references cycle sections

## Test plan
- [ ] `/sync-plan` produces correct drift report
- [ ] `/sync-plan --cycles` shows cycle summary
- [ ] plan.md structure matches Linear cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)