### PR TITLE
feat(ci): add velocity pipeline — /fill-cycle skill + capacity tracking

### DIFF
--- a/.claude/skills/fill-cycle/SKILL.md
+++ b/.claude/skills/fill-cycle/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: fill-cycle
+description: "Analyze cycle capacity gap and propose backlog items to fill the sprint to ~80% of proven velocity."
+argument-hint: "[--check | --auto | --theme <name> | empty for interactive]"
+---
+
+# Fill Cycle — Velocity Pipeline
+
+Load the current Linear cycle, compute the capacity gap against proven velocity,
+scan 4 backlog sources, and propose a ranked fill plan.
+
+Target: $ARGUMENTS
+
+## Linear Label IDs (cached)
+
+| Label | ID |
+|-------|-----|
+| `roadmap` (parent) | `922e1f2d-c839-4b8b-9eba-6c2ba4365a8c` |
+| `roadmap:gateway` | `82e07bcd-69fa-4fc5-a2e1-d4d7fa0fad70` |
+| `roadmap:dx` | `9f4356e1-f3bc-49a5-b28a-fa1077a6e326` |
+| `roadmap:platform` | `c819ff92-c9cf-453d-a0f9-451840f6f8cc` |
+| `roadmap:community` | `2de713f1-47a9-49a0-9e84-a7bd947eb707` |
+| `roadmap:observability` | `d4ce6487-92fe-4f12-a5f3-8d682e03623f` |
+
+## Step 0: Determine Mode
+
+| Argument | Mode | Description |
+|----------|------|-------------|
+| (empty) | **Interactive** | Show fill plan, ask before promoting |
+| `--check` | **Read-only** | Compute capacity report only, no writes (CI-safe) |
+| `--auto` | **Auto-promote** | Promote quick wins automatically, suggest council for MEGAs |
+| `--theme <name>` | **Themed fill** | Filter candidates by roadmap theme + optional Notion search |
+
+## Step 1: Fetch Current Cycle from Linear
+
+```
+linear.list_cycles(teamId: "624a9948-a160-4e47-aba5-7f9404d23506")
+```
+
+Identify the **current** cycle (type `"current"` or date range containing today).
+Extract: `cycle_id`, `name`, `start`, `end`, `scopeTotal`, `completedTotal`.
+
+Then fetch all issues in the cycle:
+
+```
+linear.list_issues(
+  team: "624a9948-a160-4e47-aba5-7f9404d23506",
+  cycle: "<cycle_id>",
+  first: 50
+)
+```
+
+Compute:
+- `cycle_days` = (end - start).days
+- `days_remaining` = (end - today).days
+- `pts_committed` = sum of all issue estimates in cycle
+- `pts_done` = sum of estimates for Done/Canceled issues
+
+## Step 2: Read Velocity Baseline
+
+Read `~/.claude/projects/-Users-torpedo-hlfh-repos-stoa/memory/velocity.json`.
+
+Extract:
+- `rolling_avg_pts_per_day` = `rolling_avg_3.pts_per_day`
+- `target_utilization` (default 0.80)
+
+Compute capacity gap:
+```
+capacity = rolling_avg_pts_per_day × cycle_days
+target = capacity × target_utilization
+gap = target - pts_committed
+```
+
+If `gap <= 0`: report "Cycle is fully loaded" and stop (unless `--check` which still reports).
+
+## Step 3: Scan Backlog Sources
+
+Scan 4 sources for candidate items. Each source contributes candidates with metadata.
+
+### Source 1: Linear Backlog (unassigned, no cycle)
+
+```
+linear.list_issues(
+  team: "624a9948-a160-4e47-aba5-7f9404d23506",
+  first: 50
+)
+```
+
+Filter for issues where:
+- `cycle` is null (not in any cycle)
+- `status` is "Backlog" or "Todo"
+- `assignee` is null or matches current user
+
+Extract: id, identifier, title, priority, estimate, labels.
+
+### Source 2: BACKLOG.md (post-MVP items)
+
+Read `BACKLOG.md` from repo root.
+
+Parse all `CAB-XXXX` entries from tables and lists. Extract:
+- Ticket ID, title, section (Post-MVP, Vision, MCP, Community, etc.)
+- Map section to roadmap theme:
+  - "MCP Gateway" / "Features Avancées" → `gateway`
+  - "Community" → `community`
+  - "Observability" → `observability`
+  - "Portal & UX" → `platform`
+  - "Infra & DevOps" → `platform`
+  - "Architecture" → `platform`
+  - "Vision & Strategy" → `platform`
+
+### Source 3: plan.md (parked backlog sections)
+
+Read `plan.md` from repo root.
+
+Parse entries from:
+- "Backlog — Long-term" section (current cycle)
+- "Backlog" section of next cycle
+- Any item without a checkbox (parked, not committed)
+
+Extract: ticket ID, title, estimate (if present), priority.
+
+### Source 4: CAPACITY-PLANNING.md (phased roadmap)
+
+Read `docs/CAPACITY-PLANNING.md`.
+
+Parse unchecked `[ ]` items from remaining phases:
+- Phase 2.6, 4, 5, 6, 7, 8, 9, 10, 11, 14
+- Extract: ticket ID, title, phase name
+
+Map phase to roadmap theme:
+- Phase 2.6 (Cilium), 5 (Multi-env) → `platform`
+- Phase 4 (OpenSearch) → `observability`
+- Phase 7 (Security) → `gateway`
+- Phase 8 (Portal) → `dx`
+- Phase 9 (Ticketing) → `platform`
+- Phase 6 (Demo) → `community`
+- Phase 10, 11 (Resource Lifecycle) → `platform`
+- Phase 14 (GTM) → `community`
+
+### Source 5 (conditional): Notion — only with `--theme`
+
+If `--theme <name>` is provided:
+
+```
+notion.notion-search(query: "STOA roadmap <theme>")
+```
+
+Extract any actionable items not already in Linear. Flag as "Notion-sourced" in output.
+
+## Step 4: Deduplicate & Score Candidates
+
+Merge all candidates. Deduplicate by `CAB-XXXX` identifier (Linear source wins if conflict).
+
+Score each candidate (higher = better fit):
+
+| Factor | Points | Condition |
+|--------|--------|-----------|
+| Priority | 3 × (5 - priority_value) | P1=12, P2=9, P3=6, P4=3 |
+| Has estimate | 2 | `estimate` is not null |
+| Already in Linear | 1 | Source is Linear backlog |
+| Theme match | 2 | Matches `--theme` filter (if provided) |
+| **Max score** | **17** | |
+
+Sort by score descending.
+
+## Step 5: Classify into 3 Buckets
+
+### Bucket 1: Quick Wins (promote now)
+- Estimate <= 8 pts
+- Already in Linear (has issue ID)
+- Not an EPIC or MEGA (no `[MEGA]` or `[EPIC]` in title)
+
+### Bucket 2: MEGAs (need council + decompose)
+- Estimate > 13 pts OR title contains `[MEGA]` / `[EPIC]`
+- Suggest: run `/council CAB-XXXX` then `/decompose CAB-XXXX`
+
+### Bucket 3: Unpointed (flag for estimation)
+- No estimate value
+- Action: "Estimate before promoting"
+
+## Step 6: Build Fill Plan
+
+Cap at **top 15 candidates** total across all buckets.
+
+Within the gap budget:
+1. Fill with Quick Wins first (sum estimates, stop when gap reached)
+2. If gap remains > 13 pts: suggest 1 MEGA
+3. List remaining Unpointed items as "estimate to unlock"
+
+Group MEGAs by roadmap theme for readability.
+
+## Step 7: Execute (mode-dependent)
+
+### Interactive mode (default)
+Display the fill plan. For each Quick Win, ask: "Promote Y/N?"
+On Y: `linear.update_issue(id, cycleId: "<current_cycle_id>")`
+
+### Auto mode (`--auto`)
+Promote all Quick Wins automatically:
+```
+linear.update_issue(id: "<issue_id>", cycleId: "<current_cycle_id>")
+```
+Log each promotion in operations.log.
+
+### Check mode (`--check`)
+Display the capacity report only. No Linear writes. Exit.
+
+### Themed mode (`--theme <name>`)
+Same as interactive but filtered by theme. Includes Notion results if available.
+
+## Step 8: Update State Files
+
+After any promotions:
+1. Run `/sync-plan` to refresh plan.md with newly promoted issues
+2. Append to operations.log:
+   ```
+   STEP-DONE | step=fill-cycle task=velocity-pipeline promoted=N gap_before=X gap_after=Y
+   ```
+
+## Step 9: Report
+
+```
+Capacity Report — Cycle N (dates)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Velocity baseline (rolling 3-cycle avg):
+  Avg: XX.X pts/day | Target utilization: 80%
+
+Current cycle:
+  Committed: XXX pts | Done: YYY pts (ZZ%)
+  Capacity: AAA pts | Target: BBB pts (80%)
+  Gap: CCC pts (DD% under-loaded)
+
+Fill Plan:
+━━━━━━━━━
+Quick Wins (promote now):                    Σ XX pts
+  1. CAB-XXXX: Title (N pts, P2) ............. [score: 14]
+  2. CAB-YYYY: Title (N pts, P1) ............. [score: 17]
+
+MEGAs (→ /council + /decompose):             Σ XX pts
+  [gateway] CAB-ZZZZ: Title (21 pts, P2)
+  [platform] CAB-WWWW: Title (34 pts, P3)
+
+Unpointed (estimate to unlock):
+  CAB-VVVV: Title (no estimate, P2)
+
+Summary:
+  Promotable: XX pts | After fill: YYY/ZZZ pts (WW%)
+  MEGAs needing council: N
+  Unpointed needing estimate: M
+```
+
+## MCP Budget
+
+| Call | Purpose | Mode |
+|------|---------|------|
+| `list_cycles` | Get current cycle | All |
+| `list_issues(cycle=X)` | Get cycle issues | All |
+| `list_issues(no cycle)` | Get backlog issues | All |
+| `notion-search` | Themed search | `--theme` only |
+| `update_issue` × N | Promote quick wins | Interactive/Auto only |
+| **Total read** | **3-4 calls** | |
+| **Total write** | **0-15 calls** | |
+
+## Rules
+
+- **velocity.json is the single source of truth** for capacity baseline
+- **80% target utilization** leaves 20% for unplanned work (configurable in velocity.json)
+- **Cap proposals at 15** — avoid overwhelming fill plans
+- **MCP budget: 3-4 read calls** per run — batch, don't poll
+- **BACKLOG.md items stay unpointed** until promoted (estimation happens at promotion time)
+- **No auto-promote in `--check` mode** — always read-only (CI-safe)
+- **No Notion call without `--theme`** — avoid unnecessary MCP latency
+- **Quick Wins first** — fill with small items before suggesting MEGAs
+- **Never promote without estimate** — Unpointed items must be estimated first
+- **Log all promotions** in operations.log for audit trail

--- a/.claude/skills/sync-plan/SKILL.md
+++ b/.claude/skills/sync-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sync-plan
 description: "Cycle-aware bidirectional sync between plan.md and Linear. Discovers all cycle tickets, detects drift, updates markers."
-argument-hint: "[CAB-XXXX | --push | --cycles | empty for full sync]"
+argument-hint: "[CAB-XXXX | --push | --cycles | --velocity | empty for full sync]"
 ---
 
 # Plan ↔ Linear Sync (Cycle-Aware)
@@ -18,6 +18,7 @@ Target: $ARGUMENTS
 | `CAB-XXXX` | **Single ticket** | Fetch one ticket, update plan.md marker |
 | `--push` | **Push to Linear** | Push plan.md markers → Linear statuses |
 | `--cycles` | **Cycle discovery** | Show current + next cycle summary only |
+| `--velocity` | **Velocity report** | Show velocity history table + trend + capacity forecast |
 
 ## Step 1: Fetch Linear Cycles
 
@@ -167,7 +168,7 @@ plan.md follows this exact structure:
 - When adding a new ticket, format: `- [ ] CAB-XXXX: <title> (<estimate> pts, P<priority>)`
 - Done tickets with PR references: preserve the `— PR #N` suffix
 
-## Step 7: Compute Metrics
+## Step 7: Compute Metrics + Velocity Tracking
 
 Calculate and display:
 - **Scope**: sum of all estimates in current cycle
@@ -175,6 +176,67 @@ Calculate and display:
 - **Velocity**: count of Done issues
 - **Completion %**: Done / Scope
 - **Burn rate**: issues completed per day (based on cycle start date)
+
+### 7a. Auto-Update velocity.json on Cycle Close
+
+After computing metrics, check if the current cycle should be recorded:
+
+**Trigger**: cycle completion is 100% OR today > cycle end date.
+
+If triggered AND this cycle is not already in velocity.json:
+
+1. Read `~/.claude/projects/-Users-torpedo-hlfh-repos-stoa/memory/velocity.json`
+2. Append new cycle entry:
+   ```json
+   {
+     "id": <cycle_number>,
+     "name": "<cycle_name>",
+     "start": "<start_date>",
+     "end": "<end_date>",
+     "days": <duration_days>,
+     "points_committed": <scope>,
+     "points_done": <done_pts>,
+     "issues_total": <total_issues>,
+     "issues_done": <done_issues>,
+     "prs_merged": <count from gh pr list if available, else null>,
+     "pts_per_day": <done_pts / days>,
+     "completion_pct": <done_pts / scope * 100>
+   }
+   ```
+3. Recompute `rolling_avg_3`:
+   - Take last 3 cycle entries (or fewer if < 3 exist)
+   - `pts_per_day` = average of cycle pts_per_day values
+   - `issues_per_day` = average of (issues_done / days) values
+   - `completion_pct` = average of cycle completion_pct values
+4. Write updated velocity.json
+
+**Rules**:
+- velocity.json is **append-only** for cycle entries — never modify historical data
+- Only append when cycle ID is not already present (idempotent)
+- `prs_merged` can be null if PR count isn't available (optional enrichment)
+
+### 7b. Velocity Report (--velocity mode)
+
+If mode is `--velocity`, read velocity.json and display:
+
+```
+Velocity History — STOA Platform
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+| Cycle | Dates | Pts | Done | Velocity | Completion |
+|-------|-------|-----|------|----------|------------|
+| C7    | Feb 9-15 | 505 | 505 | 72.1/day | 100% |
+| C8    | Feb 16-22 | 86 | 5 | ... | 6% |
+
+Rolling 3-cycle avg: XX.X pts/day
+Target utilization: 80%
+Capacity forecast (next cycle, 7 days): XXX pts target
+
+Trend: [↑|↓|→] <description>
+```
+
+Then exit (no sync needed).
+
 
 ## Step 8: Report
 
@@ -200,6 +262,32 @@ Updates applied: N (Linear → plan.md)
 Updates pushed: N (plan.md → Linear) [only if --push]
 
 plan.md updated. Review changes with `git diff plan.md`.
+```
+
+### 8a. Capacity Utilization Warning
+
+After every sync (all modes except `--velocity`), compute utilization:
+
+1. Read `~/.claude/projects/-Users-torpedo-hlfh-repos-stoa/memory/velocity.json`
+2. Compute: `capacity = rolling_avg_3.pts_per_day × cycle_days`
+3. Compute: `target = capacity × target_utilization`
+4. Compute: `utilization = pts_committed / target × 100`
+
+If utilization < 70%:
+```
+⚠️  Cycle under-loaded: XXX/YYY pts (ZZ% of target capacity)
+    Run `/fill-cycle` to analyze backlog and propose fill plan.
+```
+
+If utilization 70-100%:
+```
+✅  Cycle healthy: XXX/YYY pts (ZZ% of target capacity)
+```
+
+If utilization > 100%:
+```
+🔴  Cycle over-loaded: XXX/YYY pts (ZZ% of target capacity)
+    Consider deferring lower-priority items to next cycle.
 ```
 
 ## Rules

--- a/.github/workflows/claude-scheduled.yml
+++ b/.github/workflows/claude-scheduled.yml
@@ -12,6 +12,8 @@ on:
     - cron: "0 21 * * *"
     # Weekly Monday 08:00 UTC — Dependency audit + rule improvement
     - cron: "0 8 * * 1"
+    # Weekly Monday 09:30 UTC — Capacity check
+    - cron: "30 9 * * 1"
   workflow_dispatch:
     inputs:
       task:
@@ -23,6 +25,7 @@ on:
           - daily-ci-health
           - weekly-audit
           - weekly-digest
+          - weekly-capacity-check
           - self-improve
 
 permissions:
@@ -184,3 +187,57 @@ jobs:
 
             Format as a Slack-friendly summary and post it.
           claude_args: "--model claude-sonnet-4-5-20250929 --max-turns 5"
+
+  # ----- Weekly: Capacity Check -----
+  weekly-capacity-check:
+    if: |
+      (github.event.schedule == '30 9 * * 1') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.task == 'weekly-capacity-check')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Weekly capacity check — read-only analysis of cycle health.
+
+            1. Fetch the current Linear cycle for team CAB-ING (624a9948-a160-4e47-aba5-7f9404d23506):
+               - list_cycles to find current cycle
+               - list_issues for that cycle to get committed points and done points
+
+            2. Compute velocity baseline:
+               - Read velocity.json if it exists in memory/
+               - If not available, use the last closed cycle's data from plan.md
+               - rolling_avg_pts_per_day from velocity.json or fallback: compute from plan.md Cycle 7 data (505 pts / 7 days = 72.1)
+
+            3. Compute capacity gap:
+               - capacity = rolling_avg_pts_per_day × cycle_days
+               - target = capacity × 0.80 (80% utilization target)
+               - gap = target - pts_committed
+               - utilization_pct = pts_committed / target × 100
+
+            4. Generate a capacity health report:
+               - Cycle name + dates
+               - Committed vs target vs capacity
+               - Utilization percentage
+               - Gap in points
+               - Top 5 backlog items from BACKLOG.md that could fill the gap (read file, extract CAB-XXXX entries)
+
+            5. Create a GitHub issue titled "Weekly Capacity Check — YYYY-MM-DD" with label "daily-digest"
+               containing the full report.
+
+            This is a READ-ONLY check. Do NOT modify any Linear issues or promote backlog items.
+            Suggest running `/fill-cycle` if utilization is below 70%.
+          claude_args: "--model claude-sonnet-4-5-20250929 --max-turns 10"
+
+      - name: Notify Slack
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK" ]; then exit 0; fi
+          curl -s -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d '{"text":":chart_with_upwards_trend: *Weekly Capacity Check Complete* — check GitHub issues for cycle health report"}'


### PR DESCRIPTION
## Summary
- New `/fill-cycle` skill: scans 4 backlog sources (Linear, BACKLOG.md, plan.md, CAPACITY-PLANNING.md), scores candidates by priority/estimate/theme, and proposes a ranked fill plan to load cycles to ~80% of proven velocity
- `velocity.json`: persistent velocity store seeded with Cycle 7 data (505 pts, 44 issues, 72.1 pts/day)
- Enhanced `/sync-plan`: auto-updates velocity.json on cycle close + shows capacity utilization warning + new `--velocity` flag for velocity history
- Weekly capacity check: new Monday 09:30 UTC cron job in `claude-scheduled.yml` (read-only, posts to Slack)
- 6 roadmap labels created in Linear: `roadmap` parent + `roadmap:gateway`, `roadmap:dx`, `roadmap:platform`, `roadmap:community`, `roadmap:observability`

## Test plan
- [ ] `cat velocity.json | jq .` — valid JSON, C7 data matches plan.md
- [ ] `/fill-cycle --check` — produces capacity report without writes
- [ ] `/sync-plan --velocity` — shows velocity history table
- [ ] GHA dispatch: `gh workflow run claude-scheduled.yml -f task=weekly-capacity-check`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)