### PR TITLE
fix(ai-factory): drop Haiku tier from implementation routing

### DIFF
--- a/scripts/ai-ops/model-router.sh
+++ b/scripts/ai-ops/model-router.sh
@@ -5,12 +5,14 @@
 #        MODEL=$(echo "$ROUTE" | cut -d'|' -f1)
 #        TURNS=$(echo "$ROUTE" | cut -d'|' -f2)
 
-# Tiered model routing:
-#   Ship <=3pts  → Haiku, 15 turns  (~$2.50/ticket)
-#   <=8pts       → Sonnet, 30 turns (~$9.50/ticket)
-#   >8pts        → Sonnet, 60 turns (~$16.50/ticket)
-#   0pts (unknown) → Sonnet, 30 turns (safe default)
-# Weighted average: ~$6.50/ticket (vs $16.50 flat Sonnet-60)
+# Tiered model routing (implementation jobs):
+#   <=5pts       → Sonnet, 20 turns  (~$6/ticket)
+#   <=8pts       → Sonnet, 30 turns  (~$9.50/ticket)
+#   >8pts        → Sonnet, 60 turns  (~$16.50/ticket)
+#
+# Haiku is reserved for council/plan-validate (structured evaluation).
+# Implementation always requires Sonnet — Haiku lacks the capacity to
+# create branches, write code, run tests, and open PRs reliably.
 
 route_model() {
   local ESTIMATE="${1:-0}"
@@ -24,11 +26,8 @@ route_model() {
     ESTIMATE=0
   fi
 
-  # ESTIMATE=0 means unparsed/unknown — never route to Haiku for unknown complexity
-  if [ "$ESTIMATE" -eq 0 ]; then
-    echo "claude-sonnet-4-5-20250929|30"
-  elif [ "$ESTIMATE" -le 3 ] && [ "$MODE" = "ship" ]; then
-    echo "claude-haiku-4-5-20251001|15"
+  if [ "$ESTIMATE" -le 5 ]; then
+    echo "claude-sonnet-4-5-20250929|20"
   elif [ "$ESTIMATE" -le 8 ]; then
     echo "claude-sonnet-4-5-20250929|30"
   else


### PR DESCRIPTION
## Summary
- **Problem**: Previous fix (#735) added LOC fallback that maps ~80 LOC → 3pts, but `route_model(3, "ship")` still routed to Haiku/15 turns → `error_max_turns` again on CAB-499
- **Root cause**: Haiku fundamentally lacks capacity for the full implementation cycle (branch → code → test → PR), regardless of ticket size
- **Fix**: Remove Haiku tier entirely from `route_model()`. All implementation jobs now use Sonnet with tiered turns: ≤5pts → 20 turns, ≤8pts → 30 turns, >8pts → 60 turns
- Haiku remains in use for council/plan-validate steps (hardcoded in workflow `claude_args`)

## Test plan
- [ ] Merge, then retry `/go-plan` on issue #734 (CAB-499)
- [ ] Verify logs show `Routed: Xpt ... → claude-sonnet-4-5` (no more Haiku)
- [ ] Confirm Slack receives success notification instead of `:rotating_light: AI Factory Error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)