### PR TITLE
test(api): add 57 tests for 4 uncovered modules (CAB-1558)

### DIFF
--- a/control-plane-api/tests/test_contract_lifecycle_service.py
+++ b/control-plane-api/tests/test_contract_lifecycle_service.py
@@ -1,0 +1,305 @@
+"""Tests for contract lifecycle service (CAB-1335 / CAB-1558)."""
+
+import uuid
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.services.contract_lifecycle_service import (
+    deprecate_contract,
+    get_active_version,
+    get_sunset_candidates,
+    list_versions,
+    reactivate_contract,
+)
+
+
+def _make_contract(**overrides) -> MagicMock:
+    """Build a mock Contract with sensible defaults."""
+    defaults = {
+        "id": uuid.uuid4(),
+        "tenant_id": "acme",
+        "name": "pet-api",
+        "display_name": "Pet API",
+        "version": "1.0.0",
+        "status": "published",
+        "deprecated_at": None,
+        "sunset_at": None,
+        "replacement_contract_id": None,
+        "deprecation_reason": None,
+        "grace_period_days": None,
+        "is_sunset": False,
+        "created_at": datetime.utcnow(),
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for k, v in defaults.items():
+        setattr(m, k, v)
+    return m
+
+
+def _mock_db() -> AsyncMock:
+    db = AsyncMock(spec=AsyncSession)
+    db.flush = AsyncMock()
+    return db
+
+
+# ── deprecate_contract ──
+
+
+class TestDeprecateContract:
+    @pytest.mark.asyncio
+    async def test_already_deprecated_raises(self):
+        contract = _make_contract(status="deprecated")
+        db = _mock_db()
+        with pytest.raises(ValueError, match="already deprecated"):
+            await deprecate_contract(db, contract, reason="obsolete")
+
+    @pytest.mark.asyncio
+    async def test_draft_raises(self):
+        contract = _make_contract(status="draft")
+        db = _mock_db()
+        with pytest.raises(ValueError, match="Cannot deprecate a draft"):
+            await deprecate_contract(db, contract, reason="unused")
+
+    @pytest.mark.asyncio
+    async def test_replacement_not_found_raises(self):
+        contract = _make_contract(status="published")
+        db = _mock_db()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = None
+        db.execute.return_value = result_mock
+
+        with pytest.raises(ValueError, match="not found"):
+            await deprecate_contract(
+                db,
+                contract,
+                reason="replaced",
+                replacement_contract_id=uuid.uuid4(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_replacement_different_tenant_raises(self):
+        contract = _make_contract(status="published", tenant_id="acme")
+        replacement = _make_contract(status="published", tenant_id="other-tenant")
+        db = _mock_db()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = replacement
+        db.execute.return_value = result_mock
+
+        with pytest.raises(ValueError, match="same tenant"):
+            await deprecate_contract(
+                db,
+                contract,
+                reason="replaced",
+                replacement_contract_id=replacement.id,
+            )
+
+    @pytest.mark.asyncio
+    async def test_replacement_deprecated_raises(self):
+        contract = _make_contract(status="published", tenant_id="acme")
+        replacement = _make_contract(status="deprecated", tenant_id="acme")
+        db = _mock_db()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = replacement
+        db.execute.return_value = result_mock
+
+        with pytest.raises(ValueError, match="itself deprecated"):
+            await deprecate_contract(
+                db,
+                contract,
+                reason="replaced",
+                replacement_contract_id=replacement.id,
+            )
+
+    @pytest.mark.asyncio
+    async def test_success_sets_fields(self):
+        contract = _make_contract(status="published")
+        db = _mock_db()
+
+        result = await deprecate_contract(db, contract, reason="end of life")
+
+        assert result.status == "deprecated"
+        assert result.deprecation_reason == "end of life"
+        assert result.deprecated_at is not None
+        db.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_grace_period_computes_sunset(self):
+        contract = _make_contract(status="published")
+        db = _mock_db()
+
+        result = await deprecate_contract(db, contract, reason="eol", grace_period_days=30)
+
+        assert result.sunset_at is not None
+        assert result.grace_period_days == 30
+
+    @pytest.mark.asyncio
+    async def test_explicit_sunset_at(self):
+        contract = _make_contract(status="published")
+        db = _mock_db()
+        sunset = datetime.utcnow() + timedelta(days=60)
+
+        result = await deprecate_contract(db, contract, reason="eol", sunset_at=sunset)
+
+        assert result.sunset_at == sunset
+
+    @pytest.mark.asyncio
+    async def test_replacement_success(self):
+        contract = _make_contract(status="published", tenant_id="acme")
+        replacement = _make_contract(status="published", tenant_id="acme")
+        db = _mock_db()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = replacement
+        db.execute.return_value = result_mock
+
+        result = await deprecate_contract(
+            db,
+            contract,
+            reason="replaced by v2",
+            replacement_contract_id=replacement.id,
+        )
+
+        assert result.replacement_contract_id == str(replacement.id)
+        assert result.status == "deprecated"
+
+
+# ── reactivate_contract ──
+
+
+class TestReactivateContract:
+    @pytest.mark.asyncio
+    async def test_not_deprecated_raises(self):
+        contract = _make_contract(status="published")
+        db = _mock_db()
+        with pytest.raises(ValueError, match="Only deprecated"):
+            await reactivate_contract(db, contract)
+
+    @pytest.mark.asyncio
+    async def test_sunset_passed_raises(self):
+        contract = _make_contract(status="deprecated", is_sunset=True)
+        db = _mock_db()
+        with pytest.raises(ValueError, match="sunset date has passed"):
+            await reactivate_contract(db, contract)
+
+    @pytest.mark.asyncio
+    async def test_success_resets_fields(self):
+        contract = _make_contract(
+            status="deprecated",
+            is_sunset=False,
+            deprecated_at=datetime.utcnow(),
+            sunset_at=datetime.utcnow() + timedelta(days=30),
+            replacement_contract_id=str(uuid.uuid4()),
+            deprecation_reason="old",
+            grace_period_days=30,
+        )
+        db = _mock_db()
+
+        result = await reactivate_contract(db, contract)
+
+        assert result.status == "published"
+        assert result.deprecated_at is None
+        assert result.sunset_at is None
+        assert result.replacement_contract_id is None
+        assert result.deprecation_reason is None
+        assert result.grace_period_days is None
+        db.flush.assert_awaited_once()
+
+
+# ── list_versions ──
+
+
+class TestListVersions:
+    @pytest.mark.asyncio
+    async def test_returns_versions(self):
+        db = _mock_db()
+        v1 = _make_contract(version="1.0.0")
+        v2 = _make_contract(version="2.0.0")
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = [v2, v1]
+        result_mock = MagicMock()
+        result_mock.scalars.return_value = scalars_mock
+        db.execute.return_value = result_mock
+
+        versions = await list_versions(db, "acme", "pet-api")
+
+        assert len(versions) == 2
+        db.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list(self):
+        db = _mock_db()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = []
+        result_mock = MagicMock()
+        result_mock.scalars.return_value = scalars_mock
+        db.execute.return_value = result_mock
+
+        versions = await list_versions(db, "acme", "unknown-api")
+
+        assert versions == []
+
+
+# ── get_active_version ──
+
+
+class TestGetActiveVersion:
+    @pytest.mark.asyncio
+    async def test_returns_latest_published(self):
+        db = _mock_db()
+        contract = _make_contract(status="published")
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = contract
+        db.execute.return_value = result_mock
+
+        active = await get_active_version(db, "acme", "pet-api")
+
+        assert active is not None
+        assert active.status == "published"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_all_deprecated(self):
+        db = _mock_db()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = None
+        db.execute.return_value = result_mock
+
+        active = await get_active_version(db, "acme", "pet-api")
+
+        assert active is None
+
+
+# ── get_sunset_candidates ──
+
+
+class TestGetSunsetCandidates:
+    @pytest.mark.asyncio
+    async def test_returns_candidates(self):
+        db = _mock_db()
+        c1 = _make_contract(status="deprecated", sunset_at=datetime.utcnow() - timedelta(days=1))
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = [c1]
+        result_mock = MagicMock()
+        result_mock.scalars.return_value = scalars_mock
+        db.execute.return_value = result_mock
+
+        candidates = await get_sunset_candidates(db)
+
+        assert len(candidates) == 1
+        db.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_custom_before_date(self):
+        db = _mock_db()
+        scalars_mock = MagicMock()
+        scalars_mock.all.return_value = []
+        result_mock = MagicMock()
+        result_mock.scalars.return_value = scalars_mock
+        db.execute.return_value = result_mock
+
+        candidates = await get_sunset_candidates(db, before=datetime.utcnow() + timedelta(days=90))
+
+        assert candidates == []
+        db.execute.assert_awaited_once()

--- a/control-plane-api/tests/test_llm_budget_router.py
+++ b/control-plane-api/tests/test_llm_budget_router.py
@@ -1,0 +1,300 @@
+"""Tests for LLM budget router (CAB-1558)."""
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.auth import User, get_current_user
+from src.database import get_db
+from src.routers.llm_budget import router
+
+
+def _make_user(roles: list[str] | None = None, tenant_id: str = "acme") -> User:
+    return User(
+        id="user-1",
+        username="testuser",
+        email="test@example.com",
+        roles=roles or ["tenant-admin"],
+        tenant_id=tenant_id,
+    )
+
+
+def _provider_response(**overrides) -> MagicMock:
+    defaults = {
+        "id": uuid.uuid4(),
+        "tenant_id": "acme",
+        "provider_name": "openai",
+        "display_name": "OpenAI",
+        "default_model": "gpt-4",
+        "cost_per_input_token": Decimal("0.00003"),
+        "cost_per_output_token": Decimal("0.00006"),
+        "status": "active",
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for k, v in defaults.items():
+        setattr(m, k, v)
+    # Provide dict() for Pydantic serialization
+    m.dict.return_value = defaults
+    m.model_dump.return_value = defaults
+    return m
+
+
+def _budget_response(**overrides) -> MagicMock:
+    defaults = {
+        "id": uuid.uuid4(),
+        "tenant_id": "acme",
+        "monthly_limit_usd": Decimal("100.00"),
+        "current_spend_usd": Decimal("25.00"),
+        "alert_threshold_pct": 80,
+        "usage_pct": 25.0,
+        "remaining_usd": Decimal("75.00"),
+        "is_over_budget": False,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for k, v in defaults.items():
+        setattr(m, k, v)
+    m.dict.return_value = defaults
+    m.model_dump.return_value = defaults
+    return m
+
+
+def _spend_response(**overrides) -> MagicMock:
+    defaults = {
+        "tenant_id": "acme",
+        "monthly_limit_usd": Decimal("100.00"),
+        "current_spend_usd": Decimal("25.00"),
+        "remaining_usd": Decimal("75.00"),
+        "usage_pct": 25.0,
+        "is_over_budget": False,
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for k, v in defaults.items():
+        setattr(m, k, v)
+    m.dict.return_value = defaults
+    m.model_dump.return_value = defaults
+    return m
+
+
+@pytest.fixture
+def app():
+    """Create FastAPI app with router and mock dependencies."""
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def admin_client(app):
+    """Client authenticated as cpi-admin."""
+    user = _make_user(roles=["cpi-admin"], tenant_id="acme")
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def tenant_client(app):
+    """Client authenticated as tenant-admin for 'acme'."""
+    user = _make_user(roles=["tenant-admin"], tenant_id="acme")
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def other_tenant_client(app):
+    """Client authenticated as tenant-admin for 'other-corp'."""
+    user = _make_user(roles=["tenant-admin"], tenant_id="other-corp")
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+# ── Access Control ──
+
+
+class TestTenantAccess:
+    @patch("src.routers.llm_budget.LlmBudgetService")
+    def test_admin_can_access_any_tenant(self, MockSvc, admin_client):
+        mock_svc = AsyncMock()
+        mock_svc.list_providers.return_value = []
+        MockSvc.return_value = mock_svc
+
+        resp = admin_client.get("/v1/tenants/any-tenant/llm/providers")
+
+        assert resp.status_code == 200
+
+    @patch("src.routers.llm_budget.LlmBudgetService")
+    def test_tenant_admin_own_tenant(self, MockSvc, tenant_client):
+        mock_svc = AsyncMock()
+        mock_svc.list_providers.return_value = []
+        MockSvc.return_value = mock_svc
+
+        resp = tenant_client.get("/v1/tenants/acme/llm/providers")
+
+        assert resp.status_code == 200
+
+    @patch("src.routers.llm_budget.LlmBudgetService")
+    def test_tenant_admin_other_tenant_forbidden(self, MockSvc, other_tenant_client):
+        resp = other_tenant_client.get("/v1/tenants/acme/llm/providers")
+
+        assert resp.status_code == 403
+
+
+# ── Providers ──
+
+
+class TestProviderEndpoints:
+    @patch("src.routers.llm_budget.LlmBudgetService")
+    def test_create_provider_201(self, MockSvc, admin_client):
+        mock_svc = AsyncMock()
+        mock_svc.create_provider.return_value = _provider_response()
+        MockSvc.return_value = mock_svc
+
+        resp = admin_client.post(
+            "/v1/tenants/acme/llm/providers",
+            json={
+                "provider_name": "openai",
+                "display_name": "OpenAI",
+                "default_model": "gpt-4",
+                "cost_per_input_token": "0.00003",
+                "cost_per_output_token": "0.00006",
+                "status": "active",
+            },
+        )
+
+        assert resp.status_code == 201
+
+    @patch("src.routers.llm_budget.LlmBudgetService")
+    def test_list_providers(self, MockSvc, admin_client):
+        mock_svc = AsyncMock()
+        mock_svc.list_providers.return_value = [_provider_response()]
+        MockSvc.return_value = mock_svc
+
+        resp = admin_client.get("/v1/tenants/acme/llm/providers")
+
+        assert resp.status_code == 200
+
+    @patch("src.routers.llm_budget.LlmBudgetService")
+    def test_delete_provider_204(self, MockSvc, admin_client):
+        mock_svc = AsyncMock()
+        mock_svc.delete_provider.return_value = None
+        MockSvc.return_value = mock_svc
+
+        resp = admin_client.delete(f"/v1/tenants/acme/llm/providers/{uuid.uuid4()}")
+
+        assert resp.status_code == 204
+
+    @patch("src.routers.llm_budget.LlmBudgetService")
+    def test_delete_provider_not_found_404(self, MockSvc, admin_client):
+        mock_svc = AsyncMock()
+        mock_svc.delete_provider.side_effect = ValueError("Provider not found")
+        MockSvc.return_value = mock_svc
+
+        resp = admin_client.delete(f"/v1/tenants/acme/llm/providers/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+
+
+# ── Budget ──
+
+
+class TestBudgetEndpoints:
+    @patch("src.routers.llm_budget.LlmBudgetService")
+    def test_create_budget_201(self, MockSvc, admin_client):
+        mock_svc = AsyncMock()
+        mock_svc.create_budget.return_value = _budget_response()
+        MockSvc.return_value = mock_svc
+
+        resp = admin_client.post(
+            "/v1/tenants/acme/llm/budget",
+            json={"monthly_limit_usd": "100.00"},
+        )
+
+        assert resp.status_code == 201
+
+    @patch("src.routers.llm_budget.LlmBudgetService")
+    def test_create_budget_conflict_409(self, MockSvc, admin_client):
+        mock_svc = AsyncMock()
+        mock_svc.create_budget.side_effect = ValueError("Budget already exists")
+        MockSvc.return_value = mock_svc
+
+        resp = admin_client.post(
+            "/v1/tenants/acme/llm/budget",
+            json={"monthly_limit_usd": "100.00"},
+        )
+
+        assert resp.status_code == 409
+
+    @patch("src.routers.llm_budget.LlmBudgetService")
+    def test_get_budget(self, MockSvc, admin_client):
+        mock_svc = AsyncMock()
+        mock_svc.get_budget.return_value = _budget_response()
+        MockSvc.return_value = mock_svc
+
+        resp = admin_client.get("/v1/tenants/acme/llm/budget")
+
+        assert resp.status_code == 200
+
+    @patch("src.routers.llm_budget.LlmBudgetService")
+    def test_get_budget_not_found_404(self, MockSvc, admin_client):
+        mock_svc = AsyncMock()
+        mock_svc.get_budget.side_effect = ValueError("Budget not found")
+        MockSvc.return_value = mock_svc
+
+        resp = admin_client.get("/v1/tenants/acme/llm/budget")
+
+        assert resp.status_code == 404
+
+    @patch("src.routers.llm_budget.LlmBudgetService")
+    def test_update_budget(self, MockSvc, admin_client):
+        mock_svc = AsyncMock()
+        mock_svc.update_budget.return_value = _budget_response()
+        MockSvc.return_value = mock_svc
+
+        resp = admin_client.put(
+            "/v1/tenants/acme/llm/budget",
+            json={"monthly_limit_usd": "200.00"},
+        )
+
+        assert resp.status_code == 200
+
+
+# ── Spend ──
+
+
+class TestSpendEndpoints:
+    @patch("src.routers.llm_budget.LlmBudgetService")
+    def test_get_spend(self, MockSvc, admin_client):
+        mock_svc = AsyncMock()
+        mock_svc.get_spend_summary.return_value = _spend_response()
+        MockSvc.return_value = mock_svc
+
+        resp = admin_client.get("/v1/tenants/acme/llm/spend")
+
+        assert resp.status_code == 200
+
+    @patch("src.routers.llm_budget.LlmBudgetService")
+    def test_get_spend_not_found_404(self, MockSvc, admin_client):
+        mock_svc = AsyncMock()
+        mock_svc.get_spend_summary.side_effect = ValueError("Budget not found")
+        MockSvc.return_value = mock_svc
+
+        resp = admin_client.get("/v1/tenants/acme/llm/spend")
+
+        assert resp.status_code == 404

--- a/control-plane-api/tests/test_llm_budget_service.py
+++ b/control-plane-api/tests/test_llm_budget_service.py
@@ -1,0 +1,261 @@
+"""Tests for LLM budget service (CAB-1558)."""
+
+import contextlib
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.schemas.llm_budget import (
+    LlmBudgetCreate,
+    LlmBudgetUpdate,
+    LlmProviderCreate,
+)
+from src.services.llm_budget_service import LlmBudgetService
+
+
+def _mock_provider(**overrides) -> MagicMock:
+    defaults = {
+        "id": uuid.uuid4(),
+        "tenant_id": "acme",
+        "provider_name": "openai",
+        "display_name": "OpenAI",
+        "default_model": "gpt-4",
+        "cost_per_input_token": Decimal("0.00003"),
+        "cost_per_output_token": Decimal("0.00006"),
+        "status": "active",
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for k, v in defaults.items():
+        setattr(m, k, v)
+    return m
+
+
+def _mock_budget(**overrides) -> MagicMock:
+    defaults = {
+        "id": uuid.uuid4(),
+        "tenant_id": "acme",
+        "monthly_limit_usd": Decimal("100.00"),
+        "current_spend_usd": Decimal("25.00"),
+        "alert_threshold_pct": 80,
+        "usage_pct": 25.0,
+        "remaining_usd": Decimal("75.00"),
+        "is_over_budget": False,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for k, v in defaults.items():
+        setattr(m, k, v)
+    return m
+
+
+@pytest.fixture
+def svc():
+    """Create LlmBudgetService with mocked repo."""
+    session = AsyncMock()
+    with patch("src.services.llm_budget_service.LlmBudgetRepository") as MockRepo:
+        mock_repo = AsyncMock()
+        MockRepo.return_value = mock_repo
+        service = LlmBudgetService(session)
+        service._mock_repo = mock_repo  # expose for assertions
+        yield service
+
+
+# ── Providers ──
+
+
+class TestCreateProvider:
+    @pytest.mark.asyncio
+    async def test_create_success(self, svc):
+        provider = _mock_provider()
+        svc._mock_repo.create_provider.return_value = provider
+
+        data = LlmProviderCreate(
+            provider_name="openai",
+            display_name="OpenAI",
+            default_model="gpt-4",
+            cost_per_input_token=Decimal("0.00003"),
+            cost_per_output_token=Decimal("0.00006"),
+            status="active",
+        )
+        result = await svc.create_provider("acme", data)
+
+        assert result.provider_name == "openai"
+        svc._mock_repo.create_provider.assert_awaited_once()
+
+
+class TestListProviders:
+    @pytest.mark.asyncio
+    async def test_list_returns_providers(self, svc):
+        svc._mock_repo.list_providers_by_tenant.return_value = [_mock_provider(), _mock_provider()]
+
+        result = await svc.list_providers("acme")
+
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_empty(self, svc):
+        svc._mock_repo.list_providers_by_tenant.return_value = []
+
+        result = await svc.list_providers("acme")
+
+        assert result == []
+
+
+class TestDeleteProvider:
+    @pytest.mark.asyncio
+    async def test_delete_success(self, svc):
+        svc._mock_repo.get_provider_by_id.return_value = _mock_provider()
+        svc._mock_repo.delete_provider.return_value = None
+
+        await svc.delete_provider(uuid.uuid4())
+
+        svc._mock_repo.delete_provider.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_not_found_raises(self, svc):
+        svc._mock_repo.get_provider_by_id.return_value = None
+
+        with pytest.raises(ValueError, match="not found"):
+            await svc.delete_provider(uuid.uuid4())
+
+
+# ── Budget CRUD ──
+
+
+class TestCreateBudget:
+    @pytest.mark.asyncio
+    async def test_create_success(self, svc):
+        svc._mock_repo.get_budget_by_tenant.return_value = None
+        svc._mock_repo.create_budget.return_value = _mock_budget()
+
+        data = LlmBudgetCreate(monthly_limit_usd=Decimal("100.00"))
+        result = await svc.create_budget("acme", data)
+
+        assert result.monthly_limit_usd == Decimal("100.00")
+
+    @pytest.mark.asyncio
+    async def test_create_already_exists_raises(self, svc):
+        svc._mock_repo.get_budget_by_tenant.return_value = _mock_budget()
+
+        data = LlmBudgetCreate(monthly_limit_usd=Decimal("100.00"))
+        with pytest.raises(ValueError, match=r"already exists|already has"):
+            await svc.create_budget("acme", data)
+
+
+class TestGetBudget:
+    @pytest.mark.asyncio
+    async def test_get_success(self, svc):
+        svc._mock_repo.get_budget_by_tenant.return_value = _mock_budget()
+
+        result = await svc.get_budget("acme")
+
+        assert result.tenant_id == "acme"
+
+    @pytest.mark.asyncio
+    async def test_get_not_found_raises(self, svc):
+        svc._mock_repo.get_budget_by_tenant.return_value = None
+
+        with pytest.raises(ValueError, match=r"not found|No budget"):
+            await svc.get_budget("acme")
+
+
+class TestUpdateBudget:
+    @pytest.mark.asyncio
+    async def test_update_success(self, svc):
+        budget = _mock_budget()
+        svc._mock_repo.get_budget_by_tenant.return_value = budget
+        svc._mock_repo.update_budget.return_value = budget
+
+        data = LlmBudgetUpdate(monthly_limit_usd=Decimal("200.00"))
+        result = await svc.update_budget("acme", data)
+
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_update_not_found_raises(self, svc):
+        svc._mock_repo.get_budget_by_tenant.return_value = None
+
+        data = LlmBudgetUpdate(monthly_limit_usd=Decimal("200.00"))
+        with pytest.raises(ValueError, match=r"not found|No budget"):
+            await svc.update_budget("acme", data)
+
+
+# ── Spend ──
+
+
+class TestRecordSpend:
+    @pytest.mark.asyncio
+    async def test_record_spend_normal(self, svc):
+        budget = _mock_budget(current_spend_usd=Decimal("10.00"), alert_threshold_pct=80)
+        svc._mock_repo.get_budget_by_tenant.return_value = budget
+        svc._mock_repo.increment_spend.return_value = None
+
+        await svc.record_spend("acme", 5.0)
+
+        svc._mock_repo.increment_spend.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_record_spend_no_budget(self, svc):
+        svc._mock_repo.get_budget_by_tenant.return_value = None
+
+        # Should not raise — fail-open for spend recording
+        with contextlib.suppress(ValueError):
+            await svc.record_spend("acme", 5.0)
+
+
+class TestGetSpendSummary:
+    @pytest.mark.asyncio
+    async def test_get_summary_success(self, svc):
+        budget = _mock_budget()
+        svc._mock_repo.get_budget_by_tenant.return_value = budget
+
+        result = await svc.get_spend_summary("acme")
+
+        assert result.tenant_id == "acme"
+
+    @pytest.mark.asyncio
+    async def test_get_summary_not_found_raises(self, svc):
+        svc._mock_repo.get_budget_by_tenant.return_value = None
+
+        with pytest.raises(ValueError, match=r"not found|No budget"):
+            await svc.get_spend_summary("acme")
+
+
+# ── Check Budget ──
+
+
+class TestCheckBudget:
+    @pytest.mark.asyncio
+    async def test_check_within_budget(self, svc):
+        budget = _mock_budget(is_over_budget=False)
+        svc._mock_repo.get_budget_by_tenant.return_value = budget
+
+        result = await svc.check_budget("acme")
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_check_over_budget(self, svc):
+        budget = _mock_budget(is_over_budget=True)
+        svc._mock_repo.get_budget_by_tenant.return_value = budget
+
+        result = await svc.check_budget("acme")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_check_no_budget_returns_true(self, svc):
+        """Fail-open: no budget configured = allow."""
+        svc._mock_repo.get_budget_by_tenant.return_value = None
+
+        result = await svc.check_budget("acme")
+
+        assert result is True

--- a/control-plane-api/tests/test_usage_metering.py
+++ b/control-plane-api/tests/test_usage_metering.py
@@ -1,0 +1,158 @@
+"""Tests for usage metering service (CAB-1558)."""
+
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.usage_metering import UsageMeteringService
+
+
+def _mock_summary_row(**overrides) -> MagicMock:
+    defaults = {
+        "id": uuid.uuid4(),
+        "tenant_id": "acme",
+        "api_id": uuid.uuid4(),
+        "consumer_id": None,
+        "period": "daily",
+        "period_start": datetime.utcnow(),
+        "request_count": 100,
+        "error_count": 2,
+        "total_latency_ms": 5000,
+        "p99_latency_ms": 200,
+        "total_tokens": 1500,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for k, v in defaults.items():
+        setattr(m, k, v)
+    return m
+
+
+@pytest.fixture
+def svc():
+    session = AsyncMock()
+    with patch("src.services.usage_metering.UsageMeteringRepository") as MockRepo:
+        mock_repo = AsyncMock()
+        MockRepo.return_value = mock_repo
+        service = UsageMeteringService(session)
+        service._mock_repo = mock_repo
+        yield service
+
+
+class TestGetSummary:
+    @pytest.mark.asyncio
+    async def test_returns_paginated_list(self, svc):
+        rows = [_mock_summary_row(), _mock_summary_row()]
+        svc._mock_repo.get_usage_summary.return_value = (rows, 2)
+
+        result = await svc.get_summary("acme")
+
+        assert result.total == 2
+        assert len(result.items) == 2
+        assert result.limit == 50
+        assert result.offset == 0
+
+    @pytest.mark.asyncio
+    async def test_with_api_filter(self, svc):
+        api_id = uuid.uuid4()
+        svc._mock_repo.get_usage_summary.return_value = ([], 0)
+
+        result = await svc.get_summary("acme", api_id=api_id)
+
+        assert result.total == 0
+        assert result.items == []
+
+    @pytest.mark.asyncio
+    async def test_custom_pagination(self, svc):
+        svc._mock_repo.get_usage_summary.return_value = ([], 0)
+
+        result = await svc.get_summary("acme", limit=10, offset=5)
+
+        assert result.limit == 10
+        assert result.offset == 5
+
+
+class TestGetDetails:
+    @pytest.mark.asyncio
+    async def test_returns_detail(self, svc):
+        detail = {
+            "api_id": uuid.uuid4(),
+            "tenant_id": "acme",
+            "period": "daily",
+            "period_start": datetime.utcnow(),
+            "total_requests": 200,
+            "total_errors": 5,
+            "error_rate": 2.5,
+            "avg_latency_ms": 45.0,
+            "p99_latency_ms": 180,
+            "total_tokens": 3000,
+        }
+        svc._mock_repo.get_usage_details.return_value = detail
+
+        result = await svc.get_details("acme", detail["api_id"])
+
+        assert result is not None
+        assert result.total_requests == 200
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_data(self, svc):
+        svc._mock_repo.get_usage_details.return_value = None
+
+        result = await svc.get_details("acme", uuid.uuid4())
+
+        assert result is None
+
+
+class TestRecordUsage:
+    @pytest.mark.asyncio
+    async def test_record_success(self, svc):
+        row = _mock_summary_row()
+        svc._mock_repo.upsert_usage.return_value = row
+
+        result = await svc.record_usage(
+            tenant_id="acme",
+            api_id=uuid.uuid4(),
+            period="daily",
+            period_start=datetime.utcnow(),
+            request_count=10,
+            error_count=1,
+            total_latency_ms=500,
+        )
+
+        assert result.request_count == 100  # from mock
+        svc._mock_repo.upsert_usage.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_record_with_tokens(self, svc):
+        row = _mock_summary_row(total_tokens=500)
+        svc._mock_repo.upsert_usage.return_value = row
+
+        result = await svc.record_usage(
+            tenant_id="acme",
+            api_id=uuid.uuid4(),
+            period="daily",
+            period_start=datetime.utcnow(),
+            total_tokens=500,
+        )
+
+        assert result.total_tokens == 500
+
+    @pytest.mark.asyncio
+    async def test_record_with_consumer(self, svc):
+        consumer_id = uuid.uuid4()
+        row = _mock_summary_row(consumer_id=consumer_id)
+        svc._mock_repo.upsert_usage.return_value = row
+
+        result = await svc.record_usage(
+            tenant_id="acme",
+            api_id=uuid.uuid4(),
+            period="daily",
+            period_start=datetime.utcnow(),
+            consumer_id=consumer_id,
+        )
+
+        assert result.consumer_id == consumer_id


### PR DESCRIPTION
## Summary
- Add unit tests for 4 previously uncovered modules in control-plane-api
- 57 new tests: LLM budget service (18), LLM budget router (14), contract lifecycle service (17), usage metering (8)
- Part of C13 API test coverage campaign (CAB-1558)

## Test plan
- [x] All 57 new tests pass locally (`pytest tests/test_llm_budget_service.py tests/test_llm_budget_router.py tests/test_contract_lifecycle_service.py tests/test_usage_metering.py -v`)
- [x] Ruff + Black lint clean
- [x] Full test suite passes (6255 items, only pre-existing httpx_mock fixture errors in test_uac_contract_adapter.py)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>