### PR TITLE
fix(ci): add id-token permission to autopilot scan (CAB-1368)

### DIFF
--- a/.github/workflows/claude-autopilot-scan.yml
+++ b/.github/workflows/claude-autopilot-scan.yml
@@ -26,6 +26,7 @@ concurrency:
 permissions:
   contents: read
   issues: write
+  id-token: write
 
 jobs:
   scan:


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission to `claude-autopilot-scan.yml`
- `claude-code-action@v1` requires this for OIDC token generation
- Without it, Council validation fails with "Could not fetch an OIDC token" error

## Test plan
- [x] Identified from run `22119916864` — Council step failed with OIDC error
- [ ] Re-run autopilot scan after merge to verify Council executes successfully

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>