### PR TITLE
fix(docs): correct 4 broken docs.gostoa.dev URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ helm install stoa-platform ./charts/stoa-platform \
   -f charts/stoa-platform/values.yaml
 ```
 
-See [deployment docs](https://docs.gostoa.dev/deployment/hybrid-deployment) for production setup with ArgoCD.
+See [deployment docs](https://docs.gostoa.dev/docs/deployment/hybrid) for production setup with ArgoCD.
 
 ## Repository Structure
 
@@ -167,9 +167,9 @@ stoa/
 ## Documentation
 
 - **Docs**: [docs.gostoa.dev](https://docs.gostoa.dev)
-- **Architecture Decisions**: [ADRs](https://docs.gostoa.dev/architecture/adr/)
-- **API Reference**: [Control Plane API](https://docs.gostoa.dev/api/control-plane/)
-- **Guides**: [Quick Start](https://docs.gostoa.dev/guides/quick-start/)
+- **Architecture Decisions**: [ADRs](https://docs.gostoa.dev/docs/architecture/adr/)
+- **API Reference**: [Control Plane API](https://docs.gostoa.dev/docs/api/control-plane)
+- **Guides**: [Quick Start](https://docs.gostoa.dev/docs/guides/quickstart)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Add missing `/docs/` prefix to 3 documentation URLs
- Fix `guides/quick-start/` → `guides/quickstart` (matching Docusaurus slug)
- Fix `deployment/hybrid-deployment` → `deployment/hybrid` (matching actual filename)

Found during Algolia DocSearch crawler run.

## Test plan
- [x] URLs verified against live docs.gostoa.dev routes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>