### PR TITLE
fix(ci): use correct allowed_bots param for Claude Code Action

### DIFF
--- a/.github/workflows/claude-autopilot-scan.yml
+++ b/.github/workflows/claude-autopilot-scan.yml
@@ -142,7 +142,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_actors: "github-actions[bot]"
+          allowed_bots: "github-actions[bot]"
           prompt: |
             IMPORTANT: You are running in CI. Skip session-startup protocol entirely.
             Do NOT read memory.md, plan.md, or operations.log for session state.

--- a/.github/workflows/claude-scheduled.yml
+++ b/.github/workflows/claude-scheduled.yml
@@ -55,7 +55,7 @@ jobs:
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_actors: "github-actions[bot]"
+          allowed_bots: "github-actions[bot]"
           prompt: |
             IMPORTANT: You are running in CI. Skip session-startup protocol entirely.
             Do NOT read memory.md, plan.md, or operations.log for session state.
@@ -109,7 +109,7 @@ jobs:
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_actors: "github-actions[bot]"
+          allowed_bots: "github-actions[bot]"
           prompt: |
             IMPORTANT: You are running in CI. Skip session-startup protocol entirely.
             Do NOT read memory.md, plan.md, or operations.log for session state.
@@ -167,7 +167,7 @@ jobs:
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_actors: "github-actions[bot]"
+          allowed_bots: "github-actions[bot]"
           prompt: |
             IMPORTANT: You are running in CI. Skip session-startup protocol entirely.
             Do NOT read memory.md, plan.md, or operations.log for session state.


### PR DESCRIPTION
## Summary
- Fix: `allowed_actors` → `allowed_bots` (correct parameter name per claude-code-action action.yml)
- Affects: `claude-autopilot-scan.yml` (1 step) + `claude-scheduled.yml` (3 steps)
- Related: [anthropics/claude-code-action#900](https://github.com/anthropics/claude-code-action/issues/900)

## Test plan
- [ ] Trigger `gh workflow run claude-autopilot-scan.yml` — Council step should not fail with "non-human actor"

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>