### PR TITLE
fix(ci): add actions:read permission to self-improve workflow

### DIFF
--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -27,6 +27,7 @@ permissions:
   pull-requests: write
   issues: write
   id-token: write
+  actions: read
 
 jobs:
   self-improve:


### PR DESCRIPTION
## Summary
- `gh run list` in the **Collect context** step requires `actions: read` permission
- Without it, the step fails with exit 1 (403 from GitHub API), blocking the entire self-improve job
- Discovered during manual L4 trigger on 2026-02-22

## Test plan
- [x] Verified fix by triggering `workflow_dispatch` from the patched branch — `Collect context` step passed
- [x] Run #22282926289 currently in progress (batch processing phase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)