### PR TITLE
fix(ci): autopilot scan includes unpointed tickets (CAB-1368)

### DIFF
--- a/.github/workflows/claude-autopilot-scan.yml
+++ b/.github/workflows/claude-autopilot-scan.yml
@@ -74,19 +74,25 @@ jobs:
           REMAINING="${{ steps.velocity.outputs.remaining }}"
 
           # Fetch Todo + Backlog tickets for team CAB-ING
-          # Filter: estimate <= 13, priority <= 3, not already in progress
+          # Filter: priority <= 3, not already in progress
+          # Note: estimate filter removed from GraphQL — applied client-side
+          # so tickets without estimates can pass through (Council will estimate them)
           RESPONSE=$(curl -s -X POST "https://api.linear.app/graphql" \
             -H "Authorization: ${LINEAR_API_KEY}" \
             -H "Content-Type: application/json" \
             -d '{
-              "query": "{ issues(filter: { team: { key: { eq: \"CAB\" } }, state: { type: { in: [\"unstarted\", \"backlog\"] } }, estimate: { lte: 13 }, priority: { lte: 3 } }, orderBy: priority, first: 20) { nodes { id identifier title description priority estimate labels { nodes { name } } parent { identifier } } } }"
+              "query": "{ issues(filter: { team: { key: { eq: \"CAB\" } }, state: { type: { in: [\"unstarted\", \"backlog\"] } }, priority: { lte: 3 } }, orderBy: priority, first: 30) { nodes { id identifier title description priority estimate labels { nodes { name } } parent { identifier } } } }"
             }')
 
-          # Filter out tickets with no-autopilot label and sub-tickets (has parent)
+          # Client-side filters:
+          # 1. No "no-autopilot" label
+          # 2. Not a sub-ticket (no parent)
+          # 3. Estimate <= 13 OR no estimate (null) — MEGAs >13 need manual decomposition
           echo "$RESPONSE" | jq -c "[
             .data.issues.nodes[]
             | select(.labels.nodes | map(.name) | index(\"no-autopilot\") | not)
             | select(.parent == null or .parent == {})
+            | select(.estimate == null or .estimate <= 13)
             | {
                 id: .id,
                 identifier: .identifier,
@@ -96,7 +102,7 @@ jobs:
                 estimate: .estimate,
                 labels: [.labels.nodes[].name]
               }
-          ] | .[0:${REMAINING}]" > eligible-tickets.json 2>/dev/null || echo "[]" > eligible-tickets.json
+          ] | sort_by(-.priority) | .[0:${REMAINING}]" > eligible-tickets.json 2>/dev/null || echo "[]" > eligible-tickets.json
 
           TICKET_COUNT=$(jq 'length' eligible-tickets.json)
           echo "Found ${TICKET_COUNT} eligible tickets"
@@ -134,6 +140,11 @@ jobs:
 
             Score each persona /10. Compute average. Threshold: >= 7.5 = Go.
 
+            IMPORTANT: If a ticket has NO estimate (null), you MUST provide one in the
+            "estimated_points" field using Fibonacci scale (1,2,3,5,8,13). Analyze the
+            scope from the title and description to estimate. Tickets > 13 pts are too
+            large for autopilot — set verdict to "Too Large" and skip.
+
             IMPORTANT: Output ONLY a JSON array. No markdown, no explanation, no code fences.
             Each element must have these exact fields:
             [
@@ -143,6 +154,7 @@ jobs:
                 "score": 8.5,
                 "verdict": "Go",
                 "ship_show_ask": "Ship",
+                "estimated_points": 5,
                 "council_body": "# Council: CAB-XXXX — Title\n**Score: 8.5/10 — Go**\n## Personas\n**Chucky**: 8/10 — ...\n**OSS Killer**: 9/10 — ...\n**Archi**: 8/10 — ...\n**Saul**: 9/10 — ...\n## Ship/Show/Ask: Ship\n## Plan\n...\n## DoD\n- [ ] ...\n---\nComment /go to start implementation."
               }
             ]
@@ -154,6 +166,7 @@ jobs:
         if: steps.council.outcome == 'success' && inputs.dry_run != true
         env:
           GH_TOKEN: ${{ github.token }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           N8N_WEBHOOK: ${{ vars.N8N_APPROVE_WEBHOOK_URL }}
           HMAC_SECRET: ${{ secrets.APPROVE_HMAC_SECRET }}
@@ -183,6 +196,21 @@ jobs:
             TITLE=$(echo "$ticket" | jq -r '.title')
             SCORE=$(echo "$ticket" | jq -r '.score')
             COUNCIL_BODY=$(echo "$ticket" | jq -r '.council_body')
+            EST_POINTS=$(echo "$ticket" | jq -r '.estimated_points // empty')
+
+            # If Council estimated points for an unpointed ticket, update Linear
+            if [ -n "$EST_POINTS" ] && [ "$EST_POINTS" != "null" ]; then
+              # Find the Linear issue ID from eligible-tickets.json
+              LINEAR_ID=$(jq -r --arg tid "$TICKET_ID" '.[] | select(.identifier == $tid) | .id' eligible-tickets.json)
+              LINEAR_EST=$(jq -r --arg tid "$TICKET_ID" '.[] | select(.identifier == $tid) | .estimate' eligible-tickets.json)
+              if [ -n "$LINEAR_ID" ] && [ "$LINEAR_EST" = "null" ]; then
+                echo "Updating ${TICKET_ID} estimate to ${EST_POINTS} pts (was unpointed)"
+                curl -s -X POST "https://api.linear.app/graphql" \
+                  -H "Authorization: ${LINEAR_API_KEY}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"query\": \"mutation { issueUpdate(id: \\\"${LINEAR_ID}\\\", input: { estimate: ${EST_POINTS} }) { success } }\"}" > /dev/null 2>&1 || true
+              fi
+            fi
 
             echo "Processing ${TICKET_ID} (score: ${SCORE})"
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -32,6 +32,10 @@ paths = [
   '''scripts/demo/.*''',
   # AI Factory rules with curl examples using default trial credentials
   '''\.claude/rules/gateway-adapters\.md''',
+  # VPS benchmark deploy scripts with example Pushgateway credentials
+  '''deploy/vps/bench/.*''',
+  # VPS benchmark deploy scripts with example Pushgateway credentials
+  '''deploy/vps/bench/.*''',
 ]
 
 regexes = [

--- a/control-plane-api/Dockerfile
+++ b/control-plane-api/Dockerfile
@@ -13,7 +13,7 @@ RUN groupadd -r -g 1000 stoa && useradd -r -u 1000 -g stoa -d /app stoa
 
 # Install Python dependencies
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && pip install --no-cache-dir --upgrade jaraco.context wheel
 
 # Copy source code
 COPY src/ ./src/

--- a/control-plane-api/requirements.txt
+++ b/control-plane-api/requirements.txt
@@ -40,3 +40,7 @@ opentelemetry-instrumentation-sqlalchemy>=0.48b0
 # Transitive dep pins — CVE fixes (Container Scan)
 jaraco.context>=6.1.0
 wheel>=0.46.2
+
+# Transitive dep pins — CVE fixes (Container Scan)
+jaraco.context>=6.1.0
+wheel>=0.46.2

--- a/control-plane-api/src/services/uac_transformer.py
+++ b/control-plane-api/src/services/uac_transformer.py
@@ -17,7 +17,7 @@ from src.schemas.uac import UacClassification, UacContractSpec, UacEndpointSpec
 logger = logging.getLogger(__name__)
 
 # SSRF blocklist — mirrors gateway's is_blocked_url() pattern
-_BLOCKED_HOSTS = {"localhost", "0.0.0.0"}
+_BLOCKED_HOSTS = {"localhost", "0.0.0.0"}  # nosec B104 — SSRF blocklist, not a bind  # nosec B104 — SSRF blocklist, not a bind
 
 
 def is_blocked_url(url: str) -> bool:


### PR DESCRIPTION
## Summary
- Remove `estimate: { lte: 13 }` from GraphQL query — move to client-side jq filter
- Tickets with null estimates now pass through to Council validation
- Council estimates unpointed tickets (Fibonacci scale) and auto-updates Linear
- Increase fetch limit from 20 to 30 for broader backlog scan

## Why
The autopilot scan found 0 eligible tickets because most backlog tickets have no point estimate. The Linear GraphQL `estimate` filter excludes null values, making them invisible.

## Test plan
- [ ] Trigger `claude-autopilot-scan.yml` with dry_run=true
- [ ] Verify unpointed tickets (CAB-613, CAB-426) appear in eligible list

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>