### PR TITLE
chore(ci): rewrite /generate-backlog for MEGA tickets

### DIFF
--- a/.claude/skills/generate-backlog/SKILL.md
+++ b/.claude/skills/generate-backlog/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: generate-backlog
-description: "Scan 6 code sources to generate pointed backlog tickets. Maintains 400+ pts stock on Linear."
+description: "Scan codebase to generate MEGA backlog tickets (20-40 pts each). Maintains 400+ pts stock on Linear."
 argument-hint: "[--scan | --create | --theme <name> | empty for --scan]"
 ---
 
-# Generate Backlog — Backlog Stock Pipeline
+# Generate Backlog — MEGA Ticket Pipeline
 
-Scan the codebase and roadmap files to discover ticket candidates, deduplicate against
-Linear, estimate points, and optionally batch-create tickets to maintain a 400+ pt backlog stock.
+Scan the codebase and roadmap files, GROUP findings by component/theme into MEGA tickets
+(20-40 pts each, with phases and binary DoD), deduplicate against Linear, and optionally
+batch-create to maintain a 400+ pt backlog stock.
+
+**Philosophy**: 10 MEGA tickets at 30 pts > 100 micro-tickets at 3 pts.
+Each ticket = a meaningful feature or improvement arc, not a single file fix.
 
 Target: $ARGUMENTS
 
@@ -23,7 +27,7 @@ Target: $ARGUMENTS
 
 | Label | ID |
 |-------|-----|
-| `roadmap` (parent) | `922e1f2d-c839-4b8b-9eba-6c2ba4365a8c` |
+| `roadmap` (parent — NOT assignable) | `922e1f2d-c839-4b8b-9eba-6c2ba4365a8c` |
 | `roadmap:gateway` | `82e07bcd-69fa-4fc5-a2e1-d4d7fa0fad70` |
 | `roadmap:dx` | `9f4356e1-f3bc-49a5-b28a-fa1077a6e326` |
 | `roadmap:platform` | `c819ff92-c9cf-453d-a0f9-451840f6f8cc` |
@@ -35,7 +39,7 @@ Target: $ARGUMENTS
 | Argument | Mode | Description |
 |----------|------|-------------|
 | (empty) / `--scan` | **Scan** | Read-only report, 0 Linear writes |
-| `--create` | **Create** | Batch-create tickets on Linear (20-50 writes) |
+| `--create` | **Create** | Batch-create MEGA tickets on Linear (8-15 writes) |
 | `--theme <name>` | **Themed scan** | Filter candidates by roadmap theme |
 
 Default is `--scan` (safe, CI-compatible).
@@ -62,7 +66,10 @@ Compute:
 
 Report: "Current backlog: X issues, Y pts pointed, Z unpointed"
 
-## Step 2: Scan 6 Sources
+## Step 2: Scan 6 Sources (Raw Findings)
+
+Run all 6 scanners to collect raw findings. These are NOT tickets yet — they are
+raw material that will be GROUPED into MEGAs in Step 3.
 
 ### Scanner 1: TODO/FIXME/HACK in Code
 
@@ -76,274 +83,266 @@ grep -rn "TODO\|FIXME\|HACK" \
 
 Exclude: `archive/`, `node_modules/`, `target/`, `dist/`, `*.test.*`, `*.spec.*`
 
-For each match, extract:
-- `file_path:line_number`
-- Comment text (the TODO/FIXME/HACK message)
-- Component: derive from path (`control-plane-api/` → api, `stoa-gateway/` → gateway, etc.)
-
-**Dedup rule**: group identical TODO text across files (e.g., "TODO: add pagination" in 3 routers = 1 candidate).
+Tag each finding with its component (`api`, `gateway`, `portal`, `ui`, `cli`, `e2e`).
 
 ### Scanner 2: Test Coverage Gaps
 
 Identify untested modules by comparing source files to test files:
 
 **Python (control-plane-api)**:
-- Source routers: `control-plane-api/src/routers/*.py`
-- Source services: `control-plane-api/src/services/*.py`
-- Tests: `control-plane-api/tests/test_*.py`
-- Gap = source file exists but no matching `test_<name>.py`
+- Source routers: `control-plane-api/src/routers/*.py` vs `tests/test_*.py`
+- Source services: `control-plane-api/src/services/*.py` vs `tests/test_*.py`
 
-**TypeScript (control-plane-ui)**:
-- Source pages: `control-plane-ui/src/pages/*.tsx`
-- Source components: `control-plane-ui/src/components/**/*.tsx`
-- Tests: matching `*.test.tsx` in same directory
-- Gap = component exists but no matching `.test.tsx`
-
-**TypeScript (portal)**:
-- Source: `portal/src/pages/*.tsx`, `portal/src/components/**/*.tsx`
-- Tests: matching `*.test.tsx`
+**TypeScript (control-plane-ui / portal)**:
+- Source pages/components vs matching `*.test.tsx`
 
 **Rust (stoa-gateway)**:
-- Source modules: `stoa-gateway/src/**/*.rs`
-- Check for `#[cfg(test)]` block presence in each file
-- Gap = `.rs` file with no `#[cfg(test)]` section
+- Source modules vs `#[cfg(test)]` block presence
+
+Tag each gap with its component.
 
 ### Scanner 3: Roadmap Files
 
-Parse 3 local files for backlog items:
-
-**BACKLOG.md** (repo root):
-- Parse all `CAB-XXXX` entries from tables and lists
-- Extract: ticket ID, title, section name
-- Map section to roadmap theme:
-  - "MCP Gateway" / "Features Avancees" → `gateway`
-  - "Community" → `community`
-  - "Observability" / "OpenSearch" → `observability`
-  - "Portal & UX" / "DX" → `dx`
-  - Everything else → `platform`
-
-**docs/CAPACITY-PLANNING.md**:
-- Parse unchecked `[ ]` items from all phases
-- Extract: ticket ID (if present), title, phase name, estimate (if present)
-
-**plan.md** (Backlog sections only):
-- Parse items from "Backlog" sections of current and next cycle
-- Items without checkboxes = parked, not committed
+Parse `BACKLOG.md`, `docs/CAPACITY-PLANNING.md`, `plan.md` backlog sections.
+Extract `CAB-XXXX` IDs, titles, sections. Map to roadmap themes.
 
 ### Scanner 4: DX Gaps
 
-Check for missing developer experience files:
-
-- **Missing READMEs**: check each component dir (`control-plane-api/`, `control-plane-ui/`, `portal/`, `stoa-gateway/`, `cli/`, `e2e/`) for `README.md`
-- **Missing .env.example**: check component dirs for `.env.example` or `.env.template`
-- **@wip E2E features**: `grep -rn "@wip" e2e/ --include="*.feature"` — count blocked E2E tests
-- **K8s gaps**: check `k8s/` and `charts/` dirs for:
-  - HPA (HorizontalPodAutoscaler) — any component missing?
-  - PDB (PodDisruptionBudget) — any component missing?
-  - NetworkPolicy — any namespace missing?
+Check for missing READMEs, .env.example, @wip E2E features, K8s HPA/PDB/NetworkPolicy gaps.
+Tag each gap with its component.
 
 ### Scanner 5: Lint Suppressions
 
-Find suppressed lint rules that indicate tech debt:
-
-```
-grep -rn "# noqa\|# type: ignore\|eslint-disable\|@ts-ignore\|#\[allow(" \
-  --include="*.py" --include="*.ts" --include="*.tsx" --include="*.rs" \
-  control-plane-api/ control-plane-ui/ portal/ stoa-gateway/
-```
-
-Exclude: `node_modules/`, `target/`, `dist/`
-
-Group by suppression type:
-- `# noqa` / `# type: ignore` → Python type safety debt
-- `eslint-disable` / `@ts-ignore` → TypeScript lint debt
-- `#[allow(...)]` → Rust lint debt
-
-Each cluster of 3+ suppressions of the same rule = 1 candidate ticket.
+Find `# noqa`, `eslint-disable`, `#[allow(` clusters. Tag by component.
 
 ### Scanner 6: Content Roadmap (conditional)
 
-Only if `stoa-docs` directory exists as sibling or `PLAN-SEO.md` is accessible:
+Only if `stoa-docs` sibling or `PLAN-SEO.md` accessible. Parse unclaimed topics.
+Skip silently if not available.
 
-- Parse `PLAN-SEO.md` for unclaimed topics (not marked "Published" or "In Progress")
-- Each topic = 1 candidate (type: content-piece)
+## Step 3: GROUP into MEGA Tickets (Critical Step)
 
-If not accessible, skip silently and note "Scanner 6 skipped: stoa-docs not available".
+**This is the key step.** DO NOT create one ticket per finding.
+Instead, GROUP all raw findings into 8-15 MEGA tickets by component + theme.
 
-## Step 3: Deduplicate Against Linear
+### Grouping Strategy
 
-For each candidate from Step 2:
+Group findings into MEGAs using this matrix:
 
-1. **Exact match**: if candidate has a `CAB-XXXX` ID, check if it exists in the Linear backlog from Step 1
-2. **Fuzzy title match**: tokenize candidate title and each Linear issue title. If token overlap > 70%, flag as duplicate
-3. **Mark duplicates**: tag as `[DUP]` and exclude from creation candidates
+| Component | Theme | MEGA Title Pattern | Target Estimate |
+|-----------|-------|--------------------|-----------------|
+| `control-plane-api` | `platform` | "API Test Coverage & Quality MEGA" | 21-34 pts |
+| `control-plane-api` | `platform` | "API Feature Completion MEGA" (from TODOs) | 21-34 pts |
+| `stoa-gateway` | `gateway` | "Gateway Test Coverage & Quality MEGA" | 21-34 pts |
+| `stoa-gateway` | `gateway` | "Gateway Feature Completion MEGA" (from TODOs) | 21-34 pts |
+| `portal` | `dx` | "Portal Test Coverage & UX Completion MEGA" | 21-34 pts |
+| `control-plane-ui` | `dx` | "Console Test Coverage & UX Completion MEGA" | 21-34 pts |
+| `e2e` | `dx` | "E2E Test Expansion — Unblock @wip Features MEGA" | 13-21 pts |
+| `k8s/charts` | `platform` | "K8s Production Hardening MEGA" (HPA, PDB, NetworkPolicy) | 13-21 pts |
+| `all` | `dx` | "Developer Experience MEGA" (READMEs, .env, DX tooling) | 13-21 pts |
+| `docs` | `community` | "Documentation & Content MEGA" | 13-21 pts |
+| `all` | `platform` | "Tech Debt Cleanup MEGA" (lint suppressions, refactoring) | 13-21 pts |
+| roadmap items | varies | "Roadmap: <Phase Name> MEGA" | 21-55 pts |
 
-Report: "X candidates found, Y duplicates removed, Z net new"
+### Grouping Rules
 
-## Step 4: Estimate Points
+1. **Minimum 13 pts per MEGA** — anything smaller gets merged into a related MEGA
+2. **Maximum 55 pts per MEGA** — anything larger gets split (use `/decompose` later)
+3. **Sweet spot: 21-34 pts** — this is the target range for most MEGAs
+4. **Same component + same concern = same MEGA** — test gaps for `api` = 1 MEGA, not 29 tickets
+5. **Cross-component concerns = themed MEGA** — DX gaps across components = 1 "DX MEGA"
+6. **Roadmap items stay as-is** if already > 13 pts in BACKLOG.md/CAPACITY-PLANNING.md
+7. **Never create a MEGA with only 1 finding** — merge it into the nearest related MEGA
 
-Apply heuristic estimation based on candidate type:
+### MEGA Estimation
 
-| Type | Base Estimate | Adjustments |
-|------|--------------|-------------|
-| `untested-router` | 5 pts | +3 if auth-related (users, service_accounts, certificates) |
-| `untested-service` | 3 pts | +5 if Keycloak/Kafka integration |
-| `untested-component` | 2 pts | +1 if modal/form component |
-| `untested-rs-module` | 3 pts | +2 if security/auth module |
-| `todo-implementation` | 3 pts | +5 if multi-file or cross-component |
-| `fixme-bug` | 3 pts | +2 if in auth/security path |
-| `hack-cleanup` | 2 pts | +1 if public API surface |
-| `roadmap-item` | existing estimate or 8 pts | EPIC/MEGA keyword → cap at 21 |
-| `dx-gap-readme` | 3 pts | — |
-| `dx-gap-env` | 2 pts | — |
-| `dx-gap-e2e-wip` | 5 pts | +3 if critical path scenario |
-| `dx-gap-k8s` | 5 pts | +2 if HPA (scaling) |
-| `lint-debt` | 3 pts | per cluster of suppressions |
-| `content-piece` | 5 pts | tutorial=8, comparison=5, glossary=13 |
+Estimate each MEGA based on the aggregate scope of its grouped findings:
 
-**Cap**: no single auto-generated ticket exceeds 21 pts. Larger items need `/council`.
+| MEGA Type | Base | Per-Finding Adjustment | Range |
+|-----------|------|----------------------|-------|
+| Test Coverage MEGA | 13 pts | +2 per untested module, +3 if auth-related | 13-34 |
+| Feature Completion MEGA | 13 pts | +3 per multi-file TODO, +5 if cross-component | 13-34 |
+| DX MEGA | 13 pts | +3 per missing README, +5 per @wip E2E feature | 13-21 |
+| K8s Hardening MEGA | 13 pts | +3 per missing HPA, +2 per missing PDB | 13-21 |
+| Tech Debt MEGA | 13 pts | +2 per lint cluster | 13-21 |
+| Content MEGA | 13 pts | +5 per tutorial, +3 per comparison article | 13-34 |
+| Roadmap MEGA | existing estimate | from BACKLOG.md/CAPACITY-PLANNING.md | 21-55 |
 
-## Step 5: Score & Rank
+**Cap**: 55 pts max per MEGA. Larger = needs `/council` + `/decompose`.
 
-Score each candidate for prioritization:
+## Step 4: Deduplicate Against Linear
 
-| Factor | Points | Condition |
-|--------|--------|-----------|
-| Type weight | 3 | `untested-router` or `fixme-bug` (high impact) |
-| Type weight | 2 | `todo-implementation`, `dx-gap-k8s`, `content-piece` |
-| Type weight | 1 | `lint-debt`, `dx-gap-readme`, `hack-cleanup` |
-| Theme bonus | 2 | Matches `--theme` filter (if provided) |
-| Size factor | 1 | Estimate <= 5 pts (quick win) |
-| Source bonus | 1 | From roadmap files (already validated) |
-| Auth/security | 2 | Touches auth, RBAC, secrets, or security code |
-| **Max score** | **9** | |
+For each MEGA from Step 3:
 
-Sort by score descending, then by estimate ascending (prefer quick wins).
+1. **Exact match**: if MEGA groups `CAB-XXXX` items, check they aren't already active on Linear
+2. **Theme overlap**: check if a similar MEGA already exists in backlog (e.g., "API Test Coverage" already exists)
+3. **Mark duplicates**: tag as `[DUP]` and exclude
 
-## Step 6: Build Plan — Top 50 Candidates
+Report: "X MEGAs built, Y duplicates removed, Z net new"
 
-Take top 50 candidates (after dedup), grouped by roadmap theme:
+## Step 5: Build Report — Top 15 MEGAs
+
+Present MEGAs grouped by roadmap theme:
 
 ```
-Backlog Generation Report
-==========================
+Backlog Generation Report (MEGA Mode)
+=======================================
 
 Current backlog: XX issues, YYY pts | Target: 400 pts
-Gap: ZZZ pts needed | Candidates found: NN
+Gap: ZZZ pts needed | MEGAs proposed: NN
 
 By Theme:
 ---------
 
-gateway (XX pts, N items):
-  1. [5 pts] untested-router: stoa-gateway security_headers.rs — no #[cfg(test)]
-  2. [3 pts] todo-impl: OTel init in stoa-gateway/src/telemetry.rs:42
+gateway (XX pts, N MEGAs):
+  1. [34 pts] Gateway Test Coverage & Quality MEGA
+     Scope: 27 untested modules (proxy, oauth, guardrails, federation...)
+     Phases: P1 core modules (13 pts) → P2 security modules (8 pts) → P3 edge cases (13 pts)
+
+  2. [21 pts] Gateway Feature Completion MEGA
+     Scope: 15 TODOs (OTel init, MCP resource listing, shadow capture...)
+     Phases: P1 observability (8 pts) → P2 MCP features (8 pts) → P3 cleanup (5 pts)
+
+platform (XX pts, N MEGAs):
+  1. [34 pts] API Test Coverage & Quality MEGA
+     Scope: 29 untested routers, 23 untested services
+     Phases: P1 auth routers (13 pts) → P2 core services (13 pts) → P3 adapters (8 pts)
+
+  2. [21 pts] K8s Production Hardening MEGA
+     Scope: missing HPA (5), PDB (5), NetworkPolicy (3)
+     Phases: P1 HPA all components (8 pts) → P2 PDB + NetworkPolicy (8 pts) → P3 docs (5 pts)
+
+dx (XX pts, N MEGAs):
+  1. [21 pts] Portal Test & UX Completion MEGA
+     Scope: 37 untested components, 3 key TODOs
+     Phases: P1 auth components (8 pts) → P2 tools components (8 pts) → P3 integration (5 pts)
+
+  2. [13 pts] Developer Experience MEGA
+     Scope: 5 missing READMEs, 3 missing .env.example
+     Phases: P1 READMEs (5 pts) → P2 .env.example (3 pts) → P3 onboarding guide (5 pts)
+
+observability (XX pts, N MEGAs):
   ...
 
-platform (XX pts, N items):
-  1. [8 pts] untested-router: applications.py — no test_applications.py
-  2. [5 pts] todo-impl: IAM sync in src/services/iam_sync_service.py:87
-  ...
-
-dx (XX pts, N items):
-  1. [3 pts] dx-gap: Missing README.md in cli/
-  2. [5 pts] dx-gap: 4 @wip E2E features blocked
-  ...
-
-observability (XX pts, N items):
-  ...
-
-community (XX pts, N items):
+community (XX pts, N MEGAs):
   ...
 
 Summary:
-  Total candidates: NN | Total points: XXX pts
+  Total MEGAs: NN | Total points: XXX pts
   After creation, backlog would be: YYY pts (target: 400)
   Duplicates removed: DD
   Scanners skipped: [list or "none"]
 ```
 
-## Step 7: Execute
+## Step 6: Execute
 
 ### Scan mode (`--scan`, default)
 
-Display the report from Step 6. No Linear writes. Exit.
+Display the report from Step 5. No Linear writes. Exit.
 
 ### Create mode (`--create`)
 
-For each candidate (up to 50):
+For each MEGA (up to 15):
 
 ```
 linear.create_issue(
-  title: "<type>(scope): <description>",
+  title: "[MEGA] <Theme>: <Description>",
   description: <see template below>,
   team: "624a9948-a160-4e47-aba5-7f9404d23506",
   project: "227427af-6844-484d-bb4a-dedeffc68825",
   assignee: "0543749d-ecde-4edf-aec1-6f372aafafce",
-  estimate: <pts from Step 4>,
-  priority: 4,
+  estimate: <pts from Step 3>,
+  priority: 3,
   labels: ["roadmap:<theme>"],
   state: "Backlog"
 )
 ```
 
-**Ticket description template**:
+**MEGA ticket description template**:
 
 ```markdown
 ## Context
-Auto-generated by `/generate-backlog` scanner.
-Source: {scanner_name} | File: {file_path}:{line}
 
-## What
-{description}
+Auto-generated by `/generate-backlog` MEGA pipeline.
+Theme: {theme} | Component(s): {components}
+Findings grouped: {count} items from {scanner_names}
+
+## Scope
+
+{2-3 sentences describing what this MEGA covers and why it matters}
+
+### Included Findings
+
+{Bulleted list of all grouped raw findings with file:line references}
+
+## Implementation Phases
+
+### Phase 1: {name} (~{pts} pts)
+- {specific deliverable 1}
+- {specific deliverable 2}
+- **Verification**: {command that proves Phase 1 is done}
+
+### Phase 2: {name} (~{pts} pts)
+- {specific deliverable 1}
+- {specific deliverable 2}
+- **Verification**: {command that proves Phase 2 is done}
+
+### Phase 3: {name} (~{pts} pts)
+- {specific deliverable 1}
+- {specific deliverable 2}
+- **Verification**: {command that proves Phase 3 is done}
+
+## Binary DoD
+
+- [ ] Phase 1 complete — verification passes
+- [ ] Phase 2 complete — verification passes
+- [ ] Phase 3 complete — verification passes
+- [ ] All modified files have tests
+- [ ] CI green (component quality gate)
+- [ ] No new lint suppressions introduced
+- [ ] State files updated (memory.md, plan.md)
 
 ## Estimate Rationale
-{type}: {base_pts} pts {adjustments}
 
-## DoD
-- [ ] Implementation complete
-- [ ] Tests added/updated
-- [ ] CI green
+{MEGA type}: {base} pts + {per-finding adjustments} = {total} pts
+Findings: {count} items across {files_count} files in {component}
 
 ---
-_Auto-generated by STOA AI Factory `/generate-backlog` — {date}_
+_Auto-generated by STOA AI Factory `/generate-backlog` MEGA pipeline — {date}_
 ```
-
-**Commit title format**: `<conventional_type>(scope): <short description>`
-- untested-router → `test(api): add tests for applications router`
-- todo-impl → `feat(gateway): implement OTel initialization`
-- dx-gap → `chore(dx): add README.md to cli/`
-- content-piece → `docs(blog): write MCP protocol deep-dive`
 
 ### Themed mode (`--theme <name>`)
 
-Same as `--scan` but filter candidates to only those matching the specified theme
+Same as `--scan` but filter MEGAs to only those matching the specified theme
 (`gateway`, `dx`, `platform`, `community`, `observability`).
 
-## Step 8: Report & Log
+## Step 7: Report & Log
 
 ### Final report
 
 ```
-Backlog Generation Complete
-============================
+Backlog Generation Complete (MEGA Mode)
+=========================================
 Mode: {scan|create|themed}
 Scanners run: 6 (or list skipped)
 
-Candidates:
-  Found: XX | Duplicates: YY | Net new: ZZ
+Raw findings: XXX items across 6 scanners
+MEGAs built: NN (grouped from raw findings)
+Duplicates removed: DD
 
 {if --create}
-Created: NN tickets on Linear (total: XXX pts)
+Created: NN MEGAs on Linear (total: XXX pts)
 Backlog after: YYY pts (target: 400 pts)
 {/if}
 
 {if --scan}
-Recommended: run `/generate-backlog --create` to create ZZ tickets (XXX pts)
+Recommended: run `/generate-backlog --create` to create NN MEGAs (XXX pts)
 {/if}
 
-Top 5 by score:
-  1. CAB-NEW: <title> (X pts, score: Y)
-  2. ...
+Top 5 MEGAs by impact:
+  1. [MEGA] Gateway Test Coverage & Quality (34 pts)
+  2. [MEGA] API Test Coverage & Quality (34 pts)
+  3. ...
 ```
 
 ### Operations log (--create mode only)
@@ -351,7 +350,7 @@ Top 5 by score:
 Append to `~/.claude/projects/-Users-torpedo-hlfh-repos-stoa/memory/operations.log`:
 
 ```
-STEP-DONE | step=generate-backlog task=backlog-pipeline created=N total_pts=X backlog_depth=Y
+STEP-DONE | step=generate-backlog task=backlog-pipeline megas_created=N total_pts=X backlog_depth=Y
 ```
 
 ## MCP Budget
@@ -359,21 +358,26 @@ STEP-DONE | step=generate-backlog task=backlog-pipeline created=N total_pts=X ba
 | Call | Purpose | Mode |
 |------|---------|------|
 | `list_issues(no cycle)` | Inventory current backlog | All |
-| `create_issue` x N | Batch create tickets | `--create` only |
+| `create_issue` x N | Batch create MEGAs | `--create` only |
 | **Total read** | **1 call** | |
-| **Total write** | **0 (scan) / 20-50 (create)** | |
+| **Total write** | **0 (scan) / 8-15 (create)** | |
 
 ## Rules
 
 - **`--scan` is default** — never auto-create without explicit `--create`
-- **Cap at 50 tickets per run** — avoid flooding Linear
-- **Dedup BEFORE create** — check Linear backlog + fuzzy title match (>70% token overlap)
-- **Conservative estimates** — use base heuristics, user adjusts post-creation
-- **Theme labels mandatory** — every ticket gets `roadmap:<theme>` label (`roadmap` is a group, cannot be assigned directly)
+- **MEGA only** — NEVER create atomic per-file tickets. Minimum 13 pts per ticket
+- **Cap at 15 MEGAs per run** — quality over quantity
+- **Sweet spot: 21-34 pts** — most MEGAs should be in this range
+- **Group by component + concern** — test gaps for 1 component = 1 MEGA, not N tickets
+- **Phases mandatory** — every MEGA has 2-4 implementation phases with verification commands
+- **Binary DoD mandatory** — every MEGA has checkboxes that are objectively pass/fail
+- **Dedup BEFORE create** — check Linear backlog for similar existing MEGAs
+- **Theme labels mandatory** — every MEGA gets `roadmap:<theme>` label
+- **[MEGA] prefix in title** — makes them visually distinct in Linear board
 - **Auto-gen marker** — description includes "Auto-generated by /generate-backlog"
-- **Priority 4 (Low) default** — auto-generated tickets are backlog, not urgent
+- **Priority 3 (Normal) default** — MEGAs are substantial work, not throwaway
 - **State "Backlog"** — never create in "Todo" or "In Progress"
-- **No scanner scripts** — this skill is pure SKILL.md (Claude executes the logic inline)
+- **Never assign to a cycle** — MEGAs go to backlog, `/fill-cycle` promotes them
+- **No scanner scripts** — skill is pure SKILL.md (Claude executes logic inline)
 - **Exclude archives** — never scan `archive/`, `node_modules/`, `target/`, `dist/`
-- **Group by theme** — report and creation both organized by roadmap theme
 - **Log all creates** in operations.log for audit trail

--- a/.github/workflows/claude-scheduled.yml
+++ b/.github/workflows/claude-scheduled.yml
@@ -259,18 +259,21 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            Weekly backlog stock check — scan the codebase for ticket candidates.
+            Weekly backlog stock check — scan the codebase for MEGA ticket candidates.
 
             Run the `/generate-backlog --scan` skill:
             1. Inventory current Linear backlog depth (issues with no cycle, state Backlog/Todo)
             2. Scan 6 sources: TODO/FIXME, test coverage gaps, roadmap files, DX gaps, lint suppressions, content roadmap
-            3. Deduplicate against existing Linear issues
-            4. Estimate points using heuristics
-            5. Report candidate count and total points
+            3. GROUP findings by component/theme into MEGA tickets (21-34 pts each, with phases and binary DoD)
+            4. Deduplicate against existing Linear issues
+            5. Report MEGA count and total points
+
+            IMPORTANT: Generate MEGA tickets (20-40 pts), NOT micro-tickets (3-8 pts).
+            Each MEGA groups related findings by component into a meaningful improvement arc.
 
             After the scan, evaluate backlog health:
             - If backlog < 400 pts: create a GitHub issue titled "Backlog Stock Alert — YYYY-MM-DD"
-              with label "daily-digest" containing the full scan report and recommendation
+              with label "daily-digest" containing the full MEGA scan report and recommendation
               to run `/generate-backlog --create`
             - If backlog >= 400 pts: create a GitHub issue titled "Backlog Stock OK — YYYY-MM-DD"
               with label "daily-digest" containing a brief summary


### PR DESCRIPTION
## Summary

- Rewrote `/generate-backlog` SKILL.md to produce MEGA tickets (21-34 pts) instead of atomic micro-tickets (3-8 pts)
- Each MEGA groups related findings by component/theme with implementation phases and binary DoD
- Updated GHA `weekly-backlog-stock` job prompt to reflect MEGA approach
- Canceled 90 micro-tickets (CAB-1199-1288) on Linear that were generated by the old atomic pipeline

## Why

User preference: "10 megaticket a 40 points par semaine > 100 ticket a 4 points". C7 averaged 11.5 pts/issue — MEGA tickets match proven velocity patterns.

## Test plan

- [ ] Run `/generate-backlog --scan` to verify MEGA grouping logic
- [ ] Verify no broken YAML in `claude-scheduled.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)