### PR TITLE
feat(api,ui): add audience governance admin UI (CAB-1323)

### DIFF
--- a/control-plane-api/src/routers/catalog_admin.py
+++ b/control-plane-api/src/routers/catalog_admin.py
@@ -3,6 +3,7 @@
 Provides endpoints for managing the catalog cache synchronization.
 These endpoints require admin role (cpi-admin or tenant-admin).
 """
+
 import json
 import logging
 from datetime import UTC, datetime
@@ -38,6 +39,7 @@ def _require_admin(user: User) -> None:
 # ============================================================================
 # Sync Operations
 # ============================================================================
+
 
 @router.post("/sync", response_model=SyncTriggerResponse)
 async def trigger_catalog_sync(
@@ -104,8 +106,10 @@ async def trigger_mcp_servers_sync(
     _require_admin(user)
 
     try:
+
         async def run_sync():
             from ..database import get_db as get_async_db_gen
+
             async for session in get_async_db_gen():
                 service = CatalogSyncService(session, git_service)
                 await service.sync_mcp_servers(tenant_id)
@@ -142,6 +146,7 @@ async def trigger_tenant_sync(
         raise HTTPException(status_code=403, detail="Access denied to this tenant")
 
     try:
+
         async def run_sync():
             async with get_async_db() as session:
                 service = CatalogSyncService(session, git_service)
@@ -228,6 +233,7 @@ async def get_sync_history(
 # Catalog Stats
 # ============================================================================
 
+
 @router.get("/stats", response_model=CatalogStatsResponse)
 async def get_catalog_stats(
     user: User = Depends(get_current_user),
@@ -273,6 +279,7 @@ async def get_catalog_stats(
 # Cache Invalidation (for manual refresh)
 # ============================================================================
 
+
 @router.delete("/cache")
 async def invalidate_cache(
     user: User = Depends(get_current_user),
@@ -289,18 +296,17 @@ async def invalidate_cache(
         raise HTTPException(status_code=403, detail="Platform admin access required")
 
     logger.info(f"Cache invalidation requested by user {user.id}")
-    return {
-        "status": "ok",
-        "message": "Cache invalidated. Use POST /sync to refresh data from GitLab."
-    }
+    return {"status": "ok", "message": "Cache invalidated. Use POST /sync to refresh data from GitLab."}
 
 
 # ============================================================================
 # Direct Catalog Seed (offline mode — bypasses GitLab)
 # ============================================================================
 
+
 class CatalogSeedAPIEntry(BaseModel):
     """Single API entry for direct catalog seeding."""
+
     name: str
     display_name: str
     version: str = "1.0.0"
@@ -313,12 +319,14 @@ class CatalogSeedAPIEntry(BaseModel):
 
 class CatalogSeedRequest(BaseModel):
     """Request to seed APIs directly into catalog (bypasses GitLab)."""
+
     tenant_id: str
     apis: list[CatalogSeedAPIEntry]
 
 
 class CatalogSeedResponse(BaseModel):
     """Response from catalog seed operation."""
+
     seeded: int
     failed: int
     results: dict
@@ -372,35 +380,39 @@ async def seed_catalog_directly(
                 openapi_spec = None
 
         try:
-            stmt = insert(APICatalog).values(
-                tenant_id=data.tenant_id,
-                api_id=api_id,
-                api_name=api_entry.display_name,
-                version=api_entry.version,
-                status="active",
-                category=api_entry.category,
-                tags=tags,
-                portal_published=portal_published,
-                api_metadata=api_metadata,
-                openapi_spec=openapi_spec,
-                git_path=None,
-                git_commit_sha=None,
-                synced_at=datetime.now(UTC),
-                deleted_at=None,
-            ).on_conflict_do_update(
-                index_elements=["tenant_id", "api_id"],
-                set_={
-                    "api_name": api_entry.display_name,
-                    "version": api_entry.version,
-                    "status": "active",
-                    "category": api_entry.category,
-                    "tags": tags,
-                    "portal_published": portal_published,
-                    "metadata": api_metadata,  # DB column is "metadata" not "api_metadata"
-                    "openapi_spec": openapi_spec,
-                    "synced_at": datetime.now(UTC),
-                    "deleted_at": None,
-                },
+            stmt = (
+                insert(APICatalog)
+                .values(
+                    tenant_id=data.tenant_id,
+                    api_id=api_id,
+                    api_name=api_entry.display_name,
+                    version=api_entry.version,
+                    status="active",
+                    category=api_entry.category,
+                    tags=tags,
+                    portal_published=portal_published,
+                    api_metadata=api_metadata,
+                    openapi_spec=openapi_spec,
+                    git_path=None,
+                    git_commit_sha=None,
+                    synced_at=datetime.now(UTC),
+                    deleted_at=None,
+                )
+                .on_conflict_do_update(
+                    index_elements=["tenant_id", "api_id"],
+                    set_={
+                        "api_name": api_entry.display_name,
+                        "version": api_entry.version,
+                        "status": "active",
+                        "category": api_entry.category,
+                        "tags": tags,
+                        "portal_published": portal_published,
+                        "metadata": api_metadata,  # DB column is "metadata" not "api_metadata"
+                        "openapi_spec": openapi_spec,
+                        "synced_at": datetime.now(UTC),
+                        "deleted_at": None,
+                    },
+                )
             )
             await db.execute(stmt)
             seeded += 1
@@ -412,9 +424,71 @@ async def seed_catalog_directly(
 
     await db.commit()
 
-    logger.info(
-        f"Catalog seed by {user.username}: {seeded} seeded, {failed} failed "
-        f"(tenant: {data.tenant_id})"
-    )
+    logger.info(f"Catalog seed by {user.username}: {seeded} seeded, {failed} failed " f"(tenant: {data.tenant_id})")
 
     return CatalogSeedResponse(seeded=seeded, failed=failed, results=results)
+
+
+# ============================================================================
+# Audience Governance (CAB-1323 Phase 3)
+# ============================================================================
+
+
+class AudienceUpdateRequest(BaseModel):
+    """Request to update an API's audience visibility level."""
+
+    audience: str  # "public" | "internal" | "partner"
+
+
+class AudienceUpdateResponse(BaseModel):
+    """Response after updating an API's audience."""
+
+    api_id: str
+    tenant_id: str
+    audience: str
+    updated_by: str
+
+
+@router.patch("/{tenant_id}/{api_id}/audience", response_model=AudienceUpdateResponse)
+async def update_api_audience(
+    tenant_id: str,
+    api_id: str,
+    payload: AudienceUpdateRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """
+    Update the audience visibility level for an API.
+
+    Valid audiences: public, internal, partner.
+    Requires: cpi-admin (any tenant) or tenant-admin (own tenant only).
+    """
+    _require_admin(user)
+
+    # Tenant-admin scoped to own tenant
+    if "cpi-admin" not in user.roles and user.tenant_id != tenant_id:
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    valid_audiences = {"public", "internal", "partner"}
+    if payload.audience not in valid_audiences:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid audience '{payload.audience}'. Must be one of: {', '.join(sorted(valid_audiences))}",
+        )
+
+    repo = CatalogRepository(db)
+    api = await repo.get_api_by_id(tenant_id, api_id)
+    if not api:
+        raise HTTPException(status_code=404, detail=f"API '{api_id}' not found in tenant '{tenant_id}'")
+
+    api.audience = payload.audience
+    await db.commit()
+
+    logger.info(f"Audience updated for {tenant_id}/{api_id} to '{payload.audience}' by {user.username}")
+
+    return AudienceUpdateResponse(
+        api_id=api_id,
+        tenant_id=tenant_id,
+        audience=payload.audience,
+        updated_by=user.username,
+    )

--- a/control-plane-api/tests/test_catalog_admin_audience.py
+++ b/control-plane-api/tests/test_catalog_admin_audience.py
@@ -1,0 +1,215 @@
+"""Tests for PATCH /v1/admin/catalog/{tenant_id}/{api_id}/audience (CAB-1323 Phase 3)."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.auth.dependencies import User
+from src.models.catalog import APICatalog
+from src.routers.catalog_admin import router
+
+# ---------- Fixtures ----------
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+def _make_user(role: str, tenant_id: str | None = None) -> User:
+    return User(
+        id=f"user-{role}",
+        email=f"{role}@test.com",
+        username=role,
+        roles=[role],
+        tenant_id=tenant_id,
+    )
+
+
+def _make_api_catalog(tenant_id: str = "oasis", api_id: str = "payment-api", audience: str = "public"):
+    api = MagicMock(spec=APICatalog)
+    api.id = uuid.uuid4()
+    api.tenant_id = tenant_id
+    api.api_id = api_id
+    api.audience = audience
+    return api
+
+
+def _patch_deps(app: FastAPI, user: User, api_obj=None):
+    """Patch auth + DB dependencies for the test app."""
+    mock_db = AsyncMock()
+    mock_db.commit = AsyncMock()
+
+    async def override_user():
+        return user
+
+    async def override_db():
+        return mock_db
+
+    from src.auth.dependencies import get_current_user
+    from src.database import get_db
+
+    app.dependency_overrides[get_current_user] = override_user
+    app.dependency_overrides[get_db] = override_db
+
+    return mock_db
+
+
+# ---------- Tests ----------
+
+
+@pytest.mark.asyncio
+async def test_cpi_admin_can_update_audience(app):
+    user = _make_user("cpi-admin")
+    api_obj = _make_api_catalog()
+    _patch_deps(app, user)
+
+    with patch("src.routers.catalog_admin.CatalogRepository") as MockRepo:
+        MockRepo.return_value.get_api_by_id = AsyncMock(return_value=api_obj)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            resp = await ac.patch(
+                "/v1/admin/catalog/oasis/payment-api/audience",
+                json={"audience": "internal"},
+            )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["audience"] == "internal"
+    assert data["api_id"] == "payment-api"
+    assert data["tenant_id"] == "oasis"
+    assert data["updated_by"] == "cpi-admin"
+
+
+@pytest.mark.asyncio
+async def test_tenant_admin_can_update_own_tenant(app):
+    user = _make_user("tenant-admin", tenant_id="oasis")
+    api_obj = _make_api_catalog()
+    _patch_deps(app, user)
+
+    with patch("src.routers.catalog_admin.CatalogRepository") as MockRepo:
+        MockRepo.return_value.get_api_by_id = AsyncMock(return_value=api_obj)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            resp = await ac.patch(
+                "/v1/admin/catalog/oasis/payment-api/audience",
+                json={"audience": "partner"},
+            )
+
+    assert resp.status_code == 200
+    assert resp.json()["audience"] == "partner"
+
+
+@pytest.mark.asyncio
+async def test_tenant_admin_cannot_update_other_tenant(app):
+    user = _make_user("tenant-admin", tenant_id="other-tenant")
+    _patch_deps(app, user)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.patch(
+            "/v1/admin/catalog/oasis/payment-api/audience",
+            json={"audience": "internal"},
+        )
+
+    assert resp.status_code == 403
+    assert "Access denied" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_devops_cannot_update_audience(app):
+    user = _make_user("devops", tenant_id="oasis")
+    _patch_deps(app, user)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.patch(
+            "/v1/admin/catalog/oasis/payment-api/audience",
+            json={"audience": "internal"},
+        )
+
+    assert resp.status_code == 403
+    assert "Admin access required" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_viewer_cannot_update_audience(app):
+    user = _make_user("viewer", tenant_id="oasis")
+    _patch_deps(app, user)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.patch(
+            "/v1/admin/catalog/oasis/payment-api/audience",
+            json={"audience": "internal"},
+        )
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_invalid_audience_value(app):
+    user = _make_user("cpi-admin")
+    _patch_deps(app, user)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.patch(
+            "/v1/admin/catalog/oasis/payment-api/audience",
+            json={"audience": "secret"},
+        )
+
+    assert resp.status_code == 400
+    assert "Invalid audience" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_api_not_found(app):
+    user = _make_user("cpi-admin")
+    _patch_deps(app, user)
+
+    with patch("src.routers.catalog_admin.CatalogRepository") as MockRepo:
+        MockRepo.return_value.get_api_by_id = AsyncMock(return_value=None)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            resp = await ac.patch(
+                "/v1/admin/catalog/oasis/nonexistent-api/audience",
+                json={"audience": "internal"},
+            )
+
+    assert resp.status_code == 404
+    assert "not found" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_same_value_update_is_idempotent(app):
+    user = _make_user("cpi-admin")
+    api_obj = _make_api_catalog(audience="internal")
+    _patch_deps(app, user)
+
+    with patch("src.routers.catalog_admin.CatalogRepository") as MockRepo:
+        MockRepo.return_value.get_api_by_id = AsyncMock(return_value=api_obj)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            resp = await ac.patch(
+                "/v1/admin/catalog/oasis/payment-api/audience",
+                json={"audience": "internal"},
+            )
+
+    assert resp.status_code == 200
+    assert resp.json()["audience"] == "internal"
+
+
+@pytest.mark.asyncio
+async def test_response_includes_all_fields(app):
+    user = _make_user("cpi-admin")
+    api_obj = _make_api_catalog()
+    _patch_deps(app, user)
+
+    with patch("src.routers.catalog_admin.CatalogRepository") as MockRepo:
+        MockRepo.return_value.get_api_by_id = AsyncMock(return_value=api_obj)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            resp = await ac.patch(
+                "/v1/admin/catalog/oasis/payment-api/audience",
+                json={"audience": "partner"},
+            )
+
+    data = resp.json()
+    assert set(data.keys()) == {"api_id", "tenant_id", "audience", "updated_by"}

--- a/control-plane-ui/src/App.tsx
+++ b/control-plane-ui/src/App.tsx
@@ -116,6 +116,11 @@ const FederationAccountDetail = lazy(() =>
 const skillsModule = () => import('./pages/Skills');
 const SkillsList = lazy(() => skillsModule().then((m) => ({ default: m.SkillsList })));
 
+// CAB-1323: Audience Governance page
+const AudienceGovernance = lazy(() =>
+  import('./pages/AudienceGovernance').then((m) => ({ default: m.AudienceGovernance }))
+);
+
 // Loading indicator for lazy-loaded pages and auth init
 function PageLoader() {
   return <StoaLoader variant="inline" />;
@@ -407,6 +412,7 @@ function ProtectedRoutes() {
                 <Route path="/federation/accounts" element={<FederationAccountsList />} />
                 <Route path="/federation/accounts/:id" element={<FederationAccountDetail />} />
                 <Route path="/skills" element={<SkillsList />} />
+                <Route path="/audience-governance" element={<AudienceGovernance />} />
               </Routes>
             </Suspense>
           )}

--- a/control-plane-ui/src/components/Layout.tsx
+++ b/control-plane-ui/src/components/Layout.tsx
@@ -253,6 +253,12 @@ const navigationSections: NavSection[] = [
         icon: ListChecks,
         permission: 'workflows:read',
       },
+      {
+        name: 'Audience',
+        href: '/audience-governance',
+        icon: Users,
+        permission: 'apis:update',
+      },
     ],
   },
 ];

--- a/control-plane-ui/src/pages/AudienceGovernance.test.tsx
+++ b/control-plane-ui/src/pages/AudienceGovernance.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createAuthMock, renderWithProviders, mockAPI, mockTenant } from '../test/helpers';
+import { useAuth } from '../contexts/AuthContext';
+import type { PersonaRole } from '../test/helpers';
+
+vi.mock('../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+
+const mockGetApis = vi.fn().mockResolvedValue([
+  mockAPI({ id: 'api-1', name: 'payment-api', display_name: 'Payment API', audience: 'public' }),
+  mockAPI({
+    id: 'api-2',
+    name: 'billing-api',
+    display_name: 'Billing API',
+    audience: 'internal',
+  }),
+]);
+const mockGetTenants = vi
+  .fn()
+  .mockResolvedValue([
+    mockTenant({ id: 't1', name: 'oasis-gunters', display_name: 'OASIS Gunters' }),
+  ]);
+const mockUpdateAudience = vi.fn().mockResolvedValue({
+  api_id: 'payment-api',
+  tenant_id: 'oasis-gunters',
+  audience: 'internal',
+  updated_by: 'halliday',
+});
+
+vi.mock('../services/api', () => ({
+  apiService: {
+    getApis: (...args: unknown[]) => mockGetApis(...args),
+    getTenants: (...args: unknown[]) => mockGetTenants(...args),
+    updateApiAudience: (...args: unknown[]) => mockUpdateAudience(...args),
+  },
+}));
+
+vi.mock('@stoa/shared/components/Toast', () => ({
+  useToastActions: () => ({ success: vi.fn(), error: vi.fn(), info: vi.fn() }),
+}));
+
+import { AudienceGovernance } from './AudienceGovernance';
+
+function renderComponent() {
+  return renderWithProviders(<AudienceGovernance />, { route: '/audience-governance' });
+}
+
+describe('AudienceGovernance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+    mockGetApis.mockResolvedValue([
+      mockAPI({
+        id: 'api-1',
+        name: 'payment-api',
+        display_name: 'Payment API',
+        audience: 'public',
+      }),
+      mockAPI({
+        id: 'api-2',
+        name: 'billing-api',
+        display_name: 'Billing API',
+        audience: 'internal',
+      }),
+    ]);
+    mockGetTenants.mockResolvedValue([
+      mockTenant({ id: 't1', name: 'oasis-gunters', display_name: 'OASIS Gunters' }),
+    ]);
+  });
+
+  it('renders the heading', () => {
+    renderComponent();
+    expect(screen.getByRole('heading', { name: 'Audience Governance' })).toBeInTheDocument();
+  });
+
+  it('shows tenant selector for cpi-admin', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('OASIS Gunters')).toBeInTheDocument();
+    });
+  });
+
+  it('shows APIs after selecting tenant', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('OASIS Gunters')).toBeInTheDocument();
+    });
+
+    await user.selectOptions(screen.getByRole('combobox'), 'oasis-gunters');
+
+    await waitFor(() => {
+      expect(screen.getByText('Payment API')).toBeInTheDocument();
+      expect(screen.getByText('Billing API')).toBeInTheDocument();
+    });
+  });
+
+  it('shows audience badges', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('OASIS Gunters')).toBeInTheDocument();
+    });
+
+    await user.selectOptions(screen.getByRole('combobox'), 'oasis-gunters');
+
+    await waitFor(() => {
+      expect(screen.getByText('public')).toBeInTheDocument();
+      expect(screen.getByText('internal')).toBeInTheDocument();
+    });
+  });
+
+  it('filters APIs by search', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('OASIS Gunters')).toBeInTheDocument();
+    });
+
+    await user.selectOptions(screen.getByRole('combobox'), 'oasis-gunters');
+
+    await waitFor(() => {
+      expect(screen.getByText('Payment API')).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText('Search APIs...'), 'billing');
+
+    expect(screen.queryByText('Payment API')).not.toBeInTheDocument();
+    expect(screen.getByText('Billing API')).toBeInTheDocument();
+  });
+
+  describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
+    '%s persona',
+    (role) => {
+      it('renders the page', () => {
+        vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
+        renderComponent();
+        expect(screen.getByRole('heading', { name: 'Audience Governance' })).toBeInTheDocument();
+      });
+
+      // cpi-admin, tenant-admin, devops all have apis:update — badges are clickable
+      if (role === 'cpi-admin' || role === 'tenant-admin' || role === 'devops') {
+        it('audience badges are clickable', async () => {
+          vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
+          const user = userEvent.setup();
+          renderComponent();
+
+          if (role === 'cpi-admin') {
+            await waitFor(() => {
+              expect(screen.getByText('OASIS Gunters')).toBeInTheDocument();
+            });
+            await user.selectOptions(screen.getAllByRole('combobox')[0], 'oasis-gunters');
+          }
+
+          await waitFor(() => {
+            expect(screen.getByText('public')).toBeInTheDocument();
+          });
+
+          // Click the audience badge — should open an inline select
+          await user.click(screen.getByText('public'));
+
+          // The inline select replaces the badge
+          const selects = screen.getAllByRole('combobox');
+          const audienceSelect = selects.find((el) => el.tagName === 'SELECT' && el.closest('td'));
+          expect(audienceSelect).toBeDefined();
+        });
+      }
+
+      if (role === 'viewer') {
+        it('audience badges are not clickable', async () => {
+          vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
+          renderComponent();
+
+          await waitFor(() => {
+            expect(screen.getByText('public')).toBeInTheDocument();
+          });
+
+          const badge = screen.getByText('public');
+          expect(badge).toBeDisabled();
+        });
+      }
+    }
+  );
+});

--- a/control-plane-ui/src/pages/AudienceGovernance.tsx
+++ b/control-plane-ui/src/pages/AudienceGovernance.tsx
@@ -1,0 +1,214 @@
+import { useState, useCallback } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Search, Users } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext';
+import { apiService } from '../services/api';
+import { useToastActions } from '@stoa/shared/components/Toast';
+import type { API, Tenant } from '../types';
+
+const AUDIENCE_OPTIONS = ['public', 'internal', 'partner'] as const;
+type Audience = (typeof AUDIENCE_OPTIONS)[number];
+
+const audienceBadgeClasses: Record<Audience, string> = {
+  public: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  internal: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  partner: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
+};
+
+export function AudienceGovernance() {
+  const { user, hasPermission } = useAuth();
+  const toast = useToastActions();
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState('');
+  const [tenantFilter, setTenantFilter] = useState('');
+  const [editingApi, setEditingApi] = useState<string | null>(null);
+
+  const canEdit = hasPermission('apis:update');
+  const isCpiAdmin = user?.roles.includes('cpi-admin');
+
+  const { data: tenants } = useQuery({
+    queryKey: ['tenants'],
+    queryFn: () => apiService.getTenants(),
+    enabled: isCpiAdmin,
+  });
+
+  const activeTenantId = isCpiAdmin ? tenantFilter : user?.tenant_id;
+
+  const { data: apis, isLoading } = useQuery({
+    queryKey: ['apis', activeTenantId],
+    queryFn: () => apiService.getApis(activeTenantId!),
+    enabled: !!activeTenantId,
+  });
+
+  const mutation = useMutation({
+    mutationFn: ({
+      tenantId,
+      apiId,
+      audience,
+    }: {
+      tenantId: string;
+      apiId: string;
+      audience: string;
+    }) => apiService.updateApiAudience(tenantId, apiId, audience),
+    onSuccess: (_data, variables) => {
+      toast.success(`Audience updated to "${variables.audience}"`);
+      queryClient.invalidateQueries({ queryKey: ['apis', variables.tenantId] });
+      setEditingApi(null);
+    },
+    onError: () => {
+      toast.error('Failed to update audience');
+    },
+  });
+
+  const handleAudienceChange = useCallback(
+    (tenantId: string, apiId: string, audience: string) => {
+      mutation.mutate({ tenantId, apiId, audience });
+    },
+    [mutation]
+  );
+
+  const filteredApis = (apis ?? []).filter(
+    (api) =>
+      !search ||
+      api.name.toLowerCase().includes(search.toLowerCase()) ||
+      api.display_name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Audience Governance</h1>
+          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+            Manage API audience visibility levels
+          </p>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-4">
+        {isCpiAdmin && tenants && (
+          <select
+            value={tenantFilter}
+            onChange={(e) => setTenantFilter(e.target.value)}
+            className="rounded-lg border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 px-3 py-2 text-sm text-gray-900 dark:text-white"
+          >
+            <option value="">Select tenant...</option>
+            {tenants.map((t: Tenant) => (
+              <option key={t.id} value={t.name}>
+                {t.display_name}
+              </option>
+            ))}
+          </select>
+        )}
+        <div className="relative flex-1 min-w-[200px]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Search APIs..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full pl-10 pr-4 py-2 rounded-lg border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-sm text-gray-900 dark:text-white placeholder-gray-400"
+          />
+        </div>
+      </div>
+
+      {/* No tenant selected */}
+      {!activeTenantId && (
+        <div className="text-center py-12 text-gray-500 dark:text-neutral-400">
+          <Users className="w-12 h-12 mx-auto mb-4 opacity-50" />
+          <p>Select a tenant to view API audience settings.</p>
+        </div>
+      )}
+
+      {/* Loading */}
+      {isLoading && activeTenantId && (
+        <div className="text-center py-12 text-gray-500 dark:text-neutral-400">Loading APIs...</div>
+      )}
+
+      {/* API Table */}
+      {activeTenantId && !isLoading && (
+        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none overflow-hidden">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
+            <thead className="bg-gray-50 dark:bg-neutral-900/50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  API
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  Version
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  Status
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  Audience
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
+              {filteredApis.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="px-6 py-8 text-center text-gray-500 dark:text-neutral-400"
+                  >
+                    No APIs found.
+                  </td>
+                </tr>
+              ) : (
+                filteredApis.map((api: API) => (
+                  <tr key={api.id} className="hover:bg-gray-50 dark:hover:bg-neutral-700/30">
+                    <td className="px-6 py-4">
+                      <div className="text-sm font-medium text-gray-900 dark:text-white">
+                        {api.display_name}
+                      </div>
+                      <div className="text-xs text-gray-500 dark:text-neutral-400">{api.name}</div>
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-500 dark:text-neutral-400">
+                      {api.version}
+                    </td>
+                    <td className="px-6 py-4">
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-neutral-700 dark:text-neutral-300">
+                        {api.status}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4">
+                      {canEdit && editingApi === api.id ? (
+                        <select
+                          defaultValue={api.audience ?? 'public'}
+                          onChange={(e) =>
+                            handleAudienceChange(api.tenant_id, api.name, e.target.value)
+                          }
+                          onBlur={() => setEditingApi(null)}
+                          autoFocus
+                          className="rounded border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 px-2 py-1 text-xs text-gray-900 dark:text-white"
+                        >
+                          {AUDIENCE_OPTIONS.map((opt) => (
+                            <option key={opt} value={opt}>
+                              {opt}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <button
+                          onClick={() => canEdit && setEditingApi(api.id)}
+                          disabled={!canEdit}
+                          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                            audienceBadgeClasses[(api.audience as Audience) ?? 'public']
+                          } ${canEdit ? 'cursor-pointer hover:ring-2 hover:ring-offset-1 hover:ring-blue-400' : 'cursor-default'}`}
+                        >
+                          {api.audience ?? 'public'}
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -209,6 +209,17 @@ class ApiService {
     await this.client.delete(`/v1/tenants/${tenantId}/apis/${apiId}`);
   }
 
+  async updateApiAudience(
+    tenantId: string,
+    apiId: string,
+    audience: string
+  ): Promise<{ api_id: string; tenant_id: string; audience: string; updated_by: string }> {
+    const { data } = await this.client.patch(`/v1/admin/catalog/${tenantId}/${apiId}/audience`, {
+      audience,
+    });
+    return data;
+  }
+
   // Applications
   async getApplications(tenantId: string): Promise<Application[]> {
     const { data } = await this.client.get(`/v1/tenants/${tenantId}/applications`, {

--- a/control-plane-ui/src/test/helpers.tsx
+++ b/control-plane-ui/src/test/helpers.tsx
@@ -244,6 +244,7 @@ export const mockAPI = (overrides: Partial<API> = {}): API => ({
   deployed_dev: true,
   deployed_staging: false,
   tags: ['payments'],
+  audience: 'public',
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-02-01T00:00:00Z',
   ...overrides,

--- a/control-plane-ui/src/types/index.ts
+++ b/control-plane-ui/src/types/index.ts
@@ -44,6 +44,7 @@ export interface API {
   deployed_staging: boolean;
   tags?: string[];
   portal_promoted?: boolean; // Whether API is promoted to Developer Portal
+  audience?: 'public' | 'internal' | 'partner';
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- **PATCH** `/v1/admin/catalog/{tenant_id}/{api_id}/audience` endpoint with RBAC (cpi-admin any tenant, tenant-admin own tenant only)
- **Console page** (`/audience-governance`) with inline audience editing, tenant filter, search, and permission-gated actions
- **22 tests**: 9 API (pytest) + 13 Console (vitest) covering 4 personas + validation + edge cases

Phase 3 (final) of CAB-1323 MEGA — Portal Multi-Audience + RBAC (34 pts).
P1: audience field + Portal filtering (PR #697). P2: RBAC widget visibility (PR #714).

## Files changed (9)
- `control-plane-api/src/routers/catalog_admin.py` — PATCH endpoint + request/response schemas
- `control-plane-api/tests/test_catalog_admin_audience.py` — **NEW** 9 API tests
- `control-plane-ui/src/pages/AudienceGovernance.tsx` — **NEW** governance page (~190 LOC)
- `control-plane-ui/src/pages/AudienceGovernance.test.tsx` — **NEW** 13 Console tests
- `control-plane-ui/src/App.tsx` — lazy import + route
- `control-plane-ui/src/components/Layout.tsx` — nav item
- `control-plane-ui/src/services/api.ts` — `updateApiAudience()` method
- `control-plane-ui/src/types/index.ts` — `audience` field on API interface
- `control-plane-ui/src/test/helpers.tsx` — `audience` in mockAPI factory

## Test plan
- [x] 9 API tests pass (RBAC, validation, 404, idempotent)
- [x] 13 Console tests pass (4-persona, edit flow, search, badges)
- [x] ruff + black clean
- [x] ESLint (98 warnings, under 105 max) + Prettier clean
- [x] tsc --noEmit clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)