### PR TITLE
fix(helm): persist Arena L2 verify NetworkPolicy (CAB-1567)

### DIFF
--- a/k8s/arena/networkpolicy-arena-pushgateway.yaml
+++ b/k8s/arena/networkpolicy-arena-pushgateway.yaml
@@ -52,3 +52,36 @@ spec:
       ports:
         - port: 9091
           protocol: TCP
+---
+# Allow arena verify pods to push metrics to Pushgateway and ping Healthchecks.
+# Verify CronJob runs every 15 min (CAB-1567).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-arena-verify-egress
+  namespace: stoa-system
+  labels:
+    app.kubernetes.io/part-of: stoa-platform
+    security.stoa.dev/policy: cab-1567
+spec:
+  podSelector:
+    matchLabels:
+      app: gateway-arena-verify
+  policyTypes:
+    - Egress
+  egress:
+    # Pushgateway in monitoring namespace
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app: pushgateway
+      ports:
+        - port: 9091
+          protocol: TCP
+    # Healthchecks dead man's switch (external HTTPS)
+    - ports:
+        - port: 443
+          protocol: TCP


### PR DESCRIPTION
## Summary
- Persist `allow-arena-verify-egress` NetworkPolicy that was applied directly to cluster during Arena L2 deploy troubleshooting
- Follows the same pattern as existing `allow-arena-to-pushgateway` and `allow-arena-enterprise-to-pushgateway` policies
- Enables Pushgateway metric push (monitoring namespace) and Healthchecks ping (external HTTPS)

## Test plan
- [x] Policy already applied and verified on OVH MKS cluster
- [x] Arena L2 verify job runs 3/3 CUJs PASS with this policy active
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>