### PR TITLE
chore(ci): enforce MEGA Close Gate at all pipeline exit points (CAB-1575)

### DIFF
--- a/.claude/rules/instance-dispatch.md
+++ b/.claude/rules/instance-dispatch.md
@@ -158,12 +158,15 @@ The orchestrator is a **dispatcher**, not an implementer. These rules prevent co
 - Verify post-merge CD status
 - Update state files (memory.md, plan.md)
 - Run `/sync-plan`, `/fill-cycle`, `/council`
+- Run `/verify-mega` before closing any MEGA ticket
+- Weekly Monday: run `/verify-mega --all-done-7d` to audit recent Done MEGAs
 
 #### What ORCHESTRE NEVER does
 - Create feature branches
 - Write or edit code files (src/, tests/, etc.)
 - Run test suites (pytest, vitest, cargo test)
 - Create PRs
+- Mark a MEGA Done without running `/verify-mega` first
 - Stay on the same conversation for more than ~20 turns
 
 #### Context Management
@@ -174,14 +177,16 @@ The orchestrator is a **dispatcher**, not an implementer. These rules prevent co
 
 #### Dispatch Cycle Pattern
 ```
+0. Before dispatching MEGA sub-tickets: verify parent is decomposed (Gate 0 — children exist)
 1. Read session-brief.json (or memory.md + plan.md)
 2. Check instance states: heg-state remote-ls
 3. Dispatch 1-3 tickets to available instances
 4. /clear
 5. (new turn) Check progress, verify completed PRs
-6. Update state files if needed
-7. /clear
-8. Repeat
+6. For completed MEGA sub-tickets: check if all siblings Done → run /verify-mega on parent
+7. Update state files if needed
+8. /clear
+9. Repeat
 ```
 
 ### tmux Gotchas

--- a/.claude/rules/mega-verification.md
+++ b/.claude/rules/mega-verification.md
@@ -1,0 +1,83 @@
+---
+description: MEGA ticket close gate enforcement — prevents false Dones on multi-phase tickets
+globs:
+  - ".claude/rules/workflow-essentials.md"
+  - ".claude/rules/instance-dispatch.md"
+  - ".claude/rules/session-startup.md"
+  - ".github/workflows/linear-close-on-merge.yml"
+  - ".github/workflows/claude-linear-dispatch.yml"
+---
+
+# MEGA Verification — Close Gate Enforcement
+
+## Overview
+
+MEGA tickets (>= 13 pts, multi-phase) MUST pass all 5 gates before being marked Done.
+This rule is enforced at every pipeline exit point: manual sessions, `linear-close-on-merge.yml`, and `claude-linear-dispatch.yml`.
+
+## 5 Gates
+
+| # | Gate | Verification | Fail Action |
+|---|------|-------------|-------------|
+| 0 | **Decomposition Invariant** | `linear.get_issue(id)` → `children.nodes.length > 0` | BLOCK dispatch, run `/decompose` first |
+| 1 | **Per-Phase PR Evidence** | Every Done sub-ticket has a Linear comment containing `PR #` | List missing PRs, keep parent In Progress |
+| 2 | **All Sub-Tickets Done** | ALL `children.nodes` have `state.name == "Done"` | List incomplete children, keep parent In Progress |
+| 3 | **Live Verification** | Target endpoint/site confirmed working (curl, build, or screenshot) | Prompt for manual verification |
+| 4 | **Sub-tickets closed on Linear** | No child in "In Progress", "Todo", or "Blocked" state | List stale children |
+
+## Detection: Is This a MEGA?
+
+A ticket is a MEGA if ANY of these are true:
+- Title contains `[MEGA]`
+- Has child issues on Linear (`children.nodes.length > 0`)
+- Estimate >= 13 points
+
+## Enforcement Points
+
+### 1. Manual Sessions (session-startup.md Step 5)
+
+When closing a ticket in Step 5 — Linear MCP sync:
+- **Standalone ticket** (no parent, no children): mark Done as before
+- **Sub-ticket of MEGA** (has parent): mark sub-ticket Done, then check siblings. If ALL siblings Done → run `/verify-mega` on parent
+- **MEGA parent** (has children): NEVER mark Done directly — always use `/verify-mega`
+
+### 2. linear-close-on-merge.yml (CI)
+
+After extracting `TICKET_ID`, check if ticket is a MEGA (has children).
+- **MEGA**: skip Done mutation, post comment: "Sub-ticket work merged in PR #N. Parent MEGA stays In Progress."
+- **Standalone**: proceed with existing Done mutation
+
+### 3. claude-linear-dispatch.yml (L3 Pipeline)
+
+In the close-loop step, before the Done mutation:
+- Check if `TICKET_ID` is a MEGA (query Linear for children)
+- If MEGA → skip Done mutation, post progress comment
+- If standalone → existing close logic
+
+## Weekly Audit
+
+ORCHESTRE runs `/verify-mega --all-done-7d` every Monday:
+1. Query Linear for all MEGAs marked Done in the last 7 days
+2. Run all 5 gates on each
+3. Report: list of MEGAs with gate failures
+4. Reopen any MEGA that fails gates (move back to In Progress)
+
+## Anti-Patterns
+
+| Pattern | Why It's Wrong | Correct |
+|---------|---------------|---------|
+| Marking MEGA Done when 1 PR merges | Only one phase completed | Keep In Progress until all children Done |
+| Closing MEGA without `/verify-mega` | Skips gate checks | Always use `/verify-mega` |
+| Auto-closing MEGA in CI workflow | CI sees merged PR, closes parent | CI must detect MEGA and skip |
+| Marking MEGA Done with blocked children | Incomplete scope | Unblock or descope children first |
+
+## Integration
+
+| File | Reference |
+|------|-----------|
+| `workflow-essentials.md` | MEGA Close Gate table (gates 1-4) + Invariant #6 |
+| `session-startup.md` | Step 5 — differentiate standalone vs sub-ticket vs MEGA |
+| `instance-dispatch.md` | ORCHESTRE Rules — `/verify-mega` before closing MEGAs |
+| `linear-close-on-merge.yml` | MEGA bypass in Done mutation |
+| `claude-linear-dispatch.yml` | MEGA bypass in close-loop |
+| `/verify-mega` skill | Automated gate runner |

--- a/.claude/rules/session-startup.md
+++ b/.claude/rules/session-startup.md
@@ -130,7 +130,14 @@ After merging a PR for a phase, check if the same MEGA has another unclaimed unb
    - If any check fails → fix it NOW, before proceeding to step 4
    See `ai-workflow.md` → "Session-End State Lint" for full protocol.
 4. **Linear MCP sync** (if task has CAB-XXXX ID):
-   - PR merged → `linear.update_issue(status="Done")` + `linear.create_comment` with PR link
+   - **Standalone ticket** (no parent, no children):
+     PR merged → `linear.update_issue(status="Done")` + `linear.create_comment` with PR link
+   - **Sub-ticket of MEGA** (has parent):
+     PR merged → mark sub-ticket Done, then check ALL sibling sub-tickets via `linear.get_issue(parentId)`.
+     If ALL siblings Done → run `/verify-mega` on parent. If all 5 gates pass → mark parent Done.
+     If not all siblings Done → post comment on parent: "Sub-ticket CAB-XXXX completed (PR #N). X/Y siblings remaining."
+   - **MEGA parent** (has children):
+     NEVER mark Done directly from session-end — always use `/verify-mega CAB-XXXX`
    - Blocked → `linear.update_issue(status="Blocked")` + comment with reason
    - Paused → leave as "In Progress" (no change needed)
 5. **Metrics** — if a PR was merged or CI was fixed this session:

--- a/.claude/rules/workflow-essentials.md
+++ b/.claude/rules/workflow-essentials.md
@@ -77,18 +77,23 @@ description: Core behavioral rules — Ship/Show/Ask, DoD, State Machine, Operat
 3. **CI noise = P0** — Red `main` blocks ALL new work. Fix CI before starting any feature. `/ci-fix` has priority over backlog.
 4. **Multi-env gate** — DoD requires 3 proofs: local tests pass, CI pipeline green, staging/prod pod healthy.
 
-### MEGA Close Gate (titles containing `[MEGA]`)
+### MEGA Close Gate (titles containing `[MEGA]` or has children)
 
 A MEGA ticket CANNOT be marked Done unless ALL of these are true:
 
 | # | Gate | Verification |
 |---|------|-------------|
-| 1 | Every P0 item has a merged PR | `gh pr list --search "CAB-XXXX" --state merged` returns >= 1 PR per P0 item |
-| 2 | Linear comment maps items → PRs | Completion comment lists each P0 deliverable + its PR number |
+| 0 | MEGA is decomposed | `linear.get_issue(id)` → `children.nodes.length > 0` |
+| 1 | Every sub-ticket has a merged PR | Each Done child has a Linear comment containing `PR #` |
+| 2 | Linear comment maps items → PRs | Completion comment lists each deliverable + its PR number |
 | 3 | Live verification | Target site/endpoint confirmed working (curl, build, or screenshot) |
-| 4 | Sub-tickets closed | All child issues on Linear are Done (not just the parent) |
+| 4 | All sub-tickets closed | ALL child issues on Linear are Done (not just the parent) |
+
+**Enforcement**: MEGA Done is blocked at 3 points: manual sessions (Step 5), `linear-close-on-merge.yml`, `claude-linear-dispatch.yml`. See `mega-verification.md` for full protocol.
 
 **If any gate fails**: ticket stays In Progress. Log: `MEGA-GATE-FAIL | task=<ID> missing=<gate_numbers>`
+
+**Use `/verify-mega CAB-XXXX`** to run all gates programmatically before closing.
 
 ## Item State Machine (MANDATORY)
 
@@ -108,13 +113,14 @@ PENDING ──→ CLAIMED ──→ IN_PROGRESS ──→ DONE ──→ ARCHIVE
 | DONE | `[x]` | `— DONE` suffix or all sub-items ✅ | `✅ DONE` |
 | BLOCKED | `[!]` | `— BLOCKED` suffix + reason | `🚫 BLOCKED` |
 
-### Structural Invariants (5 non-negotiable rules)
+### Structural Invariants (6 non-negotiable rules)
 
 1. **No DONE in active sections** — completed items MUST be in `✅ DONE` section
 2. **Checkbox ↔ section parity** — `[x]` = `✅ DONE`, `[~]` = `🔴 IN PROGRESS`, `[ ]` = `📋 NEXT`
 3. **Single home rule** — item appears in exactly ONE section of memory.md
 4. **Partial completion** — parent stays `[~]` until ALL sub-items complete
 5. **Strikethrough = moved** — remove `~~item~~` within 1 session
+6. **MEGA parent stays IN_PROGRESS** until all 5 gates pass — never mark Done directly, always use `/verify-mega`
 
 ### Atomic State Transitions
 
@@ -137,7 +143,7 @@ PENDING ──→ CLAIMED ──→ IN_PROGRESS ──→ DONE ──→ ARCHIVE
 | 2 | No DONE in NEXT | `📋 NEXT` section | Zero items with `**DONE**`, `— DONE`, or `~~strikethrough~~` |
 | 3 | Stale `[~]` check | plan.md | Every `[~]` has at least one `[ ]` sub-item remaining |
 | 4 | Cross-file parity | plan.md vs memory.md | `[x]` → `✅ DONE`, `[~]` → `🔴 IN PROGRESS` |
-| 5 | MEGA close gate | Linear MEGAs marked Done this session | All 4 MEGA gates pass (see above) |
+| 5 | MEGA close gate | Linear MEGAs marked Done this session | All 5 MEGA gates pass — run `/verify-mega` (see `mega-verification.md`) |
 
 ## Operation Logging
 

--- a/.claude/skills/verify-mega/SKILL.md
+++ b/.claude/skills/verify-mega/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: verify-mega
+description: Verify MEGA ticket close gates — ensures all sub-tickets Done, PRs merged, live verification passed.
+argument-hint: "CAB-XXXX | --all-done-7d"
+---
+
+# Verify MEGA — $ARGUMENTS
+
+## Overview
+
+Run all 5 MEGA Close Gates on a ticket (or audit all recently-closed MEGAs).
+Prevents false Dones on multi-phase tickets.
+
+## Mode Detection
+
+- If `$ARGUMENTS` is `--all-done-7d`: **Audit mode** — scan all MEGAs marked Done in last 7 days
+- If `$ARGUMENTS` is `CAB-XXXX`: **Single mode** — verify one MEGA ticket
+
+## Step 1: Fetch MEGA Data
+
+### Single Mode
+
+```
+linear.get_issue("CAB-XXXX", includeRelations=true)
+```
+
+Extract:
+- `title` — verify contains `[MEGA]` or has children
+- `children.nodes[]` — list of sub-tickets with `id`, `identifier`, `state.name`, `estimate`
+- `estimate` — total points
+
+If no children → report: "CAB-XXXX is not a MEGA (no children). Use standard close flow."
+
+### Audit Mode
+
+```
+linear.list_issues(
+  teamId: "624a9948-a160-4e47-aba5-7f9404d23506",
+  filter: { state: { name: { eq: "Done" } }, updatedAt: { gte: "<7 days ago>" } }
+)
+```
+
+Filter results to only MEGAs (title contains `[MEGA]` or has children).
+Run gates on each.
+
+## Step 2: Gate 0 — Decomposition Invariant
+
+- Check: `children.nodes.length > 0`
+- **Pass**: MEGA has sub-tickets
+- **Fail**: "MEGA has no sub-tickets. Run `/decompose CAB-XXXX` first."
+
+## Step 3: Gate 1 — Per-Phase PR Evidence
+
+For each child ticket in Done state:
+```
+linear.list_comments(issueId: "<child_id>")
+```
+
+Check that at least one comment contains `PR #` or `PR [#`.
+
+- **Pass**: All Done children have PR evidence
+- **Fail**: List children missing PR references: "CAB-XXXX: no PR evidence found"
+
+## Step 4: Gate 2 — All Sub-Tickets Done
+
+Check each child's `state.name`:
+- **Pass**: ALL children have `state.name == "Done"` or `state.name == "Canceled"`
+- **Fail**: List non-Done children with their current state:
+  ```
+  CAB-1351: In Progress
+  CAB-1352: Todo
+  ```
+
+## Step 5: Gate 3 — Live Verification
+
+Based on the MEGA's component scope:
+- **API changes**: `curl -s https://api.gostoa.dev/health` → expect 200
+- **UI/Portal**: `curl -s https://console.gostoa.dev` or `curl -s https://portal.gostoa.dev` → expect 200
+- **Gateway**: `curl -s https://mcp.gostoa.dev/health` → expect 200
+- **Docs**: `curl -s https://docs.gostoa.dev` → expect 200
+- **Cross-component**: verify all affected endpoints
+
+If automated verification is not possible, prompt the user:
+"Gate 3 requires manual verification. Please confirm the target is working: [endpoint/site]"
+
+## Step 6: Gate 4 — No Stale Children
+
+Check no child is stuck in non-terminal state:
+- **Pass**: Zero children in "In Progress", "Todo", or "Blocked"
+- **Fail**: List stale children (these should be either Done or explicitly descoped)
+
+## Step 7: Render Verdict
+
+### Format
+
+```
+## MEGA Verification: CAB-XXXX — [Title]
+
+| # | Gate | Status | Detail |
+|---|------|--------|--------|
+| 0 | Decomposition | ✅/❌ | N sub-tickets |
+| 1 | PR Evidence | ✅/❌ | N/M children have PRs |
+| 2 | All Done | ✅/❌ | N/M children Done |
+| 3 | Live Verification | ✅/❌ | endpoint status |
+| 4 | No Stale Children | ✅/❌ | N stale |
+
+**Verdict**: Go / Fix
+```
+
+### If Go (all gates pass)
+
+1. Mark parent MEGA as Done on Linear:
+   ```
+   linear.update_issue(id, state="Done")
+   ```
+2. Post comprehensive completion comment:
+   ```
+   linear.create_comment(issueId, body="MEGA completed — all 5 gates passed.\n\nSub-tickets:\n- CAB-1350: Done (PR #578)\n- CAB-1351: Done (PR #582)\n- CAB-1352: Done (PR #590)\n\nLive verification: ✅ [endpoint] responding")
+   ```
+3. Log: `MEGA-GATE-PASS | task=CAB-XXXX gates=5/5`
+
+### If Fix (any gate fails)
+
+1. Keep parent MEGA In Progress (do NOT mark Done)
+2. Post audit comment listing gaps:
+   ```
+   linear.create_comment(issueId, body="MEGA verification failed — X/5 gates passed.\n\nFailing gates:\n- Gate 1: CAB-1352 missing PR evidence\n- Gate 2: CAB-1352 still In Progress\n\nAction required: complete remaining work before closing.")
+   ```
+3. Log: `MEGA-GATE-FAIL | task=CAB-XXXX missing=<gate_numbers>`
+4. List remediation steps for each failing gate
+
+### Audit Mode Output
+
+```
+## Weekly MEGA Audit — [date]
+
+| MEGA | Points | Gates | Verdict | Action |
+|------|--------|-------|---------|--------|
+| CAB-1470 | 21 pts | 3/5 | Fix | Gate 1,2 failing |
+| CAB-1490 | 13 pts | 5/5 | Go | Already correct |
+
+Reopened: CAB-1470 (moved back to In Progress)
+```

--- a/.github/workflows/claude-linear-dispatch.yml
+++ b/.github/workflows/claude-linear-dispatch.yml
@@ -1244,45 +1244,77 @@ jobs:
           if [ -n "$LINEAR_API_KEY" ] && [ -n "$TICKET_ID" ] && [ -n "$PR_NUM" ]; then
             echo "Updating Linear ticket ${TICKET_ID} -> Done"
 
-            # Fetch the "Done" state ID for team CAB-ING
-            DONE_STATE_ID=$(curl -s -X POST "https://api.linear.app/graphql" \
+            # Check if this is a MEGA ticket (has children or title contains [MEGA])
+            MEGA_CHECK=$(curl -s -X POST "https://api.linear.app/graphql" \
               -H "Authorization: ${LINEAR_API_KEY}" \
               -H "Content-Type: application/json" \
-              -d '{"query": "{ workflowStates(filter: { name: { eq: \"Done\" }, team: { key: { eq: \"CAB\" } } }) { nodes { id name } } }"}' \
-              | jq -r '.data.workflowStates.nodes[0].id // empty' 2>/dev/null || echo "")
+              -d "{\"query\": \"{ issues(filter: { identifier: { eq: \\\"${TICKET_ID}\\\" } }) { nodes { id title children { nodes { id state { name } } } } } }\"}" \
+              2>/dev/null || echo "{}")
 
-            if [ -n "$DONE_STATE_ID" ]; then
-              # Fetch issue ID by identifier
-              ISSUE_ID=$(curl -s -X POST "https://api.linear.app/graphql" \
-                -H "Authorization: ${LINEAR_API_KEY}" \
-                -H "Content-Type: application/json" \
-                -d "{\"query\": \"{ issueSearch(filter: { identifier: { eq: \\\"${TICKET_ID}\\\" } }) { nodes { id } } }\"}" \
-                | jq -r '.data.issueSearch.nodes[0].id // empty' 2>/dev/null || echo "")
+            CHILDREN_COUNT=$(echo "$MEGA_CHECK" | jq -r '.data.issues.nodes[0].children.nodes | length' 2>/dev/null || echo "0")
+            MEGA_TITLE=$(echo "$MEGA_CHECK" | jq -r '.data.issues.nodes[0].title // ""' 2>/dev/null || echo "")
+            MEGA_ISSUE_ID=$(echo "$MEGA_CHECK" | jq -r '.data.issues.nodes[0].id // empty' 2>/dev/null || echo "")
 
-              if [ -n "$ISSUE_ID" ]; then
-                # Move to Done
-                curl -s -X POST "https://api.linear.app/graphql" \
-                  -H "Authorization: ${LINEAR_API_KEY}" \
-                  -H "Content-Type: application/json" \
-                  -d "{\"query\": \"mutation { issueUpdate(id: \\\"${ISSUE_ID}\\\", input: { stateId: \\\"${DONE_STATE_ID}\\\" }) { success } }\"}" \
-                  > /dev/null 2>&1 || true
+            IS_MEGA=false
+            if [ "$CHILDREN_COUNT" -gt 0 ] || echo "$MEGA_TITLE" | grep -q '\[MEGA\]'; then
+              IS_MEGA=true
+            fi
 
-                # Add completion comment
+            if [ "$IS_MEGA" = "true" ]; then
+              echo "MEGA ticket detected (${TICKET_ID}, ${CHILDREN_COUNT} children) — skipping auto-close"
+              # Post progress comment instead of closing
+              if [ -n "$MEGA_ISSUE_ID" ]; then
                 PR_REF=""
                 [ -n "$PR_NUM" ] && PR_REF="PR [#${PR_NUM}](${PR_URL})"
-                COMMENT_BODY="Completed autonomously via AI Factory L3 pipeline. ${PR_REF}"
+                COMMENT_BODY="Sub-ticket work merged via L3 pipeline. ${PR_REF}. Parent MEGA stays In Progress until all sub-tickets complete."
                 curl -s -X POST "https://api.linear.app/graphql" \
                   -H "Authorization: ${LINEAR_API_KEY}" \
                   -H "Content-Type: application/json" \
-                  -d "{\"query\": \"mutation { commentCreate(input: { issueId: \\\"${ISSUE_ID}\\\", body: \\\"${COMMENT_BODY}\\\" }) { success } }\"}" \
+                  -d "{\"query\": \"mutation { commentCreate(input: { issueId: \\\"${MEGA_ISSUE_ID}\\\", body: \\\"${COMMENT_BODY}\\\" }) { success } }\"}" \
                   > /dev/null 2>&1 || true
-
-                echo "Linear ${TICKET_ID} -> Done"
-              else
-                echo "::warning::Could not find Linear issue ID for ${TICKET_ID}"
               fi
             else
-              echo "::warning::Could not find Done state ID for team CAB"
+              # Standalone ticket — proceed with Done mutation
+              # Fetch the "Done" state ID for team CAB-ING
+              DONE_STATE_ID=$(curl -s -X POST "https://api.linear.app/graphql" \
+                -H "Authorization: ${LINEAR_API_KEY}" \
+                -H "Content-Type: application/json" \
+                -d '{"query": "{ workflowStates(filter: { name: { eq: \"Done\" }, team: { key: { eq: \"CAB\" } } }) { nodes { id name } } }"}' \
+                | jq -r '.data.workflowStates.nodes[0].id // empty' 2>/dev/null || echo "")
+
+              if [ -n "$DONE_STATE_ID" ]; then
+                # Fetch issue ID by identifier
+                ISSUE_ID=$(curl -s -X POST "https://api.linear.app/graphql" \
+                  -H "Authorization: ${LINEAR_API_KEY}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"query\": \"{ issueSearch(filter: { identifier: { eq: \\\"${TICKET_ID}\\\" } }) { nodes { id } } }\"}" \
+                  | jq -r '.data.issueSearch.nodes[0].id // empty' 2>/dev/null || echo "")
+
+                if [ -n "$ISSUE_ID" ]; then
+                  # Move to Done
+                  curl -s -X POST "https://api.linear.app/graphql" \
+                    -H "Authorization: ${LINEAR_API_KEY}" \
+                    -H "Content-Type: application/json" \
+                    -d "{\"query\": \"mutation { issueUpdate(id: \\\"${ISSUE_ID}\\\", input: { stateId: \\\"${DONE_STATE_ID}\\\" }) { success } }\"}" \
+                    > /dev/null 2>&1 || true
+
+                  # Add completion comment
+                  PR_REF=""
+                  [ -n "$PR_NUM" ] && PR_REF="PR [#${PR_NUM}](${PR_URL})"
+                  COMMENT_BODY="Completed autonomously via AI Factory L3 pipeline. ${PR_REF}"
+                  curl -s -X POST "https://api.linear.app/graphql" \
+                    -H "Authorization: ${LINEAR_API_KEY}" \
+                    -H "Content-Type: application/json" \
+                    -d "{\"query\": \"mutation { commentCreate(input: { issueId: \\\"${ISSUE_ID}\\\", body: \\\"${COMMENT_BODY}\\\" }) { success } }\"}" \
+                    > /dev/null 2>&1 || true
+
+                  echo "Linear ${TICKET_ID} -> Done"
+                else
+                  echo "::warning::Could not find Linear issue ID for ${TICKET_ID}"
+                fi
+              else
+                echo "::warning::Could not find Done state ID for team CAB"
+              fi
             fi
           fi
 

--- a/.github/workflows/linear-close-on-merge.yml
+++ b/.github/workflows/linear-close-on-merge.yml
@@ -50,14 +50,16 @@ jobs:
             exit 0
           fi
 
-          # Find the issue by identifier
+          # Find the issue by identifier, including children to detect MEGAs
           ISSUE_DATA=$(curl -s -X POST https://api.linear.app/graphql \
             -H "Authorization: $LINEAR_API_KEY" \
             -H "Content-Type: application/json" \
-            -d "{\"query\": \"{ issues(filter: { identifier: { eq: \\\"$TICKET_ID\\\" } }) { nodes { id identifier state { name type } } } }\"}")
+            -d "{\"query\": \"{ issues(filter: { identifier: { eq: \\\"$TICKET_ID\\\" } }) { nodes { id identifier title state { name type } children { nodes { id identifier state { name } } } } } }\"}")
 
           ISSUE_ID=$(echo "$ISSUE_DATA" | jq -r '.data.issues.nodes[0].id // empty')
           CURRENT_STATE=$(echo "$ISSUE_DATA" | jq -r '.data.issues.nodes[0].state.type // empty')
+          ISSUE_TITLE=$(echo "$ISSUE_DATA" | jq -r '.data.issues.nodes[0].title // empty')
+          CHILDREN_COUNT=$(echo "$ISSUE_DATA" | jq -r '.data.issues.nodes[0].children.nodes | length')
 
           if [ -z "$ISSUE_ID" ]; then
             echo "Issue $TICKET_ID not found in Linear — skipping"
@@ -70,8 +72,27 @@ jobs:
             exit 0
           fi
 
+          # MEGA detection: has children or title contains [MEGA]
+          IS_MEGA=false
+          if [ "$CHILDREN_COUNT" -gt 0 ] || echo "$ISSUE_TITLE" | grep -q '\[MEGA\]'; then
+            IS_MEGA=true
+          fi
+
+          if [ "$IS_MEGA" = "true" ]; then
+            echo "MEGA ticket detected ($TICKET_ID, $CHILDREN_COUNT children) — skipping auto-close"
+            # Post progress comment instead of closing
+            COMMENT_BODY="Sub-ticket work merged in PR #${PR_NUM} ([${PR_TITLE}](${PR_URL})).\n\nParent MEGA stays In Progress until all sub-tickets complete. Use \`/verify-mega ${TICKET_ID}\` to check gate status.\n\n*Auto-detected as MEGA by merge workflow*"
+            COMMENT_MUTATION='mutation { commentCreate(input: { issueId: "'"$ISSUE_ID"'", body: "'"$COMMENT_BODY"'" }) { success } }'
+            curl -s -X POST https://api.linear.app/graphql \
+              -H "Authorization: $LINEAR_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d "{\"query\": \"$COMMENT_MUTATION\"}" > /dev/null
+            echo "Progress comment added to MEGA $TICKET_ID (not closed)"
+            exit 0
+          fi
+
+          # Standalone ticket — proceed with Done mutation
           # Get the "Done" state ID for the team
-          TEAM_ID=$(echo "$ISSUE_DATA" | jq -r '.data.issueSearch.nodes[0].id // empty')
           DONE_STATE_QUERY='{ workflowStates(filter: { type: { eq: "completed" }, team: { issues: { identifier: { eq: "'"$TICKET_ID"'" } } } }) { nodes { id name } } }'
           DONE_DATA=$(curl -s -X POST https://api.linear.app/graphql \
             -H "Authorization: $LINEAR_API_KEY" \


### PR DESCRIPTION
## Summary
- **Problem**: 33/33 Done MEGAs in C9 (645 pts) had zero sub-tickets — none were decomposed before being marked Done
- **Fix**: Enforce MEGA Close Gate at 3 pipeline exit points (manual sessions, `linear-close-on-merge.yml`, `claude-linear-dispatch.yml`)
- **New**: `/verify-mega` skill for automated 5-gate verification + `mega-verification.md` rule file

## Changes

| File | Action | Description |
|------|--------|-------------|
| `.claude/rules/mega-verification.md` | **NEW** | 5-gate enforcement protocol (single source of truth) |
| `.claude/skills/verify-mega/SKILL.md` | **NEW** | Automated gate verification skill |
| `.claude/rules/workflow-essentials.md` | EDIT | Gate 0 added, invariant #6, lint check #5 updated |
| `.claude/rules/instance-dispatch.md` | EDIT | ORCHESTRE rules: must run `/verify-mega`, weekly audit |
| `.claude/rules/session-startup.md` | EDIT | 3-case Linear sync (standalone/sub-ticket/MEGA parent) |
| `.github/workflows/linear-close-on-merge.yml` | EDIT | MEGA bypass — post comment instead of closing |
| `.github/workflows/claude-linear-dispatch.yml` | EDIT | MEGA bypass in close-loop |

## 5 MEGA Close Gates

| # | Gate | What It Checks |
|---|------|---------------|
| 0 | Decomposition | MEGA has sub-tickets (`children.nodes.length > 0`) |
| 1 | PR Evidence | Every Done sub-ticket has a Linear comment with `PR #` |
| 2 | All Sub-Tickets Done | ALL children have `state.name == "Done"` |
| 3 | Live Verification | Target endpoint/site confirmed working |
| 4 | No Stale Children | No children stuck in non-terminal state >7 days |

## C9 Audit Evidence

33 Done MEGAs spot-checked — ALL failed Gate 0 (zero decomposition):
- CAB-1347 (21pts): 0 children, 3 phases in DoD
- CAB-1336 (21pts): 0 children, 3 phases in DoD
- CAB-1448 (21pts): 0 children, 3 phases in DoD
- CAB-1476 (21pts): 0 children, 3 phases in DoD
- CAB-1538 (21pts): 0 children, 3 phases in DoD
- CAB-1479 (21pts): 0 children, 5 phases in DoD

## Test plan
- [x] YAML validation passed on both workflow files
- [x] All rule files have `globs:` frontmatter
- [ ] CI green (3 required checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>