### PR TITLE
chore(docs): AI Factory v3 — multi-instance coordination hardening

### DIFF
--- a/.claude/rules/ai-factory.md
+++ b/.claude/rules/ai-factory.md
@@ -259,10 +259,24 @@ Tache a realiser ?
 | Jamais pour | Docs-only, single-file fix, config changes, memory updates |
 | Cost awareness | ~3-4x tokens pour 3 teammates, ~7x avec overhead plan mode |
 
+#### Claim File Bridge (MANDATORY)
+
+When Agent Teams works on a MEGA with phases, the lead MUST write `.claude/claims/` files alongside TaskUpdate:
+
+```
+1. Lead reads/creates .claude/claims/<MEGA-ID>.json
+2. For each teammate assignment → write owner=<teammate-name> in the claim file
+3. Teammates log CLAIM in operations.log (same as multi-instance protocol)
+4. On completion → teammate releases claim in file + logs RELEASE
+```
+
+**Why?** Claim files are the single source of truth visible to ALL execution modes (sequential, multi-instance, multi-subagent). Without this bridge, a local terminal running `session-startup.md` Step 2 cannot see what Agent Teams teammates are working on, leading to duplicate claims.
+
 #### Workflow Agent Teams
 ```
 1. [Lead/Opus] Analyser la tache, identifier N scopes independants
 2. [Lead/Opus] Creer le plan: quel teammate fait quoi
+2b. [Lead/Opus] Write .claude/claims/<MEGA-ID>.json with teammate assignments (Claim File Bridge)
 3. [Teammate 1/Sonnet] Scope A: branch → code → tests → quality gate
 4. [Teammate 2/Sonnet] Scope B: branch → code → tests → quality gate
 5. [Teammate 3/Sonnet] Scope C: branch → code → tests → quality gate

--- a/.claude/rules/ai-workflow.md
+++ b/.claude/rules/ai-workflow.md
@@ -242,6 +242,12 @@ See `crash-recovery.md` for checkpoint schema and lifecycle.
 | `PR-MERGED` | After successful merge | `task`, `pr`, `branch_lifetime_min` (optional) |
 | `CI-FIX` | After `/ci-fix` skill runs | `task`, `check`, `auto_fixed` (true/false) |
 | `STATE-DRIFT` | Stop hook detects misplaced items | `items_misplaced` (count) |
+| `PHASE-CLAIMED` | Instance claims a MEGA phase | `task` (MEGA ID), `phase`, `instance`, `mode` (sequential/multi-instance/multi-subagent/l3) |
+| `PHASE-COMPLETED` | Instance finishes a MEGA phase | `task` (MEGA ID), `phase`, `instance`, `pr`, `duration_min` (optional) |
+| `CLAIM-CONFLICT` | Two instances race for same phase | `task` (MEGA ID), `phase`, `winner`, `loser` |
+| `PHASE-CLAIMED` | Instance claims a MEGA phase | `task` (MEGA ID), `phase`, `instance`, `mode` (sequential/multi-instance/multi-subagent/l3) |
+| `PHASE-COMPLETED` | Instance finishes a MEGA phase | `task` (MEGA ID), `phase`, `instance`, `pr`, `duration_min` (optional) |
+| `CLAIM-CONFLICT` | Two instances race for same phase | `task` (MEGA ID), `phase`, `winner`, `loser` |
 
 ### Format
 Same as operations.log: `YYYY-MM-DDTHH:MM | EVENT | key=value ...`
@@ -250,6 +256,12 @@ Same as operations.log: `YYYY-MM-DDTHH:MM | EVENT | key=value ...`
 - **PR merged** — append `PR-MERGED` in the same step as STEP-DONE step=merged
 - **CI fix** — `/ci-fix` skill appends `CI-FIX` automatically (see skill prompt)
 - **State drift** — `stop-state-lint.sh` hook appends `STATE-DRIFT` automatically
+- **Phase claimed** — append `PHASE-CLAIMED` when claiming a MEGA phase (any execution mode)
+- **Phase completed** — append `PHASE-COMPLETED` when releasing a completed phase
+- **Claim conflict** — append `CLAIM-CONFLICT` when `mkdir` lock fails and another instance wins
+- **Phase claimed** — append `PHASE-CLAIMED` when claiming a MEGA phase (any execution mode)
+- **Phase completed** — append `PHASE-COMPLETED` when releasing a completed phase
+- **Claim conflict** — append `CLAIM-CONFLICT` when `mkdir` lock fails and another instance wins
 
 ### Log Rotation
 - Keep `metrics.log` under **500 lines** (same policy as operations.log)
@@ -262,6 +274,10 @@ Periodically review `metrics.log` to identify:
 - Average branch lifetime (PR-MERGED entries)
 - Most frequent CI failure types (CI-FIX entries)
 - State drift frequency (STATE-DRIFT entries)
+- Parallelization efficiency: phases claimed vs completed, conflict rate (PHASE-CLAIMED/PHASE-COMPLETED/CLAIM-CONFLICT)
+- Average phase duration (PHASE-COMPLETED `duration_min` field)
+- Parallelization efficiency: phases claimed vs completed, conflict rate (PHASE-CLAIMED/PHASE-COMPLETED/CLAIM-CONFLICT)
+- Average phase duration (PHASE-COMPLETED `duration_min` field)
 
 ## Anti-Drift Rules
 - **1 thing at a time** — never mix feature + refactor + fix

--- a/.claude/rules/autonomous-factory.md
+++ b/.claude/rules/autonomous-factory.md
@@ -157,6 +157,36 @@ n8n workflow (`scripts/ai-ops/n8n-linear-to-claude.json`):
 3. n8n dispatches `repository_dispatch` to GitHub Actions
 4. n8n posts "Pipeline Started" to Slack
 
+### Dispatch Payload Schema
+
+The `repository_dispatch` `client_payload` includes phase-aware fields:
+
+```json
+{
+  "ticket_id": "CAB-1350",
+  "ticket_title": "Traceparent injection",
+  "ticket_description": "...",
+  "priority": 2,
+  "estimate": 5,
+  "mega_id": "CAB-1290",
+  "phase_hint": 1,
+  "component": "gateway"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `ticket_id` | Yes | Linear issue identifier (e.g., `CAB-1350`) |
+| `ticket_title` | Yes | Issue title |
+| `ticket_description` | Yes | Full issue description + DoD |
+| `priority` | Yes | Linear priority (1=Urgent, 4=Low) |
+| `estimate` | No | Story points |
+| `mega_id` | No | Parent MEGA ticket ID. If present, the dispatched agent checks `.claude/claims/<mega_id>.json` for phase ownership before starting. Prevents L3-dispatched agents from conflicting with local instances. |
+| `phase_hint` | No | Suggested phase number within the MEGA. The agent uses this to claim the correct phase instead of scanning all MEGAs. |
+| `component` | No | Target component (api, gateway, ui, portal, e2e). Used to select the right CI quality gate. |
+
+**n8n enrichment**: When a ticket has a `parent` in Linear, n8n resolves the parent ID and includes it as `mega_id`. The `phase_hint` is extracted from the ticket's position in the parent's sub-issues list.
+
 ### Setup Requirements
 
 1. **n8n**: Import `n8n-linear-to-claude.json`

--- a/.claude/rules/crash-recovery.md
+++ b/.claude/rules/crash-recovery.md
@@ -124,6 +124,13 @@ Example: `2026-02-12T14-30-task-traceability.json`
     "files_modified": [".claude/rules/ai-workflow.md", ".claude/rules/session-startup.md"],
     "notes": "CI green, ready to merge"
   },
+  "progress": {
+    "files_completed": ["src/models/consumer.py", "src/schemas/consumer.py"],
+    "files_remaining": ["src/repositories/consumer.py", "tests/test_consumer.py"],
+    "last_commit_message": "feat(api): add consumer model + schema (CAB-XXXX)",
+    "decisions_made": ["Chose SQLAlchemy hybrid_property over computed column", "UUID7 for IDs"],
+    "blockers": []
+  },
   "claimed_phase": {
     "mega_id": "CAB-1290",
     "phase_id": 1,
@@ -132,7 +139,14 @@ Example: `2026-02-12T14-30-task-traceability.json`
 }
 ```
 
-The `claimed_phase` field is optional — only present when the session was working on a phase of a decomposed MEGA ticket. Used during crash recovery to verify and restore claim ownership.
+**Field descriptions**:
+- `claimed_phase` — optional. Present when working on a phase of a decomposed MEGA ticket. Used during crash recovery to verify and restore claim ownership.
+- `progress` — optional but recommended. Enables a recovering session to resume intelligently without re-exploring the codebase:
+  - `files_completed`: files already written/modified and committed
+  - `files_remaining`: files still needed per the plan
+  - `last_commit_message`: the most recent commit (helps orient the recovering session)
+  - `decisions_made`: architectural or implementation choices made during the session (prevents re-deliberation)
+  - `blockers`: any issues discovered that need resolution before continuing
 
 ### When to Create Checkpoints
 

--- a/.claude/rules/phase-ownership.md
+++ b/.claude/rules/phase-ownership.md
@@ -16,13 +16,16 @@ Multiple Claude Code terminals can race on the same ticket because session-start
 
 **Inspired by**: Devin batch sessions, Cursor root planners, MetaGPT phase agents, Spotify squad ownership, SAFe parallel tracks, Boris Cherny 5-agent workflow.
 
-### 3 Execution Modes
+### 4 Execution Modes
 
 | Mode | When | Instances | Claim Mechanism |
 |------|------|-----------|-----------------|
-| **Sequential** | Default, single terminal | 1 | Claim one phase, finish it, claim next |
-| **Multi-instance** | User opens N terminals | 2-3 | Each terminal claims a different phase |
-| **Multi-subagent** | Agent Teams (Pattern 4) | 1 lead + N | Lead claims via TaskUpdate + writes claim file for cross-session visibility |
+| **Sequential** | Default, single terminal | 1 | Claim one phase, finish it, claim next (Step 4b chaining) |
+| **Multi-instance** | User opens N terminals | 2-3 | Each terminal claims a different phase via `mkdir` lock |
+| **Multi-subagent** | Agent Teams (Pattern 4) | 1 lead + N | Lead writes `.claude/claims/` file (Claim File Bridge) + TaskUpdate |
+| **L3 Pipeline** | Linear → n8n → GHA dispatch | 1 per ticket | Agent reads `mega_id` + `phase_hint` from dispatch payload, claims via same protocol |
+
+**Invariant**: `.claude/claims/<ID>.json` is the **single source of truth** for ownership across ALL modes. TaskUpdate (Agent Teams), operations.log (multi-instance), and plan.md `[owner: X]` markers are derived views.
 
 ## Claim File Format
 
@@ -42,8 +45,9 @@ Filename: `.claude/claims/<MEGA-ID>.json` (e.g., `CAB-1290.json`)
       "id": 1,
       "name": "API + Gateway (parallel)",
       "tickets": ["CAB-1350", "CAB-1351"],
-      "owner": "t4821",
+      "owner": "t48217-a3f2",
       "claimed_at": "2026-02-16T14:05",
+      "hostname": "macbook-pro.local",
       "branch": "feat/CAB-1350-traceparent-injection",
       "mode": "parallel",
       "deps": [],
@@ -55,6 +59,7 @@ Filename: `.claude/claims/<MEGA-ID>.json` (e.g., `CAB-1290.json`)
       "tickets": ["CAB-1352"],
       "owner": null,
       "claimed_at": null,
+      "hostname": null,
       "branch": null,
       "mode": "sequential",
       "deps": [1],
@@ -72,8 +77,9 @@ Filename: `.claude/claims/<CAB-XXXX>.json` (e.g., `CAB-1321.json`)
 {
   "ticket": "CAB-1321",
   "title": "Portal ToS link fix",
-  "owner": "t4821",
+  "owner": "t48217-a3f2",
   "pid": 12345,
+  "hostname": "macbook-pro.local",
   "claimed_at": "2026-02-16T14:10",
   "branch": "fix/CAB-1321-tos-link",
   "completed_at": null
@@ -83,9 +89,11 @@ Filename: `.claude/claims/<CAB-XXXX>.json` (e.g., `CAB-1321.json`)
 ### Instance Identity
 
 Each terminal session generates a short instance ID at startup:
-- **Format**: `t<N>` where N = epoch seconds mod 10000
+- **Format**: `t<N>-<R>` where N = epoch seconds mod 100000, R = 4 random hex chars
+- **Example**: `t48217-a3f2`
 - **Generated once** per session, logged in `SESSION-START`
 - **Purpose**: distinguish claim owners across terminals
+- **Why not shorter?**: Old format `t<mod 10000>` collides every ~2.8h with 4+ parallel instances. New format has ~1/6.5 billion collision probability per pair.
 
 ## Claim Lifecycle
 
@@ -94,12 +102,17 @@ Each terminal session generates a short instance ID at startup:
 ```
 1. Read .claude/claims/<ID>.json (or check if file exists for standalone)
 2. Find first unclaimed phase where: owner == null AND all deps satisfied
-3. Write owner + PID + timestamp to claim file
-4. Mark all phase tickets "In Progress" on Linear via MCP batch
-5. Log: CLAIM | task=<MEGA-ID> phase=<N> instance=<ID> tickets=<list>
+3. Acquire lock: mkdir .claude/claims/<ID>-phase-<N>.lock (atomic on POSIX)
+4. If mkdir succeeds → write owner + PID + hostname + timestamp to claim file → remove lockdir
+5. If mkdir fails → another instance holds the lock → wait 200ms → retry up to 3 times → backoff
+6. Mark all phase tickets "In Progress" on Linear via MCP batch
+7. Log: CLAIM | task=<MEGA-ID> phase=<N> instance=<ID> tickets=<list>
 ```
 
-**Atomicity**: Write claim → sleep 100ms → re-read → verify own PID → proceed or backoff.
+**Atomicity**: `mkdir` is atomic on all POSIX filesystems — it either succeeds or fails, no partial state.
+- Lock stale if lockdir `mtime > 30s` → safe to `rmdir` and retry (holder likely crashed during claim write)
+- Always `rmdir` the lockdir after writing the claim, even on error (use try/finally equivalent)
+- Lockdir naming: `.claude/claims/<MEGA-ID>-phase-<N>.lock` or `.claude/claims/<CAB-XXXX>.lock` for standalone
 
 ### 2. Execute
 
@@ -144,21 +157,30 @@ PID checks only work on the same machine. For truly distributed scenarios (multi
 
 ## Conflict Resolution
 
-**First-claim-wins** with filesystem verification:
+**First-claim-wins** with atomic `mkdir` locking:
 
 ```
 1. Check claim file → phase unclaimed
-2. Write own PID + timestamp as owner
-3. Sleep 100ms (filesystem sync window)
-4. Re-read claim file
-5. If own PID matches → proceed (claim successful)
-6. If different PID → backoff:
-   a. Log: CONFLICT | task=<ID> phase=<N> winner=<other_PID>
-   b. Notify user: "Phase N already claimed by <instance>. Available: Phase M."
-   c. Attempt to claim next available phase
+2. Attempt: mkdir .claude/claims/<ID>-phase-<N>.lock
+3. If mkdir SUCCEEDS:
+   a. Write own PID + hostname + timestamp as owner in claim JSON
+   b. rmdir the lockdir (release filesystem lock)
+   c. Re-read claim file → verify own PID matches
+   d. If own PID → proceed (claim successful)
+   e. If different PID → race lost (extremely unlikely), backoff
+4. If mkdir FAILS (EEXIST):
+   a. Check lockdir mtime — if > 30s, stale lock → rmdir → retry from step 2
+   b. If fresh lock → another instance is claiming right now
+   c. Wait 200ms → retry up to 3 times
+   d. After 3 retries → backoff:
+      - Log: CONFLICT | task=<ID> phase=<N> winner=<other_instance>
+      - Notify user: "Phase N already claimed by <instance>. Available: Phase M."
+      - Attempt to claim next available phase
 ```
 
-**Edge case**: If two instances write simultaneously and both see their own PID (filesystem race), the operations.log will show two CLAIM entries. The session-end lint detects this and flags it.
+**Why `mkdir`?** Unlike file writes, `mkdir` is truly atomic on POSIX — two concurrent calls will have exactly one succeed and one fail with EEXIST. This eliminates the race window that existed with the old sleep-based approach.
+
+**Stale lock cleanup**: A lockdir older than 30s means the holder crashed mid-claim. Safe to remove because claim writes take <1s.
 
 ## Phase Structure in plan.md
 

--- a/.claude/rules/session-startup.md
+++ b/.claude/rules/session-startup.md
@@ -21,10 +21,11 @@ Before reading state files, check for crashed sessions and log this session:
    - Follow `.claude/rules/crash-recovery.md` protocol
 4. **Generate instance identity** (for multi-terminal coordination):
    ```
-   Instance ID: t<N> where N = epoch seconds mod 10000
-   Example: t4821
+   Instance ID: t<N>-<R> where N = epoch seconds mod 100000, R = 4 hex chars (random)
+   Example: t48217-a3f2
    ```
    Generated once per session. Used in claim files and operations.log.
+   Old format `t<mod 10000>` collides every ~2.8h with 4+ instances. New format: ~1/6.5B collision probability.
 5. If no crash detected → **log this session immediately**:
    ```
    Append to operations.log: SESSION-START | task=<TASK> branch=<BRANCH> instance=<ID>
@@ -83,6 +84,22 @@ Use `/clear` aggressively between unrelated tasks in the same session.
 
 Follow the appropriate pattern from `ai-factory.md` (Pattern 3/5/7 for features, Pattern 1/2 for reviews).
 
+## Step 4b — Phase Chaining (after PR merge, same MEGA)
+
+After merging a PR for a phase, check if the same MEGA has another unclaimed unblocked phase:
+
+1. **Context budget gate**: Only chain if context usage < **60%**. If over 60%, end session and let a fresh instance pick up the next phase (quality degrades with deep context).
+2. Read `.claude/claims/<MEGA-ID>.json` → find the phase you just completed
+3. Set `completed_at` on your phase, clear `owner` (release)
+4. Log: `RELEASE | task=<MEGA-ID> phase=<N> instance=<ID> reason=done`
+5. Scan remaining phases: find first where `owner == null` AND all `deps` phases have `completed_at != null`
+6. If found → claim it (follow Reserve protocol from `phase-ownership.md`), continue working in same session
+7. If none available → proceed to Step 5 (End Session)
+
+**Why chain?** Avoids the overhead of a full session restart (re-reading state files, crash detection, context loading). A session that just merged a PR already has warm context about the MEGA and its architecture.
+
+**Why gate on 60%?** Phase chaining reuses the existing context window. If context is already heavy, the next phase will suffer from degraded reasoning quality. Better to start fresh.
+
 ## Step 5 — End Session
 
 1. Update `memory.md` with results (PR merged, decisions, issues found)
@@ -125,7 +142,8 @@ Follow the appropriate pattern from `ai-factory.md` (Pattern 3/5/7 for features,
 | Context at 50% | Delegate research to subagents (Step 3) |
 | Context at 70% | `/compact` then continue (Step 3) |
 | Context at 80% | Wrap up, commit, fresh session (Step 3) |
-| PR merged | Update memory.md + plan.md + EXTRACT |
+| PR merged (same MEGA) | Step 4b — chain to next phase if context < 60% |
+| PR merged (standalone) | Update memory.md + plan.md + EXTRACT |
 | CI failure / bug found | Add to gotchas.md + consider EXTRACT (Step 5) |
 | Before merge/deploy | Create checkpoint (crash-recovery.md) |
 | After merge/deploy | Log STEP-DONE, delete checkpoint |

--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ backups/
 
 # Phase Ownership claims (ephemeral, machine-local, contain PIDs)
 .claude/claims/*.json
+.claude/claims/*.lock
 
 # Infisical
 .infisical.json


### PR DESCRIPTION
## Summary
- **7 fixes** across `.claude/rules/` for reliable 4+ parallel Claude Code instance execution
- Collision-resistant instance IDs (`t<mod 100000>-<4 hex>`), POSIX `mkdir` atomic locking, phase chaining with 60% context budget gate
- Enriched checkpoint schema for crash recovery handoff, L3 dispatch phase hints, Agent Teams claim file bridge, multi-instance metrics

## Changes
| Fix | File | What |
|-----|------|------|
| 1 | `session-startup.md` + `phase-ownership.md` | Instance ID: `t<mod 10000>` → `t<mod 100000>-<4 hex random>` |
| 2 | `phase-ownership.md` | `sleep 100ms` → atomic `mkdir .lock` for claim locking |
| 3 | `session-startup.md` | New Step 4b: phase chaining (auto-scan next phase after merge) |
| 4 | `crash-recovery.md` | `progress` field in checkpoint schema (files, decisions, blockers) |
| 5 | `autonomous-factory.md` | `mega_id` + `phase_hint` in L3 dispatch payload |
| 6 | `ai-factory.md` + `phase-ownership.md` | Claim File Bridge for Agent Teams ↔ Phase Ownership |
| 7 | `ai-workflow.md` | 3 new metrics: PHASE-CLAIMED, PHASE-COMPLETED, CLAIM-CONFLICT |
| — | `.gitignore` | `.claude/claims/*.lock` for atomic lockdirs |

## Test plan
- [x] All 7 edits verified via grep for key markers
- [x] No code changes — rules/docs only
- [ ] CI green (security-scan only, no component CI for `.claude/` changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)