### PR TITLE
perf(gateway): prevent thundering herd on tool registry refresh (CAB-1558)

### DIFF
--- a/stoa-gateway/src/mcp/handlers.rs
+++ b/stoa-gateway/src/mcp/handlers.rs
@@ -218,8 +218,11 @@ pub async fn mcp_rest_tools_list(
     debug!(tenant_id = %auth.tenant_id, "REST v1: listing MCP tools");
 
     // CAB-1317: stale-while-revalidate — return cached immediately, refresh in background
+    // CAB-1558: thundering herd prevention — only one refresh per tenant at a time
     let ttl = Duration::from_secs(state.config.tool_refresh_ttl_secs);
-    if state.tool_registry.is_stale(&auth.tenant_id, ttl) {
+    if state.tool_registry.is_stale(&auth.tenant_id, ttl)
+        && state.tool_registry.try_start_refresh(&auth.tenant_id)
+    {
         let registry = state.tool_registry.clone();
         let tenant_id = auth.tenant_id.clone();
         let cp = state.control_plane.clone();
@@ -229,6 +232,7 @@ pub async fn mcp_rest_tools_list(
             if let Err(e) = refresh_tenant_tools(&registry, &cp, cb, &tenant_id).await {
                 warn!(tenant_id = %tenant_id, error = %e, "Background tool refresh failed");
             }
+            registry.finish_refresh(&tenant_id);
         });
     }
 
@@ -282,8 +286,11 @@ pub async fn mcp_tools_list(
     debug!(tenant_id = %auth.tenant_id, "Listing MCP tools");
 
     // CAB-1317: stale-while-revalidate — return cached immediately, refresh in background
+    // CAB-1558: thundering herd prevention — only one refresh per tenant at a time
     let ttl = Duration::from_secs(state.config.tool_refresh_ttl_secs);
-    if state.tool_registry.is_stale(&auth.tenant_id, ttl) {
+    if state.tool_registry.is_stale(&auth.tenant_id, ttl)
+        && state.tool_registry.try_start_refresh(&auth.tenant_id)
+    {
         let registry = state.tool_registry.clone();
         let tenant_id = auth.tenant_id.clone();
         let cp = state.control_plane.clone();
@@ -293,6 +300,7 @@ pub async fn mcp_tools_list(
             if let Err(e) = refresh_tenant_tools(&registry, &cp, cb, &tenant_id).await {
                 warn!(tenant_id = %tenant_id, error = %e, "Background tool refresh failed");
             }
+            registry.finish_refresh(&tenant_id);
         });
     }
 

--- a/stoa-gateway/src/mcp/tools/mod.rs
+++ b/stoa-gateway/src/mcp/tools/mod.rs
@@ -281,6 +281,9 @@ pub struct ToolRegistry {
     /// When a client calls a tool by its old name, the alias resolves to the
     /// canonical name and a deprecation warning is logged.
     aliases: RwLock<HashMap<String, String>>,
+    /// Guards against thundering herd: tracks which tenants have a background
+    /// refresh in flight. Only one refresh per tenant at a time (CAB-1558).
+    tenant_refreshing: RwLock<std::collections::HashSet<String>>,
 }
 
 impl ToolRegistry {
@@ -289,6 +292,7 @@ impl ToolRegistry {
             tools: RwLock::new(HashMap::new()),
             tenant_loaded_at: RwLock::new(HashMap::new()),
             aliases: RwLock::new(HashMap::new()),
+            tenant_refreshing: RwLock::new(std::collections::HashSet::new()),
         }
     }
 
@@ -429,6 +433,19 @@ impl ToolRegistry {
     /// Returns true if cache exists (even if stale), false if never loaded.
     pub fn has_been_loaded(&self, tenant_id: &str) -> bool {
         self.tenant_loaded_at.read().contains_key(tenant_id)
+    }
+
+    /// Attempt to start a background refresh for a tenant (CAB-1558).
+    /// Returns true if this caller "won" (no refresh in flight), false if
+    /// another task is already refreshing. Prevents thundering herd when
+    /// multiple VUs hit /tools/list concurrently on a stale cache.
+    pub fn try_start_refresh(&self, tenant_id: &str) -> bool {
+        self.tenant_refreshing.write().insert(tenant_id.to_string())
+    }
+
+    /// Mark a tenant refresh as complete, allowing future refreshes.
+    pub fn finish_refresh(&self, tenant_id: &str) {
+        self.tenant_refreshing.write().remove(tenant_id);
     }
 
     /// Get the age of the tool cache for a tenant (None if never loaded).
@@ -840,6 +857,42 @@ mod tests {
         assert!(registry.has_been_loaded("acme"));
         // Different tenant → still false
         assert!(!registry.has_been_loaded("other-tenant"));
+    }
+
+    // === Thundering Herd Prevention Tests (CAB-1558) ===
+
+    #[test]
+    fn test_try_start_refresh_returns_true_first_time() {
+        let registry = ToolRegistry::new();
+        // First call wins
+        assert!(registry.try_start_refresh("acme"));
+    }
+
+    #[test]
+    fn test_try_start_refresh_returns_false_when_in_flight() {
+        let registry = ToolRegistry::new();
+        // First call wins
+        assert!(registry.try_start_refresh("acme"));
+        // Second call for same tenant is blocked
+        assert!(!registry.try_start_refresh("acme"));
+    }
+
+    #[test]
+    fn test_try_start_refresh_different_tenants_independent() {
+        let registry = ToolRegistry::new();
+        // Different tenants can refresh simultaneously
+        assert!(registry.try_start_refresh("acme"));
+        assert!(registry.try_start_refresh("other-tenant"));
+    }
+
+    #[test]
+    fn test_finish_refresh_allows_next_refresh() {
+        let registry = ToolRegistry::new();
+        assert!(registry.try_start_refresh("acme"));
+        assert!(!registry.try_start_refresh("acme"));
+        // After finish, next refresh is allowed
+        registry.finish_refresh("acme");
+        assert!(registry.try_start_refresh("acme"));
     }
 
     // === Alias Tests (CAB-606) ===


### PR DESCRIPTION
## Summary
- Add `try_start_refresh`/`finish_refresh` guard on `ToolRegistry` to prevent concurrent background refresh tasks for the same tenant
- When 5 VUs hit `/mcp/tools/list` simultaneously on a stale cache, only 1 background refresh spawns instead of 5 (each making 2 HTTP calls to CP)
- Reduces CP backpressure during k6 benchmark runs

## Context
After the port fix (PR #1234) raised stoa-k8s L1 score to 97.12, `mcp_toolcall` is the lowest dimension at 91.41 (p95=112ms). Other dimensions are under 30ms. The thundering herd effect under 5 concurrent VUs causes unnecessary CP load.

## Changes
- `stoa-gateway/src/mcp/tools/mod.rs`: Add `tenant_refreshing: HashSet<String>` field + `try_start_refresh()`/`finish_refresh()` methods + 4 unit tests
- `stoa-gateway/src/mcp/handlers.rs`: Gate background refresh with `try_start_refresh()` — both tools_list handlers (REST v1 + JSON-RPC)

## Test plan
- [x] 4 new unit tests for thundering herd guard
- [x] `cargo test` — all pass
- [x] `cargo clippy` — zero warnings
- [x] `cargo fmt --check` — clean

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>