### PR TITLE
docs: add READMEs + PR template + DEVELOPER.md (CAB-1450)

### DIFF
--- a/archive/README.md
+++ b/archive/README.md
@@ -1,0 +1,40 @@
+# Archive
+
+Components that have been superseded but are preserved for reference.
+
+## Contents
+
+| Component | Replaced By | Archived |
+|-----------|-------------|----------|
+| `mcp-gateway/` | `stoa-gateway/` (Rust) | February 2026 |
+
+## mcp-gateway
+
+Python 3.11 / FastAPI implementation of the MCP Gateway. Ran in production from Q3 2025 to
+February 2026, handling MCP tool discovery, SSE transport, OPA policy enforcement, and Kafka
+metering.
+
+Replaced by the Rust `stoa-gateway` for performance, memory footprint, and unified 4-mode
+architecture (ADR-024: edge-mcp, sidecar, proxy, shadow).
+
+### Why archived (not deleted)
+
+- Reference implementation for adapter logic and OPA integration
+- Alembic migrations still used by control-plane-api's shared database
+- Docker Compose files useful for local development of non-gateway components
+- Test fixtures and patterns reusable by the Rust rewrite
+
+### Do not use for
+
+- Production deployments -- use `stoa-gateway/` instead
+- New feature development -- all MCP work targets the Rust gateway
+- CI pipelines -- mcp-gateway CI was removed in February 2026
+
+## Adding archived components
+
+When retiring a component:
+
+1. Move its directory under `archive/`
+2. Remove its CI workflow from `.github/workflows/`
+3. Add a row to the table above
+4. Keep its `CLAUDE.md` intact for context

--- a/charts/stoa-platform/README.md
+++ b/charts/stoa-platform/README.md
@@ -25,30 +25,36 @@ helm upgrade --install stoa-platform ./charts/stoa-platform \
 kubectl apply -f charts/stoa-platform/crds/
 ```
 
-## Values Files
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `stoaGateway.enabled` | `true` | Deploy the Rust gateway |
+| `stoaGateway.replicas` | `2` | Pod replica count |
+| `stoaGateway.image.repository` | `ghcr.io/stoa-platform/stoa-gateway` | Container image |
+| `stoaGateway.image.tag` | `latest` | Image tag |
+| `stoaGateway.controlPlaneUrl` | `http://control-plane-api:8000` | API sync endpoint |
+| `stoaGateway.keycloakUrl` | `http://keycloak:8080` | OIDC provider |
+| `stoaGateway.mode` | `edge-mcp` | Gateway mode (edge-mcp, sidecar, proxy, shadow) |
+| `stoaGateway.autoRegister` | `true` | Register with control plane on startup |
+| `stoaGateway.ingress.enabled` | `true` | Create Ingress resource |
+| `stoaGateway.ingress.host` | `mcp.<YOUR_DOMAIN>` | Ingress hostname |
+| `stoaGateway.serviceMonitor.enabled` | `true` | Create Prometheus ServiceMonitor |
+| `stoaGateway.resources.requests.memory` | `128Mi` | Memory request |
+| `stoaGateway.resources.limits.memory` | `256Mi` | Memory limit |
+| `stoaSidecar.enabled` | `false` | Deploy sidecar mode (future) |
+| `gatewaySync.enabled` | `false` | Enable OpenAPI sync CronJob |
+| `gatewaySync.schedule` | `*/30 * * * *` | Sync frequency |
+| `autoscaling.enabled` | `false` | Enable HPA |
+| `podDisruptionBudget.enabled` | `false` | Enable PDB |
+
+### Environment overrides
 
 | File | Environment | Usage |
 |------|-------------|-------|
-| `values.yaml` | Base defaults | Always loaded |
-| `values-dev.yaml` | Local / CI dev | `helm upgrade ... -f values-dev.yaml` |
+| `values-dev.yaml` | Local / CI | `helm upgrade ... -f values-dev.yaml` |
 | `values-staging.yaml` | Hetzner K3s | ArgoCD auto-sync |
 | `values-prod.yaml` | OVH MKS | ArgoCD auto-sync |
-
-## Key Values
-
-```yaml
-stoaGateway:
-  enabled: true            # Rust gateway (primary)
-  replicas: 2
-  image:
-    repository: ghcr.io/stoa-platform/stoa-gateway
-    tag: latest
-
-gateway:
-  image:
-    repository: ghcr.io/hlfh/mcp-gateway  # Python (legacy)
-    tag: latest
-```
 
 ## Templates
 
@@ -73,6 +79,7 @@ Custom Resource Definitions in `crds/` (applied separately, not managed by Helm 
 | `tools.gostoa.dev` | `gostoa.dev/v1alpha1` | MCP Tool definitions |
 | `toolsets.gostoa.dev` | `gostoa.dev/v1alpha1` | Tool groupings |
 | `gatewayinstances.gostoa.dev` | `gostoa.dev/v1alpha1` | Gateway instance registration |
+| `skills.gostoa.dev` | `gostoa.dev/v1alpha1` | MCP Skill definitions |
 | `gatewaybindings.gostoa.dev` | `gostoa.dev/v1alpha1` | Gateway-to-tool bindings |
 
 ## Architecture


### PR DESCRIPTION
## Summary

- Enhance `charts/stoa-platform/README.md` with structured key values table (18 rows from actual values.yaml), environment overrides section, templates table, 5 CRDs, and architecture diagram
- Create `archive/README.md` explaining the archived mcp-gateway component (replaced by Rust stoa-gateway Feb 2026) with template for future archived components
- DEVELOPER.md and PR template already merged via PR #987; this PR completes the remaining Phase 2 deliverables

## Linear Ticket

CAB-1450

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Tests (adding or updating tests)
- [ ] CI/CD (workflow, pipeline, or config changes)

## How Has This Been Tested?

- [x] Manual review of rendered markdown
- [x] Verified key values match actual values.yaml defaults
- [x] Verified CRD list matches crds/ directory contents

## Quality Gate Checklist

### All Components

- [x] No new lint warnings introduced
- [x] No secrets or credentials in code
- [x] Commit messages follow `type(scope): description` format

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>