### PR TITLE
feat(helm): auto-sync secrets from Infisical + multi-staging pattern (CAB-1342)

### DIFF
--- a/charts/stoa-platform/templates/_helpers-infisical.tpl
+++ b/charts/stoa-platform/templates/_helpers-infisical.tpl
@@ -1,0 +1,144 @@
+{{/*
+Infisical init container — fetches secrets from Infisical and writes them
+to a shared emptyDir volume at /secrets as individual files.
+
+Usage in a Deployment template:
+  initContainers:
+    {{- include "stoa-platform.infisicalInitContainer" . | nindent 8 }}
+  volumes:
+    {{- include "stoa-platform.infisicalVolume" . | nindent 8 }}
+
+The main container can then mount the volume:
+  volumeMounts:
+    - name: infisical-secrets
+      mountPath: /secrets
+      readOnly: true
+
+Or source all exported env vars via envFrom on a generated .env file.
+*/}}
+
+{{/*
+Reusable init container that fetches secrets from Infisical.
+Secrets are written as individual files under /secrets/<KEY>=<VALUE> format
+and also as a combined /secrets/.env file for envFrom consumption.
+*/}}
+{{- define "stoa-platform.infisicalInitContainer" -}}
+{{- if .Values.infisical.enabled }}
+- name: infisical-secrets-init
+  image: {{ .Values.infisical.image | default "infisical/cli:latest" }}
+  command:
+    - /bin/sh
+    - -c
+    - |
+      set -e
+      echo "Fetching secrets from Infisical..."
+      echo "  Address: ${INFISICAL_API_URL}"
+      echo "  Project: ${INFISICAL_PROJECT_ID}"
+      echo "  Env:     ${INFISICAL_ENVIRONMENT}"
+      echo "  Path:    ${INFISICAL_SECRET_PATH}"
+
+      # Authenticate with Universal Auth (Machine Identity)
+      export INFISICAL_TOKEN=$(infisical login \
+        --method=universal-auth \
+        --client-id="${INFISICAL_CLIENT_ID}" \
+        --client-secret="${INFISICAL_CLIENT_SECRET}" \
+        --domain="${INFISICAL_API_URL}" \
+        --silent 2>/dev/null || echo "")
+
+      if [ -z "${INFISICAL_TOKEN}" ]; then
+        echo "ERROR: Failed to authenticate with Infisical"
+        {{- if .Values.infisical.required }}
+        exit 1
+        {{- else }}
+        echo "WARN: infisical.required=false — continuing without secrets"
+        touch /secrets/.env
+        exit 0
+        {{- end }}
+      fi
+
+      # Export secrets as individual files + combined .env
+      infisical export \
+        --domain="${INFISICAL_API_URL}" \
+        --projectId="${INFISICAL_PROJECT_ID}" \
+        --env="${INFISICAL_ENVIRONMENT}" \
+        --path="${INFISICAL_SECRET_PATH}" \
+        --format=dotenv \
+        --token="${INFISICAL_TOKEN}" \
+        > /secrets/.env
+
+      # Also write each secret as an individual file for flexible consumption
+      while IFS='=' read -r key value; do
+        # Skip empty lines and comments
+        [ -z "$key" ] && continue
+        case "$key" in \#*) continue ;; esac
+        printf '%s' "$value" > "/secrets/${key}"
+      done < /secrets/.env
+
+      echo "Secrets synced successfully ($(wc -l < /secrets/.env) entries)"
+  env:
+    - name: INFISICAL_API_URL
+      value: {{ .Values.infisical.address | quote }}
+    - name: INFISICAL_PROJECT_ID
+      value: {{ .Values.infisical.projectId | quote }}
+    - name: INFISICAL_ENVIRONMENT
+      value: {{ .Values.infisical.environment | quote }}
+    - name: INFISICAL_SECRET_PATH
+      value: {{ .Values.infisical.secretPath | default "/" | quote }}
+    - name: INFISICAL_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.infisical.clientSecretRef.name | quote }}
+          key: {{ .Values.infisical.clientSecretRef.clientIdKey | default "client-id" | quote }}
+    - name: INFISICAL_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.infisical.clientSecretRef.name | quote }}
+          key: {{ .Values.infisical.clientSecretRef.clientSecretKey | default "client-secret" | quote }}
+  volumeMounts:
+    - name: infisical-secrets
+      mountPath: /secrets
+  securityContext:
+    privileged: false
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  resources:
+    requests:
+      cpu: 50m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+{{- end }}
+{{- end }}
+
+{{/*
+Shared volume for Infisical secrets — emptyDir that init container writes to
+and main container reads from.
+*/}}
+{{- define "stoa-platform.infisicalVolume" -}}
+{{- if .Values.infisical.enabled }}
+- name: infisical-secrets
+  emptyDir:
+    medium: Memory
+    sizeLimit: 10Mi
+{{- end }}
+{{- end }}
+
+{{/*
+Volume mount for main container to read Infisical secrets.
+*/}}
+{{- define "stoa-platform.infisicalVolumeMount" -}}
+{{- if .Values.infisical.enabled }}
+- name: infisical-secrets
+  mountPath: /secrets
+  readOnly: true
+{{- end }}
+{{- end }}

--- a/charts/stoa-platform/templates/applicationset-staging.yaml
+++ b/charts/stoa-platform/templates/applicationset-staging.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.staging.enabled }}
+---
+# ArgoCD ApplicationSet — generates one Application per staging environment.
+# Each staging env gets its own namespace and Infisical environment binding.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: stoa-staging-environments
+  namespace: {{ .Values.staging.argocdNamespace | default "argocd" }}
+  labels:
+    app.kubernetes.io/name: stoa-staging
+    app.kubernetes.io/component: applicationset
+    {{- include "stoa-platform.labels" . | nindent 4 }}
+spec:
+  generators:
+    - list:
+        elements:
+          {{- range .Values.staging.environments }}
+          - name: {{ .name }}
+            namespace: {{ .namespace }}
+            infisicalEnv: {{ .infisicalEnv | default "staging" }}
+            {{- if .domain }}
+            domain: {{ .domain }}
+            {{- end }}
+          {{- end }}
+  template:
+    metadata:
+      name: 'stoa-{{`{{name}}`}}'
+      labels:
+        app.kubernetes.io/part-of: stoa-platform
+        stoa.io/staging-env: '{{`{{name}}`}}'
+    spec:
+      project: {{ .Values.staging.argocdProject | default "default" }}
+      source:
+        repoURL: {{ .Values.staging.repoURL | default "https://github.com/stoa-platform/stoa.git" }}
+        targetRevision: {{ .Values.staging.targetRevision | default "main" }}
+        path: charts/stoa-platform
+        helm:
+          valueFiles:
+            - values.yaml
+            - values-staging.yaml
+          parameters:
+            - name: stoaGateway.environment
+              value: '{{`{{name}}`}}'
+            {{- if .Values.infisical.enabled }}
+            - name: infisical.environment
+              value: '{{`{{infisicalEnv}}`}}'
+            {{- end }}
+      destination:
+        server: {{ .Values.staging.destinationServer | default "https://kubernetes.default.svc" }}
+        namespace: '{{`{{namespace}}`}}'
+      syncPolicy:
+        automated:
+          prune: {{ .Values.staging.autoPrune | default true }}
+          selfHeal: {{ .Values.staging.selfHeal | default true }}
+        syncOptions:
+          - CreateNamespace=true
+          - PruneLast=true
+{{- end }}

--- a/charts/stoa-platform/templates/namespace-staging.yaml
+++ b/charts/stoa-platform/templates/namespace-staging.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.staging.enabled }}
+{{- range .Values.staging.environments }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .namespace }}
+  labels:
+    app.kubernetes.io/part-of: stoa-platform
+    app.kubernetes.io/managed-by: Helm
+    stoa.io/staging-env: {{ .name }}
+  annotations:
+    stoa.io/infisical-env: {{ .infisicalEnv | default "staging" }}
+{{- end }}
+{{- end }}

--- a/charts/stoa-platform/templates/stoa-gateway-deployment.yaml
+++ b/charts/stoa-platform/templates/stoa-gateway-deployment.yaml
@@ -37,6 +37,10 @@ spec:
       {{- else }}
       serviceAccountName: {{ .Values.stoaGateway.serviceAccount | default "default" }}
       {{- end }}
+      {{- if .Values.infisical.enabled }}
+      initContainers:
+        {{- include "stoa-platform.infisicalInitContainer" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: stoa-gateway
           image: "{{ .Values.stoaGateway.image.repository }}:{{ .Values.stoaGateway.image.tag }}"
@@ -163,6 +167,7 @@ spec:
               mountPath: /etc/stoa/policies
               readOnly: true
             {{- end }}
+            {{- include "stoa-platform.infisicalVolumeMount" . | nindent 12 }}
       securityContext:
         runAsNonRoot: true
         fsGroup: 1000
@@ -174,6 +179,7 @@ spec:
           configMap:
             name: stoa-gateway-policies
         {{- end }}
+        {{- include "stoa-platform.infisicalVolume" . | nindent 8 }}
       {{- with .Values.stoaGateway.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/stoa-platform/values.yaml
+++ b/charts/stoa-platform/values.yaml
@@ -425,6 +425,82 @@ mcpGateway:
     enabled: false
     minAvailable: 1
 
+# ==============================================================================
+# Infisical Secret Sync (CAB-1342 Phase 1)
+# ==============================================================================
+# Opt-in init container that fetches secrets from Infisical on pod startup.
+# Secrets are written to a shared emptyDir volume (/secrets) as individual
+# files and a combined .env file. Uses Universal Auth (Machine Identity).
+#
+# Prerequisites:
+#   1. Create a K8s Secret with Infisical Machine Identity credentials:
+#      kubectl create secret generic infisical-machine-identity \
+#        --from-literal=client-id=<CLIENT_ID> \
+#        --from-literal=client-secret=<CLIENT_SECRET> \
+#        -n stoa-system
+#   2. Set infisical.enabled=true and fill in projectId
+infisical:
+  enabled: false
+  # Infisical API address (self-hosted or cloud)
+  address: "https://vault.gostoa.dev/api"
+  # Infisical project ID
+  projectId: ""
+  # Environment to fetch secrets from (dev | staging | prod)
+  environment: "prod"
+  # Secret path within the project
+  secretPath: "/"
+  # Auth method (only universal-auth supported)
+  authMethod: "universal-auth"
+  # Init container image
+  image: "infisical/cli:latest"
+  # If true, pod fails to start when Infisical is unreachable
+  # If false, pod starts with empty /secrets (graceful degradation)
+  required: false
+  # Reference to the K8s Secret containing Machine Identity credentials
+  clientSecretRef:
+    # Name of the K8s Secret
+    name: "infisical-machine-identity"
+    # Key within the Secret for client ID
+    clientIdKey: "client-id"
+    # Key within the Secret for client secret
+    clientSecretKey: "client-secret"
+
+# ==============================================================================
+# Multi-Staging Pattern (CAB-1342 Phase 2)
+# ==============================================================================
+# ArgoCD ApplicationSet that generates N staging environments from a list.
+# Each environment gets its own namespace and Infisical env binding.
+# Requires ArgoCD ApplicationSet controller (included in ArgoCD >= 2.3).
+staging:
+  enabled: false
+  # ArgoCD namespace where the ApplicationSet will be created
+  argocdNamespace: argocd
+  # ArgoCD project
+  argocdProject: default
+  # Git repo URL for Helm source
+  repoURL: "https://github.com/stoa-platform/stoa.git"
+  # Git branch/tag/commit
+  targetRevision: main
+  # K8s API server for destination
+  destinationServer: "https://kubernetes.default.svc"
+  # Auto-prune removed resources
+  autoPrune: true
+  # Self-heal drift from desired state
+  selfHeal: true
+  # List of staging environments to generate
+  environments: []
+  # Example:
+  #   - name: staging-1
+  #     namespace: stoa-staging-1
+  #     infisicalEnv: staging
+  #   - name: staging-2
+  #     namespace: stoa-staging-2
+  #     infisicalEnv: staging
+  #   - name: qa
+  #     namespace: stoa-qa
+  #     infisicalEnv: staging
+  #     domain: qa.gostoa.dev
+
 alertmanager:
   enabled: false
   image:


### PR DESCRIPTION
## Summary

- **Phase 1**: Reusable Infisical init container template (`_helpers-infisical.tpl`) that fetches secrets via Universal Auth (Machine Identity) on pod startup. Writes to shared emptyDir volume at `/secrets` as `.env` + individual files. Opt-in via `infisical.enabled: true`, graceful degradation when `infisical.required: false`.
- **Phase 2**: ArgoCD ApplicationSet + Namespace templates for multi-staging environments. List generator creates one Application per staging env with per-env Infisical binding. Opt-in via `staging.enabled: true`.
- Both features are fully opt-in (disabled by default) with zero impact on existing deployments.

## Files Changed

| File | Change | Lines |
|------|--------|-------|
| `templates/_helpers-infisical.tpl` | NEW | 144 |
| `templates/applicationset-staging.yaml` | NEW | 59 |
| `templates/namespace-staging.yaml` | NEW | 15 |
| `templates/stoa-gateway-deployment.yaml` | Modified | +6 |
| `values.yaml` | Modified | +76 |

## Test plan

- [x] `helm template` renders init container when `infisical.enabled=true`
- [x] `helm template` renders ApplicationSet when `staging.enabled=true`
- [x] `helm template` produces no output for either feature when disabled (default)
- [x] Init container has full Kyverno-compliant securityContext (`privileged: false`, `runAsNonRoot`, drop ALL)
- [x] Values defaults are safe (both features disabled, `infisical.required: false`)
- [ ] CI passes (3 required checks: License, SBOM, Signed Commits)

> **Note**: `helm lint` has a pre-existing failure on `main` caused by `.helmignore` negation pattern (`!README.md`) confusing Helm 3.13's ignore parser. This is NOT caused by this PR.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>