### PR TITLE
fix(portal): complete self-registration — add register() + fix tests (CAB-1170)

### DIFF
--- a/portal/src/App.test.tsx
+++ b/portal/src/App.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -161,7 +161,7 @@ describe('App', () => {
 
       renderApp('/');
 
-      screen.getByText('Create Free Account').click();
+      fireEvent.click(screen.getByText('Create Free Account'));
       expect(mockAuth.register).toHaveBeenCalledOnce();
     });
 
@@ -188,7 +188,7 @@ describe('App', () => {
 
       renderApp('/');
 
-      screen.getByText(/Need enterprise access/).click();
+      fireEvent.click(screen.getByText(/Need enterprise access/));
       expect(screen.getByLabelText('First name *')).toBeInTheDocument();
       expect(screen.getByLabelText('Last name *')).toBeInTheDocument();
       expect(screen.getByLabelText('Work email *')).toBeInTheDocument();

--- a/portal/src/contexts/AuthContext.tsx
+++ b/portal/src/contexts/AuthContext.tsx
@@ -8,6 +8,7 @@ import { createContext, useContext, useEffect, useState, useCallback, ReactNode 
 import { useAuth as useOidcAuth, hasAuthParams } from 'react-oidc-context';
 import type { User, UserPermissionsResponse } from '../types';
 import { apiClient, setAccessToken } from '../services/api';
+import { config } from '../config';
 
 interface AuthContextType {
   user: User | null;
@@ -26,6 +27,7 @@ interface AuthContextType {
   // Actions
   login: () => void;
   logout: () => void;
+  register: () => void;
   refreshPermissions: () => Promise<void>;
 }
 
@@ -323,6 +325,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [user]
   );
 
+  const register = useCallback(() => {
+    const { keycloak } = config;
+    const registrationUrl =
+      `${keycloak.authority}/protocol/openid-connect/registrations` +
+      `?client_id=${encodeURIComponent(keycloak.clientId)}` +
+      `&response_type=code` +
+      `&redirect_uri=${encodeURIComponent(window.location.origin)}` +
+      `&scope=openid`;
+    window.location.href = registrationUrl;
+  }, []);
+
   const value: AuthContextType = {
     user,
     isAuthenticated: oidc.isAuthenticated,
@@ -340,6 +353,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // Actions
     login: () => oidc.signinRedirect(),
     logout: () => oidc.signoutRedirect(),
+    register,
     refreshPermissions: fetchUserPermissions,
   };
 


### PR DESCRIPTION
## Summary
- Add `register()` method to AuthContext using KC registration endpoint (`/protocol/openid-connect/registrations`)
- Fix `App.test.tsx`: use `fireEvent.click()` instead of `.click()` for React state updates in tests
- These changes complete CAB-1170 (Keycloak self-registration), fixing items missing from PR #529

## Context
PR #529 accidentally included most of the CAB-1170 implementation (LoginScreen redesign, keycloak-realm.json, setup script) due to Dropbox branch interference. This PR adds the 2 remaining pieces:
1. **AuthContext `register()` method** — constructs KC registration URL and redirects the browser
2. **Test fireEvent fix** — `fireEvent.click()` is needed for React Testing Library to properly trigger state updates

## Files Changed
| File | Change |
|------|--------|
| `portal/src/contexts/AuthContext.tsx` | +14 LOC: config import, `register` in interface, `register` useCallback, `register` in value |
| `portal/src/App.test.tsx` | 3 lines: `fireEvent` import, 2x `.click()` → `fireEvent.click()` |

## Test plan
- [x] `npm run lint` — 15 warnings (< 20 max), 0 errors
- [x] `npm run format:check` — clean
- [x] `npx tsc -p tsconfig.app.json --noEmit` — clean
- [x] `npm run test -- --run` — 564/564 tests pass (47 test files)
- [x] All 20 App.test.tsx tests pass (7 login screen + 10 routing + 3 RBAC)

## Council Validation — 8.50/10 Go
| Persona | Score | Verdict |
|---------|-------|---------|
| Chucky | 8/10 | Go |
| OSS Killer | 9/10 | Go |
| Archi | 9/10 | Go |
| Saul | 8/10 | Go |

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>