### PR TITLE
fix(ai-factory): partial success detection for max_turns hits

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -580,6 +580,38 @@ jobs:
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}, Model=${{ steps.route.outputs.model || 'sonnet-4-5' }}, MaxTurns=${{ steps.route.outputs.turns || '60' }}, Stage=implement"
 
+      - name: Detect Partial Success
+        id: detect-partial
+        if: always() && steps.verify-council.outputs.validated == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ISSUE_NUM="${{ github.event.issue.number }}"
+          TICKET_ID=$(echo "${{ github.event.issue.title }} ${{ github.event.issue.body }}" \
+            | grep -oE 'CAB-[0-9]+' | head -1 || echo "")
+
+          # Search for PRs created by this run (open or merged)
+          PR_INFO=$(gh pr list --state all --search "${TICKET_ID:-issue-${ISSUE_NUM}}" \
+            --json number,url,state --jq '.[0] // empty' 2>/dev/null || echo "")
+          PR_NUM=$(echo "$PR_INFO" | jq -r '.number // empty' 2>/dev/null || echo "")
+          PR_URL=$(echo "$PR_INFO" | jq -r '.url // empty' 2>/dev/null || echo "")
+          PR_STATE=$(echo "$PR_INFO" | jq -r '.state // empty' 2>/dev/null || echo "")
+
+          if [ -n "$PR_NUM" ]; then
+            echo "pr_found=true" >> "$GITHUB_OUTPUT"
+            echo "pr_num=$PR_NUM" >> "$GITHUB_OUTPUT"
+            echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+            echo "pr_state=$PR_STATE" >> "$GITHUB_OUTPUT"
+            echo "PR #${PR_NUM} found (${PR_STATE}) — partial success"
+          else
+            echo "pr_found=false" >> "$GITHUB_OUTPUT"
+            echo "No PR found"
+          fi
+
+          echo "TICKET_ID=${TICKET_ID}" >> "$GITHUB_ENV"
+          echo "PR_NUM=${PR_NUM}" >> "$GITHUB_ENV"
+          echo "PR_URL=${PR_URL}" >> "$GITHUB_ENV"
+
       - name: Slack Implementation Result
         if: always()
         env:
@@ -589,10 +621,13 @@ jobs:
           source scripts/ai-ops/ai-factory-notify.sh
           TICKET=$(echo "${{ github.event.issue.title }}" | grep -oE 'CAB-[0-9]+' | head -1 || echo "issue-${{ github.event.issue.number }}")
           STATUS="${{ steps.implement.outcome || 'skipped' }}"
+          PR_FOUND="${{ steps.detect-partial.outputs.pr_found }}"
           DURATION=$(( $(date +%s) - ${IMPL_START:-$(date +%s)} ))
           if [ "$STATUS" = "success" ]; then
             notify_implement "$TICKET" "success" "" "" "${{ github.event.issue.number }}" "L1 Issue-to-PR" "$DURATION"
             linear_comment "$TICKET" "completed" "" "" "L1 Issue-to-PR" "$DURATION" || true
+          elif [ "$STATUS" = "failure" ] && [ "${PR_FOUND}" = "true" ]; then
+            notify_implement "$TICKET" "ask" "$PR_NUM" "$PR_URL" "${{ github.event.issue.number }}" "L1 Issue-to-PR (max_turns)" "$DURATION"
           elif [ "$STATUS" = "failure" ]; then
             notify_error "claude-issue-to-pr" "implement" "$TICKET" "" "$DURATION"
           else

--- a/.github/workflows/claude-linear-dispatch.yml
+++ b/.github/workflows/claude-linear-dispatch.yml
@@ -385,9 +385,39 @@ jobs:
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}, Model=${{ steps.route.outputs.model }}, MaxTurns=${{ steps.route.outputs.turns }}, Stage=implement-fast"
 
+      - name: Detect Partial Success
+        id: detect-partial
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TICKET_ID="${{ github.event.client_payload.ticket_id }}"
+
+          # Search for PRs created by this run (open or merged)
+          PR_INFO=$(gh pr list --state all --search "${TICKET_ID}" \
+            --json number,url,state --jq '.[0] // empty' 2>/dev/null || echo "")
+          PR_NUM=$(echo "$PR_INFO" | jq -r '.number // empty' 2>/dev/null || echo "")
+          PR_URL=$(echo "$PR_INFO" | jq -r '.url // empty' 2>/dev/null || echo "")
+          PR_STATE=$(echo "$PR_INFO" | jq -r '.state // empty' 2>/dev/null || echo "")
+
+          if [ -n "$PR_NUM" ]; then
+            echo "pr_found=true" >> "$GITHUB_OUTPUT"
+            echo "pr_num=$PR_NUM" >> "$GITHUB_OUTPUT"
+            echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+            echo "pr_state=$PR_STATE" >> "$GITHUB_OUTPUT"
+            echo "PR #${PR_NUM} found (${PR_STATE}) — partial success"
+          else
+            echo "pr_found=false" >> "$GITHUB_OUTPUT"
+            echo "No PR found"
+          fi
+
+          echo "TICKET_ID=${TICKET_ID}" >> "$GITHUB_ENV"
+          echo "PR_NUM=${PR_NUM}" >> "$GITHUB_ENV"
+          echo "PR_URL=${PR_URL}" >> "$GITHUB_ENV"
+
       # Close the loop: find PR, close issue, update Linear, notify Slack
       - name: Close the Loop
-        if: steps.claude.outcome == 'success'
+        if: steps.claude.outcome == 'success' || steps.detect-partial.outputs.pr_found == 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -462,11 +492,14 @@ jobs:
             PR_FILES=$(echo "$STAT_LINE" | grep -oE '[0-9]+ files?' | grep -oE '[0-9]+' || echo "")
             PR_LOC=$(echo "$STAT_LINE" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "")
           fi
+          PR_FOUND="${{ steps.detect-partial.outputs.pr_found }}"
           if [ "$STATUS" = "success" ] && [ -n "${PR_NUM}" ]; then
             notify_implement "$TICKET" "success" "$PR_NUM" "$PR_URL" "" "L3 Ship Fast Path" "$DURATION" "$PR_FILES" "$PR_LOC"
             linear_comment "$TICKET" "success" "$PR_NUM" "$PR_URL" "L3 Ship Fast Path" "$DURATION" "$PR_FILES" "$PR_LOC" "Ship"
           elif [ "$STATUS" = "success" ]; then
             notify_implement "$TICKET" "success" "" "" "" "L3 Ship Fast Path" "$DURATION"
+          elif [ "$STATUS" = "failure" ] && [ "${PR_FOUND}" = "true" ]; then
+            notify_implement "$TICKET" "ask" "$PR_NUM" "$PR_URL" "" "L3 Ship Fast Path (max_turns)" "$DURATION" "$PR_FILES" "$PR_LOC"
           else
             notify_error "claude-linear-dispatch" "implement-fast" "$TICKET" "" "$DURATION"
           fi
@@ -804,10 +837,44 @@ jobs:
         run: |
           echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}, Model=${{ steps.route.outputs.model || 'sonnet-4-5' }}, MaxTurns=${{ steps.route.outputs.turns || '60' }}, Stage=implement"
 
+      - name: Detect Partial Success
+        id: detect-partial
+        if: always() && steps.verify.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ISSUE_NUM="${{ github.event.issue.number }}"
+          TICKET_ID=$(gh issue view "$ISSUE_NUM" --json labels --jq \
+            '[.labels[].name | select(test("^CAB-[0-9]+$"))][0] // empty')
+
+          # Search for PRs created by this run (open or merged)
+          PR_INFO=$(gh pr list --state all --search "${TICKET_ID:-issue-${ISSUE_NUM}}" \
+            --json number,url,state --jq '.[0] // empty' 2>/dev/null || echo "")
+          PR_NUM=$(echo "$PR_INFO" | jq -r '.number // empty' 2>/dev/null || echo "")
+          PR_URL=$(echo "$PR_INFO" | jq -r '.url // empty' 2>/dev/null || echo "")
+          PR_STATE=$(echo "$PR_INFO" | jq -r '.state // empty' 2>/dev/null || echo "")
+
+          if [ -n "$PR_NUM" ]; then
+            echo "pr_found=true" >> "$GITHUB_OUTPUT"
+            echo "pr_num=$PR_NUM" >> "$GITHUB_OUTPUT"
+            echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+            echo "pr_state=$PR_STATE" >> "$GITHUB_OUTPUT"
+            echo "PR #${PR_NUM} found (${PR_STATE}) — partial success"
+          else
+            echo "pr_found=false" >> "$GITHUB_OUTPUT"
+            echo "No PR found"
+          fi
+
+          echo "TICKET_ID=${TICKET_ID}" >> "$GITHUB_ENV"
+          echo "PR_NUM=${PR_NUM}" >> "$GITHUB_ENV"
+          echo "PR_URL=${PR_URL}" >> "$GITHUB_ENV"
+
       # ----- Close the Loop (post-merge feedback) -----
       # After implementation: find merged PR, close GitHub issue, update Linear, notify Slack
       - name: Close the Loop
-        if: steps.claude.outcome == 'success' && steps.verify.outputs.valid == 'true'
+        if: |
+          (steps.claude.outcome == 'success' || steps.detect-partial.outputs.pr_found == 'true') &&
+          steps.verify.outputs.valid == 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -940,6 +1007,7 @@ jobs:
             PR_LOC=$(echo "$STAT_LINE" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "")
           fi
 
+          PR_FOUND="${{ steps.detect-partial.outputs.pr_found }}"
           if [ "$STATUS" = "success" ] && [ -n "${PR_NUM}" ]; then
             notify_implement "$TICKET" "success" "$PR_NUM" "$PR_URL" "${{ github.event.issue.number }}" "L3 Pipeline" "$DURATION" "$PR_FILES" "$PR_LOC"
             linear_comment "$TICKET" "success" "$PR_NUM" "$PR_URL" "L3 Pipeline" "$DURATION" "$PR_FILES" "$PR_LOC"
@@ -947,6 +1015,8 @@ jobs:
             notify_implement "$TICKET" "ask" "${PR_NUM:-}" "${PR_URL:-}" "${{ github.event.issue.number }}" "L3 Pipeline" "$DURATION"
           elif [ "$STATUS" = "success" ]; then
             notify_implement "$TICKET" "success" "" "" "${{ github.event.issue.number }}" "L3 Pipeline" "$DURATION"
+          elif [ "$STATUS" != "success" ] && [ "${PR_FOUND}" = "true" ]; then
+            notify_implement "$TICKET" "ask" "$PR_NUM" "$PR_URL" "${{ github.event.issue.number }}" "L3 Pipeline (max_turns)" "$DURATION" "$PR_FILES" "$PR_LOC"
           elif [ "$STATUS" = "skipped" ]; then
             notify_implement "$TICKET" "skipped" "" "" "${{ github.event.issue.number }}" "L3 Pipeline"
           else

--- a/scripts/ai-ops/model-router.sh
+++ b/scripts/ai-ops/model-router.sh
@@ -6,13 +6,15 @@
 #        TURNS=$(echo "$ROUTE" | cut -d'|' -f2)
 
 # Tiered model routing (implementation jobs):
-#   <=5pts       → Sonnet, 20 turns  (~$6/ticket)
-#   <=8pts       → Sonnet, 30 turns  (~$9.50/ticket)
+#   <=3pts       → Sonnet, 25 turns  (~$7/ticket)
+#   <=8pts       → Sonnet, 40 turns  (~$12/ticket)
 #   >8pts        → Sonnet, 60 turns  (~$16.50/ticket)
 #
 # Haiku is reserved for council/plan-validate (structured evaluation).
 # Implementation always requires Sonnet — Haiku lacks the capacity to
 # create branches, write code, run tests, and open PRs reliably.
+#
+# Turn budget accounts for action overhead (~5-8 turns for branch+PR+tests).
 
 route_model() {
   local ESTIMATE="${1:-0}"
@@ -26,10 +28,10 @@ route_model() {
     ESTIMATE=0
   fi
 
-  if [ "$ESTIMATE" -le 5 ]; then
-    echo "claude-sonnet-4-5-20250929|20"
+  if [ "$ESTIMATE" -le 3 ]; then
+    echo "claude-sonnet-4-5-20250929|25"
   elif [ "$ESTIMATE" -le 8 ]; then
-    echo "claude-sonnet-4-5-20250929|30"
+    echo "claude-sonnet-4-5-20250929|40"
   else
     echo "claude-sonnet-4-5-20250929|60"
   fi


### PR DESCRIPTION
## Summary

- **Fixes**: `error_max_turns` from `claude-code-action@v1` treated as total failure — Slack gets `:rotating_light: AI Factory Error` even when Claude successfully created a PR
- **Root cause**: `Close the Loop` gated on `steps.claude.outcome == 'success'`, so any max_turns hit orphans the PR and triggers `notify_error`
- **Fix**: Add a `Detect Partial Success` step that searches for PRs created during the run. If found, Close the Loop still runs and Slack gets a "PR created (max_turns)" notification instead of an error

### Changes

| File | Change |
|------|--------|
| `scripts/ai-ops/model-router.sh` | Lower first tier <=5→<=3pts, bump turns 20→25 / 30→40 (action overhead ~5-8 turns) |
| `.github/workflows/claude-linear-dispatch.yml` | Add `detect-partial` step in both `implement` and `implement-fast` jobs; update `Close the Loop` and `Notify Slack` conditions |
| `.github/workflows/claude-issue-to-pr.yml` | Same partial-success pattern for L1 `implement` job |

### What stays unchanged
- Council/plan-validate steps (hardcoded Sonnet/5-10 turns)
- Autopilot scan (Haiku/5 turns)
- Review workflow (Haiku/5 turns)
- Multi-agent workflow (Sonnet/60)

## Test plan

- [ ] Merge and re-run `/go-plan` on an existing issue
- [ ] Confirm logs show updated routing (e.g. `3pt ... → claude-sonnet-4-5, 25 turns`)
- [ ] If max_turns hit with PR created: Slack shows "PR created (max_turns)" instead of error
- [ ] If full success: normal notification + issue closed + Linear updated
- [ ] If total failure (no PR): error notification unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)