### PR TITLE
chore(docs): deduplicate rules + workflow-essentials (CAB-1367)

### DIFF
--- a/.claude/rules/ai-factory.md
+++ b/.claude/rules/ai-factory.md
@@ -1,5 +1,5 @@
 ---
-description: Multi-agent workflow patterns, subagent delegation, cost awareness, plan structure, and binary DoD for STOA AI Factory
+description: Multi-agent workflow patterns, subagent delegation, cost awareness, plan structure for STOA AI Factory
 globs: ".claude/agents/**,.claude/skills/**"
 ---
 
@@ -7,7 +7,7 @@ globs: ".claude/agents/**,.claude/skills/**"
 
 > **HEGEMON Foundation**: Universal AI Factory rules live in `hegemon/rules/ai-factory.md`.
 > This file contains STOA-specific extensions (subagents, MCP integrations, delegation patterns).
-> When hegemon is loaded as additional working dir, both rule sets apply.
+> **Shared behavioral rules** (Ship/Show/Ask, DoD, State Machine, Logging): see `workflow-essentials.md`.
 
 ## Subagents disponibles
 
@@ -21,18 +21,17 @@ globs: ".claude/agents/**,.claude/skills/**"
 
 ## MCP Integrations (Claude.ai Native)
 
-External services connected via Claude.ai MCP servers — no local config needed.
 Full reference: `.claude/rules/mcp-integrations.md`
 
 | Service | Key Actions | When |
 |---------|-------------|------|
 | **Linear** | `get_issue`, `update_issue`, `create_comment` | Session start (fetch DoD), PR merge (close ticket), blocked (update status) |
-| **Cloudflare** | `search_cloudflare_documentation` | DNS troubleshooting, Cloudflare docs |
+| **Cloudflare** | `search_cloudflare_documentation` | DNS troubleshooting |
 | **Vercel** | `list_deployments`, `get_deployment_build_logs` | stoa-web/stoa-docs deploy verification |
 | **Notion** | `notion-search`, `notion-fetch` | Cross-workspace knowledge search |
 | **n8n** | `execute_workflow` | Trigger automation workflows |
 
-**Rule**: Use MCP for **state changes** (Linear status, Vercel deploy check). Use local files for **context** (memory.md, plan.md, CLAUDE.md). MCP calls are free but add latency — batch reads, minimize writes.
+**Rule**: MCP for **state changes**, local files for **context**. Batch reads, minimize writes.
 
 ## Cost Awareness
 
@@ -43,17 +42,11 @@ Full reference: `.claude/rules/mcp-integrations.md`
 | Architecture decisions, security review | **opus** | Critical decisions need best reasoning |
 | Plan review, implementation | **opus** (inline) | Main conversation, full context needed |
 
-**Rules**:
-- Never use opus for subagents — cost explodes with fresh context
-- Prefer haiku for `Explore` agents (codebase search)
-- Sonnet is the default for all 5 subagents
-- Maximum **3-4 subagents active simultaneously**
+**Rules**: Never opus for subagents. Prefer haiku for `Explore`. Max **3-4 subagents active**.
 
 ## Plan Structure Standard
 
-Every implementation plan MUST follow this structure. Inspired by AGENTS.md spec, Stripe engineering, and Addy Osmani's AI workflow. Plans are machine-readable documents that enable autonomous execution.
-
-### Mandatory Plan Sections
+Every implementation plan MUST follow this structure:
 
 ```markdown
 # Plan: <ticket-id> — <short title>
@@ -67,346 +60,58 @@ Every implementation plan MUST follow this structure. Inspired by AGENTS.md spec
 - **Files to modify** (with line numbers if known):
   - `path/to/file.ext:L42` — reason for change
 - **Dependencies and risks**: what could break, what blocks this
-- **Alternatives considered**: (if >1 viable approach) option A vs B, chosen B because...
+- **Alternatives considered**: option A vs B, chosen B because...
 
 ## Implementation Steps
 1. Step title — (files: `path/to/file.ext`)
    - What to change and why
    - Expected LOC: ~N
    - **Verification**: `<command that proves this step works>`
-2. ...
-(Each step must be independently testable. Dependencies between steps explicit.)
+(Each step independently testable. Dependencies explicit.)
 
 ## Binary DoD
-- [ ] All modified files listed in Implementation Steps
-- [ ] Each step is independently testable
-- [ ] Total LOC < 300 (or split into micro-PRs)
-- [ ] No new `any` types, `todo!()`, or `// TODO`
-- [ ] Component-specific quality gate passes (see below)
+→ See `workflow-essentials.md` for Universal + Component + Post-Merge checks.
 
 ## Ship/Show/Ask
-- **Mode**: Ship | Show | Ask
-- **Rationale**: <why this mode>
+- **Mode**: Ship | Show | Ask (see `workflow-essentials.md` decision matrix)
 
 ## Confidence
 **[High/Medium/Low]** — <1 sentence justification>
-(If Medium/Low: list open questions before implementation)
 ```
 
-### PR Size Thresholds (Stripe-inspired)
+## Delegation Patterns
 
-| Size | LOC Changed | Action |
-|------|-------------|--------|
-| Ideal | <50 | Auto-merge eligible with tests |
-| Good | 50-150 | Single micro-commit |
-| Acceptable | 150-300 | Single PR, multiple commits |
-| Too large | >300 | MUST split into micro-PRs |
+### When to delegate vs work inline
+- **Delegate**: verbose output, isolated context, self-contained task, read-only tools needed
+- **Inline**: frequent user interaction, shared context, <5 files, latency matters
 
-### Binary Definition of Done
+### Pattern 1-2: Sequential / Parallel Review
+- **P1**: security-reviewer → test-writer → k8s-ops (sequential pipeline)
+- **P2** (`/parallel-review`): all 3 in parallel → synthesize → Go/Fix/Redo verdict
 
-A task is DONE if and only if ALL checks pass. No partial credit, no "mostly done".
-
-#### Universal Checks (every task)
-
-| # | Check | Pass Criteria | How to Verify |
-|---|-------|--------------|---------------|
-| 1 | Code compiles | Zero errors | `cargo check` / `tsc --noEmit` / `ruff check` |
-| 2 | Tests pass | Zero failures | `cargo test` / `npm test -- --run` / `pytest` |
-| 3 | No regressions | Existing tests still green | Full test suite run |
-| 4 | Lint clean | Zero new warnings | Component lint command |
-| 5 | Format clean | Zero diffs | `cargo fmt --check` / `npm run format:check` |
-| 6 | No secrets | Zero matches | `gitleaks detect --no-git` on changed files |
-| 7 | PR created | PR URL exists | `gh pr view` |
-| 8 | CI green | 3 required checks pass | `gh pr checks` |
-| 9 | State files updated | `memory.md` reflects changes | Manual check |
-| 10 | Session logged | SESSION-START exists in operations.log for this task | `tail -20 operations.log` |
-
-#### Component-Specific Checks
-
-| Component | Extra Checks |
-|-----------|-------------|
-| Python (api, mcp) | Coverage >= threshold, ruff + black clean, mypy clean |
-| TypeScript (ui, portal) | ESLint max-warnings not exceeded, prettier clean, tsc clean |
-| Rust (gateway) | Clippy zero warnings (strict + SAST rules), cargo test --all-features |
-| K8s/Helm | `helm lint`, `privileged: false` present, probes use `/health` |
-| Docs/Content | Content compliance scan (no P0/P1 violations) |
-
-#### Post-Merge Checks (code changes only)
-
-| # | Check | Pass Criteria |
-|---|-------|--------------|
-| 1 | CI on main | Component workflow `conclusion: success` |
-| 2 | Docker build | Image pushed to ECR |
-| 3 | Pod updated | New image running in `stoa-system` |
-| 4 | ArgoCD synced | Synced + Healthy (if ArgoCD-managed) |
-
-## Ship/Show/Ask Decision Matrix
-
-| Change Type | Mode | Examples |
-|-------------|------|---------|
-| `.claude/` config, rules, prompts | **Ship** | AI Factory rules, agent configs |
-| `memory.md`, `plan.md`, docs (`.md`) | **Ship** | State files, runbooks, README |
-| Dependency bumps (minor/patch) | **Ship** | Dependabot PRs, lockfile updates |
-| Test additions (no code changes) | **Show** | New unit tests, coverage improvement |
-| Refactoring (no behavior change) | **Show** | Extract function, rename, reorganize |
-| Style/format fixes | **Show** | Prettier, ESLint autofix, ruff format |
-| Bug fix (isolated, clear root cause) | **Show** | Off-by-one, null check, typo in logic |
-| New feature (any scope) | **Ask** | New endpoint, new component, new model |
-| Security-related changes | **Ask** | Auth, RBAC, secrets, crypto, CORS |
-| Database migrations | **Ask** | Alembic, schema changes |
-| K8s/Helm/infra changes | **Ask** | Deployments, services, ingress, ArgoCD |
-| Breaking API changes | **Ask** | Endpoint removal, schema change, renamed fields |
-| Cross-component changes | **Ask** | Gateway + API, UI + Portal |
-
-## Quand deleguer vs travailler inline
-
-### Deleguer a un subagent quand:
-- La tache produit beaucoup d'output (logs k8s, rapports securite, analyse de couverture)
-- On veut isoler le contexte (ne pas polluer la conversation principale)
-- La tache est auto-contenue (ecrire des tests, analyser une PR, diagnostiquer un deploy)
-- On a besoin d'outils restreints (securite et k8s = read-only par design)
-
-### Travailler inline quand:
-- La tache necessite des allers-retours frequents avec l'utilisateur
-- Plusieurs phases partagent du contexte significatif
-- Le changement est rapide et cible (< 5 fichiers)
-- La latence compte (les subagents demarrent avec un contexte frais)
-
-## Patterns de delegation
-
-### Pattern 1: Review sequentielle
-```
-1. security-reviewer analyse les changements
-2. Resultats → test-writer genere les tests manquants
-3. k8s-ops valide si des fichiers infra sont modifies
-```
-Usage: feature development standard, PR review approfondie.
-
-### Pattern 2: Review parallele (/parallel-review)
-```
-Lancer security-reviewer + test-writer + k8s-ops en parallele
-Synthetiser les resultats dans le thread principal
-Produire un verdict global Go / Fix / Refaire
-```
-Usage: PR review rapide, validation pre-merge.
-
-### Pattern 3: Feature development (Ship/Show/Ask)
-```
-1.  [Inline] Explorer + planifier (Plan mode)
-2.  [Inline] Branch: git checkout -b feat/CAB-XXXX-description
-3.  [LOG] SESSION-START | task=CAB-XXXX branch=feat/...
-4.  [Inline] Implementer le code + micro-commits (<150 LOC chacun)
-5.  [test-writer] Generer les tests
-6.  [security-reviewer] Review securite
-7.  [docs-writer] Documenter si ADR ou guide necessaire
-8.  [Inline] Local quality gate (ci-quality-gates.md)
-9.  [Inline] Push + PR (gh pr create)
-10. [LOG] STEP-DONE | step=pr-created task=CAB-XXXX pr=XXX
-11. [Inline] CI green (gh pr checks --watch)
-12. [LOG+CHECKPOINT] Before merge — create checkpoint file
-13. [Inline] Ship/Show → merge auto | Ask → attendre "merge"
-14. [LOG] STEP-DONE | step=merged task=CAB-XXXX pr=XXX — delete checkpoint
-15. [Inline] Verify CD: CI main → ArgoCD sync → Pod healthy
-16. [k8s-ops] Si ArgoCD OutOfSync ou pod CrashLoop → diagnostiquer
-17. [Inline] Update state files (memory.md, plan.md) + cleanup branch
-18. [LOG] SESSION-END | task=CAB-XXXX status=success
-```
-Usage: implementation complete d'un ticket CAB-XXXX. Voir `git-workflow.md` pour Ship/Show/Ask + CD verification map.
+### Pattern 3: Feature Development
+`[Inline] Plan → Branch → Code → [test-writer] Tests → [security-reviewer] Review → Quality gate → PR → CI → Merge → CD verify → State files`
 
 ### Pattern 4: Agent Teams (opt-in, experimental)
+Activation: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`. Prereq: `tmux`. Max 3 teammates (Sonnet), lead (Opus). Only for multi-component independent scopes >= 300 LOC. Must write `.claude/claims/` files (Claim File Bridge). See `phase-ownership.md`.
 
-**Activation**: `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` dans `.claude/settings.json` (auto, pas de .zshrc).
-**Prerequis runtime**: `brew install tmux`
+### Pattern 5-7: CI-first / Content compliance / Spec-driven
+- **P5**: Branch → code → pre-commit checklist → tests → security → merge → CD verify
+- **P6**: docs-writer → content-reviewer → security-reviewer → corrections → PR
+- **P7** (Osmani): Plan → test-writer (failing tests first) → implement → security → merge
 
-**IMPORTANT**: Le flag rend la feature disponible. Il ne l'active PAS automatiquement.
-Claude ne spawne des teammates que si les criteres ci-dessous sont remplis.
+### Pattern 8-9: Decompose + Phase Ownership
+- **P8** (`/decompose`): MEGA → N component sub-issues on Linear → N parallel instances/worktrees
+- **P9**: `.claude/claims/<ID>.json` coordination. 3 modes: sequential, multi-instance, multi-subagent
 
-#### Gate de decision — Quand utiliser Agent Teams
-
-```
-Tache a realiser ?
-│
-├── Mono-composant (api, ui, portal, gateway, mcp, e2e)
-│   └── ❌ Single session — Agent Teams interdit (overhead inutile)
-│
-├── Multi-composants MAIS sequentiels (couplage fort)
-│   └── ❌ Single session — micro-PRs Stripe (Pattern 5/7)
-│
-├── Multi-composants ET independants (aucune dependance entre eux)
-│   │   Exemples:
-│   │   - API endpoints + UI components + tests E2E (3 scopes isoles)
-│   │   - Refactoring gateway + refactoring portal (zero couplage)
-│   │   - Debug concurrent: 3 hypotheses a tester en parallele
-│   │
-│   ├── LOC total < 300 ?
-│   │   └── ❌ Single session — pas assez de travail pour justifier N contextes
-│   │
-│   └── LOC total >= 300, 2-3 scopes independants ?
-│       └── ✅ Agent Teams (max 3 teammates)
-│           Lead: Opus (coordination) | Teammates: Sonnet (implementation)
-│
-└── User demande explicitement "use teams" / "parallelize"
-    └── ✅ Agent Teams — user override, pas de gate
-```
-
-#### Regles d'usage
-
-| Regle | Detail |
-|-------|--------|
-| Max teammates | **3** (au-dela, cout explose sans gain proportionnel) |
-| Lead model | Opus (coordination strategique) |
-| Teammate model | Sonnet (implementation, cout maitrise) |
-| Chaque teammate | 1 scope, 1 branche, 1 micro-PR independante |
-| Jamais pour | Docs-only, single-file fix, config changes, memory updates |
-| Cost awareness | ~3-4x tokens pour 3 teammates, ~7x avec overhead plan mode |
-
-#### Claim File Bridge (MANDATORY)
-
-When Agent Teams works on a MEGA with phases, the lead MUST write `.claude/claims/` files alongside TaskUpdate:
-
-```
-1. Lead reads/creates .claude/claims/<MEGA-ID>.json
-2. For each teammate assignment → write owner=<teammate-name> in the claim file
-3. Teammates log CLAIM in operations.log (same as multi-instance protocol)
-4. On completion → teammate releases claim in file + logs RELEASE
-```
-
-**Why?** Claim files are the single source of truth visible to ALL execution modes (sequential, multi-instance, multi-subagent). Without this bridge, a local terminal running `session-startup.md` Step 2 cannot see what Agent Teams teammates are working on, leading to duplicate claims.
-
-#### Workflow Agent Teams
-```
-1. [Lead/Opus] Analyser la tache, identifier N scopes independants
-2. [Lead/Opus] Creer le plan: quel teammate fait quoi
-2b. [Lead/Opus] Write .claude/claims/<MEGA-ID>.json with teammate assignments (Claim File Bridge)
-3. [Teammate 1/Sonnet] Scope A: branch → code → tests → quality gate
-4. [Teammate 2/Sonnet] Scope B: branch → code → tests → quality gate
-5. [Teammate 3/Sonnet] Scope C: branch → code → tests → quality gate
-6. [Lead/Opus] Synthetiser: verifier coherence, pas de conflit
-7. [Inline] Push + PRs + CI green + merge (sequentiel)
-8. [Inline] Update state files
-```
-
-### Pattern 5: CI-first development (always-green main)
-```
-1.  [Inline] Branch + implementer la feature + micro-commits
-2.  [LOG] SESSION-START | task=<TASK> branch=<BRANCH>
-3.  [Inline] Executer le pre-commit checklist (voir ci-quality-gates.md)
-4.  [test-writer] Generer les tests + verifier coverage seuil
-5.  [security-reviewer] Review securite + secrets
-6.  [LOG+CHECKPOINT] Before merge — create checkpoint file
-7.  [Inline] Push + PR + CI green + merge (voir git-workflow.md)
-8.  [LOG] STEP-DONE | step=merged — delete checkpoint
-9.  [Inline] Verify CD: CI main + ArgoCD + Pod (voir git-workflow.md step 7)
-10. [k8s-ops] Si probleme CD → diagnostiquer et proposer fix
-11. [Inline] Update state files
-12. [LOG] SESSION-END | task=<TASK> status=success
-```
-Usage: tout changement de code. Objectif: zero surprise en CI, always-green main.
-
-### Pattern 6: Content compliance review
-```
-1. [docs-writer] Rediger le contenu
-2. [content-reviewer] Scanner conformite (concurrents, prix, clients, reglementation)
-3. [security-reviewer] Si contenu touche securite/RBAC
-4. [Inline] Corrections + commit + PR
-```
-Usage: tout contenu public avec mentions concurrents, reglementations ou clients.
-
-### Pattern 7: Spec-driven development (Osmani-inspired)
-```
-1.  [Inline] User provides feature request
-2.  [Inline] Claude generates plan in Plan Mode (plan structure standard above)
-3.  [Inline] User approves or iterates on plan
-4.  [LOG] SESSION-START | task=<TASK> branch=<BRANCH>
-5.  [test-writer] Generate failing tests from plan (test-first)
-6.  [Inline] Implement code to pass tests (<300 LOC per PR)
-7.  [security-reviewer] Review securite
-8.  [Inline] Local quality gate (all DoD checkboxes green)
-9.  [Inline] Ship/Show/Ask categorization (decision matrix)
-10. [LOG+CHECKPOINT] Before merge — create checkpoint file
-11. [Inline] PR + CI + merge
-12. [LOG] STEP-DONE | step=merged — delete checkpoint
-13. [Inline] CD verification (post-merge checks)
-14. [Inline] Update state files (memory.md, plan.md)
-15. [LOG] SESSION-END | task=<TASK> status=success
-```
-Usage: all new features. Objective: test-first + quality parity with human code.
-
-### Pattern 8: Decompose + Parallel Instances (multi-Claude)
-
-Uses Phase Ownership claims for cross-session coordination. See Pattern 9 and `phase-ownership.md`.
-
-Prerequis: MEGA ticket (>= 21 pts) touching >= 2 components.
-Trigger: `/decompose CAB-XXXX` skill.
-
-```
-1.  [Inline] /decompose CAB-XXXX → creates N component-scoped sub-issues on Linear
-2.  [Inline] Review the DAG and execution plan
-3.  User launches N Claude Code instances (terminals or worktrees)
-
-    Phase 1 (parallel — no dependencies):
-4a. [Instance 1] CAB-XXXX-API: branch → code → tests → PR → merge
-4b. [Instance 2] CAB-XXXX-GW:  branch → code → tests → PR → merge
-4c. [Instance 3] CAB-XXXX-DOCS: branch → write → PR → merge (stoa-docs repo)
-
-    Phase 2 (parallel — after Phase 1 merges):
-5a. [Instance 1] CAB-XXXX-UI:    branch → code → tests → PR → merge
-5b. [Instance 2] CAB-XXXX-PORTAL: branch → code → tests → PR → merge
-
-    Phase 3 (sequential — after Phase 2):
-6.  [Instance 1] CAB-XXXX-E2E:   branch → tests → PR → merge
-
-7.  [Inline] Update parent ticket on Linear (Done)
-8.  [Inline] Update state files (memory.md, plan.md)
-```
-
-Key rules:
-- Each instance works in its own worktree: `git worktree add ../<name> feat/<branch>`
-- Each sub-issue = 1 PR, < 300 LOC, independently deployable
-- API always Phase 1 (upstream data provider)
-- UI always Phase 2 (depends on API endpoints)
-- E2E always last (needs all components)
-- docs always Phase 1 (separate repo, zero code coupling)
-- Worktrees share git history but isolate file changes
-- **Dropbox gotcha**: create worktrees OUTSIDE Dropbox folder to avoid sync conflicts
-
-Usage: MEGA features (>= 21 pts), cross-component work. Gain: 1.5-2x speedup.
-See `/decompose` skill for full DAG generation and Linear integration.
-
-### Pattern 9: Phase Ownership (multi-session coordination)
-
-Prerequis: Any MEGA ticket OR multi-terminal workflow.
-Coordination: `.claude/claims/<ID>.json` + `phase-ownership.md`.
-
-```
-1. [Any instance] /decompose CAB-XXXX → creates sub-issues + claim file
-   OR: manually create claim file for existing MEGA phases
-2. [Instance 1] session-startup Step 2 → claims Phase 1 (e.g., API)
-3. [Instance 2] session-startup Step 2 → sees Phase 1 claimed → claims Phase 2 (e.g., Gateway)
-4. [Instance 3] session-startup Step 2 → claims Phase 3 (e.g., Docs, stoa-docs repo)
-5. Each instance executes its phase end-to-end (Pattern 3/5/7 inside the phase)
-6. On phase completion → release claim → check for next unblocked phase
-7. When all phases done → update parent MEGA on Linear → state files
-```
-
-Regles:
-- Une instance qui prend une phase la **TERMINE** (pas de switch mid-phase)
-- Si crash → next session detects stale claim via `phase-ownership.md` protocol
-- Max **3 instances paralleles** (cost control)
-- Chaque phase <300 LOC, 1 PR (Stripe micro-PR standard)
-- Claim file is the single source of truth for ownership — plan.md `[owner: X]` is a view
-
-3 execution modes: Sequential (1 terminal), Multi-instance (N terminals), Multi-subagent (Agent Teams lead + N).
-See `phase-ownership.md` for full protocol, claim schemas, and conflict resolution.
+Rules: end-to-end phase ownership, max 3 instances, <300 LOC/PR, API=Phase1, UI=Phase2, E2E=last.
+See `phase-ownership.md` for full protocol.
 
 ## Contraintes
 
-- **Maximum 3-4 subagents actifs simultanement** (au-dela, le cout explose et le temps de review aussi)
-- **security-reviewer, k8s-ops et content-reviewer** sont read-only — ils ne modifient JAMAIS le code
-- **test-writer et docs-writer** modifient le code — verifier leurs outputs
-- Chaque subagent qui review donne un **verdict binaire**: Go / Fix / Refaire
-- Un seul P0 (critique) de n'importe quel subagent → verdict global **Fix**
-- **Toujours consulter `ci-quality-gates.md`** AVANT de committer du code
-- **Toujours consulter `secrets-management.md`** quand un env var ou credential est ajoute/modifie
-- **Toujours consulter `content-compliance.md`** quand du contenu public mentionne concurrents, prix, clients ou reglementations
-- **Toujours mettre a jour les state files** (memory.md, plan.md) apres chaque PR mergee
+- **Max 3-4 subagents simultaneously**
+- **security-reviewer, k8s-ops, content-reviewer** = read-only (never modify code)
+- **test-writer, docs-writer** = modify code (verify outputs)
+- Binary verdict per subagent: Go / Fix / Redo. One P0 → global **Fix**
+- Always consult: `ci-quality-gates.md` (before commit), `secrets-management.md` (credentials), `content-compliance.md` (public content)
+- Always update state files after PR merge

--- a/.claude/rules/ai-workflow.md
+++ b/.claude/rules/ai-workflow.md
@@ -6,8 +6,8 @@ globs: "memory.md,plan.md,.claude/**"
 # AI Workflow Rules
 
 > **HEGEMON Foundation**: Universal state files protocol and session lifecycle live in `hegemon/rules/state-files.md` + `hegemon/rules/session-lifecycle.md`.
-> This file contains STOA-specific extensions (feature dev patterns, context management, operation logging).
-> When hegemon is loaded as additional working dir, both rule sets apply.
+> This file contains STOA-specific extensions (feature dev patterns, context management, state files protocol).
+> **Shared behavioral rules** (State Machine, Logging, Anti-Drift): see `workflow-essentials.md`.
 
 ## Session Lifecycle
 1. Read `memory.md` for current state
@@ -22,7 +22,7 @@ globs: "memory.md,plan.md,.claude/**"
 3. **Choose** one option -> "Plan in 5 steps max, don't code"
 4. **Validate** the plan -> user says "Go"
 5. **Execute**: branch → code → micro-commits → local quality gate → push → PR → CI green → merge → verify
-6. Claude determines **Ship/Show/Ask** mode based on risk level (see `git-workflow.md`)
+6. Claude determines **Ship/Show/Ask** mode based on risk level (see `workflow-essentials.md`)
 7. **Ship/Show**: Claude handles the full lifecycle autonomously — no questions asked
 8. **Ask**: Claude stops after PR creation, waits for user to say "merge"
 
@@ -68,9 +68,9 @@ Update `memory.md` when:
 
 Update `plan.md` when:
 1. **PR merged** — mark ticket as `[x]` in the correct cycle section
-2. **`/sync-plan` run** — cycle-driven sync from Linear (adds missing tickets, updates markers)
+2. **`/sync-plan` run** — cycle-driven sync from Linear
 3. **Task blocked/unblocked** — update marker `[~]` ↔ `[!]`
-4. **Cycle rollover** — when a new cycle starts, current becomes historical, next becomes current
+4. **Cycle rollover** — current becomes historical, next becomes current
 
 ### plan.md Structure (Cycle-Driven)
 
@@ -112,15 +112,10 @@ Decomposed MEGA tickets in plan.md include phase sub-headers with ownership meta
     - [ ] CAB-1352 [e2e] Integration tests
 ```
 
-**Phase markers**:
-- `[owner: t4821]` — claimed by instance t4821 (from `.claude/claims/<MEGA-ID>.json`)
-- `[owner: —]` — unclaimed (available for any instance)
-- Phase dependency: `(parallel)`, `(after Phase 1)`, `(after Phase 1+2)`
+**Phase markers**: `[owner: t4821]` = claimed, `[owner: —]` = available.
+Phase dependency: `(parallel)`, `(after Phase 1)`, `(after Phase 1+2)`.
 
-**Rules**:
-- Phase ownership markers are local metadata, NOT derived from Linear
-- `/sync-plan` MUST preserve `[owner: X]` markers during regeneration
-- See `phase-ownership.md` for claim lifecycle and conflict resolution
+**Rules**: Phase ownership markers are local metadata, NOT from Linear. `/sync-plan` MUST preserve `[owner: X]` markers. See `phase-ownership.md`.
 
 Update private `MEMORY.md` when:
 1. **New ticket completed** — add to relevant section
@@ -134,158 +129,22 @@ Update private `MEMORY.md` when:
 - **Never delete DONE items** from memory.md — they serve as audit trail
 - **Archive** items older than 2 sprints to reduce noise
 
-### Item State Machine (MANDATORY)
+### Item State Machine, Session-End Lint, Operation Logging, Anti-Drift
 
-Every trackable item follows this lifecycle — no exceptions, no shortcuts:
-
-```
-PENDING ──→ CLAIMED ──→ IN_PROGRESS ──→ DONE ──→ ARCHIVED
-   │              │           │
-   └── BLOCKED ◄──┴───────────┘
-```
-
-**CLAIMED** is a transitional state for multi-instance coordination. An item is CLAIMED when an instance has reserved it (claim file written) but hasn't started producing artifacts yet. In single-instance mode, CLAIMED is implicit and transitions immediately to IN_PROGRESS.
-
-#### Markers by File
-
-| State | plan.md | memory.md text | memory.md section |
-|-------|---------|----------------|-------------------|
-| PENDING | `[ ]` | No bold marker | `📋 NEXT` |
-| CLAIMED | `[owner: tN]` metadata on phase | Claim file has owner | Phase in claimed MEGA |
-| IN_PROGRESS | `[~]` | Sub-items may be ✅ but parent has `[ ]` remaining | `🔴 IN PROGRESS` |
-| DONE | `[x]` | `— DONE` suffix or all sub-items ✅ | `✅ DONE` |
-| BLOCKED | `[!]` | `— BLOCKED` suffix + reason | `🚫 BLOCKED` |
-
-#### Structural Invariants (must be true at ALL times)
-
-These 5 rules are non-negotiable. Violating any one = state file drift.
-
-1. **No DONE in active sections** — if an item text contains `**DONE**`, `— DONE`, or has ALL sub-items marked ✅ with zero `[ ]` remaining, it MUST be in `✅ DONE` section. Never leave a completed item in `🔴 IN PROGRESS` or `📋 NEXT`.
-2. **Checkbox ↔ section parity** — `[x]` in plan.md = item in `✅ DONE` in memory.md. `[~]` = `🔴 IN PROGRESS`. `[ ]` = `📋 NEXT`. No cross-state mismatches.
-3. **Single home rule** — an item appears in exactly ONE section of memory.md. Duplicates across sections are forbidden.
-4. **Partial completion** — if a parent task has both ✅ and `[ ]` sub-items, the parent stays `[~]` in `🔴 IN PROGRESS`. Promote to `[x]` + `✅ DONE` only when ALL sub-items are complete.
-5. **Strikethrough = moved** — `~~item~~` in a section means it was relocated. Remove the strikethrough entry within 1 session to avoid clutter.
-
-#### Atomic State Transitions
-
-When an item changes state, perform ALL updates in a **single edit pass** — never split across separate tool calls or "I'll do it later":
-
-| Transition | plan.md | memory.md | MEMORY.md (private) |
-|------------|---------|-----------|---------------------|
-| Claim phase | none → `[owner: tN]` | — | Log CLAIM in operations.log |
-| Release phase | `[owner: tN]` → `[owner: —]` | — | Log RELEASE in operations.log |
-| Start work | `[ ]` → `[~]` | Move from `📋 NEXT` → `🔴 IN PROGRESS` | Update Active Tickets |
-| Complete | `[~]` → `[x]` | Add `— DONE (PR #N)` + move from `🔴 IN PROGRESS` → `✅ DONE` | Update Active Tickets |
-| Block | `[~]` → `[!]` | Move to `🚫 BLOCKED` + add reason | Update Active Tickets |
-| Unblock | `[!]` → `[~]` | Move back to `🔴 IN PROGRESS` | Update Active Tickets |
-
-**Root cause of past drift**: sessions marked items as `**DONE**` in the text but never moved them to the `✅ DONE` section. The text marker and the section move MUST happen together — always.
-
-### Session-End State Lint (MANDATORY before SESSION-END log)
-
-Before logging `SESSION-END`, run these 4 checks mentally. If any fails, fix it before ending.
-
-| # | Check | Scan target | Pass criteria |
-|---|-------|-------------|---------------|
-| 1 | No DONE in IN_PROGRESS | `🔴 IN PROGRESS` section of memory.md | Zero items with `**DONE**`, `— DONE`, or all-✅ sub-items |
-| 2 | No DONE in NEXT | `📋 NEXT` section of memory.md | Zero items with `**DONE**`, `— DONE`, or `~~strikethrough~~` |
-| 3 | Stale `[~]` check | plan.md | Every `[~]` item has at least one `[ ]` sub-item remaining |
-| 4 | Cross-file parity | plan.md vs memory.md | Each `[x]` in plan.md → matching entry in `✅ DONE`. Each `[~]` → in `🔴 IN PROGRESS` |
-
-**Enforcement**: failing this lint is equivalent to pushing code with broken tests. Fix before SESSION-END — no exceptions.
-
-## Operation Logging (Traceability)
-
-### Log Location
-`~/.claude/projects/.../memory/operations.log` — append-only, never edit existing entries.
-
-### Event Types
-
-| Event | Trigger | Required Fields |
-|-------|---------|----------------|
-| `SESSION-START` | Session begins work on a task | `task`, `branch` |
-| `SESSION-END` | Session ends (success, paused, or crash detected) | `task`, `status` |
-| `STEP-START` | Major step begins (code, test, pr, merge, cd) | `step`, `task` |
-| `STEP-DONE` | Major step completes | `step`, `task` |
-| `CHECKPOINT` | Pre-merge/deploy checkpoint created | `task`, `file` |
-| `ERROR` | Non-fatal error during execution | `task`, `error` |
-| `RECOVERY` | Crash recovery action taken | `task`, `action` |
-| `CLAIM` | Phase or ticket claimed by an instance | `task`, `phase`, `instance`, `tickets` |
-| `RELEASE` | Phase or ticket released (done or abandoned) | `task`, `phase`, `instance`, `reason` |
-
-### Format Rules
-- Timestamp: ISO 8601 short (`YYYY-MM-DDTHH:MM`)
-- Separator: ` | ` (space-pipe-space)
-- Fields: `key=value` pairs, space-separated
-- Append-only: never edit or delete existing log entries
-- One line per event, no multiline
-
-### Mandatory Events
-Every session MUST have at minimum:
-1. `SESSION-START` — logged when work begins on a task
-2. `SESSION-END` — logged when session ends, even on early exit
-
-Missing `SESSION-END` = crash indicator (see `crash-recovery.md`).
+→ See `workflow-essentials.md` for the single source of truth on:
+- Item State Machine (PENDING → CLAIMED → IN_PROGRESS → DONE → ARCHIVED)
+- Structural Invariants (5 non-negotiable rules)
+- Atomic State Transitions
+- Session-End State Lint (4 mandatory checks)
+- Operation Logging (event types, format, mandatory events)
+- Session Metrics (PR-MERGED, CI-FIX, STATE-DRIFT, PHASE-* events)
+- Anti-Drift Rules
 
 ### Checkpoint Directory
 `~/.claude/projects/.../memory/checkpoints/` — JSON files created before risky operations.
 See `crash-recovery.md` for checkpoint schema and lifecycle.
 
-## Session Metrics (Observability)
-
-### Log Location
-`~/.claude/projects/.../memory/metrics.log` — append-only, structured events for factory performance tracking.
-
-### Events
-
-| Event | When | Fields |
-|-------|------|--------|
-| `PR-MERGED` | After successful merge | `task`, `pr`, `branch_lifetime_min` (optional) |
-| `CI-FIX` | After `/ci-fix` skill runs | `task`, `check`, `auto_fixed` (true/false) |
-| `STATE-DRIFT` | Stop hook detects misplaced items | `items_misplaced` (count) |
-| `PHASE-CLAIMED` | Instance claims a MEGA phase | `task` (MEGA ID), `phase`, `instance`, `mode` (sequential/multi-instance/multi-subagent/l3) |
-| `PHASE-COMPLETED` | Instance finishes a MEGA phase | `task` (MEGA ID), `phase`, `instance`, `pr`, `duration_min` (optional) |
-| `CLAIM-CONFLICT` | Two instances race for same phase | `task` (MEGA ID), `phase`, `winner`, `loser` |
-| `PHASE-CLAIMED` | Instance claims a MEGA phase | `task` (MEGA ID), `phase`, `instance`, `mode` (sequential/multi-instance/multi-subagent/l3) |
-| `PHASE-COMPLETED` | Instance finishes a MEGA phase | `task` (MEGA ID), `phase`, `instance`, `pr`, `duration_min` (optional) |
-| `CLAIM-CONFLICT` | Two instances race for same phase | `task` (MEGA ID), `phase`, `winner`, `loser` |
-
-### Format
-Same as operations.log: `YYYY-MM-DDTHH:MM | EVENT | key=value ...`
-
-### When to Append
-- **PR merged** — append `PR-MERGED` in the same step as STEP-DONE step=merged
-- **CI fix** — `/ci-fix` skill appends `CI-FIX` automatically (see skill prompt)
-- **State drift** — `stop-state-lint.sh` hook appends `STATE-DRIFT` automatically
-- **Phase claimed** — append `PHASE-CLAIMED` when claiming a MEGA phase (any execution mode)
-- **Phase completed** — append `PHASE-COMPLETED` when releasing a completed phase
-- **Claim conflict** — append `CLAIM-CONFLICT` when `mkdir` lock fails and another instance wins
-- **Phase claimed** — append `PHASE-CLAIMED` when claiming a MEGA phase (any execution mode)
-- **Phase completed** — append `PHASE-COMPLETED` when releasing a completed phase
-- **Claim conflict** — append `CLAIM-CONFLICT` when `mkdir` lock fails and another instance wins
-
-### Log Rotation
-- Keep `metrics.log` under **500 lines** (same policy as operations.log)
-- When over 500 lines: move oldest entries to `metrics.log.1`
-- Keep `metrics.log.1` for 90 days, then delete
-- Clean up during session-end (Step 8 of session-startup.md)
-
-### Usage
-Periodically review `metrics.log` to identify:
-- Average branch lifetime (PR-MERGED entries)
-- Most frequent CI failure types (CI-FIX entries)
-- State drift frequency (STATE-DRIFT entries)
-- Parallelization efficiency: phases claimed vs completed, conflict rate (PHASE-CLAIMED/PHASE-COMPLETED/CLAIM-CONFLICT)
-- Average phase duration (PHASE-COMPLETED `duration_min` field)
-- Parallelization efficiency: phases claimed vs completed, conflict rate (PHASE-CLAIMED/PHASE-COMPLETED/CLAIM-CONFLICT)
-- Average phase duration (PHASE-COMPLETED `duration_min` field)
-
-## Anti-Drift Rules
-- **1 thing at a time** — never mix feature + refactor + fix
-- **Never code without a validated plan**
-- **Red flags** (broken tests, tech debt, security flaw) -> fix before continuing
-- **If > 10 min structuring manually** -> STOP, use Claude Code
-- **State files are mandatory** — skipping memory.md update is a workflow violation
-- **Operation log is mandatory** — every session MUST have SESSION-START and SESSION-END entries
-- **Atomic transitions only** — marking an item `**DONE**` without moving it to the `✅ DONE` section is forbidden (see Item State Machine above)
-- **Session-End State Lint** — run the 4-check lint before every SESSION-END. Inconsistent state files = workflow violation equivalent to broken tests on main
+### Metrics Log Rotation
+- Keep `metrics.log` under **500 lines**
+- When over 500 lines: move oldest to `metrics.log.1` (90-day retention)
+- Clean up during session-end

--- a/.claude/rules/workflow-essentials.md
+++ b/.claude/rules/workflow-essentials.md
@@ -1,0 +1,165 @@
+---
+description: Core behavioral rules — Ship/Show/Ask, DoD, State Machine, Operation Logging, Anti-Drift
+---
+
+# Workflow Essentials — Core Behavioral Rules
+
+> Single source of truth for rules referenced by ai-factory.md, ai-workflow.md, git-workflow.md, session-startup.md, phase-ownership.md.
+
+## Ship/Show/Ask Decision Matrix
+
+| Change Type | Mode | Examples |
+|-------------|------|---------|
+| `.claude/` config, rules, prompts | **Ship** | AI Factory rules, agent configs |
+| `memory.md`, `plan.md`, docs (`.md`) | **Ship** | State files, runbooks, README |
+| Dependency bumps (minor/patch) | **Ship** | Dependabot PRs, lockfile updates |
+| Test additions (no code changes) | **Show** | New unit tests, coverage improvement |
+| Refactoring (no behavior change) | **Show** | Extract function, rename, reorganize |
+| Style/format fixes | **Show** | Prettier, ESLint autofix, ruff format |
+| Bug fix (isolated, clear root cause) | **Show** | Off-by-one, null check, typo in logic |
+| New feature (any scope) | **Ask** | New endpoint, new component, new model |
+| Security-related changes | **Ask** | Auth, RBAC, secrets, crypto, CORS |
+| Database migrations | **Ask** | Alembic, schema changes |
+| K8s/Helm/infra changes | **Ask** | Deployments, services, ingress, ArgoCD |
+| Breaking API changes | **Ask** | Endpoint removal, schema change, renamed fields |
+| Cross-component changes | **Ask** | Gateway + API, UI + Portal |
+
+## PR Size Thresholds (Stripe-inspired)
+
+| Size | LOC Changed | Action |
+|------|-------------|--------|
+| Ideal | <50 | Auto-merge eligible with tests |
+| Good | 50-150 | Single micro-commit |
+| Acceptable | 150-300 | Single PR, multiple commits |
+| Too large | >300 | MUST split into micro-PRs |
+
+## Binary Definition of Done
+
+### Universal Checks (every task)
+
+| # | Check | Pass Criteria | How to Verify |
+|---|-------|--------------|---------------|
+| 1 | Code compiles | Zero errors | `cargo check` / `tsc --noEmit` / `ruff check` |
+| 2 | Tests pass | Zero failures | `cargo test` / `npm test -- --run` / `pytest` |
+| 3 | No regressions | Existing tests still green | Full test suite run |
+| 4 | Lint clean | Zero new warnings | Component lint command |
+| 5 | Format clean | Zero diffs | `cargo fmt --check` / `npm run format:check` |
+| 6 | No secrets | Zero matches | `gitleaks detect --no-git` on changed files |
+| 7 | PR created | PR URL exists | `gh pr view` |
+| 8 | CI green | 3 required checks pass | `gh pr checks` |
+| 9 | State files updated | `memory.md` reflects changes | Manual check |
+| 10 | Session logged | SESSION-START exists in operations.log | `tail -20 operations.log` |
+
+### Component-Specific Checks
+
+| Component | Extra Checks |
+|-----------|-------------|
+| Python (api, mcp) | Coverage >= threshold, ruff + black clean, mypy clean |
+| TypeScript (ui, portal) | ESLint max-warnings not exceeded, prettier clean, tsc clean |
+| Rust (gateway) | Clippy zero warnings (strict + SAST rules), cargo test --all-features |
+| K8s/Helm | `helm lint`, `privileged: false` present, probes use `/health` |
+| Docs/Content | Content compliance scan (no P0/P1 violations) |
+
+### Post-Merge Checks (code changes only)
+
+| # | Check | Pass Criteria |
+|---|-------|--------------|
+| 1 | CI on main | Component workflow `conclusion: success` |
+| 2 | Docker build | Image pushed to GHCR |
+| 3 | Pod updated | New image running in `stoa-system` |
+| 4 | ArgoCD synced | Synced + Healthy (if ArgoCD-managed) |
+
+## Item State Machine (MANDATORY)
+
+```
+PENDING ──→ CLAIMED ──→ IN_PROGRESS ──→ DONE ──→ ARCHIVED
+   │              │           │
+   └── BLOCKED ◄──┴───────────┘
+```
+
+### Markers by File
+
+| State | plan.md | memory.md text | memory.md section |
+|-------|---------|----------------|-------------------|
+| PENDING | `[ ]` | No bold marker | `📋 NEXT` |
+| CLAIMED | `[owner: tN]` metadata | Claim file has owner | Phase in claimed MEGA |
+| IN_PROGRESS | `[~]` | Sub-items may be ✅ but parent has `[ ]` remaining | `🔴 IN PROGRESS` |
+| DONE | `[x]` | `— DONE` suffix or all sub-items ✅ | `✅ DONE` |
+| BLOCKED | `[!]` | `— BLOCKED` suffix + reason | `🚫 BLOCKED` |
+
+### Structural Invariants (5 non-negotiable rules)
+
+1. **No DONE in active sections** — completed items MUST be in `✅ DONE` section
+2. **Checkbox ↔ section parity** — `[x]` = `✅ DONE`, `[~]` = `🔴 IN PROGRESS`, `[ ]` = `📋 NEXT`
+3. **Single home rule** — item appears in exactly ONE section of memory.md
+4. **Partial completion** — parent stays `[~]` until ALL sub-items complete
+5. **Strikethrough = moved** — remove `~~item~~` within 1 session
+
+### Atomic State Transitions
+
+| Transition | plan.md | memory.md | operations.log |
+|------------|---------|-----------|----------------|
+| Start work | `[ ]` → `[~]` | `📋 NEXT` → `🔴 IN PROGRESS` | — |
+| Complete | `[~]` → `[x]` | Add `— DONE (PR #N)` + move to `✅ DONE` | STEP-DONE |
+| Block | `[~]` → `[!]` | Move to `🚫 BLOCKED` + add reason | — |
+| Unblock | `[!]` → `[~]` | Move back to `🔴 IN PROGRESS` | — |
+| Claim phase | — | — | CLAIM |
+| Release phase | `[owner: tN]` → `[owner: —]` | — | RELEASE |
+
+**Root cause of past drift**: marking `**DONE**` in text without moving to `✅ DONE` section. Text marker + section move MUST happen together.
+
+## Session-End State Lint (MANDATORY before SESSION-END)
+
+| # | Check | Scan target | Pass criteria |
+|---|-------|-------------|---------------|
+| 1 | No DONE in IN_PROGRESS | `🔴 IN PROGRESS` section | Zero items with `**DONE**`, `— DONE`, or all-✅ sub-items |
+| 2 | No DONE in NEXT | `📋 NEXT` section | Zero items with `**DONE**`, `— DONE`, or `~~strikethrough~~` |
+| 3 | Stale `[~]` check | plan.md | Every `[~]` has at least one `[ ]` sub-item remaining |
+| 4 | Cross-file parity | plan.md vs memory.md | `[x]` → `✅ DONE`, `[~]` → `🔴 IN PROGRESS` |
+
+## Operation Logging
+
+Location: `~/.claude/projects/.../memory/operations.log` — append-only.
+
+### Event Types
+
+| Event | Trigger | Required Fields |
+|-------|---------|----------------|
+| `SESSION-START` | Session begins | `task`, `branch` |
+| `SESSION-END` | Session ends | `task`, `status` |
+| `STEP-START` | Major step begins | `step`, `task` |
+| `STEP-DONE` | Major step completes | `step`, `task` |
+| `CHECKPOINT` | Pre-merge checkpoint | `task`, `file` |
+| `ERROR` | Non-fatal error | `task`, `error` |
+| `RECOVERY` | Crash recovery | `task`, `action` |
+| `CLAIM` | Phase claimed | `task`, `phase`, `instance`, `tickets` |
+| `RELEASE` | Phase released | `task`, `phase`, `instance`, `reason` |
+
+### Format
+
+`YYYY-MM-DDTHH:MM | EVENT | key=value ...` — one line per event, no multiline.
+
+## Session Metrics
+
+Location: `~/.claude/projects/.../memory/metrics.log` — append-only, same format as operations.log.
+
+| Event | When | Fields |
+|-------|------|--------|
+| `PR-MERGED` | After merge | `task`, `pr` |
+| `CI-FIX` | After `/ci-fix` | `task`, `check`, `auto_fixed` |
+| `STATE-DRIFT` | Stop hook detects | `items_misplaced` |
+| `PHASE-CLAIMED` | Phase claimed | `task`, `phase`, `instance`, `mode` |
+| `PHASE-COMPLETED` | Phase done | `task`, `phase`, `instance`, `pr` |
+| `CLAIM-CONFLICT` | Race condition | `task`, `phase`, `winner`, `loser` |
+
+Keep under 500 lines. Rotate oldest to `metrics.log.1` (90-day retention).
+
+## Anti-Drift Rules
+
+- **1 thing at a time** — never mix feature + refactor + fix
+- **Never code without a validated plan**
+- **Red flags** (broken tests, tech debt, security flaw) → fix before continuing
+- **State files are mandatory** — skipping memory.md update is a workflow violation
+- **Operation log is mandatory** — every session MUST have SESSION-START and SESSION-END
+- **Atomic transitions only** — marking `**DONE**` without moving to `✅ DONE` is forbidden
+- **Session-End State Lint** — 4-check lint before every SESSION-END, no exceptions


### PR DESCRIPTION
## Summary
- Create `workflow-essentials.md` (165 lines, no globs = always loaded) as single source of truth for Ship/Show/Ask, Binary DoD, Item State Machine, Operation Logging, Session-End Lint, Anti-Drift Rules
- Trim `ai-factory.md` from 412 → 117 lines (72% reduction): condense 9 patterns to 1-3 lines each, remove duplicated DoD/Ship tables
- Trim `ai-workflow.md` from 291 → 150 lines (48% reduction): remove duplicated State Machine, Logging, Anti-Drift sections, fix 3 copy-paste duplicate blocks in metrics events
- Net savings: ~14K tokens/turn when both globbed files load

## Test plan
- [ ] Rules files parse correctly (no broken markdown)
- [ ] workflow-essentials.md loads on every session (no globs frontmatter)
- [ ] Pointers in trimmed files correctly reference workflow-essentials.md sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)