### PR TITLE
chore(ai-factory): update model policy — Opus default for local implementation

### DIFF
--- a/.claude/rules/cost-guardrails.md
+++ b/.claude/rules/cost-guardrails.md
@@ -15,15 +15,30 @@ globs: ".claude/**"
 
 **Exception**: `workflow-essentials.md` (behavioral core, ~8K, no globs — intentional).
 
-## Model Selection
+## Model Selection — Local (Claude Code)
 
 | Task | Model | Rationale |
 |------|-------|-----------|
-| Codebase search, exploration | `claude-haiku-4-5-20251001` | Fast, cheap |
-| Subagent work (tests, reviews, docs) | `claude-sonnet-4-6` | Quality/cost balance |
-| Architecture, security decisions | `claude-opus-4-6` | Critical reasoning |
+| **Implementation** (features, fixes, debug, deploy, multi-file) | `claude-opus-4-6` | Fewer turns = lower total cost + faster |
+| **Subagent work** (tests, reviews, docs) | `claude-sonnet-4-6` | Isolated scope, no looping risk |
+| **Codebase search, exploration** | `claude-haiku-4-5-20251001` | Fast, cheap, read-only |
+| **Single-file mechanical** (format, config, typo) | `claude-sonnet-4-6` | Overkill for Opus |
 
-**Rules**: Never opus for subagents. Max 3-4 subagents active. Prefer haiku for `Explore`.
+**Escalation rule**: Sonnet looping > 15 min → switch to Opus (costs less in total).
+
+**Why Opus for implementation**: With ~40K tokens of system rules, Sonnet saturates its context window after 30+ turns and loops. Opus resolves in 5-15 turns. Data (2026-02-22): 44% of Sonnet sessions > 1h, some > 4h. Same tasks done in < 15 min with Opus.
+
+## Model Selection — CI (GitHub Actions)
+
+| Task | Model | Rationale |
+|------|-------|-----------|
+| **Council S1** (ticket pertinence) | `claude-sonnet-4-6` | Structured eval, 5 turns |
+| **Council S2** (plan validation) | `claude-sonnet-4-6` | Structured eval, 10 turns |
+| **Autopilot scan** (backlog scoring) | `claude-haiku-4-5-20251001` | Quick scoring, high volume |
+| **Implementation** (L1/L3 pipeline) | `claude-sonnet-4-6` | CI context is lighter (no 40K rules), Sonnet sufficient |
+| **Auto-review** (PR review) | `claude-sonnet-4-6` | Read-only, structured output |
+
+**Rules**: Max 3-4 subagents active. Prefer haiku for `Explore`. CI implementation stays Sonnet (lighter context = no looping problem).
 
 ## RULES-BUDGET Metric
 


### PR DESCRIPTION
## Summary
- Updates model policy: Opus as default for local implementation tasks (features, fixes, debug, deploy)
- Sonnet for CI gates, auto-review, subagents, single-file mechanical tasks
- Haiku for Explore subagent, autopilot scan, codebase search

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>