### PR TITLE
fix(security): use Infisical CLI for secret storage on self-hosted

### DIFF
--- a/scripts/ops/rotate-secrets.sh
+++ b/scripts/ops/rotate-secrets.sh
@@ -145,7 +145,21 @@ store_infisical() {
     return
   fi
 
-  # Try to create, fall back to update
+  # Use Infisical CLI (handles encryption for self-hosted instances)
+  if command -v infisical &>/dev/null; then
+    if infisical secrets set "${key}=${value}" \
+      --env=prod \
+      --path="$path" \
+      --projectId="$INFISICAL_PROJECT_ID" \
+      --token="$INFISICAL_TOKEN" >/dev/null 2>&1; then
+      echo -e "    ${GREEN}[OK] Infisical ${path}/${key}${NC}"
+    else
+      echo -e "    ${RED}[FAIL] Infisical ${path}/${key}${NC}"
+    fi
+    return
+  fi
+
+  # Fallback: curl API (works with Infisical Cloud, not self-hosted)
   local http_code
   http_code=$(curl -sf -o /dev/null -w '%{http_code}' \
     -X POST "https://vault.gostoa.dev/api/v3/secrets/raw" \


### PR DESCRIPTION
## Summary
- Fix `store_infisical()` in `rotate-secrets.sh` to use the Infisical CLI instead of raw REST API
- Self-hosted Infisical v3 API requires encrypted fields (ciphertext, IV, tag) which the curl-based approach doesn't provide
- CLI handles encryption transparently via Machine Identity auth
- Falls back to curl API for Infisical Cloud instances (where raw API works)

## Test plan
- [x] Tested against self-hosted Infisical (`vault.gostoa.dev`) — 7 persona passwords stored successfully
- [x] Verified round-trip: secrets readable via Infisical API and CLI

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>