### PR TITLE
feat(api): usage metering pipeline — Kafka aggregation + API (CAB-1334)

### DIFF
--- a/control-plane-api/alembic/versions/042_create_usage_records.py
+++ b/control-plane-api/alembic/versions/042_create_usage_records.py
@@ -1,0 +1,58 @@
+"""Create usage_records table.
+
+Revision ID: 042
+Revises: 041
+Create Date: 2026-02-24
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "042"
+down_revision = "041"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "usage_records",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tenant_id", sa.String(255), nullable=False),
+        sa.Column("tool_name", sa.String(255), nullable=False),
+        sa.Column("period_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("period_end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("period_type", sa.String(20), nullable=False),
+        sa.Column("request_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("token_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("error_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("avg_latency_ms", sa.Float(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "tenant_id",
+            "tool_name",
+            "period_start",
+            "period_type",
+            name="uq_usage_tenant_tool_period",
+        ),
+    )
+    op.create_index("ix_usage_records_tenant_id", "usage_records", ["tenant_id"])
+    op.create_index(
+        "ix_usage_tenant_period",
+        "usage_records",
+        ["tenant_id", "period_type", "period_start"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_usage_tenant_period", table_name="usage_records")
+    op.drop_index("ix_usage_records_tenant_id", table_name="usage_records")
+    op.drop_table("usage_records")

--- a/control-plane-api/src/main.py
+++ b/control-plane-api/src/main.py
@@ -62,6 +62,7 @@ from .routers import (
     mcp_gitops,
     mcp_policy_proxy,
     mcp_proxy,
+    metering,
     monitoring,
     onboarding,
     onboarding_admin,
@@ -678,6 +679,9 @@ app.include_router(execution_logs.router)
 
 # Diagnostics — Self-diagnostic engine with auto-RCA (CAB-1316)
 app.include_router(diagnostics.router)
+
+# Usage Metering — aggregated metering pipeline (CAB-1334)
+app.include_router(metering.router)
 
 # Self-service tenant signup (CAB-1315) — public, rate-limited
 app.include_router(self_service.router)

--- a/control-plane-api/src/models/__init__.py
+++ b/control-plane-api/src/models/__init__.py
@@ -62,6 +62,7 @@ from .skill import Skill, SkillScope
 from .subscription import Subscription, SubscriptionStatus
 from .tenant import Tenant, TenantProvisioningStatus, TenantStatus
 from .traces import PipelineTrace, TraceStatus, TraceStep, trace_store
+from .usage import UsageRecord
 from .webhook import (
     TenantWebhook,
     WebhookDelivery,

--- a/control-plane-api/src/models/usage.py
+++ b/control-plane-api/src/models/usage.py
@@ -1,0 +1,57 @@
+"""UsageRecord SQLAlchemy model for aggregated metering data (CAB-1334 Phase 1)."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Float,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID
+
+from src.database import Base
+
+
+class UsageRecord(Base):
+    """Stores aggregated usage metrics per tenant/tool/period.
+
+    Records are upserted by the metering pipeline (Kafka consumer or batch job).
+    Queried by the /v1/metering endpoints for admin dashboards.
+    """
+
+    __tablename__ = "usage_records"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id = Column(String(255), nullable=False, index=True)
+    tool_name = Column(String(255), nullable=False)
+    period_start = Column(DateTime(timezone=True), nullable=False)
+    period_end = Column(DateTime(timezone=True), nullable=False)
+    period_type = Column(String(20), nullable=False)  # "hourly", "daily", "monthly"
+    request_count = Column(Integer, nullable=False, default=0)
+    token_count = Column(Integer, nullable=False, default=0)
+    error_count = Column(Integer, nullable=False, default=0)
+    avg_latency_ms = Column(Float, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime(timezone=True), nullable=True, onupdate=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id",
+            "tool_name",
+            "period_start",
+            "period_type",
+            name="uq_usage_tenant_tool_period",
+        ),
+        Index("ix_usage_tenant_period", "tenant_id", "period_type", "period_start"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<UsageRecord {self.id} tenant={self.tenant_id} "
+            f"tool={self.tool_name} period={self.period_type}>"
+        )

--- a/control-plane-api/src/repositories/usage_repository.py
+++ b/control-plane-api/src/repositories/usage_repository.py
@@ -1,0 +1,111 @@
+"""Repository for usage_records table (CAB-1334 Phase 1)."""
+
+import logging
+from datetime import datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.usage import UsageRecord
+
+logger = logging.getLogger(__name__)
+
+
+class UsageRepository:
+    """Data-access layer for aggregated usage records."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_usage_summary(
+        self,
+        tenant_id: str,
+        period_type: str,
+        start: datetime,
+        end: datetime,
+    ) -> list[UsageRecord]:
+        """Fetch usage records for the summary aggregation."""
+        stmt = select(UsageRecord).where(
+            UsageRecord.period_type == period_type,
+            UsageRecord.period_start >= start,
+            UsageRecord.period_start < end,
+        )
+        if tenant_id:
+            stmt = stmt.where(UsageRecord.tenant_id == tenant_id)
+
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_usage_details(
+        self,
+        tenant_id: str,
+        period_type: str,
+        start: datetime,
+        end: datetime,
+        tool_name: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> tuple[list[UsageRecord], int]:
+        """Fetch paginated usage detail records."""
+        base = select(UsageRecord).where(
+            UsageRecord.period_type == period_type,
+            UsageRecord.period_start >= start,
+            UsageRecord.period_start < end,
+        )
+        if tenant_id:
+            base = base.where(UsageRecord.tenant_id == tenant_id)
+        if tool_name:
+            base = base.where(UsageRecord.tool_name == tool_name)
+
+        # Total count
+        count_stmt = select(func.count()).select_from(base.subquery())
+        count_result = await self.db.execute(count_stmt)
+        total = count_result.scalar() or 0
+
+        # Paginated data
+        data_stmt = (
+            base.order_by(UsageRecord.period_start.desc()).offset(offset).limit(limit)
+        )
+        data_result = await self.db.execute(data_stmt)
+        records = list(data_result.scalars().all())
+
+        return records, total
+
+    async def upsert_usage_record(
+        self,
+        tenant_id: str,
+        tool_name: str,
+        period_start: datetime,
+        period_end: datetime,
+        period_type: str,
+        request_count: int = 0,
+        token_count: int = 0,
+        error_count: int = 0,
+        avg_latency_ms: float | None = None,
+    ) -> None:
+        """Insert or update a usage record (PostgreSQL ON CONFLICT)."""
+        stmt = pg_insert(UsageRecord).values(
+            tenant_id=tenant_id,
+            tool_name=tool_name,
+            period_start=period_start,
+            period_end=period_end,
+            period_type=period_type,
+            request_count=request_count,
+            token_count=token_count,
+            error_count=error_count,
+            avg_latency_ms=avg_latency_ms,
+        )
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_usage_tenant_tool_period",
+            set_={
+                "request_count": stmt.excluded.request_count,
+                "token_count": stmt.excluded.token_count,
+                "error_count": stmt.excluded.error_count,
+                "avg_latency_ms": stmt.excluded.avg_latency_ms,
+                "period_end": stmt.excluded.period_end,
+                "updated_at": func.now(),
+            },
+        )
+        await self.db.execute(stmt)
+        await self.db.commit()

--- a/control-plane-api/src/routers/metering.py
+++ b/control-plane-api/src/routers/metering.py
@@ -1,0 +1,72 @@
+"""Usage Metering Router — admin-facing aggregated usage endpoints (CAB-1334 Phase 1).
+
+Routes:
+- GET /v1/metering/summary — Aggregated usage summary per tenant
+- GET /v1/metering/details — Detailed usage breakdown with pagination
+"""
+
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.auth.dependencies import User
+from src.auth.rbac import require_role
+from src.database import get_db
+from src.schemas.metering import UsageDetailResponse, UsageSummary
+from src.services.usage_service import UsageMeteringService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/metering", tags=["Metering"])
+
+
+@router.get("/summary", response_model=UsageSummary)
+async def get_usage_summary(
+    period_type: str = Query(default="daily", pattern="^(hourly|daily|monthly)$"),
+    start: datetime = Query(...),
+    end: datetime = Query(...),
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_role(["cpi-admin", "tenant-admin"])),
+) -> UsageSummary:
+    """Aggregated usage metrics across tools for a tenant or platform-wide.
+
+    CPI admin sees all tenants; tenant-admin sees only own tenant.
+    """
+    tenant_id = user.tenant_id or ""
+    svc = UsageMeteringService(db)
+    return await svc.get_summary(
+        tenant_id=tenant_id,
+        period_type=period_type,
+        start=start,
+        end=end,
+    )
+
+
+@router.get("/details", response_model=UsageDetailResponse)
+async def get_usage_details(
+    period_type: str = Query(default="daily", pattern="^(hourly|daily|monthly)$"),
+    start: datetime = Query(...),
+    end: datetime = Query(...),
+    tool_name: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=1000),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_role(["cpi-admin", "tenant-admin"])),
+) -> UsageDetailResponse:
+    """Detailed per-period usage records with optional tool filter.
+
+    CPI admin sees all tenants; tenant-admin sees only own tenant.
+    """
+    tenant_id = user.tenant_id or ""
+    svc = UsageMeteringService(db)
+    return await svc.get_details(
+        tenant_id=tenant_id,
+        period_type=period_type,
+        start=start,
+        end=end,
+        tool_name=tool_name,
+        limit=limit,
+        offset=offset,
+    )

--- a/control-plane-api/src/schemas/metering.py
+++ b/control-plane-api/src/schemas/metering.py
@@ -1,0 +1,50 @@
+"""Pydantic schemas for Usage Metering endpoints (CAB-1334 Phase 1)."""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ToolUsage(BaseModel):
+    """Per-tool usage aggregation."""
+
+    tool_name: str
+    request_count: int
+    token_count: int
+    error_count: int
+    avg_latency_ms: float | None = None
+
+
+class UsageSummary(BaseModel):
+    """Aggregated usage summary for a time range."""
+
+    tenant_id: str
+    period_type: str
+    period_start: datetime
+    period_end: datetime
+    total_requests: int
+    total_tokens: int
+    total_errors: int
+    avg_latency_ms: float | None = None
+    tools: list[ToolUsage] = []
+
+
+class UsageDetailItem(BaseModel):
+    """Single usage record in the details list."""
+
+    period_start: datetime
+    period_end: datetime
+    request_count: int
+    token_count: int
+    error_count: int
+    avg_latency_ms: float | None = None
+
+
+class UsageDetailResponse(BaseModel):
+    """Paginated detail response."""
+
+    tenant_id: str
+    tool_name: str | None = None
+    period_type: str
+    items: list[UsageDetailItem] = []
+    total: int = 0

--- a/control-plane-api/src/services/usage_service.py
+++ b/control-plane-api/src/services/usage_service.py
@@ -1,0 +1,163 @@
+"""Usage metering service (CAB-1334 Phase 1)."""
+
+import logging
+from collections import defaultdict
+from datetime import datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.repositories.usage_repository import UsageRepository
+from src.schemas.metering import (
+    ToolUsage,
+    UsageDetailItem,
+    UsageDetailResponse,
+    UsageSummary,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class UsageMeteringService:
+    """Business logic for usage metering queries and recording."""
+
+    def __init__(self, db: AsyncSession):
+        self.repo = UsageRepository(db)
+
+    async def get_summary(
+        self,
+        tenant_id: str,
+        period_type: str,
+        start: datetime,
+        end: datetime,
+    ) -> UsageSummary:
+        """Aggregate usage records into a summary with per-tool breakdown."""
+        records = await self.repo.get_usage_summary(tenant_id, period_type, start, end)
+
+        # Aggregate per tool
+        tool_map: dict[str, dict] = defaultdict(
+            lambda: {
+                "request_count": 0,
+                "token_count": 0,
+                "error_count": 0,
+                "latency_sum": 0.0,
+                "latency_records": 0,
+            }
+        )
+        total_requests = 0
+        total_tokens = 0
+        total_errors = 0
+        latency_sum = 0.0
+        latency_records = 0
+
+        for rec in records:
+            t = tool_map[rec.tool_name]
+            t["request_count"] += rec.request_count
+            t["token_count"] += rec.token_count
+            t["error_count"] += rec.error_count
+            if rec.avg_latency_ms is not None:
+                t["latency_sum"] += rec.avg_latency_ms * rec.request_count
+                t["latency_records"] += rec.request_count
+
+            total_requests += rec.request_count
+            total_tokens += rec.token_count
+            total_errors += rec.error_count
+            if rec.avg_latency_ms is not None:
+                latency_sum += rec.avg_latency_ms * rec.request_count
+                latency_records += rec.request_count
+
+        tools = []
+        for tool_name, data in sorted(tool_map.items()):
+            avg_lat = (
+                data["latency_sum"] / data["latency_records"]
+                if data["latency_records"] > 0
+                else None
+            )
+            tools.append(
+                ToolUsage(
+                    tool_name=tool_name,
+                    request_count=data["request_count"],
+                    token_count=data["token_count"],
+                    error_count=data["error_count"],
+                    avg_latency_ms=round(avg_lat, 2) if avg_lat is not None else None,
+                )
+            )
+
+        overall_avg = latency_sum / latency_records if latency_records > 0 else None
+
+        return UsageSummary(
+            tenant_id=tenant_id or "(all)",
+            period_type=period_type,
+            period_start=start,
+            period_end=end,
+            total_requests=total_requests,
+            total_tokens=total_tokens,
+            total_errors=total_errors,
+            avg_latency_ms=round(overall_avg, 2) if overall_avg is not None else None,
+            tools=tools,
+        )
+
+    async def get_details(
+        self,
+        tenant_id: str,
+        period_type: str,
+        start: datetime,
+        end: datetime,
+        tool_name: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> UsageDetailResponse:
+        """Fetch paginated usage detail records."""
+        records, total = await self.repo.get_usage_details(
+            tenant_id=tenant_id,
+            period_type=period_type,
+            start=start,
+            end=end,
+            tool_name=tool_name,
+            limit=limit,
+            offset=offset,
+        )
+
+        items = [
+            UsageDetailItem(
+                period_start=rec.period_start,
+                period_end=rec.period_end,
+                request_count=rec.request_count,
+                token_count=rec.token_count,
+                error_count=rec.error_count,
+                avg_latency_ms=rec.avg_latency_ms,
+            )
+            for rec in records
+        ]
+
+        return UsageDetailResponse(
+            tenant_id=tenant_id or "(all)",
+            tool_name=tool_name,
+            period_type=period_type,
+            items=items,
+            total=total,
+        )
+
+    async def record_usage(
+        self,
+        tenant_id: str,
+        tool_name: str,
+        period_start: datetime,
+        period_end: datetime,
+        period_type: str,
+        request_count: int = 0,
+        token_count: int = 0,
+        error_count: int = 0,
+        avg_latency_ms: float | None = None,
+    ) -> None:
+        """Record (upsert) a usage entry — called by Kafka consumer or batch job."""
+        await self.repo.upsert_usage_record(
+            tenant_id=tenant_id,
+            tool_name=tool_name,
+            period_start=period_start,
+            period_end=period_end,
+            period_type=period_type,
+            request_count=request_count,
+            token_count=token_count,
+            error_count=error_count,
+            avg_latency_ms=avg_latency_ms,
+        )

--- a/control-plane-api/tests/test_metering.py
+++ b/control-plane-api/tests/test_metering.py
@@ -1,0 +1,484 @@
+"""Tests for Usage Metering Router + Service + Repository — CAB-1334 Phase 1.
+
+Covers:
+- GET /v1/metering/summary (200, RBAC, tenant isolation, period validation)
+- GET /v1/metering/details (200, pagination, tool filter, RBAC)
+- UsageMeteringService aggregation logic
+- UsageRepository upsert + query
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+SVC_PATH = "src.routers.metering.UsageMeteringService"
+
+
+# ---- Helpers ----
+
+
+def _mock_summary():
+    """Return a mock UsageSummary-like object."""
+    return MagicMock(
+        tenant_id="acme",
+        period_type="daily",
+        period_start=datetime(2026, 2, 1, tzinfo=UTC),
+        period_end=datetime(2026, 2, 28, tzinfo=UTC),
+        total_requests=1000,
+        total_tokens=50000,
+        total_errors=10,
+        avg_latency_ms=120.5,
+        tools=[],
+    )
+
+
+def _mock_details():
+    """Return a mock UsageDetailResponse-like object."""
+    return MagicMock(
+        tenant_id="acme",
+        tool_name=None,
+        period_type="daily",
+        items=[],
+        total=0,
+    )
+
+
+# ---- Router Tests: /v1/metering/summary ----
+
+
+class TestMeteringSummary:
+    """Tests for GET /v1/metering/summary."""
+
+    def test_summary_success_cpi_admin(self, app_with_cpi_admin, mock_db_session):
+        """CPI admin gets usage summary across all tenants."""
+        mock_svc = MagicMock()
+        mock_svc.get_summary = AsyncMock(return_value=_mock_summary())
+
+        with patch(SVC_PATH, return_value=mock_svc), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(
+                "/v1/metering/summary?start=2026-02-01T00:00:00Z&end=2026-02-28T00:00:00Z"
+            )
+
+        assert resp.status_code == 200
+        mock_svc.get_summary.assert_called_once()
+        # CPI admin has no tenant_id → passes ""
+        call_kwargs = mock_svc.get_summary.call_args.kwargs
+        assert call_kwargs["tenant_id"] == ""
+
+    def test_summary_success_tenant_admin(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admin gets usage summary scoped to own tenant."""
+        mock_svc = MagicMock()
+        mock_svc.get_summary = AsyncMock(return_value=_mock_summary())
+
+        with patch(SVC_PATH, return_value=mock_svc), TestClient(app_with_tenant_admin) as client:
+            resp = client.get(
+                "/v1/metering/summary?start=2026-02-01T00:00:00Z&end=2026-02-28T00:00:00Z"
+            )
+
+        assert resp.status_code == 200
+        call_kwargs = mock_svc.get_summary.call_args.kwargs
+        assert call_kwargs["tenant_id"] == "acme"
+
+    def test_summary_with_hourly_period(self, app_with_cpi_admin, mock_db_session):
+        """Summary with hourly period_type is accepted."""
+        mock_svc = MagicMock()
+        mock_svc.get_summary = AsyncMock(return_value=_mock_summary())
+
+        with patch(SVC_PATH, return_value=mock_svc), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(
+                "/v1/metering/summary"
+                "?period_type=hourly&start=2026-02-01T00:00:00Z&end=2026-02-01T23:59:59Z"
+            )
+
+        assert resp.status_code == 200
+        call_kwargs = mock_svc.get_summary.call_args.kwargs
+        assert call_kwargs["period_type"] == "hourly"
+
+    def test_summary_with_monthly_period(self, app_with_cpi_admin, mock_db_session):
+        """Summary with monthly period_type is accepted."""
+        mock_svc = MagicMock()
+        mock_svc.get_summary = AsyncMock(return_value=_mock_summary())
+
+        with patch(SVC_PATH, return_value=mock_svc), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(
+                "/v1/metering/summary"
+                "?period_type=monthly&start=2026-01-01T00:00:00Z&end=2026-12-31T23:59:59Z"
+            )
+
+        assert resp.status_code == 200
+        call_kwargs = mock_svc.get_summary.call_args.kwargs
+        assert call_kwargs["period_type"] == "monthly"
+
+    def test_summary_invalid_period_type(self, app_with_cpi_admin, mock_db_session):
+        """Invalid period_type returns 422."""
+        with TestClient(app_with_cpi_admin) as client:
+            resp = client.get(
+                "/v1/metering/summary"
+                "?period_type=weekly&start=2026-02-01T00:00:00Z&end=2026-02-28T00:00:00Z"
+            )
+
+        assert resp.status_code == 422
+
+    def test_summary_missing_start(self, app_with_cpi_admin, mock_db_session):
+        """Missing start parameter returns 422."""
+        with TestClient(app_with_cpi_admin) as client:
+            resp = client.get("/v1/metering/summary?end=2026-02-28T00:00:00Z")
+
+        assert resp.status_code == 422
+
+    def test_summary_403_viewer(self, app_with_no_tenant_user):
+        """Viewer role is denied access to summary."""
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.get(
+                "/v1/metering/summary?start=2026-02-01T00:00:00Z&end=2026-02-28T00:00:00Z"
+            )
+
+        assert resp.status_code == 403
+
+
+# ---- Router Tests: /v1/metering/details ----
+
+
+class TestMeteringDetails:
+    """Tests for GET /v1/metering/details."""
+
+    def test_details_success(self, app_with_cpi_admin, mock_db_session):
+        """CPI admin gets detailed usage breakdown."""
+        mock_svc = MagicMock()
+        mock_svc.get_details = AsyncMock(return_value=_mock_details())
+
+        with patch(SVC_PATH, return_value=mock_svc), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(
+                "/v1/metering/details?start=2026-02-01T00:00:00Z&end=2026-02-28T00:00:00Z"
+            )
+
+        assert resp.status_code == 200
+        mock_svc.get_details.assert_called_once()
+
+    def test_details_with_tool_filter(self, app_with_cpi_admin, mock_db_session):
+        """Details with tool_name filter forwards the parameter."""
+        mock_svc = MagicMock()
+        mock_svc.get_details = AsyncMock(return_value=_mock_details())
+
+        with patch(SVC_PATH, return_value=mock_svc), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(
+                "/v1/metering/details"
+                "?start=2026-02-01T00:00:00Z&end=2026-02-28T00:00:00Z"
+                "&tool_name=crm-search"
+            )
+
+        assert resp.status_code == 200
+        call_kwargs = mock_svc.get_details.call_args.kwargs
+        assert call_kwargs["tool_name"] == "crm-search"
+
+    def test_details_pagination(self, app_with_cpi_admin, mock_db_session):
+        """Details with custom limit and offset."""
+        mock_svc = MagicMock()
+        mock_svc.get_details = AsyncMock(return_value=_mock_details())
+
+        with patch(SVC_PATH, return_value=mock_svc), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(
+                "/v1/metering/details"
+                "?start=2026-02-01T00:00:00Z&end=2026-02-28T00:00:00Z"
+                "&limit=50&offset=100"
+            )
+
+        assert resp.status_code == 200
+        call_kwargs = mock_svc.get_details.call_args.kwargs
+        assert call_kwargs["limit"] == 50
+        assert call_kwargs["offset"] == 100
+
+    def test_details_tenant_admin_scoped(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admin details are scoped to own tenant."""
+        mock_svc = MagicMock()
+        mock_svc.get_details = AsyncMock(return_value=_mock_details())
+
+        with patch(SVC_PATH, return_value=mock_svc), TestClient(app_with_tenant_admin) as client:
+            resp = client.get(
+                "/v1/metering/details?start=2026-02-01T00:00:00Z&end=2026-02-28T00:00:00Z"
+            )
+
+        assert resp.status_code == 200
+        call_kwargs = mock_svc.get_details.call_args.kwargs
+        assert call_kwargs["tenant_id"] == "acme"
+
+    def test_details_403_viewer(self, app_with_no_tenant_user):
+        """Viewer role is denied access to details."""
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.get(
+                "/v1/metering/details?start=2026-02-01T00:00:00Z&end=2026-02-28T00:00:00Z"
+            )
+
+        assert resp.status_code == 403
+
+    def test_details_invalid_period_type(self, app_with_cpi_admin, mock_db_session):
+        """Invalid period_type returns 422."""
+        with TestClient(app_with_cpi_admin) as client:
+            resp = client.get(
+                "/v1/metering/details"
+                "?period_type=yearly&start=2026-02-01T00:00:00Z&end=2026-02-28T00:00:00Z"
+            )
+
+        assert resp.status_code == 422
+
+
+# ---- Service Tests ----
+
+
+class TestUsageMeteringService:
+    """Tests for UsageMeteringService aggregation logic."""
+
+    @pytest.mark.asyncio
+    async def test_summary_aggregates_tools(self):
+        """Summary groups records by tool and computes weighted avg latency."""
+        from src.services.usage_service import UsageMeteringService
+
+        mock_db = AsyncMock()
+        svc = UsageMeteringService(mock_db)
+
+        rec1 = MagicMock(
+            tool_name="crm-search",
+            request_count=100,
+            token_count=5000,
+            error_count=2,
+            avg_latency_ms=120.0,
+        )
+        rec2 = MagicMock(
+            tool_name="crm-search",
+            request_count=200,
+            token_count=10000,
+            error_count=3,
+            avg_latency_ms=150.0,
+        )
+        rec3 = MagicMock(
+            tool_name="weather-api",
+            request_count=50,
+            token_count=1000,
+            error_count=0,
+            avg_latency_ms=80.0,
+        )
+
+        with patch.object(svc.repo, "get_usage_summary", new_callable=AsyncMock) as mock_repo:
+            mock_repo.return_value = [rec1, rec2, rec3]
+
+            result = await svc.get_summary(
+                tenant_id="acme",
+                period_type="daily",
+                start=datetime(2026, 2, 1, tzinfo=UTC),
+                end=datetime(2026, 2, 28, tzinfo=UTC),
+            )
+
+        assert result.total_requests == 350
+        assert result.total_tokens == 16000
+        assert result.total_errors == 5
+        assert len(result.tools) == 2
+        # crm-search: weighted avg = (120*100 + 150*200) / 300 = 42000/300 = 140.0
+        crm = next(t for t in result.tools if t.tool_name == "crm-search")
+        assert crm.request_count == 300
+        assert crm.avg_latency_ms == 140.0
+
+    @pytest.mark.asyncio
+    async def test_summary_no_records(self):
+        """Summary with no records returns zeros."""
+        from src.services.usage_service import UsageMeteringService
+
+        mock_db = AsyncMock()
+        svc = UsageMeteringService(mock_db)
+
+        with patch.object(svc.repo, "get_usage_summary", new_callable=AsyncMock) as mock_repo:
+            mock_repo.return_value = []
+
+            result = await svc.get_summary(
+                tenant_id="acme",
+                period_type="daily",
+                start=datetime(2026, 2, 1, tzinfo=UTC),
+                end=datetime(2026, 2, 28, tzinfo=UTC),
+            )
+
+        assert result.total_requests == 0
+        assert result.total_tokens == 0
+        assert result.total_errors == 0
+        assert result.avg_latency_ms is None
+        assert result.tools == []
+
+    @pytest.mark.asyncio
+    async def test_summary_null_latency(self):
+        """Records with None latency are handled gracefully."""
+        from src.services.usage_service import UsageMeteringService
+
+        mock_db = AsyncMock()
+        svc = UsageMeteringService(mock_db)
+
+        rec = MagicMock(
+            tool_name="api-tool",
+            request_count=50,
+            token_count=1000,
+            error_count=1,
+            avg_latency_ms=None,
+        )
+
+        with patch.object(svc.repo, "get_usage_summary", new_callable=AsyncMock) as mock_repo:
+            mock_repo.return_value = [rec]
+
+            result = await svc.get_summary(
+                tenant_id="acme",
+                period_type="daily",
+                start=datetime(2026, 2, 1, tzinfo=UTC),
+                end=datetime(2026, 2, 28, tzinfo=UTC),
+            )
+
+        assert result.total_requests == 50
+        assert result.avg_latency_ms is None
+        assert result.tools[0].avg_latency_ms is None
+
+    @pytest.mark.asyncio
+    async def test_details_delegates_to_repo(self):
+        """Details endpoint delegates to repository with correct params."""
+        from src.services.usage_service import UsageMeteringService
+
+        mock_db = AsyncMock()
+        svc = UsageMeteringService(mock_db)
+
+        rec = MagicMock(
+            period_start=datetime(2026, 2, 1, tzinfo=UTC),
+            period_end=datetime(2026, 2, 2, tzinfo=UTC),
+            request_count=100,
+            token_count=5000,
+            error_count=2,
+            avg_latency_ms=120.0,
+        )
+
+        with patch.object(svc.repo, "get_usage_details", new_callable=AsyncMock) as mock_repo:
+            mock_repo.return_value = ([rec], 1)
+
+            result = await svc.get_details(
+                tenant_id="acme",
+                period_type="daily",
+                start=datetime(2026, 2, 1, tzinfo=UTC),
+                end=datetime(2026, 2, 28, tzinfo=UTC),
+                tool_name="crm-search",
+                limit=50,
+                offset=0,
+            )
+
+        assert result.total == 1
+        assert len(result.items) == 1
+        assert result.items[0].request_count == 100
+        mock_repo.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_record_usage_delegates_to_repo(self):
+        """record_usage delegates upsert to repository."""
+        from src.services.usage_service import UsageMeteringService
+
+        mock_db = AsyncMock()
+        svc = UsageMeteringService(mock_db)
+
+        with patch.object(svc.repo, "upsert_usage_record", new_callable=AsyncMock) as mock_upsert:
+            await svc.record_usage(
+                tenant_id="acme",
+                tool_name="crm-search",
+                period_start=datetime(2026, 2, 1, tzinfo=UTC),
+                period_end=datetime(2026, 2, 2, tzinfo=UTC),
+                period_type="daily",
+                request_count=50,
+                token_count=2000,
+                error_count=1,
+                avg_latency_ms=130.0,
+            )
+
+        mock_upsert.assert_called_once_with(
+            tenant_id="acme",
+            tool_name="crm-search",
+            period_start=datetime(2026, 2, 1, tzinfo=UTC),
+            period_end=datetime(2026, 2, 2, tzinfo=UTC),
+            period_type="daily",
+            request_count=50,
+            token_count=2000,
+            error_count=1,
+            avg_latency_ms=130.0,
+        )
+
+
+# ---- Schema Tests ----
+
+
+class TestMeteringSchemas:
+    """Tests for Pydantic schema validation."""
+
+    def test_usage_summary_valid(self):
+        """UsageSummary schema accepts valid data."""
+        from src.schemas.metering import UsageSummary
+
+        summary = UsageSummary(
+            tenant_id="acme",
+            period_type="daily",
+            period_start=datetime(2026, 2, 1, tzinfo=UTC),
+            period_end=datetime(2026, 2, 28, tzinfo=UTC),
+            total_requests=100,
+            total_tokens=5000,
+            total_errors=2,
+            avg_latency_ms=120.5,
+            tools=[],
+        )
+        assert summary.total_requests == 100
+
+    def test_usage_detail_response_valid(self):
+        """UsageDetailResponse schema accepts valid data."""
+        from src.schemas.metering import UsageDetailResponse
+
+        detail = UsageDetailResponse(
+            tenant_id="acme",
+            tool_name="crm-search",
+            period_type="hourly",
+            items=[],
+            total=0,
+        )
+        assert detail.total == 0
+
+    def test_tool_usage_valid(self):
+        """ToolUsage schema accepts valid data."""
+        from src.schemas.metering import ToolUsage
+
+        tool = ToolUsage(
+            tool_name="crm-search",
+            request_count=100,
+            token_count=5000,
+            error_count=2,
+            avg_latency_ms=120.5,
+        )
+        assert tool.tool_name == "crm-search"
+
+
+# ---- Model Tests ----
+
+
+class TestUsageRecordModel:
+    """Tests for UsageRecord SQLAlchemy model."""
+
+    def test_model_repr(self):
+        """UsageRecord __repr__ returns readable string."""
+        from src.models.usage import UsageRecord
+
+        record = UsageRecord(
+            tenant_id="acme",
+            tool_name="crm-search",
+            period_type="daily",
+        )
+        assert "acme" in repr(record)
+        assert "crm-search" in repr(record)
+        assert "daily" in repr(record)
+
+    def test_model_columns(self):
+        """UsageRecord has expected columns with correct defaults."""
+        from src.models.usage import UsageRecord
+
+        # Column defaults are applied at INSERT time, not at Python instantiation.
+        # Verify columns exist and have the expected default callables.
+        table = UsageRecord.__table__
+        assert table.c.request_count.default.arg == 0
+        assert table.c.token_count.default.arg == 0
+        assert table.c.error_count.default.arg == 0
+        assert table.c.avg_latency_ms.default is None


### PR DESCRIPTION
## Summary
- Add `UsageRecord` SQLAlchemy model with upsert-friendly unique constraint (tenant_id, tool_name, period_start, period_type)
- Add Alembic migration 042 creating `usage_records` table with composite indexes
- Add `/v1/metering/summary` and `/v1/metering/details` endpoints with RBAC (cpi-admin sees all, tenant-admin sees own)
- Add repository with PostgreSQL `ON CONFLICT DO UPDATE` upsert for Kafka consumer/batch job write path
- Add service layer with weighted-average latency aggregation across multi-period records
- 23 tests covering router (RBAC, validation, tenant isolation), service (aggregation, null handling), schema, and model layers

## Context
Phase 1 of CAB-1334 Usage Metering Pipeline. Phases 2-3 (Tier Management, Stripe integration) are deferred post-PMF.

## Files
| File | Purpose |
|------|---------|
| `src/models/usage.py` | UsageRecord model |
| `alembic/versions/042_create_usage_records.py` | Migration |
| `src/schemas/metering.py` | Pydantic schemas |
| `src/repositories/usage_repository.py` | Data access layer |
| `src/services/usage_service.py` | Business logic |
| `src/routers/metering.py` | API endpoints |
| `tests/test_metering.py` | 23 tests |
| `src/models/__init__.py` | Added UsageRecord export |
| `src/main.py` | Router registration |

## Test plan
- [x] 23 unit tests passing locally
- [x] ruff lint clean
- [x] black format clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>