### PR TITLE
feat(api): add self-service TTL extension endpoint (CAB-86)

### DIFF
--- a/control-plane-api/alembic/versions/035_add_ttl_extension_fields.py
+++ b/control-plane-api/alembic/versions/035_add_ttl_extension_fields.py
@@ -1,0 +1,33 @@
+"""add TTL extension tracking fields to subscriptions
+
+Revision ID: 035
+Revises: 034
+Create Date: 2026-02-22
+
+CAB-86: Self-service TTL extension endpoint.
+Tracks extension count and total days extended.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "035"
+down_revision = "034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "subscriptions",
+        sa.Column("ttl_extension_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "subscriptions",
+        sa.Column("ttl_total_extended_days", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("subscriptions", "ttl_total_extended_days")
+    op.drop_column("subscriptions", "ttl_extension_count")

--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -14225,6 +14225,73 @@
         "title": "SyncTypeEnum",
         "type": "string"
       },
+      "TTLExtendRequest": {
+        "description": "Schema for requesting a TTL extension on a subscription.",
+        "example": {
+          "extend_days": 7,
+          "reason": "Need more time to complete integration testing"
+        },
+        "properties": {
+          "extend_days": {
+            "description": "Days to extend (7 or 14)",
+            "enum": [
+              7,
+              14
+            ],
+            "title": "Extend Days",
+            "type": "integer"
+          },
+          "reason": {
+            "description": "Reason for extension",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "extend_days",
+          "reason"
+        ],
+        "title": "TTLExtendRequest",
+        "type": "object"
+      },
+      "TTLExtendResponse": {
+        "description": "Schema for TTL extension response.",
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "new_expires_at": {
+            "format": "date-time",
+            "title": "New Expires At",
+            "type": "string"
+          },
+          "remaining_extensions": {
+            "title": "Remaining Extensions",
+            "type": "integer"
+          },
+          "ttl_extension_count": {
+            "title": "Ttl Extension Count",
+            "type": "integer"
+          },
+          "ttl_total_extended_days": {
+            "title": "Ttl Total Extended Days",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "new_expires_at",
+          "ttl_extension_count",
+          "ttl_total_extended_days",
+          "remaining_extensions"
+        ],
+        "title": "TTLExtendResponse",
+        "type": "object"
+      },
       "TaxonomyItem": {
         "description": "Single error category aggregate.",
         "properties": {
@@ -29238,6 +29305,65 @@
           }
         ],
         "summary": "Suspend Subscription",
+        "tags": [
+          "Subscriptions"
+        ]
+      }
+    },
+    "/v1/subscriptions/{subscription_id}/ttl": {
+      "patch": {
+        "description": "Extend the TTL of an active subscription.\n\nSubscription owners can extend their expiry by 7 or 14 days.\nLimited to 2 extensions and 60 total extended days.\nTenant admins and cpi-admins can extend any subscription in their scope.",
+        "operationId": "extend_subscription_ttl_v1_subscriptions__subscription_id__ttl_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "subscription_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Subscription Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TTLExtendRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TTLExtendResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Extend Subscription Ttl",
         "tags": [
           "Subscriptions"
         ]

--- a/control-plane-api/src/models/subscription.py
+++ b/control-plane-api/src/models/subscription.py
@@ -1,4 +1,5 @@
 """Subscription SQLAlchemy model for API subscriptions"""
+
 import enum
 import uuid
 from datetime import datetime
@@ -11,6 +12,7 @@ from src.database import Base
 
 class SubscriptionStatus(enum.StrEnum):
     """Subscription status enum"""
+
     PENDING = "pending"
     ACTIVE = "active"
     SUSPENDED = "suspended"
@@ -20,17 +22,19 @@ class SubscriptionStatus(enum.StrEnum):
 
 class ProvisioningStatus(enum.StrEnum):
     """Gateway provisioning status for webMethods integration (CAB-800)"""
-    NONE = "none"                        # No provisioning needed
-    PENDING = "pending"                  # Awaiting provisioning
-    PROVISIONING = "provisioning"        # In progress
-    READY = "ready"                      # Route active in gateway
-    FAILED = "failed"                    # Provisioning failed
-    DEPROVISIONING = "deprovisioning"    # Removal in progress
-    DEPROVISIONED = "deprovisioned"      # Removed from gateway
+
+    NONE = "none"  # No provisioning needed
+    PENDING = "pending"  # Awaiting provisioning
+    PROVISIONING = "provisioning"  # In progress
+    READY = "ready"  # Route active in gateway
+    FAILED = "failed"  # Provisioning failed
+    DEPROVISIONING = "deprovisioning"  # Removal in progress
+    DEPROVISIONED = "deprovisioned"  # Removed from gateway
 
 
 class Subscription(Base):
     """Subscription model - represents an API subscription with API key"""
+
     __tablename__ = "subscriptions"
 
     # Primary key
@@ -80,9 +84,13 @@ class Subscription(Base):
     expires_at = Column(DateTime, nullable=True)
     revoked_at = Column(DateTime, nullable=True)
 
+    # TTL extension tracking (CAB-86)
+    ttl_extension_count = Column(Integer, nullable=False, default=0, server_default="0")
+    ttl_total_extended_days = Column(Integer, nullable=False, default=0, server_default="0")
+
     # Audit fields
     approved_by = Column(String(255), nullable=True)  # Admin user ID who approved
-    revoked_by = Column(String(255), nullable=True)   # Admin user ID who revoked
+    revoked_by = Column(String(255), nullable=True)  # Admin user ID who revoked
 
     # Gateway provisioning (CAB-800)
     provisioning_status = Column(
@@ -91,16 +99,16 @@ class Subscription(Base):
         default=ProvisioningStatus.NONE,
         server_default="none",
     )
-    gateway_app_id = Column(String(255), nullable=True)    # webMethods application ID
-    provisioning_error = Column(Text, nullable=True)        # Last error message
-    provisioned_at = Column(DateTime, nullable=True)        # When route was created
+    gateway_app_id = Column(String(255), nullable=True)  # webMethods application ID
+    provisioning_error = Column(Text, nullable=True)  # Last error message
+    provisioned_at = Column(DateTime, nullable=True)  # When route was created
 
     # Indexes for common queries
     __table_args__ = (
-        Index('ix_subscriptions_tenant_api', 'tenant_id', 'api_id'),
-        Index('ix_subscriptions_subscriber_status', 'subscriber_id', 'status'),
-        Index('ix_subscriptions_application_api', 'application_id', 'api_id'),
-        Index('ix_subscriptions_provisioning_status', 'provisioning_status'),
+        Index("ix_subscriptions_tenant_api", "tenant_id", "api_id"),
+        Index("ix_subscriptions_subscriber_status", "subscriber_id", "status"),
+        Index("ix_subscriptions_application_api", "application_id", "api_id"),
+        Index("ix_subscriptions_provisioning_status", "provisioning_status"),
     )
 
     def __repr__(self) -> str:

--- a/control-plane-api/src/routers/subscriptions.py
+++ b/control-plane-api/src/routers/subscriptions.py
@@ -25,9 +25,12 @@ from ..schemas.subscription import (
     SubscriptionRevoke,
     SubscriptionStatusEnum,
     SubscriptionWithRotationInfo,
+    TTLExtendRequest,
+    TTLExtendResponse,
 )
 from ..services.api_key import APIKeyService
 from ..services.email import email_service
+from ..services.kafka_service import Topics, kafka_service
 from ..services.provisioning_service import deprovision_on_revocation, provision_on_approval
 from ..services.webhook_service import (
     emit_subscription_approved,
@@ -385,6 +388,108 @@ async def get_subscription_rotation_info(
     response.has_active_grace_period = has_active_grace_period
 
     return response
+
+
+# ============== TTL Extension Endpoint (CAB-86) ==============
+
+
+MAX_TTL_EXTENSIONS = 2
+MAX_TTL_TOTAL_DAYS = 60
+
+
+@router.patch("/{subscription_id}/ttl", response_model=TTLExtendResponse)
+async def extend_subscription_ttl(
+    subscription_id: UUID,
+    request: TTLExtendRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Extend the TTL of an active subscription.
+
+    Subscription owners can extend their expiry by 7 or 14 days.
+    Limited to 2 extensions and 60 total extended days.
+    Tenant admins and cpi-admins can extend any subscription in their scope.
+    """
+    repo = SubscriptionRepository(db)
+    subscription = await repo.get_by_id(subscription_id)
+
+    if not subscription:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+
+    # Tenant access check
+    if not _has_tenant_access(user, subscription.tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    # Ownership check: subscriber OR admin roles
+    is_owner = subscription.subscriber_id == user.id
+    is_admin = "cpi-admin" in user.roles or "tenant-admin" in user.roles
+    if not is_owner and not is_admin:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    # Must be active
+    if subscription.status != SubscriptionStatus.ACTIVE:
+        raise HTTPException(status_code=409, detail="Only active subscriptions can be extended")
+
+    # Must have an expiry date
+    if subscription.expires_at is None:
+        raise HTTPException(status_code=409, detail="Subscription has no expiry date")
+
+    # Extension count limit
+    if subscription.ttl_extension_count >= MAX_TTL_EXTENSIONS:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Maximum extensions reached ({MAX_TTL_EXTENSIONS})",
+        )
+
+    # Total days limit
+    if subscription.ttl_total_extended_days + request.extend_days > MAX_TTL_TOTAL_DAYS:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Would exceed {MAX_TTL_TOTAL_DAYS}-day maximum total extension",
+        )
+
+    # Apply extension
+    from datetime import timedelta
+
+    subscription.expires_at = subscription.expires_at + timedelta(days=request.extend_days)
+    subscription.ttl_extension_count += 1
+    subscription.ttl_total_extended_days += request.extend_days
+
+    await db.flush()
+
+    logger.info(
+        f"TTL extended for subscription {subscription_id} by {request.extend_days}d "
+        f"(count={subscription.ttl_extension_count}, total={subscription.ttl_total_extended_days}d) "
+        f"by {user.email}, reason: {request.reason}"
+    )
+
+    # Kafka event
+    try:
+        await kafka_service.publish(
+            topic=Topics.RESOURCE_LIFECYCLE,
+            event_type="resource-ttl-extended",
+            tenant_id=subscription.tenant_id,
+            payload={
+                "subscription_id": str(subscription.id),
+                "extend_days": request.extend_days,
+                "reason": request.reason,
+                "new_expires_at": subscription.expires_at.isoformat(),
+                "ttl_extension_count": subscription.ttl_extension_count,
+                "ttl_total_extended_days": subscription.ttl_total_extended_days,
+            },
+            user_id=user.id,
+        )
+    except Exception as e:
+        logger.warning(f"Failed to emit resource-ttl-extended Kafka event: {e}")
+
+    return TTLExtendResponse(
+        id=subscription.id,
+        new_expires_at=subscription.expires_at,
+        ttl_extension_count=subscription.ttl_extension_count,
+        ttl_total_extended_days=subscription.ttl_total_extended_days,
+        remaining_extensions=MAX_TTL_EXTENSIONS - subscription.ttl_extension_count,
+    )
 
 
 # ============== Admin Endpoints (Control Plane) ==============

--- a/control-plane-api/src/schemas/subscription.py
+++ b/control-plane-api/src/schemas/subscription.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from enum import StrEnum
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -193,5 +194,31 @@ class SubscriptionWithRotationInfo(SubscriptionResponse):
     has_active_grace_period: bool = Field(
         default=False, description="True if old key is still valid during grace period"
     )
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# ============== TTL Extension Schemas (CAB-86) ==============
+
+
+class TTLExtendRequest(BaseModel):
+    """Schema for requesting a TTL extension on a subscription."""
+
+    extend_days: Literal[7, 14] = Field(..., description="Days to extend (7 or 14)")
+    reason: str = Field(..., min_length=1, max_length=500, description="Reason for extension")
+
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"extend_days": 7, "reason": "Need more time to complete integration testing"}}
+    )
+
+
+class TTLExtendResponse(BaseModel):
+    """Schema for TTL extension response."""
+
+    id: UUID
+    new_expires_at: datetime
+    ttl_extension_count: int
+    ttl_total_extended_days: int
+    remaining_extensions: int
 
     model_config = ConfigDict(from_attributes=True)

--- a/control-plane-api/tests/test_ttl_extension.py
+++ b/control-plane-api/tests/test_ttl_extension.py
@@ -1,0 +1,302 @@
+"""
+Tests for TTL Extension Endpoint — CAB-86
+
+Target: PATCH /v1/subscriptions/{id}/ttl
+Tests: 11 cases covering happy path, limits, auth, edge cases
+"""
+
+from datetime import datetime, timedelta
+from enum import Enum
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+
+class SubscriptionStatus(str, Enum):
+    """Mirror of src.models.subscription.SubscriptionStatus for testing."""
+
+    PENDING = "pending"
+    ACTIVE = "active"
+    SUSPENDED = "suspended"
+    REVOKED = "revoked"
+    EXPIRED = "expired"
+
+
+def _make_sub(overrides: dict | None = None) -> MagicMock:
+    """Create a mock Subscription with TTL-related fields."""
+    defaults = {
+        "id": uuid4(),
+        "application_id": "app-test-123",
+        "application_name": "Test App",
+        "subscriber_id": "tenant-admin-user-id",
+        "subscriber_email": "admin@acme.com",
+        "api_id": "api-weather-456",
+        "api_name": "Weather API",
+        "api_version": "1.0",
+        "tenant_id": "acme",
+        "plan_id": "basic",
+        "plan_name": "Basic Plan",
+        "api_key_hash": "hashed",
+        "api_key_prefix": "stoa_sk_tes",
+        "status": SubscriptionStatus.ACTIVE,
+        "status_reason": None,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+        "approved_at": datetime.utcnow(),
+        "expires_at": datetime.utcnow() + timedelta(days=30),
+        "revoked_at": None,
+        "approved_by": "admin",
+        "revoked_by": None,
+        "previous_api_key_hash": None,
+        "previous_key_expires_at": None,
+        "last_rotated_at": None,
+        "rotation_count": 0,
+        "provisioning_status": "none",
+        "gateway_app_id": None,
+        "provisioning_error": None,
+        "provisioned_at": None,
+        "consumer_id": None,
+        "ttl_extension_count": 0,
+        "ttl_total_extended_days": 0,
+    }
+    if overrides:
+        defaults.update(overrides)
+    mock = MagicMock()
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+class TestTTLExtension:
+    """Test suite for PATCH /v1/subscriptions/{id}/ttl"""
+
+    def test_extend_ttl_7_days(self, app_with_tenant_admin, mock_db_session):
+        """Happy path: extend by 7 days."""
+        sub = _make_sub()
+        original_expires = sub.expires_at
+
+        with (
+            patch("src.routers.subscriptions.SubscriptionRepository") as MockRepo,
+            patch("src.routers.subscriptions.kafka_service") as mock_kafka,
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=sub)
+            mock_kafka.publish = AsyncMock()
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.patch(
+                    f"/v1/subscriptions/{sub.id}/ttl",
+                    json={"extend_days": 7, "reason": "Need more testing time"},
+                )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["ttl_extension_count"] == 1
+            assert data["ttl_total_extended_days"] == 7
+            assert data["remaining_extensions"] == 1
+            # expires_at should be 7 days later
+            assert sub.expires_at == original_expires + timedelta(days=7)
+
+    def test_extend_ttl_14_days(self, app_with_tenant_admin, mock_db_session):
+        """Happy path: extend by 14 days."""
+        sub = _make_sub()
+
+        with (
+            patch("src.routers.subscriptions.SubscriptionRepository") as MockRepo,
+            patch("src.routers.subscriptions.kafka_service") as mock_kafka,
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=sub)
+            mock_kafka.publish = AsyncMock()
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.patch(
+                    f"/v1/subscriptions/{sub.id}/ttl",
+                    json={"extend_days": 14, "reason": "Integration testing"},
+                )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["ttl_extension_count"] == 1
+            assert data["ttl_total_extended_days"] == 14
+            assert data["remaining_extensions"] == 1
+
+    def test_extend_ttl_twice(self, app_with_tenant_admin, mock_db_session):
+        """Two extensions succeed, count reaches 2."""
+        sub = _make_sub()
+
+        with (
+            patch("src.routers.subscriptions.SubscriptionRepository") as MockRepo,
+            patch("src.routers.subscriptions.kafka_service") as mock_kafka,
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=sub)
+            mock_kafka.publish = AsyncMock()
+
+            with TestClient(app_with_tenant_admin) as client:
+                # First extension
+                resp1 = client.patch(
+                    f"/v1/subscriptions/{sub.id}/ttl",
+                    json={"extend_days": 7, "reason": "First extension"},
+                )
+                assert resp1.status_code == 200
+                assert resp1.json()["ttl_extension_count"] == 1
+
+                # Second extension
+                resp2 = client.patch(
+                    f"/v1/subscriptions/{sub.id}/ttl",
+                    json={"extend_days": 14, "reason": "Second extension"},
+                )
+                assert resp2.status_code == 200
+                data = resp2.json()
+                assert data["ttl_extension_count"] == 2
+                assert data["ttl_total_extended_days"] == 21
+                assert data["remaining_extensions"] == 0
+
+    def test_extend_ttl_max_reached(self, app_with_tenant_admin, mock_db_session):
+        """Third extension is rejected (max 2)."""
+        sub = _make_sub({"ttl_extension_count": 2, "ttl_total_extended_days": 21})
+
+        with (
+            patch("src.routers.subscriptions.SubscriptionRepository") as MockRepo,
+            patch("src.routers.subscriptions.kafka_service"),
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=sub)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.patch(
+                    f"/v1/subscriptions/{sub.id}/ttl",
+                    json={"extend_days": 7, "reason": "One more please"},
+                )
+
+            assert response.status_code == 409
+            assert "Maximum extensions reached" in response.json()["detail"]
+
+    def test_extend_ttl_total_days_exceeded(self, app_with_tenant_admin, mock_db_session):
+        """Reject when total would exceed 60-day cap."""
+        sub = _make_sub({"ttl_extension_count": 1, "ttl_total_extended_days": 50})
+
+        with (
+            patch("src.routers.subscriptions.SubscriptionRepository") as MockRepo,
+            patch("src.routers.subscriptions.kafka_service"),
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=sub)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.patch(
+                    f"/v1/subscriptions/{sub.id}/ttl",
+                    json={"extend_days": 14, "reason": "Too many days"},
+                )
+
+            assert response.status_code == 409
+            assert "60-day maximum" in response.json()["detail"]
+
+    def test_extend_ttl_not_owner(self, app_with_other_tenant, mock_db_session):
+        """Different tenant user gets 403."""
+        sub = _make_sub()  # tenant_id=acme, subscriber_id=tenant-admin-user-id
+
+        with (
+            patch("src.routers.subscriptions.SubscriptionRepository") as MockRepo,
+            patch("src.routers.subscriptions.kafka_service"),
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=sub)
+
+            with TestClient(app_with_other_tenant) as client:
+                response = client.patch(
+                    f"/v1/subscriptions/{sub.id}/ttl",
+                    json={"extend_days": 7, "reason": "Sneaky"},
+                )
+
+            assert response.status_code == 403
+
+    def test_extend_ttl_admin_override(self, app_with_cpi_admin, mock_db_session):
+        """cpi-admin can extend any subscription."""
+        sub = _make_sub({"subscriber_id": "some-other-user-id"})
+
+        with (
+            patch("src.routers.subscriptions.SubscriptionRepository") as MockRepo,
+            patch("src.routers.subscriptions.kafka_service") as mock_kafka,
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=sub)
+            mock_kafka.publish = AsyncMock()
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.patch(
+                    f"/v1/subscriptions/{sub.id}/ttl",
+                    json={"extend_days": 7, "reason": "Admin extension"},
+                )
+
+            assert response.status_code == 200
+            assert response.json()["ttl_extension_count"] == 1
+
+    def test_extend_ttl_not_found(self, app_with_tenant_admin, mock_db_session):
+        """Non-existent subscription returns 404."""
+        fake_id = uuid4()
+
+        with (
+            patch("src.routers.subscriptions.SubscriptionRepository") as MockRepo,
+            patch("src.routers.subscriptions.kafka_service"),
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=None)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.patch(
+                    f"/v1/subscriptions/{fake_id}/ttl",
+                    json={"extend_days": 7, "reason": "Not here"},
+                )
+
+            assert response.status_code == 404
+
+    def test_extend_ttl_inactive(self, app_with_tenant_admin, mock_db_session):
+        """PENDING subscription returns 409."""
+        sub = _make_sub({"status": SubscriptionStatus.PENDING})
+
+        with (
+            patch("src.routers.subscriptions.SubscriptionRepository") as MockRepo,
+            patch("src.routers.subscriptions.kafka_service"),
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=sub)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.patch(
+                    f"/v1/subscriptions/{sub.id}/ttl",
+                    json={"extend_days": 7, "reason": "Not active yet"},
+                )
+
+            assert response.status_code == 409
+            assert "Only active subscriptions" in response.json()["detail"]
+
+    def test_extend_ttl_no_expiry(self, app_with_tenant_admin, mock_db_session):
+        """Subscription without expires_at returns 409."""
+        sub = _make_sub({"expires_at": None})
+
+        with (
+            patch("src.routers.subscriptions.SubscriptionRepository") as MockRepo,
+            patch("src.routers.subscriptions.kafka_service"),
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=sub)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.patch(
+                    f"/v1/subscriptions/{sub.id}/ttl",
+                    json={"extend_days": 7, "reason": "No expiry"},
+                )
+
+            assert response.status_code == 409
+            assert "no expiry date" in response.json()["detail"]
+
+    def test_extend_ttl_invalid_days(self, app_with_tenant_admin, mock_db_session):
+        """extend_days=30 is rejected by Pydantic Literal validation (422)."""
+        sub = _make_sub()
+
+        with (
+            patch("src.routers.subscriptions.SubscriptionRepository") as MockRepo,
+            patch("src.routers.subscriptions.kafka_service"),
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=sub)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.patch(
+                    f"/v1/subscriptions/{sub.id}/ttl",
+                    json={"extend_days": 30, "reason": "Invalid days"},
+                )
+
+            assert response.status_code == 422


### PR DESCRIPTION
## Summary
- Add `PATCH /v1/subscriptions/{id}/ttl` endpoint for self-service subscription TTL extension
- Subscription owners can extend expiry by 7 or 14 days, capped at 2 extensions / 60 total days
- Includes Alembic migration (035), model columns, Pydantic schemas, Kafka event, and OpenAPI snapshot update

## Changes
- **Migration**: `035_add_ttl_extension_fields.py` — adds `ttl_extension_count` and `ttl_total_extended_days` columns
- **Model**: `subscription.py` — 2 new Integer columns with server_default="0"
- **Schema**: `TTLExtendRequest` (Literal[7, 14]) + `TTLExtendResponse`
- **Router**: PATCH endpoint with auth, tenant isolation, ownership/admin checks, business rule enforcement
- **Tests**: 11 unit tests covering happy path, limits, auth, edge cases
- **Snapshot**: OpenAPI contract updated

## Business Rules
- Only ACTIVE subscriptions with an `expires_at` can be extended
- Max 2 extensions per subscription
- Max 60 total extended days
- Owner or cpi-admin/tenant-admin can extend
- Publishes `resource-ttl-extended` Kafka event

## Test plan
- [x] 11/11 unit tests pass (`pytest tests/test_ttl_extension.py -v`)
- [x] OpenAPI contract tests pass (snapshot updated)
- [x] Coverage 73.67% (threshold: 53%)
- [x] Ruff + Black clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>