### PR TITLE
fix(gateway): prevent retry storm on tool discovery failure (CAB-1558)

### DIFF
--- a/stoa-gateway/src/mcp/tools/stoa_tools.rs
+++ b/stoa-gateway/src/mcp/tools/stoa_tools.rs
@@ -301,7 +301,23 @@ pub async fn refresh_tools_for_tenant(
     cb: Arc<CircuitBreaker>,
     tenant_id: &str,
 ) -> Result<usize, String> {
-    let defs = discover_with_resilience(cp, &cb).await?;
+    // CAB-1558: Always mark tenant as loaded, even on discovery failure.
+    // Without this, a failed refresh leaves the tenant "never loaded" —
+    // every subsequent request retriggers a synchronous HTTP call to the
+    // control plane, creating a retry storm that tanks p95 latency.
+    // The TTL-based refresh (default 300s) will reattempt later.
+    let defs = match discover_with_resilience(cp, &cb).await {
+        Ok(d) => d,
+        Err(e) => {
+            registry.mark_loaded(tenant_id);
+            tracing::warn!(
+                tenant_id = %tenant_id,
+                error = %e,
+                "Tool discovery failed — marked loaded to prevent retry storm (CAB-1558)"
+            );
+            return Err(e);
+        }
+    };
     let mut new_count = 0;
     for def in &defs {
         if !has_native_implementation(&def.name) && registry.get(&def.name).is_none() {


### PR DESCRIPTION
## Summary
- Fix `refresh_tools_for_tenant` to call `mark_loaded()` even when `discover_with_resilience` fails
- Prevents retry storm: without this fix, a failed discovery left the tenant in a "never loaded" state, causing every subsequent tool-not-found request to retrigger a synchronous HTTP call to the control plane
- Under arena benchmarks (resilience: 3 VUs × 15 iterations), this retry storm pushed p95 above the 1s latency cap, scoring resilience dimension at 60/100

## Root Cause
The `?` operator on `discover_with_resilience().await?` returned early without calling `mark_loaded()`. The `is_stale()` check in the tool-not-found handler always returned `true` for "never loaded" tenants, triggering blocking synchronous refresh on every request.

## Fix
Replace `?` with `match` — on error, call `registry.mark_loaded(tenant_id)` before returning `Err`. The TTL-based refresh (default 300s) will reattempt discovery later.

## Impact
- **Resilience dimension**: 60 → 80+ (eliminating retry storm keeps p95 under 1s cap)
- **Auth chain, guardrails, toolcall**: may also improve since they share the same sync refresh path
- **Target**: L1 enterprise score from 78.00 → 80%+

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 22 tests pass, 13 stoa_tools tests pass
- [ ] Deploy to K8s and run arena diagnostic job to verify score improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>