### PR TITLE
style(ui): migrate Console gray→neutral tokens + adopt shared Button (CAB-1322)

### DIFF
--- a/control-plane-ui/src/App.tsx
+++ b/control-plane-ui/src/App.tsx
@@ -140,8 +140,10 @@ function Dashboard() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{t('dashboard.title')}</h1>
-        <p className="text-gray-500 dark:text-neutral-400 mt-2">{t('dashboard.welcome')}</p>
+        <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
+          {t('dashboard.title')}
+        </h1>
+        <p className="text-neutral-500 dark:text-neutral-400 mt-2">{t('dashboard.welcome')}</p>
       </div>
 
       {/* Welcome Card */}
@@ -163,10 +165,10 @@ function Dashboard() {
             </svg>
           </div>
           <div>
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
               {t('dashboard.hello', { name: user?.name || 'User' })}
             </h2>
-            <p className="text-sm text-gray-500 dark:text-neutral-400">{user?.email}</p>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">{user?.email}</p>
           </div>
         </div>
       </div>
@@ -251,7 +253,7 @@ function Dashboard() {
       {/* Info Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none p-6">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4">
             {t('dashboard.quickLinks')}
           </h3>
           <ul className="space-y-3">
@@ -279,10 +281,10 @@ function Dashboard() {
         </div>
 
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none p-6">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4">
             {t('dashboard.gettingStarted')}
           </h3>
-          <ol className="space-y-3 text-sm text-gray-600 dark:text-neutral-400">
+          <ol className="space-y-3 text-sm text-neutral-600 dark:text-neutral-400">
             <li className="flex gap-2">
               <span className="font-bold text-blue-600">1.</span>
               <span>
@@ -458,8 +460,8 @@ function Login() {
               />
             </svg>
           </div>
-          <h1 className="text-2xl font-bold text-gray-900">{t('login.title')}</h1>
-          <p className="text-gray-500 mt-1">{t('login.subtitle')}</p>
+          <h1 className="text-2xl font-bold text-neutral-900">{t('login.title')}</h1>
+          <p className="text-neutral-500 mt-1">{t('login.subtitle')}</p>
         </div>
         <button
           onClick={login}

--- a/control-plane-ui/src/components/CertificateHealthBadge.tsx
+++ b/control-plane-ui/src/components/CertificateHealthBadge.tsx
@@ -50,8 +50,8 @@ const healthStyles: Record<HealthLevel, { bg: string; text: string; label: strin
     label: 'Critical',
   },
   expired: {
-    bg: 'bg-gray-100 dark:bg-gray-700',
-    text: 'text-gray-800 dark:text-gray-400',
+    bg: 'bg-neutral-100 dark:bg-neutral-700',
+    text: 'text-neutral-800 dark:text-neutral-400',
     label: 'Expired',
   },
   revoked: {

--- a/control-plane-ui/src/components/ConsumerDetailModal.tsx
+++ b/control-plane-ui/src/components/ConsumerDetailModal.tsx
@@ -11,7 +11,7 @@ const certStatusStyles: Record<CertificateStatus, string> = {
   active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
   rotating: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
   revoked: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-  expired: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-400',
+  expired: 'bg-neutral-100 text-neutral-800 dark:bg-neutral-700 dark:text-neutral-400',
 };
 
 interface Props {
@@ -127,18 +127,18 @@ export function ConsumerDetailModal({ consumer, tenantId, onClose }: Props) {
           onClick={(e) => e.stopPropagation()}
         >
           {/* Header */}
-          <div className="flex justify-between items-start p-6 border-b border-gray-200 dark:border-neutral-700">
+          <div className="flex justify-between items-start p-6 border-b border-neutral-200 dark:border-neutral-700">
             <div>
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+              <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
                 {consumer.name}
               </h2>
-              <p className="text-sm text-gray-500 dark:text-neutral-400 font-mono">
+              <p className="text-sm text-neutral-500 dark:text-neutral-400 font-mono">
                 {consumer.external_id}
               </p>
             </div>
             <button
               onClick={onClose}
-              className="text-gray-400 hover:text-gray-600 dark:hover:text-neutral-300"
+              className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
             >
               <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path
@@ -155,18 +155,18 @@ export function ConsumerDetailModal({ consumer, tenantId, onClose }: Props) {
           <div className="p-6 space-y-6">
             {/* Consumer Info */}
             <section className="space-y-2">
-              <h3 className="text-sm font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+              <h3 className="text-sm font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                 Consumer
               </h3>
               <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-                <dt className="text-gray-500 dark:text-neutral-400">Email</dt>
-                <dd className="text-gray-900 dark:text-white">{consumer.email}</dd>
-                <dt className="text-gray-500 dark:text-neutral-400">Company</dt>
-                <dd className="text-gray-900 dark:text-white">{consumer.company || '—'}</dd>
-                <dt className="text-gray-500 dark:text-neutral-400">Status</dt>
-                <dd className="text-gray-900 dark:text-white capitalize">{consumer.status}</dd>
-                <dt className="text-gray-500 dark:text-neutral-400">Created</dt>
-                <dd className="text-gray-900 dark:text-white">
+                <dt className="text-neutral-500 dark:text-neutral-400">Email</dt>
+                <dd className="text-neutral-900 dark:text-white">{consumer.email}</dd>
+                <dt className="text-neutral-500 dark:text-neutral-400">Company</dt>
+                <dd className="text-neutral-900 dark:text-white">{consumer.company || '—'}</dd>
+                <dt className="text-neutral-500 dark:text-neutral-400">Status</dt>
+                <dd className="text-neutral-900 dark:text-white capitalize">{consumer.status}</dd>
+                <dt className="text-neutral-500 dark:text-neutral-400">Created</dt>
+                <dd className="text-neutral-900 dark:text-white">
                   {new Date(consumer.created_at).toLocaleDateString()}
                 </dd>
               </dl>
@@ -174,19 +174,19 @@ export function ConsumerDetailModal({ consumer, tenantId, onClose }: Props) {
 
             {/* Certificate Info */}
             <section className="space-y-2">
-              <h3 className="text-sm font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+              <h3 className="text-sm font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                 Certificate
               </h3>
               {hasCert ? (
                 <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-                  <dt className="text-gray-500 dark:text-neutral-400">Health</dt>
+                  <dt className="text-neutral-500 dark:text-neutral-400">Health</dt>
                   <dd>
                     <CertificateHealthBadge
                       status={certStatus}
                       notAfter={consumer.certificate_not_after}
                     />
                   </dd>
-                  <dt className="text-gray-500 dark:text-neutral-400">Status</dt>
+                  <dt className="text-neutral-500 dark:text-neutral-400">Status</dt>
                   <dd>
                     <span
                       className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${certStatus ? certStatusStyles[certStatus] : ''}`}
@@ -194,44 +194,46 @@ export function ConsumerDetailModal({ consumer, tenantId, onClose }: Props) {
                       {certStatus || 'unknown'}
                     </span>
                   </dd>
-                  <dt className="text-gray-500 dark:text-neutral-400">Fingerprint</dt>
-                  <dd className="text-gray-900 dark:text-white font-mono text-xs break-all">
+                  <dt className="text-neutral-500 dark:text-neutral-400">Fingerprint</dt>
+                  <dd className="text-neutral-900 dark:text-white font-mono text-xs break-all">
                     {consumer.certificate_fingerprint}
                   </dd>
                   {consumer.certificate_subject_dn && (
                     <>
-                      <dt className="text-gray-500 dark:text-neutral-400">Subject</dt>
-                      <dd className="text-gray-900 dark:text-white text-xs break-all">
+                      <dt className="text-neutral-500 dark:text-neutral-400">Subject</dt>
+                      <dd className="text-neutral-900 dark:text-white text-xs break-all">
                         {consumer.certificate_subject_dn}
                       </dd>
                     </>
                   )}
                   {consumer.certificate_not_before && (
                     <>
-                      <dt className="text-gray-500 dark:text-neutral-400">Valid from</dt>
-                      <dd className="text-gray-900 dark:text-white">
+                      <dt className="text-neutral-500 dark:text-neutral-400">Valid from</dt>
+                      <dd className="text-neutral-900 dark:text-white">
                         {new Date(consumer.certificate_not_before).toLocaleDateString()}
                       </dd>
                     </>
                   )}
                   {consumer.certificate_not_after && (
                     <>
-                      <dt className="text-gray-500 dark:text-neutral-400">Valid until</dt>
-                      <dd className="text-gray-900 dark:text-white">
+                      <dt className="text-neutral-500 dark:text-neutral-400">Valid until</dt>
+                      <dd className="text-neutral-900 dark:text-white">
                         {new Date(consumer.certificate_not_after).toLocaleDateString()}
                       </dd>
                     </>
                   )}
                   {(consumer.rotation_count ?? 0) > 0 && (
                     <>
-                      <dt className="text-gray-500 dark:text-neutral-400">Rotations</dt>
-                      <dd className="text-gray-900 dark:text-white">{consumer.rotation_count}</dd>
+                      <dt className="text-neutral-500 dark:text-neutral-400">Rotations</dt>
+                      <dd className="text-neutral-900 dark:text-white">
+                        {consumer.rotation_count}
+                      </dd>
                     </>
                   )}
                   {consumer.last_rotated_at && (
                     <>
-                      <dt className="text-gray-500 dark:text-neutral-400">Last rotated</dt>
-                      <dd className="text-gray-900 dark:text-white">
+                      <dt className="text-neutral-500 dark:text-neutral-400">Last rotated</dt>
+                      <dd className="text-neutral-900 dark:text-white">
                         {new Date(consumer.last_rotated_at).toLocaleDateString()}
                       </dd>
                     </>
@@ -239,7 +241,7 @@ export function ConsumerDetailModal({ consumer, tenantId, onClose }: Props) {
                 </dl>
               ) : (
                 <div className="space-y-2">
-                  <p className="text-sm text-gray-500 dark:text-neutral-400 italic">
+                  <p className="text-sm text-neutral-500 dark:text-neutral-400 italic">
                     No certificate bound to this consumer.
                   </p>
                   {canEdit && (
@@ -266,12 +268,12 @@ export function ConsumerDetailModal({ consumer, tenantId, onClose }: Props) {
 
             {/* Bind Certificate Form (CAB-872) */}
             {showBindForm && (
-              <section className="space-y-3 border-t border-gray-200 dark:border-neutral-700 pt-4">
-                <h3 className="text-sm font-medium text-gray-900 dark:text-white">
+              <section className="space-y-3 border-t border-neutral-200 dark:border-neutral-700 pt-4">
+                <h3 className="text-sm font-medium text-neutral-900 dark:text-white">
                   {hasCert ? 'Replace Certificate' : 'Bind Certificate'}
                 </h3>
                 <div>
-                  <label className="block text-sm text-gray-600 dark:text-neutral-400 mb-1">
+                  <label className="block text-sm text-neutral-600 dark:text-neutral-400 mb-1">
                     PEM Certificate
                   </label>
                   <textarea
@@ -279,7 +281,7 @@ export function ConsumerDetailModal({ consumer, tenantId, onClose }: Props) {
                     onChange={(e) => setPemValue(e.target.value)}
                     placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
                     rows={5}
-                    className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm font-mono bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+                    className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm font-mono bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
                   />
                   <input
                     ref={fileInputRef}
@@ -308,7 +310,7 @@ export function ConsumerDetailModal({ consumer, tenantId, onClose }: Props) {
                       setShowBindForm(false);
                       setPemValue('');
                     }}
-                    className="px-4 py-2 border border-gray-300 dark:border-neutral-600 text-sm rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 dark:text-white"
+                    className="px-4 py-2 border border-neutral-300 dark:border-neutral-600 text-sm rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 dark:text-white"
                   >
                     Cancel
                   </button>
@@ -318,12 +320,12 @@ export function ConsumerDetailModal({ consumer, tenantId, onClose }: Props) {
 
             {/* Rotate Form */}
             {showRotateForm && (
-              <section className="space-y-3 border-t border-gray-200 dark:border-neutral-700 pt-4">
-                <h3 className="text-sm font-medium text-gray-900 dark:text-white">
+              <section className="space-y-3 border-t border-neutral-200 dark:border-neutral-700 pt-4">
+                <h3 className="text-sm font-medium text-neutral-900 dark:text-white">
                   Rotate Certificate
                 </h3>
                 <div>
-                  <label className="block text-sm text-gray-600 dark:text-neutral-400 mb-1">
+                  <label className="block text-sm text-neutral-600 dark:text-neutral-400 mb-1">
                     New PEM Certificate
                   </label>
                   <textarea
@@ -331,7 +333,7 @@ export function ConsumerDetailModal({ consumer, tenantId, onClose }: Props) {
                     onChange={(e) => setPemValue(e.target.value)}
                     placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
                     rows={5}
-                    className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm font-mono bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+                    className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm font-mono bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
                   />
                   <input
                     ref={fileInputRef}
@@ -348,7 +350,7 @@ export function ConsumerDetailModal({ consumer, tenantId, onClose }: Props) {
                   </button>
                 </div>
                 <div>
-                  <label className="block text-sm text-gray-600 dark:text-neutral-400 mb-1">
+                  <label className="block text-sm text-neutral-600 dark:text-neutral-400 mb-1">
                     Grace period (hours)
                   </label>
                   <input
@@ -357,9 +359,9 @@ export function ConsumerDetailModal({ consumer, tenantId, onClose }: Props) {
                     onChange={(e) => setGracePeriod(Number(e.target.value))}
                     min={1}
                     max={720}
-                    className="w-24 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+                    className="w-24 border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
                   />
-                  <span className="ml-2 text-xs text-gray-500 dark:text-neutral-400">
+                  <span className="ml-2 text-xs text-neutral-500 dark:text-neutral-400">
                     Old cert stays valid during this period
                   </span>
                 </div>
@@ -376,7 +378,7 @@ export function ConsumerDetailModal({ consumer, tenantId, onClose }: Props) {
                       setShowRotateForm(false);
                       setPemValue('');
                     }}
-                    className="px-4 py-2 border border-gray-300 dark:border-neutral-600 text-sm rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 dark:text-white"
+                    className="px-4 py-2 border border-neutral-300 dark:border-neutral-600 text-sm rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 dark:text-white"
                   >
                     Cancel
                   </button>
@@ -387,7 +389,7 @@ export function ConsumerDetailModal({ consumer, tenantId, onClose }: Props) {
 
           {/* Footer Actions */}
           {canEdit && hasCert && certStatus !== 'revoked' && !showRotateForm && (
-            <div className="p-6 border-t border-gray-200 dark:border-neutral-700 flex gap-3">
+            <div className="p-6 border-t border-neutral-200 dark:border-neutral-700 flex gap-3">
               <button
                 onClick={() => setShowRotateForm(true)}
                 className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700"

--- a/control-plane-ui/src/components/DeployLogViewer.tsx
+++ b/control-plane-ui/src/components/DeployLogViewer.tsx
@@ -3,10 +3,10 @@ import { clsx } from 'clsx';
 import type { DeploymentLog } from '../types';
 
 const levelStyles: Record<string, { text: string; icon: string }> = {
-  info: { text: 'text-gray-400 dark:text-neutral-500', icon: 'text-blue-400' },
+  info: { text: 'text-neutral-400 dark:text-neutral-500', icon: 'text-blue-400' },
   warn: { text: 'text-yellow-600 dark:text-yellow-400', icon: 'text-yellow-500' },
   error: { text: 'text-red-500 dark:text-red-400', icon: 'text-red-500' },
-  debug: { text: 'text-gray-500 dark:text-neutral-600', icon: 'text-gray-400' },
+  debug: { text: 'text-neutral-500 dark:text-neutral-600', icon: 'text-neutral-400' },
 };
 
 function formatLogTime(isoString: string): string {
@@ -43,7 +43,7 @@ export function DeployLogViewer({ logs, maxHeight = '300px' }: DeployLogViewerPr
 
   if (logs.length === 0) {
     return (
-      <div className="rounded-lg bg-gray-900 dark:bg-neutral-950 p-4 text-center text-sm text-gray-500">
+      <div className="rounded-lg bg-neutral-900 dark:bg-neutral-950 p-4 text-center text-sm text-neutral-500">
         Waiting for deploy logs...
       </div>
     );
@@ -53,7 +53,7 @@ export function DeployLogViewer({ logs, maxHeight = '300px' }: DeployLogViewerPr
     <div
       ref={containerRef}
       onScroll={handleScroll}
-      className="rounded-lg bg-gray-900 dark:bg-neutral-950 overflow-auto font-mono text-xs leading-5"
+      className="rounded-lg bg-neutral-900 dark:bg-neutral-950 overflow-auto font-mono text-xs leading-5"
       style={{ maxHeight }}
     >
       <div className="p-3 space-y-0.5">
@@ -61,7 +61,7 @@ export function DeployLogViewer({ logs, maxHeight = '300px' }: DeployLogViewerPr
           const style = levelStyles[log.level] || levelStyles.info;
           return (
             <div key={log.id} className="flex gap-2">
-              <span className="text-gray-600 dark:text-neutral-600 shrink-0 select-none">
+              <span className="text-neutral-600 dark:text-neutral-600 shrink-0 select-none">
                 {formatLogTime(log.created_at)}
               </span>
               <span

--- a/control-plane-ui/src/components/DeployProgress.tsx
+++ b/control-plane-ui/src/components/DeployProgress.tsx
@@ -52,7 +52,7 @@ export function DeployProgress({ currentStep, status }: DeployProgressProps) {
                   stepStatus === 'done' && 'bg-green-100 dark:bg-green-900/30',
                   stepStatus === 'active' && 'bg-blue-100 dark:bg-blue-900/30',
                   stepStatus === 'failed' && 'bg-red-100 dark:bg-red-900/30',
-                  stepStatus === 'pending' && 'bg-gray-100 dark:bg-neutral-700'
+                  stepStatus === 'pending' && 'bg-neutral-100 dark:bg-neutral-700'
                 )}
               >
                 {stepStatus === 'done' && (
@@ -65,7 +65,7 @@ export function DeployProgress({ currentStep, status }: DeployProgressProps) {
                   <Circle className="h-4 w-4 text-red-600 dark:text-red-400" />
                 )}
                 {stepStatus === 'pending' && (
-                  <Circle className="h-4 w-4 text-gray-400 dark:text-neutral-500" />
+                  <Circle className="h-4 w-4 text-neutral-400 dark:text-neutral-500" />
                 )}
               </div>
               <span
@@ -74,7 +74,7 @@ export function DeployProgress({ currentStep, status }: DeployProgressProps) {
                   stepStatus === 'done' && 'text-green-600 dark:text-green-400',
                   stepStatus === 'active' && 'text-blue-600 dark:text-blue-400 font-medium',
                   stepStatus === 'failed' && 'text-red-600 dark:text-red-400',
-                  stepStatus === 'pending' && 'text-gray-400 dark:text-neutral-500'
+                  stepStatus === 'pending' && 'text-neutral-400 dark:text-neutral-500'
                 )}
               >
                 {step.label}
@@ -86,7 +86,7 @@ export function DeployProgress({ currentStep, status }: DeployProgressProps) {
                   'w-8 h-0.5 mx-1 mb-4',
                   stepStatus === 'done'
                     ? 'bg-green-300 dark:bg-green-700'
-                    : 'bg-gray-200 dark:bg-neutral-600'
+                    : 'bg-neutral-200 dark:bg-neutral-600'
                 )}
               />
             )}

--- a/control-plane-ui/src/components/FloatingChat/FloatingChat.tsx
+++ b/control-plane-ui/src/components/FloatingChat/FloatingChat.tsx
@@ -74,7 +74,7 @@ function ToolBlock({ tool }: { tool: ChatToolUse }) {
         Tool: {tool.tool_name}
       </button>
       {expanded && truncated && (
-        <pre className="mt-1 whitespace-pre-wrap text-gray-600 dark:text-neutral-400 overflow-hidden max-h-32">
+        <pre className="mt-1 whitespace-pre-wrap text-neutral-600 dark:text-neutral-400 overflow-hidden max-h-32">
           {truncated}
         </pre>
       )}
@@ -177,7 +177,7 @@ export function FloatingChat({ initialOpen = false, onSendMessage }: FloatingCha
       {/* Chat Panel */}
       {isOpen && (
         <div
-          className="w-80 bg-white dark:bg-neutral-800 rounded-2xl shadow-2xl border border-gray-200 dark:border-neutral-700 flex flex-col overflow-hidden"
+          className="w-80 bg-white dark:bg-neutral-800 rounded-2xl shadow-2xl border border-neutral-200 dark:border-neutral-700 flex flex-col overflow-hidden"
           style={{ height: '420px' }}
           role="dialog"
           aria-label="AI assistant chat"
@@ -210,7 +210,7 @@ export function FloatingChat({ initialOpen = false, onSendMessage }: FloatingCha
                   className={`flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center ${
                     message.role === 'assistant'
                       ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-400'
-                      : 'bg-gray-200 dark:bg-neutral-600 text-gray-600 dark:text-neutral-300'
+                      : 'bg-neutral-200 dark:bg-neutral-600 text-neutral-600 dark:text-neutral-300'
                   }`}
                   aria-hidden="true"
                 >
@@ -229,7 +229,7 @@ export function FloatingChat({ initialOpen = false, onSendMessage }: FloatingCha
                     className={`rounded-2xl px-3 py-2 text-sm ${
                       message.role === 'user'
                         ? 'bg-blue-600 text-white rounded-tr-sm'
-                        : 'bg-gray-100 dark:bg-neutral-700 text-gray-800 dark:text-neutral-100 rounded-tl-sm'
+                        : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-800 dark:text-neutral-100 rounded-tl-sm'
                     }`}
                   >
                     {message.content}
@@ -237,7 +237,7 @@ export function FloatingChat({ initialOpen = false, onSendMessage }: FloatingCha
                       <ToolBlock key={tool.tool_use_id} tool={tool} />
                     ))}
                   </div>
-                  <span className="text-xs text-gray-400 dark:text-neutral-500 mt-1">
+                  <span className="text-xs text-neutral-400 dark:text-neutral-500 mt-1">
                     {formatTime(message.timestamp)}
                   </span>
                 </div>
@@ -250,11 +250,11 @@ export function FloatingChat({ initialOpen = false, onSendMessage }: FloatingCha
                 <div className="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-400">
                   <Bot className="w-4 h-4" />
                 </div>
-                <div className="bg-gray-100 dark:bg-neutral-700 rounded-2xl rounded-tl-sm px-3 py-2">
+                <div className="bg-neutral-100 dark:bg-neutral-700 rounded-2xl rounded-tl-sm px-3 py-2">
                   <div className="flex gap-1 items-center h-5" aria-label="Assistant is typing">
-                    <span className="w-1.5 h-1.5 bg-gray-400 dark:bg-neutral-400 rounded-full animate-bounce [animation-delay:0ms]" />
-                    <span className="w-1.5 h-1.5 bg-gray-400 dark:bg-neutral-400 rounded-full animate-bounce [animation-delay:150ms]" />
-                    <span className="w-1.5 h-1.5 bg-gray-400 dark:bg-neutral-400 rounded-full animate-bounce [animation-delay:300ms]" />
+                    <span className="w-1.5 h-1.5 bg-neutral-400 dark:bg-neutral-400 rounded-full animate-bounce [animation-delay:0ms]" />
+                    <span className="w-1.5 h-1.5 bg-neutral-400 dark:bg-neutral-400 rounded-full animate-bounce [animation-delay:150ms]" />
+                    <span className="w-1.5 h-1.5 bg-neutral-400 dark:bg-neutral-400 rounded-full animate-bounce [animation-delay:300ms]" />
                   </div>
                 </div>
               </div>
@@ -265,7 +265,7 @@ export function FloatingChat({ initialOpen = false, onSendMessage }: FloatingCha
           </div>
 
           {/* Input */}
-          <div className="px-3 py-3 border-t border-gray-200 dark:border-neutral-700">
+          <div className="px-3 py-3 border-t border-neutral-200 dark:border-neutral-700">
             <div className="flex gap-2 items-end">
               <textarea
                 ref={inputRef}
@@ -275,7 +275,7 @@ export function FloatingChat({ initialOpen = false, onSendMessage }: FloatingCha
                 placeholder="Ask STOA anything..."
                 disabled={isLoading}
                 rows={1}
-                className="flex-1 resize-none rounded-xl border border-gray-200 dark:border-neutral-600 bg-gray-50 dark:bg-neutral-900 text-sm text-gray-800 dark:text-neutral-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 placeholder:text-gray-400 dark:placeholder:text-neutral-500"
+                className="flex-1 resize-none rounded-xl border border-neutral-200 dark:border-neutral-600 bg-neutral-50 dark:bg-neutral-900 text-sm text-neutral-800 dark:text-neutral-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 placeholder:text-neutral-400 dark:placeholder:text-neutral-500"
                 style={{ maxHeight: '80px' }}
                 aria-label="Message input"
               />
@@ -288,7 +288,7 @@ export function FloatingChat({ initialOpen = false, onSendMessage }: FloatingCha
                 <Send className="w-4 h-4" />
               </button>
             </div>
-            <p className="text-xs text-gray-400 dark:text-neutral-500 mt-1.5 text-center">
+            <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1.5 text-center">
               Press Enter to send, Shift+Enter for new line
             </p>
           </div>

--- a/control-plane-ui/src/components/LanguageToggle.tsx
+++ b/control-plane-ui/src/components/LanguageToggle.tsx
@@ -22,7 +22,7 @@ export function LanguageToggle() {
   return (
     <button
       onClick={handleToggle}
-      className="flex items-center gap-1 px-2 py-2 text-sm text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-800 rounded-md transition-colors"
+      className="flex items-center gap-1 px-2 py-2 text-sm text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-md transition-colors"
       aria-label={`Switch language (current: ${currentLabel})`}
     >
       <Globe className="h-4 w-4" aria-hidden="true" />

--- a/control-plane-ui/src/components/Layout.tsx
+++ b/control-plane-ui/src/components/Layout.tsx
@@ -503,7 +503,7 @@ export function Layout({ children }: LayoutProps) {
   }, [navigationCommands, navigate, logout, setCommandItems, resolvedTheme, toggleTheme, t]);
 
   return (
-    <div className="min-h-screen bg-gray-100 dark:bg-neutral-900 transition-colors">
+    <div className="min-h-screen bg-neutral-100 dark:bg-neutral-900 transition-colors">
       {/* Mobile sidebar backdrop */}
       {sidebarOpen && (
         <div
@@ -515,26 +515,26 @@ export function Layout({ children }: LayoutProps) {
       {/* Sidebar */}
       <div
         className={clsx(
-          'fixed inset-y-0 left-0 z-50 w-64 bg-gray-100 dark:bg-neutral-950 border-r border-gray-200 dark:border-neutral-800 transition-transform duration-300 ease-in-out lg:translate-x-0',
+          'fixed inset-y-0 left-0 z-50 w-64 bg-neutral-100 dark:bg-neutral-950 border-r border-neutral-200 dark:border-neutral-800 transition-transform duration-300 ease-in-out lg:translate-x-0',
           sidebarOpen ? 'translate-x-0' : '-translate-x-full'
         )}
       >
         {/* Sidebar header */}
-        <div className="flex h-16 items-center justify-between border-b border-gray-200 dark:border-neutral-800 px-4">
+        <div className="flex h-16 items-center justify-between border-b border-neutral-200 dark:border-neutral-800 px-4">
           <div className="flex items-center gap-2">
             <StoaLogo size="sm" />
             <div>
-              <h1 className="text-lg font-bold text-gray-900 dark:text-white leading-tight">
+              <h1 className="text-lg font-bold text-neutral-900 dark:text-white leading-tight">
                 STOA
               </h1>
-              <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 tracking-wider uppercase">
+              <p className="text-[10px] font-medium text-neutral-500 dark:text-neutral-400 tracking-wider uppercase">
                 {t('layout.controlPlane')}
               </p>
             </div>
           </div>
           <button
             onClick={() => setSidebarOpen(false)}
-            className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-200 dark:hover:bg-neutral-800 hover:text-gray-900 dark:hover:text-white lg:hidden"
+            className="rounded-lg p-1.5 text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-800 hover:text-neutral-900 dark:hover:text-white lg:hidden"
           >
             <X className="h-5 w-5" />
           </button>
@@ -556,10 +556,10 @@ export function Layout({ children }: LayoutProps) {
                   <button
                     onClick={() => toggleSection(section.title)}
                     className={clsx(
-                      'flex items-center w-full px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wider transition-colors rounded hover:bg-gray-200/50 dark:hover:bg-neutral-800/50',
+                      'flex items-center w-full px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wider transition-colors rounded hover:bg-neutral-200/50 dark:hover:bg-neutral-800/50',
                       section.accent
                         ? 'text-primary-600 dark:text-primary-400'
-                        : 'text-gray-500 dark:text-gray-500'
+                        : 'text-neutral-500 dark:text-neutral-500'
                     )}
                   >
                     <ChevronDown
@@ -593,7 +593,7 @@ export function Layout({ children }: LayoutProps) {
                                   'flex items-center gap-3 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
                                   isActive
                                     ? 'bg-primary-600 text-white'
-                                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-neutral-800 hover:text-gray-900 dark:hover:text-white'
+                                    : 'text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-800 hover:text-neutral-900 dark:hover:text-white'
                                 )}
                               >
                                 <item.icon className="h-4 w-4 flex-shrink-0" />
@@ -604,7 +604,7 @@ export function Layout({ children }: LayoutProps) {
                                   </span>
                                 )}
                                 {!item.badge && item.shortcut && (
-                                  <span className="ml-auto text-xs text-gray-500 hidden xl:block">
+                                  <span className="ml-auto text-xs text-neutral-500 hidden xl:block">
                                     g{item.shortcut[1]}
                                   </span>
                                 )}
@@ -622,10 +622,10 @@ export function Layout({ children }: LayoutProps) {
         </nav>
 
         {/* Mobile-only: Env & Tenant selectors */}
-        <div className="lg:hidden border-t border-gray-200 dark:border-neutral-800 px-3 py-3 space-y-2">
+        <div className="lg:hidden border-t border-neutral-200 dark:border-neutral-800 px-3 py-3 space-y-2">
           {/* Environment selector */}
           <div>
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-500 mb-1 px-1">
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-500 mb-1 px-1">
               {t('layout.environment')}
             </p>
             {environments.map((env) => (
@@ -639,7 +639,7 @@ export function Layout({ children }: LayoutProps) {
                   'w-full flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors',
                   activeEnvironment === env.name
                     ? 'bg-primary-50 dark:bg-primary-900/20 text-primary-700 dark:text-primary-300'
-                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-neutral-800'
+                    : 'text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-800'
                 )}
               >
                 <span
@@ -664,7 +664,7 @@ export function Layout({ children }: LayoutProps) {
           {/* Tenant selector */}
           {tenants && tenants.length > 0 && (
             <div>
-              <p className="text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-500 mb-1 px-1">
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-500 mb-1 px-1">
                 {t('layout.tenant')}
               </p>
               {tenants.map((tenant) => {
@@ -681,10 +681,10 @@ export function Layout({ children }: LayoutProps) {
                       'w-full flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors',
                       isSelected
                         ? 'bg-primary-50 dark:bg-primary-900/20 text-primary-700 dark:text-primary-300'
-                        : 'text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-neutral-800'
+                        : 'text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-800'
                     )}
                   >
-                    <Building2 className="h-4 w-4 flex-shrink-0 text-gray-400" />
+                    <Building2 className="h-4 w-4 flex-shrink-0 text-neutral-400" />
                     <span className="flex-1 text-left truncate">
                       {tenant.display_name || tenant.name}
                     </span>
@@ -697,7 +697,7 @@ export function Layout({ children }: LayoutProps) {
         </div>
 
         {/* User section */}
-        <div className="absolute bottom-0 left-0 right-0 border-t border-gray-200 dark:border-neutral-800 p-4">
+        <div className="absolute bottom-0 left-0 right-0 border-t border-neutral-200 dark:border-neutral-800 p-4">
           <div className="flex items-center gap-3">
             <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary-600 flex-shrink-0">
               <User className="h-5 w-5 text-white" />
@@ -705,24 +705,24 @@ export function Layout({ children }: LayoutProps) {
             <div className="flex-1 min-w-0">
               {user ? (
                 <>
-                  <p className="truncate text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="truncate text-sm font-medium text-neutral-900 dark:text-white">
                     {user.name}
                   </p>
-                  <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                  <p className="truncate text-xs text-neutral-500 dark:text-neutral-400">
                     {user.roles.join(', ')}
                   </p>
                 </>
               ) : (
                 <>
-                  <div className="h-4 w-24 bg-gray-300 dark:bg-gray-700 rounded animate-pulse" />
-                  <div className="h-3 w-16 bg-gray-300 dark:bg-gray-700 rounded animate-pulse mt-1" />
+                  <div className="h-4 w-24 bg-neutral-300 dark:bg-neutral-700 rounded animate-pulse" />
+                  <div className="h-3 w-16 bg-neutral-300 dark:bg-neutral-700 rounded animate-pulse mt-1" />
                 </>
               )}
             </div>
             {user && (
               <button
                 onClick={logout}
-                className="rounded-lg p-2 text-gray-400 hover:bg-gray-200 dark:hover:bg-neutral-800 hover:text-gray-900 dark:hover:text-white flex-shrink-0"
+                className="rounded-lg p-2 text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-800 hover:text-neutral-900 dark:hover:text-white flex-shrink-0"
                 title={t('common.logout')}
               >
                 <LogOut className="h-5 w-5" />
@@ -739,7 +739,7 @@ export function Layout({ children }: LayoutProps) {
           {/* Mobile menu button */}
           <button
             onClick={() => setSidebarOpen(true)}
-            className="rounded-lg p-2.5 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-neutral-800 lg:hidden"
+            className="rounded-lg p-2.5 text-neutral-500 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-neutral-800 lg:hidden"
           >
             <Menu className="h-5 w-5" />
           </button>
@@ -753,18 +753,18 @@ export function Layout({ children }: LayoutProps) {
           />
 
           {/* Mobile: Just show current page name */}
-          <span className="flex-1 font-medium text-gray-900 dark:text-white truncate sm:hidden">
+          <span className="flex-1 font-medium text-neutral-900 dark:text-white truncate sm:hidden">
             {breadcrumbItems[breadcrumbItems.length - 1]?.label || 'Dashboard'}
           </span>
 
           {/* Command Palette trigger */}
           <button
             onClick={() => setCommandPaletteOpen(true)}
-            className="hidden sm:flex items-center gap-2 rounded-lg border border-gray-200 dark:border-neutral-700 bg-gray-50 dark:bg-neutral-800 px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-neutral-700 hover:border-gray-300 dark:hover:border-neutral-600 transition-colors"
+            className="hidden sm:flex items-center gap-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800 px-3 py-1.5 text-sm text-neutral-500 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-neutral-700 hover:border-neutral-300 dark:hover:border-neutral-600 transition-colors"
           >
             <Search className="h-4 w-4" />
             <span className="hidden md:inline">{t('common.search')}</span>
-            <kbd className="hidden md:flex items-center gap-0.5 rounded bg-white dark:bg-neutral-700 px-1.5 py-0.5 text-xs font-medium border border-gray-200 dark:border-neutral-600">
+            <kbd className="hidden md:flex items-center gap-0.5 rounded bg-white dark:bg-neutral-700 px-1.5 py-0.5 text-xs font-medium border border-neutral-200 dark:border-neutral-600">
               <span className="text-xs">⌘</span>K
             </kbd>
           </button>
@@ -772,7 +772,7 @@ export function Layout({ children }: LayoutProps) {
           {/* Mobile search button */}
           <button
             onClick={() => setCommandPaletteOpen(true)}
-            className="rounded-lg p-2 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-neutral-800 sm:hidden"
+            className="rounded-lg p-2 text-neutral-500 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-neutral-800 sm:hidden"
           >
             <Search className="h-5 w-5" />
           </button>
@@ -809,7 +809,7 @@ export function Layout({ children }: LayoutProps) {
               />
             </button>
             {envDropdownOpen && (
-              <div className="absolute right-0 mt-1 w-56 bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 shadow-lg z-50 py-1">
+              <div className="absolute right-0 mt-1 w-56 bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-lg z-50 py-1">
                 {environments.map((env) => (
                   <button
                     key={env.name}
@@ -818,7 +818,7 @@ export function Layout({ children }: LayoutProps) {
                       'w-full flex items-center gap-3 px-3 py-2 text-left text-sm transition-colors',
                       activeEnvironment === env.name
                         ? 'bg-primary-50 dark:bg-primary-900/20 text-primary-700 dark:text-primary-300'
-                        : 'text-gray-700 dark:text-neutral-300 hover:bg-gray-50 dark:hover:bg-neutral-700'
+                        : 'text-neutral-700 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700'
                     )}
                   >
                     <span
@@ -831,7 +831,7 @@ export function Layout({ children }: LayoutProps) {
                     />
                     <div className="flex-1 min-w-0">
                       <p className="truncate font-medium">{env.label}</p>
-                      <p className="truncate text-xs text-gray-500 dark:text-neutral-400">
+                      <p className="truncate text-xs text-neutral-500 dark:text-neutral-400">
                         {env.mode === 'read-only' ? t('common.readOnly') : t('common.fullAccess')}
                       </p>
                     </div>
@@ -869,7 +869,7 @@ export function Layout({ children }: LayoutProps) {
                 />
               </button>
               {tenantDropdownOpen && tenants && tenants.length > 0 && (
-                <div className="absolute right-0 mt-1 w-64 bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 shadow-lg z-50 py-1 max-h-64 overflow-y-auto">
+                <div className="absolute right-0 mt-1 w-64 bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-lg z-50 py-1 max-h-64 overflow-y-auto">
                   {tenants.map((tenant) => {
                     const selectedId = activeTenantId || user?.tenant_id;
                     const isSelected = selectedId === tenant.id || selectedId === tenant.name;
@@ -881,15 +881,15 @@ export function Layout({ children }: LayoutProps) {
                           'w-full flex items-center gap-3 px-3 py-2 text-left text-sm transition-colors',
                           isSelected
                             ? 'bg-primary-50 dark:bg-primary-900/20 text-primary-700 dark:text-primary-300'
-                            : 'text-gray-700 dark:text-neutral-300 hover:bg-gray-50 dark:hover:bg-neutral-700'
+                            : 'text-neutral-700 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700'
                         )}
                       >
-                        <Building2 className="h-4 w-4 flex-shrink-0 text-gray-400" />
+                        <Building2 className="h-4 w-4 flex-shrink-0 text-neutral-400" />
                         <div className="flex-1 min-w-0">
                           <p className="truncate font-medium">
                             {tenant.display_name || tenant.name}
                           </p>
-                          <p className="truncate text-xs text-gray-500 dark:text-neutral-400">
+                          <p className="truncate text-xs text-neutral-500 dark:text-neutral-400">
                             {tenant.name}
                           </p>
                         </div>

--- a/control-plane-ui/src/components/ServiceUnavailable.tsx
+++ b/control-plane-ui/src/components/ServiceUnavailable.tsx
@@ -25,13 +25,13 @@ export function ServiceUnavailable({
   return (
     <div className="flex items-center justify-center min-h-[400px]">
       <div className="text-center max-w-md px-6">
-        <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-gray-100 dark:bg-neutral-800 flex items-center justify-center">
-          <Icon className="h-8 w-8 text-gray-400 dark:text-neutral-500" />
+        <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-neutral-100 dark:bg-neutral-800 flex items-center justify-center">
+          <Icon className="h-8 w-8 text-neutral-400 dark:text-neutral-500" />
         </div>
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+        <h2 className="text-xl font-semibold text-neutral-900 dark:text-white mb-2">
           {serviceName} is not available
         </h2>
-        <p className="text-gray-500 dark:text-neutral-400 mb-6">{description}</p>
+        <p className="text-neutral-500 dark:text-neutral-400 mb-6">{description}</p>
 
         {configHint && (
           <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg px-4 py-3 mb-6 text-left">
@@ -45,7 +45,7 @@ export function ServiceUnavailable({
           {onRetry && (
             <button
               onClick={onRetry}
-              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-neutral-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors"
             >
               <RefreshCw className="h-4 w-4" />
               Retry

--- a/control-plane-ui/src/components/SyncStatusBadge.test.tsx
+++ b/control-plane-ui/src/components/SyncStatusBadge.test.tsx
@@ -10,7 +10,7 @@ describe('SyncStatusBadge', () => {
     { status: 'synced', label: 'Synced', colorClass: 'bg-green-100' },
     { status: 'drifted', label: 'Drifted', colorClass: 'bg-orange-100' },
     { status: 'error', label: 'Error', colorClass: 'bg-red-100' },
-    { status: 'deleting', label: 'Deleting', colorClass: 'bg-gray-100' },
+    { status: 'deleting', label: 'Deleting', colorClass: 'bg-neutral-100' },
   ];
 
   it.each(statuses)('renders "$label" for status "$status"', ({ status, label }) => {

--- a/control-plane-ui/src/components/SyncStatusBadge.tsx
+++ b/control-plane-ui/src/components/SyncStatusBadge.tsx
@@ -24,7 +24,7 @@ const statusConfig: Record<DeploymentSyncStatus, { label: string; classes: strin
   },
   deleting: {
     label: 'Deleting',
-    classes: 'bg-gray-100 text-gray-800 dark:bg-neutral-800 dark:text-neutral-400',
+    classes: 'bg-neutral-100 text-neutral-800 dark:bg-neutral-800 dark:text-neutral-400',
   },
 };
 
@@ -36,7 +36,7 @@ interface SyncStatusBadgeProps {
 export function SyncStatusBadge({ status, className }: SyncStatusBadgeProps) {
   const config = statusConfig[status] || {
     label: status,
-    classes: 'bg-gray-100 text-gray-800 dark:bg-neutral-800 dark:text-neutral-400',
+    classes: 'bg-neutral-100 text-neutral-800 dark:bg-neutral-800 dark:text-neutral-400',
   };
 
   return (

--- a/control-plane-ui/src/components/__tests__/DeployProgress.test.tsx
+++ b/control-plane-ui/src/components/__tests__/DeployProgress.test.tsx
@@ -27,7 +27,7 @@ describe('DeployProgress', () => {
 
     // "Health Check" is after → pending (gray)
     const healthLabel = Array.from(labels).find((el) => el.textContent === 'Health Check');
-    expect(healthLabel?.className).toContain('text-gray-400');
+    expect(healthLabel?.className).toContain('text-neutral-400');
   });
 
   it('marks all steps as done on success', () => {
@@ -55,7 +55,7 @@ describe('DeployProgress', () => {
 
     // complete is after → pending
     const completeLabel = Array.from(labels).find((el) => el.textContent === 'Complete');
-    expect(completeLabel?.className).toContain('text-gray-400');
+    expect(completeLabel?.className).toContain('text-neutral-400');
   });
 
   it('renders 3 connector lines between 4 steps', () => {

--- a/control-plane-ui/src/components/charts/SparklineChart.tsx
+++ b/control-plane-ui/src/components/charts/SparklineChart.tsx
@@ -48,7 +48,7 @@ export function SparklineChart({
   if (data.length < 2) {
     return (
       <div
-        className={`flex items-center justify-center text-xs text-gray-400 dark:text-gray-500 ${className}`}
+        className={`flex items-center justify-center text-xs text-neutral-400 dark:text-neutral-500 ${className}`}
         style={{ height, width }}
       >
         No data

--- a/control-plane-ui/src/components/tools/QuickStartGuide.tsx
+++ b/control-plane-ui/src/components/tools/QuickStartGuide.tsx
@@ -138,9 +138,9 @@ curl -X POST "${mcpGatewayUrl}/mcp/tools/invoke" \\
   };
 
   return (
-    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700">
       {/* Tabs */}
-      <div className="flex border-b border-gray-200 dark:border-neutral-700">
+      <div className="flex border-b border-neutral-200 dark:border-neutral-700">
         {tabs.map((tab) => (
           <button
             key={tab.id}
@@ -148,7 +148,7 @@ curl -X POST "${mcpGatewayUrl}/mcp/tools/invoke" \\
             className={`flex items-center gap-2 px-4 py-3 text-sm font-medium transition-colors ${
               activeTab === tab.id
                 ? 'text-blue-600 border-b-2 border-blue-600 -mb-px bg-blue-50 dark:bg-blue-950/30'
-                : 'text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-200 hover:bg-gray-50 dark:hover:bg-neutral-700'
+                : 'text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 hover:bg-neutral-50 dark:hover:bg-neutral-700'
             }`}
           >
             {tab.icon}
@@ -161,23 +161,23 @@ curl -X POST "${mcpGatewayUrl}/mcp/tools/invoke" \\
       <div className="relative">
         <button
           onClick={handleCopy}
-          className="absolute top-3 right-3 p-2 bg-gray-700 hover:bg-gray-600 rounded text-gray-300 transition-colors z-10"
+          className="absolute top-3 right-3 p-2 bg-neutral-700 hover:bg-neutral-600 rounded text-neutral-300 transition-colors z-10"
           title="Copy to clipboard"
         >
           {copied ? <Check className="h-4 w-4 text-green-400" /> : <Copy className="h-4 w-4" />}
         </button>
-        <pre className="bg-gray-900 text-gray-100 p-4 overflow-x-auto text-xs leading-relaxed rounded-b-lg">
+        <pre className="bg-neutral-900 text-neutral-100 p-4 overflow-x-auto text-xs leading-relaxed rounded-b-lg">
           <code>{codeSnippets[activeTab]}</code>
         </pre>
       </div>
 
       {/* Help Text */}
-      <div className="px-4 py-3 bg-gray-50 dark:bg-neutral-800/50 border-t border-gray-200 dark:border-neutral-700 rounded-b-lg">
-        <p className="text-xs text-gray-500 dark:text-neutral-400">
+      <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-800/50 border-t border-neutral-200 dark:border-neutral-700 rounded-b-lg">
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">
           {activeTab === 'claude-desktop' && (
             <>
               Add this configuration to your Claude Desktop config file at{' '}
-              <code className="bg-gray-200 dark:bg-neutral-700 px-1 rounded">
+              <code className="bg-neutral-200 dark:bg-neutral-700 px-1 rounded">
                 ~/Library/Application Support/Claude/claude_desktop_config.json
               </code>
             </>
@@ -185,7 +185,7 @@ curl -X POST "${mcpGatewayUrl}/mcp/tools/invoke" \\
           {activeTab === 'python' && (
             <>
               Install the Anthropic SDK:{' '}
-              <code className="bg-gray-200 dark:bg-neutral-700 px-1 rounded">
+              <code className="bg-neutral-200 dark:bg-neutral-700 px-1 rounded">
                 pip install anthropic
               </code>
             </>
@@ -193,8 +193,8 @@ curl -X POST "${mcpGatewayUrl}/mcp/tools/invoke" \\
           {activeTab === 'curl' && (
             <>
               Replace{' '}
-              <code className="bg-gray-200 dark:bg-neutral-700 px-1 rounded">YOUR_TOKEN</code> with
-              your Keycloak access token.
+              <code className="bg-neutral-200 dark:bg-neutral-700 px-1 rounded">YOUR_TOKEN</code>{' '}
+              with your Keycloak access token.
             </>
           )}
         </p>

--- a/control-plane-ui/src/components/tools/ToolCard.tsx
+++ b/control-plane-ui/src/components/tools/ToolCard.tsx
@@ -29,7 +29,7 @@ export const ToolCard = memo(function ToolCard({
 
   return (
     <div
-      className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-200 dark:border-neutral-700 hover:shadow-md hover:border-blue-300 dark:hover:border-blue-600 transition-all cursor-pointer"
+      className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-200 dark:border-neutral-700 hover:shadow-md hover:border-blue-300 dark:hover:border-blue-600 transition-all cursor-pointer"
       onClick={onClick}
     >
       <div className="p-5">
@@ -40,19 +40,23 @@ export const ToolCard = memo(function ToolCard({
               <Wrench className="h-5 w-5 text-blue-600" />
             </div>
             <div>
-              <h3 className="font-semibold text-gray-900 dark:text-white text-sm">{tool.name}</h3>
-              <span className="text-xs text-gray-500 dark:text-neutral-400">v{tool.version}</span>
+              <h3 className="font-semibold text-neutral-900 dark:text-white text-sm">
+                {tool.name}
+              </h3>
+              <span className="text-xs text-neutral-500 dark:text-neutral-400">
+                v{tool.version}
+              </span>
             </div>
           </div>
           <span
-            className={`px-2 py-0.5 rounded text-xs font-medium ${methodColors[tool.method] || 'bg-gray-100 dark:bg-neutral-700 text-gray-800 dark:text-neutral-300'}`}
+            className={`px-2 py-0.5 rounded text-xs font-medium ${methodColors[tool.method] || 'bg-neutral-100 dark:bg-neutral-700 text-neutral-800 dark:text-neutral-300'}`}
           >
             {tool.method}
           </span>
         </div>
 
         {/* Description */}
-        <p className="text-sm text-gray-600 dark:text-neutral-300 mb-4 line-clamp-2">
+        <p className="text-sm text-neutral-600 dark:text-neutral-300 mb-4 line-clamp-2">
           {tool.description}
         </p>
 
@@ -62,14 +66,14 @@ export const ToolCard = memo(function ToolCard({
             {tool.tags.slice(0, 3).map((tag) => (
               <span
                 key={tag}
-                className="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 dark:bg-neutral-700 text-gray-600 dark:text-neutral-300 rounded text-xs"
+                className="inline-flex items-center gap-1 px-2 py-0.5 bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300 rounded text-xs"
               >
                 <Tag className="h-3 w-3" />
                 {tag}
               </span>
             ))}
             {tool.tags.length > 3 && (
-              <span className="text-xs text-gray-400 dark:text-neutral-500">
+              <span className="text-xs text-neutral-400 dark:text-neutral-500">
                 +{tool.tags.length - 3} more
               </span>
             )}
@@ -77,7 +81,7 @@ export const ToolCard = memo(function ToolCard({
         )}
 
         {/* Stats */}
-        <div className="flex items-center gap-4 text-xs text-gray-500 dark:text-neutral-400 mb-4">
+        <div className="flex items-center gap-4 text-xs text-neutral-500 dark:text-neutral-400 mb-4">
           <span className="flex items-center gap-1">
             <Zap className="h-3.5 w-3.5" />
             {paramCount} params
@@ -96,9 +100,9 @@ export const ToolCard = memo(function ToolCard({
         </div>
 
         {/* Actions */}
-        <div className="flex items-center justify-between pt-3 border-t border-gray-100 dark:border-neutral-700">
+        <div className="flex items-center justify-between pt-3 border-t border-neutral-100 dark:border-neutral-700">
           {tool.tenantId && (
-            <span className="text-xs text-gray-400 dark:text-neutral-500">
+            <span className="text-xs text-neutral-400 dark:text-neutral-500">
               Tenant: {tool.tenantId}
             </span>
           )}
@@ -112,7 +116,7 @@ export const ToolCard = memo(function ToolCard({
               }}
               className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
                 isSubscribed
-                  ? 'bg-gray-100 dark:bg-neutral-700 text-gray-600 dark:text-neutral-300 hover:bg-gray-200 dark:hover:bg-neutral-600'
+                  ? 'bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'
                   : 'bg-blue-600 text-white hover:bg-blue-700'
               }`}
             >

--- a/control-plane-ui/src/components/tools/ToolSchemaViewer.tsx
+++ b/control-plane-ui/src/components/tools/ToolSchemaViewer.tsx
@@ -13,16 +13,16 @@ export function ToolSchemaViewer({ schema, title = 'Input Schema' }: ToolSchemaV
 
   if (Object.keys(properties).length === 0) {
     return (
-      <div className="text-sm text-gray-500 dark:text-neutral-400 italic">
+      <div className="text-sm text-neutral-500 dark:text-neutral-400 italic">
         This tool has no input parameters.
       </div>
     );
   }
 
   return (
-    <div className="bg-gray-50 dark:bg-neutral-900 rounded-lg border border-gray-200 dark:border-neutral-700">
-      <div className="px-4 py-3 border-b border-gray-200 dark:border-neutral-700">
-        <h4 className="text-sm font-medium text-gray-700 dark:text-neutral-300">{title}</h4>
+    <div className="bg-neutral-50 dark:bg-neutral-900 rounded-lg border border-neutral-200 dark:border-neutral-700">
+      <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-700">
+        <h4 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">{title}</h4>
       </div>
       <div className="p-4 space-y-2">
         {Object.entries(properties).map(([name, prop]) => (
@@ -69,25 +69,27 @@ function PropertyRow({ name, property, isRequired, depth = 0 }: PropertyRowProps
   return (
     <div className="text-sm" style={{ marginLeft: depth * 16 }}>
       <div
-        className={`flex items-start gap-2 py-1.5 ${hasNestedProperties || hasItems ? 'cursor-pointer hover:bg-gray-100 dark:hover:bg-neutral-800 rounded' : ''}`}
+        className={`flex items-start gap-2 py-1.5 ${hasNestedProperties || hasItems ? 'cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded' : ''}`}
         onClick={() => (hasNestedProperties || hasItems) && setIsExpanded(!isExpanded)}
       >
         {/* Expand/Collapse Icon */}
         {hasNestedProperties || hasItems ? (
           isExpanded ? (
-            <ChevronDown className="h-4 w-4 text-gray-400 dark:text-neutral-500 mt-0.5 flex-shrink-0" />
+            <ChevronDown className="h-4 w-4 text-neutral-400 dark:text-neutral-500 mt-0.5 flex-shrink-0" />
           ) : (
-            <ChevronRight className="h-4 w-4 text-gray-400 dark:text-neutral-500 mt-0.5 flex-shrink-0" />
+            <ChevronRight className="h-4 w-4 text-neutral-400 dark:text-neutral-500 mt-0.5 flex-shrink-0" />
           )
         ) : (
-          <Circle className="h-2 w-2 text-gray-300 dark:text-neutral-600 mt-1.5 ml-1 mr-1 flex-shrink-0" />
+          <Circle className="h-2 w-2 text-neutral-300 dark:text-neutral-600 mt-1.5 ml-1 mr-1 flex-shrink-0" />
         )}
 
         {/* Property Name */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <span className="font-mono font-medium text-gray-900 dark:text-white">{name}</span>
-            <span className={`font-mono text-xs ${typeColors[property.type] || 'text-gray-500'}`}>
+            <span className="font-mono font-medium text-neutral-900 dark:text-white">{name}</span>
+            <span
+              className={`font-mono text-xs ${typeColors[property.type] || 'text-neutral-500'}`}
+            >
               {formatType(property)}
             </span>
             {isRequired && (
@@ -97,18 +99,18 @@ function PropertyRow({ name, property, isRequired, depth = 0 }: PropertyRowProps
               </span>
             )}
             {property.enum && (
-              <span className="text-xs text-gray-400 dark:text-neutral-500">
+              <span className="text-xs text-neutral-400 dark:text-neutral-500">
                 enum: [{property.enum.join(', ')}]
               </span>
             )}
             {property.default !== undefined && (
-              <span className="text-xs text-gray-400 dark:text-neutral-500">
+              <span className="text-xs text-neutral-400 dark:text-neutral-500">
                 default: {JSON.stringify(property.default)}
               </span>
             )}
           </div>
           {property.description && (
-            <p className="text-gray-500 dark:text-neutral-400 text-xs mt-0.5">
+            <p className="text-neutral-500 dark:text-neutral-400 text-xs mt-0.5">
               {property.description}
             </p>
           )}
@@ -117,7 +119,7 @@ function PropertyRow({ name, property, isRequired, depth = 0 }: PropertyRowProps
 
       {/* Nested Properties */}
       {isExpanded && hasNestedProperties && (
-        <div className="mt-1 pl-2 border-l border-gray-200 dark:border-neutral-700 ml-2">
+        <div className="mt-1 pl-2 border-l border-neutral-200 dark:border-neutral-700 ml-2">
           {Object.entries(property.properties!).map(([nestedName, nestedProp]) => (
             <PropertyRow
               key={nestedName}
@@ -132,8 +134,8 @@ function PropertyRow({ name, property, isRequired, depth = 0 }: PropertyRowProps
 
       {/* Array Items */}
       {isExpanded && hasItems && property.items?.properties && (
-        <div className="mt-1 pl-2 border-l border-gray-200 dark:border-neutral-700 ml-2">
-          <div className="text-xs text-gray-400 dark:text-neutral-500 mb-1">Array items:</div>
+        <div className="mt-1 pl-2 border-l border-neutral-200 dark:border-neutral-700 ml-2">
+          <div className="text-xs text-neutral-400 dark:text-neutral-500 mb-1">Array items:</div>
           {Object.entries(property.items.properties).map(([itemName, itemProp]) => (
             <PropertyRow
               key={itemName}
@@ -155,7 +157,7 @@ interface SchemaJsonViewerProps {
 
 export function SchemaJsonViewer({ schema }: SchemaJsonViewerProps) {
   return (
-    <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 overflow-x-auto text-xs">
+    <pre className="bg-neutral-900 text-neutral-100 rounded-lg p-4 overflow-x-auto text-xs">
       <code>{JSON.stringify(schema, null, 2)}</code>
     </pre>
   );

--- a/control-plane-ui/src/components/tools/UsageChart.tsx
+++ b/control-plane-ui/src/components/tools/UsageChart.tsx
@@ -58,18 +58,18 @@ export function UsageChart({ data, metric, title, height = 200 }: UsageChartProp
         ? 'text-green-600'
         : trend < 0
           ? 'text-red-600'
-          : 'text-gray-500'
+          : 'text-neutral-500'
       : metric === 'avgLatencyMs'
         ? trend < 0
           ? 'text-green-600'
           : trend > 0
             ? 'text-red-600'
-            : 'text-gray-500'
+            : 'text-neutral-500'
         : trend > 0
           ? 'text-green-600'
           : trend < 0
             ? 'text-red-600'
-            : 'text-gray-500';
+            : 'text-neutral-500';
 
   const barColor = {
     calls: 'bg-blue-500',
@@ -80,10 +80,10 @@ export function UsageChart({ data, metric, title, height = 200 }: UsageChartProp
 
   if (data.length === 0) {
     return (
-      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4">
-        <h3 className="text-sm font-medium text-gray-700 dark:text-neutral-300 mb-4">{title}</h3>
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 p-4">
+        <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-4">{title}</h3>
         <div
-          className="flex items-center justify-center text-gray-400 dark:text-neutral-500 text-sm"
+          className="flex items-center justify-center text-neutral-400 dark:text-neutral-500 text-sm"
           style={{ height }}
         >
           No data available
@@ -93,10 +93,10 @@ export function UsageChart({ data, metric, title, height = 200 }: UsageChartProp
   }
 
   return (
-    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 p-4">
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-sm font-medium text-gray-700 dark:text-neutral-300">{title}</h3>
+        <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">{title}</h3>
         <div className={`flex items-center gap-1 text-sm ${trendColor}`}>
           <TrendIcon className="h-4 w-4" />
           <span>{Math.abs(trend).toFixed(1)}%</span>
@@ -109,9 +109,9 @@ export function UsageChart({ data, metric, title, height = 200 }: UsageChartProp
           {values.map((value, index) => (
             <div key={index} className="flex-1 flex flex-col items-center group">
               {/* Tooltip */}
-              <div className="opacity-0 group-hover:opacity-100 absolute bottom-full mb-2 px-2 py-1 bg-gray-800 text-white text-xs rounded whitespace-nowrap transition-opacity z-10">
+              <div className="opacity-0 group-hover:opacity-100 absolute bottom-full mb-2 px-2 py-1 bg-neutral-800 text-white text-xs rounded whitespace-nowrap transition-opacity z-10">
                 <div className="font-medium">{formattedValues[index]}</div>
-                <div className="text-gray-400">{formatLabel(data[index].timestamp)}</div>
+                <div className="text-neutral-400">{formatLabel(data[index].timestamp)}</div>
               </div>
 
               {/* Bar */}
@@ -124,7 +124,7 @@ export function UsageChart({ data, metric, title, height = 200 }: UsageChartProp
         </div>
 
         {/* Y-axis labels */}
-        <div className="absolute left-0 top-0 bottom-0 flex flex-col justify-between text-xs text-gray-400 dark:text-neutral-500 -ml-8 w-8 text-right">
+        <div className="absolute left-0 top-0 bottom-0 flex flex-col justify-between text-xs text-neutral-400 dark:text-neutral-500 -ml-8 w-8 text-right">
           <span>
             {metric === 'successRate' ? `${(max * 100).toFixed(0)}%` : max.toLocaleString()}
           </span>
@@ -135,7 +135,7 @@ export function UsageChart({ data, metric, title, height = 200 }: UsageChartProp
       </div>
 
       {/* X-axis labels */}
-      <div className="flex justify-between mt-2 text-xs text-gray-400 dark:text-neutral-500">
+      <div className="flex justify-between mt-2 text-xs text-neutral-400 dark:text-neutral-500">
         <span>{data.length > 0 ? formatLabel(data[0].timestamp) : ''}</span>
         <span>{data.length > 0 ? formatLabel(data[data.length - 1].timestamp) : ''}</span>
       </div>
@@ -169,15 +169,15 @@ export function UsageStatsCard({
   };
 
   return (
-    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 p-4">
       <div className="flex items-center justify-between mb-2">
-        <span className="text-sm text-gray-500 dark:text-neutral-400">{title}</span>
+        <span className="text-sm text-neutral-500 dark:text-neutral-400">{title}</span>
         {icon && <div className={`p-2 rounded-lg ${colorClasses[color]}`}>{icon}</div>}
       </div>
-      <div className="text-2xl font-bold text-gray-900 dark:text-white">{value}</div>
+      <div className="text-2xl font-bold text-neutral-900 dark:text-white">{value}</div>
       <div className="flex items-center justify-between mt-1">
         {subtitle && (
-          <span className="text-xs text-gray-400 dark:text-neutral-500">{subtitle}</span>
+          <span className="text-xs text-neutral-400 dark:text-neutral-500">{subtitle}</span>
         )}
         {trend !== undefined && (
           <span

--- a/control-plane-ui/src/pages/AITools/MySubscriptions.tsx
+++ b/control-plane-ui/src/pages/AITools/MySubscriptions.tsx
@@ -74,15 +74,15 @@ export function MySubscriptions() {
   const statusColors: Record<string, string> = {
     active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
     suspended: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
-    pending: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300',
+    pending: 'bg-neutral-100 text-neutral-800 dark:bg-neutral-700 dark:text-neutral-300',
   };
 
   if (loading) {
     return (
       <div className="space-y-6">
         <div className="flex items-center justify-between">
-          <div className="h-8 w-48 bg-gray-200 rounded animate-pulse" />
-          <div className="h-10 w-32 bg-gray-200 rounded animate-pulse" />
+          <div className="h-8 w-48 bg-neutral-200 rounded animate-pulse" />
+          <div className="h-10 w-32 bg-neutral-200 rounded animate-pulse" />
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {[1, 2, 3].map((i) => (
@@ -98,8 +98,8 @@ export function MySubscriptions() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">My Subscriptions</h1>
-          <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">My Subscriptions</h1>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
             Manage your subscribed AI tools
           </p>
         </div>
@@ -122,32 +122,32 @@ export function MySubscriptions() {
 
       {/* Subscriptions List */}
       {subscriptions.length > 0 ? (
-        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 overflow-hidden">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 overflow-hidden">
           <table className="w-full">
-            <thead className="bg-gray-50 dark:bg-neutral-700 border-b border-gray-200 dark:border-neutral-600">
+            <thead className="bg-neutral-50 dark:bg-neutral-700 border-b border-neutral-200 dark:border-neutral-600">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Tool
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Status
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Usage
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Subscribed
                 </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Actions
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
+            <tbody className="divide-y divide-neutral-200 dark:divide-neutral-700">
               {subscriptions.map((sub) => {
                 const tool = tools.get(sub.toolName);
                 return (
-                  <tr key={sub.id} className="hover:bg-gray-50 dark:hover:bg-neutral-700">
+                  <tr key={sub.id} className="hover:bg-neutral-50 dark:hover:bg-neutral-700">
                     <td className="px-6 py-4">
                       <div className="flex items-center gap-3">
                         <div className="p-2 bg-blue-50 dark:bg-blue-900/30 rounded-lg">
@@ -158,12 +158,12 @@ export function MySubscriptions() {
                             onClick={() =>
                               navigate(`/ai-tools/${encodeURIComponent(sub.toolName)}`)
                             }
-                            className="font-medium text-gray-900 dark:text-white hover:text-blue-600"
+                            className="font-medium text-neutral-900 dark:text-white hover:text-blue-600"
                           >
                             {sub.toolName}
                           </button>
                           {tool && (
-                            <p className="text-sm text-gray-500 dark:text-neutral-400 line-clamp-1 max-w-xs">
+                            <p className="text-sm text-neutral-500 dark:text-neutral-400 line-clamp-1 max-w-xs">
                               {tool.description}
                             </p>
                           )}
@@ -178,18 +178,18 @@ export function MySubscriptions() {
                       </span>
                     </td>
                     <td className="px-6 py-4">
-                      <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-neutral-300">
-                        <Activity className="h-4 w-4 text-gray-400 dark:text-neutral-500" />
+                      <div className="flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-300">
+                        <Activity className="h-4 w-4 text-neutral-400 dark:text-neutral-500" />
                         <span>{sub.usageCount} calls</span>
                         {sub.usageLimit && (
-                          <span className="text-gray-400 dark:text-neutral-500">
+                          <span className="text-neutral-400 dark:text-neutral-500">
                             / {sub.usageLimit} limit
                           </span>
                         )}
                       </div>
                     </td>
                     <td className="px-6 py-4">
-                      <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-neutral-400">
+                      <div className="flex items-center gap-2 text-sm text-neutral-500 dark:text-neutral-400">
                         <Clock className="h-4 w-4" />
                         {new Date(sub.subscribedAt).toLocaleDateString()}
                       </div>
@@ -198,7 +198,7 @@ export function MySubscriptions() {
                       <div className="flex items-center justify-end gap-2">
                         <button
                           onClick={() => navigate(`/ai-tools/${encodeURIComponent(sub.toolName)}`)}
-                          className="p-2 text-gray-400 hover:text-gray-600 transition-colors"
+                          className="p-2 text-neutral-400 hover:text-neutral-600 transition-colors"
                           title="View details"
                         >
                           <ExternalLink className="h-4 w-4" />
@@ -224,7 +224,7 @@ export function MySubscriptions() {
           </table>
         </div>
       ) : (
-        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700">
           <EmptyState
             variant="subscriptions"
             title="No subscriptions yet"

--- a/control-plane-ui/src/pages/AITools/ToolCatalog.tsx
+++ b/control-plane-ui/src/pages/AITools/ToolCatalog.tsx
@@ -90,14 +90,14 @@ export function ToolCatalog() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">AI Tool Catalog</h1>
-          <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">AI Tool Catalog</h1>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
             Browse MCP tools available for AI-powered API interactions
           </p>
         </div>
         <button
           onClick={loadTools}
-          className="flex items-center gap-2 px-4 py-2 bg-white dark:bg-neutral-700 border border-gray-300 dark:border-neutral-600 rounded-lg text-sm text-gray-700 dark:text-neutral-300 hover:bg-gray-50 dark:hover:bg-neutral-600 transition-colors"
+          className="flex items-center gap-2 px-4 py-2 bg-white dark:bg-neutral-700 border border-neutral-300 dark:border-neutral-600 rounded-lg text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-600 transition-colors"
         >
           <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
           Refresh
@@ -105,18 +105,18 @@ export function ToolCatalog() {
       </div>
 
       {/* Filters Bar */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 p-4">
         <div className="flex flex-wrap items-center gap-4">
           {/* Search */}
           <div className="flex-1 min-w-[250px]">
             <div className="relative">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400" />
               <input
                 type="text"
                 placeholder="Search tools by name or description..."
                 value={searchQuery}
                 onChange={(e) => handleSearch(e.target.value)}
-                className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full pl-10 pr-4 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               />
             </div>
           </div>
@@ -126,7 +126,7 @@ export function ToolCatalog() {
             <select
               value={selectedTag}
               onChange={(e) => handleTagFilter(e.target.value)}
-              className="appearance-none pl-10 pr-8 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="appearance-none pl-10 pr-8 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               <option value="">All Tags</option>
               {tags.map((tag) => (
@@ -135,14 +135,14 @@ export function ToolCatalog() {
                 </option>
               ))}
             </select>
-            <Tag className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <Tag className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400" />
           </div>
 
           {/* Clear Filters */}
           {hasActiveFilters && (
             <button
               onClick={clearFilters}
-              className="flex items-center gap-1 px-3 py-2 text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+              className="flex items-center gap-1 px-3 py-2 text-sm text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white transition-colors"
             >
               <Filter className="h-4 w-4" />
               Clear filters
@@ -152,7 +152,7 @@ export function ToolCatalog() {
 
         {/* Active Filters */}
         {hasActiveFilters && (
-          <div className="flex flex-wrap gap-2 mt-3 pt-3 border-t border-gray-100 dark:border-neutral-700">
+          <div className="flex flex-wrap gap-2 mt-3 pt-3 border-t border-neutral-100 dark:border-neutral-700">
             {searchQuery && (
               <span className="inline-flex items-center gap-1 px-2 py-1 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 rounded text-xs">
                 Search: {searchQuery}
@@ -197,7 +197,7 @@ export function ToolCatalog() {
       {!loading && !error && (
         <>
           {/* Results Count */}
-          <div className="flex items-center justify-between text-sm text-gray-500 dark:text-neutral-400">
+          <div className="flex items-center justify-between text-sm text-neutral-500 dark:text-neutral-400">
             <span>
               Showing {tools.length} of {totalCount} tools
             </span>
@@ -211,7 +211,7 @@ export function ToolCatalog() {
               ))}
             </div>
           ) : (
-            <div className="col-span-full bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700">
+            <div className="col-span-full bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700">
               <EmptyState
                 variant={hasActiveFilters ? 'search' : 'tools'}
                 action={

--- a/control-plane-ui/src/pages/AITools/ToolDetail.tsx
+++ b/control-plane-ui/src/pages/AITools/ToolDetail.tsx
@@ -77,14 +77,14 @@ export function ToolDetail() {
     return (
       <div className="space-y-6">
         <div className="flex items-center gap-4">
-          <div className="h-4 w-4 bg-gray-200 rounded animate-pulse" />
-          <div className="h-4 w-24 bg-gray-200 rounded animate-pulse" />
+          <div className="h-4 w-4 bg-neutral-200 rounded animate-pulse" />
+          <div className="h-4 w-24 bg-neutral-200 rounded animate-pulse" />
         </div>
         <div className="flex items-center gap-6">
-          <div className="h-16 w-16 bg-gray-200 rounded-lg animate-pulse" />
+          <div className="h-16 w-16 bg-neutral-200 rounded-lg animate-pulse" />
           <div className="space-y-2 flex-1">
-            <div className="h-8 w-64 bg-gray-200 rounded animate-pulse" />
-            <div className="h-4 w-96 bg-gray-200 rounded animate-pulse" />
+            <div className="h-8 w-64 bg-neutral-200 rounded animate-pulse" />
+            <div className="h-4 w-96 bg-neutral-200 rounded animate-pulse" />
           </div>
         </div>
         <CardSkeleton className="h-64" />
@@ -97,7 +97,7 @@ export function ToolDetail() {
       <div className="space-y-6">
         <button
           onClick={() => navigate('/ai-tools')}
-          className="flex items-center gap-2 text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white"
+          className="flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white"
         >
           <ArrowLeft className="h-4 w-4" />
           Back to catalog
@@ -117,16 +117,16 @@ export function ToolDetail() {
       <nav className="flex items-center gap-2 text-sm">
         <Link
           to="/ai-tools"
-          className="text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-300"
+          className="text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300"
         >
           AI Tools
         </Link>
-        <span className="text-gray-300 dark:text-neutral-600">/</span>
-        <span className="text-gray-900 dark:text-white font-medium">{tool.name}</span>
+        <span className="text-neutral-300 dark:text-neutral-600">/</span>
+        <span className="text-neutral-900 dark:text-white font-medium">{tool.name}</span>
       </nav>
 
       {/* Header */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 p-6">
         <div className="flex items-start justify-between">
           <div className="flex items-start gap-4">
             <div className="p-3 bg-blue-50 dark:bg-blue-900/30 rounded-lg">
@@ -134,17 +134,20 @@ export function ToolDetail() {
             </div>
             <div>
               <div className="flex items-center gap-3 mb-1">
-                <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{tool.name}</h1>
+                <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">{tool.name}</h1>
                 <span
                   className={`px-2.5 py-0.5 rounded border text-sm font-medium ${
-                    methodColors[tool.method] || 'bg-gray-100 text-gray-800 border-gray-200'
+                    methodColors[tool.method] ||
+                    'bg-neutral-100 text-neutral-800 border-neutral-200'
                   }`}
                 >
                   {tool.method}
                 </span>
-                <span className="text-sm text-gray-500 dark:text-neutral-400">v{tool.version}</span>
+                <span className="text-sm text-neutral-500 dark:text-neutral-400">
+                  v{tool.version}
+                </span>
               </div>
-              <p className="text-gray-600 dark:text-neutral-400 max-w-2xl">{tool.description}</p>
+              <p className="text-neutral-600 dark:text-neutral-400 max-w-2xl">{tool.description}</p>
 
               {/* Metadata */}
               <div className="flex flex-wrap items-center gap-4 mt-4">
@@ -153,7 +156,7 @@ export function ToolDetail() {
                     {tool.tags.map((tag) => (
                       <span
                         key={tag}
-                        className="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 dark:bg-neutral-700 text-gray-600 dark:text-neutral-300 rounded text-xs"
+                        className="inline-flex items-center gap-1 px-2 py-0.5 bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300 rounded text-xs"
                       >
                         <Tag className="h-3 w-3" />
                         {tag}
@@ -162,12 +165,12 @@ export function ToolDetail() {
                   </div>
                 )}
                 {tool.tenantId && (
-                  <span className="text-xs text-gray-400 dark:text-neutral-500">
+                  <span className="text-xs text-neutral-400 dark:text-neutral-500">
                     Tenant: {tool.tenantId}
                   </span>
                 )}
                 {tool.endpoint && (
-                  <span className="flex items-center gap-1 text-xs text-gray-400 dark:text-neutral-500">
+                  <span className="flex items-center gap-1 text-xs text-neutral-400 dark:text-neutral-500">
                     <ExternalLink className="h-3 w-3" />
                     API-backed
                   </span>
@@ -179,7 +182,7 @@ export function ToolDetail() {
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-gray-200 dark:border-neutral-700">
+      <div className="border-b border-neutral-200 dark:border-neutral-700">
         <nav className="flex gap-6">
           {tabs.map((tab) => (
             <button
@@ -188,7 +191,7 @@ export function ToolDetail() {
               className={`flex items-center gap-2 px-1 py-3 text-sm font-medium border-b-2 transition-colors ${
                 activeTab === tab.id
                   ? 'text-blue-600 border-blue-600'
-                  : 'text-gray-500 dark:text-neutral-400 border-transparent hover:text-gray-700 dark:hover:text-neutral-300 hover:border-gray-300 dark:hover:border-neutral-500'
+                  : 'text-neutral-500 dark:text-neutral-400 border-transparent hover:text-neutral-700 dark:hover:text-neutral-300 hover:border-neutral-300 dark:hover:border-neutral-500'
               }`}
             >
               {tab.icon}
@@ -199,27 +202,29 @@ export function ToolDetail() {
       </div>
 
       {/* Tab Content */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-6">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 p-6">
         {activeTab === 'overview' && (
           <div className="space-y-6">
             <div>
-              <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+              <h3 className="text-lg font-medium text-neutral-900 dark:text-white mb-2">
                 Description
               </h3>
-              <p className="text-gray-600 dark:text-neutral-400">{tool.description}</p>
+              <p className="text-neutral-600 dark:text-neutral-400">{tool.description}</p>
             </div>
 
             <div>
-              <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-3">Parameters</h3>
+              <h3 className="text-lg font-medium text-neutral-900 dark:text-white mb-3">
+                Parameters
+              </h3>
               <ToolSchemaViewer schema={tool.inputSchema} title="Input Parameters" />
             </div>
 
             {tool.endpoint && (
               <div>
-                <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+                <h3 className="text-lg font-medium text-neutral-900 dark:text-white mb-2">
                   Backend Endpoint
                 </h3>
-                <code className="block px-4 py-3 bg-gray-100 dark:bg-neutral-900 rounded-lg text-sm font-mono text-gray-800 dark:text-neutral-300">
+                <code className="block px-4 py-3 bg-neutral-100 dark:bg-neutral-900 rounded-lg text-sm font-mono text-neutral-800 dark:text-neutral-300">
                   {tool.method} {tool.endpoint}
                 </code>
               </div>
@@ -230,12 +235,12 @@ export function ToolDetail() {
         {activeTab === 'schema' && (
           <div className="space-y-6">
             <div className="flex items-center justify-between">
-              <h3 className="text-lg font-medium text-gray-900 dark:text-white">JSON Schema</h3>
+              <h3 className="text-lg font-medium text-neutral-900 dark:text-white">JSON Schema</h3>
               <button
                 onClick={() =>
                   navigator.clipboard.writeText(JSON.stringify(tool.inputSchema, null, 2))
                 }
-                className="flex items-center gap-1 px-3 py-1.5 text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+                className="flex items-center gap-1 px-3 py-1.5 text-sm text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white transition-colors"
               >
                 <Code className="h-4 w-4" />
                 Copy JSON
@@ -252,32 +257,32 @@ export function ToolDetail() {
             {usage ? (
               <>
                 <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-                  <div className="p-4 bg-gray-50 dark:bg-neutral-700 rounded-lg">
-                    <div className="text-sm text-gray-500 dark:text-neutral-400 mb-1">
+                  <div className="p-4 bg-neutral-50 dark:bg-neutral-700 rounded-lg">
+                    <div className="text-sm text-neutral-500 dark:text-neutral-400 mb-1">
                       Total Calls
                     </div>
-                    <div className="text-2xl font-bold text-gray-900 dark:text-white">
+                    <div className="text-2xl font-bold text-neutral-900 dark:text-white">
                       {usage.totalCalls.toLocaleString()}
                     </div>
                   </div>
-                  <div className="p-4 bg-gray-50 dark:bg-neutral-700 rounded-lg">
-                    <div className="text-sm text-gray-500 dark:text-neutral-400 mb-1">
+                  <div className="p-4 bg-neutral-50 dark:bg-neutral-700 rounded-lg">
+                    <div className="text-sm text-neutral-500 dark:text-neutral-400 mb-1">
                       Success Rate
                     </div>
                     <div className="text-2xl font-bold text-green-600">
                       {(usage.successRate * 100).toFixed(1)}%
                     </div>
                   </div>
-                  <div className="p-4 bg-gray-50 dark:bg-neutral-700 rounded-lg">
-                    <div className="text-sm text-gray-500 dark:text-neutral-400 mb-1">
+                  <div className="p-4 bg-neutral-50 dark:bg-neutral-700 rounded-lg">
+                    <div className="text-sm text-neutral-500 dark:text-neutral-400 mb-1">
                       Avg Latency
                     </div>
-                    <div className="text-2xl font-bold text-gray-900 dark:text-white">
+                    <div className="text-2xl font-bold text-neutral-900 dark:text-white">
                       {usage.avgLatencyMs.toFixed(0)}ms
                     </div>
                   </div>
-                  <div className="p-4 bg-gray-50 dark:bg-neutral-700 rounded-lg">
-                    <div className="text-sm text-gray-500 dark:text-neutral-400 mb-1">
+                  <div className="p-4 bg-neutral-50 dark:bg-neutral-700 rounded-lg">
+                    <div className="text-sm text-neutral-500 dark:text-neutral-400 mb-1">
                       Cost Units
                     </div>
                     <div className="text-2xl font-bold text-purple-600">
@@ -286,13 +291,13 @@ export function ToolDetail() {
                   </div>
                 </div>
 
-                <div className="text-sm text-gray-500 dark:text-neutral-400">
+                <div className="text-sm text-neutral-500 dark:text-neutral-400">
                   Usage data for the last {usage.period} ({usage.startDate} - {usage.endDate})
                 </div>
               </>
             ) : (
-              <div className="text-center py-8 text-gray-500 dark:text-neutral-400">
-                <Clock className="h-12 w-12 mx-auto mb-4 text-gray-300 dark:text-neutral-600" />
+              <div className="text-center py-8 text-neutral-500 dark:text-neutral-400">
+                <Clock className="h-12 w-12 mx-auto mb-4 text-neutral-300 dark:text-neutral-600" />
                 <p>No usage data available yet.</p>
                 <p className="text-sm mt-1">Start using this tool to see usage statistics.</p>
               </div>

--- a/control-plane-ui/src/pages/AITools/UsageDashboard.tsx
+++ b/control-plane-ui/src/pages/AITools/UsageDashboard.tsx
@@ -69,8 +69,8 @@ export function UsageDashboard() {
     return (
       <div className="space-y-6">
         <div className="flex items-center justify-between">
-          <div className="h-8 w-48 bg-gray-200 rounded animate-pulse" />
-          <div className="h-10 w-36 bg-gray-200 rounded animate-pulse" />
+          <div className="h-8 w-48 bg-neutral-200 rounded animate-pulse" />
+          <div className="h-10 w-36 bg-neutral-200 rounded animate-pulse" />
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           {[1, 2, 3, 4].map((i) => (
@@ -87,19 +87,19 @@ export function UsageDashboard() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Usage Dashboard</h1>
-          <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Usage Dashboard</h1>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
             Monitor your AI tool usage and costs
           </p>
         </div>
         <div className="flex items-center gap-3">
           {/* Period Selector */}
           <div className="flex items-center gap-2">
-            <Calendar className="h-4 w-4 text-gray-400" />
+            <Calendar className="h-4 w-4 text-neutral-400" />
             <select
               value={period}
               onChange={(e) => setPeriod(e.target.value as PeriodType)}
-              className="border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               {periodOptions.map((opt) => (
                 <option key={opt.value} value={opt.value}>
@@ -170,44 +170,46 @@ export function UsageDashboard() {
 
           {/* Tool Breakdown */}
           {usage.toolBreakdown && usage.toolBreakdown.length > 0 && (
-            <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700">
-              <div className="px-6 py-4 border-b border-gray-200 dark:border-neutral-700">
-                <h3 className="text-lg font-medium text-gray-900 dark:text-white">Usage by Tool</h3>
+            <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700">
+              <div className="px-6 py-4 border-b border-neutral-200 dark:border-neutral-700">
+                <h3 className="text-lg font-medium text-neutral-900 dark:text-white">
+                  Usage by Tool
+                </h3>
               </div>
               <div className="overflow-x-auto">
                 <table className="w-full">
-                  <thead className="bg-gray-50 dark:bg-neutral-700">
+                  <thead className="bg-neutral-50 dark:bg-neutral-700">
                     <tr>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                         Tool
                       </th>
-                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                         Calls
                       </th>
-                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                         Success
                       </th>
-                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                         Errors
                       </th>
-                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                         Avg Latency
                       </th>
-                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                         Cost
                       </th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
+                  <tbody className="divide-y divide-neutral-200 dark:divide-neutral-700">
                     {usage.toolBreakdown.map((tool) => (
                       <tr
                         key={tool.toolName}
-                        className="hover:bg-gray-50 dark:hover:bg-neutral-700"
+                        className="hover:bg-neutral-50 dark:hover:bg-neutral-700"
                       >
-                        <td className="px-6 py-4 text-sm font-medium text-gray-900 dark:text-white">
+                        <td className="px-6 py-4 text-sm font-medium text-neutral-900 dark:text-white">
                           {tool.toolName}
                         </td>
-                        <td className="px-6 py-4 text-sm text-gray-600 dark:text-neutral-300 text-right">
+                        <td className="px-6 py-4 text-sm text-neutral-600 dark:text-neutral-300 text-right">
                           {tool.totalCalls.toLocaleString()}
                         </td>
                         <td className="px-6 py-4 text-sm text-green-600 text-right">
@@ -216,7 +218,7 @@ export function UsageDashboard() {
                         <td className="px-6 py-4 text-sm text-red-600 text-right">
                           {tool.errorCount.toLocaleString()}
                         </td>
-                        <td className="px-6 py-4 text-sm text-gray-600 dark:text-neutral-300 text-right">
+                        <td className="px-6 py-4 text-sm text-neutral-600 dark:text-neutral-300 text-right">
                           {tool.avgLatencyMs.toFixed(0)}ms
                         </td>
                         <td className="px-6 py-4 text-sm text-purple-600 text-right">
@@ -231,18 +233,18 @@ export function UsageDashboard() {
           )}
 
           {/* Period Info */}
-          <div className="text-sm text-gray-500 dark:text-neutral-400 text-center">
+          <div className="text-sm text-neutral-500 dark:text-neutral-400 text-center">
             Showing data from {new Date(usage.startDate).toLocaleDateString()} to{' '}
             {new Date(usage.endDate).toLocaleDateString()}
           </div>
         </>
       ) : (
-        <div className="text-center py-12 bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700">
-          <BarChart3 className="h-12 w-12 text-gray-300 dark:text-neutral-600 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+        <div className="text-center py-12 bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700">
+          <BarChart3 className="h-12 w-12 text-neutral-300 dark:text-neutral-600 mx-auto mb-4" />
+          <h3 className="text-lg font-medium text-neutral-900 dark:text-white mb-2">
             No usage data yet
           </h3>
-          <p className="text-sm text-gray-500 dark:text-neutral-400">
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">
             Start using AI tools to see your usage metrics here
           </p>
         </div>

--- a/control-plane-ui/src/pages/APIMonitoring.tsx
+++ b/control-plane-ui/src/pages/APIMonitoring.tsx
@@ -104,7 +104,7 @@ function getStatusCodeColor(code: number): string {
   if (code >= 400 && code < 500)
     return 'text-orange-600 bg-orange-50 dark:bg-orange-900/20 dark:text-orange-400';
   if (code >= 500) return 'text-red-600 bg-red-50 dark:bg-red-900/20 dark:text-red-400';
-  return 'text-gray-600 bg-gray-50 dark:bg-neutral-700 dark:text-neutral-400';
+  return 'text-neutral-600 bg-neutral-50 dark:bg-neutral-700 dark:text-neutral-400';
 }
 
 // =============================================================================
@@ -127,16 +127,18 @@ function StatsCard({
   trend?: { value: number; positive: boolean };
 }) {
   return (
-    <div className="rounded-lg bg-white dark:bg-neutral-800 p-6 shadow-sm border border-gray-100 dark:border-neutral-700">
+    <div className="rounded-lg bg-white dark:bg-neutral-800 p-6 shadow-sm border border-neutral-100 dark:border-neutral-700">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
           <div className={clsx('rounded-lg p-3', color)}>
             <Icon className="h-6 w-6 text-white" />
           </div>
           <div>
-            <p className="text-sm font-medium text-gray-500 dark:text-neutral-400">{title}</p>
-            <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
-            {subtitle && <p className="text-xs text-gray-400 dark:text-neutral-500">{subtitle}</p>}
+            <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">{title}</p>
+            <p className="text-2xl font-bold text-neutral-900 dark:text-white">{value}</p>
+            {subtitle && (
+              <p className="text-xs text-neutral-400 dark:text-neutral-500">{subtitle}</p>
+            )}
           </div>
         </div>
         {trend && (
@@ -162,7 +164,7 @@ function StatsCard({
 function TransactionFlow({ spans }: { spans: TransactionSpan[] }) {
   if (!spans || spans.length === 0) {
     return (
-      <div className="text-sm text-gray-500 dark:text-neutral-400 italic">
+      <div className="text-sm text-neutral-500 dark:text-neutral-400 italic">
         No span data available
       </div>
     );
@@ -192,19 +194,19 @@ function TransactionFlow({ spans }: { spans: TransactionSpan[] }) {
                     ? 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20'
                     : span.status === 'timeout'
                       ? 'border-orange-200 bg-orange-50 dark:border-orange-800 dark:bg-orange-900/20'
-                      : 'border-gray-200 bg-gray-50 dark:border-neutral-700 dark:bg-neutral-800'
+                      : 'border-neutral-200 bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800'
               )}
             >
               <Icon className={clsx('h-4 w-4', config.color)} />
               <div className="text-xs">
-                <div className="font-medium text-gray-900 dark:text-white">{span.service}</div>
-                <div className="text-gray-500 dark:text-neutral-400">
+                <div className="font-medium text-neutral-900 dark:text-white">{span.service}</div>
+                <div className="text-neutral-500 dark:text-neutral-400">
                   {formatDuration(span.duration_ms)}
                 </div>
               </div>
             </div>
             {index < spans.length - 1 && (
-              <ArrowRight className="h-4 w-4 text-gray-400 mx-1 flex-shrink-0" />
+              <ArrowRight className="h-4 w-4 text-neutral-400 mx-1 flex-shrink-0" />
             )}
           </div>
         );
@@ -232,7 +234,7 @@ function TransactionRow({
   return (
     <tr
       className={clsx(
-        'hover:bg-gray-50 dark:hover:bg-neutral-700 cursor-pointer transition-colors',
+        'hover:bg-neutral-50 dark:hover:bg-neutral-700 cursor-pointer transition-colors',
         isExpanded && 'bg-blue-50 dark:bg-blue-900/20'
       )}
       onClick={onToggle}
@@ -240,11 +242,11 @@ function TransactionRow({
       <td className="px-4 py-3">
         <div className="flex items-center gap-2">
           {isExpanded ? (
-            <ChevronDown className="h-4 w-4 text-gray-400" />
+            <ChevronDown className="h-4 w-4 text-neutral-400" />
           ) : (
-            <ChevronRight className="h-4 w-4 text-gray-400" />
+            <ChevronRight className="h-4 w-4 text-neutral-400" />
           )}
-          <code className="text-xs font-mono text-gray-500 dark:text-neutral-400">
+          <code className="text-xs font-mono text-neutral-500 dark:text-neutral-400">
             {transaction.trace_id.slice(0, 8)}...
           </code>
         </div>
@@ -254,7 +256,7 @@ function TransactionRow({
           className={clsx(
             'px-2 py-1 rounded text-xs font-bold',
             methodColors[transaction.method] ||
-              'bg-gray-100 text-gray-700 dark:bg-neutral-700 dark:text-neutral-300'
+              'bg-neutral-100 text-neutral-700 dark:bg-neutral-700 dark:text-neutral-300'
           )}
         >
           {transaction.method}
@@ -262,8 +264,10 @@ function TransactionRow({
       </td>
       <td className="px-4 py-3">
         <div className="flex flex-col">
-          <span className="font-medium text-gray-900 dark:text-white">{transaction.api_name}</span>
-          <span className="text-xs text-gray-500 dark:text-neutral-400 truncate max-w-[200px]">
+          <span className="font-medium text-neutral-900 dark:text-white">
+            {transaction.api_name}
+          </span>
+          <span className="text-xs text-neutral-500 dark:text-neutral-400 truncate max-w-[200px]">
             {transaction.path}
           </span>
         </div>
@@ -287,12 +291,12 @@ function TransactionRow({
         </div>
       </td>
       <td className="px-4 py-3">
-        <div className="flex items-center gap-1 text-sm text-gray-600 dark:text-neutral-400">
+        <div className="flex items-center gap-1 text-sm text-neutral-600 dark:text-neutral-400">
           <Timer className="h-4 w-4" />
           {formatDuration(transaction.total_duration_ms)}
         </div>
       </td>
-      <td className="px-4 py-3 text-sm text-gray-500 dark:text-neutral-400">
+      <td className="px-4 py-3 text-sm text-neutral-500 dark:text-neutral-400">
         {formatTime(transaction.started_at)}
       </td>
     </tr>
@@ -329,8 +333,8 @@ function TransactionDetail({ transactionId }: { transactionId: string }) {
   if (loading) {
     return (
       <tr>
-        <td colSpan={7} className="px-4 py-8 bg-gray-50 dark:bg-neutral-900">
-          <div className="flex items-center justify-center gap-2 text-gray-500 dark:text-neutral-400">
+        <td colSpan={7} className="px-4 py-8 bg-neutral-50 dark:bg-neutral-900">
+          <div className="flex items-center justify-center gap-2 text-neutral-500 dark:text-neutral-400">
             <Loader2 className="h-5 w-5 animate-spin" />
             Loading transaction details...
           </div>
@@ -353,12 +357,12 @@ function TransactionDetail({ transactionId }: { transactionId: string }) {
     <tr>
       <td
         colSpan={7}
-        className="px-4 py-4 bg-gray-50 dark:bg-neutral-900 border-t border-b border-gray-200 dark:border-neutral-700"
+        className="px-4 py-4 bg-neutral-50 dark:bg-neutral-900 border-t border-b border-neutral-200 dark:border-neutral-700"
       >
         <div className="space-y-4">
           {/* Flow Visualization */}
           <div>
-            <h4 className="text-sm font-semibold text-gray-700 dark:text-neutral-300 mb-2">
+            <h4 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-2">
               Transaction Flow
             </h4>
             <TransactionFlow spans={transaction.spans} />
@@ -366,7 +370,7 @@ function TransactionDetail({ transactionId }: { transactionId: string }) {
 
           {/* Span Details */}
           <div>
-            <h4 className="text-sm font-semibold text-gray-700 dark:text-neutral-300 mb-2">
+            <h4 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-2">
               Span Details
             </h4>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
@@ -385,26 +389,28 @@ function TransactionDetail({ transactionId }: { transactionId: string }) {
                           ? 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20'
                           : span.status === 'timeout'
                             ? 'border-orange-200 bg-orange-50 dark:border-orange-800 dark:bg-orange-900/20'
-                            : 'border-gray-200 bg-white dark:border-neutral-700 dark:bg-neutral-800'
+                            : 'border-neutral-200 bg-white dark:border-neutral-700 dark:bg-neutral-800'
                     )}
                   >
                     <div className="flex items-center justify-between mb-2">
-                      <span className="font-medium text-gray-900 dark:text-white">{span.name}</span>
+                      <span className="font-medium text-neutral-900 dark:text-white">
+                        {span.name}
+                      </span>
                       <StatusIcon className={clsx('h-4 w-4', config.color)} />
                     </div>
                     <div className="text-xs space-y-1">
                       <div className="flex justify-between">
-                        <span className="text-gray-500 dark:text-neutral-400">Service:</span>
+                        <span className="text-neutral-500 dark:text-neutral-400">Service:</span>
                         <span className="font-medium dark:text-neutral-200">{span.service}</span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-gray-500 dark:text-neutral-400">Duration:</span>
+                        <span className="text-neutral-500 dark:text-neutral-400">Duration:</span>
                         <span className="font-medium dark:text-neutral-200">
                           {formatDuration(span.duration_ms)}
                         </span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-gray-500 dark:text-neutral-400">Started:</span>
+                        <span className="text-neutral-500 dark:text-neutral-400">Started:</span>
                         <span className="font-medium dark:text-neutral-200">
                           {formatTime(span.started_at)}
                         </span>
@@ -441,26 +447,26 @@ function TransactionDetail({ transactionId }: { transactionId: string }) {
           {/* Metadata */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-xs">
             <div>
-              <span className="text-gray-500 dark:text-neutral-400">Trace ID:</span>
-              <code className="block font-mono text-gray-900 dark:text-neutral-200">
+              <span className="text-neutral-500 dark:text-neutral-400">Trace ID:</span>
+              <code className="block font-mono text-neutral-900 dark:text-neutral-200">
                 {transaction.trace_id}
               </code>
             </div>
             <div>
-              <span className="text-gray-500 dark:text-neutral-400">Client IP:</span>
-              <span className="block text-gray-900 dark:text-neutral-200">
+              <span className="text-neutral-500 dark:text-neutral-400">Client IP:</span>
+              <span className="block text-neutral-900 dark:text-neutral-200">
                 {transaction.client_ip || '-'}
               </span>
             </div>
             <div>
-              <span className="text-gray-500 dark:text-neutral-400">User:</span>
-              <span className="block text-gray-900 dark:text-neutral-200">
+              <span className="text-neutral-500 dark:text-neutral-400">User:</span>
+              <span className="block text-neutral-900 dark:text-neutral-200">
                 {transaction.user_id || 'Anonymous'}
               </span>
             </div>
             <div>
-              <span className="text-gray-500 dark:text-neutral-400">Tenant:</span>
-              <span className="block text-gray-900 dark:text-neutral-200">
+              <span className="text-neutral-500 dark:text-neutral-400">Tenant:</span>
+              <span className="block text-neutral-900 dark:text-neutral-200">
                 {transaction.tenant_id}
               </span>
             </div>
@@ -671,8 +677,8 @@ export function APIMonitoring() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">API Monitoring</h1>
-          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">API Monitoring</h1>
+          <p className="text-neutral-500 dark:text-neutral-400 mt-1">
             Real-time E2E transaction tracing - Gateway → Backend → Response
           </p>
         </div>
@@ -692,7 +698,7 @@ export function APIMonitoring() {
               'flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
               autoRefresh
                 ? 'bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-900/30 dark:text-green-400 dark:hover:bg-green-900/50'
-                : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-600'
+                : 'bg-neutral-100 text-neutral-600 hover:bg-neutral-200 dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-600'
             )}
           >
             <Activity className={clsx('h-4 w-4', autoRefresh && 'animate-pulse')} />
@@ -700,7 +706,7 @@ export function APIMonitoring() {
           </button>
           <button
             onClick={fetchData}
-            className="flex items-center gap-2 px-3 py-2 bg-white dark:bg-neutral-800 border border-gray-300 dark:border-neutral-600 rounded-lg text-sm font-medium text-gray-700 dark:text-neutral-300 hover:bg-gray-50 dark:hover:bg-neutral-700"
+            className="flex items-center gap-2 px-3 py-2 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 rounded-lg text-sm font-medium text-neutral-700 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700"
           >
             <RefreshCw className="h-4 w-4" />
             Refresh
@@ -750,27 +756,27 @@ export function APIMonitoring() {
       )}
 
       {/* Filters */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 p-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-100 dark:border-neutral-700 p-4">
         <div className="flex flex-wrap items-center gap-4">
           {/* Search */}
           <div className="relative flex-1 min-w-[200px]">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-neutral-400" />
             <input
               type="text"
               placeholder="Search by trace ID, API, or path..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full pl-10 pr-4 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
           </div>
 
           {/* Status Filter */}
           <div className="flex items-center gap-2">
-            <Filter className="h-4 w-4 text-gray-400" />
+            <Filter className="h-4 w-4 text-neutral-400" />
             <select
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value as TransactionStatus | 'all')}
-              className="border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               <option value="all">All Statuses</option>
               <option value="success">Success</option>
@@ -783,7 +789,7 @@ export function APIMonitoring() {
           <select
             value={apiFilter}
             onChange={(e) => setApiFilter(e.target.value)}
-            className="border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
             <option value="all">All APIs</option>
             {uniqueApis.map((api) => (
@@ -796,42 +802,42 @@ export function APIMonitoring() {
       </div>
 
       {/* Transactions Table */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 overflow-hidden">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-100 dark:border-neutral-700 overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full">
-            <thead className="bg-gray-50 dark:bg-neutral-700 border-b border-gray-200 dark:border-neutral-600">
+            <thead className="bg-neutral-50 dark:bg-neutral-700 border-b border-neutral-200 dark:border-neutral-600">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-semibold text-neutral-600 dark:text-neutral-400 uppercase tracking-wider">
                   Trace ID
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-semibold text-neutral-600 dark:text-neutral-400 uppercase tracking-wider">
                   Method
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-semibold text-neutral-600 dark:text-neutral-400 uppercase tracking-wider">
                   API / Path
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-semibold text-neutral-600 dark:text-neutral-400 uppercase tracking-wider">
                   Status
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-semibold text-neutral-600 dark:text-neutral-400 uppercase tracking-wider">
                   Result
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-semibold text-neutral-600 dark:text-neutral-400 uppercase tracking-wider">
                   Duration
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-semibold text-neutral-600 dark:text-neutral-400 uppercase tracking-wider">
                   Time
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-100 dark:divide-neutral-700">
+            <tbody className="divide-y divide-neutral-100 dark:divide-neutral-700">
               {filteredTransactions.length === 0 ? (
                 <tr>
                   <td
                     colSpan={7}
-                    className="px-4 py-12 text-center text-gray-500 dark:text-neutral-400"
+                    className="px-4 py-12 text-center text-neutral-500 dark:text-neutral-400"
                   >
-                    <Activity className="h-12 w-12 mx-auto mb-4 text-gray-300 dark:text-neutral-600" />
+                    <Activity className="h-12 w-12 mx-auto mb-4 text-neutral-300 dark:text-neutral-600" />
                     <p className="text-lg font-medium">No transactions found</p>
                     <p className="text-sm">Try adjusting your filters or wait for new requests</p>
                   </td>

--- a/control-plane-ui/src/pages/APIs.tsx
+++ b/control-plane-ui/src/pages/APIs.tsx
@@ -15,13 +15,14 @@ import { EmptyState } from '@stoa/shared/components/EmptyState';
 import { TableSkeleton } from '@stoa/shared/components/Skeleton';
 import { useCelebration } from '@stoa/shared/components/Celebration';
 import { Collapsible } from '@stoa/shared/components/Collapsible';
-import { FileText, Server, Code2, Settings } from 'lucide-react';
+import { FileText, Server, Code2, Settings, Plus } from 'lucide-react';
+import { Button } from '@stoa/shared/components/Button';
 
 const PAGE_SIZE = 20;
 
 // Status colors moved outside component to prevent recreation
 const statusColors: Record<string, string> = {
-  draft: 'bg-gray-100 text-gray-800 dark:bg-neutral-700 dark:text-neutral-300',
+  draft: 'bg-neutral-100 text-neutral-800 dark:bg-neutral-700 dark:text-neutral-300',
   published: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
   deprecated: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
 };
@@ -232,27 +233,19 @@ export function APIs() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">APIs</h1>
-          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">APIs</h1>
+          <p className="text-neutral-500 dark:text-neutral-400 mt-1">
             Manage API definitions and deployments
           </p>
         </div>
         {canCreate && (
-          <button
+          <Button
             onClick={() => setShowCreateModal(true)}
             disabled={!selectedTenant}
-            className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            icon={<Plus className="w-5 h-5" />}
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 4v16m8-8H4"
-              />
-            </svg>
             Create API
-          </button>
+          </Button>
         )}
       </div>
 
@@ -280,13 +273,13 @@ export function APIs() {
         <div className="flex flex-wrap gap-4 items-end">
           {/* Tenant Selector */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               Tenant
             </label>
             <select
               value={selectedTenant}
               onChange={(e) => setSelectedTenant(e.target.value)}
-              className="w-48 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-48 border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               {tenants.map((tenant) => (
                 <option key={tenant.id} value={tenant.id}>
@@ -298,7 +291,7 @@ export function APIs() {
 
           {/* Search Input */}
           <div className="flex-1 min-w-[200px]">
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               Search
             </label>
             <div className="relative">
@@ -307,10 +300,10 @@ export function APIs() {
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Search by name, description, URL..."
-                className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 pl-10 bg-white dark:bg-neutral-700 dark:text-white dark:placeholder-neutral-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 pl-10 bg-white dark:bg-neutral-700 dark:text-white dark:placeholder-neutral-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
               <svg
-                className="absolute left-3 top-2.5 h-5 w-5 text-gray-400"
+                className="absolute left-3 top-2.5 h-5 w-5 text-neutral-400"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -325,7 +318,7 @@ export function APIs() {
               {searchQuery && (
                 <button
                   onClick={() => setSearchQuery('')}
-                  className="absolute right-3 top-2.5 text-gray-400 hover:text-gray-600"
+                  className="absolute right-3 top-2.5 text-neutral-400 hover:text-neutral-600"
                 >
                   <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path
@@ -342,13 +335,13 @@ export function APIs() {
 
           {/* Status Filter */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               Status
             </label>
             <select
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
-              className="w-36 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-36 border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               <option value="">All Status</option>
               <option value="draft">Draft</option>
@@ -358,7 +351,7 @@ export function APIs() {
           </div>
 
           {/* Results count */}
-          <div className="text-sm text-gray-500 dark:text-neutral-400 self-end pb-2">
+          <div className="text-sm text-neutral-500 dark:text-neutral-400 self-end pb-2">
             {filteredApis.length} of {apis.length} APIs
           </div>
         </div>
@@ -395,19 +388,19 @@ export function APIs() {
             }}
           />
         ) : isMobile ? (
-          <div className="divide-y divide-gray-200 dark:divide-neutral-700">
+          <div className="divide-y divide-neutral-200 dark:divide-neutral-700">
             {paginatedApis.map((api) => (
               <div key={api.id} className="p-4 space-y-3">
                 <div className="flex items-start justify-between gap-2">
                   <div className="min-w-0">
-                    <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                    <p className="text-sm font-medium text-neutral-900 dark:text-white truncate">
                       {api.display_name || api.name}
                     </p>
-                    <p className="text-xs text-gray-500 dark:text-neutral-400 truncate">
+                    <p className="text-xs text-neutral-500 dark:text-neutral-400 truncate">
                       {api.backend_url}
                     </p>
                   </div>
-                  <span className="text-xs text-gray-500 dark:text-neutral-400 flex-shrink-0">
+                  <span className="text-xs text-neutral-500 dark:text-neutral-400 flex-shrink-0">
                     v{api.version}
                   </span>
                 </div>
@@ -424,12 +417,12 @@ export function APIs() {
                     </span>
                   )}
                   <span
-                    className={`px-2 py-1 rounded text-xs ${api.deployed_dev ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' : 'bg-gray-100 text-gray-500 dark:bg-neutral-700 dark:text-neutral-400'}`}
+                    className={`px-2 py-1 rounded text-xs ${api.deployed_dev ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}
                   >
                     DEV
                   </span>
                   <span
-                    className={`px-2 py-1 rounded text-xs ${api.deployed_staging ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' : 'bg-gray-100 text-gray-500 dark:bg-neutral-700 dark:text-neutral-400'}`}
+                    className={`px-2 py-1 rounded text-xs ${api.deployed_staging ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}
                   >
                     STG
                   </span>
@@ -455,7 +448,7 @@ export function APIs() {
                   {canEdit && (
                     <button
                       onClick={() => setEditingApi(api)}
-                      className="text-gray-600 hover:text-gray-800 dark:text-neutral-400 dark:hover:text-white text-sm py-1"
+                      className="text-neutral-600 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-white text-sm py-1"
                     >
                       Edit
                     </button>
@@ -474,43 +467,43 @@ export function APIs() {
           </div>
         ) : (
           <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
-              <thead className="bg-gray-50 dark:bg-neutral-700">
+            <table className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700">
+              <thead className="bg-neutral-50 dark:bg-neutral-700">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                     Name
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                     Version
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                     Status
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                     Portal
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                     Deployed
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                     Actions
                   </th>
                 </tr>
               </thead>
-              <tbody className="bg-white dark:bg-neutral-800 divide-y divide-gray-200 dark:divide-neutral-700">
+              <tbody className="bg-white dark:bg-neutral-800 divide-y divide-neutral-200 dark:divide-neutral-700">
                 {paginatedApis.map((api) => (
-                  <tr key={api.id} className="hover:bg-gray-50 dark:hover:bg-neutral-700">
+                  <tr key={api.id} className="hover:bg-neutral-50 dark:hover:bg-neutral-700">
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div>
-                        <div className="text-sm font-medium text-gray-900 dark:text-white">
+                        <div className="text-sm font-medium text-neutral-900 dark:text-white">
                           {api.display_name || api.name}
                         </div>
-                        <div className="text-sm text-gray-500 dark:text-neutral-400">
+                        <div className="text-sm text-neutral-500 dark:text-neutral-400">
                           {api.backend_url}
                         </div>
                       </div>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-neutral-400">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-500 dark:text-neutral-400">
                       v{api.version}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
@@ -533,7 +526,7 @@ export function APIs() {
                           Published
                         </span>
                       ) : (
-                        <span className="text-gray-400 dark:text-neutral-500 text-xs">
+                        <span className="text-neutral-400 dark:text-neutral-500 text-xs">
                           Not promoted
                         </span>
                       )}
@@ -541,12 +534,12 @@ export function APIs() {
                     <td className="px-6 py-4 whitespace-nowrap text-sm">
                       <div className="flex gap-2">
                         <span
-                          className={`px-2 py-1 rounded text-xs ${api.deployed_dev ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' : 'bg-gray-100 text-gray-500 dark:bg-neutral-700 dark:text-neutral-400'}`}
+                          className={`px-2 py-1 rounded text-xs ${api.deployed_dev ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}
                         >
                           DEV
                         </span>
                         <span
-                          className={`px-2 py-1 rounded text-xs ${api.deployed_staging ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' : 'bg-gray-100 text-gray-500 dark:bg-neutral-700 dark:text-neutral-400'}`}
+                          className={`px-2 py-1 rounded text-xs ${api.deployed_staging ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}
                         >
                           STG
                         </span>
@@ -575,7 +568,7 @@ export function APIs() {
                         {canEdit && (
                           <button
                             onClick={() => setEditingApi(api)}
-                            className="text-gray-600 hover:text-gray-800 dark:text-neutral-400 dark:hover:text-white"
+                            className="text-neutral-600 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-white"
                           >
                             Edit
                           </button>
@@ -599,30 +592,32 @@ export function APIs() {
 
         {/* Pagination */}
         {!loading && filteredApis.length > 0 && totalPages > 1 && (
-          <div className="bg-gray-50 dark:bg-neutral-700 px-6 py-3 flex items-center justify-between border-t border-gray-200 dark:border-neutral-600">
-            <div className="text-sm text-gray-500 dark:text-neutral-400">
+          <div className="bg-neutral-50 dark:bg-neutral-700 px-6 py-3 flex items-center justify-between border-t border-neutral-200 dark:border-neutral-600">
+            <div className="text-sm text-neutral-500 dark:text-neutral-400">
               Showing {(currentPage - 1) * PAGE_SIZE + 1} to{' '}
               {Math.min(currentPage * PAGE_SIZE, filteredApis.length)} of {filteredApis.length}{' '}
               results
             </div>
             <div className="flex gap-2">
-              <button
+              <Button
+                variant="secondary"
+                size="sm"
                 onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
                 disabled={currentPage === 1}
-                className="px-3 py-1 text-sm border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-600 dark:text-neutral-300 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Previous
-              </button>
-              <span className="px-3 py-1 text-sm text-gray-700 dark:text-neutral-300">
+              </Button>
+              <span className="px-3 py-1 text-sm text-neutral-700 dark:text-neutral-300">
                 Page {currentPage} of {totalPages}
               </span>
-              <button
+              <Button
+                variant="secondary"
+                size="sm"
                 onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
                 disabled={currentPage === totalPages}
-                className="px-3 py-1 text-sm border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-600 dark:text-neutral-300 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Next
-              </button>
+              </Button>
             </div>
           </div>
         )}
@@ -773,10 +768,10 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
         <div className="flex justify-between items-center px-6 py-4 border-b dark:border-neutral-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h2>
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">{title}</h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-neutral-300"
+            className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
           >
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
@@ -792,14 +787,14 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
         {/* Mode Selector (only for create) */}
         {!isEdit && (
           <div className="px-6 pt-4">
-            <div className="flex rounded-lg bg-gray-100 dark:bg-neutral-700 p-1">
+            <div className="flex rounded-lg bg-neutral-100 dark:bg-neutral-700 p-1">
               <button
                 type="button"
                 onClick={() => setMode('manual')}
                 className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors ${
                   mode === 'manual'
-                    ? 'bg-white dark:bg-neutral-600 text-gray-900 dark:text-white shadow'
-                    : 'text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-300'
+                    ? 'bg-white dark:bg-neutral-600 text-neutral-900 dark:text-white shadow'
+                    : 'text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300'
                 }`}
               >
                 Manual Entry
@@ -809,8 +804,8 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
                 onClick={() => setMode('openapi')}
                 className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors ${
                   mode === 'openapi'
-                    ? 'bg-white dark:bg-neutral-600 text-gray-900 dark:text-white shadow'
-                    : 'text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-300'
+                    ? 'bg-white dark:bg-neutral-600 text-neutral-900 dark:text-white shadow'
+                    : 'text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300'
                 }`}
               >
                 Import OpenAPI/Swagger
@@ -824,7 +819,7 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
           {mode === 'openapi' && !isEdit && (
             <div className="space-y-4 pb-4 border-b dark:border-neutral-700">
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+                <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
                   Upload OpenAPI/Swagger File
                 </label>
                 <div className="flex gap-2">
@@ -838,10 +833,10 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
                   <button
                     type="button"
                     onClick={() => fileInputRef.current?.click()}
-                    className="flex items-center gap-2 px-4 py-2 border-2 border-dashed border-gray-300 dark:border-neutral-600 rounded-lg hover:border-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors dark:text-neutral-300"
+                    className="flex items-center gap-2 px-4 py-2 border-2 border-dashed border-neutral-300 dark:border-neutral-600 rounded-lg hover:border-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors dark:text-neutral-300"
                   >
                     <svg
-                      className="w-5 h-5 text-gray-400"
+                      className="w-5 h-5 text-neutral-400"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"
@@ -859,7 +854,7 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+                <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
                   Or Paste OpenAPI/Swagger Content
                 </label>
                 <textarea
@@ -870,7 +865,7 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
                       parseOpenApiSpec(e.target.value);
                     }
                   }}
-                  className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"
+                  className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"
                   rows={8}
                   placeholder={`openapi: "3.0.0"
 info:
@@ -911,7 +906,7 @@ paths:
             <div className="space-y-4">
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+                  <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                     Name (slug)
                   </label>
                   <input
@@ -923,20 +918,20 @@ paths:
                         name: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '-'),
                       })
                     }
-                    className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     placeholder="payment-api"
                     required
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+                  <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                     Version
                   </label>
                   <input
                     type="text"
                     value={formData.version}
                     onChange={(e) => setFormData({ ...formData, version: e.target.value })}
-                    className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     placeholder="1.0.0"
                     required
                   />
@@ -944,23 +939,27 @@ paths:
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Display Name</label>
+                <label className="block text-sm font-medium text-neutral-700 mb-1">
+                  Display Name
+                </label>
                 <input
                   type="text"
                   value={formData.display_name}
                   onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  className="w-full border border-neutral-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   placeholder="Payment API"
                   required
                 />
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+                <label className="block text-sm font-medium text-neutral-700 mb-1">
+                  Description
+                </label>
                 <textarea
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  className="w-full border border-neutral-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   rows={2}
                   placeholder="API for handling payments..."
                 />
@@ -976,18 +975,18 @@ paths:
             variant="bordered"
           >
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                 Backend URL
               </label>
               <input
                 type="url"
                 value={formData.backend_url}
                 onChange={(e) => setFormData({ ...formData, backend_url: e.target.value })}
-                className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 placeholder="https://backend.internal/api/v1"
                 required
               />
-              <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
+              <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
                 The backend service URL that the Gateway will proxy requests to
               </p>
             </div>
@@ -1003,17 +1002,17 @@ paths:
               variant="bordered"
             >
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+                <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                   OpenAPI Spec
                 </label>
                 <textarea
                   value={formData.openapi_spec}
                   onChange={(e) => setFormData({ ...formData, openapi_spec: e.target.value })}
-                  className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"
+                  className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"
                   rows={6}
                   placeholder="Paste OpenAPI/Swagger spec here (YAML or JSON)..."
                 />
-                <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
+                <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
                   Adding an OpenAPI spec enables API documentation and validation
                 </p>
               </div>
@@ -1038,17 +1037,17 @@ paths:
                     onChange={(e) =>
                       setFormData({ ...formData, portal_promoted: e.target.checked })
                     }
-                    className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                    className="w-4 h-4 text-blue-600 border-neutral-300 rounded focus:ring-blue-500"
                   />
                 </div>
                 <div className="flex-1">
                   <label
                     htmlFor="portalPromoted"
-                    className="text-sm font-medium text-gray-700 dark:text-neutral-300"
+                    className="text-sm font-medium text-neutral-700 dark:text-neutral-300"
                   >
                     Promote to Developer Portal
                   </label>
-                  <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
                     When enabled, this API will be visible in the Developer Portal for consumers to
                     discover and subscribe.
                   </p>
@@ -1064,17 +1063,17 @@ paths:
                       id="deployToDev"
                       checked={deployToDev}
                       onChange={(e) => setDeployToDev(e.target.checked)}
-                      className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                      className="w-4 h-4 text-blue-600 border-neutral-300 rounded focus:ring-blue-500"
                     />
                   </div>
                   <div className="flex-1">
                     <label
                       htmlFor="deployToDev"
-                      className="text-sm font-medium text-gray-700 dark:text-neutral-300"
+                      className="text-sm font-medium text-neutral-700 dark:text-neutral-300"
                     >
                       Deploy to DEV environment
                     </label>
-                    <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
+                    <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
                       Automatically deploy this API to the DEV environment after creation.
                     </p>
                   </div>
@@ -1084,29 +1083,12 @@ paths:
           </Collapsible>
 
           <div className="flex justify-end gap-3 pt-4 border-t dark:border-neutral-700 mt-6">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg text-gray-700 dark:text-neutral-300 hover:bg-gray-50 dark:hover:bg-neutral-700"
-            >
+            <Button variant="secondary" type="button" onClick={onClose}>
               Cancel
-            </button>
-            <button
-              type="submit"
-              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center gap-2"
-            >
-              {!isEdit && deployToDev && (
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M13 10V3L4 14h7v7l9-11h-7z"
-                  />
-                </svg>
-              )}
+            </Button>
+            <Button type="submit">
               {isEdit ? 'Update API' : deployToDev ? 'Create & Deploy' : 'Create API'}
-            </button>
+            </Button>
           </div>
         </form>
       </div>

--- a/control-plane-ui/src/pages/AdminProspects.tsx
+++ b/control-plane-ui/src/pages/AdminProspects.tsx
@@ -52,9 +52,9 @@ const statusColors: Record<ProspectStatus, { bg: string; text: string; dot: stri
     dot: 'bg-blue-500',
   },
   pending: {
-    bg: 'bg-gray-100 dark:bg-neutral-700',
-    text: 'text-gray-800 dark:text-neutral-300',
-    dot: 'bg-gray-400',
+    bg: 'bg-neutral-100 dark:bg-neutral-700',
+    text: 'text-neutral-800 dark:text-neutral-300',
+    dot: 'bg-neutral-400',
   },
   expired: {
     bg: 'bg-red-100 dark:bg-red-900/30',
@@ -143,10 +143,10 @@ export function AdminProspects() {
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
           <AlertTriangle className="h-12 w-12 text-red-500 mx-auto mb-4" />
-          <h1 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+          <h1 className="text-xl font-semibold text-neutral-900 dark:text-white mb-2">
             Access Denied
           </h1>
-          <p className="text-gray-600 dark:text-neutral-400">
+          <p className="text-neutral-600 dark:text-neutral-400">
             Platform admin role required to view this page.
           </p>
         </div>
@@ -157,22 +157,22 @@ export function AdminProspects() {
   const totalPages = prospectsData ? Math.ceil(prospectsData.meta.total / PAGE_SIZE) : 0;
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-neutral-900 p-6">
+    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 p-6">
       <div className="max-w-7xl mx-auto space-y-6">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
               Prospects Dashboard
             </h1>
-            <p className="text-gray-500 dark:text-neutral-400 mt-1">
+            <p className="text-neutral-500 dark:text-neutral-400 mt-1">
               Conversion tracking for demo prospects
             </p>
           </div>
           <div className="flex items-center gap-3">
             <button
               onClick={() => refresh()}
-              className="flex items-center gap-2 px-3 py-2 text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
+              className="flex items-center gap-2 px-3 py-2 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
             >
               <RefreshCw className="h-4 w-4" />
               Refresh
@@ -192,7 +192,7 @@ export function AdminProspects() {
         <MetricsHeader metrics={metrics} isLoading={metricsLoading} />
 
         {/* Filters */}
-        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-200 dark:border-neutral-700 p-4">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-200 dark:border-neutral-700 p-4">
           <div className="flex flex-wrap items-center gap-4">
             <div className="flex-1 min-w-[200px]">
               <input
@@ -200,13 +200,13 @@ export function AdminProspects() {
                 placeholder="Search by company..."
                 value={companySearch}
                 onChange={(e) => setCompanySearch(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 dark:text-white dark:placeholder-neutral-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 dark:text-white dark:placeholder-neutral-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
             </div>
             <select
               value={filters.status || ''}
               onChange={(e) => handleStatusFilter(e.target.value as ProspectStatus | '')}
-              className="px-3 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               <option value="">All Statuses</option>
               <option value="pending">Pending</option>
@@ -214,18 +214,18 @@ export function AdminProspects() {
               <option value="converted">Converted</option>
               <option value="expired">Expired</option>
             </select>
-            <span className="text-sm text-gray-500 dark:text-neutral-400">
+            <span className="text-sm text-neutral-500 dark:text-neutral-400">
               {prospectsData?.meta.total ?? 0} prospects
             </span>
           </div>
         </div>
 
         {/* Table */}
-        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-200 dark:border-neutral-700 overflow-hidden">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-200 dark:border-neutral-700 overflow-hidden">
           {prospectsLoading ? (
             <div className="p-8 text-center">
               <RefreshCw className="h-8 w-8 animate-spin text-blue-600 mx-auto" />
-              <p className="mt-2 text-gray-500 dark:text-neutral-400">Loading prospects...</p>
+              <p className="mt-2 text-neutral-500 dark:text-neutral-400">Loading prospects...</p>
             </div>
           ) : prospectsError ? (
             <div className="p-8 text-center">
@@ -234,35 +234,35 @@ export function AdminProspects() {
             </div>
           ) : !prospectsData?.data.length ? (
             <div className="p-8 text-center">
-              <Users className="h-8 w-8 text-gray-400 dark:text-neutral-500 mx-auto" />
-              <p className="mt-2 text-gray-500 dark:text-neutral-400">No prospects found</p>
+              <Users className="h-8 w-8 text-neutral-400 dark:text-neutral-500 mx-auto" />
+              <p className="mt-2 text-neutral-500 dark:text-neutral-400">No prospects found</p>
             </div>
           ) : (
             <>
-              <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
-                <thead className="bg-gray-50 dark:bg-neutral-700">
+              <table className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700">
+                <thead className="bg-neutral-50 dark:bg-neutral-700">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                       Name / Email
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                       Status
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                       Time to Tool
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                       NPS
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                       Events
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                       Last Activity
                     </th>
                   </tr>
                 </thead>
-                <tbody className="bg-white dark:bg-neutral-800 divide-y divide-gray-200 dark:divide-neutral-700">
+                <tbody className="bg-white dark:bg-neutral-800 divide-y divide-neutral-200 dark:divide-neutral-700">
                   {prospectsData.data.map((prospect) => (
                     <ProspectRow
                       key={prospect.id}
@@ -275,22 +275,22 @@ export function AdminProspects() {
 
               {/* Pagination */}
               {totalPages > 1 && (
-                <div className="bg-gray-50 dark:bg-neutral-700 px-6 py-3 flex items-center justify-between border-t dark:border-neutral-600">
-                  <span className="text-sm text-gray-500 dark:text-neutral-400">
+                <div className="bg-neutral-50 dark:bg-neutral-700 px-6 py-3 flex items-center justify-between border-t dark:border-neutral-600">
+                  <span className="text-sm text-neutral-500 dark:text-neutral-400">
                     Page {page} of {totalPages}
                   </span>
                   <div className="flex items-center gap-2">
                     <button
                       onClick={() => setPage((p) => Math.max(1, p - 1))}
                       disabled={page === 1}
-                      className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-600 disabled:opacity-50 disabled:cursor-not-allowed dark:text-neutral-300"
+                      className="p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-600 disabled:opacity-50 disabled:cursor-not-allowed dark:text-neutral-300"
                     >
                       <ChevronLeft className="h-5 w-5" />
                     </button>
                     <button
                       onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                       disabled={page === totalPages}
-                      className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-600 disabled:opacity-50 disabled:cursor-not-allowed dark:text-neutral-300"
+                      className="p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-600 disabled:opacity-50 disabled:cursor-not-allowed dark:text-neutral-300"
                     >
                       <ChevronRight className="h-5 w-5" />
                     </button>
@@ -331,10 +331,10 @@ function MetricsHeader({
         {[...Array(4)].map((_, i) => (
           <div
             key={i}
-            className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-200 dark:border-neutral-700 p-6 animate-pulse"
+            className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-200 dark:border-neutral-700 p-6 animate-pulse"
           >
-            <div className="h-4 bg-gray-200 rounded w-20 mb-2" />
-            <div className="h-8 bg-gray-200 rounded w-16" />
+            <div className="h-4 bg-neutral-200 rounded w-20 mb-2" />
+            <div className="h-8 bg-neutral-200 rounded w-16" />
           </div>
         ))}
       </div>
@@ -389,15 +389,15 @@ function MetricCard({
   color: string;
 }) {
   return (
-    <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-200 dark:border-neutral-700 p-6">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-200 dark:border-neutral-700 p-6">
       <div className="flex items-center gap-4">
         <div className={`rounded-lg p-3 ${color}`}>
           <Icon className="h-6 w-6 text-white" />
         </div>
         <div>
-          <p className="text-sm font-medium text-gray-500 dark:text-neutral-400">{title}</p>
-          <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
-          <p className="text-xs text-gray-400 dark:text-neutral-500">{subtitle}</p>
+          <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">{title}</p>
+          <p className="text-2xl font-bold text-neutral-900 dark:text-white">{value}</p>
+          <p className="text-xs text-neutral-400 dark:text-neutral-500">{subtitle}</p>
         </div>
       </div>
     </div>
@@ -410,18 +410,18 @@ function ProspectRow({ prospect, onClick }: { prospect: ProspectSummary; onClick
   return (
     <tr
       onClick={onClick}
-      className="hover:bg-gray-50 dark:hover:bg-neutral-700 cursor-pointer transition-colors"
+      className="hover:bg-neutral-50 dark:hover:bg-neutral-700 cursor-pointer transition-colors"
     >
       <td className="px-6 py-4">
-        <div className="font-medium text-gray-900 dark:text-white">
+        <div className="font-medium text-neutral-900 dark:text-white">
           {prospect.first_name || prospect.last_name
             ? `${prospect.first_name ?? ''} ${prospect.last_name ?? ''}`.trim()
             : prospect.company || prospect.email}
         </div>
-        <div className="text-sm text-gray-500 dark:text-neutral-400">
+        <div className="text-sm text-neutral-500 dark:text-neutral-400">
           {prospect.email}
           {prospect.role && (
-            <span className="ml-2 text-xs bg-gray-100 dark:bg-neutral-700 px-1.5 py-0.5 rounded">
+            <span className="ml-2 text-xs bg-neutral-100 dark:bg-neutral-700 px-1.5 py-0.5 rounded">
               {prospect.role}
             </span>
           )}
@@ -435,7 +435,7 @@ function ProspectRow({ prospect, onClick }: { prospect: ProspectSummary; onClick
           {prospect.status}
         </span>
       </td>
-      <td className="px-6 py-4 text-sm text-gray-900 dark:text-white">
+      <td className="px-6 py-4 text-sm text-neutral-900 dark:text-white">
         {formatDuration(prospect.time_to_first_tool_seconds)}
       </td>
       <td className="px-6 py-4">
@@ -446,11 +446,13 @@ function ProspectRow({ prospect, onClick }: { prospect: ProspectSummary; onClick
             {prospect.nps_score}/10
           </span>
         ) : (
-          <span className="text-gray-400 dark:text-neutral-500">—</span>
+          <span className="text-neutral-400 dark:text-neutral-500">—</span>
         )}
       </td>
-      <td className="px-6 py-4 text-sm text-gray-900 dark:text-white">{prospect.total_events}</td>
-      <td className="px-6 py-4 text-sm text-gray-500 dark:text-neutral-400">
+      <td className="px-6 py-4 text-sm text-neutral-900 dark:text-white">
+        {prospect.total_events}
+      </td>
+      <td className="px-6 py-4 text-sm text-neutral-500 dark:text-neutral-400">
         {formatDate(prospect.last_activity_at)}
       </td>
     </tr>
@@ -476,15 +478,15 @@ function ProspectDetailModal({
         <div className="flex items-center justify-between px-6 py-4 border-b dark:border-neutral-700">
           <div>
             {isLoading ? (
-              <div className="h-6 bg-gray-200 dark:bg-neutral-700 rounded w-40 animate-pulse" />
+              <div className="h-6 bg-neutral-200 dark:bg-neutral-700 rounded w-40 animate-pulse" />
             ) : prospect ? (
               <>
-                <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
                   {prospect.first_name || prospect.last_name
                     ? `${prospect.first_name ?? ''} ${prospect.last_name ?? ''}`.trim()
                     : prospect.company || prospect.email}
                 </h2>
-                <p className="text-sm text-gray-500 dark:text-neutral-400">
+                <p className="text-sm text-neutral-500 dark:text-neutral-400">
                   {prospect.email}
                   {prospect.company && ` · ${prospect.company}`}
                 </p>
@@ -493,9 +495,9 @@ function ProspectDetailModal({
           </div>
           <button
             onClick={onClose}
-            className="p-2 hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
+            className="p-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
           >
-            <X className="h-5 w-5 text-gray-500 dark:text-neutral-400" />
+            <X className="h-5 w-5 text-neutral-500 dark:text-neutral-400" />
           </button>
         </div>
 
@@ -503,9 +505,9 @@ function ProspectDetailModal({
         <div className="flex-1 overflow-y-auto p-6 space-y-6">
           {isLoading ? (
             <div className="animate-pulse space-y-4">
-              <div className="h-4 bg-gray-200 dark:bg-neutral-700 rounded w-3/4" />
-              <div className="h-4 bg-gray-200 dark:bg-neutral-700 rounded w-1/2" />
-              <div className="h-32 bg-gray-200 dark:bg-neutral-700 rounded" />
+              <div className="h-4 bg-neutral-200 dark:bg-neutral-700 rounded w-3/4" />
+              <div className="h-4 bg-neutral-200 dark:bg-neutral-700 rounded w-1/2" />
+              <div className="h-32 bg-neutral-200 dark:bg-neutral-700 rounded" />
             </div>
           ) : prospect ? (
             <>
@@ -561,7 +563,7 @@ function ProspectDetailModal({
 
               {/* Timeline */}
               <div>
-                <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-3">
+                <h3 className="text-sm font-medium text-neutral-900 dark:text-white mb-3">
                   Timeline ({prospect.timeline.length} events)
                 </h3>
                 <div className="space-y-2 max-h-64 overflow-y-auto">
@@ -595,7 +597,7 @@ function ProspectDetailModal({
               )}
             </>
           ) : (
-            <p className="text-gray-500 dark:text-neutral-400">Prospect not found</p>
+            <p className="text-neutral-500 dark:text-neutral-400">Prospect not found</p>
           )}
         </div>
       </div>
@@ -606,8 +608,8 @@ function ProspectDetailModal({
 function InfoItem({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <p className="text-xs text-gray-500 dark:text-neutral-400">{label}</p>
-      <p className="text-sm font-medium text-gray-900 dark:text-white capitalize">{value}</p>
+      <p className="text-xs text-neutral-500 dark:text-neutral-400">{label}</p>
+      <p className="text-sm font-medium text-neutral-900 dark:text-white capitalize">{value}</p>
     </div>
   );
 }
@@ -625,13 +627,13 @@ function StatBox({
 }) {
   return (
     <div
-      className={`rounded-lg p-3 text-center ${highlight ? 'bg-red-50 dark:bg-red-900/20' : 'bg-gray-50 dark:bg-neutral-700'}`}
+      className={`rounded-lg p-3 text-center ${highlight ? 'bg-red-50 dark:bg-red-900/20' : 'bg-neutral-50 dark:bg-neutral-700'}`}
     >
       <Icon
-        className={`h-5 w-5 mx-auto ${highlight ? 'text-red-500' : 'text-gray-400 dark:text-neutral-400'}`}
+        className={`h-5 w-5 mx-auto ${highlight ? 'text-red-500' : 'text-neutral-400 dark:text-neutral-400'}`}
       />
-      <p className="text-lg font-semibold text-gray-900 dark:text-white mt-1">{value}</p>
-      <p className="text-xs text-gray-500 dark:text-neutral-400">{label}</p>
+      <p className="text-lg font-semibold text-neutral-900 dark:text-white mt-1">{value}</p>
+      <p className="text-xs text-neutral-500 dark:text-neutral-400">{label}</p>
     </div>
   );
 }
@@ -648,27 +650,29 @@ function TimelineEvent({ event }: { event: ProspectDetail['timeline'][0] }) {
 
   return (
     <div className="flex items-start gap-3 text-sm">
-      <span className="text-xs text-gray-400 dark:text-neutral-500 w-20 flex-shrink-0">
+      <span className="text-xs text-neutral-400 dark:text-neutral-500 w-20 flex-shrink-0">
         {new Date(event.timestamp).toLocaleTimeString('fr-FR', {
           hour: '2-digit',
           minute: '2-digit',
         })}
       </span>
-      <Icon className="h-4 w-4 text-gray-400 dark:text-neutral-500 mt-0.5 flex-shrink-0" />
+      <Icon className="h-4 w-4 text-neutral-400 dark:text-neutral-500 mt-0.5 flex-shrink-0" />
       <div className="flex-1">
-        <span className="font-medium text-gray-700 dark:text-neutral-300">{event.event_type}</span>
+        <span className="font-medium text-neutral-700 dark:text-neutral-300">
+          {event.event_type}
+        </span>
         {event.is_first_tool_call && (
           <span className="ml-2 text-xs bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 px-1.5 py-0.5 rounded">
             First!
           </span>
         )}
         {(event.metadata as { tool?: string; page?: string }).tool && (
-          <span className="ml-2 text-gray-500 dark:text-neutral-400">
+          <span className="ml-2 text-neutral-500 dark:text-neutral-400">
             {(event.metadata as { tool: string }).tool}
           </span>
         )}
         {(event.metadata as { page?: string }).page && (
-          <span className="ml-2 text-gray-500 dark:text-neutral-400">
+          <span className="ml-2 text-neutral-500 dark:text-neutral-400">
             {(event.metadata as { page: string }).page}
           </span>
         )}

--- a/control-plane-ui/src/pages/Applications.tsx
+++ b/control-plane-ui/src/pages/Applications.tsx
@@ -2,7 +2,9 @@ import { useState, useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { apiService } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
+import { Plus } from 'lucide-react';
 import { useDebounce } from '../hooks/useDebounce';
+import { Button } from '@stoa/shared/components/Button';
 import { useToastActions } from '@stoa/shared/components/Toast';
 import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
 import { EmptyState } from '@stoa/shared/components/EmptyState';
@@ -171,8 +173,8 @@ export function Applications() {
     return (
       <div className="space-y-6">
         <div className="flex justify-between items-center">
-          <div className="h-8 w-48 bg-gray-200 rounded animate-pulse" />
-          <div className="h-10 w-40 bg-gray-200 rounded animate-pulse" />
+          <div className="h-8 w-48 bg-neutral-200 rounded animate-pulse" />
+          <div className="h-10 w-40 bg-neutral-200 rounded animate-pulse" />
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {[1, 2, 3].map((i) => (
@@ -187,21 +189,18 @@ export function Applications() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Applications</h1>
-          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Applications</h1>
+          <p className="text-neutral-500 dark:text-neutral-400 mt-1">
             Manage consumer applications and API subscriptions
           </p>
         </div>
-        <button
+        <Button
           onClick={() => setShowCreateModal(true)}
           disabled={!selectedTenant}
-          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          icon={<Plus className="w-5 h-5" />}
         >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
           Create Application
-        </button>
+        </Button>
       </div>
 
       {/* Filters */}
@@ -209,13 +208,13 @@ export function Applications() {
         <div className="flex flex-wrap gap-4 items-end">
           {/* Tenant Selector */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               Tenant
             </label>
             <select
               value={selectedTenant}
               onChange={(e) => setSelectedTenant(e.target.value)}
-              className="w-48 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-48 border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               {tenants.map((tenant) => (
                 <option key={tenant.id} value={tenant.id}>
@@ -227,7 +226,7 @@ export function Applications() {
 
           {/* Search Input */}
           <div className="flex-1 min-w-[200px]">
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               Search
             </label>
             <div className="relative">
@@ -236,10 +235,10 @@ export function Applications() {
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Search by name, description, client ID..."
-                className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 pl-10 bg-white dark:bg-neutral-700 dark:text-white dark:placeholder-neutral-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 pl-10 bg-white dark:bg-neutral-700 dark:text-white dark:placeholder-neutral-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
               <svg
-                className="absolute left-3 top-2.5 h-5 w-5 text-gray-400"
+                className="absolute left-3 top-2.5 h-5 w-5 text-neutral-400"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -254,7 +253,7 @@ export function Applications() {
               {searchQuery && (
                 <button
                   onClick={() => setSearchQuery('')}
-                  className="absolute right-3 top-2.5 text-gray-400 hover:text-gray-600"
+                  className="absolute right-3 top-2.5 text-neutral-400 hover:text-neutral-600"
                 >
                   <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path
@@ -271,13 +270,13 @@ export function Applications() {
 
           {/* Status Filter */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               Status
             </label>
             <select
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
-              className="w-36 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-36 border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               <option value="">All Status</option>
               <option value="pending">Pending</option>
@@ -287,7 +286,7 @@ export function Applications() {
           </div>
 
           {/* Results count */}
-          <div className="text-sm text-gray-500 dark:text-neutral-400 self-end pb-2">
+          <div className="text-sm text-neutral-500 dark:text-neutral-400 self-end pb-2">
             {filteredApplications.length} of {applications.length} applications
           </div>
         </div>
@@ -340,10 +339,10 @@ export function Applications() {
             >
               <div className="flex justify-between items-start mb-4">
                 <div>
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                  <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">
                     {app.display_name || app.name}
                   </h3>
-                  <p className="text-sm text-gray-500 dark:text-neutral-400">{app.name}</p>
+                  <p className="text-sm text-neutral-500 dark:text-neutral-400">{app.name}</p>
                 </div>
                 <span
                   className={`px-2 py-1 text-xs font-medium rounded-full ${statusColors[app.status]}`}
@@ -352,14 +351,14 @@ export function Applications() {
                 </span>
               </div>
 
-              <p className="text-sm text-gray-600 dark:text-neutral-300 mb-4 line-clamp-2">
+              <p className="text-sm text-neutral-600 dark:text-neutral-300 mb-4 line-clamp-2">
                 {app.description || 'No description'}
               </p>
 
-              <div className="text-sm text-gray-600 dark:text-neutral-300 mb-4">
+              <div className="text-sm text-neutral-600 dark:text-neutral-300 mb-4">
                 <div className="flex items-center gap-2 mb-1">
                   <span className="font-medium">Client ID:</span>
-                  <code className="bg-gray-100 dark:bg-neutral-700 px-2 py-0.5 rounded text-xs">
+                  <code className="bg-neutral-100 dark:bg-neutral-700 px-2 py-0.5 rounded text-xs">
                     {app.client_id}
                   </code>
                 </div>
@@ -372,7 +371,7 @@ export function Applications() {
               {/* Subscribed APIs */}
               {app.api_subscriptions && app.api_subscriptions.length > 0 && (
                 <div className="mb-4">
-                  <p className="text-xs font-medium text-gray-500 dark:text-neutral-400 mb-2">
+                  <p className="text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-2">
                     Subscribed APIs:
                   </p>
                   <div className="flex flex-wrap gap-1">
@@ -385,7 +384,7 @@ export function Applications() {
                       </span>
                     ))}
                     {app.api_subscriptions.length > 3 && (
-                      <span className="px-2 py-0.5 bg-gray-100 dark:bg-neutral-700 text-gray-600 dark:text-neutral-300 text-xs rounded">
+                      <span className="px-2 py-0.5 bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300 text-xs rounded">
                         +{app.api_subscriptions.length - 3} more
                       </span>
                     )}
@@ -394,18 +393,22 @@ export function Applications() {
               )}
 
               <div className="flex gap-2 pt-4 border-t dark:border-neutral-700">
-                <button
+                <Button
+                  variant="ghost"
+                  size="sm"
                   onClick={() => setEditingApp(app)}
-                  className="flex-1 px-3 py-2 text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-800 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-neutral-700 rounded-lg"
+                  className="flex-1"
                 >
                   Edit
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant="danger"
+                  size="sm"
                   onClick={() => handleDelete(app.id, app.display_name || app.name)}
-                  className="flex-1 px-3 py-2 text-sm text-red-600 dark:text-red-400 hover:text-red-800 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg"
+                  className="flex-1"
                 >
                   Delete
-                </button>
+                </Button>
               </div>
             </div>
           ))
@@ -415,29 +418,31 @@ export function Applications() {
       {/* Pagination */}
       {!loading && filteredApplications.length > 0 && totalPages > 1 && (
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow px-6 py-3 flex items-center justify-between">
-          <div className="text-sm text-gray-500 dark:text-neutral-400">
+          <div className="text-sm text-neutral-500 dark:text-neutral-400">
             Showing {(currentPage - 1) * PAGE_SIZE + 1} to{' '}
             {Math.min(currentPage * PAGE_SIZE, filteredApplications.length)} of{' '}
             {filteredApplications.length} results
           </div>
           <div className="flex gap-2">
-            <button
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
               disabled={currentPage === 1}
-              className="px-3 py-1 text-sm border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-700 dark:text-neutral-300 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Previous
-            </button>
-            <span className="px-3 py-1 text-sm text-gray-700 dark:text-neutral-300">
+            </Button>
+            <span className="px-3 py-1 text-sm text-neutral-700 dark:text-neutral-300">
               Page {currentPage} of {totalPages}
             </span>
-            <button
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
               disabled={currentPage === totalPages}
-              className="px-3 py-1 text-sm border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-700 dark:text-neutral-300 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Next
-            </button>
+            </Button>
           </div>
         </div>
       )}
@@ -527,10 +532,10 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
         <div className="flex justify-between items-center px-6 py-4 border-b dark:border-neutral-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h2>
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">{title}</h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-neutral-300"
+            className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
           >
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
@@ -545,7 +550,7 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
         <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-6 space-y-4">
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                 Name (slug)
               </label>
               <input
@@ -557,20 +562,20 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
                     name: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '-'),
                   })
                 }
-                className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 placeholder="my-mobile-app"
                 required
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                 Display Name
               </label>
               <input
                 type="text"
                 value={formData.display_name}
                 onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
-                className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 placeholder="My Mobile App"
                 required
               />
@@ -578,11 +583,11 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+            <label className="block text-sm font-medium text-neutral-700 mb-1">Description</label>
             <textarea
               value={formData.description}
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               rows={2}
               placeholder="Application description..."
             />
@@ -590,7 +595,7 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
 
           {/* Redirect URIs */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Redirect URIs
             </label>
             <div className="flex gap-2 mb-2">
@@ -598,29 +603,25 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
                 type="url"
                 value={redirectUri}
                 onChange={(e) => setRedirectUri(e.target.value)}
-                className="flex-1 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="flex-1 border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 placeholder="https://myapp.example.com/callback"
               />
-              <button
-                type="button"
-                onClick={addRedirectUri}
-                className="px-4 py-2 bg-gray-100 dark:bg-neutral-700 text-gray-700 dark:text-neutral-300 rounded-lg hover:bg-gray-200 dark:hover:bg-neutral-600"
-              >
+              <Button type="button" variant="secondary" onClick={addRedirectUri}>
                 Add
-              </button>
+              </Button>
             </div>
             {formData.redirect_uris.length > 0 && (
               <div className="flex flex-wrap gap-2">
                 {formData.redirect_uris.map((uri) => (
                   <span
                     key={uri}
-                    className="inline-flex items-center gap-1 px-3 py-1 bg-gray-100 dark:bg-neutral-700 rounded-lg text-sm dark:text-neutral-300"
+                    className="inline-flex items-center gap-1 px-3 py-1 bg-neutral-100 dark:bg-neutral-700 rounded-lg text-sm dark:text-neutral-300"
                   >
                     {uri}
                     <button
                       type="button"
                       onClick={() => removeRedirectUri(uri)}
-                      className="text-gray-500 hover:text-red-600"
+                      className="text-neutral-500 hover:text-red-600"
                     >
                       &times;
                     </button>
@@ -632,37 +633,39 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
 
           {/* API Subscriptions */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               API Subscriptions
             </label>
             {apis.length === 0 ? (
-              <p className="text-sm text-gray-500 dark:text-neutral-400 italic">
+              <p className="text-sm text-neutral-500 dark:text-neutral-400 italic">
                 No APIs available for subscription
               </p>
             ) : (
-              <div className="border border-gray-200 dark:border-neutral-600 rounded-lg divide-y dark:divide-neutral-700 max-h-48 overflow-y-auto">
+              <div className="border border-neutral-200 dark:border-neutral-600 rounded-lg divide-y dark:divide-neutral-700 max-h-48 overflow-y-auto">
                 {apis.map((api) => (
                   <label
                     key={api.id}
-                    className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 dark:hover:bg-neutral-700 cursor-pointer"
+                    className="flex items-center gap-3 px-4 py-3 hover:bg-neutral-50 dark:hover:bg-neutral-700 cursor-pointer"
                   >
                     <input
                       type="checkbox"
                       checked={formData.api_subscriptions.includes(api.id)}
                       onChange={() => toggleApiSubscription(api.id)}
-                      className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                      className="w-4 h-4 text-blue-600 border-neutral-300 rounded focus:ring-blue-500"
                     />
                     <div className="flex-1">
-                      <p className="text-sm font-medium text-gray-900 dark:text-white">
+                      <p className="text-sm font-medium text-neutral-900 dark:text-white">
                         {api.display_name || api.name}
                       </p>
-                      <p className="text-xs text-gray-500 dark:text-neutral-400">v{api.version}</p>
+                      <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                        v{api.version}
+                      </p>
                     </div>
                     <span
                       className={`px-2 py-0.5 text-xs rounded ${
                         api.status === 'published'
                           ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-                          : 'bg-gray-100 text-gray-600 dark:bg-neutral-700 dark:text-neutral-300'
+                          : 'bg-neutral-100 text-neutral-600 dark:bg-neutral-700 dark:text-neutral-300'
                       }`}
                     >
                       {api.status}
@@ -674,19 +677,10 @@ function ApplicationFormModal({ app, apis, onClose, onSubmit, title }: Applicati
           </div>
 
           <div className="flex justify-end gap-3 pt-4 border-t dark:border-neutral-700 mt-6">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg text-gray-700 dark:text-neutral-300 hover:bg-gray-50 dark:hover:bg-neutral-700"
-            >
+            <Button variant="secondary" type="button" onClick={onClose}>
               Cancel
-            </button>
-            <button
-              type="submit"
-              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
-            >
-              {app ? 'Update' : 'Create'} Application
-            </button>
+            </Button>
+            <Button type="submit">{app ? 'Update' : 'Create'} Application</Button>
           </div>
         </form>
       </div>

--- a/control-plane-ui/src/pages/AudienceGovernance.tsx
+++ b/control-plane-ui/src/pages/AudienceGovernance.tsx
@@ -78,8 +78,10 @@ export function AudienceGovernance() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Audience Governance</h1>
-          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
+            Audience Governance
+          </h1>
+          <p className="text-neutral-500 dark:text-neutral-400 mt-1">
             Manage API audience visibility levels
           </p>
         </div>
@@ -91,7 +93,7 @@ export function AudienceGovernance() {
           <select
             value={tenantFilter}
             onChange={(e) => setTenantFilter(e.target.value)}
-            className="rounded-lg border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 px-3 py-2 text-sm text-gray-900 dark:text-white"
+            className="rounded-lg border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 px-3 py-2 text-sm text-neutral-900 dark:text-white"
           >
             <option value="">Select tenant...</option>
             {tenants.map((t: Tenant) => (
@@ -102,20 +104,20 @@ export function AudienceGovernance() {
           </select>
         )}
         <div className="relative flex-1 min-w-[200px]">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400" />
           <input
             type="text"
             placeholder="Search APIs..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 rounded-lg border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-sm text-gray-900 dark:text-white placeholder-gray-400"
+            className="w-full pl-10 pr-4 py-2 rounded-lg border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-sm text-neutral-900 dark:text-white placeholder-neutral-400"
           />
         </div>
       </div>
 
       {/* No tenant selected */}
       {!activeTenantId && (
-        <div className="text-center py-12 text-gray-500 dark:text-neutral-400">
+        <div className="text-center py-12 text-neutral-500 dark:text-neutral-400">
           <Users className="w-12 h-12 mx-auto mb-4 opacity-50" />
           <p>Select a tenant to view API audience settings.</p>
         </div>
@@ -123,53 +125,57 @@ export function AudienceGovernance() {
 
       {/* Loading */}
       {isLoading && activeTenantId && (
-        <div className="text-center py-12 text-gray-500 dark:text-neutral-400">Loading APIs...</div>
+        <div className="text-center py-12 text-neutral-500 dark:text-neutral-400">
+          Loading APIs...
+        </div>
       )}
 
       {/* API Table */}
       {activeTenantId && !isLoading && (
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none overflow-hidden">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
-            <thead className="bg-gray-50 dark:bg-neutral-900/50">
+          <table className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700">
+            <thead className="bg-neutral-50 dark:bg-neutral-900/50">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   API
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Version
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Status
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Audience
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
+            <tbody className="divide-y divide-neutral-200 dark:divide-neutral-700">
               {filteredApis.length === 0 ? (
                 <tr>
                   <td
                     colSpan={4}
-                    className="px-6 py-8 text-center text-gray-500 dark:text-neutral-400"
+                    className="px-6 py-8 text-center text-neutral-500 dark:text-neutral-400"
                   >
                     No APIs found.
                   </td>
                 </tr>
               ) : (
                 filteredApis.map((api: API) => (
-                  <tr key={api.id} className="hover:bg-gray-50 dark:hover:bg-neutral-700/30">
+                  <tr key={api.id} className="hover:bg-neutral-50 dark:hover:bg-neutral-700/30">
                     <td className="px-6 py-4">
-                      <div className="text-sm font-medium text-gray-900 dark:text-white">
+                      <div className="text-sm font-medium text-neutral-900 dark:text-white">
                         {api.display_name}
                       </div>
-                      <div className="text-xs text-gray-500 dark:text-neutral-400">{api.name}</div>
+                      <div className="text-xs text-neutral-500 dark:text-neutral-400">
+                        {api.name}
+                      </div>
                     </td>
-                    <td className="px-6 py-4 text-sm text-gray-500 dark:text-neutral-400">
+                    <td className="px-6 py-4 text-sm text-neutral-500 dark:text-neutral-400">
                       {api.version}
                     </td>
                     <td className="px-6 py-4">
-                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-neutral-700 dark:text-neutral-300">
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-neutral-100 text-neutral-800 dark:bg-neutral-700 dark:text-neutral-300">
                         {api.status}
                       </span>
                     </td>
@@ -182,7 +188,7 @@ export function AudienceGovernance() {
                           }
                           onBlur={() => setEditingApi(null)}
                           autoFocus
-                          className="rounded border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 px-2 py-1 text-xs text-gray-900 dark:text-white"
+                          className="rounded border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 px-2 py-1 text-xs text-neutral-900 dark:text-white"
                         >
                           {AUDIENCE_OPTIONS.map((opt) => (
                             <option key={opt} value={opt}>

--- a/control-plane-ui/src/pages/AuditLog.tsx
+++ b/control-plane-ui/src/pages/AuditLog.tsx
@@ -4,8 +4,8 @@ export function AuditLog() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Audit Log</h1>
-        <p className="text-gray-500 dark:text-neutral-400 mt-2">
+        <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Audit Log</h1>
+        <p className="text-neutral-500 dark:text-neutral-400 mt-2">
           Track all platform actions, configuration changes, and access events
         </p>
       </div>
@@ -14,8 +14,8 @@ export function AuditLog() {
         <div className="w-16 h-16 bg-primary-100 dark:bg-primary-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
           <ClipboardList className="h-8 w-8 text-primary-600 dark:text-primary-400" />
         </div>
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Coming Soon</h2>
-        <p className="text-gray-500 dark:text-neutral-400 max-w-md mx-auto">
+        <h2 className="text-lg font-semibold text-neutral-900 dark:text-white mb-2">Coming Soon</h2>
+        <p className="text-neutral-500 dark:text-neutral-400 max-w-md mx-auto">
           The Audit Log will provide a comprehensive timeline of all actions performed on the
           platform, with filtering, search, and export capabilities for compliance needs.
         </p>

--- a/control-plane-ui/src/pages/BackendApis/BackendApisList.tsx
+++ b/control-plane-ui/src/pages/BackendApis/BackendApisList.tsx
@@ -11,7 +11,7 @@ import type { BackendApi, BackendApiStatus } from '../../types';
 
 const statusConfig: Record<BackendApiStatus, { color: string; label: string }> = {
   draft: {
-    color: 'bg-gray-100 text-gray-800 dark:bg-neutral-700 dark:text-neutral-300',
+    color: 'bg-neutral-100 text-neutral-800 dark:bg-neutral-700 dark:text-neutral-300',
     label: 'Draft',
   },
   active: {
@@ -122,13 +122,16 @@ export function BackendApisList() {
     return (
       <div className="space-y-6">
         <div className="flex justify-between items-center">
-          <div className="h-8 w-48 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
-          <div className="h-10 w-32 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+          <div className="h-8 w-48 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
+          <div className="h-10 w-32 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
         </div>
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow">
           <div className="p-6 space-y-4">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="h-12 bg-gray-100 dark:bg-neutral-700 rounded animate-pulse" />
+              <div
+                key={i}
+                className="h-12 bg-neutral-100 dark:bg-neutral-700 rounded animate-pulse"
+              />
             ))}
           </div>
         </div>
@@ -141,8 +144,8 @@ export function BackendApisList() {
       {/* Header */}
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Backend APIs</h1>
-          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Backend APIs</h1>
+          <p className="text-neutral-500 dark:text-neutral-400 mt-1">
             Register backend APIs to expose them as MCP tools through the gateway
           </p>
         </div>
@@ -167,7 +170,7 @@ export function BackendApisList() {
       {/* Filters */}
       <div className="flex gap-4">
         <div className="relative flex-1 max-w-sm">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400" />
           <input
             type="text"
             placeholder="Search APIs..."
@@ -176,7 +179,7 @@ export function BackendApisList() {
               setSearchTerm(e.target.value);
               setPage(1);
             }}
-            className="w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+            className="w-full pl-10 pr-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
           />
         </div>
         <select
@@ -185,7 +188,7 @@ export function BackendApisList() {
             setStatusFilter(e.target.value);
             setPage(1);
           }}
-          className="border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white"
+          className="border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white"
         >
           <option value="all">All statuses</option>
           <option value="draft">Draft</option>
@@ -220,23 +223,23 @@ export function BackendApisList() {
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow overflow-hidden">
           <table className="w-full">
             <thead>
-              <tr className="border-b dark:border-neutral-700 bg-gray-50 dark:bg-neutral-800">
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+              <tr className="border-b dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Name
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Backend URL
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Auth
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Status
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Tools
                 </th>
-                <th className="text-right px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-right px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Actions
                 </th>
               </tr>
@@ -245,19 +248,19 @@ export function BackendApisList() {
               {paginatedApis.map((api) => {
                 const status = statusConfig[api.status];
                 return (
-                  <tr key={api.id} className="hover:bg-gray-50 dark:hover:bg-neutral-750">
+                  <tr key={api.id} className="hover:bg-neutral-50 dark:hover:bg-neutral-750">
                     <td className="px-4 py-3">
-                      <div className="font-medium text-gray-900 dark:text-white">
+                      <div className="font-medium text-neutral-900 dark:text-white">
                         {api.display_name || api.name}
                       </div>
-                      <div className="text-xs text-gray-500 dark:text-neutral-400 font-mono">
+                      <div className="text-xs text-neutral-500 dark:text-neutral-400 font-mono">
                         {api.name}
                       </div>
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-neutral-300 font-mono truncate max-w-xs">
+                    <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300 font-mono truncate max-w-xs">
                       {api.backend_url}
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-neutral-300">
+                    <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                       {authTypeLabels[api.auth_type] || api.auth_type}
                     </td>
                     <td className="px-4 py-3">
@@ -267,7 +270,7 @@ export function BackendApisList() {
                         {status.label}
                       </span>
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-neutral-300">
+                    <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                       {api.tool_count}
                     </td>
                     <td className="px-4 py-3 text-right">
@@ -275,7 +278,7 @@ export function BackendApisList() {
                         {hasPermission('apis:update') && api.status !== 'draft' && (
                           <button
                             onClick={() => handleToggleStatus(api)}
-                            className="text-xs px-2 py-1 border border-gray-300 dark:border-neutral-600 rounded hover:bg-gray-50 dark:hover:bg-neutral-700 dark:text-neutral-300"
+                            className="text-xs px-2 py-1 border border-neutral-300 dark:border-neutral-600 rounded hover:bg-neutral-50 dark:hover:bg-neutral-700 dark:text-neutral-300"
                           >
                             {api.status === 'active' ? 'Disable' : 'Enable'}
                           </button>
@@ -299,7 +302,7 @@ export function BackendApisList() {
           {/* Pagination */}
           {totalPages > 1 && (
             <div className="flex justify-between items-center px-4 py-3 border-t dark:border-neutral-700">
-              <span className="text-sm text-gray-500 dark:text-neutral-400">
+              <span className="text-sm text-neutral-500 dark:text-neutral-400">
                 {filteredApis.length} results
               </span>
               <div className="flex gap-2">
@@ -310,7 +313,7 @@ export function BackendApisList() {
                 >
                   Previous
                 </button>
-                <span className="px-3 py-1 text-sm text-gray-500 dark:text-neutral-400">
+                <span className="px-3 py-1 text-sm text-neutral-500 dark:text-neutral-400">
                   {page} / {totalPages}
                 </span>
                 <button

--- a/control-plane-ui/src/pages/BackendApis/RegisterApiModal.tsx
+++ b/control-plane-ui/src/pages/BackendApis/RegisterApiModal.tsx
@@ -88,12 +88,12 @@ export function RegisterApiModal({ tenantId, onClose, onCreated }: RegisterApiMo
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
         {/* Header */}
         <div className="flex justify-between items-center px-6 py-4 border-b dark:border-neutral-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
             Register Backend API
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-neutral-300"
+            className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
           >
             <X className="h-5 w-5" />
           </button>
@@ -109,14 +109,14 @@ export function RegisterApiModal({ tenantId, onClose, onCreated }: RegisterApiMo
 
           {/* Name */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Name <span className="text-red-500">*</span>
             </label>
             <input
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
               placeholder="petstore-api"
               required
               pattern="^[a-z][a-z0-9-_]*$"
@@ -126,28 +126,28 @@ export function RegisterApiModal({ tenantId, onClose, onCreated }: RegisterApiMo
 
           {/* Display Name */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Display Name
             </label>
             <input
               type="text"
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
               placeholder="Petstore API"
             />
           </div>
 
           {/* Backend URL */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Backend URL <span className="text-red-500">*</span>
             </label>
             <input
               type="url"
               value={backendUrl}
               onChange={(e) => setBackendUrl(e.target.value)}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
               placeholder="https://api.example.com/v1"
               required
             />
@@ -155,27 +155,27 @@ export function RegisterApiModal({ tenantId, onClose, onCreated }: RegisterApiMo
 
           {/* OpenAPI Spec URL */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               OpenAPI Spec URL
             </label>
             <input
               type="url"
               value={openapiSpecUrl}
               onChange={(e) => setOpenapiSpecUrl(e.target.value)}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
               placeholder="https://api.example.com/openapi.json"
             />
           </div>
 
           {/* Description */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Description
             </label>
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
               rows={2}
               placeholder="A brief description of this API"
             />
@@ -183,13 +183,13 @@ export function RegisterApiModal({ tenantId, onClose, onCreated }: RegisterApiMo
 
           {/* Auth Type */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Authentication
             </label>
             <select
               value={authType}
               onChange={(e) => setAuthType(e.target.value as BackendApiAuthType)}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
             >
               {authTypeOptions.map((opt) => (
                 <option key={opt.value} value={opt.value}>
@@ -201,31 +201,31 @@ export function RegisterApiModal({ tenantId, onClose, onCreated }: RegisterApiMo
 
           {/* Dynamic auth config fields */}
           {authType === 'api_key' && (
-            <div className="space-y-3 p-4 bg-gray-50 dark:bg-neutral-700 rounded-lg">
-              <h4 className="text-sm font-medium text-gray-700 dark:text-neutral-300">
+            <div className="space-y-3 p-4 bg-neutral-50 dark:bg-neutral-700 rounded-lg">
+              <h4 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
                 API Key Configuration
               </h4>
               <div>
-                <label className="block text-xs text-gray-600 dark:text-neutral-400 mb-1">
+                <label className="block text-xs text-neutral-600 dark:text-neutral-400 mb-1">
                   Header Name
                 </label>
                 <input
                   type="text"
                   value={headerName}
                   onChange={(e) => setHeaderName(e.target.value)}
-                  className="w-full border border-gray-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
+                  className="w-full border border-neutral-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
                   placeholder="X-API-Key"
                 />
               </div>
               <div>
-                <label className="block text-xs text-gray-600 dark:text-neutral-400 mb-1">
+                <label className="block text-xs text-neutral-600 dark:text-neutral-400 mb-1">
                   API Key Value
                 </label>
                 <input
                   type="password"
                   value={headerValue}
                   onChange={(e) => setHeaderValue(e.target.value)}
-                  className="w-full border border-gray-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
+                  className="w-full border border-neutral-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
                   placeholder="Enter API key"
                 />
               </div>
@@ -233,86 +233,86 @@ export function RegisterApiModal({ tenantId, onClose, onCreated }: RegisterApiMo
           )}
 
           {authType === 'bearer' && (
-            <div className="p-4 bg-gray-50 dark:bg-neutral-700 rounded-lg">
-              <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <div className="p-4 bg-neutral-50 dark:bg-neutral-700 rounded-lg">
+              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                 Bearer Token
               </label>
               <input
                 type="password"
                 value={bearerToken}
                 onChange={(e) => setBearerToken(e.target.value)}
-                className="w-full border border-gray-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
+                className="w-full border border-neutral-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
                 placeholder="Enter bearer token"
               />
             </div>
           )}
 
           {authType === 'basic' && (
-            <div className="space-y-3 p-4 bg-gray-50 dark:bg-neutral-700 rounded-lg">
-              <h4 className="text-sm font-medium text-gray-700 dark:text-neutral-300">
+            <div className="space-y-3 p-4 bg-neutral-50 dark:bg-neutral-700 rounded-lg">
+              <h4 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
                 Basic Auth Credentials
               </h4>
               <div>
-                <label className="block text-xs text-gray-600 dark:text-neutral-400 mb-1">
+                <label className="block text-xs text-neutral-600 dark:text-neutral-400 mb-1">
                   Username
                 </label>
                 <input
                   type="text"
                   value={basicUsername}
                   onChange={(e) => setBasicUsername(e.target.value)}
-                  className="w-full border border-gray-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
+                  className="w-full border border-neutral-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
                 />
               </div>
               <div>
-                <label className="block text-xs text-gray-600 dark:text-neutral-400 mb-1">
+                <label className="block text-xs text-neutral-600 dark:text-neutral-400 mb-1">
                   Password
                 </label>
                 <input
                   type="password"
                   value={basicPassword}
                   onChange={(e) => setBasicPassword(e.target.value)}
-                  className="w-full border border-gray-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
+                  className="w-full border border-neutral-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
                 />
               </div>
             </div>
           )}
 
           {authType === 'oauth2_cc' && (
-            <div className="space-y-3 p-4 bg-gray-50 dark:bg-neutral-700 rounded-lg">
-              <h4 className="text-sm font-medium text-gray-700 dark:text-neutral-300">
+            <div className="space-y-3 p-4 bg-neutral-50 dark:bg-neutral-700 rounded-lg">
+              <h4 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
                 OAuth2 Client Credentials
               </h4>
               <div>
-                <label className="block text-xs text-gray-600 dark:text-neutral-400 mb-1">
+                <label className="block text-xs text-neutral-600 dark:text-neutral-400 mb-1">
                   Client ID
                 </label>
                 <input
                   type="text"
                   value={oauthClientId}
                   onChange={(e) => setOauthClientId(e.target.value)}
-                  className="w-full border border-gray-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
+                  className="w-full border border-neutral-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
                 />
               </div>
               <div>
-                <label className="block text-xs text-gray-600 dark:text-neutral-400 mb-1">
+                <label className="block text-xs text-neutral-600 dark:text-neutral-400 mb-1">
                   Client Secret
                 </label>
                 <input
                   type="password"
                   value={oauthClientSecret}
                   onChange={(e) => setOauthClientSecret(e.target.value)}
-                  className="w-full border border-gray-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
+                  className="w-full border border-neutral-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
                 />
               </div>
               <div>
-                <label className="block text-xs text-gray-600 dark:text-neutral-400 mb-1">
+                <label className="block text-xs text-neutral-600 dark:text-neutral-400 mb-1">
                   Token URL
                 </label>
                 <input
                   type="url"
                   value={oauthTokenUrl}
                   onChange={(e) => setOauthTokenUrl(e.target.value)}
-                  className="w-full border border-gray-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
+                  className="w-full border border-neutral-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
                   placeholder="https://auth.example.com/oauth/token"
                 />
               </div>
@@ -321,11 +321,11 @@ export function RegisterApiModal({ tenantId, onClose, onCreated }: RegisterApiMo
         </form>
 
         {/* Footer */}
-        <div className="flex justify-end gap-3 px-6 py-4 border-t dark:border-neutral-700 bg-gray-50 dark:bg-neutral-800">
+        <div className="flex justify-end gap-3 px-6 py-4 border-t dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800">
           <button
             type="button"
             onClick={onClose}
-            className="px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-white dark:hover:bg-neutral-700 dark:text-neutral-300"
+            className="px-4 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-white dark:hover:bg-neutral-700 dark:text-neutral-300"
           >
             Cancel
           </button>

--- a/control-plane-ui/src/pages/Business/BusinessDashboard.tsx
+++ b/control-plane-ui/src/pages/Business/BusinessDashboard.tsx
@@ -104,10 +104,10 @@ function KPICard({
           </div>
         )}
       </div>
-      <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
-      <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{label}</p>
+      <p className="text-2xl font-bold text-neutral-900 dark:text-white">{value}</p>
+      <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">{label}</p>
       {trendLabel && (
-        <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{trendLabel}</p>
+        <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-0.5">{trendLabel}</p>
       )}
     </div>
   );
@@ -122,7 +122,7 @@ function ApdexGauge({ score }: { score: number }) {
       <div className="relative w-40 h-20 overflow-hidden">
         {/* Background arc */}
         <div
-          className="absolute w-40 h-40 rounded-full border-8 border-gray-200 dark:border-neutral-700"
+          className="absolute w-40 h-40 rounded-full border-8 border-neutral-200 dark:border-neutral-700"
           style={{ clipPath: 'polygon(0 0, 100% 0, 100% 50%, 0 50%)' }}
         />
         {/* Colored arc */}
@@ -142,7 +142,7 @@ function ApdexGauge({ score }: { score: number }) {
         </div>
       </div>
       <p className={`text-sm font-medium ${color} mt-2`}>{getApdexLabel(score)}</p>
-      <p className="text-xs text-gray-400 dark:text-gray-500">APDEX Score</p>
+      <p className="text-xs text-neutral-400 dark:text-neutral-500">APDEX Score</p>
     </div>
   );
 }
@@ -152,16 +152,16 @@ function ModeAdoptionBar({ modes }: { modes: GatewayModeAdoption[] }) {
     'edge-mcp': 'bg-blue-500',
     sidecar: 'bg-green-500',
     proxy: 'bg-purple-500',
-    shadow: 'bg-gray-500',
+    shadow: 'bg-neutral-500',
   };
 
   return (
     <div>
-      <div className="flex h-4 rounded-full overflow-hidden bg-gray-200 dark:bg-neutral-700">
+      <div className="flex h-4 rounded-full overflow-hidden bg-neutral-200 dark:bg-neutral-700">
         {modes.map((mode) => (
           <div
             key={mode.mode}
-            className={`${colors[mode.mode as keyof typeof colors] || 'bg-gray-400'} transition-all duration-500`}
+            className={`${colors[mode.mode as keyof typeof colors] || 'bg-neutral-400'} transition-all duration-500`}
             style={{ width: `${mode.percentage}%` }}
             title={`${mode.displayName}: ${mode.percentage}%`}
           />
@@ -171,9 +171,9 @@ function ModeAdoptionBar({ modes }: { modes: GatewayModeAdoption[] }) {
         {modes.map((mode) => (
           <div key={mode.mode} className="flex items-center gap-2">
             <div
-              className={`w-3 h-3 rounded-full ${colors[mode.mode as keyof typeof colors] || 'bg-gray-400'}`}
+              className={`w-3 h-3 rounded-full ${colors[mode.mode as keyof typeof colors] || 'bg-neutral-400'}`}
             />
-            <span className="text-sm text-gray-600 dark:text-gray-300">
+            <span className="text-sm text-neutral-600 dark:text-neutral-300">
               {mode.displayName}: <span className="font-medium">{mode.percentage}%</span>
             </span>
           </div>
@@ -189,14 +189,14 @@ function TopAPIItem({ api, rank, maxCalls }: { api: TopAPI; rank: number; maxCal
 
   return (
     <div className="flex items-center gap-4 py-3">
-      <span className="w-6 text-lg font-bold text-gray-400 dark:text-gray-500">#{rank}</span>
+      <span className="w-6 text-lg font-bold text-neutral-400 dark:text-neutral-500">#{rank}</span>
       <div className="flex-1 min-w-0">
         <div className="flex items-center justify-between mb-1">
-          <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
+          <span className="text-sm font-medium text-neutral-900 dark:text-white truncate">
             {api.displayName}
           </span>
           <div className="flex items-center gap-2">
-            <span className="text-sm text-gray-600 dark:text-gray-300">
+            <span className="text-sm text-neutral-600 dark:text-neutral-300">
               {formatNumber(api.calls)} calls
             </span>
             <span
@@ -212,13 +212,15 @@ function TopAPIItem({ api, rank, maxCalls }: { api: TopAPI; rank: number; maxCal
           </div>
         </div>
         <div className="flex items-center gap-3">
-          <div className="flex-1 bg-gray-200 dark:bg-neutral-700 rounded-full h-1.5">
+          <div className="flex-1 bg-neutral-200 dark:bg-neutral-700 rounded-full h-1.5">
             <div
               className="bg-blue-500 h-1.5 rounded-full transition-all duration-300"
               style={{ width: `${barWidth}%` }}
             />
           </div>
-          <span className="text-xs text-gray-400 dark:text-gray-500">{api.tenants} tenants</span>
+          <span className="text-xs text-neutral-400 dark:text-neutral-500">
+            {api.tenants} tenants
+          </span>
         </div>
       </div>
     </div>
@@ -342,7 +344,7 @@ export function BusinessDashboard() {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="text-center">
-          <p className="text-gray-500 dark:text-gray-400">
+          <p className="text-neutral-500 dark:text-neutral-400">
             You don't have permission to view business analytics.
           </p>
         </div>
@@ -355,8 +357,10 @@ export function BusinessDashboard() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Business Analytics</h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
+            Business Analytics
+          </h1>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
             Platform adoption, usage trends, and business metrics
           </p>
         </div>
@@ -372,7 +376,7 @@ export function BusinessDashboard() {
           <button
             onClick={loadData}
             disabled={loading}
-            className="flex items-center gap-2 border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-lg text-sm hover:bg-gray-50 dark:hover:bg-neutral-700 disabled:opacity-50"
+            className="flex items-center gap-2 border border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-3 py-2 rounded-lg text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700 disabled:opacity-50"
           >
             <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
             Refresh
@@ -446,21 +450,21 @@ export function BusinessDashboard() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             {/* APDEX Score */}
             <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-6">
-              <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase mb-6">
+              <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase mb-6">
                 User Satisfaction
               </h2>
               <div className="flex items-center justify-around">
                 <ApdexGauge score={metrics.apdexScore} />
                 <div className="space-y-4">
                   <div>
-                    <p className="text-sm text-gray-500 dark:text-gray-400">DAU/MAU Ratio</p>
-                    <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                    <p className="text-sm text-neutral-500 dark:text-neutral-400">DAU/MAU Ratio</p>
+                    <p className="text-2xl font-bold text-neutral-900 dark:text-white">
                       {(metrics.dauMau * 100).toFixed(0)}%
                     </p>
                   </div>
                   <div>
-                    <p className="text-sm text-gray-500 dark:text-gray-400">Avg Session</p>
-                    <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                    <p className="text-sm text-neutral-500 dark:text-neutral-400">Avg Session</p>
+                    <p className="text-2xl font-bold text-neutral-900 dark:text-white">
                       {Math.floor(metrics.avgSessionDuration / 60)}m
                     </p>
                   </div>
@@ -471,7 +475,7 @@ export function BusinessDashboard() {
             {/* Gateway Mode Adoption */}
             <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-6">
               <div className="flex items-center justify-between mb-6">
-                <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase">
+                <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase">
                   Gateway Mode Adoption
                 </h2>
                 <a
@@ -483,10 +487,10 @@ export function BusinessDashboard() {
                 </a>
               </div>
               <ModeAdoptionBar modes={modeAdoption} />
-              <div className="mt-6 pt-4 border-t border-gray-100 dark:border-neutral-700">
+              <div className="mt-6 pt-4 border-t border-neutral-100 dark:border-neutral-700">
                 <div className="flex items-center justify-between text-sm">
-                  <span className="text-gray-500 dark:text-gray-400">Total Gateways</span>
-                  <span className="font-semibold text-gray-900 dark:text-white">
+                  <span className="text-neutral-500 dark:text-neutral-400">Total Gateways</span>
+                  <span className="font-semibold text-neutral-900 dark:text-white">
                     {modeAdoption.reduce((sum, m) => sum + m.count, 0)}
                   </span>
                 </div>
@@ -497,7 +501,7 @@ export function BusinessDashboard() {
           {/* Top APIs */}
           <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-6">
             <div className="flex items-center justify-between mb-6">
-              <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase">
+              <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase">
                 Top APIs by Usage (This Month)
               </h2>
               <a
@@ -509,12 +513,12 @@ export function BusinessDashboard() {
               </a>
             </div>
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-8">
-              <div className="divide-y divide-gray-100 dark:divide-neutral-700">
+              <div className="divide-y divide-neutral-100 dark:divide-neutral-700">
                 {topAPIs.slice(0, 4).map((api, idx) => (
                   <TopAPIItem key={api.name} api={api} rank={idx + 1} maxCalls={maxAPICalls} />
                 ))}
               </div>
-              <div className="divide-y divide-gray-100 dark:divide-neutral-700">
+              <div className="divide-y divide-neutral-100 dark:divide-neutral-700">
                 {topAPIs.slice(4, 8).map((api, idx) => (
                   <TopAPIItem key={api.name} api={api} rank={idx + 5} maxCalls={maxAPICalls} />
                 ))}
@@ -529,8 +533,8 @@ export function BusinessDashboard() {
                 <TrendingUp className="h-5 w-5 text-blue-600" />
               </div>
               <div>
-                <h3 className="font-semibold text-gray-900 dark:text-white">Growth Insights</h3>
-                <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
+                <h3 className="font-semibold text-neutral-900 dark:text-white">Growth Insights</h3>
+                <p className="text-sm text-neutral-600 dark:text-neutral-300 mt-1">
                   Platform usage is up <span className="font-semibold text-green-600">18.2%</span>{' '}
                   this month. The <span className="font-semibold">Code Assistant</span> tool saw the
                   highest growth at <span className="font-semibold text-green-600">156%</span>,
@@ -549,7 +553,7 @@ export function BusinessDashboard() {
         </>
       ) : (
         <div className="text-center py-12">
-          <p className="text-gray-500 dark:text-gray-400">No business data available.</p>
+          <p className="text-neutral-500 dark:text-neutral-400">No business data available.</p>
         </div>
       )}
     </div>

--- a/control-plane-ui/src/pages/Consumers.tsx
+++ b/control-plane-ui/src/pages/Consumers.tsx
@@ -12,6 +12,7 @@ import { EmptyState } from '@stoa/shared/components/EmptyState';
 import { TableSkeleton } from '@stoa/shared/components/Skeleton';
 import { ConsumerDetailModal } from '../components/ConsumerDetailModal';
 import { CertificateHealthBadge } from '../components/CertificateHealthBadge';
+import { Button } from '@stoa/shared/components/Button';
 
 const PAGE_SIZE = 20;
 
@@ -251,8 +252,8 @@ export function Consumers() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Consumers</h1>
-        <p className="text-gray-500 dark:text-neutral-400 mt-1">
+        <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Consumers</h1>
+        <p className="text-neutral-500 dark:text-neutral-400 mt-1">
           API consumers with mTLS certificate bindings
         </p>
       </div>
@@ -262,13 +263,13 @@ export function Consumers() {
         <div className="flex flex-wrap gap-4 items-end">
           {/* Tenant Selector */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               Tenant
             </label>
             <select
               value={activeTenant}
               onChange={(e) => handleTenantChange(e.target.value)}
-              className="w-48 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-48 border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               {tenants.map((tenant) => (
                 <option key={tenant.id} value={tenant.id}>
@@ -280,7 +281,7 @@ export function Consumers() {
 
           {/* Search */}
           <div className="flex-1 min-w-[200px]">
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               Search
             </label>
             <div className="relative">
@@ -289,10 +290,10 @@ export function Consumers() {
                 value={searchQuery}
                 onChange={(e) => handleSearchChange(e.target.value)}
                 placeholder="Search by ID, name, email, company..."
-                className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 pl-10 bg-white dark:bg-neutral-700 dark:text-white dark:placeholder-neutral-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 pl-10 bg-white dark:bg-neutral-700 dark:text-white dark:placeholder-neutral-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
               <svg
-                className="absolute left-3 top-2.5 h-5 w-5 text-gray-400"
+                className="absolute left-3 top-2.5 h-5 w-5 text-neutral-400"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -307,7 +308,7 @@ export function Consumers() {
               {searchQuery && (
                 <button
                   onClick={() => handleSearchChange('')}
-                  className="absolute right-3 top-2.5 text-gray-400 hover:text-gray-600"
+                  className="absolute right-3 top-2.5 text-neutral-400 hover:text-neutral-600"
                 >
                   <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path
@@ -324,13 +325,13 @@ export function Consumers() {
 
           {/* Status Filter */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               Status
             </label>
             <select
               value={statusFilter}
               onChange={(e) => handleStatusChange(e.target.value)}
-              className="w-36 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-36 border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               <option value="">All Status</option>
               <option value="active">Active</option>
@@ -341,7 +342,7 @@ export function Consumers() {
 
           {/* Certificate Filter */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               Certificate
             </label>
             <select
@@ -350,7 +351,7 @@ export function Consumers() {
                 setCertFilter(e.target.value);
                 setCurrentPage(1);
               }}
-              className="w-40 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-40 border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               <option value="">All Certs</option>
               <option value="expiring">Expiring Soon</option>
@@ -359,7 +360,7 @@ export function Consumers() {
           </div>
 
           {/* Results count */}
-          <div className="text-sm text-gray-500 dark:text-neutral-400 self-end pb-2">
+          <div className="text-sm text-neutral-500 dark:text-neutral-400 self-end pb-2">
             {filteredConsumers.length} of {consumers.length} consumers
           </div>
         </div>
@@ -370,19 +371,12 @@ export function Consumers() {
             <span className="text-sm font-medium text-blue-800 dark:text-blue-300">
               {selectedIds.size} selected
             </span>
-            <button
-              onClick={handleBulkRevoke}
-              disabled={bulkRevoking}
-              className="px-3 py-1.5 bg-red-600 text-white text-sm rounded-lg hover:bg-red-700 disabled:opacity-50"
-            >
+            <Button variant="danger" size="sm" onClick={handleBulkRevoke} loading={bulkRevoking}>
               {bulkRevoking ? 'Revoking...' : `Revoke Selected (${selectedIds.size})`}
-            </button>
-            <button
-              onClick={() => setSelectedIds(new Set())}
-              className="text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400"
-            >
+            </Button>
+            <Button variant="ghost" size="sm" onClick={() => setSelectedIds(new Set())}>
               Clear selection
-            </button>
+            </Button>
           </div>
         )}
       </div>
@@ -419,8 +413,8 @@ export function Consumers() {
       {/* Desktop Table */}
       {!isMobile && paginatedConsumers.length > 0 && (
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow overflow-hidden">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
-            <thead className="bg-gray-50 dark:bg-neutral-900">
+          <table className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700">
+            <thead className="bg-neutral-50 dark:bg-neutral-900">
               <tr>
                 {canEdit && (
                   <th className="px-3 py-3 w-10">
@@ -431,39 +425,39 @@ export function Consumers() {
                         selectedIds.size === paginatedConsumers.length
                       }
                       onChange={toggleAll}
-                      className="rounded border-gray-300 dark:border-neutral-600"
+                      className="rounded border-neutral-300 dark:border-neutral-600"
                     />
                   </th>
                 )}
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   External ID
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Name
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Email
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Company
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Status
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Certificate
                 </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Actions
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
+            <tbody className="divide-y divide-neutral-200 dark:divide-neutral-700">
               {paginatedConsumers.map((consumer) => (
                 <tr
                   key={consumer.id}
                   onClick={() => setSelectedConsumer(consumer)}
-                  className="hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-colors cursor-pointer"
+                  className="hover:bg-neutral-50 dark:hover:bg-neutral-700/50 transition-colors cursor-pointer"
                 >
                   {canEdit && (
                     <td className="px-3 py-4 w-10" onClick={(e) => e.stopPropagation()}>
@@ -471,20 +465,20 @@ export function Consumers() {
                         type="checkbox"
                         checked={selectedIds.has(consumer.id)}
                         onChange={() => toggleSelection(consumer.id)}
-                        className="rounded border-gray-300 dark:border-neutral-600"
+                        className="rounded border-neutral-300 dark:border-neutral-600"
                       />
                     </td>
                   )}
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-900 dark:text-white">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-mono text-neutral-900 dark:text-white">
                     {consumer.external_id}
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-900 dark:text-white">
                     {consumer.name}
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-neutral-400">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-500 dark:text-neutral-400">
                     {consumer.email}
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-neutral-400">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-500 dark:text-neutral-400">
                     {consumer.company || '—'}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
@@ -501,12 +495,12 @@ export function Consumers() {
                           status={consumer.certificate_status as CertificateStatus}
                           notAfter={consumer.certificate_not_after}
                         />
-                        <span className="font-mono text-xs text-gray-400 dark:text-neutral-500">
+                        <span className="font-mono text-xs text-neutral-400 dark:text-neutral-500">
                           {consumer.certificate_fingerprint.substring(0, 12)}...
                         </span>
                       </div>
                     ) : (
-                      <span className="text-gray-400 dark:text-neutral-500">—</span>
+                      <span className="text-neutral-400 dark:text-neutral-500">—</span>
                     )}
                   </td>
                   <td
@@ -561,8 +555,8 @@ export function Consumers() {
             >
               <div className="flex justify-between items-start">
                 <div>
-                  <p className="font-medium text-gray-900 dark:text-white">{consumer.name}</p>
-                  <p className="text-sm font-mono text-gray-500 dark:text-neutral-400">
+                  <p className="font-medium text-neutral-900 dark:text-white">{consumer.name}</p>
+                  <p className="text-sm font-mono text-neutral-500 dark:text-neutral-400">
                     {consumer.external_id}
                   </p>
                 </div>
@@ -572,9 +566,9 @@ export function Consumers() {
                   {consumer.status}
                 </span>
               </div>
-              <p className="text-sm text-gray-500 dark:text-neutral-400">{consumer.email}</p>
+              <p className="text-sm text-neutral-500 dark:text-neutral-400">{consumer.email}</p>
               {consumer.company && (
-                <p className="text-sm text-gray-500 dark:text-neutral-400">{consumer.company}</p>
+                <p className="text-sm text-neutral-500 dark:text-neutral-400">{consumer.company}</p>
               )}
               {consumer.certificate_fingerprint && (
                 <div className="flex items-center gap-2">
@@ -582,13 +576,13 @@ export function Consumers() {
                     status={consumer.certificate_status as CertificateStatus}
                     notAfter={consumer.certificate_not_after}
                   />
-                  <span className="text-xs font-mono text-gray-400 dark:text-neutral-500 truncate">
+                  <span className="text-xs font-mono text-neutral-400 dark:text-neutral-500 truncate">
                     {consumer.certificate_fingerprint.substring(0, 20)}...
                   </span>
                 </div>
               )}
               <div
-                className="flex gap-2 pt-2 border-t border-gray-100 dark:border-neutral-700"
+                className="flex gap-2 pt-2 border-t border-neutral-100 dark:border-neutral-700"
                 onClick={(e) => e.stopPropagation()}
               >
                 {canEdit && consumer.status === 'active' && (
@@ -624,21 +618,21 @@ export function Consumers() {
       {/* Pagination */}
       {totalPages > 1 && (
         <div className="flex justify-between items-center">
-          <p className="text-sm text-gray-500 dark:text-neutral-400">
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">
             Page {currentPage} of {totalPages}
           </p>
           <div className="flex gap-2">
             <button
               onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
               disabled={currentPage === 1}
-              className="px-3 py-1 border border-gray-300 dark:border-neutral-600 rounded-lg text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-neutral-700 dark:text-white"
+              className="px-3 py-1 border border-neutral-300 dark:border-neutral-600 rounded-lg text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-neutral-50 dark:hover:bg-neutral-700 dark:text-white"
             >
               Previous
             </button>
             <button
               onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
               disabled={currentPage === totalPages}
-              className="px-3 py-1 border border-gray-300 dark:border-neutral-600 rounded-lg text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-neutral-700 dark:text-white"
+              className="px-3 py-1 border border-neutral-300 dark:border-neutral-600 rounded-lg text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-neutral-50 dark:hover:bg-neutral-700 dark:text-white"
             >
               Next
             </button>

--- a/control-plane-ui/src/pages/Deployments.tsx
+++ b/control-plane-ui/src/pages/Deployments.tsx
@@ -43,6 +43,7 @@ import {
   ScrollText,
 } from 'lucide-react';
 import { clsx } from 'clsx';
+import { Button } from '@stoa/shared/components/Button';
 
 // =============================================================================
 // TAB COMPONENTS
@@ -79,7 +80,7 @@ const tabs: Tab[] = [
 
 const statusConfig: Record<TraceStatus, { icon: typeof CheckCircle2; color: string; bg: string }> =
   {
-    pending: { icon: Clock, color: 'text-gray-500', bg: 'bg-gray-100 dark:bg-gray-800' },
+    pending: { icon: Clock, color: 'text-neutral-500', bg: 'bg-neutral-100 dark:bg-neutral-800' },
     in_progress: { icon: Loader2, color: 'text-blue-500', bg: 'bg-blue-100 dark:bg-blue-900/30' },
     success: {
       icon: CheckCircle2,
@@ -133,15 +134,15 @@ function StatsCard({
   color: string;
 }) {
   return (
-    <div className="rounded-lg bg-white dark:bg-neutral-800 p-6 shadow-sm border border-gray-100 dark:border-neutral-700">
+    <div className="rounded-lg bg-white dark:bg-neutral-800 p-6 shadow-sm border border-neutral-100 dark:border-neutral-700">
       <div className="flex items-center gap-4">
         <div className={clsx('rounded-lg p-3', color)}>
           <Icon className="h-6 w-6 text-white" />
         </div>
         <div>
-          <p className="text-sm font-medium text-gray-500 dark:text-neutral-400">{title}</p>
-          <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
-          {subtitle && <p className="text-xs text-gray-400 dark:text-neutral-500">{subtitle}</p>}
+          <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">{title}</p>
+          <p className="text-2xl font-bold text-neutral-900 dark:text-white">{value}</p>
+          {subtitle && <p className="text-xs text-neutral-400 dark:text-neutral-500">{subtitle}</p>}
         </div>
       </div>
     </div>
@@ -160,7 +161,7 @@ function StepTimeline({ steps }: { steps: TraceStep[] }) {
         return (
           <div key={index} className="relative">
             {index < steps.length - 1 && (
-              <div className="absolute left-4 top-8 h-full w-0.5 bg-gray-200 dark:bg-neutral-600" />
+              <div className="absolute left-4 top-8 h-full w-0.5 bg-neutral-200 dark:bg-neutral-600" />
             )}
             <div className={clsx('flex items-start gap-3 rounded-lg p-3', cfg.bg)}>
               <div className={clsx('rounded-full p-1', cfg.bg)}>
@@ -174,21 +175,21 @@ function StepTimeline({ steps }: { steps: TraceStep[] }) {
               </div>
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
-                  <StepTypeIcon className="h-4 w-4 text-gray-400 dark:text-neutral-500" />
-                  <span className="font-medium text-gray-900 dark:text-white">
+                  <StepTypeIcon className="h-4 w-4 text-neutral-400 dark:text-neutral-500" />
+                  <span className="font-medium text-neutral-900 dark:text-white">
                     {stepInfo.label}
                   </span>
                   {step.duration_ms && (
-                    <span className="text-xs text-gray-500">
+                    <span className="text-xs text-neutral-500">
                       ({formatDuration(step.duration_ms)})
                     </span>
                   )}
                 </div>
                 {step.details && (
-                  <div className="mt-2 text-xs text-gray-600 dark:text-neutral-300 font-mono bg-white/50 dark:bg-neutral-800/50 rounded p-2">
+                  <div className="mt-2 text-xs text-neutral-600 dark:text-neutral-300 font-mono bg-white/50 dark:bg-neutral-800/50 rounded p-2">
                     {Object.entries(step.details).map(([key, value]) => (
                       <div key={key} className="flex gap-2">
-                        <span className="text-gray-400 dark:text-neutral-500">{key}:</span>
+                        <span className="text-neutral-400 dark:text-neutral-500">{key}:</span>
                         <span className="truncate">
                           {typeof value === 'object' ? JSON.stringify(value) : String(value)}
                         </span>
@@ -203,7 +204,7 @@ function StepTimeline({ steps }: { steps: TraceStep[] }) {
                 )}
               </div>
               {step.started_at && (
-                <div className="text-xs text-gray-400 text-right">
+                <div className="text-xs text-neutral-400 text-right">
                   {formatTime(step.started_at)}
                 </div>
               )}
@@ -240,12 +241,12 @@ function TraceRow({
   }, [isExpanded, trace.id, details]);
 
   return (
-    <div className="border-b border-gray-100 dark:border-neutral-700 last:border-0">
+    <div className="border-b border-neutral-100 dark:border-neutral-700 last:border-0">
       <div
-        className="flex items-center gap-4 p-4 hover:bg-gray-50 dark:hover:bg-neutral-700 cursor-pointer"
+        className="flex items-center gap-4 p-4 hover:bg-neutral-50 dark:hover:bg-neutral-700 cursor-pointer"
         onClick={onToggle}
       >
-        <button className="text-gray-400 dark:text-neutral-500">
+        <button className="text-neutral-400 dark:text-neutral-500">
           {isExpanded ? <ChevronDown className="h-5 w-5" /> : <ChevronRight className="h-5 w-5" />}
         </button>
         <div className={clsx('rounded-full p-1.5', cfg.bg)}>
@@ -255,50 +256,52 @@ function TraceRow({
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <GitBranch className="h-4 w-4 text-gray-400 dark:text-neutral-500" />
-            <span className="font-medium text-gray-900 dark:text-white">{trace.trigger_type}</span>
+            <GitBranch className="h-4 w-4 text-neutral-400 dark:text-neutral-500" />
+            <span className="font-medium text-neutral-900 dark:text-white">
+              {trace.trigger_type}
+            </span>
             {trace.api_name && (
               <>
-                <span className="text-gray-400 dark:text-neutral-500">→</span>
+                <span className="text-neutral-400 dark:text-neutral-500">→</span>
                 <span className="text-blue-600">{trace.api_name}</span>
               </>
             )}
           </div>
           {trace.git_commit_message && (
-            <p className="text-sm text-gray-500 dark:text-neutral-400 truncate mt-1">
+            <p className="text-sm text-neutral-500 dark:text-neutral-400 truncate mt-1">
               {trace.git_commit_message}
             </p>
           )}
         </div>
-        <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-neutral-400">
+        <div className="flex items-center gap-2 text-sm text-neutral-500 dark:text-neutral-400">
           <User className="h-4 w-4" />
           <span>{trace.git_author || 'unknown'}</span>
         </div>
         {trace.git_commit_sha && (
-          <div className="flex items-center gap-1 text-sm text-gray-400 dark:text-neutral-500 font-mono">
+          <div className="flex items-center gap-1 text-sm text-neutral-400 dark:text-neutral-500 font-mono">
             <GitCommit className="h-4 w-4" />
             <span>{trace.git_commit_sha}</span>
           </div>
         )}
-        <div className="flex items-center gap-1 text-sm text-gray-500 dark:text-neutral-400 w-20 justify-end">
+        <div className="flex items-center gap-1 text-sm text-neutral-500 dark:text-neutral-400 w-20 justify-end">
           <Clock className="h-4 w-4" />
           <span>{formatDuration(trace.total_duration_ms)}</span>
         </div>
         <div className="flex items-center gap-1 text-sm w-16">
           <span className="text-green-600">{trace.steps_completed}</span>
-          <span className="text-gray-400 dark:text-neutral-500">/</span>
-          <span className="text-gray-600 dark:text-neutral-300">{trace.steps_count}</span>
+          <span className="text-neutral-400 dark:text-neutral-500">/</span>
+          <span className="text-neutral-600 dark:text-neutral-300">{trace.steps_count}</span>
           {trace.steps_failed > 0 && (
             <span className="text-red-500 ml-1">({trace.steps_failed})</span>
           )}
         </div>
-        <div className="text-sm text-gray-400 dark:text-neutral-500 w-24 text-right">
+        <div className="text-sm text-neutral-400 dark:text-neutral-500 w-24 text-right">
           {formatTime(trace.created_at)}
         </div>
       </div>
 
       {isExpanded && (
-        <div className="bg-gray-50 dark:bg-neutral-800 p-4 border-t border-gray-100 dark:border-neutral-700">
+        <div className="bg-neutral-50 dark:bg-neutral-800 p-4 border-t border-neutral-100 dark:border-neutral-700">
           {loading ? (
             <div className="flex items-center justify-center py-8">
               <Loader2 className="h-6 w-6 animate-spin text-blue-500" />
@@ -306,37 +309,37 @@ function TraceRow({
           ) : details ? (
             <div className="grid grid-cols-2 gap-6">
               <div className="space-y-4">
-                <h4 className="font-medium text-gray-900 dark:text-white">Git Information</h4>
+                <h4 className="font-medium text-neutral-900 dark:text-white">Git Information</h4>
                 <div className="bg-white dark:bg-neutral-700 rounded-lg p-4 space-y-2 text-sm">
                   <div className="flex justify-between">
-                    <span className="text-gray-500 dark:text-neutral-400">Project:</span>
+                    <span className="text-neutral-500 dark:text-neutral-400">Project:</span>
                     <span className="font-mono dark:text-neutral-200">
                       {details.git_project || '-'}
                     </span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-gray-500 dark:text-neutral-400">Branch:</span>
+                    <span className="text-neutral-500 dark:text-neutral-400">Branch:</span>
                     <span className="font-mono dark:text-neutral-200">
                       {details.git_branch || '-'}
                     </span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-gray-500 dark:text-neutral-400">Author:</span>
+                    <span className="text-neutral-500 dark:text-neutral-400">Author:</span>
                     <span>
                       {details.git_author}{' '}
                       {details.git_author_email && `<${details.git_author_email}>`}
                     </span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-gray-500 dark:text-neutral-400">Commit:</span>
+                    <span className="text-neutral-500 dark:text-neutral-400">Commit:</span>
                     <span className="font-mono dark:text-neutral-200">
                       {details.git_commit_sha || '-'}
                     </span>
                   </div>
                   {details.git_files_changed && details.git_files_changed.length > 0 && (
                     <div>
-                      <span className="text-gray-500 dark:text-neutral-400">Files changed:</span>
-                      <ul className="mt-1 text-xs font-mono text-gray-600 dark:text-neutral-300 max-h-32 overflow-auto">
+                      <span className="text-neutral-500 dark:text-neutral-400">Files changed:</span>
+                      <ul className="mt-1 text-xs font-mono text-neutral-600 dark:text-neutral-300 max-h-32 overflow-auto">
                         {details.git_files_changed.map((file, i) => (
                           <li key={i} className="truncate">
                             {file}
@@ -356,12 +359,12 @@ function TraceRow({
                 )}
               </div>
               <div className="space-y-4">
-                <h4 className="font-medium text-gray-900 dark:text-white">Pipeline Steps</h4>
+                <h4 className="font-medium text-neutral-900 dark:text-white">Pipeline Steps</h4>
                 <StepTimeline steps={details.steps} />
               </div>
             </div>
           ) : (
-            <p className="text-center text-gray-500 dark:text-neutral-400 py-4">
+            <p className="text-center text-neutral-500 dark:text-neutral-400 py-4">
               Failed to load details
             </p>
           )}
@@ -414,26 +417,22 @@ function PipelineTracesTab() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <p className="text-gray-500 dark:text-neutral-400">
+        <p className="text-neutral-500 dark:text-neutral-400">
           End-to-end tracing of GitLab → Kafka → AWX pipeline
         </p>
         <div className="flex items-center gap-4">
-          <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-neutral-400">
+          <label className="flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-400">
             <input
               type="checkbox"
               checked={autoRefresh}
               onChange={(e) => setAutoRefresh(e.target.checked)}
-              className="rounded border-gray-300"
+              className="rounded border-neutral-300"
             />
             Auto-refresh (5s)
           </label>
-          <button
-            onClick={loadData}
-            className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
-          >
-            <RefreshCw className="h-4 w-4" />
+          <Button onClick={loadData} icon={<RefreshCw className="h-4 w-4" />}>
             Refresh
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -467,13 +466,15 @@ function PipelineTracesTab() {
         </div>
       )}
 
-      <div className="rounded-lg bg-white dark:bg-neutral-800 shadow-sm border border-gray-100 dark:border-neutral-700">
-        <div className="border-b border-gray-100 dark:border-neutral-700 px-4 py-3">
-          <h2 className="font-medium text-gray-900 dark:text-white">Recent Pipeline Executions</h2>
+      <div className="rounded-lg bg-white dark:bg-neutral-800 shadow-sm border border-neutral-100 dark:border-neutral-700">
+        <div className="border-b border-neutral-100 dark:border-neutral-700 px-4 py-3">
+          <h2 className="font-medium text-neutral-900 dark:text-white">
+            Recent Pipeline Executions
+          </h2>
         </div>
         {traces.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-12 text-gray-500 dark:text-neutral-400">
-            <Activity className="h-12 w-12 mb-4 text-gray-300 dark:text-neutral-600" />
+          <div className="flex flex-col items-center justify-center py-12 text-neutral-500 dark:text-neutral-400">
+            <Activity className="h-12 w-12 mb-4 text-neutral-300 dark:text-neutral-600" />
             <p>No pipeline traces yet</p>
             <p className="text-sm">Push to GitLab to trigger a pipeline</p>
           </div>
@@ -654,7 +655,7 @@ function DeploymentHistoryTab() {
     in_progress: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
     success: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
     failed: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-    rolled_back: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300',
+    rolled_back: 'bg-neutral-100 text-neutral-800 dark:bg-neutral-700 dark:text-neutral-300',
   };
 
   const envColors: Record<string, string> = {
@@ -668,10 +669,10 @@ function DeploymentHistoryTab() {
   if (loading && tenants.length === 0) {
     return (
       <div className="space-y-6">
-        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 p-4">
-          <div className="h-10 w-48 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-100 dark:border-neutral-700 p-4">
+          <div className="h-10 w-48 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
         </div>
-        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 overflow-hidden">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-100 dark:border-neutral-700 overflow-hidden">
           <TableSkeleton rows={5} columns={7} />
         </div>
       </div>
@@ -681,10 +682,10 @@ function DeploymentHistoryTab() {
   return (
     <div className="space-y-6">
       {/* Filters */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 p-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-100 dark:border-neutral-700 p-4">
         <div className="flex flex-wrap gap-4 items-end">
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Tenant
             </label>
             <select
@@ -694,7 +695,7 @@ function DeploymentHistoryTab() {
                 setSelectedApi('');
                 setPage(1);
               }}
-              className="w-48 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-48 border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               {tenants.map((tenant) => (
                 <option key={tenant.id} value={tenant.id}>
@@ -704,7 +705,7 @@ function DeploymentHistoryTab() {
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               API
             </label>
             <select
@@ -713,7 +714,7 @@ function DeploymentHistoryTab() {
                 setSelectedApi(e.target.value);
                 setPage(1);
               }}
-              className="w-48 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-48 border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               <option value="">All APIs</option>
               {apis.map((api) => (
@@ -724,7 +725,7 @@ function DeploymentHistoryTab() {
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Environment
             </label>
             <select
@@ -733,7 +734,7 @@ function DeploymentHistoryTab() {
                 setSelectedEnv(e.target.value);
                 setPage(1);
               }}
-              className="w-40 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-40 border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               <option value="">All</option>
               <option value="dev">Dev</option>
@@ -742,7 +743,7 @@ function DeploymentHistoryTab() {
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Status
             </label>
             <select
@@ -751,7 +752,7 @@ function DeploymentHistoryTab() {
                 setSelectedStatus(e.target.value);
                 setPage(1);
               }}
-              className="w-40 border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-40 border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               <option value="">All</option>
               <option value="pending">Pending</option>
@@ -781,15 +782,15 @@ function DeploymentHistoryTab() {
       )}
 
       {/* Deployments List */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 overflow-hidden">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-100 dark:border-neutral-700 overflow-hidden">
         {loading ? (
           <TableSkeleton rows={5} columns={7} />
         ) : deployments.length === 0 ? (
           <EmptyState variant="deployments" description="Deploy an API to see it here." />
         ) : (
-          <div className="divide-y divide-gray-200 dark:divide-neutral-700">
+          <div className="divide-y divide-neutral-200 dark:divide-neutral-700">
             {/* Table header */}
-            <div className="grid grid-cols-[2fr_1fr_1fr_1fr_1.5fr_1fr_1fr] gap-2 px-6 py-3 bg-gray-50 dark:bg-neutral-700 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase tracking-wider">
+            <div className="grid grid-cols-[2fr_1fr_1fr_1fr_1.5fr_1fr_1fr] gap-2 px-6 py-3 bg-neutral-50 dark:bg-neutral-700 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
               <span>API</span>
               <span>Environment</span>
               <span>Version</span>
@@ -810,12 +811,12 @@ function DeploymentHistoryTab() {
                       'grid grid-cols-[2fr_1fr_1fr_1fr_1.5fr_1fr_1fr] gap-2 px-6 py-4 items-center cursor-pointer transition-colors',
                       isExpanded
                         ? 'bg-blue-50 dark:bg-blue-900/10'
-                        : 'hover:bg-gray-50 dark:hover:bg-neutral-700'
+                        : 'hover:bg-neutral-50 dark:hover:bg-neutral-700'
                     )}
                     onClick={() => handleExpand(deployment.id)}
                   >
                     <div className="flex items-center gap-2 min-w-0">
-                      <button className="text-gray-400 dark:text-neutral-500 shrink-0">
+                      <button className="text-neutral-400 dark:text-neutral-500 shrink-0">
                         {isExpanded ? (
                           <ChevronDown className="h-4 w-4" />
                         ) : (
@@ -823,11 +824,11 @@ function DeploymentHistoryTab() {
                         )}
                       </button>
                       <div className="min-w-0">
-                        <div className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                        <div className="text-sm font-medium text-neutral-900 dark:text-white truncate">
                           {deployment.api_name}
                         </div>
                         {deployment.commit_sha && (
-                          <div className="text-xs text-gray-400 dark:text-neutral-500 font-mono">
+                          <div className="text-xs text-neutral-400 dark:text-neutral-500 font-mono">
                             {deployment.commit_sha.slice(0, 7)}
                           </div>
                         )}
@@ -840,12 +841,12 @@ function DeploymentHistoryTab() {
                     </div>
                     <div>
                       <span
-                        className={`px-2 py-1 text-xs font-medium rounded ${envColors[deployment.environment] || 'bg-gray-100 text-gray-700'}`}
+                        className={`px-2 py-1 text-xs font-medium rounded ${envColors[deployment.environment] || 'bg-neutral-100 text-neutral-700'}`}
                       >
                         {deployment.environment.toUpperCase()}
                       </span>
                     </div>
-                    <div className="text-sm text-gray-500 dark:text-neutral-400">
+                    <div className="text-sm text-neutral-500 dark:text-neutral-400">
                       v{deployment.version}
                       {deployment.rollback_of && (
                         <div className="text-xs text-orange-500 dark:text-orange-400">
@@ -866,10 +867,10 @@ function DeploymentHistoryTab() {
                         {liveStatus.replace('_', ' ')}
                       </span>
                     </div>
-                    <div className="text-sm text-gray-500 dark:text-neutral-400">
+                    <div className="text-sm text-neutral-500 dark:text-neutral-400">
                       {new Date(deployment.created_at).toLocaleString()}
                     </div>
-                    <div className="text-sm text-gray-500 dark:text-neutral-400 truncate">
+                    <div className="text-sm text-neutral-500 dark:text-neutral-400 truncate">
                       {deployment.deployed_by}
                     </div>
                     <div className="text-sm" onClick={(e) => e.stopPropagation()}>
@@ -888,11 +889,11 @@ function DeploymentHistoryTab() {
 
                   {/* Expanded detail: live logs + progress */}
                   {isExpanded && (
-                    <div className="bg-gray-50 dark:bg-neutral-800/50 border-t border-gray-100 dark:border-neutral-700 px-6 py-4 space-y-4">
+                    <div className="bg-neutral-50 dark:bg-neutral-800/50 border-t border-neutral-100 dark:border-neutral-700 px-6 py-4 space-y-4">
                       {/* Progress indicator for active deployments */}
                       {(liveStatus === 'in_progress' || deployState) && (
                         <div className="flex items-center gap-4">
-                          <span className="text-sm font-medium text-gray-700 dark:text-neutral-300">
+                          <span className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
                             Progress
                           </span>
                           <DeployProgress
@@ -906,7 +907,7 @@ function DeploymentHistoryTab() {
                       <div className="grid grid-cols-3 gap-4 text-sm">
                         {deployment.rollback_of && (
                           <div>
-                            <span className="text-gray-500 dark:text-neutral-400">
+                            <span className="text-neutral-500 dark:text-neutral-400">
                               Rollback of:
                             </span>{' '}
                             <span className="text-orange-600 dark:text-orange-400">
@@ -916,8 +917,10 @@ function DeploymentHistoryTab() {
                         )}
                         {deployment.spec_hash && (
                           <div>
-                            <span className="text-gray-500 dark:text-neutral-400">Spec hash:</span>{' '}
-                            <span className="font-mono text-gray-700 dark:text-neutral-300">
+                            <span className="text-neutral-500 dark:text-neutral-400">
+                              Spec hash:
+                            </span>{' '}
+                            <span className="font-mono text-neutral-700 dark:text-neutral-300">
                               {deployment.spec_hash.slice(0, 12)}
                             </span>
                           </div>
@@ -932,8 +935,8 @@ function DeploymentHistoryTab() {
                       {/* Live log viewer */}
                       <div>
                         <div className="flex items-center gap-2 mb-2">
-                          <ScrollText className="h-4 w-4 text-gray-500 dark:text-neutral-400" />
-                          <span className="text-sm font-medium text-gray-700 dark:text-neutral-300">
+                          <ScrollText className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
+                          <span className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
                             Deploy Logs
                           </span>
                           {liveStatus === 'in_progress' && (
@@ -960,28 +963,30 @@ function DeploymentHistoryTab() {
       {/* Pagination */}
       {totalPages > 1 && (
         <div className="flex items-center justify-between">
-          <p className="text-sm text-gray-500 dark:text-neutral-400">
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">
             Showing {(page - 1) * pageSize + 1}–{Math.min(page * pageSize, totalCount)} of{' '}
             {totalCount}
           </p>
           <div className="flex gap-2">
-            <button
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="px-3 py-1.5 text-sm border border-gray-300 dark:border-neutral-600 rounded-lg disabled:opacity-50 hover:bg-gray-50 dark:hover:bg-neutral-700 dark:text-white"
             >
               Previous
-            </button>
-            <span className="px-3 py-1.5 text-sm text-gray-700 dark:text-neutral-300">
+            </Button>
+            <span className="px-3 py-1.5 text-sm text-neutral-700 dark:text-neutral-300">
               {page} / {totalPages}
             </span>
-            <button
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
               disabled={page === totalPages}
-              className="px-3 py-1.5 text-sm border border-gray-300 dark:border-neutral-600 rounded-lg disabled:opacity-50 hover:bg-gray-50 dark:hover:bg-neutral-700 dark:text-white"
             >
               Next
-            </button>
+            </Button>
           </div>
         </div>
       )}
@@ -999,35 +1004,35 @@ function GitLabConfigTab() {
   return (
     <div className="space-y-6">
       {/* GitOps Overview */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-100 dark:border-neutral-700 p-6">
+        <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4">
           GitOps Integration
         </h3>
-        <p className="text-gray-600 dark:text-neutral-400 mb-4">
+        <p className="text-neutral-600 dark:text-neutral-400 mb-4">
           API definitions are managed through Git. When you commit changes to the repository,
           webhooks automatically trigger the deployment pipeline.
         </p>
-        <div className="bg-gray-50 dark:bg-neutral-900 rounded-lg p-4 font-mono text-sm">
-          <div className="text-gray-500 dark:text-neutral-400 mb-2"># Pipeline flow</div>
+        <div className="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-4 font-mono text-sm">
+          <div className="text-neutral-500 dark:text-neutral-400 mb-2"># Pipeline flow</div>
           <div className="text-blue-600">GitLab Push</div>
-          <div className="text-gray-400 ml-4">↓ webhook</div>
+          <div className="text-neutral-400 ml-4">↓ webhook</div>
           <div className="text-green-600 ml-4">Control-Plane-API</div>
-          <div className="text-gray-400 ml-8">↓ publish event</div>
+          <div className="text-neutral-400 ml-8">↓ publish event</div>
           <div className="text-purple-600 ml-8">Kafka (deploy-requests)</div>
-          <div className="text-gray-400 ml-12">↓ consume</div>
+          <div className="text-neutral-400 ml-12">↓ consume</div>
           <div className="text-orange-600 ml-12">AWX Job Template</div>
-          <div className="text-gray-400 ml-16">↓ deploy</div>
+          <div className="text-neutral-400 ml-16">↓ deploy</div>
           <div className="text-green-600 ml-16">webMethods Gateway</div>
         </div>
       </div>
 
       {/* Repository Structure */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-100 dark:border-neutral-700 p-6">
+        <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4">
           Repository Structure
         </h3>
-        <div className="bg-gray-50 dark:bg-neutral-900 rounded-lg p-4 font-mono text-sm">
-          <pre className="text-gray-700 dark:text-neutral-300">{`stoa-api-definitions/
+        <div className="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-4 font-mono text-sm">
+          <pre className="text-neutral-700 dark:text-neutral-300">{`stoa-api-definitions/
 ├── tenants/
 │   ├── tenant-acme/
 │   │   ├── apis/
@@ -1051,8 +1056,8 @@ function GitLabConfigTab() {
       </div>
 
       {/* External Links */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-100 dark:border-neutral-700 p-6">
+        <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4">
           External Resources
         </h3>
         <div className="flex flex-wrap gap-4">
@@ -1080,15 +1085,15 @@ function GitLabConfigTab() {
       </div>
 
       {/* Webhook Status */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-700 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-100 dark:border-neutral-700 p-6">
+        <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4">
           Webhook Configuration
         </h3>
         <div className="space-y-3">
-          <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-neutral-900 rounded-lg">
+          <div className="flex items-center justify-between p-3 bg-neutral-50 dark:bg-neutral-900 rounded-lg">
             <div>
-              <p className="font-medium text-gray-900 dark:text-white">GitLab Webhook</p>
-              <p className="text-sm text-gray-500 dark:text-neutral-400">
+              <p className="font-medium text-neutral-900 dark:text-white">GitLab Webhook</p>
+              <p className="text-sm text-neutral-500 dark:text-neutral-400">
                 Receives push and merge request events
               </p>
             </div>
@@ -1097,10 +1102,10 @@ function GitLabConfigTab() {
               Active
             </span>
           </div>
-          <div className="text-sm text-gray-500 dark:text-neutral-400">
+          <div className="text-sm text-neutral-500 dark:text-neutral-400">
             <p>
               <strong>Endpoint:</strong>{' '}
-              <code className="bg-gray-100 dark:bg-neutral-700 px-2 py-0.5 rounded">
+              <code className="bg-neutral-100 dark:bg-neutral-700 px-2 py-0.5 rounded">
                 {config.api.baseUrl}/webhooks/gitlab
               </code>
             </p>
@@ -1125,14 +1130,14 @@ export function Deployments() {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Deployments</h1>
-        <p className="text-gray-500 dark:text-neutral-400 mt-1">
+        <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Deployments</h1>
+        <p className="text-neutral-500 dark:text-neutral-400 mt-1">
           GitOps pipeline monitoring and deployment history
         </p>
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-gray-200 dark:border-neutral-700">
+      <div className="border-b border-neutral-200 dark:border-neutral-700">
         <nav className="flex gap-8">
           {tabs.map((tab) => (
             <button
@@ -1142,7 +1147,7 @@ export function Deployments() {
                 'flex items-center gap-2 py-4 px-1 border-b-2 font-medium text-sm transition-colors',
                 activeTab === tab.id
                   ? 'border-blue-500 text-blue-600'
-                  : 'border-transparent text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-300 hover:border-gray-300 dark:hover:border-neutral-500'
+                  : 'border-transparent text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300 hover:border-neutral-300 dark:hover:border-neutral-500'
               )}
             >
               <tab.icon className="h-5 w-5" />

--- a/control-plane-ui/src/pages/DriftDetection/DriftDetection.tsx
+++ b/control-plane-ui/src/pages/DriftDetection/DriftDetection.tsx
@@ -56,15 +56,17 @@ const gatewayStatusConfig: Record<
 
 const fallbackStatus = {
   icon: AlertTriangle,
-  color: 'text-gray-600 dark:text-gray-400',
-  bg: 'bg-gray-100 dark:bg-neutral-700',
+  color: 'text-neutral-600 dark:text-neutral-400',
+  bg: 'bg-neutral-100 dark:bg-neutral-700',
   label: 'Unknown',
 };
 
 function SummaryCard({ label, value, color }: { label: string; value: number; color: string }) {
   return (
-    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 px-4 py-3">
-      <p className="text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">{label}</p>
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 px-4 py-3">
+      <p className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
+        {label}
+      </p>
       <p className={`text-2xl font-bold ${color}`}>{value}</p>
     </div>
   );
@@ -154,10 +156,13 @@ export function DriftDetection() {
   if (loading) {
     return (
       <div className="space-y-6">
-        <div className="h-8 bg-gray-200 dark:bg-neutral-700 rounded w-1/4 animate-pulse" />
+        <div className="h-8 bg-neutral-200 dark:bg-neutral-700 rounded w-1/4 animate-pulse" />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="h-20 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+            <div
+              key={i}
+              className="h-20 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse"
+            />
           ))}
         </div>
         <TableSkeleton />
@@ -198,14 +203,14 @@ export function DriftDetection() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Drift Detection</h1>
-          <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Drift Detection</h1>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
             Monitor gateway health and deployment sync across all gateways
           </p>
         </div>
         <button
           onClick={loadData}
-          className="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-neutral-600 rounded-md text-sm font-medium text-gray-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 hover:bg-gray-50 dark:hover:bg-neutral-700"
+          className="inline-flex items-center px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md text-sm font-medium text-neutral-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 hover:bg-neutral-50 dark:hover:bg-neutral-700"
         >
           <RefreshCw className="w-4 h-4 mr-2" />
           Refresh
@@ -217,24 +222,26 @@ export function DriftDetection() {
         <SummaryCard
           label="Total Gateways"
           value={gateways.length}
-          color="text-gray-900 dark:text-white"
+          color="text-neutral-900 dark:text-white"
         />
         <SummaryCard label="Healthy" value={healthyGateways} color="text-green-600" />
         <SummaryCard
           label="Drifted"
           value={driftedCount}
-          color={driftedCount > 0 ? 'text-orange-600' : 'text-gray-900 dark:text-white'}
+          color={driftedCount > 0 ? 'text-orange-600' : 'text-neutral-900 dark:text-white'}
         />
         <SummaryCard
           label="Errors"
           value={errorCount}
-          color={errorCount > 0 ? 'text-red-600' : 'text-gray-900 dark:text-white'}
+          color={errorCount > 0 ? 'text-red-600' : 'text-neutral-900 dark:text-white'}
         />
       </div>
 
       {/* Gateway Health Grid */}
       <div>
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">Gateway Health</h2>
+        <h2 className="text-lg font-semibold text-neutral-900 dark:text-white mb-3">
+          Gateway Health
+        </h2>
         {gateways.length === 0 ? (
           <EmptyState
             title="No gateways registered"
@@ -248,12 +255,12 @@ export function DriftDetection() {
               return (
                 <div
                   key={gw.id}
-                  className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4"
+                  className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 p-4"
                 >
                   <div className="flex items-center justify-between mb-3">
                     <div className="flex items-center gap-2 min-w-0">
-                      <Server className="w-4 h-4 text-gray-400 flex-shrink-0" />
-                      <span className="font-medium text-gray-900 dark:text-white text-sm truncate">
+                      <Server className="w-4 h-4 text-neutral-400 flex-shrink-0" />
+                      <span className="font-medium text-neutral-900 dark:text-white text-sm truncate">
                         {gw.display_name || gw.name}
                       </span>
                     </div>
@@ -264,7 +271,7 @@ export function DriftDetection() {
                       {cfg.label}
                     </span>
                   </div>
-                  <div className="text-xs text-gray-500 dark:text-neutral-400 space-y-1">
+                  <div className="text-xs text-neutral-500 dark:text-neutral-400 space-y-1">
                     <p>Type: {gw.gateway_type}</p>
                     {gw.last_health_check && (
                       <p>Last check: {new Date(gw.last_health_check).toLocaleString()}</p>
@@ -289,7 +296,7 @@ export function DriftDetection() {
 
       {/* Drifted Deployments */}
       <div>
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
+        <h2 className="text-lg font-semibold text-neutral-900 dark:text-white mb-3">
           Drifted Deployments
         </h2>
         {driftedDeployments.length === 0 ? (
@@ -301,39 +308,39 @@ export function DriftDetection() {
             </p>
           </div>
         ) : (
-          <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 overflow-hidden">
-            <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
-              <thead className="bg-gray-50 dark:bg-neutral-900">
+          <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 overflow-hidden">
+            <table className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700">
+              <thead className="bg-neutral-50 dark:bg-neutral-900">
                 <tr>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                  <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     API
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                  <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     Gateway
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                  <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     Status
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                  <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     Error
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                  <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     Last Sync
                   </th>
                   {isAdmin && (
-                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                    <th className="px-4 py-3 text-right text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                       Actions
                     </th>
                   )}
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
+              <tbody className="divide-y divide-neutral-200 dark:divide-neutral-700">
                 {driftedDeployments.map((dep) => (
                   <tr key={dep.id}>
-                    <td className="px-4 py-3 text-sm text-gray-900 dark:text-white">
+                    <td className="px-4 py-3 text-sm text-neutral-900 dark:text-white">
                       {String(dep.desired_state?.['api_name'] ?? dep.api_catalog_id)}
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-500 dark:text-neutral-400">
+                    <td className="px-4 py-3 text-sm text-neutral-500 dark:text-neutral-400">
                       {dep.gateway_instance_id}
                     </td>
                     <td className="px-4 py-3">
@@ -342,7 +349,7 @@ export function DriftDetection() {
                     <td className="px-4 py-3 text-sm text-red-600 dark:text-red-400 max-w-xs truncate">
                       {dep.sync_error || '\u2014'}
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-500 dark:text-neutral-400">
+                    <td className="px-4 py-3 text-sm text-neutral-500 dark:text-neutral-400">
                       {dep.last_sync_attempt
                         ? new Date(dep.last_sync_attempt).toLocaleString()
                         : '\u2014'}

--- a/control-plane-ui/src/pages/ErrorSnapshots.tsx
+++ b/control-plane-ui/src/pages/ErrorSnapshots.tsx
@@ -47,8 +47,8 @@ const triggerConfig: Record<string, { label: string; color: string; bg: string }
   },
   manual: {
     label: 'Manual',
-    color: 'text-gray-600 dark:text-neutral-400',
-    bg: 'bg-gray-100 dark:bg-neutral-700',
+    color: 'text-neutral-600 dark:text-neutral-400',
+    bg: 'bg-neutral-100 dark:bg-neutral-700',
   },
 };
 
@@ -73,8 +73,8 @@ const resolutionConfig: Record<
   },
   ignored: {
     label: 'Ignored',
-    color: 'text-gray-600 dark:text-neutral-400',
-    bg: 'bg-gray-100 dark:bg-neutral-700',
+    color: 'text-neutral-600 dark:text-neutral-400',
+    bg: 'bg-neutral-100 dark:bg-neutral-700',
   },
 };
 
@@ -115,9 +115,9 @@ function StatsCard({
           <Icon className="h-6 w-6 text-white" />
         </div>
         <div>
-          <p className="text-sm font-medium text-gray-500 dark:text-neutral-400">{title}</p>
-          <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
-          {subtitle && <p className="text-xs text-gray-400 dark:text-neutral-500">{subtitle}</p>}
+          <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">{title}</p>
+          <p className="text-2xl font-bold text-neutral-900 dark:text-white">{value}</p>
+          {subtitle && <p className="text-xs text-neutral-400 dark:text-neutral-500">{subtitle}</p>}
         </div>
       </div>
     </div>
@@ -200,7 +200,7 @@ function ReplayCommand({ snapshotId }: { snapshotId: string }) {
       </button>
 
       {visible && command && (
-        <div className="mt-2 bg-gray-900 rounded-lg p-4 relative">
+        <div className="mt-2 bg-neutral-900 rounded-lg p-4 relative">
           {warning && (
             <div className="mb-2 text-xs text-yellow-400 flex items-center gap-1">
               <AlertCircle className="h-3 w-3" />
@@ -209,7 +209,7 @@ function ReplayCommand({ snapshotId }: { snapshotId: string }) {
           )}
           <button
             onClick={copyToClipboard}
-            className="absolute top-2 right-2 text-gray-400 hover:text-white"
+            className="absolute top-2 right-2 text-neutral-400 hover:text-white"
           >
             {copied ? <Check className="h-4 w-4 text-green-400" /> : <Copy className="h-4 w-4" />}
           </button>
@@ -250,14 +250,14 @@ function SnapshotRow({
   }, [isExpanded, snapshot.id, details]);
 
   return (
-    <div className="border-b border-gray-100 dark:border-neutral-700 last:border-0">
+    <div className="border-b border-neutral-100 dark:border-neutral-700 last:border-0">
       {/* Summary row */}
       <div
-        className="flex items-center gap-4 p-4 hover:bg-gray-50 dark:hover:bg-neutral-700 cursor-pointer"
+        className="flex items-center gap-4 p-4 hover:bg-neutral-50 dark:hover:bg-neutral-700 cursor-pointer"
         onClick={onToggle}
       >
         {/* Expand icon */}
-        <button className="text-gray-400">
+        <button className="text-neutral-400">
           {isExpanded ? <ChevronDown className="h-5 w-5" /> : <ChevronRight className="h-5 w-5" />}
         </button>
 
@@ -286,11 +286,11 @@ function SnapshotRow({
 
         {/* Method + Path */}
         <div className="flex-1 min-w-0">
-          <p className="text-sm text-gray-900 dark:text-white truncate">
+          <p className="text-sm text-neutral-900 dark:text-white truncate">
             <span className="font-mono font-medium">{snapshot.method}</span>{' '}
-            <span className="text-gray-600 dark:text-neutral-400">{snapshot.path}</span>
+            <span className="text-neutral-600 dark:text-neutral-400">{snapshot.path}</span>
           </p>
-          <div className="flex items-center gap-2 mt-1 text-xs text-gray-500 dark:text-neutral-400">
+          <div className="flex items-center gap-2 mt-1 text-xs text-neutral-500 dark:text-neutral-400">
             <span className="flex items-center gap-1">
               <Server className="h-3 w-3" />
               {snapshot.source}
@@ -311,14 +311,14 @@ function SnapshotRow({
         />
 
         {/* Timestamp */}
-        <span className="text-xs text-gray-400 dark:text-neutral-500 w-24 text-right">
+        <span className="text-xs text-neutral-400 dark:text-neutral-500 w-24 text-right">
           {formatDateTime(snapshot.timestamp)}
         </span>
       </div>
 
       {/* Expanded details */}
       {isExpanded && (
-        <div className="bg-gray-50 dark:bg-neutral-900 p-4 border-t border-gray-100 dark:border-neutral-700">
+        <div className="bg-neutral-50 dark:bg-neutral-900 p-4 border-t border-neutral-100 dark:border-neutral-700">
           {loading ? (
             <div className="flex items-center justify-center py-8">
               <Loader2 className="h-6 w-6 animate-spin text-blue-500" />
@@ -326,8 +326,8 @@ function SnapshotRow({
           ) : details ? (
             <div className="space-y-4">
               {/* Resolution actions */}
-              <div className="flex items-center gap-2 pb-4 border-b border-gray-200 dark:border-neutral-700">
-                <span className="text-sm text-gray-600 dark:text-neutral-400">Set status:</span>
+              <div className="flex items-center gap-2 pb-4 border-b border-neutral-200 dark:border-neutral-700">
+                <span className="text-sm text-neutral-600 dark:text-neutral-400">Set status:</span>
                 {(
                   [
                     'unresolved',
@@ -343,7 +343,7 @@ function SnapshotRow({
                       'px-3 py-1 rounded-full text-xs font-medium transition-colors',
                       details.resolution_status === s
                         ? `${resolutionConfig[s].bg} ${resolutionConfig[s].color}`
-                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-600'
+                        : 'bg-neutral-100 text-neutral-600 hover:bg-neutral-200 dark:bg-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-600'
                     )}
                   >
                     {resolutionConfig[s].label}
@@ -354,14 +354,14 @@ function SnapshotRow({
               <div className="grid grid-cols-3 gap-6">
                 {/* Left: Request Info */}
                 <div className="space-y-4">
-                  <h4 className="font-medium text-gray-900 dark:text-white">Request</h4>
+                  <h4 className="font-medium text-neutral-900 dark:text-white">Request</h4>
                   <div className="bg-white dark:bg-neutral-800 rounded-lg p-4 space-y-2 text-sm">
                     <div className="flex justify-between">
-                      <span className="text-gray-500 dark:text-neutral-400">Method:</span>
+                      <span className="text-neutral-500 dark:text-neutral-400">Method:</span>
                       <span className="font-mono">{details.request.method}</span>
                     </div>
                     <div className="flex justify-between">
-                      <span className="text-gray-500 dark:text-neutral-400">Path:</span>
+                      <span className="text-neutral-500 dark:text-neutral-400">Path:</span>
                       <span
                         className="font-mono text-xs truncate max-w-48"
                         title={details.request.path}
@@ -370,24 +370,24 @@ function SnapshotRow({
                       </span>
                     </div>
                     <div className="flex justify-between">
-                      <span className="text-gray-500 dark:text-neutral-400">Status:</span>
+                      <span className="text-neutral-500 dark:text-neutral-400">Status:</span>
                       <span className="font-mono">{details.response.status}</span>
                     </div>
                     <div className="flex justify-between">
-                      <span className="text-gray-500 dark:text-neutral-400">Duration:</span>
+                      <span className="text-neutral-500 dark:text-neutral-400">Duration:</span>
                       <span className="font-mono">
                         {formatDuration(details.response.duration_ms)}
                       </span>
                     </div>
                     {details.trace_id && (
                       <div className="flex justify-between">
-                        <span className="text-gray-500 dark:text-neutral-400">Trace ID:</span>
+                        <span className="text-neutral-500 dark:text-neutral-400">Trace ID:</span>
                         <span className="font-mono text-xs">{details.trace_id}</span>
                       </div>
                     )}
                     {details.request.client_ip && (
                       <div className="flex justify-between">
-                        <span className="text-gray-500 dark:text-neutral-400">Client IP:</span>
+                        <span className="text-neutral-500 dark:text-neutral-400">Client IP:</span>
                         <span className="font-mono text-xs">{details.request.client_ip}</span>
                       </div>
                     )}
@@ -412,15 +412,15 @@ function SnapshotRow({
 
                 {/* Middle: Routing & Backend */}
                 <div className="space-y-4">
-                  <h4 className="font-medium text-gray-900 dark:text-white">Routing</h4>
+                  <h4 className="font-medium text-neutral-900 dark:text-white">Routing</h4>
                   <div className="bg-white dark:bg-neutral-800 rounded-lg p-4 space-y-2 text-sm">
                     <div className="flex justify-between">
-                      <span className="text-gray-500 dark:text-neutral-400">Source:</span>
+                      <span className="text-neutral-500 dark:text-neutral-400">Source:</span>
                       <span>{details.source}</span>
                     </div>
                     {details.routing.api_name && (
                       <div className="flex justify-between">
-                        <span className="text-gray-500 dark:text-neutral-400">API:</span>
+                        <span className="text-neutral-500 dark:text-neutral-400">API:</span>
                         <span>
                           {details.routing.api_name}
                           {details.routing.api_version && ` v${details.routing.api_version}`}
@@ -429,7 +429,7 @@ function SnapshotRow({
                     )}
                     {details.routing.backend_url && (
                       <div className="flex justify-between">
-                        <span className="text-gray-500 dark:text-neutral-400">Backend:</span>
+                        <span className="text-neutral-500 dark:text-neutral-400">Backend:</span>
                         <span
                           className="text-xs truncate max-w-40"
                           title={details.routing.backend_url}
@@ -443,11 +443,11 @@ function SnapshotRow({
                   {/* Backend state */}
                   {details.backend_state.health !== 'unknown' && (
                     <div className="bg-white dark:bg-neutral-800 rounded-lg p-4 space-y-2 text-sm">
-                      <h5 className="font-medium text-gray-700 dark:text-neutral-300">
+                      <h5 className="font-medium text-neutral-700 dark:text-neutral-300">
                         Backend Health
                       </h5>
                       <div className="flex justify-between">
-                        <span className="text-gray-500 dark:text-neutral-400">Health:</span>
+                        <span className="text-neutral-500 dark:text-neutral-400">Health:</span>
                         <span
                           className={clsx(
                             'font-medium',
@@ -463,13 +463,17 @@ function SnapshotRow({
                       </div>
                       {details.backend_state.error_rate_1m != null && (
                         <div className="flex justify-between">
-                          <span className="text-gray-500 dark:text-neutral-400">Error Rate:</span>
+                          <span className="text-neutral-500 dark:text-neutral-400">
+                            Error Rate:
+                          </span>
                           <span>{(details.backend_state.error_rate_1m * 100).toFixed(1)}%</span>
                         </div>
                       )}
                       {details.backend_state.p99_latency_ms != null && (
                         <div className="flex justify-between">
-                          <span className="text-gray-500 dark:text-neutral-400">P99 Latency:</span>
+                          <span className="text-neutral-500 dark:text-neutral-400">
+                            P99 Latency:
+                          </span>
                           <span>{formatDuration(details.backend_state.p99_latency_ms)}</span>
                         </div>
                       )}
@@ -479,11 +483,11 @@ function SnapshotRow({
 
                 {/* Right: Environment */}
                 <div className="space-y-4">
-                  <h4 className="font-medium text-gray-900 dark:text-white">Environment</h4>
+                  <h4 className="font-medium text-neutral-900 dark:text-white">Environment</h4>
                   <div className="bg-white dark:bg-neutral-800 rounded-lg p-4 space-y-2 text-sm">
                     {details.environment.pod && (
                       <div className="flex justify-between">
-                        <span className="text-gray-500 dark:text-neutral-400">Pod:</span>
+                        <span className="text-neutral-500 dark:text-neutral-400">Pod:</span>
                         <span className="text-xs font-mono truncate max-w-40">
                           {details.environment.pod}
                         </span>
@@ -491,18 +495,18 @@ function SnapshotRow({
                     )}
                     {details.environment.node && (
                       <div className="flex justify-between">
-                        <span className="text-gray-500 dark:text-neutral-400">Node:</span>
+                        <span className="text-neutral-500 dark:text-neutral-400">Node:</span>
                         <span className="text-xs">{details.environment.node}</span>
                       </div>
                     )}
                     {details.environment.namespace && (
                       <div className="flex justify-between">
-                        <span className="text-gray-500 dark:text-neutral-400">Namespace:</span>
+                        <span className="text-neutral-500 dark:text-neutral-400">Namespace:</span>
                         <span>{details.environment.namespace}</span>
                       </div>
                     )}
                     <div className="flex justify-between">
-                      <span className="text-gray-500 dark:text-neutral-400">Trigger:</span>
+                      <span className="text-neutral-500 dark:text-neutral-400">Trigger:</span>
                       <span>{details.trigger}</span>
                     </div>
                   </div>
@@ -521,7 +525,7 @@ function SnapshotRow({
               <ReplayCommand snapshotId={snapshot.id} />
             </div>
           ) : (
-            <p className="text-center text-gray-500 dark:text-neutral-400 py-4">
+            <p className="text-center text-neutral-500 dark:text-neutral-400 py-4">
               Failed to load details
             </p>
           )}
@@ -613,18 +617,18 @@ export function ErrorSnapshots() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Error Snapshots</h1>
-          <p className="text-gray-500 dark:text-neutral-400">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Error Snapshots</h1>
+          <p className="text-neutral-500 dark:text-neutral-400">
             Time-travel debugging for gateway errors
           </p>
         </div>
         <div className="flex items-center gap-4">
-          <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-neutral-400">
+          <label className="flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-400">
             <input
               type="checkbox"
               checked={autoRefresh}
               onChange={(e) => setAutoRefresh(e.target.checked)}
-              className="rounded border-gray-300"
+              className="rounded border-neutral-300"
             />
             Auto-refresh (10s)
           </label>
@@ -677,13 +681,13 @@ export function ErrorSnapshots() {
         <div className="flex flex-wrap gap-4">
           {/* Search */}
           <form onSubmit={handleSearch} className="relative flex-1 min-w-64">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400" />
             <input
               type="text"
               placeholder="Search by path..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full pl-10 pr-4 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
           </form>
 
@@ -696,7 +700,7 @@ export function ErrorSnapshots() {
                 trigger: (e.target.value as SnapshotTrigger) || undefined,
               }))
             }
-            className="border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white"
+            className="border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white"
           >
             <option value="">All Triggers</option>
             {availableFilters?.triggers.map((t) => (
@@ -715,7 +719,7 @@ export function ErrorSnapshots() {
                 source: e.target.value || undefined,
               }))
             }
-            className="border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white"
+            className="border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white"
           >
             <option value="">All Gateways</option>
             {availableFilters?.sources.map((s) => (
@@ -734,7 +738,7 @@ export function ErrorSnapshots() {
                 resolution_status: (e.target.value as SnapshotResolutionStatus) || undefined,
               }))
             }
-            className="border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white"
+            className="border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white"
           >
             <option value="">All Statuses</option>
             {availableFilters?.resolution_statuses.map((s) => (
@@ -748,16 +752,18 @@ export function ErrorSnapshots() {
 
       {/* Snapshots Table */}
       <div className="rounded-lg bg-white dark:bg-neutral-800 shadow-sm">
-        <div className="border-b border-gray-100 dark:border-neutral-700 px-4 py-3 flex justify-between items-center">
-          <h2 className="font-medium text-gray-900 dark:text-white">Error Snapshots ({total})</h2>
-          <div className="text-sm text-gray-500 dark:text-neutral-400">
+        <div className="border-b border-neutral-100 dark:border-neutral-700 px-4 py-3 flex justify-between items-center">
+          <h2 className="font-medium text-neutral-900 dark:text-white">
+            Error Snapshots ({total})
+          </h2>
+          <div className="text-sm text-neutral-500 dark:text-neutral-400">
             Page {page} of {Math.max(1, Math.ceil(total / pageSize))}
           </div>
         </div>
 
         {snapshots.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-12 text-gray-500 dark:text-neutral-400">
-            <AlertTriangle className="h-12 w-12 mb-4 text-gray-300 dark:text-neutral-600" />
+          <div className="flex flex-col items-center justify-center py-12 text-neutral-500 dark:text-neutral-400">
+            <AlertTriangle className="h-12 w-12 mb-4 text-neutral-300 dark:text-neutral-600" />
             <p>No error snapshots found</p>
             <p className="text-sm">Errors will appear here when they occur</p>
           </div>
@@ -777,21 +783,21 @@ export function ErrorSnapshots() {
 
         {/* Pagination */}
         {total > pageSize && (
-          <div className="flex justify-between items-center px-4 py-3 border-t border-gray-100 dark:border-neutral-700">
+          <div className="flex justify-between items-center px-4 py-3 border-t border-neutral-100 dark:border-neutral-700">
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="px-4 py-2 text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-4 py-2 text-sm text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Previous
             </button>
-            <span className="text-sm text-gray-500 dark:text-neutral-400">
+            <span className="text-sm text-neutral-500 dark:text-neutral-400">
               Showing {(page - 1) * pageSize + 1} to {Math.min(page * pageSize, total)} of {total}
             </span>
             <button
               onClick={() => setPage((p) => p + 1)}
               disabled={!hasNext}
-              className="px-4 py-2 text-sm text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-4 py-2 text-sm text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Next
             </button>

--- a/control-plane-ui/src/pages/ExecutionView/ErrorTaxonomyChart.tsx
+++ b/control-plane-ui/src/pages/ExecutionView/ErrorTaxonomyChart.tsx
@@ -34,7 +34,9 @@ const CATEGORY_LABELS: Record<string, string> = {
 
 export function ErrorTaxonomyChart({ items, totalErrors }: ErrorTaxonomyChartProps) {
   if (items.length === 0) {
-    return <p className="text-sm text-gray-500 dark:text-neutral-400">No error data available</p>;
+    return (
+      <p className="text-sm text-neutral-500 dark:text-neutral-400">No error data available</p>
+    );
   }
 
   const maxCount = Math.max(...items.map((i) => i.count));
@@ -44,14 +46,14 @@ export function ErrorTaxonomyChart({ items, totalErrors }: ErrorTaxonomyChartPro
       {items.map((item) => {
         const colors = CATEGORY_COLORS[item.category] || {
           bar: '#6b7280',
-          text: 'text-gray-600',
+          text: 'text-neutral-600',
         };
         const label = CATEGORY_LABELS[item.category] || item.category;
         const widthPct = maxCount > 0 ? (item.count / maxCount) * 100 : 0;
 
         return (
           <div key={item.category} className="flex items-center gap-4">
-            <div className="w-24 text-sm font-medium text-gray-700 dark:text-neutral-300">
+            <div className="w-24 text-sm font-medium text-neutral-700 dark:text-neutral-300">
               {label}
             </div>
             <div className="flex-1">
@@ -60,16 +62,16 @@ export function ErrorTaxonomyChart({ items, totalErrors }: ErrorTaxonomyChartPro
                 <rect x="0" y="2" width={`${widthPct}%`} height="20" rx="4" fill={colors.bar} />
               </svg>
             </div>
-            <div className="w-16 text-right text-sm font-semibold text-gray-900 dark:text-white">
+            <div className="w-16 text-right text-sm font-semibold text-neutral-900 dark:text-white">
               {item.count}
             </div>
-            <div className="w-16 text-right text-xs text-gray-500 dark:text-neutral-400">
+            <div className="w-16 text-right text-xs text-neutral-500 dark:text-neutral-400">
               {item.percentage}%
             </div>
           </div>
         );
       })}
-      <p className="text-xs text-gray-500 dark:text-neutral-400 mt-2">
+      <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-2">
         {totalErrors} total errors across {items.length} categories
       </p>
     </div>

--- a/control-plane-ui/src/pages/ExecutionView/ExecutionDetailModal.tsx
+++ b/control-plane-ui/src/pages/ExecutionView/ExecutionDetailModal.tsx
@@ -40,11 +40,13 @@ export function ExecutionDetailModal({ execution, onClose }: ExecutionDetailModa
         className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[80vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-neutral-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Execution Detail</h2>
+        <div className="flex items-center justify-between p-4 border-b border-neutral-200 dark:border-neutral-700">
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
+            Execution Detail
+          </h2>
           <button
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+            className="text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
             aria-label="Close"
           >
             &times;
@@ -73,7 +75,7 @@ export function ExecutionDetailModal({ execution, onClose }: ExecutionDetailModa
 
           {execution.error_message && (
             <div>
-              <p className="text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                 Error Message
               </p>
               <pre className="text-sm bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-300 p-3 rounded-md overflow-x-auto">
@@ -84,10 +86,10 @@ export function ExecutionDetailModal({ execution, onClose }: ExecutionDetailModa
 
           {execution.request_headers && (
             <div>
-              <p className="text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                 Request Headers
               </p>
-              <pre className="text-xs bg-gray-50 dark:bg-neutral-900 text-gray-700 dark:text-neutral-300 p-3 rounded-md overflow-x-auto">
+              <pre className="text-xs bg-neutral-50 dark:bg-neutral-900 text-neutral-700 dark:text-neutral-300 p-3 rounded-md overflow-x-auto">
                 {JSON.stringify(execution.request_headers, null, 2)}
               </pre>
             </div>
@@ -95,10 +97,10 @@ export function ExecutionDetailModal({ execution, onClose }: ExecutionDetailModa
 
           {execution.response_summary && (
             <div>
-              <p className="text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                 Response Summary
               </p>
-              <pre className="text-xs bg-gray-50 dark:bg-neutral-900 text-gray-700 dark:text-neutral-300 p-3 rounded-md overflow-x-auto">
+              <pre className="text-xs bg-neutral-50 dark:bg-neutral-900 text-neutral-700 dark:text-neutral-300 p-3 rounded-md overflow-x-auto">
                 {JSON.stringify(execution.response_summary, null, 2)}
               </pre>
             </div>
@@ -112,8 +114,8 @@ export function ExecutionDetailModal({ execution, onClose }: ExecutionDetailModa
 function Field({ label, value }: { label: string; value: string | null | undefined }) {
   return (
     <div>
-      <p className="text-xs text-gray-500 dark:text-neutral-400">{label}</p>
-      <p className="text-sm font-medium text-gray-900 dark:text-white">{value || '—'}</p>
+      <p className="text-xs text-neutral-500 dark:text-neutral-400">{label}</p>
+      <p className="text-sm font-medium text-neutral-900 dark:text-white">{value || '—'}</p>
     </div>
   );
 }

--- a/control-plane-ui/src/pages/ExecutionView/ExecutionViewDashboard.tsx
+++ b/control-plane-ui/src/pages/ExecutionView/ExecutionViewDashboard.tsx
@@ -141,8 +141,8 @@ export function ExecutionViewDashboard() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Execution View</h1>
-        <p className="text-gray-500 dark:text-neutral-400 mt-1">
+        <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Execution View</h1>
+        <p className="text-neutral-500 dark:text-neutral-400 mt-1">
           Monitor API executions and error patterns
         </p>
       </div>
@@ -150,22 +150,22 @@ export function ExecutionViewDashboard() {
       {/* Stats Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none p-4">
-          <p className="text-sm text-gray-500 dark:text-neutral-400">Total Calls</p>
-          <p className="text-2xl font-bold text-gray-900 dark:text-white">
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">Total Calls</p>
+          <p className="text-2xl font-bold text-neutral-900 dark:text-white">
             {taxonomy?.total_executions ?? 0}
           </p>
         </div>
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none p-4">
-          <p className="text-sm text-gray-500 dark:text-neutral-400">Success</p>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">Success</p>
           <p className="text-2xl font-bold text-green-600">{successCount}</p>
         </div>
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none p-4">
-          <p className="text-sm text-gray-500 dark:text-neutral-400">Errors</p>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">Errors</p>
           <p className="text-2xl font-bold text-red-600">{taxonomy?.total_errors ?? 0}</p>
         </div>
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none p-4">
-          <p className="text-sm text-gray-500 dark:text-neutral-400">Error Rate</p>
-          <p className="text-2xl font-bold text-gray-900 dark:text-white">
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">Error Rate</p>
+          <p className="text-2xl font-bold text-neutral-900 dark:text-white">
             {taxonomy?.error_rate ?? 0}%
           </p>
         </div>
@@ -174,7 +174,7 @@ export function ExecutionViewDashboard() {
       {/* Error Taxonomy Chart */}
       {taxonomy && taxonomy.items.length > 0 && (
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none p-6">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4">
             Error Taxonomy
           </h2>
           <ErrorTaxonomyChart items={taxonomy.items} totalErrors={taxonomy.total_errors} />
@@ -189,7 +189,7 @@ export function ExecutionViewDashboard() {
             setStatusFilter(e.target.value);
             setPage(1);
           }}
-          className="rounded-md border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-sm px-3 py-2 text-gray-900 dark:text-white"
+          className="rounded-md border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-sm px-3 py-2 text-neutral-900 dark:text-white"
           aria-label="Filter by status"
         >
           <option value="">All Statuses</option>
@@ -203,7 +203,7 @@ export function ExecutionViewDashboard() {
             setCategoryFilter(e.target.value);
             setPage(1);
           }}
-          className="rounded-md border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-sm px-3 py-2 text-gray-900 dark:text-white"
+          className="rounded-md border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-sm px-3 py-2 text-neutral-900 dark:text-white"
           aria-label="Filter by error category"
         >
           <option value="">All Categories</option>
@@ -218,49 +218,49 @@ export function ExecutionViewDashboard() {
       {/* Executions Table */}
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none overflow-hidden">
         {loading ? (
-          <div className="p-8 text-center text-gray-500 dark:text-neutral-400">Loading...</div>
+          <div className="p-8 text-center text-neutral-500 dark:text-neutral-400">Loading...</div>
         ) : executions.length === 0 ? (
-          <div className="p-8 text-center text-gray-500 dark:text-neutral-400">
+          <div className="p-8 text-center text-neutral-500 dark:text-neutral-400">
             No executions found
           </div>
         ) : (
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
-            <thead className="bg-gray-50 dark:bg-neutral-900">
+          <table className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700">
+            <thead className="bg-neutral-50 dark:bg-neutral-900">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Time
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   API / Tool
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Method
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Status
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Duration
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Error
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
+            <tbody className="divide-y divide-neutral-200 dark:divide-neutral-700">
               {executions.map((exec) => (
                 <tr
                   key={exec.id}
                   onClick={() => handleRowClick(exec)}
-                  className="hover:bg-gray-50 dark:hover:bg-neutral-700 cursor-pointer"
+                  className="hover:bg-neutral-50 dark:hover:bg-neutral-700 cursor-pointer"
                 >
-                  <td className="px-4 py-3 text-sm text-gray-900 dark:text-white whitespace-nowrap">
+                  <td className="px-4 py-3 text-sm text-neutral-900 dark:text-white whitespace-nowrap">
                     {new Date(exec.started_at).toLocaleTimeString()}
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-900 dark:text-white">
+                  <td className="px-4 py-3 text-sm text-neutral-900 dark:text-white">
                     {exec.api_name || exec.tool_name || exec.path || '—'}
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-500 dark:text-neutral-400">
+                  <td className="px-4 py-3 text-sm text-neutral-500 dark:text-neutral-400">
                     {exec.method || '—'}
                   </td>
                   <td className="px-4 py-3">
@@ -270,10 +270,10 @@ export function ExecutionViewDashboard() {
                       {exec.status_code ?? exec.status}
                     </span>
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-500 dark:text-neutral-400">
+                  <td className="px-4 py-3 text-sm text-neutral-500 dark:text-neutral-400">
                     {exec.duration_ms != null ? `${exec.duration_ms}ms` : '—'}
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-500 dark:text-neutral-400">
+                  <td className="px-4 py-3 text-sm text-neutral-500 dark:text-neutral-400">
                     {exec.error_category || '—'}
                   </td>
                 </tr>
@@ -284,22 +284,22 @@ export function ExecutionViewDashboard() {
 
         {/* Pagination */}
         {totalPages > 1 && (
-          <div className="px-4 py-3 border-t border-gray-200 dark:border-neutral-700 flex items-center justify-between">
-            <p className="text-sm text-gray-500 dark:text-neutral-400">
+          <div className="px-4 py-3 border-t border-neutral-200 dark:border-neutral-700 flex items-center justify-between">
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
               Page {page} of {totalPages} ({total} total)
             </p>
             <div className="flex gap-2">
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page <= 1}
-                className="px-3 py-1 text-sm rounded border border-gray-300 dark:border-neutral-600 disabled:opacity-50"
+                className="px-3 py-1 text-sm rounded border border-neutral-300 dark:border-neutral-600 disabled:opacity-50"
               >
                 Previous
               </button>
               <button
                 onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                 disabled={page >= totalPages}
-                className="px-3 py-1 text-sm rounded border border-gray-300 dark:border-neutral-600 disabled:opacity-50"
+                className="px-3 py-1 text-sm rounded border border-neutral-300 dark:border-neutral-600 disabled:opacity-50"
               >
                 Next
               </button>

--- a/control-plane-ui/src/pages/ExternalMCPServers/ExternalMCPServerDetail.tsx
+++ b/control-plane-ui/src/pages/ExternalMCPServers/ExternalMCPServerDetail.tsx
@@ -31,8 +31,8 @@ const healthStatusConfig: Record<
   { color: string; bgColor: string; icon: typeof CheckCircle; label: string }
 > = {
   unknown: {
-    color: 'text-gray-600 dark:text-neutral-400',
-    bgColor: 'bg-gray-100 dark:bg-neutral-700',
+    color: 'text-neutral-600 dark:text-neutral-400',
+    bgColor: 'bg-neutral-100 dark:bg-neutral-700',
     icon: Clock,
     label: 'Unknown',
   },
@@ -191,11 +191,11 @@ export function ExternalMCPServerDetail() {
     return (
       <div className="space-y-6">
         <div className="flex items-center gap-4">
-          <div className="h-6 w-6 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
-          <div className="h-12 w-12 bg-gray-200 dark:bg-neutral-700 rounded-lg animate-pulse" />
+          <div className="h-6 w-6 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
+          <div className="h-12 w-12 bg-neutral-200 dark:bg-neutral-700 rounded-lg animate-pulse" />
           <div className="space-y-2">
-            <div className="h-6 w-48 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
-            <div className="h-4 w-32 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+            <div className="h-6 w-48 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
+            <div className="h-4 w-32 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
           </div>
         </div>
         <CardSkeleton className="h-48" />
@@ -209,7 +209,7 @@ export function ExternalMCPServerDetail() {
       <div className="space-y-4">
         <button
           onClick={() => navigate('/external-mcp-servers')}
-          className="flex items-center gap-2 text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white"
+          className="flex items-center gap-2 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white"
         >
           <ArrowLeft className="h-4 w-4" />
           Back to Servers
@@ -231,7 +231,7 @@ export function ExternalMCPServerDetail() {
         <div className="flex items-center gap-4">
           <button
             onClick={() => navigate('/external-mcp-servers')}
-            className="flex items-center gap-2 text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white"
+            className="flex items-center gap-2 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white"
           >
             <ArrowLeft className="h-4 w-4" />
           </button>
@@ -239,15 +239,17 @@ export function ExternalMCPServerDetail() {
             {server.icon ? (
               <img src={server.icon} alt="" className="w-12 h-12 rounded-lg" />
             ) : (
-              <div className="w-12 h-12 bg-gray-100 dark:bg-neutral-700 rounded-lg flex items-center justify-center">
-                <Server className="h-6 w-6 text-gray-500 dark:text-neutral-400" />
+              <div className="w-12 h-12 bg-neutral-100 dark:bg-neutral-700 rounded-lg flex items-center justify-center">
+                <Server className="h-6 w-6 text-neutral-500 dark:text-neutral-400" />
               </div>
             )}
             <div>
-              <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+              <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
                 {server.display_name}
               </h1>
-              <p className="text-sm text-gray-500 dark:text-neutral-400 font-mono">{server.name}</p>
+              <p className="text-sm text-neutral-500 dark:text-neutral-400 font-mono">
+                {server.name}
+              </p>
             </div>
           </div>
         </div>
@@ -256,7 +258,7 @@ export function ExternalMCPServerDetail() {
           <button
             onClick={handleTestConnection}
             disabled={testing}
-            className="flex items-center gap-2 px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 dark:text-neutral-300 disabled:opacity-50"
+            className="flex items-center gap-2 px-4 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 dark:text-neutral-300 disabled:opacity-50"
           >
             <Play className="h-4 w-4" />
             {testing ? 'Testing...' : 'Test Connection'}
@@ -264,7 +266,7 @@ export function ExternalMCPServerDetail() {
           <button
             onClick={handleSyncTools}
             disabled={syncing}
-            className="flex items-center gap-2 px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 dark:text-neutral-300 disabled:opacity-50"
+            className="flex items-center gap-2 px-4 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 dark:text-neutral-300 disabled:opacity-50"
           >
             <RefreshCw className={`h-4 w-4 ${syncing ? 'animate-spin' : ''}`} />
             {syncing ? 'Syncing...' : 'Sync Tools'}
@@ -284,7 +286,7 @@ export function ExternalMCPServerDetail() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           {/* Health Status */}
           <div>
-            <label className="block text-sm font-medium text-gray-500 dark:text-neutral-400 mb-1">
+            <label className="block text-sm font-medium text-neutral-500 dark:text-neutral-400 mb-1">
               Health Status
             </label>
             <div
@@ -296,7 +298,7 @@ export function ExternalMCPServerDetail() {
               </span>
             </div>
             {server.last_health_check && (
-              <p className="text-xs text-gray-500 dark:text-neutral-500 mt-1">
+              <p className="text-xs text-neutral-500 dark:text-neutral-500 mt-1">
                 Last checked: {new Date(server.last_health_check).toLocaleString()}
               </p>
             )}
@@ -304,7 +306,7 @@ export function ExternalMCPServerDetail() {
 
           {/* Base URL */}
           <div>
-            <label className="block text-sm font-medium text-gray-500 dark:text-neutral-400 mb-1">
+            <label className="block text-sm font-medium text-neutral-500 dark:text-neutral-400 mb-1">
               Base URL
             </label>
             <a
@@ -320,21 +322,21 @@ export function ExternalMCPServerDetail() {
 
           {/* Transport & Auth */}
           <div>
-            <label className="block text-sm font-medium text-gray-500 dark:text-neutral-400 mb-1">
+            <label className="block text-sm font-medium text-neutral-500 dark:text-neutral-400 mb-1">
               Transport / Auth
             </label>
-            <p className="text-sm text-gray-900 dark:text-white">
+            <p className="text-sm text-neutral-900 dark:text-white">
               {server.transport.toUpperCase()} / {server.auth_type.replace('_', ' ')}
             </p>
           </div>
 
           {/* Status */}
           <div>
-            <label className="block text-sm font-medium text-gray-500 dark:text-neutral-400 mb-1">
+            <label className="block text-sm font-medium text-neutral-500 dark:text-neutral-400 mb-1">
               Status
             </label>
             <span
-              className={`inline-flex px-2 py-1 text-xs rounded-full ${server.enabled ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-gray-100 text-gray-800 dark:bg-neutral-700 dark:text-neutral-300'}`}
+              className={`inline-flex px-2 py-1 text-xs rounded-full ${server.enabled ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-neutral-100 text-neutral-800 dark:bg-neutral-700 dark:text-neutral-300'}`}
             >
               {server.enabled ? 'Enabled' : 'Disabled'}
             </span>
@@ -344,10 +346,10 @@ export function ExternalMCPServerDetail() {
         {/* Description */}
         {server.description && (
           <div className="mt-6 pt-6 border-t dark:border-neutral-700">
-            <label className="block text-sm font-medium text-gray-500 dark:text-neutral-400 mb-1">
+            <label className="block text-sm font-medium text-neutral-500 dark:text-neutral-400 mb-1">
               Description
             </label>
-            <p className="text-sm text-gray-700 dark:text-neutral-300">{server.description}</p>
+            <p className="text-sm text-neutral-700 dark:text-neutral-300">{server.description}</p>
           </div>
         )}
 
@@ -362,21 +364,21 @@ export function ExternalMCPServerDetail() {
         {/* Metadata */}
         <div className="mt-6 pt-6 border-t dark:border-neutral-700 grid grid-cols-2 md:grid-cols-4 gap-4 text-sm dark:text-neutral-300">
           <div>
-            <span className="text-gray-500 dark:text-neutral-400">Tool Prefix:</span>{' '}
-            <code className="bg-gray-100 dark:bg-neutral-700 px-1 rounded">
+            <span className="text-neutral-500 dark:text-neutral-400">Tool Prefix:</span>{' '}
+            <code className="bg-neutral-100 dark:bg-neutral-700 px-1 rounded">
               {server.tool_prefix || server.name}__
             </code>
           </div>
           <div>
-            <span className="text-gray-500 dark:text-neutral-400">Tools Count:</span>{' '}
+            <span className="text-neutral-500 dark:text-neutral-400">Tools Count:</span>{' '}
             {server.tools.length}
           </div>
           <div>
-            <span className="text-gray-500 dark:text-neutral-400">Last Synced:</span>{' '}
+            <span className="text-neutral-500 dark:text-neutral-400">Last Synced:</span>{' '}
             {server.last_sync_at ? new Date(server.last_sync_at).toLocaleString() : 'Never'}
           </div>
           <div>
-            <span className="text-gray-500 dark:text-neutral-400">Created:</span>{' '}
+            <span className="text-neutral-500 dark:text-neutral-400">Created:</span>{' '}
             {new Date(server.created_at).toLocaleString()}
           </div>
         </div>
@@ -385,10 +387,10 @@ export function ExternalMCPServerDetail() {
       {/* Tools List */}
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow">
         <div className="px-6 py-4 border-b dark:border-neutral-700 flex justify-between items-center">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
             Tools ({server.tools.length})
           </h2>
-          <p className="text-sm text-gray-500 dark:text-neutral-400">
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">
             Enable/disable tools to control which are exposed via STOA
           </p>
         </div>
@@ -405,23 +407,23 @@ export function ExternalMCPServerDetail() {
             {server.tools.map((tool) => (
               <div
                 key={tool.id}
-                className="px-6 py-4 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-neutral-700"
+                className="px-6 py-4 flex items-center justify-between hover:bg-neutral-50 dark:hover:bg-neutral-700"
               >
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
-                    <h3 className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                    <h3 className="text-sm font-medium text-neutral-900 dark:text-white truncate">
                       {tool.display_name || tool.name}
                     </h3>
-                    <code className="text-xs bg-gray-100 dark:bg-neutral-700 px-1.5 py-0.5 rounded text-gray-600 dark:text-neutral-400">
+                    <code className="text-xs bg-neutral-100 dark:bg-neutral-700 px-1.5 py-0.5 rounded text-neutral-600 dark:text-neutral-400">
                       {tool.namespaced_name}
                     </code>
                   </div>
                   {tool.description && (
-                    <p className="text-sm text-gray-500 dark:text-neutral-400 truncate mt-1">
+                    <p className="text-sm text-neutral-500 dark:text-neutral-400 truncate mt-1">
                       {tool.description}
                     </p>
                   )}
-                  <p className="text-xs text-gray-400 dark:text-neutral-500 mt-1">
+                  <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1">
                     Synced: {new Date(tool.synced_at).toLocaleString()}
                   </p>
                 </div>
@@ -434,7 +436,7 @@ export function ExternalMCPServerDetail() {
                         navigator.clipboard.writeText(JSON.stringify(tool.input_schema, null, 2));
                         toast.info('Schema copied', 'Input schema copied to clipboard');
                       }}
-                      className="text-xs text-gray-500 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+                      className="text-xs text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
                     >
                       Copy Schema
                     </button>
@@ -449,8 +451,8 @@ export function ExternalMCPServerDetail() {
                       disabled={togglingTool === tool.id}
                       className="sr-only peer"
                     />
-                    <div className="w-11 h-6 bg-gray-200 dark:bg-neutral-600 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
-                    <span className="ml-2 text-sm text-gray-600 dark:text-neutral-400">
+                    <div className="w-11 h-6 bg-neutral-200 dark:bg-neutral-600 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-neutral-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+                    <span className="ml-2 text-sm text-neutral-600 dark:text-neutral-400">
                       {togglingTool === tool.id ? '...' : tool.enabled ? 'Enabled' : 'Disabled'}
                     </span>
                   </label>
@@ -465,7 +467,7 @@ export function ExternalMCPServerDetail() {
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow border border-red-200 dark:border-red-800">
         <div className="px-6 py-4">
           <h2 className="text-lg font-semibold text-red-600 dark:text-red-400">Danger Zone</h2>
-          <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
             Permanently delete this external MCP server and all its synced tools.
           </p>
           <button

--- a/control-plane-ui/src/pages/ExternalMCPServers/ExternalMCPServerModal.tsx
+++ b/control-plane-ui/src/pages/ExternalMCPServers/ExternalMCPServerModal.tsx
@@ -115,12 +115,12 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
         {/* Header */}
         <div className="flex justify-between items-center px-6 py-4 border-b dark:border-neutral-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
             {isEdit ? 'Edit External MCP Server' : 'Add External MCP Server'}
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-neutral-300"
+            className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
           >
             <X className="h-5 w-5" />
           </button>
@@ -137,35 +137,35 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
 
           {/* Name */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Name <span className="text-red-500">*</span>
             </label>
             <input
               type="text"
               value={formData.name}
               onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               placeholder="linear"
               required
               disabled={isEdit}
               pattern="^[a-z][a-z0-9-_]*$"
               title="Lowercase letters, numbers, hyphens, and underscores. Must start with a letter."
             />
-            <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
+            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
               Unique identifier (slug). Used for tool prefixes.
             </p>
           </div>
 
           {/* Display Name */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Display Name <span className="text-red-500">*</span>
             </label>
             <input
               type="text"
               value={formData.display_name}
               onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               placeholder="Linear"
               required
             />
@@ -173,13 +173,13 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
 
           {/* Description */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Description
             </label>
             <textarea
               value={formData.description || ''}
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               rows={2}
               placeholder="Issue tracking for modern software teams"
             />
@@ -187,14 +187,14 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
 
           {/* Base URL */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Base URL <span className="text-red-500">*</span>
             </label>
             <input
               type="url"
               value={formData.base_url}
               onChange={(e) => setFormData({ ...formData, base_url: e.target.value })}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               placeholder="https://mcp.linear.app/sse"
               required
             />
@@ -202,7 +202,7 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
 
           {/* Transport */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Transport
             </label>
             <select
@@ -210,7 +210,7 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
               onChange={(e) =>
                 setFormData({ ...formData, transport: e.target.value as ExternalMCPTransport })
               }
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               {transportOptions.map((opt) => (
                 <option key={opt.value} value={opt.value}>
@@ -222,7 +222,7 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
 
           {/* Auth Type */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Authentication
             </label>
             <select
@@ -230,7 +230,7 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
               onChange={(e) =>
                 setFormData({ ...formData, auth_type: e.target.value as ExternalMCPAuthType })
               }
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               {authTypeOptions.map((opt) => (
                 <option key={opt.value} value={opt.value}>
@@ -243,17 +243,17 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
           {/* Credentials - API Key */}
           {formData.auth_type === 'api_key' && (
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                 API Key
               </label>
               <input
                 type="password"
                 value={credentialApiKey}
                 onChange={(e) => setCredentialApiKey(e.target.value)}
-                className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 placeholder="Enter API key"
               />
-              <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
+              <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
                 Stored securely in Vault. Leave empty to keep existing.
               </p>
             </div>
@@ -262,17 +262,17 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
           {/* Credentials - Bearer Token */}
           {formData.auth_type === 'bearer_token' && (
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                 Bearer Token
               </label>
               <input
                 type="password"
                 value={credentialBearerToken}
                 onChange={(e) => setCredentialBearerToken(e.target.value)}
-                className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 placeholder="Enter bearer token"
               />
-              <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
+              <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
                 Stored securely in Vault. Leave empty to keep existing.
               </p>
             </div>
@@ -280,12 +280,12 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
 
           {/* Credentials - OAuth2 */}
           {formData.auth_type === 'oauth2' && (
-            <div className="space-y-3 p-4 bg-gray-50 dark:bg-neutral-700 rounded-lg">
-              <h4 className="text-sm font-medium text-gray-700 dark:text-neutral-300">
+            <div className="space-y-3 p-4 bg-neutral-50 dark:bg-neutral-700 rounded-lg">
+              <h4 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
                 OAuth2 Configuration
               </h4>
               <div>
-                <label className="block text-xs text-gray-600 dark:text-neutral-400 mb-1">
+                <label className="block text-xs text-neutral-600 dark:text-neutral-400 mb-1">
                   Client ID
                 </label>
                 <input
@@ -294,12 +294,12 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
                   onChange={(e) =>
                     setCredentialOAuth2({ ...credentialOAuth2, client_id: e.target.value })
                   }
-                  className="w-full border border-gray-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
+                  className="w-full border border-neutral-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
                   placeholder="Client ID"
                 />
               </div>
               <div>
-                <label className="block text-xs text-gray-600 dark:text-neutral-400 mb-1">
+                <label className="block text-xs text-neutral-600 dark:text-neutral-400 mb-1">
                   Client Secret
                 </label>
                 <input
@@ -308,12 +308,12 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
                   onChange={(e) =>
                     setCredentialOAuth2({ ...credentialOAuth2, client_secret: e.target.value })
                   }
-                  className="w-full border border-gray-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
+                  className="w-full border border-neutral-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
                   placeholder="Client Secret"
                 />
               </div>
               <div>
-                <label className="block text-xs text-gray-600 dark:text-neutral-400 mb-1">
+                <label className="block text-xs text-neutral-600 dark:text-neutral-400 mb-1">
                   Token URL
                 </label>
                 <input
@@ -322,12 +322,12 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
                   onChange={(e) =>
                     setCredentialOAuth2({ ...credentialOAuth2, token_url: e.target.value })
                   }
-                  className="w-full border border-gray-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
+                  className="w-full border border-neutral-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
                   placeholder="https://auth.example.com/oauth/token"
                 />
               </div>
               <div>
-                <label className="block text-xs text-gray-600 dark:text-neutral-400 mb-1">
+                <label className="block text-xs text-neutral-600 dark:text-neutral-400 mb-1">
                   Scope (optional)
                 </label>
                 <input
@@ -336,7 +336,7 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
                   onChange={(e) =>
                     setCredentialOAuth2({ ...credentialOAuth2, scope: e.target.value })
                   }
-                  className="w-full border border-gray-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
+                  className="w-full border border-neutral-300 dark:border-neutral-600 rounded px-3 py-2 text-sm bg-white dark:bg-neutral-600 dark:text-white"
                   placeholder="read write"
                 />
               </div>
@@ -345,19 +345,19 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
 
           {/* Tool Prefix */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Tool Prefix
             </label>
             <input
               type="text"
               value={formData.tool_prefix || ''}
               onChange={(e) => setFormData({ ...formData, tool_prefix: e.target.value })}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               placeholder={formData.name || 'linear'}
             />
-            <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
+            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
               Tools will be named:{' '}
-              <code className="bg-gray-100 dark:bg-neutral-700 px-1 rounded">
+              <code className="bg-neutral-100 dark:bg-neutral-700 px-1 rounded">
                 {formData.tool_prefix || formData.name || 'prefix'}__tool_name
               </code>
             </p>
@@ -365,14 +365,14 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
 
           {/* Icon URL */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Icon URL
             </label>
             <input
               type="url"
               value={formData.icon || ''}
               onChange={(e) => setFormData({ ...formData, icon: e.target.value })}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               placeholder="https://example.com/icon.png"
             />
           </div>
@@ -388,14 +388,14 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
         </form>
 
         {/* Footer */}
-        <div className="flex justify-between items-center px-6 py-4 border-t dark:border-neutral-700 bg-gray-50 dark:bg-neutral-800">
+        <div className="flex justify-between items-center px-6 py-4 border-t dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800">
           <div>
             {isEdit && (
               <button
                 type="button"
                 onClick={handleTestConnection}
                 disabled={testing}
-                className="px-4 py-2 text-sm border border-gray-300 rounded-lg hover:bg-white disabled:opacity-50"
+                className="px-4 py-2 text-sm border border-neutral-300 rounded-lg hover:bg-white disabled:opacity-50"
               >
                 {testing ? 'Testing...' : 'Test Connection'}
               </button>
@@ -405,7 +405,7 @@ export function ExternalMCPServerModal({ server, onClose, onSubmit }: ExternalMC
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-white dark:hover:bg-neutral-700 dark:text-neutral-300"
+              className="px-4 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-white dark:hover:bg-neutral-700 dark:text-neutral-300"
             >
               Cancel
             </button>

--- a/control-plane-ui/src/pages/ExternalMCPServers/ExternalMCPServersList.tsx
+++ b/control-plane-ui/src/pages/ExternalMCPServers/ExternalMCPServersList.tsx
@@ -20,7 +20,7 @@ const healthStatusConfig: Record<
   { color: string; icon: typeof CheckCircle; label: string }
 > = {
   unknown: {
-    color: 'bg-gray-100 text-gray-800 dark:bg-neutral-700 dark:text-neutral-300',
+    color: 'bg-neutral-100 text-neutral-800 dark:bg-neutral-700 dark:text-neutral-300',
     icon: Clock,
     label: 'Unknown',
   },
@@ -160,10 +160,10 @@ export function ExternalMCPServersList() {
     return (
       <div className="space-y-6">
         <div className="flex justify-between items-center">
-          <div className="h-8 w-64 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+          <div className="h-8 w-64 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
           <div className="flex gap-3">
-            <div className="h-10 w-24 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
-            <div className="h-10 w-28 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+            <div className="h-10 w-24 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
+            <div className="h-10 w-28 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
           </div>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -180,8 +180,10 @@ export function ExternalMCPServersList() {
       {/* Header */}
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">External MCP Servers</h1>
-          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
+            External MCP Servers
+          </h1>
+          <p className="text-neutral-500 dark:text-neutral-400 mt-1">
             Register external MCP servers (Linear, GitHub, etc.) to proxy through STOA with
             governance
           </p>
@@ -189,7 +191,7 @@ export function ExternalMCPServersList() {
         <div className="flex gap-3">
           <button
             onClick={loadServers}
-            className="flex items-center gap-2 px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 dark:text-neutral-300"
+            className="flex items-center gap-2 px-4 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 dark:text-neutral-300"
           >
             <RefreshCw className="h-4 w-4" />
             Refresh
@@ -241,15 +243,15 @@ export function ExternalMCPServersList() {
                     {server.icon ? (
                       <img src={server.icon} alt="" className="w-10 h-10 rounded" />
                     ) : (
-                      <div className="w-10 h-10 bg-gray-100 dark:bg-neutral-700 rounded flex items-center justify-center">
-                        <Server className="h-5 w-5 text-gray-500 dark:text-neutral-400" />
+                      <div className="w-10 h-10 bg-neutral-100 dark:bg-neutral-700 rounded flex items-center justify-center">
+                        <Server className="h-5 w-5 text-neutral-500 dark:text-neutral-400" />
                       </div>
                     )}
                     <div>
-                      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                      <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">
                         {server.display_name}
                       </h3>
-                      <p className="text-sm text-gray-500 dark:text-neutral-400 font-mono">
+                      <p className="text-sm text-neutral-500 dark:text-neutral-400 font-mono">
                         {server.name}
                       </p>
                     </div>
@@ -263,31 +265,31 @@ export function ExternalMCPServersList() {
                 </div>
 
                 {/* Info */}
-                <div className="space-y-2 text-sm text-gray-600 dark:text-neutral-300 mb-4">
+                <div className="space-y-2 text-sm text-neutral-600 dark:text-neutral-300 mb-4">
                   <div className="flex justify-between">
-                    <span className="text-gray-500 dark:text-neutral-400">Transport:</span>
+                    <span className="text-neutral-500 dark:text-neutral-400">Transport:</span>
                     <span className="font-mono">
                       {transportLabels[server.transport] || server.transport}
                     </span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-gray-500 dark:text-neutral-400">Auth:</span>
+                    <span className="text-neutral-500 dark:text-neutral-400">Auth:</span>
                     <span>{server.auth_type.replace('_', ' ')}</span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-gray-500 dark:text-neutral-400">Tools:</span>
+                    <span className="text-neutral-500 dark:text-neutral-400">Tools:</span>
                     <span>{server.tools_count}</span>
                   </div>
                   {server.tool_prefix && (
                     <div className="flex justify-between">
-                      <span className="text-gray-500 dark:text-neutral-400">Prefix:</span>
+                      <span className="text-neutral-500 dark:text-neutral-400">Prefix:</span>
                       <span className="font-mono">{server.tool_prefix}__</span>
                     </div>
                   )}
                   <div className="flex justify-between items-center">
-                    <span className="text-gray-500 dark:text-neutral-400">Status:</span>
+                    <span className="text-neutral-500 dark:text-neutral-400">Status:</span>
                     <span
-                      className={`px-2 py-0.5 text-xs rounded ${server.enabled ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-gray-100 text-gray-800 dark:bg-neutral-700 dark:text-neutral-300'}`}
+                      className={`px-2 py-0.5 text-xs rounded ${server.enabled ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-neutral-100 text-neutral-800 dark:bg-neutral-700 dark:text-neutral-300'}`}
                     >
                       {server.enabled ? 'Enabled' : 'Disabled'}
                     </span>
@@ -309,14 +311,14 @@ export function ExternalMCPServersList() {
                   <button
                     onClick={() => handleTestConnection(server.id)}
                     disabled={testingServerId === server.id}
-                    className="flex-1 px-3 py-2 text-sm border border-gray-300 dark:border-neutral-600 rounded hover:bg-gray-50 dark:hover:bg-neutral-700 dark:text-neutral-300 disabled:opacity-50"
+                    className="flex-1 px-3 py-2 text-sm border border-neutral-300 dark:border-neutral-600 rounded hover:bg-neutral-50 dark:hover:bg-neutral-700 dark:text-neutral-300 disabled:opacity-50"
                   >
                     {testingServerId === server.id ? 'Testing...' : 'Test'}
                   </button>
                   <button
                     onClick={() => handleSyncTools(server.id)}
                     disabled={syncingServerId === server.id}
-                    className="flex-1 px-3 py-2 text-sm border border-gray-300 dark:border-neutral-600 rounded hover:bg-gray-50 dark:hover:bg-neutral-700 dark:text-neutral-300 disabled:opacity-50"
+                    className="flex-1 px-3 py-2 text-sm border border-neutral-300 dark:border-neutral-600 rounded hover:bg-neutral-50 dark:hover:bg-neutral-700 dark:text-neutral-300 disabled:opacity-50"
                   >
                     {syncingServerId === server.id ? 'Syncing...' : 'Sync'}
                   </button>

--- a/control-plane-ui/src/pages/FederationAccounts/ApiKeyRevealDialog.tsx
+++ b/control-plane-ui/src/pages/FederationAccounts/ApiKeyRevealDialog.tsx
@@ -19,7 +19,7 @@ export function ApiKeyRevealDialog({ apiKey, name, onClose }: ApiKeyRevealDialog
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-lg p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+        <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-2">
           API Key for {name}
         </h3>
 
@@ -30,11 +30,11 @@ export function ApiKeyRevealDialog({ apiKey, name, onClose }: ApiKeyRevealDialog
           </p>
         </div>
 
-        <div className="flex items-center gap-2 p-3 bg-gray-100 dark:bg-neutral-700 rounded-lg font-mono text-sm break-all">
-          <span className="flex-1 text-gray-900 dark:text-white">{apiKey}</span>
+        <div className="flex items-center gap-2 p-3 bg-neutral-100 dark:bg-neutral-700 rounded-lg font-mono text-sm break-all">
+          <span className="flex-1 text-neutral-900 dark:text-white">{apiKey}</span>
           <button
             onClick={handleCopy}
-            className="shrink-0 p-1.5 text-gray-500 hover:text-gray-700 dark:hover:text-neutral-300 rounded"
+            className="shrink-0 p-1.5 text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 rounded"
             title="Copy to clipboard"
           >
             {copied ? <Check className="h-4 w-4 text-green-600" /> : <Copy className="h-4 w-4" />}

--- a/control-plane-ui/src/pages/FederationAccounts/FederationAccountDetail.tsx
+++ b/control-plane-ui/src/pages/FederationAccounts/FederationAccountDetail.tsx
@@ -199,10 +199,10 @@ export function FederationAccountDetail() {
   if (isLoading) {
     return (
       <div className="space-y-6">
-        <div className="h-8 w-64 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+        <div className="h-8 w-64 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-6 space-y-4">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="h-6 bg-gray-100 dark:bg-neutral-700 rounded animate-pulse" />
+            <div key={i} className="h-6 bg-neutral-100 dark:bg-neutral-700 rounded animate-pulse" />
           ))}
         </div>
       </div>
@@ -214,7 +214,7 @@ export function FederationAccountDetail() {
       <div className="space-y-6">
         <button
           onClick={() => navigate('/federation/accounts')}
-          className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+          className="flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
         >
           <ArrowLeft className="h-4 w-4" /> Back to Federation
         </button>
@@ -232,7 +232,7 @@ export function FederationAccountDetail() {
       {/* Back link */}
       <button
         onClick={() => navigate('/federation/accounts')}
-        className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+        className="flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
       >
         <ArrowLeft className="h-4 w-4" /> Back to Federation
       </button>
@@ -241,7 +241,7 @@ export function FederationAccountDetail() {
       <div className="flex justify-between items-start">
         <div>
           <div className="flex items-center gap-3">
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{account.name}</h1>
+            <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">{account.name}</h1>
             <span
               className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${status.color}`}
             >
@@ -249,7 +249,7 @@ export function FederationAccountDetail() {
             </span>
           </div>
           {account.description && (
-            <p className="text-gray-500 dark:text-neutral-400 mt-1">{account.description}</p>
+            <p className="text-neutral-500 dark:text-neutral-400 mt-1">{account.description}</p>
           )}
         </div>
         {isAdmin && account.status !== 'revoked' && (
@@ -282,37 +282,37 @@ export function FederationAccountDetail() {
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-6">
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <div>
-            <div className="text-xs text-gray-500 dark:text-neutral-400 uppercase font-medium">
+            <div className="text-xs text-neutral-500 dark:text-neutral-400 uppercase font-medium">
               Sub-accounts
             </div>
-            <div className="mt-1 flex items-center gap-1 text-lg font-semibold text-gray-900 dark:text-white">
-              <Users className="h-4 w-4 text-gray-400" />
+            <div className="mt-1 flex items-center gap-1 text-lg font-semibold text-neutral-900 dark:text-white">
+              <Users className="h-4 w-4 text-neutral-400" />
               {account.sub_account_count} / {account.max_sub_accounts}
             </div>
           </div>
           <div>
-            <div className="text-xs text-gray-500 dark:text-neutral-400 uppercase font-medium">
+            <div className="text-xs text-neutral-500 dark:text-neutral-400 uppercase font-medium">
               Created
             </div>
-            <div className="mt-1 flex items-center gap-1 text-sm text-gray-900 dark:text-white">
-              <Clock className="h-4 w-4 text-gray-400" />
+            <div className="mt-1 flex items-center gap-1 text-sm text-neutral-900 dark:text-white">
+              <Clock className="h-4 w-4 text-neutral-400" />
               {formatDate(account.created_at)}
             </div>
           </div>
           <div>
-            <div className="text-xs text-gray-500 dark:text-neutral-400 uppercase font-medium">
+            <div className="text-xs text-neutral-500 dark:text-neutral-400 uppercase font-medium">
               Updated
             </div>
-            <div className="mt-1 text-sm text-gray-900 dark:text-white">
+            <div className="mt-1 text-sm text-neutral-900 dark:text-white">
               {formatDate(account.updated_at)}
             </div>
           </div>
           <div>
-            <div className="text-xs text-gray-500 dark:text-neutral-400 uppercase font-medium">
+            <div className="text-xs text-neutral-500 dark:text-neutral-400 uppercase font-medium">
               Requests ({usageDays}d)
             </div>
-            <div className="mt-1 flex items-center gap-1 text-lg font-semibold text-gray-900 dark:text-white">
-              <BarChart3 className="h-4 w-4 text-gray-400" />
+            <div className="mt-1 flex items-center gap-1 text-lg font-semibold text-neutral-900 dark:text-white">
+              <BarChart3 className="h-4 w-4 text-neutral-400" />
               {usageData ? usageData.total_requests.toLocaleString() : '-'}
             </div>
           </div>
@@ -323,14 +323,14 @@ export function FederationAccountDetail() {
       {usageData && usageData.sub_accounts.length > 0 && (
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow overflow-hidden">
           <div className="px-4 py-3 border-b dark:border-neutral-700 flex items-center justify-between">
-            <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
+            <h2 className="text-sm font-semibold text-neutral-900 dark:text-white">
               Usage Breakdown (last {usageData.period_days} days)
             </h2>
             <select
               value={usageDays}
               onChange={(e) => setUsageDays(Number(e.target.value) as 7 | 30 | 90)}
               aria-label="Usage period"
-              className="text-xs border border-gray-300 dark:border-neutral-600 rounded-md bg-white dark:bg-neutral-700 text-gray-700 dark:text-neutral-300 px-2 py-1 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="text-xs border border-neutral-300 dark:border-neutral-600 rounded-md bg-white dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 px-2 py-1 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             >
               <option value={7}>7 days</option>
               <option value={30}>30 days</option>
@@ -339,20 +339,20 @@ export function FederationAccountDetail() {
           </div>
           <table className="w-full">
             <thead>
-              <tr className="bg-gray-50 dark:bg-neutral-800 border-b dark:border-neutral-700">
-                <th className="text-left px-4 py-2 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+              <tr className="bg-neutral-50 dark:bg-neutral-800 border-b dark:border-neutral-700">
+                <th className="text-left px-4 py-2 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Sub-account
                 </th>
-                <th className="text-right px-4 py-2 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-right px-4 py-2 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Requests
                 </th>
-                <th className="text-right px-4 py-2 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-right px-4 py-2 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Tokens
                 </th>
-                <th className="text-right px-4 py-2 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-right px-4 py-2 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Avg Latency
                 </th>
-                <th className="text-right px-4 py-2 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-right px-4 py-2 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Errors
                 </th>
               </tr>
@@ -360,16 +360,16 @@ export function FederationAccountDetail() {
             <tbody className="divide-y dark:divide-neutral-700">
               {usageData.sub_accounts.map((stat) => (
                 <tr key={stat.sub_account_id}>
-                  <td className="px-4 py-2 text-sm text-gray-900 dark:text-white">
+                  <td className="px-4 py-2 text-sm text-neutral-900 dark:text-white">
                     {stat.sub_account_name}
                   </td>
-                  <td className="px-4 py-2 text-sm text-right text-gray-600 dark:text-neutral-300">
+                  <td className="px-4 py-2 text-sm text-right text-neutral-600 dark:text-neutral-300">
                     {stat.total_requests.toLocaleString()}
                   </td>
-                  <td className="px-4 py-2 text-sm text-right text-gray-600 dark:text-neutral-300">
+                  <td className="px-4 py-2 text-sm text-right text-neutral-600 dark:text-neutral-300">
                     {stat.total_tokens.toLocaleString()}
                   </td>
-                  <td className="px-4 py-2 text-sm text-right text-gray-600 dark:text-neutral-300">
+                  <td className="px-4 py-2 text-sm text-right text-neutral-600 dark:text-neutral-300">
                     {stat.avg_latency_ms}ms
                   </td>
                   <td className="px-4 py-2 text-sm text-right">
@@ -377,7 +377,7 @@ export function FederationAccountDetail() {
                       className={
                         stat.error_count > 0
                           ? 'text-red-600 dark:text-red-400 font-medium'
-                          : 'text-gray-600 dark:text-neutral-300'
+                          : 'text-neutral-600 dark:text-neutral-300'
                       }
                     >
                       {stat.error_count}
@@ -393,7 +393,7 @@ export function FederationAccountDetail() {
       {/* Sub-accounts section */}
       <div className="space-y-4">
         <div className="flex justify-between items-center">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Sub-accounts</h2>
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">Sub-accounts</h2>
           {isAdmin && account.status === 'active' && (
             <button
               onClick={() => setShowSubAccountModal(true)}
@@ -425,23 +425,23 @@ export function FederationAccountDetail() {
           <div className="bg-white dark:bg-neutral-800 rounded-lg shadow overflow-hidden">
             <table className="w-full">
               <thead>
-                <tr className="border-b dark:border-neutral-700 bg-gray-50 dark:bg-neutral-800">
-                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <tr className="border-b dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     Name
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     Status
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     API Key
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     Tools
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     Last Used
                   </th>
-                  <th className="text-right px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                  <th className="text-right px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     Actions
                   </th>
                 </tr>
@@ -450,13 +450,13 @@ export function FederationAccountDetail() {
                 {subAccounts.map((sub) => {
                   const subStatus = statusConfig[sub.status];
                   return (
-                    <tr key={sub.id} className="hover:bg-gray-50 dark:hover:bg-neutral-750">
+                    <tr key={sub.id} className="hover:bg-neutral-50 dark:hover:bg-neutral-750">
                       <td className="px-4 py-3">
-                        <div className="font-medium text-gray-900 dark:text-white text-sm">
+                        <div className="font-medium text-neutral-900 dark:text-white text-sm">
                           {sub.name}
                         </div>
                         {sub.description && (
-                          <div className="text-xs text-gray-500 dark:text-neutral-400 truncate max-w-xs">
+                          <div className="text-xs text-neutral-500 dark:text-neutral-400 truncate max-w-xs">
                             {sub.description}
                           </div>
                         )}
@@ -468,10 +468,10 @@ export function FederationAccountDetail() {
                           {subStatus.label}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-sm font-mono text-gray-600 dark:text-neutral-300">
+                      <td className="px-4 py-3 text-sm font-mono text-neutral-600 dark:text-neutral-300">
                         {sub.api_key_prefix}...
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-neutral-300">
+                      <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                         {isAdmin ? (
                           <button
                             onClick={() => setToolEditSub({ id: sub.id, name: sub.name })}
@@ -488,7 +488,7 @@ export function FederationAccountDetail() {
                           </span>
                         )}
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-neutral-300">
+                      <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                         {formatDate(sub.last_used_at)}
                       </td>
                       <td className="px-4 py-3 text-right">

--- a/control-plane-ui/src/pages/FederationAccounts/FederationAccountsList.tsx
+++ b/control-plane-ui/src/pages/FederationAccounts/FederationAccountsList.tsx
@@ -79,13 +79,16 @@ export function FederationAccountsList() {
     return (
       <div className="space-y-6">
         <div className="flex justify-between items-center">
-          <div className="h-8 w-64 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
-          <div className="h-10 w-40 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+          <div className="h-8 w-64 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
+          <div className="h-10 w-40 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
         </div>
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow">
           <div className="p-6 space-y-4">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="h-12 bg-gray-100 dark:bg-neutral-700 rounded animate-pulse" />
+              <div
+                key={i}
+                className="h-12 bg-neutral-100 dark:bg-neutral-700 rounded animate-pulse"
+              />
             ))}
           </div>
         </div>
@@ -98,8 +101,8 @@ export function FederationAccountsList() {
       {/* Header */}
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Federation</h1>
-          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Federation</h1>
+          <p className="text-neutral-500 dark:text-neutral-400 mt-1">
             Manage master accounts and delegated sub-accounts for MCP federation
           </p>
         </div>
@@ -140,20 +143,20 @@ export function FederationAccountsList() {
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow overflow-hidden">
           <table className="w-full">
             <thead>
-              <tr className="border-b dark:border-neutral-700 bg-gray-50 dark:bg-neutral-800">
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+              <tr className="border-b dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Name
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Status
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Sub-accounts
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Created
                 </th>
-                <th className="text-right px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-right px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Actions
                 </th>
               </tr>
@@ -164,15 +167,15 @@ export function FederationAccountsList() {
                 return (
                   <tr
                     key={account.id}
-                    className="hover:bg-gray-50 dark:hover:bg-neutral-750 cursor-pointer"
+                    className="hover:bg-neutral-50 dark:hover:bg-neutral-750 cursor-pointer"
                     onClick={() => navigate(`/federation/accounts/${account.id}`)}
                   >
                     <td className="px-4 py-3">
-                      <div className="font-medium text-gray-900 dark:text-white text-sm">
+                      <div className="font-medium text-neutral-900 dark:text-white text-sm">
                         {account.name}
                       </div>
                       {account.description && (
-                        <div className="text-xs text-gray-500 dark:text-neutral-400 truncate max-w-xs">
+                        <div className="text-xs text-neutral-500 dark:text-neutral-400 truncate max-w-xs">
                           {account.description}
                         </div>
                       )}
@@ -184,13 +187,13 @@ export function FederationAccountsList() {
                         {status.label}
                       </span>
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-neutral-300">
+                    <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                       <span className="inline-flex items-center gap-1">
                         <Users className="h-3.5 w-3.5" />
                         {account.sub_account_count} / {account.max_sub_accounts}
                       </span>
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-neutral-300">
+                    <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                       {formatDate(account.created_at)}
                     </td>
                     <td className="px-4 py-3 text-right">

--- a/control-plane-ui/src/pages/FederationAccounts/MasterAccountModal.tsx
+++ b/control-plane-ui/src/pages/FederationAccounts/MasterAccountModal.tsx
@@ -41,12 +41,12 @@ export function MasterAccountModal({ tenantId, onClose, onCreated }: MasterAccou
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-md">
         <div className="flex items-center justify-between px-6 py-4 border-b dark:border-neutral-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
             Create Master Account
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-neutral-300"
+            className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
           >
             <X className="h-5 w-5" />
           </button>
@@ -54,34 +54,34 @@ export function MasterAccountModal({ tenantId, onClose, onCreated }: MasterAccou
 
         <form onSubmit={handleSubmit} className="p-6 space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Name <span className="text-red-500">*</span>
             </label>
             <input
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               placeholder="e.g., Partner Federation"
               required
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Description
             </label>
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               rows={3}
               placeholder="Optional description"
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Max Sub-Accounts
             </label>
             <input
@@ -90,7 +90,7 @@ export function MasterAccountModal({ tenantId, onClose, onCreated }: MasterAccou
               onChange={(e) => setMaxSubAccounts(parseInt(e.target.value) || 1)}
               min={1}
               max={100}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
           </div>
 
@@ -98,7 +98,7 @@ export function MasterAccountModal({ tenantId, onClose, onCreated }: MasterAccou
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 text-gray-700 dark:text-neutral-300 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700"
+              className="px-4 py-2 text-neutral-700 dark:text-neutral-300 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700"
             >
               Cancel
             </button>

--- a/control-plane-ui/src/pages/FederationAccounts/SubAccountModal.tsx
+++ b/control-plane-ui/src/pages/FederationAccounts/SubAccountModal.tsx
@@ -44,12 +44,12 @@ export function SubAccountModal({ tenantId, masterId, onClose, onCreated }: SubA
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-md p-6">
         <div className="flex justify-between items-center mb-4">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+          <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">
             Create Sub-Account
           </h3>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-neutral-300"
+            className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
           >
             <X className="h-5 w-5" />
           </button>
@@ -57,7 +57,7 @@ export function SubAccountModal({ tenantId, masterId, onClose, onCreated }: SubA
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Name <span className="text-red-500">*</span>
             </label>
             <input
@@ -66,12 +66,12 @@ export function SubAccountModal({ tenantId, masterId, onClose, onCreated }: SubA
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g. Partner Agent"
               required
-              className="w-full px-3 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Description
             </label>
             <textarea
@@ -79,7 +79,7 @@ export function SubAccountModal({ tenantId, masterId, onClose, onCreated }: SubA
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Optional description"
               rows={2}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
           </div>
 
@@ -87,7 +87,7 @@ export function SubAccountModal({ tenantId, masterId, onClose, onCreated }: SubA
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 text-sm text-gray-700 dark:text-neutral-300 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700"
+              className="px-4 py-2 text-sm text-neutral-700 dark:text-neutral-300 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700"
             >
               Cancel
             </button>

--- a/control-plane-ui/src/pages/FederationAccounts/ToolAllowListModal.tsx
+++ b/control-plane-ui/src/pages/FederationAccounts/ToolAllowListModal.tsx
@@ -98,15 +98,17 @@ export function ToolAllowListModal({
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-lg p-6 max-h-[80vh] flex flex-col">
         <div className="flex justify-between items-center mb-4">
           <div>
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+            <h3 className="text-lg font-semibold text-neutral-900 dark:text-white flex items-center gap-2">
               <Wrench className="h-5 w-5" />
               Tool Allow-List
             </h3>
-            <p className="text-sm text-gray-500 dark:text-neutral-400 mt-0.5">{subAccountName}</p>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-0.5">
+              {subAccountName}
+            </p>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-neutral-300"
+            className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
           >
             <X className="h-5 w-5" />
           </button>
@@ -118,7 +120,7 @@ export function ToolAllowListModal({
           </div>
         ) : catalogError || !catalog ? (
           <div className="flex-1 overflow-y-auto">
-            <p className="text-sm text-gray-500 dark:text-neutral-400 mb-3">
+            <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-3">
               Tool catalog unavailable. Showing current allow-list as read-only.
             </p>
             <div className="flex flex-wrap gap-2">
@@ -132,20 +134,20 @@ export function ToolAllowListModal({
                 </span>
               ))}
               {selectedTools.size === 0 && (
-                <p className="text-sm text-gray-400 dark:text-neutral-500">No tools allowed</p>
+                <p className="text-sm text-neutral-400 dark:text-neutral-500">No tools allowed</p>
               )}
             </div>
           </div>
         ) : (
           <>
             <div className="relative mb-3">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400" />
               <input
                 type="text"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search tools..."
-                className="w-full pl-9 pr-3 py-2 text-sm border border-gray-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full pl-9 pr-3 py-2 text-sm border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               />
             </div>
 
@@ -156,7 +158,7 @@ export function ToolAllowListModal({
                     key={tool.name}
                     className={`flex items-start gap-3 p-2 rounded-lg ${
                       isAdmin
-                        ? 'hover:bg-gray-50 dark:hover:bg-neutral-750 cursor-pointer'
+                        ? 'hover:bg-neutral-50 dark:hover:bg-neutral-750 cursor-pointer'
                         : 'opacity-75 cursor-default'
                     }`}
                   >
@@ -165,20 +167,20 @@ export function ToolAllowListModal({
                       checked={selectedTools.has(tool.name)}
                       onChange={() => handleToggle(tool.name)}
                       disabled={!isAdmin}
-                      className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 disabled:opacity-50"
+                      className="mt-0.5 h-4 w-4 rounded border-neutral-300 text-blue-600 focus:ring-blue-500 disabled:opacity-50"
                     />
                     <div className="min-w-0">
-                      <div className="text-sm font-medium text-gray-900 dark:text-white">
+                      <div className="text-sm font-medium text-neutral-900 dark:text-white">
                         {tool.name}
                       </div>
-                      <div className="text-xs text-gray-500 dark:text-neutral-400 truncate">
+                      <div className="text-xs text-neutral-500 dark:text-neutral-400 truncate">
                         {tool.description}
                       </div>
                     </div>
                   </label>
                 ))
               ) : (
-                <p className="text-sm text-gray-400 dark:text-neutral-500 text-center py-4">
+                <p className="text-sm text-neutral-400 dark:text-neutral-500 text-center py-4">
                   {search ? 'No tools match your search' : 'No tools available'}
                 </p>
               )}
@@ -187,14 +189,14 @@ export function ToolAllowListModal({
         )}
 
         <div className="flex justify-between items-center pt-4 mt-4 border-t dark:border-neutral-700">
-          <span className="text-xs text-gray-500 dark:text-neutral-400">
+          <span className="text-xs text-neutral-500 dark:text-neutral-400">
             {selectedTools.size} tool{selectedTools.size !== 1 ? 's' : ''} selected
           </span>
           <div className="flex gap-2">
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 text-sm text-gray-700 dark:text-neutral-300 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700"
+              className="px-4 py-2 text-sm text-neutral-700 dark:text-neutral-300 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700"
             >
               Cancel
             </button>

--- a/control-plane-ui/src/pages/GatewayDeployments/DeployAPIDialog.tsx
+++ b/control-plane-ui/src/pages/GatewayDeployments/DeployAPIDialog.tsx
@@ -80,12 +80,12 @@ export function DeployAPIDialog({ onClose, onDeployed }: DeployAPIDialogProps) {
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-2xl mx-4">
         {/* Header */}
         <div className="flex items-center justify-between border-b dark:border-neutral-700 px-6 py-4">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
             Deploy API to Gateways
           </h2>
           <button
             onClick={onClose}
-            className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 dark:hover:bg-neutral-700 hover:text-gray-600 dark:hover:text-neutral-300"
+            className="rounded-lg p-1 text-neutral-400 hover:bg-neutral-100 dark:hover:bg-neutral-700 hover:text-neutral-600 dark:hover:text-neutral-300"
           >
             <X className="h-5 w-5" />
           </button>
@@ -102,26 +102,26 @@ export function DeployAPIDialog({ onClose, onDeployed }: DeployAPIDialogProps) {
           {loading ? (
             <div className="space-y-4 py-4">
               <div className="space-y-2">
-                <div className="h-4 w-32 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
-                <div className="h-10 w-full bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+                <div className="h-4 w-32 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
+                <div className="h-10 w-full bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
               </div>
               <div className="space-y-2">
-                <div className="h-4 w-28 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
-                <div className="h-32 w-full bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+                <div className="h-4 w-28 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
+                <div className="h-32 w-full bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
               </div>
             </div>
           ) : (
             <>
               {/* API Selection */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+                <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                   API Catalog Entry
                 </label>
                 <select
                   value={selectedApi}
                   onChange={(e) => setSelectedApi(e.target.value)}
                   required
-                  className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 >
                   <option value="">Select an API...</option>
                   {catalogEntries.map((entry) => (
@@ -134,31 +134,31 @@ export function DeployAPIDialog({ onClose, onDeployed }: DeployAPIDialogProps) {
 
               {/* Gateway Multi-Select */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+                <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
                   Target Gateways
                 </label>
                 {gateways.length === 0 ? (
-                  <p className="text-sm text-gray-500 dark:text-neutral-400">
+                  <p className="text-sm text-neutral-500 dark:text-neutral-400">
                     No gateways registered. Register a gateway first.
                   </p>
                 ) : (
-                  <div className="space-y-2 max-h-48 overflow-y-auto border border-gray-200 dark:border-neutral-600 rounded-lg p-3">
+                  <div className="space-y-2 max-h-48 overflow-y-auto border border-neutral-200 dark:border-neutral-600 rounded-lg p-3">
                     {gateways.map((gw) => (
                       <label
                         key={gw.id}
-                        className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 cursor-pointer"
+                        className="flex items-center gap-3 p-2 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 cursor-pointer"
                       >
                         <input
                           type="checkbox"
                           checked={selectedGateways.includes(gw.id)}
                           onChange={() => toggleGateway(gw.id)}
-                          className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                          className="h-4 w-4 rounded border-neutral-300 text-blue-600 focus:ring-blue-500"
                         />
                         <div className="flex-1 min-w-0">
-                          <p className="text-sm font-medium text-gray-900 dark:text-white">
+                          <p className="text-sm font-medium text-neutral-900 dark:text-white">
                             {gw.display_name}
                           </p>
-                          <p className="text-xs text-gray-500 dark:text-neutral-400">
+                          <p className="text-xs text-neutral-500 dark:text-neutral-400">
                             {gw.gateway_type} &middot; {gw.environment}
                           </p>
                         </div>
@@ -175,7 +175,7 @@ export function DeployAPIDialog({ onClose, onDeployed }: DeployAPIDialogProps) {
             <button
               type="button"
               onClick={onClose}
-              className="border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-neutral-300 px-4 py-2 rounded-lg text-sm hover:bg-gray-50 dark:hover:bg-neutral-700"
+              className="border border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-4 py-2 rounded-lg text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700"
             >
               Cancel
             </button>

--- a/control-plane-ui/src/pages/GatewayDeployments/GatewayDeploymentsDashboard.tsx
+++ b/control-plane-ui/src/pages/GatewayDeployments/GatewayDeploymentsDashboard.tsx
@@ -26,7 +26,9 @@ const statusFilterOptions: { value: string; label: string }[] = [
 function StatCard({ label, count, color }: { label: string; count: number; color: string }) {
   return (
     <div className="bg-white dark:bg-neutral-800 rounded-lg shadow px-4 py-3">
-      <p className="text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">{label}</p>
+      <p className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
+        {label}
+      </p>
       <p className={`text-2xl font-bold ${color}`}>{count}</p>
     </div>
   );
@@ -144,15 +146,17 @@ export function GatewayDeploymentsDashboard() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Gateway Deployments</h1>
-          <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
+            Gateway Deployments
+          </h1>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
             Manage API deployments across gateway instances
           </p>
         </div>
         <div className="flex items-center gap-3">
           <button
             onClick={loadData}
-            className="flex items-center gap-2 border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-neutral-300 px-3 py-2 rounded-lg text-sm hover:bg-gray-50 dark:hover:bg-neutral-700"
+            className="flex items-center gap-2 border border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-3 py-2 rounded-lg text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700"
           >
             <RefreshCw className="h-4 w-4" />
             Refresh
@@ -175,7 +179,7 @@ export function GatewayDeploymentsDashboard() {
           <StatCard label="Drifted" count={summary.drifted} color="text-orange-600" />
           <StatCard label="Error" count={summary.error} color="text-red-600" />
           <StatCard label="Syncing" count={summary.syncing} color="text-blue-600" />
-          <StatCard label="Total" count={summary.total} color="text-gray-900 dark:text-white" />
+          <StatCard label="Total" count={summary.total} color="text-neutral-900 dark:text-white" />
         </div>
       )}
 
@@ -184,7 +188,7 @@ export function GatewayDeploymentsDashboard() {
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
-          className="border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+          className="border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
         >
           {statusFilterOptions.map((opt) => (
             <option key={opt.value} value={opt.value}>
@@ -192,7 +196,7 @@ export function GatewayDeploymentsDashboard() {
             </option>
           ))}
         </select>
-        <span className="text-sm text-gray-500 dark:text-neutral-400">
+        <span className="text-sm text-neutral-500 dark:text-neutral-400">
           {total} deployment{total !== 1 ? 's' : ''}
         </span>
       </div>
@@ -219,38 +223,38 @@ export function GatewayDeploymentsDashboard() {
             action={{ label: 'Deploy API', onClick: () => setShowDeployDialog(true) }}
           />
         ) : (
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
-            <thead className="bg-gray-50 dark:bg-neutral-700">
+          <table className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700">
+            <thead className="bg-neutral-50 dark:bg-neutral-700">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   API
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Status
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Gateway Resource
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Last Sync
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Attempts
                 </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Actions
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 dark:divide-neutral-700">
+            <tbody className="divide-y divide-neutral-200 dark:divide-neutral-700">
               {deployments.map((dep) => (
-                <tr key={dep.id} className="hover:bg-gray-50 dark:hover:bg-neutral-700">
+                <tr key={dep.id} className="hover:bg-neutral-50 dark:hover:bg-neutral-700">
                   <td className="px-6 py-4">
                     <div>
-                      <p className="text-sm font-medium text-gray-900 dark:text-white">
+                      <p className="text-sm font-medium text-neutral-900 dark:text-white">
                         {(dep.desired_state as any)?.api_name || dep.api_catalog_id.slice(0, 8)}
                       </p>
-                      <p className="text-xs text-gray-500 dark:text-neutral-400">
+                      <p className="text-xs text-neutral-500 dark:text-neutral-400">
                         {(dep.desired_state as any)?.tenant_id || '-'}
                       </p>
                     </div>
@@ -266,13 +270,13 @@ export function GatewayDeploymentsDashboard() {
                       </p>
                     )}
                   </td>
-                  <td className="px-6 py-4 text-sm text-gray-500 dark:text-neutral-400 font-mono">
+                  <td className="px-6 py-4 text-sm text-neutral-500 dark:text-neutral-400 font-mono">
                     {dep.gateway_resource_id || '-'}
                   </td>
-                  <td className="px-6 py-4 text-sm text-gray-500 dark:text-neutral-400">
+                  <td className="px-6 py-4 text-sm text-neutral-500 dark:text-neutral-400">
                     {formatTime(dep.last_sync_attempt)}
                   </td>
-                  <td className="px-6 py-4 text-sm text-gray-500 dark:text-neutral-400">
+                  <td className="px-6 py-4 text-sm text-neutral-500 dark:text-neutral-400">
                     {dep.sync_attempts}
                   </td>
                   <td className="px-6 py-4 text-right">
@@ -305,21 +309,21 @@ export function GatewayDeploymentsDashboard() {
         {/* Pagination */}
         {totalPages > 1 && (
           <div className="flex items-center justify-between border-t dark:border-neutral-700 px-6 py-3">
-            <p className="text-sm text-gray-500 dark:text-neutral-400">
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
               Page {currentPage} of {totalPages}
             </p>
             <div className="flex gap-2">
               <button
                 onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
                 disabled={currentPage <= 1}
-                className="border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-neutral-300 px-3 py-1 rounded text-sm disabled:opacity-50 hover:bg-gray-50 dark:hover:bg-neutral-700"
+                className="border border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-3 py-1 rounded text-sm disabled:opacity-50 hover:bg-neutral-50 dark:hover:bg-neutral-700"
               >
                 Previous
               </button>
               <button
                 onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
                 disabled={currentPage >= totalPages}
-                className="border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-neutral-300 px-3 py-1 rounded text-sm disabled:opacity-50 hover:bg-gray-50 dark:hover:bg-neutral-700"
+                className="border border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-3 py-1 rounded text-sm disabled:opacity-50 hover:bg-neutral-50 dark:hover:bg-neutral-700"
               >
                 Next
               </button>

--- a/control-plane-ui/src/pages/GatewayObservability/GatewayObservabilityDashboard.tsx
+++ b/control-plane-ui/src/pages/GatewayObservability/GatewayObservabilityDashboard.tsx
@@ -29,15 +29,17 @@ const overallStatusConfig: Record<string, { label: string; color: string; bg: st
   },
   unknown: {
     label: 'UNKNOWN',
-    color: 'text-gray-700 dark:text-neutral-400',
-    bg: 'bg-gray-100 dark:bg-neutral-700',
+    color: 'text-neutral-700 dark:text-neutral-400',
+    bg: 'bg-neutral-100 dark:bg-neutral-700',
   },
 };
 
 function StatCard({ label, count, color }: { label: string; count: number; color: string }) {
   return (
     <div className="bg-white dark:bg-neutral-800 rounded-lg shadow px-4 py-3">
-      <p className="text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">{label}</p>
+      <p className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
+        {label}
+      </p>
       <p className={`text-2xl font-bold ${color}`}>{count}</p>
     </div>
   );
@@ -50,10 +52,10 @@ function ProgressBar({ label, percentage }: { label: string; percentage: number 
   return (
     <div className="bg-white dark:bg-neutral-800 rounded-lg shadow px-4 py-3">
       <div className="flex items-center justify-between mb-1">
-        <p className="text-sm font-medium text-gray-700 dark:text-neutral-300">{label}</p>
-        <p className="text-sm font-bold text-gray-900 dark:text-white">{percentage}%</p>
+        <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300">{label}</p>
+        <p className="text-sm font-bold text-neutral-900 dark:text-white">{percentage}%</p>
       </div>
-      <div className="w-full bg-gray-200 dark:bg-neutral-700 rounded-full h-2.5">
+      <div className="w-full bg-neutral-200 dark:bg-neutral-700 rounded-full h-2.5">
         <div
           className={`h-2.5 rounded-full ${barColor}`}
           style={{ width: `${Math.min(percentage, 100)}%` }}
@@ -81,8 +83,8 @@ function APDEXGauge({ score }: { score: number }) {
   return (
     <div className="bg-white dark:bg-neutral-800 rounded-lg shadow px-4 py-4">
       <div className="flex items-center gap-2 mb-2">
-        <Gauge className="h-4 w-4 text-gray-500 dark:text-neutral-400" />
-        <p className="text-sm font-medium text-gray-700 dark:text-neutral-300">APDEX Score</p>
+        <Gauge className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
+        <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300">APDEX Score</p>
       </div>
       <div className="flex items-end gap-3">
         <span className={`text-3xl font-bold ${colorConfig.text}`}>{score.toFixed(2)}</span>
@@ -92,13 +94,13 @@ function APDEXGauge({ score }: { score: number }) {
           {colorConfig.label}
         </span>
       </div>
-      <div className="w-full bg-gray-200 dark:bg-neutral-700 rounded-full h-2 mt-3">
+      <div className="w-full bg-neutral-200 dark:bg-neutral-700 rounded-full h-2 mt-3">
         <div
           className={`h-2 rounded-full ${colorConfig.bg} transition-all duration-500`}
           style={{ width: `${percentage}%` }}
         />
       </div>
-      <p className="text-xs text-gray-500 dark:text-neutral-400 mt-2">
+      <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-2">
         Target: 0.94 (Excellent) | T=500ms
       </p>
     </div>
@@ -154,10 +156,10 @@ export function GatewayObservabilityDashboard() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
             Gateway Observability
           </h1>
-          <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
             Health and sync metrics across all gateway instances
           </p>
         </div>
@@ -173,7 +175,7 @@ export function GatewayObservabilityDashboard() {
           </button>
           <button
             onClick={loadData}
-            className="flex items-center gap-2 border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-neutral-300 px-3 py-2 rounded-lg text-sm hover:bg-gray-50 dark:hover:bg-neutral-700"
+            className="flex items-center gap-2 border border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-3 py-2 rounded-lg text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700"
           >
             <RefreshCw className="h-4 w-4" />
             Refresh
@@ -196,9 +198,9 @@ export function GatewayObservabilityDashboard() {
 
       {loading ? (
         <div className="space-y-6">
-          <div className="h-8 w-32 bg-gray-200 dark:bg-neutral-700 rounded-full animate-pulse" />
+          <div className="h-8 w-32 bg-neutral-200 dark:bg-neutral-700 rounded-full animate-pulse" />
           <div>
-            <div className="h-4 w-32 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse mb-3" />
+            <div className="h-4 w-32 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse mb-3" />
             <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
               {[1, 2, 3, 4, 5].map((i) => (
                 <CardSkeleton key={i} className="h-20" />
@@ -206,7 +208,7 @@ export function GatewayObservabilityDashboard() {
             </div>
           </div>
           <div>
-            <div className="h-4 w-24 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse mb-3" />
+            <div className="h-4 w-24 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse mb-3" />
             <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
               {[1, 2, 3].map((i) => (
                 <CardSkeleton key={i} className="h-16" />
@@ -227,14 +229,14 @@ export function GatewayObservabilityDashboard() {
 
           {/* Gateway Health Cards */}
           <div>
-            <h2 className="text-sm font-semibold text-gray-700 dark:text-neutral-300 uppercase mb-3">
+            <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase mb-3">
               Gateway Health
             </h2>
             <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
               <StatCard
                 label="Total"
                 count={metrics.health.total_gateways}
-                color="text-gray-900 dark:text-white"
+                color="text-neutral-900 dark:text-white"
               />
               <StatCard label="Online" count={metrics.health.online} color="text-green-600" />
               <StatCard label="Degraded" count={metrics.health.degraded} color="text-yellow-600" />
@@ -242,21 +244,21 @@ export function GatewayObservabilityDashboard() {
               <StatCard
                 label="Maintenance"
                 count={metrics.health.maintenance}
-                color="text-gray-600 dark:text-neutral-400"
+                color="text-neutral-600 dark:text-neutral-400"
               />
             </div>
           </div>
 
           {/* Sync Status Cards */}
           <div>
-            <h2 className="text-sm font-semibold text-gray-700 dark:text-neutral-300 uppercase mb-3">
+            <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase mb-3">
               Deployment Sync Status
             </h2>
             <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-4">
               <StatCard
                 label="Total"
                 count={metrics.sync.total_deployments}
-                color="text-gray-900 dark:text-white"
+                color="text-neutral-900 dark:text-white"
               />
               <StatCard label="Synced" count={metrics.sync.synced} color="text-green-600" />
               <StatCard label="Pending" count={metrics.sync.pending} color="text-yellow-600" />
@@ -266,7 +268,7 @@ export function GatewayObservabilityDashboard() {
               <StatCard
                 label="Deleting"
                 count={metrics.sync.deleting ?? 0}
-                color="text-gray-600 dark:text-neutral-400"
+                color="text-neutral-600 dark:text-neutral-400"
               />
             </div>
           </div>

--- a/control-plane-ui/src/pages/GatewayStatus.tsx
+++ b/control-plane-ui/src/pages/GatewayStatus.tsx
@@ -38,8 +38,8 @@ const healthConfig = {
 } as const;
 
 const fallbackHealth = {
-  bg: 'bg-gray-100 dark:bg-neutral-700',
-  text: 'text-gray-800 dark:text-neutral-300',
+  bg: 'bg-neutral-100 dark:bg-neutral-700',
+  text: 'text-neutral-800 dark:text-neutral-300',
   icon: AlertCircle,
   label: 'Unknown',
 };
@@ -76,14 +76,14 @@ const StatsCard = memo(function StatsCard({
   color?: keyof typeof statsColorClasses;
 }) {
   return (
-    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 p-4">
+    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 p-4">
       <div className="flex items-center">
         <div className={`p-2 rounded-lg ${statsColorClasses[color]}`}>
           <Icon className="w-5 h-5" />
         </div>
         <div className="ml-3">
-          <p className="text-sm font-medium text-gray-500 dark:text-neutral-400">{title}</p>
-          <p className="text-2xl font-semibold text-gray-900 dark:text-white">{value}</p>
+          <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">{title}</p>
+          <p className="text-2xl font-semibold text-neutral-900 dark:text-white">{value}</p>
         </div>
       </div>
     </div>
@@ -104,8 +104,8 @@ function SyncBadge({ status }: { status: string }) {
       label: 'Out of Sync',
     },
     Unknown: {
-      bg: 'bg-gray-100 dark:bg-neutral-700',
-      text: 'text-gray-800 dark:text-neutral-300',
+      bg: 'bg-neutral-100 dark:bg-neutral-700',
+      text: 'text-neutral-800 dark:text-neutral-300',
       label: 'Unknown',
     },
   };
@@ -131,14 +131,14 @@ function HealthBadge({ status }: { status: string }) {
     },
     Degraded: { bg: 'bg-red-100 dark:bg-red-900/30', text: 'text-red-800 dark:text-red-400' },
     Suspended: {
-      bg: 'bg-gray-100 dark:bg-neutral-700',
-      text: 'text-gray-800 dark:text-neutral-300',
+      bg: 'bg-neutral-100 dark:bg-neutral-700',
+      text: 'text-neutral-800 dark:text-neutral-300',
     },
     Missing: { bg: 'bg-red-100 dark:bg-red-900/30', text: 'text-red-800 dark:text-red-400' },
   };
   const c = cfg[status] || {
-    bg: 'bg-gray-100 dark:bg-neutral-700',
-    text: 'text-gray-800 dark:text-neutral-300',
+    bg: 'bg-neutral-100 dark:bg-neutral-700',
+    text: 'text-neutral-800 dark:text-neutral-300',
   };
   return (
     <span
@@ -158,12 +158,12 @@ export default function GatewayStatus() {
     return (
       <div className="space-y-6">
         <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-neutral-700 rounded w-1/4"></div>
-          <div className="h-32 bg-gray-200 dark:bg-neutral-700 rounded"></div>
+          <div className="h-8 bg-neutral-200 dark:bg-neutral-700 rounded w-1/4"></div>
+          <div className="h-32 bg-neutral-200 dark:bg-neutral-700 rounded"></div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div className="h-24 bg-gray-200 dark:bg-neutral-700 rounded"></div>
-            <div className="h-24 bg-gray-200 dark:bg-neutral-700 rounded"></div>
-            <div className="h-24 bg-gray-200 dark:bg-neutral-700 rounded"></div>
+            <div className="h-24 bg-neutral-200 dark:bg-neutral-700 rounded"></div>
+            <div className="h-24 bg-neutral-200 dark:bg-neutral-700 rounded"></div>
+            <div className="h-24 bg-neutral-200 dark:bg-neutral-700 rounded"></div>
           </div>
         </div>
       </div>
@@ -198,14 +198,14 @@ export default function GatewayStatus() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Gateway Adapters</h1>
-          <p className="text-sm text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Gateway Adapters</h1>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
             Zero-Touch GitOps monitoring — configured via Git, not UI
           </p>
         </div>
         <button
           onClick={() => refetch()}
-          className="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-neutral-600 rounded-md text-sm font-medium text-gray-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 hover:bg-gray-50 dark:hover:bg-neutral-700"
+          className="inline-flex items-center px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md text-sm font-medium text-neutral-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 hover:bg-neutral-50 dark:hover:bg-neutral-700"
         >
           <RefreshCw className="w-4 h-4 mr-2" />
           Refresh
@@ -213,7 +213,7 @@ export default function GatewayStatus() {
       </div>
 
       {/* Main Status Card */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 shadow-sm">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm">
         <div className="p-6">
           <div className="flex items-center justify-between">
             <div className="flex items-center">
@@ -221,10 +221,10 @@ export default function GatewayStatus() {
                 <Server className="w-6 h-6 text-indigo-600 dark:text-indigo-400" />
               </div>
               <div className="ml-4">
-                <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
                   webMethods Gateway
                 </h2>
-                <p className="text-sm text-gray-500 dark:text-neutral-400">
+                <p className="text-sm text-neutral-500 dark:text-neutral-400">
                   {data?.health.proxy_mode ? 'OIDC Proxy' : 'Direct'} mode
                 </p>
               </div>
@@ -247,16 +247,16 @@ export default function GatewayStatus() {
           {/* Resource Details (collapsible) */}
           {data && (data.apis.length > 0 || data.applications.length > 0) && (
             <details className="mt-6">
-              <summary className="cursor-pointer text-sm font-medium text-gray-700 dark:text-neutral-300 hover:text-gray-900 dark:hover:text-white">
+              <summary className="cursor-pointer text-sm font-medium text-neutral-700 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-white">
                 View resource details
               </summary>
               <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-4">
                 {/* APIs */}
-                <div className="bg-gray-50 dark:bg-neutral-900 rounded-lg p-4">
-                  <h4 className="text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+                <div className="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-4">
+                  <h4 className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
                     APIs ({data.apis.length})
                   </h4>
-                  <ul className="space-y-1 text-sm text-gray-600 dark:text-neutral-400 max-h-40 overflow-y-auto">
+                  <ul className="space-y-1 text-sm text-neutral-600 dark:text-neutral-400 max-h-40 overflow-y-auto">
                     {data.apis.slice(0, 10).map((api) => (
                       <li key={api.id} className="flex items-center">
                         {api.isActive ? (
@@ -265,13 +265,13 @@ export default function GatewayStatus() {
                           <AlertCircle className="w-3 h-3 text-yellow-500 mr-2 flex-shrink-0" />
                         )}
                         {api.apiName}{' '}
-                        <span className="text-gray-400 dark:text-neutral-500 ml-1">
+                        <span className="text-neutral-400 dark:text-neutral-500 ml-1">
                           v{api.apiVersion}
                         </span>
                       </li>
                     ))}
                     {data.apis.length > 10 && (
-                      <li className="text-gray-400 dark:text-neutral-500">
+                      <li className="text-neutral-400 dark:text-neutral-500">
                         ... and {data.apis.length - 10} more
                       </li>
                     )}
@@ -279,11 +279,11 @@ export default function GatewayStatus() {
                 </div>
 
                 {/* Applications */}
-                <div className="bg-gray-50 dark:bg-neutral-900 rounded-lg p-4">
-                  <h4 className="text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">
+                <div className="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-4">
+                  <h4 className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
                     Applications ({data.applications.length})
                   </h4>
-                  <ul className="space-y-1 text-sm text-gray-600 dark:text-neutral-400 max-h-40 overflow-y-auto">
+                  <ul className="space-y-1 text-sm text-neutral-600 dark:text-neutral-400 max-h-40 overflow-y-auto">
                     {data.applications.slice(0, 10).map((app) => (
                       <li key={app.id} className="flex items-center">
                         <CheckCircle2 className="w-3 h-3 text-green-500 mr-2 flex-shrink-0" />
@@ -291,7 +291,7 @@ export default function GatewayStatus() {
                       </li>
                     ))}
                     {data.applications.length > 10 && (
-                      <li className="text-gray-400 dark:text-neutral-500">
+                      <li className="text-neutral-400 dark:text-neutral-500">
                         ... and {data.applications.length - 10} more
                       </li>
                     )}
@@ -303,12 +303,12 @@ export default function GatewayStatus() {
         </div>
 
         {/* Footer - GitOps */}
-        <div className="bg-gray-50 dark:bg-neutral-900 border-t border-gray-200 dark:border-neutral-700 px-6 py-4 rounded-b-lg">
+        <div className="bg-neutral-50 dark:bg-neutral-900 border-t border-neutral-200 dark:border-neutral-700 px-6 py-4 rounded-b-lg">
           <div className="flex items-center justify-between text-sm">
-            <div className="flex items-center text-gray-600 dark:text-neutral-400">
+            <div className="flex items-center text-neutral-600 dark:text-neutral-400">
               <GitBranch className="w-4 h-4 mr-2" />
               <span>Configured via GitOps: </span>
-              <code className="ml-1 px-1.5 py-0.5 bg-gray-200 dark:bg-neutral-700 rounded text-xs">
+              <code className="ml-1 px-1.5 py-0.5 bg-neutral-200 dark:bg-neutral-700 rounded text-xs">
                 webmethods/*.yaml
               </code>
             </div>
@@ -328,13 +328,13 @@ export default function GatewayStatus() {
       {/* SLO Compliance Row */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {/* SLO Compliance Card */}
-        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 shadow-sm p-5">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm p-5">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center">
               <div className="p-2 bg-green-50 dark:bg-green-900/30 rounded-lg">
                 <Target className="w-5 h-5 text-green-600" />
               </div>
-              <h3 className="ml-3 text-sm font-semibold text-gray-900 dark:text-white">
+              <h3 className="ml-3 text-sm font-semibold text-neutral-900 dark:text-white">
                 SLO Compliance
               </h3>
             </div>
@@ -345,23 +345,23 @@ export default function GatewayStatus() {
           <div className="space-y-3">
             <div>
               <div className="flex justify-between text-sm mb-1">
-                <span className="text-gray-600 dark:text-neutral-400">
+                <span className="text-neutral-600 dark:text-neutral-400">
                   Availability (99.9% target)
                 </span>
-                <span className="font-medium text-gray-900 dark:text-white">99.95%</span>
+                <span className="font-medium text-neutral-900 dark:text-white">99.95%</span>
               </div>
-              <div className="w-full bg-gray-200 dark:bg-neutral-700 rounded-full h-2">
+              <div className="w-full bg-neutral-200 dark:bg-neutral-700 rounded-full h-2">
                 <div className="h-2 rounded-full bg-green-500" style={{ width: '99.95%' }} />
               </div>
             </div>
             <div>
               <div className="flex justify-between text-sm mb-1">
-                <span className="text-gray-600 dark:text-neutral-400">
+                <span className="text-neutral-600 dark:text-neutral-400">
                   Latency P95 (&lt;500ms target)
                 </span>
-                <span className="font-medium text-gray-900 dark:text-white">342ms</span>
+                <span className="font-medium text-neutral-900 dark:text-white">342ms</span>
               </div>
-              <div className="w-full bg-gray-200 dark:bg-neutral-700 rounded-full h-2">
+              <div className="w-full bg-neutral-200 dark:bg-neutral-700 rounded-full h-2">
                 <div className="h-2 rounded-full bg-green-500" style={{ width: '68%' }} />
               </div>
             </div>
@@ -369,13 +369,13 @@ export default function GatewayStatus() {
         </div>
 
         {/* Error Budget Card */}
-        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 shadow-sm p-5">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm p-5">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center">
               <div className="p-2 bg-blue-50 dark:bg-blue-900/30 rounded-lg">
                 <Gauge className="w-5 h-5 text-blue-600 dark:text-blue-400" />
               </div>
-              <h3 className="ml-3 text-sm font-semibold text-gray-900 dark:text-white">
+              <h3 className="ml-3 text-sm font-semibold text-neutral-900 dark:text-white">
                 Error Budget
               </h3>
             </div>
@@ -386,23 +386,23 @@ export default function GatewayStatus() {
           <div className="flex items-end gap-4">
             <div>
               <p className="text-3xl font-bold text-blue-600">67.2%</p>
-              <p className="text-xs text-gray-500 dark:text-neutral-400">remaining this month</p>
+              <p className="text-xs text-neutral-500 dark:text-neutral-400">remaining this month</p>
             </div>
             <div className="flex-1">
-              <div className="w-full bg-gray-200 dark:bg-neutral-700 rounded-full h-4">
+              <div className="w-full bg-neutral-200 dark:bg-neutral-700 rounded-full h-4">
                 <div
                   className="h-4 rounded-full bg-gradient-to-r from-blue-500 to-blue-400"
                   style={{ width: '67.2%' }}
                 />
               </div>
-              <div className="flex justify-between text-xs text-gray-500 dark:text-neutral-400 mt-1">
+              <div className="flex justify-between text-xs text-neutral-500 dark:text-neutral-400 mt-1">
                 <span>0%</span>
                 <span>Consumed: 32.8%</span>
                 <span>100%</span>
               </div>
             </div>
           </div>
-          <p className="text-xs text-gray-500 dark:text-neutral-400 mt-3">
+          <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-3">
             Based on 99.9% availability SLO = 43.2 min downtime/month allowed
           </p>
         </div>
@@ -411,17 +411,17 @@ export default function GatewayStatus() {
       {/* Extension Cards (CAB-1023) */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {/* Card 1: ArgoCD Sync Status */}
-        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 shadow-sm p-5">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm p-5">
           <div className="flex items-center mb-4">
             <div className="p-2 bg-orange-50 dark:bg-orange-900/30 rounded-lg">
               <GitCommit className="w-5 h-5 text-orange-600 dark:text-orange-400" />
             </div>
-            <h3 className="ml-3 text-sm font-semibold text-gray-900 dark:text-white">
+            <h3 className="ml-3 text-sm font-semibold text-neutral-900 dark:text-white">
               ArgoCD Sync
             </h3>
           </div>
           {platform.isLoading ? (
-            <div className="flex items-center text-sm text-gray-500 dark:text-neutral-400">
+            <div className="flex items-center text-sm text-neutral-500 dark:text-neutral-400">
               <Loader2 className="w-4 h-4 mr-2 animate-spin" />
               Loading...
             </div>
@@ -434,21 +434,21 @@ export default function GatewayStatus() {
                 <HealthBadge status={platform.gatewayComponent.health_status} />
               </div>
               {platform.gatewayComponent.revision && (
-                <p className="text-xs text-gray-500 dark:text-neutral-400">
+                <p className="text-xs text-neutral-500 dark:text-neutral-400">
                   Rev:{' '}
-                  <code className="px-1 py-0.5 bg-gray-100 dark:bg-neutral-700 rounded">
+                  <code className="px-1 py-0.5 bg-neutral-100 dark:bg-neutral-700 rounded">
                     {platform.gatewayComponent.revision.slice(0, 7)}
                   </code>
                 </p>
               )}
               {platform.gatewayComponent.last_sync && (
-                <p className="text-xs text-gray-500 dark:text-neutral-400">
+                <p className="text-xs text-neutral-500 dark:text-neutral-400">
                   Last sync: {new Date(platform.gatewayComponent.last_sync).toLocaleTimeString()}
                 </p>
               )}
             </div>
           ) : (
-            <p className="text-sm text-gray-500 dark:text-neutral-400">
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
               No gateway component found in ArgoCD
             </p>
           )}
@@ -467,36 +467,36 @@ export default function GatewayStatus() {
         </div>
 
         {/* Card 2: Observability */}
-        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 shadow-sm p-5">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm p-5">
           <div className="flex items-center mb-4">
             <div className="p-2 bg-blue-50 dark:bg-blue-900/30 rounded-lg">
               <BarChart3 className="w-5 h-5 text-blue-600 dark:text-blue-400" />
             </div>
-            <h3 className="ml-3 text-sm font-semibold text-gray-900 dark:text-white">
+            <h3 className="ml-3 text-sm font-semibold text-neutral-900 dark:text-white">
               Observability
             </h3>
           </div>
-          <p className="text-xs text-gray-500 dark:text-neutral-400 mb-3">
+          <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-3">
             Metrics, dashboards &amp; logs
           </p>
           <div className="space-y-2">
             <button
               onClick={() => navigate(observabilityPath())}
-              className="flex items-center w-full p-2 rounded-md hover:bg-gray-50 dark:hover:bg-neutral-700 text-sm text-gray-700 dark:text-neutral-300 text-left"
+              className="flex items-center w-full p-2 rounded-md hover:bg-neutral-50 dark:hover:bg-neutral-700 text-sm text-neutral-700 dark:text-neutral-300 text-left"
             >
               <BarChart3 className="w-4 h-4 mr-2 text-orange-500" />
               Grafana Dashboards
             </button>
             <button
               onClick={() => navigate(observabilityPath(config.services.prometheus.url))}
-              className="flex items-center w-full p-2 rounded-md hover:bg-gray-50 dark:hover:bg-neutral-700 text-sm text-gray-700 dark:text-neutral-300 text-left"
+              className="flex items-center w-full p-2 rounded-md hover:bg-neutral-50 dark:hover:bg-neutral-700 text-sm text-neutral-700 dark:text-neutral-300 text-left"
             >
               <Search className="w-4 h-4 mr-2 text-red-500" />
               Prometheus
             </button>
             <button
               onClick={() => navigate(logsPath())}
-              className="flex items-center w-full p-2 rounded-md hover:bg-gray-50 dark:hover:bg-neutral-700 text-sm text-gray-700 dark:text-neutral-300 text-left"
+              className="flex items-center w-full p-2 rounded-md hover:bg-neutral-50 dark:hover:bg-neutral-700 text-sm text-neutral-700 dark:text-neutral-300 text-left"
             >
               <Activity className="w-4 h-4 mr-2 text-green-500" />
               Logs Explorer
@@ -505,17 +505,17 @@ export default function GatewayStatus() {
         </div>
 
         {/* Card 3: Platform Health */}
-        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 shadow-sm p-5">
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm p-5">
           <div className="flex items-center mb-4">
             <div className="p-2 bg-red-50 dark:bg-red-900/30 rounded-lg">
               <ShieldAlert className="w-5 h-5 text-red-600 dark:text-red-400" />
             </div>
-            <h3 className="ml-3 text-sm font-semibold text-gray-900 dark:text-white">
+            <h3 className="ml-3 text-sm font-semibold text-neutral-900 dark:text-white">
               Platform Health
             </h3>
           </div>
           {platform.isLoading ? (
-            <div className="flex items-center text-sm text-gray-500 dark:text-neutral-400">
+            <div className="flex items-center text-sm text-neutral-500 dark:text-neutral-400">
               <Loader2 className="w-4 h-4 mr-2 animate-spin" />
               Loading...
             </div>
@@ -528,22 +528,22 @@ export default function GatewayStatus() {
                   <p className="text-lg font-semibold text-green-600">
                     {platform.healthSummary.healthy}
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-neutral-400">Healthy</p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">Healthy</p>
                 </div>
                 <div>
                   <p className="text-lg font-semibold text-yellow-600">
                     {platform.healthSummary.progressing}
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-neutral-400">In Progress</p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">In Progress</p>
                 </div>
                 <div>
                   <p className="text-lg font-semibold text-red-600">
                     {platform.healthSummary.degraded}
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-neutral-400">Degraded</p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">Degraded</p>
                 </div>
               </div>
-              <p className="text-xs text-gray-500 dark:text-neutral-400 text-center">
+              <p className="text-xs text-neutral-500 dark:text-neutral-400 text-center">
                 {platform.healthSummary.total} components monitored
               </p>
             </div>
@@ -558,15 +558,17 @@ export default function GatewayStatus() {
       </div>
 
       {/* Gateway Arena */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 shadow-sm p-5">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm p-5">
         <div className="flex items-center justify-between">
           <div className="flex items-center">
             <div className="p-2 bg-purple-50 dark:bg-purple-900/30 rounded-lg">
               <Gauge className="w-5 h-5 text-purple-600 dark:text-purple-400" />
             </div>
             <div className="ml-3">
-              <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Gateway Arena</h3>
-              <p className="text-xs text-gray-500 dark:text-neutral-400">
+              <h3 className="text-sm font-semibold text-neutral-900 dark:text-white">
+                Gateway Arena
+              </h3>
+              <p className="text-xs text-neutral-500 dark:text-neutral-400">
                 Continuous benchmark leaderboard — STOA vs Kong vs Gravitee
               </p>
             </div>

--- a/control-plane-ui/src/pages/Gateways/GatewayList.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayList.tsx
@@ -9,11 +9,12 @@ import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
 import { EmptyState } from '@stoa/shared/components/EmptyState';
 import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 import { RefreshCw } from 'lucide-react';
+import { Button } from '@stoa/shared/components/Button';
 import type { GatewayInstance, GatewayType, GatewayInstanceStatus, GatewayMode } from '../../types';
 
 const statusColors: Record<GatewayInstanceStatus, string> = {
   online: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-  offline: 'bg-gray-100 text-gray-800 dark:bg-neutral-700 dark:text-neutral-300',
+  offline: 'bg-neutral-100 text-neutral-800 dark:bg-neutral-700 dark:text-neutral-300',
   degraded: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
   maintenance: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
 };
@@ -164,8 +165,8 @@ export function GatewayList() {
     return (
       <div className="space-y-6">
         <div className="flex items-center justify-between">
-          <div className="h-8 w-48 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
-          <div className="h-10 w-40 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+          <div className="h-8 w-48 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
+          <div className="h-10 w-40 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {[1, 2, 3].map((i) => (
@@ -181,8 +182,8 @@ export function GatewayList() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Gateway Registry</h1>
-          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Gateway Registry</h1>
+          <p className="text-neutral-500 dark:text-neutral-400 mt-1">
             Manage registered gateway instances across all environments
           </p>
         </div>
@@ -192,7 +193,7 @@ export function GatewayList() {
             <select
               value={modeFilter}
               onChange={(e) => setModeFilter(e.target.value as GatewayMode | '')}
-              className="text-sm border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-gray-900 dark:text-neutral-200 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="text-sm border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-200 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               <option value="">All Modes ({gateways.length})</option>
               {(['edge-mcp', 'sidecar', 'proxy', 'shadow'] as GatewayMode[]).map((mode) =>
@@ -204,12 +205,12 @@ export function GatewayList() {
               )}
             </select>
           )}
-          <button
+          <Button
+            variant={showForm ? 'secondary' : 'primary'}
             onClick={() => setShowForm(!showForm)}
-            className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
           >
             {showForm ? 'Cancel' : '+ Register Gateway'}
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -217,13 +218,15 @@ export function GatewayList() {
       {error && (
         <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 px-4 py-3 rounded-lg flex items-center justify-between">
           <span className="text-sm text-red-700 dark:text-red-400">{error}</span>
-          <button
+          <Button
+            variant="secondary"
+            size="sm"
             onClick={refetchGateways}
-            className="ml-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-red-700 dark:text-red-300 bg-white dark:bg-neutral-800 border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors"
+            className="ml-4"
+            icon={<RefreshCw className="w-3.5 h-3.5" />}
           >
-            <RefreshCw className="w-3.5 h-3.5" />
             Retry
-          </button>
+          </Button>
         </div>
       )}
 
@@ -265,7 +268,7 @@ export function GatewayList() {
                           ? 'bg-green-500 animate-pulse'
                           : gw.status === 'degraded'
                             ? 'bg-yellow-500'
-                            : 'bg-gray-400'
+                            : 'bg-neutral-400'
                       }`}
                       title={isLive(gw) ? 'Live (heartbeat active)' : 'No recent heartbeat'}
                     />
@@ -282,20 +285,20 @@ export function GatewayList() {
                       </span>
                     )}
                   </div>
-                  <span className="text-xs text-gray-400 dark:text-neutral-500 font-mono">
+                  <span className="text-xs text-neutral-400 dark:text-neutral-500 font-mono">
                     {typeLabels[gw.gateway_type] || gw.gateway_type}
                   </span>
                 </div>
 
                 {/* Name */}
                 <h3
-                  className="text-lg font-semibold text-gray-900 dark:text-white truncate"
+                  className="text-lg font-semibold text-neutral-900 dark:text-white truncate"
                   title={gw.name}
                 >
                   {gw.display_name}
                 </h3>
                 <p
-                  className="text-sm text-gray-500 dark:text-neutral-400 font-mono truncate"
+                  className="text-sm text-neutral-500 dark:text-neutral-400 font-mono truncate"
                   title={gw.name}
                 >
                   {gw.name}
@@ -304,15 +307,15 @@ export function GatewayList() {
                 {/* Details */}
                 <div className="mt-4 space-y-2 text-sm">
                   <div className="flex justify-between">
-                    <span className="text-gray-500 dark:text-neutral-400">Environment</span>
-                    <span className="font-medium text-gray-900 dark:text-white">
+                    <span className="text-neutral-500 dark:text-neutral-400">Environment</span>
+                    <span className="font-medium text-neutral-900 dark:text-white">
                       {gw.environment}
                     </span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-gray-500 dark:text-neutral-400">Base URL</span>
+                    <span className="text-neutral-500 dark:text-neutral-400">Base URL</span>
                     <span
-                      className="font-mono text-xs text-gray-700 dark:text-neutral-300 truncate ml-2 max-w-[180px]"
+                      className="font-mono text-xs text-neutral-700 dark:text-neutral-300 truncate ml-2 max-w-[180px]"
                       title={gw.base_url}
                     >
                       {gw.base_url}
@@ -320,8 +323,8 @@ export function GatewayList() {
                   </div>
                   {gw.tenant_id && (
                     <div className="flex justify-between">
-                      <span className="text-gray-500 dark:text-neutral-400">Tenant</span>
-                      <span className="font-medium text-gray-900 dark:text-white">
+                      <span className="text-neutral-500 dark:text-neutral-400">Tenant</span>
+                      <span className="font-medium text-neutral-900 dark:text-white">
                         {gw.tenant_id}
                       </span>
                     </div>
@@ -331,7 +334,7 @@ export function GatewayList() {
                       {gw.capabilities.map((cap) => (
                         <span
                           key={cap}
-                          className="px-1.5 py-0.5 bg-gray-100 dark:bg-neutral-700 text-gray-600 dark:text-neutral-300 text-xs rounded"
+                          className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300 text-xs rounded"
                         >
                           {cap}
                         </span>
@@ -342,7 +345,7 @@ export function GatewayList() {
 
                 {/* Last health check */}
                 {gw.last_health_check && (
-                  <p className="text-xs text-gray-400 dark:text-neutral-500 mt-3">
+                  <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-3">
                     Last check: {new Date(gw.last_health_check).toLocaleString()}
                   </p>
                 )}
@@ -360,7 +363,7 @@ export function GatewayList() {
                 >
                   {healthChecking === gw.id ? 'Checking...' : 'Health Check'}
                 </button>
-                <span className="text-gray-300 dark:text-neutral-600">|</span>
+                <span className="text-neutral-300 dark:text-neutral-600">|</span>
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
@@ -419,16 +422,16 @@ function GatewayDetailPanel({
           <div className="flex items-center gap-2">
             <span
               className={`inline-block w-3 h-3 rounded-full ${
-                isLive(gw) ? 'bg-green-500 animate-pulse' : 'bg-gray-400'
+                isLive(gw) ? 'bg-green-500 animate-pulse' : 'bg-neutral-400'
               }`}
             />
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white truncate">
+            <h2 className="text-lg font-semibold text-neutral-900 dark:text-white truncate">
               {gw.display_name}
             </h2>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-neutral-300 text-xl leading-none"
+            className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 text-xl leading-none"
             aria-label="Close detail panel"
           >
             &times;
@@ -459,7 +462,7 @@ function GatewayDetailPanel({
 
           {/* Heartbeat metrics */}
           <section>
-            <h3 className="text-sm font-semibold text-gray-700 dark:text-neutral-300 mb-3">
+            <h3 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-3">
               Heartbeat Metrics
             </h3>
             <dl className="grid grid-cols-2 gap-3 text-sm">
@@ -501,49 +504,49 @@ function GatewayDetailPanel({
 
           {/* Instance info */}
           <section>
-            <h3 className="text-sm font-semibold text-gray-700 dark:text-neutral-300 mb-3">
+            <h3 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-3">
               Instance Info
             </h3>
             <dl className="space-y-2 text-sm">
               <div className="flex justify-between">
-                <dt className="text-gray-500 dark:text-neutral-400">Name</dt>
-                <dd className="font-mono text-gray-900 dark:text-white text-xs truncate max-w-[220px]">
+                <dt className="text-neutral-500 dark:text-neutral-400">Name</dt>
+                <dd className="font-mono text-neutral-900 dark:text-white text-xs truncate max-w-[220px]">
                   {gw.name}
                 </dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-gray-500 dark:text-neutral-400">Type</dt>
-                <dd className="text-gray-900 dark:text-white">
+                <dt className="text-neutral-500 dark:text-neutral-400">Type</dt>
+                <dd className="text-neutral-900 dark:text-white">
                   {typeLabels[gw.gateway_type] || gw.gateway_type}
                 </dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-gray-500 dark:text-neutral-400">Environment</dt>
-                <dd className="text-gray-900 dark:text-white">{gw.environment}</dd>
+                <dt className="text-neutral-500 dark:text-neutral-400">Environment</dt>
+                <dd className="text-neutral-900 dark:text-white">{gw.environment}</dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-gray-500 dark:text-neutral-400">Base URL</dt>
-                <dd className="font-mono text-xs text-gray-700 dark:text-neutral-300 truncate max-w-[220px]">
+                <dt className="text-neutral-500 dark:text-neutral-400">Base URL</dt>
+                <dd className="font-mono text-xs text-neutral-700 dark:text-neutral-300 truncate max-w-[220px]">
                   {gw.base_url}
                 </dd>
               </div>
               {gw.version && (
                 <div className="flex justify-between">
-                  <dt className="text-gray-500 dark:text-neutral-400">Version</dt>
-                  <dd className="font-mono text-gray-900 dark:text-white">{gw.version}</dd>
+                  <dt className="text-neutral-500 dark:text-neutral-400">Version</dt>
+                  <dd className="font-mono text-neutral-900 dark:text-white">{gw.version}</dd>
                 </div>
               )}
               {typeof hd.registered_at === 'string' && (
                 <div className="flex justify-between">
-                  <dt className="text-gray-500 dark:text-neutral-400">Registered</dt>
-                  <dd className="text-gray-900 dark:text-white">
+                  <dt className="text-neutral-500 dark:text-neutral-400">Registered</dt>
+                  <dd className="text-neutral-900 dark:text-white">
                     {new Date(hd.registered_at).toLocaleString()}
                   </dd>
                 </div>
               )}
               <div className="flex justify-between">
-                <dt className="text-gray-500 dark:text-neutral-400">Created</dt>
-                <dd className="text-gray-900 dark:text-white">
+                <dt className="text-neutral-500 dark:text-neutral-400">Created</dt>
+                <dd className="text-neutral-900 dark:text-white">
                   {new Date(gw.created_at).toLocaleString()}
                 </dd>
               </div>
@@ -553,14 +556,14 @@ function GatewayDetailPanel({
           {/* Capabilities */}
           {gw.capabilities.length > 0 && (
             <section>
-              <h3 className="text-sm font-semibold text-gray-700 dark:text-neutral-300 mb-2">
+              <h3 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-2">
                 Capabilities
               </h3>
               <div className="flex flex-wrap gap-1">
                 {gw.capabilities.map((cap) => (
                   <span
                     key={cap}
-                    className="px-2 py-1 bg-gray-100 dark:bg-neutral-700 text-gray-600 dark:text-neutral-300 text-xs rounded"
+                    className="px-2 py-1 bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300 text-xs rounded"
                   >
                     {cap}
                   </span>
@@ -572,7 +575,7 @@ function GatewayDetailPanel({
           {/* Tags */}
           {gw.tags.length > 0 && (
             <section>
-              <h3 className="text-sm font-semibold text-gray-700 dark:text-neutral-300 mb-2">
+              <h3 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-2">
                 Tags
               </h3>
               <div className="flex flex-wrap gap-1">
@@ -595,10 +598,10 @@ function GatewayDetailPanel({
 
 function MetricItem({ label, value, warn }: { label: string; value: string; warn?: boolean }) {
   return (
-    <div className="bg-gray-50 dark:bg-neutral-700 rounded-lg p-3">
-      <dt className="text-xs text-gray-500 dark:text-neutral-400">{label}</dt>
+    <div className="bg-neutral-50 dark:bg-neutral-700 rounded-lg p-3">
+      <dt className="text-xs text-neutral-500 dark:text-neutral-400">{label}</dt>
       <dd
-        className={`text-lg font-semibold ${warn ? 'text-orange-600' : 'text-gray-900 dark:text-white'}`}
+        className={`text-lg font-semibold ${warn ? 'text-orange-600' : 'text-neutral-900 dark:text-white'}`}
       >
         {value}
       </dd>

--- a/control-plane-ui/src/pages/Gateways/GatewayModesDashboard.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayModesDashboard.tsx
@@ -94,7 +94,7 @@ export function GatewayModesDashboard() {
   if (loading) {
     return (
       <div className="space-y-6">
-        <div className="h-8 w-64 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+        <div className="h-8 w-64 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           {[1, 2, 3, 4].map((i) => (
             <CardSkeleton key={i} />
@@ -107,8 +107,8 @@ export function GatewayModesDashboard() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Gateway Modes</h1>
-        <p className="text-gray-500 dark:text-neutral-400 mt-1">
+        <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Gateway Modes</h1>
+        <p className="text-neutral-500 dark:text-neutral-400 mt-1">
           STOA Gateway deployment modes across your infrastructure (ADR-024)
         </p>
       </div>
@@ -165,34 +165,36 @@ export function GatewayModesDashboard() {
                       />
                     </svg>
                   </div>
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                  <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">
                     {mode.name}
                   </h3>
                 </div>
-                <p className="text-sm text-gray-600 dark:text-neutral-400 mb-4 min-h-[40px]">
+                <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-4 min-h-[40px]">
                   {mode.description}
                 </p>
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <span className="text-2xl font-bold text-gray-900 dark:text-white">
+                    <span className="text-2xl font-bold text-neutral-900 dark:text-white">
                       {stat.total}
                     </span>
-                    <span className="text-sm text-gray-500 dark:text-neutral-400">instances</span>
+                    <span className="text-sm text-neutral-500 dark:text-neutral-400">
+                      instances
+                    </span>
                   </div>
                   <div className="grid grid-cols-3 gap-2 text-center">
                     <div className="bg-white dark:bg-neutral-800 rounded-lg px-2 py-1.5 shadow-sm">
                       <div className="text-green-600 font-semibold">{stat.online}</div>
-                      <div className="text-xs text-gray-500 dark:text-neutral-400">online</div>
+                      <div className="text-xs text-neutral-500 dark:text-neutral-400">online</div>
                     </div>
                     <div className="bg-white dark:bg-neutral-800 rounded-lg px-2 py-1.5 shadow-sm">
                       <div className="text-yellow-600 font-semibold">{stat.degraded}</div>
-                      <div className="text-xs text-gray-500 dark:text-neutral-400">degraded</div>
+                      <div className="text-xs text-neutral-500 dark:text-neutral-400">degraded</div>
                     </div>
                     <div className="bg-white dark:bg-neutral-800 rounded-lg px-2 py-1.5 shadow-sm">
-                      <div className="text-gray-600 dark:text-neutral-400 font-semibold">
+                      <div className="text-neutral-600 dark:text-neutral-400 font-semibold">
                         {stat.offline}
                       </div>
-                      <div className="text-xs text-gray-500 dark:text-neutral-400">offline</div>
+                      <div className="text-xs text-neutral-500 dark:text-neutral-400">offline</div>
                     </div>
                   </div>
                 </div>
@@ -209,30 +211,30 @@ export function GatewayModesDashboard() {
           );
         })}
       </div>
-      <div className="bg-white dark:bg-neutral-800 rounded-xl border border-gray-200 dark:border-neutral-700 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-xl border border-neutral-200 dark:border-neutral-700 p-6">
+        <h2 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4">
           STOA Gateway Architecture (ADR-024)
         </h2>
-        <div className="prose prose-sm text-gray-600 dark:text-neutral-400">
+        <div className="prose prose-sm text-neutral-600 dark:text-neutral-400">
           <p>
             The STOA Gateway uses a unified architecture with 4 deployment modes, all from a single
             Rust binary:
           </p>
           <ul className="mt-2 space-y-1">
             <li>
-              <strong className="text-gray-900 dark:text-white">Edge MCP:</strong> Native MCP
+              <strong className="text-neutral-900 dark:text-white">Edge MCP:</strong> Native MCP
               protocol with SSE transport for AI agents (Claude, GPT, etc.)
             </li>
             <li>
-              <strong className="text-gray-900 dark:text-white">Sidecar:</strong> Policy enforcement
-              deployed alongside existing gateways
+              <strong className="text-neutral-900 dark:text-white">Sidecar:</strong> Policy
+              enforcement deployed alongside existing gateways
             </li>
             <li>
-              <strong className="text-gray-900 dark:text-white">Proxy:</strong> Full inline proxy
+              <strong className="text-neutral-900 dark:text-white">Proxy:</strong> Full inline proxy
               with request/response transformation
             </li>
             <li>
-              <strong className="text-gray-900 dark:text-white">Shadow:</strong> Passive traffic
+              <strong className="text-neutral-900 dark:text-white">Shadow:</strong> Passive traffic
               observation for auto-generating API contracts
             </li>
           </ul>

--- a/control-plane-ui/src/pages/Gateways/GatewayRegistrationForm.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayRegistrationForm.tsx
@@ -75,7 +75,7 @@ export function GatewayRegistrationForm({ onCreated, onCancel }: GatewayRegistra
 
   return (
     <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-6">
-      <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+      <h2 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4">
         Register Gateway Instance
       </h2>
 
@@ -89,7 +89,7 @@ export function GatewayRegistrationForm({ onCreated, onCancel }: GatewayRegistra
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {/* Name */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Name <span className="text-red-500">*</span>
             </label>
             <input
@@ -99,16 +99,16 @@ export function GatewayRegistrationForm({ onCreated, onCancel }: GatewayRegistra
               onChange={handleChange}
               required
               placeholder="webmethods-prod"
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
-            <p className="text-xs text-gray-400 dark:text-neutral-500 mt-1">
+            <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1">
               Unique identifier (lowercase, hyphens)
             </p>
           </div>
 
           {/* Display Name */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Display Name <span className="text-red-500">*</span>
             </label>
             <input
@@ -118,20 +118,20 @@ export function GatewayRegistrationForm({ onCreated, onCancel }: GatewayRegistra
               onChange={handleChange}
               required
               placeholder="webMethods Production"
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
           </div>
 
           {/* Gateway Type */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Gateway Type <span className="text-red-500">*</span>
             </label>
             <select
               name="gateway_type"
               value={form.gateway_type}
               onChange={handleChange}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               {gatewayTypes.map((t) => (
                 <option key={t.value} value={t.value}>
@@ -143,14 +143,14 @@ export function GatewayRegistrationForm({ onCreated, onCancel }: GatewayRegistra
 
           {/* Environment */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Environment <span className="text-red-500">*</span>
             </label>
             <select
               name="environment"
               value={form.environment}
               onChange={handleChange}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               {environments.map((env) => (
                 <option key={env} value={env}>
@@ -162,7 +162,7 @@ export function GatewayRegistrationForm({ onCreated, onCancel }: GatewayRegistra
 
           {/* Base URL */}
           <div className="md:col-span-2">
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Admin API URL <span className="text-red-500">*</span>
             </label>
             <input
@@ -172,13 +172,13 @@ export function GatewayRegistrationForm({ onCreated, onCancel }: GatewayRegistra
               onChange={handleChange}
               required
               placeholder="https://gateway-admin.example.com"
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
           </div>
 
           {/* Tenant (optional) */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Tenant ID
             </label>
             <input
@@ -187,13 +187,13 @@ export function GatewayRegistrationForm({ onCreated, onCancel }: GatewayRegistra
               value={form.tenant_id}
               onChange={handleChange}
               placeholder="Leave empty for platform-wide"
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
           </div>
 
           {/* Capabilities */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Capabilities
             </label>
             <input
@@ -202,9 +202,11 @@ export function GatewayRegistrationForm({ onCreated, onCancel }: GatewayRegistra
               value={form.capabilities}
               onChange={handleChange}
               placeholder="rest, oidc, rate_limiting"
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
-            <p className="text-xs text-gray-400 dark:text-neutral-500 mt-1">Comma-separated list</p>
+            <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1">
+              Comma-separated list
+            </p>
           </div>
         </div>
 
@@ -220,7 +222,7 @@ export function GatewayRegistrationForm({ onCreated, onCancel }: GatewayRegistra
           <button
             type="button"
             onClick={onCancel}
-            className="border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-neutral-300 px-4 py-2 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors text-sm"
+            className="border border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-4 py-2 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors text-sm"
           >
             Cancel
           </button>

--- a/control-plane-ui/src/pages/GrafanaEmbed.tsx
+++ b/control-plane-ui/src/pages/GrafanaEmbed.tsx
@@ -60,18 +60,20 @@ export function GrafanaEmbed() {
     >
       {/* Header */}
       <div
-        className={`flex items-center justify-between ${isFullscreen ? 'p-4 border-b border-gray-200 dark:border-neutral-700' : ''}`}
+        className={`flex items-center justify-between ${isFullscreen ? 'p-4 border-b border-neutral-200 dark:border-neutral-700' : ''}`}
       >
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">STOA Observability</h1>
-          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
+            STOA Observability
+          </h1>
+          <p className="text-neutral-500 dark:text-neutral-400 mt-1">
             Platform metrics, dashboards, and monitoring
           </p>
         </div>
         <div className="flex items-center gap-2">
           <button
             onClick={handleRefresh}
-            className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
+            className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-neutral-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors"
             title="Refresh"
           >
             <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
@@ -79,7 +81,7 @@ export function GrafanaEmbed() {
           </button>
           <button
             onClick={() => setIsFullscreen(!isFullscreen)}
-            className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
+            className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-neutral-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors"
             title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
           >
             {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
@@ -98,17 +100,17 @@ export function GrafanaEmbed() {
 
       {/* Iframe Container */}
       <div
-        className={`relative bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 overflow-hidden ${
+        className={`relative bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 overflow-hidden ${
           isFullscreen ? 'flex-1 m-4 mb-4' : ''
         }`}
         style={{ height: isFullscreen ? 'calc(100vh - 120px)' : 'calc(100vh - 220px)' }}
       >
         {/* Loading State */}
         {(isLoading || serviceStatus === 'checking') && (
-          <div className="absolute inset-0 flex items-center justify-center bg-gray-50 dark:bg-neutral-900 z-10">
+          <div className="absolute inset-0 flex items-center justify-center bg-neutral-50 dark:bg-neutral-900 z-10">
             <div className="text-center">
               <div className="w-12 h-12 border-4 border-primary-600 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
-              <p className="text-gray-500 dark:text-neutral-400">Loading {serviceLabel}...</p>
+              <p className="text-neutral-500 dark:text-neutral-400">Loading {serviceLabel}...</p>
             </div>
           </div>
         )}

--- a/control-plane-ui/src/pages/IdentityEmbed.tsx
+++ b/control-plane-ui/src/pages/IdentityEmbed.tsx
@@ -31,7 +31,7 @@ export function IdentityEmbed() {
     'cpi-admin': 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
     'tenant-admin': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
     devops: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
-    viewer: 'bg-gray-100 text-gray-800 dark:bg-neutral-700 dark:text-neutral-300',
+    viewer: 'bg-neutral-100 text-neutral-800 dark:bg-neutral-700 dark:text-neutral-300',
   };
 
   return (
@@ -43,10 +43,10 @@ export function IdentityEmbed() {
             <Shield className="h-5 w-5 text-purple-600 dark:text-purple-400" />
           </div>
           <div>
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
               Identity Management
             </h1>
-            <p className="text-gray-500 dark:text-neutral-400 mt-0.5">
+            <p className="text-neutral-500 dark:text-neutral-400 mt-0.5">
               Your profile, roles, and security settings
             </p>
           </div>
@@ -61,16 +61,18 @@ export function IdentityEmbed() {
       </div>
 
       {/* Profile Card */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none border border-gray-200 dark:border-neutral-700 p-6">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none border border-neutral-200 dark:border-neutral-700 p-6">
         <div className="flex items-start gap-6">
           <div className="w-16 h-16 bg-purple-100 dark:bg-purple-900/30 rounded-full flex items-center justify-center flex-shrink-0">
             <User className="h-8 w-8 text-purple-600 dark:text-purple-400" />
           </div>
           <div className="flex-1 min-w-0">
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+            <h2 className="text-xl font-semibold text-neutral-900 dark:text-white">
               {user?.name || 'Unknown User'}
             </h2>
-            <p className="text-gray-500 dark:text-neutral-400 mt-1">{user?.email || 'No email'}</p>
+            <p className="text-neutral-500 dark:text-neutral-400 mt-1">
+              {user?.email || 'No email'}
+            </p>
             <div className="flex flex-wrap gap-2 mt-3">
               {user?.roles?.map((role) => (
                 <span
@@ -87,33 +89,39 @@ export function IdentityEmbed() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {/* Account Details */}
-        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none border border-gray-200 dark:border-neutral-700 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-            <Key className="h-5 w-5 text-gray-400" />
+        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none border border-neutral-200 dark:border-neutral-700 p-6">
+          <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4 flex items-center gap-2">
+            <Key className="h-5 w-5 text-neutral-400" />
             Account Details
           </h3>
           <dl className="space-y-4">
             <div>
-              <dt className="text-sm font-medium text-gray-500 dark:text-neutral-400">User ID</dt>
-              <dd className="mt-1 text-sm text-gray-900 dark:text-white font-mono">
+              <dt className="text-sm font-medium text-neutral-500 dark:text-neutral-400">
+                User ID
+              </dt>
+              <dd className="mt-1 text-sm text-neutral-900 dark:text-white font-mono">
                 {user?.id || '—'}
               </dd>
             </div>
             <div>
-              <dt className="text-sm font-medium text-gray-500 dark:text-neutral-400">Email</dt>
-              <dd className="mt-1 text-sm text-gray-900 dark:text-white">{user?.email || '—'}</dd>
+              <dt className="text-sm font-medium text-neutral-500 dark:text-neutral-400">Email</dt>
+              <dd className="mt-1 text-sm text-neutral-900 dark:text-white">
+                {user?.email || '—'}
+              </dd>
             </div>
             <div>
-              <dt className="text-sm font-medium text-gray-500 dark:text-neutral-400">
+              <dt className="text-sm font-medium text-neutral-500 dark:text-neutral-400">
                 Authentication Provider
               </dt>
-              <dd className="mt-1 text-sm text-gray-900 dark:text-white">
+              <dd className="mt-1 text-sm text-neutral-900 dark:text-white">
                 Keycloak OIDC ({config.keycloak.realm} realm)
               </dd>
             </div>
             <div>
-              <dt className="text-sm font-medium text-gray-500 dark:text-neutral-400">Client ID</dt>
-              <dd className="mt-1 text-sm text-gray-900 dark:text-white font-mono">
+              <dt className="text-sm font-medium text-neutral-500 dark:text-neutral-400">
+                Client ID
+              </dt>
+              <dd className="mt-1 text-sm text-neutral-900 dark:text-white font-mono">
                 {config.keycloak.clientId}
               </dd>
             </div>
@@ -121,23 +129,23 @@ export function IdentityEmbed() {
         </div>
 
         {/* Organization */}
-        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none border border-gray-200 dark:border-neutral-700 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-            <Building2 className="h-5 w-5 text-gray-400" />
+        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none border border-neutral-200 dark:border-neutral-700 p-6">
+          <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4 flex items-center gap-2">
+            <Building2 className="h-5 w-5 text-neutral-400" />
             Organization
           </h3>
           <dl className="space-y-4">
             <div>
-              <dt className="text-sm font-medium text-gray-500 dark:text-neutral-400">Tenant</dt>
-              <dd className="mt-1 text-sm text-gray-900 dark:text-white">
+              <dt className="text-sm font-medium text-neutral-500 dark:text-neutral-400">Tenant</dt>
+              <dd className="mt-1 text-sm text-neutral-900 dark:text-white">
                 {user?.tenant_id || '—'}
               </dd>
             </div>
             <div>
-              <dt className="text-sm font-medium text-gray-500 dark:text-neutral-400">
+              <dt className="text-sm font-medium text-neutral-500 dark:text-neutral-400">
                 Access Level
               </dt>
-              <dd className="mt-1 text-sm text-gray-900 dark:text-white">
+              <dd className="mt-1 text-sm text-neutral-900 dark:text-white">
                 {hasRole('cpi-admin')
                   ? 'Full Platform Access'
                   : hasRole('tenant-admin')
@@ -148,10 +156,10 @@ export function IdentityEmbed() {
               </dd>
             </div>
             <div>
-              <dt className="text-sm font-medium text-gray-500 dark:text-neutral-400">
+              <dt className="text-sm font-medium text-neutral-500 dark:text-neutral-400">
                 Permissions
               </dt>
-              <dd className="mt-1 text-sm text-gray-900 dark:text-white">
+              <dd className="mt-1 text-sm text-neutral-900 dark:text-white">
                 {user?.permissions?.length || 0} active permissions
               </dd>
             </div>
@@ -160,9 +168,9 @@ export function IdentityEmbed() {
       </div>
 
       {/* Quick Actions */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none border border-gray-200 dark:border-neutral-700 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-          <Clock className="h-5 w-5 text-gray-400" />
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow dark:shadow-none border border-neutral-200 dark:border-neutral-700 p-6">
+        <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4 flex items-center gap-2">
+          <Clock className="h-5 w-5 text-neutral-400" />
           Security Actions
         </h3>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
@@ -174,12 +182,16 @@ export function IdentityEmbed() {
                 'noopener,noreferrer'
               )
             }
-            className="flex items-center gap-3 p-4 rounded-lg border border-gray-200 dark:border-neutral-600 hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors text-left"
+            className="flex items-center gap-3 p-4 rounded-lg border border-neutral-200 dark:border-neutral-600 hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors text-left"
           >
             <Key className="h-5 w-5 text-purple-500 flex-shrink-0" />
             <div>
-              <p className="text-sm font-medium text-gray-900 dark:text-white">Change Password</p>
-              <p className="text-xs text-gray-500 dark:text-neutral-400">Update your credentials</p>
+              <p className="text-sm font-medium text-neutral-900 dark:text-white">
+                Change Password
+              </p>
+              <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                Update your credentials
+              </p>
             </div>
           </button>
           <button
@@ -190,26 +202,28 @@ export function IdentityEmbed() {
                 'noopener,noreferrer'
               )
             }
-            className="flex items-center gap-3 p-4 rounded-lg border border-gray-200 dark:border-neutral-600 hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors text-left"
+            className="flex items-center gap-3 p-4 rounded-lg border border-neutral-200 dark:border-neutral-600 hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors text-left"
           >
             <Shield className="h-5 w-5 text-blue-500 flex-shrink-0" />
             <div>
-              <p className="text-sm font-medium text-gray-900 dark:text-white">Active Sessions</p>
-              <p className="text-xs text-gray-500 dark:text-neutral-400">
+              <p className="text-sm font-medium text-neutral-900 dark:text-white">
+                Active Sessions
+              </p>
+              <p className="text-xs text-neutral-500 dark:text-neutral-400">
                 View and manage sessions
               </p>
             </div>
           </button>
           <button
             onClick={handleOpenKeycloak}
-            className="flex items-center gap-3 p-4 rounded-lg border border-gray-200 dark:border-neutral-600 hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors text-left"
+            className="flex items-center gap-3 p-4 rounded-lg border border-neutral-200 dark:border-neutral-600 hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors text-left"
           >
             <ExternalLink className="h-5 w-5 text-green-500 flex-shrink-0" />
             <div>
-              <p className="text-sm font-medium text-gray-900 dark:text-white">
+              <p className="text-sm font-medium text-neutral-900 dark:text-white">
                 Full Account Console
               </p>
-              <p className="text-xs text-gray-500 dark:text-neutral-400">
+              <p className="text-xs text-neutral-500 dark:text-neutral-400">
                 Open Keycloak management
               </p>
             </div>

--- a/control-plane-ui/src/pages/LogsEmbed.tsx
+++ b/control-plane-ui/src/pages/LogsEmbed.tsx
@@ -51,15 +51,15 @@ export function LogsEmbed() {
     >
       {/* Header */}
       <div
-        className={`flex items-center justify-between ${isFullscreen ? 'p-4 border-b border-gray-200 dark:border-neutral-700' : ''}`}
+        className={`flex items-center justify-between ${isFullscreen ? 'p-4 border-b border-neutral-200 dark:border-neutral-700' : ''}`}
       >
         <div className="flex items-center gap-3">
           <div className="w-10 h-10 bg-amber-100 dark:bg-amber-900/30 rounded-lg flex items-center justify-center">
             <ScrollText className="h-5 w-5 text-amber-600 dark:text-amber-400" />
           </div>
           <div>
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">STOA Logs</h1>
-            <p className="text-gray-500 dark:text-neutral-400 mt-0.5">
+            <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">STOA Logs</h1>
+            <p className="text-neutral-500 dark:text-neutral-400 mt-0.5">
               Search and analyze API traces across tenants
             </p>
           </div>
@@ -67,7 +67,7 @@ export function LogsEmbed() {
         <div className="flex items-center gap-2">
           <button
             onClick={handleRefresh}
-            className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
+            className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-neutral-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors"
             title="Refresh"
           >
             <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
@@ -75,7 +75,7 @@ export function LogsEmbed() {
           </button>
           <button
             onClick={() => setIsFullscreen(!isFullscreen)}
-            className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
+            className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-neutral-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors"
             title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
           >
             {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
@@ -94,17 +94,17 @@ export function LogsEmbed() {
 
       {/* Iframe Container */}
       <div
-        className={`relative bg-white dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700 overflow-hidden ${
+        className={`relative bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 overflow-hidden ${
           isFullscreen ? 'flex-1 m-4 mb-4' : ''
         }`}
         style={{ height: isFullscreen ? 'calc(100vh - 120px)' : 'calc(100vh - 220px)' }}
       >
         {/* Loading State */}
         {(isLoading || serviceStatus === 'checking') && (
-          <div className="absolute inset-0 flex items-center justify-center bg-gray-50 dark:bg-neutral-900 z-10">
+          <div className="absolute inset-0 flex items-center justify-center bg-neutral-50 dark:bg-neutral-900 z-10">
             <div className="text-center">
               <div className="w-12 h-12 border-4 border-amber-600 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
-              <p className="text-gray-500 dark:text-neutral-400">Loading STOA Logs...</p>
+              <p className="text-neutral-500 dark:text-neutral-400">Loading STOA Logs...</p>
             </div>
           </div>
         )}

--- a/control-plane-ui/src/pages/Operations/OperationsDashboard.tsx
+++ b/control-plane-ui/src/pages/Operations/OperationsDashboard.tsx
@@ -88,19 +88,23 @@ function StatCard({
         <Icon className={`h-5 w-5 ${colorClass || 'text-blue-600 dark:text-blue-400'}`} />
       </div>
       <div className="flex-1">
-        <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{label}</p>
+        <p className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
+          {label}
+        </p>
         <div className="flex items-baseline gap-1">
-          <p className={`text-2xl font-bold ${colorClass || 'text-gray-900 dark:text-white'}`}>
+          <p className={`text-2xl font-bold ${colorClass || 'text-neutral-900 dark:text-white'}`}>
             {value}
           </p>
-          {unit && <span className="text-sm text-gray-500 dark:text-gray-400">{unit}</span>}
+          {unit && <span className="text-sm text-neutral-500 dark:text-neutral-400">{unit}</span>}
           {TrendIcon && (
             <TrendIcon
               className={`h-4 w-4 ml-1 ${trend === 'up' ? 'text-red-500' : 'text-green-500'}`}
             />
           )}
         </div>
-        {subtitle && <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{subtitle}</p>}
+        {subtitle && (
+          <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-0.5">{subtitle}</p>
+        )}
       </div>
     </div>
   );
@@ -125,11 +129,11 @@ function DeploymentItem({ deployment }: { deployment: RecentDeployment }) {
         />
       </div>
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+        <p className="text-sm font-medium text-neutral-900 dark:text-white truncate">
           {deployment.name}{' '}
-          <span className="text-gray-500 dark:text-gray-400">v{deployment.version}</span>
+          <span className="text-neutral-500 dark:text-neutral-400">v{deployment.version}</span>
         </p>
-        <p className="text-xs text-gray-500 dark:text-gray-400">{deployment.timestamp}</p>
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">{deployment.timestamp}</p>
       </div>
     </div>
   );
@@ -241,19 +245,21 @@ export function OperationsDashboard() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Operations Dashboard</h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
+            Operations Dashboard
+          </h1>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
             Platform health, performance metrics, and incident overview
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <span className="text-xs text-gray-400 dark:text-gray-500">
+          <span className="text-xs text-neutral-400 dark:text-neutral-500">
             Last refresh: {lastRefresh.toLocaleTimeString('fr-FR')}
           </span>
           <button
             onClick={loadData}
             disabled={loading}
-            className="flex items-center gap-2 border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-lg text-sm hover:bg-gray-50 dark:hover:bg-neutral-700 disabled:opacity-50"
+            className="flex items-center gap-2 border border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-3 py-2 rounded-lg text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700 disabled:opacity-50"
           >
             <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
             Refresh
@@ -347,7 +353,7 @@ export function OperationsDashboard() {
           {gatewayMetrics && (
             <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
               <div className="flex items-center justify-between mb-4">
-                <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase">
+                <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase">
                   Gateway Health
                 </h2>
                 <a
@@ -360,32 +366,32 @@ export function OperationsDashboard() {
               </div>
               <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
                 <div className="text-center">
-                  <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                  <p className="text-2xl font-bold text-neutral-900 dark:text-white">
                     {gatewayMetrics.health.total_gateways}
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Total</p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">Total</p>
                 </div>
                 <div className="text-center">
                   <p className="text-2xl font-bold text-green-600">
                     {gatewayMetrics.health.online}
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Online</p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">Online</p>
                 </div>
                 <div className="text-center">
                   <p className="text-2xl font-bold text-yellow-600">
                     {gatewayMetrics.health.degraded}
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Degraded</p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">Degraded</p>
                 </div>
                 <div className="text-center">
                   <p className="text-2xl font-bold text-red-600">{gatewayMetrics.health.offline}</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Offline</p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">Offline</p>
                 </div>
                 <div className="text-center">
-                  <p className="text-2xl font-bold text-gray-600 dark:text-gray-400">
+                  <p className="text-2xl font-bold text-neutral-600 dark:text-neutral-400">
                     {gatewayMetrics.health.maintenance}
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Maintenance</p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">Maintenance</p>
                 </div>
               </div>
             </div>
@@ -396,7 +402,7 @@ export function OperationsDashboard() {
             {/* Recent Deployments */}
             <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
               <div className="flex items-center justify-between mb-4">
-                <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase">
+                <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase">
                   Recent Deployments
                 </h2>
                 <a
@@ -408,13 +414,13 @@ export function OperationsDashboard() {
                 </a>
               </div>
               {recentDeployments.length > 0 ? (
-                <div className="divide-y divide-gray-100 dark:divide-neutral-700">
+                <div className="divide-y divide-neutral-100 dark:divide-neutral-700">
                   {recentDeployments.map((deployment) => (
                     <DeploymentItem key={deployment.id} deployment={deployment} />
                   ))}
                 </div>
               ) : (
-                <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-8">
+                <p className="text-sm text-neutral-500 dark:text-neutral-400 text-center py-8">
                   No recent deployments
                 </p>
               )}
@@ -423,7 +429,7 @@ export function OperationsDashboard() {
             {/* Active Incidents / Alerts */}
             <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
               <div className="flex items-center justify-between mb-4">
-                <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase">
+                <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase">
                   Active Incidents
                 </h2>
                 <button
@@ -440,7 +446,7 @@ export function OperationsDashboard() {
                     <CheckCircle className="h-6 w-6 text-green-600" />
                   </div>
                   <p className="text-sm font-medium text-green-600">All Systems Operational</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
                     No active incidents at this time
                   </p>
                 </div>
@@ -465,62 +471,62 @@ export function OperationsDashboard() {
 
           {/* Quick Links to Observability Tools */}
           <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
-            <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase mb-4">
+            <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase mb-4">
               Observability Tools
             </h2>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
               <button
                 onClick={() => navigate(observabilityPath(grafanaUrl))}
-                className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-neutral-700 hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors text-left"
+                className="flex items-center gap-3 p-3 rounded-lg border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors text-left"
               >
                 <div className="w-10 h-10 bg-orange-100 dark:bg-orange-900/30 rounded-lg flex items-center justify-center">
                   <Activity className="h-5 w-5 text-orange-600" />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-gray-900 dark:text-white">Grafana</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Dashboards</p>
+                  <p className="text-sm font-medium text-neutral-900 dark:text-white">Grafana</p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">Dashboards</p>
                 </div>
-                <ExternalLink className="h-4 w-4 text-gray-400 ml-auto" />
+                <ExternalLink className="h-4 w-4 text-neutral-400 ml-auto" />
               </button>
               <button
                 onClick={() => navigate(observabilityPath(prometheusUrl))}
-                className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-neutral-700 hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors text-left"
+                className="flex items-center gap-3 p-3 rounded-lg border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors text-left"
               >
                 <div className="w-10 h-10 bg-red-100 dark:bg-red-900/30 rounded-lg flex items-center justify-center">
                   <TrendingUp className="h-5 w-5 text-red-600" />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-gray-900 dark:text-white">Prometheus</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Metrics</p>
+                  <p className="text-sm font-medium text-neutral-900 dark:text-white">Prometheus</p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">Metrics</p>
                 </div>
-                <ExternalLink className="h-4 w-4 text-gray-400 ml-auto" />
+                <ExternalLink className="h-4 w-4 text-neutral-400 ml-auto" />
               </button>
               <a
                 href="/monitoring"
-                className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-neutral-700 hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
+                className="flex items-center gap-3 p-3 rounded-lg border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors"
               >
                 <div className="w-10 h-10 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center">
                   <Zap className="h-5 w-5 text-blue-600" />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="text-sm font-medium text-neutral-900 dark:text-white">
                     API Monitoring
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Tracing</p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">Tracing</p>
                 </div>
               </a>
               <a
                 href="/errors"
-                className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-neutral-700 hover:bg-gray-50 dark:hover:bg-neutral-700 transition-colors"
+                className="flex items-center gap-3 p-3 rounded-lg border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors"
               >
                 <div className="w-10 h-10 bg-purple-100 dark:bg-purple-900/30 rounded-lg flex items-center justify-center">
                   <AlertTriangle className="h-5 w-5 text-purple-600" />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="text-sm font-medium text-neutral-900 dark:text-white">
                     Error Snapshots
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Debugging</p>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">Debugging</p>
                 </div>
               </a>
             </div>

--- a/control-plane-ui/src/pages/PlatformMetrics/PlatformMetricsDashboard.tsx
+++ b/control-plane-ui/src/pages/PlatformMetrics/PlatformMetricsDashboard.tsx
@@ -70,14 +70,18 @@ function StatCard({
         <Icon className={`h-5 w-5 ${colorClass || 'text-blue-600 dark:text-blue-400'}`} />
       </div>
       <div className="flex-1 min-w-0">
-        <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{label}</p>
+        <p className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
+          {label}
+        </p>
         <div className="flex items-baseline gap-1">
-          <p className={`text-2xl font-bold ${colorClass || 'text-gray-900 dark:text-white'}`}>
+          <p className={`text-2xl font-bold ${colorClass || 'text-neutral-900 dark:text-white'}`}>
             {value}
           </p>
-          {unit && <span className="text-sm text-gray-500 dark:text-gray-400">{unit}</span>}
+          {unit && <span className="text-sm text-neutral-500 dark:text-neutral-400">{unit}</span>}
         </div>
-        {subtitle && <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{subtitle}</p>}
+        {subtitle && (
+          <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-0.5">{subtitle}</p>
+        )}
         {sparkline && <div className="mt-2">{sparkline}</div>}
       </div>
     </div>
@@ -181,14 +185,14 @@ export function PlatformMetricsDashboard() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Platform Metrics</h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Platform Metrics</h1>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
             Real-time platform performance and health
           </p>
         </div>
         <div className="flex items-center gap-3">
           {/* Time range selector */}
-          <div className="flex items-center bg-white dark:bg-neutral-800 border border-gray-300 dark:border-neutral-600 rounded-lg overflow-hidden">
+          <div className="flex items-center bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 rounded-lg overflow-hidden">
             {(['1h', '6h', '24h'] as const).map((range) => (
               <button
                 key={range}
@@ -196,19 +200,19 @@ export function PlatformMetricsDashboard() {
                 className={`px-3 py-1.5 text-xs font-medium transition-colors ${
                   timeRange === range
                     ? 'bg-blue-600 text-white'
-                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-neutral-700'
+                    : 'text-neutral-600 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700'
                 }`}
               >
                 {range}
               </button>
             ))}
           </div>
-          <span className="text-xs text-gray-400 dark:text-gray-500">
+          <span className="text-xs text-neutral-400 dark:text-neutral-500">
             {lastRefresh.toLocaleTimeString('fr-FR')}
           </span>
           <button
             onClick={handleRefresh}
-            className="flex items-center gap-2 border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-lg text-sm hover:bg-gray-50 dark:hover:bg-neutral-700 disabled:opacity-50"
+            className="flex items-center gap-2 border border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-3 py-2 rounded-lg text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700 disabled:opacity-50"
           >
             <RefreshCw className={`h-4 w-4 ${totalRequests.loading ? 'animate-spin' : ''}`} />
             Refresh
@@ -284,7 +288,7 @@ export function PlatformMetricsDashboard() {
               value={servicesUpVal !== null ? Math.round(servicesUpVal).toString() : '--'}
               icon={Server}
               colorClass={
-                servicesUpVal !== null && servicesUpVal > 0 ? 'text-green-600' : 'text-gray-400'
+                servicesUpVal !== null && servicesUpVal > 0 ? 'text-green-600' : 'text-neutral-400'
               }
               subtitle="Healthy targets"
             />
@@ -296,10 +300,10 @@ export function PlatformMetricsDashboard() {
             <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
               <div className="flex items-center justify-between mb-4">
                 <div>
-                  <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase">
+                  <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase">
                     Request Rate
                   </h2>
-                  <p className="text-xs text-gray-400 dark:text-gray-500">
+                  <p className="text-xs text-neutral-400 dark:text-neutral-500">
                     req/s over {rangeCfg.label}
                   </p>
                 </div>
@@ -317,7 +321,7 @@ export function PlatformMetricsDashboard() {
                   className="w-full"
                 />
               ) : (
-                <div className="h-[120px] flex items-center justify-center text-sm text-gray-400 dark:text-gray-500">
+                <div className="h-[120px] flex items-center justify-center text-sm text-neutral-400 dark:text-neutral-500">
                   {requestRateSeries.error ? 'Metrics unavailable' : 'Loading...'}
                 </div>
               )}
@@ -327,10 +331,10 @@ export function PlatformMetricsDashboard() {
             <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
               <div className="flex items-center justify-between mb-4">
                 <div>
-                  <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase">
+                  <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase">
                     Error Rate
                   </h2>
-                  <p className="text-xs text-gray-400 dark:text-gray-500">
+                  <p className="text-xs text-neutral-400 dark:text-neutral-500">
                     5xx ratio over {rangeCfg.label}
                   </p>
                 </div>
@@ -348,7 +352,7 @@ export function PlatformMetricsDashboard() {
                   className="w-full"
                 />
               ) : (
-                <div className="h-[120px] flex items-center justify-center text-sm text-gray-400 dark:text-gray-500">
+                <div className="h-[120px] flex items-center justify-center text-sm text-neutral-400 dark:text-neutral-500">
                   {errorRateSeries.error ? 'Metrics unavailable' : 'Loading...'}
                 </div>
               )}
@@ -360,7 +364,7 @@ export function PlatformMetricsDashboard() {
             {/* Top Endpoints */}
             <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
               <div className="flex items-center justify-between mb-4">
-                <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase">
+                <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase">
                   Top Endpoints
                 </h2>
                 <a
@@ -377,19 +381,19 @@ export function PlatformMetricsDashboard() {
                     const maxCalls = topApis[0]?.calls || 1;
                     return (
                       <div key={api.tool_name} className="flex items-center gap-3">
-                        <span className="text-xs font-bold text-gray-400 dark:text-gray-500 w-5 text-right">
+                        <span className="text-xs font-bold text-neutral-400 dark:text-neutral-500 w-5 text-right">
                           {i + 1}
                         </span>
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center justify-between mb-1">
-                            <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                            <span className="text-sm font-medium text-neutral-900 dark:text-white truncate">
                               {api.display_name || api.tool_name}
                             </span>
-                            <span className="text-xs text-gray-500 dark:text-gray-400 ml-2">
+                            <span className="text-xs text-neutral-500 dark:text-neutral-400 ml-2">
                               {api.calls.toLocaleString()} calls
                             </span>
                           </div>
-                          <div className="w-full bg-gray-100 dark:bg-neutral-700 rounded-full h-1.5">
+                          <div className="w-full bg-neutral-100 dark:bg-neutral-700 rounded-full h-1.5">
                             <div
                               className="bg-blue-500 h-1.5 rounded-full transition-all"
                               style={{ width: `${(api.calls / maxCalls) * 100}%` }}
@@ -401,7 +405,7 @@ export function PlatformMetricsDashboard() {
                   })}
                 </div>
               ) : (
-                <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-8">
+                <p className="text-sm text-neutral-500 dark:text-neutral-400 text-center py-8">
                   No API data available
                 </p>
               )}
@@ -410,7 +414,7 @@ export function PlatformMetricsDashboard() {
             {/* Component Health */}
             <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
               <div className="flex items-center justify-between mb-4">
-                <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase">
+                <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase">
                   Component Health
                 </h2>
                 <a
@@ -426,12 +430,12 @@ export function PlatformMetricsDashboard() {
                   {componentHealth.map((c) => (
                     <div
                       key={c.name}
-                      className="flex items-center gap-2 p-2 rounded-lg border border-gray-100 dark:border-neutral-700"
+                      className="flex items-center gap-2 p-2 rounded-lg border border-neutral-100 dark:border-neutral-700"
                     >
                       <CheckCircle
                         className={`h-4 w-4 flex-shrink-0 ${c.healthy ? 'text-green-500' : 'text-red-500'}`}
                       />
-                      <span className="text-sm text-gray-700 dark:text-gray-300 truncate">
+                      <span className="text-sm text-neutral-700 dark:text-neutral-300 truncate">
                         {c.name}
                       </span>
                     </div>
@@ -439,8 +443,8 @@ export function PlatformMetricsDashboard() {
                 </div>
               ) : (
                 <div className="flex flex-col items-center justify-center py-8">
-                  <Server className="h-8 w-8 text-gray-300 dark:text-gray-600 mb-2" />
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                  <Server className="h-8 w-8 text-neutral-300 dark:text-neutral-600 mb-2" />
+                  <p className="text-sm text-neutral-500 dark:text-neutral-400">
                     Component status unavailable
                   </p>
                 </div>

--- a/control-plane-ui/src/pages/Policies.tsx
+++ b/control-plane-ui/src/pages/Policies.tsx
@@ -4,8 +4,8 @@ export function Policies() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Policies</h1>
-        <p className="text-gray-500 dark:text-neutral-400 mt-2">
+        <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Policies</h1>
+        <p className="text-neutral-500 dark:text-neutral-400 mt-2">
           Define and manage gateway policies for rate limiting, CORS, JWT validation, and more
         </p>
       </div>
@@ -14,8 +14,8 @@ export function Policies() {
         <div className="w-16 h-16 bg-primary-100 dark:bg-primary-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
           <FileCheck className="h-8 w-8 text-primary-600 dark:text-primary-400" />
         </div>
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Coming Soon</h2>
-        <p className="text-gray-500 dark:text-neutral-400 max-w-md mx-auto">
+        <h2 className="text-lg font-semibold text-neutral-900 dark:text-white mb-2">Coming Soon</h2>
+        <p className="text-neutral-500 dark:text-neutral-400 max-w-md mx-auto">
           The Policies engine will let you create, assign, and enforce gateway policies across your
           APIs and tenants with a visual rule builder.
         </p>

--- a/control-plane-ui/src/pages/RequestExplorer/RequestExplorerDashboard.tsx
+++ b/control-plane-ui/src/pages/RequestExplorer/RequestExplorerDashboard.tsx
@@ -68,14 +68,18 @@ function StatCard({
         <Icon className={`h-5 w-5 ${colorClass || 'text-blue-600 dark:text-blue-400'}`} />
       </div>
       <div className="flex-1 min-w-0">
-        <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{label}</p>
+        <p className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
+          {label}
+        </p>
         <div className="flex items-baseline gap-1">
-          <p className={`text-2xl font-bold ${colorClass || 'text-gray-900 dark:text-white'}`}>
+          <p className={`text-2xl font-bold ${colorClass || 'text-neutral-900 dark:text-white'}`}>
             {value}
           </p>
-          {unit && <span className="text-sm text-gray-500 dark:text-gray-400">{unit}</span>}
+          {unit && <span className="text-sm text-neutral-500 dark:text-neutral-400">{unit}</span>}
         </div>
-        {subtitle && <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{subtitle}</p>}
+        {subtitle && (
+          <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-0.5">{subtitle}</p>
+        )}
       </div>
     </div>
   );
@@ -182,13 +186,13 @@ export function RequestExplorerDashboard() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Request Explorer</h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Request Explorer</h1>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
             Analyze API traffic patterns and error distribution
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <div className="flex items-center bg-white dark:bg-neutral-800 border border-gray-300 dark:border-neutral-600 rounded-lg overflow-hidden">
+          <div className="flex items-center bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 rounded-lg overflow-hidden">
             {(['1h', '6h', '24h'] as const).map((range) => (
               <button
                 key={range}
@@ -196,19 +200,19 @@ export function RequestExplorerDashboard() {
                 className={`px-3 py-1.5 text-xs font-medium transition-colors ${
                   timeRange === range
                     ? 'bg-blue-600 text-white'
-                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-neutral-700'
+                    : 'text-neutral-600 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700'
                 }`}
               >
                 {range}
               </button>
             ))}
           </div>
-          <span className="text-xs text-gray-400 dark:text-gray-500">
+          <span className="text-xs text-neutral-400 dark:text-neutral-500">
             {lastRefresh.toLocaleTimeString('fr-FR')}
           </span>
           <button
             onClick={handleRefresh}
-            className="flex items-center gap-2 border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-lg text-sm hover:bg-gray-50 dark:hover:bg-neutral-700 disabled:opacity-50"
+            className="flex items-center gap-2 border border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-3 py-2 rounded-lg text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700 disabled:opacity-50"
           >
             <RefreshCw className={`h-4 w-4 ${totalRequests.loading ? 'animate-spin' : ''}`} />
             Refresh
@@ -305,7 +309,7 @@ export function RequestExplorerDashboard() {
           {/* Status Breakdown Bar */}
           {statusTotal > 0 && (
             <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
-              <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase mb-3">
+              <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase mb-3">
                 Status Code Distribution
               </h2>
               {/* Stacked bar */}
@@ -334,7 +338,7 @@ export function RequestExplorerDashboard() {
                   return (
                     <div key={group} className="flex items-center gap-1.5">
                       <span className={`w-2.5 h-2.5 rounded-full ${colorCfg.bg}`} />
-                      <span className="text-gray-600 dark:text-gray-400">
+                      <span className="text-neutral-600 dark:text-neutral-400">
                         {colorCfg.label}: {Math.round(count).toLocaleString()}
                       </span>
                     </div>
@@ -346,8 +350,8 @@ export function RequestExplorerDashboard() {
 
           {/* Request Table */}
           <div className="bg-white dark:bg-neutral-800 rounded-lg shadow overflow-hidden">
-            <div className="flex items-center justify-between p-4 border-b border-gray-100 dark:border-neutral-700">
-              <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase">
+            <div className="flex items-center justify-between p-4 border-b border-neutral-100 dark:border-neutral-700">
+              <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase">
                 Top Endpoints
               </h2>
               <a
@@ -362,20 +366,20 @@ export function RequestExplorerDashboard() {
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase border-b border-gray-100 dark:border-neutral-700">
+                    <tr className="text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase border-b border-neutral-100 dark:border-neutral-700">
                       <th className="px-4 py-3">Endpoint</th>
                       <th className="px-4 py-3">Method</th>
                       <th className="px-4 py-3 text-right">Requests</th>
                       <th className="px-4 py-3 text-right">Error Rate</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-50 dark:divide-neutral-700">
+                  <tbody className="divide-y divide-neutral-50 dark:divide-neutral-700">
                     {endpointRows.map((row) => (
                       <tr
                         key={`${row.method}:${row.path}`}
-                        className="hover:bg-gray-50 dark:hover:bg-neutral-750"
+                        className="hover:bg-neutral-50 dark:hover:bg-neutral-750"
                       >
-                        <td className="px-4 py-3 font-mono text-xs text-gray-900 dark:text-white">
+                        <td className="px-4 py-3 font-mono text-xs text-neutral-900 dark:text-white">
                           {row.path}
                         </td>
                         <td className="px-4 py-3">
@@ -389,13 +393,13 @@ export function RequestExplorerDashboard() {
                                     ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
                                     : row.method === 'DELETE'
                                       ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-                                      : 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400'
+                                      : 'bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-400'
                             }`}
                           >
                             {row.method}
                           </span>
                         </td>
-                        <td className="px-4 py-3 text-right text-gray-700 dark:text-gray-300">
+                        <td className="px-4 py-3 text-right text-neutral-700 dark:text-neutral-300">
                           {row.requests.toLocaleString()}
                         </td>
                         <td className="px-4 py-3 text-right">
@@ -410,8 +414,8 @@ export function RequestExplorerDashboard() {
               </div>
             ) : (
               <div className="flex flex-col items-center justify-center py-12">
-                <Activity className="h-8 w-8 text-gray-300 dark:text-gray-600 mb-2" />
-                <p className="text-sm text-gray-500 dark:text-gray-400">
+                <Activity className="h-8 w-8 text-neutral-300 dark:text-neutral-600 mb-2" />
+                <p className="text-sm text-neutral-500 dark:text-neutral-400">
                   {prometheusAvailable
                     ? 'No request data in this time range'
                     : 'Metrics unavailable'}

--- a/control-plane-ui/src/pages/SaasApiKeys/CreateKeyModal.tsx
+++ b/control-plane-ui/src/pages/SaasApiKeys/CreateKeyModal.tsx
@@ -61,10 +61,10 @@ export function CreateKeyModal({ tenantId, onClose, onCreated }: CreateKeyModalP
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-lg max-h-[90vh] overflow-hidden flex flex-col">
         {/* Header */}
         <div className="flex justify-between items-center px-6 py-4 border-b dark:border-neutral-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Create API Key</h2>
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">Create API Key</h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-neutral-300"
+            className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
           >
             <X className="h-5 w-5" />
           </button>
@@ -80,14 +80,14 @@ export function CreateKeyModal({ tenantId, onClose, onCreated }: CreateKeyModalP
 
           {/* Name */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Name <span className="text-red-500">*</span>
             </label>
             <input
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
               placeholder="my-api-key"
               required
             />
@@ -95,59 +95,59 @@ export function CreateKeyModal({ tenantId, onClose, onCreated }: CreateKeyModalP
 
           {/* Description */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Description
             </label>
             <input
               type="text"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
               placeholder="Key for production use"
             />
           </div>
 
           {/* Allowed Backend APIs */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Allowed Backend APIs
             </label>
             {activeApis.length === 0 ? (
-              <p className="text-sm text-gray-500 dark:text-neutral-400">
+              <p className="text-sm text-neutral-500 dark:text-neutral-400">
                 No active backend APIs available. Register and activate an API first.
               </p>
             ) : (
-              <div className="space-y-2 max-h-40 overflow-y-auto border border-gray-200 dark:border-neutral-600 rounded-lg p-3">
+              <div className="space-y-2 max-h-40 overflow-y-auto border border-neutral-200 dark:border-neutral-600 rounded-lg p-3">
                 {activeApis.map((api) => (
                   <label key={api.id} className="flex items-center gap-2 cursor-pointer">
                     <input
                       type="checkbox"
                       checked={selectedApiIds.includes(api.id)}
                       onChange={() => toggleApi(api.id)}
-                      className="rounded border-gray-300 dark:border-neutral-600"
+                      className="rounded border-neutral-300 dark:border-neutral-600"
                     />
-                    <span className="text-sm text-gray-700 dark:text-neutral-300">
+                    <span className="text-sm text-neutral-700 dark:text-neutral-300">
                       {api.display_name || api.name}
                     </span>
                   </label>
                 ))}
               </div>
             )}
-            <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
+            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
               Leave empty to allow access to all APIs.
             </p>
           </div>
 
           {/* Rate Limit */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Rate Limit (requests/min)
             </label>
             <input
               type="number"
               value={rateLimitRpm}
               onChange={(e) => setRateLimitRpm(e.target.value)}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
               placeholder="No limit"
               min="1"
             />
@@ -155,28 +155,28 @@ export function CreateKeyModal({ tenantId, onClose, onCreated }: CreateKeyModalP
 
           {/* Expires At */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Expiration Date
             </label>
             <input
               type="date"
               value={expiresAt}
               onChange={(e) => setExpiresAt(e.target.value)}
-              className="w-full border border-gray-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500"
               min={new Date().toISOString().split('T')[0]}
             />
-            <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
+            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
               Leave empty for no expiration.
             </p>
           </div>
         </form>
 
         {/* Footer */}
-        <div className="flex justify-end gap-3 px-6 py-4 border-t dark:border-neutral-700 bg-gray-50 dark:bg-neutral-800">
+        <div className="flex justify-end gap-3 px-6 py-4 border-t dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800">
           <button
             type="button"
             onClick={onClose}
-            className="px-4 py-2 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-white dark:hover:bg-neutral-700 dark:text-neutral-300"
+            className="px-4 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-white dark:hover:bg-neutral-700 dark:text-neutral-300"
           >
             Cancel
           </button>

--- a/control-plane-ui/src/pages/SaasApiKeys/SaasApiKeysList.tsx
+++ b/control-plane-ui/src/pages/SaasApiKeys/SaasApiKeysList.tsx
@@ -15,7 +15,7 @@ const statusConfig: Record<SaasApiKeyStatus, { color: string; label: string }> =
     label: 'Active',
   },
   revoked: {
-    color: 'bg-gray-100 text-gray-800 dark:bg-neutral-700 dark:text-neutral-300',
+    color: 'bg-neutral-100 text-neutral-800 dark:bg-neutral-700 dark:text-neutral-300',
     label: 'Revoked',
   },
   expired: {
@@ -110,13 +110,16 @@ export function SaasApiKeysList() {
     return (
       <div className="space-y-6">
         <div className="flex justify-between items-center">
-          <div className="h-8 w-48 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
-          <div className="h-10 w-32 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+          <div className="h-8 w-48 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
+          <div className="h-10 w-32 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
         </div>
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow">
           <div className="p-6 space-y-4">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="h-12 bg-gray-100 dark:bg-neutral-700 rounded animate-pulse" />
+              <div
+                key={i}
+                className="h-12 bg-neutral-100 dark:bg-neutral-700 rounded animate-pulse"
+              />
             ))}
           </div>
         </div>
@@ -129,8 +132,8 @@ export function SaasApiKeysList() {
       {/* Header */}
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">API Keys</h1>
-          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">API Keys</h1>
+          <p className="text-neutral-500 dark:text-neutral-400 mt-1">
             Create scoped API keys to access backend APIs through the gateway
           </p>
         </div>
@@ -170,29 +173,29 @@ export function SaasApiKeysList() {
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow overflow-hidden">
           <table className="w-full">
             <thead>
-              <tr className="border-b dark:border-neutral-700 bg-gray-50 dark:bg-neutral-800">
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+              <tr className="border-b dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Key
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Name
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Allowed APIs
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   RPM
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Status
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Expires
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Last Used
                 </th>
-                <th className="text-right px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-right px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Actions
                 </th>
               </tr>
@@ -201,21 +204,21 @@ export function SaasApiKeysList() {
               {keys.map((key) => {
                 const status = statusConfig[key.status];
                 return (
-                  <tr key={key.id} className="hover:bg-gray-50 dark:hover:bg-neutral-750">
-                    <td className="px-4 py-3 text-sm font-mono text-gray-600 dark:text-neutral-300">
+                  <tr key={key.id} className="hover:bg-neutral-50 dark:hover:bg-neutral-750">
+                    <td className="px-4 py-3 text-sm font-mono text-neutral-600 dark:text-neutral-300">
                       {key.key_prefix}...
                     </td>
                     <td className="px-4 py-3">
-                      <div className="font-medium text-gray-900 dark:text-white text-sm">
+                      <div className="font-medium text-neutral-900 dark:text-white text-sm">
                         {key.name}
                       </div>
                       {key.description && (
-                        <div className="text-xs text-gray-500 dark:text-neutral-400 truncate max-w-xs">
+                        <div className="text-xs text-neutral-500 dark:text-neutral-400 truncate max-w-xs">
                           {key.description}
                         </div>
                       )}
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-neutral-300">
+                    <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                       {key.allowed_backend_api_ids.length === 0 ? (
                         '-'
                       ) : (
@@ -229,7 +232,7 @@ export function SaasApiKeysList() {
                         </span>
                       )}
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-neutral-300">
+                    <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                       {key.rate_limit_rpm ?? '-'}
                     </td>
                     <td className="px-4 py-3">
@@ -239,10 +242,10 @@ export function SaasApiKeysList() {
                         {status.label}
                       </span>
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-neutral-300">
+                    <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                       {formatDate(key.expires_at)}
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-neutral-300">
+                    <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                       {formatDate(key.last_used_at)}
                     </td>
                     <td className="px-4 py-3 text-right">
@@ -267,27 +270,29 @@ export function SaasApiKeysList() {
       {revealedKey && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
           <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-lg p-6 space-y-4">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">API Key Created</h2>
+            <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
+              API Key Created
+            </h2>
             <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 text-yellow-800 dark:text-yellow-300 px-4 py-3 rounded-lg text-sm">
               Copy this key now. It will not be shown again.
             </div>
             <div className="flex items-center gap-2">
-              <code className="flex-1 bg-gray-100 dark:bg-neutral-700 px-4 py-3 rounded-lg text-sm font-mono text-gray-900 dark:text-white break-all select-all">
+              <code className="flex-1 bg-neutral-100 dark:bg-neutral-700 px-4 py-3 rounded-lg text-sm font-mono text-neutral-900 dark:text-white break-all select-all">
                 {revealedKey.key}
               </code>
               <button
                 onClick={handleCopyKey}
-                className="flex-shrink-0 p-2 border border-gray-300 dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700"
+                className="flex-shrink-0 p-2 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700"
                 title="Copy to clipboard"
               >
                 {copied ? (
                   <Check className="h-5 w-5 text-green-500" />
                 ) : (
-                  <Copy className="h-5 w-5 text-gray-500 dark:text-neutral-400" />
+                  <Copy className="h-5 w-5 text-neutral-500 dark:text-neutral-400" />
                 )}
               </button>
             </div>
-            <div className="text-sm text-gray-500 dark:text-neutral-400">
+            <div className="text-sm text-neutral-500 dark:text-neutral-400">
               <strong>Name:</strong> {revealedKey.name}
               <br />
               <strong>Prefix:</strong> {revealedKey.key_prefix}

--- a/control-plane-ui/src/pages/ShadowDiscovery.tsx
+++ b/control-plane-ui/src/pages/ShadowDiscovery.tsx
@@ -4,8 +4,10 @@ export function ShadowDiscovery() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Shadow API Discovery</h1>
-        <p className="text-gray-500 dark:text-neutral-400 mt-2">
+        <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
+          Shadow API Discovery
+        </h1>
+        <p className="text-neutral-500 dark:text-neutral-400 mt-2">
           Automatically detect undocumented APIs and shadow endpoints across your infrastructure
         </p>
       </div>
@@ -14,8 +16,8 @@ export function ShadowDiscovery() {
         <div className="w-16 h-16 bg-primary-100 dark:bg-primary-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
           <Eye className="h-8 w-8 text-primary-600 dark:text-primary-400" />
         </div>
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Coming Soon</h2>
-        <p className="text-gray-500 dark:text-neutral-400 max-w-md mx-auto">
+        <h2 className="text-lg font-semibold text-neutral-900 dark:text-white mb-2">Coming Soon</h2>
+        <p className="text-neutral-500 dark:text-neutral-400 max-w-md mx-auto">
           Shadow API Discovery will scan your network traffic to identify undocumented APIs, helping
           you maintain a complete API inventory and reduce security risks.
         </p>

--- a/control-plane-ui/src/pages/Skills/SkillFormModal.tsx
+++ b/control-plane-ui/src/pages/Skills/SkillFormModal.tsx
@@ -51,10 +51,10 @@ export function SkillFormModal({ skill, onClose, onSave }: SkillFormModalProps) 
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between px-6 py-4 border-b dark:border-neutral-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
             {isEdit ? 'Edit Skill' : 'Add Skill'}
           </h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+          <button onClick={onClose} className="text-neutral-400 hover:text-neutral-600">
             <X className="h-5 w-5" />
           </button>
         </div>
@@ -62,7 +62,7 @@ export function SkillFormModal({ skill, onClose, onSave }: SkillFormModalProps) 
         <form onSubmit={handleSubmit} className="px-6 py-4 space-y-4">
           {/* Key */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Key
             </label>
             <input
@@ -72,16 +72,16 @@ export function SkillFormModal({ skill, onClose, onSave }: SkillFormModalProps) 
               placeholder="namespace/skill-name"
               required
               disabled={isEdit}
-              className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white disabled:opacity-50"
+              className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white disabled:opacity-50"
             />
-            <p className="text-xs text-gray-500 dark:text-neutral-400 mt-1">
+            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
               Unique identifier (namespace/name format from K8s CRD)
             </p>
           </div>
 
           {/* Name */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Name
             </label>
             <input
@@ -90,13 +90,13 @@ export function SkillFormModal({ skill, onClose, onSave }: SkillFormModalProps) 
               onChange={(e) => setName(e.target.value)}
               placeholder="Human-readable name"
               required
-              className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white"
+              className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white"
             />
           </div>
 
           {/* Tenant ID */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Tenant ID
             </label>
             <input
@@ -105,20 +105,20 @@ export function SkillFormModal({ skill, onClose, onSave }: SkillFormModalProps) 
               onChange={(e) => setTenantId(e.target.value)}
               placeholder="tenant-id"
               required
-              className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white"
+              className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white"
             />
           </div>
 
           {/* Scope + Priority row */}
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                 Scope
               </label>
               <select
                 value={scope}
                 onChange={(e) => setScope(e.target.value)}
-                className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white"
+                className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white"
               >
                 {SCOPES.map((s) => (
                   <option key={s} value={s}>
@@ -128,7 +128,7 @@ export function SkillFormModal({ skill, onClose, onSave }: SkillFormModalProps) 
               </select>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                 Priority (0-100)
               </label>
               <input
@@ -137,7 +137,7 @@ export function SkillFormModal({ skill, onClose, onSave }: SkillFormModalProps) 
                 max={100}
                 value={priority}
                 onChange={(e) => setPriority(e.target.value)}
-                className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white"
+                className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white"
               />
             </div>
           </div>
@@ -145,7 +145,7 @@ export function SkillFormModal({ skill, onClose, onSave }: SkillFormModalProps) 
           {/* Conditional refs */}
           {scope === 'tool' && (
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                 Tool Reference
               </label>
               <input
@@ -153,13 +153,13 @@ export function SkillFormModal({ skill, onClose, onSave }: SkillFormModalProps) 
                 value={toolRef}
                 onChange={(e) => setToolRef(e.target.value)}
                 placeholder="code-review"
-                className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white"
+                className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white"
               />
             </div>
           )}
           {scope === 'user' && (
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                 User Reference
               </label>
               <input
@@ -167,14 +167,14 @@ export function SkillFormModal({ skill, onClose, onSave }: SkillFormModalProps) 
                 value={userRef}
                 onChange={(e) => setUserRef(e.target.value)}
                 placeholder="alice"
-                className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white"
+                className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white"
               />
             </div>
           )}
 
           {/* Description */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Description
             </label>
             <input
@@ -182,13 +182,13 @@ export function SkillFormModal({ skill, onClose, onSave }: SkillFormModalProps) 
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Optional description"
-              className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white"
+              className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white"
             />
           </div>
 
           {/* Instructions */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1">
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
               Instructions
             </label>
             <textarea
@@ -196,7 +196,7 @@ export function SkillFormModal({ skill, onClose, onSave }: SkillFormModalProps) 
               onChange={(e) => setInstructions(e.target.value)}
               placeholder="System prompt instructions injected into agent context..."
               rows={4}
-              className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white font-mono text-sm"
+              className="w-full px-3 py-2 border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white font-mono text-sm"
             />
           </div>
 
@@ -206,9 +206,9 @@ export function SkillFormModal({ skill, onClose, onSave }: SkillFormModalProps) 
               type="checkbox"
               checked={enabled}
               onChange={(e) => setEnabled(e.target.checked)}
-              className="h-4 w-4 rounded border-gray-300 text-blue-600"
+              className="h-4 w-4 rounded border-neutral-300 text-blue-600"
             />
-            <span className="text-sm text-gray-700 dark:text-neutral-300">Enabled</span>
+            <span className="text-sm text-neutral-700 dark:text-neutral-300">Enabled</span>
           </label>
 
           {/* Actions */}
@@ -216,7 +216,7 @@ export function SkillFormModal({ skill, onClose, onSave }: SkillFormModalProps) 
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 text-sm text-gray-700 dark:text-neutral-300 border dark:border-neutral-600 rounded-lg hover:bg-gray-50 dark:hover:bg-neutral-700"
+              className="px-4 py-2 text-sm text-neutral-700 dark:text-neutral-300 border dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700"
             >
               Cancel
             </button>

--- a/control-plane-ui/src/pages/Skills/SkillPreview.tsx
+++ b/control-plane-ui/src/pages/Skills/SkillPreview.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { skillsService, type ResolvedSkill } from '../../services/skillsApi';
 
 const scopeColors: Record<string, string> = {
-  global: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400',
+  global: 'bg-neutral-100 text-neutral-800 dark:bg-neutral-900/30 dark:text-neutral-400',
   tenant: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
   tool: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
   user: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400',
@@ -42,7 +42,7 @@ export function SkillPreview() {
     <div className="bg-white dark:bg-neutral-800 rounded-lg shadow">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center gap-2 px-4 py-3 text-sm font-medium text-gray-700 dark:text-neutral-300 hover:bg-gray-50 dark:hover:bg-neutral-750"
+        className="w-full flex items-center gap-2 px-4 py-3 text-sm font-medium text-neutral-700 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-750"
       >
         {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
         Resolution Preview
@@ -50,14 +50,14 @@ export function SkillPreview() {
 
       {expanded && (
         <div className="px-4 pb-4 space-y-4 border-t dark:border-neutral-700">
-          <p className="text-xs text-gray-500 dark:text-neutral-400 pt-3">
+          <p className="text-xs text-neutral-500 dark:text-neutral-400 pt-3">
             Test the CSS cascade resolution for a given context. Skills are resolved by specificity
             (global &lt; tenant &lt; tool &lt; user), then by priority within the same scope.
           </p>
 
           <div className="flex items-end gap-3">
             <div className="flex-1">
-              <label className="block text-xs font-medium text-gray-600 dark:text-neutral-400 mb-1">
+              <label className="block text-xs font-medium text-neutral-600 dark:text-neutral-400 mb-1">
                 Tool Name
               </label>
               <input
@@ -65,11 +65,11 @@ export function SkillPreview() {
                 value={toolRef}
                 onChange={(e) => setToolRef(e.target.value)}
                 placeholder="e.g. code-review"
-                className="w-full px-3 py-1.5 text-sm border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white"
+                className="w-full px-3 py-1.5 text-sm border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white"
               />
             </div>
             <div className="flex-1">
-              <label className="block text-xs font-medium text-gray-600 dark:text-neutral-400 mb-1">
+              <label className="block text-xs font-medium text-neutral-600 dark:text-neutral-400 mb-1">
                 User Ref
               </label>
               <input
@@ -77,7 +77,7 @@ export function SkillPreview() {
                 value={userRef}
                 onChange={(e) => setUserRef(e.target.value)}
                 placeholder="e.g. alice"
-                className="w-full px-3 py-1.5 text-sm border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-gray-900 dark:text-white"
+                className="w-full px-3 py-1.5 text-sm border dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white"
               />
             </div>
             <button
@@ -95,16 +95,16 @@ export function SkillPreview() {
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b dark:border-neutral-700">
-                    <th className="text-left py-2 text-xs font-medium text-gray-500 dark:text-neutral-400">
+                    <th className="text-left py-2 text-xs font-medium text-neutral-500 dark:text-neutral-400">
                       Name
                     </th>
-                    <th className="text-left py-2 text-xs font-medium text-gray-500 dark:text-neutral-400">
+                    <th className="text-left py-2 text-xs font-medium text-neutral-500 dark:text-neutral-400">
                       Scope
                     </th>
-                    <th className="text-left py-2 text-xs font-medium text-gray-500 dark:text-neutral-400">
+                    <th className="text-left py-2 text-xs font-medium text-neutral-500 dark:text-neutral-400">
                       Specificity
                     </th>
-                    <th className="text-left py-2 text-xs font-medium text-gray-500 dark:text-neutral-400">
+                    <th className="text-left py-2 text-xs font-medium text-neutral-500 dark:text-neutral-400">
                       Priority
                     </th>
                   </tr>
@@ -112,7 +112,7 @@ export function SkillPreview() {
                 <tbody className="divide-y dark:divide-neutral-700">
                   {resolved.map((skill, i) => (
                     <tr key={i}>
-                      <td className="py-2 text-gray-900 dark:text-white">{skill.name}</td>
+                      <td className="py-2 text-neutral-900 dark:text-white">{skill.name}</td>
                       <td className="py-2">
                         <span
                           className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${scopeColors[skill.scope] || scopeColors.global}`}
@@ -120,10 +120,10 @@ export function SkillPreview() {
                           {skill.scope}
                         </span>
                       </td>
-                      <td className="py-2 font-mono text-gray-600 dark:text-neutral-300">
+                      <td className="py-2 font-mono text-neutral-600 dark:text-neutral-300">
                         {skill.specificity}
                       </td>
-                      <td className="py-2 font-mono text-gray-600 dark:text-neutral-300">
+                      <td className="py-2 font-mono text-neutral-600 dark:text-neutral-300">
                         {skill.priority}
                       </td>
                     </tr>
@@ -133,10 +133,10 @@ export function SkillPreview() {
 
               {mergedInstructions && (
                 <div>
-                  <h4 className="text-xs font-medium text-gray-500 dark:text-neutral-400 mb-1">
+                  <h4 className="text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-1">
                     Merged Instructions
                   </h4>
-                  <pre className="text-xs bg-gray-50 dark:bg-neutral-900 p-3 rounded-lg overflow-x-auto whitespace-pre-wrap text-gray-800 dark:text-neutral-200 max-h-48 overflow-y-auto">
+                  <pre className="text-xs bg-neutral-50 dark:bg-neutral-900 p-3 rounded-lg overflow-x-auto whitespace-pre-wrap text-neutral-800 dark:text-neutral-200 max-h-48 overflow-y-auto">
                     {mergedInstructions}
                   </pre>
                 </div>
@@ -145,7 +145,7 @@ export function SkillPreview() {
           )}
 
           {resolved && resolved.length === 0 && (
-            <p className="text-sm text-gray-500 dark:text-neutral-400 italic">
+            <p className="text-sm text-neutral-500 dark:text-neutral-400 italic">
               No skills matched the given context.
             </p>
           )}

--- a/control-plane-ui/src/pages/Skills/SkillsList.tsx
+++ b/control-plane-ui/src/pages/Skills/SkillsList.tsx
@@ -11,7 +11,7 @@ import { SkillPreview } from './SkillPreview';
 
 const scopeConfig: Record<string, { color: string; label: string; specificity: number }> = {
   global: {
-    color: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400',
+    color: 'bg-neutral-100 text-neutral-800 dark:bg-neutral-900/30 dark:text-neutral-400',
     label: 'Global',
     specificity: 0,
   },
@@ -97,13 +97,16 @@ export function SkillsList() {
     return (
       <div className="space-y-6">
         <div className="flex justify-between items-center">
-          <div className="h-8 w-64 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
-          <div className="h-10 w-36 bg-gray-200 dark:bg-neutral-700 rounded animate-pulse" />
+          <div className="h-8 w-64 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
+          <div className="h-10 w-36 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
         </div>
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow">
           <div className="p-6 space-y-4">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="h-12 bg-gray-100 dark:bg-neutral-700 rounded animate-pulse" />
+              <div
+                key={i}
+                className="h-12 bg-neutral-100 dark:bg-neutral-700 rounded animate-pulse"
+              />
             ))}
           </div>
         </div>
@@ -116,8 +119,8 @@ export function SkillsList() {
       {/* Header */}
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Skills</h1>
-          <p className="text-gray-500 dark:text-neutral-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Skills</h1>
+          <p className="text-neutral-500 dark:text-neutral-400 mt-1">
             Manage agent skill instructions using the CSS cascade model
           </p>
         </div>
@@ -144,7 +147,7 @@ export function SkillsList() {
       )}
 
       {/* Cascade legend */}
-      <div className="flex items-center gap-3 text-xs text-gray-500 dark:text-neutral-400">
+      <div className="flex items-center gap-3 text-xs text-neutral-500 dark:text-neutral-400">
         <span className="font-medium">Cascade order:</span>
         {['global', 'tenant', 'tool', 'user'].map((scope) => {
           const cfg = scopeConfig[scope];
@@ -181,24 +184,24 @@ export function SkillsList() {
         <div className="bg-white dark:bg-neutral-800 rounded-lg shadow overflow-hidden">
           <table className="w-full">
             <thead>
-              <tr className="border-b dark:border-neutral-700 bg-gray-50 dark:bg-neutral-800">
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+              <tr className="border-b dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Name
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Scope
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Priority
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Tenant
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Status
                 </th>
                 {isAdmin && (
-                  <th className="text-right px-4 py-3 text-xs font-medium text-gray-500 dark:text-neutral-400 uppercase">
+                  <th className="text-right px-4 py-3 text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     Actions
                   </th>
                 )}
@@ -208,15 +211,15 @@ export function SkillsList() {
               {items.map((skill) => {
                 const scope = scopeConfig[skill.scope] || scopeConfig.global;
                 return (
-                  <tr key={skill.key} className="hover:bg-gray-50 dark:hover:bg-neutral-750">
+                  <tr key={skill.key} className="hover:bg-neutral-50 dark:hover:bg-neutral-750">
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-2">
                         <Sparkles className="h-4 w-4 text-amber-500 flex-shrink-0" />
                         <div>
-                          <div className="font-medium text-gray-900 dark:text-white text-sm">
+                          <div className="font-medium text-neutral-900 dark:text-white text-sm">
                             {skill.name}
                           </div>
-                          <div className="text-xs text-gray-500 dark:text-neutral-400 font-mono truncate max-w-xs">
+                          <div className="text-xs text-neutral-500 dark:text-neutral-400 font-mono truncate max-w-xs">
                             {skill.key}
                           </div>
                         </div>
@@ -229,10 +232,10 @@ export function SkillsList() {
                         {scope.label}
                       </span>
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-neutral-300 font-mono">
+                    <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300 font-mono">
                       {skill.priority}
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-neutral-300">
+                    <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                       {skill.tenant_id}
                     </td>
                     <td className="px-4 py-3">
@@ -240,7 +243,7 @@ export function SkillsList() {
                         className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${
                           skill.enabled
                             ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
-                            : 'bg-gray-100 text-gray-600 dark:bg-gray-900/30 dark:text-gray-400'
+                            : 'bg-neutral-100 text-neutral-600 dark:bg-neutral-900/30 dark:text-neutral-400'
                         }`}
                       >
                         {skill.enabled ? 'Enabled' : 'Disabled'}

--- a/control-plane-ui/src/pages/TenantDashboard/TenantDashboard.tsx
+++ b/control-plane-ui/src/pages/TenantDashboard/TenantDashboard.tsx
@@ -83,14 +83,18 @@ function StatCard({
         <Icon className={`h-5 w-5 ${colorClass || 'text-blue-600 dark:text-blue-400'}`} />
       </div>
       <div className="flex-1 min-w-0">
-        <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{label}</p>
+        <p className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
+          {label}
+        </p>
         <div className="flex items-baseline gap-1">
-          <p className={`text-2xl font-bold ${colorClass || 'text-gray-900 dark:text-white'}`}>
+          <p className={`text-2xl font-bold ${colorClass || 'text-neutral-900 dark:text-white'}`}>
             {value}
           </p>
-          {unit && <span className="text-sm text-gray-500 dark:text-gray-400">{unit}</span>}
+          {unit && <span className="text-sm text-neutral-500 dark:text-neutral-400">{unit}</span>}
         </div>
-        {subtitle && <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{subtitle}</p>}
+        {subtitle && (
+          <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-0.5">{subtitle}</p>
+        )}
         {sparkline && <div className="mt-2">{sparkline}</div>}
       </div>
     </div>
@@ -213,8 +217,8 @@ export function TenantDashboard() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">My Usage</h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">My Usage</h1>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
             Metrics for{' '}
             <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
               {tenantId}
@@ -222,7 +226,7 @@ export function TenantDashboard() {
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <div className="flex items-center bg-white dark:bg-neutral-800 border border-gray-300 dark:border-neutral-600 rounded-lg overflow-hidden">
+          <div className="flex items-center bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 rounded-lg overflow-hidden">
             {(['1h', '6h', '24h'] as const).map((range) => (
               <button
                 key={range}
@@ -230,7 +234,7 @@ export function TenantDashboard() {
                 className={`px-3 py-1.5 text-xs font-medium transition-colors ${
                   timeRange === range
                     ? 'bg-blue-600 text-white'
-                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-neutral-700'
+                    : 'text-neutral-600 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700'
                 }`}
               >
                 {range}
@@ -239,7 +243,7 @@ export function TenantDashboard() {
           </div>
           <button
             onClick={handleRefresh}
-            className="flex items-center gap-2 border border-gray-300 dark:border-neutral-600 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-lg text-sm hover:bg-gray-50 dark:hover:bg-neutral-700 disabled:opacity-50"
+            className="flex items-center gap-2 border border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-3 py-2 rounded-lg text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700 disabled:opacity-50"
           >
             <RefreshCw className={`h-4 w-4 ${toolCalls.loading ? 'animate-spin' : ''}`} />
             Refresh
@@ -323,10 +327,10 @@ export function TenantDashboard() {
             <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
               <div className="flex items-center justify-between mb-4">
                 <div>
-                  <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase">
+                  <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase">
                     Usage Trend
                   </h2>
-                  <p className="text-xs text-gray-400 dark:text-gray-500">
+                  <p className="text-xs text-neutral-400 dark:text-neutral-500">
                     req/s over {rangeCfg.label}
                   </p>
                 </div>
@@ -344,7 +348,7 @@ export function TenantDashboard() {
                   className="w-full"
                 />
               ) : (
-                <div className="h-[120px] flex items-center justify-center text-sm text-gray-400 dark:text-gray-500">
+                <div className="h-[120px] flex items-center justify-center text-sm text-neutral-400 dark:text-neutral-500">
                   {usageTrend.error ? 'Metrics unavailable' : 'Loading...'}
                 </div>
               )}
@@ -354,10 +358,10 @@ export function TenantDashboard() {
             <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
               <div className="flex items-center justify-between mb-4">
                 <div>
-                  <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase">
+                  <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase">
                     Error Trend
                   </h2>
-                  <p className="text-xs text-gray-400 dark:text-gray-500">
+                  <p className="text-xs text-neutral-400 dark:text-neutral-500">
                     errors/s over {rangeCfg.label}
                   </p>
                 </div>
@@ -375,7 +379,7 @@ export function TenantDashboard() {
                   className="w-full"
                 />
               ) : (
-                <div className="h-[120px] flex items-center justify-center text-sm text-gray-400 dark:text-gray-500">
+                <div className="h-[120px] flex items-center justify-center text-sm text-neutral-400 dark:text-neutral-500">
                   {errorTrend.error ? 'Metrics unavailable' : 'Loading...'}
                 </div>
               )}
@@ -384,32 +388,32 @@ export function TenantDashboard() {
 
           {/* Top Tools */}
           <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
-            <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase mb-4">
+            <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase mb-4">
               Top 5 Tools ({timeRange})
             </h2>
             {topToolsList.length > 0 ? (
               <div className="space-y-3">
                 {topToolsList.map((tool, i) => (
                   <div key={tool.name} className="flex items-center gap-3">
-                    <span className="text-xs font-bold text-gray-400 dark:text-gray-500 w-5 text-right">
+                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-500 w-5 text-right">
                       {i + 1}
                     </span>
-                    <Cpu className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                    <Cpu className="h-4 w-4 text-neutral-400 flex-shrink-0" />
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center justify-between mb-1">
-                        <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                        <span className="text-sm font-medium text-neutral-900 dark:text-white truncate">
                           {tool.name}
                         </span>
                         <div className="flex items-center gap-3 ml-2">
-                          <span className="text-xs text-gray-500 dark:text-gray-400">
+                          <span className="text-xs text-neutral-500 dark:text-neutral-400">
                             {formatNumber(tool.calls)} calls
                           </span>
-                          <span className="text-xs text-gray-400 dark:text-gray-500 w-16 text-right">
+                          <span className="text-xs text-neutral-400 dark:text-neutral-500 w-16 text-right">
                             {Math.round(tool.latencyMs)}ms avg
                           </span>
                         </div>
                       </div>
-                      <div className="w-full bg-gray-100 dark:bg-neutral-700 rounded-full h-1.5">
+                      <div className="w-full bg-neutral-100 dark:bg-neutral-700 rounded-full h-1.5">
                         <div
                           className="bg-blue-500 h-1.5 rounded-full transition-all"
                           style={{ width: `${(tool.calls / maxToolCalls) * 100}%` }}
@@ -420,7 +424,7 @@ export function TenantDashboard() {
                 ))}
               </div>
             ) : (
-              <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-8">
+              <p className="text-sm text-neutral-500 dark:text-neutral-400 text-center py-8">
                 No tool usage data available
               </p>
             )}

--- a/control-plane-ui/src/pages/Tenants.tsx
+++ b/control-plane-ui/src/pages/Tenants.tsx
@@ -42,10 +42,12 @@ export function Tenants() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{t('tenants.title')}</h1>
-          <p className="text-gray-500 dark:text-neutral-400 mt-1">{t('tenants.subtitle')}</p>
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
+            {t('tenants.title')}
+          </h1>
+          <p className="text-neutral-500 dark:text-neutral-400 mt-1">{t('tenants.subtitle')}</p>
         </div>
-        <div className="text-sm text-gray-500 dark:text-neutral-400 bg-gray-100 dark:bg-neutral-700 px-3 py-2 rounded-lg">
+        <div className="text-sm text-neutral-500 dark:text-neutral-400 bg-neutral-100 dark:bg-neutral-700 px-3 py-2 rounded-lg">
           {t('tenants.managedViaGitops')}
         </div>
       </div>
@@ -79,10 +81,10 @@ export function Tenants() {
             >
               <div className="flex justify-between items-start mb-4">
                 <div>
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                  <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">
                     {tenant.display_name || tenant.name}
                   </h3>
-                  <p className="text-sm text-gray-500 dark:text-neutral-400 font-mono">
+                  <p className="text-sm text-neutral-500 dark:text-neutral-400 font-mono">
                     {tenant.name}
                   </p>
                 </div>
@@ -93,21 +95,21 @@ export function Tenants() {
                 </span>
               </div>
 
-              <div className="space-y-2 text-sm text-gray-600 dark:text-neutral-300">
+              <div className="space-y-2 text-sm text-neutral-600 dark:text-neutral-300">
                 <div className="flex justify-between">
-                  <span className="text-gray-500 dark:text-neutral-400">
+                  <span className="text-neutral-500 dark:text-neutral-400">
                     {t('tenants.tenantId')}
                   </span>
                   <span className="font-mono text-xs">{tenant.id}</span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-gray-500 dark:text-neutral-400">
+                  <span className="text-neutral-500 dark:text-neutral-400">
                     {t('tenants.created')}
                   </span>
                   <span>{new Date(tenant.created_at).toLocaleDateString()}</span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-gray-500 dark:text-neutral-400">
+                  <span className="text-neutral-500 dark:text-neutral-400">
                     {t('common.lastUpdated')}
                   </span>
                   <span>{new Date(tenant.updated_at).toLocaleDateString()}</span>

--- a/control-plane-ui/src/pages/TokenOptimizer.tsx
+++ b/control-plane-ui/src/pages/TokenOptimizer.tsx
@@ -4,8 +4,8 @@ export function TokenOptimizer() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Token Optimizer</h1>
-        <p className="text-gray-500 dark:text-neutral-400 mt-2">
+        <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Token Optimizer</h1>
+        <p className="text-neutral-500 dark:text-neutral-400 mt-2">
           Analyze and optimize token usage across your MCP tool invocations
         </p>
       </div>
@@ -14,8 +14,8 @@ export function TokenOptimizer() {
         <div className="w-16 h-16 bg-primary-100 dark:bg-primary-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
           <Coins className="h-8 w-8 text-primary-600 dark:text-primary-400" />
         </div>
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Coming Soon</h2>
-        <p className="text-gray-500 dark:text-neutral-400 max-w-md mx-auto">
+        <h2 className="text-lg font-semibold text-neutral-900 dark:text-white mb-2">Coming Soon</h2>
+        <p className="text-neutral-500 dark:text-neutral-400 max-w-md mx-auto">
           Token Optimizer will provide insights into your LLM token consumption, identify wasteful
           patterns, and suggest optimizations to reduce costs.
         </p>

--- a/control-plane-ui/src/pages/Workflows.tsx
+++ b/control-plane-ui/src/pages/Workflows.tsx
@@ -66,7 +66,7 @@ function ModeBadge({ mode }: { mode: WorkflowMode }) {
     approval_chain: 'Chain',
   };
   return (
-    <span className="inline-flex items-center rounded-full bg-gray-100 dark:bg-gray-700 px-2.5 py-0.5 text-xs font-medium text-gray-700 dark:text-gray-300">
+    <span className="inline-flex items-center rounded-full bg-neutral-100 dark:bg-neutral-700 px-2.5 py-0.5 text-xs font-medium text-neutral-700 dark:text-neutral-300">
       {labels[mode]}
     </span>
   );
@@ -116,7 +116,7 @@ function TemplatesTab({ tenantId, canManage }: { tenantId: string; canManage: bo
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+        <Loader2 className="h-6 w-6 animate-spin text-neutral-400" />
       </div>
     );
   }
@@ -132,13 +132,13 @@ function TemplatesTab({ tenantId, canManage }: { tenantId: string; canManage: bo
   return (
     <div>
       <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
+        <h3 className="text-sm font-medium text-neutral-500 dark:text-neutral-400">
           {templates.length} template{templates.length !== 1 ? 's' : ''}
         </h3>
         <div className="flex gap-2">
           <button
             onClick={fetchTemplates}
-            className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-700"
+            className="inline-flex items-center gap-1.5 rounded-md border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 px-3 py-1.5 text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700"
           >
             <RefreshCw className="h-3.5 w-3.5" /> Refresh
           </button>
@@ -146,54 +146,54 @@ function TemplatesTab({ tenantId, canManage }: { tenantId: string; canManage: bo
       </div>
 
       {templates.length === 0 ? (
-        <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+        <div className="text-center py-12 text-neutral-500 dark:text-neutral-400">
           <FileText className="mx-auto h-10 w-10 mb-3 opacity-50" />
           <p>No workflow templates yet.</p>
           {canManage && <p className="text-xs mt-1">Create a template to get started.</p>}
         </div>
       ) : (
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-800/50">
+          <table className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700">
+            <thead className="bg-neutral-50 dark:bg-neutral-800/50">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Name
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Type
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Mode
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Steps
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Sector
                 </th>
                 {canManage && (
-                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                  <th className="px-4 py-3 text-right text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     Actions
                   </th>
                 )}
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            <tbody className="divide-y divide-neutral-200 dark:divide-neutral-700">
               {templates.map((t) => (
-                <tr key={t.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/30">
-                  <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">
+                <tr key={t.id} className="hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+                  <td className="px-4 py-3 text-sm font-medium text-neutral-900 dark:text-neutral-100">
                     {t.name}
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                  <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                     {TYPE_LABELS[t.workflow_type] ?? t.workflow_type}
                   </td>
                   <td className="px-4 py-3 text-sm">
                     <ModeBadge mode={t.mode} />
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                  <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                     {t.approval_steps.length}
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                  <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                     {t.sector ?? '—'}
                   </td>
                   {canManage && (
@@ -267,7 +267,7 @@ function InstancesTab({ tenantId, canManage }: { tenantId: string; canManage: bo
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+        <Loader2 className="h-6 w-6 animate-spin text-neutral-400" />
       </div>
     );
   }
@@ -296,7 +296,7 @@ function InstancesTab({ tenantId, canManage }: { tenantId: string; canManage: bo
           <select
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value)}
-            className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm"
+            className="rounded-md border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 px-3 py-1.5 text-sm"
           >
             <option value="">All statuses</option>
             {STATUSES.map((s) => (
@@ -305,71 +305,71 @@ function InstancesTab({ tenantId, canManage }: { tenantId: string; canManage: bo
               </option>
             ))}
           </select>
-          <span className="text-sm text-gray-500 dark:text-gray-400">
+          <span className="text-sm text-neutral-500 dark:text-neutral-400">
             {instances.length} instance{instances.length !== 1 ? 's' : ''}
           </span>
         </div>
         <button
           onClick={fetchInstances}
-          className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-700"
+          className="inline-flex items-center gap-1.5 rounded-md border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 px-3 py-1.5 text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700"
         >
           <RefreshCw className="h-3.5 w-3.5" /> Refresh
         </button>
       </div>
 
       {instances.length === 0 ? (
-        <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+        <div className="text-center py-12 text-neutral-500 dark:text-neutral-400">
           <PlayCircle className="mx-auto h-10 w-10 mb-3 opacity-50" />
           <p>No workflow instances found.</p>
         </div>
       ) : (
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-800/50">
+          <table className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700">
+            <thead className="bg-neutral-50 dark:bg-neutral-800/50">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Subject
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Type
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Status
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Step
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                   Created
                 </th>
                 {canManage && (
-                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                  <th className="px-4 py-3 text-right text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase">
                     Actions
                   </th>
                 )}
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            <tbody className="divide-y divide-neutral-200 dark:divide-neutral-700">
               {instances.map((inst) => (
-                <tr key={inst.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/30">
+                <tr key={inst.id} className="hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
                   <td className="px-4 py-3 text-sm">
-                    <div className="font-medium text-gray-900 dark:text-gray-100">
+                    <div className="font-medium text-neutral-900 dark:text-neutral-100">
                       {inst.subject_email}
                     </div>
-                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                    <div className="text-xs text-neutral-500 dark:text-neutral-400">
                       {inst.subject_id}
                     </div>
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                  <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                     {TYPE_LABELS[inst.workflow_type] ?? inst.workflow_type}
                   </td>
                   <td className="px-4 py-3 text-sm">
                     <StatusBadge status={inst.status} />
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                  <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                     {inst.current_step_index}
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                  <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
                     {new Date(inst.created_at).toLocaleDateString()}
                   </td>
                   {canManage && (
@@ -424,16 +424,16 @@ export function Workflows() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+        <h1 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
           Onboarding Workflows
         </h1>
-        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
           Manage approval workflows for user registration, consumer onboarding, and tenant setup.
         </p>
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-gray-200 dark:border-gray-700">
+      <div className="border-b border-neutral-200 dark:border-neutral-700">
         <nav className="flex -mb-px space-x-8">
           {tabs.map((tab) => {
             const Icon = tab.icon;
@@ -445,7 +445,7 @@ export function Workflows() {
                 className={`flex items-center gap-2 border-b-2 px-1 py-3 text-sm font-medium transition-colors ${
                   isActive
                     ? 'border-blue-500 text-blue-600 dark:text-blue-400'
-                    : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300'
+                    : 'border-transparent text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300 hover:border-neutral-300'
                 }`}
               >
                 <Icon className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- Bulk replace 1674 `gray-*` → `neutral-*` occurrences across 70 Console files (true Apple-style neutral palette)
- Adopt shared `<Button>` component in 5 key Console pages: APIs, Deployments, GatewayList, Consumers, Applications
- Zero `gray-*` remaining in Console after migration

## Phase 3 of 3 (CAB-1322 — Full UX Audit)
- Phase 1: Shared Button + focus-visible + tests (PR #892)
- Phase 2: Portal token migration + Button adoption (PR #901)
- **Phase 3**: Console token migration + Button adoption (this PR)

## Test plan
- [x] ESLint: 97 warnings, 0 errors (max 105)
- [x] Prettier: all files clean
- [x] Zero `gray-*` remaining: `grep -r 'gray-' src/ | wc -l` = 0
- [x] TypeScript: pre-existing shared/ errors only (same as main)
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>