### PR TITLE
feat(api): wire UAC gateway dispatch in enable_binding (Gap #1)

### DIFF
--- a/control-plane-api/src/adapters/apigee/adapter.py
+++ b/control-plane-api/src/adapters/apigee/adapter.py
@@ -236,3 +236,7 @@ class ApigeeGatewayAdapter(GatewayAdapterInterface):
     async def export_archive(self, auth_token: str | None = None) -> bytes:
         """Not supported."""
         return b""
+
+    async def deploy_contract(self, contract_spec: dict, auth_token: str | None = None) -> AdapterResult:
+        """Not supported."""
+        return AdapterResult(success=False, error="Not supported by Apigee adapter")

--- a/control-plane-api/src/adapters/gateway_adapter_interface.py
+++ b/control-plane-api/src/adapters/gateway_adapter_interface.py
@@ -180,3 +180,16 @@ class GatewayAdapterInterface(ABC):
     ) -> bytes:
         """Export full gateway state as a portable archive (ZIP)."""
         ...
+
+    # --- UAC Contract Deployment ---
+
+    async def deploy_contract(
+        self, contract_spec: dict, auth_token: str | None = None
+    ) -> AdapterResult:
+        """Deploy a UAC contract to the gateway.
+
+        Optional method — adapters that do not support UAC contracts return a
+        non-fatal AdapterResult(success=False).  Only STOA-type adapters provide
+        a real implementation.
+        """
+        return AdapterResult(success=False, error="deploy_contract not supported by this adapter")

--- a/control-plane-api/src/adapters/gravitee/adapter.py
+++ b/control-plane-api/src/adapters/gravitee/adapter.py
@@ -402,6 +402,9 @@ class GraviteeGatewayAdapter(GatewayAdapterInterface):
     async def export_archive(self, auth_token: str | None = None) -> bytes:
         return b""
 
+    async def deploy_contract(self, contract_spec: dict, auth_token: str | None = None) -> AdapterResult:
+        return AdapterResult(success=False, error=_NOT_SUPPORTED)
+
     # --- Internal helpers ---
 
     def _auth_headers(self) -> dict:

--- a/control-plane-api/src/adapters/kong/adapter.py
+++ b/control-plane-api/src/adapters/kong/adapter.py
@@ -315,6 +315,9 @@ class KongGatewayAdapter(GatewayAdapterInterface):
     async def export_archive(self, auth_token: str | None = None) -> bytes:
         return b""
 
+    async def deploy_contract(self, contract_spec: dict, auth_token: str | None = None) -> AdapterResult:
+        return AdapterResult(success=False, error=_NOT_SUPPORTED)
+
     # --- Internal helpers ---
 
     def _auth_headers(self) -> dict:

--- a/control-plane-api/src/adapters/webmethods/adapter.py
+++ b/control-plane-api/src/adapters/webmethods/adapter.py
@@ -299,3 +299,6 @@ class WebMethodsGatewayAdapter(GatewayAdapterInterface):
             )
             response.raise_for_status()
             return response.content
+
+    async def deploy_contract(self, contract_spec: dict, auth_token: str | None = None) -> AdapterResult:
+        return AdapterResult(success=False, error="Not supported by webMethods adapter")

--- a/control-plane-api/src/routers/contracts.py
+++ b/control-plane-api/src/routers/contracts.py
@@ -9,14 +9,16 @@ import uuid
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.adapters.registry import AdapterRegistry
 from src.auth.dependencies import User, get_current_user
 from src.config import settings
 from src.database import get_db
 from src.logging_config import get_logger
 from src.models.contract import Contract, ProtocolBinding, ProtocolType
+from src.models.gateway_instance import GatewayInstance, GatewayInstanceStatus, GatewayType
 from src.schemas.contract import (
     BindingsListResponse,
     ContractCreate,
@@ -514,6 +516,60 @@ async def enable_binding(
     binding.generation_error = None
 
     await db.flush()
+
+    # --- Best-effort UAC gateway dispatch ---
+    # Deploy the contract to all online STOA gateways.  Failures are non-blocking:
+    # the binding is already committed to the DB; generation_error stores the reason.
+    _stoa_types = [
+        GatewayType.STOA,
+        GatewayType.STOA_EDGE_MCP,
+        GatewayType.STOA_SIDECAR,
+        GatewayType.STOA_PROXY,
+        GatewayType.STOA_SHADOW,
+    ]
+    gw_result = await db.execute(
+        select(GatewayInstance).where(
+            and_(
+                GatewayInstance.gateway_type.in_(_stoa_types),
+                GatewayInstance.status == GatewayInstanceStatus.ONLINE,
+                or_(
+                    GatewayInstance.tenant_id == contract.tenant_id,
+                    GatewayInstance.tenant_id.is_(None),
+                ),
+            )
+        )
+    )
+    gateways = gw_result.scalars().all()
+
+    contract_spec = {
+        "name": contract.name,
+        "version": contract.version,
+        "tenant_id": str(contract.tenant_id),
+        "endpoints": [],
+    }
+
+    dispatch_errors: list[str] = []
+    for gw in gateways:
+        try:
+            adapter = AdapterRegistry.create(
+                gw.gateway_type.value,
+                config={"base_url": gw.base_url, "auth_config": gw.auth_config},
+            )
+            await adapter.connect()
+            result = await adapter.deploy_contract(contract_spec)
+            if not result.success:
+                dispatch_errors.append(f"{gw.name}: {result.error}")
+        except Exception as exc:
+            dispatch_errors.append(f"{gw.name}: {exc}")
+
+    if dispatch_errors:
+        binding.generation_error = "; ".join(dispatch_errors)
+        logger.warning(
+            "UAC gateway dispatch partial failure",
+            contract_id=str(contract_id),
+            errors=dispatch_errors,
+        )
+    # --- end gateway dispatch ---
 
     logger.info(
         "Protocol binding enabled",

--- a/control-plane-api/tests/test_contracts.py
+++ b/control-plane-api/tests/test_contracts.py
@@ -347,6 +347,123 @@ class TestContractsRouter:
         assert response.status_code == 409
         assert "already enabled" in response.json()["detail"]
 
+    def test_enable_binding_dispatches_to_stoa_gateway(
+        self, app_with_tenant_admin, mock_db_session, sample_contract_data
+    ):
+        """enable_binding calls deploy_contract on online STOA gateways (CAB-Gap1)."""
+        mock_contract = self._create_mock_contract(sample_contract_data)
+        mock_binding = self._create_mock_binding(
+            sample_contract_data["id"],
+            ProtocolType.MCP,
+            enabled=False,
+        )
+
+        mock_contract_result = MagicMock()
+        mock_contract_result.scalar_one_or_none.return_value = mock_contract
+
+        mock_binding_result = MagicMock()
+        mock_binding_result.scalar_one_or_none.return_value = mock_binding
+
+        mock_gw = MagicMock()
+        mock_gw.name = "stoa-k8s"
+        mock_gw.gateway_type.value = "stoa"
+        mock_gw.base_url = "http://stoa-gateway:8080"
+        mock_gw.auth_config = {}
+        mock_gw_result = MagicMock()
+        mock_gw_result.scalars.return_value.all.return_value = [mock_gw]
+
+        call_count = [0]
+
+        async def mock_execute(query):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return mock_contract_result
+            elif call_count[0] == 2:
+                return mock_binding_result
+            else:
+                return mock_gw_result
+
+        mock_db_session.execute = AsyncMock(side_effect=mock_execute)
+
+        mock_adapter = MagicMock()
+        mock_adapter.connect = AsyncMock()
+        mock_dispatch_result = MagicMock()
+        mock_dispatch_result.success = True
+        mock_adapter.deploy_contract = AsyncMock(return_value=mock_dispatch_result)
+
+        with patch("src.routers.contracts.AdapterRegistry") as mock_registry:
+            mock_registry.create.return_value = mock_adapter
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.post(
+                    f"/v1/contracts/{sample_contract_data['id']}/bindings",
+                    json={"protocol": "mcp"},
+                )
+
+        assert response.status_code == 200
+        mock_adapter.deploy_contract.assert_called_once()
+        call_args = mock_adapter.deploy_contract.call_args[0][0]
+        assert call_args["name"] == sample_contract_data["name"]
+        assert call_args["endpoints"] == []
+
+    def test_enable_binding_gateway_down_graceful_degradation(
+        self, app_with_tenant_admin, mock_db_session, sample_contract_data
+    ):
+        """Gateway dispatch failure does not block 200 — generation_error is set (CAB-Gap1)."""
+        mock_contract = self._create_mock_contract(sample_contract_data)
+        mock_binding = self._create_mock_binding(
+            sample_contract_data["id"],
+            ProtocolType.MCP,
+            enabled=False,
+        )
+
+        mock_contract_result = MagicMock()
+        mock_contract_result.scalar_one_or_none.return_value = mock_contract
+
+        mock_binding_result = MagicMock()
+        mock_binding_result.scalar_one_or_none.return_value = mock_binding
+
+        mock_gw = MagicMock()
+        mock_gw.name = "stoa-k8s"
+        mock_gw.gateway_type.value = "stoa"
+        mock_gw.base_url = "http://stoa-gateway:8080"
+        mock_gw.auth_config = {}
+        mock_gw_result = MagicMock()
+        mock_gw_result.scalars.return_value.all.return_value = [mock_gw]
+
+        call_count = [0]
+
+        async def mock_execute(query):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return mock_contract_result
+            elif call_count[0] == 2:
+                return mock_binding_result
+            else:
+                return mock_gw_result
+
+        mock_db_session.execute = AsyncMock(side_effect=mock_execute)
+
+        mock_adapter = MagicMock()
+        mock_adapter.connect = AsyncMock()
+        mock_fail_result = MagicMock()
+        mock_fail_result.success = False
+        mock_fail_result.error = "connection refused"
+        mock_adapter.deploy_contract = AsyncMock(return_value=mock_fail_result)
+
+        with patch("src.routers.contracts.AdapterRegistry") as mock_registry:
+            mock_registry.create.return_value = mock_adapter
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.post(
+                    f"/v1/contracts/{sample_contract_data['id']}/bindings",
+                    json={"protocol": "mcp"},
+                )
+
+        # Binding is still returned successfully — dispatch failure is non-blocking
+        assert response.status_code == 200
+        assert response.json()["status"] == "active"
+        # generation_error was set on the binding object
+        assert mock_binding.generation_error == "stoa-k8s: connection refused"
+
     # ============== Disable Binding Tests ==============
 
     def test_disable_binding_success(


### PR DESCRIPTION
## Summary

- `deploy_contract()` ajouté comme méthode optionnelle sur `GatewayAdapterInterface` (non-abstractmethod — fallback `success=False` intégré pour tous les adaptateurs qui ne supportent pas encore UAC)
- No-ops sur Kong, Gravitee, webMethods, Apigee
- `enable_binding` cable le dispatch best-effort vers tous les gateways STOA online (`stoa`, `stoa_edge_mcp`, `stoa_sidecar`, `stoa_proxy`, `stoa_shadow`) — les erreurs sont stockées dans `binding.generation_error`, jamais bloquantes
- 2 nouveaux tests : dispatch success + gateway down graceful degradation

## Test plan

- [x] 24/24 tests verts localement
- [x] ruff lint clean
- [x] Option A validée sur staging : stoa-gateway accepte `endpoints: []` avec HTTP 201

## Demo path

`enable_binding` (MCP) → stoa-gateway `/admin/contracts` → Grafana montre `routes_generated: 0` (pre-demo) → "Define Once, Expose Everywhere" demonstrable

🤖 Generated with [Claude Code](https://claude.com/claude-code)