### PR TITLE
fix(gateway): add missing secret_key field in UpstreamAuth test (CAB-1382)

### DIFF
--- a/stoa-gateway/src/k8s/crds.rs
+++ b/stoa-gateway/src/k8s/crds.rs
@@ -386,6 +386,7 @@ mod tests {
                 auth: Some(UpstreamAuth {
                     auth_type: "bearer".to_string(),
                     secret_ref: "api-token".to_string(),
+                    secret_key: None,
                     header_name: None,
                 }),
                 timeout_seconds: Some(30),


### PR DESCRIPTION
## Summary
- Pre-existing SAST clippy failure: `k8s` feature test was missing the `secret_key` field added to `UpstreamAuth` struct
- One-line fix: adds `secret_key: None` to the test constructor

## Test plan
- [x] `cargo check --features k8s` — clean
- [x] `cargo clippy --features k8s` — zero warnings
- [x] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>