### PR TITLE
feat(portal): add JSON Schema validation to Try-It form (CAB-1185)

### DIFF
--- a/portal/package-lock.json
+++ b/portal/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.90.20",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "axios": "^1.6.5",
         "clsx": "^2.1.0",
         "lucide-react": "^0.475.0",
@@ -1017,6 +1019,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1027,6 +1046,13 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -2204,20 +2230,36 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -3555,6 +3597,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3565,6 +3624,13 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
@@ -3667,7 +3733,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3713,6 +3778,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -4924,10 +5005,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -6049,6 +6129,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/requires-port": {

--- a/portal/package.json
+++ b/portal/package.json
@@ -18,6 +18,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.20",
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "axios": "^1.6.5",
     "clsx": "^2.1.0",
     "lucide-react": "^0.475.0",

--- a/portal/src/components/tools/TryItForm.tsx
+++ b/portal/src/components/tools/TryItForm.tsx
@@ -22,7 +22,12 @@ import {
   Trash2,
   Info,
 } from 'lucide-react';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
 import type { MCPInputSchema, MCPPropertySchema } from '../../types';
+
+const ajv = new Ajv({ allErrors: true, coerceTypes: true });
+addFormats(ajv);
 
 interface TryItFormProps {
   schema: MCPInputSchema | null | undefined;
@@ -326,6 +331,7 @@ export function TryItForm({
   className = '',
 }: TryItFormProps) {
   const [formData, setFormData] = useState<Record<string, unknown>>({});
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string | undefined>>({});
   const [response, setResponse] = useState<unknown>(null);
   const [error, setError] = useState<string | null>(null);
   const [showResponse, setShowResponse] = useState(true);
@@ -344,6 +350,7 @@ export function TryItForm({
         value={formData[name]}
         onChange={(value) => handleFieldChange(name, value)}
         isRequired={requiredFields.includes(name)}
+        error={fieldErrors[name]}
       />
     ));
   };
@@ -353,6 +360,12 @@ export function TryItForm({
       ...prev,
       [fieldName]: value,
     }));
+    setFieldErrors((prev) => {
+      if (!prev[fieldName]) return prev;
+      const next = { ...prev };
+      delete next[fieldName];
+      return next;
+    });
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -360,19 +373,31 @@ export function TryItForm({
     setError(null);
     setResponse(null);
 
-    // Validate required fields
-    const missingRequired = requiredFields.filter(
-      (field) => formData[field] === undefined || formData[field] === ''
-    );
-    if (missingRequired.length > 0) {
-      setError(`Missing required fields: ${missingRequired.join(', ')}`);
-      return;
-    }
-
     // Filter out empty values
     const cleanedData = Object.fromEntries(
       Object.entries(formData).filter(([, v]) => v !== undefined && v !== '')
     );
+
+    // Validate against JSON Schema using ajv
+    if (schema) {
+      const valid = ajv.validate(schema, cleanedData);
+      if (!valid && ajv.errors) {
+        const errors: Record<string, string | undefined> = {};
+        for (const err of ajv.errors) {
+          const field =
+            err.keyword === 'required'
+              ? (err.params as { missingProperty: string }).missingProperty
+              : err.instancePath.replace(/^\//, '');
+          if (field && !errors[field]) {
+            errors[field] = err.message ?? 'Invalid value';
+          }
+        }
+        setFieldErrors(errors);
+        setError('Validation failed — check highlighted fields above');
+        return;
+      }
+    }
+    setFieldErrors({});
 
     if (onInvoke) {
       try {
@@ -407,6 +432,7 @@ export function TryItForm({
 
   const handleReset = () => {
     setFormData({});
+    setFieldErrors({});
     setResponse(null);
     setError(null);
   };

--- a/portal/src/components/tools/__tests__/TryItForm.test.tsx
+++ b/portal/src/components/tools/__tests__/TryItForm.test.tsx
@@ -1,0 +1,134 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../../test/helpers';
+import { TryItForm } from '../TryItForm';
+import type { MCPInputSchema } from '../../../types';
+
+const baseSchema: MCPInputSchema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string', minLength: 2, maxLength: 50 },
+    email: { type: 'string', format: 'email' },
+    age: { type: 'integer', minimum: 0, maximum: 150 },
+    code: { type: 'string', pattern: '^[A-Z]{3}-\\d{3}$' },
+    role: { type: 'string', enum: ['admin', 'user', 'viewer'] },
+  },
+  required: ['name', 'email'],
+};
+
+describe('TryItForm', () => {
+  const mockOnInvoke = vi.fn().mockResolvedValue({ ok: true });
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOnInvoke.mockResolvedValue({ ok: true });
+  });
+
+  it('submits valid data without errors', async () => {
+    renderWithProviders(
+      <TryItForm schema={baseSchema} toolName="test-tool" onInvoke={mockOnInvoke} />
+    );
+
+    await user.type(screen.getByPlaceholderText('Enter name...'), 'Alice');
+    await user.type(screen.getByPlaceholderText('Enter email...'), 'alice@example.com');
+    await user.click(screen.getByRole('button', { name: /Invoke Tool/ }));
+
+    await waitFor(() => {
+      expect(mockOnInvoke).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Alice', email: 'alice@example.com' })
+      );
+    });
+    expect(screen.queryByText(/Validation failed/)).not.toBeInTheDocument();
+  });
+
+  it('shows error for missing required field', async () => {
+    renderWithProviders(
+      <TryItForm schema={baseSchema} toolName="test-tool" onInvoke={mockOnInvoke} />
+    );
+
+    // Only fill name, skip email
+    await user.type(screen.getByPlaceholderText('Enter name...'), 'Alice');
+    await user.click(screen.getByRole('button', { name: /Invoke Tool/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Validation failed/)).toBeInTheDocument();
+    });
+    expect(mockOnInvoke).not.toHaveBeenCalled();
+  });
+
+  it('shows error for invalid pattern', async () => {
+    renderWithProviders(
+      <TryItForm schema={baseSchema} toolName="test-tool" onInvoke={mockOnInvoke} />
+    );
+
+    await user.type(screen.getByPlaceholderText('Enter name...'), 'Alice');
+    await user.type(screen.getByPlaceholderText('Enter email...'), 'alice@example.com');
+    await user.type(screen.getByPlaceholderText('Enter code...'), 'bad-code');
+    await user.click(screen.getByRole('button', { name: /Invoke Tool/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Validation failed/)).toBeInTheDocument();
+    });
+    expect(mockOnInvoke).not.toHaveBeenCalled();
+  });
+
+  it('shows error for string shorter than minLength', async () => {
+    renderWithProviders(
+      <TryItForm schema={baseSchema} toolName="test-tool" onInvoke={mockOnInvoke} />
+    );
+
+    await user.type(screen.getByPlaceholderText('Enter name...'), 'A');
+    await user.type(screen.getByPlaceholderText('Enter email...'), 'a@b.co');
+    await user.click(screen.getByRole('button', { name: /Invoke Tool/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Validation failed/)).toBeInTheDocument();
+    });
+    expect(mockOnInvoke).not.toHaveBeenCalled();
+  });
+
+  it('shows error for string exceeding maxLength', async () => {
+    renderWithProviders(
+      <TryItForm schema={baseSchema} toolName="test-tool" onInvoke={mockOnInvoke} />
+    );
+
+    // name has maxLength: 50 — type a string longer than 50 chars
+    const longName = 'A'.repeat(51);
+    await user.type(screen.getByPlaceholderText('Enter name...'), longName);
+    await user.type(screen.getByPlaceholderText('Enter email...'), 'alice@example.com');
+    await user.click(screen.getByRole('button', { name: /Invoke Tool/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Validation failed/)).toBeInTheDocument();
+    });
+    expect(mockOnInvoke).not.toHaveBeenCalled();
+  });
+
+  it('clears field error when user fixes the value', async () => {
+    renderWithProviders(
+      <TryItForm schema={baseSchema} toolName="test-tool" onInvoke={mockOnInvoke} />
+    );
+
+    // Submit empty to get required error
+    await user.click(screen.getByRole('button', { name: /Invoke Tool/ }));
+    await waitFor(() => {
+      expect(screen.getByText(/Validation failed/)).toBeInTheDocument();
+    });
+
+    // Fix the fields
+    await user.type(screen.getByPlaceholderText('Enter name...'), 'Alice');
+    await user.type(screen.getByPlaceholderText('Enter email...'), 'alice@example.com');
+
+    // Per-field errors should be cleared on change
+    const fieldErrors = screen.queryAllByText(/is a required property/i);
+    expect(fieldErrors).toHaveLength(0);
+  });
+
+  it('renders "No input schema" when schema is empty', () => {
+    renderWithProviders(<TryItForm schema={null} toolName="test-tool" onInvoke={mockOnInvoke} />);
+
+    expect(screen.getByText('No input schema available')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Invoke Tool/ })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Replace simplistic required-field check in Portal Try-It form with full `ajv` JSON Schema validation
- Validates `pattern`, `minLength`, `maxLength`, `minimum`, `maximum`, `format`, `enum`, and `required` constraints
- Per-field error messages shown inline via existing `FormField` `error` prop, with field errors clearing on user input
- 7 test cases covering valid submit, missing required, pattern violation, minLength, maxLength, error clearing, and empty schema

## Test plan
- [x] `npm run test -- --run` — 571 tests pass (0 failures)
- [x] `npm run lint` — 15 warnings (max 20)
- [x] `npm run format:check` — clean
- [x] `npx tsc -p tsconfig.app.json --noEmit` — zero errors
- [x] PR < 300 LOC (~140 net additions)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)