### PR TITLE
feat(api): add billing consumer + CRUD endpoints (CAB-1458)

### DIFF
--- a/control-plane-api/src/main.py
+++ b/control-plane-api/src/main.py
@@ -37,6 +37,7 @@ from .routers import (
     applications,
     audit,
     backend_apis,
+    billing,
     billing_internal,
     business,
     catalog_admin,
@@ -110,6 +111,7 @@ from .services import (
 )
 from .services.gateway_service import gateway_service
 from .tracing_config import configure_tracing, shutdown_tracing
+from .workers.billing_metering_consumer import billing_metering_consumer
 from .workers.chat_metering_consumer import chat_metering_consumer
 from .workers.error_snapshot_consumer import error_snapshot_consumer
 from .workers.gateway_health_worker import gateway_health_worker
@@ -125,6 +127,7 @@ ENABLE_SNAPSHOT_CONSUMER = os.getenv("ENABLE_SNAPSHOT_CONSUMER", "true").lower()
 ENABLE_SYNC_ENGINE = os.getenv("ENABLE_SYNC_ENGINE", "true").lower() == "true"
 ENABLE_GATEWAY_HEALTH_WORKER = os.getenv("ENABLE_GATEWAY_HEALTH_WORKER", "true").lower() == "true"
 ENABLE_CHAT_METERING_CONSUMER = os.getenv("ENABLE_CHAT_METERING_CONSUMER", "true").lower() == "true"
+ENABLE_BILLING_METERING_CONSUMER = os.getenv("ENABLE_BILLING_METERING_CONSUMER", "true").lower() == "true"
 
 
 @asynccontextmanager
@@ -235,6 +238,15 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.warning("Failed to start chat metering consumer", error=str(e))
 
+    # Start billing metering consumer (CAB-1458)
+    billing_metering_task = None
+    if ENABLE_BILLING_METERING_CONSUMER:
+        try:
+            billing_metering_task = asyncio.create_task(billing_metering_consumer.start())
+            logger.info("Billing metering consumer started")
+        except Exception as e:
+            logger.warning("Failed to start billing metering consumer", error=str(e))
+
     yield
 
     # Shutdown
@@ -274,6 +286,13 @@ async def lifespan(app: FastAPI):
         chat_metering_task.cancel()
         with suppress(asyncio.CancelledError):
             await chat_metering_task
+
+    # Stop billing metering consumer (CAB-1458)
+    if ENABLE_BILLING_METERING_CONSUMER and billing_metering_task:
+        await billing_metering_consumer.stop()
+        billing_metering_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await billing_metering_task
 
     await kafka_service.disconnect()
     await git_service.disconnect()
@@ -629,6 +648,8 @@ app.include_router(gateway_policies.router)
 app.include_router(gateway_internal.router)
 # Internal billing API for gateway budget enforcement (CAB-1457)
 app.include_router(billing_internal.router)
+# Billing CRUD API for tenant admins (CAB-1458)
+app.include_router(billing.router)
 
 # Environments (ADR-040 — Born GitOps)
 app.include_router(environments.router)

--- a/control-plane-api/src/routers/billing.py
+++ b/control-plane-api/src/routers/billing.py
@@ -1,0 +1,127 @@
+"""Billing API — Department budget CRUD for tenant admins (CAB-1458)."""
+
+import logging
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth import User, get_current_user
+from ..database import get_db
+from ..schemas.billing import (
+    DepartmentBudgetCreate,
+    DepartmentBudgetListResponse,
+    DepartmentBudgetResponse,
+    DepartmentBudgetUpdate,
+)
+from ..services.billing_service import BillingService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/v1/tenants/{tenant_id}/budgets",
+    tags=["Billing - Department Budgets"],
+)
+
+
+def _has_tenant_access(user: User, tenant_id: str) -> bool:
+    """Check if user has access to a tenant."""
+    if "cpi-admin" in user.roles:
+        return True
+    return user.tenant_id == tenant_id
+
+
+@router.post("", response_model=DepartmentBudgetResponse, status_code=201)
+async def create_budget(
+    tenant_id: str,
+    request: DepartmentBudgetCreate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new department budget."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    service = BillingService(db)
+    budget = await service.create_budget(tenant_id, request, created_by=user.email)
+    await db.commit()
+    logger.info("Created budget %s for tenant %s by %s", budget.id, tenant_id, user.email)
+    return budget
+
+
+@router.get("", response_model=DepartmentBudgetListResponse)
+async def list_budgets(
+    tenant_id: str,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List department budgets for a tenant."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    service = BillingService(db)
+    return await service.list_budgets(tenant_id, page, page_size)
+
+
+@router.get("/{budget_id}", response_model=DepartmentBudgetResponse)
+async def get_budget(
+    tenant_id: str,
+    budget_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get a specific department budget."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    service = BillingService(db)
+    try:
+        return await service.get_budget(budget_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Budget not found")
+
+
+@router.put("/{budget_id}", response_model=DepartmentBudgetResponse)
+async def update_budget(
+    tenant_id: str,
+    budget_id: UUID,
+    request: DepartmentBudgetUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update a department budget configuration."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    service = BillingService(db)
+    try:
+        budget = await service.update_budget(budget_id, request)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Budget not found")
+
+    await db.commit()
+    logger.info("Updated budget %s by %s", budget_id, user.email)
+    return budget
+
+
+@router.delete("/{budget_id}", status_code=204)
+async def delete_budget(
+    tenant_id: str,
+    budget_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a department budget."""
+    if not _has_tenant_access(user, tenant_id):
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    service = BillingService(db)
+    budget_obj = await service.repo.get_by_id(budget_id)
+    if not budget_obj or budget_obj.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Budget not found")
+
+    await service.repo.delete(budget_obj)
+    await db.commit()
+    logger.info("Deleted budget %s by %s", budget_id, user.email)

--- a/control-plane-api/src/workers/billing_metering_consumer.py
+++ b/control-plane-api/src/workers/billing_metering_consumer.py
@@ -1,0 +1,131 @@
+"""Billing metering Kafka consumer (CAB-1458).
+
+Consumes `stoa.metering` events (ToolCallEvent) and records spend
+against department budgets via BillingService.record_spend().
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import Any
+
+from pydantic import BaseModel
+
+from ..database import _get_session_factory
+from ..services.billing_service import BillingService
+
+logger = logging.getLogger(__name__)
+
+
+class ToolCallMeteringEvent(BaseModel):
+    """Pydantic schema for stoa.metering topic ToolCallEvent (billing fields)."""
+
+    tenant_id: str
+    department_id: str | None = None
+    cost_units_microcents: int = 0
+    token_count: int = 0
+    tool_tier: str = "standard"
+
+
+class BillingMeteringConsumer:
+    """Thread-based Kafka consumer with asyncio bridge for billing metering."""
+
+    TOPIC = "stoa.metering"
+    GROUP = "billing-metering-consumer"
+
+    def __init__(self) -> None:
+        self._running = False
+        self._consumer: Any = None
+        self._thread: threading.Thread | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    async def start(self) -> None:
+        """Start the consumer thread."""
+        self._running = True
+        self._loop = asyncio.get_running_loop()
+        self._thread = threading.Thread(
+            target=self._consume_thread,
+            daemon=True,
+            name="billing-metering-consumer",
+        )
+        self._thread.start()
+        logger.info("Billing metering consumer started")
+
+    async def stop(self) -> None:
+        """Stop the consumer."""
+        self._running = False
+        if self._consumer:
+            self._consumer.close()
+        logger.info("Billing metering consumer stopped")
+
+    def _consume_thread(self) -> None:
+        """Kafka polling loop (runs in daemon thread)."""
+        try:
+            from kafka import KafkaConsumer
+
+            from ..config import settings
+
+            kafka_config: dict[str, Any] = {
+                "bootstrap_servers": settings.KAFKA_BOOTSTRAP_SERVERS,
+                "group_id": self.GROUP,
+                "auto_offset_reset": "latest",
+                "enable_auto_commit": True,
+                "value_deserializer": lambda m: __import__("json").loads(m.decode("utf-8")),
+            }
+            if settings.KAFKA_SECURITY_PROTOCOL != "PLAINTEXT":
+                kafka_config["security_protocol"] = settings.KAFKA_SECURITY_PROTOCOL
+            if settings.KAFKA_SASL_MECHANISM:
+                kafka_config["sasl_mechanism"] = settings.KAFKA_SASL_MECHANISM
+                kafka_config["sasl_plain_username"] = settings.KAFKA_SASL_USERNAME
+                kafka_config["sasl_plain_password"] = settings.KAFKA_SASL_PASSWORD
+
+            self._consumer = KafkaConsumer(self.TOPIC, **kafka_config)
+            logger.info("Billing metering Kafka consumer connected")
+
+            while self._running:
+                records = self._consumer.poll(timeout_ms=1000)
+                for _tp, messages in records.items():
+                    for message in messages:
+                        self._process_message_sync(message)
+
+        except Exception:
+            logger.warning("Billing metering consumer thread error", exc_info=True)
+
+    def _process_message_sync(self, message: Any) -> None:
+        """Parse and dispatch a single message to the async handler."""
+        try:
+            event = ToolCallMeteringEvent.model_validate(message.value)
+            if not event.department_id:
+                return  # Skip events without department attribution
+            if event.cost_units_microcents <= 0:
+                return  # Skip zero-cost events
+            if self._loop:
+                asyncio.run_coroutine_threadsafe(self._handle_event(event), self._loop)
+        except Exception:
+            logger.warning("Failed to process billing metering message", exc_info=True)
+
+    async def _handle_event(self, event: ToolCallMeteringEvent) -> None:
+        """Record spend via BillingService."""
+        try:
+            session_factory = _get_session_factory()
+            async with session_factory() as session:
+                service = BillingService(session)
+                await service.record_spend(
+                    tenant_id=event.tenant_id,
+                    department_id=event.department_id,
+                    amount_microcents=event.cost_units_microcents,
+                )
+                await session.commit()
+        except Exception:
+            logger.warning(
+                "Failed to record billing spend for dept=%s tenant=%s",
+                event.department_id,
+                event.tenant_id,
+                exc_info=True,
+            )
+
+
+# Singleton instance
+billing_metering_consumer = BillingMeteringConsumer()

--- a/control-plane-api/tests/test_billing_consumer.py
+++ b/control-plane-api/tests/test_billing_consumer.py
@@ -1,0 +1,208 @@
+"""Tests for billing metering consumer + billing CRUD router (CAB-1458)."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from src.workers.billing_metering_consumer import (
+    BillingMeteringConsumer,
+    ToolCallMeteringEvent,
+)
+
+# ── ToolCallMeteringEvent schema ──
+
+
+class TestToolCallMeteringEvent:
+    def test_valid_event(self):
+        evt = ToolCallMeteringEvent(
+            tenant_id="t1",
+            department_id="d1",
+            cost_units_microcents=5000,
+            token_count=100,
+            tool_tier="premium",
+        )
+        assert evt.tenant_id == "t1"
+        assert evt.department_id == "d1"
+        assert evt.cost_units_microcents == 5000
+
+    def test_defaults(self):
+        evt = ToolCallMeteringEvent(tenant_id="t1")
+        assert evt.department_id is None
+        assert evt.cost_units_microcents == 0
+        assert evt.token_count == 0
+        assert evt.tool_tier == "standard"
+
+    def test_from_dict(self):
+        data = {"tenant_id": "t2", "department_id": "d2", "cost_units_microcents": 1000}
+        evt = ToolCallMeteringEvent.model_validate(data)
+        assert evt.tenant_id == "t2"
+        assert evt.cost_units_microcents == 1000
+
+    def test_missing_tenant_rejected(self):
+        with pytest.raises(ValidationError):
+            ToolCallMeteringEvent.model_validate({})
+
+
+# ── BillingMeteringConsumer ──
+
+
+class TestBillingMeteringConsumer:
+    def test_init(self):
+        consumer = BillingMeteringConsumer()
+        assert consumer.TOPIC == "stoa.metering"
+        assert consumer.GROUP == "billing-metering-consumer"
+        assert consumer._running is False
+
+    def test_skip_no_department(self):
+        consumer = BillingMeteringConsumer()
+        consumer._loop = MagicMock()
+        msg = MagicMock()
+        msg.value = {"tenant_id": "t1", "cost_units_microcents": 100}
+        consumer._process_message_sync(msg)
+        # No coroutine dispatched (department_id is None)
+
+    def test_skip_zero_cost(self):
+        consumer = BillingMeteringConsumer()
+        consumer._loop = MagicMock()
+        msg = MagicMock()
+        msg.value = {
+            "tenant_id": "t1",
+            "department_id": "d1",
+            "cost_units_microcents": 0,
+        }
+        consumer._process_message_sync(msg)
+        # No coroutine dispatched (zero cost)
+
+    @patch("src.workers.billing_metering_consumer.asyncio.run_coroutine_threadsafe")
+    def test_dispatch_valid_event(self, mock_dispatch):
+        consumer = BillingMeteringConsumer()
+        consumer._loop = MagicMock()
+        msg = MagicMock()
+        msg.value = {
+            "tenant_id": "t1",
+            "department_id": "d1",
+            "cost_units_microcents": 5000,
+        }
+        consumer._process_message_sync(msg)
+        mock_dispatch.assert_called_once()
+
+    def test_handle_invalid_json(self):
+        consumer = BillingMeteringConsumer()
+        consumer._loop = MagicMock()
+        msg = MagicMock()
+        msg.value = "not-a-dict"
+        # Should not raise — logs warning internally
+        consumer._process_message_sync(msg)
+
+    @pytest.mark.asyncio
+    async def test_handle_event_calls_record_spend(self):
+        consumer = BillingMeteringConsumer()
+        event = ToolCallMeteringEvent(
+            tenant_id="t1",
+            department_id="d1",
+            cost_units_microcents=5000,
+        )
+        mock_session = AsyncMock()
+        mock_session_factory = MagicMock()
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "src.workers.billing_metering_consumer._get_session_factory",
+                return_value=mock_session_factory,
+            ),
+            patch("src.workers.billing_metering_consumer.BillingService") as mock_svc_cls,
+        ):
+            mock_svc = AsyncMock()
+            mock_svc_cls.return_value = mock_svc
+            await consumer._handle_event(event)
+            mock_svc.record_spend.assert_called_once_with(
+                tenant_id="t1",
+                department_id="d1",
+                amount_microcents=5000,
+            )
+            mock_session.commit.assert_called_once()
+
+
+# ── Billing Router ──
+
+
+class TestBillingRouter:
+    def test_create_roundtrip(self):
+        from src.schemas.billing import DepartmentBudgetCreate, DepartmentBudgetResponse
+
+        now = datetime.now(tz=UTC)
+        payload = DepartmentBudgetCreate(
+            department_id="eng",
+            budget_limit_microcents=100_000_000,
+            period="monthly",
+            period_start=now,
+            enforcement="warn_only",
+        )
+        assert payload.department_id == "eng"
+        assert payload.budget_limit_microcents == 100_000_000
+
+        resp = DepartmentBudgetResponse(
+            id=uuid4(),
+            tenant_id="t1",
+            department_id="eng",
+            department_name="Engineering",
+            budget_limit_microcents=100_000_000,
+            current_spend_microcents=0,
+            period="monthly",
+            period_start=now,
+            warning_threshold_pct=80,
+            critical_threshold_pct=95,
+            enforcement="warn_only",
+            usage_pct=0.0,
+            is_over_budget=False,
+            created_by="admin@test.com",
+            created_at=now,
+            updated_at=now,
+        )
+        assert resp.department_id == "eng"
+
+    def test_update_partial(self):
+        from src.schemas.billing import DepartmentBudgetUpdate
+
+        update = DepartmentBudgetUpdate(enforcement="enabled")
+        dumped = update.model_dump(exclude_unset=True)
+        assert dumped == {"enforcement": "enabled"}
+
+    def test_list_empty(self):
+        from src.schemas.billing import DepartmentBudgetListResponse
+
+        resp = DepartmentBudgetListResponse(items=[], total=0, page=1, page_size=20)
+        assert resp.total == 0
+        assert len(resp.items) == 0
+
+    def test_response_from_model_data(self):
+        from src.schemas.billing import DepartmentBudgetResponse
+
+        budget_id = uuid4()
+        now = datetime.now(tz=UTC)
+        data = {
+            "id": budget_id,
+            "tenant_id": "t1",
+            "department_id": "eng",
+            "department_name": "Engineering",
+            "budget_limit_microcents": 50_000_000,
+            "current_spend_microcents": 10_000_000,
+            "period": "monthly",
+            "period_start": now,
+            "warning_threshold_pct": 80,
+            "critical_threshold_pct": 95,
+            "enforcement": "warn_only",
+            "usage_pct": 20.0,
+            "is_over_budget": False,
+            "created_by": "admin@test.com",
+            "created_at": now,
+            "updated_at": now,
+        }
+        resp = DepartmentBudgetResponse(**data)
+        assert resp.id == budget_id
+        assert resp.current_spend_microcents == 10_000_000


### PR DESCRIPTION
## Summary
- Add `BillingMeteringConsumer` — Kafka consumer for `stoa.metering` topic that records spend against department budgets via `BillingService.record_spend()`
- Add billing CRUD router at `/v1/tenants/{tenant_id}/budgets` with tenant-isolation guard (cpi-admin bypass)
- Wire consumer startup/shutdown in `main.py` lifespan (with `ENABLE_BILLING_METERING_CONSUMER` env flag)
- 14 new tests (consumer schema validation, event dispatch, record_spend integration, router schema roundtrip)

Depends on: PR #1000 (CAB-1457 — billing models + service + internal endpoint) ✅ merged

## Test plan
- [x] `pytest tests/test_billing_consumer.py` — 14/14 pass
- [x] `pytest tests/test_billing.py` — 23/23 pass (CAB-1457 regression)
- [x] `ruff check` + `black --check` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)