### PR TITLE
feat(ops): instance-based permission enforcement + Slack notify (CAB-1481)

### DIFF
--- a/.claude/hooks/pre-instance-scope.sh
+++ b/.claude/hooks/pre-instance-scope.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Pre-tool hook: Enforce per-instance file scope and command restrictions.
+#
+# Reads STOA_INSTANCE env var (backend, frontend, auth, mcp, qa).
+# If set, loads deny rules from .claude/instances/<role>.json and blocks
+# Edit/Write on denied paths + Bash commands matching deny patterns.
+#
+# Works for any Claude session:
+#   export STOA_INSTANCE=backend && claude   # standalone
+#   stoa-parallel                             # sets per-window
+#
+# Exit 0 = allow, Exit 2 = block
+
+# No instance set → allow everything
+if [[ -z "${STOA_INSTANCE:-}" ]]; then
+  exit 0
+fi
+
+# Resolve paths
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTANCE_FILE="$PROJECT_DIR/.claude/instances/${STOA_INSTANCE}.json"
+
+if [[ ! -f "$INSTANCE_FILE" ]]; then
+  exit 0
+fi
+
+# Read tool input from stdin
+INPUT=$(cat)
+TOOL_NAME="${CLAUDE_TOOL_NAME:-}"
+
+# Fallback: extract tool name from JSON if env var not available
+if [[ -z "$TOOL_NAME" ]]; then
+  TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+fi
+
+if [[ -z "$TOOL_NAME" ]]; then
+  exit 0
+fi
+
+# --- Edit/Write: check file_path against deny_paths ---
+if [[ "$TOOL_NAME" == "Edit" || "$TOOL_NAME" == "Write" ]]; then
+  FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+  if [[ -z "$FILE_PATH" ]]; then
+    exit 0
+  fi
+
+  # Make path relative to project for matching
+  REL_PATH="${FILE_PATH#"$PROJECT_DIR"}"
+
+  # Read deny patterns for Edit/Write from instance file
+  # Format: "Edit(/portal/**)" or "Write(/stoa-gateway/src/**)"
+  while IFS= read -r pattern; do
+    [[ -z "$pattern" ]] && continue
+    # Extract path from pattern: "Edit(/portal/**)" → "/portal/"
+    # Match both Edit and Write deny rules for either tool
+    deny_path=$(echo "$pattern" | sed -n 's/^[^(]*(\/\(.*\)\*\*)/\/\1/p')
+    if [[ -n "$deny_path" && "$REL_PATH" == "$deny_path"* ]]; then
+      echo "BLOCKED by instance:${STOA_INSTANCE} — ${TOOL_NAME} on ${REL_PATH} is outside your scope. Denied path: ${deny_path}" >&2
+      exit 2
+    fi
+  done < <(jq -r '.permissions.deny[]? // empty' "$INSTANCE_FILE" 2>/dev/null | grep -E '^(Edit|Write)\(')
+fi
+
+# --- Bash: check command against deny patterns ---
+if [[ "$TOOL_NAME" == "Bash" ]]; then
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+  if [[ -z "$COMMAND" ]]; then
+    exit 0
+  fi
+
+  # Read Bash deny patterns from instance file
+  # Format: "Bash(rm -rf *)" or "Bash(npm:*)" or "Bash(sudo *)"
+  while IFS= read -r pattern; do
+    [[ -z "$pattern" ]] && continue
+    # Extract inner: "Bash(npm:*)" → "npm:*", strip Bash() wrapper
+    inner=$(echo "$pattern" | sed -n 's/^Bash(\(.*\))/\1/p')
+    # Strip trailing :* or space-* to get the command prefix
+    cmd_prefix=$(echo "$inner" | sed 's/[[:space:]:]*\*$//')
+    if [[ -n "$cmd_prefix" ]]; then
+      # Check if command starts with the denied prefix
+      if [[ "$COMMAND" == "$cmd_prefix"* || "$COMMAND" == *" $cmd_prefix"* ]]; then
+        echo "BLOCKED by instance:${STOA_INSTANCE} — Bash command '${cmd_prefix}...' is not allowed for this instance." >&2
+        exit 2
+      fi
+    fi
+  done < <(jq -r '.permissions.deny[]? // empty' "$INSTANCE_FILE" 2>/dev/null | grep '^Bash(')
+fi
+
+exit 0

--- a/.claude/hooks/stop-slack-notify.sh
+++ b/.claude/hooks/stop-slack-notify.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Stop hook: Send Slack notification when Claude session ends.
+# Sends a summary with instance role, branch, recent commits, and PR status.
+#
+# Requires: SLACK_WEBHOOK_URL env var (set in .claude/settings.json env or shell)
+# Optional: STOA_INSTANCE env var (set by stoa-parallel or manually)
+#
+# Gracefully degrades: no webhook = no notification (silent skip).
+
+WEBHOOK="${SLACK_WEBHOOK_URL:-}"
+[ -z "$WEBHOOK" ] && exit 0
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+cd "$PROJECT_DIR" 2>/dev/null || exit 0
+
+# Gather context
+INSTANCE="${STOA_INSTANCE:-default}"
+BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+RECENT_COMMITS=$(git log --oneline -3 2>/dev/null | head -3 | sed 's/"/\\"/g' | tr '\n' '\\' | sed 's/\\/\\n/g')
+HOSTNAME=$(hostname -s 2>/dev/null || echo "local")
+
+# Check for open PR on current branch
+PR_INFO=""
+if command -v gh &>/dev/null; then
+  PR_NUM=$(gh pr view --json number -q '.number' 2>/dev/null || true)
+  if [ -n "$PR_NUM" ]; then
+    PR_STATE=$(gh pr view --json state -q '.state' 2>/dev/null || echo "UNKNOWN")
+    PR_TITLE=$(gh pr view --json title -q '.title' 2>/dev/null | head -c 80 || true)
+    PR_INFO="\\n*PR #${PR_NUM}*: ${PR_TITLE} (${PR_STATE})"
+  fi
+fi
+
+# Check for modified files (uncommitted work)
+DIRTY=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+DIRTY_MSG=""
+if [ "$DIRTY" -gt 0 ]; then
+  DIRTY_MSG="\\n:warning: ${DIRTY} uncommitted file(s)"
+fi
+
+# Build Slack message
+EMOJI=":white_check_mark:"
+[ "$INSTANCE" != "default" ] && ROLE_LABEL=" (instance:${INSTANCE})" || ROLE_LABEL=""
+
+PAYLOAD=$(cat <<SLACKEOF
+{
+  "blocks": [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "${EMOJI} *Claude session ended*${ROLE_LABEL}\\n\\n*Branch*: \`${BRANCH}\`\\n*Host*: ${HOSTNAME}${PR_INFO}${DIRTY_MSG}"
+      }
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "*Recent commits*:\\n\`\`\`${RECENT_COMMITS}\`\`\`"
+      }
+    },
+    {
+      "type": "context",
+      "elements": [
+        {
+          "type": "mrkdwn",
+          "text": ":hourglass: Waiting for next instruction | $(date '+%H:%M %Z')"
+        }
+      ]
+    }
+  ]
+}
+SLACKEOF
+)
+
+# Send (best-effort, never fail the parent hook)
+curl -sf -X POST "$WEBHOOK" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD" >/dev/null 2>&1 || true
+
+exit 0

--- a/.claude/instances/auth.json
+++ b/.claude/instances/auth.json
@@ -1,0 +1,39 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(curl:*)",
+      "Bash(jq:*)",
+      "Bash(kubectl:*)",
+      "Bash(ls:*)",
+      "Bash(tree:*)",
+      "Bash(test:*)",
+      "Bash(mkdir:*)",
+      "Bash(chmod:*)",
+      "Bash(wc:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(diff:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)"
+    ],
+    "deny": [
+      "Edit(/portal/src/**)",
+      "Write(/portal/src/**)",
+      "Edit(/stoa-gateway/src/**)",
+      "Write(/stoa-gateway/src/**)",
+      "Edit(/control-plane-ui/src/**)",
+      "Write(/control-plane-ui/src/**)",
+      "Edit(/e2e/**)",
+      "Write(/e2e/**)",
+      "Bash(rm -rf *)",
+      "Bash(sudo *)",
+      "Bash(npm:*)",
+      "Bash(cargo:*)",
+      "Bash(pytest:*)",
+      "Bash(alembic:*)"
+    ]
+  }
+}

--- a/.claude/instances/backend.json
+++ b/.claude/instances/backend.json
@@ -1,0 +1,47 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(pip:*)",
+      "Bash(pip3:*)",
+      "Bash(pytest:*)",
+      "Bash(ruff:*)",
+      "Bash(black:*)",
+      "Bash(mypy:*)",
+      "Bash(alembic:*)",
+      "Bash(curl:*)",
+      "Bash(jq:*)",
+      "Bash(kubectl:*)",
+      "Bash(helm:*)",
+      "Bash(docker:*)",
+      "Bash(docker-compose:*)",
+      "Bash(ls:*)",
+      "Bash(tree:*)",
+      "Bash(test:*)",
+      "Bash(mkdir:*)",
+      "Bash(chmod:*)",
+      "Bash(wc:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(diff:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)"
+    ],
+    "deny": [
+      "Edit(/portal/**)",
+      "Write(/portal/**)",
+      "Edit(/stoa-gateway/src/**)",
+      "Write(/stoa-gateway/src/**)",
+      "Edit(/control-plane-ui/src/**)",
+      "Write(/control-plane-ui/src/**)",
+      "Edit(/e2e/**)",
+      "Write(/e2e/**)",
+      "Bash(rm -rf *)",
+      "Bash(sudo *)"
+    ]
+  }
+}

--- a/.claude/instances/frontend.json
+++ b/.claude/instances/frontend.json
@@ -1,0 +1,45 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(vitest:*)",
+      "Bash(eslint:*)",
+      "Bash(prettier:*)",
+      "Bash(tsc:*)",
+      "Bash(curl:*)",
+      "Bash(jq:*)",
+      "Bash(ls:*)",
+      "Bash(tree:*)",
+      "Bash(test:*)",
+      "Bash(mkdir:*)",
+      "Bash(chmod:*)",
+      "Bash(wc:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(diff:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)"
+    ],
+    "deny": [
+      "Edit(/control-plane-api/src/**)",
+      "Write(/control-plane-api/src/**)",
+      "Edit(/stoa-gateway/**)",
+      "Write(/stoa-gateway/**)",
+      "Edit(/e2e/**)",
+      "Write(/e2e/**)",
+      "Edit(/charts/**)",
+      "Write(/charts/**)",
+      "Edit(/k8s/**)",
+      "Write(/k8s/**)",
+      "Bash(rm -rf *)",
+      "Bash(sudo *)",
+      "Bash(pytest:*)",
+      "Bash(cargo:*)",
+      "Bash(alembic:*)"
+    ]
+  }
+}

--- a/.claude/instances/mcp.json
+++ b/.claude/instances/mcp.json
@@ -1,0 +1,39 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(cargo:*)",
+      "Bash(rustup:*)",
+      "Bash(curl:*)",
+      "Bash(jq:*)",
+      "Bash(ls:*)",
+      "Bash(tree:*)",
+      "Bash(test:*)",
+      "Bash(mkdir:*)",
+      "Bash(chmod:*)",
+      "Bash(wc:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(diff:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)"
+    ],
+    "deny": [
+      "Edit(/control-plane-ui/**)",
+      "Write(/control-plane-ui/**)",
+      "Edit(/portal/**)",
+      "Write(/portal/**)",
+      "Edit(/e2e/**)",
+      "Write(/e2e/**)",
+      "Edit(/control-plane-api/src/**)",
+      "Write(/control-plane-api/src/**)",
+      "Bash(rm -rf *)",
+      "Bash(sudo *)",
+      "Bash(npm:*)",
+      "Bash(pytest:*)",
+      "Bash(alembic:*)"
+    ]
+  }
+}

--- a/.claude/instances/qa.json
+++ b/.claude/instances/qa.json
@@ -1,0 +1,45 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(pytest:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(vitest:*)",
+      "Bash(playwright:*)",
+      "Bash(curl:*)",
+      "Bash(jq:*)",
+      "Bash(ls:*)",
+      "Bash(tree:*)",
+      "Bash(test:*)",
+      "Bash(mkdir:*)",
+      "Bash(wc:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(diff:*)"
+    ],
+    "deny": [
+      "Edit(/control-plane-api/src/**)",
+      "Write(/control-plane-api/src/**)",
+      "Edit(/control-plane-ui/src/**)",
+      "Write(/control-plane-ui/src/**)",
+      "Edit(/portal/src/**)",
+      "Write(/portal/src/**)",
+      "Edit(/stoa-gateway/src/**)",
+      "Write(/stoa-gateway/src/**)",
+      "Edit(/charts/**)",
+      "Write(/charts/**)",
+      "Edit(/k8s/**)",
+      "Write(/k8s/**)",
+      "Bash(rm -rf *)",
+      "Bash(sudo *)",
+      "Bash(cargo:*)",
+      "Bash(alembic:*)",
+      "Bash(terraform *)"
+    ]
+  }
+}

--- a/.claude/rules/instance-dispatch.md
+++ b/.claude/rules/instance-dispatch.md
@@ -66,20 +66,77 @@ If a ticket touches multiple instances:
 | `e2e/**` | `instance:qa` |
 | `stoa-docs` (separate repo) | `instance:backend` |
 
+## Permission Enforcement (CAB-1481)
+
+Each instance has a deny list preventing cross-scope file edits and unauthorized commands.
+
+### Mechanism
+
+Two layers of enforcement:
+1. **PreToolUse hook** (`pre-instance-scope.sh`) — reads `STOA_INSTANCE` env var, blocks denied operations at runtime
+2. **Instance settings files** (`.claude/instances/<role>.json`) — define deny rules per role
+
+### Usage
+
+```bash
+# Standalone session (any terminal)
+export STOA_INSTANCE=backend && claude
+
+# stoa-parallel (automatic per window)
+stoa-parallel  # each window gets STOA_INSTANCE=<role>
+
+# Clear instance scope
+unset STOA_INSTANCE
+```
+
+### Deny Matrix
+
+| Instance | Denied Paths (Edit/Write) | Denied Commands |
+|----------|--------------------------|-----------------|
+| backend | `/portal/`, `/stoa-gateway/src/`, `/control-plane-ui/src/`, `/e2e/` | `rm -rf`, `sudo` |
+| frontend | `/control-plane-api/src/`, `/stoa-gateway/`, `/e2e/`, `/charts/`, `/k8s/` | `rm -rf`, `sudo`, `pytest`, `cargo`, `alembic` |
+| auth | `/portal/src/`, `/stoa-gateway/src/`, `/control-plane-ui/src/`, `/e2e/` | `rm -rf`, `sudo`, `npm`, `cargo`, `pytest`, `alembic` |
+| mcp | `/control-plane-ui/`, `/portal/`, `/e2e/`, `/control-plane-api/src/` | `rm -rf`, `sudo`, `npm`, `pytest`, `alembic` |
+| qa | `/control-plane-api/src/`, `/control-plane-ui/src/`, `/portal/src/`, `/stoa-gateway/src/`, `/charts/`, `/k8s/` | `rm -rf`, `sudo`, `cargo`, `alembic`, `terraform` |
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `.claude/instances/backend.json` | Backend instance deny rules |
+| `.claude/instances/frontend.json` | Frontend instance deny rules |
+| `.claude/instances/auth.json` | Auth instance deny rules |
+| `.claude/instances/mcp.json` | MCP/Gateway instance deny rules |
+| `.claude/instances/qa.json` | QA instance deny rules |
+| `.claude/hooks/pre-instance-scope.sh` | PreToolUse hook enforcing scope |
+| `.claude/hooks/stop-slack-notify.sh` | Stop hook sending Slack session summary |
+
+## Slack Session Notifications
+
+When `SLACK_WEBHOOK_URL` is set, each Claude session sends a Slack notification on Stop with:
+- Instance role and branch name
+- Last 3 commits
+- Open PR status (if any)
+- Uncommitted file count
+- "Waiting for next instruction" footer
+
+Set `SLACK_WEBHOOK_URL` in your shell profile or `.claude/settings.local.json` env section.
+
 ## tmux Layout (`stoa-parallel`)
 
 ```
 Session: stoa
-├── Window 0: MONITOR    (htop + watchdog)
-├── Window 1: ORCHESTRE  (user coordination terminal)
-├── Window 2: BACKEND    (Claude — instance:backend)
-├── Window 3: FRONTEND   (Claude — instance:frontend)
-├── Window 4: AUTH       (Claude — instance:auth)
-├── Window 5: MCP        (Claude — instance:mcp)
-└── Window 6: QA         (Claude — instance:qa)
++-- Window 0: MONITOR    (htop + watchdog)
++-- Window 1: ORCHESTRE  (user coordination terminal)
++-- Window 2: BACKEND    (STOA_INSTANCE=backend)
++-- Window 3: FRONTEND   (STOA_INSTANCE=frontend)
++-- Window 4: AUTH       (STOA_INSTANCE=auth)
++-- Window 5: MCP        (STOA_INSTANCE=mcp)
++-- Window 6: QA         (STOA_INSTANCE=qa)
 ```
 
 Each Claude instance at startup:
+- `STOA_INSTANCE` env var set -> hook enforces deny rules
 - Session startup mechanism loads context automatically (memory.md, plan.md, CLAUDE.md)
 - Startup prompt includes: instance role, scope exclusif, max 5 tickets from Linear cycle
 - Linear filter: `list_issues(labels: ['instance:<role>'], cycle: current)`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,15 @@
   "hooks": {
     "PreToolUse": [
       {
+        "matcher": "Edit|Write|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-instance-scope.sh\""
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write",
         "hooks": [
           {
@@ -51,6 +60,10 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-cost-tracker.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-slack-notify.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Summary
- **Per-instance permission enforcement** via `STOA_INSTANCE` env var + PreToolUse hook — prevents cross-scope file edits and unauthorized commands at runtime
- **5 instance deny matrices** (`.claude/instances/*.json`) for backend, frontend, auth, mcp, qa
- **Slack session notifications** on Stop hook — sends branch, last 3 commits, PR status, and uncommitted file count when a session ends

## How it works

1. `pre-instance-scope.sh` (PreToolUse hook) reads `STOA_INSTANCE` env var
2. Loads deny rules from `.claude/instances/<role>.json`
3. For Edit/Write: blocks file paths matching deny patterns
4. For Bash: blocks commands matching deny prefixes
5. If `STOA_INSTANCE` unset → no-op (backwards compatible)

## Deny Matrix

| Instance | Denied Paths | Denied Commands |
|----------|-------------|-----------------|
| backend | portal/, stoa-gateway/src/, control-plane-ui/src/, e2e/ | rm -rf, sudo |
| frontend | control-plane-api/src/, stoa-gateway/, e2e/, charts/, k8s/ | rm -rf, sudo, pytest, cargo, alembic |
| auth | portal/src/, stoa-gateway/src/, control-plane-ui/src/, e2e/ | rm -rf, sudo, npm, cargo, pytest, alembic |
| mcp | control-plane-ui/, portal/, e2e/, control-plane-api/src/ | rm -rf, sudo, npm, pytest, alembic |
| qa | all src/ dirs, charts/, k8s/ | rm -rf, sudo, cargo, alembic, terraform |

## Test plan
- [x] Hook tested with 10 scenarios (blocked/allowed paths and commands)
- [x] No-op when `STOA_INSTANCE` unset
- [x] Slack notification best-effort (silent skip if `SLACK_WEBHOOK_URL` unset)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)