### PR TITLE
fix(ci): use env var for SSH key in hegemon deploy

### DIFF
--- a/.github/workflows/hegemon-deploy.yml
+++ b/.github/workflows/hegemon-deploy.yml
@@ -69,16 +69,18 @@ jobs:
       - name: Install SSH key
         env:
           VPS_HOST: ${{ secrets.HEGEMON_VPS_HOST }}
+          SSH_PRIVATE_KEY: ${{ secrets.HEGEMON_SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.HEGEMON_SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          printenv SSH_PRIVATE_KEY > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
+          ssh-keygen -l -f ~/.ssh/id_ed25519
           printf "Host hegemon-vps\n  HostName %s\n  User hegemon\n  IdentityFile ~/.ssh/id_ed25519\n  StrictHostKeyChecking accept-new\n" "$VPS_HOST" > ~/.ssh/config
           chmod 600 ~/.ssh/config
 
       - name: Stop service
         run: |
-          ssh hegemon-vps "sudo systemctl stop hegemon 2>/dev/null || true; pkill -f 'hegemon --config' 2>/dev/null || true; sleep 1"
+          ssh -vvv hegemon-vps "sudo systemctl stop hegemon 2>/dev/null || true; pkill -f 'hegemon --config' 2>/dev/null || true; sleep 1"
 
       - name: Deploy binary
         run: |


### PR DESCRIPTION
## Summary
- Switch from `echo "${{ secrets }}"` to `printenv` via env block — avoids multi-line secret corruption during GHA YAML substitution
- Add `ssh-keygen -l` key validation step  
- Add `-vvv` verbose SSH for debugging the 255 exit code

Previous run (PR #1171) fixed the SSH key mismatch but still got exit 255. The `echo` with inline secret substitution is the suspected culprit.

## Test plan
- [ ] Workflow triggers on merge
- [ ] `ssh-keygen -l` shows correct fingerprint
- [ ] SSH verbose output reveals auth success/failure reason
- [ ] Full pipeline: Build → Stop → Deploy → Start → Verify

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>