### PR TITLE
docs(ci): update model IDs in autonomous-factory.md to 4.6

### DIFF
--- a/.claude/rules/autonomous-factory.md
+++ b/.claude/rules/autonomous-factory.md
@@ -78,9 +78,9 @@ All implementation workflows use `scripts/ai-ops/model-router.sh` for cost-optim
 
 | Estimate | Mode | Model | Max Turns | Est. Cost/Ticket |
 |----------|------|-------|-----------|-----------------|
-| ≤3 pts | Ship | Sonnet | 25 | ~$7 |
-| ≤8 pts | Any | Sonnet | 40 | ~$12 |
-| >8 pts | Any | Sonnet | 60 | ~$16.50 |
+| ≤3 pts | Ship | `claude-sonnet-4-6` | 25 | ~$7 |
+| ≤8 pts | Any | `claude-sonnet-4-6` | 40 | ~$12 |
+| >8 pts | Any | `claude-sonnet-4-6` | 60 | ~$16.50 |
 
 Weighted average: ~$11/ticket. Haiku dropped from implementation routing (PR #737) — lacks capacity for branch creation, code gen, and PR workflows.
 
@@ -122,16 +122,16 @@ Adjust `AUTOPILOT_DAILY_MAX` via GitHub repo variables — no code change needed
 
 | Trigger | Stage | Council Mode | Model | Threshold | Approval |
 |---------|-------|-------------|-------|-----------|----------|
-| Issue labeled `claude-implement` | Stage 1 | Full (4 personas, detailed) | Sonnet | >= 8.0 | `/go` → Stage 2 |
-| `/go` on Stage 1 issue | Stage 2 | Full (4 personas, plan-focused) | Sonnet | >= 8.0 | `/go-plan` → implement |
+| Issue labeled `claude-implement` | Stage 1 | Full (4 personas, detailed) | `claude-sonnet-4-6` | >= 8.0 | `/go` → Stage 2 |
+| `/go` on Stage 1 issue | Stage 2 | Full (4 personas, plan-focused) | `claude-sonnet-4-6` | >= 8.0 | `/go-plan` → implement |
 | `/go` on Stage 1 (Ship ≤5pt) | Fast Path | Skipped | — | — | Auto → implement |
-| Linear ticket → In Progress | Stage 1 | Full (4 personas, detailed) | Sonnet | >= 8.0 | `/go` → Stage 2 |
-| `/go` on council-review issue | Stage 2 | Full (4 personas, plan-focused) | Sonnet | >= 8.0 | `/go-plan` → implement |
+| Linear ticket → In Progress | Stage 1 | Full (4 personas, detailed) | `claude-sonnet-4-6` | >= 8.0 | `/go` → Stage 2 |
+| `/go` on council-review issue | Stage 2 | Full (4 personas, plan-focused) | `claude-sonnet-4-6` | >= 8.0 | `/go-plan` → implement |
 | Linear dispatch (Ship ≤5pt) | Fast Path | Skipped | — | — | Auto → implement |
-| Multi-agent batch dispatch | Stage 1 only | Quick (4 personas, scores only) | Sonnet | >= 8.0 | `/go-batch` |
-| Autopilot backlog scan | Stage 1 only | Quick (4 personas, scores only) | Haiku | >= 8.0 | Slack → `/go` |
+| Multi-agent batch dispatch | Stage 1 only | Quick (4 personas, scores only) | `claude-sonnet-4-6` | >= 8.0 | `/go-batch` |
+| Autopilot backlog scan | Stage 1 only | Quick (4 personas, scores only) | `claude-haiku-4-5-20251001` | >= 8.0 | Slack → `/go` |
 | Scheduled CI auto-fix | Skip | — | — | N/A | Auto |
-| Self-improvement proposal | Stage 1 only | Full (analysis, no code) | Sonnet | >= 8.0 | Label `claude-implement` |
+| Self-improvement proposal | Stage 1 only | Full (analysis, no code) | `claude-sonnet-4-6` | >= 8.0 | Label `claude-implement` |
 | PR auto-review | Skip | — | — | N/A | Auto |
 | Daily triage | Skip | — | — | N/A | Auto |
 
@@ -386,13 +386,13 @@ The `repository_dispatch` `client_payload` includes phase-aware fields:
 | Velocity tracking | Autopilot scan increments `AUTOPILOT_TODAY_COUNT` after creating issues | Prevents exceeding daily cap |
 | Precise matching | Ticket ID regex with word boundaries | Prevents CAB-1 matching CAB-123 |
 | Max turns per agent | 20/25/40/60 (tiered by estimate + mode) | Prevent runaway costs |
-| Default model | Sonnet (code gen), Haiku (council scan) | Right model per task |
+| Default model | `claude-sonnet-4-6` (code gen), `claude-haiku-4-5-20251001` (council scan) | Right model per task |
 | Council threshold | 8.0 (all levels) | Harmonized — no per-level exceptions |
 | Max parallel agents | 3 | Cost caps at ~3x single agent |
 | Timeout per job | 15-60 min | Hard stop on runaway jobs |
 | Skip Council S2 for | Ship-mode ≤5 pts | Avoid unnecessary plan validation |
 | Schedule frequency | Daily/weekly (not hourly) | Control API usage |
-| Kill-switch model | `CLAUDE_DEFAULT_MODEL` repo var | Revert all tiers to Sonnet |
+| Kill-switch model | `CLAUDE_DEFAULT_MODEL` repo var | Revert all tiers to `claude-sonnet-4-6` |
 
 ## Security
 


### PR DESCRIPTION
## Summary
- Replace generic model aliases with exact version strings in `autonomous-factory.md`
- H24 Scaling table, Council When table, Cost Control section
- `Sonnet` → `claude-sonnet-4-6`
- `Haiku` → `claude-haiku-4-5-20251001` (no 4.6 available)

Follows PR #804 + #805 (full model ID migration to 4.6).

## Test plan
- [ ] 3 required security checks green (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)