### PR TITLE
fix(ai-factory): prevent Haiku routing for unknown estimates

### DIFF
--- a/scripts/ai-ops/model-router.sh
+++ b/scripts/ai-ops/model-router.sh
@@ -9,6 +9,7 @@
 #   Ship <=3pts  → Haiku, 15 turns  (~$2.50/ticket)
 #   <=8pts       → Sonnet, 30 turns (~$9.50/ticket)
 #   >8pts        → Sonnet, 60 turns (~$16.50/ticket)
+#   0pts (unknown) → Sonnet, 30 turns (safe default)
 # Weighted average: ~$6.50/ticket (vs $16.50 flat Sonnet-60)
 
 route_model() {
@@ -23,7 +24,10 @@ route_model() {
     ESTIMATE=0
   fi
 
-  if [ "$ESTIMATE" -le 3 ] && [ "$MODE" = "ship" ]; then
+  # ESTIMATE=0 means unparsed/unknown — never route to Haiku for unknown complexity
+  if [ "$ESTIMATE" -eq 0 ]; then
+    echo "claude-sonnet-4-5-20250929|30"
+  elif [ "$ESTIMATE" -le 3 ] && [ "$MODE" = "ship" ]; then
     echo "claude-haiku-4-5-20251001|15"
   elif [ "$ESTIMATE" -le 8 ]; then
     echo "claude-sonnet-4-5-20250929|30"
@@ -33,6 +37,7 @@ route_model() {
 }
 
 # Extract estimate from issue body text (searches for "Estimate: X pts" or "X pts" patterns)
+# Falls back to LOC-based heuristic: ~80 LOC ≈ 3pts, ~200 LOC ≈ 5pts, ~500+ LOC ≈ 8pts
 extract_estimate() {
   local TEXT="$1"
   local EST=""
@@ -43,6 +48,24 @@ extract_estimate() {
   # Fallback: try "(X pts" pattern
   if [ -z "$EST" ]; then
     EST=$(echo "$TEXT" | grep -oE '\([0-9]+ pts' | head -1 | grep -oE '[0-9]+' | head -1)
+  fi
+
+  # Fallback: derive from LOC estimate ("Estimated LOC: ~80" or "~150 LOC")
+  if [ -z "$EST" ]; then
+    local LOC
+    LOC=$(echo "$TEXT" | grep -oiE '(estimated\s+loc|loc):?\s*~?[0-9]+' | head -1 | grep -oE '[0-9]+' | head -1)
+    if [ -z "$LOC" ]; then
+      LOC=$(echo "$TEXT" | grep -oE '~[0-9]+ LOC' | head -1 | grep -oE '[0-9]+' | head -1)
+    fi
+    if [ -n "$LOC" ]; then
+      if [ "$LOC" -le 100 ]; then
+        EST=3
+      elif [ "$LOC" -le 300 ]; then
+        EST=5
+      else
+        EST=8
+      fi
+    fi
   fi
 
   echo "${EST:-0}"


### PR DESCRIPTION
## Summary
- **Root cause**: When Council reports use "Estimated LOC: ~80" instead of "Estimate: X pts", `extract_estimate()` returns 0. Combined with Ship mode, `route_model(0, "ship")` incorrectly routes to Haiku/15 turns — too weak for infra tasks.
- **Impact**: CAB-499 (Kafka Multi-tenant Quotas) hit `error_max_turns` at 16 turns, producing `:rotating_light: AI Factory Error` on Slack.
- **Fix 1**: `route_model()` now treats `estimate=0` as unknown complexity → defaults to Sonnet/30 turns (never Haiku for unknowns)
- **Fix 2**: `extract_estimate()` now parses LOC-based estimates as fallback heuristic (≤100 LOC → 3pts, ≤300 → 5pts, 300+ → 8pts)

## Test plan
- [ ] Verify CAB-499 re-run with `/go-plan` routes to Sonnet instead of Haiku
- [ ] Verify CAB-498 also routes correctly
- [ ] Check that explicit "Estimate: 2 pts" + Ship mode still routes to Haiku (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)