### PR TITLE
test(ui): add tests for 5 untested dashboard pages

### DIFF
--- a/control-plane-ui/src/pages/AdminAccessRequests.test.tsx
+++ b/control-plane-ui/src/pages/AdminAccessRequests.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AdminAccessRequests } from './AdminAccessRequests';
+import { createAuthMock } from '../test/helpers';
+import { useAuth } from '../contexts/AuthContext';
+import type { PersonaRole } from '../test/helpers';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+
+vi.mock('../hooks/useAccessRequests', () => ({
+  useAccessRequests: vi.fn(() => ({
+    data: { data: [], total: 0 },
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+function renderWithQuery(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+describe('AdminAccessRequests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+  });
+
+  it('renders the page title for cpi-admin', () => {
+    renderWithQuery(<AdminAccessRequests />);
+    expect(screen.getByText('Access Requests')).toBeInTheDocument();
+  });
+
+  it('renders the subtitle', () => {
+    renderWithQuery(<AdminAccessRequests />);
+    expect(
+      screen.getByText('Enterprise access requests from the Developer Portal')
+    ).toBeInTheDocument();
+  });
+
+  it('shows status filter', () => {
+    renderWithQuery(<AdminAccessRequests />);
+    expect(screen.getByDisplayValue('All statuses')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no requests', () => {
+    renderWithQuery(<AdminAccessRequests />);
+    expect(screen.getByText('No access requests found')).toBeInTheDocument();
+  });
+
+  it('shows access denied for non-admin roles', () => {
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('viewer'));
+    renderWithQuery(<AdminAccessRequests />);
+    expect(screen.getByText('Access Denied')).toBeInTheDocument();
+  });
+
+  it('shows access denied for devops', () => {
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('devops'));
+    renderWithQuery(<AdminAccessRequests />);
+    expect(screen.getByText('Access Denied')).toBeInTheDocument();
+  });
+
+  describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
+    '%s persona',
+    (role) => {
+      it('renders the page', () => {
+        vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
+        renderWithQuery(<AdminAccessRequests />);
+        // cpi-admin sees the page, others see Access Denied
+        if (role === 'cpi-admin') {
+          expect(screen.getByText('Access Requests')).toBeInTheDocument();
+        } else {
+          expect(screen.getByText('Access Denied')).toBeInTheDocument();
+        }
+      });
+    }
+  );
+});

--- a/control-plane-ui/src/pages/AnalyticsDashboard/AnalyticsDashboard.test.tsx
+++ b/control-plane-ui/src/pages/AnalyticsDashboard/AnalyticsDashboard.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { AnalyticsDashboard } from './AnalyticsDashboard';
+import { createAuthMock } from '../../test/helpers';
+import { useAuth } from '../../contexts/AuthContext';
+import type { PersonaRole } from '../../test/helpers';
+
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+
+vi.mock('../../services/api', () => ({
+  apiService: {
+    getTopAPIs: vi.fn(() => Promise.resolve([])),
+    get: vi.fn(() =>
+      Promise.resolve({
+        data: { items: [], total_errors: 0, error_rate: 0 },
+      })
+    ),
+  },
+}));
+
+vi.mock('../../hooks/usePrometheus', () => ({
+  usePrometheusQuery: vi.fn(() => ({
+    data: null,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+  usePrometheusRange: vi.fn(() => ({
+    data: null,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+  scalarValue: vi.fn(() => null),
+  groupByLabel: vi.fn(() => ({})),
+}));
+
+vi.mock('../../components/charts/SparklineChart', () => ({
+  SparklineChart: () => <div data-testid="sparkline-chart">Sparkline</div>,
+}));
+
+describe('AnalyticsDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+  });
+
+  it('renders the page title', () => {
+    render(<AnalyticsDashboard />);
+    expect(screen.getByText('Usage Analytics')).toBeInTheDocument();
+  });
+
+  it('renders time range selector with default 24h selected', () => {
+    render(<AnalyticsDashboard />);
+    const buttons = screen.getAllByRole('button');
+    const dayButton = buttons.find((btn) => btn.textContent === '24h');
+    expect(dayButton).toHaveClass('bg-white');
+  });
+
+  it('changes time range when button clicked', () => {
+    render(<AnalyticsDashboard />);
+    const buttons = screen.getAllByRole('button');
+    const oneHourButton = buttons.find((btn) => btn.textContent === '1h');
+
+    if (oneHourButton) {
+      fireEvent.click(oneHourButton);
+      expect(oneHourButton).toHaveClass('bg-white');
+    }
+  });
+
+  it('renders refresh button', () => {
+    render(<AnalyticsDashboard />);
+    expect(screen.getByText('Refresh')).toBeInTheDocument();
+  });
+
+  it('shows KPI stat cards after loading', async () => {
+    render(<AnalyticsDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText(/Total Calls/i)).toBeInTheDocument();
+      expect(screen.getByText(/Avg Latency/i)).toBeInTheDocument();
+      expect(screen.getByText(/Error Rate/i)).toBeInTheDocument();
+      expect(screen.getByText(/Active Consumers/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows "--" for null values', async () => {
+    render(<AnalyticsDashboard />);
+    await waitFor(() => {
+      const dashes = screen.getAllByText('--');
+      expect(dashes.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('renders chart section titles', async () => {
+    render(<AnalyticsDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText('Call Volume')).toBeInTheDocument();
+      expect(screen.getByText('Latency Trend')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state for tools and errors', async () => {
+    render(<AnalyticsDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText('No usage data')).toBeInTheDocument();
+      expect(screen.getByText('No errors')).toBeInTheDocument();
+    });
+  });
+
+  it('shows all time range options', () => {
+    render(<AnalyticsDashboard />);
+    expect(screen.getByText('1h')).toBeInTheDocument();
+    expect(screen.getByText('6h')).toBeInTheDocument();
+    expect(screen.getByText('24h')).toBeInTheDocument();
+    expect(screen.getByText('7d')).toBeInTheDocument();
+    expect(screen.getByText('30d')).toBeInTheDocument();
+  });
+
+  describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
+    '%s persona',
+    (role) => {
+      it('renders the page', () => {
+        vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
+        render(<AnalyticsDashboard />);
+        expect(screen.getByText('Usage Analytics')).toBeInTheDocument();
+      });
+    }
+  );
+});

--- a/control-plane-ui/src/pages/ExecutionView/ErrorTaxonomyChart.test.tsx
+++ b/control-plane-ui/src/pages/ExecutionView/ErrorTaxonomyChart.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ErrorTaxonomyChart } from './ErrorTaxonomyChart';
+
+describe('ErrorTaxonomyChart', () => {
+  it('renders empty state when no items', () => {
+    render(<ErrorTaxonomyChart items={[]} totalErrors={0} />);
+    expect(screen.getByText('No error data available')).toBeInTheDocument();
+  });
+
+  it('renders bars for each category', () => {
+    const items = [
+      { category: 'auth', count: 50, avg_duration_ms: 120, percentage: 50 },
+      { category: 'timeout', count: 30, avg_duration_ms: 500, percentage: 30 },
+      { category: 'validation', count: 20, avg_duration_ms: 80, percentage: 20 },
+    ];
+    render(<ErrorTaxonomyChart items={items} totalErrors={100} />);
+
+    expect(screen.getByText('Auth')).toBeInTheDocument();
+    expect(screen.getByText('Timeout')).toBeInTheDocument();
+    expect(screen.getByText('Validation')).toBeInTheDocument();
+  });
+
+  it('shows counts for each category', () => {
+    const items = [
+      { category: 'auth', count: 50, avg_duration_ms: 120, percentage: 50 },
+      { category: 'backend', count: 25, avg_duration_ms: 200, percentage: 25 },
+    ];
+    render(<ErrorTaxonomyChart items={items} totalErrors={75} />);
+
+    expect(screen.getByText('50')).toBeInTheDocument();
+    expect(screen.getByText('25')).toBeInTheDocument();
+  });
+
+  it('shows total errors summary', () => {
+    const items = [{ category: 'auth', count: 10, avg_duration_ms: 100, percentage: 100 }];
+    render(<ErrorTaxonomyChart items={items} totalErrors={10} />);
+
+    expect(screen.getByText('10 total errors across 1 categories')).toBeInTheDocument();
+  });
+
+  it('shows percentages', () => {
+    const items = [
+      { category: 'rate_limit', count: 40, avg_duration_ms: null, percentage: 66.7 },
+      { category: 'backend', count: 20, avg_duration_ms: 300, percentage: 33.3 },
+    ];
+    render(<ErrorTaxonomyChart items={items} totalErrors={60} />);
+
+    expect(screen.getByText('66.7%')).toBeInTheDocument();
+    expect(screen.getByText('33.3%')).toBeInTheDocument();
+  });
+
+  it('renders SVG bars with aria labels', () => {
+    const items = [{ category: 'auth', count: 10, avg_duration_ms: 100, percentage: 100 }];
+    render(<ErrorTaxonomyChart items={items} totalErrors={10} />);
+
+    const svg = screen.getByRole('img');
+    expect(svg).toHaveAttribute('aria-label', 'Auth: 10');
+  });
+
+  it('handles unknown category gracefully', () => {
+    const items = [{ category: 'unknown_error', count: 5, avg_duration_ms: 50, percentage: 100 }];
+    render(<ErrorTaxonomyChart items={items} totalErrors={5} />);
+
+    expect(screen.getByText('unknown_error')).toBeInTheDocument();
+  });
+});

--- a/control-plane-ui/src/pages/ExecutionView/ExecutionDetailModal.test.tsx
+++ b/control-plane-ui/src/pages/ExecutionView/ExecutionDetailModal.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ExecutionDetailModal } from './ExecutionDetailModal';
+
+const baseExecution = {
+  id: 'exec-1',
+  tenant_id: 'test-tenant',
+  consumer_id: 'consumer-1',
+  api_id: 'api-1',
+  api_name: 'Payment API',
+  tool_name: 'create-payment',
+  request_id: 'req-abc-123',
+  method: 'POST',
+  path: '/v1/payments',
+  status_code: 200,
+  status: 'success',
+  error_category: null,
+  error_message: null,
+  started_at: '2026-02-15T10:00:00Z',
+  completed_at: '2026-02-15T10:00:01Z',
+  duration_ms: 120,
+  request_headers: null,
+  response_summary: null,
+};
+
+describe('ExecutionDetailModal', () => {
+  it('renders the modal title', () => {
+    render(<ExecutionDetailModal execution={baseExecution} onClose={vi.fn()} />);
+    expect(screen.getByText('Execution Detail')).toBeInTheDocument();
+  });
+
+  it('displays execution fields', () => {
+    render(<ExecutionDetailModal execution={baseExecution} onClose={vi.fn()} />);
+
+    expect(screen.getByText('req-abc-123')).toBeInTheDocument();
+    expect(screen.getByText('POST')).toBeInTheDocument();
+    expect(screen.getByText('/v1/payments')).toBeInTheDocument();
+    expect(screen.getByText('Payment API')).toBeInTheDocument();
+    expect(screen.getByText('create-payment')).toBeInTheDocument();
+    expect(screen.getByText('120ms')).toBeInTheDocument();
+  });
+
+  it('shows status code and status', () => {
+    render(<ExecutionDetailModal execution={baseExecution} onClose={vi.fn()} />);
+    expect(screen.getByText('200 (success)')).toBeInTheDocument();
+  });
+
+  it('calls onClose when close button clicked', () => {
+    const onClose = vi.fn();
+    render(<ExecutionDetailModal execution={baseExecution} onClose={onClose} />);
+
+    const closeButton = screen.getByLabelText('Close');
+    fireEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when backdrop clicked', () => {
+    const onClose = vi.fn();
+    render(<ExecutionDetailModal execution={baseExecution} onClose={onClose} />);
+
+    const backdrop = screen.getByRole('dialog');
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows error message when present', () => {
+    const exec = { ...baseExecution, error_message: 'Connection timeout', status: 'error' };
+    render(<ExecutionDetailModal execution={exec} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Error Message')).toBeInTheDocument();
+    expect(screen.getByText('Connection timeout')).toBeInTheDocument();
+  });
+
+  it('shows request headers when present', () => {
+    const exec = {
+      ...baseExecution,
+      request_headers: { 'Content-Type': 'application/json' },
+    };
+    render(<ExecutionDetailModal execution={exec} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Request Headers')).toBeInTheDocument();
+  });
+
+  it('shows response summary when present', () => {
+    const exec = { ...baseExecution, response_summary: { status: 'ok' } };
+    render(<ExecutionDetailModal execution={exec} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Response Summary')).toBeInTheDocument();
+  });
+
+  it('shows dashes for null fields', () => {
+    const exec = {
+      ...baseExecution,
+      method: null,
+      path: null,
+      api_name: null,
+      tool_name: null,
+      duration_ms: null,
+    };
+    render(<ExecutionDetailModal execution={exec} onClose={vi.fn()} />);
+
+    // Multiple "—" for null fields
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/control-plane-ui/src/pages/SecurityPosture/SecurityPostureDashboard.test.tsx
+++ b/control-plane-ui/src/pages/SecurityPosture/SecurityPostureDashboard.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { SecurityPostureDashboard } from './SecurityPostureDashboard';
+import { createAuthMock } from '../../test/helpers';
+import { useAuth } from '../../contexts/AuthContext';
+import type { PersonaRole } from '../../test/helpers';
+
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+
+vi.mock('../../services/api', () => ({
+  apiService: {
+    get: vi.fn(() =>
+      Promise.resolve({
+        data: { events: [], summary: {} },
+      })
+    ),
+  },
+}));
+
+describe('SecurityPostureDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+  });
+
+  it('renders the page title', () => {
+    render(<SecurityPostureDashboard />);
+    expect(screen.getByText('Security Posture')).toBeInTheDocument();
+  });
+
+  it('renders the subtitle', () => {
+    render(<SecurityPostureDashboard />);
+    expect(
+      screen.getByText('Continuous security monitoring and compliance scoring')
+    ).toBeInTheDocument();
+  });
+
+  it('renders refresh button', () => {
+    render(<SecurityPostureDashboard />);
+    expect(screen.getByText('Refresh')).toBeInTheDocument();
+  });
+
+  it('shows KPI stat cards after loading', async () => {
+    render(<SecurityPostureDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText('Open Findings')).toBeInTheDocument();
+      expect(screen.getByText('Auth Failures (24h)')).toBeInTheDocument();
+      expect(screen.getByText('Config Drift')).toBeInTheDocument();
+      expect(screen.getByText('Compliance')).toBeInTheDocument();
+    });
+  });
+
+  it('shows security score gauge', async () => {
+    render(<SecurityPostureDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText('Security Score')).toBeInTheDocument();
+    });
+  });
+
+  it('shows compliance checks', async () => {
+    render(<SecurityPostureDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText('Compliance Checks')).toBeInTheDocument();
+      expect(screen.getByText('mTLS enforcement')).toBeInTheDocument();
+      expect(screen.getByText('Audit logging enabled')).toBeInTheDocument();
+    });
+  });
+
+  it('shows security findings section', async () => {
+    render(<SecurityPostureDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText('Security Findings')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty findings message when no data', async () => {
+    render(<SecurityPostureDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText('No open security findings')).toBeInTheDocument();
+    });
+  });
+
+  it('renders severity filter', async () => {
+    render(<SecurityPostureDashboard />);
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('All Severities')).toBeInTheDocument();
+    });
+  });
+
+  describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
+    '%s persona',
+    (role) => {
+      it('renders the page', () => {
+        vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
+        render(<SecurityPostureDashboard />);
+        expect(screen.getByText('Security Posture')).toBeInTheDocument();
+      });
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- Add test coverage for AnalyticsDashboard, SecurityPostureDashboard, AdminAccessRequests, ErrorTaxonomyChart, and ExecutionDetailModal
- These pages were added in PR #1080 without tests, causing coverage to drop below CI thresholds (51% functions < 53%, 62% statements < 63%)
- 52 new tests total covering rendering, interactions, error states, and 4-persona RBAC

## Test plan
- [x] All 52 new tests pass locally
- [x] Pre-commit hooks pass (ESLint + Prettier)
- [ ] CI coverage thresholds restored

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>