### PR TITLE
feat(api): add SCIM↔Gateway reconciliation service (CAB-1484)

### DIFF
--- a/control-plane-api/src/main.py
+++ b/control-plane-api/src/main.py
@@ -78,6 +78,7 @@ from .routers import (
     portal,
     portal_applications,
     quotas,
+    reconciliation,
     security_posture,
     self_service,
     self_service_logs,
@@ -711,6 +712,9 @@ app.include_router(data_governance.router)
 
 # Security Posture Dashboard — score, findings, drift, compliance (CAB-1461)
 app.include_router(security_posture.router)
+
+# SCIM↔Gateway Reconciliation — drift detection + sync (CAB-1484)
+app.include_router(reconciliation.router)
 
 # OAuth Client DCR — SCIM→Roles protocol mapper + identity governance (CAB-1483)
 app.include_router(oauth_clients_router)

--- a/control-plane-api/src/routers/reconciliation.py
+++ b/control-plane-api/src/routers/reconciliation.py
@@ -1,0 +1,41 @@
+"""SCIM↔Gateway reconciliation API endpoints (CAB-1484)."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..database import get_db
+from ..schemas.reconciliation import DriftReport, ReconciliationResult, ReconciliationStatus
+from ..services.scim_gateway_reconciliation import ReconciliationService
+
+router = APIRouter(prefix="/v1/tenants/{tenant_id}/reconciliation", tags=["reconciliation"])
+
+
+def _get_service(db: AsyncSession = Depends(get_db)) -> ReconciliationService:
+    return ReconciliationService(db=db)
+
+
+@router.get("/drift", response_model=DriftReport)
+async def check_drift(
+    tenant_id: str,
+    service: ReconciliationService = Depends(_get_service),
+) -> DriftReport:
+    """Check drift between SCIM clients and gateway consumers."""
+    return await service.check_drift(tenant_id)
+
+
+@router.post("/sync", response_model=ReconciliationResult)
+async def trigger_reconciliation(
+    tenant_id: str,
+    service: ReconciliationService = Depends(_get_service),
+) -> ReconciliationResult:
+    """Trigger reconciliation — sync SCIM state to gateway."""
+    return await service.reconcile(tenant_id)
+
+
+@router.get("/status", response_model=ReconciliationStatus)
+async def get_status(
+    tenant_id: str,
+    service: ReconciliationService = Depends(_get_service),
+) -> ReconciliationStatus:
+    """Get current reconciliation status for a tenant."""
+    return await service.get_status(tenant_id)

--- a/control-plane-api/src/schemas/reconciliation.py
+++ b/control-plane-api/src/schemas/reconciliation.py
@@ -1,0 +1,98 @@
+"""Pydantic schemas for SCIM↔Gateway reconciliation API (CAB-1484)."""
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DriftType(StrEnum):
+    """Type of drift between SCIM and gateway."""
+
+    MISSING_IN_GATEWAY = "missing_in_gateway"
+    ORPHANED_IN_GATEWAY = "orphaned_in_gateway"
+    ROLE_MISMATCH = "role_mismatch"
+
+
+class DriftItem(BaseModel):
+    """A single drift entry between SCIM and gateway state."""
+
+    drift_type: DriftType
+    client_id: str | None = None
+    client_name: str
+    detail: str
+    scim_roles: list[str] = Field(default_factory=list)
+    gateway_roles: list[str] = Field(default_factory=list)
+
+
+class DriftReport(BaseModel):
+    """Full drift report comparing SCIM state with gateway consumers."""
+
+    tenant_id: str
+    checked_at: datetime
+    in_sync: bool
+    total_scim_clients: int
+    total_gateway_consumers: int
+    drift_items: list[DriftItem] = Field(default_factory=list)
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "tenant_id": "tenant-acme",
+                "checked_at": "2026-02-26T12:00:00Z",
+                "in_sync": False,
+                "total_scim_clients": 5,
+                "total_gateway_consumers": 4,
+                "drift_items": [
+                    {
+                        "drift_type": "missing_in_gateway",
+                        "client_name": "acme-billing-service",
+                        "detail": "Client exists in SCIM but not provisioned in gateway",
+                        "scim_roles": ["api:read", "billing:admin"],
+                        "gateway_roles": [],
+                    }
+                ],
+            }
+        }
+    )
+
+
+class ReconciliationAction(StrEnum):
+    """Action taken during reconciliation."""
+
+    PROVISIONED = "provisioned"
+    DEPROVISIONED = "deprovisioned"
+    UPDATED_ROLES = "updated_roles"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+
+
+class ReconciliationActionResult(BaseModel):
+    """Result of a single reconciliation action."""
+
+    client_name: str
+    action: ReconciliationAction
+    detail: str
+
+
+class ReconciliationResult(BaseModel):
+    """Result of a full reconciliation run."""
+
+    tenant_id: str
+    started_at: datetime
+    completed_at: datetime
+    success: bool
+    actions_taken: int
+    actions_failed: int
+    results: list[ReconciliationActionResult] = Field(default_factory=list)
+
+
+class ReconciliationStatus(BaseModel):
+    """Current reconciliation status for a tenant."""
+
+    tenant_id: str
+    last_check: datetime | None = None
+    last_sync: datetime | None = None
+    in_sync: bool = True
+    drift_count: int = 0
+    last_error: str | None = None

--- a/control-plane-api/src/services/scim_gateway_reconciliation.py
+++ b/control-plane-api/src/services/scim_gateway_reconciliation.py
@@ -1,0 +1,261 @@
+"""SCIM↔Gateway Reconciliation service (CAB-1484).
+
+Compares SCIM-provisioned OAuth clients with gateway consumer registrations.
+Detects drift and provides automated reconciliation (sync SCIM→Gateway).
+"""
+
+import logging
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..adapters.gateway_adapter_interface import AdapterResult
+from ..models.oauth_client import OAuthClientStatus
+from ..repositories.oauth_client import OAuthClientRepository
+from ..schemas.reconciliation import (
+    DriftItem,
+    DriftReport,
+    DriftType,
+    ReconciliationAction,
+    ReconciliationActionResult,
+    ReconciliationResult,
+    ReconciliationStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ReconciliationService:
+    """Detects and resolves drift between SCIM clients and gateway consumers."""
+
+    def __init__(self, db: AsyncSession, gateway_adapter=None):
+        self.db = db
+        self.repo = OAuthClientRepository(db)
+        self.gateway = gateway_adapter
+        self._last_check: dict[str, datetime] = {}
+        self._last_sync: dict[str, datetime] = {}
+        self._last_error: dict[str, str] = {}
+        self._drift_counts: dict[str, int] = {}
+
+    async def check_drift(self, tenant_id: str) -> DriftReport:
+        """Compare SCIM clients with gateway consumers and report drift.
+
+        Returns a DriftReport with all discrepancies found.
+        """
+        now = datetime.now(UTC)
+        drift_items: list[DriftItem] = []
+
+        # Get all active SCIM clients for tenant
+        scim_clients = await self.repo.list_by_tenant(tenant_id)
+        active_clients = [c for c in scim_clients if c.status == OAuthClientStatus.ACTIVE.value]
+
+        # Get gateway consumers
+        gateway_consumers: dict[str, dict] = {}
+        if self.gateway:
+            result: AdapterResult = await self.gateway.list_applications(tenant_id)
+            if result.success and result.data:
+                for app in result.data.get("applications", []):
+                    app_name = app.get("name", "")
+                    gateway_consumers[app_name] = app
+
+        # Check for clients missing in gateway
+        for client in active_clients:
+            if client.keycloak_client_id not in gateway_consumers:
+                drift_items.append(
+                    DriftItem(
+                        drift_type=DriftType.MISSING_IN_GATEWAY,
+                        client_id=client.id,
+                        client_name=client.keycloak_client_id,
+                        detail="Client exists in SCIM but not provisioned in gateway",
+                        scim_roles=client.product_roles or [],
+                        gateway_roles=[],
+                    )
+                )
+
+        # Check for orphaned gateway consumers (in gateway but not in SCIM)
+        scim_client_ids = {c.keycloak_client_id for c in active_clients}
+        for gw_name, gw_app in gateway_consumers.items():
+            if gw_name not in scim_client_ids:
+                drift_items.append(
+                    DriftItem(
+                        drift_type=DriftType.ORPHANED_IN_GATEWAY,
+                        client_name=gw_name,
+                        detail="Consumer exists in gateway but not in SCIM",
+                        scim_roles=[],
+                        gateway_roles=gw_app.get("roles", []),
+                    )
+                )
+
+        in_sync = len(drift_items) == 0
+        self._last_check[tenant_id] = now
+        self._drift_counts[tenant_id] = len(drift_items)
+
+        return DriftReport(
+            tenant_id=tenant_id,
+            checked_at=now,
+            in_sync=in_sync,
+            total_scim_clients=len(active_clients),
+            total_gateway_consumers=len(gateway_consumers),
+            drift_items=drift_items,
+        )
+
+    async def reconcile(self, tenant_id: str) -> ReconciliationResult:
+        """Sync SCIM state to gateway — provision missing, deprovision orphaned."""
+        started_at = datetime.now(UTC)
+        results: list[ReconciliationActionResult] = []
+        actions_failed = 0
+
+        # First check drift
+        drift = await self.check_drift(tenant_id)
+
+        for item in drift.drift_items:
+            if item.drift_type == DriftType.MISSING_IN_GATEWAY:
+                result = await self._provision_consumer(tenant_id, item)
+            elif item.drift_type == DriftType.ORPHANED_IN_GATEWAY:
+                result = await self._deprovision_consumer(tenant_id, item)
+            elif item.drift_type == DriftType.ROLE_MISMATCH:
+                result = await self._update_consumer_roles(tenant_id, item)
+            else:
+                result = ReconciliationActionResult(
+                    client_name=item.client_name,
+                    action=ReconciliationAction.SKIPPED,
+                    detail=f"Unknown drift type: {item.drift_type}",
+                )
+
+            if result.action == ReconciliationAction.FAILED:
+                actions_failed += 1
+            results.append(result)
+
+        completed_at = datetime.now(UTC)
+        success = actions_failed == 0
+
+        self._last_sync[tenant_id] = completed_at
+        if not success:
+            self._last_error[tenant_id] = f"{actions_failed} action(s) failed"
+        else:
+            self._last_error.pop(tenant_id, None)
+        self._drift_counts[tenant_id] = 0 if success else actions_failed
+
+        return ReconciliationResult(
+            tenant_id=tenant_id,
+            started_at=started_at,
+            completed_at=completed_at,
+            success=success,
+            actions_taken=len(results) - actions_failed,
+            actions_failed=actions_failed,
+            results=results,
+        )
+
+    async def get_status(self, tenant_id: str) -> ReconciliationStatus:
+        """Return the current reconciliation status for a tenant."""
+        return ReconciliationStatus(
+            tenant_id=tenant_id,
+            last_check=self._last_check.get(tenant_id),
+            last_sync=self._last_sync.get(tenant_id),
+            in_sync=self._drift_counts.get(tenant_id, 0) == 0,
+            drift_count=self._drift_counts.get(tenant_id, 0),
+            last_error=self._last_error.get(tenant_id),
+        )
+
+    async def _provision_consumer(self, tenant_id: str, item: DriftItem) -> ReconciliationActionResult:
+        """Provision a missing consumer in the gateway."""
+        if not self.gateway:
+            return ReconciliationActionResult(
+                client_name=item.client_name,
+                action=ReconciliationAction.SKIPPED,
+                detail="No gateway adapter configured",
+            )
+
+        try:
+            spec = {
+                "name": item.client_name,
+                "tenant_id": tenant_id,
+                "roles": item.scim_roles,
+            }
+            result = await self.gateway.provision_application(tenant_id, spec)
+            if result.success:
+                logger.info(f"Provisioned consumer {item.client_name} in gateway for tenant {tenant_id}")
+                return ReconciliationActionResult(
+                    client_name=item.client_name,
+                    action=ReconciliationAction.PROVISIONED,
+                    detail=f"Provisioned with roles: {', '.join(item.scim_roles)}",
+                )
+            return ReconciliationActionResult(
+                client_name=item.client_name,
+                action=ReconciliationAction.FAILED,
+                detail=f"Gateway provisioning failed: {result.error}",
+            )
+        except Exception as e:
+            logger.error(f"Failed to provision {item.client_name}: {e}")
+            return ReconciliationActionResult(
+                client_name=item.client_name,
+                action=ReconciliationAction.FAILED,
+                detail=str(e),
+            )
+
+    async def _deprovision_consumer(self, tenant_id: str, item: DriftItem) -> ReconciliationActionResult:
+        """Remove an orphaned consumer from the gateway."""
+        if not self.gateway:
+            return ReconciliationActionResult(
+                client_name=item.client_name,
+                action=ReconciliationAction.SKIPPED,
+                detail="No gateway adapter configured",
+            )
+
+        try:
+            result = await self.gateway.deprovision_application(tenant_id, item.client_name)
+            if result.success:
+                logger.info(f"Deprovisioned orphaned consumer {item.client_name} from gateway")
+                return ReconciliationActionResult(
+                    client_name=item.client_name,
+                    action=ReconciliationAction.DEPROVISIONED,
+                    detail="Removed orphaned consumer from gateway",
+                )
+            return ReconciliationActionResult(
+                client_name=item.client_name,
+                action=ReconciliationAction.FAILED,
+                detail=f"Gateway deprovisioning failed: {result.error}",
+            )
+        except Exception as e:
+            logger.error(f"Failed to deprovision {item.client_name}: {e}")
+            return ReconciliationActionResult(
+                client_name=item.client_name,
+                action=ReconciliationAction.FAILED,
+                detail=str(e),
+            )
+
+    async def _update_consumer_roles(self, tenant_id: str, item: DriftItem) -> ReconciliationActionResult:
+        """Update consumer roles in the gateway to match SCIM."""
+        if not self.gateway:
+            return ReconciliationActionResult(
+                client_name=item.client_name,
+                action=ReconciliationAction.SKIPPED,
+                detail="No gateway adapter configured",
+            )
+
+        try:
+            spec = {
+                "name": item.client_name,
+                "tenant_id": tenant_id,
+                "roles": item.scim_roles,
+            }
+            result = await self.gateway.provision_application(tenant_id, spec)
+            if result.success:
+                logger.info(f"Updated roles for {item.client_name} in gateway")
+                return ReconciliationActionResult(
+                    client_name=item.client_name,
+                    action=ReconciliationAction.UPDATED_ROLES,
+                    detail=f"Updated roles: {', '.join(item.scim_roles)}",
+                )
+            return ReconciliationActionResult(
+                client_name=item.client_name,
+                action=ReconciliationAction.FAILED,
+                detail=f"Gateway role update failed: {result.error}",
+            )
+        except Exception as e:
+            logger.error(f"Failed to update roles for {item.client_name}: {e}")
+            return ReconciliationActionResult(
+                client_name=item.client_name,
+                action=ReconciliationAction.FAILED,
+                detail=str(e),
+            )

--- a/control-plane-api/tests/test_scim_gateway_reconciliation.py
+++ b/control-plane-api/tests/test_scim_gateway_reconciliation.py
@@ -1,0 +1,347 @@
+"""Tests for SCIM↔Gateway reconciliation service (CAB-1484)."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.adapters.gateway_adapter_interface import AdapterResult
+from src.models.oauth_client import OAuthClientStatus
+from src.schemas.reconciliation import (
+    DriftItem,
+    DriftType,
+    ReconciliationAction,
+    ReconciliationActionResult,
+    ReconciliationResult,
+    ReconciliationStatus,
+)
+from src.services.scim_gateway_reconciliation import ReconciliationService
+
+
+# ---- Fixtures ----
+
+
+def _make_client(client_id: str, name: str, tenant: str, roles: list[str] | None = None, status: str = "active"):
+    """Create a mock OAuthClient."""
+    client = MagicMock()
+    client.id = client_id
+    client.tenant_id = tenant
+    client.keycloak_client_id = name
+    client.client_name = name
+    client.product_roles = roles or []
+    client.status = status
+    return client
+
+
+def _make_gateway_adapter(apps: list[dict] | None = None, provision_ok: bool = True, deprovision_ok: bool = True):
+    """Create a mock gateway adapter."""
+    adapter = AsyncMock()
+    adapter.list_applications.return_value = AdapterResult(
+        success=True, data={"applications": apps or []}
+    )
+    adapter.provision_application.return_value = AdapterResult(success=provision_ok, error=None if provision_ok else "provision failed")
+    adapter.deprovision_application.return_value = AdapterResult(success=deprovision_ok, error=None if deprovision_ok else "deprovision failed")
+    return adapter
+
+
+@pytest.fixture
+def db():
+    return AsyncMock()
+
+
+# ---- Schema Tests ----
+
+
+class TestSchemas:
+    def test_drift_item_creation(self):
+        item = DriftItem(
+            drift_type=DriftType.MISSING_IN_GATEWAY,
+            client_name="acme-svc",
+            detail="Not in gateway",
+            scim_roles=["api:read"],
+        )
+        assert item.drift_type == DriftType.MISSING_IN_GATEWAY
+        assert item.client_name == "acme-svc"
+        assert item.scim_roles == ["api:read"]
+        assert item.gateway_roles == []
+
+    def test_drift_type_values(self):
+        assert DriftType.MISSING_IN_GATEWAY.value == "missing_in_gateway"
+        assert DriftType.ORPHANED_IN_GATEWAY.value == "orphaned_in_gateway"
+        assert DriftType.ROLE_MISMATCH.value == "role_mismatch"
+
+    def test_reconciliation_action_values(self):
+        assert ReconciliationAction.PROVISIONED.value == "provisioned"
+        assert ReconciliationAction.DEPROVISIONED.value == "deprovisioned"
+        assert ReconciliationAction.UPDATED_ROLES.value == "updated_roles"
+        assert ReconciliationAction.SKIPPED.value == "skipped"
+        assert ReconciliationAction.FAILED.value == "failed"
+
+    def test_reconciliation_status_defaults(self):
+        status = ReconciliationStatus(tenant_id="t1")
+        assert status.in_sync is True
+        assert status.drift_count == 0
+        assert status.last_check is None
+        assert status.last_sync is None
+        assert status.last_error is None
+
+    def test_reconciliation_action_result(self):
+        result = ReconciliationActionResult(
+            client_name="svc-1",
+            action=ReconciliationAction.PROVISIONED,
+            detail="Created with roles",
+        )
+        assert result.action == ReconciliationAction.PROVISIONED
+
+
+# ---- Service Tests ----
+
+
+class TestCheckDrift:
+    @pytest.mark.asyncio
+    async def test_in_sync_no_drift(self, db):
+        """All SCIM clients have matching gateway consumers."""
+        adapter = _make_gateway_adapter(apps=[{"name": "t1-svc-a"}, {"name": "t1-svc-b"}])
+        service = ReconciliationService(db=db, gateway_adapter=adapter)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = [
+            _make_client("1", "t1-svc-a", "t1", ["api:read"]),
+            _make_client("2", "t1-svc-b", "t1", ["api:write"]),
+        ]
+
+        report = await service.check_drift("t1")
+        assert report.in_sync is True
+        assert len(report.drift_items) == 0
+        assert report.total_scim_clients == 2
+        assert report.total_gateway_consumers == 2
+
+    @pytest.mark.asyncio
+    async def test_missing_in_gateway(self, db):
+        """SCIM client not provisioned in gateway."""
+        adapter = _make_gateway_adapter(apps=[])
+        service = ReconciliationService(db=db, gateway_adapter=adapter)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = [
+            _make_client("1", "t1-svc-a", "t1", ["api:read"]),
+        ]
+
+        report = await service.check_drift("t1")
+        assert report.in_sync is False
+        assert len(report.drift_items) == 1
+        assert report.drift_items[0].drift_type == DriftType.MISSING_IN_GATEWAY
+        assert report.drift_items[0].client_name == "t1-svc-a"
+
+    @pytest.mark.asyncio
+    async def test_orphaned_in_gateway(self, db):
+        """Gateway consumer has no matching SCIM client."""
+        adapter = _make_gateway_adapter(apps=[{"name": "orphan-svc", "roles": ["stale"]}])
+        service = ReconciliationService(db=db, gateway_adapter=adapter)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = []
+
+        report = await service.check_drift("t1")
+        assert report.in_sync is False
+        assert len(report.drift_items) == 1
+        assert report.drift_items[0].drift_type == DriftType.ORPHANED_IN_GATEWAY
+        assert report.drift_items[0].gateway_roles == ["stale"]
+
+    @pytest.mark.asyncio
+    async def test_mixed_drift(self, db):
+        """Both missing and orphaned consumers."""
+        adapter = _make_gateway_adapter(apps=[{"name": "orphan-svc"}])
+        service = ReconciliationService(db=db, gateway_adapter=adapter)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = [
+            _make_client("1", "missing-svc", "t1"),
+        ]
+
+        report = await service.check_drift("t1")
+        assert not report.in_sync
+        assert len(report.drift_items) == 2
+        types = {i.drift_type for i in report.drift_items}
+        assert types == {DriftType.MISSING_IN_GATEWAY, DriftType.ORPHANED_IN_GATEWAY}
+
+    @pytest.mark.asyncio
+    async def test_no_gateway_adapter(self, db):
+        """Without gateway adapter, only SCIM clients are counted."""
+        service = ReconciliationService(db=db, gateway_adapter=None)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = [
+            _make_client("1", "svc-a", "t1"),
+        ]
+
+        report = await service.check_drift("t1")
+        assert report.total_gateway_consumers == 0
+        assert len(report.drift_items) == 1
+
+    @pytest.mark.asyncio
+    async def test_revoked_clients_excluded(self, db):
+        """Revoked clients should not appear in drift report."""
+        adapter = _make_gateway_adapter(apps=[])
+        service = ReconciliationService(db=db, gateway_adapter=adapter)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = [
+            _make_client("1", "revoked-svc", "t1", status="revoked"),
+        ]
+
+        report = await service.check_drift("t1")
+        assert report.in_sync is True
+        assert report.total_scim_clients == 0
+
+    @pytest.mark.asyncio
+    async def test_updates_last_check(self, db):
+        """check_drift updates internal status tracking."""
+        adapter = _make_gateway_adapter(apps=[])
+        service = ReconciliationService(db=db, gateway_adapter=adapter)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = []
+
+        await service.check_drift("t1")
+        status = await service.get_status("t1")
+        assert status.last_check is not None
+
+
+class TestReconcile:
+    @pytest.mark.asyncio
+    async def test_provisions_missing(self, db):
+        """Reconcile provisions clients missing from gateway."""
+        adapter = _make_gateway_adapter(apps=[])
+        service = ReconciliationService(db=db, gateway_adapter=adapter)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = [
+            _make_client("1", "svc-a", "t1", ["api:read"]),
+        ]
+
+        result = await service.reconcile("t1")
+        assert result.success is True
+        assert result.actions_taken == 1
+        assert result.results[0].action == ReconciliationAction.PROVISIONED
+        adapter.provision_application.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_deprovisions_orphaned(self, db):
+        """Reconcile removes orphaned gateway consumers."""
+        adapter = _make_gateway_adapter(apps=[{"name": "orphan"}])
+        service = ReconciliationService(db=db, gateway_adapter=adapter)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = []
+
+        result = await service.reconcile("t1")
+        assert result.success is True
+        assert result.results[0].action == ReconciliationAction.DEPROVISIONED
+        adapter.deprovision_application.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_provision_failure(self, db):
+        """Failed provisioning reported correctly."""
+        adapter = _make_gateway_adapter(apps=[], provision_ok=False)
+        service = ReconciliationService(db=db, gateway_adapter=adapter)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = [
+            _make_client("1", "svc-a", "t1"),
+        ]
+
+        result = await service.reconcile("t1")
+        assert result.success is False
+        assert result.actions_failed == 1
+        assert result.results[0].action == ReconciliationAction.FAILED
+
+    @pytest.mark.asyncio
+    async def test_no_drift_no_actions(self, db):
+        """When in sync, reconcile takes no actions."""
+        adapter = _make_gateway_adapter(apps=[{"name": "svc-a"}])
+        service = ReconciliationService(db=db, gateway_adapter=adapter)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = [
+            _make_client("1", "svc-a", "t1"),
+        ]
+
+        result = await service.reconcile("t1")
+        assert result.success is True
+        assert result.actions_taken == 0
+        assert len(result.results) == 0
+
+    @pytest.mark.asyncio
+    async def test_reconcile_updates_status(self, db):
+        """After reconcile, status reflects the sync."""
+        adapter = _make_gateway_adapter(apps=[{"name": "svc-a"}])
+        service = ReconciliationService(db=db, gateway_adapter=adapter)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = [
+            _make_client("1", "svc-a", "t1"),
+        ]
+
+        await service.reconcile("t1")
+        status = await service.get_status("t1")
+        assert status.last_sync is not None
+        assert status.in_sync is True
+
+    @pytest.mark.asyncio
+    async def test_reconcile_without_gateway(self, db):
+        """Without adapter, actions are skipped."""
+        service = ReconciliationService(db=db, gateway_adapter=None)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = [
+            _make_client("1", "svc-a", "t1"),
+        ]
+
+        result = await service.reconcile("t1")
+        assert result.success is True
+        assert result.results[0].action == ReconciliationAction.SKIPPED
+
+    @pytest.mark.asyncio
+    async def test_provision_exception_handled(self, db):
+        """Gateway adapter exception is caught and reported."""
+        adapter = AsyncMock()
+        adapter.list_applications.return_value = AdapterResult(success=True, data={"applications": []})
+        adapter.provision_application.side_effect = ConnectionError("gateway down")
+        service = ReconciliationService(db=db, gateway_adapter=adapter)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = [
+            _make_client("1", "svc-a", "t1"),
+        ]
+
+        result = await service.reconcile("t1")
+        assert result.success is False
+        assert "gateway down" in result.results[0].detail
+
+
+class TestGetStatus:
+    @pytest.mark.asyncio
+    async def test_default_status(self, db):
+        """Fresh service returns default status."""
+        service = ReconciliationService(db=db)
+        status = await service.get_status("t1")
+        assert status.tenant_id == "t1"
+        assert status.in_sync is True
+        assert status.drift_count == 0
+
+    @pytest.mark.asyncio
+    async def test_status_after_drift_detected(self, db):
+        """Status reflects drift after check."""
+        adapter = _make_gateway_adapter(apps=[])
+        service = ReconciliationService(db=db, gateway_adapter=adapter)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = [
+            _make_client("1", "svc-a", "t1"),
+        ]
+
+        await service.check_drift("t1")
+        status = await service.get_status("t1")
+        assert status.in_sync is False
+        assert status.drift_count == 1
+
+    @pytest.mark.asyncio
+    async def test_status_after_failed_reconcile(self, db):
+        """Status reflects error after failed reconcile."""
+        adapter = _make_gateway_adapter(apps=[], provision_ok=False)
+        service = ReconciliationService(db=db, gateway_adapter=adapter)
+        service.repo = AsyncMock()
+        service.repo.list_by_tenant.return_value = [
+            _make_client("1", "svc-a", "t1"),
+        ]
+
+        await service.reconcile("t1")
+        status = await service.get_status("t1")
+        assert status.last_error is not None
+        assert "failed" in status.last_error


### PR DESCRIPTION
## Summary
- SCIM↔Gateway drift detection: compares OAuth clients with gateway consumers
- Automated reconciliation: provisions missing, deprovisions orphaned
- Status tracking: per-tenant reconciliation state
- 3 API endpoints + 22 unit tests

## Test plan
- [x] ruff check: clean
- [x] black format: clean
- [x] pytest: 22/22 pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>