### PR TITLE
chore: update state files — W4 legacy backlog triage

### DIFF
--- a/memory.md
+++ b/memory.md
@@ -115,6 +115,7 @@ CAB-1128: Design Partner Communication (3 pts, P2)
 - MEGA Strike W1-W4: 11 tickets, 173 pts in single day (PRs #968-#991)
 - Test Blitz + Metering: PRs #984, #996, #997, #998 (3 partial MEGAs + CAB-1456 done)
 - MEGA Strike W3: CAB-1347 done (PRs #1032, #1034), CAB-1348 cancelled (tokio-uring infeasible)
+- MEGA Strike W4 triage: 3 cancelled (CAB-1307, 1309, 1310 — off-mission), 2 kept (CAB-1304, 1311), 3 deferred (CAB-1308, 1324, 1402)
 - PR hygiene: 10 merged, 3 stale closed, 3 deferred (OTel 0.31 breaking, TS-eslint 6→8 breaking)
 - Veille system: L1 weekly (skill+CLI), L2 monthly (GHA audit), L3 quarterly (benchmark command+agent)
 - Benchmark Q1 gaps: sandbox isolation (P1, Codex), plugin marketplace (P2, Cursor). Cursor copie patterns CC.

--- a/plan.md
+++ b/plan.md
@@ -194,18 +194,23 @@
 
 ### Backlog (not committed, no checkbox)
 
-- CAB-1324: [MEGA] Runtime Data Governance (21 pts)
 - CAB-1320: [MEGA] Repo Consolidation (21 pts) — PR #1004 (partial, root configs unified)
 
-### Backlog — Legacy (parked)
+### Backlog — Legacy (triaged 2026-02-24)
 
-- CAB-1402: [infra] Cilium CNI Foundation — Deferred (13 pts, blocked: MKS Standard GA)
-- CAB-1307: [MEGA] Ticketing ITSM (34 pts)
-- CAB-1308: [MEGA] Resource Lifecycle Management (34 pts)
-- CAB-1309: [MEGA] Resource Lifecycle Advanced (34 pts)
-- CAB-1310: [MEGA] Jenkins Orchestration Layer (34 pts)
-- CAB-1304: [MEGA] Demo Tenant Automation (13 pts)
-- CAB-1311: [MEGA] GTM Strategy & Licensing (13 pts)
+*Keep (demo/launch prerequisites):*
+- CAB-1304: [MEGA] Demo Tenant Automation (13 pts) — supports March 17 demo
+- CAB-1311: [MEGA] GTM Strategy & Licensing (13 pts) — unblocks post-demo execution
+
+*Deferred (post-launch, Q2+):*
+- CAB-1308: [MEGA] Resource Lifecycle Management (34 pts) — operational maturity, not launch-critical
+- CAB-1324: [MEGA] Runtime Data Governance (21 pts) — architectural refinement
+- CAB-1402: [infra] Cilium CNI Foundation (13 pts) — blocked: MKS Standard GA
+
+*Canceled (off-mission):*
+- ~~CAB-1307: [MEGA] Ticketing ITSM (34 pts) — ITSM not core to API gateway~~
+- ~~CAB-1309: [MEGA] Resource Lifecycle Advanced (34 pts) — speculative, no demand signal~~
+- ~~CAB-1310: [MEGA] Jenkins Orchestration Layer (34 pts) — orthogonal to gateway mission~~
 
 ---
 


### PR DESCRIPTION
## Summary
- Triaged 8 legacy backlog MEGAs on Linear
- 3 canceled (CAB-1307, 1309, 1310 — off-mission)
- 2 kept (CAB-1304 demo tenant, CAB-1311 GTM)
- 3 deferred (CAB-1308, 1324, 1402 — post-launch Q2+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)