### PR TITLE
fix(ci): use $vars for n8n cloud compatibility (CAB-1368)

### DIFF
--- a/scripts/ai-ops/n8n-approve-ticket.json
+++ b/scripts/ai-ops/n8n-approve-ticket.json
@@ -54,7 +54,7 @@
     },
     {
       "parameters": {
-        "jsCode": "const crypto = require('crypto');\n\nconst issue = $input.first().json.query.issue;\nconst token = $input.first().json.query.token;\nconst secret = $env.APPROVE_HMAC_SECRET;\n\nif (!secret) {\n  throw new Error('APPROVE_HMAC_SECRET not configured');\n}\n\nconst expected = crypto.createHmac('sha256', secret).update(issue).digest('hex');\n\nif (token !== expected) {\n  throw new Error('Invalid HMAC token');\n}\n\nreturn [{ json: { issue, token, valid: true } }];"
+        "jsCode": "const crypto = require('crypto');\n\nconst issue = $input.first().json.query.issue;\nconst token = $input.first().json.query.token;\n\n// n8n cloud: use $vars (Settings > Variables). Self-hosted: use $env.\nconst secret = $vars?.APPROVE_HMAC_SECRET || $env?.APPROVE_HMAC_SECRET;\n\nif (!secret) {\n  throw new Error('APPROVE_HMAC_SECRET not configured — add it in n8n Settings > Variables');\n}\n\nconst expected = crypto.createHmac('sha256', secret).update(issue).digest('hex');\n\nif (token !== expected) {\n  throw new Error('Invalid HMAC token');\n}\n\nreturn [{ json: { issue, token, valid: true } }];"
       },
       "id": "validate-hmac",
       "name": "Validate HMAC",


### PR DESCRIPTION
## Summary
- n8n cloud uses `$vars` (Settings > Variables) instead of `$env` for environment variables
- Updated HMAC validation code in `n8n-approve-ticket.json` to try `$vars` first, fallback to `$env` (self-hosted compat)

## Test plan
- [ ] Import updated JSON in n8n cloud, add `APPROVE_HMAC_SECRET` in Settings > Variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)