### PR TITLE
fix(ci): use printf format for pr-hygiene pushgateway metrics (CAB-1433)

### DIFF
--- a/scripts/ai-ops/ai-factory-notify.sh
+++ b/scripts/ai-ops/ai-factory-notify.sh
@@ -576,14 +576,14 @@ notify_pr_hygiene() {
 # Push PR hygiene gauge metrics to Pushgateway.
 push_metrics_pr_hygiene() {
   local TOTAL="${1:-0}" STALE="${2:-0}" ABANDONED="${3:-0}" DRAFT="${4:-0}"
-
-  _push_metrics "workflow/scheduled/stage/pr-hygiene" "$(cat <<PROM
-ai_factory_pr_hygiene{type="total"} ${TOTAL}
-ai_factory_pr_hygiene{type="stale"} ${STALE}
-ai_factory_pr_hygiene{type="abandoned"} ${ABANDONED}
-ai_factory_pr_hygiene{type="draft"} ${DRAFT}
-PROM
-)"
+  local METRICS=""
+  METRICS+="# HELP ai_factory_pr_hygiene PR hygiene gauge by type\n"
+  METRICS+="# TYPE ai_factory_pr_hygiene gauge\n"
+  METRICS+="ai_factory_pr_hygiene{type=\"total\"} ${TOTAL}\n"
+  METRICS+="ai_factory_pr_hygiene{type=\"stale\"} ${STALE}\n"
+  METRICS+="ai_factory_pr_hygiene{type=\"abandoned\"} ${ABANDONED}\n"
+  METRICS+="ai_factory_pr_hygiene{type=\"draft\"} ${DRAFT}\n"
+  _push_metrics "workflow/scheduled/stage/pr-hygiene" "$(printf '%b' "$METRICS")"
 }
 
 # notify_plan ISSUE_NUM ISSUE_TITLE ISSUE_URL STATUS


### PR DESCRIPTION
## Summary
- Pushgateway returned HTTP 400 because heredoc inside `$()` lost double-quote escaping on label values
- Switched to `printf '%b'` pattern with escaped quotes, matching all other `push_metrics_*` functions
- Added `# HELP` and `# TYPE` comments for Prometheus exposition format compliance

## Test plan
- [ ] `gh workflow run claude-scheduled.yml --field task=daily-pr-hygiene` — no Pushgateway 400 warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)