### PR TITLE
fix(ci): dispatch gap fixes for AI Factory (CAB-1388)

### DIFF
--- a/.github/workflows/claude-autopilot-scan.yml
+++ b/.github/workflows/claude-autopilot-scan.yml
@@ -307,7 +307,9 @@ jobs:
             # Extract mode and LOC from council candidate JSON
             C_MODE=$(echo "$ticket" | jq -r '.ship_show_ask // empty' 2>/dev/null || echo "")
             C_LOC=$(echo "$ticket" | jq -r '.estimated_points // empty' 2>/dev/null || echo "")
-            notify_council "$TICKET_ID" "$TITLE" "$SCORE" "Go" "$ISSUE_URL" "$ISSUE_NUM" "$C_MODE" "$C_LOC" ""
+            # Use verdict from Council JSON (already filtered to Go/>=8.0 by the jq select above)
+            C_VERDICT=$(echo "$ticket" | jq -r '.verdict // "Go"' 2>/dev/null || echo "Go")
+            notify_council "$TICKET_ID" "$TITLE" "$SCORE" "$C_VERDICT" "$ISSUE_URL" "$ISSUE_NUM" "$C_MODE" "$C_LOC" ""
 
             CREATED=$((CREATED + 1))
           done < <(echo "$CANDIDATES" | jq -c '.[] | select(.verdict == "Go" and .score >= 8.0)')

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -234,8 +234,28 @@ jobs:
         run: |
           source scripts/ai-ops/ai-factory-notify.sh
           TICKET=$(echo "${{ github.event.issue.title }} ${{ github.event.issue.body }}" | grep -oE 'CAB-[0-9]+' | head -1 || echo "#${{ github.event.issue.number }}")
-          notify_council "$TICKET" "${{ github.event.issue.title }}" "" "Go" "${{ github.event.issue.html_url }}" "${{ github.event.issue.number }}"
-          push_metrics_council "issue-to-pr" "$TICKET" "0" "go"
+
+          # Extract score from Council execution output
+          SCORE=""
+          EXEC_FILE="${{ steps.council.outputs.execution_file }}"
+          EXEC_FILE="${EXEC_FILE:-/home/runner/work/_temp/claude-execution-output.json}"
+          if [ -f "$EXEC_FILE" ]; then
+            SCORE=$(jq -r '[.[] | select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text] | join("\n")' "$EXEC_FILE" 2>/dev/null \
+              | grep -oE 'Score:?\s*[0-9]+\.?[0-9]*/10' | head -1 | grep -oE '[0-9]+\.?[0-9]*' | head -1 || echo "")
+          fi
+
+          # Compute verdict from score (don't hardcode "Go")
+          VERDICT="Go"
+          if [ -n "$SCORE" ]; then
+            if echo "$SCORE < 6.0" | bc -l 2>/dev/null | grep -q 1; then VERDICT="Redo"
+            elif echo "$SCORE < 8.0" | bc -l 2>/dev/null | grep -q 1; then VERDICT="Fix"; fi
+          fi
+
+          notify_council "$TICKET" "${{ github.event.issue.title }}" "${SCORE:-?}" "$VERDICT" "${{ github.event.issue.html_url }}" "${{ github.event.issue.number }}"
+
+          # Push metrics with actual verdict
+          METRIC_VERDICT=$(echo "$VERDICT" | tr '[:upper:]' '[:lower:]')
+          push_metrics_council "issue-to-pr" "$TICKET" "${SCORE:-0}" "$METRIC_VERDICT"
 
       - name: Write Job Summary — Council
         if: always() && steps.guard.outputs.skip != 'true'

--- a/.github/workflows/claude-linear-dispatch.yml
+++ b/.github/workflows/claude-linear-dispatch.yml
@@ -134,6 +134,20 @@ jobs:
           head -15 council-body.md
           echo "=== ($(wc -l < council-body.md | tr -d ' ') lines total) ==="
 
+      # Validate that extraction produced usable content (Gap 4 fix)
+      - name: Validate Council Extraction
+        if: steps.council.outcome == 'success'
+        run: |
+          if [ ! -s council-body.md ]; then
+            echo "::error::Council ran but produced no parseable report"
+            echo "EXTRACTION_FAILED=true" >> "$GITHUB_ENV"
+          else
+            # Check if the report contains a score (minimum viable extraction)
+            if ! grep -qE 'Score:?\s*[0-9]+\.?[0-9]*/10' council-body.md; then
+              echo "::warning::Council report extracted but no score found — fallback verdict will be used"
+            fi
+          fi
+
       # Check if a GitHub issue already exists for this ticket (dedup guard)
       - name: Check Existing Issue
         id: dedup
@@ -316,7 +330,14 @@ jobs:
             FILES=$(grep -oE '[0-9]+ files?' council-body.md | head -1 | grep -oE '[0-9]+' | head -1 || echo "")
           fi
 
-          notify_council "$TICKET" "$TITLE" "${SCORE:-?}" "Go" "$ISSUE" "$ISSUE_NUM" "$MODE" "$LOC" "$FILES"
+          # Compute verdict from score (don't hardcode "Go")
+          VERDICT="Go"
+          if [ -n "$SCORE" ]; then
+            if echo "$SCORE < 6.0" | bc -l 2>/dev/null | grep -q 1; then VERDICT="Redo"
+            elif echo "$SCORE < 8.0" | bc -l 2>/dev/null | grep -q 1; then VERDICT="Fix"; fi
+          fi
+
+          notify_council "$TICKET" "$TITLE" "${SCORE:-?}" "$VERDICT" "$ISSUE" "$ISSUE_NUM" "$MODE" "$LOC" "$FILES"
 
           # Push council metrics
           VERDICT="go"

--- a/scripts/ai-ops/n8n-linear-to-claude.json
+++ b/scripts/ai-ops/n8n-linear-to-claude.json
@@ -35,16 +35,6 @@
               }
             },
             {
-              "id": "filter-autopilot-label",
-              "leftValue": "={{ $json.body.data.labels.some(l => l.name === \"autopilot\") }}",
-              "rightValue": "=true",
-              "operator": {
-                "type": "boolean",
-                "operation": "true",
-                "singleValue": true
-              }
-            },
-            {
               "id": "filter-state-changed",
               "leftValue": "={{ $json.body.updatedFrom?.stateId ?? '' }}",
               "rightValue": "",
@@ -80,7 +70,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"event_type\": \"linear-ticket-started\",\n  \"client_payload\": {\n    \"ticket_id\": \"{{ $json.body.data.identifier }}\",\n    \"ticket_title\": \"{{ $json.body.data.title }}\",\n    \"ticket_description\": \"{{ $json.body.data.description }}\",\n    \"ticket_priority\": \"{{ $json.body.data.priorityLabel }}\",\n    \"ticket_estimate\": \"{{ $json.body.data.estimate }}\"\n  }\n}"
+        "jsonBody": "={\n  \"event_type\": \"linear-ticket-started\",\n  \"client_payload\": {\n    \"ticket_id\": \"{{ $json.body.data.identifier }}\",\n    \"ticket_title\": \"{{ $json.body.data.title }}\",\n    \"ticket_description\": \"{{ $json.body.data.description }}\",\n    \"ticket_priority\": \"{{ $json.body.data.priorityLabel }}\",\n    \"ticket_estimate\": \"{{ $json.body.data.estimate }}\",\n    \"mega_id\": \"{{ $json.body.data.parent?.identifier ?? '' }}\",\n    \"phase_hint\": \"{{ $json.body.data.sortOrder ?? '' }}\",\n    \"component\": \"{{ ($json.body.data.labels?.nodes ?? []).find(l => ['api','gateway','ui','portal','e2e'].includes(l.name))?.name ?? '' }}\"\n  }\n}"
       },
       "id": "dispatch-github",
       "name": "Dispatch GitHub Actions",


### PR DESCRIPTION
## Summary

Phase 1 of MEGA CAB-1388 (AI Factory Slack Upgrade + Dispatch Gap Fixes — 26 pts, 4 phases).

Fixes 4 dispatch pipeline gaps:
- **Gap 1** (HIGH): Remove `autopilot` label filter from n8n workflow — most tickets were silently blocked because they lacked this label. Only `In Progress` state + `stateId` changed guard remain.
- **Gap 2** (MEDIUM): Add `mega_id`, `phase_hint`, `component` to dispatch `client_payload` for MEGA ticket phase coordination.
- **Gap 4** (MEDIUM): Add Council extraction validation step with explicit `::error::` logging when report is empty or score is missing.
- **Gap 10** (MEDIUM): Replace hardcoded `"Go"` verdict with actual computed verdict (`Go`/`Fix`/`Redo` based on score thresholds) in all 3 workflows: `claude-linear-dispatch.yml`, `claude-issue-to-pr.yml`, `claude-autopilot-scan.yml`.

### Files changed (4)
| File | Change |
|------|--------|
| `scripts/ai-ops/n8n-linear-to-claude.json` | Gap 1 + Gap 2 |
| `.github/workflows/claude-linear-dispatch.yml` | Gap 4 + Gap 10 |
| `.github/workflows/claude-issue-to-pr.yml` | Gap 10 |
| `.github/workflows/claude-autopilot-scan.yml` | Gap 10 |

## Test plan
- [ ] Import updated `n8n-linear-to-claude.json` in n8n → move Linear ticket to "In Progress" (no autopilot label) → verify GHA `linear-ticket-started` triggers
- [ ] Verify Slack shows correct verdict (Fix/Redo) for scores < 8.0
- [ ] CI green (no path triggers for these files — security-scan only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>