### PR TITLE
fix(ui): gate PlatformStatus actions by RBAC permission (CAB-1553)

### DIFF
--- a/control-plane-ui/src/components/PlatformStatus.test.tsx
+++ b/control-plane-ui/src/components/PlatformStatus.test.tsx
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
+import { createAuthMock, type PersonaRole } from '../test/helpers';
+import { useAuth } from '../contexts/AuthContext';
 
 // Mock hooks
 const mockRefetch = vi.fn();
@@ -9,6 +11,10 @@ const mockMutateAsync = vi.fn();
 vi.mock('../hooks/usePlatformStatus', () => ({
   usePlatformStatus: vi.fn(),
   useSyncComponent: vi.fn(),
+}));
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
 }));
 
 vi.mock('react-router-dom', () => ({
@@ -73,6 +79,7 @@ const mockStatus = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
   mockUseSyncComponent.mockReturnValue({
     mutateAsync: mockMutateAsync,
     isPending: false,
@@ -216,4 +223,53 @@ describe('PlatformStatus', () => {
     renderComponent();
     expect(screen.getByText('Checking Status...')).toBeInTheDocument();
   });
+
+  // CAB-1553: 4-persona RBAC tests for dashboard widgets
+  describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
+    '%s persona',
+    (role) => {
+      beforeEach(() => {
+        vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
+        mockUsePlatformStatus.mockReturnValue({
+          data: mockStatus,
+          isLoading: false,
+          error: null,
+          refetch: mockRefetch,
+        } as any);
+      });
+
+      it('sees platform status heading and components', () => {
+        renderComponent();
+        expect(screen.getByText('Platform Status')).toBeInTheDocument();
+        expect(screen.getByText('STOA Gateway')).toBeInTheDocument();
+        expect(screen.getByText('Control Plane API')).toBeInTheDocument();
+      });
+
+      if (role === 'viewer') {
+        it('does not see Sync Now button', () => {
+          renderComponent();
+          expect(screen.queryByText('Sync Now')).not.toBeInTheDocument();
+        });
+
+        it('does not see external links', () => {
+          renderComponent();
+          expect(screen.queryByText('ArgoCD')).not.toBeInTheDocument();
+          expect(screen.queryByText('Grafana')).not.toBeInTheDocument();
+        });
+      } else {
+        it('sees Sync Now button for OutOfSync components', () => {
+          renderComponent();
+          expect(screen.getByText('Sync Now')).toBeInTheDocument();
+        });
+
+        it('sees external links', () => {
+          renderComponent();
+          expect(screen.getByText('ArgoCD')).toBeInTheDocument();
+          expect(screen.getByText('Grafana')).toBeInTheDocument();
+          expect(screen.getByText('Prometheus')).toBeInTheDocument();
+          expect(screen.getByText('Logs')).toBeInTheDocument();
+        });
+      }
+    }
+  );
 });

--- a/control-plane-ui/src/components/PlatformStatus.tsx
+++ b/control-plane-ui/src/components/PlatformStatus.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { usePlatformStatus, useSyncComponent } from '../hooks/usePlatformStatus';
 import { ComponentStatus } from '../services/api';
 import { observabilityPath, logsPath } from '../utils/navigation';
+import { PermissionGate } from './PermissionGate';
 
 // Status color mappings — light + dark
 const syncStatusColors: Record<string, string> = {
@@ -264,46 +265,48 @@ export function PlatformStatus({ compact = false, onStatusChange }: PlatformStat
           ))}
         </div>
 
-        {/* External Links */}
-        {status.external_links && (
-          <div className="mt-6 pt-6 border-t border-neutral-200 dark:border-neutral-700">
-            <h4 className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-3">
-              Quick Links
-            </h4>
-            <div className="flex flex-wrap gap-2">
-              <a
-                href={status.external_links.argocd}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-neutral-600 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700 hover:bg-neutral-200 dark:hover:bg-neutral-600 rounded-lg transition-colors"
-              >
-                <ExternalLinkIcon className="w-4 h-4" />
-                ArgoCD
-              </a>
-              <button
-                onClick={() => navigate(observabilityPath(status.external_links.grafana))}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-neutral-600 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700 hover:bg-neutral-200 dark:hover:bg-neutral-600 rounded-lg transition-colors"
-              >
-                <ExternalLinkIcon className="w-4 h-4" />
-                Grafana
-              </button>
-              <button
-                onClick={() => navigate(observabilityPath(status.external_links.prometheus))}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-neutral-600 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700 hover:bg-neutral-200 dark:hover:bg-neutral-600 rounded-lg transition-colors"
-              >
-                <ExternalLinkIcon className="w-4 h-4" />
-                Prometheus
-              </button>
-              <button
-                onClick={() => navigate(logsPath(status.external_links.logs))}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-neutral-600 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700 hover:bg-neutral-200 dark:hover:bg-neutral-600 rounded-lg transition-colors"
-              >
-                <ExternalLinkIcon className="w-4 h-4" />
-                Logs
-              </button>
+        {/* External Links — visible to roles with deploy permission (CAB-1553) */}
+        <PermissionGate permission="apis:deploy">
+          {status.external_links && (
+            <div className="mt-6 pt-6 border-t border-neutral-200 dark:border-neutral-700">
+              <h4 className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-3">
+                Quick Links
+              </h4>
+              <div className="flex flex-wrap gap-2">
+                <a
+                  href={status.external_links.argocd}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-neutral-600 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700 hover:bg-neutral-200 dark:hover:bg-neutral-600 rounded-lg transition-colors"
+                >
+                  <ExternalLinkIcon className="w-4 h-4" />
+                  ArgoCD
+                </a>
+                <button
+                  onClick={() => navigate(observabilityPath(status.external_links.grafana))}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-neutral-600 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700 hover:bg-neutral-200 dark:hover:bg-neutral-600 rounded-lg transition-colors"
+                >
+                  <ExternalLinkIcon className="w-4 h-4" />
+                  Grafana
+                </button>
+                <button
+                  onClick={() => navigate(observabilityPath(status.external_links.prometheus))}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-neutral-600 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700 hover:bg-neutral-200 dark:hover:bg-neutral-600 rounded-lg transition-colors"
+                >
+                  <ExternalLinkIcon className="w-4 h-4" />
+                  Prometheus
+                </button>
+                <button
+                  onClick={() => navigate(logsPath(status.external_links.logs))}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-neutral-600 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700 hover:bg-neutral-200 dark:hover:bg-neutral-600 rounded-lg transition-colors"
+                >
+                  <ExternalLinkIcon className="w-4 h-4" />
+                  Logs
+                </button>
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        </PermissionGate>
 
         {/* Last Updated */}
         {lastUpdated && (
@@ -364,20 +367,22 @@ const ComponentCard = memo(function ComponentCard({
           </p>
         )}
         {isOutOfSync && (
-          <button
-            onClick={() => onSync(component.name)}
-            disabled={isSyncing}
-            className="ml-auto px-2 py-1 text-xs font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {isSyncing ? (
-              <span className="flex items-center gap-1">
-                <RefreshIcon className="w-3 h-3 animate-spin" />
-                Syncing...
-              </span>
-            ) : (
-              'Sync Now'
-            )}
-          </button>
+          <PermissionGate permission="apis:deploy">
+            <button
+              onClick={() => onSync(component.name)}
+              disabled={isSyncing}
+              className="ml-auto px-2 py-1 text-xs font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSyncing ? (
+                <span className="flex items-center gap-1">
+                  <RefreshIcon className="w-3 h-3 animate-spin" />
+                  Syncing...
+                </span>
+              ) : (
+                'Sync Now'
+              )}
+            </button>
+          </PermissionGate>
         )}
       </div>
     </div>

--- a/control-plane-ui/src/pages/Dashboard.test.tsx
+++ b/control-plane-ui/src/pages/Dashboard.test.tsx
@@ -126,14 +126,33 @@ describe('Dashboard', () => {
     expect(await screen.findByText('Quick Links')).toBeInTheDocument();
   });
 
-  // 4-persona coverage
+  // CAB-1553: 4-persona widget permission coverage
   describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
     '%s persona',
     (role) => {
-      it('renders the page', async () => {
+      beforeEach(() => {
         vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
+      });
+
+      it('renders the page with welcome card', async () => {
         renderApp('/');
         expect(await screen.findByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
+      });
+
+      it('renders all four quick action cards', async () => {
+        renderApp('/');
+        expect(
+          await screen.findByText('Manage API definitions and deployments')
+        ).toBeInTheDocument();
+        expect(screen.getByText('Browse MCP tools catalog')).toBeInTheDocument();
+        expect(screen.getByText('Manage consumer applications')).toBeInTheDocument();
+        expect(screen.getByText('View deployment history')).toBeInTheDocument();
+      });
+
+      it('renders Getting Started and Quick Links sections', async () => {
+        renderApp('/');
+        expect(await screen.findByText('Getting Started')).toBeInTheDocument();
+        expect(screen.getByText('Quick Links')).toBeInTheDocument();
       });
     }
   );


### PR DESCRIPTION
## Summary
- Audited all Dashboard widgets for RBAC compliance (CAB-1553)
- Wrapped PlatformStatus "Sync Now" button with `PermissionGate permission="apis:deploy"` — hidden from `viewer` role
- Wrapped PlatformStatus external links (ArgoCD, Grafana, Prometheus, Logs) with `PermissionGate permission="apis:deploy"` — hidden from `viewer` role
- Added 4-persona `describe.each` test coverage to PlatformStatus (12 new tests)
- Enhanced Dashboard tests with 4-persona widget visibility coverage (12 new tests)

### Audit Results
| Widget | Status | Gate |
|--------|--------|------|
| Welcome Card | OK | None needed (all roles) |
| TokenUsageWidget | OK | Self-scoped by `user.tenant_id` |
| Quick Actions (4 cards) | OK | Navigation links, all roles have `apis:read`/`apps:read` |
| PlatformStatus (view) | OK | Read-only status visible to all |
| PlatformStatus (Sync Now) | **Fixed** | `apis:deploy` (cpi-admin, tenant-admin, devops) |
| PlatformStatus (external links) | **Fixed** | `apis:deploy` (cpi-admin, tenant-admin, devops) |
| Quick Links / Getting Started | OK | Static/informational content |

## Test plan
- [x] 58 tests pass (PlatformStatus + Dashboard + PermissionGate)
- [x] ESLint 103 warnings (< 105 max)
- [x] Prettier clean
- [x] TypeScript clean (`tsc --noEmit`)
- [x] LOC: +135/-55 (< 300 limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>