### PR TITLE
fix(ci): auto-close GitHub Council issues on PR merge

### DIFF
--- a/.github/workflows/linear-close-on-merge.yml
+++ b/.github/workflows/linear-close-on-merge.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   close-linear:
@@ -111,3 +112,21 @@ jobs:
             -d "{\"query\": \"$COMMENT_MUTATION\"}" > /dev/null
 
           echo "Comment added to $TICKET_ID"
+
+      # Close GitHub Council issue (L3/L3.5 create issues labeled with CAB-XXXX)
+      - name: Close GitHub Council issue
+        if: steps.extract.outputs.skip != 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TICKET_ID: ${{ steps.extract.outputs.ticket_id }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          # Find open issues labeled with the ticket ID (Council issues from L3/L3.5)
+          ISSUE_NUM=$(gh issue list --label "$TICKET_ID" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$ISSUE_NUM" ] && [ "$ISSUE_NUM" != "null" ]; then
+            gh issue close "$ISSUE_NUM" --comment "Completed via PR #${PR_NUM}. Auto-closed on merge." || true
+            echo "Closed GitHub issue #${ISSUE_NUM} (Council issue for ${TICKET_ID})"
+          else
+            echo "No open GitHub Council issue found for ${TICKET_ID} — skipping"
+          fi


### PR DESCRIPTION
## Summary
- When a PR with `CAB-XXXX` in the title is merged, the `linear-close-on-merge` workflow now also closes the corresponding GitHub Council issue (created by L3/L3.5 pipelines with a `CAB-XXXX` label)
- Adds `issues: write` permission to the workflow
- Uses `continue-on-error: true` so Council issue close failure never blocks the workflow

## Context
Ask-mode PRs from the L3 pipeline are merged manually by the user. The L3 "Close the Loop" step has already terminated by then, so the GitHub Council issue was left orphaned. This universal fallback now handles that gap.

## Test plan
- [ ] CI green (security-scan required checks)
- [ ] Merge a PR with `CAB-XXXX` title → verify Council issue auto-closes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>