### PR TITLE
feat(gateway): classification-OPA integration + soft-mode enforcement (CAB-1299)

### DIFF
--- a/stoa-gateway/src/config.rs
+++ b/stoa-gateway/src/config.rs
@@ -266,6 +266,12 @@ pub struct Config {
     #[serde(default = "default_fallback_timeout_ms")]
     pub fallback_timeout_ms: u64,
 
+    // === Classification Enforcement (CAB-1299) ===
+    /// Enable classification-based enforcement for contract routes (soft mode: log only).
+    /// Env: STOA_CLASSIFICATION_ENFORCEMENT_ENABLED
+    #[serde(default)]
+    pub classification_enforcement_enabled: bool,
+
     // === Per-Upstream Circuit Breaker (CAB-362) ===
     /// Failure threshold before opening circuit (default: 5)
     /// Env: STOA_CB_FAILURE_THRESHOLD
@@ -564,6 +570,7 @@ impl Default for Config {
             fallback_enabled: false,
             fallback_chains: None,
             fallback_timeout_ms: default_fallback_timeout_ms(),
+            classification_enforcement_enabled: false,
             cb_failure_threshold: default_cb_failure_threshold(),
             cb_reset_timeout_secs: default_cb_reset_timeout_secs(),
             cb_success_threshold: default_cb_success_threshold(),
@@ -714,6 +721,12 @@ mod tests {
         assert_eq!(config.quota_sync_interval_secs, 60);
         assert_eq!(config.quota_default_rate_per_minute, 60);
         assert_eq!(config.quota_default_daily_limit, 10_000);
+    }
+
+    #[test]
+    fn test_default_classification_enforcement_disabled() {
+        let config = Config::default();
+        assert!(!config.classification_enforcement_enabled);
     }
 
     #[test]

--- a/stoa-gateway/src/proxy/dynamic.rs
+++ b/stoa-gateway/src/proxy/dynamic.rs
@@ -68,6 +68,33 @@ pub async fn dynamic_proxy(State(state): State<AppState>, request: Request<Body>
             .into_response();
     }
 
+    // Soft-mode classification enforcement (CAB-1299)
+    // If a route has a classification (from a UAC contract), log the enforcement
+    // decision but do NOT deny — this is observability-only until graduation.
+    if let (Some(classification), Some(ref enforcer)) =
+        (route.classification, &state.classification_enforcer)
+    {
+        let ctx = crate::uac::enforcer::EnforcementContext::new(
+            &route.tenant_id,
+            "anonymous", // TODO: extract from JWT when wired
+        );
+        let decision = enforcer.enforce(classification, &route.methods, &ctx);
+        if decision.is_allowed() {
+            debug!(
+                route_id = %route.id,
+                classification = %classification,
+                policy_version = ?decision.policy_version(),
+                "Classification enforcement: ALLOW (soft mode)"
+            );
+        } else {
+            warn!(
+                route_id = %route.id,
+                classification = %classification,
+                "Classification enforcement: DENY logged (soft mode — not blocking)"
+            );
+        }
+    }
+
     // Per-upstream circuit breaker (CAB-362)
     let cb = state.circuit_breakers.get_or_create(&route.id);
     if !cb.allow_request() {

--- a/stoa-gateway/src/state.rs
+++ b/stoa-gateway/src/state.rs
@@ -24,6 +24,8 @@ use crate::resilience::{
     CircuitBreaker, CircuitBreakerConfig, CircuitBreakerRegistry, FallbackChain,
 };
 use crate::routes::{PolicyRegistry, RouteRegistry};
+use crate::uac::cache::VersionedPolicyCache;
+use crate::uac::enforcer::ClassificationEnforcer;
 use crate::uac::{Action, ContractRegistry};
 
 /// Application state shared across all handlers
@@ -67,6 +69,9 @@ pub struct AppState {
     pub credential_store: Arc<CredentialStore>,
     /// UAC contract registry (CAB-1299)
     pub contract_registry: Arc<ContractRegistry>,
+    /// Classification-based enforcer for contract routes (CAB-1299)
+    /// None when classification enforcement is disabled.
+    pub classification_enforcer: Option<Arc<ClassificationEnforcer>>,
 }
 
 impl AppState {
@@ -255,6 +260,17 @@ impl AppState {
         // Initialize UAC contract registry (CAB-1299)
         let contract_registry = Arc::new(ContractRegistry::new());
 
+        // Initialize classification enforcer (CAB-1299) — soft mode
+        let classification_enforcer = if config.classification_enforcement_enabled {
+            let policy_cache = Arc::new(VersionedPolicyCache::new(3600));
+            let enforcer = ClassificationEnforcer::new(policy_cache);
+            tracing::info!("Classification enforcement enabled (soft mode — log only)");
+            Some(Arc::new(enforcer))
+        } else {
+            tracing::info!("Classification enforcement disabled");
+            None
+        };
+
         // Initialize mTLS stats (CAB-864)
         let mtls_stats = Arc::new(MtlsStats::new());
         if config.mtls.enabled {
@@ -293,6 +309,7 @@ impl AppState {
             quota_manager,
             credential_store,
             contract_registry,
+            classification_enforcer,
         }
     }
 

--- a/stoa-gateway/src/uac/cache.rs
+++ b/stoa-gateway/src/uac/cache.rs
@@ -7,8 +7,6 @@
 //! 2. Invalidating cache when Git version changes
 //! 3. TTL-based expiration for automatic refresh
 
-#![allow(dead_code)] // Infrastructure for UAC enforcement, wired incrementally
-
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -54,7 +52,8 @@ struct CacheEntry {
     /// Git commit hash when this was cached
     git_version: String,
 
-    /// When this entry was cached
+    /// When this entry was cached (audit metadata, not read in logic)
+    #[allow(dead_code)]
     cached_at: DateTime<Utc>,
 
     /// When this entry expires

--- a/stoa-gateway/src/uac/enforcer.rs
+++ b/stoa-gateway/src/uac/enforcer.rs
@@ -8,8 +8,6 @@
 //! 3. Policy version is logged for audit trail
 //! 4. Safe mode fallback when policies unavailable
 
-#![allow(dead_code)] // Infrastructure for UAC enforcement, wired incrementally
-
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{info, warn};
@@ -166,7 +164,7 @@ impl EnforcementDecision {
 /// UAC (Unified Access Control) Enforcer.
 ///
 /// Enforces policies based on classification and validates requirements.
-pub struct UacEnforcer {
+pub struct ClassificationEnforcer {
     /// Policy cache with version checking
     cache: Arc<VersionedPolicyCache>,
 
@@ -174,7 +172,7 @@ pub struct UacEnforcer {
     safe_mode: SafeModeConfig,
 }
 
-impl UacEnforcer {
+impl ClassificationEnforcer {
     /// Create a new enforcer with the given cache.
     pub fn new(cache: Arc<VersionedPolicyCache>) -> Self {
         Self {
@@ -306,10 +304,10 @@ impl UacEnforcer {
 mod tests {
     use super::*;
 
-    fn make_enforcer() -> UacEnforcer {
+    fn make_enforcer() -> ClassificationEnforcer {
         let cache = Arc::new(VersionedPolicyCache::new(3600));
         cache.set_version("test-version-123".to_string());
-        UacEnforcer::new(cache)
+        ClassificationEnforcer::new(cache)
     }
 
     fn make_context() -> EnforcementContext {
@@ -411,7 +409,7 @@ mod tests {
         let cache = Arc::new(VersionedPolicyCache::new(3600));
         // Don't set version - simulates unavailable policy service
 
-        let enforcer = UacEnforcer::new(cache).with_safe_mode(SafeModeConfig {
+        let enforcer = ClassificationEnforcer::new(cache).with_safe_mode(SafeModeConfig {
             mode: SafeMode::DenyAll,
             ..Default::default()
         });
@@ -429,7 +427,7 @@ mod tests {
         let cache = Arc::new(VersionedPolicyCache::new(3600));
         // Don't set version
 
-        let enforcer = UacEnforcer::new(cache).with_safe_mode(SafeModeConfig {
+        let enforcer = ClassificationEnforcer::new(cache).with_safe_mode(SafeModeConfig {
             mode: SafeMode::ForceReview,
             ..Default::default()
         });

--- a/stoa-gateway/src/uac/mod.rs
+++ b/stoa-gateway/src/uac/mod.rs
@@ -11,6 +11,7 @@ pub mod safe_mode;
 pub mod schema;
 
 pub use classifications::Classification;
+pub use enforcer::ClassificationEnforcer;
 pub use registry::ContractRegistry;
 pub use schema::{ContractStatus, UacContractSpec, UacEndpoint};
 

--- a/stoa-gateway/src/uac/safe_mode.rs
+++ b/stoa-gateway/src/uac/safe_mode.rs
@@ -7,8 +7,6 @@
 //! - ForceReview: Allow but require human review (balanced)
 //! - AllowCached: Allow if we have valid cached policies (risk of stale)
 
-#![allow(dead_code)] // Infrastructure for UAC enforcement, wired incrementally
-
 use serde::{Deserialize, Serialize};
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Rename dead `UacEnforcer` → `ClassificationEnforcer` in `uac/enforcer.rs` (distinct from OPA-based `UacEnforcer` in `state.rs`)
- Remove `#![allow(dead_code)]` from `cache.rs`, `safe_mode.rs`, `enforcer.rs` — infrastructure is now alive
- Add `classification_enforcement_enabled` config flag (default: `false`, env: `STOA_CLASSIFICATION_ENFORCEMENT_ENABLED`)
- Wire `ClassificationEnforcer` into `AppState` (optional, created only when enabled)
- Add soft-mode classification check in `proxy/dynamic.rs` — logs enforcement decision but never blocks requests

**PR 5 of 7** for CAB-1299 (UAC Spec + Protocol Binders + Dynamic Routing).

## Design
Two enforcers coexist:
- **`UacEnforcer`** (`state.rs`): OPA scope-based access control — unchanged, primary enforcer
- **`ClassificationEnforcer`** (`uac/enforcer.rs`): Classification-based policy requirements (H/VH/VVH) — now wired as optional second check

Soft mode means: `request → OPA scope check → classification check (log only) → proxy`. No request is ever denied by classification in Phase 1.

## Test plan
- [x] All 825 gateway tests pass (743 unit + 82 integration/contract/resilience/security)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets` clean (zero warnings)
- [x] Config default test added

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>