### PR TITLE
chore(docs): add MEGA close gate + orchestrator context discipline (CAB-1554)

### DIFF
--- a/.claude/rules/instance-dispatch.md
+++ b/.claude/rules/instance-dispatch.md
@@ -147,6 +147,43 @@ Pane borders show role names via `pane-border-format` with nested `#{?#{==:#{pan
 
 Navigation: `Ctrl+B q` (show numbers + jump), `Ctrl+B z` (zoom toggle), `Ctrl+B o` (cycle).
 
+### ORCHESTRE Rules (Pane 0 — MANDATORY)
+
+The orchestrator is a **dispatcher**, not an implementer. These rules prevent context overflow.
+
+#### What ORCHESTRE does
+- Read state (brief, memory.md, plan.md)
+- Dispatch tickets to instances via `stoa-dispatch`
+- Monitor progress via `heg-state remote-ls`
+- Verify post-merge CD status
+- Update state files (memory.md, plan.md)
+- Run `/sync-plan`, `/fill-cycle`, `/council`
+
+#### What ORCHESTRE NEVER does
+- Create feature branches
+- Write or edit code files (src/, tests/, etc.)
+- Run test suites (pytest, vitest, cargo test)
+- Create PRs
+- Stay on the same conversation for more than ~20 turns
+
+#### Context Management
+- `/compact` every **10 turns** or at **40% context** — whichever comes first
+- `/clear` between each dispatch cycle (dispatch → verify → clear → next)
+- Delegate ALL codebase exploration to `Explore` subagents
+- If context reaches 60%: STOP, update state files, `/clear`, start fresh cycle
+
+#### Dispatch Cycle Pattern
+```
+1. Read session-brief.json (or memory.md + plan.md)
+2. Check instance states: heg-state remote-ls
+3. Dispatch 1-3 tickets to available instances
+4. /clear
+5. (new turn) Check progress, verify completed PRs
+6. Update state files if needed
+7. /clear
+8. Repeat
+```
+
 ### tmux Gotchas
 
 | Issue | Cause | Fix |

--- a/.claude/rules/session-startup.md
+++ b/.claude/rules/session-startup.md
@@ -88,6 +88,17 @@ Monitor context window usage throughout the session:
 
 Use `/clear` aggressively between unrelated tasks in the same session.
 
+### Orchestrator Override (STOA_INSTANCE=orchestrator or Pane 0)
+
+The orchestrator has **stricter** context limits because it runs continuously:
+- **Target**: stay under **40% context** (vs 60% for implementation instances)
+- **At 30%**: `/compact` proactively
+- **At 50%**: STOP current cycle, update state files, `/clear`, start fresh
+- **Never open code files** — delegate to Explore subagents or instances
+- **Cycle-based workflow**: each dispatch cycle is a mini-session (dispatch → verify → clear)
+
+See `instance-dispatch.md` → "ORCHESTRE Rules" for the full discipline.
+
 ## Step 4 — Work
 
 Follow the appropriate pattern from `ai-factory.md` (Pattern 3/5/7 for features, Pattern 1/2 for reviews).

--- a/.claude/rules/workflow-essentials.md
+++ b/.claude/rules/workflow-essentials.md
@@ -77,6 +77,19 @@ description: Core behavioral rules — Ship/Show/Ask, DoD, State Machine, Operat
 3. **CI noise = P0** — Red `main` blocks ALL new work. Fix CI before starting any feature. `/ci-fix` has priority over backlog.
 4. **Multi-env gate** — DoD requires 3 proofs: local tests pass, CI pipeline green, staging/prod pod healthy.
 
+### MEGA Close Gate (titles containing `[MEGA]`)
+
+A MEGA ticket CANNOT be marked Done unless ALL of these are true:
+
+| # | Gate | Verification |
+|---|------|-------------|
+| 1 | Every P0 item has a merged PR | `gh pr list --search "CAB-XXXX" --state merged` returns >= 1 PR per P0 item |
+| 2 | Linear comment maps items → PRs | Completion comment lists each P0 deliverable + its PR number |
+| 3 | Live verification | Target site/endpoint confirmed working (curl, build, or screenshot) |
+| 4 | Sub-tickets closed | All child issues on Linear are Done (not just the parent) |
+
+**If any gate fails**: ticket stays In Progress. Log: `MEGA-GATE-FAIL | task=<ID> missing=<gate_numbers>`
+
 ## Item State Machine (MANDATORY)
 
 ```
@@ -124,6 +137,7 @@ PENDING ──→ CLAIMED ──→ IN_PROGRESS ──→ DONE ──→ ARCHIVE
 | 2 | No DONE in NEXT | `📋 NEXT` section | Zero items with `**DONE**`, `— DONE`, or `~~strikethrough~~` |
 | 3 | Stale `[~]` check | plan.md | Every `[~]` has at least one `[ ]` sub-item remaining |
 | 4 | Cross-file parity | plan.md vs memory.md | `[x]` → `✅ DONE`, `[~]` → `🔴 IN PROGRESS` |
+| 5 | MEGA close gate | Linear MEGAs marked Done this session | All 4 MEGA gates pass (see above) |
 
 ## Operation Logging
 
@@ -170,4 +184,4 @@ Keep under 500 lines. Rotate oldest to `metrics.log.1` (90-day retention).
 - **State files are mandatory** — skipping memory.md update is a workflow violation
 - **Operation log is mandatory** — every session MUST have SESSION-START and SESSION-END
 - **Atomic transitions only** — marking `**DONE**` without moving to `✅ DONE` is forbidden
-- **Session-End State Lint** — 4-check lint before every SESSION-END, no exceptions
+- **Session-End State Lint** — 5-check lint before every SESSION-END, no exceptions


### PR DESCRIPTION
## Summary
- **MEGA Close Gate**: 4 mandatory verification gates before any MEGA ticket can be marked Done (prevents false-Done like CAB-1470)
- **ORCHESTRE Rules**: orchestrator is a dispatcher only — no code editing, no test running, strict context limits
- **Orchestrator Context Override**: 40% context target (vs 60% for implementation instances) to prevent context overflow crashes

## Files Changed
- `.claude/rules/workflow-essentials.md` — MEGA Close Gate + lint check #5
- `.claude/rules/instance-dispatch.md` — ORCHESTRE Rules section
- `.claude/rules/session-startup.md` — orchestrator context override

## Council Validation — 9.00/10 Go

| Persona | Score | Verdict |
|---------|-------|---------|
| Chucky | 9/10 | Go |
| OSS Killer | 8/10 | Go |
| Archi | 9/10 | Go |
| Saul | 10/10 | Go |

## Test plan
- [ ] Rules-only change — no code to test
- [ ] File sizes verified within cost-guardrails thresholds
- [ ] CI green (3 required checks)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)