### PR TITLE
ci(security): expand Trivy container scan to 5/5 images (CAB-1305)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -429,6 +429,7 @@ jobs:
   container-scan:
     name: Container Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # Rust build (~10 min) + Trivy scan
     continue-on-error: true  # Base image vulns — tracked, not blocking
     strategy:
       fail-fast: false
@@ -440,6 +441,10 @@ jobs:
             path: mcp-gateway
           - name: portal
             path: portal
+          - name: stoa-gateway
+            path: stoa-gateway
+          - name: control-plane-ui
+            path: control-plane-ui
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Add `stoa-gateway` and `control-plane-ui` to the Trivy `container-scan` matrix (was 3/5, now 5/5)
- `control-plane-ui` already handled by existing monorepo-context `if` block
- `stoa-gateway` is self-contained (builds from `stoa-gateway/`)
- Add `timeout-minutes: 30` for Rust build time (~10 min)

## Test plan
- [ ] CI green (YAML validated locally)
- [ ] Container scan runs for all 5 images on next security-scan trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>