### PR TITLE
fix(ci): add Council dedup guards to prevent double validation

### DIFF
--- a/.claude/rules/autonomous-factory.md
+++ b/.claude/rules/autonomous-factory.md
@@ -48,6 +48,27 @@ All workflows include these safety measures:
 - **Ask mode enforcement** — rule changes (`.claude/rules/`) are always Ask mode, never auto-merged
 - **Timeouts** — every job has an explicit `timeout-minutes` (15-60)
 - **Concurrency groups** — prevent parallel runs on the same issue/PR
+- **Council dedup guards** — label-based state machine prevents double Council runs (see below)
+
+### Council Label State Machine
+
+Labels track the Council pipeline state on each GitHub issue. Guards at each stage prevent re-runs:
+
+```
+[no labels]
+  → council-validated    (S1 passed — ticket pertinence)
+  → ship-fast-path       (optional — Ship ≤5pts, S2 will be skipped)
+  → plan-validated       (S2 passed — plan validation, or auto-set by fast-path)
+```
+
+| Guard | Workflow | Prevents |
+|-------|----------|----------|
+| Skip S1 if `council-validated` exists | L1 (issue-to-pr) | Re-labeling `claude-implement` re-runs Council |
+| Skip S2 if `plan-validated` exists | L1 (issue-to-pr) | Re-commenting `/go` re-runs plan validation |
+| Skip issue creation if ticket label exists | L3 (linear-dispatch) | n8n re-dispatch creates duplicate issues |
+| Skip issue creation if ticket label exists | L3.5 (autopilot-scan) | Daily scan creates duplicate issues |
+
+**Cross-workflow dedup**: L3 and L3.5 both create issues with `{TICKET_ID}` as a label. Before creating, they search for open issues with that label. If found, the new Council report is posted as a comment on the existing issue instead.
 
 ## H24 Scaling — Progressive Velocity Control
 

--- a/.github/workflows/claude-autopilot-scan.yml
+++ b/.github/workflows/claude-autopilot-scan.yml
@@ -236,6 +236,13 @@ jobs:
 
             echo "Processing ${TICKET_ID} (score: ${SCORE})"
 
+            # Dedup guard: skip if GitHub issue already exists for this ticket
+            EXISTING_ISSUE=$(gh issue list --label "$TICKET_ID" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+            if [ -n "$EXISTING_ISSUE" ] && [ "$EXISTING_ISSUE" != "null" ]; then
+              echo "Issue #${EXISTING_ISSUE} already exists for ${TICKET_ID} — skipping"
+              continue
+            fi
+
             # Sync council:ticket-go label to Linear
             if [ -n "$LINEAR_API_KEY" ]; then
               LINEAR_ISSUE_ID=$(jq -r --arg tid "$TICKET_ID" '.[] | select(.identifier == $tid) | .id' eligible-tickets.json)

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -35,7 +35,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Guard: skip Council S1 if already validated (prevents double-run on re-label)
+      - name: Check Council Already Done
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LABELS=$(gh issue view "${{ github.event.issue.number }}" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+          if echo "$LABELS" | grep -q "council-validated"; then
+            echo "Council S1 already passed (council-validated label present). Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run Council Validation
+        if: steps.guard.outputs.skip != 'true'
         id: council
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
@@ -71,13 +86,13 @@ jobs:
           claude_args: "--model claude-sonnet-4-5-20250929 --max-turns 5 --allowedTools Read,Glob,Grep"
 
       - name: Log token usage
-        if: always()
+        if: always() && steps.guard.outputs.skip != 'true'
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}, Model=sonnet-4-5, MaxTurns=5, Stage=council-validate"
 
       # Add council-validated label so plan-validate job can verify
       - name: Mark Council complete
-        if: steps.council.outcome == 'success'
+        if: steps.council.outcome == 'success' || steps.guard.outputs.skip == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -87,7 +102,7 @@ jobs:
       # Check if this ticket qualifies for Ship fast-path (skip Stage 2)
       - name: Check Ship Fast Path
         id: check-fast
-        if: steps.council.outcome == 'success'
+        if: steps.council.outcome == 'success' || steps.guard.outputs.skip == 'true'
         run: |
           source scripts/ai-ops/model-router.sh
 
@@ -278,6 +293,14 @@ jobs:
         run: |
           ISSUE_NUM="${{ github.event.issue.number }}"
           LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+
+          # Guard: skip S2 if plan-validated already exists (prevents double-run)
+          if echo "$LABELS" | grep -q "plan-validated"; then
+            echo "Plan already validated (plan-validated label present). Skipping S2."
+            echo "validated=false" >> "$GITHUB_OUTPUT"
+            echo "already_validated=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if echo "$LABELS" | grep -q "council-validated"; then
             echo "Stage 1 Council confirmed"

--- a/.github/workflows/claude-linear-dispatch.yml
+++ b/.github/workflows/claude-linear-dispatch.yml
@@ -34,8 +34,8 @@ jobs:
     timeout-minutes: 15
     outputs:
       fast_path: ${{ steps.check-fast.outputs.fast_path }}
-      issue_num: ${{ steps.create-issue.outputs.issue_num }}
-      issue_url: ${{ steps.create-issue.outputs.issue_url }}
+      issue_num: ${{ steps.create-issue.outputs.issue_num || steps.dedup.outputs.issue_num }}
+      issue_url: ${{ steps.create-issue.outputs.issue_url || steps.dedup.outputs.issue_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -85,12 +85,10 @@ jobs:
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}, Model=sonnet-4-5, MaxTurns=5, Stage=council"
 
-      # Extract Claude's report from execution log and create GitHub issue
-      - name: Create Council Issue
-        id: create-issue
+      # Extract Claude's Council report from execution log
+      - name: Extract Council Report
+        id: extract-report
         if: steps.council.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           TICKET="${{ github.event.client_payload.ticket_id }}"
           TITLE="${{ github.event.client_payload.ticket_title }}"
@@ -135,6 +133,41 @@ jobs:
           echo "=== Council body preview ==="
           head -15 council-body.md
           echo "=== ($(wc -l < council-body.md | tr -d ' ') lines total) ==="
+
+      # Check if a GitHub issue already exists for this ticket (dedup guard)
+      - name: Check Existing Issue
+        id: dedup
+        if: steps.council.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TICKET="${{ github.event.client_payload.ticket_id }}"
+          # Search for open issues with the ticket label
+          EXISTING=$(gh issue list --label "$TICKET" --state open --json number,title --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
+            echo "Issue #${EXISTING} already exists for ${TICKET} — skipping creation"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "issue_num=${EXISTING}" >> "$GITHUB_OUTPUT"
+            ISSUE_URL="https://github.com/stoa-platform/stoa/issues/${EXISTING}"
+            echo "issue_url=${ISSUE_URL}" >> "$GITHUB_OUTPUT"
+            # Post updated Council report as comment on existing issue
+            if [ -f council-body.md ] && [ -s council-body.md ]; then
+              gh issue comment "$EXISTING" --body "**Updated Council Report** (re-dispatch)\n\n$(cat council-body.md)" || true
+            fi
+          else
+            echo "No existing issue for ${TICKET}"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Create GitHub issue (only if no existing issue found)
+      - name: Create Council Issue
+        id: create-issue
+        if: steps.council.outcome == 'success' && steps.dedup.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TICKET="${{ github.event.client_payload.ticket_id }}"
+          TITLE="${{ github.event.client_payload.ticket_title }}"
 
           # Create label (idempotent)
           gh label create "${TICKET}" --color "0075ca" --description "Linear ticket" --force 2>/dev/null || true


### PR DESCRIPTION
## Summary

Prevents double Council validation runs across all 3 AI Factory pipelines:

- **L1 (issue-to-pr)**: Guard S1 — skip if `council-validated` label already present (prevents re-run on re-label). Guard S2 — skip if `plan-validated` already present (prevents re-run on duplicate `/go`).
- **L3 (linear-dispatch)**: Search for existing open issue by ticket label before creating. If found, posts updated Council report as comment instead of creating duplicate issue.
- **L3.5 (autopilot-scan)**: Skip issue creation if open issue with ticket label already exists (daily scan dedup).
- **Rules**: Document the Council label state machine in `autonomous-factory.md`.

## Council Label State Machine

```
[no labels] → council-validated (S1) → plan-validated (S2) → implement
                                     ↘ ship-fast-path → auto plan-validated → implement
```

Each transition is guarded: label existence is checked before running the corresponding Council stage.

## Test plan

- [ ] CI green (3 required checks)
- [ ] Re-label `claude-implement` on an issue that already has `council-validated` → S1 skipped
- [ ] n8n re-dispatches same ticket → existing issue found, report posted as comment
- [ ] Autopilot scan finds ticket with existing issue → skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)