### PR TITLE
fix(portal): polish dashboard dark-mode, a11y & focus styles (CAB-1471)

### DIFF
--- a/portal/src/components/dashboard/DashboardStats.tsx
+++ b/portal/src/components/dashboard/DashboardStats.tsx
@@ -81,6 +81,7 @@ function StatCard({ title, value, subtitle, icon, color, trend, isLoading }: Sta
           >
             {trend > 0 ? <TrendingUp className="h-4 w-4" /> : <TrendingDown className="h-4 w-4" />}
             <span>{Math.abs(trend)}%</span>
+            <span className="sr-only">{trend > 0 ? 'increase' : 'decrease'}</span>
           </div>
         )}
       </div>
@@ -90,7 +91,7 @@ function StatCard({ title, value, subtitle, icon, color, trend, isLoading }: Sta
           {typeof value === 'number' ? value.toLocaleString() : value}
         </p>
         <p className="text-sm font-medium text-neutral-600 dark:text-neutral-400 mt-1">{title}</p>
-        <p className="text-xs text-neutral-500 dark:text-neutral-500 mt-0.5">{subtitle}</p>
+        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">{subtitle}</p>
       </div>
     </div>
   );

--- a/portal/src/components/dashboard/FeaturedAITools.tsx
+++ b/portal/src/components/dashboard/FeaturedAITools.tsx
@@ -78,7 +78,7 @@ export function FeaturedAITools() {
                 <Link
                   key={tool.id || tool.name}
                   to={`/servers/${tool.id || tool.name}`}
-                  className="group flex items-start gap-3 p-3 rounded-lg border border-neutral-100 dark:border-neutral-800 hover:border-primary-200 dark:hover:border-primary-800 hover:bg-primary-50/50 dark:hover:bg-primary-950/30 transition-all"
+                  className="group flex items-start gap-3 p-3 rounded-lg border border-neutral-100 dark:border-neutral-800 hover:border-primary-200 dark:hover:border-primary-800 hover:bg-primary-50/50 dark:hover:bg-primary-950/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900 transition-all"
                 >
                   <div className="p-2 bg-primary-100 dark:bg-primary-900/50 rounded-lg">
                     <CategoryIcon className="h-4 w-4 text-primary-600 dark:text-primary-400" />

--- a/portal/src/components/dashboard/FeaturedAPIs.tsx
+++ b/portal/src/components/dashboard/FeaturedAPIs.tsx
@@ -70,7 +70,7 @@ export function FeaturedAPIs() {
               <Link
                 key={api.id || api.name}
                 to={`/apis/${api.name}`}
-                className="group flex items-start gap-3 p-3 rounded-lg border border-neutral-100 dark:border-neutral-800 hover:border-primary-200 dark:hover:border-primary-800 hover:bg-primary-50/50 dark:hover:bg-primary-950/30 transition-all"
+                className="group flex items-start gap-3 p-3 rounded-lg border border-neutral-100 dark:border-neutral-800 hover:border-primary-200 dark:hover:border-primary-800 hover:bg-primary-50/50 dark:hover:bg-primary-950/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900 transition-all"
               >
                 <div className="p-2 bg-indigo-100 dark:bg-indigo-900/50 rounded-lg">
                   <BookOpen className="h-4 w-4 text-indigo-600 dark:text-indigo-400" />

--- a/portal/src/components/dashboard/QuickActions.tsx
+++ b/portal/src/components/dashboard/QuickActions.tsx
@@ -133,14 +133,24 @@ export function QuickActions() {
 
           if (action.external) {
             return (
-              <a key={action.title} href={action.href} target="_blank" rel="noopener noreferrer">
+              <a
+                key={action.title}
+                href={action.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-950 rounded-xl"
+              >
                 {content}
               </a>
             );
           }
 
           return (
-            <Link key={action.title} to={action.href}>
+            <Link
+              key={action.title}
+              to={action.href}
+              className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-950 rounded-xl"
+            >
               {content}
             </Link>
           );

--- a/portal/src/components/dashboard/RecentActivity.tsx
+++ b/portal/src/components/dashboard/RecentActivity.tsx
@@ -87,7 +87,10 @@ export function RecentActivity({ activity, isLoading }: RecentActivityProps) {
   return (
     <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-700">
       <div className="px-5 py-4 border-b border-neutral-100 dark:border-neutral-800 flex items-center justify-between">
-        <h2 className="font-semibold text-neutral-900 dark:text-white">Recent Activity</h2>
+        <div className="flex items-center gap-2">
+          <Activity className="h-5 w-5 text-cyan-600 dark:text-cyan-400" />
+          <h2 className="font-semibold text-neutral-900 dark:text-white">Recent Activity</h2>
+        </div>
         <Link
           to="/usage"
           className="text-sm text-primary-600 hover:text-primary-700 font-medium flex items-center gap-1"
@@ -130,7 +133,9 @@ export function RecentActivity({ activity, isLoading }: RecentActivityProps) {
                     {item.title}
                   </p>
                   {item.description && (
-                    <p className="text-xs text-neutral-500 truncate">{item.description}</p>
+                    <p className="text-xs text-neutral-500 dark:text-neutral-400 truncate">
+                      {item.description}
+                    </p>
                   )}
                 </div>
                 <span className="text-xs text-neutral-400 whitespace-nowrap">


### PR DESCRIPTION
## Summary
- Fix dark mode subtitle contrast in DashboardStats (`dark:text-neutral-500` → `dark:text-neutral-400`)
- Add `sr-only` accessible text to trend indicators for screen readers
- Add section header icon to RecentActivity for consistency with FeaturedAPIs/FeaturedAITools
- Add missing `dark:text-neutral-400` on activity item descriptions
- Add `focus-visible` ring styles to all interactive cards in FeaturedAPIs, FeaturedAITools, QuickActions

## Test plan
- [x] Local quality gate passed (lint 0 warnings, format, tsc, 1595 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>