### PR TITLE
chore(docs): update ADR numbering to ADR-047 (next: ADR-048)

### DIFF
--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -77,7 +77,7 @@ Is it user-facing (customers, developers, partners)?
 ## ADR Numbering Rules
 
 - **stoa-docs owns ADR numbers** — never create an ADR number in stoa repo
-- Current range: ADR-001 through ADR-044. **Next available: ADR-045**
+- Current range: ADR-001 through ADR-047. **Next available: ADR-048**
 - Filename format: `adr-NNN-short-description.md`
 - Draft ADRs can live temporarily in stoa repo but MUST be renumbered when moved to stoa-docs
 - Always check `stoa-docs/docs/architecture/adr/` for the latest number before creating


### PR DESCRIPTION
## Summary
- Update `.claude/rules/documentation.md` ADR numbering range
- ADR-046 (MCP Federation Architecture) and ADR-047 (MCP Skills System) created in stoa-docs PR #59
- Next available ADR number is now **ADR-048**

## Test plan
- [x] No code changes — documentation rule metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>