### PR TITLE
fix(ci): simplify heg-state PocketBase auth (admin endpoint)

### DIFF
--- a/hegemon/tools/state/heg_state.py
+++ b/hegemon/tools/state/heg_state.py
@@ -21,7 +21,6 @@ import json
 import os
 import platform
 import sqlite3
-import ssl
 import sys
 import time
 import urllib.error
@@ -50,21 +49,12 @@ TOKEN_CACHE_FILE = Path.home() / ".hegemon" / ".pb_token"
 _token_cache: dict = {"token": None, "expires": 0.0}
 
 
-def _ssl_context() -> ssl.SSLContext:
-    """Create SSL context with certifi CA bundle (macOS Python needs this)."""
-    try:
-        import certifi
-        return ssl.create_default_context(cafile=certifi.where())
-    except ImportError:
-        return ssl.create_default_context()
-
-
 def _remote_enabled() -> bool:
     return bool(REMOTE_URL and REMOTE_PASSWORD)
 
 
 def _remote_auth() -> str | None:
-    """Get PocketBase superuser auth token. Cached in memory + file."""
+    """Get PocketBase admin auth token. Cached in memory + file."""
     if not _remote_enabled():
         return None
 
@@ -83,18 +73,18 @@ def _remote_auth() -> str | None:
         except (json.JSONDecodeError, KeyError):
             pass
 
-    # Fresh auth (PocketBase v0.23+ uses _superusers collection)
+    # Fresh auth
     try:
         data = json.dumps({"identity": REMOTE_EMAIL, "password": REMOTE_PASSWORD}).encode()
         req = urllib.request.Request(
-            f"{REMOTE_URL}/api/collections/_superusers/auth-with-password",
+            f"{REMOTE_URL}/api/admins/auth-with-password",
             data=data,
             headers={"Content-Type": "application/json"},
         )
-        resp = urllib.request.urlopen(req, timeout=5, context=_ssl_context())
+        resp = urllib.request.urlopen(req, timeout=5)
         result = json.loads(resp.read())
         token = result["token"]
-        expires = time.time() + 7200  # 2h (PB tokens last 14d, but refresh often)
+        expires = time.time() + 7200  # 2h (PB admin tokens last 14d, but refresh often)
 
         _token_cache["token"] = token
         _token_cache["expires"] = expires
@@ -120,7 +110,7 @@ def _remote_push(collection: str, data: dict) -> None:
             data=body,
             headers={"Content-Type": "application/json", "Authorization": token},
         )
-        urllib.request.urlopen(req, timeout=5, context=_ssl_context())
+        urllib.request.urlopen(req, timeout=5)
     except Exception:
         pass  # best-effort, SQLite is primary
 
@@ -136,7 +126,7 @@ def _remote_upsert(collection: str, filter_field: str, filter_value: str, data: 
             f"{REMOTE_URL}/api/collections/{collection}/records?filter={encoded_filter}&perPage=1",
             headers={"Authorization": token},
         )
-        resp = urllib.request.urlopen(req, timeout=5, context=_ssl_context())
+        resp = urllib.request.urlopen(req, timeout=5)
         result = json.loads(resp.read())
 
         if result.get("totalItems", 0) > 0:
@@ -148,7 +138,7 @@ def _remote_upsert(collection: str, filter_field: str, filter_value: str, data: 
                 headers={"Content-Type": "application/json", "Authorization": token},
                 method="PATCH",
             )
-            urllib.request.urlopen(req, timeout=5, context=_ssl_context())
+            urllib.request.urlopen(req, timeout=5)
         else:
             _remote_push(collection, data)
     except Exception:
@@ -166,7 +156,7 @@ def _remote_delete(collection: str, filter_field: str, filter_value: str) -> Non
             f"{REMOTE_URL}/api/collections/{collection}/records?filter={encoded_filter}&perPage=1",
             headers={"Authorization": token},
         )
-        resp = urllib.request.urlopen(req, timeout=5, context=_ssl_context())
+        resp = urllib.request.urlopen(req, timeout=5)
         result = json.loads(resp.read())
 
         if result.get("totalItems", 0) > 0:
@@ -176,9 +166,10 @@ def _remote_delete(collection: str, filter_field: str, filter_value: str) -> Non
                 headers={"Authorization": token},
                 method="DELETE",
             )
-            urllib.request.urlopen(req, timeout=5, context=_ssl_context())
+            urllib.request.urlopen(req, timeout=5)
     except Exception:
         pass
+
 
 def _now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
## Summary
- Switch from `_superusers` to `/api/admins/auth-with-password` endpoint
- Remove `ssl`/`certifi` dependency — stdlib defaults suffice
- Drop `_ssl_context()` helper (6 calls removed)

## Test plan
- [ ] `heg-state remote-ls` works against state.gostoa.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)