### PR TITLE
docs: decompose CAB-374 — Vercel-Style DX Phase 16a (4 sub-issues)

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -172,7 +172,13 @@
 - CAB-1320: [MEGA] Repo Consolidation (21 pts)
 - CAB-1312: [MEGA] GTM Docs + Community Channels (21 pts)
 - CAB-1123: Prompt Cache for HEGEMON (21 pts)
-- CAB-374: [MEGA] Vercel-Style DX (34 pts)
+- [~] CAB-374: [MEGA] Vercel-Style DX (34 pts) — Council 8.25/10 ✅ — 2 phases
+  - **Phase 1** (parallel) [owner: —]
+    - [ ] CAB-1410 [cp-api] stoa.yaml spec + deployment lifecycle API (13 pts)
+    - [ ] CAB-1411 [docs] stoa.yaml spec v1.0 reference + CLI guide (5 pts)
+  - **Phase 2** (after Phase 1) [owner: —]
+    - [ ] CAB-1412 [stoactl] Audit + complete CLI commands (13 pts)
+    - [ ] CAB-1413 [cp-api] Notification Service — Kafka → Slack (3 pts)
 
 ### Backlog — Legacy (parked)
 


### PR DESCRIPTION
## Summary

- Ran `/council CAB-374` (Vercel-Style DX MEGA, 34 pts) → **8.25/10 Go**
- Ran `/decompose CAB-374` → 4 component-scoped sub-issues, 2-phase DAG
- Updated plan.md with phase structure + fill-cycle scope update (76 → 118 pts, 6 promoted quick wins)

## Linear Changes

### Council (Stage 1)
- CAB-374: `council:ticket-go` label applied (8.25/10)
- 5 adjustments scoped to Phase 16a only (Preview Envs, Console WebSocket deferred to C10+)

### Sub-issues created
| Ticket | Component | Phase | Points | Parallel? |
|--------|-----------|-------|--------|-----------|
| CAB-1410 | [cp-api] stoa.yaml spec + deployment lifecycle API | 1 | 13 | Yes |
| CAB-1411 | [docs] stoa.yaml spec v1.0 reference + CLI guide | 1 | 5 | Yes |
| CAB-1412 | [stoactl] Audit + complete CLI commands | 2 | 13 | After CAB-1410 |
| CAB-1413 | [cp-api] Notification Service — Kafka → Slack | 2 | 3 | After CAB-1410 |

Claim file initialized: `.claude/claims/CAB-374.json` (machine-local, gitignored)

## Test plan
- [ ] plan.md renders correctly (CAB-374 phase structure visible)
- [ ] Linear sub-issues exist (CAB-1410 through CAB-1413)
- [ ] No broken CI (docs-only change, only security-scan.yml runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)