### PR TITLE
fix(ci): allow bot actors in scheduled workflows + n8n dedup filter

### DIFF
--- a/.github/workflows/claude-autopilot-scan.yml
+++ b/.github/workflows/claude-autopilot-scan.yml
@@ -142,6 +142,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_actors: "github-actions[bot]"
           prompt: |
             IMPORTANT: You are running in CI. Skip session-startup protocol entirely.
             Do NOT read memory.md, plan.md, or operations.log for session state.

--- a/.github/workflows/claude-scheduled.yml
+++ b/.github/workflows/claude-scheduled.yml
@@ -55,6 +55,7 @@ jobs:
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_actors: "github-actions[bot]"
           prompt: |
             IMPORTANT: You are running in CI. Skip session-startup protocol entirely.
             Do NOT read memory.md, plan.md, or operations.log for session state.
@@ -108,6 +109,7 @@ jobs:
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_actors: "github-actions[bot]"
           prompt: |
             IMPORTANT: You are running in CI. Skip session-startup protocol entirely.
             Do NOT read memory.md, plan.md, or operations.log for session state.
@@ -165,6 +167,7 @@ jobs:
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_actors: "github-actions[bot]"
           prompt: |
             IMPORTANT: You are running in CI. Skip session-startup protocol entirely.
             Do NOT read memory.md, plan.md, or operations.log for session state.

--- a/scripts/ai-ops/n8n-linear-to-claude.json
+++ b/scripts/ai-ops/n8n-linear-to-claude.json
@@ -21,16 +21,36 @@
           "options": {
             "caseSensitive": true,
             "leftValue": "",
-            "typeValidation": "strict"
+            "typeValidation": "strict",
+            "version": 1
           },
           "conditions": [
             {
               "id": "filter-in-progress",
-              "leftValue": "={{ $json.data.status.name }}",
+              "leftValue": "={{ $json.body.data.state.name }}",
               "rightValue": "In Progress",
               "operator": {
                 "type": "string",
                 "operation": "equals"
+              }
+            },
+            {
+              "id": "filter-autopilot-label",
+              "leftValue": "={{ $json.body.data.labels.some(l => l.name === \"autopilot\") }}",
+              "rightValue": "=true",
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            },
+            {
+              "id": "filter-state-changed",
+              "leftValue": "={{ $json.body.updatedFrom?.stateId ?? '' }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
               }
             }
           ],
@@ -60,7 +80,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"event_type\": \"linear-ticket-started\",\n  \"client_payload\": {\n    \"ticket_id\": \"{{ $json.data.identifier }}\",\n    \"ticket_title\": \"{{ $json.data.title }}\",\n    \"ticket_description\": \"{{ $json.data.description }}\",\n    \"ticket_priority\": \"{{ $json.data.priority }}\",\n    \"ticket_estimate\": \"{{ $json.data.estimate }}\"\n  }\n}"
+        "jsonBody": "={\n  \"event_type\": \"linear-ticket-started\",\n  \"client_payload\": {\n    \"ticket_id\": \"{{ $json.body.data.identifier }}\",\n    \"ticket_title\": \"{{ $json.body.data.title }}\",\n    \"ticket_description\": \"{{ $json.body.data.description }}\",\n    \"ticket_priority\": \"{{ $json.body.data.priorityLabel }}\",\n    \"ticket_estimate\": \"{{ $json.body.data.estimate }}\"\n  }\n}"
       },
       "id": "dispatch-github",
       "name": "Dispatch GitHub Actions",
@@ -80,7 +100,7 @@
         "url": "={{ $env.SLACK_WEBHOOK }}",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"blocks\": [\n    {\n      \"type\": \"header\",\n      \"text\": {\n        \"type\": \"plain_text\",\n        \"text\": \":rocket: Linear → Claude: {{ $json.data.identifier }}\",\n        \"emoji\": true\n      }\n    },\n    {\n      \"type\": \"section\",\n      \"text\": {\n        \"type\": \"mrkdwn\",\n        \"text\": \"*{{ $json.data.title }}*\\nTicket moved to In Progress. Council validation + autonomous implementation triggered.\\n\\n:hourglass: Waiting for Council report...\"\n      }\n    }\n  ]\n}"
+        "jsonBody": "={\n  \"blocks\": [\n    {\n      \"type\": \"header\",\n      \"text\": {\n        \"type\": \"plain_text\",\n        \"text\": \":rocket: Linear → Claude: {{ $json.body.data.identifier }}\",\n        \"emoji\": true\n      }\n    },\n    {\n      \"type\": \"section\",\n      \"text\": {\n        \"type\": \"mrkdwn\",\n        \"text\": \"*{{ $json.body.data.title }}*\\nTicket moved to In Progress. Council validation + autonomous implementation triggered.\\n\\n:hourglass: Waiting for Council report...\"\n      }\n    }\n  ]\n}"
       },
       "id": "slack-notify-start",
       "name": "Slack: Pipeline Started",


### PR DESCRIPTION
## Summary
- Add `allowed_actors: "github-actions[bot]"` to `claude-autopilot-scan.yml` and `claude-scheduled.yml` (4 steps) — fixes cron-triggered workflows rejected by Claude Code Action
- Add `updatedFrom.stateId` not-empty filter to `n8n-linear-to-claude.json` — prevents duplicate Council dispatches on label-only updates
- Sync n8n JSON field paths to match live n8n instance (`$json.body.data.*`)

## Test plan
- [ ] Next autopilot scan (cron or manual dispatch) runs without "non-human actor" error
- [ ] Label updates on In Progress tickets no longer trigger duplicate Council reports
- [ ] Reimport `n8n-linear-to-claude.json` in n8n after merge

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>