### PR TITLE
fix(portal): load onboarding i18n namespace on wizard mount

### DIFF
--- a/portal/src/pages/__tests__/OnboardingWizard.test.tsx
+++ b/portal/src/pages/__tests__/OnboardingWizard.test.tsx
@@ -57,7 +57,9 @@ vi.mock('../../contexts/AuthContext', () => ({
   useAuth: () => createAuthMock('cpi-admin'),
 }));
 
-vi.mock('../../i18n', () => ({}));
+vi.mock('../../i18n', () => ({
+  loadNamespace: vi.fn(),
+}));
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (k: string) => k,

--- a/portal/src/pages/onboarding/OnboardingWizard.tsx
+++ b/portal/src/pages/onboarding/OnboardingWizard.tsx
@@ -4,8 +4,9 @@
  * 4-step wizard: Choose use case -> Create app -> Subscribe -> First call
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { StepIndicator } from '../../components/onboarding/StepIndicator';
 import { ChooseUseCase } from '../../components/onboarding/steps/ChooseUseCase';
 import { CreateApp } from '../../components/onboarding/steps/CreateApp';
@@ -13,9 +14,21 @@ import { SubscribeAPI } from '../../components/onboarding/steps/SubscribeAPI';
 import { FirstCall } from '../../components/onboarding/steps/FirstCall';
 import type { UseCase } from '../../components/onboarding/steps/ChooseUseCase';
 import type { Application, API } from '../../types';
+import { config } from '../../config';
+import { loadNamespace } from '../../i18n';
 
 export function OnboardingWizardPage() {
   const navigate = useNavigate();
+  const { i18n: i18nInstance } = useTranslation('onboarding');
+  const i18nEnabled = config.features.enableI18n;
+
+  useEffect(() => {
+    if (i18nEnabled) {
+      const lng = i18nInstance.language;
+      loadNamespace(lng, 'onboarding');
+      if (lng !== 'en') loadNamespace('en', 'onboarding');
+    }
+  }, [i18nEnabled, i18nInstance.language]);
   const [step, setStep] = useState(0);
   const [useCase, setUseCase] = useState<UseCase>('rest-api');
   const [createdApp, setCreatedApp] = useState<Application | null>(null);


### PR DESCRIPTION
## Summary
- The onboarding page (`/onboarding`) showed raw i18n keys instead of translated text (e.g. `chooseUseCase.title` instead of "How will you use STOA?")
- Root cause: `OnboardingWizardPage` was missing the `loadNamespace('onboarding')` call that all other portal pages have
- Added `useEffect` with `loadNamespace` following the exact pattern from `UsagePage`, `WorkspacePage`, and `APICatalog`

## Test plan
- [x] 9/9 existing OnboardingWizard tests pass
- [x] TypeScript compiles cleanly
- [x] ESLint + Prettier pass (lint-staged)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>