### PR TITLE
feat(demo): add Citadelle + Middle-Earth Banking demo scenarios (CAB-1329)

### DIFF
--- a/scripts/demo/scenarios/citadelle/README.md
+++ b/scripts/demo/scenarios/citadelle/README.md
@@ -1,0 +1,74 @@
+# La Citadelle — Public Sector Demo
+
+**Theme**: French public sector ministry — API interoperability for citizen services.
+
+**Compliance context**: RGS (Referentiel General de Securite), SecNumCloud
+
+## Scenario Overview
+
+La Citadelle is a fictional French ministry ("Ministere de l'Interoperabilite
+Numerique") that exposes citizen-facing APIs through STOA. The scenario
+demonstrates:
+
+1. **Citizen Identity Verification** — FranceConnect-style identity checks
+2. **Secure Document Management** — eIDAS signatures, archival with integrity hashes
+3. **Inter-Ministry Data Exchange** — structured data exchange with schema validation
+
+## Personas
+
+| Username | Role | Description | Password |
+|----------|------|-------------|----------|
+| `durand` | tenant-admin | RSSI / Responsable Securite des SI | `Durand2026!` |
+| `martin` | devops | Developpeur services citoyens | `Martin2026!` |
+| `leroy` | viewer | Administratrice ministere | `Leroy2026!` |
+
+## APIs
+
+| API | Category | Endpoints | Description |
+|-----|----------|-----------|-------------|
+| citizen-identity-api | Identity | 3 | Verification d'identite, profil citoyen, documents |
+| document-management-api | Documents | 4 | Depot, consultation, suivi statut, signature |
+| interop-api | Interop | 4 | Echange inter-ministeres, catalogue de schemas |
+
+## Plans
+
+| Plan | Rate Limit | Approval | Use Case |
+|------|-----------|----------|----------|
+| Souverain | 60/min | Required | External partners, controlled access |
+| Interne | 300/min | Auto | Internal ministry applications |
+
+## Demo Walkthrough
+
+### Setup
+
+```bash
+export ADMIN_PASSWORD=<keycloak-admin-password>
+./scripts/demo/setup.sh --scenario=citadelle
+```
+
+### Talking Points
+
+1. **Portal view (as `martin`)**: Browse the API catalog, see citizen-identity-api
+   with its OpenAPI spec, subscribe to the Souverain plan
+
+2. **Console view (as `durand`)**: Approve subscription requests, review audit logs,
+   manage access policies — demonstrate the RSSI's control over API access
+
+3. **Interoperability**: Show the exchange API — structured data exchange between
+   ministries with full traceability and schema validation
+
+4. **Compliance posture**: Highlight rate limiting, API key requirements, audit
+   logging — all contributing to the RGS compliance posture
+
+### Teardown
+
+```bash
+./scripts/demo/teardown.sh --scenario=citadelle
+```
+
+## Compliance Disclaimer
+
+> This demo illustrates technical capabilities that support RGS compliance
+> posture, including data sovereignty controls and secure API interoperability.
+> STOA Platform is not RGS-certified or SecNumCloud-qualified. Organizations
+> must consult ANSSI guidelines and qualified auditors for official evaluation.

--- a/scripts/demo/scenarios/citadelle/scenario.yaml
+++ b/scripts/demo/scenarios/citadelle/scenario.yaml
@@ -1,0 +1,62 @@
+name: citadelle
+display_name: "La Citadelle — Ministere de l'Interoperabilite Numerique"
+description: "Public sector API interoperability demo with RGS compliance posture"
+theme: public-sector
+
+compliance:
+  frameworks:
+    - RGS
+    - SecNumCloud
+  disclaimer: |
+    This demo illustrates technical capabilities that support RGS compliance
+    posture, including data sovereignty controls and secure API interoperability.
+    STOA Platform is not RGS-certified or SecNumCloud-qualified. Organizations
+    must consult ANSSI guidelines and qualified auditors for official evaluation.
+
+tenant:
+  id: citadelle
+  ref: tenants/citadelle/tenant.yaml
+
+personas:
+  - username: durand
+    email: durand@citadelle.gouv.demo
+    first_name: Claire
+    last_name: Durand
+    role: tenant-admin
+    password: Durand2026!
+    description: "RSSI / Responsable Securite des SI"
+  - username: martin
+    email: martin@citadelle.gouv.demo
+    first_name: Thomas
+    last_name: Martin
+    role: devops
+    password: Martin2026!
+    description: "Developpeur services citoyens"
+  - username: leroy
+    email: leroy@citadelle.gouv.demo
+    first_name: Sophie
+    last_name: Leroy
+    role: viewer
+    password: Leroy2026!
+    description: "Administratrice ministere"
+
+plans:
+  - slug: souverain
+    display_name: "Plan Souverain"
+    rate_limit_per_minute: 60
+    requires_approval: true
+  - slug: interne
+    display_name: "Plan Interne"
+    rate_limit_per_minute: 300
+    requires_approval: false
+
+applications:
+  - name: "Portail Citoyen"
+    plan: souverain
+    apis:
+      - citizen-identity-api
+      - document-management-api
+  - name: "Plateforme Interop"
+    plan: interne
+    apis:
+      - interop-api

--- a/scripts/demo/scenarios/middle-earth-banking/README.md
+++ b/scripts/demo/scenarios/middle-earth-banking/README.md
@@ -1,0 +1,77 @@
+# Bank of Gondor — Financial Services Demo
+
+**Theme**: Fantasy bank — financial services APIs with regulatory compliance posture.
+
+**Compliance context**: DORA (Digital Operational Resilience Act), NIS2
+
+## Scenario Overview
+
+The Bank of Gondor is a fictional financial institution that exposes core
+banking APIs through STOA. The scenario demonstrates:
+
+1. **Account Management** — KYC/AML-aware account operations
+2. **Payment Processing** — SEPA and instant payments with SCA
+3. **Risk Assessment** — Credit scoring and DORA ICT risk reporting
+
+## Personas
+
+| Username | Role | Description | Password |
+|----------|------|-------------|----------|
+| `gandalf` | tenant-admin | CISO / Risk Manager | `Gandalf2026!` |
+| `aragorn` | devops | Trading Desk Developer | `Aragorn2026!` |
+| `elrond` | viewer | Bank CTO / Architecture Review | `Elrond2026!` |
+
+## APIs
+
+| API | Category | Endpoints | Description |
+|-----|----------|-----------|-------------|
+| account-api | Banking | 4 | Account CRUD, balance inquiry, KYC status |
+| payment-api | Payments | 4 | SEPA payments, status tracking, cancellation |
+| risk-assessment-api | Risk | 4 | Risk scoring, assessment results, reporting |
+
+## Plans
+
+| Plan | Rate Limit | Approval | Use Case |
+|------|-----------|----------|----------|
+| Regulated | 30/min | Required | Internal regulated operations |
+| Partner | 120/min | Required | External partner integrations (Rohan, etc.) |
+
+## Demo Walkthrough
+
+### Setup
+
+```bash
+export ADMIN_PASSWORD=<keycloak-admin-password>
+./scripts/demo/setup.sh --scenario=middle-earth-banking
+```
+
+### Talking Points
+
+1. **Portal view (as `aragorn`)**: Browse financial APIs, see OpenAPI specs
+   with PSD2-compliant endpoints, subscribe to the Regulated plan
+
+2. **Console view (as `gandalf`)**: CISO perspective — approve subscription
+   requests, review rate limits, manage strict access policies for
+   regulated workloads
+
+3. **Risk & Compliance**: Demonstrate the risk-assessment-api with DORA
+   ICT risk reporting — show how API governance supports the bank's
+   compliance posture
+
+4. **Multi-tenant isolation**: Show that Gondor's APIs are completely
+   isolated from other tenants — Rohan partner can only access APIs
+   through the Partner plan
+
+### Teardown
+
+```bash
+./scripts/demo/teardown.sh --scenario=middle-earth-banking
+```
+
+## Compliance Disclaimer
+
+> This demo illustrates technical capabilities relevant to DORA and NIS2
+> compliance posture, including audit logging, access control, and incident
+> response readiness. STOA Platform does not provide financial regulatory
+> advice. Organizations must engage qualified compliance officers and auditors
+> for official DORA/NIS2 assessment.

--- a/scripts/demo/scenarios/middle-earth-banking/scenario.yaml
+++ b/scripts/demo/scenarios/middle-earth-banking/scenario.yaml
@@ -1,0 +1,65 @@
+name: middle-earth-banking
+display_name: "Bank of Gondor — Digital Financial Services"
+description: "Financial services demo with NIS2/DORA compliance posture"
+theme: financial-services
+
+compliance:
+  frameworks:
+    - DORA
+    - NIS2
+  disclaimer: |
+    This demo illustrates technical capabilities relevant to DORA and NIS2
+    compliance posture, including audit logging, access control, and incident
+    response readiness. STOA Platform does not provide financial regulatory
+    advice. Organizations must engage qualified compliance officers and auditors
+    for official DORA/NIS2 assessment.
+
+tenant:
+  id: middle-earth-bank
+  ref: tenants/middle-earth-bank/tenant.yaml
+
+personas:
+  - username: gandalf
+    email: gandalf@gondor-bank.demo
+    first_name: Gandalf
+    last_name: the White
+    role: tenant-admin
+    password: Gandalf2026!
+    description: "CISO / Risk Manager"
+  - username: aragorn
+    email: aragorn@gondor-bank.demo
+    first_name: Aragorn
+    last_name: Elessar
+    role: devops
+    password: Aragorn2026!
+    description: "Trading Desk Developer"
+  - username: elrond
+    email: elrond@gondor-bank.demo
+    first_name: Elrond
+    last_name: Half-elven
+    role: viewer
+    password: Elrond2026!
+    description: "Bank CTO / Architecture Review"
+
+plans:
+  - slug: regulated
+    display_name: "Regulated Plan"
+    rate_limit_per_minute: 30
+    requires_approval: true
+  - slug: partner
+    display_name: "Partner Plan"
+    rate_limit_per_minute: 120
+    requires_approval: true
+
+applications:
+  - name: "Gondor Trading Platform"
+    plan: regulated
+    apis:
+      - account-api
+      - payment-api
+      - risk-assessment-api
+  - name: "Rohan Partner Integration"
+    plan: partner
+    apis:
+      - account-api
+      - payment-api

--- a/tenants/citadelle/apis/citizen-identity-api/api.yaml
+++ b/tenants/citadelle/apis/citizen-identity-api/api.yaml
@@ -1,0 +1,27 @@
+id: citizen-identity-api
+name: citizen-identity-api
+display_name: "Service d'Identite Citoyenne"
+version: "1.2.0"
+description: |
+  API de verification d'identite pour les services citoyens.
+
+  Fonctionnalites:
+  - Verification d'identite (FranceConnect-style)
+  - Consultation de profil citoyen
+  - Validation de pieces justificatives
+  - Historique des verifications
+
+  Conforme aux exigences d'interoperabilite du RGI.
+backend_url: https://httpbin.org/anything
+status: active
+category: Identity
+tags:
+  - portal:published
+  - public-sector
+  - identity
+  - rest
+  - rgs
+  - franceconnect
+deployments:
+  dev: true
+  staging: false

--- a/tenants/citadelle/apis/citizen-identity-api/openapi.yaml
+++ b/tenants/citadelle/apis/citizen-identity-api/openapi.yaml
@@ -1,0 +1,122 @@
+openapi: "3.0.3"
+info:
+  title: Service d'Identite Citoyenne
+  version: "1.2.0"
+  description: |
+    API de verification d'identite pour les services citoyens.
+    Conforme aux exigences d'interoperabilite du RGI.
+  contact:
+    name: Direction du Numerique
+    email: dnum@citadelle.gouv.demo
+servers:
+  - url: https://httpbin.org/anything
+    description: Mock backend
+paths:
+  /citizens/{citizenId}:
+    get:
+      summary: Consulter le profil d'un citoyen
+      operationId: getCitizen
+      parameters:
+        - name: citizenId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Profil citoyen
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Citizen"
+        "404":
+          description: Citoyen non trouve
+  /citizens/verify:
+    post:
+      summary: Verifier l'identite d'un citoyen
+      operationId: verifyCitizen
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - nationalId
+                - dateOfBirth
+              properties:
+                nationalId:
+                  type: string
+                  description: Numero national d'identite
+                dateOfBirth:
+                  type: string
+                  format: date
+      responses:
+        "200":
+          description: Resultat de la verification
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  verified:
+                    type: boolean
+                  confidence:
+                    type: number
+                    format: float
+                  timestamp:
+                    type: string
+                    format: date-time
+  /citizens/{citizenId}/documents:
+    get:
+      summary: Lister les pieces justificatives
+      operationId: listCitizenDocuments
+      parameters:
+        - name: citizenId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Liste des documents
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DocumentRef"
+components:
+  schemas:
+    Citizen:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        firstName:
+          type: string
+        lastName:
+          type: string
+        dateOfBirth:
+          type: string
+          format: date
+        verified:
+          type: boolean
+    DocumentRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum: [identity_card, passport, proof_of_address]
+        status:
+          type: string
+          enum: [pending, verified, rejected]
+        uploadedAt:
+          type: string
+          format: date-time

--- a/tenants/citadelle/apis/document-management-api/api.yaml
+++ b/tenants/citadelle/apis/document-management-api/api.yaml
@@ -1,0 +1,28 @@
+id: document-management-api
+name: document-management-api
+display_name: "Gestion Electronique de Documents"
+version: "2.0.0"
+description: |
+  API de gestion electronique de documents (GED) securisee.
+
+  Fonctionnalites:
+  - Depot de documents avec controle d'integrite
+  - Suivi du cycle de vie documentaire
+  - Signature electronique (eIDAS)
+  - Archivage a valeur probante
+
+  Supporte les formats NF Z42-013 pour l'archivage electronique.
+backend_url: https://httpbin.org/anything
+status: active
+category: Document Management
+tags:
+  - portal:published
+  - public-sector
+  - documents
+  - rest
+  - rgs
+  - eidas
+  - archivage
+deployments:
+  dev: true
+  staging: false

--- a/tenants/citadelle/apis/document-management-api/openapi.yaml
+++ b/tenants/citadelle/apis/document-management-api/openapi.yaml
@@ -1,0 +1,167 @@
+openapi: "3.0.3"
+info:
+  title: Gestion Electronique de Documents
+  version: "2.0.0"
+  description: |
+    API de gestion electronique de documents securisee.
+    Supporte les formats NF Z42-013 pour l'archivage electronique.
+  contact:
+    name: Direction du Numerique
+    email: dnum@citadelle.gouv.demo
+servers:
+  - url: https://httpbin.org/anything
+    description: Mock backend
+paths:
+  /documents:
+    post:
+      summary: Deposer un document
+      operationId: uploadDocument
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - title
+                - category
+                - content
+              properties:
+                title:
+                  type: string
+                category:
+                  type: string
+                  enum: [administrative, legal, technical, financial]
+                content:
+                  type: string
+                  format: byte
+                  description: Contenu du document encode en base64
+                metadata:
+                  type: object
+                  additionalProperties:
+                    type: string
+      responses:
+        "201":
+          description: Document depose
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Document"
+  /documents/{documentId}:
+    get:
+      summary: Consulter un document
+      operationId: getDocument
+      parameters:
+        - name: documentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Detail du document
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Document"
+        "404":
+          description: Document non trouve
+  /documents/{documentId}/status:
+    get:
+      summary: Suivre le statut d'un document
+      operationId: getDocumentStatus
+      parameters:
+        - name: documentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Statut du document
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  documentId:
+                    type: string
+                    format: uuid
+                  status:
+                    type: string
+                    enum: [received, validating, archived, rejected]
+                  integrityHash:
+                    type: string
+                    description: SHA-256 hash for integrity verification
+                  archivedAt:
+                    type: string
+                    format: date-time
+  /documents/{documentId}/sign:
+    post:
+      summary: Signer electroniquement un document
+      operationId: signDocument
+      parameters:
+        - name: documentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - signerId
+              properties:
+                signerId:
+                  type: string
+                  format: uuid
+                signatureLevel:
+                  type: string
+                  enum: [simple, advanced, qualified]
+                  default: advanced
+      responses:
+        "200":
+          description: Document signe
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  signatureId:
+                    type: string
+                    format: uuid
+                  signedAt:
+                    type: string
+                    format: date-time
+                  level:
+                    type: string
+components:
+  schemas:
+    Document:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        category:
+          type: string
+        status:
+          type: string
+          enum: [received, validating, archived, rejected]
+        integrityHash:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        metadata:
+          type: object
+          additionalProperties:
+            type: string

--- a/tenants/citadelle/apis/interop-api/api.yaml
+++ b/tenants/citadelle/apis/interop-api/api.yaml
@@ -1,0 +1,27 @@
+id: interop-api
+name: interop-api
+display_name: "Plateforme d'Interoperabilite"
+version: "1.0.0"
+description: |
+  API d'echange de donnees inter-ministeres.
+
+  Fonctionnalites:
+  - Echange de donnees structure entre administrations
+  - Catalogue de schemas de donnees partages
+  - Routage vers les SI ministeriels
+  - Tracabilite des echanges
+
+  Conforme au Cadre Commun d'Interoperabilite (CCI).
+backend_url: https://httpbin.org/anything
+status: active
+category: Interoperability
+tags:
+  - portal:published
+  - public-sector
+  - interoperability
+  - rest
+  - rgs
+  - cci
+deployments:
+  dev: true
+  staging: false

--- a/tenants/citadelle/apis/interop-api/openapi.yaml
+++ b/tenants/citadelle/apis/interop-api/openapi.yaml
@@ -1,0 +1,153 @@
+openapi: "3.0.3"
+info:
+  title: Plateforme d'Interoperabilite
+  version: "1.0.0"
+  description: |
+    API d'echange de donnees inter-ministeres.
+    Conforme au Cadre Commun d'Interoperabilite (CCI).
+  contact:
+    name: Direction du Numerique
+    email: dnum@citadelle.gouv.demo
+servers:
+  - url: https://httpbin.org/anything
+    description: Mock backend
+paths:
+  /exchange:
+    post:
+      summary: Envoyer un echange de donnees
+      operationId: submitExchange
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - sourceMinistry
+                - targetMinistry
+                - schemaId
+                - payload
+              properties:
+                sourceMinistry:
+                  type: string
+                  description: Code du ministere emetteur
+                targetMinistry:
+                  type: string
+                  description: Code du ministere destinataire
+                schemaId:
+                  type: string
+                  description: Identifiant du schema de donnees
+                payload:
+                  type: object
+                  description: Donnees conformes au schema
+                priority:
+                  type: string
+                  enum: [normal, urgent]
+                  default: normal
+      responses:
+        "202":
+          description: Echange accepte
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExchangeReceipt"
+  /exchange/{exchangeId}:
+    get:
+      summary: Consulter le statut d'un echange
+      operationId: getExchangeStatus
+      parameters:
+        - name: exchangeId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Statut de l'echange
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExchangeReceipt"
+  /schemas:
+    get:
+      summary: Lister les schemas de donnees disponibles
+      operationId: listSchemas
+      parameters:
+        - name: ministry
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filtrer par ministere
+      responses:
+        "200":
+          description: Liste des schemas
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DataSchema"
+  /schemas/{schemaId}:
+    get:
+      summary: Consulter un schema de donnees
+      operationId: getSchema
+      parameters:
+        - name: schemaId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Detail du schema
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DataSchema"
+components:
+  schemas:
+    ExchangeReceipt:
+      type: object
+      properties:
+        exchangeId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [accepted, routing, delivered, failed]
+        sourceMinistry:
+          type: string
+        targetMinistry:
+          type: string
+        submittedAt:
+          type: string
+          format: date-time
+        deliveredAt:
+          type: string
+          format: date-time
+    DataSchema:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+        ministry:
+          type: string
+        description:
+          type: string
+        fields:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              type:
+                type: string
+              required:
+                type: boolean

--- a/tenants/citadelle/tenant.yaml
+++ b/tenants/citadelle/tenant.yaml
@@ -1,0 +1,47 @@
+apiVersion: stoa.io/v1
+kind: Tenant
+metadata:
+  name: citadelle
+  displayName: "La Citadelle — Ministere de l'Interoperabilite Numerique"
+  description: "Public sector tenant for citizen services and inter-ministry data exchange"
+  labels:
+    tier: enterprise
+    visibility: public
+    managed-by: gitops
+    sector: public-sector
+
+spec:
+  portalVisibility: public
+
+  visibility:
+    allowedRoles:
+      - cpi-admin
+      - tenant-admin
+      - devops
+      - viewer
+    denyRoles: []
+
+  defaultPolicies:
+    - name: rate-limit-standard
+      config:
+        requestsPerMinute: 60
+        burstLimit: 10
+    - name: require-api-key
+      description: "Mandatory API key for all endpoints"
+
+  settings:
+    max_apis: 50
+    max_applications: 20
+    environments:
+      - dev
+      - staging
+
+  tags:
+    - public-sector
+    - rgs
+    - interoperability
+    - france
+
+  contact:
+    team: "Direction du Numerique"
+    email: "dnum@citadelle.gouv.demo"

--- a/tenants/middle-earth-bank/apis/account-api/api.yaml
+++ b/tenants/middle-earth-bank/apis/account-api/api.yaml
@@ -1,0 +1,28 @@
+id: account-api
+name: account-api
+display_name: "Account Management API"
+version: "2.1.0"
+description: |
+  Account management API for the Bank of Gondor.
+
+  Fonctionnalites:
+  - Account creation with KYC verification
+  - Account details and balance inquiry
+  - Account holder management
+  - AML screening integration
+
+  Supports PSD2 Account Information Service (AIS) patterns.
+backend_url: https://httpbin.org/anything
+status: active
+category: Banking
+tags:
+  - portal:published
+  - banking
+  - accounts
+  - rest
+  - kyc
+  - aml
+  - psd2
+deployments:
+  dev: true
+  staging: false

--- a/tenants/middle-earth-bank/apis/account-api/openapi.yaml
+++ b/tenants/middle-earth-bank/apis/account-api/openapi.yaml
@@ -1,0 +1,149 @@
+openapi: "3.0.3"
+info:
+  title: Account Management API
+  version: "2.1.0"
+  description: |
+    Account management for the Bank of Gondor.
+    Supports PSD2 Account Information Service (AIS) patterns.
+  contact:
+    name: Gondor IT Department
+    email: it@gondor-bank.demo
+servers:
+  - url: https://httpbin.org/anything
+    description: Mock backend
+paths:
+  /accounts:
+    post:
+      summary: Create a new account
+      operationId: createAccount
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - holderName
+                - accountType
+                - currency
+              properties:
+                holderName:
+                  type: string
+                accountType:
+                  type: string
+                  enum: [current, savings, trading]
+                currency:
+                  type: string
+                  enum: [EUR, GBP, USD]
+                  default: EUR
+                kycReference:
+                  type: string
+                  description: Reference to completed KYC verification
+      responses:
+        "201":
+          description: Account created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Account"
+    get:
+      summary: List accounts
+      operationId: listAccounts
+      parameters:
+        - name: holderName
+          in: query
+          schema:
+            type: string
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [active, frozen, closed]
+      responses:
+        "200":
+          description: List of accounts
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Account"
+  /accounts/{accountId}:
+    get:
+      summary: Get account details
+      operationId: getAccount
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Account details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Account"
+        "404":
+          description: Account not found
+  /accounts/{accountId}/balance:
+    get:
+      summary: Get account balance
+      operationId: getAccountBalance
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Account balance
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accountId:
+                    type: string
+                    format: uuid
+                  available:
+                    type: number
+                    format: double
+                  pending:
+                    type: number
+                    format: double
+                  currency:
+                    type: string
+                  asOf:
+                    type: string
+                    format: date-time
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        iban:
+          type: string
+        holderName:
+          type: string
+        accountType:
+          type: string
+          enum: [current, savings, trading]
+        currency:
+          type: string
+        status:
+          type: string
+          enum: [active, frozen, closed]
+        kycStatus:
+          type: string
+          enum: [pending, verified, rejected]
+        createdAt:
+          type: string
+          format: date-time

--- a/tenants/middle-earth-bank/apis/payment-api/api.yaml
+++ b/tenants/middle-earth-bank/apis/payment-api/api.yaml
@@ -1,0 +1,28 @@
+id: payment-api
+name: payment-api
+display_name: "Payment Processing API"
+version: "3.0.0"
+description: |
+  Payment initiation and processing for the Bank of Gondor.
+
+  Fonctionnalites:
+  - SEPA Credit Transfers
+  - Instant Payments (SEPA Instant)
+  - Payment status tracking
+  - Beneficiary management
+
+  Supports PSD2 Payment Initiation Service (PIS) with SCA.
+backend_url: https://httpbin.org/anything
+status: active
+category: Payments
+tags:
+  - portal:published
+  - banking
+  - payments
+  - rest
+  - sepa
+  - psd2
+  - sca
+deployments:
+  dev: true
+  staging: false

--- a/tenants/middle-earth-bank/apis/payment-api/openapi.yaml
+++ b/tenants/middle-earth-bank/apis/payment-api/openapi.yaml
@@ -1,0 +1,156 @@
+openapi: "3.0.3"
+info:
+  title: Payment Processing API
+  version: "3.0.0"
+  description: |
+    Payment initiation and processing for the Bank of Gondor.
+    Supports PSD2 Payment Initiation Service (PIS) with SCA.
+  contact:
+    name: Gondor IT Department
+    email: it@gondor-bank.demo
+servers:
+  - url: https://httpbin.org/anything
+    description: Mock backend
+paths:
+  /payments:
+    post:
+      summary: Initiate a payment
+      operationId: initiatePayment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - debtorAccount
+                - creditorAccount
+                - amount
+                - currency
+              properties:
+                debtorAccount:
+                  type: string
+                  description: Debtor IBAN
+                creditorAccount:
+                  type: string
+                  description: Creditor IBAN
+                creditorName:
+                  type: string
+                amount:
+                  type: number
+                  format: double
+                currency:
+                  type: string
+                  enum: [EUR, GBP, USD]
+                  default: EUR
+                paymentType:
+                  type: string
+                  enum: [sepa_credit, sepa_instant, swift]
+                  default: sepa_credit
+                reference:
+                  type: string
+                  description: Payment reference / remittance info
+      responses:
+        "201":
+          description: Payment initiated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Payment"
+        "422":
+          description: Insufficient funds or validation error
+  /payments/{paymentId}:
+    get:
+      summary: Get payment details
+      operationId: getPayment
+      parameters:
+        - name: paymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Payment details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Payment"
+  /payments/{paymentId}/status:
+    get:
+      summary: Get payment status
+      operationId: getPaymentStatus
+      parameters:
+        - name: paymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Payment status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  paymentId:
+                    type: string
+                    format: uuid
+                  status:
+                    type: string
+                    enum: [pending, processing, completed, rejected, cancelled]
+                  scaStatus:
+                    type: string
+                    enum: [required, completed, exempted]
+                  updatedAt:
+                    type: string
+                    format: date-time
+  /payments/{paymentId}/cancel:
+    post:
+      summary: Cancel a pending payment
+      operationId: cancelPayment
+      parameters:
+        - name: paymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Payment cancelled
+        "409":
+          description: Payment already processed
+components:
+  schemas:
+    Payment:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        debtorAccount:
+          type: string
+        creditorAccount:
+          type: string
+        creditorName:
+          type: string
+        amount:
+          type: number
+          format: double
+        currency:
+          type: string
+        paymentType:
+          type: string
+          enum: [sepa_credit, sepa_instant, swift]
+        status:
+          type: string
+          enum: [pending, processing, completed, rejected, cancelled]
+        reference:
+          type: string
+        createdAt:
+          type: string
+          format: date-time

--- a/tenants/middle-earth-bank/apis/risk-assessment-api/api.yaml
+++ b/tenants/middle-earth-bank/apis/risk-assessment-api/api.yaml
@@ -1,0 +1,27 @@
+id: risk-assessment-api
+name: risk-assessment-api
+display_name: "Risk Assessment API"
+version: "1.5.0"
+description: |
+  Credit scoring and risk assessment for the Bank of Gondor.
+
+  Fonctionnalites:
+  - Credit risk scoring
+  - Transaction risk assessment
+  - Risk report generation
+  - Regulatory reporting (DORA ICT risk)
+
+  Supports DORA ICT risk management framework requirements.
+backend_url: https://httpbin.org/anything
+status: active
+category: Risk
+tags:
+  - portal:published
+  - banking
+  - risk
+  - rest
+  - dora
+  - credit-scoring
+deployments:
+  dev: true
+  staging: false

--- a/tenants/middle-earth-bank/apis/risk-assessment-api/openapi.yaml
+++ b/tenants/middle-earth-bank/apis/risk-assessment-api/openapi.yaml
@@ -1,0 +1,189 @@
+openapi: "3.0.3"
+info:
+  title: Risk Assessment API
+  version: "1.5.0"
+  description: |
+    Credit scoring and risk assessment for the Bank of Gondor.
+    Supports DORA ICT risk management framework requirements.
+  contact:
+    name: Gondor IT Department
+    email: it@gondor-bank.demo
+servers:
+  - url: https://httpbin.org/anything
+    description: Mock backend
+paths:
+  /assess:
+    post:
+      summary: Request a risk assessment
+      operationId: requestAssessment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - assessmentType
+                - subjectId
+              properties:
+                assessmentType:
+                  type: string
+                  enum: [credit, transaction, ict_risk]
+                subjectId:
+                  type: string
+                  format: uuid
+                  description: Account ID or entity ID
+                transactionAmount:
+                  type: number
+                  format: double
+                  description: Required for transaction assessments
+                context:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: Additional context for the assessment
+      responses:
+        "201":
+          description: Assessment created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Assessment"
+  /assess/{assessmentId}:
+    get:
+      summary: Get assessment result
+      operationId: getAssessment
+      parameters:
+        - name: assessmentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Assessment result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Assessment"
+  /reports/{reportId}:
+    get:
+      summary: Get risk report
+      operationId: getRiskReport
+      parameters:
+        - name: reportId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Risk report
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RiskReport"
+  /reports:
+    get:
+      summary: List risk reports
+      operationId: listRiskReports
+      parameters:
+        - name: type
+          in: query
+          schema:
+            type: string
+            enum: [credit, transaction, ict_risk, regulatory]
+        - name: from
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: to
+          in: query
+          schema:
+            type: string
+            format: date
+      responses:
+        "200":
+          description: List of risk reports
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/RiskReport"
+components:
+  schemas:
+    Assessment:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        assessmentType:
+          type: string
+          enum: [credit, transaction, ict_risk]
+        subjectId:
+          type: string
+          format: uuid
+        score:
+          type: number
+          format: float
+          description: Risk score (0-100, lower is better)
+        riskLevel:
+          type: string
+          enum: [low, medium, high, critical]
+        factors:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              impact:
+                type: string
+                enum: [positive, negative, neutral]
+              weight:
+                type: number
+                format: float
+        createdAt:
+          type: string
+          format: date-time
+    RiskReport:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum: [credit, transaction, ict_risk, regulatory]
+        period:
+          type: object
+          properties:
+            from:
+              type: string
+              format: date
+            to:
+              type: string
+              format: date
+        summary:
+          type: string
+        totalAssessments:
+          type: integer
+        riskDistribution:
+          type: object
+          properties:
+            low:
+              type: integer
+            medium:
+              type: integer
+            high:
+              type: integer
+            critical:
+              type: integer
+        generatedAt:
+          type: string
+          format: date-time

--- a/tenants/middle-earth-bank/tenant.yaml
+++ b/tenants/middle-earth-bank/tenant.yaml
@@ -1,0 +1,50 @@
+apiVersion: stoa.io/v1
+kind: Tenant
+metadata:
+  name: middle-earth-bank
+  displayName: "Bank of Gondor — Digital Financial Services"
+  description: "Fantasy bank demonstrating financial API governance with DORA/NIS2 compliance posture"
+  labels:
+    tier: enterprise
+    visibility: public
+    managed-by: gitops
+    sector: financial-services
+
+spec:
+  portalVisibility: public
+
+  visibility:
+    allowedRoles:
+      - cpi-admin
+      - tenant-admin
+      - devops
+      - viewer
+    denyRoles: []
+
+  defaultPolicies:
+    - name: rate-limit-strict
+      config:
+        requestsPerMinute: 30
+        burstLimit: 5
+    - name: require-api-key
+      description: "Mandatory API key for all financial endpoints"
+    - name: cors-strict
+      description: "Strict CORS for banking applications"
+
+  settings:
+    max_apis: 30
+    max_applications: 10
+    environments:
+      - dev
+      - staging
+
+  tags:
+    - financial-services
+    - dora
+    - nis2
+    - banking
+    - regulated
+
+  contact:
+    team: "Gondor IT Department"
+    email: "it@gondor-bank.demo"


### PR DESCRIPTION
## Summary
- Adds 2 industry-vertical demo scenarios for the STOA demo content library (CAB-1329 Phase 2a + 2b)
- **La Citadelle**: French public sector (RGS/SecNumCloud), 3 APIs, 3 personas, 2 plans
- **Middle-Earth Banking**: Financial services (DORA/NIS2), 3 APIs, 3 personas, 2 plans
- Framework (Phase 1) already merged to main — `scenario-manager.py`, setup/teardown scripts, 23 unit tests

## What's in this PR

### Phase 2a — La Citadelle (Public Sector / RGS)
- `tenants/citadelle/tenant.yaml` — GitOps tenant (enterprise tier, public-sector)
- 3 OpenAPI 3.0.3 specs: citizen-identity-api, document-management-api, interop-api
- `scenarios/citadelle/scenario.yaml` — Scenario manifest with personas (durand, martin, leroy), plans (souverain, interne), compliance disclaimer
- `scenarios/citadelle/README.md` — Demo walkthrough with talking points

### Phase 2b — Middle-Earth Banking (NIS2 / DORA)
- `tenants/middle-earth-bank/tenant.yaml` — GitOps tenant (enterprise tier, financial-services)
- 3 OpenAPI 3.0.3 specs: account-api, payment-api, risk-assessment-api
- `scenarios/middle-earth-banking/scenario.yaml` — Scenario manifest with personas (gandalf, aragorn, elrond), plans (regulated, partner), compliance disclaimer
- `scenarios/middle-earth-banking/README.md` — Demo walkthrough with talking points

## Verified
- `python3 scripts/demo/scenario-manager.py list` — shows both scenarios
- `python3 scripts/demo/scenario-manager.py setup --scenario=citadelle --dry-run` — prints full plan
- `python3 scripts/demo/scenario-manager.py setup --scenario=middle-earth-banking --dry-run` — prints full plan
- All 23 unit tests pass

## Test plan
- [x] Both dry-runs produce correct output
- [x] `list` shows both scenarios with metadata
- [x] All 23 unit tests pass
- [x] No real company names — fictional universes only
- [x] Compliance disclaimers use "supports compliance" (never "certified")
- [ ] CI green (security scan — no code changes, content only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>