### PR TITLE
perf(gateway): upgrade reqwest 0.11→0.12 + socket2 0.5→0.6 (CAB-1359)

### DIFF
--- a/stoa-gateway/Cargo.toml
+++ b/stoa-gateway/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1"
 chrono = { version = "0.4", features = ["serde"] }
 prometheus = { version = "0.13", default-features = false }  # no protobuf (RUSTSEC-2024-0437)
 jsonwebtoken = "9"
-reqwest = { version = "0.11", features = ["json", "stream"] }
+reqwest = { version = "0.12", features = ["json", "stream"] }
 async-trait = "0.1"
 
 # === NEW - Phase 1: Quality Fixes ===
@@ -36,7 +36,7 @@ tokio-stream = "0.1"                    # SSE event streams
 futures = "0.3"                          # Stream combinators
 uuid = { version = "1", features = ["v4", "serde"] }  # Session IDs
 rand = "0.9"                                # Thread-local PRNG for traceparent (perf)
-socket2 = "0.5"                             # TCP backlog tuning (perf)
+socket2 = "0.6"                             # TCP backlog tuning (perf)
 urlencoding = "2"                           # URL encoding for query params
 
 # === NEW - Phase 3: Auth ===

--- a/stoa-gateway/src/oauth/proxy.rs
+++ b/stoa-gateway/src/oauth/proxy.rs
@@ -76,7 +76,8 @@ pub async fn token_proxy(
         }
     };
 
-    let status = StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    // reqwest 0.12 shares http 1.0 StatusCode with axum — no conversion needed
+    let status = resp.status();
 
     // Extract content-type from reqwest response before consuming body
     let resp_content_type = resp

--- a/stoa-gateway/src/proxy/dynamic.rs
+++ b/stoa-gateway/src/proxy/dynamic.rs
@@ -6,7 +6,7 @@
 use axum::{
     body::Body,
     extract::{Request, State},
-    http::{header, HeaderMap, HeaderValue, Method, StatusCode},
+    http::{HeaderMap, HeaderValue, Method, StatusCode},
     response::{IntoResponse, Response},
 };
 use std::net::IpAddr;
@@ -231,10 +231,7 @@ async fn forward_request(
         Method::DELETE => client.delete(target_url),
         Method::PATCH => client.patch(target_url),
         Method::HEAD => client.head(target_url),
-        Method::OPTIONS => {
-            let m = reqwest::Method::from_bytes(b"OPTIONS").unwrap();
-            client.request(m, target_url)
-        }
+        Method::OPTIONS => client.request(Method::OPTIONS, target_url),
         _ => {
             warn!(method = %method, "Unsupported HTTP method in dynamic proxy");
             return (StatusCode::METHOD_NOT_ALLOWED, "Method not allowed").into_response();
@@ -293,19 +290,15 @@ async fn forward_request(
 
 /// Copy headers excluding hop-by-hop headers.
 ///
-/// HeaderName is already lowercase in http crate, so no `.to_lowercase()` needed.
+/// reqwest 0.12 and axum 0.7 share the same `http` 1.0 types,
+/// so HeaderName/HeaderValue can be cloned directly (no conversion needed).
 fn copy_headers(
     mut builder: reqwest::RequestBuilder,
     headers: &HeaderMap<HeaderValue>,
 ) -> reqwest::RequestBuilder {
     for (name, value) in headers.iter() {
         if !is_hop_by_hop(name.as_str()) {
-            if let Ok(header_name) = reqwest::header::HeaderName::from_bytes(name.as_ref()) {
-                if let Ok(header_value) = reqwest::header::HeaderValue::from_bytes(value.as_bytes())
-                {
-                    builder = builder.header(header_name, header_value);
-                }
-            }
+            builder = builder.header(name.clone(), value.clone());
         }
     }
 
@@ -329,21 +322,19 @@ fn is_hop_by_hop(name: &str) -> bool {
 }
 
 /// Convert a reqwest response to an axum response (streaming, zero-copy).
+///
+/// reqwest 0.12 shares `http` 1.0 types with axum 0.7, so StatusCode
+/// and HeaderName/HeaderValue pass through without conversion.
 fn convert_response(resp: reqwest::Response) -> Response {
     let status = resp.status();
     let headers = resp.headers().clone();
 
-    let mut response =
-        Response::builder().status(StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::OK));
+    let mut response = Response::builder().status(status);
 
-    // Copy response headers (excluding hop-by-hop)
+    // Copy response headers (excluding hop-by-hop) — direct clone, same types
     for (name, value) in headers.iter() {
         if !is_hop_by_hop(name.as_str()) {
-            if let Ok(header_name) = header::HeaderName::from_bytes(name.as_ref()) {
-                if let Ok(header_value) = header::HeaderValue::from_bytes(value.as_bytes()) {
-                    response = response.header(header_name, header_value);
-                }
-            }
+            response = response.header(name.clone(), value.clone());
         }
     }
 

--- a/stoa-gateway/src/proxy/webmethods.rs
+++ b/stoa-gateway/src/proxy/webmethods.rs
@@ -3,7 +3,7 @@
 use axum::{
     body::Body,
     extract::Request,
-    http::{header, HeaderMap, HeaderValue, Method, StatusCode},
+    http::{HeaderMap, HeaderValue, Method, StatusCode},
     response::{IntoResponse, Response},
 };
 use std::time::Duration;
@@ -65,10 +65,7 @@ impl WebMethodsProxy {
             Method::DELETE => self.client.delete(&target_url),
             Method::PATCH => self.client.patch(&target_url),
             Method::HEAD => self.client.head(&target_url),
-            Method::OPTIONS => {
-                let m = reqwest::Method::from_bytes(b"OPTIONS").unwrap();
-                self.client.request(m, &target_url)
-            }
+            Method::OPTIONS => self.client.request(Method::OPTIONS, &target_url),
             _ => {
                 tracing::warn!(method = %method, "unsupported HTTP method");
                 return (StatusCode::METHOD_NOT_ALLOWED, "Method not allowed").into_response();
@@ -116,6 +113,7 @@ impl WebMethodsProxy {
     /// Copy headers from the incoming request to the outgoing request.
     ///
     /// Excludes hop-by-hop headers that should not be forwarded.
+    /// reqwest 0.12 and axum 0.7 share `http` 1.0 types — direct clone, no conversion.
     fn copy_headers(
         mut builder: reqwest::RequestBuilder,
         headers: &HeaderMap<HeaderValue>,
@@ -134,15 +132,9 @@ impl WebMethodsProxy {
         ];
 
         for (name, value) in headers.iter() {
-            let name_str = name.as_str().to_lowercase();
-            if !HOP_BY_HOP.contains(&name_str.as_str()) {
-                if let Ok(header_name) = reqwest::header::HeaderName::from_bytes(name.as_ref()) {
-                    if let Ok(header_value) =
-                        reqwest::header::HeaderValue::from_bytes(value.as_bytes())
-                    {
-                        builder = builder.header(header_name, header_value);
-                    }
-                }
+            // HeaderName::as_str() already returns lowercase (http crate guarantee)
+            if !HOP_BY_HOP.contains(&name.as_str()) {
+                builder = builder.header(name.clone(), value.clone());
             }
         }
 
@@ -150,6 +142,8 @@ impl WebMethodsProxy {
     }
 
     /// Convert a reqwest response to an axum response.
+    ///
+    /// reqwest 0.12 shares `http` 1.0 types with axum 0.7 — direct pass-through.
     async fn convert_response(resp: reqwest::Response) -> Response {
         let status = resp.status();
         let headers = resp.headers().clone();
@@ -164,20 +158,14 @@ impl WebMethodsProxy {
             }
         };
 
-        // Build axum response
-        let mut response = Response::builder()
-            .status(StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::OK));
+        // Build axum response — same StatusCode type, no conversion needed
+        let mut response = Response::builder().status(status);
 
-        // Copy response headers
+        // Copy response headers — same types, direct clone
         for (name, value) in headers.iter() {
-            let name_str = name.as_str().to_lowercase();
-            // Skip hop-by-hop headers
-            if !["connection", "keep-alive", "transfer-encoding"].contains(&name_str.as_str()) {
-                if let Ok(header_name) = header::HeaderName::from_bytes(name.as_ref()) {
-                    if let Ok(header_value) = header::HeaderValue::from_bytes(value.as_bytes()) {
-                        response = response.header(header_name, header_value);
-                    }
-                }
+            // HeaderName::as_str() already returns lowercase (http crate guarantee)
+            if !["connection", "keep-alive", "transfer-encoding"].contains(&name.as_str()) {
+                response = response.header(name.clone(), value.clone());
             }
         }
 


### PR DESCRIPTION
## Summary
- **reqwest 0.11 → 0.12**: hyper 1.0 with lock-free connection pool (replaces Mutex-based pool in hyper 0.14), reducing contention under burst/ramp_up traffic
- **socket2 0.5 → 0.6**: aligns with hyper-util dependency (eliminates duplicate crate)
- **Type unification**: reqwest 0.12 + axum 0.7 share `http` 1.0 types — removes per-request `StatusCode::from_u16()`, `HeaderName::from_bytes()`, `HeaderValue::from_bytes()` allocations in proxy hot paths
- **Phase 3** of CAB-1359 Arena Performance Optimization (Phase 1+2 merged in PR #626)

## Changes
| File | What Changed |
|------|-------------|
| `Cargo.toml` | reqwest 0.11→0.12, socket2 0.5→0.6 |
| `proxy/dynamic.rs` | Eliminate redundant type conversions in copy_headers + convert_response, simplify Method::OPTIONS |
| `proxy/webmethods.rs` | Same type unification, remove redundant .to_lowercase() on HeaderName |
| `oauth/proxy.rs` | StatusCode pass-through (no from_u16 needed) |

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -D warnings` — zero warnings
- [x] `cargo test` — 826 passed (744 unit + 30 integration + 15 contract + 15 resilience + 22 security)
- [ ] Arena benchmark: target ramp_up p95 < 100ms (from 381ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>