### PR TITLE
chore(ci): hegemon quota resilience (CAB-1546)

### DIFF
--- a/hegemon/daemon/cmd/hegemon/main.go
+++ b/hegemon/daemon/cmd/hegemon/main.go
@@ -254,6 +254,19 @@ func (d *daemon) executeAndReport(ctx context.Context, issue linear.Issue, w *co
 		return
 	}
 
+	// Rate-limit detection: if the result indicates a 429/529, apply backoff + alert.
+	if result.RateLimited {
+		d.scheduler.RecordRateLimit(w.Name)
+		qs := d.scheduler.GetQuotaState(w.Name)
+		if qs != nil {
+			d.reporter.NotifyRateLimit(w.Name, qs.HitCount, qs.BackoffAt)
+			log.Printf("RATE-LIMIT %s on %s — backoff until %s (hit #%d)", issue.Identifier, w.Name, qs.BackoffAt.UTC().Format("15:04"), qs.HitCount)
+		}
+	} else {
+		// Successful execution clears any backoff state.
+		d.scheduler.ClearRateLimit(w.Name)
+	}
+
 	status := "completed"
 	if result.Status == "blocked" {
 		status = "blocked"

--- a/hegemon/daemon/config.example.yaml
+++ b/hegemon/daemon/config.example.yaml
@@ -13,30 +13,35 @@ workers:
     user: hegemon
     ssh_key: "~/.ssh/id_ed25519"
     roles: [backend]
+    infisical_secret_path: "/hegemon/worker-1"  # Per-worker API key (fallback: /anthropic)
 
   - name: worker-2
     host: "207.180.255.223"
     user: hegemon
     ssh_key: "~/.ssh/id_ed25519"
     roles: [frontend]
+    infisical_secret_path: "/hegemon/worker-2"
 
   - name: worker-3
     host: "164.68.121.123"
     user: hegemon
     ssh_key: "~/.ssh/id_ed25519"
     roles: [mcp]
+    infisical_secret_path: "/hegemon/worker-3"
 
   - name: worker-4
     host: "167.86.115.51"
     user: hegemon
     ssh_key: "~/.ssh/id_ed25519"
     roles: [auth]
+    infisical_secret_path: "/hegemon/worker-4"
 
   - name: worker-5
     host: "144.91.73.37"
     user: hegemon
     ssh_key: "~/.ssh/id_ed25519"
     roles: [qa]
+    infisical_secret_path: "/hegemon/worker-5"
 
 slack:
   webhook_url: "${SLACK_WEBHOOK_URL}"

--- a/hegemon/daemon/infisical-loader.sh
+++ b/hegemon/daemon/infisical-loader.sh
@@ -49,7 +49,21 @@ _hegemon_load_secrets() {
   fi
 
   # Fetch secrets into env vars (memory only, never disk)
-  export ANTHROPIC_API_KEY=$(_infisical_fetch "/anthropic" "ANTHROPIC_API_KEY")
+  #
+  # Per-worker API key: try /hegemon/<hostname>/ANTHROPIC_API_KEY first,
+  # fallback to shared /anthropic/ANTHROPIC_API_KEY if worker-specific path fails.
+  # This allows 1 API key per worker to avoid single-key quota exhaustion.
+  local _worker_path="/hegemon/$(hostname -s)"
+  local _worker_key
+  _worker_key=$(_infisical_fetch "$_worker_path" "ANTHROPIC_API_KEY")
+  if [ -n "$_worker_key" ]; then
+    export ANTHROPIC_API_KEY="$_worker_key"
+    echo "[hegemon] API key loaded from worker path: $_worker_path"
+  else
+    export ANTHROPIC_API_KEY=$(_infisical_fetch "/anthropic" "ANTHROPIC_API_KEY")
+    echo "[hegemon] API key loaded from shared path: /anthropic (worker path $_worker_path not found)"
+  fi
+
   export SLACK_WEBHOOK_URL=$(_infisical_fetch "/n8n" "SLACK_WEBHOOK_URL")
   export HEGEMON_REMOTE_PASSWORD=$(_infisical_fetch "/pocketbase" "PB_ADMIN_PASSWORD")
   export HEGEMON_REMOTE_URL="https://state.gostoa.dev"

--- a/hegemon/daemon/internal/config/config.go
+++ b/hegemon/daemon/internal/config/config.go
@@ -28,12 +28,13 @@ type LinearConfig struct {
 }
 
 type WorkerConfig struct {
-	Name   string   `yaml:"name"`
-	Host   string   `yaml:"host"`
-	Port   int      `yaml:"port"`
-	User   string   `yaml:"user"`
-	SSHKey string   `yaml:"ssh_key"`
-	Roles  []string `yaml:"roles"`
+	Name               string   `yaml:"name"`
+	Host               string   `yaml:"host"`
+	Port               int      `yaml:"port"`
+	User               string   `yaml:"user"`
+	SSHKey             string   `yaml:"ssh_key"`
+	Roles              []string `yaml:"roles"`
+	InfisicalSecretPath string  `yaml:"infisical_secret_path"` // Per-worker Infisical path (e.g. /hegemon/worker-1)
 }
 
 type SlackConfig struct {

--- a/hegemon/daemon/internal/reporter/reporter.go
+++ b/hegemon/daemon/internal/reporter/reporter.go
@@ -126,6 +126,16 @@ func (r *Reporter) NotifyRetriesExhausted(ticketID, title string, retries int) {
 	))
 }
 
+// NotifyRateLimit sends a rate-limit alert when a worker hits API quota (immediate, P0).
+// Includes backoff duration and consecutive hit count for operator awareness.
+func (r *Reporter) NotifyRateLimit(workerName string, hitCount int, backoffUntil time.Time) {
+	backoff := time.Until(backoffUntil).Round(time.Second)
+	r.slack(fmt.Sprintf(
+		":rotating_light: *HEGEMON rate limit* `%s`\nAPI quota hit (429/529) — consecutive: %d\nBackoff: %s (until %s)",
+		workerName, hitCount, backoff, backoffUntil.UTC().Format("15:04 UTC"),
+	))
+}
+
 // NotifyHealthFailure sends a worker health failure notification with per-worker cooldown.
 // Only fires once per healthCooldown per worker to prevent spam.
 func (r *Reporter) NotifyHealthFailure(workerName, errMsg string) {

--- a/hegemon/daemon/internal/reporter/reporter_test.go
+++ b/hegemon/daemon/internal/reporter/reporter_test.go
@@ -236,6 +236,46 @@ func TestCompletedFailedGoesImmediate(t *testing.T) {
 	}
 }
 
+func TestNotifyRateLimit(t *testing.T) {
+	var mu sync.Mutex
+	var message string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Blocks []struct {
+				Text struct {
+					Text string `json:"text"`
+				} `json:"text"`
+			} `json:"blocks"`
+		}
+		json.Unmarshal(body, &payload)
+		if len(payload.Blocks) > 0 {
+			mu.Lock()
+			message = payload.Blocks[0].Text.Text
+			mu.Unlock()
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	r := New(srv.URL, nil, "test-host", time.Hour, 0)
+
+	backoffUntil := time.Now().Add(2 * time.Minute)
+	r.NotifyRateLimit("worker-1", 3, backoffUntil)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !strings.Contains(message, "rate limit") {
+		t.Errorf("message should contain 'rate limit', got: %s", message)
+	}
+	if !strings.Contains(message, "worker-1") {
+		t.Errorf("message should contain worker name, got: %s", message)
+	}
+	if !strings.Contains(message, "consecutive: 3") {
+		t.Errorf("message should contain hit count, got: %s", message)
+	}
+}
+
 func TestNoSlackURLNoops(t *testing.T) {
 	r := New("", nil, "test-host", time.Hour, 0)
 

--- a/hegemon/daemon/internal/scheduler/scheduler.go
+++ b/hegemon/daemon/internal/scheduler/scheduler.go
@@ -3,32 +3,50 @@ package scheduler
 import (
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/stoa-platform/stoa/hegemon/daemon/internal/config"
 	"github.com/stoa-platform/stoa/hegemon/daemon/internal/state"
 )
 
+// QuotaState tracks per-worker API rate-limit state for backoff decisions.
+type QuotaState struct {
+	HitAt     time.Time     // When the rate limit was last hit
+	BackoffAt time.Time     // When the worker can be dispatched again
+	HitCount  int           // Consecutive rate-limit hits
+}
+
 // Scheduler assigns tickets to workers based on instance labels.
 type Scheduler struct {
-	workers []config.WorkerConfig
-	state   *state.Store
-	mu      sync.Mutex
+	workers    []config.WorkerConfig
+	state      *state.Store
+	mu         sync.Mutex
+	quotaState map[string]*QuotaState // keyed by worker name
 }
 
 // New creates a scheduler with the given worker pool.
 func New(workers []config.WorkerConfig, store *state.Store) *Scheduler {
-	return &Scheduler{workers: workers, state: store}
+	return &Scheduler{
+		workers:    workers,
+		state:      store,
+		quotaState: make(map[string]*QuotaState),
+	}
 }
 
 // FindAvailableWorker returns the first idle worker that handles the given role.
-// Returns nil if no worker is available.
+// Skips workers in rate-limit backoff. Returns nil if no worker is available.
 func (s *Scheduler) FindAvailableWorker(role string) *config.WorkerConfig {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	now := time.Now()
 	for i := range s.workers {
 		w := &s.workers[i]
 		if !hasRole(w.Roles, role) {
+			continue
+		}
+		// Skip workers in rate-limit backoff.
+		if qs, ok := s.quotaState[w.Name]; ok && now.Before(qs.BackoffAt) {
 			continue
 		}
 		status, err := s.state.GetWorkerStatus(w.Name)
@@ -40,6 +58,44 @@ func (s *Scheduler) FindAvailableWorker(role string) *config.WorkerConfig {
 		}
 	}
 	return nil
+}
+
+// RecordRateLimit marks a worker as rate-limited with exponential backoff.
+// Backoff: 1min, 2min, 4min, 8min, 15min (capped).
+func (s *Scheduler) RecordRateLimit(workerName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	qs, ok := s.quotaState[workerName]
+	if !ok {
+		qs = &QuotaState{}
+		s.quotaState[workerName] = qs
+	}
+
+	qs.HitAt = time.Now()
+	qs.HitCount++
+
+	// Exponential backoff: 1min * 2^(hits-1), capped at 15min.
+	backoff := time.Minute * time.Duration(1<<uint(qs.HitCount-1))
+	const maxBackoff = 15 * time.Minute
+	if backoff > maxBackoff {
+		backoff = maxBackoff
+	}
+	qs.BackoffAt = qs.HitAt.Add(backoff)
+}
+
+// ClearRateLimit resets the quota state for a worker after a successful execution.
+func (s *Scheduler) ClearRateLimit(workerName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.quotaState, workerName)
+}
+
+// GetQuotaState returns the current quota state for a worker (for alerting).
+func (s *Scheduler) GetQuotaState(workerName string) *QuotaState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.quotaState[workerName]
 }
 
 // ExtractInstanceLabel finds the instance:* label from a list of labels.

--- a/hegemon/daemon/internal/scheduler/scheduler_test.go
+++ b/hegemon/daemon/internal/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"testing"
+	"time"
 )
 
 func TestExtractInstanceLabel(t *testing.T) {
@@ -39,5 +40,79 @@ func TestInstanceLabelToRole(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("InstanceLabelToRole(%q) = %q, want %q", tt.label, got, tt.want)
 		}
+	}
+}
+
+func TestRecordRateLimitExponentialBackoff(t *testing.T) {
+	s := &Scheduler{
+		quotaState: make(map[string]*QuotaState),
+	}
+
+	// First hit: 1 minute backoff.
+	s.RecordRateLimit("worker-1")
+	qs := s.GetQuotaState("worker-1")
+	if qs == nil {
+		t.Fatal("QuotaState should exist after RecordRateLimit")
+	}
+	if qs.HitCount != 1 {
+		t.Errorf("HitCount = %d, want 1", qs.HitCount)
+	}
+	backoff1 := qs.BackoffAt.Sub(qs.HitAt)
+	if backoff1 < 59*time.Second || backoff1 > 61*time.Second {
+		t.Errorf("first backoff = %s, want ~1m", backoff1)
+	}
+
+	// Second hit: 2 minute backoff.
+	s.RecordRateLimit("worker-1")
+	qs = s.GetQuotaState("worker-1")
+	if qs.HitCount != 2 {
+		t.Errorf("HitCount = %d, want 2", qs.HitCount)
+	}
+	backoff2 := qs.BackoffAt.Sub(qs.HitAt)
+	if backoff2 < 119*time.Second || backoff2 > 121*time.Second {
+		t.Errorf("second backoff = %s, want ~2m", backoff2)
+	}
+
+	// Third hit: 4 minute backoff.
+	s.RecordRateLimit("worker-1")
+	qs = s.GetQuotaState("worker-1")
+	if qs.HitCount != 3 {
+		t.Errorf("HitCount = %d, want 3", qs.HitCount)
+	}
+	backoff3 := qs.BackoffAt.Sub(qs.HitAt)
+	if backoff3 < 239*time.Second || backoff3 > 241*time.Second {
+		t.Errorf("third backoff = %s, want ~4m", backoff3)
+	}
+}
+
+func TestRecordRateLimitCap(t *testing.T) {
+	s := &Scheduler{
+		quotaState: make(map[string]*QuotaState),
+	}
+
+	// Hit 5 times — backoff should cap at 15 minutes.
+	for i := 0; i < 5; i++ {
+		s.RecordRateLimit("worker-1")
+	}
+	qs := s.GetQuotaState("worker-1")
+	backoff := qs.BackoffAt.Sub(qs.HitAt)
+	if backoff > 15*time.Minute+time.Second {
+		t.Errorf("backoff = %s, should be capped at 15m", backoff)
+	}
+}
+
+func TestClearRateLimit(t *testing.T) {
+	s := &Scheduler{
+		quotaState: make(map[string]*QuotaState),
+	}
+
+	s.RecordRateLimit("worker-1")
+	if s.GetQuotaState("worker-1") == nil {
+		t.Fatal("QuotaState should exist")
+	}
+
+	s.ClearRateLimit("worker-1")
+	if s.GetQuotaState("worker-1") != nil {
+		t.Error("QuotaState should be nil after ClearRateLimit")
 	}
 }

--- a/hegemon/daemon/internal/worker/executor.go
+++ b/hegemon/daemon/internal/worker/executor.go
@@ -22,6 +22,7 @@ type Result struct {
 	FilesChanged int     `json:"files_changed"`
 	Summary      string  `json:"summary"`
 	CostUSD      float64 `json:"cost_usd"`
+	RateLimited  bool    `json:"-"` // true if 429/529 detected in output (not serialized)
 }
 
 // Executor runs Claude CLI on remote workers via SSH.
@@ -59,9 +60,10 @@ func (e *Executor) Execute(ctx context.Context, w *config.WorkerConfig, ticketID
 	// bash -l sources .profile which loads Infisical secrets (ANTHROPIC_API_KEY, GH_TOKEN).
 	// --dangerously-skip-permissions: workers are sandboxed fleet, bypasses all permission checks
 	// including PreToolUse hooks (pre-instance-scope.sh blocks Bash otherwise).
-	// --model: route to Opus for complex tickets (>5pts), Sonnet for small ones.
+	// --model: route to Haiku for <=3pts, Opus for everything else (v2 routing).
+	// stderr is captured (not silenced) to detect rate-limit signals (429/529).
 	cmd := fmt.Sprintf(
-		`bash -l -c 'cd %s && git checkout %s && git pull --ff-only && claude -p "$(cat %s)" --output-format json --dangerously-skip-permissions --model %s --max-turns %d --verbose 2>/dev/null; rm -f %s'`,
+		`bash -l -c 'cd %s && git checkout %s && git pull --ff-only && claude -p "$(cat %s)" --output-format json --dangerously-skip-permissions --model %s --max-turns %d --verbose 2>&1; rm -f %s'`,
 		e.repoPath, e.branch, promptFile, model, maxTurns, promptFile,
 	)
 
@@ -157,26 +159,26 @@ func (e *Executor) writeRemoteFile(client *ssh.Client, path, content string) err
 }
 
 // modelForEstimate selects claude model based on ticket complexity.
-// All STOA tickets use Opus: the codebase has 40K tokens of rules that saturate
-// Sonnet's context, causing it to spend all turns reading without writing.
-// Sonnet 3pt attempt: $2.91 wasted (31 turns, 0 output). Opus resolves in 5-15 turns.
+// v2 Opus-first routing: Haiku for small tasks (<=3pts), Opus for everything else.
+// Sonnet removed from autonomous mode: 44% of sessions >1h, same tasks <15min with Opus.
+// Haiku for <=3pts: structural changes that don't need deep reasoning, 80% cheaper.
 func modelForEstimate(estimate int) string {
-	// Always Opus for STOA — Sonnet can't handle the rule density.
-	// Keep the estimate param for future per-repo routing.
-	_ = estimate
+	if estimate <= 3 {
+		return "haiku"
+	}
 	return "opus"
 }
 
 func turnsForEstimate(estimate int) int {
 	switch {
 	case estimate <= 3:
-		return 40
+		return 20 // Haiku: small tasks, tight budget
 	case estimate <= 5:
-		return 50
+		return 30 // Opus: standard tasks
 	case estimate <= 8:
-		return 60
+		return 40 // Opus: complex tasks
 	default:
-		return 75
+		return 50 // Opus: MEGA tasks
 	}
 }
 
@@ -238,6 +240,10 @@ func parseResult(raw string) (*Result, error) {
 		if strings.Contains(raw, "Not logged in") || strings.Contains(raw, "authentication_failed") {
 			return &Result{Status: "failed", Summary: "Claude CLI not authenticated on worker"}, nil
 		}
+		// Check for rate-limit errors (429/529).
+		if isRateLimited(raw) {
+			return &Result{Status: "failed", Summary: "API rate limit hit (429/529)", RateLimited: true}, nil
+		}
 		// Try legacy single-object parse.
 		return parseLegacyResult(raw)
 	}
@@ -267,6 +273,7 @@ func parseResult(raw string) (*Result, error) {
 			if items[i].IsError {
 				r.Status = "failed"
 				r.Summary = truncate(items[i].Result, 200)
+				r.RateLimited = isRateLimited(items[i].Result)
 			} else {
 				// Try to extract our structured JSON from the result text.
 				if parsed := extractResultJSON(items[i].Result); parsed != nil {
@@ -317,6 +324,27 @@ func extractResultJSON(text string) *Result {
 		}
 	}
 	return nil
+}
+
+// isRateLimited checks raw output for API rate-limit signals (429/529 status codes,
+// overloaded errors, or quota exhaustion messages from Claude CLI stderr).
+func isRateLimited(raw string) bool {
+	patterns := []string{
+		"429",              // Too Many Requests
+		"529",              // Overloaded
+		"rate_limit",       // Anthropic rate limit error type
+		"overloaded",       // Anthropic overloaded error
+		"quota",            // Quota exhaustion
+		"credit balance",   // Account billing issue
+		"RateLimitError",   // SDK error class
+	}
+	lower := strings.ToLower(raw)
+	for _, p := range patterns {
+		if strings.Contains(lower, strings.ToLower(p)) {
+			return true
+		}
+	}
+	return false
 }
 
 func truncate(s string, maxLen int) string {

--- a/hegemon/daemon/internal/worker/executor_test.go
+++ b/hegemon/daemon/internal/worker/executor_test.go
@@ -91,7 +91,7 @@ func TestTurnsForEstimate(t *testing.T) {
 		est  int
 		want int
 	}{
-		{1, 40}, {3, 40}, {5, 50}, {8, 60}, {13, 75}, {21, 75},
+		{1, 20}, {3, 20}, {5, 30}, {8, 40}, {13, 50}, {21, 50},
 	}
 	for _, tt := range tests {
 		got := turnsForEstimate(tt.est)
@@ -102,12 +102,12 @@ func TestTurnsForEstimate(t *testing.T) {
 }
 
 func TestModelForEstimate(t *testing.T) {
-	// All estimates → opus (Sonnet can't handle STOA rule density).
+	// v2 routing: Haiku for <=3pts, Opus for everything else.
 	tests := []struct {
 		est  int
 		want string
 	}{
-		{1, "opus"}, {3, "opus"}, {5, "opus"}, {8, "opus"}, {13, "opus"},
+		{1, "haiku"}, {3, "haiku"}, {4, "opus"}, {5, "opus"}, {8, "opus"}, {13, "opus"},
 	}
 	for _, tt := range tests {
 		got := modelForEstimate(tt.est)
@@ -115,6 +115,50 @@ func TestModelForEstimate(t *testing.T) {
 			t.Errorf("modelForEstimate(%d) = %q, want %q", tt.est, got, tt.want)
 		}
 	}
+}
+
+func TestIsRateLimited(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want bool
+	}{
+		{"error: 429 Too Many Requests", true},
+		{"error: 529 Overloaded", true},
+		{"RateLimitError: rate_limit_exceeded", true},
+		{"API overloaded, please try again", true},
+		{"quota exhausted for this billing period", true},
+		{"insufficient credit balance", true},
+		{"All done. PR #42 created.", false},
+		{"Not logged in. Please run claude login.", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		got := isRateLimited(tt.raw)
+		if got != tt.want {
+			t.Errorf("isRateLimited(%q) = %v, want %v", tt.raw[:min(len(tt.raw), 40)], got, tt.want)
+		}
+	}
+}
+
+func TestParseResultRateLimited(t *testing.T) {
+	raw := "error: 429 Too Many Requests - rate_limit_exceeded"
+	r, err := parseResult(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Status != "failed" {
+		t.Errorf("status = %q, want failed", r.Status)
+	}
+	if !r.RateLimited {
+		t.Error("RateLimited should be true")
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func TestBuildPrompt(t *testing.T) {

--- a/scripts/ai-ops/model-router.sh
+++ b/scripts/ai-ops/model-router.sh
@@ -5,17 +5,18 @@
 #        MODEL=$(echo "$ROUTE" | cut -d'|' -f1)
 #        TURNS=$(echo "$ROUTE" | cut -d'|' -f2)
 
-# Tiered model routing (implementation jobs):
-#   <=3pts Ship   → Sonnet, 20 turns  (~$5/ticket)
-#   <=3pts        → Sonnet, 25 turns  (~$7/ticket)
-#   4-5pts        → Sonnet, 35 turns  (~$10/ticket)
+# Tiered model routing v2 — Opus-first (implementation jobs):
+#   <=3pts Ship   → Haiku,  20 turns  (~$1/ticket)
+#   <=3pts        → Haiku,  20 turns  (~$1/ticket)
+#   4-5pts        → Opus,   20 turns  (~$15/ticket)
 #   6-8pts        → Opus,   30 turns  (~$18/ticket)
 #   >8pts         → Opus,   40 turns  (~$25/ticket)
 #
 # Kill-switch: set CLAUDE_DEFAULT_MODEL repo variable to force a single model
 # for all tiers (e.g. "claude-sonnet-4-6" to revert to Sonnet-only).
 #
-# Haiku is reserved for council/plan-validate (structured evaluation).
+# Sonnet removed from autonomous mode: 44% sessions >1h, Opus resolves same tasks in <15min.
+# Haiku for <=3pts: structural/scoring tasks, 80% cheaper than Sonnet.
 # Turn budget accounts for action overhead (~5-8 turns for branch+PR+tests).
 
 route_model() {
@@ -41,22 +42,17 @@ route_model() {
 
   local MODEL TURNS
   if [ "$ESTIMATE" -le 3 ]; then
-    MODEL="claude-sonnet-4-6"
-    TURNS=25
+    MODEL="claude-haiku-4-5-20251001"
+    TURNS=20
   elif [ "$ESTIMATE" -le 5 ]; then
-    MODEL="claude-sonnet-4-6"
-    TURNS=35
+    MODEL="claude-opus-4-6"
+    TURNS=20
   elif [ "$ESTIMATE" -le 8 ]; then
     MODEL="claude-opus-4-6"
     TURNS=30
   else
     MODEL="claude-opus-4-6"
     TURNS=40
-  fi
-
-  # Ship mode: tighter budget on small tickets (faster, cheaper)
-  if [ "$MODE" = "ship" ] && [ "$ESTIMATE" -le 3 ]; then
-    TURNS=20
   fi
 
   echo "${MODEL}|${TURNS}"


### PR DESCRIPTION
## Summary
- **Multi-API-key**: per-worker Infisical path (`/hegemon/worker-N/`) with fallback to shared `/anthropic`
- **Model routing v2**: Haiku for <=3pts (80% cheaper), Opus for 4+ pts (kill Sonnet in autonomous mode)
- **Rate-limit awareness**: capture stderr (was `2>/dev/null`), detect 429/529, per-worker `QuotaState` with exponential backoff (1m→2m→4m→8m→15m cap)
- **Alerting**: `NotifyRateLimit` sends Slack P0 alert with backoff duration and consecutive hit count

Council: 8.75/10 — Go | Linear: CAB-1546 (13 pts)

## Files changed (11)
- `hegemon/daemon/internal/worker/executor.go` — model routing v2 + rate-limit detection
- `hegemon/daemon/internal/scheduler/scheduler.go` — QuotaState per worker
- `hegemon/daemon/cmd/hegemon/main.go` — integrate rate-limit → backoff + alert
- `hegemon/daemon/internal/reporter/reporter.go` — NotifyRateLimit method
- `hegemon/daemon/infisical-loader.sh` — per-worker API key with fallback
- `hegemon/daemon/internal/config/config.go` — InfisicalSecretPath field
- `hegemon/daemon/config.example.yaml` — per-worker paths
- `scripts/ai-ops/model-router.sh` — CI routing: Haiku <=3pts, Opus 4-5pts

## Test plan
- [x] `go test ./...` — all 5 test packages pass
- [x] New tests: `TestIsRateLimited`, `TestParseResultRateLimited`, `TestRecordRateLimitExponentialBackoff`, `TestRecordRateLimitCap`, `TestClearRateLimit`, `TestNotifyRateLimit`
- [x] Updated tests: `TestModelForEstimate` (haiku/opus), `TestTurnsForEstimate` (new budgets)
- [ ] Deploy to worker-1 and verify Infisical per-worker path resolution

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>