### PR TITLE
fix(security): add password reset prohibition for AI agents

### DIFF
--- a/.claude/rules/secrets-management.md
+++ b/.claude/rules/secrets-management.md
@@ -123,12 +123,14 @@ infisical secrets set MY_SECRET=value --env=prod --path=/my-service
 When touching secrets, env vars, or credentials:
 
 1. **Never hardcode** — use Infisical + K8s Secret reference
-2. **New secret?** → Add to Infisical (correct env + path) + reference in K8s manifest
-3. **K8s manifest** → Use `envFrom: secretRef` or `env.valueFrom.secretKeyRef`
-4. **Non-critical secret** → Set `optional: true` on the secretRef to avoid pod crash
-5. **CI/CD secret** → Add to GitHub repo/org secrets, reference as `${{ secrets.NAME }}`
-6. **Local dev** → Use `infisical run` to inject, or `.env` file (gitignored)
-7. **Retrieve programmatically** → `infisical secrets get <NAME> --env=prod --path=/<service>`
+2. **NEVER reset/change/rotate passwords or credentials autonomously** — see `security.md` Password Reset Prohibition
+3. **New secret?** → Add to Infisical (correct env + path) + reference in K8s manifest
+4. **K8s manifest** → Use `envFrom: secretRef` or `env.valueFrom.secretKeyRef`
+5. **Non-critical secret** → Set `optional: true` on the secretRef to avoid pod crash
+6. **CI/CD secret** → Add to GitHub repo/org secrets, reference as `${{ secrets.NAME }}`
+7. **Local dev** → Use `infisical run` to inject, or `.env` file (gitignored)
+8. **Retrieve programmatically** → `infisical secrets get <NAME> --env=prod --path=/<service>`
+9. **Rotation scripts are human-only** — `rotate-secrets.sh`, `infisical-rotate-secret` must be run by a human, never by an agent
 
 ## Anti-Patterns
 
@@ -141,6 +143,9 @@ When touching secrets, env vars, or credentials:
 | Secret in GitHub Actions workflow file | Committed to git | Use GitHub Secrets (`${{ secrets.X }}`) |
 | `.env` file committed | Plaintext in repo history forever | `.gitignore` + `infisical run` for shared secrets |
 | Token in MEMORY.md / rules | AI context = potential leak | Reference path only, never values |
+| Agent runs `rotate-secrets.sh` | Uncoordinated password change breaks service chain | Human-only operation, agent must ask first |
+| Agent calls KC `reset-password` API | Changes live credential, may lose new password | Agent reads only, human rotates |
+| Agent runs `infisical secrets set` on passwords | Overwrites production credential | Agent references path, human sets value |
 
 ## Rotation Procedures
 

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -11,6 +11,35 @@ globs: "terraform/**,charts/**,deploy/**,*.tfvars,*.pem,*.key,.env*"
 - **NEVER delete GitLab repositories** with production data
 - **NEVER delete Kafka topics** with unprocessed events
 - **NEVER modify Keycloak realm** without backup
+- **NEVER reset or change passwords** (Keycloak users, admin, OIDC clients, OpenSearch, arena tokens) — see Password Reset Prohibition below
+- **NEVER run `rotate-secrets.sh`** or any rotation script without explicit user command
+
+## Password Reset Prohibition (MANDATORY)
+
+Agents MUST NEVER autonomously reset, change, or rotate any password or credential. This includes:
+
+| Forbidden Action | Why |
+|-----------------|-----|
+| Keycloak `reset-password` API calls | Changes live credential, breaks all sessions |
+| Running `scripts/ops/rotate-secrets.sh` | Resets passwords in Keycloak + stores in Infisical |
+| Running `infisical-rotate-secret` | Rotates Machine Identity client secret |
+| `infisical secrets set` for password fields | Overwrites stored credential |
+| Generating new passwords to replace existing ones | Causes credential mismatch across services |
+| `kubectl create secret` with new password values | Overrides live K8s secrets |
+
+### What Agents CAN Do (read-only)
+- **Read** password policy requirements (e.g., "must have uppercase, digit, special char")
+- **Read** secret paths from Infisical (to reference in code/manifests)
+- **Verify** a password works (e.g., `curl` to get a KC token — read-only validation)
+- **Generate** passwords in code that will be used by the rotation script later (human-triggered)
+- **Document** rotation procedures in runbooks
+
+### Password Storage Strategy — Awareness
+- **Source of truth**: Infisical (`vault.gostoa.dev`) — all credentials live here
+- **Flow**: Human runs rotation script → script changes password in service → stores new value in Infisical → human restarts dependent pods
+- **Never skip Infisical**: if a password is changed in a service but NOT stored in Infisical, the credential is effectively lost
+- **Coordination required**: password changes affect multiple services (KC → API → Gateway → E2E). An uncoordinated change breaks the chain
+- **When agent sees "password" in a task**: STOP and ask the user. Do not attempt to change it, even if a script exists to do so
 
 ## Safe Operations (Always OK)
 - `terraform plan` — run before apply

--- a/scripts/ops/rotate-secrets.sh
+++ b/scripts/ops/rotate-secrets.sh
@@ -98,7 +98,7 @@ generate_password() {
   suffix="A"
   suffix+="z"
   suffix+="$(( RANDOM % 10 ))"
-  suffix+="!"
+  suffix+="@"
   echo "${base}${suffix}"
 }
 


### PR DESCRIPTION
## Summary
- Add explicit **Password Reset Prohibition** rule to `security.md` — agents must never autonomously reset, change, or rotate any password or credential
- Update `secrets-management.md` Agent Checklist with rotation guardrails + 3 new anti-patterns
- Fix `rotate-secrets.sh` special char (`!` → `@`) for KC password policy compatibility

## Context
An agent instance autonomously triggered a password reset, breaking the credential chain across services. These guardrails ensure all rotation scripts remain human-only operations.

## Test plan
- [ ] Rules are `.md` only — no code logic to test
- [ ] `rotate-secrets.sh` change is a single char fix, tested in prior PR #536

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)