### PR TITLE
fix(portal): make number formatting tests locale-agnostic

### DIFF
--- a/portal/src/components/contracts/DisableBindingModal.test.tsx
+++ b/portal/src/components/contracts/DisableBindingModal.test.tsx
@@ -44,8 +44,8 @@ describe('DisableBindingModal', () => {
   it('shows traffic count formatted with locale separator', () => {
     renderWithProviders(<DisableBindingModal {...defaultProps} />);
 
-    // 1250 formatted with toLocaleString → "1,250" in en-US
-    expect(screen.getByText(/1[,.]?250/)).toBeInTheDocument();
+    // 1250 formatted with toLocaleString → "1,250" (en-US), "1 250" (fr-FR)
+    expect(screen.getByText(/1[\s\u202f,.]?250/)).toBeInTheDocument();
   });
 
   it('shows the endpoint URL', () => {

--- a/portal/src/components/contracts/ProtocolRow.test.tsx
+++ b/portal/src/components/contracts/ProtocolRow.test.tsx
@@ -139,7 +139,7 @@ describe('ProtocolRow', () => {
 
   it('should show traffic stats when enabled and available', () => {
     render(<ProtocolRow {...defaultProps} binding={makeBinding({ traffic_24h: 12345 })} />);
-    expect(screen.getByText(/12,345 req\/24h/)).toBeInTheDocument();
+    expect(screen.getByText(/12[\s\u202f,.]?345 req\/24h/)).toBeInTheDocument();
   });
 
   it('should not show traffic stats when not enabled', () => {


### PR DESCRIPTION
## Summary
- ProtocolRow and DisableBindingModal tests expected en-US comma separators (`12,345`, `1,250`) but `toLocaleString()` produces narrow no-break spaces (U+202F) on French-locale systems
- Use regex character class `[\s\u202f,.]` to match any thousands separator (comma, period, space, narrow no-break space)
- SubscriptionCard was already fixed in a prior commit

## Test plan
- [x] All 1454 portal tests pass locally
- [x] ESLint + Prettier clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)