### PR TITLE
fix(ui): wire dead buttons in 3 console dashboards

### DIFF
--- a/control-plane-api/src/routers/monitoring.py
+++ b/control-plane-api/src/routers/monitoring.py
@@ -1,4 +1,5 @@
 """API Monitoring endpoints for transaction tracking and analytics."""
+
 import logging
 import random
 from datetime import datetime, timedelta
@@ -16,6 +17,7 @@ router = APIRouter(prefix="/v1/monitoring", tags=["Monitoring"])
 # =============================================================================
 # MODELS
 # =============================================================================
+
 
 class TransactionSpan(BaseModel):
     name: str
@@ -75,6 +77,7 @@ class APITransactionStats(BaseModel):
 # DEMO DATA GENERATOR
 # =============================================================================
 
+
 def generate_demo_transactions(count: int = 50, tenant_id: str | None = None) -> list[APITransactionSummary]:
     """Generate realistic demo transaction data."""
     apis = [
@@ -108,10 +111,7 @@ def generate_demo_transactions(count: int = 50, tenant_id: str | None = None) ->
         method = random.choices(methods, weights=method_weights)[0]
 
         # Select status based on weights
-        status_choice = random.choices(
-            status_configs,
-            weights=[s[2] for s in status_configs]
-        )[0]
+        status_choice = random.choices(status_configs, weights=[s[2] for s in status_configs])[0]
         status_code, status, _ = status_choice
 
         # Random time within last hour
@@ -129,18 +129,20 @@ def generate_demo_transactions(count: int = 50, tenant_id: str | None = None) ->
         tx_id = f"tx-{i:06d}-{random.randint(1000, 9999)}"
         trace_id = f"trace-{random.randint(100000, 999999)}"
 
-        transactions.append(APITransactionSummary(
-            id=tx_id,
-            trace_id=trace_id,
-            api_name=api["name"],
-            method=method,
-            path=random.choice(api["paths"]),
-            status_code=status_code,
-            status=status,
-            started_at=started_at.isoformat() + "Z",
-            total_duration_ms=latency,
-            spans_count=random.randint(3, 8),
-        ))
+        transactions.append(
+            APITransactionSummary(
+                id=tx_id,
+                trace_id=trace_id,
+                api_name=api["name"],
+                method=method,
+                path=random.choice(api["paths"]),
+                status_code=status_code,
+                status=status,
+                started_at=started_at.isoformat() + "Z",
+                total_duration_ms=latency,
+                spans_count=random.randint(3, 8),
+            )
+        )
 
     # Sort by time, most recent first
     transactions.sort(key=lambda x: x.started_at, reverse=True)
@@ -172,14 +174,16 @@ def generate_transaction_detail(tx_id: str, tenant_id: str = "demo") -> APITrans
         duration = random.randint(min_ms, max_ms)
         span_status = "error" if is_error and name == "backend_call" else "success"
 
-        spans.append(TransactionSpan(
-            name=name,
-            service=service,
-            start_offset_ms=current_offset,
-            duration_ms=duration,
-            status=span_status,
-            metadata={"processed": True}
-        ))
+        spans.append(
+            TransactionSpan(
+                name=name,
+                service=service,
+                start_offset_ms=current_offset,
+                duration_ms=duration,
+                status=span_status,
+                metadata={"processed": True},
+            )
+        )
         current_offset += duration
 
     total_duration = current_offset
@@ -255,6 +259,7 @@ def generate_stats() -> APITransactionStats:
 # ENDPOINTS
 # =============================================================================
 
+
 @router.get("/transactions")
 async def list_transactions(
     limit: int = Query(50, ge=1, le=200),
@@ -284,6 +289,7 @@ async def list_transactions(
     return {
         "transactions": [t.model_dump() for t in transactions],
         "total": len(transactions),
+        "demo_mode": True,
     }
 
 
@@ -296,7 +302,7 @@ async def get_transaction_stats(
 
     Returns aggregated metrics about API calls.
     """
-    return generate_stats().model_dump()
+    return {**generate_stats().model_dump(), "demo_mode": True}
 
 
 @router.get("/transactions/{transaction_id}")
@@ -311,4 +317,4 @@ async def get_transaction(
     """
     tenant_id = user.tenant_id or "demo"
     transaction = generate_transaction_detail(transaction_id, tenant_id)
-    return transaction.model_dump()
+    return {**transaction.model_dump(), "demo_mode": True}

--- a/control-plane-ui/src/pages/AccessReview/AccessReviewDashboard.tsx
+++ b/control-plane-ui/src/pages/AccessReview/AccessReviewDashboard.tsx
@@ -68,6 +68,29 @@ export function AccessReviewDashboard() {
     fetchClients();
   };
 
+  const handleApprove = async (clientId: string) => {
+    try {
+      await apiService.post(`/v1/oauth-clients/${clientId}/approve`);
+      setClients((prev) =>
+        prev.map((c) => (c.id === clientId ? { ...c, status: 'active' as const } : c))
+      );
+    } catch {
+      alert('Failed to approve client');
+    }
+  };
+
+  const handleRevoke = async (clientId: string) => {
+    if (!confirm('Are you sure you want to revoke this OAuth client?')) return;
+    try {
+      await apiService.delete(`/v1/oauth-clients/${clientId}`);
+      setClients((prev) =>
+        prev.map((c) => (c.id === clientId ? { ...c, status: 'revoked' as const } : c))
+      );
+    } catch {
+      alert('Failed to revoke client');
+    }
+  };
+
   const activeCount = clients.filter((c) => c.status === 'active').length;
   const revokedCount = clients.filter((c) => c.status === 'revoked').length;
   const pendingCount = clients.filter((c) => c.status === 'pending_review').length;
@@ -194,6 +217,7 @@ export function AccessReviewDashboard() {
                       <div className="flex gap-2">
                         {client.status === 'pending_review' && (
                           <button
+                            onClick={() => handleApprove(client.id)}
                             className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-green-700 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20"
                             data-testid={`approve-${client.id}`}
                           >
@@ -203,6 +227,7 @@ export function AccessReviewDashboard() {
                         )}
                         {client.status === 'active' && (
                           <button
+                            onClick={() => handleRevoke(client.id)}
                             className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
                             data-testid={`revoke-${client.id}`}
                           >

--- a/control-plane-ui/src/pages/LLMCost/LLMCostDashboard.tsx
+++ b/control-plane-ui/src/pages/LLMCost/LLMCostDashboard.tsx
@@ -81,6 +81,16 @@ export function LLMCostDashboard() {
     fetchData();
   };
 
+  const handleDeleteProvider = async (providerId: string) => {
+    if (!confirm('Are you sure you want to delete this provider?')) return;
+    try {
+      await apiService.delete(`/v1/tenants/${tenantId}/llm/providers/${providerId}`);
+      setProviders((prev) => prev.filter((p) => p.id !== providerId));
+    } catch {
+      alert('Failed to delete provider');
+    }
+  };
+
   const activeProviders = providers.filter((p) => p.status === 'active').length;
   const rateLimitedProviders = providers.filter((p) => p.status === 'rate_limited').length;
 
@@ -278,6 +288,7 @@ export function LLMCostDashboard() {
                   {canManageProviders && (
                     <td className="whitespace-nowrap px-6 py-4">
                       <button
+                        onClick={() => handleDeleteProvider(provider.id)}
                         className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
                         data-testid={`delete-provider-${provider.id}`}
                       >

--- a/control-plane-ui/src/pages/SecurityPosture/SecurityPostureDashboard.tsx
+++ b/control-plane-ui/src/pages/SecurityPosture/SecurityPostureDashboard.tsx
@@ -167,6 +167,38 @@ export function SecurityPostureDashboard() {
 
   const canManageFindings = hasPermission('admin:servers');
 
+  const handleAcknowledgeAll = async () => {
+    const openItems = findings.filter((f) => f.status === 'open');
+    if (openItems.length === 0) return;
+    if (!confirm(`Resolve all ${openItems.length} open findings?`)) return;
+    try {
+      await Promise.all(
+        openItems.map((f) => apiService.post(`/v1/security/${tenantId}/findings/${f.id}/resolve`))
+      );
+      setFindings((prev) => prev.map((f) => ({ ...f, status: 'resolved' as const })));
+    } catch {
+      setError('Failed to resolve some findings');
+    }
+  };
+
+  const handleSuppressLow = async () => {
+    const lowFindings = findings.filter((f) => f.status === 'open' && f.severity === 'low');
+    if (lowFindings.length === 0) return;
+    if (!confirm(`Suppress ${lowFindings.length} low-severity findings?`)) return;
+    try {
+      await Promise.all(
+        lowFindings.map((f) => apiService.post(`/v1/security/${tenantId}/findings/${f.id}/resolve`))
+      );
+      setFindings((prev) =>
+        prev.map((f) =>
+          f.severity === 'low' && f.status === 'open' ? { ...f, status: 'suppressed' as const } : f
+        )
+      );
+    } catch {
+      setError('Failed to suppress low findings');
+    }
+  };
+
   const loadData = useCallback(async () => {
     try {
       const [securityRes, driftRes, tokenBindingRes, scansRes, cronJobRes] = await Promise.all([
@@ -747,11 +779,17 @@ export function SecurityPostureDashboard() {
                 Quick Actions
               </h2>
               <div className="flex flex-wrap gap-3">
-                <button className="flex items-center gap-2 px-4 py-2 rounded-lg border border-neutral-300 dark:border-neutral-600 text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700">
+                <button
+                  onClick={handleAcknowledgeAll}
+                  className="flex items-center gap-2 px-4 py-2 rounded-lg border border-neutral-300 dark:border-neutral-600 text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700"
+                >
                   <Ban className="h-4 w-4" />
                   Acknowledge All
                 </button>
-                <button className="flex items-center gap-2 px-4 py-2 rounded-lg border border-neutral-300 dark:border-neutral-600 text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700">
+                <button
+                  onClick={handleSuppressLow}
+                  className="flex items-center gap-2 px-4 py-2 rounded-lg border border-neutral-300 dark:border-neutral-600 text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700"
+                >
                   <EyeOff className="h-4 w-4" />
                   Suppress Low
                 </button>


### PR DESCRIPTION
## Summary
- Wire onClick handlers to 5 dead buttons across 3 console dashboards
- AccessReview: Approve + Revoke buttons now call API endpoints
- LLMCost: Delete provider button now calls DELETE endpoint
- SecurityPosture: Acknowledge All + Suppress Low buttons now call resolve endpoint
- Monitoring API: add `demo_mode: true` flag so UI can warn users data is synthetic

## Files changed (4)
- `control-plane-api/src/routers/monitoring.py`
- `control-plane-ui/src/pages/AccessReview/AccessReviewDashboard.tsx`
- `control-plane-ui/src/pages/LLMCost/LLMCostDashboard.tsx`
- `control-plane-ui/src/pages/SecurityPosture/SecurityPostureDashboard.tsx`

## Test plan
- [ ] Verify AccessReview Approve/Revoke buttons call API
- [ ] Verify LLMCost Delete button calls API with confirmation
- [ ] Verify SecurityPosture Acknowledge All/Suppress Low buttons work
- [ ] Verify monitoring endpoints include `demo_mode: true`
- [ ] CI green (lint, format, type check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)