### PR TITLE
feat(ops): add Token Observatory cost tracking (CAB-1433)

### DIFF
--- a/.claude/hooks/stop-cost-tracker.sh
+++ b/.claude/hooks/stop-cost-tracker.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# stop-cost-tracker.sh — Token Observatory stop hook
+# Parses ~/.claude/stats-cache.json, logs TOKEN-SPEND to metrics.log,
+# pushes cost gauges to Pushgateway.
+# Runs on every session end (Stop hook). Always exits 0 (warn-only).
+set -euo pipefail
+
+# --- Config ---
+STATS_FILE="$HOME/.claude/stats-cache.json"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+METRICS_LOG="$HOME/.claude/projects/-Users-torpedo-hlfh-repos-stoa/memory/metrics.log"
+TODAY="${COST_DATE:-$(date -u +%Y-%m-%d)}"
+NOW="$(date -u +%Y-%m-%dT%H:%M)"
+COST_ALERT_THRESHOLD="${COST_ALERT_THRESHOLD:-50}"
+
+# --- Functions ---
+
+# Shorten model name: claude-opus-4-6 → opus-4-6, claude-haiku-4-5-20251001 → haiku-4-5
+shorten_model() {
+  echo "$1" | sed 's/claude-//;s/-20[0-9]*//'
+}
+
+# Get API-equivalent pricing per million tokens: input output cache_read cache_write
+# Usage: get_pricing MODEL → sets PI PO PCR PCW
+get_pricing() {
+  case "$1" in
+    opus-4-6)    PI=15;   PO=75;  PCR=1.50;  PCW=18.75 ;;
+    sonnet-4-6)  PI=3;    PO=15;  PCR=0.30;  PCW=3.75 ;;
+    sonnet-4-5)  PI=3;    PO=15;  PCR=0.30;  PCW=3.75 ;;
+    haiku-4-5)   PI=0.80; PO=4;   PCR=0.08;  PCW=1 ;;
+    *)           PI=3;    PO=15;  PCR=0.30;  PCW=3.75 ;;  # default to sonnet pricing
+  esac
+}
+
+# Calculate cost for a model given estimated token breakdown
+# Usage: calc_model_cost MODEL TOKENS INPUT_RATIO OUTPUT_RATIO CACHE_READ_RATIO CACHE_WRITE_RATIO
+calc_model_cost() {
+  local model="$1" tokens="$2"
+  local in_ratio="$3" out_ratio="$4" cr_ratio="$5" cw_ratio="$6"
+
+  local PI PO PCR PCW
+  get_pricing "$model"
+
+  # tokens * ratio * price_per_M / 1_000_000
+  awk -v t="$tokens" -v ir="$in_ratio" -v or="$out_ratio" -v crr="$cr_ratio" -v cwr="$cw_ratio" \
+      -v pi="$PI" -v po="$PO" -v pcr="$PCR" -v pcw="$PCW" \
+      'BEGIN { printf "%.4f", (t*ir*pi + t*or*po + t*crr*pcr + t*cwr*pcw) / 1000000 }'
+}
+
+# --- Main ---
+main() {
+  if [[ ! -f "$STATS_FILE" ]]; then
+    exit 0
+  fi
+
+  if ! command -v jq &>/dev/null; then
+    exit 0
+  fi
+
+  # Extract today's daily tokens by model
+  local daily_json
+  daily_json=$(jq -r --arg d "$TODAY" '
+    (.dailyModelTokens // []) | map(select(.date == $d)) | .[0] // empty
+  ' "$STATS_FILE" 2>/dev/null) || true
+
+  if [[ -z "$daily_json" || "$daily_json" == "null" ]]; then
+    exit 0
+  fi
+
+  # Extract today's activity
+  local sessions messages
+  sessions=$(jq -r --arg d "$TODAY" '
+    (.dailyActivity // []) | map(select(.date == $d)) | .[0].sessionCount // 0
+  ' "$STATS_FILE" 2>/dev/null) || sessions=0
+  messages=$(jq -r --arg d "$TODAY" '
+    (.dailyActivity // []) | map(select(.date == $d)) | .[0].messageCount // 0
+  ' "$STATS_FILE" 2>/dev/null) || messages=0
+
+  # Get cumulative modelUsage for ratio estimation
+  local model_usage
+  model_usage=$(jq -r '.modelUsage // {}' "$STATS_FILE" 2>/dev/null) || model_usage="{}"
+
+  # Parse daily tokens by model
+  local tokens_by_model
+  tokens_by_model=$(echo "$daily_json" | jq -r '.tokensByModel // {} | to_entries[] | "\(.key)=\(.value)"' 2>/dev/null) || true
+
+  if [[ -z "$tokens_by_model" ]]; then
+    exit 0
+  fi
+
+  local total_tokens=0
+  local total_cost=0
+  local model_summary=""
+
+  while IFS='=' read -r raw_model tokens; do
+    local model
+    model=$(shorten_model "$raw_model")
+    total_tokens=$((total_tokens + tokens))
+
+    # Get cumulative stats for this model to estimate in/out/cache ratios
+    local cum_in cum_out cum_cr cum_cw cum_total
+    cum_in=$(echo "$model_usage" | jq -r --arg m "$raw_model" '.[$m].inputTokens // 0' 2>/dev/null) || cum_in=0
+    cum_out=$(echo "$model_usage" | jq -r --arg m "$raw_model" '.[$m].outputTokens // 0' 2>/dev/null) || cum_out=0
+    cum_cr=$(echo "$model_usage" | jq -r --arg m "$raw_model" '.[$m].cacheReadInputTokens // 0' 2>/dev/null) || cum_cr=0
+    cum_cw=$(echo "$model_usage" | jq -r --arg m "$raw_model" '.[$m].cacheCreationInputTokens // 0' 2>/dev/null) || cum_cw=0
+    cum_total=$((cum_in + cum_out + cum_cr + cum_cw))
+
+    # Calculate ratios (default: 40% in, 30% out, 20% cache read, 10% cache write)
+    local in_ratio out_ratio cr_ratio cw_ratio
+    if [[ "$cum_total" -gt 0 ]]; then
+      in_ratio=$(awk -v a="$cum_in" -v t="$cum_total" 'BEGIN { printf "%.4f", a/t }')
+      out_ratio=$(awk -v a="$cum_out" -v t="$cum_total" 'BEGIN { printf "%.4f", a/t }')
+      cr_ratio=$(awk -v a="$cum_cr" -v t="$cum_total" 'BEGIN { printf "%.4f", a/t }')
+      cw_ratio=$(awk -v a="$cum_cw" -v t="$cum_total" 'BEGIN { printf "%.4f", a/t }')
+    else
+      in_ratio="0.40"; out_ratio="0.30"; cr_ratio="0.20"; cw_ratio="0.10"
+    fi
+
+    local cost
+    cost=$(calc_model_cost "$model" "$tokens" "$in_ratio" "$out_ratio" "$cr_ratio" "$cw_ratio")
+    total_cost=$(awk -v a="$total_cost" -v b="$cost" 'BEGIN { printf "%.4f", a+b }')
+
+    if [[ -n "$model_summary" ]]; then
+      model_summary+=" "
+    fi
+    model_summary+="${model}=${tokens}"
+  done <<< "$tokens_by_model"
+
+  # Format cost with 2 decimals
+  local cost_display
+  cost_display=$(awk -v c="$total_cost" 'BEGIN { printf "%.2f", c }')
+
+  # Log TOKEN-SPEND
+  echo "${NOW} | TOKEN-SPEND | date=${TODAY} tokens_total=${total_tokens} cost_usd=${cost_display} sessions=${sessions} messages=${messages} models=${model_summary}" >> "$METRICS_LOG"
+
+  # Check cost alert
+  local alert
+  alert=$(awk -v c="$total_cost" -v t="$COST_ALERT_THRESHOLD" 'BEGIN { print (c > t) ? "yes" : "no" }')
+  if [[ "$alert" == "yes" ]]; then
+    echo "${NOW} | COST-ALERT | threshold=${COST_ALERT_THRESHOLD} actual=${cost_display} date=${TODAY}" >> "$METRICS_LOG"
+  fi
+
+  # Push to Pushgateway (if ai-factory-notify.sh is available and PUSHGATEWAY_URL set)
+  local notify_script="${PROJECT_DIR}/scripts/ai-ops/ai-factory-notify.sh"
+  if [[ -f "$notify_script" && -n "${PUSHGATEWAY_URL:-}" ]]; then
+    # shellcheck source=/dev/null
+    source "$notify_script"
+
+    local METRICS=""
+    METRICS+="# HELP ai_factory_daily_tokens Daily token consumption\n"
+    METRICS+="# TYPE ai_factory_daily_tokens gauge\n"
+    METRICS+="ai_factory_daily_tokens{date=\"${TODAY}\"} ${total_tokens}\n"
+    METRICS+="# HELP ai_factory_daily_cost_usd Daily estimated cost (API equivalent)\n"
+    METRICS+="# TYPE ai_factory_daily_cost_usd gauge\n"
+    METRICS+="ai_factory_daily_cost_usd{date=\"${TODAY}\"} ${total_cost}\n"
+    METRICS+="# HELP ai_factory_daily_sessions Daily session count\n"
+    METRICS+="# TYPE ai_factory_daily_sessions gauge\n"
+    METRICS+="ai_factory_daily_sessions{date=\"${TODAY}\"} ${sessions}\n"
+    METRICS+="# HELP ai_factory_daily_messages Daily message count\n"
+    METRICS+="# TYPE ai_factory_daily_messages gauge\n"
+    METRICS+="ai_factory_daily_messages{date=\"${TODAY}\"} ${messages}\n"
+
+    # Per-model token breakdown
+    METRICS+="# HELP ai_factory_daily_tokens_by_model Daily tokens per model\n"
+    METRICS+="# TYPE ai_factory_daily_tokens_by_model gauge\n"
+    while IFS='=' read -r raw_model tokens; do
+      local model
+      model=$(shorten_model "$raw_model")
+      METRICS+="ai_factory_daily_tokens_by_model{date=\"${TODAY}\",model=\"${model}\"} ${tokens}\n"
+    done <<< "$tokens_by_model"
+
+    _push_metrics "cost-tracker/${TODAY}" "$(printf '%b' "$METRICS")" 2>/dev/null || true
+  fi
+}
+
+main "$@" || true

--- a/.claude/rules/cost-guardrails.md
+++ b/.claude/rules/cost-guardrails.md
@@ -40,6 +40,40 @@ globs: ".claude/**"
 
 **Rules**: Max 3-4 subagents active. Prefer haiku for `Explore`. CI implementation stays Sonnet (lighter context = no looping problem).
 
+## Token Observatory (HEGEMON auto-tracked)
+
+### Data Flow
+Stop hook → metrics.log + Pushgateway → Grafana + Daily Slack report (VPS cron)
+
+### Metrics Tracked
+| Metric | Source | Frequency |
+|--------|--------|-----------|
+| Daily tokens (per model) | stats-cache.json via stop hook | Every session end |
+| Daily cost estimate (API equivalent) | stop-cost-tracker.sh | Every session end |
+| Cost alerts (>$50/day) | stop hook → metrics.log | Real-time |
+| Daily Slack report | VPS cron → Pushgateway query | Daily 08:00 UTC |
+| Grafana dashboard | Pushgateway → Prometheus | Continuous |
+
+### Thresholds
+| Level | Daily Cost | Action |
+|-------|-----------|--------|
+| Green | < $30 | Normal — no notification |
+| Yellow | $30-50 | TOKEN-SPEND logged, Grafana visible |
+| Red | > $50 | COST-ALERT logged, Slack warning in daily report |
+
+### Metrics Log Events
+| Event | Fields | Trigger |
+|-------|--------|---------|
+| TOKEN-SPEND | date, tokens_total, cost_usd, model, sessions, messages | Every session end |
+| COST-ALERT | threshold, actual, date | cost_today > $50 |
+
+### API-Equivalent Pricing (reference)
+| Model | Input/MTok | Output/MTok | Cache Read/MTok | Cache Write/MTok |
+|-------|-----------|-------------|----------------|-----------------|
+| Opus 4.6 | $15 | $75 | $1.50 | $18.75 |
+| Sonnet 4.6 | $3 | $15 | $0.30 | $3.75 |
+| Haiku 4.5 | $0.80 | $4 | $0.08 | $1 |
+
 ## RULES-BUDGET Metric
 
 Format in `metrics.log`:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,10 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/rules-budget-lint.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-cost-tracker.sh\""
           }
         ]
       }

--- a/.github/workflows/claude-scheduled.yml
+++ b/.github/workflows/claude-scheduled.yml
@@ -11,6 +11,8 @@ on:
     - cron: "0 7 * * *"
     # Daily 21:00 UTC — CI health check + auto-fix
     - cron: "0 21 * * *"
+    # Daily 07:30 UTC — PR Hygiene (zero-token, labels + Slack)
+    - cron: "30 7 * * *"
     # Weekly Monday 08:00 UTC — Dependency audit + rule improvement
     - cron: "0 8 * * 1"
     # Weekly Monday 09:30 UTC — Capacity check
@@ -173,7 +175,7 @@ jobs:
             Do NOT read memory.md, plan.md, or operations.log for session state.
             Focus exclusively on the task below.
 
-            Weekly audit: dependency scan + coverage check + stale branch cleanup.
+            Weekly audit: dependency scan + coverage check + stale branch cleanup + cost analysis.
             1. Dependency audit:
                - pip-audit in control-plane-api/ (install first: pip install pip-audit)
                - npm audit in control-plane-ui/ and portal/
@@ -181,6 +183,11 @@ jobs:
             2. If safe upgrades exist (patch/minor): create PR "chore(deps): weekly dependency update YYYY-MM-DD"
             3. Coverage check: read thresholds from .claude/rules/ci-quality-gates.md, check latest CI. If dropped: issue with "coverage-drop" label
             4. Stale branches >14 days: report which can be deleted
+            5. AI Factory cost efficiency:
+               - Read metrics.log for TOKEN-SPEND and COST-ALERT events from last 7 days
+               - Calculate: total weekly cost, avg daily, cost per PR, model distribution
+               - Flag anomalies: COST-ALERT events, sessions with >50K tokens, cost/PR > $20
+               - Recommend: session splitting, model routing adjustments
 
             Create issue "Weekly Audit — YYYY-MM-DD" with label "weekly-audit".
           # Model tier: sonnet (audit, may create upgrade PRs)

--- a/docker/observability/grafana/dashboards/ai-factory-cost.json
+++ b/docker/observability/grafana/dashboards/ai-factory-cost.json
@@ -1,0 +1,244 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": ["ai-factory"],
+      "targetBlank": true,
+      "title": "AI Factory Observability",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "title": "Daily Token Burn",
+      "type": "barchart",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "stacking": "normal",
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "ai_factory_daily_tokens_by_model",
+          "legendFormat": "{{model}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Daily Cost Estimate (USD)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "currencyUSD",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 30 },
+              { "color": "red", "value": 50 }
+            ]
+          },
+          "custom": {
+            "thresholdsStyle": { "mode": "line+area" }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "ai_factory_daily_cost_usd",
+          "legendFormat": "Daily Cost",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Sessions & Messages",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Messages" },
+            "properties": [
+              { "id": "custom.axisPlacement", "value": "right" }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "ai_factory_daily_sessions",
+          "legendFormat": "Sessions",
+          "refId": "A"
+        },
+        {
+          "expr": "ai_factory_daily_messages",
+          "legendFormat": "Messages",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "title": "7-Day Rolling Cost",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 200 },
+              { "color": "red", "value": 350 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(ai_factory_daily_cost_usd)",
+          "legendFormat": "7-Day Cost",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Model Mix",
+      "type": "piechart",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "pieType": "donut",
+        "legend": { "displayMode": "list", "placement": "right" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "sum by (model) (ai_factory_daily_tokens_by_model)",
+          "legendFormat": "{{model}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Cost per PR",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 15 },
+              { "color": "red", "value": 25 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "ai_factory_daily_cost_usd / (ai_factory_events_total{verdict=\"merged\"} > 0 or vector(1))",
+          "legendFormat": "$/PR",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Cost Alerts",
+      "type": "table",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "currencyUSD" },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Value", "desc": true }]
+      },
+      "targets": [
+        {
+          "expr": "ai_factory_daily_cost_usd > 50",
+          "legendFormat": "{{date}}",
+          "refId": "A",
+          "format": "table",
+          "instant": true
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["ai-factory", "cost", "hegemon"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus"
+      }
+    ]
+  },
+  "time": { "from": "now-30d", "to": "now" },
+  "title": "AI Factory — Cost Observatory",
+  "uid": "ai-factory-cost"
+}

--- a/scripts/ai-ops/ai-factory-notify.sh
+++ b/scripts/ai-ops/ai-factory-notify.sh
@@ -761,3 +761,111 @@ push_metrics_error() {
   METRICS+="ai_factory_events_total{workflow=\"${WORKFLOW}\",stage=\"${STAGE}\",verdict=\"error\"} 1\n"
   _push_metrics "workflow/${WORKFLOW}/stage/${STAGE}/instance/${TICKET_ID:-error}" "$(printf '%b' "$METRICS")"
 }
+
+# push_metrics_cost DATE TOKENS_TOTAL COST_USD MODEL_BREAKDOWN SESSIONS MESSAGES
+# Push daily cost metrics to Pushgateway.
+push_metrics_cost() {
+  local DATE="${1:-}" TOKENS="${2:-0}" COST="${3:-0}" MODELS="${4:-}" SESSIONS="${5:-0}" MESSAGES="${6:-0}"
+  local METRICS=""
+  METRICS+="# HELP ai_factory_daily_tokens Daily token consumption\n"
+  METRICS+="# TYPE ai_factory_daily_tokens gauge\n"
+  METRICS+="ai_factory_daily_tokens{date=\"${DATE}\"} ${TOKENS}\n"
+  METRICS+="# HELP ai_factory_daily_cost_usd Daily estimated cost (API equivalent)\n"
+  METRICS+="# TYPE ai_factory_daily_cost_usd gauge\n"
+  METRICS+="ai_factory_daily_cost_usd{date=\"${DATE}\"} ${COST}\n"
+  METRICS+="# HELP ai_factory_daily_sessions Daily session count\n"
+  METRICS+="# TYPE ai_factory_daily_sessions gauge\n"
+  METRICS+="ai_factory_daily_sessions{date=\"${DATE}\"} ${SESSIONS}\n"
+  METRICS+="# HELP ai_factory_daily_messages Daily message count\n"
+  METRICS+="# TYPE ai_factory_daily_messages gauge\n"
+  METRICS+="ai_factory_daily_messages{date=\"${DATE}\"} ${MESSAGES}\n"
+
+  # Per-model token breakdown (MODELS format: "opus-4-6=123 sonnet-4-6=456")
+  if [[ -n "$MODELS" ]]; then
+    METRICS+="# HELP ai_factory_daily_tokens_by_model Daily tokens per model\n"
+    METRICS+="# TYPE ai_factory_daily_tokens_by_model gauge\n"
+    for entry in $MODELS; do
+      local model="${entry%%=*}" tokens="${entry#*=}"
+      METRICS+="ai_factory_daily_tokens_by_model{date=\"${DATE}\",model=\"${model}\"} ${tokens}\n"
+    done
+  fi
+
+  _push_metrics "cost-tracker/${DATE}" "$(printf '%b' "$METRICS")"
+}
+
+# notify_cost_report DATE TOKENS_TODAY COST_TODAY COST_7D_AVG SESSIONS MESSAGES PRS_MERGED MODEL_MIX TREND
+# Send daily cost report to Slack as Block Kit message.
+notify_cost_report() {
+  local DATE="${1:-}" TOKENS="${2:-0}" COST="${3:-0}" AVG_7D="${4:-0}"
+  local SESSIONS="${5:-0}" MESSAGES="${6:-0}" PRS="${7:-0}" MODEL_MIX="${8:-}" TREND="${9:-flat}"
+
+  [[ -z "${SLACK_WEBHOOK:-}" ]] && return 0
+
+  # Trend arrow
+  local trend_arrow="→"
+  case "$TREND" in
+    up) trend_arrow="↑" ;;
+    down) trend_arrow="↓" ;;
+  esac
+
+  # Color based on cost
+  local color="good"  # green
+  local cost_int
+  cost_int=$(awk -v c="$COST" 'BEGIN { printf "%d", c }')
+  if [[ "$cost_int" -ge 50 ]]; then
+    color="danger"  # red
+  elif [[ "$cost_int" -ge 30 ]]; then
+    color="warning"  # yellow
+  fi
+
+  # Cost per PR
+  local cost_per_pr="N/A"
+  local prs_int
+  prs_int=$(awk -v p="$PRS" 'BEGIN { printf "%d", p }')
+  if [[ "$prs_int" -gt 0 ]]; then
+    cost_per_pr=$(awk -v c="$COST" -v p="$PRS" 'BEGIN { printf "$%.2f", c/p }')
+  fi
+
+  # Format tokens with K/M suffix
+  local tokens_fmt
+  tokens_fmt=$(awk -v t="$TOKENS" 'BEGIN {
+    if (t >= 1000000) printf "%.1fM", t/1000000
+    else if (t >= 1000) printf "%.0fK", t/1000
+    else printf "%d", t
+  }')
+
+  local payload
+  payload=$(cat <<EOJSON
+{
+  "attachments": [{
+    "color": "${color}",
+    "blocks": [
+      {
+        "type": "header",
+        "text": { "type": "plain_text", "text": "AI Factory Daily Report — ${DATE}" }
+      },
+      {
+        "type": "section",
+        "fields": [
+          { "type": "mrkdwn", "text": "*Tokens*\n${tokens_fmt}" },
+          { "type": "mrkdwn", "text": "*Cost (API eq.)*\n\$${COST}" },
+          { "type": "mrkdwn", "text": "*Sessions*\n${SESSIONS}" },
+          { "type": "mrkdwn", "text": "*Messages*\n${MESSAGES}" },
+          { "type": "mrkdwn", "text": "*PRs Merged*\n${PRS}" },
+          { "type": "mrkdwn", "text": "*Cost/PR*\n${cost_per_pr}" }
+        ]
+      },
+      {
+        "type": "context",
+        "elements": [
+          { "type": "mrkdwn", "text": "7d avg: \$${AVG_7D} ${trend_arrow} | Models: ${MODEL_MIX:-n/a}" }
+        ]
+      }
+    ]
+  }]
+}
+EOJSON
+  )
+
+  curl -sf -X POST -H "Content-Type: application/json" -d "$payload" "$SLACK_WEBHOOK" >/dev/null 2>&1 || true
+}

--- a/scripts/ai-ops/daily-cost-report.sh
+++ b/scripts/ai-ops/daily-cost-report.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# daily-cost-report.sh — Daily AI Factory cost report
+# Runs from VPS cron, reads Pushgateway metrics, sends Slack Block Kit message.
+# Usage: SLACK_WEBHOOK=... PUSHGATEWAY_URL=... bash daily-cost-report.sh
+# Cron: 0 8 * * * /opt/stoa-ops/daily-cost-report.sh >> /var/log/stoa-cost-report.log 2>&1
+set -euo pipefail
+
+# --- Source notification library ---
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [[ -f "${SCRIPT_DIR}/ai-factory-notify.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "${SCRIPT_DIR}/ai-factory-notify.sh"
+elif [[ -f "/opt/stoa-ops/ai-factory-notify.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "/opt/stoa-ops/ai-factory-notify.sh"
+else
+  echo "ERROR: ai-factory-notify.sh not found" >&2
+  exit 1
+fi
+
+# --- Config ---
+TODAY=$(date -u +%Y-%m-%d)
+PUSHGATEWAY_URL="${PUSHGATEWAY_URL:?PUSHGATEWAY_URL is required}"
+SLACK_WEBHOOK="${SLACK_WEBHOOK:?SLACK_WEBHOOK is required}"
+
+# --- Functions ---
+
+# Fetch a metric value from Pushgateway
+# Usage: fetch_metric METRIC_NAME [LABEL_FILTER]
+fetch_metric() {
+  local metric="$1" filter="${2:-}"
+  local url="${PUSHGATEWAY_URL}/metrics"
+  local auth_header=""
+  if [[ -n "${PUSHGATEWAY_AUTH:-}" ]]; then
+    auth_header="-H \"Authorization: Basic ${PUSHGATEWAY_AUTH}\""
+  fi
+
+  local raw
+  raw=$(eval curl -sf ${auth_header} "$url" 2>/dev/null) || { echo "0"; return; }
+
+  if [[ -n "$filter" ]]; then
+    echo "$raw" | grep "^${metric}{.*${filter}" | tail -1 | awk '{print $NF}' || echo "0"
+  else
+    echo "$raw" | grep "^${metric}" | grep -v "^#" | tail -1 | awk '{print $NF}' || echo "0"
+  fi
+}
+
+# Fetch daily metric for a specific date
+fetch_daily() {
+  local metric="$1" date="$2"
+  fetch_metric "$metric" "date=\"${date}\""
+}
+
+# --- Main ---
+main() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M)] Starting daily cost report for ${TODAY}"
+
+  # Fetch today's metrics
+  local tokens_today cost_today sessions_today messages_today
+  tokens_today=$(fetch_daily "ai_factory_daily_tokens" "$TODAY")
+  cost_today=$(fetch_daily "ai_factory_daily_cost_usd" "$TODAY")
+  sessions_today=$(fetch_daily "ai_factory_daily_sessions" "$TODAY")
+  messages_today=$(fetch_daily "ai_factory_daily_messages" "$TODAY")
+
+  # Default to 0 if empty
+  tokens_today="${tokens_today:-0}"
+  cost_today="${cost_today:-0}"
+  sessions_today="${sessions_today:-0}"
+  messages_today="${messages_today:-0}"
+
+  # Fetch last 7 days for average
+  local cost_sum=0 days_with_data=0
+  for i in $(seq 1 7); do
+    local d
+    d=$(date -u -v-${i}d +%Y-%m-%d 2>/dev/null || date -u -d "-${i} days" +%Y-%m-%d 2>/dev/null)
+    local c
+    c=$(fetch_daily "ai_factory_daily_cost_usd" "$d")
+    if [[ -n "$c" && "$c" != "0" ]]; then
+      cost_sum=$(awk -v a="$cost_sum" -v b="$c" 'BEGIN { printf "%.2f", a+b }')
+      days_with_data=$((days_with_data + 1))
+    fi
+  done
+
+  local cost_7d_avg="0"
+  if [[ "$days_with_data" -gt 0 ]]; then
+    cost_7d_avg=$(awk -v s="$cost_sum" -v d="$days_with_data" 'BEGIN { printf "%.2f", s/d }')
+  fi
+
+  # Trend: compare today vs 3-day average
+  local cost_3d_sum=0 days_3d=0
+  for i in 1 2 3; do
+    local d
+    d=$(date -u -v-${i}d +%Y-%m-%d 2>/dev/null || date -u -d "-${i} days" +%Y-%m-%d 2>/dev/null)
+    local c
+    c=$(fetch_daily "ai_factory_daily_cost_usd" "$d")
+    if [[ -n "$c" && "$c" != "0" ]]; then
+      cost_3d_sum=$(awk -v a="$cost_3d_sum" -v b="$c" 'BEGIN { printf "%.2f", a+b }')
+      days_3d=$((days_3d + 1))
+    fi
+  done
+
+  local trend="flat"
+  if [[ "$days_3d" -gt 0 && "$cost_today" != "0" ]]; then
+    local cost_3d_avg
+    cost_3d_avg=$(awk -v s="$cost_3d_sum" -v d="$days_3d" 'BEGIN { printf "%.2f", s/d }')
+    local deviation
+    deviation=$(awk -v t="$cost_today" -v a="$cost_3d_avg" 'BEGIN {
+      if (a == 0) { print "flat"; exit }
+      d = (t - a) / a
+      if (d > 0.20) print "up"
+      else if (d < -0.20) print "down"
+      else print "flat"
+    }')
+    trend="$deviation"
+  fi
+
+  # Fetch PRs merged count (from events_total with verdict=merged)
+  local prs_merged
+  prs_merged=$(fetch_metric "ai_factory_events_total" "verdict=\"merged\"")
+  prs_merged="${prs_merged:-0}"
+
+  # Model mix (from daily tokens by model)
+  local model_mix=""
+  local raw_metrics
+  raw_metrics=$(curl -sf "${PUSHGATEWAY_URL}/metrics" 2>/dev/null) || raw_metrics=""
+  if [[ -n "$raw_metrics" ]]; then
+    model_mix=$(echo "$raw_metrics" | grep "^ai_factory_daily_tokens_by_model{.*date=\"${TODAY}\"" | \
+      sed 's/.*model="\([^"]*\)".* \([0-9.]*\)$/\1:\2/' | tr '\n' ' ' | xargs) || model_mix=""
+  fi
+
+  # Call notify_cost_report
+  notify_cost_report "$TODAY" "$tokens_today" "$cost_today" "$cost_7d_avg" \
+    "$sessions_today" "$messages_today" "$prs_merged" "$model_mix" "$trend"
+
+  echo "[$(date -u +%Y-%m-%dT%H:%M)] Report sent: cost=\$${cost_today}, 7d_avg=\$${cost_7d_avg}, trend=${trend}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Stop hook (`stop-cost-tracker.sh`) parses `~/.claude/stats-cache.json` at session end, estimates API-equivalent cost per model, logs TOKEN-SPEND/COST-ALERT to metrics.log, pushes gauges to Pushgateway
- Daily Slack report (`daily-cost-report.sh`) runs via VPS cron, reads Pushgateway, sends Block Kit message with 7-day trends and color-coded cost alerts
- Grafana dashboard (7 panels): daily token burn, cost estimate with $50 threshold, sessions/messages, 7-day rolling cost, model mix donut, cost/PR, cost alerts table
- Weekly audit prompt enhanced with cost efficiency analysis step

## Test plan
- [x] Hook tested with real stats-cache.json data (Feb 9 multi-model, Feb 15 single-model)
- [x] COST-ALERT fires correctly with low threshold override
- [x] Model name shortening preserves version numbers (opus-4-6, not opus-4)
- [ ] CI green (security-scan required checks)
- [ ] Grafana dashboard import on OVH K8s
- [ ] VPS cron deployment for daily-cost-report.sh

## Council Validation — 8.00/10 (Go)
| Persona | Score | Verdict |
|---------|-------|---------|
| Chucky | 8/10 | Go |
| OSS Killer | 7/10 | Go |
| Archi | 8/10 | Go |
| Saul | 9/10 | Go |

Linear: CAB-1433 (8 pts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>