### PR TITLE
feat(portal): add execution taxonomy filters + 4-persona tests (CAB-1554)

### DIFF
--- a/portal/src/pages/executions/ExecutionHistory.test.tsx
+++ b/portal/src/pages/executions/ExecutionHistory.test.tsx
@@ -1,25 +1,19 @@
 /**
- * ExecutionHistory Tests (CAB-1318)
+ * ExecutionHistory Tests (CAB-1318, CAB-1554)
  *
- * Covers: render, stats, table, filter, empty, loading, error breakdown.
+ * Covers: render, stats, taxonomy, table, filters (status, error type,
+ * API name, date range), clear, empty, loading — across 4 personas.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { ExecutionHistoryPage } from './ExecutionHistory';
+import { createAuthMock, renderWithProviders, type PersonaRole } from '../../test/helpers';
 
-// Mock auth
+// Mock auth — vi.hoisted ensures mock fn exists before vi.mock runs
+const mockAuth = vi.hoisted(() => vi.fn());
 vi.mock('../../contexts/AuthContext', () => ({
-  useAuth: () => ({
-    isAuthenticated: true,
-    accessToken: 'test-token',
-    user: { name: 'Dev', email: 'dev@test.com', roles: ['viewer'] },
-    hasPermission: () => true,
-    hasScope: () => true,
-    hasRole: () => true,
-  }),
+  useAuth: () => mockAuth(),
 }));
 
 // Mock services
@@ -33,18 +27,7 @@ vi.mock('../../services/executions', () => ({
   },
 }));
 
-function renderPage() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
-        <ExecutionHistoryPage />
-      </MemoryRouter>
-    </QueryClientProvider>
-  );
-}
+// ============ Mock Data ============
 
 const mockExecutionsData = {
   items: [
@@ -78,75 +61,139 @@ const mockExecutionsData = {
       completed_at: '2026-02-19T14:01:00Z',
       duration_ms: 12,
     },
+    {
+      id: 'exec-3',
+      api_name: 'Payments API',
+      tool_name: null,
+      request_id: 'req-3',
+      method: 'POST',
+      path: '/v1/payments',
+      status_code: 502,
+      status: 'error',
+      error_category: 'upstream',
+      error_message: 'Bad gateway',
+      started_at: '2026-02-19T14:02:00Z',
+      completed_at: '2026-02-19T14:02:00Z',
+      duration_ms: 1200,
+    },
+    {
+      id: 'exec-4',
+      api_name: 'Auth API',
+      tool_name: null,
+      request_id: 'req-4',
+      method: 'GET',
+      path: '/v1/auth/verify',
+      status_code: 500,
+      status: 'error',
+      error_category: 'internal',
+      error_message: 'Internal error',
+      started_at: '2026-02-19T14:03:00Z',
+      completed_at: '2026-02-19T14:03:00Z',
+      duration_ms: 80,
+    },
   ],
-  total: 2,
+  total: 4,
   page: 1,
   page_size: 20,
 };
 
 const mockTaxonomyData = {
   items: [
-    { category: 'auth', count: 4, avg_duration_ms: 10.0, percentage: 33.3 },
-    {
-      category: 'rate_limit',
-      count: 5,
-      avg_duration_ms: 8.0,
-      percentage: 41.7,
-    },
-    { category: 'backend', count: 3, avg_duration_ms: 120.0, percentage: 25.0 },
+    { category: 'auth', count: 4, avg_duration_ms: 10.0, percentage: 20.0 },
+    { category: 'rate_limit', count: 5, avg_duration_ms: 8.0, percentage: 25.0 },
+    { category: 'upstream', count: 3, avg_duration_ms: 120.0, percentage: 15.0 },
+    { category: 'validation', count: 2, avg_duration_ms: 5.0, percentage: 10.0 },
+    { category: 'internal', count: 4, avg_duration_ms: 90.0, percentage: 20.0 },
+    { category: 'timeout', count: 2, avg_duration_ms: 3000.0, percentage: 10.0 },
   ],
-  total_errors: 12,
-  total_executions: 234,
-  error_rate: 5.1,
+  total_errors: 20,
+  total_executions: 487,
+  error_rate: 4.1,
 };
 
-describe('ExecutionHistoryPage', () => {
+// ============ 4-Persona Tests ============
+
+describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
+  'ExecutionHistoryPage — %s persona',
+  (role) => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockAuth.mockReturnValue(createAuthMock(role));
+      mockList.mockResolvedValue(mockExecutionsData);
+      mockGetTaxonomy.mockResolvedValue(mockTaxonomyData);
+    });
+
+    it('renders page title and subtitle', async () => {
+      renderWithProviders(<ExecutionHistoryPage />);
+      expect(screen.getByText('My Execution History')).toBeInTheDocument();
+      expect(screen.getByText('View your API call history and error patterns')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('487')).toBeInTheDocument();
+      });
+    });
+
+    it('shows stats cards with taxonomy data', async () => {
+      renderWithProviders(<ExecutionHistoryPage />);
+      await waitFor(() => {
+        expect(screen.getByText('487')).toBeInTheDocument();
+        expect(screen.getByText('20')).toBeInTheDocument();
+      });
+    });
+
+    it('shows all 6 error taxonomy categories', async () => {
+      renderWithProviders(<ExecutionHistoryPage />);
+      await waitFor(() => {
+        expect(screen.getByText('Auth: 4')).toBeInTheDocument();
+        expect(screen.getAllByText(/Rate Limit/).length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText('Upstream: 3')).toBeInTheDocument();
+        expect(screen.getByText('Validation: 2')).toBeInTheDocument();
+        expect(screen.getByText('Internal: 4')).toBeInTheDocument();
+        expect(screen.getByText('Timeout: 2')).toBeInTheDocument();
+      });
+    });
+
+    it('renders execution table with API names', async () => {
+      renderWithProviders(<ExecutionHistoryPage />);
+      await waitFor(() => {
+        expect(screen.getByText('Users API')).toBeInTheDocument();
+        expect(screen.getByText('Orders API')).toBeInTheDocument();
+        expect(screen.getByText('Payments API')).toBeInTheDocument();
+        expect(screen.getByText('Auth API')).toBeInTheDocument();
+      });
+    });
+
+    it('maps error categories in table rows', async () => {
+      renderWithProviders(<ExecutionHistoryPage />);
+      await waitFor(() => {
+        expect(screen.getByText('Rate Limit')).toBeInTheDocument();
+        expect(screen.getByText('Upstream')).toBeInTheDocument();
+        expect(screen.getByText('Internal')).toBeInTheDocument();
+      });
+    });
+  }
+);
+
+// ============ Filter Tests ============
+
+describe('ExecutionHistoryPage — filters', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAuth.mockReturnValue(createAuthMock('viewer'));
     mockList.mockResolvedValue(mockExecutionsData);
     mockGetTaxonomy.mockResolvedValue(mockTaxonomyData);
   });
 
-  it('renders page title', async () => {
-    renderPage();
-    expect(screen.getByText('My Execution History')).toBeInTheDocument();
-    await waitFor(() => {
-      expect(screen.getByText('234')).toBeInTheDocument();
-    });
-  });
-
-  it('shows stats cards', async () => {
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByText('234')).toBeInTheDocument();
-      expect(screen.getByText('12')).toBeInTheDocument();
-    });
-  });
-
-  it('shows error breakdown tags', async () => {
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByText('Auth: 4')).toBeInTheDocument();
-      // Rate Limit appears in breakdown AND possibly table
-      expect(screen.getAllByText(/Rate Limit/).length).toBeGreaterThanOrEqual(1);
-    });
-  });
-
-  it('renders execution table', async () => {
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByText('Users API')).toBeInTheDocument();
-      expect(screen.getByText('Orders API')).toBeInTheDocument();
-    });
-  });
-
-  it('shows status filter', () => {
-    renderPage();
+  it('shows all filter controls', async () => {
+    renderWithProviders(<ExecutionHistoryPage />);
     expect(screen.getByLabelText('Filter by status')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filter by error type')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filter by API name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Date from')).toBeInTheDocument();
+    expect(screen.getByLabelText('Date to')).toBeInTheDocument();
   });
 
   it('applies status filter', async () => {
-    renderPage();
+    renderWithProviders(<ExecutionHistoryPage />);
     await waitFor(() => {
       expect(screen.getByText('Users API')).toBeInTheDocument();
     });
@@ -160,6 +207,118 @@ describe('ExecutionHistoryPage', () => {
     });
   });
 
+  it('applies error category filter', async () => {
+    renderWithProviders(<ExecutionHistoryPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Users API')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Filter by error type'), {
+      target: { value: 'auth' },
+    });
+
+    await waitFor(() => {
+      expect(mockList).toHaveBeenCalledWith(expect.objectContaining({ error_category: 'auth' }));
+    });
+  });
+
+  it('applies API name filter', async () => {
+    renderWithProviders(<ExecutionHistoryPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Users API')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Filter by API name'), {
+      target: { value: 'Orders' },
+    });
+
+    await waitFor(() => {
+      expect(mockList).toHaveBeenCalledWith(expect.objectContaining({ api_name: 'Orders' }));
+    });
+  });
+
+  it('applies date range filter', async () => {
+    renderWithProviders(<ExecutionHistoryPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Users API')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Date from'), {
+      target: { value: '2026-02-01' },
+    });
+    fireEvent.change(screen.getByLabelText('Date to'), {
+      target: { value: '2026-02-28' },
+    });
+
+    await waitFor(() => {
+      expect(mockList).toHaveBeenCalledWith(
+        expect.objectContaining({ date_from: '2026-02-01', date_to: '2026-02-28' })
+      );
+    });
+  });
+
+  it('shows clear filters button when filters active', async () => {
+    renderWithProviders(<ExecutionHistoryPage />);
+    expect(screen.queryByText('Clear filters')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Filter by status'), {
+      target: { value: 'error' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Clear filters')).toBeInTheDocument();
+    });
+  });
+
+  it('resets all filters on clear', async () => {
+    renderWithProviders(<ExecutionHistoryPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Users API')).toBeInTheDocument();
+    });
+
+    // Set multiple filters
+    fireEvent.change(screen.getByLabelText('Filter by status'), {
+      target: { value: 'error' },
+    });
+    fireEvent.change(screen.getByLabelText('Filter by error type'), {
+      target: { value: 'auth' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Clear filters')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Clear filters'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Clear filters')).not.toBeInTheDocument();
+    });
+    expect((screen.getByLabelText('Filter by status') as HTMLSelectElement).value).toBe('');
+    expect((screen.getByLabelText('Filter by error type') as HTMLSelectElement).value).toBe('');
+  });
+
+  it('error type dropdown has all taxonomy categories', () => {
+    renderWithProviders(<ExecutionHistoryPage />);
+    const select = screen.getByLabelText('Filter by error type') as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.value);
+    expect(options).toContain('');
+    expect(options).toContain('auth');
+    expect(options).toContain('rate_limit');
+    expect(options).toContain('upstream');
+    expect(options).toContain('validation');
+    expect(options).toContain('internal');
+    expect(options).toContain('timeout');
+  });
+});
+
+// ============ Edge Cases ============
+
+describe('ExecutionHistoryPage — edge cases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockReturnValue(createAuthMock('viewer'));
+  });
+
   it('shows empty state', async () => {
     mockList.mockResolvedValue({ items: [], total: 0, page: 1, page_size: 20 });
     mockGetTaxonomy.mockResolvedValue({
@@ -169,7 +328,7 @@ describe('ExecutionHistoryPage', () => {
       error_rate: 0,
     });
 
-    renderPage();
+    renderWithProviders(<ExecutionHistoryPage />);
     await waitFor(() => {
       expect(screen.getByText('No executions found')).toBeInTheDocument();
     });
@@ -179,7 +338,55 @@ describe('ExecutionHistoryPage', () => {
     mockList.mockImplementation(() => new Promise(() => {}));
     mockGetTaxonomy.mockImplementation(() => new Promise(() => {}));
 
-    renderPage();
+    renderWithProviders(<ExecutionHistoryPage />);
     expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('handles unknown error category gracefully', async () => {
+    mockList.mockResolvedValue({
+      items: [
+        {
+          id: 'exec-unk',
+          api_name: 'Mystery API',
+          tool_name: null,
+          request_id: 'req-unk',
+          method: 'GET',
+          path: '/v1/mystery',
+          status_code: 500,
+          status: 'error',
+          error_category: 'unknown_category',
+          error_message: 'Unknown',
+          started_at: '2026-02-19T14:00:00Z',
+          completed_at: '2026-02-19T14:00:00Z',
+          duration_ms: 50,
+        },
+      ],
+      total: 1,
+      page: 1,
+      page_size: 20,
+    });
+    mockGetTaxonomy.mockResolvedValue(mockTaxonomyData);
+
+    renderWithProviders(<ExecutionHistoryPage />);
+    await waitFor(() => {
+      // Falls back to raw category string when no label match
+      expect(screen.getByText('unknown_category')).toBeInTheDocument();
+    });
+  });
+
+  it('renders all 6 category labels in filter dropdown', () => {
+    mockList.mockResolvedValue(mockExecutionsData);
+    mockGetTaxonomy.mockResolvedValue(mockTaxonomyData);
+    renderWithProviders(<ExecutionHistoryPage />);
+    const select = screen.getByLabelText('Filter by error type') as HTMLSelectElement;
+    const optionLabels = Array.from(select.options).map((o) => o.text);
+    expect(optionLabels).toContain('Auth');
+    expect(optionLabels).toContain('Rate Limit');
+    expect(optionLabels).toContain('Upstream');
+    expect(optionLabels).toContain('Validation');
+    expect(optionLabels).toContain('Internal');
+    expect(optionLabels).toContain('Timeout');
+    // 6 categories + 1 "All Error Types" placeholder
+    expect(select.options).toHaveLength(7);
   });
 });

--- a/portal/src/pages/executions/ExecutionHistory.tsx
+++ b/portal/src/pages/executions/ExecutionHistory.tsx
@@ -1,7 +1,7 @@
 /**
- * Execution History Page — Portal read-only consumer view (CAB-1318)
+ * Execution History Page — Portal read-only consumer view (CAB-1318, CAB-1554)
  *
- * Shows execution logs, error breakdown, and status filtering.
+ * Shows execution logs, error breakdown, and multi-filter controls.
  */
 
 import { useState } from 'react';
@@ -16,23 +16,42 @@ const STATUS_COLORS: Record<string, string> = {
 const CATEGORY_LABELS: Record<string, string> = {
   auth: 'Auth',
   rate_limit: 'Rate Limit',
-  backend: 'Backend',
-  timeout: 'Timeout',
+  upstream: 'Upstream',
   validation: 'Validation',
+  internal: 'Internal',
+  timeout: 'Timeout',
 };
 
 export function ExecutionHistoryPage() {
   const [page, setPage] = useState(1);
   const [statusFilter, setStatusFilter] = useState<string>('');
+  const [categoryFilter, setCategoryFilter] = useState<string>('');
+  const [apiNameFilter, setApiNameFilter] = useState<string>('');
+  const [dateFrom, setDateFrom] = useState<string>('');
+  const [dateTo, setDateTo] = useState<string>('');
 
   const { data: executions, isLoading } = useExecutions({
     page,
     page_size: 20,
     status: statusFilter || undefined,
+    error_category: categoryFilter || undefined,
+    api_name: apiNameFilter || undefined,
+    date_from: dateFrom || undefined,
+    date_to: dateTo || undefined,
   });
   const { data: taxonomy } = useExecutionTaxonomy();
 
   const totalPages = executions ? Math.ceil(executions.total / executions.page_size) : 0;
+  const hasActiveFilters = statusFilter || categoryFilter || apiNameFilter || dateFrom || dateTo;
+
+  function clearFilters() {
+    setStatusFilter('');
+    setCategoryFilter('');
+    setApiNameFilter('');
+    setDateFrom('');
+    setDateTo('');
+    setPage(1);
+  }
 
   return (
     <div className="space-y-6">
@@ -72,8 +91,8 @@ export function ExecutionHistoryPage() {
         </div>
       </div>
 
-      {/* Filter */}
-      <div className="flex gap-4">
+      {/* Filters */}
+      <div className="flex flex-wrap gap-4 items-end">
         <select
           value={statusFilter}
           onChange={(e) => {
@@ -88,6 +107,66 @@ export function ExecutionHistoryPage() {
           <option value="error">Error</option>
           <option value="timeout">Timeout</option>
         </select>
+
+        <select
+          value={categoryFilter}
+          onChange={(e) => {
+            setCategoryFilter(e.target.value);
+            setPage(1);
+          }}
+          className="rounded-md border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-sm px-3 py-2 text-neutral-900 dark:text-white"
+          aria-label="Filter by error type"
+        >
+          <option value="">All Error Types</option>
+          {Object.entries(CATEGORY_LABELS).map(([key, label]) => (
+            <option key={key} value={key}>
+              {label}
+            </option>
+          ))}
+        </select>
+
+        <input
+          type="text"
+          value={apiNameFilter}
+          onChange={(e) => {
+            setApiNameFilter(e.target.value);
+            setPage(1);
+          }}
+          placeholder="API name..."
+          className="rounded-md border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-sm px-3 py-2 text-neutral-900 dark:text-white"
+          aria-label="Filter by API name"
+        />
+
+        <input
+          type="date"
+          value={dateFrom}
+          onChange={(e) => {
+            setDateFrom(e.target.value);
+            setPage(1);
+          }}
+          className="rounded-md border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-sm px-3 py-2 text-neutral-900 dark:text-white"
+          aria-label="Date from"
+        />
+
+        <input
+          type="date"
+          value={dateTo}
+          onChange={(e) => {
+            setDateTo(e.target.value);
+            setPage(1);
+          }}
+          className="rounded-md border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-sm px-3 py-2 text-neutral-900 dark:text-white"
+          aria-label="Date to"
+        />
+
+        {hasActiveFilters && (
+          <button
+            onClick={clearFilters}
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            Clear filters
+          </button>
+        )}
       </div>
 
       {/* Executions Table */}

--- a/portal/src/services/executions.ts
+++ b/portal/src/services/executions.ts
@@ -47,6 +47,10 @@ export interface TaxonomyResponse {
 
 export interface ExecutionParams {
   status?: string;
+  error_category?: string;
+  api_name?: string;
+  date_from?: string;
+  date_to?: string;
   page?: number;
   page_size?: number;
 }
@@ -64,6 +68,10 @@ export const executionsService = {
         page: params?.page || 1,
         page_size: params?.page_size || 20,
         status: params?.status,
+        error_category: params?.error_category,
+        api_name: params?.api_name,
+        date_from: params?.date_from,
+        date_to: params?.date_to,
       },
     });
     return response.data;


### PR DESCRIPTION
## Summary
- Add multi-filter controls (status, error type, API name, date range) to Execution History page
- Update error taxonomy to 6 categories: auth, rate_limit, upstream, validation, internal, timeout
- Add clear filters button that appears when any filter is active
- 32 tests across 4 personas (cpi-admin, tenant-admin, devops, viewer)

## Test plan
- [x] 32/32 vitest tests pass (4-persona × 5 + 8 filter + 4 edge cases)
- [x] ESLint 0 warnings
- [x] Prettier clean
- [x] TypeScript clean
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>