### PR TITLE
test(ui): add tests to restore function coverage threshold

### DIFF
--- a/control-plane-ui/src/components/DeployProgress.test.tsx
+++ b/control-plane-ui/src/components/DeployProgress.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DeployProgress } from './DeployProgress';
+
+describe('DeployProgress', () => {
+  it('renders all 4 step labels', () => {
+    render(<DeployProgress currentStep={null} status={null} />);
+    expect(screen.getByText('Validating')).toBeInTheDocument();
+    expect(screen.getByText('Syncing')).toBeInTheDocument();
+    expect(screen.getByText('Health Check')).toBeInTheDocument();
+    expect(screen.getByText('Complete')).toBeInTheDocument();
+  });
+
+  it('shows all steps as pending when no current step', () => {
+    const { container } = render(<DeployProgress currentStep={null} status={null} />);
+    const pendingCircles = container.querySelectorAll('.bg-neutral-100');
+    expect(pendingCircles.length).toBe(4);
+  });
+
+  it('shows active step with blue styling', () => {
+    const { container } = render(<DeployProgress currentStep="sync" status="in_progress" />);
+    const activeCircles = container.querySelectorAll('.bg-blue-100');
+    expect(activeCircles.length).toBe(1);
+  });
+
+  it('shows done steps with green styling when status is success', () => {
+    const { container } = render(<DeployProgress currentStep="complete" status="success" />);
+    const doneCircles = container.querySelectorAll('.bg-green-100');
+    expect(doneCircles.length).toBe(4);
+  });
+
+  it('shows failed step with red styling', () => {
+    const { container } = render(<DeployProgress currentStep="sync" status="failed" />);
+    const failedCircles = container.querySelectorAll('.bg-red-100');
+    expect(failedCircles.length).toBe(1);
+  });
+
+  it('shows completed steps before failed step as done', () => {
+    const { container } = render(<DeployProgress currentStep="sync" status="failed" />);
+    const doneCircles = container.querySelectorAll('.bg-green-100');
+    expect(doneCircles.length).toBe(1);
+  });
+});

--- a/control-plane-ui/src/services/diagnosticService.test.ts
+++ b/control-plane-ui/src/services/diagnosticService.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runDiagnostic, checkConnectivity, getDiagnosticHistory } from './diagnosticService';
+import { apiService } from './api';
+
+vi.mock('./api', () => ({
+  apiService: {
+    get: vi.fn(),
+  },
+}));
+
+const mockReport = {
+  id: 'diag-1',
+  timestamp: '2026-02-15T10:00:00Z',
+  tenant_id: 'tenant-1',
+  gateway_id: 'gw-1',
+  root_causes: [],
+  timing: null,
+  network_path: null,
+  redacted: false,
+};
+
+const mockConnectivity = {
+  overall_status: 'healthy',
+  stages: [{ name: 'dns', status: 'ok', latency_ms: 5, detail: null }],
+  network_path: null,
+  checked_at: '2026-02-15T10:00:00Z',
+};
+
+describe('diagnosticService', () => {
+  it('runDiagnostic calls the correct endpoint', async () => {
+    vi.mocked(apiService.get).mockResolvedValue({ data: mockReport });
+    const result = await runDiagnostic('gw-1');
+    expect(apiService.get).toHaveBeenCalledWith('/v1/admin/diagnostics/gw-1');
+    expect(result).toEqual(mockReport);
+  });
+
+  it('checkConnectivity calls the correct endpoint', async () => {
+    vi.mocked(apiService.get).mockResolvedValue({ data: mockConnectivity });
+    const result = await checkConnectivity('gw-1');
+    expect(apiService.get).toHaveBeenCalledWith('/v1/admin/diagnostics/gw-1/connectivity');
+    expect(result).toEqual(mockConnectivity);
+  });
+
+  it('getDiagnosticHistory calls the correct endpoint with default limit', async () => {
+    vi.mocked(apiService.get).mockResolvedValue({ data: [mockReport] });
+    const result = await getDiagnosticHistory('gw-1');
+    expect(apiService.get).toHaveBeenCalledWith('/v1/admin/diagnostics/gw-1/history', {
+      params: { limit: 20 },
+    });
+    expect(result).toEqual([mockReport]);
+  });
+
+  it('getDiagnosticHistory accepts custom limit', async () => {
+    vi.mocked(apiService.get).mockResolvedValue({ data: [] });
+    await getDiagnosticHistory('gw-1', 5);
+    expect(apiService.get).toHaveBeenCalledWith('/v1/admin/diagnostics/gw-1/history', {
+      params: { limit: 5 },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds unit tests for `diagnosticService` (4 tests covering all 3 exported functions)
- Adds unit tests for `DeployProgress` component (6 tests covering step states and styling)
- Together with DeployLogViewer and LanguageToggle tests (already merged in #1087), these push function coverage above the 53% CI threshold

## Context
PR #1083 added tests for 5 dashboard pages but function coverage remained at 52.26% (below the 53% threshold). These additional tests target files with the highest function-to-LOC ratio for maximum coverage impact.

## Test plan
- [x] All 10 new tests pass locally (`npx vitest run`)
- [ ] CI green (3 required checks + coverage threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)