### PR TITLE
feat(helm): add HPA + PDB for all components (CAB-1438)

### DIFF
--- a/charts/stoa-platform/templates/control-plane-api-hpa.yaml
+++ b/charts/stoa-platform/templates/control-plane-api-hpa.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.controlPlaneApi.autoscaling .Values.controlPlaneApi.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: stoa-control-plane-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: stoa-control-plane-api
+    app.kubernetes.io/component: api
+    {{- include "stoa-platform.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: stoa-control-plane-api
+  minReplicas: {{ .Values.controlPlaneApi.autoscaling.minReplicas | default 2 }}
+  maxReplicas: {{ .Values.controlPlaneApi.autoscaling.maxReplicas | default 5 }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.controlPlaneApi.autoscaling.scaleDownStabilizationSeconds | default 300 }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.controlPlaneApi.autoscaling.targetCPUUtilizationPercentage | default 70 }}
+    {{- if .Values.controlPlaneApi.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.controlPlaneApi.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/stoa-platform/templates/control-plane-api-pdb.yaml
+++ b/charts/stoa-platform/templates/control-plane-api-pdb.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.controlPlaneApi.podDisruptionBudget .Values.controlPlaneApi.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: stoa-control-plane-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: stoa-control-plane-api
+    app.kubernetes.io/component: api
+    {{- include "stoa-platform.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.controlPlaneApi.podDisruptionBudget.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: stoa-control-plane-api
+{{- end }}

--- a/charts/stoa-platform/templates/control-plane-ui-hpa.yaml
+++ b/charts/stoa-platform/templates/control-plane-ui-hpa.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.controlPlaneUi .Values.controlPlaneUi.autoscaling .Values.controlPlaneUi.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: control-plane-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: control-plane-ui
+    app.kubernetes.io/component: console
+    {{- include "stoa-platform.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: control-plane-ui
+  minReplicas: {{ .Values.controlPlaneUi.autoscaling.minReplicas | default 2 }}
+  maxReplicas: {{ .Values.controlPlaneUi.autoscaling.maxReplicas | default 5 }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.controlPlaneUi.autoscaling.scaleDownStabilizationSeconds | default 300 }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.controlPlaneUi.autoscaling.targetCPUUtilizationPercentage | default 70 }}
+    {{- if .Values.controlPlaneUi.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.controlPlaneUi.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/stoa-platform/templates/control-plane-ui-pdb.yaml
+++ b/charts/stoa-platform/templates/control-plane-ui-pdb.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.controlPlaneUi .Values.controlPlaneUi.podDisruptionBudget .Values.controlPlaneUi.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: control-plane-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: control-plane-ui
+    app.kubernetes.io/component: console
+    {{- include "stoa-platform.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.controlPlaneUi.podDisruptionBudget.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: control-plane-ui
+{{- end }}

--- a/charts/stoa-platform/templates/mcp-gateway-hpa.yaml
+++ b/charts/stoa-platform/templates/mcp-gateway-hpa.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.mcpGateway .Values.mcpGateway.autoscaling .Values.mcpGateway.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: stoa-mcp-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: stoa-mcp-gateway
+    app.kubernetes.io/component: mcp-gateway
+    {{- include "stoa-platform.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: stoa-mcp-gateway
+  minReplicas: {{ .Values.mcpGateway.autoscaling.minReplicas | default 2 }}
+  maxReplicas: {{ .Values.mcpGateway.autoscaling.maxReplicas | default 5 }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.mcpGateway.autoscaling.scaleDownStabilizationSeconds | default 300 }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.mcpGateway.autoscaling.targetCPUUtilizationPercentage | default 70 }}
+    {{- if .Values.mcpGateway.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.mcpGateway.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/stoa-platform/templates/mcp-gateway-pdb.yaml
+++ b/charts/stoa-platform/templates/mcp-gateway-pdb.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.mcpGateway .Values.mcpGateway.podDisruptionBudget .Values.mcpGateway.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: stoa-mcp-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: stoa-mcp-gateway
+    app.kubernetes.io/component: mcp-gateway
+    {{- include "stoa-platform.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.mcpGateway.podDisruptionBudget.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: stoa-mcp-gateway
+{{- end }}

--- a/charts/stoa-platform/templates/portal-hpa.yaml
+++ b/charts/stoa-platform/templates/portal-hpa.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.portal .Values.portal.autoscaling .Values.portal.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: stoa-portal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: stoa-portal
+    app.kubernetes.io/component: portal
+    {{- include "stoa-platform.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: stoa-portal
+  minReplicas: {{ .Values.portal.autoscaling.minReplicas | default 2 }}
+  maxReplicas: {{ .Values.portal.autoscaling.maxReplicas | default 5 }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.portal.autoscaling.scaleDownStabilizationSeconds | default 300 }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.portal.autoscaling.targetCPUUtilizationPercentage | default 70 }}
+    {{- if .Values.portal.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.portal.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/stoa-platform/templates/portal-pdb.yaml
+++ b/charts/stoa-platform/templates/portal-pdb.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.portal .Values.portal.podDisruptionBudget .Values.portal.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: stoa-portal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: stoa-portal
+    app.kubernetes.io/component: portal
+    {{- include "stoa-platform.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.portal.podDisruptionBudget.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: stoa-portal
+{{- end }}

--- a/charts/stoa-platform/values.yaml
+++ b/charts/stoa-platform/values.yaml
@@ -134,7 +134,7 @@ stoaGateway:
   tolerations: []
   extraEnv: []
 
-# Autoscaling (HPA) — gateway only (other components use standalone manifests)
+# Autoscaling (HPA) — stoa-gateway (Rust). Other components: see controlPlaneApi/controlPlaneUi/portal/mcpGateway sections below.
 autoscaling:
   enabled: false
   minReplicas: 2
@@ -143,7 +143,7 @@ autoscaling:
   targetMemoryUtilizationPercentage: 80
   scaleDownStabilizationSeconds: 300
 
-# Pod Disruption Budget — gateway only (other components use standalone manifests)
+# Pod Disruption Budget — stoa-gateway (Rust). Other components: see controlPlaneApi/controlPlaneUi/portal/mcpGateway sections below.
 podDisruptionBudget:
   enabled: false
   minAvailable: 1
@@ -364,6 +364,66 @@ controlPlaneApi:
   # Cluster name for multi-cluster observability labels (CAB-1426)
   clusterName: default
   environment: dev
+  # HPA — target: stoa-control-plane-api Deployment (standalone k8s manifest)
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+    scaleDownStabilizationSeconds: 300
+  # PDB — target: stoa-control-plane-api Deployment
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+
+# ==============================================================================
+# Control Plane UI (Console) — HPA & PDB (CAB-1438)
+# ==============================================================================
+# Deployment: control-plane-ui (standalone k8s manifest)
+controlPlaneUi:
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+    scaleDownStabilizationSeconds: 300
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+
+# ==============================================================================
+# Developer Portal — HPA & PDB (CAB-1438)
+# ==============================================================================
+# Deployment: stoa-portal (standalone k8s manifest)
+portal:
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+    scaleDownStabilizationSeconds: 300
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+
+# ==============================================================================
+# MCP Gateway (Python) — HPA & PDB (CAB-1438)
+# ==============================================================================
+# Deployment: stoa-mcp-gateway (standalone k8s manifest)
+mcpGateway:
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+    scaleDownStabilizationSeconds: 300
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
 
 alertmanager:
   enabled: false


### PR DESCRIPTION
## Summary
- Add HorizontalPodAutoscaler for control-plane-api, control-plane-ui, portal, mcp-gateway
- Add PodDisruptionBudget for same 4 components
- Follows existing stoa-gateway HPA/PDB pattern (autoscaling/v2, policy/v1)
- All gated by per-component values.yaml flags (disabled by default for dev, enable for prod)
- Correct deployment names verified from standalone k8s manifests

## Details

| Component | Deployment Name | HPA Values Path | PDB Values Path |
|-----------|----------------|-----------------|-----------------|
| Control Plane API | `stoa-control-plane-api` | `controlPlaneApi.autoscaling` | `controlPlaneApi.podDisruptionBudget` |
| Control Plane UI | `control-plane-ui` | `controlPlaneUi.autoscaling` | `controlPlaneUi.podDisruptionBudget` |
| Portal | `stoa-portal` | `portal.autoscaling` | `portal.podDisruptionBudget` |
| MCP Gateway | `stoa-mcp-gateway` | `mcpGateway.autoscaling` | `mcpGateway.podDisruptionBudget` |
| STOA Gateway | `stoa-gateway` | `autoscaling` (existing) | `podDisruptionBudget` (existing) |

Defaults: CPU 70%, memory 80%, min 2 replicas, max 5, scale-down stabilization 300s, PDB minAvailable 1.

## Test plan
- [x] All 8 new templates parse as valid YAML
- [x] values.yaml validates as valid YAML
- [x] 5 HPA + 5 PDB template files total
- [ ] helm lint passes (pre-existing Chart.yaml issue on local Helm v3.13.0, CI should pass)
- [ ] CI green (3 required checks)

**Note**: `helm lint` fails locally with a pre-existing "Chart.yaml file is missing" error (confirmed on `main` before changes). This is a known Helm v3.13.0 issue, not caused by this PR.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>