### PR TITLE
fix(ci): autopilot scan reports accurate counts and existing issue links

### DIFF
--- a/.github/workflows/claude-autopilot-scan.yml
+++ b/.github/workflows/claude-autopilot-scan.yml
@@ -216,7 +216,10 @@ jobs:
           echo "Council validated ${CANDIDATE_COUNT} candidates"
 
           CREATED=0
-          echo "$CANDIDATES" | jq -c '.[] | select(.verdict == "Go" and .score >= 8.0)' | while IFS= read -r ticket; do
+          SKIPPED=0
+          EXISTING_LINKS=""
+          # Use process substitution (not pipe) so counters propagate to parent shell
+          while IFS= read -r ticket; do
             TICKET_ID=$(echo "$ticket" | jq -r '.ticket_id')
             TITLE=$(echo "$ticket" | jq -r '.title')
             SCORE=$(echo "$ticket" | jq -r '.score')
@@ -243,6 +246,8 @@ jobs:
             EXISTING_ISSUE=$(gh issue list --label "$TICKET_ID" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
             if [ -n "$EXISTING_ISSUE" ] && [ "$EXISTING_ISSUE" != "null" ]; then
               echo "Issue #${EXISTING_ISSUE} already exists for ${TICKET_ID} — skipping"
+              SKIPPED=$((SKIPPED + 1))
+              EXISTING_LINKS="${EXISTING_LINKS}• <https://github.com/stoa-platform/stoa/issues/${EXISTING_ISSUE}|#${EXISTING_ISSUE}> ${TICKET_ID} — ${TITLE}\n"
               continue
             fi
 
@@ -297,16 +302,20 @@ jobs:
 
             # Send Slack notification with approve button
             source scripts/ai-ops/ai-factory-notify.sh
-            # Extract mode and LOC from council output
-            C_MODE=$(jq -r '.mode // empty' council-output.json 2>/dev/null || echo "")
-            C_LOC=$(jq -r '.loc // empty' council-output.json 2>/dev/null || echo "")
-            C_FILES=$(jq -r '.files // empty' council-output.json 2>/dev/null || echo "")
-            notify_council "$TICKET_ID" "$TITLE" "$SCORE" "Go" "$ISSUE_URL" "$ISSUE_NUM" "$C_MODE" "$C_LOC" "$C_FILES"
+            # Extract mode and LOC from council candidate JSON
+            C_MODE=$(echo "$ticket" | jq -r '.ship_show_ask // empty' 2>/dev/null || echo "")
+            C_LOC=$(echo "$ticket" | jq -r '.estimated_points // empty' 2>/dev/null || echo "")
+            notify_council "$TICKET_ID" "$TITLE" "$SCORE" "Go" "$ISSUE_URL" "$ISSUE_NUM" "$C_MODE" "$C_LOC" ""
 
             CREATED=$((CREATED + 1))
-          done
+          done < <(echo "$CANDIDATES" | jq -c '.[] | select(.verdict == "Go" and .score >= 8.0)')
 
-          echo "Created ${CREATED} autopilot candidate issues"
+          echo "Created ${CREATED} autopilot candidate issues (${SKIPPED} skipped — already existed)"
+          # Export to GITHUB_ENV so the summary step can read accurate counts
+          echo "SCAN_CREATED=${CREATED}" >> "$GITHUB_ENV"
+          echo "SCAN_SKIPPED=${SKIPPED}" >> "$GITHUB_ENV"
+          # Write existing issue links to a file (multiline strings don't work in GITHUB_ENV)
+          printf '%b' "$EXISTING_LINKS" > /tmp/existing-issues.txt
 
       # Summary Slack notification + Job Summary
       - name: Slack Summary
@@ -318,7 +327,8 @@ jobs:
 
           CAPPED="${{ steps.velocity.outputs.capped }}"
           TOTAL="${{ steps.linear.outputs.count || '0' }}"
-          # CREATED is set in the council step env, may not propagate — use fallback
+          CREATED="${SCAN_CREATED:-0}"
+          SKIPPED="${SCAN_SKIPPED:-0}"
           DRY="${{ inputs.dry_run }}"
           COUNCIL_OK="${{ steps.council.outcome }}"
 
@@ -332,7 +342,7 @@ jobs:
           elif [ "$DRY" = "true" ]; then
             notify_scan "$TOTAL" "0"
           else
-            notify_scan "$TOTAL" "$TOTAL"
+            notify_scan "$TOTAL" "$CREATED" "" "$SKIPPED"
           fi
 
       - name: Write Job Summary

--- a/scripts/ai-ops/ai-factory-notify.sh
+++ b/scripts/ai-ops/ai-factory-notify.sh
@@ -272,10 +272,11 @@ notify_error() {
   }"
 }
 
-# notify_scan TOTAL_ELIGIBLE CREATED [CAPPED]
+# notify_scan TOTAL_ELIGIBLE CREATED [CAPPED] [SKIPPED]
 # Autopilot scan summary notification.
+# SKIPPED = candidates that already had open GitHub issues (dedup guard).
 notify_scan() {
-  local TOTAL="${1:-0}" CREATED="${2:-0}" CAPPED="${3:-false}"
+  local TOTAL="${1:-0}" CREATED="${2:-0}" CAPPED="${3:-false}" SKIPPED="${4:-0}"
   local RUN_LINK="$(_run_url)"
 
   local MSG=""
@@ -283,15 +284,29 @@ notify_scan() {
     MSG=":pause_button: Autopilot scan skipped — daily velocity cap reached."
   elif [ "$TOTAL" = "0" ]; then
     MSG=":inbox_tray: Autopilot scan complete — no eligible tickets in backlog."
-  elif [ "$CREATED" = "0" ]; then
+  elif [ "$CREATED" = "0" ] && [ "$SKIPPED" = "0" ]; then
     MSG=":mag: Autopilot scan — ${TOTAL} eligible tickets found (dry run, no issues created)."
+  elif [ "$CREATED" = "0" ] && [ "$SKIPPED" -gt 0 ] 2>/dev/null; then
+    MSG=":recycle: Autopilot scan — ${TOTAL} eligible, all ${SKIPPED} already have open issues. <${RUN_LINK}|Details>"
   else
-    MSG=":sunrise: Autopilot scan complete — ${CREATED}/${TOTAL} candidates dispatched. <${RUN_LINK}|Details>"
+    local SUFFIX=""
+    if [ "$SKIPPED" -gt 0 ] 2>/dev/null; then
+      SUFFIX=" (${SKIPPED} already existed)"
+    fi
+    MSG=":sunrise: Autopilot scan complete — ${CREATED}/${TOTAL} candidates dispatched${SUFFIX}. <${RUN_LINK}|Details>"
+  fi
+
+  # Build blocks array — add existing issues list if available
+  local EXISTING_BLOCK=""
+  if [ "$SKIPPED" -gt 0 ] 2>/dev/null && [ -f /tmp/existing-issues.txt ]; then
+    local LINKS
+    LINKS=$(_escape_json "$(cat /tmp/existing-issues.txt)")
+    EXISTING_BLOCK=",{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*Existing issues awaiting approval:*\n${LINKS}\"}}"
   fi
 
   _send_slack "{
     \"blocks\": [
-      {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"${MSG}\"}},
+      {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"${MSG}\"}}${EXISTING_BLOCK},
       {\"type\":\"context\",\"elements\":[{\"type\":\"mrkdwn\",\"text\":\"STOA AI Factory | Autopilot Scan | $(date -u +%H:%M) UTC\"}]}
     ]
   }"


### PR DESCRIPTION
## Summary
- **Fix subshell counter bug**: `CREATED` was incremented inside a bash pipe subshell (`| while`), so it never propagated — Slack always showed `TOTAL/TOTAL` instead of actual `CREATED/TOTAL`. Fixed with process substitution (`< <(...)`)
- **Fix phantom `council-output.json` reference**: mode/LOC/files were read from a non-existent file. Now extracted from the candidate JSON variable directly
- **Add existing issue visibility**: when dedup guard skips candidates that already have open GitHub issues, Slack now reports accurate counts ("5 eligible, all 5 already have open issues") and lists links to the existing issues awaiting approval

## Test plan
- [ ] Trigger `workflow_dispatch` on `claude-autopilot-scan.yml` — verify Slack shows accurate created vs skipped counts
- [ ] Verify existing issue links appear in Slack message when candidates are deduped
- [ ] Verify new issues still get created correctly when no dedup match exists

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>