### PR TITLE
docs: fix state drift — CAB-1398 + CAB-86 marked Done

### DIFF
--- a/memory.md
+++ b/memory.md
@@ -1,6 +1,6 @@
 # STOA Memory
 
-> Derniere MAJ: 2026-02-22 (CAB-1301 MEGA complete — all 3 phases done)
+> Derniere MAJ: 2026-02-22 (state drift fix: CAB-1398 + CAB-86 marked Done)
 
 ## ✅ DONE
 
@@ -11,10 +11,12 @@
 - ✅ Gap #5 CP API Prometheus scraping — PRs #788, #793, #799
   - ServiceMonitor (Helm), fix generate_latest(REGISTRY), NetworkPolicies port 8000
   - Prometheus targets: 2/2 health: up ✅
+- ✅ CAB-1391 [MEGA] Migration Guide Expansion (13 pts) — stoa-docs PR #68 (Layer7 guide + hub), stoa-web PR #10 (llms.txt)
 - ✅ CAB-1301 [MEGA] Gateway API + NetworkPolicy (21 pts) — ALL 3 PHASES DONE
   - P1: CRDs + NGF (PR #785), P2: HTTPRoutes + DNS cutover (PR #791), P3: NetworkPolicies (PR #797)
   - New LB: 92.222.226.6, 30 NetworkPolicies, 9 HTTPRoutes, 8 DNS records updated
-- ✅ CAB-1398 Phase 3 Slack Threading + Reactions — PR #781 (`SLACK_THREAD_TS` env var fallback, `_react_slack()`, L1/L3/L3.5 reactions)
+- ✅ CAB-1398 [MEGA] AI Factory Slack Upgrade + Dispatch Gap Fixes (26 pts) — ALL 4 PHASES DONE
+  - P1: Dispatch fixes (PR #768), P2: Bot API dual-path (PR #775), P3: Threading+Reactions (PR #781), P4: /stoa+gaps (PRs #792, #795)
 - ✅ CAB-86 TTL Extension — PR #780 (PATCH /v1/subscriptions/{id}/ttl, migration 035, 11 tests, +616 LOC)
 - ✅ AI Factory Slack Bot threading — PR #775 (Bot API dual-path, n8n sequential pipeline, thread_ts propagation)
 - ✅ Promote-to-prod workflow — PR #771 (reusable-promote.yml + promote-to-prod.yml + runbook)
@@ -37,7 +39,6 @@ CAB-802: Dry Run + Script + Video Backup (3 pts) — HUMAN ONLY
 
 ## 📋 NEXT
 
-CAB-1398: [MEGA] AI Factory Slack Upgrade + Dispatch Gap Fixes (26 pts, P2) — Phase 3 DONE (PR #781)
 CAB-1132: Business Model Validation — Post Demo (8 pts, P1)
 CAB-1126: Demo Video (8 pts, P2)
 CAB-1125: Video Punchline AI Factory (8 pts, P2)

--- a/plan.md
+++ b/plan.md
@@ -95,7 +95,7 @@
 
 ## Cycle 9 (Feb 23–Mar 1) — CURRENT
 
-**Scope**: 68 pts (committed) + 700+ pts backlog | **Done**: 5 pts
+**Scope**: 68 pts (committed) + 700+ pts backlog | **Done**: 31 pts
 **Theme**: Post-Demo + Product Roadmap + Community Content
 
 ### In Progress
@@ -104,9 +104,13 @@
   - ✅ demo-dry-run.sh: 8 acts, 23 checks, GO/NO-GO (PRs #456, #463, #469)
   - ✅ Production validated: 23/23 PASS, GO in 5s
   - [ ] Repetitions + video backup (human-only)
-- [~] CAB-86: TTL Extension — Self-Service (5 pts)
-- [~] CAB-1398: [MEGA] AI Factory Slack Upgrade + Dispatch Gap Fixes (26 pts, P2)
+### Done (3)
+- [x] CAB-86: TTL Extension — Self-Service (5 pts) — PR #780
+- [x] CAB-1398: [MEGA] AI Factory Slack Upgrade + Dispatch Gap Fixes (26 pts, P2) — PRs #768, #775, #781, #792, #795
+  - [x] Phase 1: Dispatch Fixes — PR #768
+  - [x] Phase 2: Slack Bot API dual-path — PR #775
   - [x] Phase 3: Slack Threading + Reactions — PR #781
+  - [x] Phase 4: /stoa slash command + gap fixes — PRs #792, #795
 
 ### Todo
 - [ ] CAB-1132: Business Model Validation — Post Demo 17 Mars (8 pts, P1)
@@ -146,7 +150,7 @@
 - CAB-1394: [MEGA] SaaS Playbook Series (13 pts)
 - CAB-1393: [MEGA] Developer Onboarding Content (21 pts)
 - CAB-1392: [MEGA] Security & MCP Deep-Dive Content (21 pts)
-- CAB-1391: [MEGA] Migration Guide Expansion — Axway + WSO2 (13 pts)
+- [x] CAB-1391: [MEGA] Migration Guide Expansion — Axway, WSO2, Layer7 (13 pts) — stoa-docs PR #68 + stoa-web PR #10
 - CAB-1329: [MEGA] Demo Content Library — 8 Themes (34 pts)
 - CAB-1327: [MEGA] Docs as Code — RAG Chatbot (21 pts)
 


### PR DESCRIPTION
## Summary
- Mark CAB-1398 [MEGA] as `[x]` in plan.md with all 4 phases (was `[~]` with only Phase 3)
- Mark CAB-86 as `[x]` in plan.md (was `[~]`)
- Move CAB-1398 from NEXT to DONE in memory.md
- Update Cycle 9 done count: 5 → 31 pts

Root cause: PR #796 was a no-op squash merge (state files had diverged by the time it merged).

## Test plan
- [x] State lint: no DONE items in active sections
- [x] Cross-file parity: plan.md `[x]` ↔ memory.md `✅ DONE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)