### PR TITLE
feat(hegemon): Agent State Store with auto-tracking hooks (CAB-1482)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,10 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-bash-log.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/hegemon/tools/state/hook-state-tracker.sh\""
           }
         ]
       },
@@ -64,6 +68,10 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-slack-notify.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/hegemon/tools/state/hook-session-end.sh\""
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ journal.md
 
 # Database dumps (may contain PII)
 *.sql
+!hegemon/tools/state/schema.sql
 *.dump
 *.db
 *.sqlite

--- a/hegemon/tools/state/heg_state.py
+++ b/hegemon/tools/state/heg_state.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+"""heg-state — HEGEMON Agent State Store CLI.
+
+Centralized SQLite WAL state tracking for parallel Claude Code sessions.
+Replaces .claude/claims/*.json with queryable, concurrent-safe SQL.
+
+Usage:
+    heg-state start  --ticket CAB-1350 --role backend --branch feat/...
+    heg-state step   CAB-1350 pr-created --pr 578
+    heg-state done   CAB-1350
+    heg-state ls     [--project stoa] [--mine]
+    heg-state history CAB-1350
+    heg-state claim  CAB-1350 [--phase 1 --mega CAB-1290 --tickets T1,T2]
+    heg-state release CAB-1350 [--phase 1]
+    heg-state claims [MEGA-ID]
+    heg-state cleanup --stale 2h
+"""
+
+import argparse
+import json
+import os
+import platform
+import sqlite3
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+DB_PATH = Path(os.environ.get("HEGEMON_STATE_DB", Path.home() / ".hegemon" / "state.db"))
+SCHEMA_PATH = Path(__file__).parent / "schema.sql"
+
+VALID_STEPS = [
+    "claimed", "coding", "pr-created", "ci-green", "ci-failed",
+    "merging", "merged", "cd-verified", "blocked", "paused", "done",
+]
+VALID_ROLES = ["interactive", "backend", "frontend", "auth", "mcp", "qa"]
+VALID_SOURCES = ["local", "ci-l1", "ci-l3", "ci-l3.5"]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _hostname() -> str:
+    return platform.node()
+
+
+def _connect() -> sqlite3.Connection:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(DB_PATH), timeout=15)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=10000")
+    if not _tables_exist(conn):
+        conn.executescript(SCHEMA_PATH.read_text())
+    return conn
+
+
+def _tables_exist(conn: sqlite3.Connection) -> bool:
+    row = conn.execute(
+        "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='sessions'"
+    ).fetchone()
+    return row[0] > 0
+
+
+# ── Session commands ──────────────────────────────────────────────
+
+
+def cmd_start(args: argparse.Namespace) -> None:
+    instance_id = args.instance or f"t{int(time.time()) % 100000}-{os.urandom(2).hex()}"
+    now = _now()
+    project = args.project or os.environ.get("HEGEMON_PROJECT", "stoa")
+    role = args.role or os.environ.get("STOA_INSTANCE", "interactive")
+
+    conn = _connect()
+    conn.execute(
+        """INSERT OR REPLACE INTO sessions
+           (instance_id, project, role, ticket, branch, step, pr, host, source, pid, started_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, 'claimed', NULL, ?, ?, ?, ?, ?)""",
+        (instance_id, project, role, args.ticket, args.branch,
+         _hostname(), args.source or "local", os.getpid(), now, now),
+    )
+    # Milestone
+    if args.ticket:
+        conn.execute(
+            "INSERT INTO milestones (ticket, step, instance_id, project, created_at) VALUES (?, 'claimed', ?, ?, ?)",
+            (args.ticket, instance_id, project, now),
+        )
+    conn.commit()
+    conn.close()
+    print(f"Session started: {instance_id} → {args.ticket or '(no ticket)'}")
+
+
+def cmd_step(args: argparse.Namespace) -> None:
+    if args.step not in VALID_STEPS:
+        print(f"Invalid step '{args.step}'. Valid: {', '.join(VALID_STEPS)}", file=sys.stderr)
+        sys.exit(1)
+
+    now = _now()
+    conn = _connect()
+
+    # Update session
+    updated = conn.execute(
+        "UPDATE sessions SET step=?, pr=COALESCE(?, pr), updated_at=? WHERE ticket=?",
+        (args.step, args.pr, now, args.ticket),
+    ).rowcount
+
+    if updated == 0:
+        print(f"No active session for ticket {args.ticket}", file=sys.stderr)
+        sys.exit(1)
+
+    # Fetch instance_id and project for milestone
+    row = conn.execute(
+        "SELECT instance_id, project FROM sessions WHERE ticket=?", (args.ticket,)
+    ).fetchone()
+
+    conn.execute(
+        "INSERT INTO milestones (ticket, step, instance_id, project, pr, sha, detail, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (args.ticket, args.step, row["instance_id"], row["project"],
+         args.pr, args.sha, args.detail, now),
+    )
+
+    # Auto-transition: done → clean up session
+    if args.step == "done":
+        conn.execute("DELETE FROM sessions WHERE ticket=?", (args.ticket,))
+
+    conn.commit()
+    conn.close()
+    pr_info = f" (PR #{args.pr})" if args.pr else ""
+    sha_info = f" [{args.sha[:7]}]" if args.sha else ""
+    print(f"{args.ticket} → {args.step}{pr_info}{sha_info}")
+
+
+def cmd_pause(args: argparse.Namespace) -> None:
+    args.step = "paused"
+    args.pr = None
+    args.sha = None
+    args.detail = args.reason
+    cmd_step(args)
+
+
+def cmd_done(args: argparse.Namespace) -> None:
+    args.step = "done"
+    args.pr = None
+    args.sha = None
+    args.detail = None
+    cmd_step(args)
+
+
+def cmd_block(args: argparse.Namespace) -> None:
+    args.step = "blocked"
+    args.pr = None
+    args.sha = None
+    args.detail = args.reason
+    cmd_step(args)
+
+
+# ── Query commands ────────────────────────────────────────────────
+
+
+def cmd_ls(args: argparse.Namespace) -> None:
+    conn = _connect()
+    query = "SELECT * FROM sessions WHERE 1=1"
+    params: list = []
+
+    if args.project:
+        query += " AND project=?"
+        params.append(args.project)
+    if args.mine:
+        query += " AND host=?"
+        params.append(_hostname())
+
+    query += " ORDER BY updated_at DESC"
+    rows = conn.execute(query, params).fetchall()
+    conn.close()
+
+    if not rows:
+        print("No active sessions.")
+        return
+
+    # Table format
+    print(f"{'INSTANCE':<20} {'ROLE':<12} {'TICKET':<12} {'STEP':<14} {'PR':<6} {'SOURCE':<8} {'UPDATED':<20}")
+    print("─" * 92)
+    for r in rows:
+        pr = str(r["pr"]) if r["pr"] else "—"
+        print(f"{r['instance_id']:<20} {r['role']:<12} {r['ticket'] or '—':<12} {r['step']:<14} {pr:<6} {r['source']:<8} {r['updated_at']:<20}")
+
+
+def cmd_history(args: argparse.Namespace) -> None:
+    conn = _connect()
+    rows = conn.execute(
+        "SELECT * FROM milestones WHERE ticket=? ORDER BY created_at ASC",
+        (args.ticket,),
+    ).fetchall()
+    conn.close()
+
+    if not rows:
+        print(f"No milestones for {args.ticket}.")
+        return
+
+    print(f"History for {args.ticket}:")
+    print(f"{'TIME':<22} {'STEP':<14} {'INSTANCE':<20} {'PR':<6} {'SHA':<10} {'DETAIL'}")
+    print("─" * 90)
+    for r in rows:
+        pr = str(r["pr"]) if r["pr"] else "—"
+        sha = r["sha"][:7] if r["sha"] else "—"
+        detail = r["detail"] or ""
+        print(f"{r['created_at']:<22} {r['step']:<14} {r['instance_id']:<20} {pr:<6} {sha:<10} {detail}")
+
+
+# ── Claim commands ────────────────────────────────────────────────
+
+
+def cmd_claim(args: argparse.Namespace) -> None:
+    now = _now()
+    instance_id = args.instance or f"t{int(time.time()) % 100000}-{os.urandom(2).hex()}"
+
+    conn = _connect()
+    try:
+        conn.execute("BEGIN EXCLUSIVE")
+
+        if args.mega and args.phase is not None:
+            # MEGA phase claim
+            claim_id = f"{args.mega}-phase-{args.phase}"
+            row = conn.execute(
+                "SELECT owner FROM claims WHERE id=? AND owner IS NULL", (claim_id,)
+            ).fetchone()
+            if row is None:
+                existing = conn.execute("SELECT owner FROM claims WHERE id=?", (claim_id,)).fetchone()
+                if existing:
+                    print(f"Phase {args.phase} of {args.mega} already claimed by {existing['owner']}", file=sys.stderr)
+                else:
+                    print(f"Claim {claim_id} not found. Create MEGA phases first.", file=sys.stderr)
+                conn.rollback()
+                sys.exit(1)
+            conn.execute(
+                "UPDATE claims SET owner=?, pid=?, host=?, branch=?, claimed_at=? WHERE id=?",
+                (instance_id, os.getpid(), _hostname(), args.branch, now, claim_id),
+            )
+        else:
+            # Standalone claim
+            claim_id = args.ticket
+            existing = conn.execute("SELECT owner FROM claims WHERE id=?", (claim_id,)).fetchone()
+            if existing and existing["owner"]:
+                print(f"{args.ticket} already claimed by {existing['owner']}", file=sys.stderr)
+                conn.rollback()
+                sys.exit(1)
+            conn.execute(
+                """INSERT OR REPLACE INTO claims (id, ticket, phase, mega_id, owner, pid, host, branch, deps, claimed_at, completed_at)
+                   VALUES (?, ?, NULL, NULL, ?, ?, ?, ?, NULL, ?, NULL)""",
+                (claim_id, args.ticket, instance_id, os.getpid(), _hostname(), args.branch, now),
+            )
+
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    print(f"Claimed: {claim_id} → {instance_id}")
+
+    # Dual-write: also create .claude/claims/ JSON for backward compatibility
+    _dual_write_claim_json(args, instance_id, now)
+
+
+def cmd_release(args: argparse.Namespace) -> None:
+    now = _now()
+    conn = _connect()
+
+    if args.phase is not None:
+        claim_id = f"{args.ticket}-phase-{args.phase}"
+    else:
+        claim_id = args.ticket
+
+    updated = conn.execute(
+        "UPDATE claims SET owner=NULL, pid=NULL, completed_at=? WHERE id=?",
+        (now, claim_id),
+    ).rowcount
+
+    if updated == 0:
+        print(f"Claim {claim_id} not found.", file=sys.stderr)
+        sys.exit(1)
+
+    conn.commit()
+    conn.close()
+    print(f"Released: {claim_id}")
+
+
+def cmd_claims(args: argparse.Namespace) -> None:
+    conn = _connect()
+
+    if args.mega_id:
+        rows = conn.execute(
+            "SELECT * FROM claims WHERE mega_id=? ORDER BY phase ASC", (args.mega_id,)
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT * FROM claims WHERE completed_at IS NULL ORDER BY claimed_at DESC"
+        ).fetchall()
+
+    conn.close()
+
+    if not rows:
+        print("No active claims." if not args.mega_id else f"No claims for {args.mega_id}.")
+        return
+
+    print(f"{'ID':<30} {'TICKET':<12} {'OWNER':<20} {'HOST':<18} {'CLAIMED':<22} {'DONE'}")
+    print("─" * 110)
+    for r in rows:
+        owner = r["owner"] or "—"
+        host = r["host"] or "—"
+        claimed = r["claimed_at"] or "—"
+        done = r["completed_at"] or "—"
+        print(f"{r['id']:<30} {r['ticket']:<12} {owner:<20} {host:<18} {claimed:<22} {done}")
+
+
+def cmd_init_mega(args: argparse.Namespace) -> None:
+    """Initialize MEGA phases from a JSON definition or inline args."""
+    conn = _connect()
+    tickets_list = [t.strip() for t in args.tickets.split(",")] if args.tickets else []
+    deps_list = [int(d.strip()) for d in args.deps.split(",")] if args.deps else []
+
+    claim_id = f"{args.mega}-phase-{args.phase}"
+    conn.execute(
+        """INSERT OR REPLACE INTO claims (id, ticket, phase, mega_id, owner, pid, host, branch, deps, claimed_at, completed_at)
+           VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, NULL, NULL)""",
+        (claim_id, ",".join(tickets_list), args.phase, args.mega, json.dumps(deps_list)),
+    )
+    conn.commit()
+    conn.close()
+    print(f"MEGA phase initialized: {claim_id} (tickets: {tickets_list}, deps: {deps_list})")
+
+
+# ── Maintenance ───────────────────────────────────────────────────
+
+
+def cmd_cleanup(args: argparse.Namespace) -> None:
+    hours = int(args.stale.rstrip("h"))
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=hours)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    conn = _connect()
+
+    # Stale sessions
+    stale_sessions = conn.execute(
+        "SELECT instance_id, ticket FROM sessions WHERE updated_at < ?", (cutoff,)
+    ).fetchall()
+    if stale_sessions:
+        conn.execute("DELETE FROM sessions WHERE updated_at < ?", (cutoff,))
+        for s in stale_sessions:
+            print(f"Cleaned session: {s['instance_id']} ({s['ticket']})")
+
+    # Stale claims (claimed but not completed, old)
+    stale_claims = conn.execute(
+        "SELECT id, owner FROM claims WHERE owner IS NOT NULL AND completed_at IS NULL AND claimed_at < ?",
+        (cutoff,),
+    ).fetchall()
+    if stale_claims:
+        conn.execute(
+            "UPDATE claims SET owner=NULL, pid=NULL WHERE owner IS NOT NULL AND completed_at IS NULL AND claimed_at < ?",
+            (cutoff,),
+        )
+        for c in stale_claims:
+            print(f"Released stale claim: {c['id']} (was {c['owner']})")
+
+    if not stale_sessions and not stale_claims:
+        print(f"Nothing stale (cutoff: {hours}h).")
+
+    conn.commit()
+    conn.close()
+
+
+# ── Dual-write backward compat ───────────────────────────────────
+
+
+def _dual_write_claim_json(args: argparse.Namespace, instance_id: str, now: str) -> None:
+    """Write .claude/claims/ JSON for backward compatibility with existing rules."""
+    claims_dir = Path.cwd() / ".claude" / "claims"
+    if not claims_dir.exists():
+        return  # not in a stoa repo, skip
+
+    if args.mega:
+        # Don't dual-write MEGA phases (too complex, let existing JSON handle it)
+        return
+
+    claim_file = claims_dir / f"{args.ticket}.json"
+    data = {
+        "ticket": args.ticket,
+        "title": "",
+        "owner": instance_id,
+        "pid": os.getpid(),
+        "hostname": _hostname(),
+        "claimed_at": now,
+        "branch": args.branch or "",
+        "completed_at": None,
+    }
+    claim_file.write_text(json.dumps(data, indent=2) + "\n")
+
+
+# ── Import existing claims ────────────────────────────────────────
+
+
+def cmd_import_claims(args: argparse.Namespace) -> None:
+    """Import existing .claude/claims/*.json into SQLite."""
+    claims_dir = Path(args.path)
+    if not claims_dir.exists():
+        print(f"Claims directory not found: {claims_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    conn = _connect()
+    imported = 0
+
+    for f in sorted(claims_dir.glob("*.json")):
+        data = json.loads(f.read_text())
+
+        if "mega" in data:
+            # MEGA claim with phases
+            for phase in data.get("phases", []):
+                claim_id = f"{data['mega']}-phase-{phase['id']}"
+                tickets = ",".join(phase.get("tickets", []))
+                deps = json.dumps(phase.get("deps", []))
+                conn.execute(
+                    """INSERT OR REPLACE INTO claims
+                       (id, ticket, phase, mega_id, owner, pid, host, branch, deps, claimed_at, completed_at)
+                       VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)""",
+                    (claim_id, tickets, phase["id"], data["mega"],
+                     phase.get("owner"), phase.get("hostname"),
+                     phase.get("branch"), deps,
+                     phase.get("claimed_at"), phase.get("completed_at")),
+                )
+                imported += 1
+        elif "ticket" in data:
+            # Standalone claim
+            conn.execute(
+                """INSERT OR REPLACE INTO claims
+                   (id, ticket, phase, mega_id, owner, pid, host, branch, deps, claimed_at, completed_at)
+                   VALUES (?, ?, NULL, NULL, ?, ?, ?, ?, NULL, ?, ?)""",
+                (data["ticket"], data["ticket"],
+                 data.get("owner"), data.get("pid"),
+                 data.get("hostname"), data.get("branch"),
+                 data.get("claimed_at"), data.get("completed_at")),
+            )
+            imported += 1
+
+    conn.commit()
+    conn.close()
+    print(f"Imported {imported} claims from {claims_dir}")
+
+
+# ── Main ──────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="heg-state", description="HEGEMON Agent State Store")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # start
+    p = sub.add_parser("start", help="Register a new session")
+    p.add_argument("--ticket", "-t")
+    p.add_argument("--role", "-r", choices=VALID_ROLES)
+    p.add_argument("--branch", "-b")
+    p.add_argument("--project", "-p")
+    p.add_argument("--instance", "-i")
+    p.add_argument("--source", "-s", choices=VALID_SOURCES)
+
+    # step
+    p = sub.add_parser("step", help="Update ticket step")
+    p.add_argument("ticket")
+    p.add_argument("step", choices=VALID_STEPS)
+    p.add_argument("--pr", type=int)
+    p.add_argument("--sha")
+    p.add_argument("--detail")
+
+    # pause
+    p = sub.add_parser("pause", help="Mark session as paused")
+    p.add_argument("ticket")
+    p.add_argument("--reason")
+
+    # done
+    p = sub.add_parser("done", help="Mark ticket as done and remove session")
+    p.add_argument("ticket")
+
+    # block
+    p = sub.add_parser("block", help="Mark ticket as blocked")
+    p.add_argument("ticket")
+    p.add_argument("--reason", required=True)
+
+    # ls
+    p = sub.add_parser("ls", help="List active sessions")
+    p.add_argument("--project", "-p")
+    p.add_argument("--mine", action="store_true")
+
+    # history
+    p = sub.add_parser("history", help="Show milestones for a ticket")
+    p.add_argument("ticket")
+
+    # claim
+    p = sub.add_parser("claim", help="Claim a ticket or MEGA phase")
+    p.add_argument("ticket")
+    p.add_argument("--phase", type=int)
+    p.add_argument("--mega")
+    p.add_argument("--branch", "-b")
+    p.add_argument("--tickets", help="Comma-separated ticket IDs for MEGA phase")
+    p.add_argument("--instance", "-i")
+
+    # release
+    p = sub.add_parser("release", help="Release a claim")
+    p.add_argument("ticket")
+    p.add_argument("--phase", type=int)
+
+    # claims
+    p = sub.add_parser("claims", help="List active claims")
+    p.add_argument("mega_id", nargs="?")
+
+    # init-mega
+    p = sub.add_parser("init-mega", help="Initialize a MEGA phase")
+    p.add_argument("mega")
+    p.add_argument("--phase", type=int, required=True)
+    p.add_argument("--tickets", default="")
+    p.add_argument("--deps", default="")
+
+    # cleanup
+    p = sub.add_parser("cleanup", help="Remove stale sessions and claims")
+    p.add_argument("--stale", default="2h", help="Stale threshold (e.g., 2h, 24h)")
+
+    # import
+    p = sub.add_parser("import-claims", help="Import .claude/claims/*.json into SQLite")
+    p.add_argument("--path", default=".claude/claims")
+
+    args = parser.parse_args()
+
+    commands = {
+        "start": cmd_start,
+        "step": cmd_step,
+        "pause": cmd_pause,
+        "done": cmd_done,
+        "block": cmd_block,
+        "ls": cmd_ls,
+        "history": cmd_history,
+        "claim": cmd_claim,
+        "release": cmd_release,
+        "claims": cmd_claims,
+        "init-mega": cmd_init_mega,
+        "cleanup": cmd_cleanup,
+        "import-claims": cmd_import_claims,
+    }
+    commands[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/hegemon/tools/state/hook-session-end.sh
+++ b/hegemon/tools/state/hook-session-end.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Stop hook: pause active sessions and run cleanup on session end.
+#
+# On session end:
+# 1. Find current ticket from git branch → mark as paused
+# 2. Clean up stale sessions (>24h)
+# 3. Print active sessions summary
+#
+# Requires: heg-state CLI installed (~/.local/bin/heg-state via setup.sh)
+# Graceful degradation: no heg-state = silent skip, never blocks session exit.
+
+# Locate heg-state: direct path first (hook subprocess lacks ~/.local/bin on PATH)
+HEG_STATE=""
+if [ -x "${HOME}/.local/bin/heg-state" ]; then
+  HEG_STATE="${HOME}/.local/bin/heg-state"
+elif command -v heg-state &>/dev/null; then
+  HEG_STATE="heg-state"
+elif [ -n "$CLAUDE_PROJECT_DIR" ] && [ -f "${CLAUDE_PROJECT_DIR}/hegemon/tools/state/heg_state.py" ]; then
+  HEG_STATE="python3 ${CLAUDE_PROJECT_DIR}/hegemon/tools/state/heg_state.py"
+fi
+[ -z "$HEG_STATE" ] && exit 0
+
+# Check state.db exists (setup was run)
+[ ! -f "${HOME}/.hegemon/state.db" ] && exit 0
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "$PROJECT_DIR" 2>/dev/null || exit 0
+
+# Extract ticket from current branch
+BRANCH=$(git branch --show-current 2>/dev/null)
+TICKET=""
+if [ -n "$BRANCH" ]; then
+  TICKET=$(echo "$BRANCH" | grep -oiE 'cab-[0-9]+' | head -1 | tr '[:lower:]' '[:upper:]')
+fi
+
+# Pause current ticket session (if active and not already done/merged)
+if [ -n "$TICKET" ]; then
+  # Check current step — don't pause if already done or merged
+  CURRENT_STEP=$($HEG_STATE ls 2>/dev/null | grep "$TICKET" | awk '{print $4}')
+  case "$CURRENT_STEP" in
+    done|merged|cd-verified)
+      ;; # Already complete, don't override with pause
+    "")
+      ;; # No active session for this ticket
+    *)
+      $HEG_STATE pause "$TICKET" --reason "session-end" >/dev/null 2>&1 || true
+      ;;
+  esac
+fi
+
+# Cleanup stale sessions (>24h) — best-effort hygiene
+$HEG_STATE cleanup --stale 24h >/dev/null 2>&1 || true
+
+# Print summary of remaining active sessions (informational)
+ACTIVE=$($HEG_STATE ls --mine 2>/dev/null)
+if [ -n "$ACTIVE" ] && ! echo "$ACTIVE" | grep -q "No active sessions"; then
+  echo ""
+  echo "--- HEGEMON State Store ---"
+  echo "$ACTIVE"
+  echo "---------------------------"
+fi
+
+exit 0

--- a/hegemon/tools/state/hook-state-tracker.sh
+++ b/hegemon/tools/state/hook-state-tracker.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# PostToolUse hook: auto-track lifecycle events in HEGEMON State Store.
+# Detects git checkout -b, gh pr create, gh pr merge, git push → calls heg-state.
+#
+# Fires on every Bash tool call. Fast early-exit (<1ms) for non-lifecycle commands.
+# Requires: heg-state CLI installed (~/.local/bin/heg-state via setup.sh)
+# Graceful degradation: no heg-state = silent skip, never blocks Claude.
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+[ "$TOOL_NAME" != "Bash" ] && exit 0
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -z "$COMMAND" ] && exit 0
+
+# Fast early exit for non-lifecycle commands (99% of calls)
+case "$COMMAND" in
+  git\ checkout\ -b*|gh\ pr\ create*|gh\ pr\ merge*|git\ push*)
+    ;; # lifecycle event — continue
+  *)
+    exit 0 ;;
+esac
+
+# Locate heg-state: direct path first (hook subprocess lacks ~/.local/bin on PATH)
+HEG_STATE=""
+if [ -x "${HOME}/.local/bin/heg-state" ]; then
+  HEG_STATE="${HOME}/.local/bin/heg-state"
+elif command -v heg-state &>/dev/null; then
+  HEG_STATE="heg-state"
+elif [ -f "${CLAUDE_PROJECT_DIR}/hegemon/tools/state/heg_state.py" ]; then
+  HEG_STATE="python3 ${CLAUDE_PROJECT_DIR}/hegemon/tools/state/heg_state.py"
+fi
+[ -z "$HEG_STATE" ] && exit 0
+
+# Check state.db exists (setup was run)
+[ ! -f "${HOME}/.hegemon/state.db" ] && exit 0
+
+# Instance guard: skip if too many Claude processes (prevents hook storms)
+MAX_INSTANCES="${CLAUDE_MAX_HOOK_INSTANCES:-8}"
+INSTANCE_COUNT=$(pgrep -fc "claude" 2>/dev/null || echo 0)
+[ "$INSTANCE_COUNT" -gt "$MAX_INSTANCES" ] && exit 0
+
+# Get project dir for branch detection
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "$PROJECT_DIR" 2>/dev/null || exit 0
+
+# Extract ticket ID from branch name (CAB-XXXX pattern)
+extract_ticket() {
+  local branch="${1:-$(git branch --show-current 2>/dev/null)}"
+  echo "$branch" | grep -oiE 'cab-[0-9]+' | head -1 | tr '[:lower:]' '[:upper:]'
+}
+
+# Get current role from STOA_INSTANCE or default
+ROLE="${STOA_INSTANCE:-interactive}"
+
+# Parse tool output (for PR number extraction)
+OUTPUT=$(echo "$INPUT" | jq -r '.tool_output.stdout // .tool_output // empty' 2>/dev/null)
+
+# ── Event Detection ────────────────────────────────────────────
+
+# 1. Branch creation: git checkout -b feat/cab-1350-description
+if [[ "$COMMAND" =~ ^git\ checkout\ -b\ (.+) ]]; then
+  BRANCH="${BASH_REMATCH[1]}"
+  # Strip trailing flags or chained commands
+  BRANCH=$(echo "$BRANCH" | awk '{print $1}')
+  TICKET=$(extract_ticket "$BRANCH")
+  if [ -n "$TICKET" ]; then
+    $HEG_STATE start --ticket "$TICKET" --branch "$BRANCH" --role "$ROLE" >/dev/null 2>&1 || true
+  fi
+  exit 0
+fi
+
+# 2. PR creation: gh pr create ...
+if [[ "$COMMAND" =~ ^gh\ pr\ create ]]; then
+  TICKET=$(extract_ticket)
+  [ -z "$TICKET" ] && exit 0
+
+  # Extract PR number from output (URL pattern: /pull/NNN)
+  PR_NUM=""
+  if [ -n "$OUTPUT" ]; then
+    PR_NUM=$(echo "$OUTPUT" | grep -oE '/pull/[0-9]+' | grep -oE '[0-9]+' | head -1)
+  fi
+  # Fallback: try gh pr view on current branch
+  if [ -z "$PR_NUM" ]; then
+    PR_NUM=$(gh pr view --json number -q '.number' 2>/dev/null || true)
+  fi
+
+  if [ -n "$PR_NUM" ]; then
+    $HEG_STATE step "$TICKET" pr-created --pr "$PR_NUM" >/dev/null 2>&1 || true
+  else
+    $HEG_STATE step "$TICKET" pr-created >/dev/null 2>&1 || true
+  fi
+  exit 0
+fi
+
+# 3. PR merge: gh pr merge ...
+if [[ "$COMMAND" =~ ^gh\ pr\ merge ]]; then
+  TICKET=$(extract_ticket)
+  [ -z "$TICKET" ] && exit 0
+
+  # Extract PR number from the merge command (gh pr merge NNN ...)
+  PR_NUM=$(echo "$COMMAND" | grep -oE 'gh pr merge [0-9]+' | grep -oE '[0-9]+' | head -1)
+
+  if [ -n "$PR_NUM" ]; then
+    $HEG_STATE step "$TICKET" merged --pr "$PR_NUM" >/dev/null 2>&1 || true
+  else
+    $HEG_STATE step "$TICKET" merged >/dev/null 2>&1 || true
+  fi
+  exit 0
+fi
+
+# 4. Git push: first push on a ticket branch = coding milestone
+if [[ "$COMMAND" =~ ^git\ push ]]; then
+  TICKET=$(extract_ticket)
+  [ -z "$TICKET" ] && exit 0
+
+  $HEG_STATE step "$TICKET" coding >/dev/null 2>&1 || true
+  exit 0
+fi
+
+exit 0

--- a/hegemon/tools/state/schema.sql
+++ b/hegemon/tools/state/schema.sql
@@ -1,0 +1,54 @@
+-- HEGEMON Agent State Store — Schema v1
+-- SQLite WAL mode for concurrent multi-agent access
+-- Location: ~/.hegemon/state.db
+
+PRAGMA journal_mode=WAL;
+PRAGMA busy_timeout=10000;
+
+CREATE TABLE IF NOT EXISTS sessions (
+    instance_id  TEXT PRIMARY KEY,
+    project      TEXT NOT NULL,
+    role         TEXT NOT NULL DEFAULT 'interactive',
+    ticket       TEXT,
+    branch       TEXT,
+    step         TEXT NOT NULL DEFAULT 'claimed',
+    pr           INTEGER,
+    host         TEXT,
+    source       TEXT NOT NULL DEFAULT 'local',
+    pid          INTEGER,
+    started_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS milestones (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticket       TEXT NOT NULL,
+    step         TEXT NOT NULL,
+    instance_id  TEXT NOT NULL,
+    project      TEXT NOT NULL,
+    pr           INTEGER,
+    sha          TEXT,
+    detail       TEXT,
+    created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS claims (
+    id           TEXT PRIMARY KEY,
+    ticket       TEXT NOT NULL,
+    phase        INTEGER,
+    mega_id      TEXT,
+    owner        TEXT,
+    pid          INTEGER,
+    host         TEXT,
+    branch       TEXT,
+    deps         TEXT,
+    claimed_at   TEXT,
+    completed_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project);
+CREATE INDEX IF NOT EXISTS idx_sessions_ticket ON sessions(ticket);
+CREATE INDEX IF NOT EXISTS idx_milestones_ticket ON milestones(ticket);
+CREATE INDEX IF NOT EXISTS idx_milestones_created ON milestones(created_at);
+CREATE INDEX IF NOT EXISTS idx_claims_owner ON claims(owner);
+CREATE INDEX IF NOT EXISTS idx_claims_mega ON claims(mega_id);

--- a/hegemon/tools/state/setup.sh
+++ b/hegemon/tools/state/setup.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# HEGEMON State Store — Setup
+# Creates ~/.hegemon/state.db and symlinks heg-state CLI
+#
+# Usage: bash hegemon/tools/state/setup.sh
+# Idempotent: safe to run multiple times.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HEGEMON_DIR="${HOME}/.hegemon"
+DB_PATH="${HEGEMON_DIR}/state.db"
+SCHEMA_PATH="${SCRIPT_DIR}/schema.sql"
+CLI_SOURCE="${SCRIPT_DIR}/heg_state.py"
+CLI_TARGET="${HOME}/.local/bin/heg-state"
+
+echo "HEGEMON State Store Setup"
+echo "========================="
+
+# 1. Create ~/.hegemon/
+mkdir -p "$HEGEMON_DIR"
+echo "[1/4] Directory: $HEGEMON_DIR"
+
+# 2. Initialize SQLite database
+if [ ! -f "$DB_PATH" ]; then
+  sqlite3 "$DB_PATH" < "$SCHEMA_PATH"
+  echo "[2/4] Database created: $DB_PATH"
+else
+  # Apply schema (CREATE IF NOT EXISTS = safe)
+  sqlite3 "$DB_PATH" < "$SCHEMA_PATH"
+  echo "[2/4] Database updated: $DB_PATH"
+fi
+
+# 3. Verify WAL mode
+WAL_MODE=$(sqlite3 "$DB_PATH" "PRAGMA journal_mode;" 2>/dev/null)
+if [ "$WAL_MODE" = "wal" ]; then
+  echo "[3/4] WAL mode: active"
+else
+  echo "[3/4] WAL mode: $WAL_MODE (expected: wal)"
+fi
+
+# 4. Symlink CLI
+mkdir -p "$(dirname "$CLI_TARGET")"
+chmod +x "$CLI_SOURCE"
+ln -sf "$CLI_SOURCE" "$CLI_TARGET"
+echo "[4/4] CLI symlinked: $CLI_TARGET -> $CLI_SOURCE"
+
+echo ""
+echo "Done. Test with: heg-state ls"
+echo ""
+echo "Note: ensure ~/.local/bin is on your PATH:"
+echo '  export PATH="$HOME/.local/bin:$PATH"'


### PR DESCRIPTION
## Summary
- **P1**: SQLite WAL state store (`~/.hegemon/state.db`) for centralized session/milestone/claim tracking across parallel Claude Code instances
- **P2**: PostToolUse + Stop hooks that auto-detect `git checkout -b`, `gh pr create`, `gh pr merge`, `git push` and record milestones in the state store
- Replaces `mkdir`-based POSIX locks with atomic `BEGIN EXCLUSIVE` SQL transactions
- Backward-compatible dual-write to `.claude/claims/*.json` during migration

## Files
| File | LOC | Purpose |
|------|-----|---------|
| `hegemon/tools/state/schema.sql` | 54 | SQLite DDL (sessions, milestones, claims) |
| `hegemon/tools/state/heg_state.py` | 551 | CLI: start/step/done/ls/history/claim/release/cleanup |
| `hegemon/tools/state/setup.sh` | 52 | Creates `~/.hegemon/state.db` + symlink |
| `hegemon/tools/state/hook-state-tracker.sh` | 121 | PostToolUse hook — auto-tracks lifecycle |
| `hegemon/tools/state/hook-session-end.sh` | 63 | Stop hook — pauses sessions on exit |
| `.claude/settings.json` | +8 | Hook registration |
| `.gitignore` | +1 | Exception for schema.sql |

## Test plan
- [x] Full lifecycle test: branch → push → PR → merge (all milestones recorded)
- [x] Concurrent claim test: `BEGIN EXCLUSIVE` correctly rejects race conditions
- [x] Graceful degradation: hook exits 0 when heg-state not installed
- [x] Fast path: non-lifecycle Bash commands exit in <1ms
- [ ] CI security scan (no secrets, no new deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)