### PR TITLE
test(api): expand router test coverage for 8 modules (CAB-1448)

### DIFF
--- a/control-plane-api/tests/test_certificates_router.py
+++ b/control-plane-api/tests/test_certificates_router.py
@@ -15,7 +15,6 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Helpers: generate real PEM certificates via the cryptography library
 # ---------------------------------------------------------------------------

--- a/control-plane-api/tests/test_external_mcp_servers_router.py
+++ b/control-plane-api/tests/test_external_mcp_servers_router.py
@@ -14,7 +14,7 @@ Endpoints:
 Auth: get_current_user + _require_admin (cpi-admin or tenant-admin).
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -57,8 +57,8 @@ def _mock_server(**overrides):
         "tenant_id": "acme",
         "tools": [],
         "credential_vault_path": None,
-        "created_at": datetime(2026, 2, 1),
-        "updated_at": datetime(2026, 2, 1),
+        "created_at": datetime(2026, 2, 1, tzinfo=UTC),
+        "updated_at": datetime(2026, 2, 1, tzinfo=UTC),
         "created_by": "admin-user-id",
     }
     for k, v in {**defaults, **overrides}.items():
@@ -77,7 +77,7 @@ def _mock_tool(**overrides):
         "description": "Create a Linear issue",
         "input_schema": {"type": "object"},
         "enabled": True,
-        "synced_at": datetime(2026, 2, 1),
+        "synced_at": datetime(2026, 2, 1, tzinfo=UTC),
     }
     for k, v in {**defaults, **overrides}.items():
         setattr(mock, k, v)
@@ -292,13 +292,9 @@ class TestSyncTools:
             patch(REPO_PATH) as MockRepo,
             patch(MCP_CLIENT_PATH) as MockMCPClient,
         ):
-            MockRepo.return_value.get_by_id = AsyncMock(
-                side_effect=[mock_srv, mock_srv_refreshed]
-            )
+            MockRepo.return_value.get_by_id = AsyncMock(side_effect=[mock_srv, mock_srv_refreshed])
             MockRepo.return_value.sync_tools = AsyncMock(return_value=(1, 0))
-            MockMCPClient.return_value.list_tools = AsyncMock(
-                return_value=[mock_discovered]
-            )
+            MockMCPClient.return_value.list_tools = AsyncMock(return_value=[mock_discovered])
 
             with TestClient(app_with_cpi_admin) as client:
                 response = client.post(f"{BASE}/{server_id}/sync-tools")
@@ -369,9 +365,7 @@ class TestInternalGatewayEndpoint:
             patch("src.routers.external_mcp_servers.settings") as mock_settings,
         ):
             mock_settings.gateway_api_keys_list = ["test_key"]
-            MockRepo.return_value.list_enabled_with_tools = AsyncMock(
-                return_value=[mock_srv]
-            )
+            MockRepo.return_value.list_enabled_with_tools = AsyncMock(return_value=[mock_srv])
             MockVault.return_value.retrieve_credential = AsyncMock(return_value=None)
 
             with TestClient(app_with_cpi_admin) as client:
@@ -383,3 +377,499 @@ class TestInternalGatewayEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert len(data["servers"]) == 1
+
+    def test_internal_endpoint_invalid_key_401(self, app_with_cpi_admin, mock_db_session):
+        """Returns 401 for invalid gateway key."""
+        with patch("src.routers.external_mcp_servers.settings") as mock_settings:
+            mock_settings.gateway_api_keys_list = ["valid_key"]
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get(
+                    INTERNAL_BASE,
+                    headers={"X-Gateway-Key": "wrong_key"},
+                )
+
+        assert response.status_code == 401
+
+    def test_internal_endpoint_no_keys_configured_503(self, app_with_cpi_admin, mock_db_session):
+        """Returns 503 when gateway_api_keys_list is empty."""
+        with patch("src.routers.external_mcp_servers.settings") as mock_settings:
+            mock_settings.gateway_api_keys_list = []
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get(
+                    INTERNAL_BASE,
+                    headers={"X-Gateway-Key": "any"},
+                )
+
+        assert response.status_code == 503
+
+    def test_internal_endpoint_vault_failure_still_returns(self, app_with_cpi_admin, mock_db_session):
+        """Vault failure for credentials doesn't block gateway list."""
+        auth_mock = MagicMock()
+        auth_mock.value = "bearer_token"
+        mock_srv = _mock_server(
+            credential_vault_path="/v1/secret/data/srv-1",
+            auth_type=auth_mock,
+        )
+
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(VAULT_PATH) as MockVault,
+            patch("src.routers.external_mcp_servers.settings") as mock_settings,
+        ):
+            mock_settings.gateway_api_keys_list = ["test_key"]
+            MockRepo.return_value.list_enabled_with_tools = AsyncMock(return_value=[mock_srv])
+            MockVault.return_value.retrieve_credential = AsyncMock(side_effect=Exception("vault down"))
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get(
+                    INTERNAL_BASE,
+                    headers={"X-Gateway-Key": "test_key"},
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["servers"]) == 1
+        assert data["servers"][0]["credentials"] is None
+
+
+# ============ Vault Credential Paths ============
+
+
+class TestVaultCredentials:
+    """Tests for vault credential storage/retrieval across endpoints."""
+
+    def test_create_server_with_vault_credentials(self, app_with_cpi_admin, mock_db_session):
+        """Create server stores credentials in vault."""
+        mock_srv = _mock_server()
+
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(VAULT_PATH) as MockVault,
+        ):
+            MockRepo.return_value.get_by_name = AsyncMock(return_value=None)
+            MockRepo.return_value.create = AsyncMock(return_value=mock_srv)
+            MockVault.return_value.store_credential = AsyncMock(return_value="/v1/secret/data/srv-1")
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(
+                    BASE,
+                    json={
+                        "name": "secure-mcp",
+                        "display_name": "Secure MCP",
+                        "base_url": "https://mcp.secure.dev/sse",
+                        "auth_type": "bearer_token",
+                        "credentials": {"bearer_token": "secret-token"},
+                    },
+                )
+
+        assert response.status_code == 201
+
+    def test_create_server_vault_failure_500(self, app_with_cpi_admin, mock_db_session):
+        """Vault failure during create returns 500."""
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(VAULT_PATH) as MockVault,
+        ):
+            MockRepo.return_value.get_by_name = AsyncMock(return_value=None)
+            MockVault.return_value.store_credential = AsyncMock(side_effect=Exception("vault unavailable"))
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(
+                    BASE,
+                    json={
+                        "name": "secure-mcp",
+                        "display_name": "Secure MCP",
+                        "base_url": "https://mcp.secure.dev/sse",
+                        "auth_type": "bearer_token",
+                        "credentials": {"bearer_token": "secret-token"},
+                    },
+                )
+
+        assert response.status_code == 500
+        assert "credentials" in response.json()["detail"].lower()
+
+    def test_update_server_with_vault_credentials(self, app_with_cpi_admin, mock_db_session):
+        """Update server stores new credentials in vault."""
+        server_id = uuid4()
+        mock_srv = _mock_server(id=server_id)
+
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(VAULT_PATH) as MockVault,
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+            MockRepo.return_value.update = AsyncMock(return_value=mock_srv)
+            MockVault.return_value.store_credential = AsyncMock(return_value="/v1/secret/data/srv")
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.put(
+                    f"{BASE}/{server_id}",
+                    json={"credentials": {"bearer_token": "new-secret"}},
+                )
+
+        assert response.status_code == 200
+
+    def test_update_server_vault_failure_500(self, app_with_cpi_admin, mock_db_session):
+        """Vault failure during update returns 500."""
+        server_id = uuid4()
+        mock_srv = _mock_server(id=server_id)
+
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(VAULT_PATH) as MockVault,
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+            MockVault.return_value.store_credential = AsyncMock(side_effect=Exception("vault down"))
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.put(
+                    f"{BASE}/{server_id}",
+                    json={"credentials": {"bearer_token": "secret"}},
+                )
+
+        assert response.status_code == 500
+        assert "credentials" in response.json()["detail"].lower()
+
+    def test_delete_server_with_vault_cleanup(self, app_with_cpi_admin, mock_db_session):
+        """Delete server cleans up vault credentials."""
+        server_id = uuid4()
+        mock_srv = _mock_server(id=server_id, credential_vault_path="/v1/secret/data/srv")
+
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(VAULT_PATH) as MockVault,
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+            MockRepo.return_value.delete = AsyncMock()
+            MockVault.return_value.delete_credential = AsyncMock()
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.delete(f"{BASE}/{server_id}")
+
+        assert response.status_code == 204
+        MockVault.return_value.delete_credential.assert_awaited_once()
+
+    def test_delete_server_vault_failure_still_deletes(self, app_with_cpi_admin, mock_db_session):
+        """Vault cleanup failure does not block server deletion."""
+        server_id = uuid4()
+        mock_srv = _mock_server(id=server_id, credential_vault_path="/v1/secret/data/srv")
+
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(VAULT_PATH) as MockVault,
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+            MockRepo.return_value.delete = AsyncMock()
+            MockVault.return_value.delete_credential = AsyncMock(side_effect=Exception("vault error"))
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.delete(f"{BASE}/{server_id}")
+
+        assert response.status_code == 204
+
+    def test_test_connection_with_vault_creds(self, app_with_cpi_admin, mock_db_session):
+        """Test connection retrieves credentials from vault."""
+        server_id = uuid4()
+        auth_mock = MagicMock()
+        auth_mock.value = "bearer_token"
+        mock_srv = _mock_server(
+            id=server_id,
+            credential_vault_path="/v1/secret/data/srv",
+            auth_type=auth_mock,
+        )
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.latency_ms = 30
+        mock_result.error = None
+        mock_result.server_info = {}
+        mock_result.tools_discovered = 3
+
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(VAULT_PATH) as MockVault,
+            patch(MCP_CLIENT_PATH) as MockMCPClient,
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+            MockRepo.return_value.update_health_status = AsyncMock()
+            MockVault.return_value.retrieve_credential = AsyncMock(return_value={"token": "secret"})
+            MockMCPClient.return_value.test_connection = AsyncMock(return_value=mock_result)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(f"{BASE}/{server_id}/test-connection")
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    def test_test_connection_vault_failure_returns_error(self, app_with_cpi_admin, mock_db_session):
+        """Vault failure during test-connection returns error without 500."""
+        server_id = uuid4()
+        auth_mock = MagicMock()
+        auth_mock.value = "bearer_token"
+        mock_srv = _mock_server(
+            id=server_id,
+            credential_vault_path="/v1/secret/data/srv",
+            auth_type=auth_mock,
+        )
+
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(VAULT_PATH) as MockVault,
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+            MockVault.return_value.retrieve_credential = AsyncMock(side_effect=Exception("vault down"))
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(f"{BASE}/{server_id}/test-connection")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert "credentials" in data["error"].lower()
+
+    def test_sync_tools_vault_failure_500(self, app_with_cpi_admin, mock_db_session):
+        """Vault failure during sync-tools returns 500."""
+        server_id = uuid4()
+        auth_mock = MagicMock()
+        auth_mock.value = "bearer_token"
+        mock_srv = _mock_server(
+            id=server_id,
+            credential_vault_path="/v1/secret/data/srv",
+            auth_type=auth_mock,
+        )
+
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(VAULT_PATH) as MockVault,
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+            MockVault.return_value.retrieve_credential = AsyncMock(side_effect=Exception("vault down"))
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(f"{BASE}/{server_id}/sync-tools")
+
+        assert response.status_code == 500
+
+
+# ============ Tenant Access Denied ============
+
+
+class TestTenantAccessDenied:
+    """Tests for tenant access control via _has_tenant_access."""
+
+    def test_get_server_access_denied_tenant_admin(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admin cannot access platform-wide server (tenant_id=None)."""
+        server_id = uuid4()
+        mock_srv = _mock_server(id=server_id, tenant_id=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.get(f"{BASE}/{server_id}")
+
+        assert response.status_code == 403
+
+    def test_update_server_access_denied(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admin cannot update platform-wide server."""
+        server_id = uuid4()
+        mock_srv = _mock_server(id=server_id, tenant_id=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.put(f"{BASE}/{server_id}", json={"display_name": "New"})
+
+        assert response.status_code == 403
+
+    def test_delete_server_access_denied(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admin cannot delete platform-wide server."""
+        server_id = uuid4()
+        mock_srv = _mock_server(id=server_id, tenant_id=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.delete(f"{BASE}/{server_id}")
+
+        assert response.status_code == 403
+
+    def test_create_server_platform_wide_denied_tenant_admin(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admin cannot create platform-wide server (tenant_id=null)."""
+        with TestClient(app_with_tenant_admin) as client:
+            response = client.post(
+                BASE,
+                json={
+                    "name": "platform-mcp",
+                    "display_name": "Platform",
+                    "base_url": "https://mcp.example.com/sse",
+                    "tenant_id": None,
+                },
+            )
+
+        assert response.status_code == 403
+
+    def test_test_connection_access_denied(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admin cannot test-connection on platform-wide server."""
+        server_id = uuid4()
+        mock_srv = _mock_server(id=server_id, tenant_id=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.post(f"{BASE}/{server_id}/test-connection")
+
+        assert response.status_code == 403
+
+    def test_sync_tools_access_denied(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admin cannot sync-tools on platform-wide server."""
+        server_id = uuid4()
+        mock_srv = _mock_server(id=server_id, tenant_id=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.post(f"{BASE}/{server_id}/sync-tools")
+
+        assert response.status_code == 403
+
+    def test_update_tool_access_denied(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admin cannot update tool on platform-wide server."""
+        server_id = uuid4()
+        tool_id = uuid4()
+        mock_srv = _mock_server(id=server_id, tenant_id=None)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.patch(
+                    f"{BASE}/{server_id}/tools/{tool_id}",
+                    json={"enabled": True},
+                )
+
+        assert response.status_code == 403
+
+
+# ============ Error Paths ============
+
+
+class TestErrorPaths:
+    """Tests for database and service error handling."""
+
+    def test_create_server_db_failure_500(self, app_with_cpi_admin, mock_db_session):
+        """Database failure during create returns 500."""
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value.get_by_name = AsyncMock(return_value=None)
+            MockRepo.return_value.create = AsyncMock(side_effect=Exception("db error"))
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(
+                    BASE,
+                    json={
+                        "name": "test-mcp",
+                        "display_name": "Test",
+                        "base_url": "https://mcp.test.dev/sse",
+                    },
+                )
+
+        assert response.status_code == 500
+
+    def test_update_server_db_failure_500(self, app_with_cpi_admin, mock_db_session):
+        """Database failure during update returns 500."""
+        server_id = uuid4()
+        mock_srv = _mock_server(id=server_id)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+            MockRepo.return_value.update = AsyncMock(side_effect=Exception("db error"))
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.put(
+                    f"{BASE}/{server_id}",
+                    json={"display_name": "Updated"},
+                )
+
+        assert response.status_code == 500
+
+    def test_delete_server_db_failure_500(self, app_with_cpi_admin, mock_db_session):
+        """Database failure during delete returns 500."""
+        server_id = uuid4()
+        mock_srv = _mock_server(id=server_id)
+
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+            MockRepo.return_value.delete = AsyncMock(side_effect=Exception("db error"))
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.delete(f"{BASE}/{server_id}")
+
+        assert response.status_code == 500
+
+    def test_sync_tools_discovery_failure_sets_error(self, app_with_cpi_admin, mock_db_session):
+        """Failed tool discovery sets sync_error on server."""
+        server_id = uuid4()
+        mock_srv = _mock_server(id=server_id)
+
+        with (
+            patch(REPO_PATH) as MockRepo,
+            patch(MCP_CLIENT_PATH) as MockMCPClient,
+        ):
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_srv)
+            MockRepo.return_value.set_sync_error = AsyncMock()
+            MockMCPClient.return_value.list_tools = AsyncMock(side_effect=Exception("connection refused"))
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(f"{BASE}/{server_id}/sync-tools")
+
+        assert response.status_code == 500
+        MockRepo.return_value.set_sync_error.assert_awaited_once()
+
+    def test_test_connection_404(self, app_with_cpi_admin, mock_db_session):
+        """Test connection on non-existent server returns 404."""
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=None)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(f"{BASE}/{uuid4()}/test-connection")
+
+        assert response.status_code == 404
+
+    def test_sync_tools_404(self, app_with_cpi_admin, mock_db_session):
+        """Sync tools on non-existent server returns 404."""
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=None)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(f"{BASE}/{uuid4()}/sync-tools")
+
+        assert response.status_code == 404
+
+    def test_update_server_404(self, app_with_cpi_admin, mock_db_session):
+        """Update non-existent server returns 404."""
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=None)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.put(f"{BASE}/{uuid4()}", json={"display_name": "New"})
+
+        assert response.status_code == 404
+
+    def test_update_tool_server_404(self, app_with_cpi_admin, mock_db_session):
+        """Update tool on non-existent server returns 404."""
+        with patch(REPO_PATH) as MockRepo:
+            MockRepo.return_value.get_by_id = AsyncMock(return_value=None)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.patch(
+                    f"{BASE}/{uuid4()}/tools/{uuid4()}",
+                    json={"enabled": True},
+                )
+
+        assert response.status_code == 404

--- a/control-plane-api/tests/test_gateway_health_worker.py
+++ b/control-plane-api/tests/test_gateway_health_worker.py
@@ -1,6 +1,5 @@
 """Tests for GatewayHealthWorker (src/workers/gateway_health_worker.py)."""
 
-import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -10,7 +9,6 @@ import pytest
 
 from src.models.gateway_instance import GatewayInstanceStatus, GatewayType
 from src.workers.gateway_health_worker import GatewayHealthWorker
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -172,9 +170,11 @@ class TestStart:
 
         worker._check_gateway_health = boom  # type: ignore[assignment]
 
-        with patch("src.workers.gateway_health_worker.asyncio.sleep", new=AsyncMock()):
-            with caplog.at_level(logging.ERROR, logger="src.workers.gateway_health_worker"):
-                await worker.start()
+        with (
+            patch("src.workers.gateway_health_worker.asyncio.sleep", new=AsyncMock()),
+            caplog.at_level(logging.ERROR, logger="src.workers.gateway_health_worker"),
+        ):
+            await worker.start()
 
         assert any("gateway health check" in msg.lower() for msg in caplog.messages)
 
@@ -292,8 +292,7 @@ class TestMarkStaleGatewaysOffline:
         worker = GatewayHealthWorker()
         stale_hc = datetime.now(UTC) - timedelta(seconds=200)
         gateways = [
-            _make_gateway(name=f"gw-{i}", last_health_check=stale_hc, gateway_type=GatewayType.STOA)
-            for i in range(3)
+            _make_gateway(name=f"gw-{i}", last_health_check=stale_hc, gateway_type=GatewayType.STOA) for i in range(3)
         ]
         mock_session = _make_session(scalars_result=gateways)
 
@@ -303,14 +302,10 @@ class TestMarkStaleGatewaysOffline:
             assert gw.status == GatewayInstanceStatus.OFFLINE
             assert gw.health_details["offline_reason"] == "heartbeat_timeout"
 
-    async def test_multiple_stale_gateways_logs_count(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    async def test_multiple_stale_gateways_logs_count(self, caplog: pytest.LogCaptureFixture) -> None:
         worker = GatewayHealthWorker()
         stale_hc = datetime.now(UTC) - timedelta(seconds=200)
-        gateways = [
-            _make_gateway(name=f"gw-{i}", last_health_check=stale_hc) for i in range(2)
-        ]
+        gateways = [_make_gateway(name=f"gw-{i}", last_health_check=stale_hc) for i in range(2)]
         mock_session = _make_session(scalars_result=gateways)
 
         with caplog.at_level(logging.INFO, logger="src.workers.gateway_health_worker"):

--- a/control-plane-api/tests/test_gateway_instances_router.py
+++ b/control-plane-api/tests/test_gateway_instances_router.py
@@ -14,7 +14,7 @@ Endpoints:
 Auth: require_role — cpi-admin for writes, cpi-admin/tenant-admin for reads.
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -43,8 +43,8 @@ class TestGatewayInstancesRouter:
             "capabilities": [],
             "version": None,
             "tags": [],
-            "created_at": datetime(2026, 2, 1),
-            "updated_at": datetime(2026, 2, 1),
+            "created_at": datetime(2026, 2, 1, tzinfo=UTC),
+            "updated_at": datetime(2026, 2, 1, tzinfo=UTC),
         }
         for k, v in {**defaults, **overrides}.items():
             setattr(mock, k, v)
@@ -198,9 +198,7 @@ class TestGatewayInstancesRouter:
         gw_id = uuid4()
 
         with patch("src.routers.gateway_instances.GatewayInstanceService") as MockSvc:
-            MockSvc.return_value.delete = AsyncMock(
-                side_effect=ValueError("Gateway not found")
-            )
+            MockSvc.return_value.delete = AsyncMock(side_effect=ValueError("Gateway not found"))
 
             with TestClient(app_with_cpi_admin) as client:
                 response = client.delete(f"/v1/admin/gateways/{gw_id}")
@@ -229,9 +227,7 @@ class TestGatewayInstancesRouter:
         gw_id = uuid4()
 
         with patch("src.routers.gateway_instances.GatewayInstanceService") as MockSvc:
-            MockSvc.return_value.health_check = AsyncMock(
-                side_effect=ValueError("Gateway not found")
-            )
+            MockSvc.return_value.health_check = AsyncMock(side_effect=ValueError("Gateway not found"))
 
             with TestClient(app_with_cpi_admin) as client:
                 response = client.post(f"/v1/admin/gateways/{gw_id}/health")
@@ -320,9 +316,7 @@ class TestGatewayInstancesRouter:
     def test_update_gateway_not_found(self, app_with_cpi_admin, mock_db_session):
         """PUT /{id} returns 404 when gateway not found."""
         with patch("src.routers.gateway_instances.GatewayInstanceService") as MockSvc:
-            MockSvc.return_value.update = AsyncMock(
-                side_effect=ValueError("Gateway instance not found")
-            )
+            MockSvc.return_value.update = AsyncMock(side_effect=ValueError("Gateway instance not found"))
 
             with TestClient(app_with_cpi_admin) as client:
                 response = client.put(f"/v1/admin/gateways/{uuid4()}", json={"display_name": "X"})
@@ -374,9 +368,7 @@ class TestGatewayInstancesRouter:
     def test_preview_import_not_found(self, app_with_cpi_admin, mock_db_session):
         """POST /{id}/import/preview returns 404 when gateway not found."""
         with patch("src.routers.gateway_instances.GatewayImportService") as MockImportSvc:
-            MockImportSvc.return_value.preview_import = AsyncMock(
-                side_effect=ValueError("Gateway instance not found")
-            )
+            MockImportSvc.return_value.preview_import = AsyncMock(side_effect=ValueError("Gateway instance not found"))
 
             with TestClient(app_with_cpi_admin) as client:
                 response = client.post(f"/v1/admin/gateways/{uuid4()}/import/preview")

--- a/control-plane-api/tests/test_git_router.py
+++ b/control-plane-api/tests/test_git_router.py
@@ -263,3 +263,252 @@ def test_viewer_cannot_delete_file(mock_git):
     client = TestClient(_build_test_app(user=_VIEWER_USER))
     resp = client.delete(f"{BASE}/files/test.yaml")
     assert resp.status_code == 403
+
+
+# ---- 503 when _project is None ----
+
+
+@patch("src.routers.git.git_service")
+def test_tree_503_when_project_none(mock_git):
+    mock_git._project = None
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/tree")
+    assert resp.status_code == 503
+    assert "GitLab not connected" in resp.json()["detail"]
+
+
+@patch("src.routers.git.git_service")
+def test_create_file_503_when_project_none(mock_git):
+    mock_git._project = None
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/files/new.yaml", json={"content": "x"})
+    assert resp.status_code == 503
+
+
+@patch("src.routers.git.git_service")
+def test_delete_file_503_when_project_none(mock_git):
+    mock_git._project = None
+    client = TestClient(_build_test_app())
+    resp = client.delete(f"{BASE}/files/old.yaml")
+    assert resp.status_code == 503
+
+
+@patch("src.routers.git.git_service")
+def test_list_merge_requests_503_when_project_none(mock_git):
+    mock_git._project = None
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/merge-requests")
+    assert resp.status_code == 503
+
+
+@patch("src.routers.git.git_service")
+def test_create_merge_request_503_when_project_none(mock_git):
+    mock_git._project = None
+    client = TestClient(_build_test_app())
+    resp = client.post(
+        f"{BASE}/merge-requests",
+        json={"title": "T", "description": "D", "source_branch": "feat/x", "target_branch": "main"},
+    )
+    assert resp.status_code == 503
+
+
+@patch("src.routers.git.git_service")
+def test_merge_request_503_when_project_none(mock_git):
+    mock_git._project = None
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/merge-requests/1/merge")
+    assert resp.status_code == 503
+
+
+@patch("src.routers.git.git_service")
+def test_list_branches_503_when_project_none(mock_git):
+    mock_git._project = None
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/branches")
+    assert resp.status_code == 503
+
+
+@patch("src.routers.git.git_service")
+def test_create_branch_503_when_project_none(mock_git):
+    mock_git._project = None
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/branches", json={"name": "feat/new", "ref": "main"})
+    assert resp.status_code == 503
+
+
+# ---- Exception / error fallback paths ----
+
+
+@patch("src.routers.git.git_service")
+def test_list_commits_exception_returns_empty(mock_git):
+    mock_git.list_commits = AsyncMock(side_effect=Exception("gitlab timeout"))
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/commits")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@patch("src.routers.git.git_service")
+def test_create_file_exception_returns_500(mock_git):
+    mock_git._project = MagicMock()
+    mock_git.get_file = AsyncMock(return_value=None)
+    mock_git._project.files.create = MagicMock(side_effect=Exception("write failed"))
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/files/new.yaml", json={"content": "x"})
+    assert resp.status_code == 500
+    assert "Failed to save file" in resp.json()["detail"]
+
+
+@patch("src.routers.git.git_service")
+def test_update_file_exception_returns_500(mock_git):
+    mock_git._project = MagicMock()
+    mock_git.get_file = AsyncMock(return_value="old content")
+    file_obj = MagicMock()
+    file_obj.save = MagicMock(side_effect=Exception("save failed"))
+    mock_git._project.files.get = MagicMock(return_value=file_obj)
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/files/existing.yaml", json={"content": "new"})
+    assert resp.status_code == 500
+
+
+@patch("src.routers.git.git_service")
+def test_delete_file_exception_returns_404(mock_git):
+    mock_git._project = MagicMock()
+    mock_git._project.files.delete = MagicMock(side_effect=Exception("not found"))
+    client = TestClient(_build_test_app())
+    resp = client.delete(f"{BASE}/files/missing.yaml")
+    assert resp.status_code == 404
+    assert "File not found" in resp.json()["detail"]
+
+
+@patch("src.routers.git.git_service")
+def test_list_merge_requests_exception_returns_empty(mock_git):
+    mock_git._project = MagicMock()
+    mock_git._project.mergerequests.list = MagicMock(side_effect=Exception("gitlab error"))
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/merge-requests")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@patch("src.routers.git.git_service")
+def test_create_merge_request_exception_returns_500(mock_git):
+    mock_git._project = MagicMock()
+    mock_git._project.mergerequests.create = MagicMock(side_effect=Exception("create failed"))
+    client = TestClient(_build_test_app())
+    resp = client.post(
+        f"{BASE}/merge-requests",
+        json={"title": "T", "description": "D", "source_branch": "feat/x", "target_branch": "main"},
+    )
+    assert resp.status_code == 500
+    assert "Failed to create merge request" in resp.json()["detail"]
+
+
+@patch("src.routers.git.git_service")
+def test_merge_merge_request_exception_returns_500(mock_git):
+    mock_git._project = MagicMock()
+    mock_git._project.mergerequests.get = MagicMock(side_effect=Exception("merge failed"))
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/merge-requests/1/merge")
+    assert resp.status_code == 500
+    assert "Failed to merge" in resp.json()["detail"]
+
+
+@patch("src.routers.git.git_service")
+def test_list_branches_exception_returns_empty(mock_git):
+    mock_git._project = MagicMock()
+    mock_git._project.branches.list = MagicMock(side_effect=Exception("gitlab error"))
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/branches")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@patch("src.routers.git.git_service")
+def test_create_branch_exception_returns_500(mock_git):
+    mock_git._project = MagicMock()
+    mock_git._project.branches.create = MagicMock(side_effect=Exception("create failed"))
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/branches", json={"name": "feat/err", "ref": "main"})
+    assert resp.status_code == 500
+    assert "Failed to create branch" in resp.json()["detail"]
+
+
+# ---- Additional edge cases ----
+
+
+@patch("src.routers.git.git_service")
+def test_list_commits_with_custom_limit(mock_git):
+    mock_git.list_commits = AsyncMock(return_value=[])
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/commits?limit=50")
+    assert resp.status_code == 200
+    mock_git.list_commits.assert_called_once_with(path="tenants/acme", limit=50)
+
+
+@patch("src.routers.git.git_service")
+def test_list_merge_requests_with_data(mock_git):
+    mock_git._project = MagicMock()
+    mr_mock = MagicMock()
+    mr_mock.id = 10
+    mr_mock.iid = 5
+    mr_mock.title = "Fix bug"
+    mr_mock.description = None  # test None description
+    mr_mock.state = "merged"
+    mr_mock.source_branch = "fix/bug"
+    mr_mock.target_branch = "main"
+    mr_mock.web_url = "https://gitlab.com/mr/5"
+    mr_mock.created_at = "2026-01-15T00:00:00"
+    mr_mock.author = "dev-string"  # test non-dict author
+    mock_git._project.mergerequests.list = MagicMock(return_value=[mr_mock])
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/merge-requests")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["description"] == ""
+    assert data[0]["author"] == "dev-string"
+
+
+@patch("src.routers.git.git_service")
+def test_create_file_with_custom_commit_message(mock_git):
+    mock_git._project = MagicMock()
+    mock_git.get_file = AsyncMock(return_value=None)
+    mock_git._project.files.create = MagicMock()
+    client = TestClient(_build_test_app())
+    resp = client.post(f"{BASE}/files/new.yaml?commit_message=custom+msg", json={"content": "data"})
+    assert resp.status_code == 201
+
+
+@patch("src.routers.git.git_service")
+def test_get_tree_with_path_param(mock_git):
+    mock_git._project = MagicMock()
+    mock_git._project.repository_tree = MagicMock(return_value=[])
+    client = TestClient(_build_test_app())
+    resp = client.get(f"{BASE}/tree?path=apis")
+    assert resp.status_code == 200
+    mock_git._project.repository_tree.assert_called_once_with(path="tenants/acme/apis", ref="main")
+
+
+@patch("src.routers.git.git_service")
+def test_viewer_cannot_create_branch(mock_git):
+    client = TestClient(_build_test_app(user=_VIEWER_USER))
+    resp = client.post(f"{BASE}/branches", json={"name": "feat/x", "ref": "main"})
+    assert resp.status_code == 403
+
+
+@patch("src.routers.git.git_service")
+def test_viewer_cannot_create_merge_request(mock_git):
+    client = TestClient(_build_test_app(user=_VIEWER_USER))
+    resp = client.post(
+        f"{BASE}/merge-requests",
+        json={"title": "T", "description": "D", "source_branch": "feat/x", "target_branch": "main"},
+    )
+    assert resp.status_code == 403
+
+
+@patch("src.routers.git.git_service")
+def test_viewer_cannot_merge_request(mock_git):
+    client = TestClient(_build_test_app(user=_VIEWER_USER))
+    resp = client.post(f"{BASE}/merge-requests/1/merge")
+    assert resp.status_code == 403

--- a/control-plane-api/tests/test_mcp_proxy_router.py
+++ b/control-plane-api/tests/test_mcp_proxy_router.py
@@ -12,8 +12,10 @@ Auth: get_current_user + HTTPBearer (all endpoints).
 Delegates to proxy_to_mcp which proxies to MCP Gateway.
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
+import pytest
 from fastapi.testclient import TestClient
 
 
@@ -210,3 +212,253 @@ class TestMCPProxyRouter:
         assert tools_resp.status_code in (401, 403)
         assert tags_resp.status_code in (401, 403)
         assert invoke_resp.status_code in (401, 403)
+
+
+# ============== proxy_to_mcp function unit tests ==============
+
+
+class TestProxyToMCP:
+    """Direct unit tests for the proxy_to_mcp function."""
+
+    @pytest.mark.asyncio
+    async def test_proxy_get_request(self):
+        """proxy_to_mcp sends GET requests correctly."""
+        from src.routers.mcp_proxy import proxy_to_mcp
+
+        mock_user = MagicMock()
+        mock_user.id = "user-1"
+        mock_user.email = "user@test.com"
+        mock_user.roles = ["viewer"]
+        mock_user.tenant_id = "acme"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"tools": []}
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("src.routers.mcp_proxy.get_http_client", return_value=mock_client):
+            result = await proxy_to_mcp("GET", "/mcp/v1/tools", mock_user, "test-token", params={"limit": 10})
+
+        assert result == {"tools": []}
+        mock_client.get.assert_awaited_once()
+        call_kwargs = mock_client.get.call_args
+        assert call_kwargs[1]["params"] == {"limit": 10}
+        assert "Bearer test-token" in call_kwargs[1]["headers"]["Authorization"]
+
+    @pytest.mark.asyncio
+    async def test_proxy_post_request(self):
+        """proxy_to_mcp sends POST requests with JSON body."""
+        from src.routers.mcp_proxy import proxy_to_mcp
+
+        mock_user = MagicMock()
+        mock_user.id = "user-1"
+        mock_user.email = "user@test.com"
+        mock_user.roles = ["cpi-admin"]
+        mock_user.tenant_id = "acme"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"content": [], "isError": False}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("src.routers.mcp_proxy.get_http_client", return_value=mock_client):
+            result = await proxy_to_mcp(
+                "POST", "/mcp/v1/tools/test/invoke", mock_user, "tok", json_body={"name": "test"}
+            )
+
+        assert result == {"content": [], "isError": False}
+        mock_client.post.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_proxy_unsupported_method_405(self):
+        """proxy_to_mcp raises 405 for unsupported HTTP methods."""
+        from fastapi import HTTPException
+
+        from src.routers.mcp_proxy import proxy_to_mcp
+
+        mock_user = MagicMock()
+        mock_user.id = "u"
+        mock_user.email = "u@t.com"
+        mock_user.roles = []
+        mock_user.tenant_id = None
+
+        mock_client = AsyncMock()
+
+        with (
+            patch("src.routers.mcp_proxy.get_http_client", return_value=mock_client),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await proxy_to_mcp("DELETE", "/path", mock_user, "tok")
+
+        assert exc_info.value.status_code == 405
+
+    @pytest.mark.asyncio
+    async def test_proxy_gateway_error_passthrough(self):
+        """proxy_to_mcp passes through error status from MCP Gateway."""
+        from fastapi import HTTPException
+
+        from src.routers.mcp_proxy import proxy_to_mcp
+
+        mock_user = MagicMock()
+        mock_user.id = "u"
+        mock_user.email = "u@t.com"
+        mock_user.roles = []
+        mock_user.tenant_id = None
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.json.return_value = {"detail": "Tool not found"}
+        mock_response.text = "Tool not found"
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("src.routers.mcp_proxy.get_http_client", return_value=mock_client),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await proxy_to_mcp("GET", "/mcp/v1/tools/missing", mock_user, "tok")
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_proxy_gateway_error_json_parse_failure(self):
+        """proxy_to_mcp falls back to response.text when JSON parsing fails."""
+        from fastapi import HTTPException
+
+        from src.routers.mcp_proxy import proxy_to_mcp
+
+        mock_user = MagicMock()
+        mock_user.id = "u"
+        mock_user.email = "u@t.com"
+        mock_user.roles = []
+        mock_user.tenant_id = None
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.json.side_effect = ValueError("not json")
+        mock_response.text = "Internal Server Error"
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("src.routers.mcp_proxy.get_http_client", return_value=mock_client),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await proxy_to_mcp("GET", "/path", mock_user, "tok")
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.detail == "Internal Server Error"
+
+    @pytest.mark.asyncio
+    async def test_proxy_httpx_error_returns_503(self):
+        """proxy_to_mcp returns 503 when httpx raises HTTPError."""
+        from fastapi import HTTPException
+
+        from src.routers.mcp_proxy import proxy_to_mcp
+
+        mock_user = MagicMock()
+        mock_user.id = "u"
+        mock_user.email = "u@t.com"
+        mock_user.roles = []
+        mock_user.tenant_id = None
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+
+        with (
+            patch("src.routers.mcp_proxy.get_http_client", return_value=mock_client),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await proxy_to_mcp("GET", "/path", mock_user, "tok")
+
+        assert exc_info.value.status_code == 503
+        assert "MCP Gateway unavailable" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_proxy_forwards_user_context_headers(self):
+        """proxy_to_mcp includes user context in request headers."""
+        from src.routers.mcp_proxy import proxy_to_mcp
+
+        mock_user = MagicMock()
+        mock_user.id = "user-42"
+        mock_user.email = "dev@gostoa.dev"
+        mock_user.roles = ["cpi-admin", "tenant-admin"]
+        mock_user.tenant_id = "acme"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {}
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("src.routers.mcp_proxy.get_http_client", return_value=mock_client):
+            await proxy_to_mcp("GET", "/path", mock_user, "my-token")
+
+        headers = mock_client.get.call_args[1]["headers"]
+        assert headers["X-User-Id"] == "user-42"
+        assert headers["X-User-Email"] == "dev@gostoa.dev"
+        assert headers["X-User-Roles"] == "cpi-admin,tenant-admin"
+        assert headers["X-Tenant-Id"] == "acme"
+
+
+# ============== get_http_client tests ==============
+
+
+class TestGetHTTPClient:
+    """Tests for the HTTP client singleton."""
+
+    @pytest.mark.asyncio
+    async def test_get_http_client_creates_client(self):
+        """get_http_client creates a new client when none exists."""
+        import src.routers.mcp_proxy as mod
+
+        old_client = mod._http_client
+        mod._http_client = None
+        try:
+            client = await mod.get_http_client()
+            assert client is not None
+            assert isinstance(client, httpx.AsyncClient)
+        finally:
+            if mod._http_client and not mod._http_client.is_closed:
+                await mod._http_client.aclose()
+            mod._http_client = old_client
+
+    @pytest.mark.asyncio
+    async def test_get_http_client_reuses_existing(self):
+        """get_http_client reuses existing open client."""
+        import src.routers.mcp_proxy as mod
+
+        old_client = mod._http_client
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mod._http_client = mock_client
+        try:
+            client = await mod.get_http_client()
+            assert client is mock_client
+        finally:
+            mod._http_client = old_client
+
+    @pytest.mark.asyncio
+    async def test_get_http_client_recreates_if_closed(self):
+        """get_http_client creates new client when existing one is closed."""
+        import src.routers.mcp_proxy as mod
+
+        old_client = mod._http_client
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = True
+        mod._http_client = mock_client
+        try:
+            client = await mod.get_http_client()
+            assert client is not mock_client
+            assert isinstance(client, httpx.AsyncClient)
+        finally:
+            if mod._http_client and not mod._http_client.is_closed:
+                await mod._http_client.aclose()
+            mod._http_client = old_client

--- a/control-plane-api/tests/test_security_alert_consumer.py
+++ b/control-plane-api/tests/test_security_alert_consumer.py
@@ -14,7 +14,6 @@ from src.workers.security_alert_consumer import (
     SecurityAlertPayload,
 )
 
-
 # ── SecurityAlertPayload schema ──────────────────────────────────────────────
 
 
@@ -65,9 +64,7 @@ class TestSecurityAlertPayload:
     # severity property
 
     def test_severity_from_payload(self):
-        alert = SecurityAlertPayload(
-            id="e1", type="t1", payload={"severity": "critical"}
-        )
+        alert = SecurityAlertPayload(id="e1", type="t1", payload={"severity": "critical"})
         assert alert.severity == "critical"
 
     def test_severity_default_medium(self):
@@ -81,9 +78,7 @@ class TestSecurityAlertPayload:
     # details property
 
     def test_details_from_payload(self):
-        alert = SecurityAlertPayload(
-            id="e1", type="t1", payload={"details": {"ip": "10.0.0.1", "count": 5}}
-        )
+        alert = SecurityAlertPayload(id="e1", type="t1", payload={"details": {"ip": "10.0.0.1", "count": 5}})
         assert alert.details == {"ip": "10.0.0.1", "count": 5}
 
     def test_details_default_empty_dict(self):
@@ -109,7 +104,7 @@ class TestSecurityAlertConsumerInit:
     def test_constants(self):
         assert TOPIC == "stoa.security.alerts"
         assert GROUP_ID == "security-alert-consumer"
-        assert VALID_SEVERITIES == {"critical", "high", "medium", "low"}
+        assert {"critical", "high", "medium", "low"} == VALID_SEVERITIES
 
 
 # ── start() ──────────────────────────────────────────────────────────────────
@@ -254,7 +249,6 @@ class TestCreateConsumer:
     @patch("src.workers.security_alert_consumer.KafkaConsumer")
     @patch("src.workers.security_alert_consumer.settings")
     def test_value_deserializer_decodes_json(self, mock_settings, mock_kafka_cls):
-        import json
 
         mock_settings.KAFKA_BOOTSTRAP_SERVERS = "localhost:9092"
         mock_settings.KAFKA_SASL_USERNAME = ""
@@ -295,15 +289,14 @@ class TestProcessMessage:
         consumer._loop = MagicMock()
         mock_future = MagicMock()
 
-        with patch(
-            "src.workers.security_alert_consumer.asyncio.run_coroutine_threadsafe",
-            return_value=mock_future,
-        ) as mock_dispatch, patch.object(
-            consumer, "_persist_alert", new_callable=AsyncMock
+        with (
+            patch(
+                "src.workers.security_alert_consumer.asyncio.run_coroutine_threadsafe",
+                return_value=mock_future,
+            ) as mock_dispatch,
+            patch.object(consumer, "_persist_alert", new_callable=AsyncMock),
         ):
-            msg = self._make_message(
-                {"id": "evt-001", "type": "auth_failure", "payload": {"severity": "high"}}
-            )
+            msg = self._make_message({"id": "evt-001", "type": "auth_failure", "payload": {"severity": "high"}})
             consumer._process_message(msg)
 
         mock_dispatch.assert_called_once()
@@ -318,13 +311,14 @@ class TestProcessMessage:
         async def fake_persist(alert, severity):
             captured_severity.append(severity)
 
-        with patch(
-            "src.workers.security_alert_consumer.asyncio.run_coroutine_threadsafe",
-            return_value=mock_future,
-        ), patch.object(consumer, "_persist_alert", side_effect=fake_persist):
-            msg = self._make_message(
-                {"id": "evt-002", "type": "brute_force", "payload": {"severity": "unknown_value"}}
-            )
+        with (
+            patch(
+                "src.workers.security_alert_consumer.asyncio.run_coroutine_threadsafe",
+                return_value=mock_future,
+            ),
+            patch.object(consumer, "_persist_alert", side_effect=fake_persist),
+        ):
+            msg = self._make_message({"id": "evt-002", "type": "brute_force", "payload": {"severity": "unknown_value"}})
             consumer._process_message(msg)
 
         # severity was captured via run_coroutine_threadsafe call args
@@ -341,19 +335,20 @@ class TestProcessMessage:
         mock_future = MagicMock()
 
         for sev in ("critical", "high", "medium", "low"):
-            with patch(
-                "src.workers.security_alert_consumer.asyncio.run_coroutine_threadsafe",
-                return_value=mock_future,
-            ) as mock_dispatch, patch(
-                "src.workers.security_alert_consumer.asyncio.iscoroutine",
-                return_value=False,
+            with (
+                patch(
+                    "src.workers.security_alert_consumer.asyncio.run_coroutine_threadsafe",
+                    return_value=mock_future,
+                ) as mock_dispatch,
+                patch(
+                    "src.workers.security_alert_consumer.asyncio.iscoroutine",
+                    return_value=False,
+                ),
             ):
                 # Replace _persist_alert with a MagicMock that returns a sentinel
                 # to avoid unawaited coroutine warnings from AsyncMock
                 consumer._persist_alert = MagicMock(return_value=MagicMock())
-                msg = self._make_message(
-                    {"id": "evt-003", "type": "t", "payload": {"severity": sev}}
-                )
+                msg = self._make_message({"id": "evt-003", "type": "t", "payload": {"severity": sev}})
                 consumer._process_message(msg)
                 mock_dispatch.assert_called_once()
                 mock_dispatch.reset_mock()
@@ -384,8 +379,10 @@ class TestProcessMessage:
         consumer = SecurityAlertConsumer()
         consumer._loop = None
 
-        with patch.object(consumer, "_persist_alert", new_callable=AsyncMock) as mock_persist, \
-             patch("src.workers.security_alert_consumer.asyncio.run_coroutine_threadsafe") as mock_dispatch:
+        with (
+            patch.object(consumer, "_persist_alert", new_callable=AsyncMock) as mock_persist,
+            patch("src.workers.security_alert_consumer.asyncio.run_coroutine_threadsafe") as mock_dispatch,
+        ):
             msg = self._make_message({"id": "evt-004", "type": "t"})
             consumer._process_message(msg)
 
@@ -397,14 +394,17 @@ class TestProcessMessage:
         consumer = SecurityAlertConsumer()
         consumer._loop = MagicMock()
 
-        with patch.object(
-            consumer,
-            "_persist_alert",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("db down"),
-        ), patch(
-            "src.workers.security_alert_consumer.asyncio.run_coroutine_threadsafe",
-        ) as mock_dispatch:
+        with (
+            patch.object(
+                consumer,
+                "_persist_alert",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("db down"),
+            ),
+            patch(
+                "src.workers.security_alert_consumer.asyncio.run_coroutine_threadsafe",
+            ) as mock_dispatch,
+        ):
             mock_future = MagicMock()
             mock_future.result.side_effect = RuntimeError("db down")
             mock_dispatch.return_value = mock_future
@@ -419,13 +419,14 @@ class TestProcessMessage:
         consumer._loop = mock_loop
         mock_future = MagicMock()
 
-        with patch(
-            "src.workers.security_alert_consumer.asyncio.run_coroutine_threadsafe",
-            return_value=mock_future,
-        ) as mock_dispatch, patch.object(consumer, "_persist_alert", new_callable=AsyncMock):
-            msg = self._make_message(
-                {"id": "evt-006", "type": "injection", "payload": {"severity": "critical"}}
-            )
+        with (
+            patch(
+                "src.workers.security_alert_consumer.asyncio.run_coroutine_threadsafe",
+                return_value=mock_future,
+            ) as mock_dispatch,
+            patch.object(consumer, "_persist_alert", new_callable=AsyncMock),
+        ):
+            msg = self._make_message({"id": "evt-006", "type": "injection", "payload": {"severity": "critical"}})
             consumer._process_message(msg)
 
         # Second positional arg to run_coroutine_threadsafe must be the event loop
@@ -531,7 +532,7 @@ class TestPersistAlert:
 
         assert len(captured_stmt) == 1
         # The compiled parameters should carry the right values
-        params = captured_stmt[0].compile(compile_kwargs={"literal_binds": False})
+        captured_stmt[0].compile(compile_kwargs={"literal_binds": False})
         # Check that the statement targets security_events table
         assert "security_events" in str(captured_stmt[0])
 

--- a/control-plane-api/tests/test_workflows_router.py
+++ b/control-plane-api/tests/test_workflows_router.py
@@ -184,18 +184,14 @@ class TestListTemplates:
         data = resp.json()
         assert data["page"] == 2
         assert data["page_size"] == 10
-        mock_svc.list_templates.assert_called_once_with(
-            TENANT_ID, workflow_type=None, page=2, page_size=10
-        )
+        mock_svc.list_templates.assert_called_once_with(TENANT_ID, workflow_type=None, page=2, page_size=10)
 
     def test_list_templates_workflow_type_filter(self, client_as_tenant_admin, mock_db_session):
         with patch(WF_SVC_PATH) as MockSvc:
             mock_svc = MockSvc.return_value
             mock_svc.list_templates = AsyncMock(return_value=([], 0))
 
-            resp = client_as_tenant_admin.get(
-                f"{BASE_URL}/templates?workflow_type=user_registration"
-            )
+            resp = client_as_tenant_admin.get(f"{BASE_URL}/templates?workflow_type=user_registration")
 
         assert resp.status_code == 200
         mock_svc.list_templates.assert_called_once_with(
@@ -305,9 +301,7 @@ class TestCreateTemplate:
 
         assert resp.status_code == 403
 
-    def test_create_template_other_tenant_forbidden(
-        self, client_as_other_tenant, mock_db_session
-    ):
+    def test_create_template_other_tenant_forbidden(self, client_as_other_tenant, mock_db_session):
         resp = client_as_other_tenant.post(
             f"{BASE_URL}/templates",
             json={"workflow_type": "user_registration", "name": "T", "mode": "manual"},
@@ -340,9 +334,7 @@ class TestGetTemplate:
         assert resp.status_code == 404
         assert "Template not found" in resp.json()["detail"]
 
-    def test_get_template_other_tenant_forbidden(
-        self, client_as_other_tenant, mock_db_session
-    ):
+    def test_get_template_other_tenant_forbidden(self, client_as_other_tenant, mock_db_session):
         resp = client_as_other_tenant.get(f"{BASE_URL}/templates/{uuid4()}")
         assert resp.status_code == 403
 
@@ -368,9 +360,7 @@ class TestUpdateTemplate:
 
     def test_update_template_not_found(self, client_as_tenant_admin, mock_db_session):
         with patch(WF_SVC_PATH) as MockSvc:
-            MockSvc.return_value.update_template = AsyncMock(
-                side_effect=ValueError("Template not found")
-            )
+            MockSvc.return_value.update_template = AsyncMock(side_effect=ValueError("Template not found"))
             resp = client_as_tenant_admin.put(
                 f"{BASE_URL}/templates/{uuid4()}",
                 json={"name": "New Name"},
@@ -397,9 +387,7 @@ class TestUpdateTemplate:
         call_kwargs = mock_svc.update_template.call_args.kwargs
         assert "description" in call_kwargs
 
-    def test_update_template_other_tenant_forbidden(
-        self, client_as_other_tenant, mock_db_session
-    ):
+    def test_update_template_other_tenant_forbidden(self, client_as_other_tenant, mock_db_session):
         resp = client_as_other_tenant.put(
             f"{BASE_URL}/templates/{uuid4()}",
             json={"name": "X"},
@@ -424,17 +412,13 @@ class TestDeleteTemplate:
 
     def test_delete_template_not_found(self, client_as_tenant_admin, mock_db_session):
         with patch(WF_SVC_PATH) as MockSvc:
-            MockSvc.return_value.delete_template = AsyncMock(
-                side_effect=ValueError("Template not found")
-            )
+            MockSvc.return_value.delete_template = AsyncMock(side_effect=ValueError("Template not found"))
             resp = client_as_tenant_admin.delete(f"{BASE_URL}/templates/{uuid4()}")
 
         assert resp.status_code == 404
         assert "Template not found" in resp.json()["detail"]
 
-    def test_delete_template_other_tenant_forbidden(
-        self, client_as_other_tenant, mock_db_session
-    ):
+    def test_delete_template_other_tenant_forbidden(self, client_as_other_tenant, mock_db_session):
         resp = client_as_other_tenant.delete(f"{BASE_URL}/templates/{uuid4()}")
         assert resp.status_code == 403
 
@@ -472,9 +456,7 @@ class TestStartWorkflow:
 
     def test_start_workflow_invalid(self, client_as_tenant_admin, mock_db_session):
         with patch(WF_SVC_PATH) as MockSvc:
-            MockSvc.return_value.start_workflow = AsyncMock(
-                side_effect=ValueError("Template not found or inactive")
-            )
+            MockSvc.return_value.start_workflow = AsyncMock(side_effect=ValueError("Template not found or inactive"))
             resp = client_as_tenant_admin.post(
                 f"{BASE_URL}/instances",
                 json={
@@ -486,18 +468,14 @@ class TestStartWorkflow:
         assert resp.status_code == 400
         assert "Template not found or inactive" in resp.json()["detail"]
 
-    def test_start_workflow_missing_subject_id_422(
-        self, client_as_tenant_admin, mock_db_session
-    ):
+    def test_start_workflow_missing_subject_id_422(self, client_as_tenant_admin, mock_db_session):
         resp = client_as_tenant_admin.post(
             f"{BASE_URL}/instances",
             json={"template_id": str(uuid4())},
         )
         assert resp.status_code == 422
 
-    def test_start_workflow_other_tenant_forbidden(
-        self, client_as_other_tenant, mock_db_session
-    ):
+    def test_start_workflow_other_tenant_forbidden(self, client_as_other_tenant, mock_db_session):
         resp = client_as_other_tenant.post(
             f"{BASE_URL}/instances",
             json={"template_id": str(uuid4()), "subject_id": "x"},
@@ -547,9 +525,7 @@ class TestListInstances:
             TENANT_ID, workflow_type=None, status="pending", page=1, page_size=50
         )
 
-    def test_list_instances_other_tenant_forbidden(
-        self, client_as_other_tenant, mock_db_session
-    ):
+    def test_list_instances_other_tenant_forbidden(self, client_as_other_tenant, mock_db_session):
         resp = client_as_other_tenant.get(f"{BASE_URL}/instances")
         assert resp.status_code == 403
 
@@ -579,9 +555,7 @@ class TestGetInstance:
         assert resp.status_code == 404
         assert "Workflow instance not found" in resp.json()["detail"]
 
-    def test_get_instance_other_tenant_forbidden(
-        self, client_as_other_tenant, mock_db_session
-    ):
+    def test_get_instance_other_tenant_forbidden(self, client_as_other_tenant, mock_db_session):
         resp = client_as_other_tenant.get(f"{BASE_URL}/instances/{uuid4()}")
         assert resp.status_code == 403
 
@@ -607,9 +581,7 @@ class TestApproveStep:
                 )
 
         assert resp.status_code == 200
-        mock_svc.approve_step.assert_called_once_with(
-            TENANT_ID, instance.id, "tenant-admin-user-id", "Approved!"
-        )
+        mock_svc.approve_step.assert_called_once_with(TENANT_ID, instance.id, "tenant-admin-user-id", "Approved!")
 
     def test_approve_step_no_body(self, client_as_tenant_admin, mock_db_session):
         instance = _make_instance()
@@ -626,15 +598,11 @@ class TestApproveStep:
                 )
 
         assert resp.status_code == 200
-        mock_svc.approve_step.assert_called_once_with(
-            TENANT_ID, instance.id, "tenant-admin-user-id", None
-        )
+        mock_svc.approve_step.assert_called_once_with(TENANT_ID, instance.id, "tenant-admin-user-id", None)
 
     def test_approve_step_invalid(self, client_as_tenant_admin, mock_db_session):
         with patch(WF_SVC_PATH) as MockSvc:
-            MockSvc.return_value.approve_step = AsyncMock(
-                side_effect=ValueError("No pending step to approve")
-            )
+            MockSvc.return_value.approve_step = AsyncMock(side_effect=ValueError("No pending step to approve"))
             resp = client_as_tenant_admin.post(
                 f"{BASE_URL}/instances/{uuid4()}/approve",
                 json={"comment": "approve"},
@@ -643,9 +611,7 @@ class TestApproveStep:
         assert resp.status_code == 400
         assert "No pending step to approve" in resp.json()["detail"]
 
-    def test_approve_step_other_tenant_forbidden(
-        self, client_as_other_tenant, mock_db_session
-    ):
+    def test_approve_step_other_tenant_forbidden(self, client_as_other_tenant, mock_db_session):
         resp = client_as_other_tenant.post(
             f"{BASE_URL}/instances/{uuid4()}/approve",
             json={},
@@ -690,9 +656,7 @@ class TestRejectStep:
                 )
 
         assert resp.status_code == 200
-        mock_svc.reject_step.assert_called_once_with(
-            TENANT_ID, instance.id, "tenant-admin-user-id", None
-        )
+        mock_svc.reject_step.assert_called_once_with(TENANT_ID, instance.id, "tenant-admin-user-id", None)
 
     def test_reject_step_invalid(self, client_as_tenant_admin, mock_db_session):
         with patch(WF_SVC_PATH) as MockSvc:
@@ -707,9 +671,7 @@ class TestRejectStep:
         assert resp.status_code == 400
         assert "Instance is not in a rejectable state" in resp.json()["detail"]
 
-    def test_reject_step_other_tenant_forbidden(
-        self, client_as_other_tenant, mock_db_session
-    ):
+    def test_reject_step_other_tenant_forbidden(self, client_as_other_tenant, mock_db_session):
         resp = client_as_other_tenant.post(
             f"{BASE_URL}/instances/{uuid4()}/reject",
             json={},
@@ -762,16 +724,12 @@ class TestGetAuditTrail:
             mock_svc = MockSvc.return_value
             mock_svc.get_audit_log = AsyncMock(return_value=([], 0))
 
-            resp = client_as_tenant_admin.get(
-                f"{BASE_URL}/audit/{instance_id}?page=2&page_size=5"
-            )
+            resp = client_as_tenant_admin.get(f"{BASE_URL}/audit/{instance_id}?page=2&page_size=5")
 
         assert resp.status_code == 200
         mock_svc.get_audit_log.assert_called_once_with(instance_id, page=2, page_size=5)
 
-    def test_audit_trail_other_tenant_forbidden(
-        self, client_as_other_tenant, mock_db_session
-    ):
+    def test_audit_trail_other_tenant_forbidden(self, client_as_other_tenant, mock_db_session):
         resp = client_as_other_tenant.get(f"{BASE_URL}/audit/{uuid4()}")
         assert resp.status_code == 403
 


### PR DESCRIPTION
## Summary
- Add edge-case tests for `external_mcp_servers`, `git`, `mcp_proxy` routers (+1,000 LOC)
- Fix and improve existing tests for `certificates`, `gateway_health_worker`, `gateway_instances`, `security_alert_consumer`, `workflows` routers
- Fix `AuthTypeEnum` values (`bearer` → `bearer_token`), DTZ001 datetime timezone issues, SIM117 nested-with lint violations

## Test plan
- [x] All 259 tests in 8 modified files pass
- [x] ruff check clean (0 errors)
- [x] black format clean
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)