### PR TITLE
test(e2e): add signup flow scaffold with @wip tag (CAB-1550)

### DIFF
--- a/e2e/features/portal-signup-flow.feature
+++ b/e2e/features/portal-signup-flow.feature
@@ -1,0 +1,59 @@
+@portal @signup @wip
+Feature: Portal - Self-Service Signup Flow (CAB-1550)
+
+  As a new developer,
+  I want to sign up for STOA Platform via the portal,
+  So that I can create my first API and start building.
+
+  The signup flow is public (no auth required). It creates a trial tenant,
+  provisions resources, and redirects to login. After login, the user
+  creates their first API.
+
+  Background:
+    Given the STOA Portal is accessible
+
+  @smoke @e2e
+  Scenario: Full signup flow — register, wait for provisioning, login, create first API
+    Given I am on the signup page
+    When I fill in the signup form with:
+      | field        | value                     |
+      | name         | e2e-signup-test            |
+      | display_name | E2E Signup Test Org        |
+      | owner_email  | e2e-signup@example.com     |
+      | company      | E2E Testing Inc            |
+    And I submit the signup form
+    Then the signup is accepted with status "provisioning"
+    And I can poll the provisioning status until ready
+    When I log in with the provisioned tenant credentials
+    And I navigate to the API creation page
+    And I create an API named "My First API" with endpoint "https://api.example.com"
+    Then the API is visible in the catalog
+
+  @smoke
+  Scenario: Duplicate email is rejected
+    Given I am on the signup page
+    When I fill in the signup form with:
+      | field        | value                     |
+      | name         | e2e-duplicate-test         |
+      | display_name | E2E Duplicate Test Org     |
+      | owner_email  | e2e-signup@example.com     |
+      | company      | E2E Testing Inc            |
+    And I submit the signup form
+    Then the signup is rejected with a duplicate error
+
+  @smoke
+  Scenario: Signup form validates required fields
+    Given I am on the signup page
+    When I submit the signup form without filling required fields
+    Then I see validation errors for required fields
+
+  @smoke
+  Scenario: Signup via API — trial plan assigned by default
+    When I call the self-service signup API with:
+      | field        | value                     |
+      | name         | e2e-api-signup             |
+      | display_name | E2E API Signup Org         |
+      | owner_email  | e2e-api-signup@example.com |
+    Then the API responds with status 202
+    And the response contains a poll_url
+    And the plan is "trial"

--- a/e2e/steps/portal-signup.steps.ts
+++ b/e2e/steps/portal-signup.steps.ts
@@ -1,0 +1,210 @@
+/**
+ * Step definitions for Portal Self-Service Signup Flow (CAB-1550)
+ *
+ * Covers:
+ * - Portal signup page interactions (UI)
+ * - Self-service API calls (HTTP)
+ * - Provisioning status polling
+ * - Duplicate email error handling
+ */
+
+import { createBdd, DataTable } from 'playwright-bdd';
+import { test, expect, URLS } from '../fixtures/test-base';
+
+const { Given, When, Then } = createBdd(test);
+
+const API_URL = process.env.STOA_API_URL || 'https://api.gostoa.dev';
+
+// Track signup response across steps
+let signupResponse: {
+  tenant_id: string;
+  status: string;
+  plan: string;
+  poll_url: string;
+} | null = null;
+
+let lastApiResponse: { status: number; body: Record<string, unknown> } | null = null;
+
+// ============================================================================
+// PORTAL UI STEPS
+// ============================================================================
+
+Given('I am on the signup page', async ({ authSession }) => {
+  await authSession.page.goto(`${URLS.portal}/signup`);
+  await authSession.page.waitForLoadState('networkidle');
+  await expect(authSession.page.locator('h1, h2').first()).toBeVisible({ timeout: 10000 });
+});
+
+When('I fill in the signup form with:', async ({ authSession }, dataTable: DataTable) => {
+  const page = authSession.page;
+  const rows = dataTable.rows();
+
+  for (const [field, value] of rows) {
+    const input = page.locator(`input[name="${field}"], #${field}, [data-testid="${field}"]`);
+    await input.fill(value);
+  }
+});
+
+When('I submit the signup form', async ({ authSession }) => {
+  const page = authSession.page;
+  const submitButton = page.locator(
+    'button[type="submit"]:has-text("Sign Up"), button[type="submit"]:has-text("Create Account"), button[type="submit"]:has-text("Register")',
+  );
+  await expect(submitButton).toBeEnabled({ timeout: 5000 });
+  await submitButton.click();
+  await page.waitForLoadState('networkidle');
+});
+
+When('I submit the signup form without filling required fields', async ({ authSession }) => {
+  const page = authSession.page;
+  const submitButton = page.locator('button[type="submit"]');
+  await submitButton.click();
+});
+
+Then('the signup is accepted with status {string}', async ({ authSession }, expectedStatus: string) => {
+  const page = authSession.page;
+
+  // Check for success message or redirect
+  const successIndicator = page.locator(
+    `text=/provisioning|${expectedStatus}|success|created|check your email/i`,
+  );
+  await expect(successIndicator).toBeVisible({ timeout: 15000 });
+});
+
+Then('I can poll the provisioning status until ready', async ({ request }) => {
+  expect(signupResponse).not.toBeNull();
+
+  const maxAttempts = 30;
+  const pollInterval = 2000;
+
+  for (let i = 0; i < maxAttempts; i++) {
+    const statusResp = await request.fetch(
+      `${API_URL}/v1/self-service/tenants/${signupResponse!.tenant_id}/status`,
+    );
+    expect(statusResp.ok()).toBeTruthy();
+
+    const statusData = await statusResp.json();
+    if (statusData.provisioning_status === 'ready') {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollInterval));
+  }
+
+  throw new Error('Tenant provisioning did not complete within timeout');
+});
+
+When('I log in with the provisioned tenant credentials', async ({ authSession }) => {
+  // After provisioning, the user receives credentials (email flow).
+  // For E2E, we navigate to the portal login and authenticate.
+  const page = authSession.page;
+  await page.goto(`${URLS.portal}/`);
+  await page.waitForLoadState('networkidle');
+});
+
+When('I navigate to the API creation page', async ({ authSession }) => {
+  const page = authSession.page;
+  await page.goto(`${URLS.portal}/workspace`);
+  await page.waitForLoadState('networkidle');
+});
+
+When(
+  'I create an API named {string} with endpoint {string}',
+  async ({ authSession }, apiName: string, endpoint: string) => {
+    const page = authSession.page;
+
+    // Click the create API button
+    const createButton = page.locator(
+      'button:has-text("Create API"), button:has-text("New API"), a:has-text("Create API")',
+    );
+    await createButton.first().click();
+    await page.waitForLoadState('networkidle');
+
+    // Fill in the API creation form
+    const nameInput = page.locator('input[name="name"], #name, [data-testid="api-name"]');
+    await nameInput.fill(apiName);
+
+    const endpointInput = page.locator(
+      'input[name="endpoint"], #endpoint, [data-testid="api-endpoint"]',
+    );
+    await endpointInput.fill(endpoint);
+
+    // Submit the form
+    const submitButton = page.locator('button[type="submit"]');
+    await submitButton.click();
+    await page.waitForLoadState('networkidle');
+  },
+);
+
+Then('the API is visible in the catalog', async ({ authSession }) => {
+  const page = authSession.page;
+
+  // Navigate to catalog and verify API exists
+  await page.goto(`${URLS.portal}/servers`);
+  await page.waitForLoadState('networkidle');
+
+  const apiEntry = page.locator('text=/My First API/i');
+  await expect(apiEntry).toBeVisible({ timeout: 10000 });
+});
+
+Then('the signup is rejected with a duplicate error', async ({ authSession }) => {
+  const page = authSession.page;
+
+  const errorMessage = page.locator(
+    'text=/already exists|duplicate|already registered|email.*taken|already in use/i',
+  );
+  await expect(errorMessage).toBeVisible({ timeout: 10000 });
+});
+
+Then('I see validation errors for required fields', async ({ authSession }) => {
+  const page = authSession.page;
+
+  // Check for HTML5 validation or custom error messages
+  const validationErrors = page.locator(
+    '[class*="error"], [aria-invalid="true"], .field-error, [data-testid*="error"]',
+  );
+  const count = await validationErrors.count();
+  expect(count).toBeGreaterThan(0);
+});
+
+// ============================================================================
+// API-ONLY STEPS (no browser needed)
+// ============================================================================
+
+When('I call the self-service signup API with:', async ({ request }, dataTable: DataTable) => {
+  const rows = dataTable.rows();
+  const payload: Record<string, string> = {};
+
+  for (const [field, value] of rows) {
+    payload[field] = value;
+  }
+
+  const response = await request.fetch(`${API_URL}/v1/self-service/tenants`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    data: JSON.stringify(payload),
+  });
+
+  const body = await response.json().catch(() => ({}));
+  lastApiResponse = { status: response.status(), body };
+
+  if (response.status() === 202) {
+    signupResponse = body as typeof signupResponse;
+  }
+});
+
+Then('the API responds with status {int}', async ({}, expectedStatus: number) => {
+  expect(lastApiResponse).not.toBeNull();
+  expect(lastApiResponse!.status).toBe(expectedStatus);
+});
+
+Then('the response contains a poll_url', async ({}) => {
+  expect(lastApiResponse).not.toBeNull();
+  expect(lastApiResponse!.body).toHaveProperty('poll_url');
+  expect(lastApiResponse!.body.poll_url).toBeTruthy();
+});
+
+Then('the plan is {string}', async ({}, expectedPlan: string) => {
+  expect(lastApiResponse).not.toBeNull();
+  expect(lastApiResponse!.body).toHaveProperty('plan', expectedPlan);
+});


### PR DESCRIPTION
## Summary
- Adds Gherkin feature file for self-service signup E2E flow
- Step definitions cover: form fill, submit, provisioning poll, duplicate email, validation, API-only signup
- All scenarios tagged `@wip` — will activate when portal signup page (CAB-1548) and API endpoint (CAB-1547) are deployed

## Test plan
- [x] `bddgen` compiles without errors
- [x] `tsc --noEmit` passes (no new TS errors)
- [x] Scenarios correctly generate `.spec.js` when `@wip` filter removed
- [ ] CI green (security-scan required checks)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>