### PR TITLE
docs: add OSS community files and clean internal refs (CAB-1540)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,18 @@
+# Contributors
+
+Thank you to everyone who has contributed to STOA Platform!
+
+## Core Team
+
+- **Christophe Aboulicam** ([@cab6961310](https://github.com/cab6961310)) — Creator & Lead Maintainer
+
+## How to Get Listed
+
+Contributors are automatically recognized through:
+
+- **Pull requests** merged to main
+- **Issues** that lead to improvements
+- **Documentation** contributions
+- **Community support** in Discussions
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get started.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -196,7 +196,7 @@ alembic upgrade head
 
 ## Git Workflow
 
-- **Branch naming**: `feat/CAB-XXXX-description`, `fix/CAB-XXXX-description`
+- **Branch naming**: `feat/issue-123-description`, `fix/issue-456-description`
 - **Commit format**: `type(scope): description` (commitlint enforced)
 - **Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`
 - **Scopes**: `api`, `ui`, `portal`, `gateway`, `helm`, `ci`, `docs`, `deps`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -160,6 +160,6 @@ Each component has a `.env.example` with all available settings. Required vars f
 ## Further Reading
 
 - Component READMEs: `control-plane-api/README.md`, `control-plane-ui/README.md`, etc.
-- CI quality gates: `.claude/rules/ci-quality-gates.md`
-- Git workflow: `.claude/rules/git-workflow.md`
+- CI pipeline: see [GitHub Actions workflows](.github/workflows/) for CI configuration
+- Git workflow: see [CONTRIBUTING.md](CONTRIBUTING.md) for branch and commit conventions
 - Architecture decisions: [docs.gostoa.dev/architecture/adr](https://docs.gostoa.dev/docs/architecture/adr)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -97,4 +97,4 @@ This governance document will be updated to reflect any changes.
 
 ---
 
-*Last updated: January 2025*
+*Last updated: February 2026*

--- a/README.md
+++ b/README.md
@@ -222,12 +222,13 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
   <img src="https://contrib.rocks/image?repo=stoa-platform/stoa" alt="Contributors" />
 </a>
 
-## Community
+## Community & Support
 
 - [GitHub Discussions](https://github.com/stoa-platform/stoa/discussions) — questions, ideas, show & tell
 - [Discord](https://discord.gg/j8tHSSes) — real-time chat
 - [Documentation](https://docs.gostoa.dev) — guides, ADRs, API reference
 - [Status Page](https://status.gostoa.dev) — platform uptime monitoring
+- [Support](SUPPORT.md) — how to get help and report issues
 
 ## License
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,39 @@
+# Support
+
+## Getting Help
+
+### Community Support
+
+- **GitHub Discussions**: [stoa-platform/stoa/discussions](https://github.com/stoa-platform/stoa/discussions) — Ask questions, share ideas, and connect with the community
+- **GitHub Issues**: [stoa-platform/stoa/issues](https://github.com/stoa-platform/stoa/issues) — Report bugs or request features
+- **Documentation**: [docs.gostoa.dev](https://docs.gostoa.dev) — Guides, API reference, and architecture decisions
+
+### Reporting Bugs
+
+Before opening an issue:
+
+1. Search [existing issues](https://github.com/stoa-platform/stoa/issues) to avoid duplicates
+2. Include steps to reproduce, expected behavior, and actual behavior
+3. Include your environment (OS, Python/Node/Rust version, component)
+4. Attach relevant logs (sanitize any secrets or credentials)
+
+Use the [bug report template](https://github.com/stoa-platform/stoa/issues/new?template=bug_report.md) when available.
+
+### Feature Requests
+
+Open a [GitHub Discussion](https://github.com/stoa-platform/stoa/discussions/categories/ideas) to propose features. Include the use case and expected behavior.
+
+### Security Issues
+
+**Do not report security vulnerabilities in public issues.** See [SECURITY.md](SECURITY.md) for responsible disclosure instructions.
+
+## Commercial Support
+
+For enterprise support, SLA-backed deployments, or professional services:
+
+- **Email**: [hello@gostoa.dev](mailto:hello@gostoa.dev)
+- **Website**: [gostoa.dev](https://gostoa.dev)
+
+## Contributing
+
+Want to contribute instead? See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
## Summary
- Create SUPPORT.md with community support channels (Discussions, Discord, email, security)
- Create CONTRIBUTORS.md referenced by CONTRIBUTING.md but previously missing
- Replace internal `CAB-XXXX` branch naming with generic `issue-123` examples in DEVELOPER.md
- Replace `.claude/rules/` references in DEVELOPMENT.md with public links
- Update GOVERNANCE.md last-updated date from January 2025 to February 2026
- Add SUPPORT.md link to README.md Community section

## Test plan
- [ ] All links in new files resolve correctly
- [ ] No internal references (CAB-XXXX, .claude/rules/) in public-facing docs
- [ ] CI green (3 required checks)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>