### PR TITLE
test(gateway): add diagnostics mod tests + document test coverage (CAB-1534)

### DIFF
--- a/stoa-gateway/src/cache/mod.rs
+++ b/stoa-gateway/src/cache/mod.rs
@@ -14,6 +14,11 @@
 //!
 //! Note: Infrastructure prepared for tool response caching.
 //! Actual integration in SSE handler is a Phase 7 enhancement.
+//!
+//! # Tests
+//!
+//! Inline tests in `prompt.rs`, `semantic.rs`, and `watcher.rs`.
+//! No inline tests here — this module is re-exports only.
 
 pub mod prompt;
 mod semantic;

--- a/stoa-gateway/src/diagnostics/mod.rs
+++ b/stoa-gateway/src/diagnostics/mod.rs
@@ -50,3 +50,57 @@ fn record_diagnostic(category: &ErrorCategory) {
     };
     DIAGNOSTICS_TOTAL.with_label_values(&[label]).inc();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_record_diagnostic_all_categories() {
+        // Verify that record_diagnostic maps every ErrorCategory variant
+        // to a Prometheus label without panicking.
+        let categories = [
+            ErrorCategory::Auth,
+            ErrorCategory::Network,
+            ErrorCategory::Backend,
+            ErrorCategory::Timeout,
+            ErrorCategory::Policy,
+            ErrorCategory::RateLimit,
+            ErrorCategory::Certificate,
+            ErrorCategory::Unknown,
+        ];
+        for category in &categories {
+            record_diagnostic(category);
+        }
+    }
+
+    #[test]
+    fn test_record_diagnostic_increments_counter() {
+        // Record twice for the same category and verify the counter increases.
+        let before = DIAGNOSTICS_TOTAL.with_label_values(&["auth"]).get();
+        record_diagnostic(&ErrorCategory::Auth);
+        record_diagnostic(&ErrorCategory::Auth);
+        let after = DIAGNOSTICS_TOTAL.with_label_values(&["auth"]).get();
+        assert!(after >= before + 2.0);
+    }
+
+    #[test]
+    fn test_reexports_are_accessible() {
+        // Verify all public re-exports from sub-modules are accessible.
+        let _engine = DiagnosticEngine::new(100);
+        let _hop = Hop {
+            name: "test".to_string(),
+            address: None,
+            latency_ms: Some(1.0),
+            hop_type: HopType::Gateway,
+        };
+        let _chain = HopChain {
+            hops: vec![],
+            total_detected: 0,
+            total_latency_ms: None,
+        };
+        let _detector = HopDetector;
+        let _tracker = LatencyTracker::new();
+        let _category = ErrorCategory::Auth;
+    }
+}

--- a/stoa-gateway/src/governance/mod.rs
+++ b/stoa-gateway/src/governance/mod.rs
@@ -18,7 +18,10 @@
 //! - **Activity tracking**: Monitor last activity per session
 //! - **Attestation**: Require periodic re-attestation
 //! - **Alerts**: Notify on zombie session detection
-
-#![allow(dead_code)]
+//!
+//! # Tests
+//!
+//! Inline tests in `zombie.rs` (28 tests covering lifecycle, attestation,
+//! revocation, zombie detection, reaping, stats, and config defaults).
 
 pub mod zombie;


### PR DESCRIPTION
## Summary
- Add 3 inline tests for `record_diagnostic()` in `diagnostics/mod.rs`: all-categories mapping, counter increment, re-export accessibility
- Remove `#![allow(dead_code)]` from `governance/mod.rs` (zero warnings confirmed)
- Document test coverage in `cache/mod.rs` and `governance/mod.rs` module headers

## Test plan
- [x] `cargo clippy` zero warnings
- [x] `cargo fmt --check` clean
- [x] `cargo test` — 1,438 tests passing (3 new)
- [x] No regressions

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>