### PR TITLE
fix(ci): stop hegemon before scp to avoid ETXTBSY

### DIFF
--- a/.github/workflows/hegemon-deploy.yml
+++ b/.github/workflows/hegemon-deploy.yml
@@ -73,6 +73,12 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H "${{ secrets.HEGEMON_VPS_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
 
+      - name: Stop service
+        env:
+          VPS_HOST: ${{ secrets.HEGEMON_VPS_HOST }}
+        run: |
+          ssh "hegemon@${VPS_HOST}" "sudo systemctl stop hegemon 2>/dev/null || true; pkill -f 'hegemon --config' 2>/dev/null || true; sleep 1"
+
       - name: Deploy binary
         env:
           VPS_HOST: ${{ secrets.HEGEMON_VPS_HOST }}
@@ -80,11 +86,11 @@ jobs:
           chmod +x hegemon
           scp -o StrictHostKeyChecking=accept-new hegemon "hegemon@${VPS_HOST}:/home/hegemon/hegemon/hegemon"
 
-      - name: Restart service
+      - name: Start service
         env:
           VPS_HOST: ${{ secrets.HEGEMON_VPS_HOST }}
         run: |
-          ssh "hegemon@${VPS_HOST}" "sudo systemctl restart hegemon"
+          ssh "hegemon@${VPS_HOST}" "sudo systemctl start hegemon"
 
       - name: Verify service
         env:


### PR DESCRIPTION
## Summary
- Add `Stop service` step before `Deploy binary` in hegemon-deploy workflow
- Handles both systemd-managed and bare-process cases (`systemctl stop` + `pkill`)
- Fixes `scp: dest open: Failure` caused by overwriting a running binary on Linux

## Context
The deploy workflow was failing because `scp` tried to overwrite `/home/hegemon/hegemon/hegemon` while the daemon was running. Linux returns ETXTBSY when writing to an executing binary.

## Test plan
- [ ] Merge triggers hegemon-deploy workflow (path trigger on `.github/workflows/hegemon-deploy.yml`)
- [ ] Deploy step succeeds (no ETXTBSY)
- [ ] Verify step confirms service is active

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>