### PR TITLE
chore(ci): deduplicate model routing + Ship/Show/Ask tables (CAB-1367 Phase 2)

### DIFF
--- a/.claude/rules/ai-factory.md
+++ b/.claude/rules/ai-factory.md
@@ -33,28 +33,10 @@ Full reference: `.claude/rules/mcp-integrations.md`
 
 **Rule**: MCP for **state changes**, local files for **context**. Batch reads, minimize writes.
 
-## Cost Awareness — CI Model Routing (Active)
+## Cost Awareness
 
-### CI Workflow Tiers
-
-| Tier | Model | $/MTok (in/out) | Invocations | Use Case |
-|------|-------|-----------------|-------------|----------|
-| 1 | haiku-4-5 | $1/$5 | 6 | Triage, digest, capacity, backlog, review, scan |
-| 2 | sonnet-4-5 | $3/$15 | 7 | Code gen, CI health, audit, interactive, implement, self-improve |
-| 3 | opus-4-6 | $5/$25 | 3 | Council gate (issue-to-pr, linear-dispatch, multi-agent) |
-
-Kill-switch: set repo variable `CLAUDE_DEFAULT_MODEL=claude-sonnet-4-5-20250929` to revert all tiers to Sonnet.
-
-### Local / Subagent Tiers
-
-| Task Type | Model | Rationale |
-|-----------|-------|-----------|
-| Code exploration, search, analysis | **haiku** | Fast, cheap, sufficient for grep/glob |
-| Subagent work (tests, reviews, docs) | **sonnet** | Good balance of quality and cost |
-| Architecture decisions, security review | **opus** | Critical decisions need best reasoning |
-| Plan review, implementation | **opus** (inline) | Main conversation, full context needed |
-
-**Rules**: Never opus for subagents. Prefer haiku for `Explore`. Max **3-4 subagents active**.
+CI model routing: see `autonomous-factory.md` — "H24 Scaling" section.
+Local/subagent model selection: see `cost-guardrails.md`.
 
 ## Plan Structure Standard
 

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -29,15 +29,7 @@ When the user validates a plan ("Go") or asks to implement a feature/fix, Claude
 
 ## Ship / Show / Ask
 
-Decide the PR mode **before starting work**:
-
-| Mode | When | Review | Examples |
-|------|------|--------|----------|
-| **Ship** | Zero-risk, reversible | None — merge immediately | Typo fix, docs update, dependency bump, `.claude/` config |
-| **Show** | Low-risk, good for team awareness | Async — merge then review | Refactor, test addition, style fix, non-breaking enhancement |
-| **Ask** | Needs review before merge | Blocking — wait for human | New feature, security change, breaking API, infra/k8s, DB migration |
-
-Claude defaults to **Ship** unless the change matches **Ask** criteria. User can override: "make this an Ask PR" or "just ship it".
+See `workflow-essentials.md` for the full 12-type decision matrix. Claude defaults to **Ship** unless the change matches **Ask** criteria. User can override: "make this an Ask PR" or "just ship it".
 
 ### Ship mode (autonomous)
 ```


### PR DESCRIPTION
## Summary
- Remove duplicated "Cost Awareness — CI Model Routing" section from `ai-factory.md` → reference `autonomous-factory.md` + `cost-guardrails.md`
- Remove duplicated Ship/Show/Ask 3-row table from `git-workflow.md` → reference `workflow-essentials.md` (12-type decision matrix)
- Keep git-specific lifecycle flows (Ship/Show/Ask modes) in `git-workflow.md`

**Savings**: ~1,445 bytes (-985 `ai-factory.md`, -460 `git-workflow.md`)

## Test plan
- [x] Both files read cleanly after edit
- [x] All references point to existing files
- [x] `workflow-essentials.md` is the only unscoped file > 5K (documented exception)
- [x] No behavioral change — all information preserved in source-of-truth files

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)