### PR TITLE
feat(ui): add admin users, settings & roles pages (CAB-1454)

### DIFF
--- a/control-plane-ui/src/App.tsx
+++ b/control-plane-ui/src/App.tsx
@@ -51,6 +51,15 @@ const AdminProspects = lazy(() =>
 const AdminAccessRequests = lazy(() =>
   import('./pages/AdminAccessRequests').then((m) => ({ default: m.AdminAccessRequests }))
 );
+const AdminUsers = lazy(() =>
+  import('./pages/AdminUsers').then((m) => ({ default: m.AdminUsers }))
+);
+const AdminSettings = lazy(() =>
+  import('./pages/AdminSettings').then((m) => ({ default: m.AdminSettings }))
+);
+const AdminRoles = lazy(() =>
+  import('./pages/AdminRoles').then((m) => ({ default: m.AdminRoles }))
+);
 const GatewayStatus = lazy(() => import('./pages/GatewayStatus'));
 const GatewayRegistry = lazy(() => gatewaysModule().then((m) => ({ default: m.GatewayList })));
 const GatewayModes = lazy(() =>
@@ -425,6 +434,9 @@ function ProtectedRoutes() {
                 <Route path="/business" element={<BusinessDashboard />} />
                 <Route path="/admin/prospects" element={<AdminProspects />} />
                 <Route path="/admin/access-requests" element={<AdminAccessRequests />} />
+                <Route path="/admin/users" element={<AdminUsers />} />
+                <Route path="/admin/settings" element={<AdminSettings />} />
+                <Route path="/admin/roles" element={<AdminRoles />} />
                 {/* Native observability dashboards (replace iframe embeds) */}
                 <Route path="/observability" element={<PlatformMetrics />} />
                 <Route path="/observability/grafana" element={<GrafanaEmbed />} />

--- a/control-plane-ui/src/components/Layout.tsx
+++ b/control-plane-ui/src/components/Layout.tsx
@@ -52,6 +52,7 @@ import {
   Share2,
   Sparkles,
   Stethoscope,
+  Settings,
 } from 'lucide-react';
 import { clsx } from 'clsx';
 import { useApiConnectivity } from '../hooks/useApiConnectivity';
@@ -291,6 +292,41 @@ const navigationSections: NavSection[] = [
         href: '/audience-governance',
         icon: Users,
         permission: 'apis:update',
+      },
+    ],
+  },
+  {
+    title: 'nav.admin',
+    items: [
+      {
+        name: 'nav.prospects',
+        href: '/admin/prospects',
+        icon: Sparkles,
+        permission: 'admin:platform',
+      },
+      {
+        name: 'nav.accessRequests',
+        href: '/admin/access-requests',
+        icon: KeyRound,
+        permission: 'admin:platform',
+      },
+      {
+        name: 'nav.users',
+        href: '/admin/users',
+        icon: Users,
+        permission: 'admin:platform',
+      },
+      {
+        name: 'nav.platformSettings',
+        href: '/admin/settings',
+        icon: Settings,
+        permission: 'admin:platform',
+      },
+      {
+        name: 'nav.roles',
+        href: '/admin/roles',
+        icon: Shield,
+        permission: 'admin:platform',
       },
     ],
   },

--- a/control-plane-ui/src/hooks/useAdminRoles.ts
+++ b/control-plane-ui/src/hooks/useAdminRoles.ts
@@ -1,0 +1,19 @@
+/**
+ * Admin Roles Hook (CAB-1454)
+ *
+ * React Query hook for the RBAC role management view.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { apiService } from '../services/api';
+import type { RoleListResponse } from '../types';
+
+export function useAdminRoles(options?: { enabled?: boolean }) {
+  const { enabled = true } = options || {};
+
+  return useQuery<RoleListResponse>({
+    queryKey: ['admin-roles'],
+    queryFn: () => apiService.getAdminRoles(),
+    enabled,
+    staleTime: 30000,
+  });
+}

--- a/control-plane-ui/src/hooks/useAdminUsers.ts
+++ b/control-plane-ui/src/hooks/useAdminUsers.ts
@@ -1,0 +1,35 @@
+/**
+ * Admin Users Hook (CAB-1454)
+ *
+ * React Query hook for the admin user management table.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { apiService } from '../services/api';
+import type { AdminUserListResponse } from '../types';
+
+export function useAdminUsers(
+  filters: {
+    role?: string;
+    status?: string;
+    search?: string;
+    page?: number;
+    limit?: number;
+  },
+  options?: { enabled?: boolean }
+) {
+  const { enabled = true } = options || {};
+
+  return useQuery<AdminUserListResponse>({
+    queryKey: ['admin-users', filters],
+    queryFn: () =>
+      apiService.getAdminUsers({
+        role: filters.role,
+        status: filters.status,
+        search: filters.search,
+        page: filters.page,
+        limit: filters.limit,
+      }),
+    enabled,
+    staleTime: 5000,
+  });
+}

--- a/control-plane-ui/src/hooks/usePlatformSettings.ts
+++ b/control-plane-ui/src/hooks/usePlatformSettings.ts
@@ -1,0 +1,33 @@
+/**
+ * Platform Settings Hook (CAB-1454)
+ *
+ * React Query hooks for platform settings management.
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiService } from '../services/api';
+import type { PlatformSettingsResponse, PlatformSetting } from '../types';
+
+export function usePlatformSettings(
+  params?: { category?: string },
+  options?: { enabled?: boolean }
+) {
+  const { enabled = true } = options || {};
+
+  return useQuery<PlatformSettingsResponse>({
+    queryKey: ['platform-settings', params],
+    queryFn: () => apiService.getPlatformSettings(params),
+    enabled,
+    staleTime: 5000,
+  });
+}
+
+export function useUpdatePlatformSetting() {
+  const queryClient = useQueryClient();
+
+  return useMutation<PlatformSetting, Error, { key: string; value: string }>({
+    mutationFn: ({ key, value }) => apiService.updatePlatformSetting(key, value),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['platform-settings'] });
+    },
+  });
+}

--- a/control-plane-ui/src/pages/AdminRoles.test.tsx
+++ b/control-plane-ui/src/pages/AdminRoles.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createAuthMock } from '../test/helpers';
+import { useAuth } from '../contexts/AuthContext';
+import type { PersonaRole } from '../test/helpers';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../hooks/useAdminRoles', () => ({
+  useAdminRoles: vi.fn(() => ({
+    data: {
+      roles: [
+        {
+          name: 'cpi-admin',
+          display_name: 'Platform Admin',
+          description: 'Full platform access',
+          permissions: [
+            { name: 'stoa:admin', description: 'Full admin access' },
+            { name: 'stoa:write', description: 'Write access' },
+          ],
+          user_count: 3,
+        },
+        {
+          name: 'viewer',
+          display_name: 'Viewer',
+          description: 'Read-only access',
+          permissions: [{ name: 'stoa:read', description: 'Read access' }],
+          user_count: 12,
+        },
+      ],
+      total: 2,
+    },
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+import { AdminRoles } from './AdminRoles';
+
+function renderAdminRoles() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <AdminRoles />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('AdminRoles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+  });
+
+  it('renders the Roles & Permissions heading', () => {
+    renderAdminRoles();
+    expect(screen.getByText('Roles & Permissions')).toBeInTheDocument();
+  });
+
+  it('renders the subtitle', () => {
+    renderAdminRoles();
+    expect(
+      screen.getByText('Platform RBAC role definitions and their associated permissions')
+    ).toBeInTheDocument();
+  });
+
+  it('renders role display names', () => {
+    renderAdminRoles();
+    expect(screen.getByText('Platform Admin')).toBeInTheDocument();
+    expect(screen.getByText('Viewer')).toBeInTheDocument();
+  });
+
+  it('renders role descriptions', () => {
+    renderAdminRoles();
+    expect(screen.getByText('Full platform access')).toBeInTheDocument();
+    expect(screen.getByText('Read-only access')).toBeInTheDocument();
+  });
+
+  it('renders permission names', () => {
+    renderAdminRoles();
+    expect(screen.getByText('stoa:admin')).toBeInTheDocument();
+    expect(screen.getByText('stoa:write')).toBeInTheDocument();
+    expect(screen.getByText('stoa:read')).toBeInTheDocument();
+  });
+
+  it('renders user counts', () => {
+    renderAdminRoles();
+    expect(screen.getByText('3 users')).toBeInTheDocument();
+    expect(screen.getByText('12 users')).toBeInTheDocument();
+  });
+
+  it('renders Permissions section headers', () => {
+    renderAdminRoles();
+    const permHeaders = screen.getAllByText('Permissions');
+    expect(permHeaders.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // 4-persona coverage
+  describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
+    '%s persona',
+    (role) => {
+      it('renders the page with correct access', () => {
+        vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
+        renderAdminRoles();
+        if (role === 'cpi-admin') {
+          expect(screen.getByText('Roles & Permissions')).toBeInTheDocument();
+        } else {
+          expect(screen.getByText('Access Denied')).toBeInTheDocument();
+        }
+      });
+    }
+  );
+});

--- a/control-plane-ui/src/pages/AdminRoles.tsx
+++ b/control-plane-ui/src/pages/AdminRoles.tsx
@@ -1,0 +1,149 @@
+/**
+ * Admin Roles Page (CAB-1454)
+ *
+ * Read-only view of RBAC role definitions and their permissions.
+ * cpi-admin only.
+ */
+import { useAuth } from '../contexts/AuthContext';
+import { useAdminRoles } from '../hooks/useAdminRoles';
+import { AlertTriangle, Shield, Users, Check } from 'lucide-react';
+
+const roleColors: Record<string, { bg: string; text: string; border: string }> = {
+  'cpi-admin': {
+    bg: 'bg-red-50 dark:bg-red-900/20',
+    text: 'text-red-800 dark:text-red-400',
+    border: 'border-red-200 dark:border-red-800',
+  },
+  'tenant-admin': {
+    bg: 'bg-blue-50 dark:bg-blue-900/20',
+    text: 'text-blue-800 dark:text-blue-400',
+    border: 'border-blue-200 dark:border-blue-800',
+  },
+  devops: {
+    bg: 'bg-purple-50 dark:bg-purple-900/20',
+    text: 'text-purple-800 dark:text-purple-400',
+    border: 'border-purple-200 dark:border-purple-800',
+  },
+  viewer: {
+    bg: 'bg-neutral-50 dark:bg-neutral-800',
+    text: 'text-neutral-800 dark:text-neutral-400',
+    border: 'border-neutral-200 dark:border-neutral-700',
+  },
+};
+
+const defaultRoleColor = {
+  bg: 'bg-neutral-50 dark:bg-neutral-800',
+  text: 'text-neutral-800 dark:text-neutral-400',
+  border: 'border-neutral-200 dark:border-neutral-700',
+};
+
+export function AdminRoles() {
+  const { hasRole } = useAuth();
+
+  const { data: rolesData, isLoading, error } = useAdminRoles({ enabled: hasRole('cpi-admin') });
+
+  if (!hasRole('cpi-admin')) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <AlertTriangle className="h-12 w-12 text-red-500 mx-auto mb-4" />
+          <h1 className="text-xl font-semibold text-neutral-900 dark:text-white mb-2">
+            Access Denied
+          </h1>
+          <p className="text-neutral-600 dark:text-neutral-400">
+            Platform admin role required to view this page.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 p-6">
+      <div className="max-w-7xl mx-auto space-y-6">
+        {/* Header */}
+        <div>
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
+            Roles &amp; Permissions
+          </h1>
+          <p className="text-neutral-500 dark:text-neutral-400 mt-1">
+            Platform RBAC role definitions and their associated permissions
+          </p>
+        </div>
+
+        {/* Error state */}
+        {error && (
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
+            <p className="text-sm text-red-700 dark:text-red-400">
+              Failed to load roles. Please try again.
+            </p>
+          </div>
+        )}
+
+        {/* Loading */}
+        {isLoading ? (
+          <div className="flex items-center justify-center p-12">
+            <div className="animate-spin rounded-full h-8 w-8 border-2 border-blue-600 border-t-transparent" />
+          </div>
+        ) : !rolesData?.roles.length ? (
+          <div className="flex flex-col items-center justify-center p-12 text-neutral-500 dark:text-neutral-400">
+            <Shield className="h-10 w-10 mb-3 opacity-50" />
+            <p className="text-sm">No roles configured</p>
+          </div>
+        ) : (
+          <div className="grid gap-6 md:grid-cols-2">
+            {rolesData.roles.map((role) => {
+              const colors = roleColors[role.name] || defaultRoleColor;
+              return (
+                <div
+                  key={role.name}
+                  className={`rounded-lg border ${colors.border} ${colors.bg} p-5`}
+                >
+                  <div className="flex items-center justify-between mb-3">
+                    <div>
+                      <h3 className={`text-lg font-semibold ${colors.text}`}>
+                        {role.display_name}
+                      </h3>
+                      <p className="text-sm text-neutral-600 dark:text-neutral-400 mt-0.5">
+                        {role.description}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-1.5 text-sm text-neutral-500 dark:text-neutral-400">
+                      <Users className="h-4 w-4" />
+                      <span>
+                        {role.user_count} user{role.user_count !== 1 ? 's' : ''}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <p className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                      Permissions
+                    </p>
+                    <div className="grid gap-1">
+                      {role.permissions.map((perm) => (
+                        <div key={perm.name} className="flex items-start gap-2">
+                          <Check className="h-3.5 w-3.5 text-green-500 mt-0.5 flex-shrink-0" />
+                          <div>
+                            <span className="text-sm font-mono text-neutral-900 dark:text-white">
+                              {perm.name}
+                            </span>
+                            {perm.description && (
+                              <span className="text-xs text-neutral-500 dark:text-neutral-400 ml-2">
+                                {perm.description}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/control-plane-ui/src/pages/AdminSettings.test.tsx
+++ b/control-plane-ui/src/pages/AdminSettings.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createAuthMock } from '../test/helpers';
+import { useAuth } from '../contexts/AuthContext';
+import type { PersonaRole } from '../test/helpers';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../hooks/usePlatformSettings', () => ({
+  usePlatformSettings: vi.fn(() => ({
+    data: {
+      settings: [
+        {
+          key: 'platform.name',
+          value: 'STOA Platform',
+          category: 'general',
+          description: 'Platform display name',
+          editable: true,
+          updated_at: '2024-06-10T12:00:00Z',
+        },
+        {
+          key: 'security.mfa_required',
+          value: 'true',
+          category: 'security',
+          description: 'Require MFA for all users',
+          editable: false,
+          updated_at: '2024-05-01T08:00:00Z',
+        },
+      ],
+      total: 2,
+    },
+    isLoading: false,
+    error: null,
+  })),
+  useUpdatePlatformSetting: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+}));
+
+import { AdminSettings } from './AdminSettings';
+
+function renderAdminSettings() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <AdminSettings />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('AdminSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+  });
+
+  it('renders the Platform Settings heading', () => {
+    renderAdminSettings();
+    expect(screen.getByText('Platform Settings')).toBeInTheDocument();
+  });
+
+  it('renders the subtitle', () => {
+    renderAdminSettings();
+    expect(screen.getByText('Configure platform-wide settings and parameters')).toBeInTheDocument();
+  });
+
+  it('renders setting keys in the table', () => {
+    renderAdminSettings();
+    expect(screen.getByText('platform.name')).toBeInTheDocument();
+    expect(screen.getByText('security.mfa_required')).toBeInTheDocument();
+  });
+
+  it('renders setting values', () => {
+    renderAdminSettings();
+    expect(screen.getByText('STOA Platform')).toBeInTheDocument();
+    expect(screen.getByText('true')).toBeInTheDocument();
+  });
+
+  it('renders setting descriptions', () => {
+    renderAdminSettings();
+    expect(screen.getByText('Platform display name')).toBeInTheDocument();
+    expect(screen.getByText('Require MFA for all users')).toBeInTheDocument();
+  });
+
+  it('renders category badges', () => {
+    renderAdminSettings();
+    const generals = screen.getAllByText('General');
+    expect(generals.length).toBeGreaterThanOrEqual(1);
+    const securities = screen.getAllByText('Security');
+    expect(securities.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders the total settings count', () => {
+    renderAdminSettings();
+    expect(screen.getByText('2 settings')).toBeInTheDocument();
+  });
+
+  it('renders Edit button for editable settings only', () => {
+    renderAdminSettings();
+    const editButtons = screen.getAllByText('Edit');
+    expect(editButtons).toHaveLength(1);
+  });
+
+  it('renders the category filter', () => {
+    renderAdminSettings();
+    expect(screen.getByText('All categories')).toBeInTheDocument();
+  });
+
+  // 4-persona coverage
+  describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
+    '%s persona',
+    (role) => {
+      it('renders the page with correct access', () => {
+        vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
+        renderAdminSettings();
+        if (role === 'cpi-admin') {
+          expect(screen.getByText('Platform Settings')).toBeInTheDocument();
+        } else {
+          expect(screen.getByText('Access Denied')).toBeInTheDocument();
+        }
+      });
+    }
+  );
+});

--- a/control-plane-ui/src/pages/AdminSettings.tsx
+++ b/control-plane-ui/src/pages/AdminSettings.tsx
@@ -1,0 +1,276 @@
+/**
+ * Admin Platform Settings Page (CAB-1454)
+ *
+ * View and edit platform configuration grouped by category.
+ * cpi-admin only.
+ */
+import { useState, useCallback } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { usePlatformSettings, useUpdatePlatformSetting } from '../hooks/usePlatformSettings';
+import type { SettingCategory, PlatformSetting } from '../types';
+import { AlertTriangle, Settings, Save, Check, X } from 'lucide-react';
+
+const categoryLabels: Record<SettingCategory, string> = {
+  general: 'General',
+  security: 'Security',
+  gateway: 'Gateway',
+  notifications: 'Notifications',
+};
+
+const categoryColors: Record<SettingCategory, { bg: string; text: string }> = {
+  general: { bg: 'bg-blue-100 dark:bg-blue-900/30', text: 'text-blue-800 dark:text-blue-400' },
+  security: { bg: 'bg-red-100 dark:bg-red-900/30', text: 'text-red-800 dark:text-red-400' },
+  gateway: {
+    bg: 'bg-purple-100 dark:bg-purple-900/30',
+    text: 'text-purple-800 dark:text-purple-400',
+  },
+  notifications: {
+    bg: 'bg-amber-100 dark:bg-amber-900/30',
+    text: 'text-amber-800 dark:text-amber-400',
+  },
+};
+
+function formatDate(date: string | undefined | null): string {
+  if (!date) return '\u2014';
+  return new Date(date).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function SettingRow({
+  setting,
+  onSave,
+  isSaving,
+}: {
+  setting: PlatformSetting;
+  onSave: (key: string, value: string) => void;
+  isSaving: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState(setting.value);
+  const [saved, setSaved] = useState(false);
+
+  const handleSave = useCallback(() => {
+    onSave(setting.key, editValue);
+    setEditing(false);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  }, [setting.key, editValue, onSave]);
+
+  const handleCancel = useCallback(() => {
+    setEditValue(setting.value);
+    setEditing(false);
+  }, [setting.value]);
+
+  const colors = categoryColors[setting.category] || categoryColors.general;
+
+  return (
+    <tr className="hover:bg-neutral-50 dark:hover:bg-neutral-700/50 transition-colors">
+      <td className="px-4 py-3">
+        <div>
+          <p className="text-sm font-medium text-neutral-900 dark:text-white font-mono">
+            {setting.key}
+          </p>
+          <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">
+            {setting.description}
+          </p>
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <span
+          className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${colors.bg} ${colors.text}`}
+        >
+          {categoryLabels[setting.category]}
+        </span>
+      </td>
+      <td className="px-4 py-3">
+        {editing ? (
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              className="w-full px-2 py-1 rounded border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent font-mono"
+              autoFocus
+            />
+            <button
+              onClick={handleSave}
+              disabled={isSaving}
+              className="p-1 rounded hover:bg-green-100 dark:hover:bg-green-900/30 text-green-600 dark:text-green-400"
+            >
+              <Save className="h-4 w-4" />
+            </button>
+            <button
+              onClick={handleCancel}
+              className="p-1 rounded hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-500"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-neutral-900 dark:text-white font-mono">
+              {setting.value}
+            </span>
+            {saved && <Check className="h-4 w-4 text-green-500" />}
+          </div>
+        )}
+      </td>
+      <td className="px-4 py-3 text-sm text-neutral-500 dark:text-neutral-400">
+        {formatDate(setting.updated_at)}
+      </td>
+      <td className="px-4 py-3">
+        {setting.editable && !editing && (
+          <button
+            onClick={() => setEditing(true)}
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            Edit
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+export function AdminSettings() {
+  const { hasRole } = useAuth();
+  const [categoryFilter, setCategoryFilter] = useState<SettingCategory | ''>('');
+
+  const {
+    data: settingsData,
+    isLoading,
+    error,
+  } = usePlatformSettings(
+    { category: categoryFilter || undefined },
+    { enabled: hasRole('cpi-admin') }
+  );
+
+  const updateMutation = useUpdatePlatformSetting();
+
+  const handleSave = useCallback(
+    (key: string, value: string) => {
+      updateMutation.mutate({ key, value });
+    },
+    [updateMutation]
+  );
+
+  if (!hasRole('cpi-admin')) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <AlertTriangle className="h-12 w-12 text-red-500 mx-auto mb-4" />
+          <h1 className="text-xl font-semibold text-neutral-900 dark:text-white mb-2">
+            Access Denied
+          </h1>
+          <p className="text-neutral-600 dark:text-neutral-400">
+            Platform admin role required to view this page.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 p-6">
+      <div className="max-w-7xl mx-auto space-y-6">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
+              Platform Settings
+            </h1>
+            <p className="text-neutral-500 dark:text-neutral-400 mt-1">
+              Configure platform-wide settings and parameters
+            </p>
+          </div>
+          {settingsData && (
+            <span className="text-sm text-neutral-500 dark:text-neutral-400">
+              {settingsData.total} setting{settingsData.total !== 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+
+        {/* Filters */}
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 p-4">
+          <div className="flex items-center gap-4">
+            <label className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+              Category
+            </label>
+            <select
+              value={categoryFilter}
+              onChange={(e) => setCategoryFilter(e.target.value as SettingCategory | '')}
+              className="rounded-lg border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white px-3 py-1.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+              <option value="">All categories</option>
+              <option value="general">General</option>
+              <option value="security">Security</option>
+              <option value="gateway">Gateway</option>
+              <option value="notifications">Notifications</option>
+            </select>
+          </div>
+        </div>
+
+        {/* Error state */}
+        {error && (
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
+            <p className="text-sm text-red-700 dark:text-red-400">
+              Failed to load settings. Please try again.
+            </p>
+          </div>
+        )}
+
+        {/* Table */}
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 overflow-hidden">
+          {isLoading ? (
+            <div className="flex items-center justify-center p-12">
+              <div className="animate-spin rounded-full h-8 w-8 border-2 border-blue-600 border-t-transparent" />
+            </div>
+          ) : !settingsData?.settings.length ? (
+            <div className="flex flex-col items-center justify-center p-12 text-neutral-500 dark:text-neutral-400">
+              <Settings className="h-10 w-10 mb-3 opacity-50" />
+              <p className="text-sm">No settings found</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700">
+                <thead className="bg-neutral-50 dark:bg-neutral-800/50">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                      Setting
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                      Category
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                      Value
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                      Updated
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-neutral-200 dark:divide-neutral-700">
+                  {settingsData.settings.map((setting) => (
+                    <SettingRow
+                      key={setting.key}
+                      setting={setting}
+                      onSave={handleSave}
+                      isSaving={updateMutation.isPending}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/control-plane-ui/src/pages/AdminUsers.test.tsx
+++ b/control-plane-ui/src/pages/AdminUsers.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createAuthMock } from '../test/helpers';
+import { useAuth } from '../contexts/AuthContext';
+import type { PersonaRole } from '../test/helpers';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../hooks/useAdminUsers', () => ({
+  useAdminUsers: vi.fn(() => ({
+    data: {
+      data: [
+        {
+          id: 'u-1',
+          email: 'admin@acme.com',
+          name: 'Alice Admin',
+          roles: ['cpi-admin'],
+          tenant_id: null,
+          tenant_name: null,
+          status: 'active',
+          last_login_at: '2024-06-15T10:00:00Z',
+          created_at: '2024-01-01T00:00:00Z',
+        },
+        {
+          id: 'u-2',
+          email: 'dev@acme.com',
+          name: 'Bob Dev',
+          roles: ['devops', 'viewer'],
+          tenant_id: 't-1',
+          tenant_name: 'Acme Corp',
+          status: 'suspended',
+          last_login_at: null,
+          created_at: '2024-03-10T00:00:00Z',
+        },
+      ],
+      total: 2,
+      page: 1,
+      limit: 25,
+    },
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+import { AdminUsers } from './AdminUsers';
+
+function renderAdminUsers() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <AdminUsers />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('AdminUsers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+  });
+
+  it('renders the User Management heading', () => {
+    renderAdminUsers();
+    expect(screen.getByText('User Management')).toBeInTheDocument();
+  });
+
+  it('renders the subtitle', () => {
+    renderAdminUsers();
+    expect(
+      screen.getByText('Manage platform users, roles, and account status')
+    ).toBeInTheDocument();
+  });
+
+  it('renders user names in the table', () => {
+    renderAdminUsers();
+    expect(screen.getByText('Alice Admin')).toBeInTheDocument();
+    expect(screen.getByText('Bob Dev')).toBeInTheDocument();
+  });
+
+  it('renders user emails', () => {
+    renderAdminUsers();
+    expect(screen.getByText('admin@acme.com')).toBeInTheDocument();
+    expect(screen.getByText('dev@acme.com')).toBeInTheDocument();
+  });
+
+  it('renders user role badges', () => {
+    renderAdminUsers();
+    expect(screen.getByText('cpi-admin')).toBeInTheDocument();
+    expect(screen.getByText('devops')).toBeInTheDocument();
+    expect(screen.getByText('viewer')).toBeInTheDocument();
+  });
+
+  it('renders user status badges', () => {
+    renderAdminUsers();
+    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.getByText('suspended')).toBeInTheDocument();
+  });
+
+  it('renders the search input', () => {
+    renderAdminUsers();
+    expect(screen.getByPlaceholderText('Search by name or email...')).toBeInTheDocument();
+  });
+
+  it('renders the total user count', () => {
+    renderAdminUsers();
+    expect(screen.getByText('2 users')).toBeInTheDocument();
+  });
+
+  it('renders tenant name for assigned users', () => {
+    renderAdminUsers();
+    expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+  });
+
+  // 4-persona coverage
+  describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
+    '%s persona',
+    (role) => {
+      it('renders the page with correct access', () => {
+        vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
+        renderAdminUsers();
+        if (role === 'cpi-admin') {
+          expect(screen.getByText('User Management')).toBeInTheDocument();
+        } else {
+          expect(screen.getByText('Access Denied')).toBeInTheDocument();
+        }
+      });
+    }
+  );
+});

--- a/control-plane-ui/src/pages/AdminUsers.tsx
+++ b/control-plane-ui/src/pages/AdminUsers.tsx
@@ -1,0 +1,283 @@
+/**
+ * Admin Users Page (CAB-1454)
+ *
+ * Platform user management table with role/status filters, search, and pagination.
+ * cpi-admin only.
+ */
+import { useState, useCallback, useEffect } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { useAdminUsers } from '../hooks/useAdminUsers';
+import type { AdminUserStatus } from '../types';
+import { AlertTriangle, ChevronLeft, ChevronRight, Users, Search } from 'lucide-react';
+
+const PAGE_SIZE = 25;
+
+const statusColors: Record<AdminUserStatus, { bg: string; text: string; dot: string }> = {
+  active: {
+    bg: 'bg-green-100 dark:bg-green-900/30',
+    text: 'text-green-800 dark:text-green-400',
+    dot: 'bg-green-500',
+  },
+  suspended: {
+    bg: 'bg-red-100 dark:bg-red-900/30',
+    text: 'text-red-800 dark:text-red-400',
+    dot: 'bg-red-500',
+  },
+  pending: {
+    bg: 'bg-amber-100 dark:bg-amber-900/30',
+    text: 'text-amber-800 dark:text-amber-400',
+    dot: 'bg-amber-500',
+  },
+};
+
+function formatDate(date: string | undefined | null): string {
+  if (!date) return '\u2014';
+  return new Date(date).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function AdminUsers() {
+  const { hasRole } = useAuth();
+  const [statusFilter, setStatusFilter] = useState<AdminUserStatus | ''>('');
+  const [roleFilter, setRoleFilter] = useState('');
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [statusFilter, roleFilter, debouncedSearch]);
+
+  const {
+    data: usersData,
+    isLoading,
+    error,
+  } = useAdminUsers(
+    {
+      status: statusFilter || undefined,
+      role: roleFilter || undefined,
+      search: debouncedSearch || undefined,
+      page,
+      limit: PAGE_SIZE,
+    },
+    { enabled: hasRole('cpi-admin') }
+  );
+
+  const handleStatusChange = useCallback((value: AdminUserStatus | '') => {
+    setStatusFilter(value);
+  }, []);
+
+  if (!hasRole('cpi-admin')) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <AlertTriangle className="h-12 w-12 text-red-500 mx-auto mb-4" />
+          <h1 className="text-xl font-semibold text-neutral-900 dark:text-white mb-2">
+            Access Denied
+          </h1>
+          <p className="text-neutral-600 dark:text-neutral-400">
+            Platform admin role required to view this page.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const totalPages = usersData ? Math.ceil(usersData.total / PAGE_SIZE) : 0;
+
+  return (
+    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900 p-6">
+      <div className="max-w-7xl mx-auto space-y-6">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">User Management</h1>
+            <p className="text-neutral-500 dark:text-neutral-400 mt-1">
+              Manage platform users, roles, and account status
+            </p>
+          </div>
+          {usersData && (
+            <span className="text-sm text-neutral-500 dark:text-neutral-400">
+              {usersData.total} user{usersData.total !== 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+
+        {/* Filters */}
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 p-4">
+          <div className="flex flex-wrap items-center gap-4">
+            <div className="relative flex-1 min-w-[200px]">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400" />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search by name or email..."
+                className="w-full pl-9 pr-3 py-1.5 rounded-lg border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              />
+            </div>
+            <div className="flex items-center gap-4">
+              <label className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                Status
+              </label>
+              <select
+                value={statusFilter}
+                onChange={(e) => handleStatusChange(e.target.value as AdminUserStatus | '')}
+                className="rounded-lg border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white px-3 py-1.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              >
+                <option value="">All statuses</option>
+                <option value="active">Active</option>
+                <option value="suspended">Suspended</option>
+                <option value="pending">Pending</option>
+              </select>
+            </div>
+            <div className="flex items-center gap-4">
+              <label className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                Role
+              </label>
+              <select
+                value={roleFilter}
+                onChange={(e) => setRoleFilter(e.target.value)}
+                className="rounded-lg border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white px-3 py-1.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              >
+                <option value="">All roles</option>
+                <option value="cpi-admin">CPI Admin</option>
+                <option value="tenant-admin">Tenant Admin</option>
+                <option value="devops">DevOps</option>
+                <option value="viewer">Viewer</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        {/* Error state */}
+        {error && (
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
+            <p className="text-sm text-red-700 dark:text-red-400">
+              Failed to load users. Please try again.
+            </p>
+          </div>
+        )}
+
+        {/* Table */}
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 overflow-hidden">
+          {isLoading ? (
+            <div className="flex items-center justify-center p-12">
+              <div className="animate-spin rounded-full h-8 w-8 border-2 border-blue-600 border-t-transparent" />
+            </div>
+          ) : !usersData?.data.length ? (
+            <div className="flex flex-col items-center justify-center p-12 text-neutral-500 dark:text-neutral-400">
+              <Users className="h-10 w-10 mb-3 opacity-50" />
+              <p className="text-sm">No users found</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700">
+                <thead className="bg-neutral-50 dark:bg-neutral-800/50">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                      Name
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                      Email
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                      Roles
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                      Tenant
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                      Status
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                      Last Login
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-neutral-200 dark:divide-neutral-700">
+                  {usersData.data.map((user) => {
+                    const colors = statusColors[user.status] || statusColors.active;
+                    return (
+                      <tr
+                        key={user.id}
+                        className="hover:bg-neutral-50 dark:hover:bg-neutral-700/50 transition-colors"
+                      >
+                        <td className="px-4 py-3 text-sm font-medium text-neutral-900 dark:text-white">
+                          {user.name || '\u2014'}
+                        </td>
+                        <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
+                          {user.email}
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex flex-wrap gap-1">
+                            {user.roles.map((role) => (
+                              <span
+                                key={role}
+                                className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400"
+                              >
+                                {role}
+                              </span>
+                            ))}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-sm text-neutral-600 dark:text-neutral-300">
+                          {user.tenant_name || '\u2014'}
+                        </td>
+                        <td className="px-4 py-3">
+                          <span
+                            className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium ${colors.bg} ${colors.text}`}
+                          >
+                            <span className={`h-1.5 w-1.5 rounded-full ${colors.dot}`} />
+                            {user.status}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-sm text-neutral-500 dark:text-neutral-400">
+                          {formatDate(user.last_login_at)}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between px-4 py-3 border-t border-neutral-200 dark:border-neutral-700">
+              <p className="text-sm text-neutral-600 dark:text-neutral-400">
+                Page {page} of {totalPages}
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page <= 1}
+                  className="p-1.5 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  <ChevronLeft className="h-4 w-4 text-neutral-600 dark:text-neutral-400" />
+                </button>
+                <button
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={page >= totalPages}
+                  className="p-1.5 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  <ChevronRight className="h-4 w-4 text-neutral-600 dark:text-neutral-400" />
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -33,6 +33,10 @@ import type {
   WorkflowTemplateListResponse,
   WorkflowListResponse,
   AccessRequestListResponse,
+  AdminUserListResponse,
+  PlatformSettingsResponse,
+  PlatformSetting,
+  RoleListResponse,
 } from '../types';
 
 const API_BASE_URL = config.api.baseUrl;
@@ -789,6 +793,44 @@ class ApiService {
     const { data } = await this.client.get(`/v1/tenants/${tenantId}/chat/usage/metering`, {
       params: { days },
     });
+    return data;
+  }
+
+  // =========================================================================
+  // Admin Users Management (CAB-1454)
+  // =========================================================================
+
+  async getAdminUsers(params: {
+    role?: string;
+    status?: string;
+    search?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<AdminUserListResponse> {
+    const { data } = await this.client.get('/v1/admin/users', { params });
+    return data;
+  }
+
+  // =========================================================================
+  // Platform Settings (CAB-1454)
+  // =========================================================================
+
+  async getPlatformSettings(params?: { category?: string }): Promise<PlatformSettingsResponse> {
+    const { data } = await this.client.get('/v1/admin/settings', { params });
+    return data;
+  }
+
+  async updatePlatformSetting(key: string, value: string): Promise<PlatformSetting> {
+    const { data } = await this.client.put(`/v1/admin/settings/${key}`, { value });
+    return data;
+  }
+
+  // =========================================================================
+  // RBAC Roles (CAB-1454)
+  // =========================================================================
+
+  async getAdminRoles(): Promise<RoleListResponse> {
+    const { data } = await this.client.get('/v1/admin/roles');
     return data;
   }
 }

--- a/control-plane-ui/src/types/index.ts
+++ b/control-plane-ui/src/types/index.ts
@@ -1349,3 +1349,61 @@ export interface FederationBulkRevokeResponse {
   already_revoked: number;
   total: number;
 }
+
+// CAB-1454: Admin Users Management
+export type AdminUserStatus = 'active' | 'suspended' | 'pending';
+
+export interface AdminUser {
+  id: string;
+  email: string;
+  name: string;
+  roles: string[];
+  tenant_id: string | null;
+  tenant_name: string | null;
+  status: AdminUserStatus;
+  last_login_at: string | null;
+  created_at: string;
+}
+
+export interface AdminUserListResponse {
+  data: AdminUser[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+// CAB-1454: Platform Settings
+export type SettingCategory = 'general' | 'security' | 'gateway' | 'notifications';
+
+export interface PlatformSetting {
+  key: string;
+  value: string;
+  category: SettingCategory;
+  description: string;
+  editable: boolean;
+  updated_at: string;
+}
+
+export interface PlatformSettingsResponse {
+  settings: PlatformSetting[];
+  total: number;
+}
+
+// CAB-1454: RBAC Role Management
+export interface RolePermission {
+  name: string;
+  description: string;
+}
+
+export interface RoleDefinition {
+  name: string;
+  display_name: string;
+  description: string;
+  permissions: RolePermission[];
+  user_count: number;
+}
+
+export interface RoleListResponse {
+  roles: RoleDefinition[];
+  total: number;
+}


### PR DESCRIPTION
## Summary
- Add 3 new admin pages: User Management, Platform Settings, Roles & Permissions
- Each page includes RBAC gating (cpi-admin only), dark mode support, and responsive layout
- AdminUsers: search, role/status filters, pagination (25/page), tenant display
- AdminSettings: category filter, inline edit for editable settings, category color badges
- AdminRoles: card grid layout, permission badges, user counts
- React Query hooks (3), API service methods (4), TypeScript types (9)
- Sidebar navigation: new Admin section with 5 items (Prospects, Access Requests, Users, Settings, Roles)
- 33 new tests with 4-persona RBAC coverage across all 3 pages

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] ESLint — 103 warnings (< 105 max)
- [x] Prettier — clean
- [x] vitest — 1501 tests passed (115 files)
- [x] 4-persona RBAC tests: cpi-admin sees pages, others see Access Denied

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>