### PR TITLE
docs: mark CAB-1181 done, add diagram strategy

### DIFF
--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -77,7 +77,7 @@ Is it user-facing (customers, developers, partners)?
 ## ADR Numbering Rules
 
 - **stoa-docs owns ADR numbers** — never create an ADR number in stoa repo
-- Current range: ADR-001 through ADR-039. **Next available: ADR-040**
+- Current range: ADR-001 through ADR-044. **Next available: ADR-045**
 - Filename format: `adr-NNN-short-description.md`
 - Draft ADRs can live temporarily in stoa repo but MUST be renumbered when moved to stoa-docs
 - Always check `stoa-docs/docs/architecture/adr/` for the latest number before creating
@@ -95,6 +95,61 @@ Is it user-facing (customers, developers, partners)?
 1. Check highest ADR number in `stoa-docs/docs/architecture/adr/`
 2. Create ADR with next number in **stoa-docs** directly
 3. Reference ADR by URL in stoa code: `https://docs.gostoa.dev/architecture/adr/adr-NNN-*`
+
+## Interactive Diagram Strategy (stoa-docs)
+
+### Decision Tree: Which Diagram Type?
+
+| Diagram Type | When to Use | Effort | Example |
+|-------------|------------|--------|---------|
+| **Inline Mermaid** | Simple flows, sequence diagrams, ER diagrams | Low (~10 LOC) | ADR-001, concept pages |
+| **Interactive JSX** | Multi-tab content, clickable elements, data-rich | High (~500-700 LOC) | ADR-040, ADR-043, ADR-024, ADR-034 |
+| **ASCII art** | Never for new content | N/A | Legacy only — convert on touch |
+
+### When Interactive JSX > Mermaid
+
+Use interactive JSX (React component in `src/components/`) when:
+1. Content has **3+ logical sections** that benefit from tabs (architecture + details + roadmap)
+2. Diagram needs **clickable/interactive** elements (mode selector, phase picker)
+3. Content includes **data tables + visual layout** combined (topic lists, competitive grids)
+4. The page is **showcase-worthy** (customer-facing ADRs, core architecture)
+
+### Interactive JSX Component Pattern
+
+Components live in `stoa-docs/src/components/<Name>/index.tsx`. Key patterns:
+
+- **Theme-aware**: use `useColorMode()` from `@docusaurus/theme-common`, two color palettes
+- **CSS Grid overlay for tabs**: render ALL tabs simultaneously, `visibility: hidden` on inactive — zero layout shift
+- **Docusaurus fonts**: `var(--ifm-font-family-base)`, `var(--ifm-font-family-monospace)` — no external fonts
+- **No viewport styles**: no `minHeight: 100vh`, no body background
+- **Import in MDX**: `import Component from '@site/src/components/<Name>';` after frontmatter
+
+### Existing Interactive Components
+
+| Component | ADR | Tabs | Description |
+|-----------|-----|------|-------------|
+| `KafkaMCPArchitecture` | ADR-043 | Architecture, Kafka Topics, Roadmap, Use Cases | Kafka → MCP Event Bridge |
+| `GatewayModesArchitecture` | ADR-024 | Architecture, Mode Details, Migration, Roadmap | 4 gateway deployment modes |
+| `GitOpsArchitecture` | ADR-040 | Architecture, Promotion, Multi-Tenant, Roadmap | Born GitOps multi-env |
+| `MigrationArchitecture` | ADR-034 | Timeline, Shadow Validation, Feature Parity | Python → Rust migration |
+
+### Mermaid Conversions (Batch 1 — PR #57, Batch 2 — PR #58)
+
+| ADR | Diagram Type | PR |
+|-----|-------------|-----|
+| ADR-001 | 3 flowcharts (architecture, facade, dependencies) | #57 |
+| ADR-039 | Middleware pipeline flow (6 stages, color-coded) | #58 |
+| ADR-004 | Adapter pattern architecture (registry → adapters → gateways) | #58 |
+| ADR-006 | Mixin composition graph (8 modules, semantic colors) | #58 |
+
+**ADR-003** (Monorepo): Skipped — directory trees are optimal as code blocks.
+
+### Remaining Candidates
+
+ADRs with notable ASCII diagrams not yet converted:
+- ADR-027 (X509 Headers) — auth flow
+- ADR-028 (RFC 8705 Binding) — fingerprint normalization flow
+- ADR-012 (MCP RBAC) — policy evaluation chain
 
 ## Anti-Duplication Checklist
 

--- a/memory.md
+++ b/memory.md
@@ -101,6 +101,14 @@
 - CAB-1162: SEO Tracking (3 pts) — PR #564 (sitemap verified, 32/32 meta descriptions compliant, SEO-TRACKING.md)
 - CAB-1187: Blog Batch 7 (8 pts) — stoa-docs PR #48 (5 articles: A3 MCP tools, O8 circuit breaker, D2 stoactl, A5 rate limiting, D3 Docker Compose)
 - CAB-1289: Gateway Test Coverage & Quality (34 pts) — PR #566 (106 new tests, -620 LOC dead code, 12 #[allow] removed, 754 total gateway tests)
+- CAB-1181: Interactive Mermaid Diagrams (5 pts) — stoa-docs PRs #52-#55, #57, #58
+  - PR #52: 5 ASCII→Mermaid in concept pages (gateway, mcp-gateway, uac, gitops)
+  - PR #53: KafkaMCPArchitecture JSX component for ADR-043 (interactive tabs, theme-aware)
+  - PR #54: height fix attempt (minHeight — didn't work)
+  - PR #55: CSS Grid overlay fix + GatewayModesArchitecture JSX component for ADR-024
+  - PR #57: GitOpsArchitecture (ADR-040, 4 tabs) + MigrationArchitecture (ADR-034, 3 tabs) + ADR-001 Mermaid
+  - PR #58: ADR-039 (mTLS pipeline), ADR-004 (adapter pattern), ADR-006 (mixin composition) — all Mermaid
+  - Total: 4 JSX components + 7 Mermaid conversions across 10 ADRs + 4 concept pages
 
 ## 🔴 IN PROGRESS
 
@@ -112,7 +120,7 @@ CAB-802: Dry Run + Script + Video Backup (3 pts)
 - [ ] Video backup filmée
 - Known: API creation requires GitLab → use Console UI; rate limiting not configured; httpbin flaky
 
-## 📋 NEXT — Cycle 8 (Feb 16-22) — 5 Tracks, 160 pts scoped | Done: 192 pts (27 issues)
+## 📋 NEXT — Cycle 8 (Feb 16-22) — 5 Tracks, 160 pts scoped | Done: 197 pts (28 issues)
 
 ### Track 1 — Demo Finale (6 pts)
 - CAB-1151: Dress Rehearsal (3 pts, P0)
@@ -132,9 +140,9 @@ CAB-802: Dry Run + Script + Video Backup (3 pts)
 - ~~CAB-362~~ ✅ (PR #558), ~~CAB-1149~~ ✅ (meta-ticket, closed)
 - CAB-709: UAC for LLM (5 pts) — DEFERRED (archived, no impl target)
 
-### Track 5 — SEO + Content (16 pts) — 11/16 pts done
+### Track 5 — SEO + Content (16 pts) ✅ — ALL DONE (16/16 pts)
 - ~~CAB-1187~~ ✅ (stoa-docs PR #48), ~~CAB-1162~~ ✅ (PR #564)
-- CAB-1181: Interactive Diagrams MDX (5 pts)
+- ~~CAB-1181~~ ✅ (stoa-docs PRs #52-#58) — 4 JSX components + 7 Mermaid conversions across 10 ADRs
 
 ## 🚫 BLOCKED
 

--- a/plan.md
+++ b/plan.md
@@ -183,7 +183,7 @@
 
 ### Backlog — Long-term (parked in cycle, not committed)
 
-- CAB-1181: [Docs] Interactive React Diagrams in Docusaurus (5 pts, P2)
+- ~~CAB-1181: [Docs] Interactive React Diagrams in Docusaurus (5 pts, P2) — DONE (stoa-docs PRs #52-#58)~~
 - CAB-601: Status Page — superseded by CAB-1175
 - CAB-571: Error Snapshot Network/TLS (P2)
 - CAB-570: Error Snapshot Backend/NetworkPolicy (P2)


### PR DESCRIPTION
## Summary
- Add Interactive Diagram Strategy section to `.claude/rules/documentation.md`
- Mark CAB-1181 complete in memory.md (5 pts, stoa-docs PRs #52-#58)
- Mark Track 5 SEO+Content as ALL DONE (16/16 pts)
- Fix ADR numbering (001-044, next: 045)

Ship mode — state file update only.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>