### PR TITLE
feat(gateway): add OAuth2 client_credentials backend auth (CAB-1317)

### DIFF
--- a/stoa-gateway/src/handlers/admin.rs
+++ b/stoa-gateway/src/handlers/admin.rs
@@ -23,7 +23,8 @@ use axum::{
 use serde::Serialize;
 use tracing::warn;
 
-use crate::proxy::credentials::BackendCredential;
+use crate::proxy::credentials::{AuthType, BackendCredential};
+use crate::proxy::dynamic::is_blocked_url;
 use crate::routes::{ApiRoute, PolicyEntry};
 use crate::state::AppState;
 use crate::uac::binders::{mcp::McpBinder, rest::RestBinder, ProtocolBinder};
@@ -367,6 +368,44 @@ pub async fn upsert_backend_credential(
     State(state): State<AppState>,
     Json(cred): Json<BackendCredential>,
 ) -> impl IntoResponse {
+    // Validate OAuth2 credentials: require config, HTTPS, and SSRF check
+    if cred.auth_type == AuthType::OAuth2ClientCredentials {
+        match &cred.oauth2 {
+            None => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "status": "error",
+                        "message": "oauth2 config required for auth_type oauth2_client_credentials"
+                    })),
+                )
+                    .into_response();
+            }
+            Some(oauth2) => {
+                if !oauth2.token_url.starts_with("https://") {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({
+                            "status": "error",
+                            "message": "oauth2 token_url must use HTTPS"
+                        })),
+                    )
+                        .into_response();
+                }
+                if is_blocked_url(&oauth2.token_url) {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({
+                            "status": "error",
+                            "message": "oauth2 token_url is blocked (SSRF protection)"
+                        })),
+                    )
+                        .into_response();
+                }
+            }
+        }
+    }
+
     let route_id = cred.route_id.clone();
     let existed = state.credential_store.upsert(cred).is_some();
     let status = if existed {
@@ -378,6 +417,7 @@ pub async fn upsert_backend_credential(
         status,
         Json(serde_json::json!({"route_id": route_id, "status": "ok"})),
     )
+        .into_response()
 }
 
 /// GET /admin/backend-credentials — list all backend credentials

--- a/stoa-gateway/src/proxy/credentials.rs
+++ b/stoa-gateway/src/proxy/credentials.rs
@@ -3,10 +3,15 @@
 //! Stores backend authentication credentials per route. The Control Plane
 //! pushes credentials via the admin API; the dynamic proxy injects them
 //! into outgoing requests.
+//!
+//! Supports static credentials (API key, Bearer, Basic) and OAuth2
+//! client_credentials flow with automatic token caching (CAB-1317).
 
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tracing::debug;
 
 /// Authentication type for backend APIs.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -18,6 +23,20 @@ pub enum AuthType {
     Bearer,
     /// Basic auth (e.g., `Authorization: Basic <base64>`)
     Basic,
+    /// OAuth2 client_credentials grant — token fetched and cached automatically
+    #[serde(rename = "oauth2_client_credentials")]
+    OAuth2ClientCredentials,
+}
+
+/// OAuth2 client_credentials configuration for a backend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuth2Config {
+    /// Token endpoint URL (must be HTTPS in production)
+    pub token_url: String,
+    /// OAuth2 client ID
+    pub client_id: String,
+    /// OAuth2 client secret
+    pub client_secret: String,
 }
 
 /// A backend credential for a specific route.
@@ -31,11 +50,37 @@ pub struct BackendCredential {
     pub header_name: String,
     /// Header value (e.g., "Bearer token123", "Basic dXNlcjpwYXNz")
     pub header_value: String,
+    /// OAuth2 configuration (required when auth_type is OAuth2ClientCredentials)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oauth2: Option<OAuth2Config>,
 }
 
+/// Cached OAuth2 access token with expiry tracking.
+struct CachedOAuth2Token {
+    access_token: String,
+    expires_at: Instant,
+}
+
+/// OAuth2 token endpoint response (subset of RFC 6749 §5.1).
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default = "default_expires_in")]
+    expires_in: u64,
+}
+
+fn default_expires_in() -> u64 {
+    3600
+}
+
+/// Safety margin before token expiry — fetch a new token 30s early.
+const TOKEN_EXPIRY_MARGIN: Duration = Duration::from_secs(30);
+
 /// Thread-safe in-memory credential store, keyed by route_id.
+/// Embeds the OAuth2 token cache (Council adjustment #2).
 pub struct CredentialStore {
     credentials: RwLock<HashMap<String, BackendCredential>>,
+    oauth2_tokens: RwLock<HashMap<String, CachedOAuth2Token>>,
 }
 
 impl Default for CredentialStore {
@@ -48,16 +93,23 @@ impl CredentialStore {
     pub fn new() -> Self {
         Self {
             credentials: RwLock::new(HashMap::new()),
+            oauth2_tokens: RwLock::new(HashMap::new()),
         }
     }
 
     /// Insert or update a credential. Returns the previous value if it existed.
+    /// Invalidates the OAuth2 token cache for this route on update.
     pub fn upsert(&self, cred: BackendCredential) -> Option<BackendCredential> {
-        self.credentials.write().insert(cred.route_id.clone(), cred)
+        let route_id = cred.route_id.clone();
+        let prev = self.credentials.write().insert(route_id.clone(), cred);
+        // Invalidate cached token — config may have changed
+        self.oauth2_tokens.write().remove(&route_id);
+        prev
     }
 
-    /// Remove a credential by route_id.
+    /// Remove a credential by route_id. Also clears the OAuth2 token cache.
     pub fn remove(&self, route_id: &str) -> Option<BackendCredential> {
+        self.oauth2_tokens.write().remove(route_id);
         self.credentials.write().remove(route_id)
     }
 
@@ -75,6 +127,83 @@ impl CredentialStore {
     pub fn count(&self) -> usize {
         self.credentials.read().len()
     }
+
+    /// Number of cached OAuth2 tokens (for diagnostics).
+    pub fn oauth2_cache_count(&self) -> usize {
+        self.oauth2_tokens.read().len()
+    }
+
+    /// Get a valid OAuth2 access token for a route, fetching a new one if needed.
+    ///
+    /// Pattern generalized from `tool_proxy.rs` — 30s safety margin before expiry.
+    pub async fn get_oauth2_token(
+        &self,
+        route_id: &str,
+        client: &reqwest::Client,
+    ) -> Result<String, String> {
+        // Fast path: return cached token if still valid
+        {
+            let cache = self.oauth2_tokens.read();
+            if let Some(cached) = cache.get(route_id) {
+                if cached.expires_at > Instant::now() + TOKEN_EXPIRY_MARGIN {
+                    return Ok(cached.access_token.clone());
+                }
+            }
+        }
+
+        // Slow path: fetch new token
+        let cred = self
+            .credentials
+            .read()
+            .get(route_id)
+            .cloned()
+            .ok_or_else(|| format!("No credential found for route {route_id}"))?;
+
+        let oauth2 = cred
+            .oauth2
+            .as_ref()
+            .ok_or_else(|| format!("Route {route_id} has no OAuth2 config"))?;
+
+        debug!(route_id = %route_id, token_url = %oauth2.token_url, "Fetching OAuth2 token");
+
+        let resp = client
+            .post(&oauth2.token_url)
+            .form(&[
+                ("grant_type", "client_credentials"),
+                ("client_id", &oauth2.client_id),
+                ("client_secret", &oauth2.client_secret),
+            ])
+            .send()
+            .await
+            .map_err(|e| format!("OAuth2 token request failed: {e}"))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp
+                .text()
+                .await
+                .unwrap_or_else(|_| "<no body>".to_string());
+            return Err(format!("OAuth2 token endpoint returned {status}: {body}"));
+        }
+
+        let token_resp: TokenResponse = resp
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse OAuth2 token response: {e}"))?;
+
+        let expires_at = Instant::now() + Duration::from_secs(token_resp.expires_in);
+        let access_token = token_resp.access_token.clone();
+
+        self.oauth2_tokens.write().insert(
+            route_id.to_string(),
+            CachedOAuth2Token {
+                access_token: token_resp.access_token,
+                expires_at,
+            },
+        );
+
+        Ok(access_token)
+    }
 }
 
 #[cfg(test)]
@@ -87,6 +216,21 @@ mod tests {
             auth_type: AuthType::Bearer,
             header_name: "Authorization".to_string(),
             header_value: "Bearer test-token".to_string(),
+            oauth2: None,
+        }
+    }
+
+    fn make_oauth2_cred(route_id: &str) -> BackendCredential {
+        BackendCredential {
+            route_id: route_id.to_string(),
+            auth_type: AuthType::OAuth2ClientCredentials,
+            header_name: String::new(),
+            header_value: String::new(),
+            oauth2: Some(OAuth2Config {
+                token_url: "https://auth.example.com/token".to_string(),
+                client_id: "test-client".to_string(),
+                client_secret: "test-secret".to_string(),
+            }),
         }
     }
 
@@ -107,6 +251,7 @@ mod tests {
             auth_type: AuthType::ApiKey,
             header_name: "X-API-Key".to_string(),
             header_value: "new-key".to_string(),
+            oauth2: None,
         });
         assert!(prev.is_some());
         assert_eq!(prev.unwrap().auth_type, AuthType::Bearer);
@@ -163,5 +308,117 @@ mod tests {
         };
         let json = serde_json::to_value(&api_key_cred).unwrap();
         assert_eq!(json["auth_type"], "api_key");
+    }
+
+    #[test]
+    fn test_oauth2_auth_type_serialization() {
+        let cred = make_oauth2_cred("r1");
+        let json = serde_json::to_value(&cred).unwrap();
+        assert_eq!(json["auth_type"], "oauth2_client_credentials");
+        assert!(json["oauth2"].is_object());
+        assert_eq!(
+            json["oauth2"]["token_url"],
+            "https://auth.example.com/token"
+        );
+    }
+
+    #[test]
+    fn test_oauth2_deserialization() {
+        let json = serde_json::json!({
+            "route_id": "r1",
+            "auth_type": "oauth2_client_credentials",
+            "header_name": "",
+            "header_value": "",
+            "oauth2": {
+                "token_url": "https://auth.example.com/token",
+                "client_id": "my-client",
+                "client_secret": "my-secret"
+            }
+        });
+        let cred: BackendCredential = serde_json::from_value(json).unwrap();
+        assert_eq!(cred.auth_type, AuthType::OAuth2ClientCredentials);
+        assert!(cred.oauth2.is_some());
+        let oauth2 = cred.oauth2.unwrap();
+        assert_eq!(oauth2.client_id, "my-client");
+    }
+
+    #[test]
+    fn test_oauth2_cache_invalidation_on_upsert() {
+        let store = CredentialStore::new();
+        store.upsert(make_oauth2_cred("r1"));
+        // Manually inject a cached token
+        store.oauth2_tokens.write().insert(
+            "r1".to_string(),
+            CachedOAuth2Token {
+                access_token: "old-token".to_string(),
+                expires_at: Instant::now() + Duration::from_secs(3600),
+            },
+        );
+        assert_eq!(store.oauth2_cache_count(), 1);
+        // Upsert should clear the cache
+        store.upsert(make_oauth2_cred("r1"));
+        assert_eq!(store.oauth2_cache_count(), 0);
+    }
+
+    #[test]
+    fn test_oauth2_cache_invalidation_on_remove() {
+        let store = CredentialStore::new();
+        store.upsert(make_oauth2_cred("r1"));
+        store.oauth2_tokens.write().insert(
+            "r1".to_string(),
+            CachedOAuth2Token {
+                access_token: "old-token".to_string(),
+                expires_at: Instant::now() + Duration::from_secs(3600),
+            },
+        );
+        assert_eq!(store.oauth2_cache_count(), 1);
+        store.remove("r1");
+        assert_eq!(store.oauth2_cache_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_oauth2_token_missing_credential() {
+        let store = CredentialStore::new();
+        let client = reqwest::Client::new();
+        let result = store.get_oauth2_token("nonexistent", &client).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("No credential found"));
+    }
+
+    #[tokio::test]
+    async fn test_oauth2_token_missing_config() {
+        let store = CredentialStore::new();
+        // Insert a static bearer credential (no OAuth2 config)
+        store.upsert(make_cred("r1"));
+        let client = reqwest::Client::new();
+        let result = store.get_oauth2_token("r1", &client).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("no OAuth2 config"));
+    }
+
+    #[tokio::test]
+    async fn test_oauth2_cache_hit() {
+        let store = CredentialStore::new();
+        store.upsert(make_oauth2_cred("r1"));
+        // Inject a valid cached token
+        store.oauth2_tokens.write().insert(
+            "r1".to_string(),
+            CachedOAuth2Token {
+                access_token: "cached-token-123".to_string(),
+                expires_at: Instant::now() + Duration::from_secs(3600),
+            },
+        );
+        let client = reqwest::Client::new();
+        let result = store.get_oauth2_token("r1", &client).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "cached-token-123");
+    }
+
+    #[test]
+    fn test_static_cred_oauth2_field_omitted_in_json() {
+        let cred = make_cred("r1");
+        let json = serde_json::to_value(&cred).unwrap();
+        // oauth2 field should be absent (skip_serializing_if = "Option::is_none")
+        assert!(json.get("oauth2").is_none());
     }
 }

--- a/stoa-gateway/src/proxy/dynamic.rs
+++ b/stoa-gateway/src/proxy/dynamic.rs
@@ -17,8 +17,38 @@ use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use std::cell::RefCell;
 
+use crate::proxy::credentials::{AuthType, BackendCredential};
 use crate::resilience::RetryConfig;
 use crate::state::AppState;
+
+/// Resolve a BackendCredential into a (header_name, header_value) tuple.
+/// For OAuth2ClientCredentials, fetches/caches a token via the credential store.
+async fn resolve_credential_header(
+    state: &AppState,
+    route_id: &str,
+    credential: Option<&BackendCredential>,
+) -> Option<(String, String)> {
+    let cred = credential?;
+    if cred.auth_type == AuthType::OAuth2ClientCredentials {
+        match state
+            .credential_store
+            .get_oauth2_token(route_id, get_proxy_client())
+            .await
+        {
+            Ok(token) => Some(("Authorization".to_string(), format!("Bearer {token}"))),
+            Err(e) => {
+                warn!(
+                    route_id = %route_id,
+                    error = %e,
+                    "OAuth2 token fetch failed — skipping credential injection"
+                );
+                None
+            }
+        }
+    } else {
+        Some((cred.header_name.clone(), cred.header_value.clone()))
+    }
+}
 
 thread_local! {
     /// Thread-local fast PRNG for traceparent ID generation.
@@ -155,14 +185,16 @@ pub async fn dynamic_proxy(State(state): State<AppState>, request: Request<Body>
         "Dynamic proxy: forwarding request"
     );
 
-    // BYOK credential injection (CAB-1250): look up stored credential for this route
+    // BYOK credential injection (CAB-1250 + CAB-1317 OAuth2)
     let credential = state.credential_store.get(&route.id);
+    let resolved_header = resolve_credential_header(&state, &route.id, credential.as_ref()).await;
 
     // Clone headers before consuming the request (needed for potential retry)
     let saved_headers = request.headers().clone();
 
     let upstream_start = std::time::Instant::now();
-    let mut response = forward_request(request, &method, &target_url, credential.as_ref()).await;
+    let mut response =
+        forward_request(request, &method, &target_url, resolved_header.as_ref()).await;
 
     // Retry transient errors on idempotent methods (CAB-362)
     if is_retryable_status(response.status()) && is_idempotent(&method) {
@@ -183,8 +215,13 @@ pub async fn dynamic_proxy(State(state): State<AppState>, request: Request<Body>
                 "Retrying transient upstream error"
             );
             tokio::time::sleep(delay).await;
-            response =
-                retry_forward(&method, &target_url, &saved_headers, credential.as_ref()).await;
+            response = retry_forward(
+                &method,
+                &target_url,
+                &saved_headers,
+                resolved_header.as_ref(),
+            )
+            .await;
             if !is_retryable_status(response.status()) {
                 break;
             }
@@ -212,13 +249,13 @@ pub async fn dynamic_proxy(State(state): State<AppState>, request: Request<Body>
 
 /// Forward request to the backend, reusing the webMethods proxy pattern.
 ///
-/// When a `BackendCredential` is provided, its header is injected into the
-/// outgoing request (BYOK credential proxy — CAB-1250).
+/// When a resolved header tuple is provided, it is injected into the
+/// outgoing request (BYOK credential proxy — CAB-1250, OAuth2 — CAB-1317).
 async fn forward_request(
     request: Request<Body>,
     method: &Method,
     target_url: &str,
-    credential: Option<&super::credentials::BackendCredential>,
+    resolved_header: Option<&(String, String)>,
 ) -> Response {
     let client = get_proxy_client();
     let headers = request.headers().clone();
@@ -246,18 +283,13 @@ async fn forward_request(
     // correlate their spans with the gateway's trace.
     req_builder = inject_traceparent(req_builder);
 
-    // BYOK: inject backend credential header (CAB-1250)
-    if let Some(cred) = credential {
-        if let (Ok(name), Ok(value)) = (
-            reqwest::header::HeaderName::from_bytes(cred.header_name.as_bytes()),
-            reqwest::header::HeaderValue::from_str(&cred.header_value),
+    // BYOK: inject resolved credential header (CAB-1250 + CAB-1317)
+    if let Some((name, value)) = resolved_header {
+        if let (Ok(header_name), Ok(header_value)) = (
+            reqwest::header::HeaderName::from_bytes(name.as_bytes()),
+            reqwest::header::HeaderValue::from_str(value),
         ) {
-            req_builder = req_builder.header(name, value);
-        } else {
-            warn!(
-                route_id = %cred.route_id,
-                "BYOK: invalid credential header name/value — skipping injection"
-            );
+            req_builder = req_builder.header(header_name, header_value);
         }
     }
 
@@ -367,7 +399,7 @@ async fn retry_forward(
     method: &Method,
     target_url: &str,
     headers: &HeaderMap<HeaderValue>,
-    credential: Option<&super::credentials::BackendCredential>,
+    resolved_header: Option<&(String, String)>,
 ) -> Response {
     let client = get_proxy_client();
     let mut builder = match *method {
@@ -383,13 +415,13 @@ async fn retry_forward(
     builder = copy_headers(builder, headers);
     builder = inject_traceparent(builder);
 
-    // BYOK credential injection
-    if let Some(cred) = credential {
-        if let (Ok(name), Ok(value)) = (
-            reqwest::header::HeaderName::from_bytes(cred.header_name.as_bytes()),
-            reqwest::header::HeaderValue::from_str(&cred.header_value),
+    // BYOK: inject resolved credential header (CAB-1250 + CAB-1317)
+    if let Some((name, value)) = resolved_header {
+        if let (Ok(header_name), Ok(header_value)) = (
+            reqwest::header::HeaderName::from_bytes(name.as_bytes()),
+            reqwest::header::HeaderValue::from_str(value),
         ) {
-            builder = builder.header(name, value);
+            builder = builder.header(header_name, header_value);
         }
     }
 


### PR DESCRIPTION
## Summary
- Add OAuth2 `client_credentials` grant flow for backend API authentication (BYOK extension)
- Per-route token caching with 30s safety margin before expiry, embedded in `CredentialStore` (Council adjustment #2)
- SSRF + HTTPS validation on OAuth2 token_url in admin API
- New `resolve_credential_header()` abstraction cleanly separates static vs dynamic credential resolution

## Changes
- `src/proxy/credentials.rs`: `OAuth2ClientCredentials` auth type, `OAuth2Config`, token cache, 7 new tests
- `src/proxy/dynamic.rs`: `resolve_credential_header()`, updated `forward_request`/`retry_forward` signatures
- `src/handlers/admin.rs`: OAuth2 config validation (HTTPS required, SSRF blocked)

## Part of CAB-1317 — MCP Proxy Hardening P3 (Phase 1 of 3)
Council validated: 8.50/10 Go

## Test plan
- [x] 16/16 credential tests pass (7 new OAuth2-specific)
- [x] 752 total tests pass (unit + integration + contract + resilience + security)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` zero warnings
- [x] serde rename verified: `oauth2_client_credentials` (not `o_auth2_client_credentials`)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>