### PR TITLE
docs: sync plan.md with Linear C8 — scope + drift fix

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -46,7 +46,7 @@
 
 ## Cycle 8 (Feb 16–22) — CURRENT
 
-**Scope**: 166 pts | **Done**: 13 pts (8%) | **Velocity**: 4 issues closed
+**Scope**: 161 pts | **Done**: 5 pts (3%) | **Velocity**: 2 issues closed (Linear) | 4 locally done
 **Theme**: Demo finale + Staging V1++ + DX Remediation + Community Launch Prep
 **Fill-cycle**: +13 Quick Wins promoted, +7 items estimated (2026-02-15); +3 auto-promoted (2026-02-15)
 


### PR DESCRIPTION
## Summary
- Updated C8 scope line to match Linear truth: 161 pts committed, 5 pts done (3%)
- Pushed CAB-1172 to Done on Linear (was Backlog, PR #534 already merged)
- CAB-1170 orphan noted (completed Feb 15, assigned to C7 in Linear)

## Test plan
- [x] plan.md scope line matches Linear C8 data
- [x] CAB-1172 status pushed to Done on Linear

🤖 Generated with [Claude Code](https://claude.com/claude-code)