### PR TITLE
fix(ci): use .first() in n8n redirect expression (CAB-1368)

### DIFF
--- a/scripts/ai-ops/n8n-approve-ticket.json
+++ b/scripts/ai-ops/n8n-approve-ticket.json
@@ -96,12 +96,12 @@
     {
       "parameters": {
         "respondWith": "redirect",
-        "redirectURL": "=https://github.com/stoa-platform/stoa/issues/{{ $('Validate HMAC').item.json.issue }}"
+        "redirectURL": "=https://github.com/stoa-platform/stoa/issues/{{ $('Validate HMAC').first().json.issue }}"
       },
       "id": "redirect-to-issue",
       "name": "Redirect to Issue",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
+      "typeVersion": 1.1,
       "position": [1000, 300]
     },
     {
@@ -115,7 +115,7 @@
       "id": "error-response",
       "name": "Error Response",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
+      "typeVersion": 1.1,
       "position": [600, 500]
     }
   ],


### PR DESCRIPTION
## Summary
- Fixed 404 redirect after clicking Slack "Approve & Start" button
- Changed `$('Validate HMAC').item.json.issue` → `$('Validate HMAC').first().json.issue`
- Bumped `respondToWebhook` typeVersion from 1 to 1.1

## Root cause
The `respondToWebhook` node in n8n doesn't maintain a paired execution context, so `.item` accessor resolves to `undefined`. The redirect URL became `https://github.com/.../issues/undefined` → 404.

`.first()` always works because it explicitly grabs the first output item from the referenced node.

## Test plan
- [ ] Re-import `n8n-approve-ticket.json` into n8n
- [ ] Click an "Approve & Start" button on a Slack notification
- [ ] Verify redirect lands on the correct GitHub issue page

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>