### PR TITLE
chore: sync memory.md with hegemon daemon deployment

### DIFF
--- a/memory.md
+++ b/memory.md
@@ -135,6 +135,8 @@ CAB-1512: MCP Federation v2 (21 pts) — Council 5.50 → needs spec
 - Test suite: 5700+ tests, 91% coverage (control-plane-api), 1330 gateway tests
 - Session 2026-02-26: 25 PRs merged (#1111-#1135), parallel agents + inline implementation, 5 MEGAs completed + Go daemon
 - HEGEMON fleet: 5 Contabo VPS (8vCPU/24GB/200GB, Nuremberg), Go daemon PR #1135, Infisical dynamic secrets
+- HEGEMON daemon DEPLOYED on worker-1 (207.180.246.92) — systemd `hegemon.service`, polling 60s, 5/5 workers healthy
+  - Fixes: Linear GraphQL ID!/String! types, tilde expansion, prompt-file SSH, auto-reset failed tickets (commit ec31d378)
 - Backlog trim: 106 tickets canceled 2026-02-24
 - Velocity C8: 1305 pts / 88 issues / 186 pts/day
 - Velocity C7: 505 pts / 44 issues / 72 pts/day


### PR DESCRIPTION
## Summary
- Add hegemon daemon deployment status (worker-1, systemd, polling)
- Document daemon fixes (GraphQL types, tilde expansion, prompt-file, auto-reset)

## Test plan
- [ ] State file update only

🤖 Generated with [Claude Code](https://claude.com/claude-code)