### PR TITLE
feat(ci): migrate all Claude workflows to notification library

### DIFF
--- a/.claude/rules/autonomous-factory.md
+++ b/.claude/rules/autonomous-factory.md
@@ -187,33 +187,52 @@ Stage 2: Plan Validation (L1 + L3 only)
 Batch flows (L3.5 Autopilot, L5 Multi-Agent): Stage 1 only → `/go` starts implementation directly.
 ```
 
-## Slack Notifications
+## Notification Library
 
-### Channel Strategy
+All AI Factory notifications use `scripts/ai-ops/ai-factory-notify.sh` — a centralized shell library sourced by every workflow step. Zero extra Claude tokens (pure bash + jq).
 
-All AI Factory notifications go to a single Slack channel (configurable via `SLACK_WEBHOOK_URL`).
-Message types are distinguished by emoji prefix:
+### Usage
 
-| Emoji | Event | Action Required |
-|-------|-------|----------------|
-| :white_check_mark: | Council Go (>= 8.0) | Review and `/go` |
-| :warning: | Council Fix (6.0-7.9) | Review adjustments, `/go` or `/adjust` |
-| :x: | Council Redo (< 6.0) | Revise proposal |
-| :rocket: | Implementation started | None (info) |
-| :tada: | PR created | Review if Ask mode |
-| :merged: | PR merged | None (info) |
-| :stethoscope: | CI health check | Review if failures found |
-| :shield: | Weekly audit | Review report |
-| :brain: | Self-improvement | Review and approve |
-| :sunrise: | Daily triage | Review digest |
+```yaml
+- name: Notify
+  env:
+    SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+  run: |
+    source scripts/ai-ops/ai-factory-notify.sh
+    notify_council "CAB-1350" "Title" "8.5" "Go" "https://..." "42"
+```
 
-### Notification Frequency Control
+### Functions
 
-- **Max 10 Slack messages per day** — batch low-priority notifications
-- **Council reports**: always immediate (requires human decision)
-- **Implementation status**: immediate for Ask mode, batched for Ship/Show
-- **Digests**: once daily (07:00 UTC)
-- **Audits**: once weekly (Monday 08:00 UTC)
+| Function | Purpose | Slack | Linear | Summary |
+|----------|---------|-------|--------|---------|
+| `notify_council` | Council validation report | Block Kit + approve button | — | — |
+| `notify_implement` | Implementation success/failure | Status message | — | — |
+| `notify_error` | Error with log excerpt | Vercel-style error block | — | — |
+| `notify_scan` | Autopilot scan summary | Candidate count + velocity | — | — |
+| `notify_scheduled` | Daily/weekly task results | Task name + status | — | — |
+| `notify_plan` | Plan validation (Stage 2) | Plan status + review link | — | — |
+| `linear_comment` | Rich completion report | — | Markdown comment | — |
+| `write_job_summary` | GHA audit trail | — | — | `$GITHUB_STEP_SUMMARY` |
+
+### Env Vars (all optional, graceful degradation)
+
+| Variable | Source | Used By |
+|----------|--------|---------|
+| `SLACK_WEBHOOK` | `secrets.SLACK_WEBHOOK_URL` | All `notify_*` functions |
+| `LINEAR_API_KEY` | `secrets.LINEAR_API_KEY` | `linear_comment()` only |
+| `N8N_WEBHOOK` | `vars.N8N_APPROVE_WEBHOOK_URL` | `notify_council` approve button |
+| `HMAC_SECRET` | `secrets.APPROVE_HMAC_SECRET` | `notify_council` approve button |
+| `GITHUB_RUN_ID` | Auto-set by GHA | All functions (run link) |
+| `GITHUB_STEP_SUMMARY` | Auto-set by GHA | `write_job_summary` |
+
+### Rules
+
+- Every workflow step that previously had inline `curl $SLACK_WEBHOOK` now uses `source ... && notify_*`
+- `write_job_summary` is called in ALL 8 Claude workflows for persistent audit trail
+- Notifications are best-effort: `SLACK_WEBHOOK` unset = silent skip, never fails the parent step
+- Linear comments only on implementation success/failure (not Council, not scheduled — too noisy)
+- Deprecated scripts: `slack-notify.sh`, `council-slack-report.sh`, `daily-digest.sh` (use library instead)
 
 ## GitHub Labels for Automation
 

--- a/.github/workflows/claude-interactive.yml
+++ b/.github/workflows/claude-interactive.yml
@@ -49,3 +49,9 @@ jobs:
         if: always()
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}"
+
+      - name: Write Job Summary
+        if: always()
+        run: |
+          source scripts/ai-ops/ai-factory-notify.sh
+          write_job_summary "interactive-${{ github.event.issue.number || github.event.pull_request.number }}" "complete" "" "sonnet-4-5" "interactive"

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -223,52 +223,23 @@ jobs:
             > /dev/null 2>&1 || true
           echo "Posted Council comment on ${TICKET_ID}"
 
-      # Notify Slack with Council report
-      - name: Notify Slack — Council Report
-        if: always()
+      - name: Slack Council Report
+        if: always() && steps.guard.outputs.skip != 'true'
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          N8N_WEBHOOK: ${{ vars.N8N_APPROVE_WEBHOOK_URL }}
+          HMAC_SECRET: ${{ secrets.APPROVE_HMAC_SECRET }}
         run: |
-          if [ -z "$SLACK_WEBHOOK" ]; then
-            echo "SLACK_WEBHOOK_URL not set, skipping notification"
-            exit 0
-          fi
-          ISSUE_URL="${{ github.event.issue.html_url }}"
-          ISSUE_TITLE="${{ github.event.issue.title }}"
-          ISSUE_NUM="${{ github.event.issue.number }}"
-          STATUS="${{ steps.council.outcome }}"
-          if [ "$STATUS" = "success" ]; then
-            EMOJI=":white_check_mark:"
-          else
-            EMOJI=":warning:"
-          fi
-          curl -s -X POST "$SLACK_WEBHOOK" \
-            -H 'Content-Type: application/json' \
-            -d "{
-              \"blocks\": [
-                {
-                  \"type\": \"header\",
-                  \"text\": {
-                    \"type\": \"plain_text\",
-                    \"text\": \"${EMOJI} Stage 1 Council: #${ISSUE_NUM}\",
-                    \"emoji\": true
-                  }
-                },
-                {
-                  \"type\": \"section\",
-                  \"text\": {
-                    \"type\": \"mrkdwn\",
-                    \"text\": \"*${ISSUE_TITLE}*\nStage 1 Council complete (ticket pertinence).\nComment \`/go\` to start plan validation (Stage 2).\"
-                  },
-                  \"accessory\": {
-                    \"type\": \"button\",
-                    \"text\": {\"type\": \"plain_text\", \"text\": \"Review & Approve\"},
-                    \"url\": \"${ISSUE_URL}\",
-                    \"action_id\": \"council-review\"
-                  }
-                }
-              ]
-            }"
+          source scripts/ai-ops/ai-factory-notify.sh
+          TICKET=$(echo "${{ github.event.issue.title }} ${{ github.event.issue.body }}" | grep -oE 'CAB-[0-9]+' | head -1 || echo "#${{ github.event.issue.number }}")
+          notify_council "$TICKET" "${{ github.event.issue.title }}" "" "Go" "${{ github.event.issue.html_url }}" "${{ github.event.issue.number }}"
+
+      - name: Write Job Summary — Council
+        if: always() && steps.guard.outputs.skip != 'true'
+        run: |
+          source scripts/ai-ops/ai-factory-notify.sh
+          TICKET=$(echo "${{ github.event.issue.title }}" | grep -oE 'CAB-[0-9]+' | head -1 || echo "issue-${{ github.event.issue.number }}")
+          write_job_summary "$TICKET" "${{ steps.council.outcome }}" "" "" "council-s1"
 
   # ----- Stage 2: Plan Validation (runs on /go approval) -----
   plan-validate:
@@ -484,31 +455,20 @@ jobs:
             -d "{\"query\": \"mutation { commentCreate(input: { issueId: \\\"${ISSUE_ID}\\\", body: \\\"${COMMENT}\\\" }) { success } }\"}" \
             > /dev/null 2>&1 || true
 
-      - name: Notify Slack — Plan Validation
+      - name: Slack Plan Validation
         if: always() && steps.verify-stage1.outputs.validated == 'true' && steps.fast-path.outputs.skipped != 'true'
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          if [ -z "$SLACK_WEBHOOK" ]; then exit 0; fi
-          ISSUE_URL="${{ github.event.issue.html_url }}"
-          ISSUE_TITLE="${{ github.event.issue.title }}"
-          ISSUE_NUM="${{ github.event.issue.number }}"
-          STATUS="${{ steps.plan-council.outcome }}"
-          if [ "$STATUS" = "success" ]; then
-            EMOJI=":clipboard:"
-            TEXT="Stage 2 plan validation passed.\nComment \`/go-plan\` to start implementation."
-          else
-            EMOJI=":warning:"
-            TEXT="Stage 2 plan validation failed. Check the GitHub issue for details."
-          fi
-          curl -s -X POST "$SLACK_WEBHOOK" \
-            -H 'Content-Type: application/json' \
-            -d "{
-              \"blocks\": [
-                {\"type\":\"header\",\"text\":{\"type\":\"plain_text\",\"text\":\"${EMOJI} Plan Validation: #${ISSUE_NUM}\",\"emoji\":true}},
-                {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*${ISSUE_TITLE}*\n${TEXT}\"},\"accessory\":{\"type\":\"button\",\"text\":{\"type\":\"plain_text\",\"text\":\"Review Plan\"},\"url\":\"${ISSUE_URL}\",\"action_id\":\"plan-review\"}}
-              ]
-            }"
+          source scripts/ai-ops/ai-factory-notify.sh
+          notify_plan "${{ github.event.issue.number }}" "${{ github.event.issue.title }}" "${{ github.event.issue.html_url }}" "${{ steps.plan-council.outcome }}"
+
+      - name: Write Job Summary — Plan
+        if: always() && steps.verify-stage1.outputs.validated == 'true' && steps.fast-path.outputs.skipped != 'true'
+        run: |
+          source scripts/ai-ops/ai-factory-notify.sh
+          TICKET=$(echo "${{ github.event.issue.title }}" | grep -oE 'CAB-[0-9]+' | head -1 || echo "issue-${{ github.event.issue.number }}")
+          write_job_summary "$TICKET" "${{ steps.plan-council.outcome }}" "" "" "council-s2"
 
   # ----- Stage 3: Implementation (runs on /go-plan approval) -----
   implement:
@@ -616,25 +576,22 @@ jobs:
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}, Model=${{ steps.route.outputs.model || 'sonnet-4-5' }}, MaxTurns=${{ steps.route.outputs.turns || '60' }}, Stage=implement"
 
-      # Notify Slack on completion
-      - name: Notify Slack — Implementation Done
+      - name: Slack Implementation Result
         if: always()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         run: |
-          if [ -z "$SLACK_WEBHOOK" ]; then exit 0; fi
-          STATUS="${{ steps.implement.outcome || 'skipped' }}"
-          ISSUE_NUM="${{ github.event.issue.number }}"
-          if [ "$STATUS" = "success" ]; then
-            EMOJI="white_check_mark"
-            MSG="Implementation complete for #${ISSUE_NUM}. PR created."
-          elif [ "$STATUS" = "skipped" ]; then
-            EMOJI="warning"
-            MSG="Implementation skipped for #${ISSUE_NUM}. No plan validation."
-          else
-            EMOJI="x"
-            MSG="Implementation failed for #${ISSUE_NUM}. Check GitHub Actions logs."
+          source scripts/ai-ops/ai-factory-notify.sh
+          TICKET=$(echo "${{ github.event.issue.title }}" | grep -oE 'CAB-[0-9]+' | head -1 || echo "issue-${{ github.event.issue.number }}")
+          notify_implement "$TICKET" "${{ steps.implement.outcome || 'skipped' }}" "" "" "${{ github.event.issue.number }}" "L1 Issue-to-PR"
+          if [ "${{ steps.implement.outcome }}" = "success" ]; then
+            linear_comment "$TICKET" "completed" "" "" "L1 Issue-to-PR" || true
           fi
-          curl -s -X POST "$SLACK_WEBHOOK" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\":${EMOJI}: ${MSG}\"}"
+
+      - name: Write Job Summary — Implement
+        if: always()
+        run: |
+          source scripts/ai-ops/ai-factory-notify.sh
+          TICKET=$(echo "${{ github.event.issue.title }}" | grep -oE 'CAB-[0-9]+' | head -1 || echo "issue-${{ github.event.issue.number }}")
+          write_job_summary "$TICKET" "${{ steps.implement.outcome || 'skipped' }}" "" "${{ steps.route.outputs.model || 'sonnet-4-5' }}" "L1-implement"

--- a/.github/workflows/claude-multi-agent.yml
+++ b/.github/workflows/claude-multi-agent.yml
@@ -149,19 +149,20 @@ jobs:
             echo "Synced ${TICKET_ID} → council:ticket-go"
           done
 
-      - name: Notify Slack — Batch Council
+      - name: Slack Batch Council
+        if: always()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          if [ -z "$SLACK_WEBHOOK" ]; then exit 0; fi
-          curl -s -X POST "$SLACK_WEBHOOK" \
-            -H 'Content-Type: application/json' \
-            -d "{
-              \"blocks\": [
-                {\"type\":\"header\",\"text\":{\"type\":\"plain_text\",\"text\":\"Multi-Agent Council: ${{ inputs.tickets }}\",\"emoji\":true}},
-                {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Batch validation complete. Review on GitHub and approve to start parallel execution.\"}}
-              ]
-            }"
+          source scripts/ai-ops/ai-factory-notify.sh
+          notify_scheduled "Multi-Agent Council: ${{ inputs.tickets }}" "${{ steps.council.outcome }}" "Batch validation complete. Review on GitHub and approve."
+
+      - name: Write Job Summary — Batch Council
+        if: always()
+        run: |
+          source scripts/ai-ops/ai-factory-notify.sh
+          FIRST_TICKET=$(echo "${{ inputs.tickets }}" | cut -d',' -f1 | tr -d ' ')
+          write_job_summary "$FIRST_TICKET" "${{ steps.council.outcome }}" "" "sonnet-4-5" "council-batch"
 
   # ----- Phase 1: Parallel Implementation -----
   # Uses a matrix strategy to run each ticket as a separate job.
@@ -231,19 +232,16 @@ jobs:
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}, Model=sonnet-4-5, MaxTurns=60, Stage=implement"
 
-      - name: Notify Slack — Agent Complete
+      - name: Slack Agent Result
         if: always()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          if [ -z "$SLACK_WEBHOOK" ]; then exit 0; fi
-          STATUS="${{ job.status }}"
-          TICKET="${{ matrix.ticket }}"
-          if [ "$STATUS" = "success" ]; then
-            MSG=":white_check_mark: *${TICKET}* — Agent complete, PR created"
-          else
-            MSG=":x: *${TICKET}* — Agent failed, check logs"
-          fi
-          curl -s -X POST "$SLACK_WEBHOOK" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}"
+          source scripts/ai-ops/ai-factory-notify.sh
+          notify_implement "${{ matrix.ticket }}" "${{ job.status }}" "" "" "" "L5 Multi-Agent"
+
+      - name: Write Job Summary
+        if: always()
+        run: |
+          source scripts/ai-ops/ai-factory-notify.sh
+          write_job_summary "${{ matrix.ticket }}" "${{ job.status }}" "" "sonnet-4-5" "L5-implement"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -96,6 +96,12 @@ jobs:
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}"
 
+      - name: Write Job Summary
+        if: always()
+        run: |
+          source scripts/ai-ops/ai-factory-notify.sh
+          write_job_summary "PR-${{ github.event.pull_request.number }}" "${{ steps.claude-review.outcome }}" "${{ github.event.pull_request.number }}" "haiku-4-5" "auto-review"
+
       # Fallback comment if Claude fails
       - name: Post fallback on failure
         if: steps.claude-review.outcome == 'failure'

--- a/.github/workflows/claude-scheduled.yml
+++ b/.github/workflows/claude-scheduled.yml
@@ -74,15 +74,19 @@ jobs:
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}"
 
-      - name: Notify Slack
+      - name: Slack Daily Triage
         if: always()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          if [ -z "$SLACK_WEBHOOK" ]; then exit 0; fi
-          curl -s -X POST "$SLACK_WEBHOOK" \
-            -H 'Content-Type: application/json' \
-            -d '{"text":":sunrise: *Daily Triage Complete* — check GitHub issues for digest"}'
+          source scripts/ai-ops/ai-factory-notify.sh
+          notify_scheduled "Daily Triage" "${{ job.status }}"
+
+      - name: Write Job Summary
+        if: always()
+        run: |
+          source scripts/ai-ops/ai-factory-notify.sh
+          write_job_summary "triage-$(date -u +%Y-%m-%d)" "${{ job.status }}" "" "haiku-4-5" "daily-triage"
 
   # ----- Daily: CI Health Check + Auto-Fix -----
   daily-ci-health:
@@ -124,15 +128,19 @@ jobs:
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}"
 
-      - name: Notify Slack
+      - name: Slack CI Health
         if: always()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          if [ -z "$SLACK_WEBHOOK" ]; then exit 0; fi
-          curl -s -X POST "$SLACK_WEBHOOK" \
-            -H 'Content-Type: application/json' \
-            -d '{"text":":stethoscope: *CI Health Check Complete* — check GitHub for results"}'
+          source scripts/ai-ops/ai-factory-notify.sh
+          notify_scheduled "CI Health Check" "${{ job.status }}"
+
+      - name: Write Job Summary
+        if: always()
+        run: |
+          source scripts/ai-ops/ai-factory-notify.sh
+          write_job_summary "ci-health-$(date -u +%Y-%m-%d)" "${{ job.status }}" "" "sonnet-4-5" "ci-health"
 
   # ----- Weekly: Dependency Audit + Security -----
   weekly-audit:
@@ -174,15 +182,19 @@ jobs:
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}"
 
-      - name: Notify Slack
+      - name: Slack Weekly Audit
         if: always()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          if [ -z "$SLACK_WEBHOOK" ]; then exit 0; fi
-          curl -s -X POST "$SLACK_WEBHOOK" \
-            -H 'Content-Type: application/json' \
-            -d '{"text":":shield: *Weekly Audit Complete* — check GitHub issues for full report"}'
+          source scripts/ai-ops/ai-factory-notify.sh
+          notify_scheduled "Weekly Audit" "${{ job.status }}"
+
+      - name: Write Job Summary
+        if: always()
+        run: |
+          source scripts/ai-ops/ai-factory-notify.sh
+          write_job_summary "audit-$(date -u +%Y-%m-%d)" "${{ job.status }}" "" "sonnet-4-5" "weekly-audit"
 
   # ----- Weekly Digest (Batch API — 50% cost reduction) -----
   weekly-digest:
@@ -250,6 +262,12 @@ jobs:
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}, Mode=batch"
 
+      - name: Write Job Summary
+        if: always()
+        run: |
+          source scripts/ai-ops/ai-factory-notify.sh
+          write_job_summary "digest-$(date -u +%Y-%m-%d)" "${{ steps.batch.outcome }}" "" "haiku-4-5-batch" "weekly-digest"
+
   # ----- Weekly: Capacity Check (Batch API — 50% cost reduction) -----
   weekly-capacity-check:
     if: |
@@ -309,15 +327,19 @@ jobs:
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}, Mode=batch"
 
-      - name: Notify Slack
+      - name: Slack Capacity Check
         if: always()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          if [ -z "$SLACK_WEBHOOK" ]; then exit 0; fi
-          curl -s -X POST "$SLACK_WEBHOOK" \
-            -H 'Content-Type: application/json' \
-            -d '{"text":":chart_with_upwards_trend: *Weekly Capacity Check Complete* — check GitHub issues for cycle health report"}'
+          source scripts/ai-ops/ai-factory-notify.sh
+          notify_scheduled "Weekly Capacity Check" "${{ job.status }}"
+
+      - name: Write Job Summary
+        if: always()
+        run: |
+          source scripts/ai-ops/ai-factory-notify.sh
+          write_job_summary "capacity-$(date -u +%Y-%m-%d)" "${{ job.status }}" "" "haiku-4-5-batch" "capacity-check"
 
   # ----- Weekly: Backlog Stock Check (Batch API — 50% cost reduction) -----
   weekly-backlog-stock:
@@ -388,12 +410,16 @@ jobs:
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}, Mode=batch"
 
-      - name: Notify Slack
+      - name: Slack Backlog Stock
         if: always()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          if [ -z "$SLACK_WEBHOOK" ]; then exit 0; fi
-          curl -s -X POST "$SLACK_WEBHOOK" \
-            -H 'Content-Type: application/json' \
-            -d '{"text":":card_file_box: *Weekly Backlog Stock Check Complete* — check GitHub issues for scan report"}'
+          source scripts/ai-ops/ai-factory-notify.sh
+          notify_scheduled "Backlog Stock Check" "${{ job.status }}"
+
+      - name: Write Job Summary
+        if: always()
+        run: |
+          source scripts/ai-ops/ai-factory-notify.sh
+          write_job_summary "backlog-$(date -u +%Y-%m-%d)" "${{ job.status }}" "" "haiku-4-5-batch" "backlog-stock"

--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -118,31 +118,17 @@ jobs:
             --body "Self-improvement analysis could not complete. Check [workflow logs](https://github.com/stoa-platform/stoa/actions/runs/${{ github.run_id }})." \
             || true
 
-      - name: Notify Slack
+      - name: Slack Self-Improvement Report
         if: always()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          if [ -z "$SLACK_WEBHOOK" ]; then exit 0; fi
-          curl -s -X POST "$SLACK_WEBHOOK" \
-            -H 'Content-Type: application/json' \
-            -d "{
-              \"blocks\": [
-                {
-                  \"type\": \"header\",
-                  \"text\": {\"type\": \"plain_text\", \"text\": \"AI Factory Self-Improvement Report\", \"emoji\": true}
-                },
-                {
-                  \"type\": \"section\",
-                  \"text\": {
-                    \"type\": \"mrkdwn\",
-                    \"text\": \"Weekly retrospective complete. Review proposed improvements on GitHub.\nLabel the issue \`claude-implement\` to auto-create the improvement PR.\"
-                  },
-                  \"accessory\": {
-                    \"type\": \"button\",
-                    \"text\": {\"type\": \"plain_text\", \"text\": \"Review Improvements\"},
-                    \"url\": \"https://github.com/stoa-platform/stoa/issues?q=is%3Aissue+label%3Aself-improve+is%3Aopen\"
-                  }
-                }
-              ]
-            }"
+          source scripts/ai-ops/ai-factory-notify.sh
+          notify_scheduled "Self-Improvement Report" "${{ steps.batch.outcome }}" \
+            "Weekly retrospective complete. Label the issue \`claude-implement\` to auto-create the improvement PR."
+
+      - name: Write Job Summary
+        if: always()
+        run: |
+          source scripts/ai-ops/ai-factory-notify.sh
+          write_job_summary "self-improve-$(date -u +%Y-%m-%d)" "${{ steps.batch.outcome }}" "" "sonnet-4-5-batch" "self-improve"


### PR DESCRIPTION
## Summary

- Replace all remaining inline Slack `curl` calls in 6 Claude workflows with centralized `ai-factory-notify.sh` library (created in PR #704)
- Add `write_job_summary` to all 8 Claude workflows for persistent GHA audit trail
- Update `autonomous-factory.md` rules with Notification Library documentation

### Workflows migrated

| Workflow | Changes |
|----------|---------|
| `claude-issue-to-pr` | 3 inline curls → `notify_council` + `notify_plan` + `notify_implement` |
| `claude-multi-agent` | 2 inline curls → `notify_scheduled` + `notify_implement` |
| `claude-self-improve` | 1 inline curl → `notify_scheduled` |
| `claude-review` | Added `write_job_summary` |
| `claude-interactive` | Added `write_job_summary` |
| `claude-scheduled` | 5 inline curls → `notify_scheduled` (all 6 jobs) |

### Result

- **Zero** remaining inline `curl $SLACK_WEBHOOK` in `claude-*.yml` workflows
- **All 8** Claude workflows write `$GITHUB_STEP_SUMMARY` for audit trail
- Net: -179/+177 LOC (massive DRY improvement)

## Test plan

- [x] All 6 modified YAML files pass `yaml.safe_load()` validation
- [x] `grep -r 'curl.*\$SLACK_WEBHOOK' .github/workflows/claude-*.yml` returns zero matches
- [x] All notification functions gracefully degrade when `SLACK_WEBHOOK` is unset
- [ ] CI green (3 required checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)