### PR TITLE
feat(landing): add Apple-style landing page prototype (V4)

### DIFF
--- a/stoa-landing/index.html
+++ b/stoa-landing/index.html
@@ -1,0 +1,459 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>STOA — The European Agent Gateway | Open Source MCP Gateway</title>
+  <meta name="description" content="Open-source AI-native API gateway. Define Once, Expose Everywhere. Connect legacy APIs to AI agents via MCP in minutes. European sovereign, Apache 2.0." />
+  <meta name="keywords" content="MCP gateway, API gateway, AI agent, Model Context Protocol, open source, European sovereign, multi-gateway, UAC, Universal API Contract, Apache 2.0" />
+  <meta name="author" content="STOA Platform" />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://gostoa.dev" />
+
+  <!-- Favicon -->
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://gostoa.dev" />
+  <meta property="og:title" content="STOA — The European Agent Gateway" />
+  <meta property="og:description" content="Open-source AI-native API gateway. Define Once, Expose Everywhere. Connect legacy APIs to AI agents via MCP in minutes." />
+  <meta property="og:site_name" content="STOA Platform" />
+  <meta property="og:locale" content="en_US" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="STOA — The European Agent Gateway" />
+  <meta name="twitter:description" content="Open-source AI-native API gateway. Define Once, Expose Everywhere. MCP-native, multi-gateway, European sovereign." />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "STOA Platform",
+    "alternateName": "STOA — The European Agent Gateway",
+    "description": "Open-source AI-native API gateway. Define Once, Expose Everywhere. Connect legacy APIs to AI agents via MCP.",
+    "url": "https://gostoa.dev",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Linux, Kubernetes",
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+    "isAccessibleForFree": true,
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "author": { "@type": "Organization", "name": "STOA Platform", "url": "https://gostoa.dev" },
+    "sourceOrganization": { "@type": "Organization", "name": "STOA Platform" }
+  }
+  </script>
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Source+Code+Pro:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script type="module" src="/src/main.js"></script>
+</head>
+<body>
+
+  <!-- ========== NAV ========== -->
+  <nav class="nav" id="nav">
+    <div class="nav-inner">
+      <a href="#" class="nav-logo">
+        <svg width="28" height="28" viewBox="0 0 32 32">
+          <defs><linearGradient id="logo-grad" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" style="stop-color:#047857"/><stop offset="100%" style="stop-color:#059669"/></linearGradient></defs>
+          <circle cx="16" cy="16" r="15" fill="url(#logo-grad)"/>
+          <path d="M10 11 Q10 8, 16 8 Q22 8, 22 11 Q22 14, 16 14 Q10 14, 10 17 Q10 20, 16 20 Q22 20, 22 24 Q22 27, 16 27" stroke="white" stroke-width="2.5" stroke-linecap="round" fill="none"/>
+          <circle cx="8" cy="14" r="1.5" fill="white" opacity="0.8"/><circle cx="24" cy="14" r="1.5" fill="white" opacity="0.8"/>
+          <circle cx="8" cy="20" r="1.5" fill="white" opacity="0.8"/><circle cx="24" cy="20" r="1.5" fill="white" opacity="0.8"/>
+        </svg>
+        <span>STOA</span>
+      </a>
+      <div class="nav-links">
+        <a href="#features">Features</a>
+        <a href="#ttfac">TTFAC</a>
+        <a href="https://docs.gostoa.dev" target="_blank" rel="noopener">Docs</a>
+        <a href="https://github.com/stoa-platform/stoa" target="_blank" rel="noopener">GitHub</a>
+      </div>
+      <a href="https://console.gostoa.dev" class="nav-cta">Get Started</a>
+    </div>
+  </nav>
+
+  <!-- ========== HERO ========== -->
+  <main>
+  <section class="hero" id="hero" aria-label="Hero — The European Agent Gateway">
+    <div class="hero-bg">
+      <div class="orb orb-teal" data-parallax="0.15"></div>
+      <div class="orb orb-purple" data-parallax="0.25"></div>
+      <div class="orb orb-blue" data-parallax="0.1"></div>
+      <div class="grid-overlay"></div>
+    </div>
+
+    <div class="hero-content">
+      <div class="badge reveal" data-reveal>
+        <span class="badge-flag">&#127466;&#127482;</span>
+        Open Source &middot; Apache 2.0 &middot; European Sovereign
+      </div>
+
+      <h1 class="hero-title reveal" data-reveal data-reveal-delay="100">
+        <span class="gradient-text">The European</span><br/>
+        <span class="gradient-text-alt">Agent Gateway</span>
+      </h1>
+
+      <p class="hero-sub reveal" data-reveal data-reveal-delay="200">
+        <span class="typewriter" data-typewriter="Define Once, Expose Everywhere — connect legacy APIs to AI agents in minutes, not months."></span>
+      </p>
+
+      <div class="hero-ctas reveal" data-reveal data-reveal-delay="300">
+        <a href="https://console.gostoa.dev" class="btn btn-primary glow-btn">
+          Start Building
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 3l5 5-5 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </a>
+        <a href="https://docs.gostoa.dev/docs/guides/quick-start" class="btn btn-secondary">
+          Quick Start
+        </a>
+      </div>
+
+      <div class="hero-meta reveal" data-reveal data-reveal-delay="400">
+        <span class="meta-item">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M4 2v12l4-3 4 3V2z" stroke="#10b981" stroke-width="1.5" fill="none" stroke-linejoin="round"/></svg>
+          916 PRs merged
+        </span>
+        <span class="meta-item">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M8 1l2.5 5 5.5.8-4 3.9 1 5.3L8 13l-5 3 1-5.3-4-3.9 5.5-.8z" fill="#8b5cf6"/></svg>
+          13.5 PRs/day
+        </span>
+        <span class="meta-item">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6" stroke="#2dd4bf" stroke-width="2" fill="none"/><path d="M6 8l2 2 3-4" stroke="#2dd4bf" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          3,900+ tests
+        </span>
+        <span class="meta-item">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><rect x="2" y="2" width="12" height="12" rx="2" stroke="#f59e0b" stroke-width="1.5" fill="none"/><path d="M5 8h6M8 5v6" stroke="#f59e0b" stroke-width="1.5" stroke-linecap="round"/></svg>
+          68 days
+        </span>
+      </div>
+    </div>
+
+    <!-- Mock UI Dashboard -->
+    <div class="mock-ui reveal" data-reveal data-reveal-delay="500">
+      <div class="mock-ui-inner">
+        <div class="mock-titlebar">
+          <div class="mock-dots"><span></span><span></span><span></span></div>
+          <span class="mock-titlebar-text">STOA Console — Dashboard</span>
+        </div>
+        <div class="mock-body">
+          <!-- Row 1: Stats -->
+          <div class="mock-stats">
+            <div class="mock-stat-card stagger-child" data-stagger="0">
+              <span class="mock-stat-label">PRs Merged</span>
+              <span class="mock-stat-value" data-counter="916">0</span>
+              <div class="mock-stat-bar"><div class="mock-stat-fill" style="--fill: 92%"></div></div>
+            </div>
+            <div class="mock-stat-card stagger-child" data-stagger="1">
+              <span class="mock-stat-label">Tests Passing</span>
+              <span class="mock-stat-value" data-counter="3906">0</span>
+              <div class="mock-stat-bar"><div class="mock-stat-fill" style="--fill: 100%"></div></div>
+            </div>
+            <div class="mock-stat-card stagger-child" data-stagger="2">
+              <span class="mock-stat-label">LOC Shipped</span>
+              <span class="mock-stat-value" data-counter="194501">0</span>
+              <div class="mock-stat-bar"><div class="mock-stat-fill" style="--fill: 78%"></div></div>
+            </div>
+            <div class="mock-stat-card stagger-child" data-stagger="3">
+              <span class="mock-stat-label">PRs / Day</span>
+              <span class="mock-stat-value">13.5</span>
+              <div class="mock-stat-bar"><div class="mock-stat-fill" style="--fill: 85%"></div></div>
+            </div>
+          </div>
+          <!-- Row 2: Chart + Terminal -->
+          <div class="mock-row2">
+            <div class="mock-chart stagger-child" data-stagger="4">
+              <span class="mock-chart-title">AI Velocity (3 months)</span>
+              <svg class="mock-chart-svg" viewBox="0 0 300 80" preserveAspectRatio="none">
+                <defs>
+                  <linearGradient id="chart-grad" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="#10b981" stop-opacity="0.4"/>
+                    <stop offset="100%" stop-color="#10b981" stop-opacity="0"/>
+                  </linearGradient>
+                </defs>
+                <!-- Real data: Dec 50 commits → Jan 398 → Feb 746 (exponential growth) -->
+                <path class="chart-area" d="M0,75 C30,74 60,73 100,72 C120,70 140,45 180,35 C210,22 250,10 300,5 L300,80 L0,80 Z" fill="url(#chart-grad)"/>
+                <path class="chart-line" d="M0,75 C30,74 60,73 100,72 C120,70 140,45 180,35 C210,22 250,10 300,5" fill="none" stroke="#10b981" stroke-width="2"/>
+              </svg>
+              <div class="mock-chart-labels">
+                <span>Dec</span><span>Jan</span><span>Feb</span>
+              </div>
+            </div>
+            <div class="mock-terminal stagger-child" data-stagger="5">
+              <span class="mock-terminal-title">AI Factory</span>
+              <div class="mock-terminal-lines">
+                <div class="term-line"><span class="term-prompt">$</span> <span class="term-cmd">claude /council CAB-1432</span></div>
+                <div class="term-line term-output term-success">&#10003; Council: 9.2/10 — Go (Ship)</div>
+                <div class="term-line"><span class="term-prompt">$</span> <span class="term-cmd">gh pr merge --squash 903</span></div>
+                <div class="term-line term-output term-success">&#10003; PR #903 merged (13.5 PRs/day avg)</div>
+                <div class="term-line"><span class="term-prompt">$</span> <span class="term-cursor">|</span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ========== SOCIAL PROOF ========== -->
+  <section class="social-proof" id="social-proof" aria-label="Open standards and AI velocity">
+    <p class="social-proof-label reveal" data-reveal>916 PRs in 68 days &mdash; built on open standards</p>
+    <div class="logo-scroll">
+      <div class="logo-track">
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><circle cx="20" cy="20" r="16" stroke="#5f6880" stroke-width="1.5" fill="none"/><text x="20" y="24" text-anchor="middle" font-size="10" fill="#5f6880" font-family="Outfit">CNCF</text></svg><span>CNCF</span></div>
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><rect x="4" y="4" width="32" height="32" rx="4" stroke="#5f6880" stroke-width="1.5" fill="none"/><text x="20" y="24" text-anchor="middle" font-size="9" fill="#5f6880" font-family="Outfit">MCP</text></svg><span>MCP Protocol</span></div>
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><polygon points="20,4 36,30 4,30" stroke="#5f6880" stroke-width="1.5" fill="none"/><text x="20" y="26" text-anchor="middle" font-size="8" fill="#5f6880" font-family="Outfit">IETF</text></svg><span>IETF</span></div>
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><circle cx="20" cy="20" r="14" stroke="#5f6880" stroke-width="1.5" fill="none"/><text x="20" y="24" text-anchor="middle" font-size="7" fill="#5f6880" font-family="Outfit">OpenID</text></svg><span>OpenID Connect</span></div>
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><rect x="4" y="10" width="32" height="20" rx="3" stroke="#5f6880" stroke-width="1.5" fill="none"/><text x="20" y="24" text-anchor="middle" font-size="8" fill="#5f6880" font-family="Outfit">OAuth</text></svg><span>OAuth 2.1</span></div>
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><path d="M20 4L4 36h32z" stroke="#5f6880" stroke-width="1.5" fill="none"/><text x="20" y="30" text-anchor="middle" font-size="7" fill="#5f6880" font-family="Outfit">OPA</text></svg><span>Open Policy Agent</span></div>
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><circle cx="20" cy="20" r="14" stroke="#5f6880" stroke-width="1.5" fill="none"/><path d="M12 20h16M20 12v16" stroke="#5f6880" stroke-width="1.5"/></svg><span>Apache 2.0</span></div>
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><rect x="6" y="6" width="28" height="28" rx="6" stroke="#5f6880" stroke-width="1.5" fill="none"/><text x="20" y="24" text-anchor="middle" font-size="7" fill="#5f6880" font-family="Outfit">K8s</text></svg><span>Kubernetes</span></div>
+        <!-- Duplicate set for seamless scroll loop -->
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><circle cx="20" cy="20" r="16" stroke="#5f6880" stroke-width="1.5" fill="none"/><text x="20" y="24" text-anchor="middle" font-size="10" fill="#5f6880" font-family="Outfit">CNCF</text></svg><span>CNCF</span></div>
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><rect x="4" y="4" width="32" height="32" rx="4" stroke="#5f6880" stroke-width="1.5" fill="none"/><text x="20" y="24" text-anchor="middle" font-size="9" fill="#5f6880" font-family="Outfit">MCP</text></svg><span>MCP Protocol</span></div>
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><polygon points="20,4 36,30 4,30" stroke="#5f6880" stroke-width="1.5" fill="none"/><text x="20" y="26" text-anchor="middle" font-size="8" fill="#5f6880" font-family="Outfit">IETF</text></svg><span>IETF</span></div>
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><circle cx="20" cy="20" r="14" stroke="#5f6880" stroke-width="1.5" fill="none"/><text x="20" y="24" text-anchor="middle" font-size="7" fill="#5f6880" font-family="Outfit">OpenID</text></svg><span>OpenID Connect</span></div>
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><rect x="4" y="10" width="32" height="20" rx="3" stroke="#5f6880" stroke-width="1.5" fill="none"/><text x="20" y="24" text-anchor="middle" font-size="8" fill="#5f6880" font-family="Outfit">OAuth</text></svg><span>OAuth 2.1</span></div>
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><path d="M20 4L4 36h32z" stroke="#5f6880" stroke-width="1.5" fill="none"/><text x="20" y="30" text-anchor="middle" font-size="7" fill="#5f6880" font-family="Outfit">OPA</text></svg><span>Open Policy Agent</span></div>
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><circle cx="20" cy="20" r="14" stroke="#5f6880" stroke-width="1.5" fill="none"/><path d="M12 20h16M20 12v16" stroke="#5f6880" stroke-width="1.5"/></svg><span>Apache 2.0</span></div>
+        <div class="logo-item"><svg width="40" height="40" viewBox="0 0 40 40"><rect x="6" y="6" width="28" height="28" rx="6" stroke="#5f6880" stroke-width="1.5" fill="none"/><text x="20" y="24" text-anchor="middle" font-size="7" fill="#5f6880" font-family="Outfit">K8s</text></svg><span>Kubernetes</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ========== TTFAC ========== -->
+  <section class="ttfac" id="ttfac" aria-label="Time to First API Call comparison">
+    <div class="section-container">
+      <div class="section-header reveal" data-reveal>
+        <span class="section-tag">Time to First API Call</span>
+        <h2 class="section-title">From weeks to <span class="gradient-text">minutes</span></h2>
+        <p class="section-desc">Traditional API gateways require weeks of configuration. STOA gets your first AI agent connected in under 5 minutes.</p>
+      </div>
+
+      <div class="ttfac-compare">
+        <div class="ttfac-card ttfac-old reveal tilt-card" data-reveal data-tilt>
+          <div class="ttfac-card-header ttfac-header-old">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="#ef4444" stroke-width="2" fill="none"/><path d="M12 7v5l3 3" stroke="#ef4444" stroke-width="2" stroke-linecap="round"/></svg>
+            <span>Traditional Gateway</span>
+          </div>
+          <div class="ttfac-counter">
+            <span class="ttfac-number" data-counter="14">0</span>
+            <span class="ttfac-unit">days</span>
+          </div>
+          <ul class="ttfac-steps">
+            <li>Procurement &amp; licensing</li>
+            <li>Infrastructure provisioning</li>
+            <li>Gateway installation</li>
+            <li>API configuration</li>
+            <li>Security policy setup</li>
+            <li>Testing &amp; validation</li>
+            <li>Custom MCP adapter development</li>
+          </ul>
+        </div>
+
+        <div class="ttfac-timeline reveal" data-reveal data-reveal-delay="200">
+          <div class="ttfac-timeline-line"></div>
+          <div class="ttfac-timeline-arrow">
+            <svg width="48" height="48" viewBox="0 0 48 48" fill="none">
+              <circle cx="24" cy="24" r="22" stroke="url(#arrow-grad)" stroke-width="2" fill="none"/>
+              <path d="M18 24h12m-5-5l5 5-5 5" stroke="url(#arrow-grad)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <defs><linearGradient id="arrow-grad" x1="0" y1="0" x2="48" y2="48"><stop stop-color="#10b981"/><stop offset="1" stop-color="#8b5cf6"/></linearGradient></defs>
+            </svg>
+          </div>
+          <div class="ttfac-timeline-line"></div>
+        </div>
+
+        <div class="ttfac-card ttfac-new reveal tilt-card" data-reveal data-reveal-delay="100" data-tilt>
+          <div class="ttfac-card-header ttfac-header-new">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="#10b981" stroke-width="2" fill="none"/><path d="M8 12l3 3 5-6" stroke="#10b981" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span>STOA Platform</span>
+          </div>
+          <div class="ttfac-counter">
+            <span class="ttfac-number ttfac-number-green" data-counter="5">0</span>
+            <span class="ttfac-unit">minutes</span>
+          </div>
+          <ul class="ttfac-steps ttfac-steps-fast">
+            <li>docker compose up</li>
+            <li>Define UAC contract</li>
+            <li>Connect AI agent via MCP</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ========== FEATURES ========== -->
+  <section class="features" id="features" aria-label="Key features">
+
+    <!-- Feature 1: MCP-Native -->
+    <div class="feature-block">
+      <div class="feature-text reveal" data-reveal>
+        <span class="feature-tag">AI-Native Protocol</span>
+        <h2 class="feature-title">MCP-Native<br/>from day one</h2>
+        <p class="feature-desc">STOA speaks the Model Context Protocol natively. No adapters, no plugins, no middleware. Your AI agents connect directly to enterprise APIs through a standardized, secure gateway.</p>
+        <ul class="feature-list">
+          <li><svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#10b981" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#10b981" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>Tool discovery &amp; execution</li>
+          <li><svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#10b981" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#10b981" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>OAuth 2.1 + PKCE authentication</li>
+          <li><svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#10b981" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#10b981" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>Streaming &amp; WebSocket transport</li>
+        </ul>
+      </div>
+      <div class="feature-visual reveal" data-reveal data-reveal-delay="200">
+        <div class="feature-anim-mcp">
+          <div class="mcp-center"><div class="mcp-hub">STOA</div></div>
+          <div class="mcp-agent mcp-agent-1"><span>Claude</span></div>
+          <div class="mcp-agent mcp-agent-2"><span>GPT-4</span></div>
+          <div class="mcp-agent mcp-agent-3"><span>Gemini</span></div>
+          <div class="mcp-line mcp-line-1"></div>
+          <div class="mcp-line mcp-line-2"></div>
+          <div class="mcp-line mcp-line-3"></div>
+          <div class="mcp-pulse mcp-pulse-1"></div>
+          <div class="mcp-pulse mcp-pulse-2"></div>
+          <div class="mcp-pulse mcp-pulse-3"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Feature 2: UAC -->
+    <div class="feature-block feature-block-reverse">
+      <div class="feature-text reveal" data-reveal>
+        <span class="feature-tag">Kill Feature</span>
+        <h2 class="feature-title">Universal API<br/><span class="gradient-text">Contract</span></h2>
+        <p class="feature-desc">Define your API contract once, and STOA exposes it everywhere — REST, GraphQL, MCP, gRPC. One source of truth that adapts to any consumer.</p>
+        <ul class="feature-list">
+          <li><svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#8b5cf6" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#8b5cf6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>OpenAPI &rarr; MCP auto-transform</li>
+          <li><svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#8b5cf6" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#8b5cf6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>Schema validation at the edge</li>
+          <li><svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#8b5cf6" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#8b5cf6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>Version-aware routing</li>
+        </ul>
+      </div>
+      <div class="feature-visual reveal" data-reveal data-reveal-delay="200">
+        <div class="feature-anim-uac">
+          <div class="uac-source"><code>openapi.yaml</code></div>
+          <div class="uac-arrows">
+            <div class="uac-arrow uac-arrow-1"><span>REST</span></div>
+            <div class="uac-arrow uac-arrow-2"><span>MCP</span></div>
+            <div class="uac-arrow uac-arrow-3"><span>GraphQL</span></div>
+            <div class="uac-arrow uac-arrow-4"><span>gRPC</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Feature 3: Multi-Gateway -->
+    <div class="feature-block">
+      <div class="feature-text reveal" data-reveal>
+        <span class="feature-tag">Enterprise Ready</span>
+        <h2 class="feature-title">Multi-Gateway<br/>orchestration</h2>
+        <p class="feature-desc">One control plane for all your gateways. STOA orchestrates Kong, Gravitee, Apigee, Azure APIM, AWS API Gateway, and webMethods from a single pane of glass.</p>
+        <ul class="feature-list">
+          <li><svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#2dd4bf" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#2dd4bf" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>7 Stoa Links</li>
+          <li><svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#2dd4bf" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#2dd4bf" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>Unified policy engine (OPA)</li>
+          <li><svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#2dd4bf" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#2dd4bf" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>Hybrid cloud + on-premise</li>
+        </ul>
+      </div>
+      <div class="feature-visual reveal" data-reveal data-reveal-delay="200">
+        <div class="feature-anim-gw">
+          <div class="gw-orbit">
+            <div class="gw-center-logo">STOA</div>
+            <div class="gw-item gw-item-1">Kong</div>
+            <div class="gw-item gw-item-2">Gravitee</div>
+            <div class="gw-item gw-item-3">Apigee</div>
+            <div class="gw-item gw-item-4">Azure</div>
+            <div class="gw-item gw-item-5">AWS</div>
+            <div class="gw-item gw-item-6">wM</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ========== CTA CLOSING ========== -->
+  <section class="closing" id="closing" aria-label="Get started with STOA">
+    <div class="closing-bg">
+      <div class="orb orb-teal-lg" data-parallax="0.08"></div>
+      <div class="orb orb-purple-lg" data-parallax="0.12"></div>
+      <div class="grid-overlay"></div>
+    </div>
+    <div class="section-container closing-content">
+      <h2 class="closing-title reveal" data-reveal>
+        Ready to bridge<br/><span class="gradient-text-alt">legacy to AI?</span>
+      </h2>
+      <p class="closing-desc reveal" data-reveal data-reveal-delay="100">
+        Join hundreds of teams using STOA to connect their enterprise APIs to the AI agent ecosystem.
+      </p>
+      <div class="closing-ctas reveal" data-reveal data-reveal-delay="200">
+        <a href="https://console.gostoa.dev" class="btn btn-primary glow-btn btn-lg">
+          Start for Free
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 3l5 5-5 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </a>
+        <a href="https://github.com/stoa-platform/stoa" class="btn btn-secondary btn-lg">
+          <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          Star on GitHub
+        </a>
+      </div>
+      <div class="closing-stats reveal" data-reveal data-reveal-delay="300">
+        <div class="closing-stat">
+          <span class="closing-stat-num" data-counter="916">0</span>
+          <span class="closing-stat-label">PRs merged</span>
+        </div>
+        <div class="closing-stat">
+          <span class="closing-stat-num" data-counter="194501">0</span>
+          <span class="closing-stat-label">lines of code</span>
+        </div>
+        <div class="closing-stat">
+          <span class="closing-stat-num" data-counter="3906">0</span>
+          <span class="closing-stat-label">tests passing</span>
+        </div>
+        <div class="closing-stat">
+          <span class="closing-stat-num" data-counter="7">0</span>
+          <span class="closing-stat-label">Stoa Links</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  </main>
+
+  <!-- ========== FOOTER ========== -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-col">
+        <a href="#" class="nav-logo">
+          <svg width="24" height="24" viewBox="0 0 32 32">
+            <defs><linearGradient id="logo-grad2" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" style="stop-color:#047857"/><stop offset="100%" style="stop-color:#059669"/></linearGradient></defs>
+            <circle cx="16" cy="16" r="15" fill="url(#logo-grad2)"/>
+            <path d="M10 11 Q10 8, 16 8 Q22 8, 22 11 Q22 14, 16 14 Q10 14, 10 17 Q10 20, 16 20 Q22 20, 22 24 Q22 27, 16 27" stroke="white" stroke-width="2.5" stroke-linecap="round" fill="none"/>
+            <circle cx="8" cy="14" r="1.5" fill="white" opacity="0.8"/><circle cx="24" cy="14" r="1.5" fill="white" opacity="0.8"/>
+            <circle cx="8" cy="20" r="1.5" fill="white" opacity="0.8"/><circle cx="24" cy="20" r="1.5" fill="white" opacity="0.8"/>
+          </svg>
+          <span>STOA</span>
+        </a>
+        <p class="footer-desc">The European Agent Gateway.<br/>Open source, Apache 2.0.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Product</h4>
+        <a href="https://docs.gostoa.dev/docs/guides/quick-start">Quick Start</a>
+        <a href="https://docs.gostoa.dev/docs/concepts/architecture">Architecture</a>
+        <a href="https://docs.gostoa.dev/docs/api">API Reference</a>
+      </div>
+      <div class="footer-col">
+        <h4>Community</h4>
+        <a href="https://github.com/stoa-platform/stoa">GitHub</a>
+        <a href="https://docs.gostoa.dev/blog">Blog</a>
+        <a href="https://docs.gostoa.dev/docs/community/philosophy">Philosophy</a>
+      </div>
+      <div class="footer-col">
+        <h4>Company</h4>
+        <a href="https://docs.gostoa.dev/docs/enterprise">Enterprise</a>
+        <a href="https://docs.gostoa.dev/docs/community/faq">FAQ</a>
+        <a href="https://docs.gostoa.dev/legal/trademarks">Trademarks</a>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>&copy; 2026 STOA Platform. Apache 2.0 License.</span>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/stoa-landing/package.json
+++ b/stoa-landing/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "stoa-landing",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^6.2.0"
+  }
+}

--- a/stoa-landing/public/favicon.svg
+++ b/stoa-landing/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="stoaGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#047857"/>
+      <stop offset="100%" style="stop-color:#059669"/>
+    </linearGradient>
+  </defs>
+  <circle cx="16" cy="16" r="15" fill="url(#stoaGradient)"/>
+  <path d="M10 11 Q10 8, 16 8 Q22 8, 22 11 Q22 14, 16 14 Q10 14, 10 17 Q10 20, 16 20 Q22 20, 22 24 Q22 27, 16 27"
+        stroke="white" stroke-width="2.5" stroke-linecap="round" fill="none"/>
+  <circle cx="8" cy="14" r="1.5" fill="white" opacity="0.8"/>
+  <circle cx="24" cy="14" r="1.5" fill="white" opacity="0.8"/>
+  <circle cx="8" cy="20" r="1.5" fill="white" opacity="0.8"/>
+  <circle cx="24" cy="20" r="1.5" fill="white" opacity="0.8"/>
+</svg>

--- a/stoa-landing/src/main.js
+++ b/stoa-landing/src/main.js
@@ -1,0 +1,206 @@
+import './style.css';
+
+/* ========== Scroll-Triggered Reveals ========== */
+function initReveals() {
+  const els = document.querySelectorAll('[data-reveal]');
+  const obs = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+        const el = entry.target;
+        const delay = parseInt(el.dataset.revealDelay || '0', 10);
+        setTimeout(() => el.classList.add('visible'), delay);
+        obs.unobserve(el);
+      });
+    },
+    { threshold: 0.15, rootMargin: '0px 0px -40px 0px' }
+  );
+  els.forEach((el) => obs.observe(el));
+}
+
+/* ========== Staggered Children (Mock UI) ========== */
+function initStagger() {
+  const mockUI = document.querySelector('.mock-ui');
+  if (!mockUI) return;
+  const obs = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+        entry.target.querySelectorAll('.stagger-child').forEach((child) => {
+          const idx = parseInt(child.dataset.stagger || '0', 10);
+          setTimeout(() => child.classList.add('visible'), 200 + idx * 150);
+        });
+        obs.unobserve(entry.target);
+      });
+    },
+    { threshold: 0.1 }
+  );
+  obs.observe(mockUI);
+}
+
+/* ========== Parallax ========== */
+function initParallax() {
+  const els = document.querySelectorAll('[data-parallax]');
+  if (!els.length) return;
+  let ticking = false;
+  function onScroll() {
+    if (ticking) return;
+    ticking = true;
+    requestAnimationFrame(() => {
+      const scrollY = window.scrollY;
+      els.forEach((el) => {
+        const factor = parseFloat(el.dataset.parallax);
+        el.style.transform = `translateY(${scrollY * factor}px)`;
+      });
+      ticking = false;
+    });
+  }
+  window.addEventListener('scroll', onScroll, { passive: true });
+}
+
+/* ========== Nav Scroll ========== */
+function initNav() {
+  const nav = document.getElementById('nav');
+  if (!nav) return;
+  function update() {
+    nav.classList.toggle('scrolled', window.scrollY > 50);
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  update();
+}
+
+/* ========== Counter Animation ========== */
+function initCounters() {
+  const els = document.querySelectorAll('[data-counter]');
+  els.forEach((el) => {
+    const revealParent = el.closest('.reveal');
+    if (revealParent) {
+      // Wait for parent reveal to become visible before animating
+      const mo = new MutationObserver(() => {
+        if (revealParent.classList.contains('visible')) {
+          mo.disconnect();
+          const target = parseInt(el.dataset.counter, 10);
+          setTimeout(() => animateCounter(el, target), 300);
+        }
+      });
+      mo.observe(revealParent, { attributes: true, attributeFilter: ['class'] });
+    } else {
+      // No reveal parent — use IntersectionObserver
+      const obs = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (!entry.isIntersecting) return;
+            const target = parseInt(el.dataset.counter, 10);
+            animateCounter(el, target);
+            obs.unobserve(el);
+          });
+        },
+        { threshold: 0.5 }
+      );
+      obs.observe(el);
+    }
+  });
+}
+
+function animateCounter(el, target) {
+  const start = performance.now();
+  function easeOutExpo(x) {
+    return x === 1 ? 1 : 1 - Math.pow(2, -10 * x);
+  }
+  function step(now) {
+    const elapsed = now - start;
+    const progress = Math.min(elapsed / 1800, 1);
+    const value = Math.round(easeOutExpo(progress) * target);
+    el.textContent = value.toLocaleString();
+    if (progress < 1) requestAnimationFrame(step);
+  }
+  requestAnimationFrame(step);
+}
+
+/* ========== Typewriter Effect ========== */
+function initTypewriter() {
+  document.querySelectorAll('[data-typewriter]').forEach((el) => {
+    const text = el.dataset.typewriter;
+    let i = 0;
+    function type() {
+      if (i <= text.length) {
+        el.textContent = text.slice(0, i);
+        i++;
+        const delay = text[i - 1] === ' ' ? 20 : 30 + Math.random() * 30;
+        setTimeout(type, delay);
+      }
+    }
+    const revealParent = el.closest('.reveal');
+    if (revealParent) {
+      const mo = new MutationObserver(() => {
+        if (revealParent.classList.contains('visible')) {
+          mo.disconnect();
+          setTimeout(() => type(), 400);
+        }
+      });
+      mo.observe(revealParent, { attributes: true, attributeFilter: ['class'] });
+    } else {
+      const obs = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              obs.unobserve(entry.target);
+              setTimeout(() => type(), 600);
+            }
+          });
+        },
+        { threshold: 0.5 }
+      );
+      obs.observe(el);
+    }
+  });
+}
+
+/* ========== 3D Tilt Cards ========== */
+function initTilt() {
+  document.querySelectorAll('[data-tilt]').forEach((el) => {
+    el.addEventListener('mousemove', (e) => {
+      const rect = el.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const cx = rect.width / 2;
+      const cy = rect.height / 2;
+      const rotateX = ((y - cy) / cy) * -5;
+      const rotateY = ((x - cx) / cx) * 5;
+      el.style.transform = `perspective(1000px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale(1.02)`;
+    });
+    el.addEventListener('mouseleave', () => {
+      el.style.transform = 'perspective(1000px) rotateX(0) rotateY(0) scale(1)';
+      el.style.transition = 'transform 0.5s var(--ease-apple)';
+      setTimeout(() => (el.style.transition = ''), 500);
+    });
+    el.addEventListener('mouseenter', () => {
+      el.style.transition = 'none';
+    });
+  });
+}
+
+/* ========== Smooth Scroll ========== */
+function initSmoothScroll() {
+  document.querySelectorAll('a[href^="#"]').forEach((a) => {
+    a.addEventListener('click', (e) => {
+      const target = document.querySelector(a.getAttribute('href'));
+      if (target) {
+        e.preventDefault();
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  });
+}
+
+/* ========== Init ========== */
+document.addEventListener('DOMContentLoaded', () => {
+  initNav();
+  initReveals();
+  initStagger();
+  initParallax();
+  initCounters();
+  initTypewriter();
+  initTilt();
+  initSmoothScroll();
+});

--- a/stoa-landing/src/style.css
+++ b/stoa-landing/src/style.css
@@ -1,0 +1,279 @@
+/* ========== Design Tokens ========== */
+:root {
+  --emerald-400: #34d399;
+  --emerald-500: #10b981;
+  --emerald-600: #059669;
+  --teal: #2dd4bf;
+  --violet-300: #c4b5fd;
+  --violet-400: #a78bfa;
+  --violet-500: #8b5cf6;
+
+  --bg-deep: #08090d;
+  --bg: #0e1015;
+  --bg-elevated: #14161d;
+  --bg-card: #181b24;
+
+  --text-primary: #f2f4f8;
+  --text-secondary: #9ca3b4;
+  --text-muted: #5f6880;
+
+  --border: rgba(255, 255, 255, 0.06);
+  --border-hover: rgba(255, 255, 255, 0.12);
+
+  --ease-apple: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-out: cubic-bezier(0.33, 1, 0.68, 1);
+
+  --max-w: 1200px;
+  --gutter: clamp(1.25rem, 4vw, 3rem);
+
+  --font-sans: 'Outfit', system-ui, -apple-system, sans-serif;
+  --font-mono: 'Source Code Pro', ui-monospace, monospace;
+}
+
+/* ========== Reset ========== */
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+body { font-family: var(--font-sans); background: var(--bg-deep); color: var(--text-primary); line-height: 1.6; overflow-x: hidden; }
+a { color: inherit; text-decoration: none; }
+ul { list-style: none; }
+img, svg { display: block; max-width: 100%; }
+
+/* ========== Utilities ========== */
+.section-container { max-width: var(--max-w); margin: 0 auto; padding: 0 var(--gutter); }
+
+.reveal { opacity: 0; transform: translateY(40px); transition: opacity 0.8s var(--ease-apple), transform 0.8s var(--ease-apple); }
+.reveal.visible { opacity: 1; transform: translateY(0); }
+
+.stagger-child { opacity: 0; transform: translateY(20px) scale(0.97); transition: opacity 0.6s var(--ease-apple), transform 0.6s var(--ease-apple); }
+.stagger-child.visible { opacity: 1; transform: translateY(0) scale(1); }
+
+.gradient-text { background: linear-gradient(135deg, var(--emerald-400), var(--teal)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+.gradient-text-alt { background: linear-gradient(135deg, var(--violet-400), var(--emerald-400)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+
+/* ========== Nav ========== */
+.nav { position: fixed; top: 0; left: 0; right: 0; z-index: 100; padding: 0 var(--gutter); transition: background 0.4s, backdrop-filter 0.4s, border-color 0.4s; border-bottom: 1px solid transparent; }
+.nav.scrolled { background: rgba(8, 9, 13, 0.8); backdrop-filter: blur(20px) saturate(1.4); -webkit-backdrop-filter: blur(20px) saturate(1.4); border-bottom-color: var(--border); }
+.nav-inner { max-width: var(--max-w); margin: 0 auto; display: flex; align-items: center; justify-content: space-between; height: 64px; }
+.nav-logo { display: flex; align-items: center; gap: 0.5rem; font-weight: 700; font-size: 1.125rem; letter-spacing: -0.02em; }
+.nav-links { display: flex; gap: 2rem; }
+.nav-links a { font-size: 0.875rem; color: var(--text-secondary); transition: color 0.25s; }
+.nav-links a:hover { color: var(--text-primary); }
+.nav-cta { font-size: 0.8125rem; font-weight: 600; padding: 0.5rem 1.25rem; border-radius: 8px; background: rgba(16, 185, 129, 0.12); color: var(--emerald-400); border: 1px solid rgba(16, 185, 129, 0.25); transition: background 0.25s, border-color 0.25s; }
+.nav-cta:hover { background: rgba(16, 185, 129, 0.2); border-color: rgba(16, 185, 129, 0.4); }
+@media (max-width: 768px) { .nav-links { display: none; } }
+
+/* ========== Hero ========== */
+.hero { position: relative; min-height: 100vh; display: flex; flex-direction: column; align-items: center; justify-content: flex-start; padding: 120px var(--gutter) 80px; overflow: hidden; }
+.hero-bg { position: absolute; inset: 0; z-index: 0; overflow: hidden; }
+.orb { position: absolute; border-radius: 50%; filter: blur(100px); will-change: transform; }
+.orb-teal { width: 600px; height: 600px; background: radial-gradient(circle, rgba(45, 212, 191, 0.2), transparent 70%); top: -10%; left: -10%; }
+.orb-purple { width: 500px; height: 500px; background: radial-gradient(circle, rgba(139, 92, 246, 0.2), transparent 70%); top: 20%; right: -5%; }
+.orb-blue { width: 400px; height: 400px; background: radial-gradient(circle, rgba(59, 130, 246, 0.12), transparent 70%); bottom: 10%; left: 30%; }
+.grid-overlay { position: absolute; inset: 0; background-image: linear-gradient(rgba(255,255,255,0.02) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.02) 1px, transparent 1px); background-size: 60px 60px; mask-image: radial-gradient(ellipse 80% 60% at 50% 40%, black 30%, transparent 80%); -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 40%, black 30%, transparent 80%); }
+
+.hero-content { position: relative; z-index: 1; text-align: center; max-width: 800px; }
+.badge { display: inline-flex; align-items: center; gap: 0.5rem; font-size: 0.8125rem; font-weight: 500; color: var(--text-secondary); background: rgba(255,255,255,0.04); border: 1px solid var(--border); border-radius: 100px; padding: 0.375rem 1rem; margin-bottom: 1.5rem; }
+.badge-flag { font-size: 1rem; }
+.hero-title { font-size: clamp(3rem, 8vw, 5.5rem); font-weight: 800; line-height: 1.05; letter-spacing: -0.045em; margin-bottom: 1.25rem; }
+.hero-sub { font-size: clamp(1rem, 2vw, 1.25rem); color: var(--text-secondary); max-width: 600px; margin: 0 auto 2rem; min-height: 1.8em; }
+.typewriter::after { content: '|'; animation: blink 0.8s step-end infinite; color: var(--emerald-500); }
+@keyframes blink { 50% { opacity: 0; } }
+
+.hero-ctas { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; margin-bottom: 2rem; }
+.btn { display: inline-flex; align-items: center; gap: 0.5rem; font-family: var(--font-sans); font-weight: 600; font-size: 0.9375rem; padding: 0.75rem 1.75rem; border-radius: 12px; transition: all 0.3s var(--ease-apple); cursor: pointer; border: none; }
+.btn-primary { background: linear-gradient(135deg, var(--emerald-500), var(--emerald-600)); color: #fff; box-shadow: 0 0 0 1px rgba(16, 185, 129, 0.3), 0 4px 20px rgba(16, 185, 129, 0.15); }
+.btn-primary:hover { box-shadow: 0 0 0 1px rgba(16, 185, 129, 0.5), 0 8px 30px rgba(16, 185, 129, 0.25); transform: translateY(-1px); }
+.glow-btn { position: relative; }
+.glow-btn::before { content: ''; position: absolute; inset: -2px; border-radius: 14px; background: linear-gradient(135deg, var(--emerald-400), var(--violet-400)); opacity: 0; z-index: -1; filter: blur(12px); transition: opacity 0.4s; }
+.glow-btn:hover::before { opacity: 0.5; }
+.btn-secondary { background: rgba(255,255,255,0.05); color: var(--text-primary); border: 1px solid var(--border); }
+.btn-secondary:hover { background: rgba(255,255,255,0.08); border-color: var(--border-hover); }
+.btn-lg { font-size: 1.0625rem; padding: 0.875rem 2.25rem; }
+
+.hero-meta { display: flex; gap: 1.5rem; justify-content: center; flex-wrap: wrap; }
+.meta-item { display: inline-flex; align-items: center; gap: 0.375rem; font-size: 0.8125rem; color: var(--text-muted); }
+.meta-item svg { display: inline; flex-shrink: 0; }
+
+/* ========== Mock UI ========== */
+.mock-ui { position: relative; z-index: 1; width: 100%; max-width: 900px; margin: 3rem auto 0; }
+.mock-ui-inner { border-radius: 16px; border: 1px solid var(--border); background: var(--bg-card); overflow: hidden; box-shadow: 0 25px 80px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.03); }
+.mock-titlebar { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem 1rem; background: var(--bg-elevated); border-bottom: 1px solid var(--border); }
+.mock-dots { display: flex; gap: 6px; }
+.mock-dots span { width: 10px; height: 10px; border-radius: 50%; }
+.mock-dots span:nth-child(1) { background: #ff5f57; }
+.mock-dots span:nth-child(2) { background: #ffbd2e; }
+.mock-dots span:nth-child(3) { background: #28c840; }
+.mock-titlebar-text { font-size: 0.75rem; color: var(--text-muted); font-weight: 500; }
+.mock-body { padding: 1rem; display: flex; flex-direction: column; gap: 1rem; }
+.mock-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem; }
+.mock-stat-card { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 10px; padding: 0.875rem; display: flex; flex-direction: column; gap: 0.375rem; }
+.mock-stat-label { font-size: 0.6875rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.mock-stat-value { font-size: 1.375rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+.mock-stat-bar { height: 3px; border-radius: 2px; background: rgba(255,255,255,0.06); overflow: hidden; }
+.mock-stat-fill { height: 100%; width: var(--fill); border-radius: 2px; background: linear-gradient(90deg, var(--emerald-500), var(--teal)); transform: scaleX(0); transform-origin: left; transition: transform 1.2s var(--ease-apple); }
+.stagger-child.visible .mock-stat-fill { transform: scaleX(1); }
+.mock-row2 { display: grid; grid-template-columns: 1.4fr 1fr; gap: 0.75rem; }
+.mock-chart, .mock-terminal { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 10px; padding: 0.875rem; }
+.mock-chart-title, .mock-terminal-title { font-size: 0.6875rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; display: block; margin-bottom: 0.5rem; }
+.mock-chart-svg { width: 100%; height: 60px; }
+.chart-line { stroke-dasharray: 600; stroke-dashoffset: 600; transition: stroke-dashoffset 2s var(--ease-apple); }
+.chart-area { opacity: 0; transition: opacity 1.5s var(--ease-apple) 0.5s; }
+.stagger-child.visible .chart-line { stroke-dashoffset: 0; }
+.stagger-child.visible .chart-area { opacity: 1; }
+.mock-chart-labels { display: flex; justify-content: space-between; padding: 0.25rem 0.25rem 0; font-size: 0.5625rem; color: var(--text-muted); letter-spacing: 0.03em; }
+.mock-terminal-lines { font-family: var(--font-mono); font-size: 0.6875rem; line-height: 1.7; }
+.term-prompt { color: var(--emerald-500); font-weight: 600; }
+.term-cmd { color: var(--text-primary); }
+.term-output { color: var(--text-muted); }
+.term-success { color: var(--emerald-400); }
+.term-cursor { color: var(--emerald-500); animation: blink 0.8s step-end infinite; }
+
+@media (max-width: 768px) {
+  .mock-stats { grid-template-columns: repeat(2, 1fr); }
+  .mock-row2 { grid-template-columns: 1fr; }
+}
+@media (max-width: 480px) {
+  .mock-stats { grid-template-columns: 1fr; }
+}
+
+/* ========== Social Proof ========== */
+.social-proof { padding: 4rem 0; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); background: var(--bg); overflow: hidden; }
+.social-proof-label { text-align: center; font-size: 0.8125rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 2rem; }
+.logo-scroll { overflow: hidden; position: relative; }
+.logo-scroll::before, .logo-scroll::after { content: ''; position: absolute; top: 0; bottom: 0; width: 120px; z-index: 2; }
+.logo-scroll::before { left: 0; background: linear-gradient(to right, var(--bg), transparent); }
+.logo-scroll::after { right: 0; background: linear-gradient(to left, var(--bg), transparent); }
+.logo-track { display: flex; gap: 3.5rem; animation: scroll-logos 40s linear infinite; width: max-content; }
+.logo-item { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; flex-shrink: 0; }
+.logo-item span { font-size: 0.6875rem; color: var(--text-muted); white-space: nowrap; }
+@keyframes scroll-logos { 0% { transform: translateX(0); } 100% { transform: translateX(-50%); } }
+
+/* ========== TTFAC ========== */
+.ttfac { padding: 8rem 0; background: var(--bg-deep); position: relative; }
+.section-header { text-align: center; margin-bottom: 4rem; }
+.section-tag { display: inline-block; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.12em; color: var(--emerald-400); background: rgba(16, 185, 129, 0.08); border: 1px solid rgba(16, 185, 129, 0.2); border-radius: 100px; padding: 0.3rem 1rem; margin-bottom: 1rem; }
+.section-title { font-size: clamp(2.25rem, 5vw, 3.5rem); font-weight: 800; letter-spacing: -0.035em; line-height: 1.1; margin-bottom: 1rem; }
+.section-desc { font-size: 1.125rem; color: var(--text-secondary); max-width: 600px; margin: 0 auto; }
+
+.ttfac-compare { display: flex; align-items: center; justify-content: center; gap: 2rem; flex-wrap: wrap; }
+.ttfac-card { flex: 1; min-width: 280px; max-width: 380px; background: var(--bg-card); border: 1px solid var(--border); border-radius: 20px; padding: 2rem; transition: transform 0.3s var(--ease-apple), box-shadow 0.3s var(--ease-apple); }
+.ttfac-card:hover { box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
+.tilt-card { transform-style: preserve-3d; perspective: 1000px; }
+.ttfac-card-header { display: flex; align-items: center; gap: 0.625rem; font-weight: 600; font-size: 0.9375rem; margin-bottom: 1.5rem; }
+.ttfac-header-old { color: #ef4444; }
+.ttfac-header-new { color: var(--emerald-400); }
+.ttfac-counter { display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 1.5rem; }
+.ttfac-number { font-size: 3.5rem; font-weight: 800; font-variant-numeric: tabular-nums; line-height: 1; letter-spacing: -0.03em; }
+.ttfac-number-green { color: var(--emerald-400); }
+.ttfac-unit { font-size: 1.25rem; color: var(--text-muted); font-weight: 500; }
+.ttfac-steps { display: flex; flex-direction: column; gap: 0.625rem; }
+.ttfac-steps li { font-size: 0.875rem; color: var(--text-secondary); padding-left: 1.25rem; position: relative; }
+.ttfac-steps li::before { content: ''; position: absolute; left: 0; top: 0.5em; width: 6px; height: 6px; border-radius: 50%; background: var(--text-muted); }
+.ttfac-steps-fast li::before { background: var(--emerald-500); }
+.ttfac-steps-fast li { font-family: var(--font-mono); font-size: 0.8125rem; color: var(--emerald-400); }
+
+.ttfac-timeline { display: flex; flex-direction: column; align-items: center; gap: 0.75rem; padding: 0 1rem; }
+.ttfac-timeline-line { width: 2px; height: 40px; background: linear-gradient(180deg, transparent, var(--violet-500), transparent); }
+.ttfac-timeline-arrow svg { animation: pulse-arrow 2s ease-in-out infinite; }
+@keyframes pulse-arrow { 0%, 100% { transform: scale(1); opacity: 0.8; } 50% { transform: scale(1.1); opacity: 1; } }
+
+@media (max-width: 900px) {
+  .ttfac-compare { flex-direction: column; }
+  .ttfac-timeline { flex-direction: row; padding: 0; }
+  .ttfac-timeline-line { width: 40px; height: 2px; }
+}
+
+/* ========== Features ========== */
+.features { padding: 4rem 0; background: var(--bg); }
+.feature-block { display: grid; grid-template-columns: 1fr 1fr; gap: 4rem; align-items: center; max-width: var(--max-w); margin: 0 auto; padding: 6rem var(--gutter); }
+.feature-block-reverse { direction: rtl; }
+.feature-block-reverse > * { direction: ltr; }
+.feature-tag { display: inline-block; font-size: 0.6875rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.12em; color: var(--violet-400); background: rgba(139, 92, 246, 0.08); border: 1px solid rgba(139, 92, 246, 0.2); border-radius: 100px; padding: 0.25rem 0.875rem; margin-bottom: 1rem; }
+.feature-title { font-size: clamp(2rem, 4vw, 3rem); font-weight: 800; letter-spacing: -0.035em; line-height: 1.1; margin-bottom: 1rem; }
+.feature-desc { font-size: 1rem; color: var(--text-secondary); line-height: 1.7; margin-bottom: 1.5rem; }
+.feature-list { display: flex; flex-direction: column; gap: 0.625rem; }
+.feature-list li { display: flex; align-items: center; gap: 0.5rem; font-size: 0.9375rem; color: var(--text-primary); }
+.feature-list li svg { flex-shrink: 0; display: inline; }
+.feature-visual { display: flex; align-items: center; justify-content: center; min-height: 320px; }
+
+/* MCP Animation */
+.feature-anim-mcp { position: relative; width: 300px; height: 300px; }
+.mcp-center { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2; }
+.mcp-hub { width: 80px; height: 80px; border-radius: 20px; background: linear-gradient(135deg, var(--emerald-500), var(--violet-500)); display: flex; align-items: center; justify-content: center; font-weight: 800; font-size: 0.875rem; color: #fff; box-shadow: 0 0 40px rgba(16, 185, 129, 0.3); }
+.mcp-agent { position: absolute; display: flex; align-items: center; gap: 0.375rem; background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; padding: 0.5rem 0.875rem; font-size: 0.75rem; font-weight: 600; color: var(--text-secondary); z-index: 2; }
+.mcp-agent-1 { top: 10%; left: 5%; }
+.mcp-agent-2 { top: 10%; right: 5%; }
+.mcp-agent-3 { bottom: 10%; left: 50%; transform: translateX(-50%); }
+.mcp-line { position: absolute; background: linear-gradient(var(--border), var(--border)); z-index: 1; }
+.mcp-line-1 { width: 2px; height: 60px; top: 55px; left: 65px; transform: rotate(-30deg); transform-origin: bottom; }
+.mcp-line-2 { width: 2px; height: 60px; top: 55px; right: 65px; transform: rotate(30deg); transform-origin: bottom; }
+.mcp-line-3 { width: 2px; height: 50px; bottom: 60px; left: 50%; transform: translateX(-50%); }
+.mcp-pulse { position: absolute; width: 8px; height: 8px; border-radius: 50%; background: var(--emerald-400); z-index: 3; box-shadow: 0 0 10px var(--emerald-400); }
+.mcp-pulse-1 { animation: pulse-move-1 2.5s ease-in-out infinite; }
+.mcp-pulse-2 { animation: pulse-move-2 2.5s ease-in-out infinite 0.8s; }
+.mcp-pulse-3 { animation: pulse-move-3 2.5s ease-in-out infinite 1.6s; }
+@keyframes pulse-move-1 { 0%, 100% { top: 55px; left: 65px; opacity: 0; } 10% { opacity: 1; } 50% { top: 130px; left: 130px; opacity: 1; } 60% { opacity: 0; } }
+@keyframes pulse-move-2 { 0%, 100% { top: 55px; right: 65px; left: auto; opacity: 0; } 10% { opacity: 1; } 50% { top: 130px; right: 130px; opacity: 1; } 60% { opacity: 0; } }
+@keyframes pulse-move-3 { 0%, 100% { bottom: 60px; left: 50%; opacity: 0; } 10% { opacity: 1; } 50% { bottom: 120px; left: 50%; opacity: 1; } 60% { opacity: 0; } }
+
+/* UAC Animation */
+.feature-anim-uac { display: flex; flex-direction: column; align-items: center; gap: 2rem; width: 100%; max-width: 320px; }
+.uac-source { background: var(--bg-card); border: 1px solid var(--border); border-radius: 14px; padding: 1.25rem 2rem; position: relative; }
+.uac-source::after { content: ''; position: absolute; inset: -1px; border-radius: 14px; background: linear-gradient(135deg, var(--emerald-500), var(--violet-500)); z-index: -1; opacity: 0.4; filter: blur(8px); }
+.uac-source code { font-family: var(--font-mono); font-size: 1rem; font-weight: 600; color: var(--emerald-400); }
+.uac-arrows { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; width: 100%; }
+.uac-arrow { background: var(--bg-card); border: 1px solid var(--border); border-radius: 10px; padding: 0.75rem; text-align: center; position: relative; overflow: hidden; }
+.uac-arrow span { font-size: 0.8125rem; font-weight: 600; color: var(--text-secondary); position: relative; z-index: 1; }
+.uac-arrow::before { content: ''; position: absolute; inset: 0; background: linear-gradient(135deg, rgba(16, 185, 129, 0.06), rgba(139, 92, 246, 0.06)); opacity: 0; transition: opacity 0.5s; }
+.uac-arrow-1 { animation: uac-flash 3s ease-in-out infinite 0s; }
+.uac-arrow-2 { animation: uac-flash 3s ease-in-out infinite 0.5s; }
+.uac-arrow-3 { animation: uac-flash 3s ease-in-out infinite 1s; }
+.uac-arrow-4 { animation: uac-flash 3s ease-in-out infinite 1.5s; }
+@keyframes uac-flash { 0%, 100% { border-color: var(--border); } 30% { border-color: rgba(16, 185, 129, 0.4); } 50% { border-color: var(--border); } }
+
+/* Gateway Orbit */
+.feature-anim-gw { display: flex; align-items: center; justify-content: center; }
+.gw-orbit { position: relative; width: 280px; height: 280px; }
+.gw-center-logo { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 64px; height: 64px; border-radius: 16px; background: linear-gradient(135deg, var(--emerald-500), var(--violet-500)); display: flex; align-items: center; justify-content: center; font-weight: 800; font-size: 0.75rem; color: #fff; box-shadow: 0 0 30px rgba(16, 185, 129, 0.25); z-index: 2; }
+.gw-item { position: absolute; width: 52px; height: 52px; border-radius: 12px; background: var(--bg-card); border: 1px solid var(--border); display: flex; align-items: center; justify-content: center; font-size: 0.625rem; font-weight: 600; color: var(--text-muted); animation: orbit-float 8s ease-in-out infinite; z-index: 1; }
+.gw-item-1 { top: 0; left: 50%; transform: translateX(-50%); animation-delay: 0s; }
+.gw-item-2 { top: 22%; right: 2%; animation-delay: -1.33s; }
+.gw-item-3 { bottom: 22%; right: 2%; animation-delay: -2.66s; }
+.gw-item-4 { bottom: 0; left: 50%; transform: translateX(-50%); animation-delay: -4s; }
+.gw-item-5 { bottom: 22%; left: 2%; animation-delay: -5.33s; }
+.gw-item-6 { top: 22%; left: 2%; animation-delay: -6.66s; }
+@keyframes orbit-float { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-8px); } }
+.gw-item-1, .gw-item-4 { animation: orbit-float-center 8s ease-in-out infinite; }
+@keyframes orbit-float-center { 0%, 100% { transform: translateX(-50%) translateY(0); } 50% { transform: translateX(-50%) translateY(-8px); } }
+
+@media (max-width: 768px) {
+  .feature-block { grid-template-columns: 1fr; gap: 2rem; padding: 4rem var(--gutter); }
+  .feature-block-reverse { direction: ltr; }
+  .feature-visual { min-height: 240px; }
+}
+
+/* ========== Closing ========== */
+.closing { position: relative; padding: 8rem 0; overflow: hidden; }
+.closing-bg { position: absolute; inset: 0; z-index: 0; overflow: hidden; }
+.orb-teal-lg { width: 800px; height: 800px; background: radial-gradient(circle, rgba(45, 212, 191, 0.12), transparent 70%); top: -20%; left: -15%; }
+.orb-purple-lg { width: 700px; height: 700px; background: radial-gradient(circle, rgba(139, 92, 246, 0.12), transparent 70%); bottom: -20%; right: -10%; }
+.closing-content { position: relative; z-index: 1; text-align: center; }
+.closing-title { font-size: clamp(2.5rem, 6vw, 4.5rem); font-weight: 800; letter-spacing: -0.04em; line-height: 1.1; margin-bottom: 1.25rem; }
+.closing-desc { font-size: 1.125rem; color: var(--text-secondary); max-width: 550px; margin: 0 auto 2.5rem; }
+.closing-ctas { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; margin-bottom: 3.5rem; }
+.closing-stats { display: flex; justify-content: center; gap: 3.5rem; flex-wrap: wrap; }
+.closing-stat { text-align: center; }
+.closing-stat-num { display: block; font-size: 2.5rem; font-weight: 800; font-variant-numeric: tabular-nums; letter-spacing: -0.02em; background: linear-gradient(135deg, var(--emerald-400), var(--violet-400)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+.closing-stat-label { font-size: 0.8125rem; color: var(--text-muted); }
+
+/* ========== Footer ========== */
+.footer { border-top: 1px solid var(--border); background: var(--bg-deep); padding: 4rem var(--gutter) 2rem; }
+.footer-inner { max-width: var(--max-w); margin: 0 auto; display: grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap: 3rem; }
+.footer-desc { font-size: 0.8125rem; color: var(--text-muted); margin-top: 0.75rem; line-height: 1.6; }
+.footer-col h4 { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-secondary); margin-bottom: 1rem; }
+.footer-col a { display: block; font-size: 0.875rem; color: var(--text-muted); margin-bottom: 0.625rem; transition: color 0.2s; }
+.footer-col a:hover { color: var(--text-primary); }
+.footer-bottom { max-width: var(--max-w); margin: 3rem auto 0; padding-top: 1.5rem; border-top: 1px solid var(--border); text-align: center; font-size: 0.75rem; color: var(--text-muted); }
+
+@media (max-width: 768px) { .footer-inner { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 480px) { .footer-inner { grid-template-columns: 1fr; } }


### PR DESCRIPTION
## Summary
- Vite vanilla prototype with Apple-style scroll animations (reveals, parallax, counters, typewriter, 3D tilt)
- Real STOA velocity data: 916 PRs, 3,900 tests, 7 Stoa Links, 194K LOC
- Counter & typewriter animations tied to scroll reveals (MutationObserver waits for parent `.visible` class)

## Test plan
- [x] `npm run build` clean
- [x] `npm run dev` — scroll animations trigger correctly per section

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>