### PR TITLE
fix(ci): add allowed_tools to all Claude Code Action workflows

### DIFF
--- a/.github/workflows/claude-interactive.yml
+++ b/.github/workflows/claude-interactive.yml
@@ -38,4 +38,12 @@ jobs:
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            Bash
+            Read
+            Write
+            Edit
+            Glob
+            Grep
+            WebFetch
           claude_args: "--model claude-sonnet-4-5-20250929 --max-turns 15"

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -41,6 +41,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            Read
+            Glob
+            Grep
           prompt: |
             You are the STOA Council Gate. Read the issue description and run a 4-persona
             Council validation (Chucky, OSS Killer, Archi, Better Call Saul).
@@ -187,10 +191,22 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            Bash
+            Read
+            Write
+            Edit
+            Glob
+            Grep
+            WebFetch
           prompt: |
             Implement the feature described in issue #${{ github.event.issue.number }}.
 
-            Read the issue description and the Council validation comment (posted earlier).
+            Issue title: ${{ github.event.issue.title }}
+            Issue body:
+            ${{ github.event.issue.body }}
+
+            Read the Council validation comment (posted earlier on this issue).
             Follow the implementation plan from the Council comment.
             Follow all rules in CLAUDE.md and .claude/rules/.
 

--- a/.github/workflows/claude-linear-dispatch.yml
+++ b/.github/workflows/claude-linear-dispatch.yml
@@ -34,6 +34,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            Read
+            Glob
+            Grep
           prompt: |
             Council validation for a Linear ticket.
 

--- a/.github/workflows/claude-multi-agent.yml
+++ b/.github/workflows/claude-multi-agent.yml
@@ -46,6 +46,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            Bash(gh issue *)
+            Bash(gh pr *)
+            Read
+            Glob
+            Grep
           prompt: |
             Multi-Agent Council Validation.
 
@@ -125,6 +131,14 @@ jobs:
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            Bash
+            Read
+            Write
+            Edit
+            Glob
+            Grep
+            WebFetch
           prompt: |
             Implement ticket: ${{ matrix.ticket }}
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -64,6 +64,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            Read
+            Glob
+            Grep
           prompt: |
             Review this PR following CLAUDE.md and .claude/rules/ci-quality-gates.md.
 

--- a/.github/workflows/claude-scheduled.yml
+++ b/.github/workflows/claude-scheduled.yml
@@ -55,6 +55,12 @@ jobs:
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            Bash(gh issue *)
+            Bash(gh pr *)
+            Read
+            Glob
+            Grep
           prompt: |
             Daily triage task. Analyze the repository state:
 
@@ -99,6 +105,13 @@ jobs:
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            Bash
+            Read
+            Write
+            Edit
+            Glob
+            Grep
           prompt: |
             CI Health Check task. Analyze recent CI runs on main:
 
@@ -145,6 +158,13 @@ jobs:
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            Bash
+            Read
+            Write
+            Edit
+            Glob
+            Grep
           prompt: |
             Weekly audit task:
 
@@ -196,6 +216,12 @@ jobs:
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            Bash(gh pr *)
+            Bash(gh issue *)
+            Read
+            Glob
+            Grep
           prompt: |
             Generate a weekly digest of the STOA AI Factory:
 
@@ -225,6 +251,10 @@ jobs:
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            Read
+            Glob
+            Grep
           prompt: |
             Weekly capacity check — read-only analysis of cycle health.
 
@@ -283,6 +313,10 @@ jobs:
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            Read
+            Glob
+            Grep
           prompt: |
             Weekly backlog stock check — scan the codebase for improvement opportunities.
 

--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -45,6 +45,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            Bash(gh run *)
+            Bash(gh issue *)
+            Read
+            Glob
+            Grep
           prompt: |
             You are the STOA AI Factory Self-Improvement Agent.
             Your job: find recurring problems and propose rule improvements.


### PR DESCRIPTION
## Summary
- All 7 Claude Code Action workflows were missing `allowed_tools`, causing tool permission failures in CI (no interactive user to approve)
- Added scoped tool permissions: read-only for council/review steps, full access for implementation steps
- Also inlined issue body in the implement prompt to avoid unnecessary `gh issue view` calls

## Files changed
- `.github/workflows/claude-interactive.yml` — full tools for @claude mentions
- `.github/workflows/claude-issue-to-pr.yml` — read-only council + full implement + issue body in prompt
- `.github/workflows/claude-linear-dispatch.yml` — read-only council
- `.github/workflows/claude-multi-agent.yml` — scoped council + full implement
- `.github/workflows/claude-review.yml` — read-only review
- `.github/workflows/claude-scheduled.yml` — 6 jobs with scoped permissions per task
- `.github/workflows/claude-self-improve.yml` — scoped gh + read access

## Test plan
- [ ] Re-trigger issue #655 `/go` comment to verify the implement step can now use tools
- [ ] CI green on this PR (security-scan required checks)

Fixes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)