### PR TITLE
fix(gateway): replace floor_char_boundary with stable is_char_boundary scan

### DIFF
--- a/stoa-gateway/src/mcp/handlers.rs
+++ b/stoa-gateway/src/mcp/handlers.rs
@@ -689,7 +689,13 @@ pub async fn mcp_tools_call(
                 // Truncate to configured max bytes (CAB-1365 context size limit)
                 let max = state.config.skill_context_max_bytes;
                 if merged.len() > max {
-                    let truncated = &merged[..merged.floor_char_boundary(max)];
+                    // Stable equivalent of floor_char_boundary(max): scan back for a valid
+                    // UTF-8 char boundary at or before `max` bytes.
+                    let idx = (0..=max)
+                        .rev()
+                        .find(|&i| merged.is_char_boundary(i))
+                        .unwrap_or(0);
+                    let truncated = &merged[..idx];
                     Some(truncated.to_string())
                 } else {
                     Some(merged)


### PR DESCRIPTION
## Summary
- `floor_char_boundary` is gated behind the `round_char_boundary` unstable feature in `rust:1.88`
- Docker build for `ade043ee` failed: `error[E0658]: use of unstable library feature 'round_char_boundary'`
- Replace with a backward-compatible scan using `str::is_char_boundary` (stable since Rust 1.0)
- Semantically identical: finds the largest valid UTF-8 byte index ≤ max

## Test plan
- [x] `cargo check` passes locally (Rust 1.93)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] CI Docker build passes with `rust:1.88-bookworm`

## Root cause
`CAB-1365` introduced `merged.floor_char_boundary(max)` which requires the `round_char_boundary`
feature gate in Rust < 1.89 (approximately). Replaced with the stdlib-stable equivalent.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>