### PR TITLE
docs: update state files — CAB-1400 done

### DIFF
--- a/memory.md
+++ b/memory.md
@@ -1,6 +1,6 @@
 # STOA Memory
 
-> Derniere MAJ: 2026-02-22 (CAB-1399 Gateway API Foundation — PR #785 merged)
+> Derniere MAJ: 2026-02-22 (CAB-1400 HTTPRoute Migration — PR #791 merged)
 
 ## ✅ DONE
 
@@ -8,6 +8,7 @@
 > Key milestones: Docs v1.0 (107 pts), Rust Gateway (50 pts), ArgoCD+AWX (34 pts), UAC (34 pts)
 
 ### Cycle 9 (Feb 22+)
+- ✅ CAB-1400 HTTPRoute Migration — PR #791 (9 routes on new LB 92.222.226.6, all validated, DNS cutover pending)
 - ✅ CAB-1399 Gateway API Foundation — PR #785 (CRDs v1.4.1, NGF v2.4.2, GatewayClass accepted, dual-stack validated)
 - ✅ CAB-1301 rescoped: Cilium (34 pts) → Gateway API + NetworkPolicy (21 pts) + Cilium deferred (13 pts)
 - ✅ CAB-1398 Phase 3 Slack Threading + Reactions — PR #781 (`SLACK_THREAD_TS` env var fallback, `_react_slack()`, L1/L3/L3.5 reactions)

--- a/plan.md
+++ b/plan.md
@@ -165,7 +165,7 @@
   - **Phase 1** (parallel) [owner: —]
     - [x] CAB-1399 [infra] Gateway API CRDs + NGINX Gateway Fabric (8 pts) — PR #785
   - **Phase 2** (after Phase 1) [owner: —]
-    - [ ] CAB-1400 [infra] Ingress → HTTPRoute Migration — 9 resources (8 pts)
+    - [x] CAB-1400 [infra] Ingress → HTTPRoute Migration — 9 resources (8 pts) — PR #791
   - **Phase 3** (after Phase 2) [owner: —]
     - [ ] CAB-1401 [infra] Default-Deny NetworkPolicy per Namespace (5 pts)
 - CAB-1402: [infra] Cilium CNI Foundation — Deferred (13 pts, blocked: MKS Standard GA)


### PR DESCRIPTION
## Summary
- Mark CAB-1400 (HTTPRoute Migration) as done in plan.md and memory.md
- PR #791 merged, 9 routes validated on new LB IP (<OVH_LB_NEW_IP>)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
