### PR TITLE
fix(ci): add checkout step to claude workflows

### DIFF
--- a/.github/workflows/claude-interactive.yml
+++ b/.github/workflows/claude-interactive.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - uses: actions/checkout@v4
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - uses: actions/checkout@v4
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Added missing `actions/checkout@v4` to `claude-interactive.yml` and `claude-review.yml`
- Both workflows failed with `fatal: not a git repository` because `claude-code-action` needs the repo checked out first

## Test plan
- [x] Verified other 5 claude workflows already have checkout
- [ ] Re-test @claude on issue #493 after merge

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>