### PR TITLE
feat(gateway): add MCP protocol binder for UAC contracts (CAB-1299)

### DIFF
--- a/stoa-gateway/src/handlers/admin.rs
+++ b/stoa-gateway/src/handlers/admin.rs
@@ -26,7 +26,7 @@ use tracing::warn;
 use crate::proxy::credentials::BackendCredential;
 use crate::routes::{ApiRoute, PolicyEntry};
 use crate::state::AppState;
-use crate::uac::binders::{rest::RestBinder, ProtocolBinder};
+use crate::uac::binders::{mcp::McpBinder, rest::RestBinder, ProtocolBinder};
 use crate::uac::UacContractSpec;
 
 // =============================================================================
@@ -433,6 +433,16 @@ pub async fn upsert_contract(
         }
     };
 
+    // Auto-generate MCP tools from contract (CAB-1299 PR4)
+    let mcp_binder = McpBinder::new(state.tool_registry.clone());
+    let tools_count = match mcp_binder.bind(&contract).await {
+        Ok(_) => contract.endpoints.len(),
+        Err(e) => {
+            warn!(error = %e, contract = %key, "MCP binder failed");
+            0
+        }
+    };
+
     let status = if existed {
         StatusCode::OK
     } else {
@@ -440,7 +450,12 @@ pub async fn upsert_contract(
     };
     (
         status,
-        Json(serde_json::json!({"key": key, "status": "ok", "routes_generated": routes_count})),
+        Json(serde_json::json!({
+            "key": key,
+            "status": "ok",
+            "routes_generated": routes_count,
+            "tools_generated": tools_count,
+        })),
     )
         .into_response()
 }
@@ -472,10 +487,19 @@ pub async fn delete_contract(
         Some(_) => {
             // Cascade-delete generated routes (CAB-1299 PR3)
             let rest_binder = RestBinder::new(state.route_registry.clone());
-            let removed = rest_binder.unbind(&key).await.unwrap_or(0);
+            let routes_removed = rest_binder.unbind(&key).await.unwrap_or(0);
+
+            // Cascade-delete generated MCP tools (CAB-1299 PR4)
+            let mcp_binder = McpBinder::new(state.tool_registry.clone());
+            let tools_removed = mcp_binder.unbind(&key).await.unwrap_or(0);
+
             (
                 StatusCode::OK,
-                Json(serde_json::json!({"status": "deleted", "routes_removed": removed})),
+                Json(serde_json::json!({
+                    "status": "deleted",
+                    "routes_removed": routes_removed,
+                    "tools_removed": tools_removed,
+                })),
             )
                 .into_response()
         }
@@ -1392,6 +1416,7 @@ mod tests {
             .unwrap();
         let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(data["routes_generated"], 1); // 1 endpoint in sample_contract_json
+        assert_eq!(data["tools_generated"], 1);
 
         // Verify route is in the route registry
         assert_eq!(state.route_registry.count(), 1);
@@ -1400,6 +1425,12 @@ mod tests {
         let route = route.unwrap();
         assert_eq!(route.path_prefix, "/apis/acme/payment-api/payments/{id}");
         assert_eq!(route.contract_key.as_deref(), Some("acme:payment-api"));
+
+        // Verify MCP tool is in the tool registry (no operation_id → fallback name)
+        assert_eq!(state.tool_registry.count(), 1);
+        assert!(state
+            .tool_registry
+            .exists("uac:acme:payment-api:payment-api-0"));
     }
 
     #[tokio::test]
@@ -1427,7 +1458,9 @@ mod tests {
             .unwrap();
         let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(data["routes_removed"], 1);
+        assert_eq!(data["tools_removed"], 1);
         assert_eq!(state.route_registry.count(), 0);
+        assert_eq!(state.tool_registry.count(), 0);
     }
 
     #[tokio::test]
@@ -1508,5 +1541,90 @@ mod tests {
             .get("uac:acme:sensitive-api:0")
             .unwrap();
         assert_eq!(route.classification, Some(crate::uac::Classification::VH));
+    }
+
+    #[tokio::test]
+    async fn test_contract_upsert_generates_mcp_tools() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state.clone());
+
+        let contract = serde_json::json!({
+            "name": "orders",
+            "version": "1.0.0",
+            "tenant_id": "acme",
+            "classification": "H",
+            "endpoints": [
+                {
+                    "path": "/orders",
+                    "methods": ["GET"],
+                    "backend_url": "https://backend.acme.com/orders",
+                    "operation_id": "list_orders"
+                },
+                {
+                    "path": "/orders",
+                    "methods": ["POST"],
+                    "backend_url": "https://backend.acme.com/orders",
+                    "operation_id": "create_order"
+                }
+            ],
+            "status": "published"
+        });
+
+        let response = app
+            .oneshot(auth_json_req("POST", "/contracts", contract))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["tools_generated"], 2);
+
+        // Both tools registered
+        assert_eq!(state.tool_registry.count(), 2);
+        assert!(state.tool_registry.exists("uac:acme:orders:list_orders"));
+        assert!(state.tool_registry.exists("uac:acme:orders:create_order"));
+    }
+
+    #[tokio::test]
+    async fn test_contract_delete_cascades_tools() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state.clone());
+
+        // Create contract → generates tools
+        let _ = app
+            .clone()
+            .oneshot(auth_json_req("POST", "/contracts", sample_contract_json()))
+            .await
+            .unwrap();
+        assert_eq!(state.tool_registry.count(), 1);
+
+        // Delete contract → cascades tool removal
+        let response = app
+            .oneshot(auth_req("DELETE", "/contracts/acme:payment-api"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(state.tool_registry.count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_tools_visible_via_list() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state.clone());
+
+        let _ = app
+            .oneshot(auth_json_req("POST", "/contracts", sample_contract_json()))
+            .await
+            .unwrap();
+
+        // Tool should be visible in tool registry
+        let tools = state.tool_registry.list(Some("acme"));
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "uac:acme:payment-api:payment-api-0");
+        assert_eq!(tools[0].tenant_id.as_deref(), Some("acme"));
     }
 }

--- a/stoa-gateway/src/mcp/tools/dynamic_tool.rs
+++ b/stoa-gateway/src/mcp/tools/dynamic_tool.rs
@@ -114,6 +114,10 @@ impl Tool for DynamicTool {
         self.action
     }
 
+    fn tenant_id(&self) -> Option<&str> {
+        Some(&self.tenant_id)
+    }
+
     async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolResult, ToolError> {
         // Tenant isolation: CRD namespace must match caller tenant
         // Public tools (catalog API bridge) skip this check

--- a/stoa-gateway/src/mcp/tools/mod.rs
+++ b/stoa-gateway/src/mcp/tools/mod.rs
@@ -232,6 +232,11 @@ pub trait Tool: Send + Sync {
         Action::Read
     }
 
+    /// Owning tenant ID (None = global tool visible to all tenants)
+    fn tenant_id(&self) -> Option<&str> {
+        None
+    }
+
     /// Execute the tool with given arguments
     async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolResult, ToolError>;
 
@@ -246,7 +251,7 @@ pub trait Tool: Send + Sync {
             input_schema: self.input_schema(),
             output_schema: self.output_schema(),
             annotations: Some(annotations),
-            tenant_id: None, // Tools are global by default; set per-tenant via admin API
+            tenant_id: self.tenant_id().map(|s| s.to_string()),
         }
     }
 }
@@ -344,6 +349,16 @@ impl ToolRegistry {
     #[allow(dead_code)] // Used by k8s::CrdWatcher when k8s feature enabled
     pub fn names(&self) -> Vec<String> {
         self.tools.read().keys().cloned().collect()
+    }
+
+    /// Remove all tools whose name starts with a given prefix.
+    /// Used by MCP protocol binder to remove contract-generated tools.
+    /// Returns the number of tools removed.
+    pub fn remove_by_prefix(&self, prefix: &str) -> usize {
+        let mut tools = self.tools.write();
+        let before = tools.len();
+        tools.retain(|name, _| !name.starts_with(prefix));
+        before - tools.len()
     }
 }
 

--- a/stoa-gateway/src/uac/binders/mcp.rs
+++ b/stoa-gateway/src/uac/binders/mcp.rs
@@ -1,0 +1,404 @@
+//! MCP Protocol Binder
+//!
+//! Transforms a UAC contract into MCP tools registered in the ToolRegistry.
+//! Each endpoint in the contract becomes a DynamicTool with the naming pattern:
+//! `{tenant_id}_{contract_name}_{operation_id}`
+
+use std::sync::Arc;
+
+use crate::mcp::tools::dynamic_tool::DynamicTool;
+use crate::mcp::tools::{ToolAnnotations, ToolDefinition, ToolRegistry, ToolSchema};
+use crate::uac::schema::UacContractSpec;
+use crate::uac::Action;
+
+use super::{BindingOutput, ProtocolBinder};
+
+/// MCP protocol binder — generates MCP tools from UAC contracts.
+pub struct McpBinder {
+    tool_registry: Arc<ToolRegistry>,
+}
+
+impl McpBinder {
+    /// Create a new MCP binder backed by the given tool registry.
+    pub fn new(tool_registry: Arc<ToolRegistry>) -> Self {
+        Self { tool_registry }
+    }
+
+    /// Tool name prefix for a contract (used for cascade deletion).
+    pub fn tool_prefix(contract_key: &str) -> String {
+        // contract_key = "tenant_id:contract_name"
+        // prefix = "uac:tenant_id:contract_name:"
+        format!("uac:{}:", contract_key)
+    }
+
+    /// Map HTTP method to UAC Action.
+    fn method_to_action(method: &str) -> Action {
+        match method.to_uppercase().as_str() {
+            "GET" => Action::Read,
+            "POST" => Action::Create,
+            "PUT" | "PATCH" => Action::Update,
+            "DELETE" => Action::Delete,
+            _ => Action::Read,
+        }
+    }
+
+    /// Generate tool definitions from a contract (pure function, no side effects).
+    pub fn generate_tool_definitions(contract: &UacContractSpec) -> Vec<ToolDefinition> {
+        contract
+            .endpoints
+            .iter()
+            .enumerate()
+            .map(|(i, endpoint)| {
+                let op_id = endpoint
+                    .operation_id
+                    .clone()
+                    .unwrap_or_else(|| format!("{}-{}", contract.name, i));
+
+                let tool_name = format!("uac:{}:{}:{}", contract.tenant_id, contract.name, op_id);
+
+                // Use first method for action hint (most endpoints have one primary method)
+                let primary_method = endpoint
+                    .methods
+                    .first()
+                    .map(|m| m.as_str())
+                    .unwrap_or("GET");
+                let action = Self::method_to_action(primary_method);
+
+                let description = format!(
+                    "{} {} — {} [{}]",
+                    primary_method, endpoint.path, contract.name, contract.tenant_id
+                );
+
+                // Build input schema from endpoint schema or default empty object
+                let input_schema = endpoint
+                    .input_schema
+                    .as_ref()
+                    .map(crate::mcp::tools::dynamic_tool::schema_from_value)
+                    .unwrap_or_else(|| ToolSchema {
+                        schema_type: "object".to_string(),
+                        properties: Default::default(),
+                        required: vec![],
+                    });
+
+                ToolDefinition {
+                    name: tool_name,
+                    description,
+                    input_schema,
+                    output_schema: endpoint.output_schema.clone(),
+                    annotations: Some(ToolAnnotations::from_action(action)),
+                    tenant_id: Some(contract.tenant_id.clone()),
+                }
+            })
+            .collect()
+    }
+
+    /// Create DynamicTool instances from a contract for registration.
+    fn create_dynamic_tools(contract: &UacContractSpec) -> Vec<Arc<dyn crate::mcp::tools::Tool>> {
+        contract
+            .endpoints
+            .iter()
+            .enumerate()
+            .map(|(i, endpoint)| {
+                let op_id = endpoint
+                    .operation_id
+                    .clone()
+                    .unwrap_or_else(|| format!("{}-{}", contract.name, i));
+
+                let tool_name = format!("uac:{}:{}:{}", contract.tenant_id, contract.name, op_id);
+
+                let primary_method = endpoint
+                    .methods
+                    .first()
+                    .map(|m| m.as_str())
+                    .unwrap_or("GET");
+                let action = Self::method_to_action(primary_method);
+
+                let description = format!(
+                    "{} {} — {} [{}]",
+                    primary_method, endpoint.path, contract.name, contract.tenant_id
+                );
+
+                let input_schema = endpoint
+                    .input_schema
+                    .as_ref()
+                    .map(crate::mcp::tools::dynamic_tool::schema_from_value)
+                    .unwrap_or_else(|| ToolSchema {
+                        schema_type: "object".to_string(),
+                        properties: Default::default(),
+                        required: vec![],
+                    });
+
+                let tool = DynamicTool::new(
+                    &tool_name,
+                    &description,
+                    &endpoint.backend_url,
+                    primary_method,
+                    input_schema,
+                    &contract.tenant_id,
+                )
+                .with_action(action)
+                .with_annotations(ToolAnnotations::from_action(action));
+
+                Arc::new(tool) as Arc<dyn crate::mcp::tools::Tool>
+            })
+            .collect()
+    }
+}
+
+impl ProtocolBinder for McpBinder {
+    async fn bind(&self, contract: &UacContractSpec) -> Result<BindingOutput, String> {
+        let contract_key = format!("{}:{}", contract.tenant_id, contract.name);
+        let prefix = Self::tool_prefix(&contract_key);
+
+        // Remove existing tools for this contract (idempotent re-bind)
+        self.tool_registry.remove_by_prefix(&prefix);
+
+        // Create and register new tools
+        let tools = Self::create_dynamic_tools(contract);
+        let count = tools.len();
+
+        for tool in &tools {
+            self.tool_registry.register(Arc::clone(tool));
+        }
+
+        tracing::info!(
+            contract = %contract_key,
+            tools = count,
+            "MCP binder: tools generated"
+        );
+
+        // Return definitions for the response
+        let definitions = Self::generate_tool_definitions(contract);
+        Ok(BindingOutput::Tools(definitions))
+    }
+
+    async fn unbind(&self, contract_key: &str) -> Result<usize, String> {
+        let prefix = Self::tool_prefix(contract_key);
+        let removed = self.tool_registry.remove_by_prefix(&prefix);
+
+        tracing::info!(
+            contract = %contract_key,
+            removed,
+            "MCP binder: tools removed"
+        );
+
+        Ok(removed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::uac::classifications::Classification;
+    use crate::uac::schema::{ContractStatus, UacContractSpec, UacEndpoint};
+
+    fn sample_contract() -> UacContractSpec {
+        let mut spec = UacContractSpec::new("payments", "acme");
+        spec.status = ContractStatus::Published;
+        spec.endpoints = vec![
+            UacEndpoint {
+                path: "/payments".to_string(),
+                methods: vec!["GET".to_string(), "POST".to_string()],
+                backend_url: "https://backend.acme.com/v1/payments".to_string(),
+                operation_id: Some("list_payments".to_string()),
+                input_schema: None,
+                output_schema: None,
+            },
+            UacEndpoint {
+                path: "/payments/{id}".to_string(),
+                methods: vec!["DELETE".to_string()],
+                backend_url: "https://backend.acme.com/v1/payments".to_string(),
+                operation_id: Some("delete_payment".to_string()),
+                input_schema: None,
+                output_schema: None,
+            },
+        ];
+        spec
+    }
+
+    #[test]
+    fn test_tool_prefix() {
+        assert_eq!(
+            McpBinder::tool_prefix("acme:payments"),
+            "uac:acme:payments:"
+        );
+    }
+
+    #[test]
+    fn test_method_to_action() {
+        assert_eq!(McpBinder::method_to_action("GET"), Action::Read);
+        assert_eq!(McpBinder::method_to_action("POST"), Action::Create);
+        assert_eq!(McpBinder::method_to_action("PUT"), Action::Update);
+        assert_eq!(McpBinder::method_to_action("PATCH"), Action::Update);
+        assert_eq!(McpBinder::method_to_action("DELETE"), Action::Delete);
+        assert_eq!(McpBinder::method_to_action("OPTIONS"), Action::Read);
+    }
+
+    #[test]
+    fn test_generate_definitions_count() {
+        let contract = sample_contract();
+        let defs = McpBinder::generate_tool_definitions(&contract);
+        assert_eq!(defs.len(), 2);
+    }
+
+    #[test]
+    fn test_generate_definitions_tool_names() {
+        let contract = sample_contract();
+        let defs = McpBinder::generate_tool_definitions(&contract);
+        assert_eq!(defs[0].name, "uac:acme:payments:list_payments");
+        assert_eq!(defs[1].name, "uac:acme:payments:delete_payment");
+    }
+
+    #[test]
+    fn test_generate_definitions_name_fallback() {
+        let mut contract = sample_contract();
+        contract.endpoints[0].operation_id = None;
+        let defs = McpBinder::generate_tool_definitions(&contract);
+        assert_eq!(defs[0].name, "uac:acme:payments:payments-0");
+    }
+
+    #[test]
+    fn test_generate_definitions_description() {
+        let contract = sample_contract();
+        let defs = McpBinder::generate_tool_definitions(&contract);
+        assert!(defs[0].description.contains("GET"));
+        assert!(defs[0].description.contains("/payments"));
+        assert!(defs[0].description.contains("acme"));
+    }
+
+    #[test]
+    fn test_generate_definitions_action_from_method() {
+        let contract = sample_contract();
+        let defs = McpBinder::generate_tool_definitions(&contract);
+        // First endpoint: GET → read_only_hint: true
+        let ann0 = defs[0].annotations.as_ref().expect("annotations");
+        assert_eq!(ann0.read_only_hint, Some(true));
+        // Second endpoint: DELETE → destructive_hint: true
+        let ann1 = defs[1].annotations.as_ref().expect("annotations");
+        assert_eq!(ann1.destructive_hint, Some(true));
+    }
+
+    #[test]
+    fn test_generate_definitions_tenant_id() {
+        let contract = sample_contract();
+        let defs = McpBinder::generate_tool_definitions(&contract);
+        assert_eq!(defs[0].tenant_id.as_deref(), Some("acme"));
+        assert_eq!(defs[1].tenant_id.as_deref(), Some("acme"));
+    }
+
+    #[test]
+    fn test_generate_definitions_with_input_schema() {
+        let mut contract = sample_contract();
+        contract.endpoints[0].input_schema = Some(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "amount": {"type": "number"}
+            },
+            "required": ["amount"]
+        }));
+        let defs = McpBinder::generate_tool_definitions(&contract);
+        assert_eq!(defs[0].input_schema.properties.len(), 1);
+        assert!(defs[0].input_schema.properties.contains_key("amount"));
+        assert_eq!(defs[0].input_schema.required, vec!["amount"]);
+    }
+
+    #[test]
+    fn test_generate_definitions_with_output_schema() {
+        let mut contract = sample_contract();
+        contract.endpoints[0].output_schema = Some(serde_json::json!({"type": "array"}));
+        let defs = McpBinder::generate_tool_definitions(&contract);
+        assert!(defs[0].output_schema.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_bind_registers_tools() {
+        let registry = Arc::new(ToolRegistry::new());
+        let binder = McpBinder::new(registry.clone());
+
+        let contract = sample_contract();
+        let result = binder.bind(&contract).await;
+        assert!(result.is_ok());
+
+        // Tools should be in the registry
+        assert_eq!(registry.count(), 2);
+        assert!(registry.exists("uac:acme:payments:list_payments"));
+        assert!(registry.exists("uac:acme:payments:delete_payment"));
+    }
+
+    #[tokio::test]
+    async fn test_bind_replaces_existing_tools() {
+        let registry = Arc::new(ToolRegistry::new());
+        let binder = McpBinder::new(registry.clone());
+
+        let contract = sample_contract();
+        binder.bind(&contract).await.expect("first bind");
+        assert_eq!(registry.count(), 2);
+
+        // Re-bind with fewer endpoints
+        let mut updated = sample_contract();
+        updated.endpoints.pop();
+        binder.bind(&updated).await.expect("second bind");
+        assert_eq!(registry.count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_unbind_removes_tools() {
+        let registry = Arc::new(ToolRegistry::new());
+        let binder = McpBinder::new(registry.clone());
+
+        let contract = sample_contract();
+        binder.bind(&contract).await.expect("bind");
+        assert_eq!(registry.count(), 2);
+
+        let removed = binder.unbind("acme:payments").await.expect("unbind");
+        assert_eq!(removed, 2);
+        assert_eq!(registry.count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_unbind_nonexistent_returns_zero() {
+        let registry = Arc::new(ToolRegistry::new());
+        let binder = McpBinder::new(registry.clone());
+
+        let removed = binder.unbind("unknown:contract").await.expect("unbind");
+        assert_eq!(removed, 0);
+    }
+
+    #[tokio::test]
+    async fn test_bind_does_not_affect_non_contract_tools() {
+        let registry = Arc::new(ToolRegistry::new());
+        let binder = McpBinder::new(registry.clone());
+
+        // Register a manually added tool
+        let manual_tool = Arc::new(DynamicTool::new(
+            "manual_tool",
+            "Manual",
+            "http://localhost",
+            "GET",
+            ToolSchema {
+                schema_type: "object".to_string(),
+                properties: Default::default(),
+                required: vec![],
+            },
+            "acme",
+        ));
+        registry.register(manual_tool);
+
+        let contract = sample_contract();
+        binder.bind(&contract).await.expect("bind");
+        assert_eq!(registry.count(), 3); // 1 manual + 2 contract
+
+        binder.unbind("acme:payments").await.expect("unbind");
+        assert_eq!(registry.count(), 1); // manual tool survives
+        assert!(registry.exists("manual_tool"));
+    }
+
+    #[test]
+    fn test_classification_does_not_affect_tool_generation() {
+        let mut contract = sample_contract();
+        contract.classification = Classification::Vvh;
+        let defs = McpBinder::generate_tool_definitions(&contract);
+        // Classification is route-level concern, tools still generated
+        assert_eq!(defs.len(), 2);
+    }
+}

--- a/stoa-gateway/src/uac/binders/mod.rs
+++ b/stoa-gateway/src/uac/binders/mod.rs
@@ -6,8 +6,10 @@
 //!
 //! "Define Once, Expose Everywhere."
 
+pub mod mcp;
 pub mod rest;
 
+use crate::mcp::tools::ToolDefinition;
 use crate::routes::ApiRoute;
 use crate::uac::schema::UacContractSpec;
 
@@ -16,7 +18,8 @@ use crate::uac::schema::UacContractSpec;
 pub enum BindingOutput {
     /// REST routes generated from a contract.
     Routes(Vec<ApiRoute>),
-    // Future: Tools(Vec<ToolDefinition>), GraphQL schema, gRPC descriptors, etc.
+    /// MCP tool definitions generated from a contract.
+    Tools(Vec<ToolDefinition>),
 }
 
 /// Protocol binder trait — transforms contracts into protocol artifacts.


### PR DESCRIPTION
## Summary
- MCP protocol binder transforms UAC contracts into DynamicTool instances in the ToolRegistry
- Tool naming convention: `uac:{tenant}:{contract}:{operation_id}` with index fallback
- Cascade deletion removes all contract tools via `remove_by_prefix()` on contract delete
- Tool trait gains `tenant_id()` method so DynamicTool properly reports its owning tenant
- Admin handlers wire MCP binder alongside REST binder (both fire on contract create/delete)

PR 4 of 7 for CAB-1299 (UAC Spec + Protocol Binders). Depends on PR #586 (REST binder, merged).

## Test plan
- [x] 16 unit tests for McpBinder (tool naming, actions, schemas, bind/unbind, cascade)
- [x] 3 integration tests via admin API (create→tools registered, delete→tools removed, list→tenant-scoped)
- [x] All 825 existing tests pass (743 lib + 15 contract + 30 integration + 15 resilience + 22 security)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>