### PR TITLE
test(api): add 320 router tests across 15 routers (CAB-1448)

### DIFF
--- a/control-plane-api/tests/test_audit_router.py
+++ b/control-plane-api/tests/test_audit_router.py
@@ -1,0 +1,217 @@
+"""Tests for Audit Router — CAB-1452
+
+Covers: /v1/audit (list, export CSV/JSON, security events, isolation test, global summary).
+
+Strategy:
+  - Mock OpenSearchService so client=None => demo data fallback
+  - Demo data tenants: oasis, high-five, ioi
+  - cpi-admin bypasses @require_tenant_access
+  - Viewer with no tenant_id always gets 403
+"""
+
+import json as _json
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+OS_SVC_PATH = "src.routers.audit.OpenSearchService"
+DEMO_TENANT = "oasis"
+
+
+def _make_os_mock() -> MagicMock:
+    """OpenSearchService mock where client=None forces demo-data fallback."""
+    mock_svc = MagicMock()
+    mock_svc.client = None
+    mock_os_cls = MagicMock()
+    mock_os_cls.get_instance.return_value = mock_svc
+    return mock_os_cls
+
+
+class TestListAuditEntries:
+    """Tests for GET /v1/audit/{tenant_id}."""
+
+    def test_list_audit_entries_cpi_admin(self, app_with_cpi_admin, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "entries" in data
+        assert data["page"] == 1
+
+    def test_list_audit_entries_paginated(self, app_with_cpi_admin, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}?page=1&page_size=5")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["page_size"] == 5
+        assert "has_more" in data
+
+    def test_list_audit_entries_filter_by_action(self, app_with_cpi_admin, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}?action=api_call")
+
+        assert resp.status_code == 200
+        for entry in resp.json()["entries"]:
+            assert entry["action"] == "api_call"
+
+    def test_list_audit_entries_unknown_tenant_empty(self, app_with_cpi_admin, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_cpi_admin) as client:
+            resp = client.get("/v1/audit/nonexistent-tenant-xyz")
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_list_audit_entries_403_no_tenant_user(self, app_with_no_tenant_user, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_no_tenant_user) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}")
+
+        assert resp.status_code == 403
+
+
+class TestExportAuditCsv:
+    """Tests for GET /v1/audit/{tenant_id}/export/csv."""
+
+    def test_export_csv_success(self, app_with_cpi_admin, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/export/csv")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/csv")
+        assert "attachment" in resp.headers["Content-Disposition"]
+
+    def test_export_csv_has_header_row(self, app_with_cpi_admin, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/export/csv")
+
+        assert "Timestamp" in resp.text
+        assert "Action" in resp.text
+
+    def test_export_csv_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_no_tenant_user) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/export/csv")
+
+        assert resp.status_code == 403
+
+
+class TestExportAuditJson:
+    """Tests for GET /v1/audit/{tenant_id}/export/json."""
+
+    def test_export_json_success(self, app_with_cpi_admin, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/export/json")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/json")
+        assert "attachment" in resp.headers["Content-Disposition"]
+
+    def test_export_json_expected_keys(self, app_with_cpi_admin, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/export/json")
+
+        data = _json.loads(resp.text)
+        assert "tenant_id" in data
+        assert "entries" in data
+        assert "total_entries" in data
+        assert data["tenant_id"] == DEMO_TENANT
+
+    def test_export_json_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_no_tenant_user) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/export/json")
+
+        assert resp.status_code == 403
+
+
+class TestGetSecurityEvents:
+    """Tests for GET /v1/audit/{tenant_id}/security."""
+
+    def test_security_events_success(self, app_with_cpi_admin, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/security")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "events" in data
+        assert "summary" in data
+
+    def test_security_events_filter_severity(self, app_with_cpi_admin, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/security?severity=warning")
+
+        assert resp.status_code == 200
+        for event in resp.json()["events"]:
+            assert event["severity"] == "warning"
+
+    def test_security_events_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_no_tenant_user) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/security")
+
+        assert resp.status_code == 403
+
+
+class TestTenantIsolationTest:
+    """Tests for GET /v1/audit/{tenant_id}/isolation-test."""
+
+    def test_isolation_same_tenant_allowed(self, app_with_cpi_admin, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/isolation-test?target_tenant={DEMO_TENANT}")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "allowed"
+
+    def test_isolation_cross_tenant_blocked(self, app_with_cpi_admin, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/isolation-test?target_tenant=high-five")
+
+        assert resp.status_code == 403
+        assert "tenant_isolation_violation" in str(resp.json()["detail"])
+
+    def test_isolation_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        mock_os = _make_os_mock()
+        with patch(OS_SVC_PATH, mock_os), TestClient(app_with_no_tenant_user) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/isolation-test?target_tenant={DEMO_TENANT}")
+
+        assert resp.status_code == 403
+
+
+class TestGetGlobalAuditSummary:
+    """Tests for GET /v1/audit/global/summary."""
+
+    def test_global_summary_cpi_admin(self, app_with_cpi_admin, mock_db_session):
+        with TestClient(app_with_cpi_admin) as client:
+            resp = client.get("/v1/audit/global/summary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "total_audit_entries" in data
+        assert "total_security_events" in data
+        assert "entries_by_tenant" in data
+
+    def test_global_summary_403_tenant_admin(self, app_with_tenant_admin, mock_db_session):
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.get("/v1/audit/global/summary")
+
+        assert resp.status_code == 403
+
+    def test_global_summary_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.get("/v1/audit/global/summary")
+
+        assert resp.status_code == 403

--- a/control-plane-api/tests/test_catalog_admin_router.py
+++ b/control-plane-api/tests/test_catalog_admin_router.py
@@ -1,0 +1,432 @@
+"""Tests for Catalog Admin Router — CAB-1452
+
+Covers: /v1/admin/catalog (sync, sync/mcp-servers, sync/tenant, sync/status,
+sync/history, stats, cache, seed, audience).
+
+Admin check: _require_admin() requires cpi-admin or tenant-admin.
+Viewers always get 403.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+SYNC_SVC_PATH = "src.routers.catalog_admin.CatalogSyncService"
+CATALOG_REPO_PATH = "src.routers.catalog_admin.CatalogRepository"
+
+
+def _mock_sync_status(status: str = "success") -> MagicMock:
+    s = MagicMock()
+    s.id = uuid4()
+    s.sync_type = "full"
+    s.status = status
+    s.started_at = datetime.now(UTC)
+    s.completed_at = datetime.now(UTC)
+    s.items_synced = 42
+    s.errors = []
+    s.git_commit_sha = "abc123"
+    s.duration_seconds = 3.5
+    return s
+
+
+def _mock_catalog_api(tenant_id: str = "acme", api_id: str = "weather-api") -> MagicMock:
+    api = MagicMock()
+    api.id = uuid4()
+    api.tenant_id = tenant_id
+    api.api_id = api_id
+    api.api_name = "Weather API"
+    api.version = "1.0.0"
+    api.status = "active"
+    api.category = "data"
+    api.tags = ["weather"]
+    api.portal_published = True
+    api.api_metadata = {"display_name": "Weather API", "description": "Get weather data"}
+    api.openapi_spec = None
+    api.git_path = None
+    api.git_commit_sha = None
+    api.synced_at = datetime.now(UTC)
+    api.audience = "public"
+    return api
+
+
+class TestTriggerCatalogSync:
+    """Tests for POST /v1/admin/catalog/sync."""
+
+    def test_trigger_sync_cpi_admin(self, app_with_cpi_admin, mock_db_session):
+        mock_svc = MagicMock()
+        mock_svc.get_last_sync_status = AsyncMock(return_value=None)
+
+        with patch(SYNC_SVC_PATH, return_value=mock_svc), TestClient(app_with_cpi_admin) as client:
+            resp = client.post("/v1/admin/catalog/sync")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "sync_started"
+
+    def test_trigger_sync_tenant_admin(self, app_with_tenant_admin, mock_db_session):
+        mock_svc = MagicMock()
+        mock_svc.get_last_sync_status = AsyncMock(return_value=None)
+
+        with patch(SYNC_SVC_PATH, return_value=mock_svc), TestClient(app_with_tenant_admin) as client:
+            resp = client.post("/v1/admin/catalog/sync")
+
+        assert resp.status_code == 200
+
+    def test_trigger_sync_already_running(self, app_with_cpi_admin, mock_db_session):
+        running_sync = _mock_sync_status(status="running")
+        mock_svc = MagicMock()
+        mock_svc.get_last_sync_status = AsyncMock(return_value=running_sync)
+
+        with patch(SYNC_SVC_PATH, return_value=mock_svc), TestClient(app_with_cpi_admin) as client:
+            resp = client.post("/v1/admin/catalog/sync")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "sync_already_running"
+
+    def test_trigger_sync_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.post("/v1/admin/catalog/sync")
+
+        assert resp.status_code == 403
+
+
+class TestTriggerMcpServersSync:
+    """Tests for POST /v1/admin/catalog/sync/mcp-servers."""
+
+    def test_trigger_mcp_sync_cpi_admin(self, app_with_cpi_admin, mock_db_session):
+        with TestClient(app_with_cpi_admin) as client:
+            resp = client.post("/v1/admin/catalog/sync/mcp-servers")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "sync_started"
+
+    def test_trigger_mcp_sync_with_tenant_filter(self, app_with_cpi_admin, mock_db_session):
+        with TestClient(app_with_cpi_admin) as client:
+            resp = client.post("/v1/admin/catalog/sync/mcp-servers?tenant_id=acme")
+
+        assert resp.status_code == 200
+        assert "acme" in resp.json()["message"]
+
+    def test_trigger_mcp_sync_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.post("/v1/admin/catalog/sync/mcp-servers")
+
+        assert resp.status_code == 403
+
+
+class TestTriggerTenantSync:
+    """Tests for POST /v1/admin/catalog/sync/tenant/{tenant_id}."""
+
+    def test_trigger_tenant_sync_cpi_admin(self, app_with_cpi_admin, mock_db_session):
+        with TestClient(app_with_cpi_admin) as client:
+            resp = client.post("/v1/admin/catalog/sync/tenant/acme")
+
+        assert resp.status_code == 200
+        assert "acme" in resp.json()["message"]
+
+    def test_trigger_tenant_sync_own_tenant(self, app_with_tenant_admin, mock_db_session):
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.post("/v1/admin/catalog/sync/tenant/acme")
+
+        assert resp.status_code == 200
+
+    def test_trigger_tenant_sync_403_cross_tenant(self, app_with_tenant_admin, mock_db_session):
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.post("/v1/admin/catalog/sync/tenant/other-tenant")
+
+        assert resp.status_code == 403
+
+    def test_trigger_tenant_sync_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.post("/v1/admin/catalog/sync/tenant/acme")
+
+        assert resp.status_code == 403
+
+
+class TestGetSyncStatus:
+    """Tests for GET /v1/admin/catalog/sync/status."""
+
+    def test_get_sync_status_success(self, app_with_cpi_admin, mock_db_session):
+        sync = _mock_sync_status()
+        mock_svc = MagicMock()
+        mock_svc.get_last_sync_status = AsyncMock(return_value=sync)
+
+        with patch(SYNC_SVC_PATH, return_value=mock_svc), TestClient(app_with_cpi_admin) as client:
+            resp = client.get("/v1/admin/catalog/sync/status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "success"
+        assert data["items_synced"] == 42
+
+    def test_get_sync_status_404_no_syncs(self, app_with_cpi_admin, mock_db_session):
+        mock_svc = MagicMock()
+        mock_svc.get_last_sync_status = AsyncMock(return_value=None)
+
+        with patch(SYNC_SVC_PATH, return_value=mock_svc), TestClient(app_with_cpi_admin) as client:
+            resp = client.get("/v1/admin/catalog/sync/status")
+
+        assert resp.status_code == 404
+
+    def test_get_sync_status_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.get("/v1/admin/catalog/sync/status")
+
+        assert resp.status_code == 403
+
+
+class TestGetSyncHistory:
+    """Tests for GET /v1/admin/catalog/sync/history."""
+
+    def test_get_sync_history_success(self, app_with_cpi_admin, mock_db_session):
+        syncs = [_mock_sync_status(), _mock_sync_status(status="failed")]
+        mock_svc = MagicMock()
+        mock_svc.get_sync_history = AsyncMock(return_value=syncs)
+
+        with patch(SYNC_SVC_PATH, return_value=mock_svc), TestClient(app_with_cpi_admin) as client:
+            resp = client.get("/v1/admin/catalog/sync/history")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 2
+        assert len(data["syncs"]) == 2
+
+    def test_get_sync_history_empty(self, app_with_cpi_admin, mock_db_session):
+        mock_svc = MagicMock()
+        mock_svc.get_sync_history = AsyncMock(return_value=[])
+
+        with patch(SYNC_SVC_PATH, return_value=mock_svc), TestClient(app_with_cpi_admin) as client:
+            resp = client.get("/v1/admin/catalog/sync/history")
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_get_sync_history_custom_limit(self, app_with_cpi_admin, mock_db_session):
+        mock_svc = MagicMock()
+        mock_svc.get_sync_history = AsyncMock(return_value=[])
+
+        with patch(SYNC_SVC_PATH, return_value=mock_svc), TestClient(app_with_cpi_admin) as client:
+            resp = client.get("/v1/admin/catalog/sync/history?limit=5")
+
+        assert resp.status_code == 200
+        mock_svc.get_sync_history.assert_awaited_once_with(limit=5)
+
+    def test_get_sync_history_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.get("/v1/admin/catalog/sync/history")
+
+        assert resp.status_code == 403
+
+
+class TestGetCatalogStats:
+    """Tests for GET /v1/admin/catalog/stats."""
+
+    def test_get_stats_success(self, app_with_cpi_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_stats = AsyncMock(
+            return_value={
+                "total_apis": 10,
+                "published_apis": 7,
+                "unpublished_apis": 3,
+                "by_tenant": {"acme": 5},
+                "by_category": {"data": 10},
+            }
+        )
+        mock_svc = MagicMock()
+        mock_svc.get_last_sync_status = AsyncMock(return_value=None)
+
+        with (
+            patch(CATALOG_REPO_PATH, return_value=mock_repo),
+            patch(SYNC_SVC_PATH, return_value=mock_svc),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            resp = client.get("/v1/admin/catalog/stats")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_apis"] == 10
+        assert data["last_sync"] is None
+
+    def test_get_stats_includes_last_sync(self, app_with_cpi_admin, mock_db_session):
+        sync = _mock_sync_status()
+        mock_repo = MagicMock()
+        mock_repo.get_stats = AsyncMock(
+            return_value={
+                "total_apis": 5,
+                "published_apis": 3,
+                "unpublished_apis": 2,
+                "by_tenant": {},
+                "by_category": {},
+            }
+        )
+        mock_svc = MagicMock()
+        mock_svc.get_last_sync_status = AsyncMock(return_value=sync)
+
+        with (
+            patch(CATALOG_REPO_PATH, return_value=mock_repo),
+            patch(SYNC_SVC_PATH, return_value=mock_svc),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            resp = client.get("/v1/admin/catalog/stats")
+
+        assert resp.status_code == 200
+        assert resp.json()["last_sync"] is not None
+
+    def test_get_stats_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.get("/v1/admin/catalog/stats")
+
+        assert resp.status_code == 403
+
+
+class TestInvalidateCache:
+    """Tests for DELETE /v1/admin/catalog/cache."""
+
+    def test_invalidate_cache_cpi_admin(self, app_with_cpi_admin, mock_db_session):
+        with TestClient(app_with_cpi_admin) as client:
+            resp = client.delete("/v1/admin/catalog/cache")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_invalidate_cache_403_tenant_admin(self, app_with_tenant_admin, mock_db_session):
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.delete("/v1/admin/catalog/cache")
+
+        assert resp.status_code == 403
+
+    def test_invalidate_cache_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.delete("/v1/admin/catalog/cache")
+
+        assert resp.status_code == 403
+
+
+class TestSeedCatalog:
+    """Tests for POST /v1/admin/catalog/seed."""
+
+    def test_seed_catalog_cpi_admin(self, app_with_cpi_admin, mock_db_session):
+        mock_db_session.execute = AsyncMock(return_value=MagicMock())
+        mock_db_session.commit = AsyncMock()
+
+        payload = {
+            "tenant_id": "acme",
+            "apis": [
+                {
+                    "name": "weather-api",
+                    "display_name": "Weather API",
+                    "version": "1.0.0",
+                    "description": "Weather data",
+                    "backend_url": "https://api.weather.com",
+                    "tags": ["weather"],
+                }
+            ],
+        }
+
+        with TestClient(app_with_cpi_admin) as client:
+            resp = client.post("/v1/admin/catalog/seed", json=payload)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["seeded"] == 1
+        assert data["failed"] == 0
+
+    def test_seed_catalog_403_tenant_admin(self, app_with_tenant_admin, mock_db_session):
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.post("/v1/admin/catalog/seed", json={"tenant_id": "acme", "apis": []})
+
+        assert resp.status_code == 403
+
+    def test_seed_catalog_empty_apis(self, app_with_cpi_admin, mock_db_session):
+        mock_db_session.commit = AsyncMock()
+
+        with TestClient(app_with_cpi_admin) as client:
+            resp = client.post("/v1/admin/catalog/seed", json={"tenant_id": "acme", "apis": []})
+
+        assert resp.status_code == 200
+        assert resp.json()["seeded"] == 0
+
+    def test_seed_catalog_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.post("/v1/admin/catalog/seed", json={"tenant_id": "acme", "apis": []})
+
+        assert resp.status_code == 403
+
+
+class TestUpdateApiAudience:
+    """Tests for PATCH /v1/admin/catalog/{tenant_id}/{api_id}/audience."""
+
+    def test_update_audience_cpi_admin(self, app_with_cpi_admin, mock_db_session):
+        api = _mock_catalog_api()
+        mock_repo = MagicMock()
+        mock_repo.get_api_by_id = AsyncMock(return_value=api)
+        mock_db_session.commit = AsyncMock()
+
+        with patch(CATALOG_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.patch(
+                f"/v1/admin/catalog/acme/{api.api_id}/audience",
+                json={"audience": "internal"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["audience"] == "internal"
+        assert data["tenant_id"] == "acme"
+
+    def test_update_audience_tenant_admin_own_tenant(self, app_with_tenant_admin, mock_db_session):
+        api = _mock_catalog_api(tenant_id="acme")
+        mock_repo = MagicMock()
+        mock_repo.get_api_by_id = AsyncMock(return_value=api)
+        mock_db_session.commit = AsyncMock()
+
+        with patch(CATALOG_REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.patch(
+                f"/v1/admin/catalog/acme/{api.api_id}/audience",
+                json={"audience": "partner"},
+            )
+
+        assert resp.status_code == 200
+
+    def test_update_audience_403_tenant_admin_cross_tenant(self, app_with_tenant_admin, mock_db_session):
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.patch(
+                "/v1/admin/catalog/other-tenant/some-api/audience",
+                json={"audience": "public"},
+            )
+
+        assert resp.status_code == 403
+
+    def test_update_audience_404_api_not_found(self, app_with_cpi_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_api_by_id = AsyncMock(return_value=None)
+
+        with patch(CATALOG_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.patch(
+                "/v1/admin/catalog/acme/nonexistent-api/audience",
+                json={"audience": "public"},
+            )
+
+        assert resp.status_code == 404
+
+    def test_update_audience_400_invalid_audience(self, app_with_cpi_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_api_by_id = AsyncMock(return_value=_mock_catalog_api())
+
+        with patch(CATALOG_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.patch(
+                "/v1/admin/catalog/acme/weather-api/audience",
+                json={"audience": "classified"},
+            )
+
+        assert resp.status_code == 400
+        assert "classified" in resp.json()["detail"]
+
+    def test_update_audience_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.patch(
+                "/v1/admin/catalog/acme/weather-api/audience",
+                json={"audience": "public"},
+            )
+
+        assert resp.status_code == 403

--- a/control-plane-api/tests/test_certificates_router.py
+++ b/control-plane-api/tests/test_certificates_router.py
@@ -1,0 +1,179 @@
+"""Tests for Certificates Router — CAB-1448
+
+Covers: /v1/certificates (validate, upload, health).
+Public endpoints — no auth required.
+"""
+
+from io import BytesIO
+from unittest.mock import patch
+
+
+class TestValidateCertificate:
+    """Tests for POST /v1/certificates/validate."""
+
+    def test_validate_valid_pem(self, client_as_tenant_admin):
+        with (
+            patch("src.routers.certificates.CRYPTOGRAPHY_AVAILABLE", True),
+            patch("src.routers.certificates._parse_certificate") as mock_parse,
+        ):
+            from src.routers.certificates import CertificateInfo
+
+            cert_info = CertificateInfo(
+                subject="CN=test.com",
+                issuer="CN=CA",
+                valid_from="2026-01-01T00:00:00",
+                valid_to="2027-01-01T00:00:00",
+                days_until_expiry=365,
+                is_valid=True,
+                is_expired=False,
+                expires_soon=False,
+                serial_number="abc123",
+                fingerprint_sha256="aa:bb:cc",
+                key_size=2048,
+                signature_algorithm="sha256WithRSAEncryption",
+                san=["DNS:test.com"],
+            )
+            mock_parse.return_value = (cert_info, [], [])
+            resp = client_as_tenant_admin.post(
+                "/v1/certificates/validate",
+                json={"pem_data": "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["valid"] is True
+        assert data["certificate"]["subject"] == "CN=test.com"
+        assert data["errors"] == []
+
+    def test_validate_invalid_pem(self, client_as_tenant_admin):
+        with (
+            patch("src.routers.certificates.CRYPTOGRAPHY_AVAILABLE", True),
+            patch("src.routers.certificates._parse_certificate") as mock_parse,
+        ):
+            mock_parse.return_value = (None, ["Invalid PEM format: bad data"], [])
+            resp = client_as_tenant_admin.post(
+                "/v1/certificates/validate",
+                json={"pem_data": "not-a-certificate"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["valid"] is False
+        assert len(data["errors"]) > 0
+
+    def test_validate_expired_cert(self, client_as_tenant_admin):
+        with (
+            patch("src.routers.certificates.CRYPTOGRAPHY_AVAILABLE", True),
+            patch("src.routers.certificates._parse_certificate") as mock_parse,
+        ):
+            from src.routers.certificates import CertificateInfo
+
+            cert_info = CertificateInfo(
+                subject="CN=expired.com",
+                issuer="CN=CA",
+                valid_from="2020-01-01T00:00:00",
+                valid_to="2021-01-01T00:00:00",
+                days_until_expiry=-1000,
+                is_valid=False,
+                is_expired=True,
+                expires_soon=False,
+                serial_number="def456",
+                fingerprint_sha256="dd:ee:ff",
+                key_size=2048,
+                signature_algorithm="sha256WithRSAEncryption",
+                san=[],
+            )
+            mock_parse.return_value = (cert_info, ["Certificate expired"], [])
+            resp = client_as_tenant_admin.post(
+                "/v1/certificates/validate",
+                json={"pem_data": "-----BEGIN CERTIFICATE-----\nexpired\n-----END CERTIFICATE-----"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["valid"] is False
+        assert data["certificate"]["is_expired"] is True
+
+    def test_validate_501_no_cryptography(self, client_as_tenant_admin):
+        with patch("src.routers.certificates.CRYPTOGRAPHY_AVAILABLE", False):
+            resp = client_as_tenant_admin.post(
+                "/v1/certificates/validate",
+                json={"pem_data": "test"},
+            )
+        assert resp.status_code == 501
+
+
+class TestUploadCertificate:
+    """Tests for POST /v1/certificates/upload."""
+
+    def test_upload_pem_file(self, client_as_tenant_admin):
+        with (
+            patch("src.routers.certificates.CRYPTOGRAPHY_AVAILABLE", True),
+            patch("src.routers.certificates._parse_certificate") as mock_parse,
+        ):
+            from src.routers.certificates import CertificateInfo
+
+            cert_info = CertificateInfo(
+                subject="CN=uploaded.com",
+                issuer="CN=CA",
+                valid_from="2026-01-01T00:00:00",
+                valid_to="2027-01-01T00:00:00",
+                days_until_expiry=365,
+                is_valid=True,
+                is_expired=False,
+                expires_soon=False,
+                serial_number="789",
+                fingerprint_sha256="11:22:33",
+                key_size=4096,
+                signature_algorithm="sha256WithRSAEncryption",
+                san=[],
+            )
+            mock_parse.return_value = (cert_info, [], [])
+
+            file_content = b"-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----"
+            resp = client_as_tenant_admin.post(
+                "/v1/certificates/upload",
+                files={"file": ("test.pem", BytesIO(file_content), "application/x-pem-file")},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["valid"] is True
+
+    def test_upload_invalid_extension(self, client_as_tenant_admin):
+        with patch("src.routers.certificates.CRYPTOGRAPHY_AVAILABLE", True):
+            resp = client_as_tenant_admin.post(
+                "/v1/certificates/upload",
+                files={"file": ("test.txt", BytesIO(b"data"), "text/plain")},
+            )
+        assert resp.status_code == 400
+        assert "Invalid file extension" in resp.json()["detail"]
+
+    def test_upload_501_no_cryptography(self, client_as_tenant_admin):
+        with patch("src.routers.certificates.CRYPTOGRAPHY_AVAILABLE", False):
+            resp = client_as_tenant_admin.post(
+                "/v1/certificates/upload",
+                files={"file": ("test.pem", BytesIO(b"data"), "application/x-pem-file")},
+            )
+        assert resp.status_code == 501
+
+
+class TestCertificateHealth:
+    """Tests for GET /v1/certificates/health."""
+
+    def test_health_available(self, client_as_tenant_admin):
+        with patch("src.routers.certificates.CRYPTOGRAPHY_AVAILABLE", True):
+            resp = client_as_tenant_admin.get("/v1/certificates/health")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "healthy"
+        assert data["cryptography_available"] is True
+
+    def test_health_degraded(self, client_as_tenant_admin):
+        with patch("src.routers.certificates.CRYPTOGRAPHY_AVAILABLE", False):
+            resp = client_as_tenant_admin.get("/v1/certificates/health")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "degraded"
+        assert data["cryptography_available"] is False

--- a/control-plane-api/tests/test_consumers_router.py
+++ b/control-plane-api/tests/test_consumers_router.py
@@ -1,0 +1,765 @@
+"""Tests for Consumers Router — CAB-1436
+
+Covers: /v1/consumers CRUD, status management, credentials, token exchange,
+        expiring certificates, bulk revoke, and quota endpoints.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from src.models.consumer import CertificateStatus, ConsumerStatus
+
+REPO_PATH = "src.routers.consumers.ConsumerRepository"
+QUOTA_REPO_PATH = "src.routers.consumers.QuotaUsageRepository"
+KC_PATH = "src.routers.consumers.keycloak_service"
+
+
+def _mock_consumer(**overrides):
+    """Build a MagicMock that mimics a Consumer ORM object."""
+    mock = MagicMock()
+    defaults = {
+        "id": uuid4(),
+        "external_id": "ext-001",
+        "name": "Test Corp",
+        "email": "test@example.com",
+        "company": "Test Corp",
+        "description": None,
+        "tenant_id": "acme",
+        "status": ConsumerStatus.ACTIVE,
+        "keycloak_client_id": "kc-client-1",
+        "keycloak_user_id": None,
+        "consumer_metadata": None,
+        "certificate_fingerprint": None,
+        "certificate_status": None,
+        "certificate_fingerprint_previous": None,
+        "certificate_subject_dn": None,
+        "certificate_issuer_dn": None,
+        "certificate_serial": None,
+        "certificate_not_before": None,
+        "certificate_not_after": None,
+        "certificate_pem": None,
+        "previous_cert_expires_at": None,
+        "last_rotated_at": None,
+        "rotation_count": 0,
+        "created_by": "admin",
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _mock_consumer_response(**overrides):
+    """Build a MagicMock that mimics a ConsumerResponse Pydantic object."""
+    from src.schemas.consumer import ConsumerStatusEnum
+
+    mock = MagicMock()
+    defaults = {
+        "id": uuid4(),
+        "external_id": "ext-001",
+        "name": "Test Corp",
+        "email": "test@example.com",
+        "company": "Test Corp",
+        "description": None,
+        "tenant_id": "acme",
+        "keycloak_user_id": None,
+        "keycloak_client_id": "kc-client-1",
+        "status": ConsumerStatusEnum.ACTIVE,
+        "consumer_metadata": None,
+        "certificate_fingerprint": None,
+        "certificate_status": None,
+        "certificate_subject_dn": None,
+        "certificate_not_before": None,
+        "certificate_not_after": None,
+        "last_rotated_at": None,
+        "rotation_count": 0,
+        "created_by": "admin",
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+# ============== Create Consumer ==============
+
+
+class TestCreateConsumer:
+    """POST /v1/consumers/{tenant_id}"""
+
+    def test_create_success(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer()
+        consumer.keycloak_client_id = "kc-client-1"
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_external_id = AsyncMock(return_value=None)
+        mock_repo.create = AsyncMock(return_value=consumer)
+        mock_repo.update = AsyncMock(return_value=consumer)
+
+        mock_kc = MagicMock()
+        mock_kc.create_consumer_client = AsyncMock(return_value={"client_id": "kc-client-1"})
+
+        with (
+            patch(REPO_PATH, return_value=mock_repo),
+            patch(KC_PATH, mock_kc),
+            patch("src.routers.consumers.ConsumerResponse") as MockResp,
+        ):
+            MockResp.model_validate.return_value = _mock_consumer_response()
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.post(
+                    "/v1/consumers/acme",
+                    json={
+                        "external_id": "ext-001",
+                        "name": "Test Corp",
+                        "email": "test@example.com",
+                    },
+                )
+
+        assert resp.status_code == 201
+
+    def test_create_409_duplicate_external_id(self, app_with_tenant_admin, mock_db_session):
+        existing = _mock_consumer()
+        mock_repo = MagicMock()
+        mock_repo.get_by_external_id = AsyncMock(return_value=existing)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(
+                "/v1/consumers/acme",
+                json={"external_id": "ext-001", "name": "Test Corp", "email": "test@example.com"},
+            )
+
+        assert resp.status_code == 409
+        assert "already exists" in resp.json()["detail"]
+
+    def test_create_403_wrong_tenant(self, app_with_other_tenant, mock_db_session):
+        with TestClient(app_with_other_tenant) as client:
+            resp = client.post(
+                "/v1/consumers/acme",
+                json={"external_id": "ext-001", "name": "Test Corp", "email": "test@example.com"},
+            )
+
+        assert resp.status_code == 403
+
+    def test_create_keycloak_runtime_failure_returns_503(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer()
+        mock_repo = MagicMock()
+        mock_repo.get_by_external_id = AsyncMock(return_value=None)
+        mock_repo.create = AsyncMock(return_value=consumer)
+
+        mock_kc = MagicMock()
+        mock_kc.create_consumer_client = AsyncMock(side_effect=RuntimeError("KC down"))
+
+        with (
+            patch(REPO_PATH, return_value=mock_repo),
+            patch(KC_PATH, mock_kc),
+            TestClient(app_with_tenant_admin) as client,
+        ):
+            resp = client.post(
+                "/v1/consumers/acme",
+                json={"external_id": "ext-001", "name": "Test Corp", "email": "test@example.com"},
+            )
+
+        assert resp.status_code == 503
+
+    def test_create_cpi_admin_can_create_any_tenant(self, app_with_cpi_admin, mock_db_session):
+        consumer = _mock_consumer(tenant_id="other-tenant")
+        mock_repo = MagicMock()
+        mock_repo.get_by_external_id = AsyncMock(return_value=None)
+        mock_repo.create = AsyncMock(return_value=consumer)
+        mock_repo.update = AsyncMock(return_value=consumer)
+
+        mock_kc = MagicMock()
+        mock_kc.create_consumer_client = AsyncMock(return_value={"client_id": "kc-client-1"})
+
+        with (
+            patch(REPO_PATH, return_value=mock_repo),
+            patch(KC_PATH, mock_kc),
+            patch("src.routers.consumers.ConsumerResponse") as MockResp,
+        ):
+            MockResp.model_validate.return_value = _mock_consumer_response(tenant_id="other-tenant")
+            with TestClient(app_with_cpi_admin) as client:
+                resp = client.post(
+                    "/v1/consumers/other-tenant",
+                    json={"external_id": "ext-001", "name": "Test Corp", "email": "test@example.com"},
+                )
+
+        assert resp.status_code == 201
+
+
+# ============== List Consumers ==============
+
+
+class TestListConsumers:
+    """GET /v1/consumers/{tenant_id}"""
+
+    def test_list_success(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer()
+        mock_repo = MagicMock()
+        mock_repo.list_by_tenant = AsyncMock(return_value=([consumer], 1))
+
+        with (
+            patch(REPO_PATH, return_value=mock_repo),
+            patch("src.routers.consumers.ConsumerResponse") as MockResp,
+        ):
+            MockResp.model_validate.return_value = _mock_consumer_response()
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.get("/v1/consumers/acme")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert len(data["items"]) == 1
+
+    def test_list_empty(self, app_with_tenant_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.list_by_tenant = AsyncMock(return_value=([], 0))
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get("/v1/consumers/acme")
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_list_with_filters(self, app_with_tenant_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.list_by_tenant = AsyncMock(return_value=([], 0))
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get("/v1/consumers/acme?status=active&search=corp&page=2&page_size=10")
+
+        assert resp.status_code == 200
+        mock_repo.list_by_tenant.assert_called_once()
+
+    def test_list_403_wrong_tenant(self, app_with_other_tenant, mock_db_session):
+        with TestClient(app_with_other_tenant) as client:
+            resp = client.get("/v1/consumers/acme")
+
+        assert resp.status_code == 403
+
+
+# ============== Get Consumer ==============
+
+
+class TestGetConsumer:
+    """GET /v1/consumers/{tenant_id}/{consumer_id}"""
+
+    def test_get_success(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+
+        with (
+            patch(REPO_PATH, return_value=mock_repo),
+            patch("src.routers.consumers.ConsumerResponse") as MockResp,
+        ):
+            MockResp.model_validate.return_value = _mock_consumer_response()
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.get(f"/v1/consumers/acme/{consumer.id}")
+
+        assert resp.status_code == 200
+
+    def test_get_404_not_found(self, app_with_tenant_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get(f"/v1/consumers/acme/{uuid4()}")
+
+        assert resp.status_code == 404
+
+    def test_get_404_wrong_tenant(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer(tenant_id="other-tenant")
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get(f"/v1/consumers/acme/{consumer.id}")
+
+        assert resp.status_code == 404
+
+    def test_get_403_wrong_user_tenant(self, app_with_other_tenant, mock_db_session):
+        with TestClient(app_with_other_tenant) as client:
+            resp = client.get(f"/v1/consumers/acme/{uuid4()}")
+
+        assert resp.status_code == 403
+
+
+# ============== Update Consumer ==============
+
+
+class TestUpdateConsumer:
+    """PUT /v1/consumers/{tenant_id}/{consumer_id}"""
+
+    def test_update_success(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer()
+        updated = _mock_consumer(name="Updated Corp")
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+        mock_repo.update = AsyncMock(return_value=updated)
+
+        with (
+            patch(REPO_PATH, return_value=mock_repo),
+            patch("src.routers.consumers.ConsumerResponse") as MockResp,
+        ):
+            MockResp.model_validate.return_value = _mock_consumer_response(name="Updated Corp")
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.put(
+                    f"/v1/consumers/acme/{consumer.id}",
+                    json={"name": "Updated Corp"},
+                )
+
+        assert resp.status_code == 200
+
+    def test_update_404(self, app_with_tenant_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.put(f"/v1/consumers/acme/{uuid4()}", json={"name": "X"})
+
+        assert resp.status_code == 404
+
+
+# ============== Delete Consumer ==============
+
+
+class TestDeleteConsumer:
+    """DELETE /v1/consumers/{tenant_id}/{consumer_id}"""
+
+    def test_delete_success(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+        mock_repo.delete = AsyncMock()
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.delete(f"/v1/consumers/acme/{consumer.id}")
+
+        assert resp.status_code == 204
+
+    def test_delete_404(self, app_with_tenant_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.delete(f"/v1/consumers/acme/{uuid4()}")
+
+        assert resp.status_code == 404
+
+
+# ============== Suspend Consumer ==============
+
+
+class TestSuspendConsumer:
+    """POST /v1/consumers/{tenant_id}/{consumer_id}/suspend"""
+
+    def test_suspend_success(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer(status=ConsumerStatus.ACTIVE)
+        suspended = _mock_consumer(status=ConsumerStatus.SUSPENDED)
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+        mock_repo.update_status = AsyncMock(return_value=suspended)
+
+        with (
+            patch(REPO_PATH, return_value=mock_repo),
+            patch("src.routers.consumers.ConsumerResponse") as MockResp,
+        ):
+            MockResp.model_validate.return_value = _mock_consumer_response()
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.post(f"/v1/consumers/acme/{consumer.id}/suspend")
+
+        assert resp.status_code == 200
+
+    def test_suspend_400_already_suspended(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer(status=ConsumerStatus.SUSPENDED)
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(f"/v1/consumers/acme/{consumer.id}/suspend")
+
+        assert resp.status_code == 400
+
+    def test_suspend_404(self, app_with_tenant_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(f"/v1/consumers/acme/{uuid4()}/suspend")
+
+        assert resp.status_code == 404
+
+
+# ============== Activate Consumer ==============
+
+
+class TestActivateConsumer:
+    """POST /v1/consumers/{tenant_id}/{consumer_id}/activate"""
+
+    def test_activate_success(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer(status=ConsumerStatus.SUSPENDED, keycloak_client_id="kc-client-1")
+        activated = _mock_consumer(status=ConsumerStatus.ACTIVE)
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+        mock_repo.update_status = AsyncMock(return_value=activated)
+
+        with (
+            patch(REPO_PATH, return_value=mock_repo),
+            patch("src.routers.consumers.ConsumerResponse") as MockResp,
+        ):
+            MockResp.model_validate.return_value = _mock_consumer_response(status="active")
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.post(f"/v1/consumers/acme/{consumer.id}/activate")
+
+        assert resp.status_code == 200
+
+    def test_activate_400_already_active(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer(status=ConsumerStatus.ACTIVE)
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(f"/v1/consumers/acme/{consumer.id}/activate")
+
+        assert resp.status_code == 400
+
+
+# ============== Block Consumer ==============
+
+
+class TestBlockConsumer:
+    """POST /v1/consumers/{tenant_id}/{consumer_id}/block"""
+
+    def test_block_success(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer(status=ConsumerStatus.ACTIVE)
+        blocked = _mock_consumer(status=ConsumerStatus.BLOCKED)
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+        mock_repo.update_status = AsyncMock(return_value=blocked)
+
+        with (
+            patch(REPO_PATH, return_value=mock_repo),
+            patch("src.routers.consumers.ConsumerResponse") as MockResp,
+        ):
+            MockResp.model_validate.return_value = _mock_consumer_response()
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.post(f"/v1/consumers/acme/{consumer.id}/block")
+
+        assert resp.status_code == 200
+
+    def test_block_400_already_blocked(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer(status=ConsumerStatus.BLOCKED)
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(f"/v1/consumers/acme/{consumer.id}/block")
+
+        assert resp.status_code == 400
+
+
+# ============== Get Credentials ==============
+
+
+class TestGetCredentials:
+    """GET /v1/consumers/{tenant_id}/{consumer_id}/credentials"""
+
+    def test_get_credentials_success(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer(status=ConsumerStatus.ACTIVE, keycloak_client_id="kc-client-1")
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+
+        mock_kc = MagicMock()
+        mock_kc.get_client = AsyncMock(return_value={"id": "kc-uuid-1", "clientId": "kc-client-1"})
+        mock_kc._admin = MagicMock()
+        mock_kc._admin.generate_client_secrets.return_value = {"value": "super-secret"}
+
+        with (
+            patch(REPO_PATH, return_value=mock_repo),
+            patch(KC_PATH, mock_kc),
+            TestClient(app_with_tenant_admin) as client,
+        ):
+            resp = client.get(f"/v1/consumers/acme/{consumer.id}/credentials")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["client_id"] == "kc-client-1"
+        assert data["client_secret"] == "super-secret"
+
+    def test_get_credentials_400_inactive_consumer(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer(status=ConsumerStatus.SUSPENDED)
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get(f"/v1/consumers/acme/{consumer.id}/credentials")
+
+        assert resp.status_code == 400
+
+    def test_get_credentials_404_no_kc_client(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer(status=ConsumerStatus.ACTIVE, keycloak_client_id=None)
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get(f"/v1/consumers/acme/{consumer.id}/credentials")
+
+        assert resp.status_code == 404
+
+    def test_get_credentials_503_keycloak_runtime_error(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer(status=ConsumerStatus.ACTIVE, keycloak_client_id="kc-client-1")
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+
+        mock_kc = MagicMock()
+        mock_kc.get_client = AsyncMock(side_effect=RuntimeError("KC unavailable"))
+
+        with (
+            patch(REPO_PATH, return_value=mock_repo),
+            patch(KC_PATH, mock_kc),
+            TestClient(app_with_tenant_admin) as client,
+        ):
+            resp = client.get(f"/v1/consumers/acme/{consumer.id}/credentials")
+
+        assert resp.status_code == 503
+
+
+# ============== Token Exchange ==============
+
+
+class TestTokenExchange:
+    """POST /v1/consumers/{tenant_id}/{consumer_id}/token-exchange"""
+
+    def test_token_exchange_success(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer(status=ConsumerStatus.ACTIVE, keycloak_client_id="kc-client-1")
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+
+        mock_kc = MagicMock()
+        mock_kc.get_client = AsyncMock(return_value={"id": "kc-uuid-1"})
+        mock_kc._admin = MagicMock()
+        mock_kc._admin.get_client_secrets.return_value = {"value": "secret"}
+        mock_kc.exchange_token = AsyncMock(
+            return_value={
+                "access_token": "new-token",
+                "token_type": "Bearer",
+                "expires_in": 300,
+            }
+        )
+
+        with (
+            patch(REPO_PATH, return_value=mock_repo),
+            patch(KC_PATH, mock_kc),
+            TestClient(app_with_tenant_admin) as client,
+        ):
+            resp = client.post(
+                f"/v1/consumers/acme/{consumer.id}/token-exchange",
+                json={"subject_token": "old-token"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["access_token"] == "new-token"
+
+    def test_token_exchange_400_inactive_consumer(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer(status=ConsumerStatus.SUSPENDED)
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(
+                f"/v1/consumers/acme/{consumer.id}/token-exchange",
+                json={"subject_token": "old-token"},
+            )
+
+        assert resp.status_code == 400
+
+    def test_token_exchange_404_consumer_not_found(self, app_with_tenant_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(
+                f"/v1/consumers/acme/{uuid4()}/token-exchange",
+                json={"subject_token": "old-token"},
+            )
+
+        assert resp.status_code == 404
+
+
+# ============== List Expiring Certificates ==============
+
+
+class TestListExpiringCertificates:
+    """GET /v1/consumers/{tenant_id}/certificates/expiring"""
+
+    def test_list_expiring_success(self, app_with_tenant_admin, mock_db_session):
+        from datetime import timedelta
+
+        consumer = _mock_consumer(
+            certificate_fingerprint="fp-abc",
+            certificate_not_after=datetime.now(UTC) + timedelta(days=10),
+            certificate_status=CertificateStatus.ACTIVE,
+        )
+        mock_repo = MagicMock()
+        mock_repo.expire_overdue_certificates = AsyncMock(return_value=0)
+        mock_repo.list_expiring = AsyncMock(return_value=[consumer])
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get("/v1/consumers/acme/certificates/expiring")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+
+    def test_list_expiring_empty(self, app_with_tenant_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.expire_overdue_certificates = AsyncMock(return_value=0)
+        mock_repo.list_expiring = AsyncMock(return_value=[])
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get("/v1/consumers/acme/certificates/expiring?days=7")
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_list_expiring_403_wrong_tenant(self, app_with_other_tenant, mock_db_session):
+        with TestClient(app_with_other_tenant) as client:
+            resp = client.get("/v1/consumers/acme/certificates/expiring")
+
+        assert resp.status_code == 403
+
+
+# ============== Bulk Revoke Certificates ==============
+
+
+class TestBulkRevokeCertificates:
+    """POST /v1/consumers/{tenant_id}/certificates/bulk-revoke"""
+
+    def test_bulk_revoke_success(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer(
+            certificate_fingerprint="fp-abc",
+            certificate_status=CertificateStatus.ACTIVE,
+        )
+        consumer.keycloak_client_id = None
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+        mock_repo.update = AsyncMock(return_value=consumer)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(
+                "/v1/consumers/acme/certificates/bulk-revoke",
+                json={"consumer_ids": [str(consumer.id)]},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] == 1
+        assert data["failed"] == 0
+
+    def test_bulk_revoke_consumer_not_found(self, app_with_tenant_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        missing_id = str(uuid4())
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(
+                "/v1/consumers/acme/certificates/bulk-revoke",
+                json={"consumer_ids": [missing_id]},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["failed"] == 1
+
+    def test_bulk_revoke_403_wrong_tenant(self, app_with_other_tenant, mock_db_session):
+        with TestClient(app_with_other_tenant) as client:
+            resp = client.post(
+                "/v1/consumers/acme/certificates/bulk-revoke",
+                json={"consumer_ids": [str(uuid4())]},
+            )
+
+        assert resp.status_code == 403
+
+
+# ============== Quota Status ==============
+
+
+class TestGetConsumerQuota:
+    """GET /v1/consumers/{tenant_id}/{consumer_id}/quota"""
+
+    def test_quota_success_no_plan(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+
+        # db.execute returns mock with first() returning None (no subscription)
+        mock_result = MagicMock()
+        mock_result.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        mock_quota_repo = MagicMock()
+        mock_quota_repo.get_current = AsyncMock(return_value=None)
+
+        with (
+            patch(REPO_PATH, return_value=mock_repo),
+            patch(QUOTA_REPO_PATH, return_value=mock_quota_repo),
+            TestClient(app_with_tenant_admin) as client,
+        ):
+            resp = client.get(f"/v1/consumers/acme/{consumer.id}/quota")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["consumer_id"] == str(consumer.id)
+        assert data["usage"]["daily"] == 0
+        assert data["usage"]["monthly"] == 0
+
+    def test_quota_404_consumer_not_found(self, app_with_tenant_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get(f"/v1/consumers/acme/{uuid4()}/quota")
+
+        assert resp.status_code == 404
+
+    def test_quota_403_wrong_tenant(self, app_with_other_tenant, mock_db_session):
+        with TestClient(app_with_other_tenant) as client:
+            resp = client.get(f"/v1/consumers/acme/{uuid4()}/quota")
+
+        assert resp.status_code == 403
+
+    def test_quota_success_with_usage(self, app_with_tenant_admin, mock_db_session):
+        consumer = _mock_consumer()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=consumer)
+
+        mock_result = MagicMock()
+        mock_result.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        mock_usage = MagicMock()
+        mock_usage.request_count_daily = 150
+        mock_usage.request_count_monthly = 4500
+
+        mock_quota_repo = MagicMock()
+        mock_quota_repo.get_current = AsyncMock(return_value=mock_usage)
+
+        with (
+            patch(REPO_PATH, return_value=mock_repo),
+            patch(QUOTA_REPO_PATH, return_value=mock_quota_repo),
+            TestClient(app_with_tenant_admin) as client,
+        ):
+            resp = client.get(f"/v1/consumers/acme/{consumer.id}/quota")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["usage"]["daily"] == 150
+        assert data["usage"]["monthly"] == 4500

--- a/control-plane-api/tests/test_contracts_router.py
+++ b/control-plane-api/tests/test_contracts_router.py
@@ -1,0 +1,537 @@
+"""Tests for Contracts Router — CAB-1452
+
+Covers: /v1/contracts (CRUD, bindings, MCP tools) and /v1/mcp/generated-tools.
+Router uses direct SQLAlchemy queries (no repository pattern), so db.execute is mocked.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+CACHE_PATH = "src.routers.contracts.contract_cache"
+ADAPTER_PATH = "src.routers.contracts.AdapterRegistry"
+GENERATOR_PATH = "src.routers.contracts.UacToolGenerator"
+
+
+def _mock_contract(tenant_id: str = "acme") -> MagicMock:
+    c = MagicMock()
+    c.id = uuid4()
+    c.tenant_id = tenant_id
+    c.name = "payment-service"
+    c.display_name = "Payment Service API"
+    c.description = "API for processing payments"
+    c.version = "1.0.0"
+    c.status = "draft"
+    c.openapi_spec_url = None
+    c.schema_hash = None
+    c.created_at = datetime.utcnow()
+    c.updated_at = datetime.utcnow()
+    c.created_by = "tenant-admin-user-id"
+    return c
+
+
+def _mock_binding(protocol: str = "rest", enabled: bool = False) -> MagicMock:
+    b = MagicMock()
+    b.protocol = protocol
+    b.enabled = enabled
+    b.endpoint = None
+    b.playground_url = None
+    b.tool_name = None
+    b.operations = None
+    b.proto_file_url = None
+    b.topic_name = None
+    b.traffic_24h = None
+    b.generated_at = None
+    b.generation_error = None
+    return b
+
+
+class TestCreateContract:
+    """Tests for POST /v1/contracts."""
+
+    def test_create_contract_success(self, app_with_tenant_admin, mock_db_session):
+        _now = datetime.utcnow()
+        no_conflict_result = MagicMock()
+        no_conflict_result.scalar_one_or_none.return_value = None
+
+        # _get_or_create_default_bindings will query and get empty → creates 5 bindings
+        bindings_result = MagicMock()
+        bindings_result.scalars.return_value.all.return_value = []
+
+        mock_db_session.execute = AsyncMock(side_effect=[no_conflict_result, bindings_result])
+
+        # Intercept db.add: when the Contract object is added, stamp its timestamps.
+        from src.models.contract import Contract as ContractModel
+
+        def _fake_add(obj: object) -> None:
+            if isinstance(obj, ContractModel):
+                obj.created_at = _now
+                obj.updated_at = _now
+
+        mock_db_session.add = MagicMock(side_effect=_fake_add)
+        mock_db_session.flush = AsyncMock()
+
+        mock_cache = AsyncMock()
+        mock_cache.delete_by_prefix = AsyncMock()
+
+        with patch(CACHE_PATH, mock_cache), TestClient(app_with_tenant_admin) as client:
+            resp = client.post("/v1/contracts", json={"name": "payment-service", "version": "1.0.0"})
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "payment-service"
+        assert data["tenant_id"] == "acme"
+        assert data["status"] == "draft"
+
+    def test_create_contract_409_duplicate_name(self, app_with_tenant_admin, mock_db_session):
+        conflict_result = MagicMock()
+        conflict_result.scalar_one_or_none.return_value = _mock_contract()
+        mock_db_session.execute = AsyncMock(return_value=conflict_result)
+
+        mock_cache = AsyncMock()
+        mock_cache.delete_by_prefix = AsyncMock()
+
+        with patch(CACHE_PATH, mock_cache), TestClient(app_with_tenant_admin) as client:
+            resp = client.post("/v1/contracts", json={"name": "payment-service"})
+
+        assert resp.status_code == 409
+        assert "already exists" in resp.json()["detail"]
+
+    def test_create_contract_400_no_tenant(self, app_with_cpi_admin, mock_db_session):
+        mock_cache = AsyncMock()
+        with patch(CACHE_PATH, mock_cache), TestClient(app_with_cpi_admin) as client:
+            resp = client.post("/v1/contracts", json={"name": "payment-service"})
+        assert resp.status_code == 400
+        assert "tenant" in resp.json()["detail"].lower()
+
+
+class TestListContracts:
+    """Tests for GET /v1/contracts."""
+
+    def test_list_contracts_tenant_admin(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract()
+        mock_cache = AsyncMock()
+        mock_cache.get = AsyncMock(return_value=None)
+        mock_cache.set = AsyncMock()
+
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+
+        list_result = MagicMock()
+        list_result.scalars.return_value.all.return_value = [contract]
+
+        bindings_result = MagicMock()
+        bindings_result.scalars.return_value.all.return_value = [_mock_binding()]
+
+        mock_db_session.execute = AsyncMock(side_effect=[count_result, list_result, bindings_result])
+
+        with patch(CACHE_PATH, mock_cache), TestClient(app_with_tenant_admin) as client:
+            resp = client.get("/v1/contracts")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+
+    def test_list_contracts_uses_cache(self, app_with_tenant_admin, mock_db_session):
+        from src.schemas.contract import ContractListResponse
+
+        cached = ContractListResponse(items=[], total=0, page=1, page_size=20)
+        mock_cache = AsyncMock()
+        mock_cache.get = AsyncMock(return_value=cached)
+        mock_cache.set = AsyncMock()
+
+        with patch(CACHE_PATH, mock_cache), TestClient(app_with_tenant_admin) as client:
+            resp = client.get("/v1/contracts")
+
+        assert resp.status_code == 200
+        mock_db_session.execute.assert_not_awaited()
+
+    def test_list_contracts_cpi_admin(self, app_with_cpi_admin, mock_db_session):
+        mock_cache = AsyncMock()
+        mock_cache.get = AsyncMock(return_value=None)
+        mock_cache.set = AsyncMock()
+
+        count_result = MagicMock()
+        count_result.scalar.return_value = 0
+
+        list_result = MagicMock()
+        list_result.scalars.return_value.all.return_value = []
+
+        mock_db_session.execute = AsyncMock(side_effect=[count_result, list_result])
+
+        with patch(CACHE_PATH, mock_cache), TestClient(app_with_cpi_admin) as client:
+            resp = client.get("/v1/contracts")
+
+        assert resp.status_code == 200
+
+
+class TestGetContract:
+    """Tests for GET /v1/contracts/{contract_id}."""
+
+    def test_get_contract_success(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="acme")
+
+        contract_result = MagicMock()
+        contract_result.scalar_one_or_none.return_value = contract
+
+        bindings_result = MagicMock()
+        bindings_result.scalars.return_value.all.return_value = [_mock_binding()]
+
+        mock_db_session.execute = AsyncMock(side_effect=[contract_result, bindings_result])
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.get(f"/v1/contracts/{contract.id}")
+
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "payment-service"
+
+    def test_get_contract_404(self, app_with_tenant_admin, mock_db_session):
+        not_found = MagicMock()
+        not_found.scalar_one_or_none.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=not_found)
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.get(f"/v1/contracts/{uuid4()}")
+
+        assert resp.status_code == 404
+
+    def test_get_contract_403_cross_tenant(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="other-tenant")
+        contract_result = MagicMock()
+        contract_result.scalar_one_or_none.return_value = contract
+        mock_db_session.execute = AsyncMock(return_value=contract_result)
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.get(f"/v1/contracts/{contract.id}")
+
+        assert resp.status_code == 403
+
+
+class TestUpdateContract:
+    """Tests for PATCH /v1/contracts/{contract_id}."""
+
+    def test_update_contract_success(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="acme")
+
+        contract_result = MagicMock()
+        contract_result.scalar_one_or_none.return_value = contract
+
+        bindings_result = MagicMock()
+        bindings_result.scalars.return_value.all.return_value = [_mock_binding()]
+
+        mock_db_session.execute = AsyncMock(side_effect=[contract_result, bindings_result])
+        mock_db_session.flush = AsyncMock()
+
+        mock_cache = AsyncMock()
+        mock_cache.delete_by_prefix = AsyncMock()
+
+        with patch(CACHE_PATH, mock_cache), TestClient(app_with_tenant_admin) as client:
+            resp = client.patch(f"/v1/contracts/{contract.id}", json={"version": "2.0.0"})
+
+        assert resp.status_code == 200
+
+    def test_update_contract_404(self, app_with_tenant_admin, mock_db_session):
+        not_found = MagicMock()
+        not_found.scalar_one_or_none.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=not_found)
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.patch(f"/v1/contracts/{uuid4()}", json={"version": "2.0.0"})
+
+        assert resp.status_code == 404
+
+    def test_update_contract_403_cross_tenant(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="other-tenant")
+        contract_result = MagicMock()
+        contract_result.scalar_one_or_none.return_value = contract
+        mock_db_session.execute = AsyncMock(return_value=contract_result)
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.patch(f"/v1/contracts/{contract.id}", json={"version": "2.0.0"})
+
+        assert resp.status_code == 403
+
+
+class TestDeleteContract:
+    """Tests for DELETE /v1/contracts/{contract_id}."""
+
+    def test_delete_contract_success(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="acme")
+        contract_result = MagicMock()
+        contract_result.scalar_one_or_none.return_value = contract
+        mock_db_session.execute = AsyncMock(return_value=contract_result)
+        mock_db_session.delete = AsyncMock()
+
+        mock_cache = AsyncMock()
+        mock_cache.delete_by_prefix = AsyncMock()
+
+        with patch(CACHE_PATH, mock_cache), TestClient(app_with_tenant_admin) as client:
+            resp = client.delete(f"/v1/contracts/{contract.id}")
+
+        assert resp.status_code == 204
+        mock_db_session.delete.assert_awaited_once()
+
+    def test_delete_contract_404(self, app_with_tenant_admin, mock_db_session):
+        not_found = MagicMock()
+        not_found.scalar_one_or_none.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=not_found)
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.delete(f"/v1/contracts/{uuid4()}")
+
+        assert resp.status_code == 404
+
+    def test_delete_contract_403_cross_tenant(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="other-tenant")
+        contract_result = MagicMock()
+        contract_result.scalar_one_or_none.return_value = contract
+        mock_db_session.execute = AsyncMock(return_value=contract_result)
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.delete(f"/v1/contracts/{contract.id}")
+
+        assert resp.status_code == 403
+
+
+class TestListBindings:
+    """Tests for GET /v1/contracts/{contract_id}/bindings."""
+
+    def test_list_bindings_success(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="acme")
+
+        contract_result = MagicMock()
+        contract_result.scalar_one_or_none.return_value = contract
+
+        bindings_result = MagicMock()
+        bindings_result.scalars.return_value.all.return_value = [
+            _mock_binding("rest", True),
+            _mock_binding("mcp", False),
+        ]
+
+        mock_db_session.execute = AsyncMock(side_effect=[contract_result, bindings_result])
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.get(f"/v1/contracts/{contract.id}/bindings")
+
+        assert resp.status_code == 200
+        assert resp.json()["contract_name"] == "payment-service"
+
+    def test_list_bindings_404(self, app_with_tenant_admin, mock_db_session):
+        not_found = MagicMock()
+        not_found.scalar_one_or_none.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=not_found)
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.get(f"/v1/contracts/{uuid4()}/bindings")
+
+        assert resp.status_code == 404
+
+
+class TestEnableBinding:
+    """Tests for POST /v1/contracts/{contract_id}/bindings."""
+
+    def test_enable_binding_success(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="acme")
+
+        contract_result = MagicMock()
+        contract_result.scalar_one_or_none.return_value = contract
+
+        binding_result = MagicMock()
+        binding_result.scalar_one_or_none.return_value = None
+
+        gw_result = MagicMock()
+        gw_result.scalars.return_value.all.return_value = []
+
+        mock_db_session.execute = AsyncMock(side_effect=[contract_result, binding_result, gw_result])
+        mock_db_session.flush = AsyncMock()
+
+        with patch(ADAPTER_PATH, MagicMock()), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(f"/v1/contracts/{contract.id}/bindings", json={"protocol": "rest"})
+
+        assert resp.status_code == 200
+        assert resp.json()["protocol"] == "rest"
+        assert resp.json()["status"] == "active"
+
+    def test_enable_binding_404(self, app_with_tenant_admin, mock_db_session):
+        not_found = MagicMock()
+        not_found.scalar_one_or_none.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=not_found)
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.post(f"/v1/contracts/{uuid4()}/bindings", json={"protocol": "rest"})
+
+        assert resp.status_code == 404
+
+    def test_enable_binding_409_already_enabled(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="acme")
+        binding = _mock_binding("rest", enabled=True)
+
+        contract_result = MagicMock()
+        contract_result.scalar_one_or_none.return_value = contract
+
+        binding_result = MagicMock()
+        binding_result.scalar_one_or_none.return_value = binding
+
+        mock_db_session.execute = AsyncMock(side_effect=[contract_result, binding_result])
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.post(f"/v1/contracts/{contract.id}/bindings", json={"protocol": "rest"})
+
+        assert resp.status_code == 409
+
+
+class TestDisableBinding:
+    """Tests for DELETE /v1/contracts/{contract_id}/bindings/{protocol}."""
+
+    def test_disable_binding_success(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="acme")
+        binding = _mock_binding("rest", enabled=True)
+
+        contract_result = MagicMock()
+        contract_result.scalar_one_or_none.return_value = contract
+
+        binding_result = MagicMock()
+        binding_result.scalar_one_or_none.return_value = binding
+
+        mock_db_session.execute = AsyncMock(side_effect=[contract_result, binding_result])
+        mock_db_session.flush = AsyncMock()
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.delete(f"/v1/contracts/{contract.id}/bindings/rest")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "disabled"
+
+    def test_disable_binding_404_binding_not_found(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="acme")
+
+        contract_result = MagicMock()
+        contract_result.scalar_one_or_none.return_value = contract
+
+        binding_result = MagicMock()
+        binding_result.scalar_one_or_none.return_value = None
+
+        mock_db_session.execute = AsyncMock(side_effect=[contract_result, binding_result])
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.delete(f"/v1/contracts/{contract.id}/bindings/rest")
+
+        assert resp.status_code == 404
+
+    def test_disable_binding_409_already_disabled(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="acme")
+        binding = _mock_binding("rest", enabled=False)
+
+        contract_result = MagicMock()
+        contract_result.scalar_one_or_none.return_value = contract
+
+        binding_result = MagicMock()
+        binding_result.scalar_one_or_none.return_value = binding
+
+        mock_db_session.execute = AsyncMock(side_effect=[contract_result, binding_result])
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.delete(f"/v1/contracts/{contract.id}/bindings/rest")
+
+        assert resp.status_code == 409
+
+
+class TestGenerateMcpTools:
+    """Tests for POST /v1/contracts/{contract_id}/mcp-tools/generate."""
+
+    def test_generate_mcp_tools_success(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="acme")
+        contract_result = MagicMock()
+        contract_result.scalars.return_value.first.return_value = contract
+        mock_db_session.execute = AsyncMock(return_value=contract_result)
+
+        mock_generator = MagicMock()
+        mock_generator.generate_tools = AsyncMock(return_value=[])
+
+        with patch(GENERATOR_PATH, return_value=mock_generator), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(f"/v1/contracts/{contract.id}/mcp-tools/generate")
+
+        assert resp.status_code == 200
+        assert resp.json()["generated"] == 0
+
+    def test_generate_mcp_tools_404(self, app_with_tenant_admin, mock_db_session):
+        not_found = MagicMock()
+        not_found.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=not_found)
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.post(f"/v1/contracts/{uuid4()}/mcp-tools/generate")
+
+        assert resp.status_code == 404
+
+    def test_generate_mcp_tools_403_cross_tenant(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="other-tenant")
+        contract_result = MagicMock()
+        contract_result.scalars.return_value.first.return_value = contract
+        mock_db_session.execute = AsyncMock(return_value=contract_result)
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.post(f"/v1/contracts/{contract.id}/mcp-tools/generate")
+
+        assert resp.status_code == 403
+
+
+class TestListMcpTools:
+    """Tests for GET /v1/contracts/{contract_id}/mcp-tools."""
+
+    def test_list_mcp_tools_success(self, app_with_tenant_admin, mock_db_session):
+        contract = _mock_contract(tenant_id="acme")
+        contract_result = MagicMock()
+        contract_result.scalars.return_value.first.return_value = contract
+        mock_db_session.execute = AsyncMock(return_value=contract_result)
+
+        mock_generator = MagicMock()
+        mock_generator.get_tools_for_contract = AsyncMock(return_value=[])
+
+        with patch(GENERATOR_PATH, return_value=mock_generator), TestClient(app_with_tenant_admin) as client:
+            resp = client.get(f"/v1/contracts/{contract.id}/mcp-tools")
+
+        assert resp.status_code == 200
+        assert resp.json()["contract_name"] == "payment-service"
+
+    def test_list_mcp_tools_404(self, app_with_tenant_admin, mock_db_session):
+        not_found = MagicMock()
+        not_found.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=not_found)
+
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.get(f"/v1/contracts/{uuid4()}/mcp-tools")
+
+        assert resp.status_code == 404
+
+
+class TestGetTenantTools:
+    """Tests for GET /v1/mcp/generated-tools (discovery router)."""
+
+    def test_get_tenant_tools_success(self, app_with_tenant_admin, mock_db_session):
+        mock_generator = MagicMock()
+        mock_generator.get_tools_for_tenant = AsyncMock(return_value=[])
+
+        with patch(GENERATOR_PATH, return_value=mock_generator), TestClient(app_with_tenant_admin) as client:
+            resp = client.get("/v1/mcp/generated-tools?tenant_id=acme")
+
+        assert resp.status_code == 200
+        assert resp.json()["tenant_id"] == "acme"
+        assert resp.json()["total"] == 0
+
+    def test_get_tenant_tools_403_cross_tenant(self, app_with_tenant_admin, mock_db_session):
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.get("/v1/mcp/generated-tools?tenant_id=other-tenant")
+
+        assert resp.status_code == 403
+
+    def test_get_tenant_tools_cpi_admin_any_tenant(self, app_with_cpi_admin, mock_db_session):
+        mock_generator = MagicMock()
+        mock_generator.get_tools_for_tenant = AsyncMock(return_value=[])
+
+        with patch(GENERATOR_PATH, return_value=mock_generator), TestClient(app_with_cpi_admin) as client:
+            resp = client.get("/v1/mcp/generated-tools?tenant_id=any-tenant")
+
+        assert resp.status_code == 200

--- a/control-plane-api/tests/test_credential_mappings_router.py
+++ b/control-plane-api/tests/test_credential_mappings_router.py
@@ -1,0 +1,270 @@
+"""Tests for Credential Mappings Router — CAB-1448
+
+Covers: /v1/tenants/{tenant_id}/credential-mappings
+        CRUD + sync + RBAC (cpi-admin, tenant-admin, viewer, cross-tenant).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+REPO_PATH = "src.routers.credential_mappings.CredentialMappingRepository"
+TENANT_ID = "acme"
+
+
+def _make_mapping(**overrides):
+    """Create a mock CredentialMapping model."""
+    mock = MagicMock()
+    defaults = {
+        "id": uuid4(),
+        "consumer_id": uuid4(),
+        "api_id": "weather-api",
+        "tenant_id": TENANT_ID,
+        "auth_type": MagicMock(value="api_key"),
+        "header_name": "X-Api-Key",
+        "encrypted_value": b"encrypted-secret",
+        "description": "Test mapping",
+        "is_active": True,
+        "created_at": "2026-01-01T00:00:00",
+        "updated_at": "2026-01-01T00:00:00",
+        "created_by": "admin-user-id",
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+class TestCreateCredentialMapping:
+    """Tests for POST /v1/tenants/{tenant_id}/credential-mappings."""
+
+    def test_create_success(self, client_as_tenant_admin):
+        mapping = _make_mapping()
+        mock_repo = MagicMock()
+        mock_repo.get_by_consumer_and_api = AsyncMock(return_value=None)
+        mock_repo.create = AsyncMock(return_value=mapping)
+
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(
+                "src.routers.credential_mappings.CredentialMappingRepository.encrypt_credential",
+                return_value=b"encrypted",
+            ),
+        ):
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.post(
+                f"/v1/tenants/{TENANT_ID}/credential-mappings",
+                json={
+                    "consumer_id": str(mapping.consumer_id),
+                    "api_id": "weather-api",
+                    "auth_type": "api_key",
+                    "header_name": "X-Api-Key",
+                    "credential_value": "secret-123",
+                },
+            )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["api_id"] == "weather-api"
+        assert data["has_credential"] is True
+
+    def test_create_duplicate_409(self, client_as_tenant_admin):
+        existing = _make_mapping()
+        mock_repo = MagicMock()
+        mock_repo.get_by_consumer_and_api = AsyncMock(return_value=existing)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.post(
+                f"/v1/tenants/{TENANT_ID}/credential-mappings",
+                json={
+                    "consumer_id": str(existing.consumer_id),
+                    "api_id": "weather-api",
+                    "auth_type": "api_key",
+                    "header_name": "X-Api-Key",
+                    "credential_value": "secret-123",
+                },
+            )
+
+        assert resp.status_code == 409
+
+    def test_create_403_other_tenant(self, client_as_other_tenant):
+        resp = client_as_other_tenant.post(
+            f"/v1/tenants/{TENANT_ID}/credential-mappings",
+            json={
+                "consumer_id": str(uuid4()),
+                "api_id": "weather-api",
+                "auth_type": "api_key",
+                "header_name": "X-Api-Key",
+                "credential_value": "secret-123",
+            },
+        )
+        assert resp.status_code == 403
+
+    def test_create_403_viewer(self, client_as_no_tenant_user):
+        resp = client_as_no_tenant_user.post(
+            f"/v1/tenants/{TENANT_ID}/credential-mappings",
+            json={
+                "consumer_id": str(uuid4()),
+                "api_id": "weather-api",
+                "auth_type": "api_key",
+                "header_name": "X-Api-Key",
+                "credential_value": "secret-123",
+            },
+        )
+        assert resp.status_code == 403
+
+
+class TestListCredentialMappings:
+    """Tests for GET /v1/tenants/{tenant_id}/credential-mappings."""
+
+    def test_list_success(self, client_as_tenant_admin):
+        mapping = _make_mapping()
+        mock_repo = MagicMock()
+        mock_repo.list_by_tenant = AsyncMock(return_value=([mapping], 1))
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/tenants/{TENANT_ID}/credential-mappings")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert len(data["items"]) == 1
+
+    def test_list_empty(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.list_by_tenant = AsyncMock(return_value=([], 0))
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/tenants/{TENANT_ID}/credential-mappings")
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_list_403_other_tenant(self, client_as_other_tenant):
+        resp = client_as_other_tenant.get(f"/v1/tenants/{TENANT_ID}/credential-mappings")
+        assert resp.status_code == 403
+
+
+class TestGetCredentialMapping:
+    """Tests for GET /v1/tenants/{tenant_id}/credential-mappings/{mapping_id}."""
+
+    def test_get_success(self, client_as_tenant_admin):
+        mapping = _make_mapping()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=mapping)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/tenants/{TENANT_ID}/credential-mappings/{mapping.id}")
+
+        assert resp.status_code == 200
+
+    def test_get_404(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/tenants/{TENANT_ID}/credential-mappings/{uuid4()}")
+
+        assert resp.status_code == 404
+
+    def test_get_wrong_tenant_404(self, client_as_tenant_admin):
+        mapping = _make_mapping(tenant_id="other-tenant")
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=mapping)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/tenants/{TENANT_ID}/credential-mappings/{mapping.id}")
+
+        assert resp.status_code == 404
+
+
+class TestUpdateCredentialMapping:
+    """Tests for PUT /v1/tenants/{tenant_id}/credential-mappings/{mapping_id}."""
+
+    def test_update_success(self, client_as_tenant_admin):
+        mapping = _make_mapping()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=mapping)
+        mock_repo.update = AsyncMock(return_value=mapping)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.put(
+                f"/v1/tenants/{TENANT_ID}/credential-mappings/{mapping.id}",
+                json={"description": "Updated desc"},
+            )
+
+        assert resp.status_code == 200
+
+    def test_update_404(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.put(
+                f"/v1/tenants/{TENANT_ID}/credential-mappings/{uuid4()}",
+                json={"description": "test"},
+            )
+
+        assert resp.status_code == 404
+
+
+class TestDeleteCredentialMapping:
+    """Tests for DELETE /v1/tenants/{tenant_id}/credential-mappings/{mapping_id}."""
+
+    def test_delete_success(self, client_as_tenant_admin):
+        mapping = _make_mapping()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=mapping)
+        mock_repo.update = AsyncMock(return_value=mapping)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.delete(f"/v1/tenants/{TENANT_ID}/credential-mappings/{mapping.id}")
+
+        assert resp.status_code == 204
+
+    def test_delete_404(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.delete(f"/v1/tenants/{TENANT_ID}/credential-mappings/{uuid4()}")
+
+        assert resp.status_code == 404
+
+
+class TestSyncCredentialMappings:
+    """Tests for GET /v1/tenants/{tenant_id}/credential-mappings/sync/{gateway_id}."""
+
+    def test_sync_success_cpi_admin(self, client_as_cpi_admin):
+        mock_repo = MagicMock()
+        mock_repo.list_active_for_sync = AsyncMock(
+            return_value=[
+                {
+                    "consumer_id": str(uuid4()),
+                    "api_id": "weather-api",
+                    "auth_type": "api_key",
+                    "header_name": "X-Api-Key",
+                    "header_value": "decrypted-secret",
+                }
+            ]
+        )
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_cpi_admin.get(f"/v1/tenants/{TENANT_ID}/credential-mappings/sync/gw-instance-1")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+    def test_sync_403_tenant_admin(self, client_as_tenant_admin):
+        resp = client_as_tenant_admin.get(f"/v1/tenants/{TENANT_ID}/credential-mappings/sync/gw-instance-1")
+        assert resp.status_code == 403

--- a/control-plane-api/tests/test_environments_router.py
+++ b/control-plane-api/tests/test_environments_router.py
@@ -1,0 +1,46 @@
+"""Tests for Environments Router — CAB-1448
+
+Covers: GET /v1/environments (single endpoint, returns hardcoded defaults).
+"""
+
+
+class TestListEnvironments:
+    """Tests for GET /v1/environments."""
+
+    def test_list_environments_tenant_admin(self, client_as_tenant_admin):
+        resp = client_as_tenant_admin.get("/v1/environments")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        envs = data["environments"]
+        assert len(envs) == 3
+        names = [e["name"] for e in envs]
+        assert "dev" in names
+        assert "staging" in names
+        assert "prod" in names
+
+    def test_list_environments_cpi_admin(self, client_as_cpi_admin):
+        resp = client_as_cpi_admin.get("/v1/environments")
+        assert resp.status_code == 200
+        assert len(resp.json()["environments"]) == 3
+
+    def test_list_environments_modes(self, client_as_tenant_admin):
+        resp = client_as_tenant_admin.get("/v1/environments")
+        envs = {e["name"]: e for e in resp.json()["environments"]}
+        assert envs["dev"]["mode"] == "full"
+        assert envs["staging"]["mode"] == "full"
+        assert envs["prod"]["mode"] == "read-only"
+
+    def test_list_environments_colors(self, client_as_tenant_admin):
+        resp = client_as_tenant_admin.get("/v1/environments")
+        envs = {e["name"]: e for e in resp.json()["environments"]}
+        assert envs["dev"]["color"] == "green"
+        assert envs["staging"]["color"] == "amber"
+        assert envs["prod"]["color"] == "red"
+
+    def test_list_environments_labels(self, client_as_tenant_admin):
+        resp = client_as_tenant_admin.get("/v1/environments")
+        envs = {e["name"]: e for e in resp.json()["environments"]}
+        assert envs["dev"]["label"] == "Development"
+        assert envs["staging"]["label"] == "Staging"
+        assert envs["prod"]["label"] == "Production"

--- a/control-plane-api/tests/test_mcp_admin_router.py
+++ b/control-plane-api/tests/test_mcp_admin_router.py
@@ -1,0 +1,750 @@
+"""Tests for MCP Admin Router — admin subscriptions and server management.
+
+Covers:
+- /v1/admin/mcp/subscriptions (list pending, list tenant, approve, revoke, suspend, reactivate, stats)
+- /v1/admin/mcp/servers (list, create, add tool, update status, delete)
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from src.schemas.mcp_subscription import (
+    MCPServerCategoryEnum,
+    MCPServerResponse,
+    MCPServerStatusEnum,
+    MCPServerVisibility,
+    MCPSubscriptionResponse,
+    MCPSubscriptionStatusEnum,
+)
+
+SUB_REPO_PATH = "src.routers.mcp_admin.MCPSubscriptionRepository"
+SERVER_REPO_PATH = "src.routers.mcp_admin.MCPServerRepository"
+TOOL_REPO_PATH = "src.routers.mcp_admin.MCPToolAccessRepository"
+API_KEY_SVC_PATH = "src.routers.mcp_admin.APIKeyService"
+CONVERT_SUB_PATH = "src.routers.mcp_admin._convert_subscription_to_response"
+CONVERT_SERVER_PATH = "src.routers.mcp_admin._convert_server_to_response"
+
+
+def _make_sub_response(**overrides) -> MCPSubscriptionResponse:
+    """Build a valid MCPSubscriptionResponse Pydantic instance."""
+    defaults = {
+        "id": uuid4(),
+        "server_id": uuid4(),
+        "server": None,
+        "subscriber_id": "user-1",
+        "subscriber_email": "user@test.com",
+        "tenant_id": "acme",
+        "plan": "free",
+        "api_key_prefix": "stoa_mcp_",
+        "status": MCPSubscriptionStatusEnum.ACTIVE,
+        "status_reason": None,
+        "tool_access": [],
+        "last_rotated_at": None,
+        "rotation_count": 0,
+        "has_active_grace_period": False,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+        "approved_at": None,
+        "expires_at": None,
+        "last_used_at": None,
+        "usage_count": 0,
+    }
+    defaults.update(overrides)
+    return MCPSubscriptionResponse(**defaults)
+
+
+def _make_server_response(**overrides) -> MCPServerResponse:
+    """Build a valid MCPServerResponse Pydantic instance."""
+    defaults = {
+        "id": uuid4(),
+        "name": "test-server",
+        "display_name": "Test Server",
+        "description": "A test server",
+        "icon": None,
+        "category": MCPServerCategoryEnum.PUBLIC,
+        "tenant_id": "acme",
+        "visibility": MCPServerVisibility(public=True),
+        "requires_approval": False,
+        "status": MCPServerStatusEnum.ACTIVE,
+        "version": None,
+        "documentation_url": None,
+        "tools": [],
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+    }
+    defaults.update(overrides)
+    return MCPServerResponse(**defaults)
+
+
+def _make_sub_mock(tenant_id: str = "acme", status: str = "pending"):
+    """Build a MagicMock representing a DB subscription."""
+    from src.models.mcp_subscription import MCPSubscriptionStatus
+
+    sub = MagicMock()
+    sub.id = uuid4()
+    sub.tenant_id = tenant_id
+    sub.status = MCPSubscriptionStatus(status)
+    sub.server = MagicMock()
+    sub.server.name = "test-server"
+    sub.server.display_name = "Test Server"
+    sub.created_at = datetime.utcnow()
+    sub.subscriber_email = "user@test.com"
+    sub.tool_access = []
+    sub.api_key_prefix = "stoa_mcp_"
+    sub.previous_key_expires_at = None
+    sub.last_rotated_at = None
+    sub.rotation_count = 0
+    sub.plan = "free"
+    sub.status_reason = None
+    sub.approved_at = None
+    sub.expires_at = None
+    sub.last_used_at = None
+    sub.usage_count = 0
+    return sub
+
+
+# ============================================================
+# Admin Subscriptions — GET /pending
+# ============================================================
+
+
+class TestListPendingApprovals:
+    """Tests for GET /v1/admin/mcp/subscriptions/pending."""
+
+    def test_list_pending_cpi_admin_success(self, app_with_cpi_admin, mock_db_session):
+        sub_response = _make_sub_response(status=MCPSubscriptionStatusEnum.PENDING)
+        sub_mock = _make_sub_mock(status="pending")
+
+        mock_repo = MagicMock()
+        mock_repo.list_pending = AsyncMock(return_value=([sub_mock], 1))
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_repo),
+            patch(CONVERT_SUB_PATH, return_value=sub_response),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            resp = client.get("/v1/admin/mcp/subscriptions/pending")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert len(data["items"]) == 1
+
+    def test_list_pending_tenant_admin_scoped(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admin only sees own tenant's pending subscriptions."""
+        sub_response = _make_sub_response(status=MCPSubscriptionStatusEnum.PENDING)
+        sub_mock = _make_sub_mock(tenant_id="acme", status="pending")
+
+        mock_repo = MagicMock()
+        mock_repo.list_pending = AsyncMock(return_value=([sub_mock], 1))
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_repo),
+            patch(CONVERT_SUB_PATH, return_value=sub_response),
+            TestClient(app_with_tenant_admin) as client,
+        ):
+            resp = client.get("/v1/admin/mcp/subscriptions/pending")
+
+        assert resp.status_code == 200
+        # tenant_id filter should have been applied (acme)
+        call_kwargs = mock_repo.list_pending.call_args.kwargs
+        assert call_kwargs.get("tenant_id") == "acme"
+
+    def test_list_pending_empty_list(self, app_with_cpi_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.list_pending = AsyncMock(return_value=([], 0))
+
+        with patch(SUB_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.get("/v1/admin/mcp/subscriptions/pending")
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_list_pending_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.get("/v1/admin/mcp/subscriptions/pending")
+        assert resp.status_code == 403
+
+
+# ============================================================
+# Admin Subscriptions — GET /tenant/{tenant_id}
+# ============================================================
+
+
+class TestListTenantSubscriptions:
+    """Tests for GET /v1/admin/mcp/subscriptions/tenant/{tenant_id}."""
+
+    def test_list_tenant_subs_success(self, app_with_cpi_admin, mock_db_session):
+        sub_response = _make_sub_response()
+        mock_repo = MagicMock()
+        mock_repo.list_by_tenant = AsyncMock(return_value=([MagicMock()], 1))
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_repo),
+            patch(CONVERT_SUB_PATH, return_value=sub_response),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            resp = client.get("/v1/admin/mcp/subscriptions/tenant/acme")
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+    def test_list_tenant_subs_403_wrong_tenant(self, app_with_other_tenant, mock_db_session):
+        """Tenant admin cannot view another tenant's subscriptions."""
+        with TestClient(app_with_other_tenant) as client:
+            resp = client.get("/v1/admin/mcp/subscriptions/tenant/acme")
+        assert resp.status_code == 403
+
+    def test_list_tenant_subs_own_tenant_ok(self, app_with_tenant_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.list_by_tenant = AsyncMock(return_value=([], 0))
+
+        with patch(SUB_REPO_PATH, return_value=mock_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get("/v1/admin/mcp/subscriptions/tenant/acme")
+
+        assert resp.status_code == 200
+
+
+# ============================================================
+# Admin Subscriptions — POST /{id}/approve
+# ============================================================
+
+
+class TestApproveSubscription:
+    """Tests for POST /v1/admin/mcp/subscriptions/{id}/approve."""
+
+    def test_approve_success(self, app_with_cpi_admin, mock_db_session):
+        sub_mock = _make_sub_mock(status="pending")
+        sub_response = _make_sub_response(status=MCPSubscriptionStatusEnum.ACTIVE)
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=sub_mock)
+        mock_repo.set_api_key = AsyncMock()
+        mock_repo.set_expiration = AsyncMock()
+        mock_repo.update_status = AsyncMock(return_value=sub_mock)
+
+        mock_tool_repo = MagicMock()
+        mock_tool_repo.update_status = AsyncMock()
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_repo),
+            patch(TOOL_REPO_PATH, return_value=mock_tool_repo),
+            patch(API_KEY_SVC_PATH) as mock_api_key,
+            patch(CONVERT_SUB_PATH, return_value=sub_response),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            mock_api_key.generate_key.return_value = ("stoa_mcp_test_key", "hash123", "stoa_mcp_")
+            resp = client.post(f"/v1/admin/mcp/subscriptions/{uuid4()}/approve", json={})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "api_key" in data
+        assert data["api_key"] == "stoa_mcp_test_key"
+
+    def test_approve_400_not_pending(self, app_with_cpi_admin, mock_db_session):
+        """Cannot approve an already active subscription."""
+        sub_mock = _make_sub_mock(status="active")
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=sub_mock)
+
+        mock_tool_repo = MagicMock()
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_repo),
+            patch(TOOL_REPO_PATH, return_value=mock_tool_repo),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            resp = client.post(f"/v1/admin/mcp/subscriptions/{uuid4()}/approve", json={})
+
+        assert resp.status_code == 400
+
+    def test_approve_404_not_found(self, app_with_cpi_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+        mock_tool_repo = MagicMock()
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_repo),
+            patch(TOOL_REPO_PATH, return_value=mock_tool_repo),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            resp = client.post(f"/v1/admin/mcp/subscriptions/{uuid4()}/approve", json={})
+
+        assert resp.status_code == 404
+
+    def test_approve_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.post(f"/v1/admin/mcp/subscriptions/{uuid4()}/approve", json={})
+        assert resp.status_code == 403
+
+
+# ============================================================
+# Admin Subscriptions — POST /{id}/revoke
+# ============================================================
+
+
+class TestRevokeSubscription:
+    """Tests for POST /v1/admin/mcp/subscriptions/{id}/revoke."""
+
+    def test_revoke_success(self, app_with_cpi_admin, mock_db_session):
+        sub_mock = _make_sub_mock(status="active")
+        sub_response = _make_sub_response(status=MCPSubscriptionStatusEnum.REVOKED)
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=sub_mock)
+        mock_repo.update_status = AsyncMock(return_value=sub_mock)
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_repo),
+            patch(CONVERT_SUB_PATH, return_value=sub_response),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            resp = client.post(
+                f"/v1/admin/mcp/subscriptions/{uuid4()}/revoke",
+                json={"reason": "Policy violation"},
+            )
+
+        assert resp.status_code == 200
+
+    def test_revoke_400_already_revoked(self, app_with_cpi_admin, mock_db_session):
+        sub_mock = _make_sub_mock(status="revoked")
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=sub_mock)
+
+        with patch(SUB_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.post(
+                f"/v1/admin/mcp/subscriptions/{uuid4()}/revoke",
+                json={"reason": "Already done"},
+            )
+
+        assert resp.status_code == 400
+
+    def test_revoke_404_not_found(self, app_with_cpi_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(SUB_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.post(
+                f"/v1/admin/mcp/subscriptions/{uuid4()}/revoke",
+                json={"reason": "Not found test"},
+            )
+
+        assert resp.status_code == 404
+
+
+# ============================================================
+# Admin Subscriptions — POST /{id}/suspend
+# ============================================================
+
+
+class TestSuspendSubscription:
+    """Tests for POST /v1/admin/mcp/subscriptions/{id}/suspend."""
+
+    def test_suspend_success(self, app_with_cpi_admin, mock_db_session):
+        sub_mock = _make_sub_mock(status="active")
+        sub_response = _make_sub_response(status=MCPSubscriptionStatusEnum.SUSPENDED)
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=sub_mock)
+        mock_repo.update_status = AsyncMock(return_value=sub_mock)
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_repo),
+            patch(CONVERT_SUB_PATH, return_value=sub_response),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            resp = client.post(f"/v1/admin/mcp/subscriptions/{uuid4()}/suspend")
+
+        assert resp.status_code == 200
+
+    def test_suspend_400_not_active(self, app_with_cpi_admin, mock_db_session):
+        """Cannot suspend a pending subscription."""
+        sub_mock = _make_sub_mock(status="pending")
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=sub_mock)
+
+        with patch(SUB_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.post(f"/v1/admin/mcp/subscriptions/{uuid4()}/suspend")
+
+        assert resp.status_code == 400
+
+    def test_suspend_404_not_found(self, app_with_cpi_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(SUB_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.post(f"/v1/admin/mcp/subscriptions/{uuid4()}/suspend")
+
+        assert resp.status_code == 404
+
+
+# ============================================================
+# Admin Subscriptions — POST /{id}/reactivate
+# ============================================================
+
+
+class TestReactivateSubscription:
+    """Tests for POST /v1/admin/mcp/subscriptions/{id}/reactivate."""
+
+    def test_reactivate_success(self, app_with_cpi_admin, mock_db_session):
+        sub_mock = _make_sub_mock(status="suspended")
+        sub_response = _make_sub_response(status=MCPSubscriptionStatusEnum.ACTIVE)
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=sub_mock)
+        mock_repo.update_status = AsyncMock(return_value=sub_mock)
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_repo),
+            patch(CONVERT_SUB_PATH, return_value=sub_response),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            resp = client.post(f"/v1/admin/mcp/subscriptions/{uuid4()}/reactivate")
+
+        assert resp.status_code == 200
+
+    def test_reactivate_400_not_suspended(self, app_with_cpi_admin, mock_db_session):
+        """Cannot reactivate an active subscription."""
+        sub_mock = _make_sub_mock(status="active")
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=sub_mock)
+
+        with patch(SUB_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.post(f"/v1/admin/mcp/subscriptions/{uuid4()}/reactivate")
+
+        assert resp.status_code == 400
+
+
+# ============================================================
+# Admin Subscriptions — GET /stats
+# ============================================================
+
+
+class TestSubscriptionStats:
+    """Tests for GET /v1/admin/mcp/subscriptions/stats."""
+
+    def test_get_stats_cpi_admin(self, app_with_cpi_admin, mock_db_session):
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_stats = AsyncMock(
+            return_value={
+                "total_subscriptions": 10,
+                "by_status": {"active": 8, "pending": 2},
+                "by_server": {"server-a": 5, "server-b": 5},
+                "recent_24h": 3,
+            }
+        )
+
+        mock_server_repo = MagicMock()
+        mock_server_repo.list_all = AsyncMock(return_value=([], 5))
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch(SERVER_REPO_PATH, return_value=mock_server_repo),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            resp = client.get("/v1/admin/mcp/subscriptions/stats")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_subscriptions"] == 10
+        assert data["total_servers"] == 5
+
+    def test_get_stats_tenant_admin(self, app_with_tenant_admin, mock_db_session):
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_stats = AsyncMock(
+            return_value={
+                "total_subscriptions": 2,
+                "by_status": {"active": 2},
+                "by_server": {},
+                "recent_24h": 0,
+            }
+        )
+
+        mock_server_repo = MagicMock()
+        mock_server_repo.list_all = AsyncMock(return_value=([], 0))
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch(SERVER_REPO_PATH, return_value=mock_server_repo),
+            TestClient(app_with_tenant_admin) as client,
+        ):
+            resp = client.get("/v1/admin/mcp/subscriptions/stats")
+
+        assert resp.status_code == 200
+
+    def test_get_stats_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.get("/v1/admin/mcp/subscriptions/stats")
+        assert resp.status_code == 403
+
+
+# ============================================================
+# Admin Servers — GET /v1/admin/mcp/servers
+# ============================================================
+
+
+class TestListAllServers:
+    """Tests for GET /v1/admin/mcp/servers."""
+
+    def test_list_servers_success(self, app_with_cpi_admin, mock_db_session):
+        server_response = _make_server_response()
+        mock_repo = MagicMock()
+        mock_repo.list_all = AsyncMock(return_value=([MagicMock()], 1))
+
+        with (
+            patch(SERVER_REPO_PATH, return_value=mock_repo),
+            patch(CONVERT_SERVER_PATH, return_value=server_response),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            resp = client.get("/v1/admin/mcp/servers")
+
+        assert resp.status_code == 200
+        assert resp.json()["total_count"] == 1
+
+    def test_list_servers_with_filters(self, app_with_cpi_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.list_all = AsyncMock(return_value=([], 0))
+
+        with patch(SERVER_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.get("/v1/admin/mcp/servers?category=public&status=active")
+
+        assert resp.status_code == 200
+        call_kwargs = mock_repo.list_all.call_args.kwargs
+        assert call_kwargs.get("category") is not None
+        assert call_kwargs.get("status") is not None
+
+    def test_list_servers_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        with TestClient(app_with_no_tenant_user) as client:
+            resp = client.get("/v1/admin/mcp/servers")
+        assert resp.status_code == 403
+
+
+# ============================================================
+# Admin Servers — POST /v1/admin/mcp/servers
+# ============================================================
+
+
+class TestCreateServer:
+    """Tests for POST /v1/admin/mcp/servers."""
+
+    def _server_payload(self, **overrides):
+        payload = {
+            "name": "new-server",
+            "display_name": "New Server",
+            "description": "A brand new server",
+            "category": "public",
+            "visibility": {"public": True},
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_create_server_success(self, app_with_cpi_admin, mock_db_session):
+        server_response = _make_server_response()
+        created_server = MagicMock()
+        created_server.name = "new-server"
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_name = AsyncMock(return_value=None)
+        mock_repo.create = AsyncMock(return_value=created_server)
+
+        with (
+            patch(SERVER_REPO_PATH, return_value=mock_repo),
+            patch(CONVERT_SERVER_PATH, return_value=server_response),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            resp = client.post("/v1/admin/mcp/servers", json=self._server_payload())
+
+        assert resp.status_code == 201
+
+    def test_create_server_409_duplicate(self, app_with_cpi_admin, mock_db_session):
+        existing_server = MagicMock()
+        mock_repo = MagicMock()
+        mock_repo.get_by_name = AsyncMock(return_value=existing_server)
+
+        with patch(SERVER_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.post("/v1/admin/mcp/servers", json=self._server_payload())
+
+        assert resp.status_code == 409
+
+    def test_create_server_tenant_admin_only_tenant_category(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admin cannot create a public server."""
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.post("/v1/admin/mcp/servers", json=self._server_payload(category="public"))
+        assert resp.status_code == 403
+
+    def test_create_server_tenant_admin_can_create_tenant_server(self, app_with_tenant_admin, mock_db_session):
+        server_response = _make_server_response(category=MCPServerCategoryEnum.TENANT)
+        created_server = MagicMock()
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_name = AsyncMock(return_value=None)
+        mock_repo.create = AsyncMock(return_value=created_server)
+
+        with (
+            patch(SERVER_REPO_PATH, return_value=mock_repo),
+            patch(CONVERT_SERVER_PATH, return_value=server_response),
+            TestClient(app_with_tenant_admin) as client,
+        ):
+            resp = client.post(
+                "/v1/admin/mcp/servers",
+                json=self._server_payload(category="tenant", tenant_id="acme"),
+            )
+
+        assert resp.status_code == 201
+
+
+# ============================================================
+# Admin Servers — POST /{id}/tools
+# ============================================================
+
+
+class TestAddToolToServer:
+    """Tests for POST /v1/admin/mcp/servers/{id}/tools."""
+
+    def _tool_payload(self):
+        return {
+            "name": "get-data",
+            "display_name": "Get Data",
+            "description": "Retrieves data from the API",
+        }
+
+    def test_add_tool_success(self, app_with_cpi_admin, mock_db_session):
+        server_mock = MagicMock()
+        server_mock.id = uuid4()
+        server_mock.name = "test-server"
+        server_mock.tenant_id = "acme"
+        server_mock.tools = []
+
+        tool_mock = MagicMock()
+        tool_mock.id = uuid4()
+        tool_mock.name = "get-data"
+        tool_mock.display_name = "Get Data"
+        tool_mock.description = "Retrieves data from the API"
+        tool_mock.input_schema = None
+        tool_mock.enabled = True
+        tool_mock.requires_approval = False
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=server_mock)
+
+        mock_db_session.add = MagicMock()
+        mock_db_session.flush = AsyncMock()
+        mock_db_session.refresh = AsyncMock(side_effect=lambda _obj: None)
+
+        with (
+            patch(SERVER_REPO_PATH, return_value=mock_repo),
+            patch("src.routers.mcp_admin.MCPServerTool", return_value=tool_mock),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            resp = client.post(f"/v1/admin/mcp/servers/{uuid4()}/tools", json=self._tool_payload())
+
+        assert resp.status_code == 201
+
+    def test_add_tool_409_duplicate_name(self, app_with_cpi_admin, mock_db_session):
+        existing_tool = MagicMock()
+        existing_tool.name = "get-data"
+
+        server_mock = MagicMock()
+        server_mock.id = uuid4()
+        server_mock.tenant_id = "acme"
+        server_mock.tools = [existing_tool]
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=server_mock)
+
+        with patch(SERVER_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.post(f"/v1/admin/mcp/servers/{uuid4()}/tools", json=self._tool_payload())
+
+        assert resp.status_code == 409
+
+    def test_add_tool_404_server_not_found(self, app_with_cpi_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(SERVER_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.post(f"/v1/admin/mcp/servers/{uuid4()}/tools", json=self._tool_payload())
+
+        assert resp.status_code == 404
+
+
+# ============================================================
+# Admin Servers — PATCH /{id}/status
+# ============================================================
+
+
+class TestUpdateServerStatus:
+    """Tests for PATCH /v1/admin/mcp/servers/{id}/status."""
+
+    def test_update_status_success(self, app_with_cpi_admin, mock_db_session):
+        server_mock = MagicMock()
+        server_mock.id = uuid4()
+        server_mock.name = "test-server"
+        server_mock.tenant_id = "acme"
+
+        server_response = _make_server_response(status=MCPServerStatusEnum.MAINTENANCE)
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=server_mock)
+        mock_repo.update = AsyncMock()
+
+        with (
+            patch(SERVER_REPO_PATH, return_value=mock_repo),
+            patch(CONVERT_SERVER_PATH, return_value=server_response),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            resp = client.patch(f"/v1/admin/mcp/servers/{uuid4()}/status?status=maintenance")
+
+        assert resp.status_code == 200
+
+    def test_update_status_404_not_found(self, app_with_cpi_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(SERVER_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.patch(f"/v1/admin/mcp/servers/{uuid4()}/status?status=active")
+
+        assert resp.status_code == 404
+
+
+# ============================================================
+# Admin Servers — DELETE /{id}
+# ============================================================
+
+
+class TestDeleteServer:
+    """Tests for DELETE /v1/admin/mcp/servers/{id}."""
+
+    def test_delete_server_success(self, app_with_cpi_admin, mock_db_session):
+        server_mock = MagicMock()
+        server_mock.name = "test-server"
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=server_mock)
+        mock_repo.delete = AsyncMock()
+
+        with patch(SERVER_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.delete(f"/v1/admin/mcp/servers/{uuid4()}")
+
+        assert resp.status_code == 204
+
+    def test_delete_server_403_tenant_admin(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admins cannot delete servers."""
+        with TestClient(app_with_tenant_admin) as client:
+            resp = client.delete(f"/v1/admin/mcp/servers/{uuid4()}")
+        assert resp.status_code == 403
+
+    def test_delete_server_404_not_found(self, app_with_cpi_admin, mock_db_session):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(SERVER_REPO_PATH, return_value=mock_repo), TestClient(app_with_cpi_admin) as client:
+            resp = client.delete(f"/v1/admin/mcp/servers/{uuid4()}")
+
+        assert resp.status_code == 404

--- a/control-plane-api/tests/test_plans_router.py
+++ b/control-plane-api/tests/test_plans_router.py
@@ -1,0 +1,261 @@
+"""Tests for Plans Router — CAB-1448
+
+Covers: /v1/plans (CRUD — create, list, get by id, get by slug, update, delete).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+REPO_PATH = "src.routers.plans.PlanRepository"
+TENANT_ID = "acme"
+
+
+def _make_plan(**overrides):
+    """Create a mock Plan model."""
+    mock = MagicMock()
+    defaults = {
+        "id": uuid4(),
+        "slug": "gold",
+        "name": "Gold Plan",
+        "description": "High-volume plan",
+        "tenant_id": TENANT_ID,
+        "rate_limit_per_second": 100,
+        "rate_limit_per_minute": 5000,
+        "daily_request_limit": 1000000,
+        "monthly_request_limit": 30000000,
+        "burst_limit": 200,
+        "requires_approval": True,
+        "auto_approve_roles": None,
+        "status": "active",
+        "pricing_metadata": None,
+        "created_at": "2026-01-01T00:00:00",
+        "updated_at": "2026-01-01T00:00:00",
+        "created_by": "admin-user-id",
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+class TestCreatePlan:
+    """Tests for POST /v1/plans/{tenant_id}."""
+
+    def test_create_success(self, client_as_tenant_admin):
+        plan = _make_plan()
+        mock_repo = MagicMock()
+        mock_repo.get_by_slug = AsyncMock(return_value=None)
+        mock_repo.create = AsyncMock(return_value=plan)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.post(
+                f"/v1/plans/{TENANT_ID}",
+                json={
+                    "slug": "gold",
+                    "name": "Gold Plan",
+                    "rate_limit_per_second": 100,
+                    "rate_limit_per_minute": 5000,
+                    "daily_request_limit": 1000000,
+                    "monthly_request_limit": 30000000,
+                },
+            )
+
+        assert resp.status_code == 201
+
+    def test_create_duplicate_409(self, client_as_tenant_admin):
+        existing = _make_plan()
+        mock_repo = MagicMock()
+        mock_repo.get_by_slug = AsyncMock(return_value=existing)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.post(
+                f"/v1/plans/{TENANT_ID}",
+                json={
+                    "slug": "gold",
+                    "name": "Gold Plan",
+                    "rate_limit_per_second": 100,
+                    "rate_limit_per_minute": 5000,
+                    "daily_request_limit": 1000000,
+                    "monthly_request_limit": 30000000,
+                },
+            )
+
+        assert resp.status_code == 409
+
+    def test_create_403_other_tenant(self, client_as_other_tenant):
+        resp = client_as_other_tenant.post(
+            f"/v1/plans/{TENANT_ID}",
+            json={
+                "slug": "gold",
+                "name": "Gold Plan",
+                "rate_limit_per_second": 100,
+                "rate_limit_per_minute": 5000,
+                "daily_request_limit": 1000000,
+                "monthly_request_limit": 30000000,
+            },
+        )
+        assert resp.status_code == 403
+
+
+class TestListPlans:
+    """Tests for GET /v1/plans/{tenant_id}."""
+
+    def test_list_success(self, client_as_tenant_admin):
+        plan = _make_plan()
+        mock_repo = MagicMock()
+        mock_repo.list_by_tenant = AsyncMock(return_value=([plan], 1))
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/plans/{TENANT_ID}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+
+    def test_list_empty(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.list_by_tenant = AsyncMock(return_value=([], 0))
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/plans/{TENANT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_list_403_other_tenant(self, client_as_other_tenant):
+        resp = client_as_other_tenant.get(f"/v1/plans/{TENANT_ID}")
+        assert resp.status_code == 403
+
+
+class TestGetPlanBySlug:
+    """Tests for GET /v1/plans/{tenant_id}/by-slug/{slug}."""
+
+    def test_get_by_slug_success(self, client_as_tenant_admin):
+        plan = _make_plan()
+        mock_repo = MagicMock()
+        mock_repo.get_by_slug = AsyncMock(return_value=plan)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/plans/{TENANT_ID}/by-slug/gold")
+
+        assert resp.status_code == 200
+
+    def test_get_by_slug_404(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.get_by_slug = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/plans/{TENANT_ID}/by-slug/nonexistent")
+
+        assert resp.status_code == 404
+
+
+class TestGetPlanById:
+    """Tests for GET /v1/plans/{tenant_id}/{plan_id}."""
+
+    def test_get_by_id_success(self, client_as_tenant_admin):
+        plan = _make_plan()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=plan)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/plans/{TENANT_ID}/{plan.id}")
+
+        assert resp.status_code == 200
+
+    def test_get_by_id_404(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/plans/{TENANT_ID}/{uuid4()}")
+
+        assert resp.status_code == 404
+
+    def test_get_by_id_wrong_tenant(self, client_as_tenant_admin):
+        plan = _make_plan(tenant_id="other-tenant")
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=plan)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/plans/{TENANT_ID}/{plan.id}")
+
+        assert resp.status_code == 404
+
+
+class TestUpdatePlan:
+    """Tests for PUT /v1/plans/{tenant_id}/{plan_id}."""
+
+    def test_update_success(self, client_as_tenant_admin):
+        plan = _make_plan()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=plan)
+        mock_repo.update = AsyncMock(return_value=plan)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.put(
+                f"/v1/plans/{TENANT_ID}/{plan.id}",
+                json={"name": "Updated Gold Plan"},
+            )
+
+        assert resp.status_code == 200
+
+    def test_update_404(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.put(
+                f"/v1/plans/{TENANT_ID}/{uuid4()}",
+                json={"name": "test"},
+            )
+
+        assert resp.status_code == 404
+
+
+class TestDeletePlan:
+    """Tests for DELETE /v1/plans/{tenant_id}/{plan_id}."""
+
+    def test_delete_success(self, client_as_tenant_admin):
+        plan = _make_plan()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=plan)
+        mock_repo.delete = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.delete(f"/v1/plans/{TENANT_ID}/{plan.id}")
+
+        assert resp.status_code == 204
+
+    def test_delete_404(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.delete(f"/v1/plans/{TENANT_ID}/{uuid4()}")
+
+        assert resp.status_code == 404
+
+    def test_delete_wrong_tenant(self, client_as_tenant_admin):
+        plan = _make_plan(tenant_id="other-tenant")
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=plan)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.delete(f"/v1/plans/{TENANT_ID}/{plan.id}")
+
+        assert resp.status_code == 404

--- a/control-plane-api/tests/test_quotas_router.py
+++ b/control-plane-api/tests/test_quotas_router.py
@@ -1,0 +1,148 @@
+"""Tests for Quotas Router — CAB-1448
+
+Covers: /v1/admin/quotas (list, stats, get consumer, reset).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+REPO_PATH = "src.routers.quotas.QuotaUsageRepository"
+TENANT_ID = "acme"
+CONSUMER_ID = uuid4()
+
+
+def _make_quota_usage(**overrides):
+    """Create a mock QuotaUsage model."""
+    mock = MagicMock()
+    defaults = {
+        "id": uuid4(),
+        "consumer_id": CONSUMER_ID,
+        "subscription_id": None,
+        "tenant_id": TENANT_ID,
+        "request_count_daily": 500,
+        "request_count_monthly": 15000,
+        "bandwidth_bytes_daily": 1048576,
+        "bandwidth_bytes_monthly": 31457280,
+        "period_start_daily": "2026-01-01",
+        "period_start_monthly": "2026-01-01",
+        "last_reset_at": None,
+        "updated_at": "2026-01-01T00:00:00",
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+class TestListQuotaUsage:
+    """Tests for GET /v1/admin/quotas/{tenant_id}."""
+
+    def test_list_quotas_tenant_admin(self, client_as_tenant_admin):
+        usage = _make_quota_usage()
+        mock_repo = MagicMock()
+        mock_repo.list_by_tenant = AsyncMock(return_value=([usage], 1))
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/admin/quotas/{TENANT_ID}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+
+    def test_list_quotas_cpi_admin(self, client_as_cpi_admin):
+        mock_repo = MagicMock()
+        mock_repo.list_by_tenant = AsyncMock(return_value=([], 0))
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_cpi_admin.get(f"/v1/admin/quotas/{TENANT_ID}")
+
+        assert resp.status_code == 200
+
+    def test_list_quotas_403_other_tenant(self, client_as_other_tenant):
+        resp = client_as_other_tenant.get(f"/v1/admin/quotas/{TENANT_ID}")
+        assert resp.status_code == 403
+
+    def test_list_quotas_403_viewer(self, client_as_no_tenant_user):
+        resp = client_as_no_tenant_user.get(f"/v1/admin/quotas/{TENANT_ID}")
+        assert resp.status_code == 403
+
+
+class TestGetQuotaStats:
+    """Tests for GET /v1/admin/quotas/{tenant_id}/stats."""
+
+    def test_stats_success(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.get_stats = AsyncMock(
+            return_value={
+                "total_requests_today": 2500,
+                "total_requests_month": 75000,
+                "top_consumers": [],
+                "near_limit": [],
+            }
+        )
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/admin/quotas/{TENANT_ID}/stats")
+
+        assert resp.status_code == 200
+
+    def test_stats_403_other_tenant(self, client_as_other_tenant):
+        resp = client_as_other_tenant.get(f"/v1/admin/quotas/{TENANT_ID}/stats")
+        assert resp.status_code == 403
+
+
+class TestGetConsumerQuota:
+    """Tests for GET /v1/admin/quotas/{tenant_id}/{consumer_id}."""
+
+    def test_get_consumer_quota_success(self, client_as_tenant_admin):
+        usage = _make_quota_usage()
+        mock_repo = MagicMock()
+        mock_repo.get_current = AsyncMock(return_value=usage)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/admin/quotas/{TENANT_ID}/{CONSUMER_ID}")
+
+        assert resp.status_code == 200
+
+    def test_get_consumer_quota_404(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.get_current = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/admin/quotas/{TENANT_ID}/{CONSUMER_ID}")
+
+        assert resp.status_code == 404
+
+
+class TestResetConsumerQuota:
+    """Tests for POST /v1/admin/quotas/{tenant_id}/{consumer_id}/reset."""
+
+    def test_reset_success(self, client_as_tenant_admin):
+        usage = _make_quota_usage(request_count_daily=0, request_count_monthly=0)
+        mock_repo = MagicMock()
+        mock_repo.reset = AsyncMock(return_value=usage)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.post(f"/v1/admin/quotas/{TENANT_ID}/{CONSUMER_ID}/reset")
+
+        assert resp.status_code == 200
+
+    def test_reset_404(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.reset = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.post(f"/v1/admin/quotas/{TENANT_ID}/{CONSUMER_ID}/reset")
+
+        assert resp.status_code == 404
+
+    def test_reset_403_other_tenant(self, client_as_other_tenant):
+        resp = client_as_other_tenant.post(f"/v1/admin/quotas/{TENANT_ID}/{CONSUMER_ID}/reset")
+        assert resp.status_code == 403

--- a/control-plane-api/tests/test_service_accounts_router.py
+++ b/control-plane-api/tests/test_service_accounts_router.py
@@ -1,0 +1,130 @@
+"""Tests for Service Accounts Router — CAB-1448
+
+Covers: /v1/service-accounts (list, create, delete, regenerate-secret).
+Uses keycloak_service directly (mocked globally in conftest).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+KC_SVC_PATH = "src.routers.service_accounts.keycloak_service"
+
+
+class TestListServiceAccounts:
+    """Tests for GET /v1/service-accounts."""
+
+    def test_list_success(self, client_as_tenant_admin):
+        with patch(KC_SVC_PATH) as mock_kc:
+            mock_kc.list_user_service_accounts = AsyncMock(
+                return_value=[
+                    {
+                        "id": "sa-1",
+                        "client_id": "sa-acme-admin-claude",
+                        "name": "claude",
+                        "description": None,
+                        "enabled": True,
+                    },
+                ]
+            )
+            resp = client_as_tenant_admin.get("/v1/service-accounts")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["client_id"] == "sa-acme-admin-claude"
+
+    def test_list_empty(self, client_as_tenant_admin):
+        with patch(KC_SVC_PATH) as mock_kc:
+            mock_kc.list_user_service_accounts = AsyncMock(return_value=[])
+            resp = client_as_tenant_admin.get("/v1/service-accounts")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_error_500(self, client_as_tenant_admin):
+        with patch(KC_SVC_PATH) as mock_kc:
+            mock_kc.list_user_service_accounts = AsyncMock(side_effect=RuntimeError("KC down"))
+            resp = client_as_tenant_admin.get("/v1/service-accounts")
+
+        assert resp.status_code == 500
+
+
+class TestCreateServiceAccount:
+    """Tests for POST /v1/service-accounts."""
+
+    def test_create_success(self, client_as_tenant_admin):
+        with patch(KC_SVC_PATH) as mock_kc:
+            mock_kc.create_service_account = AsyncMock(
+                return_value={
+                    "id": "sa-1",
+                    "client_id": "sa-acme-admin-claude",
+                    "client_secret": "super-secret",
+                    "name": "claude-desktop",
+                }
+            )
+            resp = client_as_tenant_admin.post(
+                "/v1/service-accounts",
+                json={"name": "claude-desktop", "description": "For Claude Desktop"},
+            )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["client_secret"] == "super-secret"
+        assert "message" in data
+
+    def test_create_error_500(self, client_as_tenant_admin):
+        with patch(KC_SVC_PATH) as mock_kc:
+            mock_kc.create_service_account = AsyncMock(side_effect=RuntimeError("KC error"))
+            resp = client_as_tenant_admin.post(
+                "/v1/service-accounts",
+                json={"name": "test-sa"},
+            )
+
+        assert resp.status_code == 500
+
+
+class TestDeleteServiceAccount:
+    """Tests for DELETE /v1/service-accounts/{account_id}."""
+
+    def test_delete_success(self, client_as_tenant_admin):
+        with patch(KC_SVC_PATH) as mock_kc:
+            mock_kc.delete_service_account = AsyncMock(return_value=None)
+            resp = client_as_tenant_admin.delete("/v1/service-accounts/sa-1")
+
+        assert resp.status_code == 204
+
+    def test_delete_not_found(self, client_as_tenant_admin):
+        with patch(KC_SVC_PATH) as mock_kc:
+            mock_kc.delete_service_account = AsyncMock(side_effect=ValueError("Not found"))
+            resp = client_as_tenant_admin.delete("/v1/service-accounts/nonexistent")
+
+        assert resp.status_code == 404
+
+    def test_delete_forbidden(self, client_as_tenant_admin):
+        with patch(KC_SVC_PATH) as mock_kc:
+            mock_kc.delete_service_account = AsyncMock(side_effect=PermissionError("Not yours"))
+            resp = client_as_tenant_admin.delete("/v1/service-accounts/sa-other")
+
+        assert resp.status_code == 403
+
+
+class TestRegenerateSecret:
+    """Tests for POST /v1/service-accounts/{account_id}/regenerate-secret."""
+
+    def test_regenerate_success(self, client_as_tenant_admin):
+        with patch(KC_SVC_PATH) as mock_kc:
+            mock_kc.list_user_service_accounts = AsyncMock(
+                return_value=[{"id": "sa-1", "client_id": "sa-acme-admin-claude"}]
+            )
+            mock_kc.regenerate_client_secret = AsyncMock(return_value="new-secret-value")
+            resp = client_as_tenant_admin.post("/v1/service-accounts/sa-1/regenerate-secret")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["client_secret"] == "new-secret-value"
+
+    def test_regenerate_not_found(self, client_as_tenant_admin):
+        with patch(KC_SVC_PATH) as mock_kc:
+            mock_kc.list_user_service_accounts = AsyncMock(return_value=[])
+            resp = client_as_tenant_admin.post("/v1/service-accounts/nonexistent/regenerate-secret")
+
+        assert resp.status_code == 404

--- a/control-plane-api/tests/test_subscriptions_router.py
+++ b/control-plane-api/tests/test_subscriptions_router.py
@@ -1,0 +1,905 @@
+"""Tests for Subscriptions Router — CAB-1436
+
+Covers: /v1/subscriptions CRUD, key rotation, TTL extension, admin approve/revoke/suspend/reactivate,
+        tenant list, validate-key endpoint.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from src.models.subscription import SubscriptionStatus
+
+SUB_REPO_PATH = "src.routers.subscriptions.SubscriptionRepository"
+PLAN_REPO_PATH = "src.routers.subscriptions.PlanRepository"
+API_KEY_SVC_PATH = "src.routers.subscriptions.APIKeyService"
+EMAIL_SVC_PATH = "src.routers.subscriptions.email_service"
+KAFKA_SVC_PATH = "src.routers.subscriptions.kafka_service"
+PROVISION_PATH = "src.routers.subscriptions.provision_on_approval"
+DEPROVISION_PATH = "src.routers.subscriptions.deprovision_on_revocation"
+EMIT_CREATED_PATH = "src.routers.subscriptions.emit_subscription_created"
+EMIT_APPROVED_PATH = "src.routers.subscriptions.emit_subscription_approved"
+EMIT_REVOKED_PATH = "src.routers.subscriptions.emit_subscription_revoked"
+EMIT_ROTATED_PATH = "src.routers.subscriptions.emit_subscription_key_rotated"
+
+
+def _mock_subscription(**overrides):
+    """Build a MagicMock that mimics a Subscription ORM object."""
+    mock = MagicMock()
+    sid = uuid4()
+    defaults = {
+        "id": sid,
+        "application_id": "app-1",
+        "application_name": "Test App",
+        "subscriber_id": "tenant-admin-user-id",
+        "subscriber_email": "admin@acme.com",
+        "api_id": "api-1",
+        "api_name": "Test API",
+        "api_version": "1.0",
+        "tenant_id": "acme",
+        "plan_id": str(uuid4()),
+        "plan_name": "Basic",
+        "api_key_hash": "hash123",
+        "api_key_prefix": "stoa_sk_",
+        "status": SubscriptionStatus.ACTIVE,
+        "status_reason": None,
+        "expires_at": None,
+        "previous_key_expires_at": None,
+        "previous_api_key_hash": None,
+        "last_rotated_at": None,
+        "rotation_count": 0,
+        "ttl_extension_count": 0,
+        "ttl_total_extended_days": 0,
+        "approved_at": None,
+        "revoked_at": None,
+        "approved_by": None,
+        "revoked_by": None,
+        "provisioning_status": "none",
+        "gateway_app_id": None,
+        "provisioning_error": None,
+        "provisioned_at": None,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _mock_sub_response(sub):
+    """Mock SubscriptionResponse from a subscription mock."""
+    from src.schemas.subscription import SubscriptionStatusEnum
+
+    resp = MagicMock()
+    resp.id = sub.id
+    resp.application_id = sub.application_id
+    resp.application_name = sub.application_name
+    resp.subscriber_id = sub.subscriber_id
+    resp.subscriber_email = sub.subscriber_email
+    resp.api_id = sub.api_id
+    resp.api_name = sub.api_name
+    resp.api_version = sub.api_version
+    resp.tenant_id = sub.tenant_id
+    resp.plan_id = sub.plan_id
+    resp.plan_name = sub.plan_name
+    resp.api_key_prefix = sub.api_key_prefix
+    resp.status = SubscriptionStatusEnum(sub.status.value)
+    resp.status_reason = sub.status_reason
+    resp.created_at = sub.created_at
+    resp.updated_at = sub.updated_at
+    resp.approved_at = sub.approved_at
+    resp.expires_at = sub.expires_at
+    resp.revoked_at = sub.revoked_at
+    resp.approved_by = sub.approved_by
+    resp.revoked_by = sub.revoked_by
+    resp.provisioning_status = sub.provisioning_status
+    resp.gateway_app_id = sub.gateway_app_id
+    resp.provisioning_error = sub.provisioning_error
+    resp.provisioned_at = sub.provisioned_at
+    return resp
+
+
+# ============== Create Subscription ==============
+
+
+class TestCreateSubscription:
+    """POST /v1/subscriptions"""
+
+    def test_create_success_auto_approve(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(status=SubscriptionStatus.ACTIVE)
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_application_and_api = AsyncMock(return_value=None)
+        mock_sub_repo.create = AsyncMock(return_value=sub)
+        mock_sub_repo.update_status = AsyncMock(return_value=sub)
+
+        mock_plan_repo = MagicMock()
+        mock_plan = MagicMock()
+        mock_plan.requires_approval = False
+        mock_plan_repo.get_by_id = AsyncMock(return_value=mock_plan)
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch(PLAN_REPO_PATH, return_value=mock_plan_repo),
+            patch(API_KEY_SVC_PATH) as MockKey,
+            patch(EMIT_CREATED_PATH, new=AsyncMock()),
+            patch(EMIT_APPROVED_PATH, new=AsyncMock()),
+            patch(PROVISION_PATH, new=AsyncMock()),
+        ):
+            MockKey.generate_key.return_value = ("stoa_sk_fullkey", "hash", "stoa_sk_")
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.post(
+                    "/v1/subscriptions",
+                    json={
+                        "application_id": "app-1",
+                        "application_name": "Test App",
+                        "api_id": "api-1",
+                        "api_name": "Test API",
+                        "api_version": "1.0",
+                        "tenant_id": "acme",
+                    },
+                )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "api_key" in data
+        assert "subscription_id" in data
+
+    def test_create_409_existing_subscription(self, app_with_tenant_admin, mock_db_session):
+        existing = _mock_subscription()
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_application_and_api = AsyncMock(return_value=existing)
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch(API_KEY_SVC_PATH) as MockKey,
+        ):
+            MockKey.generate_key.return_value = ("stoa_sk_fullkey", "hash", "stoa_sk_")
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.post(
+                    "/v1/subscriptions",
+                    json={
+                        "application_id": "app-1",
+                        "application_name": "Test App",
+                        "api_id": "api-1",
+                        "api_name": "Test API",
+                        "api_version": "1.0",
+                        "tenant_id": "acme",
+                    },
+                )
+
+        assert resp.status_code == 409
+        assert "already exists" in resp.json()["detail"]
+
+    def test_create_no_plan_auto_approves(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(status=SubscriptionStatus.ACTIVE, plan_id=None)
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_application_and_api = AsyncMock(return_value=None)
+        mock_sub_repo.create = AsyncMock(return_value=sub)
+        mock_sub_repo.update_status = AsyncMock(return_value=sub)
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch(API_KEY_SVC_PATH) as MockKey,
+            patch(EMIT_CREATED_PATH, new=AsyncMock()),
+            patch(EMIT_APPROVED_PATH, new=AsyncMock()),
+            patch(PROVISION_PATH, new=AsyncMock()),
+        ):
+            MockKey.generate_key.return_value = ("stoa_sk_fullkey", "hash", "stoa_sk_")
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.post(
+                    "/v1/subscriptions",
+                    json={
+                        "application_id": "app-1",
+                        "application_name": "Test App",
+                        "api_id": "api-1",
+                        "api_name": "Test API",
+                        "api_version": "1.0",
+                        "tenant_id": "acme",
+                        "plan_id": None,
+                    },
+                )
+
+        assert resp.status_code == 201
+
+
+# ============== List My Subscriptions ==============
+
+
+class TestListMySubscriptions:
+    """GET /v1/subscriptions/my"""
+
+    def test_list_my_success(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription()
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.list_by_subscriber = AsyncMock(return_value=([sub], 1))
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch("src.routers.subscriptions.SubscriptionResponse") as MockResp,
+        ):
+            MockResp.model_validate.return_value = _mock_sub_response(sub)
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.get("/v1/subscriptions/my")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+
+    def test_list_my_empty(self, app_with_tenant_admin, mock_db_session):
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.list_by_subscriber = AsyncMock(return_value=([], 0))
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get("/v1/subscriptions/my")
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_list_my_with_status_filter(self, app_with_tenant_admin, mock_db_session):
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.list_by_subscriber = AsyncMock(return_value=([], 0))
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get("/v1/subscriptions/my?status=active")
+
+        assert resp.status_code == 200
+        mock_sub_repo.list_by_subscriber.assert_called_once()
+
+
+# ============== Get Subscription ==============
+
+
+class TestGetSubscription:
+    """GET /v1/subscriptions/{subscription_id}"""
+
+    def test_get_success_as_subscriber(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(subscriber_id="tenant-admin-user-id")
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch("src.routers.subscriptions.SubscriptionResponse") as MockResp,
+        ):
+            MockResp.model_validate.return_value = _mock_sub_response(sub)
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.get(f"/v1/subscriptions/{sub.id}")
+
+        assert resp.status_code == 200
+
+    def test_get_404(self, app_with_tenant_admin, mock_db_session):
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get(f"/v1/subscriptions/{uuid4()}")
+
+        assert resp.status_code == 404
+
+    def test_get_403_wrong_user(self, app_with_other_tenant, mock_db_session):
+        sub = _mock_subscription(subscriber_id="tenant-admin-user-id", tenant_id="acme")
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_other_tenant) as client:
+            resp = client.get(f"/v1/subscriptions/{sub.id}")
+
+        assert resp.status_code == 403
+
+
+# ============== Cancel Subscription ==============
+
+
+class TestCancelSubscription:
+    """DELETE /v1/subscriptions/{subscription_id}"""
+
+    def test_cancel_success(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(subscriber_id="tenant-admin-user-id", status=SubscriptionStatus.ACTIVE)
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+        mock_sub_repo.update_status = AsyncMock(return_value=sub)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.delete(f"/v1/subscriptions/{sub.id}")
+
+        assert resp.status_code == 204
+
+    def test_cancel_400_wrong_status(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(subscriber_id="tenant-admin-user-id", status=SubscriptionStatus.REVOKED)
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.delete(f"/v1/subscriptions/{sub.id}")
+
+        assert resp.status_code == 400
+
+    def test_cancel_403_not_owner(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(subscriber_id="someone-else-id", status=SubscriptionStatus.ACTIVE)
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.delete(f"/v1/subscriptions/{sub.id}")
+
+        assert resp.status_code == 403
+
+
+# ============== Rotate API Key ==============
+
+
+class TestRotateApiKey:
+    """POST /v1/subscriptions/{subscription_id}/rotate-key"""
+
+    def test_rotate_success(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(
+            subscriber_id="tenant-admin-user-id",
+            status=SubscriptionStatus.ACTIVE,
+            previous_key_expires_at=None,
+        )
+        rotated = _mock_subscription(
+            subscriber_id="tenant-admin-user-id",
+            status=SubscriptionStatus.ACTIVE,
+            rotation_count=1,
+            previous_key_expires_at=datetime.utcnow() + timedelta(hours=24),
+        )
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+        mock_sub_repo.rotate_key = AsyncMock(return_value=rotated)
+
+        mock_email = MagicMock()
+        mock_email.send_key_rotation_notification = AsyncMock()
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch(API_KEY_SVC_PATH) as MockKey,
+            patch(EMAIL_SVC_PATH, mock_email),
+            patch(EMIT_ROTATED_PATH, new_callable=lambda: lambda: AsyncMock()),
+        ):
+            MockKey.generate_key.return_value = ("stoa_sk_newkey", "new-hash", "stoa_sk_")
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.post(
+                    f"/v1/subscriptions/{sub.id}/rotate-key",
+                    json={"grace_period_hours": 24},
+                )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "new_api_key" in data
+        assert data["rotation_count"] == 1
+
+    def test_rotate_400_wrong_status(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(subscriber_id="tenant-admin-user-id", status=SubscriptionStatus.SUSPENDED)
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch(API_KEY_SVC_PATH) as MockKey,
+        ):
+            MockKey.generate_key.return_value = ("stoa_sk_newkey", "new-hash", "stoa_sk_")
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.post(f"/v1/subscriptions/{sub.id}/rotate-key", json={"grace_period_hours": 24})
+
+        assert resp.status_code == 400
+
+    def test_rotate_400_grace_period_active(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(
+            subscriber_id="tenant-admin-user-id",
+            status=SubscriptionStatus.ACTIVE,
+            previous_key_expires_at=datetime.utcnow() + timedelta(hours=12),
+        )
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch(API_KEY_SVC_PATH) as MockKey,
+        ):
+            MockKey.generate_key.return_value = ("stoa_sk_newkey", "new-hash", "stoa_sk_")
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.post(f"/v1/subscriptions/{sub.id}/rotate-key", json={"grace_period_hours": 24})
+
+        assert resp.status_code == 400
+
+    def test_rotate_403_not_owner(self, app_with_other_tenant, mock_db_session):
+        sub = _mock_subscription(subscriber_id="tenant-admin-user-id", status=SubscriptionStatus.ACTIVE)
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch(API_KEY_SVC_PATH) as MockKey,
+        ):
+            MockKey.generate_key.return_value = ("stoa_sk_newkey", "new-hash", "stoa_sk_")
+            with TestClient(app_with_other_tenant) as client:
+                resp = client.post(f"/v1/subscriptions/{sub.id}/rotate-key", json={"grace_period_hours": 24})
+
+        assert resp.status_code == 403
+
+
+# ============== Rotation Info ==============
+
+
+class TestGetRotationInfo:
+    """GET /v1/subscriptions/{subscription_id}/rotation-info"""
+
+    def test_rotation_info_success(self, app_with_tenant_admin, mock_db_session):
+        from src.schemas.subscription import SubscriptionStatusEnum, SubscriptionWithRotationInfo
+
+        sub = _mock_subscription(
+            subscriber_id="tenant-admin-user-id",
+            rotation_count=2,
+            previous_key_expires_at=None,
+            last_rotated_at=datetime.utcnow(),
+        )
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        # Build a real SubscriptionWithRotationInfo to avoid FastAPI serialization issues
+        rotation_info = SubscriptionWithRotationInfo(
+            id=sub.id,
+            application_id=sub.application_id,
+            application_name=sub.application_name,
+            subscriber_id=sub.subscriber_id,
+            subscriber_email=sub.subscriber_email,
+            api_id=sub.api_id,
+            api_name=sub.api_name,
+            api_version=sub.api_version,
+            tenant_id=sub.tenant_id,
+            plan_id=sub.plan_id,
+            plan_name=sub.plan_name,
+            api_key_prefix=sub.api_key_prefix,
+            status=SubscriptionStatusEnum.ACTIVE,
+            status_reason=None,
+            created_at=sub.created_at,
+            updated_at=sub.updated_at,
+            approved_at=None,
+            expires_at=None,
+            revoked_at=None,
+            approved_by=None,
+            revoked_by=None,
+            rotation_count=2,
+            has_active_grace_period=False,
+        )
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch("src.routers.subscriptions.SubscriptionWithRotationInfo") as MockResp,
+        ):
+            MockResp.model_validate.return_value = rotation_info
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.get(f"/v1/subscriptions/{sub.id}/rotation-info")
+
+        assert resp.status_code == 200
+
+    def test_rotation_info_404(self, app_with_tenant_admin, mock_db_session):
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get(f"/v1/subscriptions/{uuid4()}/rotation-info")
+
+        assert resp.status_code == 404
+
+
+# ============== TTL Extension ==============
+
+
+class TestExtendTTL:
+    """PATCH /v1/subscriptions/{subscription_id}/ttl"""
+
+    def test_extend_ttl_success(self, app_with_tenant_admin, mock_db_session):
+        future_expires = datetime.utcnow() + timedelta(days=30)
+        sub = _mock_subscription(
+            subscriber_id="tenant-admin-user-id",
+            status=SubscriptionStatus.ACTIVE,
+            expires_at=future_expires,
+            ttl_extension_count=0,
+            ttl_total_extended_days=0,
+        )
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        mock_kafka = MagicMock()
+        mock_kafka.publish = AsyncMock()
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch(KAFKA_SVC_PATH, mock_kafka),
+            TestClient(app_with_tenant_admin) as client,
+        ):
+            resp = client.patch(
+                f"/v1/subscriptions/{sub.id}/ttl",
+                json={"extend_days": 7, "reason": "More time needed"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ttl_extension_count"] == 1
+
+    def test_extend_ttl_409_not_active(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(
+            subscriber_id="tenant-admin-user-id",
+            status=SubscriptionStatus.SUSPENDED,
+            expires_at=datetime.utcnow() + timedelta(days=30),
+        )
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.patch(
+                f"/v1/subscriptions/{sub.id}/ttl",
+                json={"extend_days": 7, "reason": "reason"},
+            )
+
+        assert resp.status_code == 409
+
+    def test_extend_ttl_409_max_extensions_reached(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(
+            subscriber_id="tenant-admin-user-id",
+            status=SubscriptionStatus.ACTIVE,
+            expires_at=datetime.utcnow() + timedelta(days=30),
+            ttl_extension_count=2,
+            ttl_total_extended_days=14,
+        )
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.patch(
+                f"/v1/subscriptions/{sub.id}/ttl",
+                json={"extend_days": 7, "reason": "reason"},
+            )
+
+        assert resp.status_code == 409
+
+    def test_extend_ttl_403_wrong_tenant(self, app_with_other_tenant, mock_db_session):
+        sub = _mock_subscription(tenant_id="acme", status=SubscriptionStatus.ACTIVE)
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_other_tenant) as client:
+            resp = client.patch(
+                f"/v1/subscriptions/{sub.id}/ttl",
+                json={"extend_days": 7, "reason": "reason"},
+            )
+
+        assert resp.status_code == 403
+
+
+# ============== List Tenant Subscriptions ==============
+
+
+class TestListTenantSubscriptions:
+    """GET /v1/subscriptions/tenant/{tenant_id}"""
+
+    def test_list_tenant_success(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription()
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.list_by_tenant = AsyncMock(return_value=([sub], 1))
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch("src.routers.subscriptions.SubscriptionResponse") as MockResp,
+        ):
+            MockResp.model_validate.return_value = _mock_sub_response(sub)
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.get("/v1/subscriptions/tenant/acme")
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+    def test_list_tenant_403_wrong_tenant(self, app_with_other_tenant, mock_db_session):
+        with TestClient(app_with_other_tenant) as client:
+            resp = client.get("/v1/subscriptions/tenant/acme")
+
+        assert resp.status_code == 403
+
+
+# ============== List Pending Subscriptions ==============
+
+
+class TestListPendingSubscriptions:
+    """GET /v1/subscriptions/tenant/{tenant_id}/pending"""
+
+    def test_list_pending_success(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(status=SubscriptionStatus.PENDING)
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.list_pending = AsyncMock(return_value=([sub], 1))
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch("src.routers.subscriptions.SubscriptionResponse") as MockResp,
+        ):
+            MockResp.model_validate.return_value = _mock_sub_response(sub)
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.get("/v1/subscriptions/tenant/acme/pending")
+
+        assert resp.status_code == 200
+
+    def test_list_pending_empty(self, app_with_tenant_admin, mock_db_session):
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.list_pending = AsyncMock(return_value=([], 0))
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.get("/v1/subscriptions/tenant/acme/pending")
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+
+# ============== Approve Subscription ==============
+
+
+class TestApproveSubscription:
+    """POST /v1/subscriptions/{subscription_id}/approve"""
+
+    def test_approve_success(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(status=SubscriptionStatus.PENDING, tenant_id="acme")
+        approved = _mock_subscription(status=SubscriptionStatus.ACTIVE, tenant_id="acme")
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+        mock_sub_repo.update_status = AsyncMock(return_value=approved)
+        mock_sub_repo.set_expiration = AsyncMock()
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch("src.routers.subscriptions.SubscriptionResponse") as MockResp,
+            patch(EMIT_APPROVED_PATH, new=AsyncMock()),
+            patch(PROVISION_PATH, new=AsyncMock()),
+        ):
+            MockResp.model_validate.return_value = _mock_sub_response(approved)
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.post(f"/v1/subscriptions/{sub.id}/approve", json={})
+
+        assert resp.status_code == 200
+
+    def test_approve_400_not_pending(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(status=SubscriptionStatus.ACTIVE, tenant_id="acme")
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(f"/v1/subscriptions/{sub.id}/approve", json={})
+
+        assert resp.status_code == 400
+
+    def test_approve_404(self, app_with_tenant_admin, mock_db_session):
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(f"/v1/subscriptions/{uuid4()}/approve", json={})
+
+        assert resp.status_code == 404
+
+    def test_approve_403_wrong_tenant(self, app_with_other_tenant, mock_db_session):
+        sub = _mock_subscription(status=SubscriptionStatus.PENDING, tenant_id="acme")
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_other_tenant) as client:
+            resp = client.post(f"/v1/subscriptions/{sub.id}/approve", json={})
+
+        assert resp.status_code == 403
+
+
+# ============== Revoke Subscription ==============
+
+
+class TestRevokeSubscription:
+    """POST /v1/subscriptions/{subscription_id}/revoke"""
+
+    def test_revoke_success(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(status=SubscriptionStatus.ACTIVE, tenant_id="acme")
+        revoked = _mock_subscription(status=SubscriptionStatus.REVOKED, tenant_id="acme")
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+        mock_sub_repo.update_status = AsyncMock(return_value=revoked)
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch("src.routers.subscriptions.SubscriptionResponse") as MockResp,
+            patch(EMIT_REVOKED_PATH, new=AsyncMock()),
+            patch(DEPROVISION_PATH, new=AsyncMock()),
+        ):
+            MockResp.model_validate.return_value = _mock_sub_response(revoked)
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.post(
+                    f"/v1/subscriptions/{sub.id}/revoke",
+                    json={"reason": "Policy violation"},
+                )
+
+        assert resp.status_code == 200
+
+    def test_revoke_400_already_revoked(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(status=SubscriptionStatus.REVOKED, tenant_id="acme")
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(
+                f"/v1/subscriptions/{sub.id}/revoke",
+                json={"reason": "already revoked"},
+            )
+
+        assert resp.status_code == 400
+
+
+# ============== Suspend Subscription ==============
+
+
+class TestSuspendSubscription:
+    """POST /v1/subscriptions/{subscription_id}/suspend"""
+
+    def test_suspend_success(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(status=SubscriptionStatus.ACTIVE, tenant_id="acme")
+        suspended = _mock_subscription(status=SubscriptionStatus.SUSPENDED, tenant_id="acme")
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+        mock_sub_repo.update_status = AsyncMock(return_value=suspended)
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch("src.routers.subscriptions.SubscriptionResponse") as MockResp,
+        ):
+            MockResp.model_validate.return_value = _mock_sub_response(suspended)
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.post(f"/v1/subscriptions/{sub.id}/suspend")
+
+        assert resp.status_code == 200
+
+    def test_suspend_400_not_active(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(status=SubscriptionStatus.SUSPENDED, tenant_id="acme")
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(f"/v1/subscriptions/{sub.id}/suspend")
+
+        assert resp.status_code == 400
+
+
+# ============== Reactivate Subscription ==============
+
+
+class TestReactivateSubscription:
+    """POST /v1/subscriptions/{subscription_id}/reactivate"""
+
+    def test_reactivate_success(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(status=SubscriptionStatus.SUSPENDED, tenant_id="acme")
+        reactivated = _mock_subscription(status=SubscriptionStatus.ACTIVE, tenant_id="acme")
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+        mock_sub_repo.update_status = AsyncMock(return_value=reactivated)
+
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch("src.routers.subscriptions.SubscriptionResponse") as MockResp,
+        ):
+            MockResp.model_validate.return_value = _mock_sub_response(reactivated)
+            with TestClient(app_with_tenant_admin) as client:
+                resp = client.post(f"/v1/subscriptions/{sub.id}/reactivate")
+
+        assert resp.status_code == 200
+
+    def test_reactivate_400_not_suspended(self, app_with_tenant_admin, mock_db_session):
+        sub = _mock_subscription(status=SubscriptionStatus.ACTIVE, tenant_id="acme")
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_id = AsyncMock(return_value=sub)
+
+        with patch(SUB_REPO_PATH, return_value=mock_sub_repo), TestClient(app_with_tenant_admin) as client:
+            resp = client.post(f"/v1/subscriptions/{sub.id}/reactivate")
+
+        assert resp.status_code == 400
+
+
+# ============== Validate API Key ==============
+
+
+class TestValidateApiKey:
+    """POST /v1/subscriptions/validate-key (no auth required)"""
+
+    def _get_no_auth_client(self, app, mock_db_session):
+        """Create a client with only db override (no auth override)."""
+        from src.database import get_db
+
+        async def override_get_db():
+            yield mock_db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+        return app
+
+    def test_validate_key_success(self, app, mock_db_session):
+        sub = _mock_subscription(status=SubscriptionStatus.ACTIVE, expires_at=None)
+
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_api_key_hash = AsyncMock(return_value=sub)
+        mock_sub_repo.get_by_previous_key_hash = AsyncMock(return_value=None)
+
+        self._get_no_auth_client(app, mock_db_session)
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch(API_KEY_SVC_PATH) as MockKey,
+        ):
+            MockKey.validate_format.return_value = True
+            MockKey.hash_key.return_value = "hash123"
+            with TestClient(app) as client:
+                resp = client.post("/v1/subscriptions/validate-key?api_key=stoa_sk_validkey123")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["valid"] is True
+
+    def test_validate_key_401_invalid_format(self, app, mock_db_session):
+        self._get_no_auth_client(app, mock_db_session)
+        with patch(API_KEY_SVC_PATH) as MockKey:
+            MockKey.validate_format.return_value = False
+            with TestClient(app) as client:
+                resp = client.post("/v1/subscriptions/validate-key?api_key=badformat")
+
+        assert resp.status_code == 401
+        assert "Invalid API key format" in resp.json()["detail"]
+
+    def test_validate_key_401_not_found(self, app, mock_db_session):
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_api_key_hash = AsyncMock(return_value=None)
+        mock_sub_repo.get_by_previous_key_hash = AsyncMock(return_value=None)
+
+        self._get_no_auth_client(app, mock_db_session)
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch(API_KEY_SVC_PATH) as MockKey,
+        ):
+            MockKey.validate_format.return_value = True
+            MockKey.hash_key.return_value = "hash-not-found"
+            with TestClient(app) as client:
+                resp = client.post("/v1/subscriptions/validate-key?api_key=stoa_sk_validkey123")
+
+        assert resp.status_code == 401
+
+    def test_validate_key_403_not_active(self, app, mock_db_session):
+        sub = _mock_subscription(status=SubscriptionStatus.REVOKED)
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_api_key_hash = AsyncMock(return_value=sub)
+        mock_sub_repo.get_by_previous_key_hash = AsyncMock(return_value=None)
+
+        self._get_no_auth_client(app, mock_db_session)
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch(API_KEY_SVC_PATH) as MockKey,
+        ):
+            MockKey.validate_format.return_value = True
+            MockKey.hash_key.return_value = "hash123"
+            with TestClient(app) as client:
+                resp = client.post("/v1/subscriptions/validate-key?api_key=stoa_sk_validkey123")
+
+        assert resp.status_code == 403
+
+    def test_validate_key_success_previous_key_grace_period(self, app, mock_db_session):
+        sub = _mock_subscription(
+            status=SubscriptionStatus.ACTIVE,
+            previous_key_expires_at=datetime.utcnow() + timedelta(hours=12),
+        )
+        mock_sub_repo = MagicMock()
+        mock_sub_repo.get_by_api_key_hash = AsyncMock(return_value=None)
+        mock_sub_repo.get_by_previous_key_hash = AsyncMock(return_value=sub)
+
+        self._get_no_auth_client(app, mock_db_session)
+        with (
+            patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+            patch(API_KEY_SVC_PATH) as MockKey,
+        ):
+            MockKey.validate_format.return_value = True
+            MockKey.hash_key.return_value = "old-hash"
+            with TestClient(app) as client:
+                resp = client.post("/v1/subscriptions/validate-key?api_key=stoa_sk_oldkey123")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["valid"] is True
+        assert data.get("using_previous_key") is True

--- a/control-plane-api/tests/test_tenant_webhooks_router.py
+++ b/control-plane-api/tests/test_tenant_webhooks_router.py
@@ -1,0 +1,580 @@
+"""Tests for Tenant Webhooks Router — CRUD operations for webhook configurations.
+
+Covers: /tenants/{tenant_id}/webhooks (create, list, get, update, delete,
+        list deliveries, retry, test, event types)
+
+CRITICAL: This router uses current_user.get("tenant_id") — the user must be a dict,
+          NOT a Pydantic User model. Custom app fixture required.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+WEBHOOK_SVC_PATH = "src.routers.tenant_webhooks.WebhookService"
+
+
+def _mock_webhook(**overrides):
+    """Build a MagicMock mimicking a Webhook ORM object."""
+    mock = MagicMock()
+    defaults = {
+        "id": uuid4(),
+        "tenant_id": "acme",
+        "name": "Test Webhook",
+        "url": "https://example.com/hook",
+        "events": ["subscription.created"],
+        "secret": "test-secret-min16chars",
+        "headers": {},
+        "enabled": True,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+        "created_by": "tenant-admin-user-id",
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _mock_delivery(**overrides):
+    """Build a MagicMock mimicking a WebhookDelivery ORM object."""
+    mock = MagicMock()
+    defaults = {
+        "id": uuid4(),
+        "webhook_id": uuid4(),
+        "subscription_id": uuid4(),
+        "event_type": "subscription.created",
+        "payload": {"event": "subscription.created"},
+        "status": "success",
+        "attempt_count": 1,
+        "max_attempts": 3,
+        "response_status_code": 200,
+        "response_body": "OK",
+        "error_message": None,
+        "created_at": datetime.utcnow(),
+        "last_attempt_at": datetime.utcnow(),
+        "next_retry_at": None,
+        "delivered_at": datetime.utcnow(),
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _build_webhook_app(app, mock_db_session, user_dict=None):
+    """Build app with dict-based current_user override (tenant_webhooks router expects a dict)."""
+    from src.auth import get_current_user
+    from src.database import get_db
+
+    if user_dict is None:
+        user_dict = {
+            "sub": "tenant-admin-user-id",
+            "email": "admin@acme.com",
+            "tenant_id": "acme",
+            "roles": ["tenant-admin"],
+        }
+
+    async def override_user():
+        return user_dict
+
+    async def override_db():
+        yield mock_db_session
+
+    app.dependency_overrides[get_current_user] = override_user
+    app.dependency_overrides[get_db] = override_db
+    return app
+
+
+def _build_cpi_admin_app(app, mock_db_session):
+    return _build_webhook_app(
+        app,
+        mock_db_session,
+        user_dict={
+            "sub": "cpi-admin-user-id",
+            "email": "admin@gostoa.dev",
+            "tenant_id": None,
+            "roles": ["cpi-admin"],
+        },
+    )
+
+
+def _build_other_tenant_app(app, mock_db_session):
+    return _build_webhook_app(
+        app,
+        mock_db_session,
+        user_dict={
+            "sub": "other-tenant-user-id",
+            "email": "user@other.com",
+            "tenant_id": "other-tenant",
+            "roles": ["tenant-admin"],
+        },
+    )
+
+
+# ============================================================
+# GET /events — list event types
+# ============================================================
+
+
+class TestListEventTypes:
+    """Tests for GET /tenants/{tenant_id}/webhooks/events."""
+
+    def test_list_event_types_success(self, app, mock_db_session):
+        _build_webhook_app(app, mock_db_session)
+        with TestClient(app) as client:
+            resp = client.get("/tenants/acme/webhooks/events")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "events" in data
+        assert len(data["events"]) > 0
+        event_names = [e["event"] for e in data["events"]]
+        assert "subscription.created" in event_names
+
+
+# ============================================================
+# POST /tenants/{tenant_id}/webhooks — create webhook
+# ============================================================
+
+
+class TestCreateWebhook:
+    """Tests for POST /tenants/{tenant_id}/webhooks."""
+
+    def _payload(self):
+        return {
+            "name": "My Webhook",
+            "url": "https://example.com/hook",
+            "events": ["subscription.created"],
+            "secret": "a-valid-secret-key-1234",
+        }
+
+    def test_create_webhook_success(self, app, mock_db_session):
+        wh = _mock_webhook()
+        mock_svc = MagicMock()
+        mock_svc.create_webhook = AsyncMock(return_value=wh)
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.post("/tenants/acme/webhooks", json=self._payload())
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "Test Webhook"
+        assert data["tenant_id"] == "acme"
+        assert "secret" not in data  # secret is never returned directly
+        assert "has_secret" in data
+
+    def test_create_webhook_403_wrong_tenant(self, app, mock_db_session):
+        """A tenant-admin cannot create a webhook for another tenant."""
+        _build_other_tenant_app(app, mock_db_session)
+
+        with TestClient(app) as client:
+            resp = client.post("/tenants/acme/webhooks", json=self._payload())
+
+        assert resp.status_code == 403
+
+    def test_create_webhook_cpi_admin_any_tenant(self, app, mock_db_session):
+        """CPI admin can create webhooks for any tenant."""
+        wh = _mock_webhook()
+        mock_svc = MagicMock()
+        mock_svc.create_webhook = AsyncMock(return_value=wh)
+
+        _build_cpi_admin_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.post("/tenants/acme/webhooks", json=self._payload())
+
+        assert resp.status_code == 201
+
+    def test_create_webhook_400_value_error(self, app, mock_db_session):
+        """ValueError from service results in 400."""
+        mock_svc = MagicMock()
+        mock_svc.create_webhook = AsyncMock(side_effect=ValueError("Invalid URL"))
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.post("/tenants/acme/webhooks", json=self._payload())
+
+        assert resp.status_code == 400
+
+
+# ============================================================
+# GET /tenants/{tenant_id}/webhooks — list webhooks
+# ============================================================
+
+
+class TestListWebhooks:
+    """Tests for GET /tenants/{tenant_id}/webhooks."""
+
+    def test_list_webhooks_success(self, app, mock_db_session):
+        wh = _mock_webhook()
+        mock_svc = MagicMock()
+        mock_svc.list_webhooks = AsyncMock(return_value=[wh])
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.get("/tenants/acme/webhooks")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert len(data["items"]) == 1
+
+    def test_list_webhooks_403_wrong_tenant(self, app, mock_db_session):
+        _build_other_tenant_app(app, mock_db_session)
+
+        with TestClient(app) as client:
+            resp = client.get("/tenants/acme/webhooks")
+
+        assert resp.status_code == 403
+
+    def test_list_webhooks_empty(self, app, mock_db_session):
+        mock_svc = MagicMock()
+        mock_svc.list_webhooks = AsyncMock(return_value=[])
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.get("/tenants/acme/webhooks")
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+
+# ============================================================
+# GET /tenants/{tenant_id}/webhooks/{id} — get webhook
+# ============================================================
+
+
+class TestGetWebhook:
+    """Tests for GET /tenants/{tenant_id}/webhooks/{webhook_id}."""
+
+    def test_get_webhook_success(self, app, mock_db_session):
+        wh = _mock_webhook()
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=wh)
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.get(f"/tenants/acme/webhooks/{uuid4()}")
+
+        assert resp.status_code == 200
+        assert resp.json()["tenant_id"] == "acme"
+
+    def test_get_webhook_404_not_found(self, app, mock_db_session):
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=None)
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.get(f"/tenants/acme/webhooks/{uuid4()}")
+
+        assert resp.status_code == 404
+
+    def test_get_webhook_403_wrong_tenant(self, app, mock_db_session):
+        """Webhook belonging to another tenant returns 403."""
+        wh = _mock_webhook(tenant_id="other-tenant")
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=wh)
+
+        _build_webhook_app(app, mock_db_session)  # acme user
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.get(f"/tenants/acme/webhooks/{uuid4()}")
+
+        assert resp.status_code == 403
+
+    def test_get_webhook_404_tenant_mismatch(self, app, mock_db_session):
+        """Webhook from different tenant in URL path returns 404."""
+        wh = _mock_webhook(tenant_id="acme")
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=wh)
+
+        _build_cpi_admin_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            # CPI admin but URL says different-tenant while webhook belongs to acme
+            resp = client.get(f"/tenants/different-tenant/webhooks/{uuid4()}")
+
+        assert resp.status_code == 404
+
+
+# ============================================================
+# PATCH /tenants/{tenant_id}/webhooks/{id} — update webhook
+# ============================================================
+
+
+class TestUpdateWebhook:
+    """Tests for PATCH /tenants/{tenant_id}/webhooks/{webhook_id}."""
+
+    def test_update_webhook_success(self, app, mock_db_session):
+        wh = _mock_webhook(name="Old Name")
+        updated_wh = _mock_webhook(name="New Name")
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=wh)
+        mock_svc.update_webhook = AsyncMock(return_value=updated_wh)
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.patch(
+                f"/tenants/acme/webhooks/{uuid4()}",
+                json={"name": "New Name"},
+            )
+
+        assert resp.status_code == 200
+
+    def test_update_webhook_404_not_found(self, app, mock_db_session):
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=None)
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.patch(
+                f"/tenants/acme/webhooks/{uuid4()}",
+                json={"name": "Updated"},
+            )
+
+        assert resp.status_code == 404
+
+
+# ============================================================
+# DELETE /tenants/{tenant_id}/webhooks/{id} — delete webhook
+# ============================================================
+
+
+class TestDeleteWebhook:
+    """Tests for DELETE /tenants/{tenant_id}/webhooks/{webhook_id}."""
+
+    def test_delete_webhook_success(self, app, mock_db_session):
+        wh = _mock_webhook()
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=wh)
+        mock_svc.delete_webhook = AsyncMock()
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.delete(f"/tenants/acme/webhooks/{uuid4()}")
+
+        assert resp.status_code == 204
+
+    def test_delete_webhook_404_not_found(self, app, mock_db_session):
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=None)
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.delete(f"/tenants/acme/webhooks/{uuid4()}")
+
+        assert resp.status_code == 404
+
+    def test_delete_webhook_403_wrong_tenant(self, app, mock_db_session):
+        wh = _mock_webhook(tenant_id="other-tenant")
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=wh)
+
+        _build_webhook_app(app, mock_db_session)  # acme user
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.delete(f"/tenants/acme/webhooks/{uuid4()}")
+
+        assert resp.status_code == 403
+
+
+# ============================================================
+# GET /tenants/{tenant_id}/webhooks/{id}/deliveries
+# ============================================================
+
+
+class TestListDeliveries:
+    """Tests for GET /tenants/{tenant_id}/webhooks/{webhook_id}/deliveries."""
+
+    def test_list_deliveries_success(self, app, mock_db_session):
+        wh = _mock_webhook()
+        delivery = _mock_delivery(webhook_id=wh.id)
+
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=wh)
+        mock_svc.get_delivery_history = AsyncMock(return_value=[delivery])
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.get(f"/tenants/acme/webhooks/{uuid4()}/deliveries")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert len(data["items"]) == 1
+
+    def test_list_deliveries_404_webhook_not_found(self, app, mock_db_session):
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=None)
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.get(f"/tenants/acme/webhooks/{uuid4()}/deliveries")
+
+        assert resp.status_code == 404
+
+    def test_list_deliveries_empty(self, app, mock_db_session):
+        wh = _mock_webhook()
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=wh)
+        mock_svc.get_delivery_history = AsyncMock(return_value=[])
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.get(f"/tenants/acme/webhooks/{uuid4()}/deliveries")
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+
+# ============================================================
+# POST /tenants/{tenant_id}/webhooks/{id}/deliveries/{did}/retry
+# ============================================================
+
+
+class TestRetryDelivery:
+    """Tests for POST /tenants/{tenant_id}/webhooks/{wid}/deliveries/{did}/retry."""
+
+    def test_retry_delivery_success(self, app, mock_db_session):
+        wh = _mock_webhook()
+        delivery = _mock_delivery(webhook_id=wh.id)
+
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=wh)
+        mock_svc.retry_delivery = AsyncMock(return_value=delivery)
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.post(f"/tenants/acme/webhooks/{uuid4()}/deliveries/{uuid4()}/retry")
+
+        assert resp.status_code == 200
+        assert resp.json()["event_type"] == "subscription.created"
+
+    def test_retry_delivery_404_webhook_not_found(self, app, mock_db_session):
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=None)
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.post(f"/tenants/acme/webhooks/{uuid4()}/deliveries/{uuid4()}/retry")
+
+        assert resp.status_code == 404
+
+    def test_retry_delivery_404_delivery_not_found(self, app, mock_db_session):
+        wh = _mock_webhook()
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=wh)
+        mock_svc.retry_delivery = AsyncMock(return_value=None)
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.post(f"/tenants/acme/webhooks/{uuid4()}/deliveries/{uuid4()}/retry")
+
+        assert resp.status_code == 404
+
+
+# ============================================================
+# POST /tenants/{tenant_id}/webhooks/{id}/test
+# ============================================================
+
+
+class TestTestWebhook:
+    """Tests for POST /tenants/{tenant_id}/webhooks/{webhook_id}/test."""
+
+    def test_test_webhook_success(self, app, mock_db_session):
+        """Test webhook endpoint calls the real HTTP machinery (mocked via httpx)."""
+
+        wh = _mock_webhook()
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=wh)
+
+        _build_webhook_app(app, mock_db_session)
+
+        # Mock httpx.AsyncClient so no real HTTP call is made
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "OK"
+
+        mock_async_client = MagicMock()
+        mock_async_client.__aenter__ = AsyncMock(return_value=mock_async_client)
+        mock_async_client.__aexit__ = AsyncMock(return_value=None)
+        mock_async_client.post = AsyncMock(return_value=mock_response)
+
+        with (
+            patch(WEBHOOK_SVC_PATH, return_value=mock_svc),
+            patch("httpx.AsyncClient", return_value=mock_async_client),
+            TestClient(app) as client,
+        ):
+            resp = client.post(
+                f"/tenants/acme/webhooks/{uuid4()}/test",
+                json={"event_type": "subscription.created"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["status_code"] == 200
+
+    def test_test_webhook_404_not_found(self, app, mock_db_session):
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=None)
+
+        _build_webhook_app(app, mock_db_session)
+
+        with patch(WEBHOOK_SVC_PATH, return_value=mock_svc), TestClient(app) as client:
+            resp = client.post(
+                f"/tenants/acme/webhooks/{uuid4()}/test",
+                json={"event_type": "subscription.created"},
+            )
+
+        assert resp.status_code == 404
+
+    def test_test_webhook_timeout_handled(self, app, mock_db_session):
+        """Timeout from httpx returns success=False with error message."""
+        import httpx
+
+        wh = _mock_webhook()
+        mock_svc = MagicMock()
+        mock_svc.get_webhook = AsyncMock(return_value=wh)
+
+        _build_webhook_app(app, mock_db_session)
+
+        mock_async_client = MagicMock()
+        mock_async_client.__aenter__ = AsyncMock(return_value=mock_async_client)
+        mock_async_client.__aexit__ = AsyncMock(return_value=None)
+        mock_async_client.post = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+
+        with (
+            patch(WEBHOOK_SVC_PATH, return_value=mock_svc),
+            patch("httpx.AsyncClient", return_value=mock_async_client),
+            TestClient(app) as client,
+        ):
+            resp = client.post(
+                f"/tenants/acme/webhooks/{uuid4()}/test",
+                json={"event_type": "subscription.created"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is False
+        assert "timed out" in data["error"].lower() or "timeout" in data["error"].lower()

--- a/control-plane-api/tests/test_tenants_router.py
+++ b/control-plane-api/tests/test_tenants_router.py
@@ -1,0 +1,268 @@
+"""Tests for Tenants Router — CAB-1448
+
+Covers: /v1/tenants (list, get, provisioning-status, create, update, delete).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+REPO_PATH = "src.routers.tenants.TenantRepository"
+CACHE_PATH = "src.routers.tenants.tenant_cache"
+KAFKA_PATH = "src.routers.tenants.kafka_service"
+PROVISION_PATH = "src.routers.tenants.provision_tenant"
+DEPROVISION_PATH = "src.routers.tenants.deprovision_tenant"
+TENANT_ID = "acme"
+
+
+def _make_tenant(**overrides):
+    """Create a mock Tenant model."""
+    mock = MagicMock()
+    defaults = {
+        "id": TENANT_ID,
+        "name": "ACME Corporation",
+        "description": "Test tenant",
+        "status": "active",
+        "provisioning_status": "ready",
+        "provisioning_error": None,
+        "provisioning_started_at": None,
+        "provisioning_attempts": 0,
+        "kc_group_id": "kc-group-123",
+        "settings": {"owner_email": "admin@acme.com"},
+        "created_at": MagicMock(isoformat=MagicMock(return_value="2026-01-01T00:00:00")),
+        "updated_at": MagicMock(isoformat=MagicMock(return_value="2026-01-01T00:00:00")),
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+class TestListTenants:
+    """Tests for GET /v1/tenants."""
+
+    def test_list_tenants_cpi_admin(self, client_as_cpi_admin):
+        tenant = _make_tenant()
+        mock_repo = MagicMock()
+        mock_repo.list_for_user = AsyncMock(return_value=[tenant])
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_cpi_admin.get("/v1/tenants")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) >= 1
+
+    def test_list_tenants_tenant_admin(self, client_as_tenant_admin):
+        tenant = _make_tenant()
+        mock_repo = MagicMock()
+        mock_repo.list_for_user = AsyncMock(return_value=[tenant])
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get("/v1/tenants")
+
+        assert resp.status_code == 200
+
+    def test_list_tenants_error_returns_empty(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.list_for_user = AsyncMock(side_effect=RuntimeError("DB down"))
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get("/v1/tenants")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestGetTenant:
+    """Tests for GET /v1/tenants/{tenant_id}."""
+
+    def test_get_tenant_success(self, client_as_tenant_admin):
+        tenant = _make_tenant()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=tenant)
+
+        with patch(REPO_PATH) as MockRepo, patch(CACHE_PATH) as mock_cache:
+            MockRepo.return_value = mock_repo
+            mock_cache.get = AsyncMock(return_value=None)
+            mock_cache.set = AsyncMock()
+            resp = client_as_tenant_admin.get(f"/v1/tenants/{TENANT_ID}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == TENANT_ID
+
+    def test_get_tenant_404(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH) as MockRepo, patch(CACHE_PATH) as mock_cache:
+            MockRepo.return_value = mock_repo
+            mock_cache.get = AsyncMock(return_value=None)
+            resp = client_as_tenant_admin.get(f"/v1/tenants/{TENANT_ID}")
+
+        assert resp.status_code == 404
+
+    def test_get_tenant_403_other_tenant(self, client_as_other_tenant):
+        resp = client_as_other_tenant.get(f"/v1/tenants/{TENANT_ID}")
+        assert resp.status_code == 403
+
+    def test_get_tenant_cpi_admin_cross_tenant(self, client_as_cpi_admin):
+        tenant = _make_tenant()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=tenant)
+
+        with patch(REPO_PATH) as MockRepo, patch(CACHE_PATH) as mock_cache:
+            MockRepo.return_value = mock_repo
+            mock_cache.get = AsyncMock(return_value=None)
+            mock_cache.set = AsyncMock()
+            resp = client_as_cpi_admin.get(f"/v1/tenants/{TENANT_ID}")
+
+        assert resp.status_code == 200
+
+
+class TestGetProvisioningStatus:
+    """Tests for GET /v1/tenants/{tenant_id}/provisioning-status."""
+
+    def test_provisioning_status_success(self, client_as_tenant_admin):
+        tenant = _make_tenant()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=tenant)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/tenants/{TENANT_ID}/provisioning-status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["tenant_id"] == TENANT_ID
+        assert data["provisioning_status"] == "ready"
+
+    def test_provisioning_status_404(self, client_as_tenant_admin):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_tenant_admin.get(f"/v1/tenants/{TENANT_ID}/provisioning-status")
+
+        assert resp.status_code == 404
+
+
+class TestCreateTenant:
+    """Tests for POST /v1/tenants."""
+
+    def test_create_success(self, client_as_cpi_admin):
+        tenant = _make_tenant(id="new-tenant")
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+        mock_repo.create = AsyncMock(return_value=tenant)
+
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(KAFKA_PATH) as mock_kafka,
+            patch(PROVISION_PATH, new_callable=AsyncMock),
+        ):
+            MockRepo.return_value = mock_repo
+            mock_kafka.publish = AsyncMock()
+            mock_kafka.emit_audit_event = AsyncMock()
+            resp = client_as_cpi_admin.post(
+                "/v1/tenants",
+                json={
+                    "name": "New Tenant",
+                    "display_name": "New Tenant Corp",
+                    "owner_email": "owner@new.com",
+                },
+            )
+
+        assert resp.status_code == 200
+
+    def test_create_duplicate_409(self, client_as_cpi_admin):
+        existing = _make_tenant()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=existing)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_cpi_admin.post(
+                "/v1/tenants",
+                json={
+                    "name": "acme",
+                    "display_name": "ACME",
+                    "owner_email": "admin@acme.com",
+                },
+            )
+
+        assert resp.status_code == 409
+
+
+class TestUpdateTenant:
+    """Tests for PUT /v1/tenants/{tenant_id}."""
+
+    def test_update_success(self, client_as_cpi_admin):
+        tenant = _make_tenant()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=tenant)
+        mock_repo.update = AsyncMock(return_value=tenant)
+
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(CACHE_PATH) as mock_cache,
+            patch(KAFKA_PATH) as mock_kafka,
+        ):
+            MockRepo.return_value = mock_repo
+            mock_cache.delete = AsyncMock()
+            mock_kafka.emit_audit_event = AsyncMock()
+            resp = client_as_cpi_admin.put(
+                f"/v1/tenants/{TENANT_ID}",
+                json={"display_name": "Updated ACME"},
+            )
+
+        assert resp.status_code == 200
+
+    def test_update_404(self, client_as_cpi_admin):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_cpi_admin.put(
+                f"/v1/tenants/{TENANT_ID}",
+                json={"display_name": "test"},
+            )
+
+        assert resp.status_code == 404
+
+
+class TestDeleteTenant:
+    """Tests for DELETE /v1/tenants/{tenant_id}."""
+
+    def test_delete_success(self, client_as_cpi_admin):
+        tenant = _make_tenant()
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=tenant)
+
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(CACHE_PATH) as mock_cache,
+            patch(KAFKA_PATH) as mock_kafka,
+            patch(DEPROVISION_PATH, new_callable=AsyncMock),
+        ):
+            MockRepo.return_value = mock_repo
+            mock_cache.delete = AsyncMock()
+            mock_kafka.emit_audit_event = AsyncMock()
+            resp = client_as_cpi_admin.delete(f"/v1/tenants/{TENANT_ID}")
+
+        assert resp.status_code == 200
+        assert "deprovisioning" in resp.json()["message"].lower()
+
+    def test_delete_404(self, client_as_cpi_admin):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value = mock_repo
+            resp = client_as_cpi_admin.delete(f"/v1/tenants/{TENANT_ID}")
+
+        assert resp.status_code == 404

--- a/control-plane-api/tests/test_webhooks_router.py
+++ b/control-plane-api/tests/test_webhooks_router.py
@@ -1,0 +1,268 @@
+"""Tests for Webhooks Router — GitLab webhook handlers (GitOps with tracing).
+
+Covers: GET /webhooks/gitlab/health, POST /webhooks/gitlab
+
+Note: This router has NO auth dependency — uses X-Gitlab-Token header instead.
+      The TraceService and kafka_service are patched at the router module level.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+TRACE_SVC_PATH = "src.routers.webhooks.TraceService"
+KAFKA_SVC_PATH = "src.routers.webhooks.kafka_service"
+SETTINGS_PATH = "src.routers.webhooks.settings"
+
+VALID_TOKEN = "my-secret-gitlab-token"
+
+_PUSH_PAYLOAD = {
+    "object_kind": "push",
+    "event_name": "push",
+    "ref": "refs/heads/main",
+    "before": "abc123",
+    "after": "def456",
+    "project_id": 42,
+    "user_name": "Alice",
+    "user_username": "alice",
+    "user_email": "alice@example.com",
+    "project": {"path_with_namespace": "acme/api-specs"},
+    "commits": [
+        {
+            "id": "def456",
+            "message": "Add new API spec",
+            "author": {"name": "Alice", "email": "alice@example.com"},
+            "added": ["tenants/acme/apis/weather/openapi.yaml"],
+            "modified": [],
+            "removed": [],
+        }
+    ],
+    "total_commits_count": 1,
+}
+
+_MR_PAYLOAD = {
+    "object_kind": "merge_request",
+    "event_type": "merge_request",
+    "user": {"username": "bob"},
+    "project": {"path_with_namespace": "acme/api-specs"},
+    "object_attributes": {
+        "state": "merged",
+        "target_branch": "main",
+        "iid": 7,
+        "title": "Add new endpoint",
+    },
+}
+
+_TAG_PAYLOAD = {
+    "object_kind": "tag_push",
+    "ref": "refs/tags/v1.0.0",
+    "project_id": 42,
+    "user_name": "Alice",
+    "user_username": "alice",
+    "project": {"path_with_namespace": "acme/api-specs"},
+    "commits": [],
+}
+
+
+def _build_no_auth_client(app, mock_db_session):
+    """Build a TestClient with only DB override (no auth override for webhooks)."""
+    from src.database import get_db
+
+    async def override_get_db():
+        yield mock_db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+def _make_trace_service_mock():
+    """Build a complete TraceService mock."""
+    trace = MagicMock()
+    trace.id = "trace-abc-123"
+    trace.status = MagicMock()
+    trace.status.value = "success"
+    trace.total_duration_ms = 42
+    trace.tenant_id = None
+    trace.api_name = None
+    trace.environment = None
+
+    svc = MagicMock()
+    svc.create = AsyncMock(return_value=trace)
+    svc.add_step = AsyncMock()
+    svc.complete = AsyncMock()
+    svc.get_stats = AsyncMock(return_value={"total": 5, "success": 4, "failed": 1})
+    return svc, trace
+
+
+class TestWebhookHealth:
+    """Tests for GET /webhooks/gitlab/health."""
+
+    def test_health_returns_200(self, app, mock_db_session):
+        svc, _ = _make_trace_service_mock()
+
+        with patch(TRACE_SVC_PATH, return_value=svc):
+            client = _build_no_auth_client(app, mock_db_session)
+            resp = client.get("/webhooks/gitlab/health")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "healthy"
+        assert "trace_stats" in data
+        assert "supported_events" in data
+
+
+class TestGitlabWebhookPost:
+    """Tests for POST /webhooks/gitlab."""
+
+    def test_push_hook_success(self, app, mock_db_session):
+        """Valid push hook with correct token is processed."""
+        svc, _trace = _make_trace_service_mock()
+        mock_settings = MagicMock()
+        mock_settings.GITLAB_WEBHOOK_SECRET = VALID_TOKEN
+
+        mock_kafka = MagicMock()
+        mock_kafka.publish = AsyncMock(return_value="event-id-1")
+
+        with (
+            patch(TRACE_SVC_PATH, return_value=svc),
+            patch(SETTINGS_PATH, mock_settings),
+            patch(KAFKA_SVC_PATH, mock_kafka),
+        ):
+            client = _build_no_auth_client(app, mock_db_session)
+            resp = client.post(
+                "/webhooks/gitlab",
+                json=_PUSH_PAYLOAD,
+                headers={
+                    "X-Gitlab-Token": VALID_TOKEN,
+                    "X-Gitlab-Event": "Push Hook",
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "processed"
+        assert data["trace_id"] == "trace-abc-123"
+
+    def test_push_hook_401_missing_token(self, app, mock_db_session):
+        """Missing X-Gitlab-Token returns 401."""
+        svc, _ = _make_trace_service_mock()
+        mock_settings = MagicMock()
+        mock_settings.GITLAB_WEBHOOK_SECRET = VALID_TOKEN
+
+        with patch(TRACE_SVC_PATH, return_value=svc), patch(SETTINGS_PATH, mock_settings):
+            client = _build_no_auth_client(app, mock_db_session)
+            resp = client.post(
+                "/webhooks/gitlab",
+                json=_PUSH_PAYLOAD,
+                headers={"X-Gitlab-Event": "Push Hook"},
+            )
+
+        assert resp.status_code == 401
+
+    def test_push_hook_401_invalid_token(self, app, mock_db_session):
+        """Wrong X-Gitlab-Token returns 401."""
+        svc, _ = _make_trace_service_mock()
+        mock_settings = MagicMock()
+        mock_settings.GITLAB_WEBHOOK_SECRET = VALID_TOKEN
+
+        with patch(TRACE_SVC_PATH, return_value=svc), patch(SETTINGS_PATH, mock_settings):
+            client = _build_no_auth_client(app, mock_db_session)
+            resp = client.post(
+                "/webhooks/gitlab",
+                json=_PUSH_PAYLOAD,
+                headers={
+                    "X-Gitlab-Token": "wrong-token",
+                    "X-Gitlab-Event": "Push Hook",
+                },
+            )
+
+        assert resp.status_code == 401
+
+    def test_merge_request_hook_success(self, app, mock_db_session):
+        """Merge request hook is processed correctly."""
+        svc, _trace = _make_trace_service_mock()
+        mock_settings = MagicMock()
+        mock_settings.GITLAB_WEBHOOK_SECRET = VALID_TOKEN
+
+        mock_kafka = MagicMock()
+        mock_kafka.publish = AsyncMock(return_value="event-id-2")
+
+        with (
+            patch(TRACE_SVC_PATH, return_value=svc),
+            patch(SETTINGS_PATH, mock_settings),
+            patch(KAFKA_SVC_PATH, mock_kafka),
+        ):
+            client = _build_no_auth_client(app, mock_db_session)
+            resp = client.post(
+                "/webhooks/gitlab",
+                json=_MR_PAYLOAD,
+                headers={
+                    "X-Gitlab-Token": VALID_TOKEN,
+                    "X-Gitlab-Event": "Merge Request Hook",
+                },
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "processed"
+
+    def test_unsupported_event_type_ignored(self, app, mock_db_session):
+        """Unknown event type returns status=ignored."""
+        svc, _ = _make_trace_service_mock()
+        mock_settings = MagicMock()
+        mock_settings.GITLAB_WEBHOOK_SECRET = VALID_TOKEN
+
+        with patch(TRACE_SVC_PATH, return_value=svc), patch(SETTINGS_PATH, mock_settings):
+            client = _build_no_auth_client(app, mock_db_session)
+            resp = client.post(
+                "/webhooks/gitlab",
+                json={"object_kind": "issue", "project": {}, "project_id": 1},
+                headers={
+                    "X-Gitlab-Token": VALID_TOKEN,
+                    "X-Gitlab-Event": "Issue Hook",
+                },
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ignored"
+
+    def test_push_to_non_main_branch_skipped(self, app, mock_db_session):
+        """Push to non-main branch is still processed (returns status=processed)."""
+        svc, _ = _make_trace_service_mock()
+        mock_settings = MagicMock()
+        mock_settings.GITLAB_WEBHOOK_SECRET = VALID_TOKEN
+
+        feature_push = {**_PUSH_PAYLOAD, "ref": "refs/heads/feature/my-feature"}
+
+        with patch(TRACE_SVC_PATH, return_value=svc), patch(SETTINGS_PATH, mock_settings):
+            client = _build_no_auth_client(app, mock_db_session)
+            resp = client.post(
+                "/webhooks/gitlab",
+                json=feature_push,
+                headers={
+                    "X-Gitlab-Token": VALID_TOKEN,
+                    "X-Gitlab-Event": "Push Hook",
+                },
+            )
+
+        # Router processes it and returns success (branch check is internal)
+        assert resp.status_code == 200
+
+    def test_tag_push_hook_success(self, app, mock_db_session):
+        """Tag push hook is handled correctly."""
+        svc, _trace = _make_trace_service_mock()
+        mock_settings = MagicMock()
+        mock_settings.GITLAB_WEBHOOK_SECRET = VALID_TOKEN
+
+        with patch(TRACE_SVC_PATH, return_value=svc), patch(SETTINGS_PATH, mock_settings):
+            client = _build_no_auth_client(app, mock_db_session)
+            resp = client.post(
+                "/webhooks/gitlab",
+                json=_TAG_PAYLOAD,
+                headers={
+                    "X-Gitlab-Token": VALID_TOKEN,
+                    "X-Gitlab-Event": "Tag Push Hook",
+                },
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "processed"


### PR DESCRIPTION
## Summary
- Add 320 unit tests covering 15 API routers: audit, catalog_admin, certificates, consumers, contracts, credential_mappings, environments, mcp_admin, plans, quotas, service_accounts, subscriptions, tenant_webhooks, tenants, webhooks
- All tests use mock-based approach with FastAPI TestClient — no DB or infrastructure dependencies
- Part of the Wave 5 MEGA Strike test blitz

## Test plan
- [x] All 320 tests pass locally (`pytest -q` — 320 passed in 69s)
- [x] Ruff lint clean (0 errors)
- [x] Black format clean
- [x] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)