### PR TITLE
docs(security): record arena VPS token rotation

### DIFF
--- a/docs/SECRETS-ROTATION.md
+++ b/docs/SECRETS-ROTATION.md
@@ -329,13 +329,13 @@ All secret operations are logged in Infisical audit log (accessible via UI at `v
 | 2026-02-15 | OIDC opensearch-dashboards | Public client — no secret to rotate | — |
 | 2026-02-15 | E2E personas (7) | Rotated in KC + stored in Infisical + GitHub Secrets | #543 |
 | 2026-02-15 | OpenSearch admin | Rotated via securityadmin.sh + stored in Infisical | — |
+| 2026-02-15 | Arena VPS token | Rotated on VPS + stored in Infisical | — |
 
 ### Known Issues
 
 - **`opensearch-dashboards`** is `publicClient: true` in production KC — no client secret needed for OIDC flow. JWKS token validation only.
 - **OpenSearch securityadmin.sh** requires HTTP TLS enabled. Production runs with HTTP TLS disabled. Procedure: temporarily enable TLS, run securityadmin, revert, restart.
 - **Infisical self-hosted v3 API** requires encrypted fields for REST API writes. Use `infisical secrets set` CLI instead (handles encryption transparently). PR #543 fixed `store_infisical()`.
-- **Arena VPS token** (`arena-admin-token-2026`) still hardcoded on VPS. Requires SSH access to rotate.
 
 ## References
 

--- a/memory.md
+++ b/memory.md
@@ -77,6 +77,7 @@
   - 7 E2E persona passwords rotated (KC + Infisical + GitHub Secrets)
   - OIDC client secrets: 3 already non-default, 1 public client (no-op)
   - OpenSearch admin rotated (securityadmin.sh + Infisical)
+  - Arena VPS token rotated (SSH + Infisical `prod/gateway/arena/ADMIN_API_TOKEN`)
   - `rotate-secrets.sh` fixed for self-hosted Infisical (CLI-first)
 
 ## 🔴 IN PROGRESS


### PR DESCRIPTION
## Summary
- Records arena VPS token rotation in `docs/SECRETS-ROTATION.md` rotation history
- Removes arena VPS token from "Known Issues" (now rotated and stored in Infisical)
- Updates `memory.md` with arena rotation completion

Part of the Security P0+P1 rotation effort (PRs #533, #536, #543, #546).

## Test plan
- [x] Docs-only change, no code impact
- [x] CI green (3 required checks)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>