### PR TITLE
fix(ci): add Bash to council allowed tools — fixes Mark Council skip (#826)

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -83,7 +83,7 @@ jobs:
 
             IMPORTANT: Do NOT implement anything yet. Only validate the ticket pertinence.
           # Model tier: sonnet (Council gate — structured rubric evaluation, Sonnet sufficient)
-          claude_args: "--model claude-sonnet-4-6 --max-turns 5 --allowedTools Read,Glob,Grep"
+          claude_args: "--model claude-sonnet-4-6 --max-turns 5 --allowedTools Bash,Read,Glob,Grep"
 
       - name: Log token usage
         if: always() && steps.guard.outputs.skip != 'true'


### PR DESCRIPTION
## Summary
- Council step restricted to `--allowedTools Read,Glob,Grep` but Claude calls `Bash` (e.g. `ls` on workflow files) during validation
- Rejected tool call → action exits code 1 → `outcome=failure` even with `continue-on-error: true`
- "Mark Council complete" condition `steps.council.outcome == 'success'` is `false` → skipped
- `council-validated` label never added → `/go` triggers "Skip if not L1" in plan-validate → pipeline stalls

## Test plan
- [ ] CI green
- [ ] Re-trigger Council on issue #826 — "Mark Council complete" and "Check Ship Fast Path" should run
- [ ] `council-validated` label appears on issue #826
- [ ] `/go` comment triggers plan-validate successfully

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>