### PR TITLE
feat(api): auth security fixes + RBAC/JWT tests (CAB-1292)

### DIFF
--- a/control-plane-api/src/auth/dependencies.py
+++ b/control-plane-api/src/auth/dependencies.py
@@ -122,6 +122,21 @@ async def get_current_user(
             )
             raise JWTError(f"Invalid audience: {token_aud}. Expected: {list(valid_audiences)}")
 
+        # Deprecation warning for legacy audiences (control-plane-ui, stoa-portal)
+        # These clients should configure Audience Mappers in Keycloak to include
+        # 'control-plane-api' in the 'aud' claim. Legacy support will be removed
+        # after all clients have migrated (target: Q2 2026).
+        legacy_audiences = {"control-plane-ui", "stoa-portal"}
+        primary_audience = {settings.KEYCLOAK_CLIENT_ID}
+        if any(aud in legacy_audiences for aud in token_aud) and not any(aud in primary_audience for aud in token_aud):
+            logger.warning(
+                "DEPRECATION: Token uses legacy audience, migrate to Audience Mapper",
+                token_aud=token_aud,
+                azp=payload.get("azp"),
+                expected_audience=settings.KEYCLOAK_CLIENT_ID,
+                migration_deadline="Q2 2026",
+            )
+
         email = payload.get("email", "")
         username = payload.get("preferred_username", "")
         roles = payload.get("realm_access", {}).get("roles", [])

--- a/control-plane-api/tests/test_auth_operator.py
+++ b/control-plane-api/tests/test_auth_operator.py
@@ -3,17 +3,10 @@
 from unittest.mock import patch
 
 import pytest
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from src.auth.dependencies import User, get_current_user
-
-app = FastAPI()
-
-
-@app.get("/test-auth")
-async def test_endpoint(user: User = pytest.importorskip("fastapi").Depends(get_current_user)):
-    return {"user_id": user.id, "roles": user.roles}
 
 
 @pytest.mark.asyncio
@@ -24,11 +17,10 @@ async def test_operator_key_bypass(mock_settings):
     mock_settings.LOG_DEBUG_AUTH_TOKENS = False
     mock_settings.LOG_DEBUG_AUTH_PAYLOAD = False
 
-    # Re-create app with the patched dependency
     test_app = FastAPI()
 
     @test_app.get("/test-auth")
-    async def endpoint(user: User = pytest.importorskip("fastapi").Depends(get_current_user)):
+    async def endpoint(user: User = Depends(get_current_user)):
         return {"user_id": user.id, "roles": user.roles, "username": user.username}
 
     transport = ASGITransport(app=test_app)
@@ -55,7 +47,7 @@ async def test_invalid_operator_key_rejected(mock_settings):
     test_app = FastAPI()
 
     @test_app.get("/test-auth")
-    async def endpoint(user: User = pytest.importorskip("fastapi").Depends(get_current_user)):
+    async def endpoint(user: User = Depends(get_current_user)):
         return {"user_id": user.id}
 
     transport = ASGITransport(app=test_app)
@@ -78,7 +70,7 @@ async def test_no_auth_returns_401(mock_settings):
     test_app = FastAPI()
 
     @test_app.get("/test-auth")
-    async def endpoint(user: User = pytest.importorskip("fastapi").Depends(get_current_user)):
+    async def endpoint(user: User = Depends(get_current_user)):
         return {"user_id": user.id}
 
     transport = ASGITransport(app=test_app)

--- a/control-plane-api/tests/test_jwt_validation.py
+++ b/control-plane-api/tests/test_jwt_validation.py
@@ -1,0 +1,148 @@
+"""Tests for JWT validation in get_current_user (CAB-1292 Phase 2)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.auth.dependencies import User, get_current_user
+
+
+def _make_app():
+    app = FastAPI()
+
+    @app.get("/me")
+    async def me(user: User = pytest.importorskip("fastapi").Depends(get_current_user)):
+        return {"id": user.id, "email": user.email, "tenant_id": user.tenant_id, "roles": user.roles}
+
+    return app
+
+
+def _base_payload(**overrides):
+    base = {
+        "sub": "user-123",
+        "email": "user@acme.com",
+        "preferred_username": "testuser",
+        "realm_access": {"roles": ["viewer"]},
+        "tenant_id": "acme",
+        "aud": ["control-plane-api"],
+        "azp": "control-plane-ui",
+        "iss": "https://auth.gostoa.dev/realms/stoa",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def mock_settings():
+    with patch("src.auth.dependencies.settings") as m:
+        m.KEYCLOAK_URL = "https://auth.gostoa.dev"
+        m.KEYCLOAK_REALM = "stoa"
+        m.KEYCLOAK_CLIENT_ID = "control-plane-api"
+        m.gateway_api_keys_list = []
+        m.LOG_DEBUG_AUTH_TOKENS = False
+        m.LOG_DEBUG_AUTH_PAYLOAD = False
+        yield m
+
+
+@pytest.fixture
+def mock_kc_key():
+    with patch("src.auth.dependencies.get_keycloak_public_key", new_callable=AsyncMock) as m:
+        m.return_value = "-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----"
+        yield m
+
+
+class TestJwtValidation:
+
+    @pytest.mark.asyncio
+    async def test_valid_token(self, mock_settings, mock_kc_key):
+        payload = _base_payload()
+        with patch("src.auth.dependencies.jwt.decode", return_value=payload):
+            app = _make_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                resp = await c.get("/me", headers={"Authorization": "Bearer valid-token"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == "user-123"
+        assert data["email"] == "user@acme.com"
+        assert data["tenant_id"] == "acme"
+
+    @pytest.mark.asyncio
+    async def test_invalid_audience_401(self, mock_settings, mock_kc_key):
+        payload = _base_payload(aud=["some-other-api"])
+        with patch("src.auth.dependencies.jwt.decode", return_value=payload):
+            app = _make_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                resp = await c.get("/me", headers={"Authorization": "Bearer bad-aud"})
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_missing_sub_email_fallback(self, mock_settings, mock_kc_key):
+        payload = _base_payload(sub=None, email="fallback@acme.com")
+        del payload["sub"]
+        with patch("src.auth.dependencies.jwt.decode", return_value=payload):
+            app = _make_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                resp = await c.get("/me", headers={"Authorization": "Bearer no-sub"})
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "fallback@acme.com"
+
+    @pytest.mark.asyncio
+    async def test_missing_sub_no_email_401(self, mock_settings, mock_kc_key):
+        payload = _base_payload()
+        del payload["sub"]
+        payload["email"] = ""
+        payload["preferred_username"] = ""
+        with patch("src.auth.dependencies.jwt.decode", return_value=payload):
+            app = _make_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                resp = await c.get("/me", headers={"Authorization": "Bearer no-id"})
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_tenant_id_as_list(self, mock_settings, mock_kc_key):
+        payload = _base_payload(tenant_id=["acme", "globex"])
+        with patch("src.auth.dependencies.jwt.decode", return_value=payload):
+            app = _make_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                resp = await c.get("/me", headers={"Authorization": "Bearer list-tenant"})
+        assert resp.status_code == 200
+        assert resp.json()["tenant_id"] == "acme"
+
+    @pytest.mark.asyncio
+    async def test_legacy_audience_accepted(self, mock_settings, mock_kc_key):
+        payload = _base_payload(aud=["control-plane-ui"])
+        with patch("src.auth.dependencies.jwt.decode", return_value=payload):
+            app = _make_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                resp = await c.get("/me", headers={"Authorization": "Bearer legacy-aud"})
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_aud_as_string(self, mock_settings, mock_kc_key):
+        payload = _base_payload(aud="control-plane-api")
+        with patch("src.auth.dependencies.jwt.decode", return_value=payload):
+            app = _make_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                resp = await c.get("/me", headers={"Authorization": "Bearer str-aud"})
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_jwt_decode_error_401(self, mock_settings, mock_kc_key):
+        from jose import JWTError
+        with patch("src.auth.dependencies.jwt.decode", side_effect=JWTError("bad token")):
+            app = _make_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                resp = await c.get("/me", headers={"Authorization": "Bearer bad-jwt"})
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_keycloak_unreachable_503(self, mock_settings):
+        import httpx
+        with patch("src.auth.dependencies.get_keycloak_public_key", new_callable=AsyncMock,
+                    side_effect=httpx.ConnectError("Connection refused")):
+            app = _make_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                resp = await c.get("/me", headers={"Authorization": "Bearer any"})
+        assert resp.status_code == 503

--- a/control-plane-api/tests/test_personal_tenant.py
+++ b/control-plane-api/tests/test_personal_tenant.py
@@ -128,7 +128,7 @@ class TestPersonalTenantProvisioning:
         assert response.status_code == 201
         data = response.json()
         # Should be sanitized: lowercase, special chars → hyphens
-        assert data["tenant_id"] == "free-john-doe-corp-"
+        assert data["tenant_id"] == "free-john-doe-corp"
         assert "!" not in data["tenant_id"]
         assert "@" not in data["tenant_id"]
 

--- a/control-plane-api/tests/test_rbac.py
+++ b/control-plane-api/tests/test_rbac.py
@@ -1,0 +1,256 @@
+"""Tests for RBAC decorators and permission system (CAB-1292 Phase 2)."""
+
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.auth.dependencies import User, get_current_user
+from src.auth.rbac import (
+    Permission,
+    Role,
+    get_user_permissions,
+    require_permission,
+    require_role,
+    require_tenant_access,
+)
+
+
+def _make_user(roles=None, tenant_id="acme", user_id="user-1", email="u@acme.com"):
+    return User(id=user_id, email=email, username="testuser", roles=roles or [], tenant_id=tenant_id)
+
+
+def _app_with_override(user):
+    app = FastAPI()
+    app.dependency_overrides[get_current_user] = lambda: user
+    return app
+
+
+class TestGetUserPermissions:
+    def test_cpi_admin_has_all_permissions(self):
+        perms = get_user_permissions([Role.CPI_ADMIN])
+        assert len(perms) == 16
+
+    def test_viewer_read_only(self):
+        perms = get_user_permissions([Role.VIEWER])
+        assert Permission.APIS_READ in perms
+        assert Permission.APIS_CREATE not in perms
+        assert Permission.APIS_DELETE not in perms
+
+    def test_multi_role_union(self):
+        perms = get_user_permissions([Role.VIEWER, Role.DEVOPS])
+        assert Permission.APIS_READ in perms
+        assert Permission.APIS_DEPLOY in perms
+        assert Permission.APIS_DELETE not in perms
+
+    def test_unknown_role_ignored(self):
+        perms = get_user_permissions(["nonexistent-role"])
+        assert perms == []
+
+    def test_empty_roles(self):
+        perms = get_user_permissions([])
+        assert perms == []
+
+    def test_devops_no_delete(self):
+        perms = get_user_permissions([Role.DEVOPS])
+        assert Permission.APIS_DEPLOY in perms
+        assert Permission.APIS_DELETE not in perms
+        assert Permission.APPS_DELETE not in perms
+
+    def test_tenant_admin_boundaries(self):
+        perms = get_user_permissions([Role.TENANT_ADMIN])
+        assert Permission.APIS_DELETE in perms
+        assert Permission.TENANTS_CREATE not in perms
+        assert Permission.TENANTS_DELETE not in perms
+
+
+class TestRequireRole:
+    @pytest.mark.asyncio
+    async def test_allowed_role_passes(self):
+        user = _make_user(roles=["cpi-admin"])
+        app = FastAPI()
+        checker = require_role(["cpi-admin", "devops"])
+
+        @app.get("/test")
+        async def endpoint(u: User = Depends(checker)):
+            return {"ok": True}
+
+        app.dependency_overrides[get_current_user] = lambda: user
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.get("/test")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_disallowed_role_403(self):
+        user = _make_user(roles=["viewer"])
+        app = FastAPI()
+        checker = require_role(["cpi-admin"])
+
+        @app.get("/test")
+        async def endpoint(u: User = Depends(checker)):
+            return {"ok": True}
+
+        app.dependency_overrides[get_current_user] = lambda: user
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.get("/test")
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_no_roles_403(self):
+        user = _make_user(roles=[])
+        app = FastAPI()
+        checker = require_role(["cpi-admin"])
+
+        @app.get("/test")
+        async def endpoint(u: User = Depends(checker)):
+            return {"ok": True}
+
+        app.dependency_overrides[get_current_user] = lambda: user
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.get("/test")
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_any_match_passes(self):
+        user = _make_user(roles=["devops"])
+        app = FastAPI()
+        checker = require_role(["cpi-admin", "devops"])
+
+        @app.get("/test")
+        async def endpoint(u: User = Depends(checker)):
+            return {"ok": True}
+
+        app.dependency_overrides[get_current_user] = lambda: user
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.get("/test")
+        assert resp.status_code == 200
+
+
+class TestRequirePermission:
+    @pytest.mark.asyncio
+    async def test_admin_passes(self):
+        user = _make_user(roles=["cpi-admin"])
+        app = _app_with_override(user)
+
+        @app.get("/test")
+        @require_permission(Permission.APIS_DELETE)
+        async def endpoint(user: User = Depends(get_current_user)):
+            return {"ok": True}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.get("/test")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_viewer_blocked(self):
+        user = _make_user(roles=["viewer"])
+        app = _app_with_override(user)
+
+        @app.get("/test")
+        @require_permission(Permission.APIS_DELETE)
+        async def endpoint(user: User = Depends(get_current_user)):
+            return {"ok": True}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.get("/test")
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_devops_deploy_ok(self):
+        user = _make_user(roles=["devops"])
+        app = _app_with_override(user)
+
+        @app.get("/test")
+        @require_permission(Permission.APIS_DEPLOY)
+        async def endpoint(user: User = Depends(get_current_user)):
+            return {"ok": True}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.get("/test")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_devops_delete_blocked(self):
+        user = _make_user(roles=["devops"])
+        app = _app_with_override(user)
+
+        @app.get("/test")
+        @require_permission(Permission.APIS_DELETE)
+        async def endpoint(user: User = Depends(get_current_user)):
+            return {"ok": True}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.get("/test")
+        assert resp.status_code == 403
+
+
+class TestRequireTenantAccess:
+    @pytest.mark.asyncio
+    async def test_cpi_admin_any_tenant(self):
+        user = _make_user(roles=["cpi-admin"], tenant_id="other")
+        app = _app_with_override(user)
+
+        @app.get("/tenants/{tenant_id}/data")
+        @require_tenant_access
+        async def endpoint(tenant_id: str, user: User = Depends(get_current_user)):
+            return {"tenant": tenant_id}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.get("/tenants/acme/data")
+        assert resp.status_code == 200
+        assert resp.json()["tenant"] == "acme"
+
+    @pytest.mark.asyncio
+    async def test_own_tenant_ok(self):
+        user = _make_user(roles=["tenant-admin"], tenant_id="acme")
+        app = _app_with_override(user)
+
+        @app.get("/tenants/{tenant_id}/data")
+        @require_tenant_access
+        async def endpoint(tenant_id: str, user: User = Depends(get_current_user)):
+            return {"tenant": tenant_id}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.get("/tenants/acme/data")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_other_tenant_403(self):
+        user = _make_user(roles=["tenant-admin"], tenant_id="acme")
+        app = _app_with_override(user)
+
+        @app.get("/tenants/{tenant_id}/data")
+        @require_tenant_access
+        async def endpoint(tenant_id: str, user: User = Depends(get_current_user)):
+            return {"tenant": tenant_id}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.get("/tenants/globex/data")
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_viewer_wrong_tenant(self):
+        user = _make_user(roles=["viewer"], tenant_id="acme")
+        app = _app_with_override(user)
+
+        @app.get("/tenants/{tenant_id}/data")
+        @require_tenant_access
+        async def endpoint(tenant_id: str, user: User = Depends(get_current_user)):
+            return {"tenant": tenant_id}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.get("/tenants/globex/data")
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_no_tenant_id_in_user(self):
+        user = _make_user(roles=["viewer"], tenant_id=None)
+        app = _app_with_override(user)
+
+        @app.get("/tenants/{tenant_id}/data")
+        @require_tenant_access
+        async def endpoint(tenant_id: str, user: User = Depends(get_current_user)):
+            return {"tenant": tenant_id}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.get("/tenants/acme/data")
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- Fix `test_personal_tenant` trailing hyphen assertion
- Fix `test_auth_operator` module-level `Depends` import
- Add legacy audience deprecation warning (target Q2 2026)
- Add `test_rbac.py`: 20 RBAC tests (permissions, roles, tenant access)
- Add `test_jwt_validation.py`: 9 JWT tests (aud, sub fallback, 503)

## Test plan
- [x] 29 new tests pass locally
- [x] Fixes 2 pre-existing test failures (auth_operator, personal_tenant)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)