### PR TITLE
feat(ops): platform service catalog + /carto skill (CAB-1467)

### DIFF
--- a/.claude/skills/carto/SKILL.md
+++ b/.claude/skills/carto/SKILL.md
@@ -1,0 +1,137 @@
+# /carto — Platform Service Catalog
+
+> Query the STOA platform service catalog for live infrastructure state.
+
+## Modes
+
+| Command | What it does |
+|---------|-------------|
+| `/carto` or `/carto all` | Full inventory — all services with deploy status |
+| `/carto <service>` | Detail view of a single service + live state |
+| `/carto drift` | Run drift detection (catalog vs K8s live) |
+| `/carto graph` | Show the Mermaid dependency graph |
+| `/carto secrets` | Show secrets-to-services mapping |
+
+## Step 1: Read the Catalog
+
+Read `docs/platform-catalog.yaml` — this is the source of truth for all services.
+
+## Step 2: Execute Based on Mode
+
+### Mode: `all` (default)
+
+1. Read the full catalog
+2. For each service, format a summary line:
+
+```
+## Platform Inventory — {metadata.lastUpdated}
+
+### Core Services (K8s)
+| Service | Type | Port | Prod Replicas | Health | ArgoCD |
+|---------|------|------|---------------|--------|--------|
+| control-plane-api | backend | 8000 | 2 | /health | control-plane-api |
+| ... | ... | ... | ... | ... | ... |
+
+### External Services (VPS)
+| Service | Type | Host | Purpose |
+|---------|------|------|---------|
+
+### Clusters
+| Cluster | Provider | Nodes |
+|---------|----------|-------|
+```
+
+3. If kubectl is available, enrich with live status:
+```bash
+kubectl get deployments -n stoa-system -o custom-columns='NAME:.metadata.name,READY:.status.readyReplicas,IMAGE:.spec.template.spec.containers[0].image' 2>/dev/null
+```
+
+### Mode: `<service>` (single service detail)
+
+1. Find the service in the catalog by name
+2. Display all fields:
+
+```
+## {displayName} ({name})
+
+Type: {type}
+Tech: {tech}
+Path: {path}
+Port: {containerPort}
+Image: {image}
+
+### Deploy
+- Prod: {deploy.prod.cluster}/{deploy.prod.namespace} ({deploy.prod.replicas} replicas)
+- Staging: {deploy.staging...}
+
+### Dependencies
+- Depends on: {dependsOn[]}
+- Consumed by: {exposedTo[]}
+
+### Secrets
+- {consumesSecrets[]}
+
+### Health & Observability
+- Health: {health}
+- Metrics: {metrics}
+- ArgoCD: {argocdApp}
+- CI: {ciWorkflow}
+```
+
+3. If kubectl is available, add live state:
+```bash
+kubectl get deployment {k8sName} -n {namespace} -o json 2>/dev/null
+kubectl get pods -l app={k8sName} -n {namespace} -o wide 2>/dev/null
+```
+
+4. If the service has an argocdApp, check sync status:
+```bash
+kubectl get application {argocdApp} -n argocd -o custom-columns='SYNC:.status.sync.status,HEALTH:.status.health.status' 2>/dev/null
+```
+
+### Mode: `drift`
+
+Run the drift detection script:
+```bash
+./scripts/ops/catalog-sync.sh
+```
+
+Present results to the user with context about what each drift means.
+
+### Mode: `graph`
+
+1. Read `docs/architecture-graph.md`
+2. Display the Mermaid graph and summary tables
+3. If the file is missing, regenerate:
+```bash
+./scripts/ops/catalog-graph.sh
+```
+
+### Mode: `secrets`
+
+Extract secrets mapping from the catalog:
+
+```
+## Secrets → Services Mapping
+
+| Secret | Used By | Service Type |
+|--------|---------|-------------|
+| DATABASE_PASSWORD | control-plane-api | backend |
+| KEYCLOAK_CLIENT_SECRET | control-plane-api | backend |
+| KEYCLOAK_ADMIN_PASSWORD | stoa-gateway, keycloak | gateway, identity |
+| ...
+```
+
+Flag any secret used by 0 or 3+ services as a potential concern.
+
+## Step 3: Output
+
+Format output as a clean markdown table. Keep it concise — the catalog YAML has all details, the skill surfaces the most useful information at a glance.
+
+## Rules
+
+- NEVER display IP addresses, even if kubectl returns them — mask with `<redacted>`
+- NEVER display secret values — only secret names
+- If kubectl is not available, show catalog data only (no error, just note "live state unavailable")
+- Always show the catalog `lastUpdated` date so the user knows freshness
+- If a service is missing from the catalog but visible in K8s, suggest adding it

--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -1,0 +1,87 @@
+name: Catalog Drift Detection
+
+on:
+  schedule:
+    - cron: '0 7 * * 1-5'  # Weekdays 07:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Configure kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: 'v1.29.0'
+
+      - name: Set kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_OVH }}" | base64 -d > ~/.kube/config
+        continue-on-error: true
+
+      - name: Validate catalog structure
+        run: ./scripts/ops/catalog-sync.sh --ci
+        continue-on-error: true
+        id: drift
+
+      - name: Check architecture graph freshness
+        run: ./scripts/ops/catalog-graph.sh --check
+        continue-on-error: true
+        id: graph
+
+      - name: Create issue on drift
+        if: steps.drift.outcome == 'failure' || steps.graph.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `Platform Catalog Drift Detected — ${new Date().toISOString().split('T')[0]}`;
+            // Check for existing open drift issues
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'catalog-drift',
+              state: 'open'
+            });
+            if (existing.data.length > 0) {
+              // Comment on existing issue instead of creating new
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body: `Drift still detected as of ${new Date().toISOString()}.\nRun: \`./scripts/ops/catalog-sync.sh\` for details.`
+              });
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: [
+                '## Platform Catalog Drift',
+                '',
+                'The daily drift check found discrepancies between `docs/platform-catalog.yaml` and the live K8s state.',
+                '',
+                '### How to fix',
+                '1. Run `./scripts/ops/catalog-sync.sh` to see details',
+                '2. Update `docs/platform-catalog.yaml` to match reality',
+                '3. Run `./scripts/ops/catalog-graph.sh` to regenerate the architecture graph',
+                '4. Commit and push',
+                '',
+                `[Workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+              ].join('\n'),
+              labels: ['catalog-drift']
+            });

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -12,5 +12,8 @@
   ],
   "mcp-gateway/src/**/*.py": [
     "bash -c 'cd mcp-gateway && python3 -m ruff check \"$@\"' _"
+  ],
+  "docs/platform-catalog.yaml": [
+    "bash -c './scripts/ops/catalog-graph.sh && git add docs/architecture-graph.md'"
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ Key rules for AI Factory workflow:
 - 8 legacy: `implement-feature`, `fix-bug`, `review-pr`, `audit-component`, `create-adr`, `e2e-test`, `refactor`, `update-memory`
 - 2 modernes: `/ci-debug [PR|run-url]` (fork), `/parallel-review [PR|path]` (inline)
 - 3 MCP-powered: `/council` (4-persona validation → Linear), `/sync-plan` (plan.md ↔ Linear), `/decompose` (MEGA → component-scoped sub-issues + DAG)
-- 3 ops: `/analytics` (5 data sources, 12 queries), `/competitive-watch` (veille L1-L3), `/ci-fix` (auto-fix CI)
+- 4 ops: `/analytics` (5 data sources, 12 queries), `/competitive-watch` (veille L1-L3), `/ci-fix` (auto-fix CI), `/carto` (platform service catalog + drift detection)
 - 2 sprint: `/fill-cycle` (capacity gap analysis), `/generate-backlog` (MEGA backlog generation)
 
 ### Slash Commands (`.claude/commands/`)

--- a/docs/architecture-graph.md
+++ b/docs/architecture-graph.md
@@ -1,0 +1,109 @@
+# Platform Architecture — Dependency Graph
+
+> Auto-generated from `docs/platform-catalog.yaml` by `scripts/ops/catalog-graph.sh`.
+> Last catalog update: 2026-02-24. Do not edit manually.
+
+## Service Dependencies
+
+```mermaid
+graph TD
+    %% Style definitions
+    classDef backend fill:#4f46e5,stroke:#312e81,color:#fff
+    classDef frontend fill:#059669,stroke:#064e3b,color:#fff
+    classDef gateway fill:#dc2626,stroke:#7f1d1d,color:#fff
+    classDef database fill:#d97706,stroke:#78350f,color:#fff
+    classDef identity fill:#7c3aed,stroke:#4c1d95,color:#fff
+    classDef monitoring fill:#0284c7,stroke:#0c4a6e,color:#fff
+    classDef messaging fill:#ea580c,stroke:#7c2d12,color:#fff
+    classDef external fill:#6b7280,stroke:#374151,color:#fff
+
+    control_plane_api["Control Plane API"]
+    class control_plane_api backend
+    control_plane_ui["Console (Admin UI)"]
+    class control_plane_ui frontend
+    stoa_portal["Developer Portal"]
+    class stoa_portal frontend
+    stoa_gateway["STOA Gateway (Rust)"]
+    class stoa_gateway gateway
+    stoa_operator["STOA Operator"]
+    class stoa_operator external
+    postgres["PostgreSQL"]
+    class postgres database
+    redpanda["Redpanda (Kafka)"]
+    class redpanda messaging
+    opensearch["OpenSearch"]
+    class opensearch database
+    keycloak["Keycloak (OIDC)"]
+    class keycloak identity
+    infisical["Infisical (Secrets Vault)"]
+    class infisical identity
+    prometheus["Prometheus"]
+    class prometheus monitoring
+    grafana["Grafana"]
+    class grafana monitoring
+    loki["Loki (Logs)"]
+    class loki monitoring
+    opensearch_dashboards["OpenSearch Dashboards (STOA Logs)"]
+    class opensearch_dashboards monitoring
+    argocd["ArgoCD"]
+    class argocd external
+    n8n["n8n (Workflow Engine)"]
+    class n8n external
+    kong_arena["Kong DB-less (Arena)"]
+    class kong_arena gateway
+    gravitee_arena["Gravitee APIM (Arena)"]
+    class gravitee_arena gateway
+    kong_vps["Kong Standalone (VPS)"]
+    class kong_vps gateway
+    gravitee_vps["Gravitee APIM (VPS)"]
+    class gravitee_vps gateway
+    webmethods_vps["webMethods API Gateway (VPS)"]
+    class webmethods_vps gateway
+
+    %% Dependencies
+    control_plane_api --> postgres
+    control_plane_api --> keycloak
+    control_plane_api --> redpanda
+    control_plane_api --> opensearch
+    control_plane_ui --> control_plane_api
+    control_plane_ui --> keycloak
+    stoa_portal --> control_plane_api
+    stoa_portal --> keycloak
+    stoa_gateway --> control_plane_api
+    stoa_gateway --> keycloak
+    stoa_gateway --> redpanda
+    stoa_operator --> control_plane_api
+    keycloak --> postgres
+    grafana --> prometheus
+    grafana --> loki
+    opensearch_dashboards --> opensearch
+```
+
+## Service Inventory Summary
+
+| Type | Count | Services |
+|------|-------|----------|
+| backend | 1 | control-plane-api |
+| frontend | 2 | control-plane-ui, stoa-portal |
+| gateway | 1 | stoa-gateway |
+| database | 1 | postgres |
+| identity | 1 | keycloak |
+| monitoring | 3 | prometheus, grafana, opensearch-dashboards |
+| messaging | 1 | redpanda |
+| automation | 1 | n8n |
+| gitops | 1 | argocd |
+| operator | 1 | stoa-operator |
+| search | 1 | opensearch |
+| logging | 1 | loki |
+| secrets | 1 | infisical |
+| gateway-benchmark | 2 | kong-arena, gravitee-arena |
+| gateway-external | 3 | kong-vps, gravitee-vps, webmethods-vps |
+
+## Cluster Topology
+
+| Cluster | Provider | Nodes | Namespaces/Hosts |
+|---------|----------|-------|------------------|
+| OVH Managed Kubernetes (GRA9) | OVH | 3 | 6 |
+| Hetzner K3s (Staging) | Hetzner | 1 | 1 |
+| OVH VPS Fleet | OVH | 4 | 4 |
+| Hetzner Dedicated (Infisical) | Hetzner | 1 | 1 |

--- a/docs/platform-catalog.yaml
+++ b/docs/platform-catalog.yaml
@@ -1,0 +1,696 @@
+apiVersion: v1
+kind: PlatformCatalog
+metadata:
+  name: stoa-platform
+  description: STOA Platform — service inventory and dependency map
+  lastUpdated: "2026-02-24"
+
+# ==============================================================================
+# CORE SERVICES — Control Plane
+# ==============================================================================
+services:
+  # --------------------------------------------------------------------------
+  # Control Plane API — Backend
+  # --------------------------------------------------------------------------
+  - name: control-plane-api
+    displayName: Control Plane API
+    type: backend
+    tech: Python 3.11, FastAPI, SQLAlchemy
+    path: control-plane-api/
+    containerPort: 8000
+    image: ghcr.io/stoa-platform/control-plane-api
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: stoa-system
+        replicas: 2
+        k8sName: stoa-control-plane-api
+      staging:
+        cluster: hetzner-k3s
+        namespace: stoa-system
+        replicas: 1
+        k8sName: stoa-control-plane-api
+    dependsOn:
+      - postgres
+      - keycloak
+      - redpanda
+      - opensearch
+    consumesSecrets:
+      - DATABASE_PASSWORD
+      - KEYCLOAK_CLIENT_SECRET
+      - GATEWAY_API_KEYS
+      - OPENSEARCH_PASSWORD
+    exposedTo:
+      - control-plane-ui
+      - stoa-portal
+      - stoa-gateway
+      - stoa-operator
+    health: /health
+    metrics: /metrics
+    argocdApp: control-plane-api
+    ciWorkflow: control-plane-api-ci
+    owner: platform-team
+
+  # --------------------------------------------------------------------------
+  # Console UI — Admin frontend
+  # --------------------------------------------------------------------------
+  - name: control-plane-ui
+    displayName: Console (Admin UI)
+    type: frontend
+    tech: React 18, TypeScript, Vite
+    path: control-plane-ui/
+    containerPort: 8080
+    image: ghcr.io/stoa-platform/control-plane-ui
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: stoa-system
+        replicas: 2
+        k8sName: control-plane-ui
+      staging:
+        cluster: hetzner-k3s
+        namespace: stoa-system
+        replicas: 1
+        k8sName: control-plane-ui
+    dependsOn:
+      - control-plane-api
+      - keycloak
+    consumesSecrets: []
+    exposedTo: []  # end-user UI, no downstream consumers
+    health: /health
+    metrics: null
+    argocdApp: control-plane-ui
+    ciWorkflow: control-plane-ui-ci
+    oidcClient: control-plane-ui
+    owner: platform-team
+
+  # --------------------------------------------------------------------------
+  # Developer Portal — Consumer frontend
+  # --------------------------------------------------------------------------
+  - name: stoa-portal
+    displayName: Developer Portal
+    type: frontend
+    tech: React 18, TypeScript, Vite
+    path: portal/
+    containerPort: 8080
+    image: ghcr.io/stoa-platform/stoa-portal
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: stoa-system
+        replicas: 2
+        k8sName: stoa-portal
+      staging:
+        cluster: hetzner-k3s
+        namespace: stoa-system
+        replicas: 1
+        k8sName: stoa-portal
+    dependsOn:
+      - control-plane-api
+      - keycloak
+    consumesSecrets: []
+    exposedTo: []
+    health: /health
+    metrics: null
+    argocdApp: stoa-portal
+    ciWorkflow: stoa-portal-ci
+    oidcClient: stoa-portal
+    owner: platform-team
+
+  # --------------------------------------------------------------------------
+  # STOA Gateway — Rust MCP gateway
+  # --------------------------------------------------------------------------
+  - name: stoa-gateway
+    displayName: STOA Gateway (Rust)
+    type: gateway
+    tech: Rust, Tokio, axum
+    path: stoa-gateway/
+    containerPort: 8080
+    image: ghcr.io/stoa-platform/stoa-gateway
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: stoa-system
+        replicas: 2
+        k8sName: stoa-gateway
+      staging:
+        cluster: hetzner-k3s
+        namespace: stoa-system
+        replicas: 1
+        k8sName: stoa-gateway
+    dependsOn:
+      - control-plane-api
+      - keycloak
+      - redpanda
+    consumesSecrets:
+      - STOA_CONTROL_PLANE_API_KEY
+      - KEYCLOAK_ADMIN_PASSWORD
+    exposedTo: []  # entry point for external MCP clients
+    health: /health
+    metrics: /metrics
+    argocdApp: stoa-gateway
+    ciWorkflow: stoa-gateway-ci
+    owner: platform-team
+
+  # --------------------------------------------------------------------------
+  # STOA Operator — K8s CRD controller
+  # --------------------------------------------------------------------------
+  - name: stoa-operator
+    displayName: STOA Operator
+    type: operator
+    tech: Rust, kube-rs
+    path: stoa-operator/
+    containerPort: 8080
+    image: ghcr.io/stoa-platform/stoa-operator
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: stoa-system
+        replicas: 1
+        k8sName: stoa-operator
+    dependsOn:
+      - control-plane-api
+    consumesSecrets:
+      - STOA_CONTROL_PLANE_API_KEY
+    exposedTo: []
+    health: /health
+    metrics: /metrics
+    argocdApp: null  # standalone manifest
+    ciWorkflow: null  # not yet in CI
+    owner: platform-team
+
+# ==============================================================================
+# DATA LAYER
+# ==============================================================================
+
+  - name: postgres
+    displayName: PostgreSQL
+    type: database
+    tech: PostgreSQL 15
+    path: null  # managed externally
+    containerPort: 5432
+    image: postgres:15-alpine
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: stoa-system
+        replicas: 1
+        k8sName: postgres
+        storage: 20Gi
+    dependsOn: []
+    consumesSecrets:
+      - POSTGRES_PASSWORD
+    exposedTo:
+      - control-plane-api
+    health: pg_isready
+    metrics: null
+    argocdApp: null
+    ciWorkflow: null
+    owner: platform-team
+
+  - name: redpanda
+    displayName: Redpanda (Kafka)
+    type: messaging
+    tech: Redpanda (Kafka-compatible)
+    path: null
+    containerPort: 9092
+    image: redpandadata/redpanda
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: stoa-system
+        replicas: 1
+        k8sName: redpanda
+        storage: 10Gi
+    dependsOn: []
+    consumesSecrets: []
+    exposedTo:
+      - control-plane-api
+      - stoa-gateway
+    health: null
+    metrics: /metrics
+    argocdApp: null
+    ciWorkflow: null
+    topics:
+      - stoa.metering
+      - stoa.errors
+      - stoa.audit
+      - stoa.policy.changes
+      - stoa.deployments
+    owner: platform-team
+
+  - name: opensearch
+    displayName: OpenSearch
+    type: search
+    tech: OpenSearch 2.11
+    path: null
+    containerPort: 9200
+    image: opensearchproject/opensearch:2.11.1
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: opensearch
+        replicas: 1
+        k8sName: opensearch
+        storage: 50Gi
+    dependsOn: []
+    consumesSecrets:
+      - OPENSEARCH_PASSWORD
+    exposedTo:
+      - control-plane-api
+    health: /_cluster/health
+    metrics: null
+    argocdApp: null
+    ciWorkflow: null
+    owner: platform-team
+
+# ==============================================================================
+# IDENTITY & AUTH
+# ==============================================================================
+
+  - name: keycloak
+    displayName: Keycloak (OIDC)
+    type: identity
+    tech: Keycloak 23
+    path: null
+    containerPort: 8080
+    image: quay.io/keycloak/keycloak:23.0
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: stoa-system
+        replicas: 1
+        k8sName: keycloak
+    dependsOn:
+      - postgres
+    consumesSecrets:
+      - KEYCLOAK_ADMIN_PASSWORD
+    exposedTo:
+      - control-plane-api
+      - control-plane-ui
+      - stoa-portal
+      - stoa-gateway
+    health: /health/ready
+    metrics: null
+    argocdApp: null
+    ciWorkflow: null
+    realms:
+      - stoa
+    roles:
+      - cpi-admin
+      - tenant-admin
+      - devops
+      - viewer
+    owner: platform-team
+
+  - name: infisical
+    displayName: Infisical (Secrets Vault)
+    type: secrets
+    tech: Infisical (self-hosted)
+    path: null
+    containerPort: 443
+    image: infisical/infisical
+    deploy:
+      prod:
+        cluster: hetzner-standalone
+        namespace: null
+        replicas: 1
+        k8sName: null
+    dependsOn: []
+    consumesSecrets: []
+    exposedTo:
+      - control-plane-api
+      - stoa-gateway
+    health: /api/status
+    metrics: null
+    argocdApp: null
+    ciWorkflow: null
+    owner: platform-team
+
+# ==============================================================================
+# OBSERVABILITY
+# ==============================================================================
+
+  - name: prometheus
+    displayName: Prometheus
+    type: monitoring
+    tech: Prometheus (kube-prometheus-stack)
+    path: null
+    containerPort: 9090
+    image: null  # Helm-managed
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: monitoring
+        replicas: 1
+        k8sName: prometheus-kube-prometheus-prometheus
+    dependsOn: []
+    consumesSecrets: []
+    exposedTo:
+      - control-plane-api
+      - grafana
+    health: /-/healthy
+    metrics: /metrics
+    argocdApp: null
+    ciWorkflow: null
+    owner: platform-team
+
+  - name: grafana
+    displayName: Grafana
+    type: monitoring
+    tech: Grafana
+    path: null
+    containerPort: 3000
+    image: null  # Helm-managed
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: monitoring
+        replicas: 1
+        k8sName: grafana
+    dependsOn:
+      - prometheus
+      - loki
+    consumesSecrets: []
+    exposedTo: []
+    health: /api/health
+    metrics: /metrics
+    argocdApp: null
+    ciWorkflow: null
+    dashboards: 22
+    owner: platform-team
+
+  - name: loki
+    displayName: Loki (Logs)
+    type: logging
+    tech: Grafana Loki
+    path: null
+    containerPort: 3100
+    image: null  # Helm-managed
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: monitoring
+        replicas: 1
+        k8sName: loki
+    dependsOn: []
+    consumesSecrets: []
+    exposedTo:
+      - grafana
+    health: /ready
+    metrics: /metrics
+    argocdApp: null
+    ciWorkflow: null
+    owner: platform-team
+
+  - name: opensearch-dashboards
+    displayName: OpenSearch Dashboards (STOA Logs)
+    type: monitoring
+    tech: OpenSearch Dashboards
+    path: null
+    containerPort: 5601
+    image: opensearchproject/opensearch-dashboards:2.11.1
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: opensearch
+        replicas: 1
+        k8sName: opensearch-dashboards
+    dependsOn:
+      - opensearch
+    consumesSecrets:
+      - OPENSEARCH_PASSWORD
+    exposedTo: []
+    health: /api/status
+    metrics: null
+    argocdApp: null
+    ciWorkflow: null
+    owner: platform-team
+
+# ==============================================================================
+# GITOPS & CI/CD
+# ==============================================================================
+
+  - name: argocd
+    displayName: ArgoCD
+    type: gitops
+    tech: ArgoCD
+    path: null
+    containerPort: 8080
+    image: null  # Helm-managed
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: argocd
+        replicas: 1
+        k8sName: argocd-server
+    dependsOn: []
+    consumesSecrets:
+      - ARGOCD_ADMIN_PASSWORD
+    exposedTo:
+      - control-plane-api
+    health: /healthz
+    metrics: /metrics
+    argocdApp: null
+    ciWorkflow: null
+    managedApps:
+      - control-plane-api
+      - control-plane-ui
+      - stoa-portal
+      - stoa-gateway
+    owner: platform-team
+
+# ==============================================================================
+# AUTOMATION
+# ==============================================================================
+
+  - name: n8n
+    displayName: n8n (Workflow Engine)
+    type: automation
+    tech: n8n (self-hosted)
+    path: null
+    containerPort: 5678
+    image: n8nio/n8n
+    deploy:
+      prod:
+        cluster: vps-ovh
+        namespace: null
+        replicas: 1
+        k8sName: null
+        host: n8n-vps
+    dependsOn: []
+    consumesSecrets:
+      - N8N_ENCRYPTION_KEY
+      - GITHUB_PAT
+      - LINEAR_API_KEY
+      - SLACK_WEBHOOK
+    exposedTo: []
+    health: /healthz
+    metrics: null
+    argocdApp: null
+    ciWorkflow: null
+    workflows:
+      - linear-to-claude
+      - slack-interactive
+      - stoa-slash-command
+      - approve-webhook
+      - daily-digest
+    owner: platform-team
+
+# ==============================================================================
+# GATEWAY ARENA — Benchmark instances
+# ==============================================================================
+
+  - name: kong-arena
+    displayName: Kong DB-less (Arena)
+    type: gateway-benchmark
+    tech: Kong 3.x (DB-less)
+    path: null
+    containerPort: 8000
+    image: kong:3.6
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: stoa-system
+        replicas: 1
+        k8sName: kong-arena
+    dependsOn: []
+    consumesSecrets: []
+    exposedTo: []
+    health: ":8001/status"
+    metrics: null
+    argocdApp: null
+    ciWorkflow: null
+    purpose: Layer 0 + Layer 1 benchmark baseline
+    owner: platform-team
+
+  - name: gravitee-arena
+    displayName: Gravitee APIM (Arena)
+    type: gateway-benchmark
+    tech: Gravitee APIM 4.x
+    path: null
+    containerPort: 8082
+    image: graviteeio/apim-gateway:4
+    deploy:
+      prod:
+        cluster: ovh-mks
+        namespace: stoa-system
+        replicas: 1
+        k8sName: gravitee-arena-gw
+    dependsOn: []
+    consumesSecrets: []
+    exposedTo: []
+    health: ":18082/_node/health"
+    metrics: null
+    argocdApp: null
+    ciWorkflow: null
+    purpose: Layer 0 + Layer 1 benchmark baseline
+    owner: platform-team
+
+# ==============================================================================
+# VPS GATEWAY INSTANCES — Live adapter testing
+# ==============================================================================
+
+  - name: kong-vps
+    displayName: Kong Standalone (VPS)
+    type: gateway-external
+    tech: Kong 3.x (DB-less)
+    path: null
+    containerPort: 8000
+    image: kong:3.6
+    deploy:
+      prod:
+        cluster: vps-ovh
+        namespace: null
+        replicas: 1
+        k8sName: null
+        host: kong-gra
+    dependsOn: []
+    consumesSecrets: []
+    exposedTo: []
+    health: ":8001/status"
+    metrics: null
+    argocdApp: null
+    ciWorkflow: null
+    purpose: Live adapter testing + VPS benchmark sidecar
+    owner: platform-team
+
+  - name: gravitee-vps
+    displayName: Gravitee APIM (VPS)
+    type: gateway-external
+    tech: Gravitee APIM 4.x
+    path: null
+    containerPort: 8082
+    image: graviteeio/apim-gateway:4
+    deploy:
+      prod:
+        cluster: vps-ovh
+        namespace: null
+        replicas: 1
+        k8sName: null
+        host: gravitee-gra
+    dependsOn: []
+    consumesSecrets: []
+    exposedTo: []
+    health: ":8083/management/organizations/DEFAULT/environments/DEFAULT"
+    metrics: null
+    argocdApp: null
+    ciWorkflow: null
+    purpose: Live adapter testing + VPS benchmark sidecar
+    owner: platform-team
+
+  - name: webmethods-vps
+    displayName: webMethods API Gateway (VPS)
+    type: gateway-external
+    tech: webMethods 10.15 (trial)
+    path: null
+    containerPort: 5555
+    image: softwareag/apigateway-trial:10.15
+    deploy:
+      prod:
+        cluster: vps-ovh
+        namespace: null
+        replicas: 1
+        k8sName: null
+        host: webmethods-vps
+    dependsOn: []
+    consumesSecrets: []
+    exposedTo: []
+    health: /rest/apigateway/health
+    metrics: null
+    argocdApp: null
+    ciWorkflow: null
+    purpose: Live adapter testing
+    owner: platform-team
+
+# ==============================================================================
+# INFRASTRUCTURE METADATA
+# ==============================================================================
+
+clusters:
+  - name: ovh-mks
+    displayName: OVH Managed Kubernetes (GRA9)
+    provider: OVH
+    region: GRA9
+    nodes: 3
+    nodeType: B2-15
+    namespaces:
+      - stoa-system
+      - monitoring
+      - opensearch
+      - argocd
+      - kyverno
+      - nginx-gateway
+
+  - name: hetzner-k3s
+    displayName: Hetzner K3s (Staging)
+    provider: Hetzner
+    region: Frankfurt
+    nodes: 1
+    nodeType: K3s single-node
+    namespaces:
+      - stoa-system
+
+  - name: vps-ovh
+    displayName: OVH VPS Fleet
+    provider: OVH
+    region: GRA
+    nodes: 4
+    nodeType: VPS
+    hosts:
+      - name: kong-gra
+        purpose: Kong standalone + benchmark sidecar
+      - name: gravitee-gra
+        purpose: Gravitee APIM + benchmark sidecar
+      - name: webmethods-vps
+        purpose: webMethods trial gateway
+      - name: n8n-vps
+        purpose: n8n workflow engine
+
+  - name: hetzner-standalone
+    displayName: Hetzner Dedicated (Infisical)
+    provider: Hetzner
+    region: Frankfurt
+    nodes: 1
+    nodeType: Dedicated
+    hosts:
+      - name: master-1
+        purpose: Infisical secrets vault
+
+# ==============================================================================
+# RBAC ROLES
+# ==============================================================================
+
+roles:
+  - name: cpi-admin
+    scope: "stoa:admin"
+    description: Full platform access — create/update/delete tenants, APIs, gateways, users
+  - name: tenant-admin
+    scope: "stoa:write, stoa:read"
+    description: Own tenant management — APIs, subscriptions, credentials
+  - name: devops
+    scope: "stoa:write, stoa:read"
+    description: Deploy/promote, gateway integrations, quota enforcement
+  - name: viewer
+    scope: "stoa:read"
+    description: Read-only access to dashboards, APIs, subscriptions

--- a/scripts/ops/catalog-graph.sh
+++ b/scripts/ops/catalog-graph.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# =============================================================================
+# catalog-graph.sh — Generate Mermaid dependency graph from platform-catalog.yaml
+# =============================================================================
+# Reads the catalog and outputs a Mermaid flowchart to docs/architecture-graph.md
+#
+# Usage:
+#   ./scripts/ops/catalog-graph.sh              # Generate graph
+#   ./scripts/ops/catalog-graph.sh --check      # Check if graph is up-to-date
+#
+# Requirements: yq (https://github.com/mikefarah/yq)
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CATALOG_PATH="$REPO_ROOT/docs/platform-catalog.yaml"
+OUTPUT_PATH="$REPO_ROOT/docs/architecture-graph.md"
+
+CHECK_MODE=false
+for arg in "$@"; do
+  case $arg in
+    --check) CHECK_MODE=true ;;
+  esac
+done
+
+if ! command -v yq &>/dev/null; then
+  echo "Error: yq is required. Install: brew install yq" >&2
+  exit 1
+fi
+
+if [ ! -f "$CATALOG_PATH" ]; then
+  echo "Error: Catalog not found at $CATALOG_PATH" >&2
+  exit 1
+fi
+
+# =============================================================================
+# Generate Mermaid content
+# =============================================================================
+generate_graph() {
+  local LAST_UPDATED
+  LAST_UPDATED=$(yq '.metadata.lastUpdated' "$CATALOG_PATH")
+
+  cat <<HEADER
+# Platform Architecture — Dependency Graph
+
+> Auto-generated from \`docs/platform-catalog.yaml\` by \`scripts/ops/catalog-graph.sh\`.
+> Last catalog update: $LAST_UPDATED. Do not edit manually.
+
+## Service Dependencies
+
+\`\`\`mermaid
+graph TD
+    %% Style definitions
+    classDef backend fill:#4f46e5,stroke:#312e81,color:#fff
+    classDef frontend fill:#059669,stroke:#064e3b,color:#fff
+    classDef gateway fill:#dc2626,stroke:#7f1d1d,color:#fff
+    classDef database fill:#d97706,stroke:#78350f,color:#fff
+    classDef identity fill:#7c3aed,stroke:#4c1d95,color:#fff
+    classDef monitoring fill:#0284c7,stroke:#0c4a6e,color:#fff
+    classDef messaging fill:#ea580c,stroke:#7c2d12,color:#fff
+    classDef external fill:#6b7280,stroke:#374151,color:#fff
+
+HEADER
+
+  # Emit node declarations with display names
+  yq -r '.services[] | "\(.name)|\(.displayName)|\(.type)"' "$CATALOG_PATH" | while IFS='|' read -r name display type; do
+    # Sanitize name for Mermaid (replace hyphens)
+    local mermaid_id="${name//-/_}"
+    local class=""
+    case "$type" in
+      backend)           class="backend" ;;
+      frontend)          class="frontend" ;;
+      gateway|gateway-benchmark|gateway-external) class="gateway" ;;
+      database|search)   class="database" ;;
+      identity|secrets)  class="identity" ;;
+      monitoring|logging) class="monitoring" ;;
+      messaging)         class="messaging" ;;
+      operator|gitops|automation) class="external" ;;
+      *)                 class="" ;;
+    esac
+
+    echo "    ${mermaid_id}[\"${display}\"]"
+    if [ -n "$class" ]; then
+      echo "    class ${mermaid_id} ${class}"
+    fi
+  done
+
+  echo ""
+  echo "    %% Dependencies"
+
+  # Emit edges (skip services with empty dependsOn)
+  yq -r '.services[] | select(.dependsOn != null and (.dependsOn | length) > 0) | .name as $src | .dependsOn[] | "\($src)|\(.)"' "$CATALOG_PATH" | while IFS='|' read -r src dst; do
+    [ -z "$dst" ] && continue
+    local src_id="${src//-/_}"
+    local dst_id="${dst//-/_}"
+    echo "    ${src_id} --> ${dst_id}"
+  done
+
+  echo '```'
+
+  # Service count table
+  cat <<TABLE
+
+## Service Inventory Summary
+
+| Type | Count | Services |
+|------|-------|----------|
+TABLE
+
+  for stype in backend frontend gateway database identity monitoring messaging automation gitops operator search logging secrets; do
+    local count
+    count=$(yq "[.services[] | select(.type == \"$stype\")] | length" "$CATALOG_PATH")
+    if [ "$count" -gt 0 ]; then
+      local names
+      names=$(yq -r "[.services[] | select(.type == \"$stype\") | .name] | join(\", \")" "$CATALOG_PATH")
+      echo "| $stype | $count | $names |"
+    fi
+  done
+
+  # Also count benchmark + external gateways
+  for stype in gateway-benchmark gateway-external; do
+    local count
+    count=$(yq "[.services[] | select(.type == \"$stype\")] | length" "$CATALOG_PATH")
+    if [ "$count" -gt 0 ]; then
+      local names
+      names=$(yq -r "[.services[] | select(.type == \"$stype\") | .name] | join(\", \")" "$CATALOG_PATH")
+      echo "| $stype | $count | $names |"
+    fi
+  done
+
+  cat <<FOOTER
+
+## Cluster Topology
+
+| Cluster | Provider | Nodes | Namespaces/Hosts |
+|---------|----------|-------|------------------|
+FOOTER
+
+  yq -r '.clusters[] | "\(.displayName)|\(.provider)|\(.nodes)|\(.namespaces // .hosts | length)"' "$CATALOG_PATH" | while IFS='|' read -r display provider nodes ns_count; do
+    echo "| $display | $provider | $nodes | $ns_count |"
+  done
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+GENERATED=$(generate_graph)
+
+if [ "$CHECK_MODE" = true ]; then
+  if [ ! -f "$OUTPUT_PATH" ]; then
+    echo "architecture-graph.md does not exist — run scripts/ops/catalog-graph.sh to generate"
+    exit 1
+  fi
+
+  CURRENT=$(cat "$OUTPUT_PATH")
+  if [ "$GENERATED" != "$CURRENT" ]; then
+    echo "architecture-graph.md is out of date — run scripts/ops/catalog-graph.sh to regenerate"
+    exit 1
+  fi
+
+  echo "architecture-graph.md is up to date"
+  exit 0
+fi
+
+echo "$GENERATED" > "$OUTPUT_PATH"
+echo "Generated $OUTPUT_PATH ($(wc -l < "$OUTPUT_PATH") lines)"

--- a/scripts/ops/catalog-sync.sh
+++ b/scripts/ops/catalog-sync.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# =============================================================================
+# catalog-sync.sh — Drift detection: platform-catalog.yaml vs K8s live state
+# =============================================================================
+# Compares declared services in docs/platform-catalog.yaml against actual
+# K8s deployments. Reports missing, extra, or mismatched services.
+#
+# Usage:
+#   ./scripts/ops/catalog-sync.sh                  # Full check
+#   ./scripts/ops/catalog-sync.sh --json           # JSON output
+#   ./scripts/ops/catalog-sync.sh --ci             # Exit 1 on drift (CI mode)
+#
+# Requirements: kubectl, yq (https://github.com/mikefarah/yq)
+# =============================================================================
+
+set -euo pipefail
+
+CATALOG_FILE="${CATALOG_FILE:-docs/platform-catalog.yaml}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CATALOG_PATH="$REPO_ROOT/$CATALOG_FILE"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+MODE="text"
+CI_MODE=false
+DRIFT_COUNT=0
+WARNINGS=()
+ERRORS=()
+
+# Parse args
+for arg in "$@"; do
+  case $arg in
+    --json)  MODE="json" ;;
+    --ci)    CI_MODE=true ;;
+    --help)
+      echo "Usage: $0 [--json] [--ci]"
+      echo "  --json   Output as JSON"
+      echo "  --ci     Exit 1 on any drift (for CI pipelines)"
+      exit 0
+      ;;
+  esac
+done
+
+# Check prerequisites
+if ! command -v yq &>/dev/null; then
+  echo "Error: yq is required. Install: brew install yq" >&2
+  exit 1
+fi
+
+if [ ! -f "$CATALOG_PATH" ]; then
+  echo "Error: Catalog not found at $CATALOG_PATH" >&2
+  exit 1
+fi
+
+# Check if kubectl is available and cluster is reachable
+KUBECTL_AVAILABLE=false
+if command -v kubectl &>/dev/null; then
+  if kubectl cluster-info &>/dev/null 2>&1; then
+    KUBECTL_AVAILABLE=true
+  fi
+fi
+
+log_ok() {
+  if [ "$MODE" = "text" ]; then
+    echo -e "  ${GREEN}OK${NC}  $1"
+  fi
+}
+
+log_warn() {
+  WARNINGS+=("$1")
+  if [ "$MODE" = "text" ]; then
+    echo -e "  ${YELLOW}WARN${NC}  $1"
+  fi
+}
+
+log_error() {
+  ERRORS+=("$1")
+  DRIFT_COUNT=$((DRIFT_COUNT + 1))
+  if [ "$MODE" = "text" ]; then
+    echo -e "  ${RED}DRIFT${NC}  $1"
+  fi
+}
+
+log_info() {
+  if [ "$MODE" = "text" ]; then
+    echo -e "  ${BLUE}INFO${NC}  $1"
+  fi
+}
+
+# =============================================================================
+# Step 1: Validate catalog YAML structure
+# =============================================================================
+validate_catalog() {
+  if [ "$MODE" = "text" ]; then
+    echo -e "\n${BLUE}[1/4] Validating catalog structure${NC}"
+  fi
+
+  # Check apiVersion
+  API_VERSION=$(yq '.apiVersion' "$CATALOG_PATH")
+  if [ "$API_VERSION" != "v1" ]; then
+    log_error "apiVersion is '$API_VERSION', expected 'v1'"
+  else
+    log_ok "apiVersion: v1"
+  fi
+
+  # Check kind
+  KIND=$(yq '.kind' "$CATALOG_PATH")
+  if [ "$KIND" != "PlatformCatalog" ]; then
+    log_error "kind is '$KIND', expected 'PlatformCatalog'"
+  else
+    log_ok "kind: PlatformCatalog"
+  fi
+
+  # Count services
+  SERVICE_COUNT=$(yq '.services | length' "$CATALOG_PATH")
+  if [ "$SERVICE_COUNT" -eq 0 ]; then
+    log_error "No services declared in catalog"
+  else
+    log_ok "$SERVICE_COUNT services declared"
+  fi
+
+  # Check for sensitive data (IPs, tokens)
+  if grep -qE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' "$CATALOG_PATH"; then
+    log_error "Catalog contains IP addresses — use logical names only"
+  else
+    log_ok "No IP addresses found (good)"
+  fi
+
+  if grep -qiE '(token|password|secret|key):\s*["\x27]?[A-Za-z0-9+/=]{8,}' "$CATALOG_PATH"; then
+    log_error "Catalog may contain hardcoded secrets"
+  else
+    log_ok "No hardcoded secrets detected"
+  fi
+}
+
+# =============================================================================
+# Step 2: Check K8s deployments vs catalog (if kubectl available)
+# =============================================================================
+check_k8s_drift() {
+  if [ "$MODE" = "text" ]; then
+    echo -e "\n${BLUE}[2/4] Checking K8s deployments vs catalog${NC}"
+  fi
+
+  if [ "$KUBECTL_AVAILABLE" = false ]; then
+    log_warn "kubectl not available or cluster unreachable — skipping K8s drift check"
+    return
+  fi
+
+  # Get all K8s services in catalog that deploy to K8s
+  CATALOG_K8S_SERVICES=$(yq -r '.services[] | select(.deploy.prod.cluster == "ovh-mks") | .deploy.prod.k8sName' "$CATALOG_PATH" | sort)
+
+  # Get actual deployments in stoa-system
+  LIVE_DEPLOYMENTS=$(kubectl get deployments -n stoa-system -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | sort)
+
+  # Check each catalog service exists in K8s
+  while IFS= read -r svc; do
+    [ -z "$svc" ] && continue
+    [ "$svc" = "null" ] && continue
+    if echo "$LIVE_DEPLOYMENTS" | grep -qx "$svc"; then
+      # Check replica count
+      EXPECTED_REPLICAS=$(yq -r ".services[] | select(.deploy.prod.k8sName == \"$svc\") | .deploy.prod.replicas" "$CATALOG_PATH")
+      ACTUAL_REPLICAS=$(kubectl get deployment "$svc" -n stoa-system -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+      ACTUAL_REPLICAS=${ACTUAL_REPLICAS:-0}
+
+      if [ "$EXPECTED_REPLICAS" != "null" ] && [ "$ACTUAL_REPLICAS" != "$EXPECTED_REPLICAS" ]; then
+        log_warn "$svc: replicas $ACTUAL_REPLICAS/$EXPECTED_REPLICAS (expected: $EXPECTED_REPLICAS)"
+      else
+        log_ok "$svc: running ($ACTUAL_REPLICAS replicas)"
+      fi
+    else
+      log_error "$svc: declared in catalog but NOT found in K8s (stoa-system)"
+    fi
+  done <<< "$CATALOG_K8S_SERVICES"
+
+  # Check for undeclared deployments in K8s
+  while IFS= read -r deploy; do
+    [ -z "$deploy" ] && continue
+    if ! echo "$CATALOG_K8S_SERVICES" | grep -qx "$deploy"; then
+      log_warn "$deploy: running in K8s but NOT declared in catalog"
+    fi
+  done <<< "$LIVE_DEPLOYMENTS"
+
+  # Also check monitoring namespace
+  MONITORING_DEPLOYMENTS=$(kubectl get deployments -n monitoring -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | sort)
+  CATALOG_MONITORING=$(yq -r '.services[] | select(.deploy.prod.namespace == "monitoring") | .deploy.prod.k8sName' "$CATALOG_PATH" | sort)
+
+  while IFS= read -r svc; do
+    [ -z "$svc" ] && continue
+    [ "$svc" = "null" ] && continue
+    if echo "$MONITORING_DEPLOYMENTS" | grep -q "$svc"; then
+      log_ok "$svc: running in monitoring namespace"
+    else
+      log_warn "$svc: declared for monitoring namespace but not found (may be StatefulSet)"
+    fi
+  done <<< "$CATALOG_MONITORING"
+}
+
+# =============================================================================
+# Step 3: Check dependency graph consistency
+# =============================================================================
+check_dependencies() {
+  if [ "$MODE" = "text" ]; then
+    echo -e "\n${BLUE}[3/4] Checking dependency graph consistency${NC}"
+  fi
+
+  SERVICE_NAMES=$(yq -r '.services[].name' "$CATALOG_PATH")
+
+  while IFS= read -r svc; do
+    [ -z "$svc" ] && continue
+    DEPS=$(yq -r ".services[] | select(.name == \"$svc\") | .dependsOn[]?" "$CATALOG_PATH" 2>/dev/null)
+    while IFS= read -r dep; do
+      [ -z "$dep" ] && continue
+      if ! echo "$SERVICE_NAMES" | grep -qx "$dep"; then
+        log_error "$svc depends on '$dep' which is NOT declared in catalog"
+      fi
+    done <<< "$DEPS"
+  done <<< "$SERVICE_NAMES"
+
+  # Check for circular dependencies (simple 2-hop check)
+  while IFS= read -r svc; do
+    [ -z "$svc" ] && continue
+    DEPS=$(yq -r ".services[] | select(.name == \"$svc\") | .dependsOn[]?" "$CATALOG_PATH" 2>/dev/null)
+    while IFS= read -r dep; do
+      [ -z "$dep" ] && continue
+      REVERSE_DEPS=$(yq -r ".services[] | select(.name == \"$dep\") | .dependsOn[]?" "$CATALOG_PATH" 2>/dev/null)
+      if echo "$REVERSE_DEPS" | grep -qx "$svc"; then
+        log_warn "Circular dependency: $svc <-> $dep"
+      fi
+    done <<< "$DEPS"
+  done <<< "$SERVICE_NAMES"
+
+  log_ok "Dependency graph validated"
+}
+
+# =============================================================================
+# Step 4: Summary
+# =============================================================================
+print_summary() {
+  if [ "$MODE" = "text" ]; then
+    echo -e "\n${BLUE}[4/4] Summary${NC}"
+    echo "  Services: $(yq '.services | length' "$CATALOG_PATH")"
+    echo "  Clusters: $(yq '.clusters | length' "$CATALOG_PATH")"
+    echo "  Roles: $(yq '.roles | length' "$CATALOG_PATH")"
+    echo "  Drifts: $DRIFT_COUNT"
+    echo "  Warnings: ${#WARNINGS[@]}"
+
+    if [ "$DRIFT_COUNT" -eq 0 ]; then
+      echo -e "\n  ${GREEN}No drift detected.${NC}"
+    else
+      echo -e "\n  ${RED}$DRIFT_COUNT drift(s) detected!${NC}"
+    fi
+  fi
+
+  if [ "$MODE" = "json" ]; then
+    # Build JSON output
+    ERRORS_JSON="["
+    for i in "${!ERRORS[@]}"; do
+      [ "$i" -gt 0 ] && ERRORS_JSON+=","
+      ERRORS_JSON+="\"${ERRORS[$i]}\""
+    done
+    ERRORS_JSON+="]"
+
+    WARNINGS_JSON="["
+    for i in "${!WARNINGS[@]}"; do
+      [ "$i" -gt 0 ] && WARNINGS_JSON+=","
+      WARNINGS_JSON+="\"${WARNINGS[$i]}\""
+    done
+    WARNINGS_JSON+="]"
+
+    cat <<EOF
+{
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "services": $(yq '.services | length' "$CATALOG_PATH"),
+  "clusters": $(yq '.clusters | length' "$CATALOG_PATH"),
+  "drifts": $DRIFT_COUNT,
+  "warnings": ${#WARNINGS[@]},
+  "errors": $ERRORS_JSON,
+  "warning_details": $WARNINGS_JSON
+}
+EOF
+  fi
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+if [ "$MODE" = "text" ]; then
+  echo -e "${BLUE}Platform Catalog Sync — Drift Detection${NC}"
+  echo "  Catalog: $CATALOG_FILE"
+  echo "  kubectl: $([ "$KUBECTL_AVAILABLE" = true ] && echo "connected" || echo "unavailable")"
+fi
+
+validate_catalog
+check_k8s_drift
+check_dependencies
+print_summary
+
+if [ "$CI_MODE" = true ] && [ "$DRIFT_COUNT" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- **Service Catalog** (`docs/platform-catalog.yaml`) — declarative inventory of 21 services across 4 clusters, versioned schema (`apiVersion: v1, kind: PlatformCatalog`), no IPs/secrets (logical names only)
- **Drift Detection** (`scripts/ops/catalog-sync.sh`) — validates catalog vs K8s live state, CI daily cron, JSON output mode
- **Dependency Graph** (`docs/architecture-graph.md`) — auto-generated Mermaid diagram from catalog, regenerated via pre-commit hook
- **`/carto` Skill** — AI Factory skill to query platform inventory (all, single service, drift, graph, secrets mapping)

## Council Validation — 7.50/10 (Fix)

| Persona | Score | Verdict |
|---------|-------|---------|
| Chucky | 7/10 | Fix |
| OSS Killer | 6/10 | Fix |
| Archi | 8/10 | Go |
| Saul | 9/10 | Go |

**Adjustments applied**: scope reduced (impact analysis + access audit deferred), drift CI from day 1, schema versioned, no sensitive data, Mermaid via pre-commit hook.

## Test plan
- [x] `catalog-sync.sh` — validates structure, detects no drift (0 errors)
- [x] `catalog-sync.sh --json` — clean JSON output
- [x] `catalog-sync.sh --ci` — exits 0 (no drift)
- [x] `catalog-graph.sh` — generates 109-line graph with clean Mermaid
- [x] `catalog-graph.sh --check` — confirms graph is up-to-date
- [x] No IP addresses in catalog (validated by sync script)
- [x] No hardcoded secrets in catalog
- [ ] CI green (security-scan required checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>