### PR TITLE
chore(docs): add verification rules — no DONE without proof

### DIFF
--- a/.claude/rules/ci-quality-gates.md
+++ b/.claude/rules/ci-quality-gates.md
@@ -178,6 +178,18 @@ ci → docker → apply-manifest → deploy (rollout restart)
 Components with `apply-manifest`: stoa-gateway, control-plane-ui, portal.
 Exception: control-plane-api (naming mismatch, standalone manifest uses `stoa-control-plane-api`).
 
+## CI Health Policy
+
+**CI noise = P0.** A red `main` branch blocks ALL new feature work across all instances.
+
+| Priority | Action | Who |
+|----------|--------|-----|
+| P0 | Red `main` — fix immediately | Any instance, `/ci-fix` skill |
+| P1 | Flaky test — stabilize or quarantine | Same instance that introduced it |
+| P2 | Non-required check failing | Track in memory.md "CI Known Issues" |
+
+**Rule**: No instance may start a new feature ticket while `main` CI is red. Fix first, then resume.
+
 ## Common CI Failure Patterns
 
 | Pattern | Cause | Fix |

--- a/.claude/rules/instance-dispatch.md
+++ b/.claude/rules/instance-dispatch.md
@@ -192,6 +192,24 @@ stoa-dispatch BACKEND "Travaille sur CAB-1350"
 stoa-dispatch MCP "Quel est ton avancement ?"
 ```
 
+### Council Gate (MANDATORY — added post-C11 audit)
+
+`stoa-dispatch` enforces Council validation before dispatching work to any pane. If the message contains a `CAB-XXXX` ticket ID, the script queries the Linear GraphQL API for `council:ticket-go` or `council:ticket-fix` labels.
+
+| Scenario | Result |
+|----------|--------|
+| Label `council:ticket-go` found | Dispatch proceeds |
+| Label `council:ticket-fix` found | Dispatch proceeds (adjustments applied) |
+| No Council label found | **BLOCKED** — must run `/council` first |
+| `LINEAR_API_KEY` not set | Warning, dispatch proceeds (graceful degradation) |
+| Linear API unreachable | Warning, dispatch proceeds (graceful degradation) |
+
+**Bypass**: `stoa-dispatch --force ROLE "message"` skips the Council check. Use only for emergencies with audit trail.
+
+**Why**: C11 audit (2026-02-27) revealed 8 tickets (152 pts) were dispatched and implemented without Council validation. No Slack notifications, no scoring, no labels. This gate prevents recurrence.
+
+**Requirements**: `LINEAR_API_KEY` env var must be set in the shell (from Infisical or `.zshrc`). Without it, the gate degrades to a warning — dispatch is allowed but unvalidated.
+
 ### Linear Auto-Status (MANDATORY)
 
 Every instance prompt includes:

--- a/.claude/rules/mcp-integrations.md
+++ b/.claude/rules/mcp-integrations.md
@@ -80,7 +80,10 @@ Completed in PR #XXX (merged to main)
 **Changes**: <1-2 line summary>
 **Files**: <count> files, ~<LOC> LOC
 **Tests**: <pass/fail status>
-**Ship mode**: Ship | Show | Ask
+**CI**: [Pipeline #YYYY](link) — ✅ green
+**E2E**: @smoke pass | N/A (docs-only)
+**Pod**: `<image:tag>` running in stoa-system | N/A (no deploy)
+**Mode**: Ship | Show | Ask
 ```
 
 ## Cloudflare Integration

--- a/.claude/rules/test-evolution.md
+++ b/.claude/rules/test-evolution.md
@@ -41,6 +41,14 @@ beforeEach(() => {
 ### Test Adjacency Rule
 New component = tests in the same PR. No "we'll add tests later".
 
+### E2E Co-Evolution Rule
+Feature/fix tickets MUST include Playwright scenario updates in the same PR:
+- New endpoint → E2E happy path + error case
+- Changed behavior → Update affected `@smoke` or `@critical` scenarios
+- UI change → Update page object + assertions
+
+No "we'll add E2E later" tickets. If E2E infra blocks the PR, tag `@wip` and document in DoD.
+
 ### Detection
 When reviewing a PR, check:
 1. Modified files in `src/pages/` → corresponding `.test.tsx` exists?

--- a/.claude/rules/workflow-essentials.md
+++ b/.claude/rules/workflow-essentials.md
@@ -68,6 +68,14 @@ description: Core behavioral rules — Ship/Show/Ask, DoD, State Machine, Operat
 | 2 | Docker build | Image pushed to GHCR |
 | 3 | Pod updated | New image running in `stoa-system` |
 | 4 | ArgoCD synced | Synced + Healthy (if ArgoCD-managed) |
+| 5 | Verification proof | Linear comment includes CI link + E2E + pod status |
+
+### Verification Rules (4 non-negotiable)
+
+1. **No DONE without proof** — Linear completion comment MUST include: CI pipeline link, E2E pass/fail, live pod confirmation. No proof = ticket stays open.
+2. **E2E co-evolves with code** — Feature/fix tickets MUST update Playwright scenarios in the same PR. No separate "test later" tickets.
+3. **CI noise = P0** — Red `main` blocks ALL new work. Fix CI before starting any feature. `/ci-fix` has priority over backlog.
+4. **Multi-env gate** — DoD requires 3 proofs: local tests pass, CI pipeline green, staging/prod pod healthy.
 
 ## Item State Machine (MANDATORY)
 


### PR DESCRIPTION
## Summary
- Add 4 non-negotiable verification rules to AI Factory workflow (workflow-essentials.md)
- Enhance Linear comment template with CI/E2E/Pod proof fields (mcp-integrations.md)
- Add E2E Co-Evolution Rule — Playwright updates in same PR as feature (test-evolution.md)
- Add CI Health Policy — red main = P0, blocks all feature work (ci-quality-gates.md)
- Add Council Gate for stoa-dispatch — post-C11 audit guard (instance-dispatch.md)

## Verification Rules
1. **No DONE without proof** — CI link + E2E status + pod health in every Linear completion comment
2. **E2E co-evolves** — same PR, not "later"
3. **CI noise = P0** — fix before any new feature
4. **Multi-env gate** — local + CI + staging = 3 proofs required

## Test plan
- [ ] Rules budget lint passes (workflow-essentials.md at 8.6K, under 10K limit)
- [ ] No functional code changes — rules/docs only

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>