### PR TITLE
feat(api): add AWS API Gateway adapter (CAB-1427)

### DIFF
--- a/control-plane-api/src/adapters/aws/__init__.py
+++ b/control-plane-api/src/adapters/aws/__init__.py
@@ -1,0 +1,5 @@
+"""AWS API Gateway adapter for STOA platform."""
+
+from .adapter import AwsApiGatewayAdapter
+
+__all__ = ["AwsApiGatewayAdapter"]

--- a/control-plane-api/src/adapters/aws/adapter.py
+++ b/control-plane-api/src/adapters/aws/adapter.py
@@ -1,0 +1,502 @@
+"""AWS API Gateway Adapter.
+
+Implements GatewayAdapterInterface for AWS API Gateway REST APIs.
+Uses the AWS API Gateway REST API v1 via httpx (NOT boto3, for consistency
+with other STOA adapters).
+
+Auth: AWS SigV4 signing with access_key + secret_key + region.
+
+API reference:
+  https://docs.aws.amazon.com/apigateway/latest/api/API_Operations.html
+"""
+
+import hashlib
+import hmac
+import json
+import logging
+from datetime import UTC, datetime
+from urllib.parse import quote, urlparse
+
+import httpx
+
+from ..gateway_adapter_interface import AdapterResult, GatewayAdapterInterface
+from . import mappers
+
+logger = logging.getLogger(__name__)
+
+
+def _sign_v4(
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    body: bytes,
+    access_key: str,
+    secret_key: str,
+    region: str,
+    service: str = "apigateway",
+) -> dict[str, str]:
+    """Produce AWS Signature Version 4 headers.
+
+    Minimal implementation covering the signing steps needed for
+    API Gateway management API calls. Returns a dict of headers to
+    merge into the request.
+    """
+    now = datetime.now(tz=UTC)
+    datestamp = now.strftime("%Y%m%d")
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    canonical_uri = quote(parsed.path or "/", safe="/")
+    canonical_querystring = parsed.query or ""
+
+    payload_hash = hashlib.sha256(body).hexdigest()
+
+    signed_headers_list = sorted(["host", "x-amz-date", "x-amz-content-sha256"])
+    signed_headers_str = ";".join(signed_headers_list)
+
+    header_map = {
+        "host": host,
+        "x-amz-content-sha256": payload_hash,
+        "x-amz-date": amz_date,
+    }
+    canonical_headers = "".join(f"{k}:{header_map[k]}\n" for k in signed_headers_list)
+
+    canonical_request = "\n".join(
+        [
+            method.upper(),
+            canonical_uri,
+            canonical_querystring,
+            canonical_headers,
+            signed_headers_str,
+            payload_hash,
+        ]
+    )
+
+    credential_scope = f"{datestamp}/{region}/{service}/aws4_request"
+    string_to_sign = "\n".join(
+        [
+            "AWS4-HMAC-SHA256",
+            amz_date,
+            credential_scope,
+            hashlib.sha256(canonical_request.encode()).hexdigest(),
+        ]
+    )
+
+    def _hmac_sha256(key: bytes, msg: str) -> bytes:
+        return hmac.new(key, msg.encode(), hashlib.sha256).digest()
+
+    signing_key = _hmac_sha256(
+        _hmac_sha256(
+            _hmac_sha256(
+                _hmac_sha256(f"AWS4{secret_key}".encode(), datestamp),
+                region,
+            ),
+            service,
+        ),
+        "aws4_request",
+    )
+    signature = hmac.new(signing_key, string_to_sign.encode(), hashlib.sha256).hexdigest()
+
+    authorization = (
+        f"AWS4-HMAC-SHA256 Credential={access_key}/{credential_scope}, "
+        f"SignedHeaders={signed_headers_str}, Signature={signature}"
+    )
+
+    return {
+        "Authorization": authorization,
+        "x-amz-date": amz_date,
+        "x-amz-content-sha256": payload_hash,
+    }
+
+
+class AwsApiGatewayAdapter(GatewayAdapterInterface):
+    """Adapter for AWS API Gateway (REST APIs).
+
+    Config dict keys:
+        - region: AWS region (e.g. "eu-west-1")
+        - auth_config.access_key: AWS access key ID
+        - auth_config.secret_key: AWS secret access key
+        - base_url (optional): override endpoint (for localstack, etc.)
+    """
+
+    def __init__(self, config: dict | None = None) -> None:
+        super().__init__(config=config)
+        cfg = config or {}
+        self._region = cfg.get("region", "us-east-1")
+        auth_config = cfg.get("auth_config", {})
+        self._access_key = auth_config.get("access_key", "") if isinstance(auth_config, dict) else ""
+        self._secret_key = auth_config.get("secret_key", "") if isinstance(auth_config, dict) else ""
+        default_base = f"https://apigateway.{self._region}.amazonaws.com"
+        self._base_url = cfg.get("base_url", default_base)
+        self._client: httpx.AsyncClient | None = None
+
+    async def connect(self) -> None:
+        """Create persistent HTTP client."""
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=30.0,
+        )
+
+    async def disconnect(self) -> None:
+        """Close HTTP client."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        json_body: dict | None = None,
+    ) -> httpx.Response:
+        """Make a SigV4-signed request to the AWS API Gateway management API."""
+        client = self._client or httpx.AsyncClient(base_url=self._base_url, timeout=30.0)
+        close_after = self._client is None
+
+        url = f"{self._base_url}{path}"
+        body = b""
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+
+        if json_body is not None:
+            body = json.dumps(json_body).encode()
+
+        if self._access_key and self._secret_key:
+            sig_headers = _sign_v4(
+                method=method,
+                url=url,
+                headers=headers,
+                body=body,
+                access_key=self._access_key,
+                secret_key=self._secret_key,
+                region=self._region,
+            )
+            headers.update(sig_headers)
+
+        try:
+            return await client.request(method, path, content=body, headers=headers)
+        finally:
+            if close_after:
+                await client.aclose()
+
+    # --- Lifecycle ---
+
+    async def health_check(self) -> AdapterResult:
+        """Check AWS API Gateway connectivity by listing REST APIs (limit=1)."""
+        try:
+            resp = await self._request("GET", "/restapis?limit=1")
+            if resp.status_code == 200:
+                return AdapterResult(success=True, data={"status": "healthy", "region": self._region})
+            return AdapterResult(
+                success=False,
+                error=f"AWS API Gateway health check failed: HTTP {resp.status_code}",
+            )
+        except httpx.HTTPError as e:
+            return AdapterResult(success=False, error=f"Connection error: {e}")
+
+    # --- APIs ---
+
+    async def sync_api(
+        self,
+        api_spec: dict,
+        tenant_id: str,
+        auth_token: str | None = None,
+    ) -> AdapterResult:
+        """Create or update a REST API in AWS API Gateway."""
+        try:
+            aws_api = mappers.map_api_spec_to_aws(api_spec, tenant_id)
+            api_name = aws_api["name"]
+
+            # Search for existing API by name
+            existing_id = await self._find_api_by_name(api_name)
+
+            if existing_id:
+                # Update existing API
+                logger.info("REST API %s exists (%s), updating", api_name, existing_id)
+                patch_ops = [
+                    {"op": "replace", "path": "/description", "value": aws_api.get("description", "")},
+                ]
+                resp = await self._request(
+                    "PATCH", f"/restapis/{existing_id}", json_body={"patchOperations": patch_ops}
+                )
+            else:
+                # Create new API
+                logger.info("Creating new REST API: %s", api_name)
+                resp = await self._request("POST", "/restapis", json_body=aws_api)
+
+            if resp.status_code in (200, 201):
+                data = resp.json()
+                return AdapterResult(
+                    success=True,
+                    resource_id=data.get("id", existing_id or ""),
+                    data=data,
+                )
+            return AdapterResult(
+                success=False,
+                error=f"Failed to sync API: HTTP {resp.status_code} - {resp.text}",
+            )
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
+
+    async def delete_api(self, api_id: str, auth_token: str | None = None) -> AdapterResult:
+        """Delete a REST API from AWS API Gateway."""
+        try:
+            resp = await self._request("DELETE", f"/restapis/{api_id}")
+            if resp.status_code in (200, 202, 204, 404):
+                return AdapterResult(success=True, resource_id=api_id)
+            return AdapterResult(
+                success=False,
+                error=f"Failed to delete API: HTTP {resp.status_code} - {resp.text}",
+            )
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
+
+    async def list_apis(self, auth_token: str | None = None) -> list[dict]:
+        """List all REST APIs from AWS API Gateway."""
+        try:
+            resp = await self._request("GET", "/restapis")
+            if resp.status_code != 200:
+                logger.warning("Failed to list APIs: HTTP %d", resp.status_code)
+                return []
+
+            data = resp.json()
+            items = data.get("items", data.get("item", []))
+            # Filter STOA-managed APIs
+            stoa_apis = []
+            for item in items:
+                tags = item.get("tags", {})
+                if tags.get("stoa-managed") == "true":
+                    stoa_apis.append(mappers.map_aws_api_to_cp(item))
+            return stoa_apis
+        except Exception as e:
+            logger.warning("Failed to list APIs: %s", e)
+            return []
+
+    # --- Policies (Usage Plans) ---
+
+    async def upsert_policy(self, policy_spec: dict, auth_token: str | None = None) -> AdapterResult:
+        """Create or update a usage plan in AWS API Gateway."""
+        try:
+            tenant_id = policy_spec.get("tenant_id", "default")
+            plan = mappers.map_policy_to_aws_usage_plan(policy_spec, tenant_id)
+            plan_name = plan["name"]
+
+            # Search for existing plan by name
+            existing_id = await self._find_usage_plan_by_name(plan_name)
+
+            if existing_id:
+                logger.info("Usage plan %s exists (%s), updating", plan_name, existing_id)
+                patch_ops = []
+                if "throttle" in plan:
+                    patch_ops.append(
+                        {
+                            "op": "replace",
+                            "path": "/throttle/rateLimit",
+                            "value": str(plan["throttle"]["rateLimit"]),
+                        }
+                    )
+                    patch_ops.append(
+                        {
+                            "op": "replace",
+                            "path": "/throttle/burstLimit",
+                            "value": str(plan["throttle"]["burstLimit"]),
+                        }
+                    )
+                if "description" in plan:
+                    patch_ops.append(
+                        {
+                            "op": "replace",
+                            "path": "/description",
+                            "value": plan.get("description", ""),
+                        }
+                    )
+                resp = await self._request(
+                    "PATCH",
+                    f"/usageplans/{existing_id}",
+                    json_body={"patchOperations": patch_ops},
+                )
+            else:
+                logger.info("Creating new usage plan: %s", plan_name)
+                resp = await self._request("POST", "/usageplans", json_body=plan)
+
+            if resp.status_code in (200, 201):
+                data = resp.json()
+                return AdapterResult(
+                    success=True,
+                    resource_id=data.get("id", existing_id or ""),
+                    data=data,
+                )
+            return AdapterResult(
+                success=False,
+                error=f"Failed to upsert usage plan: HTTP {resp.status_code} - {resp.text}",
+            )
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
+
+    async def delete_policy(self, policy_id: str, auth_token: str | None = None) -> AdapterResult:
+        """Delete a usage plan from AWS API Gateway."""
+        try:
+            resp = await self._request("DELETE", f"/usageplans/{policy_id}")
+            if resp.status_code in (200, 202, 204, 404):
+                return AdapterResult(success=True, resource_id=policy_id)
+            return AdapterResult(
+                success=False,
+                error=f"Failed to delete usage plan: HTTP {resp.status_code} - {resp.text}",
+            )
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
+
+    async def list_policies(self, auth_token: str | None = None) -> list[dict]:
+        """List usage plans from AWS API Gateway (STOA-managed only)."""
+        try:
+            resp = await self._request("GET", "/usageplans")
+            if resp.status_code != 200:
+                logger.warning("Failed to list usage plans: HTTP %d", resp.status_code)
+                return []
+
+            data = resp.json()
+            items = data.get("items", data.get("item", []))
+            stoa_plans = []
+            for item in items:
+                tags = item.get("tags", {})
+                if tags.get("stoa-managed") == "true":
+                    stoa_plans.append(mappers.map_aws_usage_plan_to_policy(item))
+            return stoa_plans
+        except Exception as e:
+            logger.warning("Failed to list usage plans: %s", e)
+            return []
+
+    # --- Applications (API Keys) ---
+
+    async def provision_application(self, app_spec: dict, auth_token: str | None = None) -> AdapterResult:
+        """Create an API key and optionally associate it with a usage plan."""
+        try:
+            tenant_id = app_spec.get("tenant_id", "default")
+            key_payload = mappers.map_app_spec_to_aws_api_key(app_spec, tenant_id)
+
+            resp = await self._request("POST", "/apikeys", json_body=key_payload)
+            if resp.status_code not in (200, 201):
+                return AdapterResult(
+                    success=False,
+                    error=f"Failed to create API key: HTTP {resp.status_code} - {resp.text}",
+                )
+
+            key_data = resp.json()
+            key_id = key_data.get("id", "")
+
+            # Associate with usage plan if specified
+            usage_plan_id = app_spec.get("usage_plan_id")
+            if usage_plan_id and key_id:
+                assoc_resp = await self._request(
+                    "POST",
+                    f"/usageplans/{usage_plan_id}/keys",
+                    json_body={"keyId": key_id, "keyType": "API_KEY"},
+                )
+                if assoc_resp.status_code not in (200, 201):
+                    logger.warning(
+                        "API key %s created but failed to associate with usage plan %s: HTTP %d",
+                        key_id,
+                        usage_plan_id,
+                        assoc_resp.status_code,
+                    )
+
+            return AdapterResult(
+                success=True,
+                resource_id=key_id,
+                data=key_data,
+            )
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
+
+    async def deprovision_application(self, app_id: str, auth_token: str | None = None) -> AdapterResult:
+        """Delete an API key from AWS API Gateway."""
+        try:
+            resp = await self._request("DELETE", f"/apikeys/{app_id}")
+            if resp.status_code in (200, 202, 204, 404):
+                return AdapterResult(success=True, resource_id=app_id)
+            return AdapterResult(
+                success=False,
+                error=f"Failed to delete API key: HTTP {resp.status_code} - {resp.text}",
+            )
+        except Exception as e:
+            return AdapterResult(success=False, error=str(e))
+
+    async def list_applications(self, auth_token: str | None = None) -> list[dict]:
+        """List API keys from AWS API Gateway (STOA-managed only)."""
+        try:
+            resp = await self._request("GET", "/apikeys?includeValues=true")
+            if resp.status_code != 200:
+                logger.warning("Failed to list API keys: HTTP %d", resp.status_code)
+                return []
+
+            data = resp.json()
+            items = data.get("items", data.get("item", []))
+            stoa_keys = []
+            for item in items:
+                tags = item.get("tags", {})
+                if tags.get("stoa-managed") == "true":
+                    stoa_keys.append(mappers.map_aws_api_key_to_cp(item))
+            return stoa_keys
+        except Exception as e:
+            logger.warning("Failed to list API keys: %s", e)
+            return []
+
+    # --- Not supported by AWS API Gateway adapter ---
+
+    async def upsert_auth_server(self, auth_spec: dict, auth_token: str | None = None) -> AdapterResult:
+        """Not supported."""
+        return AdapterResult(success=False, error="Not supported by AWS API Gateway")
+
+    async def upsert_strategy(self, strategy_spec: dict, auth_token: str | None = None) -> AdapterResult:
+        """Not supported."""
+        return AdapterResult(success=False, error="Not supported by AWS API Gateway")
+
+    async def upsert_scope(self, scope_spec: dict, auth_token: str | None = None) -> AdapterResult:
+        """Not supported."""
+        return AdapterResult(success=False, error="Not supported by AWS API Gateway")
+
+    async def upsert_alias(self, alias_spec: dict, auth_token: str | None = None) -> AdapterResult:
+        """Not supported."""
+        return AdapterResult(success=False, error="Not supported by AWS API Gateway")
+
+    async def apply_config(self, config_spec: dict, auth_token: str | None = None) -> AdapterResult:
+        """Not supported."""
+        return AdapterResult(success=False, error="Not supported by AWS API Gateway")
+
+    async def export_archive(self, auth_token: str | None = None) -> bytes:
+        """Not supported."""
+        return b""
+
+    async def deploy_contract(self, contract_spec: dict, auth_token: str | None = None) -> AdapterResult:
+        """Not supported."""
+        return AdapterResult(success=False, error="Not supported by AWS API Gateway")
+
+    # --- Internal helpers ---
+
+    async def _find_api_by_name(self, name: str) -> str | None:
+        """Search for a REST API by name, return its ID or None."""
+        try:
+            resp = await self._request("GET", "/restapis")
+            if resp.status_code != 200:
+                return None
+            data = resp.json()
+            for item in data.get("items", data.get("item", [])):
+                if item.get("name") == name:
+                    return item.get("id")
+        except Exception:
+            pass
+        return None
+
+    async def _find_usage_plan_by_name(self, name: str) -> str | None:
+        """Search for a usage plan by name, return its ID or None."""
+        try:
+            resp = await self._request("GET", "/usageplans")
+            if resp.status_code != 200:
+                return None
+            data = resp.json()
+            for item in data.get("items", data.get("item", [])):
+                if item.get("name") == name:
+                    return item.get("id")
+        except Exception:
+            pass
+        return None

--- a/control-plane-api/src/adapters/aws/mappers.py
+++ b/control-plane-api/src/adapters/aws/mappers.py
@@ -1,0 +1,190 @@
+"""Mappers between Control Plane spec and AWS API Gateway native format.
+
+Supports AWS API Gateway REST APIs (v1). HTTP APIs (v2) are not covered
+because REST APIs provide usage plans, API keys, and stages — the full
+feature set needed for STOA orchestration.
+
+AWS REST API reference:
+  https://docs.aws.amazon.com/apigateway/latest/api/
+"""
+
+
+def map_api_spec_to_aws(api_spec: dict, tenant_id: str) -> dict:
+    """Map CP API spec to AWS REST API creation payload.
+
+    Args:
+        api_spec: Control Plane API specification dict.
+        tenant_id: Tenant owning this API.
+
+    Returns:
+        Dict suitable for CreateRestApi / UpdateRestApi calls.
+    """
+    name = api_spec.get("name", "unnamed-api")
+    safe_name = f"stoa-{tenant_id}-{name}".replace(" ", "-").lower()
+
+    return {
+        "name": safe_name,
+        "description": api_spec.get("description", ""),
+        "endpointConfiguration": {
+            "types": [api_spec.get("endpoint_type", "REGIONAL")],
+        },
+        "tags": {
+            "stoa-managed": "true",
+            "stoa-tenant": tenant_id,
+            "stoa-api-id": api_spec.get("id", ""),
+            "stoa-api-name": name,
+        },
+    }
+
+
+def map_aws_api_to_cp(api: dict) -> dict:
+    """Map AWS REST API response to CP format.
+
+    Args:
+        api: AWS REST API dict from getRestApis response.
+
+    Returns:
+        Normalized CP API dict.
+    """
+    tags = api.get("tags", {})
+
+    return {
+        "id": tags.get("stoa-api-id", api.get("id", "")),
+        "name": api.get("name", ""),
+        "display_name": api.get("name", ""),
+        "description": api.get("description", ""),
+        "gateway_resource_id": api.get("id", ""),
+        "gateway_type": "aws_apigateway",
+        "created_at": api.get("createdDate"),
+    }
+
+
+def map_policy_to_aws_usage_plan(policy_spec: dict, tenant_id: str) -> dict:
+    """Map CP policy spec to AWS usage plan creation payload.
+
+    AWS usage plans encapsulate rate limiting (throttle) and quota.
+
+    Args:
+        policy_spec: CP policy spec (type=rate_limit).
+        tenant_id: Tenant identifier.
+
+    Returns:
+        Dict suitable for CreateUsagePlan / UpdateUsagePlan calls.
+    """
+    policy_id = policy_spec.get("id", "")
+    config = policy_spec.get("config", {})
+    max_requests = config.get("max_requests", 100)
+    window_seconds = config.get("window_seconds", 60)
+
+    # AWS throttle is in requests/second
+    rate_limit = max_requests / max(window_seconds, 1)
+    burst_limit = config.get("burst_limit", max(int(rate_limit * 2), 1))
+
+    plan: dict = {
+        "name": f"stoa-{policy_id}",
+        "description": policy_spec.get("description", policy_spec.get("name", "")),
+        "throttle": {
+            "rateLimit": rate_limit,
+            "burstLimit": burst_limit,
+        },
+        "tags": {
+            "stoa-managed": "true",
+            "stoa-tenant": tenant_id,
+            "stoa-policy-id": policy_id,
+        },
+    }
+
+    # Optional quota (daily/weekly/monthly cap)
+    quota_limit = config.get("quota_limit")
+    quota_period = config.get("quota_period", "DAY")
+    if quota_limit:
+        plan["quota"] = {
+            "limit": quota_limit,
+            "period": quota_period,
+        }
+
+    return plan
+
+
+def map_aws_usage_plan_to_policy(plan: dict) -> dict:
+    """Map AWS usage plan back to CP policy format.
+
+    Args:
+        plan: AWS usage plan dict from getUsagePlans response.
+
+    Returns:
+        Normalized CP policy dict.
+    """
+    tags = plan.get("tags", {})
+    throttle = plan.get("throttle", {})
+    rate_limit = throttle.get("rateLimit", 0)
+    burst_limit = throttle.get("burstLimit", 0)
+
+    policy: dict = {
+        "id": tags.get("stoa-policy-id", plan.get("id", "")),
+        "name": plan.get("name", ""),
+        "description": plan.get("description", ""),
+        "type": "rate_limit",
+        "gateway_type": "aws_apigateway",
+        "config": {
+            "max_requests": int(rate_limit * 60),
+            "window_seconds": 60,
+            "burst_limit": burst_limit,
+        },
+    }
+
+    quota = plan.get("quota")
+    if quota:
+        policy["config"]["quota_limit"] = quota.get("limit")
+        policy["config"]["quota_period"] = quota.get("period", "DAY")
+
+    return policy
+
+
+def map_app_spec_to_aws_api_key(app_spec: dict, tenant_id: str) -> dict:
+    """Map CP application spec to AWS API key creation payload.
+
+    Args:
+        app_spec: CP application specification dict.
+        tenant_id: Tenant identifier.
+
+    Returns:
+        Dict suitable for CreateApiKey call.
+    """
+    app_id = app_spec.get("id", "")
+    name = app_spec.get("name", f"stoa-app-{app_id}")
+
+    return {
+        "name": f"stoa-{tenant_id}-{name}".replace(" ", "-").lower(),
+        "description": app_spec.get("description", ""),
+        "enabled": True,
+        "tags": {
+            "stoa-managed": "true",
+            "stoa-tenant": tenant_id,
+            "stoa-app-id": app_id,
+            "stoa-subscription-id": app_spec.get("subscription_id", ""),
+        },
+    }
+
+
+def map_aws_api_key_to_cp(key: dict) -> dict:
+    """Map AWS API key back to CP application format.
+
+    Args:
+        key: AWS API key dict from getApiKeys response.
+
+    Returns:
+        Normalized CP application dict.
+    """
+    tags = key.get("tags", {})
+
+    return {
+        "id": tags.get("stoa-app-id", key.get("id", "")),
+        "name": key.get("name", ""),
+        "description": key.get("description", ""),
+        "subscription_id": tags.get("stoa-subscription-id", ""),
+        "gateway_resource_id": key.get("id", ""),
+        "gateway_type": "aws_apigateway",
+        "enabled": key.get("enabled", False),
+        "created_at": key.get("createdDate"),
+    }

--- a/control-plane-api/src/adapters/registry.py
+++ b/control-plane-api/src/adapters/registry.py
@@ -83,5 +83,9 @@ def _register_builtin_adapters() -> None:
 
     AdapterRegistry.register("apigee", ApigeeGatewayAdapter)
 
+    from .aws import AwsApiGatewayAdapter
+
+    AdapterRegistry.register("aws_apigateway", AwsApiGatewayAdapter)
+
 
 _register_builtin_adapters()

--- a/control-plane-api/tests/test_aws_apigw_adapter.py
+++ b/control-plane-api/tests/test_aws_apigw_adapter.py
@@ -1,0 +1,605 @@
+"""Tests for AWS API Gateway Adapter."""
+
+import httpx
+import pytest
+
+from src.adapters.aws import mappers
+from src.adapters.aws.adapter import AwsApiGatewayAdapter
+
+# === Mapper Tests ===
+
+
+class TestMapApiSpecToAws:
+    def test_basic_mapping(self) -> None:
+        spec = {
+            "id": "api-1",
+            "name": "weather-api",
+            "description": "Provides weather data",
+            "endpoint_type": "REGIONAL",
+        }
+        result = mappers.map_api_spec_to_aws(spec, "acme")
+        assert result["name"] == "stoa-acme-weather-api"
+        assert result["description"] == "Provides weather data"
+        assert result["endpointConfiguration"]["types"] == ["REGIONAL"]
+        assert result["tags"]["stoa-managed"] == "true"
+        assert result["tags"]["stoa-tenant"] == "acme"
+        assert result["tags"]["stoa-api-id"] == "api-1"
+
+    def test_name_sanitization(self) -> None:
+        spec = {"name": "My Cool API", "id": "x"}
+        result = mappers.map_api_spec_to_aws(spec, "ACME Corp")
+        assert " " not in result["name"]
+        assert result["name"] == "stoa-acme-corp-my-cool-api"
+
+    def test_defaults(self) -> None:
+        result = mappers.map_api_spec_to_aws({}, "t1")
+        assert result["name"] == "stoa-t1-unnamed-api"
+        assert result["endpointConfiguration"]["types"] == ["REGIONAL"]
+        assert result["description"] == ""
+
+    def test_edge_endpoint_type(self) -> None:
+        spec = {"name": "edge-api", "endpoint_type": "EDGE"}
+        result = mappers.map_api_spec_to_aws(spec, "t1")
+        assert result["endpointConfiguration"]["types"] == ["EDGE"]
+
+
+class TestMapAwsApiToCp:
+    def test_with_tags(self) -> None:
+        api = {
+            "id": "abc123",
+            "name": "stoa-acme-weather-api",
+            "description": "Weather data",
+            "tags": {
+                "stoa-api-id": "api-1",
+                "stoa-tenant": "acme",
+                "stoa-managed": "true",
+            },
+            "createdDate": "2026-01-15",
+        }
+        result = mappers.map_aws_api_to_cp(api)
+        assert result["id"] == "api-1"
+        assert result["name"] == "stoa-acme-weather-api"
+        assert result["gateway_resource_id"] == "abc123"
+        assert result["gateway_type"] == "aws_apigateway"
+        assert result["created_at"] == "2026-01-15"
+
+    def test_without_tags(self) -> None:
+        api = {"id": "abc123", "name": "bare-api"}
+        result = mappers.map_aws_api_to_cp(api)
+        assert result["id"] == "abc123"
+        assert result["name"] == "bare-api"
+        assert result["gateway_type"] == "aws_apigateway"
+
+
+class TestPolicyMappers:
+    def test_rate_limit_to_usage_plan(self) -> None:
+        spec = {
+            "id": "pol-1",
+            "name": "Rate Limit 100/min",
+            "type": "rate_limit",
+            "config": {"max_requests": 120, "window_seconds": 60},
+        }
+        result = mappers.map_policy_to_aws_usage_plan(spec, "acme")
+        assert result["name"] == "stoa-pol-1"
+        assert result["throttle"]["rateLimit"] == 2.0  # 120/60
+        assert result["throttle"]["burstLimit"] == 4  # 2*rateLimit
+        assert result["tags"]["stoa-managed"] == "true"
+        assert result["tags"]["stoa-policy-id"] == "pol-1"
+
+    def test_usage_plan_with_quota(self) -> None:
+        spec = {
+            "id": "pol-2",
+            "type": "rate_limit",
+            "config": {
+                "max_requests": 60,
+                "window_seconds": 60,
+                "quota_limit": 10000,
+                "quota_period": "MONTH",
+            },
+        }
+        result = mappers.map_policy_to_aws_usage_plan(spec, "t1")
+        assert result["quota"]["limit"] == 10000
+        assert result["quota"]["period"] == "MONTH"
+
+    def test_usage_plan_to_policy(self) -> None:
+        plan = {
+            "id": "up-123",
+            "name": "stoa-pol-1",
+            "description": "100/min rate limit",
+            "throttle": {"rateLimit": 2.0, "burstLimit": 4},
+            "tags": {
+                "stoa-managed": "true",
+                "stoa-policy-id": "pol-1",
+            },
+        }
+        result = mappers.map_aws_usage_plan_to_policy(plan)
+        assert result["id"] == "pol-1"
+        assert result["type"] == "rate_limit"
+        assert result["config"]["max_requests"] == 120  # 2.0 * 60
+        assert result["config"]["burst_limit"] == 4
+        assert result["gateway_type"] == "aws_apigateway"
+
+    def test_usage_plan_with_quota_roundtrip(self) -> None:
+        plan = {
+            "id": "up-456",
+            "name": "stoa-pol-2",
+            "throttle": {"rateLimit": 1.0, "burstLimit": 2},
+            "quota": {"limit": 5000, "period": "DAY"},
+            "tags": {"stoa-policy-id": "pol-2"},
+        }
+        result = mappers.map_aws_usage_plan_to_policy(plan)
+        assert result["config"]["quota_limit"] == 5000
+        assert result["config"]["quota_period"] == "DAY"
+
+
+class TestAppMappers:
+    def test_app_spec_to_api_key(self) -> None:
+        spec = {
+            "id": "app-1",
+            "name": "Weather Client",
+            "description": "Weather consumer",
+            "subscription_id": "sub-42",
+        }
+        result = mappers.map_app_spec_to_aws_api_key(spec, "acme")
+        assert result["name"] == "stoa-acme-weather-client"
+        assert result["enabled"] is True
+        assert result["tags"]["stoa-managed"] == "true"
+        assert result["tags"]["stoa-app-id"] == "app-1"
+        assert result["tags"]["stoa-subscription-id"] == "sub-42"
+
+    def test_api_key_to_cp(self) -> None:
+        key = {
+            "id": "key-abc",
+            "name": "stoa-acme-weather-client",
+            "description": "Weather consumer",
+            "enabled": True,
+            "tags": {
+                "stoa-managed": "true",
+                "stoa-app-id": "app-1",
+                "stoa-subscription-id": "sub-42",
+            },
+            "createdDate": "2026-02-01",
+        }
+        result = mappers.map_aws_api_key_to_cp(key)
+        assert result["id"] == "app-1"
+        assert result["subscription_id"] == "sub-42"
+        assert result["gateway_resource_id"] == "key-abc"
+        assert result["gateway_type"] == "aws_apigateway"
+        assert result["enabled"] is True
+
+    def test_api_key_without_tags(self) -> None:
+        key = {"id": "key-xyz", "name": "bare-key", "enabled": False}
+        result = mappers.map_aws_api_key_to_cp(key)
+        assert result["id"] == "key-xyz"
+        assert result["enabled"] is False
+
+
+# === Adapter Tests (mock httpx) ===
+
+
+@pytest.fixture
+def adapter() -> AwsApiGatewayAdapter:
+    return AwsApiGatewayAdapter(
+        config={
+            "region": "eu-west-1",
+            "auth_config": {"access_key": "AKIATEST", "secret_key": "secret123"},
+        }
+    )
+
+
+class TestAdapterInit:
+    def test_default_config(self) -> None:
+        a = AwsApiGatewayAdapter()
+        assert a._region == "us-east-1"
+        assert "apigateway.us-east-1.amazonaws.com" in a._base_url
+
+    def test_custom_config(self, adapter: AwsApiGatewayAdapter) -> None:
+        assert adapter._region == "eu-west-1"
+        assert "eu-west-1" in adapter._base_url
+        assert adapter._access_key == "AKIATEST"
+        assert adapter._secret_key == "secret123"
+
+    def test_custom_base_url(self) -> None:
+        a = AwsApiGatewayAdapter(config={"base_url": "http://localhost:4566"})
+        assert a._base_url == "http://localhost:4566"
+
+
+class TestHealthCheck:
+    @pytest.mark.asyncio
+    async def test_healthy(self, adapter: AwsApiGatewayAdapter) -> None:
+        transport = httpx.MockTransport(lambda _req: httpx.Response(200, json={"items": []}))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.health_check()
+        assert result.success is True
+        assert result.data is not None
+        assert result.data["region"] == "eu-west-1"
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_unhealthy(self, adapter: AwsApiGatewayAdapter) -> None:
+        transport = httpx.MockTransport(lambda _req: httpx.Response(403, text="Forbidden"))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.health_check()
+        assert result.success is False
+        assert "403" in (result.error or "")
+        await adapter.disconnect()
+
+
+class TestSyncApi:
+    @pytest.mark.asyncio
+    async def test_create_new(self, adapter: AwsApiGatewayAdapter) -> None:
+        call_count = {"n": 0}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            call_count["n"] += 1
+            if req.method == "GET" and "/restapis" in str(req.url):
+                # First GET: list APIs (none found)
+                return httpx.Response(200, json={"items": []})
+            if req.method == "POST":
+                return httpx.Response(201, json={"id": "new-api-id", "name": "stoa-acme-test"})
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.sync_api({"name": "test", "id": "a1"}, "acme")
+        assert result.success is True
+        assert result.resource_id == "new-api-id"
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_update_existing(self, adapter: AwsApiGatewayAdapter) -> None:
+        def handler(req: httpx.Request) -> httpx.Response:
+            if req.method == "GET":
+                return httpx.Response(
+                    200,
+                    json={"items": [{"id": "existing-id", "name": "stoa-acme-test"}]},
+                )
+            if req.method == "PATCH":
+                return httpx.Response(200, json={"id": "existing-id", "name": "stoa-acme-test"})
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.sync_api({"name": "test", "id": "a1"}, "acme")
+        assert result.success is True
+        assert result.resource_id == "existing-id"
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_api_error(self, adapter: AwsApiGatewayAdapter) -> None:
+        def handler(req: httpx.Request) -> httpx.Response:
+            if req.method == "GET":
+                return httpx.Response(200, json={"items": []})
+            return httpx.Response(500, text="Internal Server Error")
+
+        transport = httpx.MockTransport(handler)
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.sync_api({"name": "test"}, "acme")
+        assert result.success is False
+        assert "500" in (result.error or "")
+        await adapter.disconnect()
+
+
+class TestDeleteApi:
+    @pytest.mark.asyncio
+    async def test_delete_success(self, adapter: AwsApiGatewayAdapter) -> None:
+        transport = httpx.MockTransport(lambda _req: httpx.Response(202))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.delete_api("api-123")
+        assert result.success is True
+        assert result.resource_id == "api-123"
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_delete_idempotent_404(self, adapter: AwsApiGatewayAdapter) -> None:
+        transport = httpx.MockTransport(lambda _req: httpx.Response(404))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.delete_api("nonexistent")
+        assert result.success is True
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_delete_failure(self, adapter: AwsApiGatewayAdapter) -> None:
+        transport = httpx.MockTransport(lambda _req: httpx.Response(409, text="Conflict"))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.delete_api("api-locked")
+        assert result.success is False
+        assert "409" in (result.error or "")
+        await adapter.disconnect()
+
+
+class TestListApis:
+    @pytest.mark.asyncio
+    async def test_list_filters_stoa_managed(self, adapter: AwsApiGatewayAdapter) -> None:
+        data = {
+            "items": [
+                {
+                    "id": "api-1",
+                    "name": "stoa-acme-weather",
+                    "description": "Weather",
+                    "tags": {"stoa-managed": "true", "stoa-api-id": "w1"},
+                },
+                {
+                    "id": "api-2",
+                    "name": "external-api",
+                    "description": "Not STOA",
+                    "tags": {},
+                },
+            ]
+        }
+        transport = httpx.MockTransport(lambda _req: httpx.Response(200, json=data))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.list_apis()
+        assert len(result) == 1
+        assert result[0]["id"] == "w1"
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_list_empty(self, adapter: AwsApiGatewayAdapter) -> None:
+        transport = httpx.MockTransport(lambda _req: httpx.Response(200, json={"items": []}))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.list_apis()
+        assert result == []
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_list_api_failure(self, adapter: AwsApiGatewayAdapter) -> None:
+        transport = httpx.MockTransport(lambda _req: httpx.Response(500))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.list_apis()
+        assert result == []
+        await adapter.disconnect()
+
+
+class TestUpsertPolicy:
+    @pytest.mark.asyncio
+    async def test_create_usage_plan(self, adapter: AwsApiGatewayAdapter) -> None:
+        def handler(req: httpx.Request) -> httpx.Response:
+            if req.method == "GET":
+                return httpx.Response(200, json={"items": []})
+            if req.method == "POST":
+                return httpx.Response(201, json={"id": "up-new", "name": "stoa-pol-1"})
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.upsert_policy(
+            {
+                "id": "pol-1",
+                "type": "rate_limit",
+                "tenant_id": "acme",
+                "config": {"max_requests": 60, "window_seconds": 60},
+            }
+        )
+        assert result.success is True
+        assert result.resource_id == "up-new"
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_update_usage_plan(self, adapter: AwsApiGatewayAdapter) -> None:
+        def handler(req: httpx.Request) -> httpx.Response:
+            if req.method == "GET":
+                return httpx.Response(
+                    200,
+                    json={"items": [{"id": "up-existing", "name": "stoa-pol-1"}]},
+                )
+            if req.method == "PATCH":
+                return httpx.Response(200, json={"id": "up-existing", "name": "stoa-pol-1"})
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.upsert_policy(
+            {
+                "id": "pol-1",
+                "type": "rate_limit",
+                "tenant_id": "acme",
+                "config": {"max_requests": 120, "window_seconds": 60},
+            }
+        )
+        assert result.success is True
+        assert result.resource_id == "up-existing"
+        await adapter.disconnect()
+
+
+class TestDeletePolicy:
+    @pytest.mark.asyncio
+    async def test_delete_success(self, adapter: AwsApiGatewayAdapter) -> None:
+        transport = httpx.MockTransport(lambda _req: httpx.Response(202))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.delete_policy("up-123")
+        assert result.success is True
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_delete_idempotent(self, adapter: AwsApiGatewayAdapter) -> None:
+        transport = httpx.MockTransport(lambda _req: httpx.Response(404))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.delete_policy("nonexistent")
+        assert result.success is True
+        await adapter.disconnect()
+
+
+class TestListPolicies:
+    @pytest.mark.asyncio
+    async def test_filters_stoa_managed(self, adapter: AwsApiGatewayAdapter) -> None:
+        data = {
+            "items": [
+                {
+                    "id": "up-1",
+                    "name": "stoa-pol-1",
+                    "throttle": {"rateLimit": 1.0, "burstLimit": 2},
+                    "tags": {"stoa-managed": "true", "stoa-policy-id": "pol-1"},
+                },
+                {
+                    "id": "up-2",
+                    "name": "external-plan",
+                    "tags": {},
+                },
+            ]
+        }
+        transport = httpx.MockTransport(lambda _req: httpx.Response(200, json=data))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.list_policies()
+        assert len(result) == 1
+        assert result[0]["id"] == "pol-1"
+        await adapter.disconnect()
+
+
+class TestProvisionApplication:
+    @pytest.mark.asyncio
+    async def test_create_api_key(self, adapter: AwsApiGatewayAdapter) -> None:
+        transport = httpx.MockTransport(
+            lambda _req: httpx.Response(201, json={"id": "key-new", "name": "stoa-acme-app"})
+        )
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.provision_application(
+            {
+                "id": "app-1",
+                "name": "My App",
+                "tenant_id": "acme",
+            }
+        )
+        assert result.success is True
+        assert result.resource_id == "key-new"
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_create_with_usage_plan(self, adapter: AwsApiGatewayAdapter) -> None:
+        calls: list[str] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            path = str(req.url.raw_path, "utf-8") if isinstance(req.url.raw_path, bytes) else str(req.url)
+            calls.append(path)
+            if "apikeys" in path and req.method == "POST" and "usageplans" not in path:
+                return httpx.Response(201, json={"id": "key-new"})
+            if "usageplans" in path and "keys" in path:
+                return httpx.Response(201, json={"id": "key-new", "keyType": "API_KEY"})
+            return httpx.Response(200)
+
+        transport = httpx.MockTransport(handler)
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.provision_application(
+            {
+                "id": "app-1",
+                "name": "My App",
+                "tenant_id": "acme",
+                "usage_plan_id": "up-123",
+            }
+        )
+        assert result.success is True
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_create_failure(self, adapter: AwsApiGatewayAdapter) -> None:
+        transport = httpx.MockTransport(lambda _req: httpx.Response(400, text="Bad Request"))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.provision_application({"id": "app-1", "tenant_id": "acme"})
+        assert result.success is False
+        assert "400" in (result.error or "")
+        await adapter.disconnect()
+
+
+class TestDeprovisionApplication:
+    @pytest.mark.asyncio
+    async def test_delete_success(self, adapter: AwsApiGatewayAdapter) -> None:
+        transport = httpx.MockTransport(lambda _req: httpx.Response(202))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.deprovision_application("key-abc")
+        assert result.success is True
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_delete_idempotent(self, adapter: AwsApiGatewayAdapter) -> None:
+        transport = httpx.MockTransport(lambda _req: httpx.Response(404))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.deprovision_application("nonexistent")
+        assert result.success is True
+        await adapter.disconnect()
+
+
+class TestListApplications:
+    @pytest.mark.asyncio
+    async def test_filters_stoa_managed(self, adapter: AwsApiGatewayAdapter) -> None:
+        data = {
+            "items": [
+                {
+                    "id": "key-1",
+                    "name": "stoa-acme-app",
+                    "enabled": True,
+                    "tags": {"stoa-managed": "true", "stoa-app-id": "app-1"},
+                },
+                {
+                    "id": "key-2",
+                    "name": "external-key",
+                    "tags": {},
+                },
+            ]
+        }
+        transport = httpx.MockTransport(lambda _req: httpx.Response(200, json=data))
+        adapter._client = httpx.AsyncClient(base_url=adapter._base_url, transport=transport)
+        result = await adapter.list_applications()
+        assert len(result) == 1
+        assert result[0]["id"] == "app-1"
+        await adapter.disconnect()
+
+
+class TestConnectDisconnect:
+    @pytest.mark.asyncio
+    async def test_connect_creates_client(self, adapter: AwsApiGatewayAdapter) -> None:
+        assert adapter._client is None
+        await adapter.connect()
+        assert adapter._client is not None
+        await adapter.disconnect()
+        assert adapter._client is None
+
+    @pytest.mark.asyncio
+    async def test_disconnect_noop_when_not_connected(self, adapter: AwsApiGatewayAdapter) -> None:
+        await adapter.disconnect()  # Should not raise
+
+
+class TestUnsupportedMethods:
+    @pytest.mark.asyncio
+    async def test_auth_server_not_supported(self, adapter: AwsApiGatewayAdapter) -> None:
+        result = await adapter.upsert_auth_server({})
+        assert result.success is False
+        assert "Not supported" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_strategy_not_supported(self, adapter: AwsApiGatewayAdapter) -> None:
+        result = await adapter.upsert_strategy({})
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_scope_not_supported(self, adapter: AwsApiGatewayAdapter) -> None:
+        result = await adapter.upsert_scope({})
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_alias_not_supported(self, adapter: AwsApiGatewayAdapter) -> None:
+        result = await adapter.upsert_alias({})
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_apply_config_not_supported(self, adapter: AwsApiGatewayAdapter) -> None:
+        result = await adapter.apply_config({})
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_export_archive_empty(self, adapter: AwsApiGatewayAdapter) -> None:
+        result = await adapter.export_archive()
+        assert result == b""
+
+    @pytest.mark.asyncio
+    async def test_deploy_contract_not_supported(self, adapter: AwsApiGatewayAdapter) -> None:
+        result = await adapter.deploy_contract({})
+        assert result.success is False
+
+
+class TestRegistry:
+    def test_aws_registered(self) -> None:
+        from src.adapters.registry import AdapterRegistry
+
+        assert AdapterRegistry.has_type("aws_apigateway")
+        instance = AdapterRegistry.create("aws_apigateway", {"region": "eu-west-1"})
+        assert isinstance(instance, AwsApiGatewayAdapter)


### PR DESCRIPTION
## Summary
- Implement `GatewayAdapterInterface` for AWS API Gateway REST APIs
- SigV4 auth signing, REST API CRUD, usage plans for rate limiting, API key management
- 48 tests covering mappers (13), adapter methods (28), unsupported stubs (7), registry (1)

## Files
- `control-plane-api/src/adapters/aws/__init__.py` — module export
- `control-plane-api/src/adapters/aws/adapter.py` — full 16-method implementation with SigV4
- `control-plane-api/src/adapters/aws/mappers.py` — 6 bidirectional mappers (API, policy, app)
- `control-plane-api/src/adapters/registry.py` — register `aws_apigateway` type
- `control-plane-api/tests/test_aws_apigw_adapter.py` — 48 tests (all passing)

## Test plan
- [x] `ruff check` clean
- [x] `black --check` clean
- [x] 48/48 tests passing
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>