### PR TITLE
style(gateway): fix discovery.rs formatting

### DIFF
--- a/stoa-gateway/src/oauth/discovery.rs
+++ b/stoa-gateway/src/oauth/discovery.rs
@@ -204,10 +204,7 @@ mod tests {
         assert_eq!(meta["resource"], "https://mcp.gostoa.dev");
         // RFC 9728: authorization_servers points to the gateway (not Keycloak)
         // so clients discover our curated metadata with public client support
-        assert_eq!(
-            meta["authorization_servers"][0],
-            "https://mcp.gostoa.dev"
-        );
+        assert_eq!(meta["authorization_servers"][0], "https://mcp.gostoa.dev");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Fix `cargo fmt` formatting issue introduced in PR #532
- Single-line assert_eq consolidation

Ship mode — formatting only.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>