### PR TITLE
feat(ui): add skill resolution preview + E2E tests (CAB-1366)

### DIFF
--- a/control-plane-ui/src/pages/Skills/SkillPreview.tsx
+++ b/control-plane-ui/src/pages/Skills/SkillPreview.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { ChevronDown, ChevronRight, Play } from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext';
+import { skillsService, type ResolvedSkill } from '../../services/skillsApi';
+
+const scopeColors: Record<string, string> = {
+  global: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400',
+  tenant: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  tool: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
+  user: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400',
+};
+
+export function SkillPreview() {
+  const { user } = useAuth();
+  const tenantId = user?.tenant_id || '';
+  const [expanded, setExpanded] = useState(false);
+  const [toolRef, setToolRef] = useState('');
+  const [userRef, setUserRef] = useState('');
+
+  const {
+    data: resolved,
+    isLoading,
+    refetch,
+  } = useQuery<ResolvedSkill[]>({
+    queryKey: ['skills-resolve', tenantId, toolRef, userRef],
+    queryFn: () =>
+      skillsService.resolveSkills(tenantId, toolRef || undefined, userRef || undefined),
+    enabled: false,
+  });
+
+  const handleResolve = () => {
+    refetch();
+  };
+
+  const mergedInstructions = resolved
+    ?.filter((s) => s.instructions)
+    .map((s) => s.instructions)
+    .join('\n\n---\n\n');
+
+  return (
+    <div className="bg-white dark:bg-neutral-800 rounded-lg shadow">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-2 px-4 py-3 text-sm font-medium text-gray-700 dark:text-neutral-300 hover:bg-gray-50 dark:hover:bg-neutral-750"
+      >
+        {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        Resolution Preview
+      </button>
+
+      {expanded && (
+        <div className="px-4 pb-4 space-y-4 border-t dark:border-neutral-700">
+          <p className="text-xs text-gray-500 dark:text-neutral-400 pt-3">
+            Test the CSS cascade resolution for a given context. Skills are resolved by specificity
+            (global &lt; tenant &lt; tool &lt; user), then by priority within the same scope.
+          </p>
+
+          <div className="flex items-end gap-3">
+            <div className="flex-1">
+              <label className="block text-xs font-medium text-gray-600 dark:text-neutral-400 mb-1">
+                Tool Name
+              </label>
+              <input
+                type="text"
+                value={toolRef}
+                onChange={(e) => setToolRef(e.target.value)}
+                placeholder="e.g. code-review"
+                className="w-full px-3 py-1.5 text-sm border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white"
+              />
+            </div>
+            <div className="flex-1">
+              <label className="block text-xs font-medium text-gray-600 dark:text-neutral-400 mb-1">
+                User Ref
+              </label>
+              <input
+                type="text"
+                value={userRef}
+                onChange={(e) => setUserRef(e.target.value)}
+                placeholder="e.g. alice"
+                className="w-full px-3 py-1.5 text-sm border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white"
+              />
+            </div>
+            <button
+              onClick={handleResolve}
+              disabled={isLoading}
+              className="flex items-center gap-1.5 px-4 py-1.5 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
+            >
+              <Play className="h-3 w-3" />
+              {isLoading ? 'Resolving...' : 'Resolve'}
+            </button>
+          </div>
+
+          {resolved && resolved.length > 0 && (
+            <div className="space-y-3">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b dark:border-neutral-700">
+                    <th className="text-left py-2 text-xs font-medium text-gray-500 dark:text-neutral-400">
+                      Name
+                    </th>
+                    <th className="text-left py-2 text-xs font-medium text-gray-500 dark:text-neutral-400">
+                      Scope
+                    </th>
+                    <th className="text-left py-2 text-xs font-medium text-gray-500 dark:text-neutral-400">
+                      Specificity
+                    </th>
+                    <th className="text-left py-2 text-xs font-medium text-gray-500 dark:text-neutral-400">
+                      Priority
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y dark:divide-neutral-700">
+                  {resolved.map((skill, i) => (
+                    <tr key={i}>
+                      <td className="py-2 text-gray-900 dark:text-white">{skill.name}</td>
+                      <td className="py-2">
+                        <span
+                          className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${scopeColors[skill.scope] || scopeColors.global}`}
+                        >
+                          {skill.scope}
+                        </span>
+                      </td>
+                      <td className="py-2 font-mono text-gray-600 dark:text-neutral-300">
+                        {skill.specificity}
+                      </td>
+                      <td className="py-2 font-mono text-gray-600 dark:text-neutral-300">
+                        {skill.priority}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+
+              {mergedInstructions && (
+                <div>
+                  <h4 className="text-xs font-medium text-gray-500 dark:text-neutral-400 mb-1">
+                    Merged Instructions
+                  </h4>
+                  <pre className="text-xs bg-gray-50 dark:bg-neutral-900 p-3 rounded-lg overflow-x-auto whitespace-pre-wrap text-gray-800 dark:text-neutral-200 max-h-48 overflow-y-auto">
+                    {mergedInstructions}
+                  </pre>
+                </div>
+              )}
+            </div>
+          )}
+
+          {resolved && resolved.length === 0 && (
+            <p className="text-sm text-gray-500 dark:text-neutral-400 italic">
+              No skills matched the given context.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/control-plane-ui/src/pages/Skills/SkillsList.test.tsx
+++ b/control-plane-ui/src/pages/Skills/SkillsList.test.tsx
@@ -61,6 +61,11 @@ vi.mock('./SkillFormModal', () => ({
   SkillFormModal: () => <div data-testid="skill-modal">Skill Modal</div>,
 }));
 
+// Mock preview
+vi.mock('./SkillPreview', () => ({
+  SkillPreview: () => <div data-testid="skill-preview">Resolution Preview</div>,
+}));
+
 import { SkillsList } from './SkillsList';
 
 function renderComponent() {
@@ -139,6 +144,11 @@ describe('SkillsList', () => {
   it('shows cascade legend', async () => {
     renderComponent();
     expect(await screen.findByText('Cascade order:')).toBeInTheDocument();
+  });
+
+  it('shows resolution preview panel', async () => {
+    renderComponent();
+    expect(await screen.findByTestId('skill-preview')).toBeInTheDocument();
   });
 
   it('shows empty state when no skills', async () => {

--- a/control-plane-ui/src/pages/Skills/SkillsList.tsx
+++ b/control-plane-ui/src/pages/Skills/SkillsList.tsx
@@ -7,6 +7,7 @@ import { useToastActions } from '@stoa/shared/components/Toast';
 import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
 import { EmptyState } from '@stoa/shared/components/EmptyState';
 import { SkillFormModal } from './SkillFormModal';
+import { SkillPreview } from './SkillPreview';
 
 const scopeConfig: Record<string, { color: string; label: string; specificity: number }> = {
   global: {
@@ -273,6 +274,9 @@ export function SkillsList() {
           </table>
         </div>
       )}
+
+      {/* Resolution Preview */}
+      <SkillPreview />
 
       {/* Modal */}
       {showModal && (

--- a/e2e/features/console-skills.feature
+++ b/e2e/features/console-skills.feature
@@ -1,0 +1,50 @@
+@wip @skills @console
+Feature: Console - Skills Management
+
+  As a tenant admin,
+  I want to manage agent skills in the Console
+  So that I can configure context injection for AI agent conversations.
+
+  @smoke
+  Scenario: Admin sees skills list page
+    Given I am logged in to Console as "parzival" from team "high-five"
+    And the STOA Console is accessible
+    When I navigate to the Skills page
+    Then the Skills page loads successfully
+
+  Scenario: Admin creates a global skill
+    Given I am logged in to Console as "parzival" from team "high-five"
+    And the STOA Console is accessible
+    When I navigate to the Skills page
+    And I create a skill named "E2E Test Skill" with scope "global"
+    Then the skill "E2E Test Skill" appears in the list
+
+  Scenario: Admin edits skill priority
+    Given I am logged in to Console as "parzival" from team "high-five"
+    And the STOA Console is accessible
+    When I navigate to the Skills page
+    And I edit the skill "E2E Test Skill" priority to "90"
+    Then the skill "E2E Test Skill" shows priority "90"
+
+  Scenario: Admin deletes a skill
+    Given I am logged in to Console as "parzival" from team "high-five"
+    And the STOA Console is accessible
+    When I navigate to the Skills page
+    And I delete the skill "E2E Test Skill"
+    And I confirm the deletion
+    Then the skill "E2E Test Skill" is no longer in the list
+
+  @security
+  Scenario: Viewer cannot create skills
+    Given I am logged in to Console as "aech" from team "high-five"
+    And the STOA Console is accessible
+    When I navigate to the Skills page
+    Then the Add Skill button is not visible
+
+  Scenario: Resolution preview shows resolved skills
+    Given I am logged in to Console as "parzival" from team "high-five"
+    And the STOA Console is accessible
+    When I navigate to the Skills page
+    And I open the Resolution Preview panel
+    And I resolve skills for tool "code-review"
+    Then the resolution results are displayed

--- a/e2e/steps/console-skills.steps.ts
+++ b/e2e/steps/console-skills.steps.ts
@@ -1,0 +1,156 @@
+/**
+ * Console step definitions for Skills Management (CAB-1366)
+ * Steps for managing agent skills via the Console UI.
+ */
+
+import { createBdd } from "playwright-bdd";
+import { test, expect, URLS } from "../fixtures/test-base";
+
+const { When, Then } = createBdd(test);
+
+// ============================================================================
+// SKILLS — NAVIGATION
+// ============================================================================
+
+When("I navigate to the Skills page", async ({ page }) => {
+  await page.goto(`${URLS.console}/skills`);
+  await page.waitForLoadState("networkidle");
+  await expect(page.locator("text=Loading").first())
+    .not.toBeVisible({ timeout: 15000 })
+    .catch(() => {});
+});
+
+Then("the Skills page loads successfully", async ({ page }) => {
+  const heading = page.locator("h1, h2").filter({ hasText: /Skills/i });
+  const content = page.locator('[class*="card"], [class*="list"], table');
+
+  const loaded =
+    (await heading.isVisible({ timeout: 10000 }).catch(() => false)) ||
+    (await content
+      .first()
+      .isVisible({ timeout: 5000 })
+      .catch(() => false));
+
+  expect(loaded || page.url().includes("/skills")).toBe(true);
+});
+
+// ============================================================================
+// SKILLS — CRUD
+// ============================================================================
+
+When(
+  "I create a skill named {string} with scope {string}",
+  async ({ page }, skillName: string, scope: string) => {
+    const addBtn = page.locator('button:has-text("Add Skill")');
+    await expect(addBtn).toBeVisible({ timeout: 15000 });
+    await addBtn.click();
+
+    await page.fill('input[placeholder*="namespace"]', `e2e/${skillName.toLowerCase().replace(/\s+/g, '-')}`);
+    await page.fill('input[placeholder*="Human-readable"]', skillName);
+    await page.fill('input[placeholder*="tenant-id"]', 'oasis');
+
+    const scopeSelect = page.locator("select");
+    await scopeSelect.selectOption(scope);
+
+    await page.click('button[type="submit"]:has-text("Create")');
+    await page.waitForLoadState("networkidle");
+  },
+);
+
+Then(
+  "the skill {string} appears in the list",
+  async ({ page }, skillName: string) => {
+    await expect(page.locator(`text=${skillName}`).first()).toBeVisible({
+      timeout: 10000,
+    });
+  },
+);
+
+When(
+  "I edit the skill {string} priority to {string}",
+  async ({ page }, skillName: string, priority: string) => {
+    const row = page.locator(`tr:has-text("${skillName}")`).first();
+    await expect(row).toBeVisible({ timeout: 10000 });
+
+    const editBtn = row.locator("button").first();
+    await editBtn.click();
+
+    const priorityInput = page.locator('input[type="number"]');
+    await priorityInput.clear();
+    await priorityInput.fill(priority);
+
+    await page.click('button[type="submit"]:has-text("Update")');
+    await page.waitForLoadState("networkidle");
+  },
+);
+
+Then(
+  "the skill {string} shows priority {string}",
+  async ({ page }, skillName: string, priority: string) => {
+    const row = page.locator(`tr:has-text("${skillName}")`).first();
+    await expect(row).toBeVisible({ timeout: 10000 });
+    await expect(row.locator(`text=${priority}`)).toBeVisible();
+  },
+);
+
+When("I delete the skill {string}", async ({ page }, skillName: string) => {
+  const row = page.locator(`tr:has-text("${skillName}")`).first();
+  await expect(row).toBeVisible({ timeout: 10000 });
+
+  const deleteBtn = row.locator('button:has(svg[class*="trash" i]), button:last-child');
+  await deleteBtn.click();
+});
+
+Then(
+  "the skill {string} is no longer in the list",
+  async ({ page }, skillName: string) => {
+    await page.waitForLoadState("networkidle");
+    const entry = page.locator(`text=${skillName}`);
+    await expect(entry).not.toBeVisible({ timeout: 10000 });
+  },
+);
+
+Then("the Add Skill button is not visible", async ({ page }) => {
+  await page.waitForLoadState("networkidle");
+  // Wait for content to load
+  await expect(
+    page.locator("h1, h2").filter({ hasText: /Skills/i }),
+  ).toBeVisible({ timeout: 10000 });
+
+  const addBtn = page.locator('button:has-text("Add Skill")');
+  await expect(addBtn).not.toBeVisible({ timeout: 5000 });
+});
+
+// ============================================================================
+// SKILLS — RESOLUTION PREVIEW
+// ============================================================================
+
+When("I open the Resolution Preview panel", async ({ page }) => {
+  const previewBtn = page.locator('button:has-text("Resolution Preview")');
+  await expect(previewBtn).toBeVisible({ timeout: 10000 });
+  await previewBtn.click();
+});
+
+When(
+  "I resolve skills for tool {string}",
+  async ({ page }, toolName: string) => {
+    const toolInput = page.locator('input[placeholder*="code-review"]');
+    await toolInput.fill(toolName);
+
+    const resolveBtn = page.locator('button:has-text("Resolve")');
+    await resolveBtn.click();
+    await page.waitForLoadState("networkidle");
+  },
+);
+
+Then("the resolution results are displayed", async ({ page }) => {
+  // Either resolved skills table or "No skills resolved" message
+  const table = page.locator("table").last();
+  const noResults = page.locator("text=No skills resolved");
+
+  const hasResults =
+    (await table.isVisible({ timeout: 10000 }).catch(() => false)) ||
+    (await noResults.isVisible({ timeout: 5000 }).catch(() => false));
+
+  expect(hasResults).toBe(true);
+});


### PR DESCRIPTION
## Summary
- **SkillPreview**: collapsible resolution preview panel to test the CSS cascade model (tool name + user ref inputs → resolved skills table + merged instructions)
- **E2E BDD**: 6 Gherkin scenarios covering admin CRUD, viewer RBAC, and resolution preview (`@wip @skills` tags)
- **Test**: added resolution preview panel test (17 total vitest tests)

Builds on PR #710 (core Skills page). Completes the remaining items from the CAB-1366 plan (Step 4 + Step 7).

**Files**: 5 files, ~376 LOC
- `control-plane-ui/src/pages/Skills/SkillPreview.tsx` (new)
- `control-plane-ui/src/pages/Skills/SkillsList.tsx` (modified — import + render)
- `control-plane-ui/src/pages/Skills/SkillsList.test.tsx` (modified — mock + test)
- `e2e/features/console-skills.feature` (new)
- `e2e/steps/console-skills.steps.ts` (new)

## Test plan
- [x] TypeScript compiles (Skills files clean; FederationAccountDetail errors are pre-existing)
- [x] Prettier passes
- [x] lint-staged passes
- [x] 17/17 vitest Skills tests pass
- [ ] CI required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)