### PR TITLE
feat(api): replace 20 TODO stubs with real implementations (CAB-1381)

### DIFF
--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -519,6 +519,45 @@
         "title": "ActivityType",
         "type": "string"
       },
+      "ApplicationCreate": {
+        "properties": {
+          "api_subscriptions": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Api Subscriptions",
+            "type": "array"
+          },
+          "description": {
+            "default": "",
+            "title": "Description",
+            "type": "string"
+          },
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "redirect_uris": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Redirect Uris",
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "display_name"
+        ],
+        "title": "ApplicationCreate",
+        "type": "object"
+      },
       "ApplicationCreateRequest": {
         "description": "Request to create an application.",
         "properties": {
@@ -562,6 +601,24 @@
         "title": "ApplicationCreateRequest",
         "type": "object"
       },
+      "ApplicationCredentials": {
+        "properties": {
+          "client_id": {
+            "title": "Client Id",
+            "type": "string"
+          },
+          "client_secret": {
+            "title": "Client Secret",
+            "type": "string"
+          }
+        },
+        "required": [
+          "client_id",
+          "client_secret"
+        ],
+        "title": "ApplicationCredentials",
+        "type": "object"
+      },
       "ApplicationDiffResponse": {
         "description": "Diff response for an application.",
         "properties": {
@@ -592,99 +649,6 @@
           "resources"
         ],
         "title": "ApplicationDiffResponse",
-        "type": "object"
-      },
-      "ApplicationResponse": {
-        "description": "Application response for Portal.",
-        "properties": {
-          "api_subscriptions": {
-            "default": [],
-            "items": {
-              "type": "string"
-            },
-            "title": "Api Subscriptions",
-            "type": "array"
-          },
-          "client_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Client Id"
-          },
-          "client_secret": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Client Secret"
-          },
-          "created_at": {
-            "title": "Created At",
-            "type": "string"
-          },
-          "description": {
-            "title": "Description",
-            "type": "string"
-          },
-          "display_name": {
-            "title": "Display Name",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "string"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "redirect_uris": {
-            "default": [],
-            "items": {
-              "type": "string"
-            },
-            "title": "Redirect Uris",
-            "type": "array"
-          },
-          "status": {
-            "default": "active",
-            "title": "Status",
-            "type": "string"
-          },
-          "tenant_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tenant Id"
-          },
-          "updated_at": {
-            "title": "Updated At",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "display_name",
-          "description",
-          "created_at",
-          "updated_at"
-        ],
-        "title": "ApplicationResponse",
         "type": "object"
       },
       "ApplicationUpdateRequest": {
@@ -735,7 +699,7 @@
         "properties": {
           "items": {
             "items": {
-              "$ref": "#/components/schemas/ApplicationResponse"
+              "$ref": "#/components/schemas/src__routers__portal_applications__ApplicationResponse"
             },
             "title": "Items",
             "type": "array"
@@ -1476,6 +1440,47 @@
           "file"
         ],
         "title": "Body_upload_certificate_v1_certificates_upload_post",
+        "type": "object"
+      },
+      "BranchCreate": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "ref": {
+            "default": "main",
+            "title": "Ref",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "BranchCreate",
+        "type": "object"
+      },
+      "BranchInfo": {
+        "properties": {
+          "commit_sha": {
+            "title": "Commit Sha",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "protected": {
+            "default": false,
+            "title": "Protected",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "commit_sha"
+        ],
+        "title": "BranchInfo",
         "type": "object"
       },
       "BulkResultItem": {
@@ -5012,7 +5017,7 @@
         "title": "FederationBulkRevokeResponse",
         "type": "object"
       },
-      "FileContent": {
+      "FileCreateUpdate": {
         "properties": {
           "content": {
             "title": "Content",
@@ -5022,17 +5027,12 @@
             "default": "text",
             "title": "Encoding",
             "type": "string"
-          },
-          "path": {
-            "title": "Path",
-            "type": "string"
           }
         },
         "required": [
-          "path",
           "content"
         ],
-        "title": "FileContent",
+        "title": "FileCreateUpdate",
         "type": "object"
       },
       "GatewayAPIResponse": {
@@ -8903,6 +8903,37 @@
           "page_size"
         ],
         "title": "PaginatedResponse[APIResponse]",
+        "type": "object"
+      },
+      "PaginatedResponse_ApplicationResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/src__routers__applications__ApplicationResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "page": {
+            "title": "Page",
+            "type": "integer"
+          },
+          "page_size": {
+            "title": "Page Size",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "page_size"
+        ],
+        "title": "PaginatedResponse[ApplicationResponse]",
         "type": "object"
       },
       "PaginatedResponse_GatewayAPIResponse_": {
@@ -15514,6 +15545,67 @@
         "title": "WebhookUpdate",
         "type": "object"
       },
+      "src__routers__applications__ApplicationResponse": {
+        "properties": {
+          "api_subscriptions": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Api Subscriptions",
+            "type": "array"
+          },
+          "client_id": {
+            "title": "Client Id",
+            "type": "string"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "status": {
+            "default": "active",
+            "title": "Status",
+            "type": "string"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "tenant_id",
+          "name",
+          "display_name",
+          "description",
+          "client_id",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ApplicationResponse",
+        "type": "object"
+      },
       "src__routers__audit__AuditListResponse": {
         "description": "Response for audit list endpoint.",
         "properties": {
@@ -15605,6 +15697,99 @@
           "untracked"
         ],
         "title": "SyncStatusResponse",
+        "type": "object"
+      },
+      "src__routers__portal_applications__ApplicationResponse": {
+        "description": "Application response for Portal.",
+        "properties": {
+          "api_subscriptions": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Api Subscriptions",
+            "type": "array"
+          },
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Secret"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "redirect_uris": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Redirect Uris",
+            "type": "array"
+          },
+          "status": {
+            "default": "active",
+            "title": "Status",
+            "type": "string"
+          },
+          "tenant_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tenant Id"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "display_name",
+          "description",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ApplicationResponse",
         "type": "object"
       },
       "src__schemas__catalog__SyncStatusResponse": {
@@ -19910,7 +20095,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApplicationResponse"
+                  "$ref": "#/components/schemas/src__routers__portal_applications__ApplicationResponse"
                 }
               }
             },
@@ -20002,7 +20187,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApplicationResponse"
+                  "$ref": "#/components/schemas/src__routers__portal_applications__ApplicationResponse"
                 }
               }
             },
@@ -20058,7 +20243,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApplicationResponse"
+                  "$ref": "#/components/schemas/src__routers__portal_applications__ApplicationResponse"
                 }
               }
             },
@@ -23167,8 +23352,18 @@
     },
     "/v1/internal/external-mcp-servers": {
       "get": {
-        "description": "List all enabled external MCP servers with credentials for MCP Gateway.\n\nThis is an internal endpoint called by MCP Gateway.\nReturns servers with decrypted credentials.",
         "operationId": "list_servers_for_gateway_v1_internal_external_mcp_servers_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Gateway-Key",
+            "required": true,
+            "schema": {
+              "title": "X-Gateway-Key",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -23179,6 +23374,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "List Servers For Gateway",
@@ -28687,6 +28892,486 @@
         ]
       }
     },
+    "/v1/tenants/{tenant_id}/applications": {
+      "get": {
+        "description": "List all applications for a tenant (paginated).",
+        "operationId": "list_applications_v1_tenants__tenant_id__applications_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_ApplicationResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Applications",
+        "tags": [
+          "Applications"
+        ]
+      },
+      "post": {
+        "description": "Create a new application (Keycloak client).",
+        "operationId": "create_application_v1_tenants__tenant_id__applications_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApplicationCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/src__routers__applications__ApplicationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Application",
+        "tags": [
+          "Applications"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/applications/{app_id}": {
+      "delete": {
+        "description": "Delete application.",
+        "operationId": "delete_application_v1_tenants__tenant_id__applications__app_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "title": "App Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete Application",
+        "tags": [
+          "Applications"
+        ]
+      },
+      "get": {
+        "description": "Get application by ID.",
+        "operationId": "get_application_v1_tenants__tenant_id__applications__app_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "title": "App Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/src__routers__applications__ApplicationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Application",
+        "tags": [
+          "Applications"
+        ]
+      },
+      "put": {
+        "description": "Update application.",
+        "operationId": "update_application_v1_tenants__tenant_id__applications__app_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "title": "App Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApplicationCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/src__routers__applications__ApplicationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Application",
+        "tags": [
+          "Applications"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/applications/{app_id}/regenerate-secret": {
+      "post": {
+        "description": "Regenerate application client secret.",
+        "operationId": "regenerate_secret_v1_tenants__tenant_id__applications__app_id__regenerate_secret_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "title": "App Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationCredentials"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Regenerate Secret",
+        "tags": [
+          "Applications"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/applications/{app_id}/subscribe/{api_id}": {
+      "delete": {
+        "description": "Unsubscribe application from an API.",
+        "operationId": "unsubscribe_from_api_v1_tenants__tenant_id__applications__app_id__subscribe__api_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "title": "App Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "api_id",
+            "required": true,
+            "schema": {
+              "title": "Api Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Unsubscribe From Api",
+        "tags": [
+          "Applications"
+        ]
+      },
+      "post": {
+        "description": "Subscribe application to an API.",
+        "operationId": "subscribe_to_api_v1_tenants__tenant_id__applications__app_id__subscribe__api_id__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "title": "App Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "api_id",
+            "required": true,
+            "schema": {
+              "title": "Api Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Subscribe To Api",
+        "tags": [
+          "Applications"
+        ]
+      }
+    },
     "/v1/tenants/{tenant_id}/backend-apis": {
       "get": {
         "description": "List backend APIs for a tenant.",
@@ -30558,7 +31243,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/BranchInfo"
+                  },
+                  "title": "Response List Branches V1 Tenants  Tenant Id  Git Branches Get",
+                  "type": "array"
+                }
               }
             },
             "description": "Successful Response"
@@ -30596,32 +31287,25 @@
               "title": "Tenant Id",
               "type": "string"
             }
-          },
-          {
-            "in": "query",
-            "name": "branch_name",
-            "required": true,
-            "schema": {
-              "title": "Branch Name",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "ref",
-            "required": false,
-            "schema": {
-              "default": "main",
-              "title": "Ref",
-              "type": "string"
-            }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BranchCreate"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
-          "200": {
+          "201": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/BranchInfo"
+                }
               }
             },
             "description": "Successful Response"
@@ -30684,6 +31368,8 @@
             "required": false,
             "schema": {
               "default": 20,
+              "maximum": 100,
+              "minimum": 1,
               "title": "Limit",
               "type": "integer"
             }
@@ -30922,14 +31608,14 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/FileContent"
+                "$ref": "#/components/schemas/FileCreateUpdate"
               }
             }
           },
           "required": true
         },
         "responses": {
-          "200": {
+          "201": {
             "content": {
               "application/json": {
                 "schema": {}
@@ -31045,7 +31731,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "201": {
             "content": {
               "application/json": {
                 "schema": {

--- a/control-plane-api/src/main.py
+++ b/control-plane-api/src/main.py
@@ -30,7 +30,7 @@ from .routers import (
     access_requests,
     admin_prospects,
     apis,
-    applications,  # noqa: F401 — router registered via import side-effect
+    applications,
     audit,
     backend_apis,
     business,
@@ -404,8 +404,7 @@ app.add_middleware(AuditMiddleware)
 # Routers
 app.include_router(tenants.router)
 app.include_router(apis.router)
-# CAB-1122: Applications router disabled — requires Keycloak service implementation
-# app.include_router(applications.router)
+app.include_router(applications.router)
 app.include_router(deployments.router)
 app.include_router(git.router)
 app.include_router(events.router)

--- a/control-plane-api/src/routers/applications.py
+++ b/control-plane-api/src/routers/applications.py
@@ -1,19 +1,28 @@
-"""Applications router - Consumer applications management"""
+"""Applications router - Consumer applications management via Keycloak"""
+
+import json
+import logging
+from datetime import UTC
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from ..auth import Permission, User, get_current_user, require_permission, require_tenant_access
 from ..schemas.pagination import PaginatedResponse
+from ..services.keycloak_service import keycloak_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/tenants/{tenant_id}/applications", tags=["Applications"])
+
 
 class ApplicationCreate(BaseModel):
     name: str
     display_name: str
     description: str = ""
     redirect_uris: list[str] = []
-    api_subscriptions: list[str] = []  # List of API IDs
+    api_subscriptions: list[str] = []
+
 
 class ApplicationResponse(BaseModel):
     id: str
@@ -22,46 +31,108 @@ class ApplicationResponse(BaseModel):
     display_name: str
     description: str
     client_id: str
-    status: str = "pending"
+    status: str = "active"
     api_subscriptions: list[str] = []
     created_at: str
     updated_at: str
+
 
 class ApplicationCredentials(BaseModel):
     client_id: str
     client_secret: str
 
+
+def _kc_client_to_response(client: dict, tenant_id: str) -> ApplicationResponse:
+    """Convert a Keycloak client dict to ApplicationResponse."""
+    attrs = client.get("attributes", {})
+    subs_raw = attrs.get("api_subscriptions", ["[]"])
+    subs_val = subs_raw[0] if isinstance(subs_raw, list) else subs_raw
+    created = attrs.get("created_at", [""])
+    updated = attrs.get("updated_at", [""])
+    return ApplicationResponse(
+        id=client["id"],
+        tenant_id=tenant_id,
+        name=client.get("clientId", "").removeprefix(f"{tenant_id}-"),
+        display_name=client.get("name", client.get("clientId", "")),
+        description=client.get("description", ""),
+        client_id=client.get("clientId", ""),
+        status="active" if client.get("enabled", True) else "disabled",
+        api_subscriptions=json.loads(subs_val),
+        created_at=created[0] if isinstance(created, list) else created,
+        updated_at=updated[0] if isinstance(updated, list) else updated,
+    )
+
+
+async def _get_tenant_client(app_id: str, tenant_id: str) -> dict:
+    """Get a KC client by UUID, verify tenant ownership, or raise 404."""
+    client = await keycloak_service.get_client_by_id(app_id)
+    if not client:
+        raise HTTPException(status_code=404, detail="Application not found")
+    # Verify tenant ownership
+    attrs = client.get("attributes", {})
+    attr_tenant = attrs.get("tenant_id", [None])
+    actual_tenant = attr_tenant[0] if isinstance(attr_tenant, list) else attr_tenant
+    client_id = client.get("clientId", "")
+    if actual_tenant != tenant_id and not client_id.startswith(f"{tenant_id}-"):
+        raise HTTPException(status_code=404, detail="Application not found")
+    return client
+
+
 @router.get("", response_model=PaginatedResponse[ApplicationResponse])
 @require_tenant_access
 async def list_applications(
     tenant_id: str,
-    page: int = Query(default=1, ge=1, description="Page number"),
-    page_size: int = Query(default=20, ge=1, le=100, description="Items per page"),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
     user: User = Depends(get_current_user),
 ):
     """List all applications for a tenant (paginated)."""
-    # TODO: Implement with Keycloak service
-    return PaginatedResponse(items=[], total=0, page=page, page_size=page_size)
+    clients = await keycloak_service.get_clients(tenant_id)
+    items = [_kc_client_to_response(c, tenant_id) for c in clients]
+    total = len(items)
+    start = (page - 1) * page_size
+    end = start + page_size
+    return PaginatedResponse(items=items[start:end], total=total, page=page, page_size=page_size)
+
 
 @router.get("/{app_id}", response_model=ApplicationResponse)
 @require_tenant_access
 async def get_application(tenant_id: str, app_id: str, user: User = Depends(get_current_user)):
-    """Get application by ID"""
-    # TODO: Implement with Keycloak service
-    raise HTTPException(status_code=404, detail="Application not found")
+    """Get application by ID."""
+    client = await _get_tenant_client(app_id, tenant_id)
+    return _kc_client_to_response(client, tenant_id)
 
-@router.post("", response_model=ApplicationResponse)
+
+@router.post("", response_model=ApplicationResponse, status_code=201)
 @require_permission(Permission.APPS_CREATE)
 @require_tenant_access
-async def create_application(
-    tenant_id: str, app: ApplicationCreate, user: User = Depends(get_current_user)
-):
-    """Create a new application (Keycloak client)"""
-    # TODO: Implement with Keycloak service
-    # 1. Create client in Keycloak
-    # 2. Store metadata in GitLab
-    # 3. Emit app-created event to Kafka
-    pass
+async def create_application(tenant_id: str, app: ApplicationCreate, user: User = Depends(get_current_user)):
+    """Create a new application (Keycloak client)."""
+    from datetime import datetime
+
+    result = await keycloak_service.create_client(
+        tenant_id=tenant_id,
+        name=app.name,
+        display_name=app.display_name,
+        redirect_uris=app.redirect_uris,
+        description=app.description,
+    )
+    now = datetime.now(UTC).isoformat()
+    # Store extra attributes
+    await keycloak_service.update_client(
+        result["id"],
+        {
+            "attributes": {
+                "tenant_id": tenant_id,
+                "api_subscriptions": json.dumps(app.api_subscriptions),
+                "created_at": now,
+                "updated_at": now,
+            }
+        },
+    )
+    client = await keycloak_service.get_client_by_id(result["id"])
+    return _kc_client_to_response(client, tenant_id)
+
 
 @router.put("/{app_id}", response_model=ApplicationResponse)
 @require_permission(Permission.APPS_UPDATE)
@@ -69,42 +140,79 @@ async def create_application(
 async def update_application(
     tenant_id: str, app_id: str, app: ApplicationCreate, user: User = Depends(get_current_user)
 ):
-    """Update application"""
-    # TODO: Implement with Keycloak service
-    pass
+    """Update application."""
+    from datetime import datetime
 
-@router.delete("/{app_id}")
+    client = await _get_tenant_client(app_id, tenant_id)
+    now = datetime.now(UTC).isoformat()
+    attrs = client.get("attributes", {})
+    attrs["updated_at"] = now
+    await keycloak_service.update_client(
+        app_id,
+        {
+            "name": app.display_name,
+            "description": app.description,
+            "redirectUris": app.redirect_uris,
+            "attributes": attrs,
+        },
+    )
+    updated = await keycloak_service.get_client_by_id(app_id)
+    return _kc_client_to_response(updated, tenant_id)
+
+
+@router.delete("/{app_id}", status_code=204)
 @require_permission(Permission.APPS_DELETE)
 @require_tenant_access
 async def delete_application(tenant_id: str, app_id: str, user: User = Depends(get_current_user)):
-    """Delete application"""
-    # TODO: Implement with Keycloak service + Kafka event
-    return {"message": "Application deleted"}
+    """Delete application."""
+    await _get_tenant_client(app_id, tenant_id)
+    await keycloak_service.delete_client(app_id)
+
 
 @router.post("/{app_id}/regenerate-secret", response_model=ApplicationCredentials)
 @require_permission(Permission.APPS_UPDATE)
 @require_tenant_access
 async def regenerate_secret(tenant_id: str, app_id: str, user: User = Depends(get_current_user)):
-    """Regenerate application client secret"""
-    # TODO: Implement with Keycloak service
-    pass
+    """Regenerate application client secret."""
+    client = await _get_tenant_client(app_id, tenant_id)
+    new_secret = await keycloak_service.regenerate_client_secret(app_id)
+    return ApplicationCredentials(
+        client_id=client.get("clientId", ""),
+        client_secret=new_secret,
+    )
+
 
 @router.post("/{app_id}/subscribe/{api_id}")
 @require_permission(Permission.APPS_UPDATE)
 @require_tenant_access
-async def subscribe_to_api(
-    tenant_id: str, app_id: str, api_id: str, user: User = Depends(get_current_user)
-):
-    """Subscribe application to an API"""
-    # TODO: Implement subscription logic
-    return {"message": f"Application {app_id} subscribed to API {api_id}"}
+async def subscribe_to_api(tenant_id: str, app_id: str, api_id: str, user: User = Depends(get_current_user)):
+    """Subscribe application to an API."""
+    client = await _get_tenant_client(app_id, tenant_id)
+    attrs = client.get("attributes", {})
+    subs_raw = attrs.get("api_subscriptions", ["[]"])
+    subs_val = subs_raw[0] if isinstance(subs_raw, list) else subs_raw
+    subs = json.loads(subs_val)
+    if api_id in subs:
+        raise HTTPException(status_code=409, detail="Already subscribed")
+    subs.append(api_id)
+    attrs["api_subscriptions"] = json.dumps(subs)
+    await keycloak_service.update_client(app_id, {"attributes": attrs})
+    return {"message": f"Application subscribed to API {api_id}"}
+
 
 @router.delete("/{app_id}/subscribe/{api_id}")
 @require_permission(Permission.APPS_UPDATE)
 @require_tenant_access
-async def unsubscribe_from_api(
-    tenant_id: str, app_id: str, api_id: str, user: User = Depends(get_current_user)
-):
-    """Unsubscribe application from an API"""
-    # TODO: Implement unsubscription logic
-    return {"message": f"Application {app_id} unsubscribed from API {api_id}"}
+async def unsubscribe_from_api(tenant_id: str, app_id: str, api_id: str, user: User = Depends(get_current_user)):
+    """Unsubscribe application from an API."""
+    client = await _get_tenant_client(app_id, tenant_id)
+    attrs = client.get("attributes", {})
+    subs_raw = attrs.get("api_subscriptions", ["[]"])
+    subs_val = subs_raw[0] if isinstance(subs_raw, list) else subs_raw
+    subs = json.loads(subs_val)
+    if api_id not in subs:
+        raise HTTPException(status_code=404, detail="Not subscribed to this API")
+    subs.remove(api_id)
+    attrs["api_subscriptions"] = json.dumps(subs)
+    await keycloak_service.update_client(app_id, {"attributes": attrs})
+    return {"message": f"Application unsubscribed from API {api_id}"}

--- a/control-plane-api/src/routers/external_mcp_servers.py
+++ b/control-plane-api/src/routers/external_mcp_servers.py
@@ -6,14 +6,16 @@ Provides endpoints for:
 
 Reference: External MCP Server Registration Plan
 """
+
 import logging
 import uuid
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import User, get_current_user
+from ..config import settings
 from ..database import get_db
 from ..models.external_mcp_server import (
     ExternalMCPAuthType,
@@ -143,10 +145,7 @@ def _convert_tool_to_response(tool: ExternalMCPServerTool) -> ExternalMCPServerT
 
 # ============ Admin Router ============
 
-admin_router = APIRouter(
-    prefix="/v1/admin/external-mcp-servers",
-    tags=["External MCP Servers - Admin"]
-)
+admin_router = APIRouter(prefix="/v1/admin/external-mcp-servers", tags=["External MCP Servers - Admin"])
 
 
 @admin_router.get("", response_model=ExternalMCPServerListResponse)
@@ -200,8 +199,7 @@ async def create_server(
     # Check tenant access
     if not _has_tenant_access(user, request.tenant_id):
         raise HTTPException(
-            status_code=403,
-            detail="Cannot create platform-wide servers (tenant_id=null) without CPI admin role"
+            status_code=403, detail="Cannot create platform-wide servers (tenant_id=null) without CPI admin role"
         )
 
     repo = ExternalMCPServerRepository(db)
@@ -235,10 +233,7 @@ async def create_server(
             server.credential_vault_path = vault_path
         except Exception as e:
             logger.error(f"Failed to store credentials in Vault: {e}")
-            raise HTTPException(
-                status_code=500,
-                detail="Failed to store credentials securely"
-            )
+            raise HTTPException(status_code=500, detail="Failed to store credentials securely")
 
     try:
         server = await repo.create(server)
@@ -319,10 +314,7 @@ async def update_server(
             server.credential_vault_path = vault_path
         except Exception as e:
             logger.error(f"Failed to update credentials in Vault: {e}")
-            raise HTTPException(
-                status_code=500,
-                detail="Failed to update credentials securely"
-            )
+            raise HTTPException(status_code=500, detail="Failed to update credentials securely")
 
     try:
         server = await repo.update(server)
@@ -399,10 +391,7 @@ async def test_connection(
             credentials = await vault.retrieve_credential(str(server.id))
         except Exception as e:
             logger.error(f"Failed to retrieve credentials from Vault: {e}")
-            return TestConnectionResponse(
-                success=False,
-                error="Failed to retrieve credentials"
-            )
+            return TestConnectionResponse(success=False, error="Failed to retrieve credentials")
 
     # Test connection
     mcp_client = get_mcp_client_service()
@@ -414,10 +403,7 @@ async def test_connection(
     )
 
     # Update health status
-    health_status = (
-        ExternalMCPHealthStatus.HEALTHY if result.success
-        else ExternalMCPHealthStatus.UNHEALTHY
-    )
+    health_status = ExternalMCPHealthStatus.HEALTHY if result.success else ExternalMCPHealthStatus.UNHEALTHY
     await repo.update_health_status(
         server_id=server.id,
         status=health_status,
@@ -460,10 +446,7 @@ async def sync_tools(
             credentials = await vault.retrieve_credential(str(server.id))
         except Exception as e:
             logger.error(f"Failed to retrieve credentials from Vault: {e}")
-            raise HTTPException(
-                status_code=500,
-                detail="Failed to retrieve credentials"
-            )
+            raise HTTPException(status_code=500, detail="Failed to retrieve credentials")
 
     # Discover tools
     mcp_client = get_mcp_client_service()
@@ -478,26 +461,25 @@ async def sync_tools(
         logger.error(f"Failed to discover tools: {e}")
         await repo.set_sync_error(server.id, str(e))
         await db.commit()
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to discover tools: {e}"
-        )
+        raise HTTPException(status_code=500, detail=f"Failed to discover tools: {e}")
 
     # Convert to tool models with namespacing
     tool_prefix = server.tool_prefix or server.name
     tools_to_sync = []
     for tool in discovered_tools:
         namespaced_name = f"{tool_prefix}__{tool.name}" if tool_prefix else tool.name
-        tools_to_sync.append(ExternalMCPServerTool(
-            id=uuid.uuid4(),
-            server_id=server.id,
-            name=tool.name,
-            namespaced_name=namespaced_name,
-            display_name=tool.name.replace("_", " ").title(),
-            description=tool.description,
-            input_schema=tool.input_schema,
-            enabled=True,
-        ))
+        tools_to_sync.append(
+            ExternalMCPServerTool(
+                id=uuid.uuid4(),
+                server_id=server.id,
+                name=tool.name,
+                namespaced_name=namespaced_name,
+                display_name=tool.name.replace("_", " ").title(),
+                description=tool.description,
+                input_schema=tool.input_schema,
+                enabled=True,
+            )
+        )
 
     # Sync tools
     synced_count, removed_count = await repo.sync_tools(server.id, tools_to_sync)
@@ -506,9 +488,7 @@ async def sync_tools(
     # Refresh to get updated tools
     server = await repo.get_by_id(server_id)
 
-    logger.info(
-        f"Synced tools for '{server.name}': {synced_count} synced, {removed_count} removed by {user.email}"
-    )
+    logger.info(f"Synced tools for '{server.name}': {synced_count} synced, {removed_count} removed by {user.email}")
 
     return SyncToolsResponse(
         synced_count=synced_count,
@@ -544,26 +524,27 @@ async def update_tool(
         raise HTTPException(status_code=404, detail="Tool not found")
 
     await db.commit()
-    logger.info(
-        f"Updated tool '{tool.name}' enabled={request.enabled} for server '{server.name}' by {user.email}"
-    )
+    logger.info(f"Updated tool '{tool.name}' enabled={request.enabled} for server '{server.name}' by {user.email}")
 
     return _convert_tool_to_response(tool)
 
 
 # ============ Internal Router (for MCP Gateway) ============
 
-internal_router = APIRouter(
-    prefix="/v1/internal",
-    tags=["Internal - MCP Gateway"]
-)
+internal_router = APIRouter(prefix="/v1/internal", tags=["Internal - MCP Gateway"])
 
 
 @internal_router.get("/external-mcp-servers", response_model=ExternalMCPServersForGatewayResponse)
 async def list_servers_for_gateway(
     db: AsyncSession = Depends(get_db),
-    # TODO: Add service-to-service authentication
+    x_gateway_key: str = Header(..., alias="X-Gateway-Key"),
 ):
+    # Service-to-service authentication via X-Gateway-Key
+    valid_keys = settings.gateway_api_keys_list
+    if not valid_keys:
+        raise HTTPException(status_code=503, detail="Internal API not configured")
+    if x_gateway_key not in valid_keys:
+        raise HTTPException(status_code=401, detail="Invalid gateway key")
     """
     List all enabled external MCP servers with credentials for MCP Gateway.
 
@@ -585,28 +566,31 @@ async def list_servers_for_gateway(
             except Exception as e:
                 logger.warning(f"Failed to retrieve credentials for server {server.name}: {e}")
 
-        result.append(ExternalMCPServerForGateway(
-            id=server.id,
-            name=server.name,
-            base_url=server.base_url,
-            transport=TransportTypeEnum(server.transport.value),
-            auth_type=AuthTypeEnum(server.auth_type.value),
-            credentials=credentials,
-            tool_prefix=server.tool_prefix,
-            tenant_id=server.tenant_id,
-            tools=[
-                ExternalMCPServerToolResponse(
-                    id=tool.id,
-                    name=tool.name,
-                    namespaced_name=tool.namespaced_name,
-                    display_name=tool.display_name,
-                    description=tool.description,
-                    input_schema=tool.input_schema,
-                    enabled=tool.enabled,
-                    synced_at=tool.synced_at,
-                )
-                for tool in (server.tools or []) if tool.enabled
-            ],
-        ))
+        result.append(
+            ExternalMCPServerForGateway(
+                id=server.id,
+                name=server.name,
+                base_url=server.base_url,
+                transport=TransportTypeEnum(server.transport.value),
+                auth_type=AuthTypeEnum(server.auth_type.value),
+                credentials=credentials,
+                tool_prefix=server.tool_prefix,
+                tenant_id=server.tenant_id,
+                tools=[
+                    ExternalMCPServerToolResponse(
+                        id=tool.id,
+                        name=tool.name,
+                        namespaced_name=tool.namespaced_name,
+                        display_name=tool.display_name,
+                        description=tool.description,
+                        input_schema=tool.input_schema,
+                        enabled=tool.enabled,
+                        synced_at=tool.synced_at,
+                    )
+                    for tool in (server.tools or [])
+                    if tool.enabled
+                ],
+            )
+        )
 
     return ExternalMCPServersForGatewayResponse(servers=result)

--- a/control-plane-api/src/routers/git.py
+++ b/control-plane-api/src/routers/git.py
@@ -1,11 +1,17 @@
 """Git router - GitLab operations for GitOps"""
 
-from fastapi import APIRouter, Depends, HTTPException
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from ..auth import Permission, User, get_current_user, require_permission, require_tenant_access
+from ..services.git_service import git_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/tenants/{tenant_id}/git", tags=["Git"])
+
 
 class CommitInfo(BaseModel):
     sha: str
@@ -13,16 +19,24 @@ class CommitInfo(BaseModel):
     author: str
     date: str
 
+
 class FileContent(BaseModel):
     path: str
     content: str
     encoding: str = "text"  # text or base64
+
+
+class FileCreateUpdate(BaseModel):
+    content: str
+    encoding: str = "text"
+
 
 class MergeRequestCreate(BaseModel):
     title: str
     description: str
     source_branch: str
     target_branch: str = "main"
+
 
 class MergeRequestResponse(BaseModel):
     id: int
@@ -36,26 +50,52 @@ class MergeRequestResponse(BaseModel):
     created_at: str
     author: str
 
+
+class BranchInfo(BaseModel):
+    name: str
+    commit_sha: str
+    protected: bool = False
+
+
+class BranchCreate(BaseModel):
+    name: str
+    ref: str = "main"
+
+
+def _tenant_path(tenant_id: str, path: str = "") -> str:
+    """Build scoped path under the tenant directory."""
+    base = f"tenants/{tenant_id}"
+    return f"{base}/{path}" if path else base
+
+
 @router.get("/commits", response_model=list[CommitInfo])
 @require_tenant_access
 async def list_commits(
     tenant_id: str,
     path: str | None = None,
-    limit: int = 20,
-    user: User = Depends(get_current_user)
+    limit: int = Query(default=20, ge=1, le=100),
+    user: User = Depends(get_current_user),
 ):
     """List recent commits for tenant repository"""
-    # TODO: Implement with GitLab service
-    return []
+    scoped_path = _tenant_path(tenant_id, path) if path else _tenant_path(tenant_id)
+    try:
+        commits = await git_service.list_commits(path=scoped_path, limit=limit)
+        return [CommitInfo(**c) for c in commits]
+    except Exception as e:
+        logger.error(f"Failed to list commits for tenant {tenant_id}: {e}")
+        return []
+
 
 @router.get("/files/{file_path:path}")
 @require_tenant_access
-async def get_file(
-    tenant_id: str, file_path: str, ref: str = "main", user: User = Depends(get_current_user)
-):
+async def get_file(tenant_id: str, file_path: str, ref: str = "main", user: User = Depends(get_current_user)):
     """Get file content from GitLab"""
-    # TODO: Implement with GitLab service
-    raise HTTPException(status_code=404, detail="File not found")
+    scoped_path = _tenant_path(tenant_id, file_path)
+    content = await git_service.get_file(scoped_path, ref=ref)
+    if content is None:
+        raise HTTPException(status_code=404, detail="File not found")
+    return FileContent(path=file_path, content=content)
+
 
 @router.get("/tree")
 @require_tenant_access
@@ -63,26 +103,61 @@ async def get_tree(
     tenant_id: str,
     path: str = "",
     ref: str = "main",
-    user: User = Depends(get_current_user)
+    user: User = Depends(get_current_user),
 ):
     """Get directory tree from GitLab"""
-    # TODO: Implement with GitLab service
-    return {"items": []}
+    scoped_path = _tenant_path(tenant_id, path) if path else _tenant_path(tenant_id)
+    if not git_service._project:
+        raise HTTPException(status_code=503, detail="GitLab not connected")
 
-@router.post("/files/{file_path:path}")
+    try:
+        tree = git_service._project.repository_tree(path=scoped_path, ref=ref)
+        items = [{"name": item["name"], "type": item["type"], "path": item["path"]} for item in tree]
+        return {"items": items}
+    except Exception:
+        return {"items": []}
+
+
+@router.post("/files/{file_path:path}", status_code=201)
 @require_permission(Permission.APIS_UPDATE)
 @require_tenant_access
 async def create_or_update_file(
     tenant_id: str,
     file_path: str,
-    content: FileContent,
-    branch: str = "main",
-    commit_message: str | None = None,
-    user: User = Depends(get_current_user)
+    body: FileCreateUpdate,
+    branch: str = Query(default="main"),
+    commit_message: str | None = Query(default=None),
+    user: User = Depends(get_current_user),
 ):
     """Create or update a file in GitLab"""
-    # TODO: Implement with GitLab service
-    pass
+    if not git_service._project:
+        raise HTTPException(status_code=503, detail="GitLab not connected")
+
+    scoped_path = _tenant_path(tenant_id, file_path)
+    msg = commit_message or f"Update {file_path} for tenant {tenant_id}"
+
+    # Try to get existing file to determine create vs update
+    existing = await git_service.get_file(scoped_path, ref=branch)
+    try:
+        if existing is not None:
+            file_obj = git_service._project.files.get(scoped_path, ref=branch)
+            file_obj.content = body.content
+            file_obj.save(branch=branch, commit_message=msg)
+        else:
+            git_service._project.files.create(
+                {
+                    "file_path": scoped_path,
+                    "branch": branch,
+                    "content": body.content,
+                    "commit_message": msg,
+                }
+            )
+    except Exception as e:
+        logger.error(f"Failed to create/update file {scoped_path}: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to save file: {e}")
+
+    return {"path": file_path, "action": "updated" if existing else "created"}
+
 
 @router.delete("/files/{file_path:path}")
 @require_permission(Permission.APIS_DELETE)
@@ -90,13 +165,25 @@ async def create_or_update_file(
 async def delete_file(
     tenant_id: str,
     file_path: str,
-    branch: str = "main",
-    commit_message: str | None = None,
-    user: User = Depends(get_current_user)
+    branch: str = Query(default="main"),
+    commit_message: str | None = Query(default=None),
+    user: User = Depends(get_current_user),
 ):
     """Delete a file from GitLab"""
-    # TODO: Implement with GitLab service
+    if not git_service._project:
+        raise HTTPException(status_code=503, detail="GitLab not connected")
+
+    scoped_path = _tenant_path(tenant_id, file_path)
+    msg = commit_message or f"Delete {file_path} for tenant {tenant_id}"
+
+    try:
+        git_service._project.files.delete(file_path=scoped_path, commit_message=msg, branch=branch)
+    except Exception as e:
+        logger.error(f"Failed to delete file {scoped_path}: {e}")
+        raise HTTPException(status_code=404, detail="File not found")
+
     return {"message": "File deleted"}
+
 
 # Merge Requests
 @router.get("/merge-requests", response_model=list[MergeRequestResponse])
@@ -104,50 +191,132 @@ async def delete_file(
 async def list_merge_requests(
     tenant_id: str,
     state: str = "opened",
-    user: User = Depends(get_current_user)
+    user: User = Depends(get_current_user),
 ):
     """List merge requests"""
-    # TODO: Implement with GitLab service
-    return []
+    if not git_service._project:
+        raise HTTPException(status_code=503, detail="GitLab not connected")
 
-@router.post("/merge-requests", response_model=MergeRequestResponse)
+    try:
+        mrs = git_service._project.mergerequests.list(state=state)
+        return [
+            MergeRequestResponse(
+                id=mr.id,
+                iid=mr.iid,
+                title=mr.title,
+                description=mr.description or "",
+                state=mr.state,
+                source_branch=mr.source_branch,
+                target_branch=mr.target_branch,
+                web_url=mr.web_url,
+                created_at=mr.created_at,
+                author=mr.author.get("name", "") if isinstance(mr.author, dict) else str(mr.author),
+            )
+            for mr in mrs
+        ]
+    except Exception as e:
+        logger.error(f"Failed to list merge requests: {e}")
+        return []
+
+
+@router.post("/merge-requests", response_model=MergeRequestResponse, status_code=201)
 @require_permission(Permission.APIS_UPDATE)
 @require_tenant_access
-async def create_merge_request(
-    tenant_id: str, mr: MergeRequestCreate, user: User = Depends(get_current_user)
-):
+async def create_merge_request(tenant_id: str, mr: MergeRequestCreate, user: User = Depends(get_current_user)):
     """Create a merge request"""
-    # TODO: Implement with GitLab service
-    pass
+    if not git_service._project:
+        raise HTTPException(status_code=503, detail="GitLab not connected")
+
+    try:
+        new_mr = git_service._project.mergerequests.create(
+            {
+                "title": mr.title,
+                "description": mr.description,
+                "source_branch": mr.source_branch,
+                "target_branch": mr.target_branch,
+            }
+        )
+        return MergeRequestResponse(
+            id=new_mr.id,
+            iid=new_mr.iid,
+            title=new_mr.title,
+            description=new_mr.description or "",
+            state=new_mr.state,
+            source_branch=new_mr.source_branch,
+            target_branch=new_mr.target_branch,
+            web_url=new_mr.web_url,
+            created_at=new_mr.created_at,
+            author=new_mr.author.get("name", "") if isinstance(new_mr.author, dict) else str(new_mr.author),
+        )
+    except Exception as e:
+        logger.error(f"Failed to create merge request: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to create merge request: {e}")
+
 
 @router.post("/merge-requests/{mr_iid}/merge")
 @require_permission(Permission.APIS_DEPLOY)
 @require_tenant_access
-async def merge_request(
-    tenant_id: str, mr_iid: int, user: User = Depends(get_current_user)
-):
+async def merge_request(tenant_id: str, mr_iid: int, user: User = Depends(get_current_user)):
     """Merge a merge request"""
-    # TODO: Implement with GitLab service
-    # This triggers GitOps deployment via webhook
-    return {"message": "Merge request merged"}
+    if not git_service._project:
+        raise HTTPException(status_code=503, detail="GitLab not connected")
+
+    try:
+        mr = git_service._project.mergerequests.get(mr_iid)
+        mr.merge()
+        return {"message": "Merge request merged", "iid": mr_iid}
+    except Exception as e:
+        logger.error(f"Failed to merge MR !{mr_iid}: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to merge: {e}")
+
 
 # Branches
-@router.get("/branches")
+@router.get("/branches", response_model=list[BranchInfo])
 @require_tenant_access
 async def list_branches(tenant_id: str, user: User = Depends(get_current_user)):
     """List branches"""
-    # TODO: Implement with GitLab service
-    return {"branches": []}
+    if not git_service._project:
+        raise HTTPException(status_code=503, detail="GitLab not connected")
 
-@router.post("/branches")
+    try:
+        branches = git_service._project.branches.list()
+        return [
+            BranchInfo(
+                name=b.name,
+                commit_sha=b.commit["id"] if isinstance(b.commit, dict) else str(b.commit),
+                protected=getattr(b, "protected", False),
+            )
+            for b in branches
+        ]
+    except Exception as e:
+        logger.error(f"Failed to list branches: {e}")
+        return []
+
+
+@router.post("/branches", response_model=BranchInfo, status_code=201)
 @require_permission(Permission.APIS_CREATE)
 @require_tenant_access
 async def create_branch(
     tenant_id: str,
-    branch_name: str,
-    ref: str = "main",
-    user: User = Depends(get_current_user)
+    body: BranchCreate,
+    user: User = Depends(get_current_user),
 ):
     """Create a new branch"""
-    # TODO: Implement with GitLab service
-    return {"branch": branch_name, "created": True}
+    if not git_service._project:
+        raise HTTPException(status_code=503, detail="GitLab not connected")
+
+    try:
+        branch = git_service._project.branches.create(
+            {
+                "branch": body.name,
+                "ref": body.ref,
+            }
+        )
+        return BranchInfo(
+            name=branch.name,
+            commit_sha=branch.commit["id"] if isinstance(branch.commit, dict) else str(branch.commit),
+            protected=getattr(branch, "protected", False),
+        )
+    except Exception as e:
+        logger.error(f"Failed to create branch {body.name}: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to create branch: {e}")

--- a/control-plane-api/src/services/iam_sync_service.py
+++ b/control-plane-api/src/services/iam_sync_service.py
@@ -5,6 +5,7 @@ This service ensures consistency between GitOps repository and Keycloak:
 - User roles and permissions
 - Application clients (OAuth2)
 """
+
 import logging
 from datetime import datetime
 
@@ -57,10 +58,7 @@ class IAMSyncService:
 
             # Ensure tenant group exists in Keycloak
             try:
-                await keycloak_service.setup_tenant_group(
-                    tenant_id,
-                    tenant_data.get("display_name", tenant_id)
-                )
+                await keycloak_service.setup_tenant_group(tenant_id, tenant_data.get("display_name", tenant_id))
                 result["actions"].append(f"Ensured group exists: {tenant_id}")
             except Exception as e:
                 logger.warning(f"Group setup failed (may already exist): {e}")
@@ -76,7 +74,14 @@ class IAMSyncService:
                         result["errors"].append(f"Failed to sync user {user_config.get('email')}: {e}")
 
             # Sync applications (OAuth2 clients)
-            # TODO: Implement application sync
+            apps_config = await self._get_tenant_apps_config(tenant_id)
+            if apps_config:
+                for app_config in apps_config.get("applications", []):
+                    try:
+                        await self._sync_application(tenant_id, app_config)
+                        result["actions"].append(f"Synced application: {app_config.get('name')}")
+                    except Exception as e:
+                        result["errors"].append(f"Failed to sync app {app_config.get('name')}: {e}")
 
             logger.info(f"Synced tenant {tenant_id}: {len(result['actions'])} actions")
             return result
@@ -89,9 +94,7 @@ class IAMSyncService:
     async def _get_tenant_users_config(self, tenant_id: str) -> dict | None:
         """Get users configuration from GitOps for a tenant."""
         try:
-            content = await git_service.get_file(
-                f"tenants/{tenant_id}/iam/users.yaml"
-            )
+            content = await git_service.get_file(f"tenants/{tenant_id}/iam/users.yaml")
             if content:
                 return yaml.safe_load(content)
         except Exception:
@@ -115,10 +118,7 @@ class IAMSyncService:
 
         # Check if user exists in Keycloak
         users = await keycloak_service.get_users(tenant_id)
-        existing_user = next(
-            (u for u in users if u.get("email") == email),
-            None
-        )
+        existing_user = next((u for u in users if u.get("email") == email), None)
 
         roles = user_config.get("roles", ["viewer"])
 
@@ -144,6 +144,45 @@ class IAMSyncService:
             except Exception as e:
                 logger.error(f"Failed to create user {email}: {e}")
                 raise
+
+        return True
+
+    async def _get_tenant_apps_config(self, tenant_id: str) -> dict | None:
+        """Get applications configuration from GitOps for a tenant."""
+        try:
+            content = await git_service.get_file(f"tenants/{tenant_id}/iam/applications.yaml")
+            if content:
+                return yaml.safe_load(content)
+        except Exception:
+            pass
+        return None
+
+    async def _sync_application(self, tenant_id: str, app_config: dict) -> bool:
+        """Sync a single application (OAuth2 client) configuration."""
+        import json
+
+        name = app_config.get("name")
+        if not name:
+            return False
+
+        client_id = f"{tenant_id}-{name}"
+        existing = await keycloak_service.get_client(client_id)
+
+        if existing:
+            # Update existing client attributes
+            attrs = existing.get("attributes", {})
+            if "api_subscriptions" in app_config:
+                attrs["api_subscriptions"] = json.dumps(app_config["api_subscriptions"])
+            await keycloak_service.update_client(existing["id"], {"attributes": attrs})
+        else:
+            # Create new client
+            await keycloak_service.create_client(
+                tenant_id=tenant_id,
+                name=name,
+                display_name=app_config.get("display_name", name),
+                redirect_uris=app_config.get("redirect_uris", []),
+                description=app_config.get("description", ""),
+            )
 
         return True
 
@@ -221,21 +260,25 @@ class IAMSyncService:
             # Users in GitOps but not in Keycloak
             missing_in_kc = gitops_emails - kc_user_emails
             for email in missing_in_kc:
-                report["drift"].append({
-                    "type": "missing_user",
-                    "email": email,
-                    "message": f"User {email} defined in GitOps but not in Keycloak",
-                })
+                report["drift"].append(
+                    {
+                        "type": "missing_user",
+                        "email": email,
+                        "message": f"User {email} defined in GitOps but not in Keycloak",
+                    }
+                )
                 report["in_sync"] = False
 
             # Users in Keycloak but not in GitOps
             extra_in_kc = kc_user_emails - gitops_emails
             for email in extra_in_kc:
-                report["drift"].append({
-                    "type": "extra_user",
-                    "email": email,
-                    "message": f"User {email} exists in Keycloak but not in GitOps",
-                })
+                report["drift"].append(
+                    {
+                        "type": "extra_user",
+                        "email": email,
+                        "message": f"User {email} exists in Keycloak but not in GitOps",
+                    }
+                )
                 report["in_sync"] = False
 
             # Check role assignments for shared users
@@ -250,22 +293,26 @@ class IAMSyncService:
 
                 missing_roles = gitops_roles - kc_roles
                 for role in missing_roles:
-                    report["drift"].append({
-                        "type": "missing_role",
-                        "email": email,
-                        "role": role,
-                        "message": f"Role {role} defined in GitOps but not assigned in Keycloak for {email}",
-                    })
+                    report["drift"].append(
+                        {
+                            "type": "missing_role",
+                            "email": email,
+                            "role": role,
+                            "message": f"Role {role} defined in GitOps but not assigned in Keycloak for {email}",
+                        }
+                    )
                     report["in_sync"] = False
 
                 extra_roles = kc_roles - gitops_roles
                 for role in extra_roles:
-                    report["drift"].append({
-                        "type": "extra_role",
-                        "email": email,
-                        "role": role,
-                        "message": f"Role {role} assigned in Keycloak but not in GitOps for {email}",
-                    })
+                    report["drift"].append(
+                        {
+                            "type": "extra_role",
+                            "email": email,
+                            "role": role,
+                            "message": f"Role {role} assigned in Keycloak but not in GitOps for {email}",
+                        }
+                    )
                     report["in_sync"] = False
 
             logger.info(f"Reconciliation for {tenant_id}: in_sync={report['in_sync']}")

--- a/control-plane-api/src/services/keycloak_service.py
+++ b/control-plane-api/src/services/keycloak_service.py
@@ -177,6 +177,15 @@ class KeycloakService:
                 return client
         return None
 
+    async def get_client_by_id(self, client_uuid: str) -> dict | None:
+        """Get client by Keycloak internal UUID."""
+        if not self._admin:
+            raise RuntimeError("Keycloak not connected")
+        try:
+            return self._admin.get_client(client_uuid)
+        except Exception:
+            return None
+
     async def create_client(
         self, tenant_id: str, name: str, display_name: str, redirect_uris: list[str], description: str = ""
     ) -> dict:

--- a/control-plane-api/tests/test_applications.py
+++ b/control-plane-api/tests/test_applications.py
@@ -1,0 +1,285 @@
+"""Tests for applications router — Keycloak-backed CRUD."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Shared mock user fixtures
+_ADMIN_USER = MagicMock()
+_ADMIN_USER.id = "admin-1"
+_ADMIN_USER.email = "admin@gostoa.dev"
+_ADMIN_USER.tenant_id = "acme"
+_ADMIN_USER.roles = ["cpi-admin"]
+
+_VIEWER_USER = MagicMock()
+_VIEWER_USER.id = "viewer-1"
+_VIEWER_USER.email = "viewer@gostoa.dev"
+_VIEWER_USER.tenant_id = "acme"
+_VIEWER_USER.roles = ["viewer"]
+
+_OTHER_TENANT_USER = MagicMock()
+_OTHER_TENANT_USER.id = "other-1"
+_OTHER_TENANT_USER.email = "other@corp.dev"
+_OTHER_TENANT_USER.tenant_id = "other-corp"
+_OTHER_TENANT_USER.roles = ["tenant-admin"]
+
+
+def _make_kc_client(
+    uuid: str = "kc-uuid-1",
+    client_id: str = "acme-myapp",
+    name: str = "My App",
+    tenant_id: str = "acme",
+    enabled: bool = True,
+    api_subscriptions: list | None = None,
+):
+    """Build a Keycloak client dict."""
+    return {
+        "id": uuid,
+        "clientId": client_id,
+        "name": name,
+        "description": "A test app",
+        "enabled": enabled,
+        "attributes": {
+            "tenant_id": [tenant_id],
+            "api_subscriptions": [json.dumps(api_subscriptions or [])],
+            "created_at": ["2026-01-01T00:00:00+00:00"],
+            "updated_at": ["2026-01-01T00:00:00+00:00"],
+        },
+    }
+
+
+def _build_test_app(user=None):
+    """Create a FastAPI test app with mocked auth."""
+    from src.routers.applications import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    if user is None:
+        user = _ADMIN_USER
+
+    async def override_get_current_user():
+        return user
+
+    from src.auth.dependencies import get_current_user
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    return app
+
+
+TENANT = "acme"
+BASE = f"/v1/tenants/{TENANT}/applications"
+
+
+# ---- List ----
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_list_empty(mock_kc):
+    mock_kc.get_clients = AsyncMock(return_value=[])
+    client = TestClient(_build_test_app())
+    resp = client.get(BASE)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"] == []
+    assert data["total"] == 0
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_list_with_data(mock_kc):
+    mock_kc.get_clients = AsyncMock(return_value=[_make_kc_client()])
+    client = TestClient(_build_test_app())
+    resp = client.get(BASE)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["items"][0]["name"] == "myapp"
+    assert data["items"][0]["client_id"] == "acme-myapp"
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_list_pagination(mock_kc):
+    clients = [_make_kc_client(uuid=f"uuid-{i}", client_id=f"acme-app{i}") for i in range(5)]
+    mock_kc.get_clients = AsyncMock(return_value=clients)
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}?page=2&page_size=2")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 5
+    assert len(data["items"]) == 2
+
+
+# ---- Get ----
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_get_success(mock_kc):
+    mock_kc.get_client_by_id = AsyncMock(return_value=_make_kc_client())
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/kc-uuid-1")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "kc-uuid-1"
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_get_not_found(mock_kc):
+    mock_kc.get_client_by_id = AsyncMock(return_value=None)
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/nonexistent")
+    assert resp.status_code == 404
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_get_wrong_tenant(mock_kc):
+    mock_kc.get_client_by_id = AsyncMock(return_value=_make_kc_client(tenant_id="other", client_id="other-x"))
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/kc-uuid-1")
+    assert resp.status_code == 404
+
+
+# ---- Create ----
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_create(mock_kc):
+    mock_kc.create_client = AsyncMock(
+        return_value={"id": "new-uuid", "client_id": "acme-newapp", "client_secret": "s3cret"}
+    )
+    mock_kc.update_client = AsyncMock(return_value=True)
+    mock_kc.get_client_by_id = AsyncMock(
+        return_value=_make_kc_client(uuid="new-uuid", client_id="acme-newapp", name="New App")
+    )
+    client = TestClient(_build_test_app())
+    resp = client.post(
+        BASE,
+        json={
+            "name": "newapp",
+            "display_name": "New App",
+            "description": "desc",
+        },
+    )
+    assert resp.status_code == 201
+    assert resp.json()["id"] == "new-uuid"
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_create_viewer_forbidden(mock_kc):
+    client = TestClient(_build_test_app(user=_VIEWER_USER))
+    resp = client.post(BASE, json={"name": "x", "display_name": "X"})
+    assert resp.status_code == 403
+
+
+# ---- Update ----
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_update(mock_kc):
+    mock_kc.get_client_by_id = AsyncMock(return_value=_make_kc_client())
+    mock_kc.update_client = AsyncMock(return_value=True)
+    updated = _make_kc_client(name="Updated Name")
+    mock_kc.get_client_by_id = AsyncMock(side_effect=[_make_kc_client(), updated])
+    client = TestClient(_build_test_app())
+    resp = client.put(
+        f"{BASE}/kc-uuid-1",
+        json={
+            "name": "myapp",
+            "display_name": "Updated Name",
+        },
+    )
+    assert resp.status_code == 200
+
+
+# ---- Delete ----
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_delete(mock_kc):
+    mock_kc.get_client_by_id = AsyncMock(return_value=_make_kc_client())
+    mock_kc.delete_client = AsyncMock(return_value=True)
+    client = TestClient(_build_test_app())
+    resp = client.delete(f"{BASE}/kc-uuid-1")
+    assert resp.status_code == 204
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_delete_viewer_forbidden(mock_kc):
+    client = TestClient(_build_test_app(user=_VIEWER_USER))
+    resp = client.delete(f"{BASE}/kc-uuid-1")
+    assert resp.status_code == 403
+
+
+# ---- Regenerate Secret ----
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_regenerate_secret(mock_kc):
+    mock_kc.get_client_by_id = AsyncMock(return_value=_make_kc_client())
+    mock_kc.regenerate_client_secret = AsyncMock(return_value="new-secret-value")
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/kc-uuid-1/regenerate-secret")
+    assert resp.status_code == 200
+    assert resp.json()["client_secret"] == "new-secret-value"
+
+
+# ---- Subscribe / Unsubscribe ----
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_subscribe(mock_kc):
+    mock_kc.get_client_by_id = AsyncMock(return_value=_make_kc_client())
+    mock_kc.update_client = AsyncMock(return_value=True)
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/kc-uuid-1/subscribe/api-123")
+    assert resp.status_code == 200
+    assert "subscribed" in resp.json()["message"]
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_subscribe_duplicate(mock_kc):
+    mock_kc.get_client_by_id = AsyncMock(return_value=_make_kc_client(api_subscriptions=["api-123"]))
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/kc-uuid-1/subscribe/api-123")
+    assert resp.status_code == 409
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_unsubscribe(mock_kc):
+    mock_kc.get_client_by_id = AsyncMock(return_value=_make_kc_client(api_subscriptions=["api-123"]))
+    mock_kc.update_client = AsyncMock(return_value=True)
+    client = TestClient(_build_test_app())
+    resp = client.delete(f"{BASE}/kc-uuid-1/subscribe/api-123")
+    assert resp.status_code == 200
+    assert "unsubscribed" in resp.json()["message"]
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_unsubscribe_not_subscribed(mock_kc):
+    mock_kc.get_client_by_id = AsyncMock(return_value=_make_kc_client())
+    client = TestClient(_build_test_app())
+    resp = client.delete(f"{BASE}/kc-uuid-1/subscribe/api-999")
+    assert resp.status_code == 404
+
+
+# ---- Tenant isolation ----
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_tenant_isolation(mock_kc):
+    """Other tenant user cannot access acme's applications."""
+    client = TestClient(_build_test_app(user=_OTHER_TENANT_USER))
+    mock_kc.get_clients = AsyncMock(return_value=[])
+    resp = client.get(BASE)
+    assert resp.status_code == 403
+
+
+# ---- Viewer can read ----
+
+
+@patch("src.routers.applications.keycloak_service")
+def test_viewer_can_list(mock_kc):
+    mock_kc.get_clients = AsyncMock(return_value=[])
+    client = TestClient(_build_test_app(user=_VIEWER_USER))
+    resp = client.get(BASE)
+    assert resp.status_code == 200

--- a/control-plane-api/tests/test_external_mcp_servers_internal.py
+++ b/control-plane-api/tests/test_external_mcp_servers_internal.py
@@ -1,0 +1,109 @@
+"""Tests for external MCP servers internal endpoint — X-Gateway-Key auth."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+VALID_KEY = "test_key_123"
+INTERNAL_URL = "/v1/internal/external-mcp-servers"
+GW_KEY_HEADER = "X-Gateway-Key"
+
+
+class TestExternalMCPServersInternal:
+    """GET /v1/internal/external-mcp-servers"""
+
+    def test_valid_key_returns_200(self, client):
+        """Valid gateway key returns servers list."""
+        with (
+            patch("src.routers.external_mcp_servers.settings") as mock_settings,
+            patch("src.routers.external_mcp_servers.ExternalMCPServerRepository") as MockRepo,
+            patch("src.routers.external_mcp_servers.get_vault_client"),
+        ):
+
+            mock_settings.gateway_api_keys_list = [VALID_KEY]
+
+            mock_repo = MockRepo.return_value
+            mock_repo.list_enabled_with_tools = AsyncMock(return_value=[])
+
+            resp = client.get(
+                INTERNAL_URL,
+                headers={GW_KEY_HEADER: VALID_KEY},
+            )
+
+            assert resp.status_code == 200
+            assert resp.json()["servers"] == []
+
+    def test_missing_header_returns_422(self, client):
+        """Missing X-Gateway-Key header returns 422 validation error."""
+        resp = client.get(INTERNAL_URL)
+        assert resp.status_code == 422
+
+    def test_invalid_key_returns_401(self, client):
+        """Invalid gateway key is rejected with 401."""
+        with patch("src.routers.external_mcp_servers.settings") as mock_settings:
+            mock_settings.gateway_api_keys_list = [VALID_KEY]
+
+            resp = client.get(
+                INTERNAL_URL,
+                headers={GW_KEY_HEADER: "wrong_key"},
+            )
+
+            assert resp.status_code == 401
+            assert "Invalid gateway key" in resp.json()["detail"]
+
+    def test_no_keys_configured_returns_503(self, client):
+        """Empty GATEWAY_API_KEYS returns 503."""
+        with patch("src.routers.external_mcp_servers.settings") as mock_settings:
+            mock_settings.gateway_api_keys_list = []
+
+            resp = client.get(
+                INTERNAL_URL,
+                headers={GW_KEY_HEADER: "any_key"},
+            )
+
+            assert resp.status_code == 503
+            assert "not configured" in resp.json()["detail"].lower()
+
+    def test_returns_servers_with_tools(self, client):
+        """Valid key returns servers with their tools."""
+        server_mock = MagicMock()
+        server_mock.id = uuid4()
+        server_mock.name = "test-server"
+        server_mock.base_url = "https://mcp.example.com"
+        server_mock.transport = MagicMock(value="sse")
+        server_mock.auth_type = MagicMock(value="none")
+        server_mock.credential_vault_path = None
+        server_mock.tool_prefix = "test"
+        server_mock.tenant_id = "acme"
+
+        tool_mock = MagicMock()
+        tool_mock.id = uuid4()
+        tool_mock.name = "get_data"
+        tool_mock.namespaced_name = "test_get_data"
+        tool_mock.display_name = "Get Data"
+        tool_mock.description = "Fetch data"
+        tool_mock.input_schema = {"type": "object"}
+        tool_mock.enabled = True
+        server_mock.tools = [tool_mock]
+
+        with (
+            patch("src.routers.external_mcp_servers.settings") as mock_settings,
+            patch("src.routers.external_mcp_servers.ExternalMCPServerRepository") as MockRepo,
+            patch("src.routers.external_mcp_servers.get_vault_client"),
+        ):
+
+            mock_settings.gateway_api_keys_list = [VALID_KEY]
+
+            mock_repo = MockRepo.return_value
+            mock_repo.list_enabled_with_tools = AsyncMock(return_value=[server_mock])
+
+            resp = client.get(
+                INTERNAL_URL,
+                headers={GW_KEY_HEADER: VALID_KEY},
+            )
+
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["servers"]) == 1
+            assert data["servers"][0]["name"] == "test-server"
+            assert len(data["servers"][0]["tools"]) == 1
+            assert data["servers"][0]["tools"][0]["name"] == "get_data"

--- a/control-plane-api/tests/test_external_mcp_servers_router.py
+++ b/control-plane-api/tests/test_external_mcp_servers_router.py
@@ -366,14 +366,19 @@ class TestInternalGatewayEndpoint:
         with (
             patch(REPO_PATH) as MockRepo,
             patch(VAULT_PATH) as MockVault,
+            patch("src.routers.external_mcp_servers.settings") as mock_settings,
         ):
+            mock_settings.gateway_api_keys_list = ["test_key"]
             MockRepo.return_value.list_enabled_with_tools = AsyncMock(
                 return_value=[mock_srv]
             )
             MockVault.return_value.retrieve_credential = AsyncMock(return_value=None)
 
             with TestClient(app_with_cpi_admin) as client:
-                response = client.get(INTERNAL_BASE)
+                response = client.get(
+                    INTERNAL_BASE,
+                    headers={"X-Gateway-Key": "test_key"},
+                )
 
         assert response.status_code == 200
         data = response.json()

--- a/control-plane-api/tests/test_git_router.py
+++ b/control-plane-api/tests/test_git_router.py
@@ -1,0 +1,265 @@
+"""Tests for git router — GitLab-backed operations."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_ADMIN_USER = MagicMock()
+_ADMIN_USER.id = "admin-1"
+_ADMIN_USER.email = "admin@gostoa.dev"
+_ADMIN_USER.tenant_id = "acme"
+_ADMIN_USER.roles = ["cpi-admin"]
+
+_VIEWER_USER = MagicMock()
+_VIEWER_USER.id = "viewer-1"
+_VIEWER_USER.email = "viewer@gostoa.dev"
+_VIEWER_USER.tenant_id = "acme"
+_VIEWER_USER.roles = ["viewer"]
+
+
+def _build_test_app(user=None):
+    from src.routers.git import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    if user is None:
+        user = _ADMIN_USER
+
+    async def override_get_current_user():
+        return user
+
+    from src.auth.dependencies import get_current_user
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    return app
+
+
+TENANT = "acme"
+BASE = f"/v1/tenants/{TENANT}/git"
+
+
+# ---- Commits ----
+
+
+@patch("src.routers.git.git_service")
+def test_list_commits_empty(mock_git):
+    mock_git.list_commits = AsyncMock(return_value=[])
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/commits")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@patch("src.routers.git.git_service")
+def test_list_commits_with_data(mock_git):
+    mock_git.list_commits = AsyncMock(
+        return_value=[{"sha": "abc123", "message": "init", "author": "dev", "date": "2026-01-01T00:00:00"}]
+    )
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/commits")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+    assert resp.json()[0]["sha"] == "abc123"
+
+
+@patch("src.routers.git.git_service")
+def test_list_commits_with_path(mock_git):
+    mock_git.list_commits = AsyncMock(return_value=[])
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/commits?path=apis")
+    assert resp.status_code == 200
+    mock_git.list_commits.assert_called_once_with(path="tenants/acme/apis", limit=20)
+
+
+# ---- Files ----
+
+
+@patch("src.routers.git.git_service")
+def test_get_file_success(mock_git):
+    mock_git.get_file = AsyncMock(return_value="file content here")
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/files/apis/test.yaml")
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "file content here"
+    mock_git.get_file.assert_called_once_with("tenants/acme/apis/test.yaml", ref="main")
+
+
+@patch("src.routers.git.git_service")
+def test_get_file_not_found(mock_git):
+    mock_git.get_file = AsyncMock(return_value=None)
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/files/nonexistent.yaml")
+    assert resp.status_code == 404
+
+
+@patch("src.routers.git.git_service")
+def test_create_file(mock_git):
+    mock_git._project = MagicMock()
+    mock_git.get_file = AsyncMock(return_value=None)  # file doesn't exist
+    mock_git._project.files.create = MagicMock()
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/files/new.yaml", json={"content": "hello"})
+    assert resp.status_code == 201
+    assert resp.json()["action"] == "created"
+
+
+@patch("src.routers.git.git_service")
+def test_update_file(mock_git):
+    mock_git._project = MagicMock()
+    mock_git.get_file = AsyncMock(return_value="old content")  # file exists
+    file_obj = MagicMock()
+    mock_git._project.files.get = MagicMock(return_value=file_obj)
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/files/existing.yaml", json={"content": "new content"})
+    assert resp.status_code == 201
+    assert resp.json()["action"] == "updated"
+
+
+@patch("src.routers.git.git_service")
+def test_delete_file(mock_git):
+    mock_git._project = MagicMock()
+    mock_git._project.files.delete = MagicMock()
+    client = TestClient(_build_test_app())
+    resp = client.delete(f"{BASE}/files/old.yaml")
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "File deleted"
+
+
+# ---- Tree ----
+
+
+@patch("src.routers.git.git_service")
+def test_tree_success(mock_git):
+    mock_git._project = MagicMock()
+    mock_git._project.repository_tree = MagicMock(
+        return_value=[
+            {"name": "apis", "type": "tree", "path": "tenants/acme/apis"},
+            {"name": "tenant.yaml", "type": "blob", "path": "tenants/acme/tenant.yaml"},
+        ]
+    )
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/tree")
+    assert resp.status_code == 200
+    assert len(resp.json()["items"]) == 2
+
+
+@patch("src.routers.git.git_service")
+def test_tree_empty(mock_git):
+    mock_git._project = MagicMock()
+    mock_git._project.repository_tree = MagicMock(side_effect=Exception("not found"))
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/tree")
+    assert resp.status_code == 200
+    assert resp.json()["items"] == []
+
+
+# ---- Merge Requests ----
+
+
+@patch("src.routers.git.git_service")
+def test_list_merge_requests_empty(mock_git):
+    mock_git._project = MagicMock()
+    mock_git._project.mergerequests.list = MagicMock(return_value=[])
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/merge-requests")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@patch("src.routers.git.git_service")
+def test_create_merge_request(mock_git):
+    mock_git._project = MagicMock()
+    mr_mock = MagicMock()
+    mr_mock.id = 1
+    mr_mock.iid = 1
+    mr_mock.title = "Test MR"
+    mr_mock.description = "desc"
+    mr_mock.state = "opened"
+    mr_mock.source_branch = "feat/x"
+    mr_mock.target_branch = "main"
+    mr_mock.web_url = "https://gitlab.com/mr/1"
+    mr_mock.created_at = "2026-01-01T00:00:00"
+    mr_mock.author = {"name": "dev"}
+    mock_git._project.mergerequests.create = MagicMock(return_value=mr_mock)
+    client = TestClient(_build_test_app())
+    resp = client.post(
+        f"{BASE}/merge-requests",
+        json={
+            "title": "Test MR",
+            "description": "desc",
+            "source_branch": "feat/x",
+            "target_branch": "main",
+        },
+    )
+    assert resp.status_code == 201
+    assert resp.json()["title"] == "Test MR"
+
+
+@patch("src.routers.git.git_service")
+def test_merge_merge_request(mock_git):
+    mock_git._project = MagicMock()
+    mr_mock = MagicMock()
+    mock_git._project.mergerequests.get = MagicMock(return_value=mr_mock)
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/merge-requests/1/merge")
+    assert resp.status_code == 200
+    mr_mock.merge.assert_called_once()
+
+
+# ---- Branches ----
+
+
+@patch("src.routers.git.git_service")
+def test_list_branches(mock_git):
+    mock_git._project = MagicMock()
+    branch_mock = MagicMock()
+    branch_mock.name = "main"
+    branch_mock.commit = {"id": "abc123"}
+    branch_mock.protected = True
+    mock_git._project.branches.list = MagicMock(return_value=[branch_mock])
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/branches")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+    assert resp.json()[0]["name"] == "main"
+
+
+@patch("src.routers.git.git_service")
+def test_create_branch(mock_git):
+    mock_git._project = MagicMock()
+    branch_mock = MagicMock()
+    branch_mock.name = "feat/new"
+    branch_mock.commit = {"id": "def456"}
+    branch_mock.protected = False
+    mock_git._project.branches.create = MagicMock(return_value=branch_mock)
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/branches", json={"name": "feat/new", "ref": "main"})
+    assert resp.status_code == 201
+    assert resp.json()["name"] == "feat/new"
+
+
+# ---- RBAC ----
+
+
+@patch("src.routers.git.git_service")
+def test_viewer_can_read(mock_git):
+    mock_git.list_commits = AsyncMock(return_value=[])
+    client = TestClient(_build_test_app(user=_VIEWER_USER))
+    resp = client.get(f"{BASE}/commits")
+    assert resp.status_code == 200
+
+
+@patch("src.routers.git.git_service")
+def test_viewer_cannot_create_file(mock_git):
+    client = TestClient(_build_test_app(user=_VIEWER_USER))
+    resp = client.post(f"{BASE}/files/test.yaml", json={"content": "x"})
+    assert resp.status_code == 403
+
+
+@patch("src.routers.git.git_service")
+def test_viewer_cannot_delete_file(mock_git):
+    client = TestClient(_build_test_app(user=_VIEWER_USER))
+    resp = client.delete(f"{BASE}/files/test.yaml")
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- **Phase 1**: Wire 8 applications.py endpoints to Keycloak (list, get, create, update, delete, regenerate-secret, subscribe, unsubscribe)
- **Phase 2**: Wire 10 git.py endpoints to existing `git_service` (commits, files, tree, merge requests, branches)
- **Phase 3**: Add `X-Gateway-Key` auth on internal MCP servers endpoint (same pattern as `gateway_internal.py`)
- Add `get_client_by_id()` to keycloak_service, app sync to iam_sync_service
- Uncomment applications router in main.py
- Regenerate OpenAPI snapshot

## Changes
- 11 files changed, ~2084 insertions, ~418 deletions
- 40 new tests (18 applications + 17 git + 5 internal auth)
- Coverage: 74% (threshold: 53%)

## Test plan
- [x] 56/56 tests pass (40 new + 16 existing external MCP server tests)
- [x] `ruff check .` clean
- [x] `black --check .` clean
- [x] OpenAPI contract snapshot updated
- [x] Full suite: 2079 passed, 0 failed

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>