### PR TITLE
test(portal): add unit tests for 15 untested components & services (CAB-1539)

### DIFF
--- a/portal/src/components/marketplace/__tests__/MarketplaceCard.test.tsx
+++ b/portal/src/components/marketplace/__tests__/MarketplaceCard.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../test/helpers';
+import { MarketplaceCard } from '../MarketplaceCard';
+import type { MarketplaceItem } from '../../../types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+vi.mock('../../../i18n', () => ({ loadNamespace: vi.fn(), LANGUAGE_KEY: 'stoa:language' }));
+vi.mock('../../../config', () => ({ config: { features: { enableI18n: false } } }));
+
+function makeItem(overrides: Partial<MarketplaceItem> = {}): MarketplaceItem {
+  return {
+    id: 'api-123',
+    type: 'api',
+    name: 'Test API',
+    displayName: 'Test API Display',
+    description: 'A test API description',
+    category: 'payments',
+    tags: ['rest', 'json'],
+    status: 'published',
+    version: '1.0.0',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-02T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('MarketplaceCard', () => {
+  it('renders display name and description', () => {
+    renderWithProviders(<MarketplaceCard item={makeItem()} />);
+
+    expect(screen.getByText('Test API Display')).toBeInTheDocument();
+    expect(screen.getByText('A test API description')).toBeInTheDocument();
+  });
+
+  it('renders API type label for api items', () => {
+    renderWithProviders(<MarketplaceCard item={makeItem({ type: 'api' })} />);
+
+    expect(screen.getByText('API')).toBeInTheDocument();
+  });
+
+  it('renders AI Tool type label for mcp-server items', () => {
+    renderWithProviders(<MarketplaceCard item={makeItem({ type: 'mcp-server', id: 'mcp-456' })} />);
+
+    expect(screen.getByText('AI Tool')).toBeInTheDocument();
+  });
+
+  it('renders version when provided', () => {
+    renderWithProviders(<MarketplaceCard item={makeItem({ version: '2.3.1' })} />);
+
+    expect(screen.getByText('v2.3.1')).toBeInTheDocument();
+  });
+
+  it('renders tags up to max of 3', () => {
+    renderWithProviders(
+      <MarketplaceCard item={makeItem({ tags: ['tag1', 'tag2', 'tag3', 'tag4', 'tag5'] })} />
+    );
+
+    expect(screen.getByText('tag1')).toBeInTheDocument();
+    expect(screen.getByText('tag2')).toBeInTheDocument();
+    expect(screen.getByText('tag3')).toBeInTheDocument();
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+
+  it('renders featured badge when item is featured', () => {
+    renderWithProviders(<MarketplaceCard item={makeItem({ featured: true })} />);
+
+    expect(screen.getByText('Featured')).toBeInTheDocument();
+  });
+
+  it('does not render featured badge when not featured', () => {
+    renderWithProviders(<MarketplaceCard item={makeItem()} />);
+
+    expect(screen.queryByText('Featured')).not.toBeInTheDocument();
+  });
+
+  it('renders a link to the correct API path', () => {
+    renderWithProviders(
+      <MarketplaceCard
+        item={makeItem({
+          id: 'api-abc',
+          type: 'api',
+          api: { id: 'abc' } as MarketplaceItem['api'],
+        })}
+      />
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/apis/abc');
+  });
+
+  it('renders a link to the correct MCP server path', () => {
+    renderWithProviders(
+      <MarketplaceCard
+        item={makeItem({
+          id: 'mcp-xyz',
+          type: 'mcp-server',
+          mcpServer: { id: 'xyz' } as MarketplaceItem['mcpServer'],
+        })}
+      />
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/servers/xyz');
+  });
+
+  it('renders status badge', () => {
+    renderWithProviders(<MarketplaceCard item={makeItem({ status: 'published' })} />);
+
+    expect(screen.getByText('published')).toBeInTheDocument();
+  });
+
+  it('renders with empty tags gracefully', () => {
+    renderWithProviders(<MarketplaceCard item={makeItem({ tags: [] })} />);
+
+    expect(screen.getByText('Test API Display')).toBeInTheDocument();
+  });
+
+  it('renders with empty description', () => {
+    renderWithProviders(<MarketplaceCard item={makeItem({ description: '' })} />);
+
+    expect(screen.getByText('Test API Display')).toBeInTheDocument();
+  });
+});

--- a/portal/src/components/marketplace/__tests__/MarketplaceFilters.test.tsx
+++ b/portal/src/components/marketplace/__tests__/MarketplaceFilters.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '../../../test/helpers';
+import { MarketplaceFilterBar } from '../MarketplaceFilters';
+import type { MarketplaceCategory } from '../../../types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+vi.mock('../../../i18n', () => ({ loadNamespace: vi.fn(), LANGUAGE_KEY: 'stoa:language' }));
+vi.mock('../../../config', () => ({ config: { features: { enableI18n: false } } }));
+
+const mockCategories: MarketplaceCategory[] = [
+  { id: 'payments', name: 'payments', count: 5 },
+  { id: 'ai', name: 'ai', count: 3 },
+  { id: 'data', name: 'data', count: 2 },
+];
+
+describe('MarketplaceFilterBar', () => {
+  const onTypeChange = vi.fn();
+  const onCategoryChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders type filter buttons', () => {
+    renderWithProviders(
+      <MarketplaceFilterBar
+        selectedType="all"
+        onTypeChange={onTypeChange}
+        categories={mockCategories}
+        selectedCategory=""
+        onCategoryChange={onCategoryChange}
+      />
+    );
+
+    expect(screen.getByText('All')).toBeInTheDocument();
+    expect(screen.getByText('APIs')).toBeInTheDocument();
+    expect(screen.getByText('AI Tools')).toBeInTheDocument();
+  });
+
+  it('calls onTypeChange when a type button is clicked', () => {
+    renderWithProviders(
+      <MarketplaceFilterBar
+        selectedType="all"
+        onTypeChange={onTypeChange}
+        categories={mockCategories}
+        selectedCategory=""
+        onCategoryChange={onCategoryChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText('APIs'));
+    expect(onTypeChange).toHaveBeenCalledWith('api');
+  });
+
+  it('calls onTypeChange with mcp-server for AI Tools click', () => {
+    renderWithProviders(
+      <MarketplaceFilterBar
+        selectedType="all"
+        onTypeChange={onTypeChange}
+        categories={mockCategories}
+        selectedCategory=""
+        onCategoryChange={onCategoryChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText('AI Tools'));
+    expect(onTypeChange).toHaveBeenCalledWith('mcp-server');
+  });
+
+  it('highlights the selected type', () => {
+    renderWithProviders(
+      <MarketplaceFilterBar
+        selectedType="api"
+        onTypeChange={onTypeChange}
+        categories={mockCategories}
+        selectedCategory=""
+        onCategoryChange={onCategoryChange}
+      />
+    );
+
+    const apisButton = screen.getByText('APIs').closest('button');
+    expect(apisButton).toHaveClass('bg-white');
+    expect(apisButton).toHaveClass('text-emerald-700');
+  });
+
+  it('renders category select with options', () => {
+    renderWithProviders(
+      <MarketplaceFilterBar
+        selectedType="all"
+        onTypeChange={onTypeChange}
+        categories={mockCategories}
+        selectedCategory=""
+        onCategoryChange={onCategoryChange}
+      />
+    );
+
+    const select = screen.getByRole('combobox');
+    expect(select).toBeInTheDocument();
+    expect(screen.getByText('payments (5)')).toBeInTheDocument();
+  });
+
+  it('calls onCategoryChange when category is selected', () => {
+    renderWithProviders(
+      <MarketplaceFilterBar
+        selectedType="all"
+        onTypeChange={onTypeChange}
+        categories={mockCategories}
+        selectedCategory=""
+        onCategoryChange={onCategoryChange}
+      />
+    );
+
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: 'payments' } });
+    expect(onCategoryChange).toHaveBeenCalledWith('payments');
+  });
+
+  it('renders with empty categories', () => {
+    renderWithProviders(
+      <MarketplaceFilterBar
+        selectedType="all"
+        onTypeChange={onTypeChange}
+        categories={[]}
+        selectedCategory=""
+        onCategoryChange={onCategoryChange}
+      />
+    );
+
+    expect(screen.getByText('All')).toBeInTheDocument();
+  });
+});

--- a/portal/src/components/marketplace/__tests__/MarketplaceSearch.test.tsx
+++ b/portal/src/components/marketplace/__tests__/MarketplaceSearch.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '../../../test/helpers';
+import { MarketplaceSearch } from '../MarketplaceSearch';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+vi.mock('../../../i18n', () => ({ loadNamespace: vi.fn(), LANGUAGE_KEY: 'stoa:language' }));
+vi.mock('../../../config', () => ({ config: { features: { enableI18n: false } } }));
+
+describe('MarketplaceSearch', () => {
+  const onChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the search input', () => {
+    renderWithProviders(<MarketplaceSearch value="" onChange={onChange} />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toBeInTheDocument();
+  });
+
+  it('renders default placeholder', () => {
+    renderWithProviders(<MarketplaceSearch value="" onChange={onChange} />);
+
+    expect(screen.getByPlaceholderText('Search APIs, AI tools, and more...')).toBeInTheDocument();
+  });
+
+  it('renders custom placeholder', () => {
+    renderWithProviders(
+      <MarketplaceSearch value="" onChange={onChange} placeholder="Custom search" />
+    );
+
+    expect(screen.getByPlaceholderText('Custom search')).toBeInTheDocument();
+  });
+
+  it('displays the current value', () => {
+    renderWithProviders(<MarketplaceSearch value="test query" onChange={onChange} />);
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toBe('test query');
+  });
+
+  it('calls onChange when user types', () => {
+    renderWithProviders(<MarketplaceSearch value="" onChange={onChange} />);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'payment' } });
+    expect(onChange).toHaveBeenCalledWith('payment');
+  });
+
+  it('renders the search icon', () => {
+    const { container } = renderWithProviders(<MarketplaceSearch value="" onChange={onChange} />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+});

--- a/portal/src/components/marketplace/__tests__/MarketplaceStats.test.tsx
+++ b/portal/src/components/marketplace/__tests__/MarketplaceStats.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../test/helpers';
+import { MarketplaceStatsBar } from '../MarketplaceStats';
+import type { MarketplaceStats } from '../../../types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+vi.mock('../../../i18n', () => ({ loadNamespace: vi.fn(), LANGUAGE_KEY: 'stoa:language' }));
+vi.mock('../../../config', () => ({ config: { features: { enableI18n: false } } }));
+
+describe('MarketplaceStatsBar', () => {
+  const defaultStats: MarketplaceStats = {
+    totalAPIs: 12,
+    totalMCPServers: 5,
+    totalItems: 17,
+    categories: [],
+  };
+
+  it('renders total APIs count', () => {
+    renderWithProviders(<MarketplaceStatsBar stats={defaultStats} />);
+
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('renders total MCP servers count', () => {
+    renderWithProviders(<MarketplaceStatsBar stats={defaultStats} />);
+
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('renders total items count', () => {
+    renderWithProviders(<MarketplaceStatsBar stats={defaultStats} />);
+
+    expect(screen.getByText('17')).toBeInTheDocument();
+  });
+
+  it('renders labels for each stat', () => {
+    renderWithProviders(<MarketplaceStatsBar stats={defaultStats} />);
+
+    expect(screen.getByText(/APIs/)).toBeInTheDocument();
+    expect(screen.getByText(/AI Tools/)).toBeInTheDocument();
+    expect(screen.getByText(/Total/)).toBeInTheDocument();
+  });
+
+  it('renders with zero stats', () => {
+    renderWithProviders(
+      <MarketplaceStatsBar
+        stats={{ totalAPIs: 0, totalMCPServers: 0, totalItems: 0, categories: [] }}
+      />
+    );
+
+    const zeros = screen.getAllByText('0');
+    expect(zeros.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/portal/src/services/apiComparison.test.ts
+++ b/portal/src/services/apiComparison.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { apiComparisonService } from './apiComparison';
+
+vi.mock('./api', () => ({
+  apiClient: {
+    post: vi.fn(),
+  },
+}));
+
+import { apiClient } from './api';
+
+const mockPost = apiClient.post as Mock;
+
+describe('apiComparisonService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('compareAPIs', () => {
+    it('posts API IDs and returns comparison result', async () => {
+      const mockData = {
+        api_ids: ['api-1', 'api-2'],
+        api_names: { 'api-1': 'Payment API', 'api-2': 'Auth API' },
+        fields: [{ name: 'auth', values: { 'api-1': 'OAuth2', 'api-2': 'API Key' } }],
+      };
+      mockPost.mockResolvedValueOnce({ data: mockData });
+
+      const result = await apiComparisonService.compareAPIs(['api-1', 'api-2']);
+
+      expect(mockPost).toHaveBeenCalledWith('/v1/portal/apis/compare', {
+        api_ids: ['api-1', 'api-2'],
+      });
+      expect(result).toEqual(mockData);
+    });
+
+    it('returns fallback on error', async () => {
+      mockPost.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await apiComparisonService.compareAPIs(['api-1', 'api-2']);
+
+      expect(result).toEqual({
+        api_ids: ['api-1', 'api-2'],
+        api_names: {},
+        fields: [],
+      });
+    });
+  });
+});

--- a/portal/src/services/auditLog.test.ts
+++ b/portal/src/services/auditLog.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { auditLogService } from './auditLog';
+
+vi.mock('./api', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from './api';
+
+const mockGet = apiClient.get as Mock;
+
+describe('auditLogService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getEntries', () => {
+    it('returns audit log entries from the API', async () => {
+      const mockData = {
+        entries: [{ id: '1', action: 'api.created', timestamp: '2026-01-01' }],
+        total: 1,
+        page: 1,
+        limit: 25,
+      };
+      mockGet.mockResolvedValueOnce({ data: mockData });
+
+      const result = await auditLogService.getEntries();
+
+      expect(mockGet).toHaveBeenCalledWith('/v1/portal/audit-log', { params: undefined });
+      expect(result).toEqual(mockData);
+    });
+
+    it('passes filters as query params', async () => {
+      const filters = { page: 2, limit: 10, action: 'api.created' };
+      mockGet.mockResolvedValueOnce({ data: { entries: [], total: 0, page: 2, limit: 10 } });
+
+      await auditLogService.getEntries(filters);
+
+      expect(mockGet).toHaveBeenCalledWith('/v1/portal/audit-log', { params: filters });
+    });
+
+    it('returns fallback on error', async () => {
+      mockGet.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await auditLogService.getEntries();
+
+      expect(result).toEqual({ entries: [], total: 0, page: 1, limit: 25 });
+    });
+  });
+});

--- a/portal/src/services/credentialMappings.test.ts
+++ b/portal/src/services/credentialMappings.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { credentialMappingsService } from './credentialMappings';
+
+vi.mock('./api', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import { apiClient } from './api';
+
+const mockGet = apiClient.get as Mock;
+const mockPost = apiClient.post as Mock;
+const mockPut = apiClient.put as Mock;
+const mockDelete = apiClient.delete as Mock;
+
+const tenantId = 'tenant-1';
+
+describe('credentialMappingsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('list', () => {
+    it('fetches credential mappings with params', async () => {
+      const mockData = { items: [], total: 0, page: 1, page_size: 20 };
+      mockGet.mockResolvedValueOnce({ data: mockData });
+
+      const result = await credentialMappingsService.list(tenantId, {
+        consumer_id: 'c-1',
+        page: 1,
+      });
+
+      expect(mockGet).toHaveBeenCalledWith(`/v1/tenants/${tenantId}/credential-mappings`, {
+        params: { consumer_id: 'c-1', page: 1 },
+      });
+      expect(result).toEqual(mockData);
+    });
+
+    it('fetches without params', async () => {
+      const mockData = { items: [], total: 0, page: 1, page_size: 20 };
+      mockGet.mockResolvedValueOnce({ data: mockData });
+
+      await credentialMappingsService.list(tenantId);
+
+      expect(mockGet).toHaveBeenCalledWith(`/v1/tenants/${tenantId}/credential-mappings`, {
+        params: undefined,
+      });
+    });
+  });
+
+  describe('get', () => {
+    it('fetches a single credential mapping', async () => {
+      const mockMapping = { id: 'cm-1', consumer_id: 'c-1', api_id: 'a-1' };
+      mockGet.mockResolvedValueOnce({ data: mockMapping });
+
+      const result = await credentialMappingsService.get(tenantId, 'cm-1');
+
+      expect(mockGet).toHaveBeenCalledWith(`/v1/tenants/${tenantId}/credential-mappings/cm-1`);
+      expect(result).toEqual(mockMapping);
+    });
+  });
+
+  describe('create', () => {
+    it('creates a credential mapping', async () => {
+      const payload = {
+        consumer_id: 'c-1',
+        api_id: 'a-1',
+        auth_type: 'api_key' as const,
+        header_name: 'X-Api-Key',
+        credential_value: 'secret',
+      };
+      const mockResult = { id: 'cm-new', ...payload };
+      mockPost.mockResolvedValueOnce({ data: mockResult });
+
+      const result = await credentialMappingsService.create(tenantId, payload);
+
+      expect(mockPost).toHaveBeenCalledWith(`/v1/tenants/${tenantId}/credential-mappings`, payload);
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('update', () => {
+    it('updates a credential mapping', async () => {
+      const payload = { auth_type: 'bearer' as const };
+      const mockResult = { id: 'cm-1', auth_type: 'bearer' };
+      mockPut.mockResolvedValueOnce({ data: mockResult });
+
+      const result = await credentialMappingsService.update(tenantId, 'cm-1', payload);
+
+      expect(mockPut).toHaveBeenCalledWith(
+        `/v1/tenants/${tenantId}/credential-mappings/cm-1`,
+        payload
+      );
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes a credential mapping', async () => {
+      mockDelete.mockResolvedValueOnce({});
+
+      await credentialMappingsService.delete(tenantId, 'cm-1');
+
+      expect(mockDelete).toHaveBeenCalledWith(`/v1/tenants/${tenantId}/credential-mappings/cm-1`);
+    });
+  });
+
+  describe('listByConsumer', () => {
+    it('fetches mappings for a specific consumer', async () => {
+      const mockData = [{ id: 'cm-1', consumer_id: 'c-1' }];
+      mockGet.mockResolvedValueOnce({ data: mockData });
+
+      const result = await credentialMappingsService.listByConsumer(tenantId, 'c-1');
+
+      expect(mockGet).toHaveBeenCalledWith(
+        `/v1/tenants/${tenantId}/credential-mappings/consumer/c-1`
+      );
+      expect(result).toEqual(mockData);
+    });
+  });
+});

--- a/portal/src/services/errorTracking.test.ts
+++ b/portal/src/services/errorTracking.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// We need to control import.meta.env.VITE_ERROR_TRACKING_ENDPOINT
+// Vitest allows overriding import.meta.env before import
+
+describe('errorTracking', () => {
+  const originalFetch = globalThis.fetch;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    globalThis.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.resetModules();
+  });
+
+  describe('captureException', () => {
+    it('does nothing when endpoint is not set', async () => {
+      vi.stubEnv('VITE_ERROR_TRACKING_ENDPOINT', '');
+
+      const { captureException } = await import('./errorTracking');
+      captureException(new Error('test'));
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('sends error to endpoint when configured', async () => {
+      vi.stubEnv('VITE_ERROR_TRACKING_ENDPOINT', 'https://errors.example.com/capture');
+
+      const { captureException } = await import('./errorTracking');
+      const error = new Error('Something broke');
+      captureException(error, { extra: { userId: 'u-1' } });
+
+      expect(mockFetch).toHaveBeenCalledWith('https://errors.example.com/capture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: expect.stringContaining('"message":"Something broke"'),
+      });
+    });
+
+    it('silently catches fetch errors', async () => {
+      vi.stubEnv('VITE_ERROR_TRACKING_ENDPOINT', 'https://errors.example.com/capture');
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const { captureException } = await import('./errorTracking');
+
+      // Should not throw
+      expect(() => captureException(new Error('test'))).not.toThrow();
+    });
+  });
+
+  describe('captureErrorBoundary', () => {
+    it('calls captureException with componentStack', async () => {
+      vi.stubEnv('VITE_ERROR_TRACKING_ENDPOINT', 'https://errors.example.com/capture');
+
+      const { captureErrorBoundary } = await import('./errorTracking');
+      const error = new Error('Render failed');
+      const errorInfo = { componentStack: '\n    in MyComponent\n    in App', digest: undefined };
+      captureErrorBoundary(error, errorInfo);
+
+      expect(mockFetch).toHaveBeenCalledWith('https://errors.example.com/capture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: expect.stringContaining('"componentStack"'),
+      });
+    });
+  });
+});

--- a/portal/src/services/executions.test.ts
+++ b/portal/src/services/executions.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { executionsService } from './executions';
+
+vi.mock('./api', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from './api';
+
+const mockGet = apiClient.get as Mock;
+
+describe('executionsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('list', () => {
+    it('fetches executions with default params', async () => {
+      const mockData = { items: [], total: 0, page: 1, page_size: 20 };
+      mockGet.mockResolvedValueOnce({ data: mockData });
+
+      const result = await executionsService.list();
+
+      expect(mockGet).toHaveBeenCalledWith('/v1/usage/me/executions', {
+        params: { page: 1, page_size: 20, status: undefined },
+      });
+      expect(result).toEqual(mockData);
+    });
+
+    it('passes custom params', async () => {
+      const mockData = { items: [], total: 0, page: 2, page_size: 10 };
+      mockGet.mockResolvedValueOnce({ data: mockData });
+
+      const result = await executionsService.list({ page: 2, page_size: 10, status: 'error' });
+
+      expect(mockGet).toHaveBeenCalledWith('/v1/usage/me/executions', {
+        params: { page: 2, page_size: 10, status: 'error' },
+      });
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe('getTaxonomy', () => {
+    it('fetches error taxonomy', async () => {
+      const mockData = {
+        items: [{ category: 'timeout', count: 5, avg_duration_ms: 3000, percentage: 50 }],
+        total_errors: 10,
+        total_executions: 100,
+        error_rate: 0.1,
+      };
+      mockGet.mockResolvedValueOnce({ data: mockData });
+
+      const result = await executionsService.getTaxonomy();
+
+      expect(mockGet).toHaveBeenCalledWith('/v1/usage/me/executions/taxonomy');
+      expect(result).toEqual(mockData);
+    });
+  });
+});

--- a/portal/src/services/favorites.test.ts
+++ b/portal/src/services/favorites.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { favoritesService } from './favorites';
+
+vi.mock('./api', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import { apiClient } from './api';
+
+const mockGet = apiClient.get as Mock;
+const mockPost = apiClient.post as Mock;
+const mockDelete = apiClient.delete as Mock;
+
+describe('favoritesService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getFavorites', () => {
+    it('returns favorites from the API', async () => {
+      const mockData = {
+        favorites: [{ id: 'fav-1', item_type: 'api', item_id: 'api-1' }],
+        total: 1,
+      };
+      mockGet.mockResolvedValueOnce({ data: mockData });
+
+      const result = await favoritesService.getFavorites();
+
+      expect(mockGet).toHaveBeenCalledWith('/v1/portal/favorites');
+      expect(result).toEqual(mockData);
+    });
+
+    it('returns fallback on error', async () => {
+      mockGet.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await favoritesService.getFavorites();
+
+      expect(result).toEqual({ favorites: [], total: 0 });
+    });
+  });
+
+  describe('addFavorite', () => {
+    it('posts a favorite to the API', async () => {
+      mockPost.mockResolvedValueOnce({});
+
+      await favoritesService.addFavorite('api', 'api-123');
+
+      expect(mockPost).toHaveBeenCalledWith('/v1/portal/favorites', {
+        item_type: 'api',
+        item_id: 'api-123',
+      });
+    });
+  });
+
+  describe('removeFavorite', () => {
+    it('deletes a favorite via the API', async () => {
+      mockDelete.mockResolvedValueOnce({});
+
+      await favoritesService.removeFavorite('fav-1');
+
+      expect(mockDelete).toHaveBeenCalledWith('/v1/portal/favorites/fav-1');
+    });
+  });
+});

--- a/portal/src/services/marketplace.test.ts
+++ b/portal/src/services/marketplace.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { marketplaceService } from './marketplace';
+
+vi.mock('./apiCatalog', () => ({
+  apiCatalogService: {
+    listAPIs: vi.fn(),
+  },
+}));
+
+vi.mock('./mcpServers', () => ({
+  mcpServersService: {
+    getServers: vi.fn(),
+  },
+}));
+
+import { apiCatalogService } from './apiCatalog';
+import { mcpServersService } from './mcpServers';
+
+const mockListAPIs = apiCatalogService.listAPIs as Mock;
+const mockGetServers = mcpServersService.getServers as Mock;
+
+const mockAPIs = [
+  {
+    id: 'api-1',
+    name: 'Payment API',
+    description: 'Process payments',
+    category: 'finance',
+    tags: ['payment', 'stripe'],
+    status: 'active',
+    version: '2.0',
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-15',
+  },
+  {
+    id: 'api-2',
+    name: 'Auth API',
+    description: 'Authentication service',
+    category: 'security',
+    tags: ['oauth', 'jwt'],
+    status: 'active',
+    version: '1.0',
+    createdAt: '2026-01-05',
+    updatedAt: '2026-01-10',
+  },
+];
+
+const mockServers = [
+  {
+    id: 'mcp-1',
+    name: 'data-fetcher',
+    displayName: 'Data Fetcher',
+    description: 'Fetch data from sources',
+    category: 'data',
+    tools: [{ name: 'fetch' }, { name: 'transform' }],
+    status: 'active',
+    version: '1.0',
+    created_at: '2026-02-01',
+    updated_at: '2026-02-10',
+  },
+];
+
+describe('marketplaceService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListAPIs.mockResolvedValue({ items: mockAPIs, total: 2 });
+    mockGetServers.mockResolvedValue(mockServers);
+  });
+
+  describe('getItems', () => {
+    it('returns combined API and MCP server items', async () => {
+      const result = await marketplaceService.getItems();
+
+      expect(result.items).toHaveLength(3);
+      expect(result.total).toBe(3);
+      expect(result.stats.totalAPIs).toBe(2);
+      expect(result.stats.totalMCPServers).toBe(1);
+      expect(result.stats.totalItems).toBe(3);
+    });
+
+    it('filters by type', async () => {
+      const result = await marketplaceService.getItems({ type: 'api' });
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items.every((item) => item.type === 'api')).toBe(true);
+    });
+
+    it('filters by search term', async () => {
+      const result = await marketplaceService.getItems({ search: 'payment' });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].name).toBe('Payment API');
+    });
+
+    it('filters by category', async () => {
+      const result = await marketplaceService.getItems({ category: 'finance' });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].name).toBe('Payment API');
+    });
+
+    it('paginates results', async () => {
+      const result = await marketplaceService.getItems({ page: 1, pageSize: 2 });
+
+      expect(result.items).toHaveLength(2);
+      expect(result.total).toBe(3);
+    });
+
+    it('extracts categories with counts', async () => {
+      const result = await marketplaceService.getItems();
+
+      expect(result.stats.categories).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'finance', count: 1 }),
+          expect.objectContaining({ name: 'security', count: 1 }),
+          expect.objectContaining({ name: 'data', count: 1 }),
+        ])
+      );
+    });
+
+    it('returns fallback on error', async () => {
+      mockListAPIs.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await marketplaceService.getItems();
+
+      expect(result.items).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(result.stats.totalItems).toBe(0);
+    });
+  });
+
+  describe('getFeaturedItems', () => {
+    it('returns top 3 APIs and top 3 MCP servers', async () => {
+      const result = await marketplaceService.getFeaturedItems();
+
+      expect(result).toHaveLength(3); // 2 APIs + 1 MCP server (only 1 available)
+      expect(result.every((item) => item.featured)).toBe(true);
+    });
+
+    it('returns empty array on error', async () => {
+      mockListAPIs.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await marketplaceService.getFeaturedItems();
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/portal/src/services/notifications.test.ts
+++ b/portal/src/services/notifications.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { notificationsService } from './notifications';
+
+vi.mock('./api', () => ({
+  apiClient: {
+    get: vi.fn(),
+    patch: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+import { apiClient } from './api';
+
+const mockGet = apiClient.get as Mock;
+const mockPatch = apiClient.patch as Mock;
+const mockPost = apiClient.post as Mock;
+
+describe('notificationsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getNotifications', () => {
+    it('returns notifications from the API', async () => {
+      const mockData = {
+        notifications: [{ id: 'n-1', title: 'New API', read: false }],
+        total: 1,
+        unread_count: 1,
+      };
+      mockGet.mockResolvedValueOnce({ data: mockData });
+
+      const result = await notificationsService.getNotifications();
+
+      expect(mockGet).toHaveBeenCalledWith('/v1/portal/notifications');
+      expect(result).toEqual(mockData);
+    });
+
+    it('returns fallback on error', async () => {
+      mockGet.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await notificationsService.getNotifications();
+
+      expect(result).toEqual({ notifications: [], total: 0, unread_count: 0 });
+    });
+  });
+
+  describe('getUnreadCount', () => {
+    it('returns unread count from the API', async () => {
+      mockGet.mockResolvedValueOnce({ data: { unread_count: 3 } });
+
+      const result = await notificationsService.getUnreadCount();
+
+      expect(mockGet).toHaveBeenCalledWith('/v1/portal/notifications/unread-count');
+      expect(result).toBe(3);
+    });
+
+    it('returns 0 on error', async () => {
+      mockGet.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await notificationsService.getUnreadCount();
+
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('markAsRead', () => {
+    it('patches a notification as read', async () => {
+      mockPatch.mockResolvedValueOnce({});
+
+      await notificationsService.markAsRead('n-1');
+
+      expect(mockPatch).toHaveBeenCalledWith('/v1/portal/notifications/n-1/read');
+    });
+  });
+
+  describe('markAllAsRead', () => {
+    it('posts to mark all notifications as read', async () => {
+      mockPost.mockResolvedValueOnce({});
+
+      await notificationsService.markAllAsRead();
+
+      expect(mockPost).toHaveBeenCalledWith('/v1/portal/notifications/mark-all-read');
+    });
+  });
+});

--- a/portal/src/services/onboarding.test.ts
+++ b/portal/src/services/onboarding.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { onboardingService } from './onboarding';
+
+vi.mock('./api', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from './api';
+
+const mockGet = apiClient.get as Mock;
+
+describe('onboardingService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getFunnel', () => {
+    it('fetches onboarding funnel data', async () => {
+      const mockData = {
+        stages: [{ stage: 'signup', count: 100, conversion_rate: 0.8 }],
+        total_started: 100,
+        total_completed: 60,
+        avg_ttftc_seconds: 120,
+        p50_ttftc_seconds: 90,
+        p90_ttftc_seconds: 300,
+      };
+      mockGet.mockResolvedValueOnce({ data: mockData });
+
+      const result = await onboardingService.getFunnel();
+
+      expect(mockGet).toHaveBeenCalledWith('/v1/admin/onboarding/funnel');
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe('getStalled', () => {
+    it('fetches stalled users with default hours', async () => {
+      const mockData = [
+        {
+          user_id: 'u-1',
+          tenant_id: 't-1',
+          last_step: 'api_key',
+          started_at: '2026-01-01',
+          hours_stalled: 48,
+        },
+      ];
+      mockGet.mockResolvedValueOnce({ data: mockData });
+
+      const result = await onboardingService.getStalled();
+
+      expect(mockGet).toHaveBeenCalledWith('/v1/admin/onboarding/stalled', {
+        params: { hours: 24 },
+      });
+      expect(result).toEqual(mockData);
+    });
+
+    it('passes custom hours parameter', async () => {
+      mockGet.mockResolvedValueOnce({ data: [] });
+
+      await onboardingService.getStalled(72);
+
+      expect(mockGet).toHaveBeenCalledWith('/v1/admin/onboarding/stalled', {
+        params: { hours: 72 },
+      });
+    });
+  });
+});

--- a/portal/src/services/rateLimits.test.ts
+++ b/portal/src/services/rateLimits.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { rateLimitsService } from './rateLimits';
+
+vi.mock('./api', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from './api';
+
+const mockGet = apiClient.get as Mock;
+
+describe('rateLimitsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getRateLimits', () => {
+    it('returns rate limits from the API', async () => {
+      const mockData = {
+        rate_limits: [{ id: '1', name: 'default', requests_per_minute: 60 }],
+        total: 1,
+      };
+      mockGet.mockResolvedValueOnce({ data: mockData });
+
+      const result = await rateLimitsService.getRateLimits();
+
+      expect(mockGet).toHaveBeenCalledWith('/v1/portal/rate-limits');
+      expect(result).toEqual(mockData);
+    });
+
+    it('returns fallback on error', async () => {
+      mockGet.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await rateLimitsService.getRateLimits();
+
+      expect(result).toEqual({ rate_limits: [], total: 0 });
+    });
+  });
+});

--- a/portal/src/services/tenantMcpServers.test.ts
+++ b/portal/src/services/tenantMcpServers.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { tenantMcpServersService } from './tenantMcpServers';
+
+vi.mock('./api', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+import { apiClient } from './api';
+
+const mockGet = apiClient.get as Mock;
+const mockPost = apiClient.post as Mock;
+const mockPut = apiClient.put as Mock;
+const mockDelete = apiClient.delete as Mock;
+const mockPatch = apiClient.patch as Mock;
+
+const tenantId = 'tenant-1';
+const serverId = 'srv-1';
+
+describe('tenantMcpServersService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('list', () => {
+    it('fetches servers with params', async () => {
+      const mockData = { servers: [], total_count: 0, page: 1, page_size: 20 };
+      mockGet.mockResolvedValueOnce({ data: mockData });
+
+      const result = await tenantMcpServersService.list(tenantId, { page: 1, enabled_only: true });
+
+      expect(mockGet).toHaveBeenCalledWith(`/v1/tenants/${tenantId}/mcp-servers`, {
+        params: { page: 1, enabled_only: true },
+      });
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe('get', () => {
+    it('fetches a single server', async () => {
+      const mockServer = { id: serverId, name: 'Test Server', tools: [] };
+      mockGet.mockResolvedValueOnce({ data: mockServer });
+
+      const result = await tenantMcpServersService.get(tenantId, serverId);
+
+      expect(mockGet).toHaveBeenCalledWith(`/v1/tenants/${tenantId}/mcp-servers/${serverId}`);
+      expect(result).toEqual(mockServer);
+    });
+  });
+
+  describe('create', () => {
+    it('creates a server', async () => {
+      const payload = { display_name: 'New Server', base_url: 'https://mcp.example.com' };
+      const mockResult = { id: 'srv-new', ...payload, tools: [] };
+      mockPost.mockResolvedValueOnce({ data: mockResult });
+
+      const result = await tenantMcpServersService.create(tenantId, payload);
+
+      expect(mockPost).toHaveBeenCalledWith(`/v1/tenants/${tenantId}/mcp-servers`, payload);
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('update', () => {
+    it('updates a server', async () => {
+      const payload = { display_name: 'Updated Server' };
+      const mockResult = { id: serverId, display_name: 'Updated Server', tools: [] };
+      mockPut.mockResolvedValueOnce({ data: mockResult });
+
+      const result = await tenantMcpServersService.update(tenantId, serverId, payload);
+
+      expect(mockPut).toHaveBeenCalledWith(
+        `/v1/tenants/${tenantId}/mcp-servers/${serverId}`,
+        payload
+      );
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes a server', async () => {
+      mockDelete.mockResolvedValueOnce({});
+
+      await tenantMcpServersService.delete(tenantId, serverId);
+
+      expect(mockDelete).toHaveBeenCalledWith(`/v1/tenants/${tenantId}/mcp-servers/${serverId}`);
+    });
+  });
+
+  describe('testConnection', () => {
+    it('tests connection to a server', async () => {
+      const mockResult = {
+        success: true,
+        latency_ms: 42,
+        error: null,
+        server_info: {},
+        tools_discovered: 5,
+      };
+      mockPost.mockResolvedValueOnce({ data: mockResult });
+
+      const result = await tenantMcpServersService.testConnection(tenantId, serverId);
+
+      expect(mockPost).toHaveBeenCalledWith(
+        `/v1/tenants/${tenantId}/mcp-servers/${serverId}/test-connection`
+      );
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('syncTools', () => {
+    it('syncs tools from a server', async () => {
+      const mockResult = { synced_count: 3, removed_count: 1, tools: [] };
+      mockPost.mockResolvedValueOnce({ data: mockResult });
+
+      const result = await tenantMcpServersService.syncTools(tenantId, serverId);
+
+      expect(mockPost).toHaveBeenCalledWith(
+        `/v1/tenants/${tenantId}/mcp-servers/${serverId}/sync-tools`
+      );
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('toggleTool', () => {
+    it('toggles a tool enabled state', async () => {
+      const mockTool = { id: 'tool-1', name: 'test-tool', enabled: false };
+      mockPatch.mockResolvedValueOnce({ data: mockTool });
+
+      const result = await tenantMcpServersService.toggleTool(tenantId, serverId, 'tool-1', false);
+
+      expect(mockPatch).toHaveBeenCalledWith(
+        `/v1/tenants/${tenantId}/mcp-servers/${serverId}/tools/tool-1`,
+        { enabled: false }
+      );
+      expect(result).toEqual(mockTool);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 4 marketplace component tests (MarketplaceCard, MarketplaceFilters, MarketplaceSearch, MarketplaceStats)
- Add 11 service tests (apiComparison, auditLog, credentialMappings, errorTracking, executions, favorites, marketplace, notifications, onboarding, rateLimits, tenantMcpServers)
- All 1676 tests passing, 0 lint warnings, clean tsc

## Test plan
- [x] `npm run test -- --run` (1676 tests passing)
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc -p tsconfig.app.json --noEmit` (clean)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>