### PR TITLE
chore(docs): update ADR numbering to 048, next 049

### DIFF
--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -77,7 +77,7 @@ Is it user-facing (customers, developers, partners)?
 ## ADR Numbering Rules
 
 - **stoa-docs owns ADR numbers** — never create an ADR number in stoa repo
-- Current range: ADR-001 through ADR-047. **Next available: ADR-048**
+- Current range: ADR-001 through ADR-048. **Next available: ADR-049**
 - Filename format: `adr-NNN-short-description.md`
 - Draft ADRs can live temporarily in stoa repo but MUST be renumbered when moved to stoa-docs
 - Always check `stoa-docs/docs/architecture/adr/` for the latest number before creating


### PR DESCRIPTION
## Summary
- Update ADR numbering in documentation.md: range now 001-048, next available ADR-049
- ADR-048 (Integrated Chat Agent Architecture) was created in stoa-docs PR #60

## Test plan
- [x] Single-line change in rules file
- Ship mode (zero-risk config change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)