### PR TITLE
chore: update state files — C9 579/572+ pts

### DIFF
--- a/memory.md
+++ b/memory.md
@@ -1,6 +1,6 @@
 # STOA Memory
 
-> Derniere MAJ: 2026-02-24 (MEGA Strike W1-W4 — C9 574/572+ pts 100%+)
+> Derniere MAJ: 2026-02-24 (C9 579/572+ pts — Test Blitz + Metering)
 
 ## ✅ DONE
 
@@ -8,6 +8,8 @@
 > Key milestones: Docs v1.0 (107 pts), Rust Gateway (50 pts), ArgoCD+AWX (34 pts), UAC (34 pts)
 
 ### Cycle 9 (Feb 22+)
+- ✅ CAB-1456 [gateway] Metering enrichment + budget enforcement (5 pts) — PR #998
+- ✅ Test Blitz: CAB-1448 PR #996 (320 tests), CAB-1451 PR #997 (E2E), CAB-1452 PR #984 (110 tests) — partial MEGAs
 - ✅ CAB-1450 [MEGA] DX: CI & Local Dev Completeness (13 pts) — PRs #975, #983, #987, #989
 - ✅ CAB-1342 [MEGA] Helm Auto-Sync Secrets + Multi-Staging (21 pts) — PR #990
 - ✅ CAB-1334 [MEGA] Usage Metering Pipeline P1 (21 pts) — PR #991
@@ -101,3 +103,5 @@ CAB-1128: Design Partner Communication (3 pts, P2)
 - Rolling avg: 129.3 pts/day (C7+C8)
 - Portal MCP pages: MOCK_SERVERS removed (PR #771) — pages now use real API only
 - MEGA Strike W1-W4: 11 tickets, 173 pts in single day (PRs #968-#991)
+- Test Blitz + Metering: PRs #984, #996, #997, #998 (3 partial MEGAs + CAB-1456 done)
+- CAB-1446 PR #995 OPEN (gateway test coverage, 3 required checks pass)

--- a/plan.md
+++ b/plan.md
@@ -1,7 +1,7 @@
 # Sprint Plan — STOA Platform
 
 > Auto-synced with Linear via `/sync-plan`. Source of truth: Linear cycles.
-> Last sync: 2026-02-24 (C9=519/572+pts 91%)
+> Last sync: 2026-02-24 (C9=579/572+pts 101%)
 
 ## Cycle 8 (Feb 16–22) — CLOSED
 
@@ -101,7 +101,7 @@
 
 ## Cycle 9 (Feb 23–Mar 1) — CURRENT
 
-**Scope**: ~572+ pts (committed, excl. Backlog/Canceled/Dup) | **Done**: 574 pts (100%+) | **Velocity**: 48 issues done
+**Scope**: ~572+ pts (committed, excl. Backlog/Canceled/Dup) | **Done**: 579 pts (101%) | **Velocity**: 49 issues done
 **Theme**: Post-Demo + Product Roadmap + MEGA Sprint + Community Content
 
 ### In Progress
@@ -111,7 +111,8 @@
   - ✅ Production validated: 23/23 PASS, GO in 5s
   - [ ] Repetitions + video backup (human-only)
 
-### Done (45)
+### Done (46)
+- [x] CAB-1456: [gateway] Metering enrichment + budget enforcement (5 pts) — PR #998
 - [x] CAB-1438: [MEGA] K8s HPA + PDB for All Components (21 pts) — PR #970
 - [x] CAB-1439: [MEGA] Portal Component Test Coverage — 14 Untested (21 pts) — PR #968
 - [x] CAB-1316: [MEGA] Self-Diagnostic Engine + Hop Detection (21 pts) — PR #981
@@ -188,8 +189,10 @@
 
 - CAB-1324: [MEGA] Runtime Data Governance (21 pts)
 - CAB-1320: [MEGA] Repo Consolidation (21 pts)
-- CAB-1452: [MEGA] DX: Chat Agent Hardening (21 pts) — PR #984 (partial)
-- CAB-1446: [MEGA] Gateway Test Coverage Expansion (21 pts) — PR #973 (partial)
+- CAB-1448: [MEGA] API Router Test Coverage Blitz (21 pts) — PR #996 (partial, 320 tests/15 routers)
+- CAB-1451: [MEGA] E2E Test Expansion (21 pts) — PR #997 (partial, @wip unblocked + chat/UAC)
+- CAB-1452: [MEGA] DX: Chat Agent Hardening (21 pts) — PR #984 (partial, 110 tests)
+- CAB-1446: [MEGA] Gateway Test Coverage Expansion (21 pts) — PRs #973, #995 (partial, PR #995 open)
 
 ### Backlog — Legacy (parked)
 


### PR DESCRIPTION
## Summary
- Update sync date to C9 579/572+ pts (101%)
- Add CAB-1456 (metering enrichment) + test blitz PRs (#984, #996, #997, #998) to Done
- Update plan.md: Done count 45→46, backlog entries for partial MEGAs (CAB-1448, 1451, 1452, 1446)

## Test plan
- [ ] State files only — no code changes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)