### PR TITLE
fix(ci): add --insecure flag for staging smoke tests (CAB-1303)

### DIFF
--- a/.github/workflows/reusable-health-smoke.yml
+++ b/.github/workflows/reusable-health-smoke.yml
@@ -36,13 +36,15 @@ jobs:
       - name: Health checks
         env:
           ENV_PREFIX: ${{ inputs.environment == 'staging' && 'staging-' || '' }}
+          CURL_INSECURE: ${{ inputs.environment == 'staging' && '--insecure' || '' }}
         run: |
           set -euo pipefail
           PASS=0; FAIL=0
 
           check() {
             local name="$1" url="$2" expected="${3:-200}"
-            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 --retry 2 --retry-delay 5 "$url") || status="000"
+            # shellcheck disable=SC2086
+            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 --retry 2 --retry-delay 5 $CURL_INSECURE "$url") || status="000"
             if [ "$status" = "$expected" ]; then
               echo "  $name: $status"
               PASS=$((PASS+1))


### PR DESCRIPTION
## Summary
- Staging on Hetzner K3s uses `letsencrypt-staging` ClusterIssuer, which produces certs from an untrusted CA
- Without `--insecure`, curl fails with SSL certificate verification errors on all 5 staging endpoints
- Adds `CURL_INSECURE` env var that resolves to `--insecure` only when `environment == staging`

## Test plan
- [x] Dev smoke tests unaffected (CURL_INSECURE is empty string)
- [x] Staging smoke tests will skip TLS verification
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>