### PR TITLE
test(gateway): expand federation test coverage (CAB-1446)

### DIFF
--- a/stoa-gateway/src/federation/cache.rs
+++ b/stoa-gateway/src/federation/cache.rs
@@ -212,4 +212,68 @@ mod tests {
         cache.cache.run_pending_tasks().await;
         assert_eq!(cache.entry_count(), 0);
     }
+
+    #[tokio::test]
+    async fn test_cache_miss_increments_miss_counter() {
+        let cp = Arc::new(ToolProxyClient::new("http://localhost:9999", None));
+        let cache = FederationCache::new(300, 1000, cp);
+
+        // Attempt get with no entry in cache and unreachable CP — should miss
+        let _result = cache
+            .get_allowed_tools("sub-unknown", "tenant", "master")
+            .await;
+
+        let stats = cache.stats();
+        assert_eq!(stats.misses, 1);
+        assert_eq!(stats.hits, 0);
+    }
+
+    #[tokio::test]
+    async fn test_cache_hit_rate_with_one_hit_one_miss() {
+        let cp = Arc::new(ToolProxyClient::new("http://localhost:9999", None));
+        let cache = FederationCache::new(300, 1000, cp);
+
+        // Seed a cache entry directly
+        let tools: HashSet<String> = vec!["tool_x".to_string()].into_iter().collect();
+        cache.cache.insert("sub-hit".to_string(), tools).await;
+
+        // One hit
+        let _ = cache.get_allowed_tools("sub-hit", "tenant", "master").await;
+        // One miss (unreachable CP)
+        let _ = cache
+            .get_allowed_tools("sub-miss", "tenant", "master")
+            .await;
+
+        let stats = cache.stats();
+        assert_eq!(stats.hits, 1);
+        assert_eq!(stats.misses, 1);
+        // hit_rate = 1 / 2 = 0.5
+        assert!((stats.hit_rate - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn test_entry_count_after_multiple_inserts() {
+        let cp = Arc::new(ToolProxyClient::new("http://localhost:8000", None));
+        let cache = FederationCache::new(300, 1000, cp);
+
+        for i in 0..5u32 {
+            let tools: HashSet<String> = vec![format!("tool_{i}")].into_iter().collect();
+            cache.cache.insert(format!("sub-{i}"), tools).await;
+        }
+        cache.cache.run_pending_tasks().await;
+
+        assert_eq!(cache.entry_count(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_hit_rate_zero_when_no_requests() {
+        let cp = Arc::new(ToolProxyClient::new("http://localhost:8000", None));
+        let cache = FederationCache::new(300, 1000, cp);
+
+        let stats = cache.stats();
+        // No requests → hit_rate must be 0.0 (avoids divide-by-zero)
+        assert_eq!(stats.hit_rate, 0.0);
+        assert_eq!(stats.hits, 0);
+        assert_eq!(stats.misses, 0);
+    }
 }

--- a/stoa-gateway/src/federation/context.rs
+++ b/stoa-gateway/src/federation/context.rs
@@ -68,4 +68,33 @@ mod tests {
         };
         assert!(ctx.is_tool_allowed("anything"));
     }
+
+    #[test]
+    fn test_empty_allow_list_denies_all_tools() {
+        // An explicit empty set means no tools are allowed (differs from None)
+        let ctx = ctx_with_tools(vec![]);
+        assert!(!ctx.is_tool_allowed("any_tool"));
+        assert!(!ctx.is_tool_allowed("tool_a"));
+        assert!(!ctx.is_tool_allowed(""));
+    }
+
+    #[test]
+    fn test_allow_list_is_case_sensitive() {
+        let ctx = ctx_with_tools(vec!["MyTool"]);
+        // Exact match works
+        assert!(ctx.is_tool_allowed("MyTool"));
+        // Different case does not match
+        assert!(!ctx.is_tool_allowed("mytool"));
+        assert!(!ctx.is_tool_allowed("MYTOOL"));
+    }
+
+    #[test]
+    fn test_clone_preserves_allowed_tools() {
+        let ctx = ctx_with_tools(vec!["tool_a", "tool_b"]);
+        let cloned = ctx.clone();
+        assert!(cloned.is_tool_allowed("tool_a"));
+        assert!(cloned.is_tool_allowed("tool_b"));
+        assert!(!cloned.is_tool_allowed("tool_c"));
+        assert_eq!(cloned.sub_account_id, ctx.sub_account_id);
+    }
 }

--- a/stoa-gateway/src/federation/middleware.rs
+++ b/stoa-gateway/src/federation/middleware.rs
@@ -162,6 +162,14 @@ mod tests {
         base_claims()
     }
 
+    fn test_claims_sub_only() -> Claims {
+        // sub_account_id set but master_account_id missing — warning path
+        let mut claims = base_claims();
+        claims.sub_account_id = Some("sub-orphan".to_string());
+        claims.master_account_id = None;
+        claims
+    }
+
     #[tokio::test]
     async fn test_disabled_passes_through() {
         let state = test_state(false);
@@ -198,6 +206,43 @@ mod tests {
             email: None,
             tenant_id: Some("acme".to_string()),
             claims: test_claims_without_federation(),
+            raw_token: "token".to_string(),
+        });
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_sub_account_without_master_passes_through_without_context() {
+        // When sub_account_id is set but master_account_id is absent, the middleware
+        // should emit a warning and pass through WITHOUT injecting SubAccountContext.
+        let state = test_state(true);
+
+        async fn check_no_context(request: axum::extract::Request) -> axum::response::Response {
+            use axum::response::IntoResponse;
+            if request.extensions().get::<SubAccountContext>().is_none() {
+                StatusCode::OK.into_response()
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            }
+        }
+
+        let app = Router::new()
+            .route("/test", get(check_no_context))
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                federation_middleware,
+            ))
+            .with_state(state);
+
+        let mut request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+        request.extensions_mut().insert(AuthenticatedUser {
+            user_id: "user-orphan".to_string(),
+            username: Some("orphan".to_string()),
+            email: None,
+            tenant_id: Some("acme".to_string()),
+            claims: test_claims_sub_only(),
             raw_token: "token".to_string(),
         });
 


### PR DESCRIPTION
## Summary
- Expand test coverage for federation edge cases in stoa-gateway
- Part of CAB-1446 Gateway Test Coverage Expansion MEGA

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>