### PR TITLE
fix(ci): hegemon tmux session dies on startup

### DIFF
--- a/deploy/vps/hegemon/hegemon-agent.service
+++ b/deploy/vps/hegemon/hegemon-agent.service
@@ -4,12 +4,13 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=forking
+Type=simple
 User=hegemon
 Environment=HOME=/home/hegemon
+Environment=TERM=xterm-256color
+Environment=LANG=en_US.UTF-8
 ExecStart=/home/hegemon/.local/bin/hegemon-start.sh
 ExecStop=/usr/bin/tmux -L hegemon kill-session -t hegemon
-RemainAfterExit=yes
 Restart=on-failure
 RestartSec=30
 

--- a/deploy/vps/hegemon/hegemon-start.sh
+++ b/deploy/vps/hegemon/hegemon-start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Start HEGEMON agent tmux session.
-# Called by hegemon-agent.service or manually.
+# Called by hegemon-agent.service (Type=simple, blocking).
 set -euo pipefail
 
 source "${HOME}/.env.hegemon"
@@ -15,16 +15,23 @@ git pull --ff-only origin main 2>/dev/null || true
 
 # Kill existing session if any
 tmux -L hegemon kill-session -t "$SESSION" 2>/dev/null || true
+sleep 1
 
 # Create tmux session
 tmux -L hegemon new-session -d -s "$SESSION" -x 200 -y 50
 
 # Window 0: Agent (main work window)
 tmux -L hegemon rename-window -t "${SESSION}:0" "AGENT"
-tmux -L hegemon send-keys -t "${SESSION}:AGENT" "cd ${STOA_DIR} && export STOA_INSTANCE=backend" C-m
+tmux -L hegemon send-keys -t "${SESSION}:AGENT" "cd ${STOA_DIR} && source ~/.env.hegemon && export STOA_INSTANCE=\${HEGEMON_ROLE:-backend}" C-m
 
 # Window 1: Monitor (htop + watchdog logs)
 tmux -L hegemon new-window -t "${SESSION}" -n "MONITOR"
 tmux -L hegemon send-keys -t "${SESSION}:MONITOR" "htop" C-m
 
 echo "HEGEMON tmux session started: tmux -L hegemon attach -t ${SESSION}"
+
+# BLOCK: keep the process alive so systemd (Type=simple) tracks the session.
+# When the tmux session dies, this loop exits, and systemd restarts the service.
+while tmux -L hegemon has-session -t "$SESSION" 2>/dev/null; do
+  sleep 30
+done

--- a/deploy/vps/hegemon/notify.sh
+++ b/deploy/vps/hegemon/notify.sh
@@ -7,7 +7,9 @@
 #   hegemon_notify "started" "CAB-1350" "Working on traceparent injection"
 #   hegemon_notify "done" "CAB-1350" "PR #578 merged"
 #   hegemon_notify "error" "CAB-1350" "CI failed: clippy warning"
-set -euo pipefail
+# NOTE: no "set -euo pipefail" here — this file is sourced from .bashrc.
+# Setting -e in a sourced script bleeds into the interactive shell and kills
+# it on the first non-zero return code.
 
 # Resolve env
 : "${SLACK_WEBHOOK_URL:=}"


### PR DESCRIPTION
## Summary
- Remove `set -euo pipefail` from `notify.sh` — it bleeds into interactive bash when sourced from `.bashrc`, killing the shell and tmux session
- Update `hegemon-agent.service` to `Type=simple` with `TERM` and `LANG` env vars
- Add blocking while loop to `hegemon-start.sh` so systemd tracks the tmux session lifecycle

## Root cause
`notify.sh` is sourced from `.bashrc`. The `set -euo pipefail` directive persists in the interactive shell context, causing bash to exit on the first non-zero return code (e.g., from infisical-loader.sh auth failure). This kills the tmux window, which kills the tmux server.

## Test plan
- [x] Verified on worker-1: tmux session persists after service start
- [ ] Deploy to workers 2-5 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)