### PR TITLE
fix(ci): remove pkill self-match in hegemon deploy

### DIFF
--- a/.github/workflows/hegemon-deploy.yml
+++ b/.github/workflows/hegemon-deploy.yml
@@ -74,13 +74,12 @@ jobs:
           mkdir -p ~/.ssh
           printenv SSH_PRIVATE_KEY > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keygen -l -f ~/.ssh/id_ed25519
           printf "Host hegemon-vps\n  HostName %s\n  User hegemon\n  IdentityFile ~/.ssh/id_ed25519\n  StrictHostKeyChecking accept-new\n" "$VPS_HOST" > ~/.ssh/config
           chmod 600 ~/.ssh/config
 
       - name: Stop service
         run: |
-          ssh -vvv hegemon-vps "sudo systemctl stop hegemon 2>/dev/null || true; pkill -f 'hegemon --config' 2>/dev/null || true; sleep 1"
+          ssh hegemon-vps "sudo systemctl stop hegemon 2>/dev/null || true; sleep 1"
 
       - name: Deploy binary
         run: |


### PR DESCRIPTION
## Summary
- Remove `pkill -f 'hegemon --config'` which kills the SSH session itself (the bash -c process contains "hegemon --config" literally as a pkill argument, matching the pattern)
- `systemctl stop hegemon` is sufficient to stop the service
- Remove debug flags from previous PR (confirmed SSH key and auth work)

Root cause of exit code 255: SSH auth succeeds, session opens, command executes, `pkill -f` matches the parent bash process → session killed by signal → exit-signal → 255.

## Test plan
- [ ] Deploy workflow succeeds end-to-end: Build → Stop → Deploy → Start → Verify

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>