### PR TITLE
fix(gateway): remove duplicate default_token_budget_* functions (CAB-1337)

### DIFF
--- a/stoa-gateway/src/config.rs
+++ b/stoa-gateway/src/config.rs
@@ -376,12 +376,6 @@ pub struct Config {
     pub federation_cache_max_entries: u64,
 }
 
-fn default_token_budget_limit() -> u64 {
-    500_000
-}
-fn default_token_budget_window_hours() -> u64 {
-    1
-}
 fn default_port() -> u16 {
     8080
 }


### PR DESCRIPTION
## Summary

- **`stoa-gateway/src/config.rs`**: Removes 6-line duplicate `default_token_budget_limit()` and `default_token_budget_window_hours()` functions introduced during CAB-1337 Phase 2 merge (PR #813). The duplicate definitions at L379-L384 collide with the canonical definitions at L588-L598, causing E0428 compilation errors on the gateway CI.

## Root Cause

PR #813 (CAB-1337 Phase 2) was created from a branch that had the functions defined once. During the `update-branch` (merge with main), a conflict resolution introduced them a second time. The `fix` commit on the PR branch targeted a different set of issues (L7e373f15) but the duplicate pattern still reached main.

## Test plan
- [ ] `cargo check` — zero errors
- [ ] `cargo fmt --check` — no formatting changes
- [ ] `cargo clippy` — zero warnings
- [ ] CI green (fmt + clippy + tests)

## Linear
CAB-1337 — AI Guardrails V2 regression fix