### PR TITLE
feat(api): add federation delegation tokens + usage API (CAB-1370)

### DIFF
--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -3135,6 +3135,72 @@
         "title": "DashboardStats",
         "type": "object"
       },
+      "DelegationTokenRequest": {
+        "description": "Request schema for token delegation via master account.",
+        "properties": {
+          "scopes": {
+            "description": "OAuth2 scopes to request",
+            "items": {
+              "type": "string"
+            },
+            "title": "Scopes",
+            "type": "array"
+          },
+          "ttl_seconds": {
+            "default": 3600,
+            "description": "Token TTL in seconds (1min to 24h)",
+            "maximum": 86400.0,
+            "minimum": 60.0,
+            "title": "Ttl Seconds",
+            "type": "integer"
+          }
+        },
+        "title": "DelegationTokenRequest",
+        "type": "object"
+      },
+      "DelegationTokenResponse": {
+        "description": "Response schema for a delegated federation token.",
+        "properties": {
+          "access_token": {
+            "description": "Delegated OAuth2 access token",
+            "title": "Access Token",
+            "type": "string"
+          },
+          "expires_in": {
+            "description": "Token lifetime in seconds",
+            "title": "Expires In",
+            "type": "integer"
+          },
+          "scope": {
+            "description": "Granted scopes (space-separated)",
+            "title": "Scope",
+            "type": "string"
+          },
+          "sub_account_id": {
+            "format": "uuid",
+            "title": "Sub Account Id",
+            "type": "string"
+          },
+          "sub_account_name": {
+            "title": "Sub Account Name",
+            "type": "string"
+          },
+          "token_type": {
+            "default": "Bearer",
+            "title": "Token Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "access_token",
+          "expires_in",
+          "scope",
+          "sub_account_id",
+          "sub_account_name"
+        ],
+        "title": "DelegationTokenResponse",
+        "type": "object"
+      },
       "DeploymentCreate": {
         "properties": {
           "api_id": {
@@ -4912,6 +4978,33 @@
           "visibility"
         ],
         "title": "FacetsResponse",
+        "type": "object"
+      },
+      "FederationBulkRevokeResponse": {
+        "description": "Response schema for bulk sub-account revocation.",
+        "properties": {
+          "already_revoked": {
+            "description": "Number already in revoked state",
+            "title": "Already Revoked",
+            "type": "integer"
+          },
+          "revoked_count": {
+            "description": "Number of sub-accounts newly revoked",
+            "title": "Revoked Count",
+            "type": "integer"
+          },
+          "total": {
+            "description": "Total sub-accounts in master account",
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "revoked_count",
+          "already_revoked",
+          "total"
+        ],
+        "title": "FederationBulkRevokeResponse",
         "type": "object"
       },
       "FileContent": {
@@ -13783,6 +13876,48 @@
         "title": "TokenExchangeResponse",
         "type": "object"
       },
+      "ToolAllowListResponse": {
+        "description": "Response schema for sub-account tool allow-list.",
+        "properties": {
+          "sub_account_id": {
+            "format": "uuid",
+            "title": "Sub Account Id",
+            "type": "string"
+          },
+          "tools": {
+            "description": "Currently allowed tool names",
+            "items": {
+              "type": "string"
+            },
+            "title": "Tools",
+            "type": "array"
+          }
+        },
+        "required": [
+          "sub_account_id",
+          "tools"
+        ],
+        "title": "ToolAllowListResponse",
+        "type": "object"
+      },
+      "ToolAllowListUpdate": {
+        "description": "Request schema for updating a sub-account tool allow-list.",
+        "properties": {
+          "tools": {
+            "description": "List of tool names (replaces existing)",
+            "items": {
+              "type": "string"
+            },
+            "title": "Tools",
+            "type": "array"
+          }
+        },
+        "required": [
+          "tools"
+        ],
+        "title": "ToolAllowListUpdate",
+        "type": "object"
+      },
       "ToolInvokeRequest": {
         "description": "Tool invocation request.",
         "properties": {
@@ -14189,6 +14324,94 @@
           "avg_latency_ms"
         ],
         "title": "UsagePeriodStats",
+        "type": "object"
+      },
+      "UsageResponse": {
+        "description": "Aggregated usage statistics for all sub-accounts of a master account.",
+        "properties": {
+          "master_account_id": {
+            "format": "uuid",
+            "title": "Master Account Id",
+            "type": "string"
+          },
+          "period_days": {
+            "title": "Period Days",
+            "type": "integer"
+          },
+          "sub_accounts": {
+            "items": {
+              "$ref": "#/components/schemas/UsageStat"
+            },
+            "title": "Sub Accounts",
+            "type": "array"
+          },
+          "total_requests": {
+            "default": 0,
+            "title": "Total Requests",
+            "type": "integer"
+          },
+          "total_tokens": {
+            "default": 0,
+            "title": "Total Tokens",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "master_account_id",
+          "period_days",
+          "sub_accounts"
+        ],
+        "title": "UsageResponse",
+        "type": "object"
+      },
+      "UsageStat": {
+        "description": "Single sub-account usage statistics entry.",
+        "properties": {
+          "error_count": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Error Count",
+            "type": "integer"
+          },
+          "last_active_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Active At"
+          },
+          "request_count": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Request Count",
+            "type": "integer"
+          },
+          "sub_account_id": {
+            "format": "uuid",
+            "title": "Sub Account Id",
+            "type": "string"
+          },
+          "sub_account_name": {
+            "title": "Sub Account Name",
+            "type": "string"
+          },
+          "token_count": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Token Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "sub_account_id",
+          "sub_account_name"
+        ],
+        "title": "UsageStat",
         "type": "object"
       },
       "UsageSummary": {
@@ -29217,6 +29440,132 @@
         ]
       }
     },
+    "/v1/tenants/{tenant_id}/federation/accounts/{account_id}/bulk-revoke": {
+      "post": {
+        "description": "Revoke all active/suspended sub-accounts under a master account.",
+        "operationId": "bulk_revoke_v1_tenants__tenant_id__federation_accounts__account_id__bulk_revoke_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Account Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FederationBulkRevokeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Bulk Revoke",
+        "tags": [
+          "Federation"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/federation/accounts/{account_id}/delegate-token": {
+      "post": {
+        "description": "Issue a delegation token for the first active sub-account with a KC client.",
+        "operationId": "delegate_token_v1_tenants__tenant_id__federation_accounts__account_id__delegate_token_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Account Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DelegationTokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelegationTokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delegate Token",
+        "tags": [
+          "Federation"
+        ]
+      }
+    },
     "/v1/tenants/{tenant_id}/federation/accounts/{account_id}/sub-accounts": {
       "get": {
         "description": "List sub-accounts for a federation master account.",
@@ -29528,7 +29877,7 @@
     },
     "/v1/tenants/{tenant_id}/federation/accounts/{account_id}/sub-accounts/{sub_id}/revoke": {
       "post": {
-        "description": "Revoke a sub-account \u2014 clears API key and sets status to revoked.",
+        "description": "Revoke a sub-account -- clears API key and sets status to revoked.",
         "operationId": "revoke_sub_account_v1_tenants__tenant_id__federation_accounts__account_id__sub_accounts__sub_id__revoke_post",
         "parameters": [
           {
@@ -29589,6 +29938,222 @@
           }
         ],
         "summary": "Revoke Sub Account",
+        "tags": [
+          "Federation"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/federation/accounts/{account_id}/sub-accounts/{sub_id}/tools": {
+      "get": {
+        "description": "Get the tool allow-list for a sub-account.",
+        "operationId": "get_tool_allow_list_v1_tenants__tenant_id__federation_accounts__account_id__sub_accounts__sub_id__tools_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Account Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sub_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Sub Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolAllowListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Tool Allow List",
+        "tags": [
+          "Federation"
+        ]
+      },
+      "put": {
+        "description": "Replace the tool allow-list for a sub-account.",
+        "operationId": "set_tool_allow_list_v1_tenants__tenant_id__federation_accounts__account_id__sub_accounts__sub_id__tools_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Account Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sub_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Sub Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ToolAllowListUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolAllowListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Set Tool Allow List",
+        "tags": [
+          "Federation"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/federation/accounts/{account_id}/usage": {
+      "get": {
+        "description": "Get aggregated usage statistics for a master account's sub-accounts.",
+        "operationId": "get_usage_v1_tenants__tenant_id__federation_accounts__account_id__usage_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Account Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Usage period in days",
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "default": 7,
+              "description": "Usage period in days",
+              "maximum": 90,
+              "minimum": 1,
+              "title": "Days",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Usage",
         "tags": [
           "Federation"
         ]

--- a/control-plane-api/src/repositories/federation.py
+++ b/control-plane-api/src/repositories/federation.py
@@ -1,11 +1,18 @@
-"""Repository for federation master/sub-account CRUD (CAB-1313/CAB-1361)."""
+"""Repository for federation master/sub-account CRUD (CAB-1313/CAB-1361/CAB-1370)."""
 
+from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.models.federation import MasterAccount, MasterAccountStatus, SubAccount, SubAccountStatus
+from src.models.federation import (
+    MasterAccount,
+    MasterAccountStatus,
+    SubAccount,
+    SubAccountStatus,
+    SubAccountTool,
+)
 
 
 class MasterAccountRepository:
@@ -120,3 +127,52 @@ class SubAccountRepository:
         await self.session.flush()
         await self.session.refresh(sub)
         return sub
+
+    # ============== CAB-1370: Bulk Revoke + Tool Allow-List ==============
+
+    async def bulk_revoke(self, master_id: UUID) -> tuple[int, int]:
+        """Revoke all active/suspended sub-accounts under a master."""
+        already_q = select(func.count()).where(
+            and_(
+                SubAccount.master_account_id == master_id,
+                SubAccount.status == SubAccountStatus.REVOKED,
+            )
+        )
+        already_result = await self.session.execute(already_q)
+        already_revoked = already_result.scalar_one()
+
+        stmt = (
+            update(SubAccount)
+            .where(
+                and_(
+                    SubAccount.master_account_id == master_id,
+                    SubAccount.status.in_([SubAccountStatus.ACTIVE, SubAccountStatus.SUSPENDED]),
+                )
+            )
+            .values(
+                status=SubAccountStatus.REVOKED,
+                api_key_hash=None,
+                updated_at=datetime.utcnow(),
+            )
+        )
+        result = await self.session.execute(stmt)
+        await self.session.flush()
+        return result.rowcount, already_revoked
+
+    async def set_tool_allow_list(self, sub_id: UUID, tool_names: list[str]) -> list[str]:
+        """Replace the tool allow-list for a sub-account."""
+        await self.session.execute(delete(SubAccountTool).where(SubAccountTool.sub_account_id == sub_id))
+        unique_tools = sorted(set(tool_names))
+        for tool_name in unique_tools:
+            self.session.add(SubAccountTool(sub_account_id=sub_id, tool_name=tool_name))
+        await self.session.flush()
+        return unique_tools
+
+    async def get_tool_allow_list(self, sub_id: UUID) -> list[str]:
+        """Get sorted tool names for a sub-account."""
+        result = await self.session.execute(
+            select(SubAccountTool.tool_name)
+            .where(SubAccountTool.sub_account_id == sub_id)
+            .order_by(SubAccountTool.tool_name)
+        )
+        return list(result.scalars().all())

--- a/control-plane-api/src/routers/federation.py
+++ b/control-plane-api/src/routers/federation.py
@@ -1,4 +1,4 @@
-"""Federation router — enterprise MCP multi-account orchestration (CAB-1313/CAB-1361)."""
+"""Federation router — enterprise MCP multi-account orchestration (CAB-1313/CAB-1361/CAB-1370)."""
 
 import logging
 from uuid import UUID
@@ -10,6 +10,9 @@ from ..auth import User, get_current_user
 from ..database import get_db
 from ..models.federation import MasterAccountStatus, SubAccountStatus
 from ..schemas.federation import (
+    DelegationTokenRequest,
+    DelegationTokenResponse,
+    FederationBulkRevokeResponse,
     MasterAccountCreate,
     MasterAccountListResponse,
     MasterAccountResponse,
@@ -19,6 +22,10 @@ from ..schemas.federation import (
     SubAccountListResponse,
     SubAccountResponse,
     SubAccountUpdate,
+    ToolAllowListResponse,
+    ToolAllowListUpdate,
+    UsageResponse,
+    UsageStat,
 )
 from ..services.federation_service import FederationService
 
@@ -316,7 +323,7 @@ async def revoke_sub_account(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Revoke a sub-account — clears API key and sets status to revoked."""
+    """Revoke a sub-account -- clears API key and sets status to revoked."""
     _require_write_access(user, tenant_id)
 
     svc = FederationService(db)
@@ -329,3 +336,145 @@ async def revoke_sub_account(
 
     logger.info("Federation sub-account revoked: %s by %s", sub.name, user.id)
     return SubAccountResponse.model_validate(sub)
+
+
+# ============== CAB-1370: Delegation Token + Usage + Bulk Ops ==============
+
+
+@router.post("/{account_id}/delegate-token", response_model=DelegationTokenResponse)
+async def delegate_token(
+    tenant_id: str,
+    account_id: UUID,
+    request: DelegationTokenRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Issue a delegation token for the first active sub-account with a KC client."""
+    _require_write_access(user, tenant_id)
+
+    svc = FederationService(db)
+    master = await svc.get_master_account(account_id)
+    if not master or master.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Master account not found")
+
+    # Find first active sub-account with a Keycloak client
+    items, _ = await svc.list_sub_accounts(master.id, status=SubAccountStatus.ACTIVE, page=1, page_size=100)
+    target_sub = next((s for s in items if s.kc_client_id), None)
+    if not target_sub:
+        raise HTTPException(status_code=404, detail="No active sub-account with Keycloak client found")
+
+    try:
+        token_data = await svc.delegate_token(target_sub, request.scopes, request.ttl_seconds)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return DelegationTokenResponse(
+        access_token=token_data["access_token"],
+        token_type=token_data.get("token_type", "Bearer"),
+        expires_in=token_data.get("expires_in", request.ttl_seconds),
+        scope=token_data.get("scope", " ".join(request.scopes)),
+        sub_account_id=target_sub.id,
+        sub_account_name=target_sub.name,
+    )
+
+
+@router.get("/{account_id}/usage", response_model=UsageResponse)
+async def get_usage(
+    tenant_id: str,
+    account_id: UUID,
+    days: int = Query(7, ge=1, le=90, description="Usage period in days"),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get aggregated usage statistics for a master account's sub-accounts."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    svc = FederationService(db)
+    master = await svc.get_master_account(account_id)
+    if not master or master.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Master account not found")
+
+    usage_data = await svc.get_usage_aggregation(master.id, period_days=days)
+    sub_stats = [UsageStat(**entry) for entry in usage_data]
+
+    return UsageResponse(
+        master_account_id=master.id,
+        period_days=days,
+        total_requests=sum(s.request_count for s in sub_stats),
+        total_tokens=sum(s.token_count for s in sub_stats),
+        sub_accounts=sub_stats,
+    )
+
+
+@router.post("/{account_id}/bulk-revoke", response_model=FederationBulkRevokeResponse)
+async def bulk_revoke(
+    tenant_id: str,
+    account_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Revoke all active/suspended sub-accounts under a master account."""
+    _require_write_access(user, tenant_id)
+
+    svc = FederationService(db)
+    master = await svc.get_master_account(account_id)
+    if not master or master.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Master account not found")
+
+    newly_revoked, already_revoked, total = await svc.bulk_revoke(master.id)
+    await db.commit()
+
+    logger.info(
+        "Federation bulk revoke: %s/%s by %s — %d revoked",
+        tenant_id,
+        master.name,
+        user.id,
+        newly_revoked,
+    )
+    return FederationBulkRevokeResponse(revoked_count=newly_revoked, already_revoked=already_revoked, total=total)
+
+
+@router.put("/{account_id}/sub-accounts/{sub_id}/tools", response_model=ToolAllowListResponse)
+async def set_tool_allow_list(
+    tenant_id: str,
+    account_id: UUID,
+    sub_id: UUID,
+    request: ToolAllowListUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Replace the tool allow-list for a sub-account."""
+    _require_write_access(user, tenant_id)
+
+    svc = FederationService(db)
+    sub = await svc.get_sub_account(sub_id)
+    if not sub or sub.master_account_id != account_id or sub.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Sub-account not found")
+
+    tools = await svc.set_tool_allow_list(sub_id, request.tools)
+    await db.commit()
+
+    logger.info("Federation tool allow-list updated: %s/%s by %s", sub.name, sub_id, user.id)
+    return ToolAllowListResponse(sub_account_id=sub_id, tools=tools)
+
+
+@router.get("/{account_id}/sub-accounts/{sub_id}/tools", response_model=ToolAllowListResponse)
+async def get_tool_allow_list(
+    tenant_id: str,
+    account_id: UUID,
+    sub_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get the tool allow-list for a sub-account."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    svc = FederationService(db)
+    sub = await svc.get_sub_account(sub_id)
+    if not sub or sub.master_account_id != account_id or sub.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Sub-account not found")
+
+    tools = await svc.get_tool_allow_list(sub_id)
+    return ToolAllowListResponse(sub_account_id=sub_id, tools=tools)

--- a/control-plane-api/src/schemas/federation.py
+++ b/control-plane-api/src/schemas/federation.py
@@ -1,4 +1,4 @@
-"""Pydantic schemas for federation endpoints (CAB-1313/CAB-1361)."""
+"""Pydantic schemas for federation endpoints (CAB-1313/CAB-1361/CAB-1370)."""
 
 from datetime import datetime
 from enum import StrEnum
@@ -166,3 +166,66 @@ class SubAccountListResponse(BaseModel):
     total: int
     page: int
     page_size: int
+
+
+# ============== CAB-1370: Delegation Token + Usage Schemas ==============
+
+
+class DelegationTokenRequest(BaseModel):
+    """Request schema for token delegation via master account."""
+
+    scopes: list[str] = Field(default_factory=lambda: ["stoa:read"], description="OAuth2 scopes to request")
+    ttl_seconds: int = Field(3600, ge=60, le=86400, description="Token TTL in seconds (1min to 24h)")
+
+
+class DelegationTokenResponse(BaseModel):
+    """Response schema for a delegated federation token."""
+
+    access_token: str = Field(description="Delegated OAuth2 access token")
+    token_type: str = Field(default="Bearer")
+    expires_in: int = Field(description="Token lifetime in seconds")
+    scope: str = Field(description="Granted scopes (space-separated)")
+    sub_account_id: UUID
+    sub_account_name: str
+
+
+class UsageStat(BaseModel):
+    """Single sub-account usage statistics entry."""
+
+    sub_account_id: UUID
+    sub_account_name: str
+    request_count: int = Field(0, ge=0)
+    token_count: int = Field(0, ge=0)
+    error_count: int = Field(0, ge=0)
+    last_active_at: datetime | None = None
+
+
+class UsageResponse(BaseModel):
+    """Aggregated usage statistics for all sub-accounts of a master account."""
+
+    master_account_id: UUID
+    period_days: int
+    total_requests: int = 0
+    total_tokens: int = 0
+    sub_accounts: list[UsageStat]
+
+
+class FederationBulkRevokeResponse(BaseModel):
+    """Response schema for bulk sub-account revocation."""
+
+    revoked_count: int = Field(description="Number of sub-accounts newly revoked")
+    already_revoked: int = Field(description="Number already in revoked state")
+    total: int = Field(description="Total sub-accounts in master account")
+
+
+class ToolAllowListUpdate(BaseModel):
+    """Request schema for updating a sub-account tool allow-list."""
+
+    tools: list[str] = Field(..., description="List of tool names (replaces existing)")
+
+
+class ToolAllowListResponse(BaseModel):
+    """Response schema for sub-account tool allow-list."""
+
+    sub_account_id: UUID
+    tools: list[str] = Field(description="Currently allowed tool names")

--- a/control-plane-api/src/services/federation_service.py
+++ b/control-plane-api/src/services/federation_service.py
@@ -1,4 +1,4 @@
-"""Federation service — orchestrates repos, KC helper, key generation (CAB-1313/CAB-1361)."""
+"""Federation service — orchestrates repos, KC helper, key generation (CAB-1313/CAB-1361/CAB-1370)."""
 
 import hashlib
 import logging
@@ -161,3 +161,58 @@ class FederationService:
         sub = await self.sub_repo.update(sub)
         logger.info("Sub-account revoked: %s", sub.name)
         return sub
+
+    # ============== CAB-1370: Delegation Token + Usage + Bulk Ops ==============
+
+    async def delegate_token(self, sub: SubAccount, scopes: list[str], ttl_seconds: int) -> dict:
+        """Exchange a sub-account's KC client credentials for a delegation token."""
+        if sub.status != SubAccountStatus.ACTIVE:
+            raise ValueError(f"Sub-account '{sub.name}' is not active (status={sub.status})")
+        if not sub.kc_client_id:
+            raise ValueError(f"Sub-account '{sub.name}' has no Keycloak client configured")
+
+        token_data = await keycloak_service.exchange_federation_token(
+            client_id=sub.kc_client_id, scopes=scopes, ttl_seconds=ttl_seconds
+        )
+        if not token_data:
+            raise ValueError(f"Token exchange failed for sub-account '{sub.name}'")
+
+        logger.info("Delegation token issued for sub-account %s", sub.name)
+        return token_data
+
+    async def get_usage_aggregation(self, master_id: UUID, period_days: int) -> list[dict]:
+        """Return usage statistics per sub-account (stub -- Phase 1 returns zeroes)."""
+        items, _ = await self.sub_repo.list_by_master(master_id, page=1, page_size=1000)
+        return [
+            {
+                "sub_account_id": sub.id,
+                "sub_account_name": sub.name,
+                "request_count": 0,
+                "token_count": 0,
+                "error_count": 0,
+                "last_active_at": None,
+            }
+            for sub in items
+        ]
+
+    async def bulk_revoke(self, master_id: UUID) -> tuple[int, int, int]:
+        """Revoke all active/suspended sub-accounts under a master."""
+        total = await self.master_repo.count_sub_accounts(master_id)
+        newly_revoked, already_revoked = await self.sub_repo.bulk_revoke(master_id)
+        logger.info(
+            "Bulk revoke for master %s: %d revoked, %d already revoked",
+            master_id,
+            newly_revoked,
+            already_revoked,
+        )
+        return newly_revoked, already_revoked, total
+
+    async def set_tool_allow_list(self, sub_id: UUID, tool_names: list[str]) -> list[str]:
+        """Replace the tool allow-list for a sub-account."""
+        tools = await self.sub_repo.set_tool_allow_list(sub_id, tool_names)
+        logger.info("Tool allow-list updated for sub %s: %d tools", sub_id, len(tools))
+        return tools
+
+    async def get_tool_allow_list(self, sub_id: UUID) -> list[str]:
+        """Get the tool allow-list for a sub-account."""
+        return await self.sub_repo.get_tool_allow_list(sub_id)

--- a/control-plane-api/src/services/keycloak_service.py
+++ b/control-plane-api/src/services/keycloak_service.py
@@ -865,6 +865,57 @@ class KeycloakService:
         roles = self._admin.get_realm_roles_of_user(user_id)
         return [r["name"] for r in roles if r["name"] not in system_roles]
 
+    async def exchange_federation_token(
+        self,
+        client_id: str,
+        scopes: list[str],
+        ttl_seconds: int,
+    ) -> dict | None:
+        """Exchange a federation sub-account's KC client credentials for an access token (CAB-1370).
+
+        Best-effort: returns token dict on success, None on any failure.
+        Never raises -- caller handles None gracefully.
+        """
+        try:
+            if not self._admin:
+                logger.warning("Keycloak not connected, cannot exchange federation token")
+                return None
+
+            internal_id = self._admin.get_client_id(client_id)
+            if not internal_id:
+                logger.warning("Federation token exchange: KC client '%s' not found", client_id)
+                return None
+
+            secret_data = self._admin.get_client_secret(internal_id)
+            client_secret = secret_data.get("value", "") if secret_data else ""
+            if not client_secret:
+                logger.warning("Federation token exchange: no secret for client '%s'", client_id)
+                return None
+
+            token_url = f"{settings.KEYCLOAK_URL}/realms/{settings.KEYCLOAK_REALM}" "/protocol/openid-connect/token"
+            async with httpx.AsyncClient(timeout=10.0) as http:
+                resp = await http.post(
+                    token_url,
+                    data={
+                        "grant_type": "client_credentials",
+                        "client_id": client_id,
+                        "client_secret": client_secret,
+                        "scope": " ".join(scopes),
+                    },
+                )
+                resp.raise_for_status()
+                data = resp.json()
+
+            return {
+                "access_token": data["access_token"],
+                "token_type": data.get("token_type", "Bearer"),
+                "expires_in": data.get("expires_in", ttl_seconds),
+                "scope": data.get("scope", " ".join(scopes)),
+            }
+        except Exception as e:
+            logger.warning("Federation token exchange failed for client '%s': %s", client_id, e)
+            return None
+
     async def setup_federation_client(
         self,
         sub_account_id: str,
@@ -874,7 +925,7 @@ class KeycloakService:
         """Create a confidential KC client for federation Token Exchange (CAB-1313).
 
         Best-effort: returns client_id on success, None on any failure.
-        Never raises — caller handles None gracefully.
+        Never raises -- caller handles None gracefully.
         """
         try:
             if not self._admin:

--- a/control-plane-api/tests/test_federation.py
+++ b/control-plane-api/tests/test_federation.py
@@ -2,7 +2,7 @@
 
 import hashlib
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -415,3 +415,225 @@ class TestFederationService:
                 account_type="developer",
                 created_by="test",
             )
+
+
+# ============== CAB-1370: Delegation Token + Usage Tests ==============
+
+
+class TestCAB1370Schemas:
+    """Tests for CAB-1370 new schemas."""
+
+    def test_delegation_token_request_defaults(self):
+        from src.schemas.federation import DelegationTokenRequest
+
+        req = DelegationTokenRequest()
+        assert req.scopes == ["stoa:read"]
+        assert req.ttl_seconds == 3600
+
+    def test_delegation_token_request_custom(self):
+        from src.schemas.federation import DelegationTokenRequest
+
+        req = DelegationTokenRequest(scopes=["stoa:read", "stoa:write"], ttl_seconds=7200)
+        assert req.scopes == ["stoa:read", "stoa:write"]
+        assert req.ttl_seconds == 7200
+
+    def test_delegation_token_request_ttl_validation(self):
+        from src.schemas.federation import DelegationTokenRequest
+
+        with pytest.raises(ValidationError):
+            DelegationTokenRequest(ttl_seconds=10)  # Below min 60
+        with pytest.raises(ValidationError):
+            DelegationTokenRequest(ttl_seconds=100000)  # Above max 86400
+
+    def test_delegation_token_response(self):
+        from src.schemas.federation import DelegationTokenResponse
+
+        resp = DelegationTokenResponse(
+            access_token="eyJhbGciOiJSUzI1NiJ9.test",  # noqa: S106
+            token_type="Bearer",  # noqa: S106
+            expires_in=3600,
+            scope="stoa:read",
+            sub_account_id=uuid4(),
+            sub_account_name="agent-alpha",
+        )
+        assert resp.token_type == "Bearer"
+        assert resp.expires_in == 3600
+
+    def test_usage_response(self):
+        from src.schemas.federation import UsageResponse, UsageStat
+
+        stat = UsageStat(
+            sub_account_id=uuid4(),
+            sub_account_name="test-sub",
+            request_count=100,
+            token_count=50,
+        )
+        resp = UsageResponse(
+            master_account_id=uuid4(),
+            period_days=7,
+            total_requests=100,
+            total_tokens=50,
+            sub_accounts=[stat],
+        )
+        assert resp.period_days == 7
+        assert len(resp.sub_accounts) == 1
+
+    def test_usage_stat_defaults(self):
+        from src.schemas.federation import UsageStat
+
+        stat = UsageStat(sub_account_id=uuid4(), sub_account_name="test")
+        assert stat.request_count == 0
+        assert stat.token_count == 0
+        assert stat.error_count == 0
+        assert stat.last_active_at is None
+
+    def test_bulk_revoke_response(self):
+        from src.schemas.federation import FederationBulkRevokeResponse
+
+        resp = FederationBulkRevokeResponse(revoked_count=3, already_revoked=1, total=5)
+        assert resp.revoked_count == 3
+        assert resp.total == 5
+
+    def test_tool_allow_list_update(self):
+        from src.schemas.federation import ToolAllowListUpdate
+
+        update = ToolAllowListUpdate(tools=["weather-tool", "search-tool"])
+        assert len(update.tools) == 2
+
+    def test_tool_allow_list_response(self):
+        from src.schemas.federation import ToolAllowListResponse
+
+        resp = ToolAllowListResponse(sub_account_id=uuid4(), tools=["a-tool", "b-tool"])
+        assert resp.tools == ["a-tool", "b-tool"]
+
+    def test_tool_allow_list_update_required(self):
+        from src.schemas.federation import ToolAllowListUpdate
+
+        with pytest.raises(ValidationError):
+            ToolAllowListUpdate()  # tools is required
+
+    def test_tool_allow_list_empty(self):
+        from src.schemas.federation import ToolAllowListUpdate
+
+        update = ToolAllowListUpdate(tools=[])
+        assert update.tools == []
+
+
+class TestCAB1370Service:
+    """Tests for CAB-1370 service methods."""
+
+    @pytest.mark.asyncio
+    async def test_delegate_token_inactive_sub(self):
+        from src.services.federation_service import FederationService
+
+        session = AsyncMock()
+        svc = FederationService(session)
+        sub = _make_sub(status=SubAccountStatus.SUSPENDED)
+        sub.kc_client_id = "test-client"
+
+        with pytest.raises(ValueError, match="not active"):
+            await svc.delegate_token(sub, scopes=["stoa:read"], ttl_seconds=3600)
+
+    @pytest.mark.asyncio
+    async def test_delegate_token_no_kc_client(self):
+        from src.services.federation_service import FederationService
+
+        session = AsyncMock()
+        svc = FederationService(session)
+        sub = _make_sub()
+        sub.kc_client_id = None
+
+        with pytest.raises(ValueError, match="no Keycloak client"):
+            await svc.delegate_token(sub, scopes=["stoa:read"], ttl_seconds=3600)
+
+    @pytest.mark.asyncio
+    async def test_delegate_token_kc_returns_none(self):
+        from src.services.federation_service import FederationService
+
+        session = AsyncMock()
+        svc = FederationService(session)
+        sub = _make_sub()
+        sub.kc_client_id = "test-client"
+
+        with patch("src.services.federation_service.keycloak_service") as mock_kc:
+            mock_kc.exchange_federation_token = AsyncMock(return_value=None)
+            with pytest.raises(ValueError, match="Token exchange failed"):
+                await svc.delegate_token(sub, scopes=["stoa:read"], ttl_seconds=3600)
+
+    @pytest.mark.asyncio
+    async def test_delegate_token_success(self):
+        from src.services.federation_service import FederationService
+
+        session = AsyncMock()
+        svc = FederationService(session)
+        sub = _make_sub()
+        sub.kc_client_id = "test-client"
+
+        token_data = {
+            "access_token": "eyJ.test.token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "scope": "stoa:read",
+        }
+        with patch("src.services.federation_service.keycloak_service") as mock_kc:
+            mock_kc.exchange_federation_token = AsyncMock(return_value=token_data)
+            result = await svc.delegate_token(sub, scopes=["stoa:read"], ttl_seconds=3600)
+
+        assert result["access_token"] == "eyJ.test.token"
+        assert result["token_type"] == "Bearer"
+
+    @pytest.mark.asyncio
+    async def test_usage_aggregation_stub(self):
+        from src.services.federation_service import FederationService
+
+        session = AsyncMock()
+        svc = FederationService(session)
+
+        sub1 = _make_sub(name="sub-1")
+        sub2 = _make_sub(name="sub-2")
+        svc.sub_repo.list_by_master = AsyncMock(return_value=([sub1, sub2], 2))
+
+        result = await svc.get_usage_aggregation(uuid4(), period_days=7)
+        assert len(result) == 2
+        assert all(s["request_count"] == 0 for s in result)
+        assert all(s["token_count"] == 0 for s in result)
+
+    @pytest.mark.asyncio
+    async def test_bulk_revoke(self):
+        from src.services.federation_service import FederationService
+
+        session = AsyncMock()
+        svc = FederationService(session)
+        master_id = uuid4()
+
+        svc.master_repo.count_sub_accounts = AsyncMock(return_value=5)
+        svc.sub_repo.bulk_revoke = AsyncMock(return_value=(3, 1))
+
+        newly, already, total = await svc.bulk_revoke(master_id)
+        assert newly == 3
+        assert already == 1
+        assert total == 5
+
+    @pytest.mark.asyncio
+    async def test_set_tool_allow_list(self):
+        from src.services.federation_service import FederationService
+
+        session = AsyncMock()
+        svc = FederationService(session)
+        sub_id = uuid4()
+
+        svc.sub_repo.set_tool_allow_list = AsyncMock(return_value=["a-tool", "b-tool"])
+        result = await svc.set_tool_allow_list(sub_id, ["b-tool", "a-tool"])
+        assert result == ["a-tool", "b-tool"]
+
+    @pytest.mark.asyncio
+    async def test_get_tool_allow_list(self):
+        from src.services.federation_service import FederationService
+
+        session = AsyncMock()
+        svc = FederationService(session)
+        sub_id = uuid4()
+
+        svc.sub_repo.get_tool_allow_list = AsyncMock(return_value=["weather-tool"])
+        result = await svc.get_tool_allow_list(sub_id)
+        assert result == ["weather-tool"]


### PR DESCRIPTION
## Summary
- 5 new federation endpoints: delegate-token exchange, usage aggregation, bulk sub-account revoke, tool allow-list CRUD
- 7 new Pydantic schemas for delegation tokens, usage stats, bulk operations, and tool management
- 3 new SubAccountRepository methods: bulk_revoke, set/get_tool_allow_list
- 5 new FederationService methods with Keycloak token exchange integration
- New `exchange_federation_token` method in KeycloakService (client_credentials flow)
- 19 new unit tests across 2 test classes (TestCAB1370Schemas, TestCAB1370Service)
- Usage aggregation returns stub/zero data (Phase 1 — real metering deferred to CAB-1371)

## Test plan
- [x] `ruff check` passes on all 6 files
- [x] `black --check` passes on all 6 files
- [x] 51 tests pass (32 original + 19 new)
- [ ] CI green (3 required checks)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>