### PR TITLE
feat(hegemon): add PocketBase remote tier + sync (CAB-1482 P3)

### DIFF
--- a/deploy/vps/pocketbase/.env.template
+++ b/deploy/vps/pocketbase/.env.template
@@ -1,0 +1,8 @@
+# PocketBase — HEGEMON State Store
+# Copy to .env and fill values
+
+# Admin credentials (required for first-time setup)
+PB_ADMIN_EMAIL=admin@gostoa.dev
+PB_ADMIN_PASSWORD=
+
+# Store in Infisical: /pocketbase/PB_ADMIN_PASSWORD

--- a/deploy/vps/pocketbase/deploy.sh
+++ b/deploy/vps/pocketbase/deploy.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Deploy PocketBase to OVH VPS (state.gostoa.dev)
+# Shares VPS with n8n (51.254.139.205)
+#
+# Prerequisites:
+#   - SSH key: ~/.ssh/id_ed25519_stoa
+#   - DNS: state.gostoa.dev → 51.254.139.205 (Cloudflare, DNS-only)
+#   - Docker running on VPS (already installed for n8n)
+#   - n8n stack running (Caddy handles TLS)
+#
+# Usage: ./deploy/vps/pocketbase/deploy.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SSH_KEY=~/.ssh/id_ed25519_stoa
+VPS_IP="51.254.139.205"
+VPS_USER="ubuntu"
+REMOTE_DIR="/opt/pocketbase"
+N8N_DIR="/opt/n8n"
+
+echo "=== PocketBase Deploy (HEGEMON State Store) ==="
+echo "Target: ${VPS_USER}@${VPS_IP}"
+echo ""
+
+SSH_CMD="ssh -i $SSH_KEY ${VPS_USER}@${VPS_IP}"
+
+# Step 1: Create remote directory
+echo "[1/7] Creating remote directory ${REMOTE_DIR}..."
+$SSH_CMD "sudo mkdir -p ${REMOTE_DIR} && sudo chown ${VPS_USER}:${VPS_USER} ${REMOTE_DIR}"
+
+# Step 2: Copy files
+echo "[2/7] Copying docker-compose.yml + .env.template..."
+scp -i "$SSH_KEY" -q \
+  "$SCRIPT_DIR/docker-compose.yml" \
+  "$SCRIPT_DIR/.env.template" \
+  "$SCRIPT_DIR/setup-collections.sh" \
+  "${VPS_USER}@${VPS_IP}:${REMOTE_DIR}/"
+$SSH_CMD "chmod +x ${REMOTE_DIR}/setup-collections.sh"
+
+# Step 3: Generate .env if not exists
+echo "[3/7] Checking .env file..."
+$SSH_CMD bash -c "'
+  if [ ! -f ${REMOTE_DIR}/.env ]; then
+    PB_PASS=\$(openssl rand -base64 24)
+    cat > ${REMOTE_DIR}/.env <<INNEREOF
+PB_ADMIN_EMAIL=admin@gostoa.dev
+PB_ADMIN_PASSWORD=\${PB_PASS}
+INNEREOF
+    echo \".env created. IMPORTANT: Save PB_ADMIN_PASSWORD to Infisical!\"
+    echo \"Password: \${PB_PASS}\"
+  else
+    echo \".env already exists — keeping current values.\"
+  fi
+'"
+
+# Step 4: Create shared-proxy network (idempotent)
+echo "[4/7] Setting up shared-proxy Docker network..."
+$SSH_CMD "docker network create shared-proxy 2>/dev/null || true"
+$SSH_CMD "docker network connect shared-proxy n8n-caddy 2>/dev/null || echo '  n8n-caddy already on shared-proxy (or not running)'"
+
+# Step 5: Update n8n Caddyfile with state.gostoa.dev
+echo "[5/7] Adding state.gostoa.dev to Caddy..."
+$SSH_CMD bash -c "'
+  CADDYFILE=${N8N_DIR}/Caddyfile
+  if ! grep -q \"state.gostoa.dev\" \$CADDYFILE 2>/dev/null; then
+    echo \"\" >> \$CADDYFILE
+    echo \"state.gostoa.dev {\" >> \$CADDYFILE
+    echo \"	reverse_proxy pocketbase:8090\" >> \$CADDYFILE
+    echo \"}\" >> \$CADDYFILE
+    echo \"  Added state.gostoa.dev to Caddyfile\"
+  else
+    echo \"  state.gostoa.dev already in Caddyfile\"
+  fi
+'"
+
+# Step 6: Pull + start PocketBase, reload Caddy
+echo "[6/7] Starting PocketBase + reloading Caddy..."
+$SSH_CMD "cd ${REMOTE_DIR} && docker compose pull && docker compose up -d"
+$SSH_CMD "docker exec n8n-caddy caddy reload --config /etc/caddy/Caddyfile 2>/dev/null || echo '  Caddy reload: will pick up on next restart'"
+
+# Step 7: Health check
+echo "[7/7] Waiting for PocketBase..."
+for i in $(seq 1 20); do
+  if $SSH_CMD "curl -sf http://localhost:8090/api/health > /dev/null 2>&1"; then
+    echo "  PocketBase healthy! (attempt $i)"
+    break
+  fi
+  if [ "$i" -eq 20 ]; then
+    echo "  WARNING: PocketBase not healthy after 20 attempts."
+    echo "  Check: $SSH_CMD 'cd ${REMOTE_DIR} && docker compose logs --tail=30'"
+    exit 1
+  fi
+  sleep 2
+done
+
+echo ""
+echo "=== Deploy Complete ==="
+echo ""
+echo "Next steps:"
+echo "  1. Create DNS: state.gostoa.dev → ${VPS_IP} (Cloudflare, DNS-only)"
+echo "  2. Run collection setup:"
+echo "     $SSH_CMD 'cd ${REMOTE_DIR} && source .env && ./setup-collections.sh'"
+echo "  3. Save PB_ADMIN_PASSWORD to Infisical: /pocketbase/PB_ADMIN_PASSWORD"
+echo "  4. Set local env vars:"
+echo "     export HEGEMON_REMOTE_URL=https://state.gostoa.dev"
+echo "     export HEGEMON_REMOTE_PASSWORD=<password>"
+echo ""
+echo "Verify:"
+echo "  curl -s https://state.gostoa.dev/api/health"
+echo "  heg-state ls  # should show remote sync status"

--- a/deploy/vps/pocketbase/docker-compose.yml
+++ b/deploy/vps/pocketbase/docker-compose.yml
@@ -1,0 +1,39 @@
+# PocketBase — HEGEMON Agent State Store Remote Tier
+# VPS: 51.254.139.205 (shared with n8n + Healthchecks)
+# URL: state.gostoa.dev (Caddy TLS via shared-proxy network)
+#
+# Usage:
+#   cp .env.template .env   # fill PB_ADMIN_PASSWORD
+#   docker compose up -d
+#
+# Health: curl http://localhost:8090/api/health
+
+services:
+  pocketbase:
+    image: elestio/pocketbase:latest
+    container_name: pocketbase
+    restart: unless-stopped
+    command: ["serve", "--http=0.0.0.0:8090"]
+    volumes:
+      - pb_data:/pb/pb_data
+    environment:
+      PB_ADMIN_EMAIL: ${PB_ADMIN_EMAIL:-admin@gostoa.dev}
+      PB_ADMIN_PASSWORD: ${PB_ADMIN_PASSWORD:?Set PB_ADMIN_PASSWORD in .env}
+    ports:
+      - "127.0.0.1:8090:8090"
+    networks:
+      - shared-proxy
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8090/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+networks:
+  shared-proxy:
+    external: true
+
+volumes:
+  pb_data:

--- a/deploy/vps/pocketbase/setup-collections.sh
+++ b/deploy/vps/pocketbase/setup-collections.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Create PocketBase collections matching HEGEMON state.db schema
+# Run once after first deploy, or after schema changes.
+#
+# Usage: ./setup-collections.sh [PB_URL]
+set -euo pipefail
+
+PB_URL="${1:-http://localhost:8090}"
+ADMIN_EMAIL="${PB_ADMIN_EMAIL:-admin@gostoa.dev}"
+ADMIN_PASSWORD="${PB_ADMIN_PASSWORD:?Set PB_ADMIN_PASSWORD}"
+
+echo "=== PocketBase Collection Setup ==="
+echo "Target: ${PB_URL}"
+echo ""
+
+# Step 1: Create admin account (only works when no admins exist)
+echo "[1/5] Bootstrapping admin account..."
+BOOTSTRAP=$(curl -sf -X POST "${PB_URL}/api/admins" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"${ADMIN_EMAIL}\",\"password\":\"${ADMIN_PASSWORD}\",\"passwordConfirm\":\"${ADMIN_PASSWORD}\"}" 2>&1) || true
+
+if echo "$BOOTSTRAP" | grep -q '"id"'; then
+  echo "  Admin created: ${ADMIN_EMAIL}"
+else
+  echo "  Admin already exists (or error) — continuing with auth"
+fi
+
+# Step 2: Authenticate
+echo "[2/5] Authenticating..."
+AUTH_RESPONSE=$(curl -sf -X POST "${PB_URL}/api/admins/auth-with-password" \
+  -H "Content-Type: application/json" \
+  -d "{\"identity\":\"${ADMIN_EMAIL}\",\"password\":\"${ADMIN_PASSWORD}\"}")
+
+TOKEN=$(echo "$AUTH_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+echo "  Token obtained."
+
+# Step 3: Create "sessions" collection
+echo "[3/5] Creating 'sessions' collection..."
+curl -sf -X POST "${PB_URL}/api/collections" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: ${TOKEN}" \
+  -d '{
+    "name": "sessions",
+    "type": "base",
+    "schema": [
+      {"name": "instance_id", "type": "text", "required": true, "options": {"min": 1, "max": 50}},
+      {"name": "project",     "type": "text", "required": true, "options": {"min": 1, "max": 50}},
+      {"name": "role",        "type": "text", "required": false, "options": {"max": 20}},
+      {"name": "ticket",      "type": "text", "required": false, "options": {"max": 20}},
+      {"name": "branch",      "type": "text", "required": false, "options": {"max": 200}},
+      {"name": "step",        "type": "text", "required": true, "options": {"min": 1, "max": 20}},
+      {"name": "pr",          "type": "number", "required": false},
+      {"name": "host",        "type": "text", "required": false, "options": {"max": 100}},
+      {"name": "source",      "type": "text", "required": false, "options": {"max": 20}},
+      {"name": "pid",         "type": "number", "required": false},
+      {"name": "started_at",  "type": "text", "required": false, "options": {"max": 30}},
+      {"name": "updated_at",  "type": "text", "required": false, "options": {"max": 30}}
+    ],
+    "indexes": ["CREATE UNIQUE INDEX idx_session_instance ON sessions (instance_id)"],
+    "listRule": "@request.auth.id != \"\"",
+    "viewRule": "@request.auth.id != \"\"",
+    "createRule": "@request.auth.id != \"\"",
+    "updateRule": "@request.auth.id != \"\"",
+    "deleteRule": "@request.auth.id != \"\""
+  }' > /dev/null && echo "  sessions: OK" || echo "  sessions: already exists or error"
+
+# Step 4: Create "milestones" collection
+echo "[4/5] Creating 'milestones' collection..."
+curl -sf -X POST "${PB_URL}/api/collections" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: ${TOKEN}" \
+  -d '{
+    "name": "milestones",
+    "type": "base",
+    "schema": [
+      {"name": "ticket",      "type": "text", "required": true, "options": {"max": 20}},
+      {"name": "step",        "type": "text", "required": true, "options": {"max": 20}},
+      {"name": "instance_id", "type": "text", "required": true, "options": {"max": 50}},
+      {"name": "project",     "type": "text", "required": true, "options": {"max": 50}},
+      {"name": "pr",          "type": "number", "required": false},
+      {"name": "sha",         "type": "text", "required": false, "options": {"max": 40}},
+      {"name": "detail",      "type": "text", "required": false, "options": {"max": 500}},
+      {"name": "event_at",    "type": "text", "required": false, "options": {"max": 30}}
+    ],
+    "indexes": [
+      "CREATE INDEX idx_milestone_ticket ON milestones (ticket)",
+      "CREATE INDEX idx_milestone_created ON milestones (created)"
+    ],
+    "listRule": "@request.auth.id != \"\"",
+    "viewRule": "@request.auth.id != \"\"",
+    "createRule": "@request.auth.id != \"\"",
+    "updateRule": null,
+    "deleteRule": null
+  }' > /dev/null && echo "  milestones: OK" || echo "  milestones: already exists or error"
+
+# Step 5: Create "claims" collection
+echo "[5/5] Creating 'claims' collection..."
+curl -sf -X POST "${PB_URL}/api/collections" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: ${TOKEN}" \
+  -d '{
+    "name": "claims",
+    "type": "base",
+    "schema": [
+      {"name": "claim_id",     "type": "text", "required": true, "options": {"min": 1, "max": 60}},
+      {"name": "ticket",       "type": "text", "required": true, "options": {"max": 60}},
+      {"name": "phase",        "type": "number", "required": false},
+      {"name": "mega_id",      "type": "text", "required": false, "options": {"max": 20}},
+      {"name": "owner",        "type": "text", "required": false, "options": {"max": 50}},
+      {"name": "pid",          "type": "number", "required": false},
+      {"name": "host",         "type": "text", "required": false, "options": {"max": 100}},
+      {"name": "branch",       "type": "text", "required": false, "options": {"max": 200}},
+      {"name": "deps",         "type": "text", "required": false, "options": {"max": 200}},
+      {"name": "claimed_at",   "type": "text", "required": false, "options": {"max": 30}},
+      {"name": "completed_at", "type": "text", "required": false, "options": {"max": 30}}
+    ],
+    "indexes": [
+      "CREATE UNIQUE INDEX idx_claim_id ON claims (claim_id)",
+      "CREATE INDEX idx_claim_owner ON claims (owner)",
+      "CREATE INDEX idx_claim_mega ON claims (mega_id)"
+    ],
+    "listRule": "@request.auth.id != \"\"",
+    "viewRule": "@request.auth.id != \"\"",
+    "createRule": "@request.auth.id != \"\"",
+    "updateRule": "@request.auth.id != \"\"",
+    "deleteRule": "@request.auth.id != \"\""
+  }' > /dev/null && echo "  claims: OK" || echo "  claims: already exists or error"
+
+echo ""
+echo "=== Setup Complete ==="
+echo "Admin UI: ${PB_URL}/_/"
+echo "API: ${PB_URL}/api/collections/{sessions,milestones,claims}/records"

--- a/hegemon/tools/state/heg_state.py
+++ b/hegemon/tools/state/heg_state.py
@@ -23,6 +23,9 @@ import platform
 import sqlite3
 import sys
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -35,6 +38,137 @@ VALID_STEPS = [
 ]
 VALID_ROLES = ["interactive", "backend", "frontend", "auth", "mcp", "qa"]
 VALID_SOURCES = ["local", "ci-l1", "ci-l3", "ci-l3.5"]
+
+# ── Remote sync (PocketBase) ─────────────────────────────────────
+
+REMOTE_URL = os.environ.get("HEGEMON_REMOTE_URL")  # e.g., https://state.gostoa.dev
+REMOTE_EMAIL = os.environ.get("HEGEMON_REMOTE_EMAIL", "admin@gostoa.dev")
+REMOTE_PASSWORD = os.environ.get("HEGEMON_REMOTE_PASSWORD")
+TOKEN_CACHE_FILE = Path.home() / ".hegemon" / ".pb_token"
+
+_token_cache: dict = {"token": None, "expires": 0.0}
+
+
+def _remote_enabled() -> bool:
+    return bool(REMOTE_URL and REMOTE_PASSWORD)
+
+
+def _remote_auth() -> str | None:
+    """Get PocketBase admin auth token. Cached in memory + file."""
+    if not _remote_enabled():
+        return None
+
+    # Memory cache
+    if _token_cache["token"] and time.time() < _token_cache["expires"]:
+        return _token_cache["token"]
+
+    # File cache (for cross-process reuse by hooks)
+    if TOKEN_CACHE_FILE.exists():
+        try:
+            cached = json.loads(TOKEN_CACHE_FILE.read_text())
+            if cached.get("expires", 0) > time.time():
+                _token_cache["token"] = cached["token"]
+                _token_cache["expires"] = cached["expires"]
+                return cached["token"]
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+    # Fresh auth
+    try:
+        data = json.dumps({"identity": REMOTE_EMAIL, "password": REMOTE_PASSWORD}).encode()
+        req = urllib.request.Request(
+            f"{REMOTE_URL}/api/admins/auth-with-password",
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        resp = urllib.request.urlopen(req, timeout=5)
+        result = json.loads(resp.read())
+        token = result["token"]
+        expires = time.time() + 7200  # 2h (PB admin tokens last 14d, but refresh often)
+
+        _token_cache["token"] = token
+        _token_cache["expires"] = expires
+
+        # Persist for hooks
+        TOKEN_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        TOKEN_CACHE_FILE.write_text(json.dumps({"token": token, "expires": expires}))
+
+        return token
+    except Exception:
+        return None
+
+
+def _remote_push(collection: str, data: dict) -> None:
+    """Create a record in PocketBase. Best-effort."""
+    token = _remote_auth()
+    if not token:
+        return
+    try:
+        body = json.dumps(data).encode()
+        req = urllib.request.Request(
+            f"{REMOTE_URL}/api/collections/{collection}/records",
+            data=body,
+            headers={"Content-Type": "application/json", "Authorization": token},
+        )
+        urllib.request.urlopen(req, timeout=5)
+    except Exception:
+        pass  # best-effort, SQLite is primary
+
+
+def _remote_upsert(collection: str, filter_field: str, filter_value: str, data: dict) -> None:
+    """Upsert: find by filter field, update or create."""
+    token = _remote_auth()
+    if not token:
+        return
+    try:
+        encoded_filter = urllib.parse.quote(f'{filter_field}="{filter_value}"')
+        req = urllib.request.Request(
+            f"{REMOTE_URL}/api/collections/{collection}/records?filter={encoded_filter}&perPage=1",
+            headers={"Authorization": token},
+        )
+        resp = urllib.request.urlopen(req, timeout=5)
+        result = json.loads(resp.read())
+
+        if result.get("totalItems", 0) > 0:
+            pb_id = result["items"][0]["id"]
+            body = json.dumps(data).encode()
+            req = urllib.request.Request(
+                f"{REMOTE_URL}/api/collections/{collection}/records/{pb_id}",
+                data=body,
+                headers={"Content-Type": "application/json", "Authorization": token},
+                method="PATCH",
+            )
+            urllib.request.urlopen(req, timeout=5)
+        else:
+            _remote_push(collection, data)
+    except Exception:
+        pass
+
+
+def _remote_delete(collection: str, filter_field: str, filter_value: str) -> None:
+    """Delete a record by filter. Best-effort."""
+    token = _remote_auth()
+    if not token:
+        return
+    try:
+        encoded_filter = urllib.parse.quote(f'{filter_field}="{filter_value}"')
+        req = urllib.request.Request(
+            f"{REMOTE_URL}/api/collections/{collection}/records?filter={encoded_filter}&perPage=1",
+            headers={"Authorization": token},
+        )
+        resp = urllib.request.urlopen(req, timeout=5)
+        result = json.loads(resp.read())
+
+        if result.get("totalItems", 0) > 0:
+            pb_id = result["items"][0]["id"]
+            req = urllib.request.Request(
+                f"{REMOTE_URL}/api/collections/{collection}/records/{pb_id}",
+                headers={"Authorization": token},
+                method="DELETE",
+            )
+            urllib.request.urlopen(req, timeout=5)
+    except Exception:
+        pass
 
 
 def _now() -> str:
@@ -90,6 +224,19 @@ def cmd_start(args: argparse.Namespace) -> None:
     conn.close()
     print(f"Session started: {instance_id} → {args.ticket or '(no ticket)'}")
 
+    # Remote sync
+    _remote_upsert("sessions", "instance_id", instance_id, {
+        "instance_id": instance_id, "project": project, "role": role,
+        "ticket": args.ticket or "", "branch": args.branch or "",
+        "step": "claimed", "host": _hostname(), "source": args.source or "local",
+        "pid": os.getpid(), "started_at": now, "updated_at": now,
+    })
+    if args.ticket:
+        _remote_push("milestones", {
+            "ticket": args.ticket, "step": "claimed",
+            "instance_id": instance_id, "project": project, "event_at": now,
+        })
+
 
 def cmd_step(args: argparse.Namespace) -> None:
     if args.step not in VALID_STEPS:
@@ -129,6 +276,21 @@ def cmd_step(args: argparse.Namespace) -> None:
     pr_info = f" (PR #{args.pr})" if args.pr else ""
     sha_info = f" [{args.sha[:7]}]" if args.sha else ""
     print(f"{args.ticket} → {args.step}{pr_info}{sha_info}")
+
+    # Remote sync
+    if args.step == "done":
+        _remote_delete("sessions", "ticket", args.ticket)
+    else:
+        _remote_upsert("sessions", "ticket", args.ticket, {
+            "step": args.step, "pr": args.pr or 0,
+            "updated_at": now,
+        })
+    _remote_push("milestones", {
+        "ticket": args.ticket, "step": args.step,
+        "instance_id": row["instance_id"], "project": row["project"],
+        "pr": args.pr or 0, "sha": args.sha or "", "detail": args.detail or "",
+        "event_at": now,
+    })
 
 
 def cmd_pause(args: argparse.Namespace) -> None:
@@ -263,6 +425,15 @@ def cmd_claim(args: argparse.Namespace) -> None:
     # Dual-write: also create .claude/claims/ JSON for backward compatibility
     _dual_write_claim_json(args, instance_id, now)
 
+    # Remote sync
+    _remote_upsert("claims", "claim_id", claim_id, {
+        "claim_id": claim_id, "ticket": args.ticket,
+        "phase": args.phase, "mega_id": args.mega or "",
+        "owner": instance_id, "pid": os.getpid(),
+        "host": _hostname(), "branch": args.branch or "",
+        "claimed_at": now,
+    })
+
 
 def cmd_release(args: argparse.Namespace) -> None:
     now = _now()
@@ -285,6 +456,11 @@ def cmd_release(args: argparse.Namespace) -> None:
     conn.commit()
     conn.close()
     print(f"Released: {claim_id}")
+
+    # Remote sync
+    _remote_upsert("claims", "claim_id", claim_id, {
+        "owner": "", "pid": 0, "completed_at": now,
+    })
 
 
 def cmd_claims(args: argparse.Namespace) -> None:
@@ -395,6 +571,88 @@ def _dual_write_claim_json(args: argparse.Namespace, instance_id: str, now: str)
         "completed_at": None,
     }
     claim_file.write_text(json.dumps(data, indent=2) + "\n")
+
+
+# ── Remote query ──────────────────────────────────────────────────
+
+
+def cmd_remote_ls(args: argparse.Namespace) -> None:
+    """List sessions from PocketBase remote."""
+    if not _remote_enabled():
+        print("Remote not configured. Set HEGEMON_REMOTE_URL + HEGEMON_REMOTE_PASSWORD.", file=sys.stderr)
+        sys.exit(1)
+
+    token = _remote_auth()
+    if not token:
+        print("Failed to authenticate with PocketBase.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        params = "perPage=50&sort=-updated_at"
+        if args.project:
+            params += f'&filter=project="{args.project}"'
+        req = urllib.request.Request(
+            f"{REMOTE_URL}/api/collections/sessions/records?{params}",
+            headers={"Authorization": token},
+        )
+        resp = urllib.request.urlopen(req, timeout=10)
+        result = json.loads(resp.read())
+    except Exception as e:
+        print(f"Remote query failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    items = result.get("items", [])
+    if not items:
+        print("No remote sessions.")
+        return
+
+    print(f"Remote sessions ({REMOTE_URL}):")
+    print(f"{'INSTANCE':<20} {'ROLE':<12} {'TICKET':<12} {'STEP':<14} {'PR':<6} {'SOURCE':<8} {'UPDATED':<20}")
+    print("─" * 92)
+    for r in items:
+        pr = str(r.get("pr", 0)) if r.get("pr") else "—"
+        print(f"{r.get('instance_id','?'):<20} {r.get('role','?'):<12} {r.get('ticket','—'):<12} {r.get('step','?'):<14} {pr:<6} {r.get('source','?'):<8} {r.get('updated_at','?'):<20}")
+
+
+def cmd_sync(args: argparse.Namespace) -> None:
+    """Full sync: push all local sessions + claims to PocketBase."""
+    if not _remote_enabled():
+        print("Remote not configured. Set HEGEMON_REMOTE_URL + HEGEMON_REMOTE_PASSWORD.", file=sys.stderr)
+        sys.exit(1)
+
+    conn = _connect()
+
+    # Sync sessions
+    sessions = conn.execute("SELECT * FROM sessions").fetchall()
+    synced = 0
+    for s in sessions:
+        _remote_upsert("sessions", "instance_id", s["instance_id"], {
+            "instance_id": s["instance_id"], "project": s["project"],
+            "role": s["role"], "ticket": s["ticket"] or "",
+            "branch": s["branch"] or "", "step": s["step"],
+            "pr": s["pr"] or 0, "host": s["host"] or "",
+            "source": s["source"], "pid": s["pid"] or 0,
+            "started_at": s["started_at"], "updated_at": s["updated_at"],
+        })
+        synced += 1
+
+    # Sync active claims
+    claims = conn.execute(
+        "SELECT * FROM claims WHERE completed_at IS NULL"
+    ).fetchall()
+    claims_synced = 0
+    for c in claims:
+        _remote_upsert("claims", "claim_id", c["id"], {
+            "claim_id": c["id"], "ticket": c["ticket"],
+            "phase": c["phase"], "mega_id": c["mega_id"] or "",
+            "owner": c["owner"] or "", "pid": c["pid"] or 0,
+            "host": c["host"] or "", "branch": c["branch"] or "",
+            "deps": c["deps"] or "", "claimed_at": c["claimed_at"] or "",
+        })
+        claims_synced += 1
+
+    conn.close()
+    print(f"Synced to {REMOTE_URL}: {synced} sessions, {claims_synced} claims")
 
 
 # ── Import existing claims ────────────────────────────────────────
@@ -527,6 +785,13 @@ def main() -> None:
     p = sub.add_parser("import-claims", help="Import .claude/claims/*.json into SQLite")
     p.add_argument("--path", default=".claude/claims")
 
+    # remote-ls
+    p = sub.add_parser("remote-ls", help="List sessions from PocketBase remote")
+    p.add_argument("--project", "-p")
+
+    # sync
+    p = sub.add_parser("sync", help="Full sync: push local state to PocketBase")
+
     args = parser.parse_args()
 
     commands = {
@@ -543,6 +808,8 @@ def main() -> None:
         "init-mega": cmd_init_mega,
         "cleanup": cmd_cleanup,
         "import-claims": cmd_import_claims,
+        "remote-ls": cmd_remote_ls,
+        "sync": cmd_sync,
     }
     commands[args.command](args)
 


### PR DESCRIPTION
## Summary
- PocketBase deployment on VPS (shared with n8n, TLS via Caddy shared-proxy network)
- Remote sync module: auto-push to PocketBase after every SQLite write (best-effort, silent skip on failure)
- Token caching (memory + file `~/.hegemon/.pb_token`) for cross-process reuse by hooks
- New CLI commands: `heg-state sync` (full push) and `heg-state remote-ls` (query remote)
- Deploy script with SSH + setup-collections.sh for initial schema creation

## Architecture
```
Local (SQLite WAL)          Remote (PocketBase)
~/.hegemon/state.db  ────→  state.gostoa.dev/api/
  ↑ primary                    ↑ best-effort push
  heg-state CLI                heg-state sync / auto
  hooks (PostToolUse)          remote-ls query
```

## Files
| File | LOC | Purpose |
|------|-----|---------|
| `hegemon/tools/state/heg_state.py` | +267 | Remote sync module + 2 new commands |
| `deploy/vps/pocketbase/docker-compose.yml` | 36 | PocketBase service + shared-proxy |
| `deploy/vps/pocketbase/deploy.sh` | 74 | SSH deploy + Caddy + health check |
| `deploy/vps/pocketbase/setup-collections.sh` | 102 | Create 3 PB collections via API |
| `deploy/vps/pocketbase/.env.template` | 8 | Env var template |

## Test plan
- [x] Python syntax check: OK
- [x] New subcommands registered: `sync`, `remote-ls`
- [x] Graceful degradation: no env vars = silent skip
- [x] Full local lifecycle: start → step → done (no regression)
- [ ] Deploy to VPS + DNS setup (manual, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)