### PR TITLE
fix(ci): add Bash to plan-validate allowed tools (same root cause as #837)

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -400,7 +400,7 @@ jobs:
 
             IMPORTANT: Do NOT implement anything. Only write the plan and validate it.
           # Model tier: sonnet (Stage 2 Council — plan validation, Sonnet sufficient)
-          claude_args: "--model claude-sonnet-4-6 --max-turns 10 --allowedTools Read,Glob,Grep"
+          claude_args: "--model claude-sonnet-4-6 --max-turns 10 --allowedTools Bash,Read,Glob,Grep"
 
       - name: Log token usage
         if: always()


### PR DESCRIPTION
## Summary
- Same bug as PR #837 (council step) but in Stage 2 plan-validation
- `--allowedTools Read,Glob,Grep` → Claude calls Bash to explore codebase → action exits code 1
- `outcome=failure` → "Mark Plan validated" skipped → `plan-validated` label never added
- Implement job checks for `plan-validated` → "Abort if no Plan validation" fires → job fails

## Test plan
- [ ] CI green
- [ ] Re-trigger `/go` on issue #826 — "Mark Plan validated" should succeed and add `plan-validated` label
- [ ] Implement job should start

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>