### PR TITLE
docs: update state files with CAB-374 MEGA + CAB-1291 + CAB-1154

### DIFF
--- a/memory.md
+++ b/memory.md
@@ -1,6 +1,6 @@
 # STOA Memory
 
-> Dernière MAJ: 2026-02-16 (session 14 — CAB-1162 SEO Tracking + CAB-1187 Blog Batch 7)
+> Dernière MAJ: 2026-02-16 (session 16 — CAB-374 MEGA + CAB-1291 + CAB-1154)
 
 ## ✅ DONE
 
@@ -109,6 +109,15 @@
   - PR #57: GitOpsArchitecture (ADR-040, 4 tabs) + MigrationArchitecture (ADR-034, 3 tabs) + ADR-001 Mermaid
   - PR #58: ADR-039 (mTLS pipeline), ADR-004 (adapter pattern), ADR-006 (mixin composition) — all Mermaid
   - Total: 4 JSX components + 7 Mermaid conversions across 10 ADRs + 4 concept pages
+- CAB-1154: Algolia DocSearch LIVE (1 pt) — stoa-docs PR #49
+- CAB-1291: API Test Coverage & Quality (34 pts) — PR #576 (142 tests, 14 modules)
+- CAB-374: Deployment Lifecycle MEGA (34 pts) — 3 phases, 3 repos
+  - CAB-1353: Deployment Lifecycle API (8 pts) — PR #570
+  - CAB-1354: Deploy Event Notifications (5 pts) — PR #570
+  - CAB-1352: ADR-045 Deployment Lifecycle (5 pts) — stoa-docs PR #56
+  - CAB-1355: Console UI Deployment Dashboard (8 pts) — PR #573
+  - CAB-1356: stoactl deploy commands (5 pts) — stoactl PR #7
+  - CAB-1357: E2E BDD Deployment Lifecycle (3 pts) — PR #574
 
 ## 🔴 IN PROGRESS
 
@@ -120,7 +129,7 @@ CAB-802: Dry Run + Script + Video Backup (3 pts)
 - [ ] Video backup filmée
 - Known: API creation requires GitLab → use Console UI; rate limiting not configured; httpbin flaky
 
-## 📋 NEXT — Cycle 8 (Feb 16-22) — 5 Tracks, 160 pts scoped | Done: 197 pts (28 issues)
+## 📋 NEXT — Cycle 8 (Feb 16-22) — 5 Tracks, 339 pts scoped | Done: 266 pts (37 issues)
 
 ### Track 1 — Demo Finale (6 pts)
 - CAB-1151: Dress Rehearsal (3 pts, P0)
@@ -128,7 +137,7 @@ CAB-802: Dry Run + Script + Video Backup (3 pts)
 
 ### Track 2 — Community Infrastructure (11 pts, P0) — DONE ✅
 - ~~CAB-1152~~ + ~~CAB-1182~~ — PR #525 merged
-- Remaining for stoa-docs: Algolia DocSearch, Announcement bar (separate repo)
+- ~~CAB-1154~~ Algolia DocSearch LIVE (PR #49), Announcement bar (separate repo)
 
 ### Track 3 — DX Remediation (14 pts, fixes CAB-1035) ✅ — ALL DONE
 - ~~CAB-1170~~ ✅ (PRs #529+#530), ~~CAB-1172~~ ✅ (PR #534)
@@ -152,7 +161,7 @@ CAB-802: Dry Run + Script + Video Backup (3 pts)
 - Demo MVP: mardi 24 février 2026
 - Présentation "ESB is Dead" même jour
 - docs.gostoa.dev = 37 articles, 0 "Coming Soon"
-- ADR numbering: stoa-docs owns numbers (001-043). Next: **ADR-044**
+- ADR numbering: stoa-docs owns numbers (001-045). Next: **ADR-046**
 - Velocity C7: 436 pts / 32 issues / 22 PRs en 7 jours = 62 pts/jour
 - Velocity C8 target: 160 pts (5 tracks parallèles, AI Factory optimized)
 - Portal 2FA for cert upload: user requirement from Council — use Keycloak TOTP step-up

--- a/plan.md
+++ b/plan.md
@@ -46,12 +46,12 @@
 
 ## Cycle 8 (Feb 16–22) — CURRENT
 
-**Scope**: 339 pts (active) | **Done**: 134 pts (40%) | **Velocity**: 26 issues closed
+**Scope**: 339 pts (active) | **Done**: 266 pts (78%) | **Velocity**: 37 issues closed
 **Theme**: Demo finale + Staging V1++ + DX Remediation + Community Launch Prep + SaaS MVP
 **Fill-cycle**: +13 Quick Wins promoted (2026-02-15); +30 backlog items promoted to cycle (2026-02-16, 526 pts)
 **Backlog in cycle**: ~604 pts (18 new MEGAs + 12 strategic/business items + legacy parked)
 
-### Done (25 issues)
+### Done (37 issues)
 
 - [x] CAB-353: Go/No-Go Checklist 3 Months (5 pts) — PR #482 (9.00/10 → GO)
 - [x] CAB-1146: Baseline PROD — Documenter etat de reference avant freeze (P1)
@@ -79,6 +79,16 @@
 - [x] CAB-1162: SEO Tracking — Looker Studio + Search Console archive (3 pts) — PR #564
 - [x] CAB-1187: [SEO] Blog Batch 7 — 5 Articles Week of Feb 17 (8 pts) — stoa-docs PR #48
 - [x] CAB-1289: [MEGA] Gateway Test Coverage & Quality (34 pts) — PR #566 (106 tests, -620 LOC dead code)
+- [x] CAB-1154: Algolia DocSearch LIVE (1 pt) — stoa-docs PR #49
+- [x] CAB-1181: [Docs] Interactive Mermaid Diagrams (5 pts) — stoa-docs PRs #52-#58
+- [x] CAB-1291: [MEGA] API Test Coverage (34 pts) — PR #576 (142 tests, 14 modules)
+- [x] CAB-374: [MEGA] Deployment Lifecycle (34 pts) — 3 phases, 3 repos
+  - [x] CAB-1353: [API] Deployment Lifecycle API (8 pts) — PR #570
+  - [x] CAB-1354: [API] Deploy Event Notifications (5 pts) — PR #570
+  - [x] CAB-1352: [Docs] ADR-045 Deployment Lifecycle (5 pts) — stoa-docs PR #56
+  - [x] CAB-1355: [UI] Console Deployment Dashboard (8 pts) — PR #573
+  - [x] CAB-1356: [CLI] stoactl deploy commands (5 pts) — stoactl PR #7
+  - [x] CAB-1357: [E2E] Deployment Lifecycle BDD tests (3 pts) — PR #574
 
 ### In Progress
 
@@ -89,7 +99,6 @@
   - [ ] Repetition #1 (mercredi 19) — timer 5 min
   - [ ] Repetition #2 (vendredi 21) — avec Cedric comme temoin
   - [ ] Video backup filmee
-- [~] CAB-1154: Algolia DocSearch — Soumettre candidature (1 pt, P1)
 
 ### Todo
 
@@ -103,10 +112,9 @@
 - [x] CAB-1172: [DX] Auto-approve free-tier subscriptions (3 pts, P2) — PR #534 (Council 8.50/10)
 - [x] CAB-1173: [DX] MCP guide for developers — zero kubectl (3 pts, P2) — stoa-docs PR #46
 
-### Backlog — Community Infrastructure (CAB-1152 sub-tickets) — 5/6 Done
+### Backlog — Community Infrastructure (CAB-1152 sub-tickets) — 6/6 Done ✅
 
 - [x] CAB-1153: Activer GitHub Discussions (1 pt, P1)
-- [~] CAB-1154: Algolia DocSearch — Soumettre candidature (1 pt, P1)
 - [x] CAB-1155: FUNDING.yml — Activer GitHub Sponsors (P2)
 - [x] CAB-1156: Labelliser 10 issues "good first issue" (1 pt, P1)
 - [x] CAB-1157: Announcement Bar Docusaurus (P2)
@@ -134,7 +142,7 @@
 
 - [x] CAB-1289: [MEGA] Gateway Test Coverage & Quality — 27 Untested Modules (34 pts, P3) — PR #566 (Council 8.75/10)
 - [ ] CAB-1297: [MEGA] DX: Developer Experience — READMEs, .env.example, Onboarding (13 pts, P3) — Council 8.50/10
-- [ ] CAB-1291: [MEGA] Platform: API Test Coverage & Quality — 44 Untested Modules (34 pts, P3) — Council 8.00/10
+- [x] CAB-1291: [MEGA] Platform: API Test Coverage & Quality — 44 Untested Modules (34 pts, P3) — PR #576 (Council 8.00/10)
 - [ ] CAB-1294: [MEGA] DX: Portal Test Coverage & UX Completion — 26 Untested Modules (21 pts, P3) — Council 8.00/10
 - [ ] CAB-1290: [MEGA] Gateway: Live-Code Feature Completion — MCP Protocol + Observability (13 pts, P3) — Council 7.75/10
 - [ ] CAB-1299: [MEGA] Roadmap: UAC Spec + Protocol Binders + Dynamic Routing (34 pts, P3) — Council 7.75/10


### PR DESCRIPTION
## Summary
- Record completion of CAB-374 Deployment Lifecycle MEGA (34 pts) across 3 repos (6 sub-tickets)
- Record CAB-1291 API Test Coverage (34 pts, PR #576)
- Record CAB-1154 Algolia DocSearch LIVE (1 pt, stoa-docs PR #49)
- Record CAB-1181 Interactive Diagrams (5 pts, stoa-docs PRs #52-#58)
- Update Cycle 8 stats: 266/339 pts (78%), 37 issues closed
- Fix ADR numbering: 001-045, next ADR-046

## Test plan
- [ ] State file changes only — no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)