### PR TITLE
test(e2e): add MCP resources and prompts E2E scenarios (CAB-1472)

### DIFF
--- a/e2e/features/gateway-mcp-prompts.feature
+++ b/e2e/features/gateway-mcp-prompts.feature
@@ -1,0 +1,28 @@
+@gateway @mcp @api
+Feature: Gateway - MCP Prompts & Completion (MCP 2025-11-25)
+  The STOA Gateway exposes MCP prompts and completion endpoints.
+  Currently returns empty results (no prompts registered yet) but validates
+  correct MCP protocol behavior per spec (CAB-1472).
+
+  @smoke @mcp
+  Scenario: MCP capabilities advertise prompt support
+    When I request MCP capabilities
+    Then the MCP response status is 200
+    And the MCP capabilities include "prompts"
+
+  Scenario: List prompts returns empty array
+    When I list MCP prompts
+    Then the MCP response status is 200
+    And the MCP response body has key "prompts"
+    And the MCP response has 0 items in "prompts"
+
+  Scenario: Get unknown prompt returns not-found error
+    When I get MCP prompt "nonexistent-prompt"
+    Then the MCP response status is 404
+    And the MCP error contains "not found"
+
+  Scenario: Completion returns empty suggestions
+    When I request MCP completion for prompt "test" argument "query" value "hello"
+    Then the MCP response status is 200
+    And the MCP response body has key "completion"
+    And the MCP completion has empty values

--- a/e2e/features/gateway-mcp-resources.feature
+++ b/e2e/features/gateway-mcp-resources.feature
@@ -1,0 +1,41 @@
+@gateway @mcp @api
+Feature: Gateway - MCP Resource Discovery (MCP 2025-11-25)
+  The STOA Gateway exposes registered tools as MCP resources per the MCP spec.
+  REST endpoints: POST /mcp/resources/list, POST /mcp/resources/read,
+  POST /mcp/resources/templates/list (CAB-1472).
+
+  @smoke @mcp
+  Scenario: MCP capabilities advertise resource support
+    When I request MCP capabilities
+    Then the MCP response status is 200
+    And the MCP response body has key "capabilities"
+    And the MCP capabilities include "resources"
+
+  Scenario: List resources returns valid structure
+    When I list MCP resources
+    Then the MCP response status is 200
+    And the MCP response body has key "resources"
+
+  Scenario: List resource templates returns RFC 6570 template
+    When I list MCP resource templates
+    Then the MCP response status is 200
+    And the MCP response body has key "resourceTemplates"
+    And the first resource template has uriTemplate "stoa://tools/{name}"
+
+  Scenario: Read resource with unsupported URI scheme returns error
+    When I read MCP resource "https://evil.example.com/stolen"
+    Then the MCP response status is 400
+    And the MCP error contains "unsupported"
+
+  Scenario: Read resource for unknown tool returns not found
+    When I read MCP resource "stoa://tools/nonexistent-tool-xyz"
+    Then the MCP response status is 404
+    And the MCP error contains "not found"
+
+  @wip
+  Scenario: Read resource for registered tool returns tool schema
+    When I list MCP resources
+    And I read the first available MCP resource
+    Then the MCP response status is 200
+    And the MCP response body has key "contents"
+    And the first content has valid JSON text

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -103,7 +103,7 @@ export default defineConfig({
       use: {
         baseURL: process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev',
       },
-      testMatch: /gateway-(access|mtls|uac|federation|credential|dpop)/,
+      testMatch: /gateway-(access|mtls|uac|federation|credential|dpop|mcp)/,
     },
   ],
 

--- a/e2e/steps/gateway-mcp.steps.ts
+++ b/e2e/steps/gateway-mcp.steps.ts
@@ -1,0 +1,170 @@
+/**
+ * MCP Resource, Prompt & Completion step definitions for STOA E2E Tests
+ *
+ * Tests MCP specification REST endpoints (CAB-1472):
+ * - POST /mcp/resources/list, /mcp/resources/read, /mcp/resources/templates/list
+ * - POST /mcp/prompts/list, /mcp/prompts/get
+ * - POST /mcp/completion/complete
+ * - GET /mcp/capabilities
+ *
+ * IMPORTANT: Uses its own response state (mcpResponse) because Then steps in
+ * gateway.steps.ts reference a module-scoped lastResponse that is NOT shared
+ * across files. All MCP Then steps use "the MCP ..." patterns to stay unique.
+ */
+
+import { createBdd } from 'playwright-bdd';
+import { test, expect, URLS } from '../fixtures/test-base';
+
+const { When, Then } = createBdd(test);
+
+// ---------------------------------------------------------------------------
+// MCP response state (module-scoped, independent from gateway.steps.ts)
+// ---------------------------------------------------------------------------
+
+let mcpResponse: { status: number; body: any } | null = null;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function mcpPost(
+  request: any,
+  path: string,
+  body: Record<string, unknown> = {},
+): Promise<void> {
+  try {
+    const response = await request.fetch(`${URLS.gateway}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      data: JSON.stringify(body),
+    });
+    mcpResponse = {
+      status: response.status(),
+      body: await response.json().catch(() => ({})),
+    };
+  } catch (error: any) {
+    mcpResponse = { status: 0, body: { error: error.message } };
+  }
+}
+
+async function mcpGet(request: any, path: string): Promise<void> {
+  try {
+    const response = await request.fetch(`${URLS.gateway}${path}`, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+    mcpResponse = {
+      status: response.status(),
+      body: await response.json().catch(() => ({})),
+    };
+  } catch (error: any) {
+    mcpResponse = { status: 0, body: { error: error.message } };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// When steps — MCP endpoints
+// ---------------------------------------------------------------------------
+
+When('I request MCP capabilities', async ({ request }) => {
+  await mcpGet(request, '/mcp/capabilities');
+});
+
+When('I list MCP resources', async ({ request }) => {
+  await mcpPost(request, '/mcp/resources/list', {});
+});
+
+When('I read MCP resource {string}', async ({ request }, uri: string) => {
+  await mcpPost(request, '/mcp/resources/read', { uri });
+});
+
+When('I read the first available MCP resource', async ({ request }) => {
+  expect(mcpResponse).not.toBeNull();
+  expect(mcpResponse!.body.resources).toBeDefined();
+  expect(mcpResponse!.body.resources.length).toBeGreaterThan(0);
+
+  const firstUri = mcpResponse!.body.resources[0].uri;
+  await mcpPost(request, '/mcp/resources/read', { uri: firstUri });
+});
+
+When('I list MCP resource templates', async ({ request }) => {
+  await mcpPost(request, '/mcp/resources/templates/list', {});
+});
+
+When('I list MCP prompts', async ({ request }) => {
+  await mcpPost(request, '/mcp/prompts/list', {});
+});
+
+When('I get MCP prompt {string}', async ({ request }, name: string) => {
+  await mcpPost(request, '/mcp/prompts/get', { name });
+});
+
+When(
+  'I request MCP completion for prompt {string} argument {string} value {string}',
+  async ({ request }, promptName: string, argName: string, argValue: string) => {
+    await mcpPost(request, '/mcp/completion/complete', {
+      ref: { type: 'ref/prompt', name: promptName },
+      argument: { name: argName, value: argValue },
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Then steps — MCP-specific assertions (unique patterns, no collision)
+// ---------------------------------------------------------------------------
+
+Then('the MCP response status is {int}', async ({}, expectedStatus: number) => {
+  expect(mcpResponse).not.toBeNull();
+  expect(mcpResponse!.status).toBe(expectedStatus);
+});
+
+Then('the MCP response body has key {string}', async ({}, key: string) => {
+  expect(mcpResponse).not.toBeNull();
+  expect(mcpResponse!.body).toHaveProperty(key);
+});
+
+Then('the MCP capabilities include {string}', async ({}, capability: string) => {
+  expect(mcpResponse).not.toBeNull();
+  expect(mcpResponse!.body.capabilities).toBeDefined();
+  expect(mcpResponse!.body.capabilities).toHaveProperty(capability);
+});
+
+Then('the MCP error contains {string}', async ({}, expectedMessage: string) => {
+  expect(mcpResponse).not.toBeNull();
+  const bodyStr = JSON.stringify(mcpResponse!.body).toLowerCase();
+  expect(bodyStr).toContain(expectedMessage.toLowerCase());
+});
+
+Then(
+  'the MCP response has {int} items in {string}',
+  async ({}, count: number, key: string) => {
+    expect(mcpResponse).not.toBeNull();
+    expect(mcpResponse!.body).toHaveProperty(key);
+    expect(mcpResponse!.body[key]).toHaveLength(count);
+  },
+);
+
+Then(
+  'the first resource template has uriTemplate {string}',
+  async ({}, expectedTemplate: string) => {
+    expect(mcpResponse).not.toBeNull();
+    expect(mcpResponse!.body.resourceTemplates).toBeDefined();
+    expect(mcpResponse!.body.resourceTemplates.length).toBeGreaterThan(0);
+    expect(mcpResponse!.body.resourceTemplates[0].uriTemplate).toBe(expectedTemplate);
+  },
+);
+
+Then('the MCP completion has empty values', async () => {
+  expect(mcpResponse).not.toBeNull();
+  expect(mcpResponse!.body.completion).toBeDefined();
+  expect(mcpResponse!.body.completion.values).toEqual([]);
+});
+
+Then('the first content has valid JSON text', async () => {
+  expect(mcpResponse).not.toBeNull();
+  expect(mcpResponse!.body.contents).toBeDefined();
+  expect(mcpResponse!.body.contents.length).toBeGreaterThan(0);
+  const text = mcpResponse!.body.contents[0].text;
+  expect(text).toBeDefined();
+  expect(() => JSON.parse(text)).not.toThrow();
+});


### PR DESCRIPTION
## Summary
- Add 2 new Gherkin features: `gateway-mcp-resources` (6 scenarios) and `gateway-mcp-prompts` (4 scenarios)
- Self-contained step file `gateway-mcp.steps.ts` with own `mcpResponse` state (avoids cross-module `lastResponse` issue)
- Add `mcp` to gateway project `testMatch` regex in `playwright.config.ts`
- Covers all 6 MCP REST endpoints from CAB-1472: `resources/list`, `resources/read`, `resources/templates/list`, `prompts/list`, `prompts/get`, `completion/complete`

## Test plan
- [x] `npx bddgen` resolves all steps (9 active scenarios generated, 1 @wip excluded)
- [ ] CI green (3 required checks)
- [ ] Run against live gateway: `npx playwright test --project=gateway --grep mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)