### PR TITLE
fix(security): ensure generated passwords meet KC policy complexity

### DIFF
--- a/scripts/ops/rotate-secrets.sh
+++ b/scripts/ops/rotate-secrets.sh
@@ -89,7 +89,17 @@ fi
 
 generate_password() {
   local length="${1:-32}"
-  openssl rand -base64 "$length" | tr -d '/+=' | head -c "$length"
+  # Generate base alphanumeric, then inject required complexity chars
+  # to guarantee NIST/DORA policy compliance (upper, lower, digit, special)
+  local base
+  base=$(openssl rand -base64 "$length" | tr -d '/+=' | head -c "$((length - 4))")
+  # Append guaranteed complexity: 1 upper, 1 lower, 1 digit, 1 special
+  local suffix
+  suffix="A"
+  suffix+="z"
+  suffix+="$(( RANDOM % 10 ))"
+  suffix+="!"
+  echo "${base}${suffix}"
 }
 
 get_kc_token() {


### PR DESCRIPTION
## Summary

- `generate_password()` in `rotate-secrets.sh` stripped all special chars (`tr -d '/+='`), producing alphanumeric-only passwords
- After applying the NIST/DORA password policy (`specialChars(1)` required), Keycloak rejected these with HTTP 400
- Fix: append a guaranteed complexity suffix (`Az<digit>!`) to every generated password

Found during live rotation of KC admin on prod (PR #533).

## Test plan

- [x] `bash -n` syntax check
- [x] Dry-run produces passwords ending with complexity suffix
- [x] Live rotation succeeded after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)