### PR TITLE
chore(ci): add helm release workflow + fix CI agent startup (CAB-457)

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -188,6 +188,12 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
+            IMPORTANT: You are running in CI. Skip session-startup protocol entirely.
+            Do NOT read memory.md, plan.md, or operations.log.
+            Do NOT log SESSION-START or SESSION-END.
+            Do NOT run crash recovery checks.
+            Focus exclusively on implementing the task below.
+
             Implement the feature described in issue #${{ github.event.issue.number }}.
 
             Issue title: ${{ github.event.issue.title }}
@@ -196,7 +202,7 @@ jobs:
 
             Read the Council validation comment (posted earlier on this issue).
             Follow the implementation plan from the Council comment.
-            Follow all rules in CLAUDE.md and .claude/rules/.
+            Follow code style rules in CLAUDE.md and .claude/rules/ (but skip workflow/session rules).
 
             Steps:
             1. Create a feature branch: feat/issue-${{ github.event.issue.number }}-<slug>
@@ -210,7 +216,7 @@ jobs:
             If Ask: leave PR open for human review.
 
             IMPORTANT: Rule changes (.claude/rules/) are ALWAYS Ask mode — never auto-merge.
-          claude_args: "--model claude-sonnet-4-5-20250929 --max-turns 30 --allowedTools Bash,Read,Write,Edit,Glob,Grep,WebFetch"
+          claude_args: "--model claude-sonnet-4-5-20250929 --max-turns 60 --allowedTools Bash,Read,Write,Edit,Glob,Grep,WebFetch"
 
       # Notify Slack on completion
       - name: Notify Slack — Implementation Done

--- a/.github/workflows/claude-multi-agent.yml
+++ b/.github/workflows/claude-multi-agent.yml
@@ -126,11 +126,17 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
+            IMPORTANT: You are running in CI. Skip session-startup protocol entirely.
+            Do NOT read memory.md, plan.md, or operations.log.
+            Do NOT log SESSION-START or SESSION-END.
+            Do NOT run crash recovery checks.
+            Focus exclusively on implementing the task below.
+
             Implement ticket: ${{ matrix.ticket }}
 
             Find the GitHub issue matching this ticket ID.
             Read the issue description for requirements.
-            Follow CLAUDE.md and all .claude/rules/.
+            Follow code style rules in CLAUDE.md and .claude/rules/ (but skip workflow/session rules).
 
             Steps:
             1. Create branch: feat/${{ matrix.ticket }}-<slug>
@@ -145,7 +151,7 @@ jobs:
             Only modify files in your component scope.
             Do NOT modify shared files (memory.md, plan.md, CLAUDE.md).
             Rule changes (.claude/rules/) are ALWAYS Ask mode — never auto-merge.
-          claude_args: "--model claude-sonnet-4-5-20250929 --max-turns 25 --allowedTools Bash,Read,Write,Edit,Glob,Grep,WebFetch"
+          claude_args: "--model claude-sonnet-4-5-20250929 --max-turns 60 --allowedTools Bash,Read,Write,Edit,Glob,Grep,WebFetch"
 
       - name: Notify Slack — Agent Complete
         if: always()

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,101 @@
+# Helm Chart Release — creates GitHub Release when Chart.yaml version changes
+# Triggers on push to main with changes in charts/ directory.
+# Creates a git tag helm-vX.Y.Z and attaches the helm package tarball.
+
+name: Helm Chart Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "charts/stoa-platform/Chart.yaml"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for tag detection
+
+      - name: Extract chart version
+        id: version
+        run: |
+          VERSION=$(grep '^version:' charts/stoa-platform/Chart.yaml | awk '{print $2}')
+          APP_VERSION=$(grep '^appVersion:' charts/stoa-platform/Chart.yaml | awk '{print $2}' | tr -d '"')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=helm-v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Chart version: $VERSION, App version: $APP_VERSION"
+
+      - name: Check if tag exists
+        id: check_tag
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if git tag -l "$TAG" | grep -q "$TAG"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG already exists, skipping release"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG does not exist, will create release"
+          fi
+
+      - name: Install Helm
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Lint chart
+        if: steps.check_tag.outputs.exists == 'false'
+        run: helm lint charts/stoa-platform
+
+      - name: Package chart
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          helm package charts/stoa-platform --destination /tmp/helm-release/
+          echo "Package contents:"
+          ls -la /tmp/helm-release/
+
+      - name: Create tag and release
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          APP_VERSION="${{ steps.version.outputs.app_version }}"
+          TARBALL=$(ls /tmp/helm-release/stoa-platform-*.tgz)
+
+          git tag "$TAG"
+          git push origin "$TAG"
+
+          gh release create "$TAG" "$TARBALL" \
+            --title "Helm Chart $VERSION" \
+            --notes "## stoa-platform Helm Chart v${VERSION}
+
+          **App Version**: ${APP_VERSION}
+
+          ### Install
+
+          \`\`\`bash
+          helm install stoa-platform $TARBALL -n stoa-system --create-namespace
+          \`\`\`
+
+          Or from source:
+
+          \`\`\`bash
+          git clone https://github.com/stoa-platform/stoa.git
+          cd stoa
+          git checkout ${TAG}
+          helm install stoa-platform ./charts/stoa-platform -n stoa-system --create-namespace
+          \`\`\`
+
+          ### License
+
+          Apache 2.0 — see [LICENSE](https://github.com/stoa-platform/stoa/blob/main/LICENSE)
+          "

--- a/charts/stoa-platform/.helmignore
+++ b/charts/stoa-platform/.helmignore
@@ -1,0 +1,33 @@
+# Patterns to ignore when building packages.
+# Matches .gitignore patterns.
+
+# VCS
+.git/
+.gitignore
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# CI/CD
+.github/
+.claude/
+
+# Development
+*.md
+!README.md
+CLAUDE.md
+
+# Build artifacts
+*.tgz
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Test fixtures
+examples/
+tests/

--- a/charts/stoa-platform/CLAUDE.md
+++ b/charts/stoa-platform/CLAUDE.md
@@ -55,6 +55,12 @@ helm template stoa-platform ./charts/stoa-platform  # Dry-run
 helm upgrade --install stoa-platform ./charts/stoa-platform -n stoa-system --create-namespace
 ```
 
+## Release Workflow
+- **Workflow**: `.github/workflows/helm-release.yml`
+- **Trigger**: Push to main changing `charts/stoa-platform/Chart.yaml`
+- **Creates**: Git tag `helm-vX.Y.Z` + GitHub Release with packaged `.tgz`
+- **Idempotent**: Skips if tag already exists
+
 ## Dependencies
 - **Depends on**: Container images (control-plane-api, mcp-gateway, stoa-gateway)
 - **Depended on by**: ArgoCD (GitOps deployment)


### PR DESCRIPTION
## Summary
- Add `helm-release.yml` workflow: auto-creates GitHub Release with packaged `.tgz` tarball when `Chart.yaml` version changes on main
- Add `.helmignore` to exclude dev files (`.git/`, `.claude/`, `*.md`, tests) from Helm packages
- Fix CI agents burning 10+ turns on STOA's session-startup protocol by adding "skip startup" instructions to implementation prompts
- Increase `--max-turns` from 25-30 to 60 for `claude-issue-to-pr` and `claude-multi-agent` workflows

## Context
- Issue #661 (CAB-457): Helm chart needed automated GitHub Releases
- Issues #655, #661 failed with `error_max_turns` — agents exhausted 30 turns reading memory.md, plan.md, operations.log before doing real work

## Test plan
- [ ] CI green (3 required checks)
- [ ] `helm-release.yml` syntax valid (YAML lint in CI)
- [ ] Next Chart.yaml version bump triggers release creation

Closes #661

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>