### PR TITLE
docs: polish README + CONTRIBUTING for OSS readiness (CAB-1555)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,6 +226,22 @@ make test-gateway    # cargo test (gateway)
 make test-cli        # pytest (CLI)
 ```
 
+## Linting
+
+```bash
+# Run all linters
+make lint
+
+# Run by component
+make lint-api        # ruff + black
+make lint-ui         # eslint + prettier + tsc
+make lint-portal     # eslint + prettier + tsc
+make lint-gateway    # clippy + fmt
+
+# List all available make targets
+make help
+```
+
 ## Documentation
 
 - Update relevant docs when changing functionality
@@ -235,9 +251,9 @@ make test-cli        # pytest (CLI)
 
 ## Community
 
-- 💬 [Discord](https://discord.gg/stoa) — Chat with the community
-- 🐦 [Twitter/X](https://x.com/gostoa) — Follow for updates
-- 📧 [Email](mailto:hello@gostoa.dev) — Reach out directly
+- [Discord](https://discord.gg/j8tHSSes) — Chat with the community
+- [Twitter/X](https://x.com/gostoa) — Follow for updates
+- [Email](mailto:hello@gostoa.dev) — Reach out directly
 
 ## Recognition
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,16 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
   <a href="https://github.com/stoa-platform/stoa/actions/workflows/security-scan.yml"><img src="https://github.com/stoa-platform/stoa/actions/workflows/security-scan.yml/badge.svg" alt="Security Scan"></a>
+  <a href="https://github.com/stoa-platform/stoa/actions/workflows/control-plane-api-ci.yml"><img src="https://github.com/stoa-platform/stoa/actions/workflows/control-plane-api-ci.yml/badge.svg" alt="API CI"></a>
+  <a href="https://github.com/stoa-platform/stoa/actions/workflows/stoa-gateway-ci.yml"><img src="https://github.com/stoa-platform/stoa/actions/workflows/stoa-gateway-ci.yml/badge.svg" alt="Gateway CI"></a>
+  <a href="https://github.com/stoa-platform/stoa/actions/workflows/control-plane-ui-ci.yml"><img src="https://github.com/stoa-platform/stoa/actions/workflows/control-plane-ui-ci.yml/badge.svg" alt="Console CI"></a>
+  <a href="https://github.com/stoa-platform/stoa/actions/workflows/stoa-portal-ci.yml"><img src="https://github.com/stoa-platform/stoa/actions/workflows/stoa-portal-ci.yml/badge.svg" alt="Portal CI"></a>
+</p>
+<p align="center">
   <a href="https://github.com/stoa-platform/stoa/stargazers"><img src="https://img.shields.io/github/stars/stoa-platform/stoa?style=social" alt="GitHub Stars"></a>
   <a href="https://discord.gg/j8tHSSes"><img src="https://img.shields.io/badge/Discord-Join%20us-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://status.gostoa.dev"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/stoa-platform/status/master/api/stoa-api-gateway/uptime.json" alt="Uptime"></a>
+  <a href="https://github.com/stoa-platform/stoa/actions/workflows/scorecard.yml"><img src="https://github.com/stoa-platform/stoa/actions/workflows/scorecard.yml/badge.svg" alt="OpenSSF Scorecard"></a>
 </p>
 <p align="center">
   <a href="https://docs.gostoa.dev"><img src="https://img.shields.io/badge/docs-docs.gostoa.dev-green.svg" alt="Documentation"></a>
@@ -42,19 +49,19 @@
 ## Architecture
 
 ```
-┌──────────────────────────────────────────────────────────────┐
-│                     STOA Platform                             │
-│                                                               │
-│  Console ──── API ──── Keycloak ──── Portal                   │
-│  (React)    (Python)   (OIDC)      (React)                    │
-│                │                                              │
-│         ┌──────┴──────┐                                       │
-│         │ Rust Gateway │ ◄── JWT + Rate Limit + MCP Bridge    │
-│         └──────┬──────┘                                       │
-│                │                                              │
-│  Prometheus ── Grafana ── Loki ── OpenSearch                  │
-│  (Metrics)    (Dashboards) (Logs) (Error Tracking)            │
-└──────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────┐
+│                       STOA Platform                         │
+│                                                             │
+│  Console ──── API ──── Keycloak ──── Portal                 │
+│  (React)    (Python)    (OIDC)      (React)                 │
+│                │                                            │
+│         ┌──────┴──────┐                                     │
+│         │ Rust Gateway │ ◄── JWT + Rate Limit + MCP Bridge  │
+│         └──────┬──────┘                                     │
+│                │                                            │
+│  Prometheus ── Grafana ── Loki ── OpenSearch                │
+│  (Metrics)   (Dashboards) (Logs) (Error Tracking)           │
+└─────────────────────────────────────────────────────────────┘
 ```
 
 ## Quick Start
@@ -76,6 +83,8 @@ docker compose up -d
 ```
 
 Open http://localhost — login as `halliday` / `readyplayerone`.
+
+For component-by-component local development (without Docker), see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 | Service | URL |
 |---------|-----|
@@ -150,23 +159,23 @@ stoa/
 ├── control-plane-api/     # FastAPI backend
 ├── control-plane-ui/      # React admin console
 ├── portal/                # React developer portal
-├── stoa-gateway/          # Rust API gateway
-├── mcp-gateway/           # Python MCP gateway (legacy, migrating to Rust)
-├── e2e/                   # Playwright E2E tests
+├── stoa-gateway/          # Rust API gateway + MCP bridge
+├── cli/                   # Python CLI (Typer + Rich)
+├── e2e/                   # Playwright E2E tests (BDD)
 ├── charts/                # Helm charts
 ├── deploy/                # Docker Compose + configs
 │   ├── docker-compose/    # Quick-start setup (17 services)
 │   └── grafana/           # Analytics dashboards
-└── scripts/               # Demo + seed scripts
+├── scripts/               # Demo, seed, migration scripts
+└── docs/                  # Runbooks + benchmark methodology
 ```
 
 ## Related Repositories
 
 | Repository | Purpose |
 |------------|---------|
-| [stoa-infra](https://github.com/stoa-platform/stoa-infra) | Terraform + Ansible + Helm |
-| [stoa-docs](https://github.com/stoa-platform/stoa-docs) | Documentation (docs.gostoa.dev) |
-| [stoa-web](https://github.com/stoa-platform/stoa-web) | Landing page (gostoa.dev) |
+| [stoa-docs](https://github.com/stoa-platform/stoa-docs) | Documentation ([docs.gostoa.dev](https://docs.gostoa.dev)) |
+| [stoa-web](https://github.com/stoa-platform/stoa-web) | Landing page ([gostoa.dev](https://gostoa.dev)) |
 | [stoa-quickstart](https://github.com/stoa-platform/stoa-quickstart) | Self-hosted quickstart |
 | [stoactl](https://github.com/stoa-platform/stoactl) | CLI tool (Go) |
 


### PR DESCRIPTION
## Summary
- Add component CI badges (API, Gateway, Console, Portal) + OpenSSF Scorecard
- Fix architecture diagram alignment, add DEVELOPMENT.md link in Quick Start
- Remove private repo from Related Repositories, fix repo structure diagram
- Fix Discord link mismatch in CONTRIBUTING.md, add Linting section

## Changes

### README.md
- **Badges**: Added 4 component CI badges (control-plane-api-ci, stoa-gateway-ci, control-plane-ui-ci, stoa-portal-ci) and OpenSSF Scorecard badge
- **Quick Start**: Added link to DEVELOPMENT.md for component-by-component local dev
- **Architecture diagram**: Fixed right-edge alignment
- **Repo structure**: Removed archived `mcp-gateway/`, added `cli/` and `docs/`
- **Related Repositories**: Removed private `stoa-infra`, added live URLs to stoa-docs and stoa-web

### CONTRIBUTING.md
- **Discord link**: Fixed from `discord.gg/stoa` (broken) to `discord.gg/j8tHSSes` (correct)
- **Linting section**: Added `make lint`, `make lint-*`, and `make help` references

## Test plan
- [ ] Badges render correctly on GitHub
- [ ] All internal links resolve (DEVELOPMENT.md, CLA.md, etc.)
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>