### PR TITLE
fix(docs): correct quickstart URL in tests and rules

### DIFF
--- a/.claude/rules/seo-content.md
+++ b/.claude/rules/seo-content.md
@@ -161,7 +161,7 @@ Blog posts link to each other using relative paths:
 
 Docs pages use full paths:
 ```markdown
-[Quick Start](/docs/guides/quick-start)
+[Quick Start](/docs/guides/quickstart)
 [Architecture Overview](/docs/concepts/architecture)
 [Migration Guide](/docs/guides/migration/)
 [ADR-024 Gateway Modes](/docs/architecture/adr/adr-024-gateway-unified-modes)
@@ -216,7 +216,7 @@ When delegating to `docs-writer`, ALWAYS provide:
 2. **Valid link list** — extract from build or provide known-good paths:
    ```
    Blog: /blog/what-is-mcp-gateway, /blog/open-source-api-gateway-2026, ...
-   Docs: /docs/guides/quick-start, /docs/concepts/architecture, ...
+   Docs: /docs/guides/quickstart, /docs/concepts/architecture, ...
    ```
 3. **Hub article** — which pillar hub to link back to
 4. **Word count target** — minimum for the content type

--- a/control-plane-api/tests/test_docs_search.py
+++ b/control-plane-api/tests/test_docs_search.py
@@ -40,7 +40,7 @@ def sample_algolia_hits():
     return [
         {
             "title": "Quick Start Guide",
-            "url": "https://docs.gostoa.dev/docs/guides/quick-start",
+            "url": "https://docs.gostoa.dev/docs/guides/quickstart",
             "content": "Get started with STOA in 5 minutes...",
             "_snippetResult": {"content": {"value": "Get started with <em>STOA</em> in 5 minutes..."}},
         },
@@ -59,7 +59,7 @@ def sample_llms_entries():
     return [
         {
             "title": "Quick Start Guide",
-            "url": "https://docs.gostoa.dev/docs/guides/quick-start",
+            "url": "https://docs.gostoa.dev/docs/guides/quickstart",
             "description": "Get started with STOA in 5 minutes",
         },
         {
@@ -177,7 +177,7 @@ class TestBoostLogic:
         algolia_results = [
             DocsSearchResult(
                 title="Quick Start Guide",
-                url="https://docs.gostoa.dev/docs/guides/quick-start",
+                url="https://docs.gostoa.dev/docs/guides/quickstart",
                 snippet="...",
                 score=1.0,
             )
@@ -197,7 +197,7 @@ class TestBoostLogic:
         algolia_results = [
             DocsSearchResult(
                 title="Quick Start",
-                url="https://docs.gostoa.dev/docs/guides/quick-start",
+                url="https://docs.gostoa.dev/docs/guides/quickstart",
                 snippet="...",
                 score=1.0,
             )
@@ -216,7 +216,7 @@ class TestBoostLogic:
             ),
             DocsSearchResult(
                 title="Quick Start Guide",
-                url="https://docs.gostoa.dev/docs/guides/quick-start",
+                url="https://docs.gostoa.dev/docs/guides/quickstart",
                 snippet="...",
                 score=1.0,
             ),
@@ -429,7 +429,7 @@ class TestCategoryDetection:
                 return_value=[
                     {
                         "title": "Guide",
-                        "url": "https://docs.gostoa.dev/guides/quick-start",
+                        "url": "https://docs.gostoa.dev/guides/quickstart",
                         "content": "...",
                         "_snippetResult": {"content": {"value": "..."}},
                     }
@@ -763,7 +763,7 @@ class TestSemanticSearch:
                     {
                         "_source": {
                             "title": "Quick Start",
-                            "url": "https://docs.gostoa.dev/guides/quick-start",
+                            "url": "https://docs.gostoa.dev/guides/quickstart",
                             "content": "Get started quickly",
                             "heading": "Overview",
                         },
@@ -1030,7 +1030,7 @@ class TestCategorizeUrl:
         assert _categorize_url("https://docs.gostoa.dev/adr/adr-024") == "adr"
 
     def test_guide(self):
-        assert _categorize_url("https://docs.gostoa.dev/guides/quick-start") == "guide"
+        assert _categorize_url("https://docs.gostoa.dev/guides/quickstart") == "guide"
 
     def test_docs(self):
         assert _categorize_url("https://docs.gostoa.dev/docs/overview") == "docs"


### PR DESCRIPTION
## Summary
- Fix `quick-start` → `quickstart` in test fixtures (`test_docs_search.py`) and SEO rules (`.claude/rules/seo-content.md`)
- Aligns with the actual Docusaurus slug (`slug: /guides/quickstart` in `quick-start.md`)
- Companion fix to stoa-web commit `e9983f8` (already deployed on Vercel)

## Test plan
- [ ] CI green (docs-only + test data change, no behavior change)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>