### PR TITLE
fix(ci): harden hegemon daemon — tilde expansion, prompt file, retry

### DIFF
--- a/hegemon/daemon/cmd/hegemon/main.go
+++ b/hegemon/daemon/cmd/hegemon/main.go
@@ -166,6 +166,8 @@ func (d *daemon) pollAndDispatch(ctx context.Context) {
 
 	if dispatched > 0 {
 		log.Printf("Poll: dispatched %d tickets from cycle %s", dispatched, cycle.Name)
+	} else {
+		log.Printf("Poll: no dispatchable tickets in cycle %s (%d issues scanned)", cycle.Name, len(issues))
 	}
 }
 
@@ -225,7 +227,10 @@ func (d *daemon) executeAndReport(ctx context.Context, issue linear.Issue, w *co
 		} else {
 			d.state.CompleteDispatch(dispatchID, "failed", raw, 0, errMsg)
 			d.reporter.NotifyError(issue.Identifier, issue.Title, errMsg, duration)
-			d.reporter.LinearUpdateBlocked(issue.ID, errMsg)
+			// Reset ticket to Todo so it can be retried.
+			if resetErr := d.linear.UpdateIssueState(issue.ID, "Todo"); resetErr != nil {
+				log.Printf("WARN reset %s to Todo: %v", issue.Identifier, resetErr)
+			}
 		}
 		log.Printf("FAIL %s on %s after %s: %v", issue.Identifier, w.Name, duration.Round(time.Second), err)
 		return

--- a/hegemon/daemon/internal/config/config.go
+++ b/hegemon/daemon/internal/config/config.go
@@ -95,6 +95,7 @@ func Load(path string) (*Config, error) {
 	}
 
 	setDefaults(cfg)
+	expandTildes(cfg)
 	return cfg, nil
 }
 
@@ -128,6 +129,24 @@ func setDefaults(cfg *Config) {
 			cfg.Workers[i].User = "hegemon"
 		}
 	}
+}
+
+func expandTildes(cfg *Config) {
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		return
+	}
+	expand := func(s string) string {
+		if len(s) >= 2 && s[:2] == "~/" {
+			return home + s[1:]
+		}
+		return s
+	}
+	for i := range cfg.Workers {
+		cfg.Workers[i].SSHKey = expand(cfg.Workers[i].SSHKey)
+	}
+	cfg.Repo.Path = expand(cfg.Repo.Path)
+	cfg.State.DBPath = expand(cfg.State.DBPath)
 }
 
 // TimeoutForEstimate returns the max execution time for a ticket based on its

--- a/hegemon/daemon/internal/config/config_test.go
+++ b/hegemon/daemon/internal/config/config_test.go
@@ -158,8 +158,10 @@ workers: []
 	if cfg.State.DBPath != "./hegemon.db" {
 		t.Errorf("default db_path = %q, want %q", cfg.State.DBPath, "./hegemon.db")
 	}
-	if cfg.Repo.Path != "~/stoa" {
-		t.Errorf("default repo.path = %q, want %q", cfg.Repo.Path, "~/stoa")
+	home, _ := os.UserHomeDir()
+	wantRepoPath := home + "/stoa"
+	if cfg.Repo.Path != wantRepoPath {
+		t.Errorf("default repo.path = %q, want %q", cfg.Repo.Path, wantRepoPath)
 	}
 	if cfg.Log.MaxAgeDays != 7 {
 		t.Errorf("default max_age_days = %d, want 7", cfg.Log.MaxAgeDays)

--- a/hegemon/daemon/internal/worker/executor.go
+++ b/hegemon/daemon/internal/worker/executor.go
@@ -47,11 +47,18 @@ func (e *Executor) Execute(ctx context.Context, w *config.WorkerConfig, ticketID
 	maxTurns := turnsForEstimate(estimate)
 	prompt := buildPrompt(ticketID, title, description)
 
+	// Write prompt to a temp file on the remote, then run claude with it.
+	// This avoids shell quoting issues with multi-line prompts containing special characters.
+	promptFile := fmt.Sprintf("/tmp/hegemon-prompt-%s.txt", ticketID)
+	if err := e.writeRemoteFile(client, promptFile, prompt); err != nil {
+		return nil, "", fmt.Errorf("write prompt file: %w", err)
+	}
+
 	// Build the remote command.
 	// bash -l sources .profile which loads Infisical secrets.
 	cmd := fmt.Sprintf(
-		`bash -l -c 'cd %s && git checkout %s && git pull --ff-only && claude -p %s --output-format json --max-turns %d --verbose 2>/dev/null'`,
-		e.repoPath, e.branch, shellQuote(prompt), maxTurns,
+		`bash -l -c 'cd %s && git checkout %s && git pull --ff-only && claude -p "$(cat %s)" --output-format json --max-turns %d --verbose 2>/dev/null; rm -f %s'`,
+		e.repoPath, e.branch, promptFile, maxTurns, promptFile,
 	)
 
 	session, err := client.NewSession()
@@ -132,6 +139,17 @@ func (e *Executor) dialWithTimeout(w *config.WorkerConfig, timeout time.Duration
 
 	addr := fmt.Sprintf("%s:%d", w.Host, w.Port)
 	return ssh.Dial("tcp", addr, cfg)
+}
+
+// writeRemoteFile writes content to a file on the remote host via SSH.
+func (e *Executor) writeRemoteFile(client *ssh.Client, path, content string) error {
+	session, err := client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+	session.Stdin = bytes.NewReader([]byte(content))
+	return session.Run(fmt.Sprintf("cat > %s", path))
 }
 
 func turnsForEstimate(estimate int) int {


### PR DESCRIPTION
## Summary
- Add `expandTildes()` for config paths (`~/stoa` → absolute path)
- Write prompt to remote temp file to avoid shell quoting issues with special chars
- Reset failed tickets to Todo (instead of Blocked) so they can be retried
- Log scan count when no tickets are dispatched

## Test plan
- [x] config_test.go updated for expanded tilde assertion
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)