### PR TITLE
fix(ci): use SSH config alias for hegemon deploy

### DIFF
--- a/.github/workflows/hegemon-deploy.yml
+++ b/.github/workflows/hegemon-deploy.yml
@@ -67,37 +67,38 @@ jobs:
           name: hegemon-binary
 
       - name: Install SSH key
+        env:
+          VPS_HOST: ${{ secrets.HEGEMON_VPS_HOST }}
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.HEGEMON_SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "${{ secrets.HEGEMON_VPS_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
+          cat >> ~/.ssh/config <<SSHEOF
+          Host hegemon-vps
+            HostName ${VPS_HOST}
+            User hegemon
+            IdentityFile ~/.ssh/id_ed25519
+            StrictHostKeyChecking accept-new
+          SSHEOF
+          chmod 600 ~/.ssh/config
 
       - name: Stop service
-        env:
-          VPS_HOST: ${{ secrets.HEGEMON_VPS_HOST }}
         run: |
-          ssh "hegemon@${VPS_HOST}" "sudo systemctl stop hegemon 2>/dev/null || true; pkill -f 'hegemon --config' 2>/dev/null || true; sleep 1"
+          ssh hegemon-vps "sudo systemctl stop hegemon 2>/dev/null || true; pkill -f 'hegemon --config' 2>/dev/null || true; sleep 1"
 
       - name: Deploy binary
-        env:
-          VPS_HOST: ${{ secrets.HEGEMON_VPS_HOST }}
         run: |
           chmod +x hegemon
-          scp -o StrictHostKeyChecking=accept-new hegemon "hegemon@${VPS_HOST}:/home/hegemon/hegemon/hegemon"
+          scp hegemon hegemon-vps:/home/hegemon/hegemon/hegemon
 
       - name: Start service
-        env:
-          VPS_HOST: ${{ secrets.HEGEMON_VPS_HOST }}
         run: |
-          ssh "hegemon@${VPS_HOST}" "sudo systemctl start hegemon"
+          ssh hegemon-vps "sudo systemctl start hegemon"
 
       - name: Verify service
-        env:
-          VPS_HOST: ${{ secrets.HEGEMON_VPS_HOST }}
         run: |
           sleep 3
-          ssh "hegemon@${VPS_HOST}" "sudo systemctl is-active hegemon"
+          ssh hegemon-vps "sudo systemctl is-active hegemon"
 
   notify:
     name: Notify


### PR DESCRIPTION
## Summary
- Replace per-command `StrictHostKeyChecking` with a global SSH config alias (`hegemon-vps`)
- Fixes SSH exit code 255 on Stop/Start/Verify steps (host key verification mismatch)
- All `ssh`/`scp` commands now use the same config, simplifying the workflow

## Context
Previous fix (PR #1167) added the Stop step but SSH failed with exit 255 because
`ssh-keyscan -H` stores hashed hostnames that don't always match the plain hostname
used by `ssh`. The `scp` worked because it had `-o StrictHostKeyChecking=accept-new`
inline, but the `ssh` commands didn't.

## Test plan
- [ ] Merge triggers hegemon-deploy workflow
- [ ] All 4 deploy steps succeed: Stop → Deploy → Start → Verify

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>