### PR TITLE
fix(arena): correct OpenSearch namespace and add auth support (CAB-1601)

### DIFF
--- a/docker/observability/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/observability/grafana/provisioning/datasources/prometheus.yml
@@ -52,7 +52,7 @@ datasources:
     type: grafana-opensearch-datasource
     uid: opensearch-bench
     access: proxy
-    url: ${OPENSEARCH_URL:-http://opensearch.stoa-system.svc:9200}
+    url: ${OPENSEARCH_URL:-http://opensearch.opensearch.svc:9200}
     editable: true
     jsonData:
       database: stoa-bench-*

--- a/k8s/arena/cronjob-enterprise.yaml
+++ b/k8s/arena/cronjob-enterprise.yaml
@@ -58,7 +58,15 @@ spec:
                 - name: ARENA_INSTANCE
                   value: "k8s"
                 - name: OPENSEARCH_URL
-                  value: "http://opensearch.stoa-system.svc:9200"
+                  value: "http://opensearch.opensearch.svc:9200"
+                - name: OPENSEARCH_USER
+                  value: "admin"
+                - name: OPENSEARCH_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: opensearch-credentials
+                      key: admin-password
+                      optional: true
                 - name: LLM_MOCK_URL
                   value: "http://llm-mock-backend.stoa-system.svc:8889"
                   # OIDC credentials for JWT auto-fetch (reuses L2 verify config)

--- a/k8s/arena/deploy-enterprise.sh
+++ b/k8s/arena/deploy-enterprise.sh
@@ -5,23 +5,40 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-OPENSEARCH_URL="${OPENSEARCH_URL:-http://opensearch.stoa-system.svc:9200}"
-TOTAL=8
+OPENSEARCH_URL="${OPENSEARCH_URL:-http://opensearch.opensearch.svc:9200}"
+# OpenSearch auth — required when security plugin is enabled
+OPENSEARCH_USER="${OPENSEARCH_USER:-admin}"
+OPENSEARCH_PASSWORD="${OPENSEARCH_PASSWORD:-}"
+TOTAL=9
+
+AUTH_ARGS=""
+if [ -n "$OPENSEARCH_PASSWORD" ]; then
+  AUTH_ARGS="-u ${OPENSEARCH_USER}:${OPENSEARCH_PASSWORD}"
+fi
 
 echo "=== Gateway Arena Enterprise Deploy (Layer 1: AI Readiness) ==="
 
+# 0. Create OpenSearch credentials K8s Secret (if password provided)
+if [ -n "$OPENSEARCH_PASSWORD" ]; then
+  echo "[0/$TOTAL] Creating/updating opensearch-credentials secret..."
+  kubectl create secret generic opensearch-credentials \
+    --from-literal=admin-password="$OPENSEARCH_PASSWORD" \
+    -n stoa-system \
+    --dry-run=client -o yaml | kubectl apply -f -
+fi
+
 # 1. Bootstrap OpenSearch index template
 echo "[1/$TOTAL] Applying OpenSearch index template (stoa-bench-*)..."
-kubectl exec -n stoa-system deploy/opensearch -- \
-  curl -s -XPUT "${OPENSEARCH_URL}/_index_template/stoa-bench" \
+kubectl exec -n opensearch opensearch-0 -- \
+  curl -s $AUTH_ARGS -XPUT "${OPENSEARCH_URL}/_index_template/stoa-bench" \
   -H "Content-Type: application/json" \
   -d "$(cat "$SCRIPT_DIR/opensearch-index-template.json")" 2>/dev/null \
   || echo "  (OpenSearch not reachable in-cluster, apply template manually)"
 
 # 2. Apply ISM lifecycle policy
 echo "[2/$TOTAL] Applying ISM lifecycle policy (stoa-bench-lifecycle)..."
-kubectl exec -n stoa-system deploy/opensearch -- \
-  curl -s -XPUT "${OPENSEARCH_URL}/_plugins/_ism/policies/stoa-bench-lifecycle" \
+kubectl exec -n opensearch opensearch-0 -- \
+  curl -s $AUTH_ARGS -XPUT "${OPENSEARCH_URL}/_plugins/_ism/policies/stoa-bench-lifecycle" \
   -H "Content-Type: application/json" \
   -d "$(cat "$SCRIPT_DIR/opensearch-ism-policy.json")" 2>/dev/null \
   || echo "  (OpenSearch ISM not reachable, apply policy manually)"
@@ -50,10 +67,12 @@ fi
 echo "[5/$TOTAL] Importing OpenSearch Dashboards visualizations..."
 OSD_FILE="$REPO_ROOT/docker/observability/opensearch-dashboards/saved-objects/stoa-bench-dashboards.ndjson"
 if [ -f "$OSD_FILE" ]; then
-  kubectl exec -n stoa-system deploy/opensearch-dashboards -- \
-    curl -s -XPOST "http://localhost:5601/api/saved_objects/_import?overwrite=true" \
-    -H "osd-xsrf: true" \
-    --form file=@- < "$OSD_FILE" 2>/dev/null \
+  # Copy file to OSD pod then import (kubectl exec with stdin piping is unreliable)
+  kubectl cp "$OSD_FILE" opensearch/$(kubectl get pod -n opensearch -l app=opensearch-dashboards -o jsonpath='{.items[0].metadata.name}'):/tmp/stoa-bench-dashboards.ndjson 2>/dev/null \
+    && kubectl exec -n opensearch deploy/opensearch-dashboards -- \
+      curl -s -XPOST "http://localhost:5601/api/saved_objects/_import?overwrite=true" \
+      -H "osd-xsrf: true" \
+      -F file=@/tmp/stoa-bench-dashboards.ndjson 2>/dev/null \
     || echo "  (OpenSearch Dashboards not reachable, import manually via UI: Stack Management > Saved Objects > Import)"
 else
   echo "  (saved objects file not found, skipping)"
@@ -67,9 +86,16 @@ kubectl apply -f "$SCRIPT_DIR/cronjob-enterprise.yaml"
 echo "[7/$TOTAL] Verifying CronJob..."
 kubectl get cronjob gateway-arena-enterprise -n stoa-system
 
-# 8. Smoke test — trigger manual run
+# 8. Verify OpenSearch connectivity from stoa-system namespace
+echo "[8/$TOTAL] Verifying cross-namespace OpenSearch connectivity..."
+kubectl run os-test --rm -it --restart=Never -n stoa-system \
+  --image=curlimages/curl --command -- \
+  curl -s $AUTH_ARGS "${OPENSEARCH_URL}/_cluster/health" 2>/dev/null \
+  || echo "  (Cross-namespace connectivity check failed — verify NetworkPolicy)"
+
+# 9. Smoke test — trigger manual run
 JOB_NAME="arena-ent-smoke-$(date +%s)"
-echo "[8/$TOTAL] Triggering smoke test: $JOB_NAME"
+echo "[9/$TOTAL] Triggering smoke test: $JOB_NAME"
 kubectl create job --from=cronjob/gateway-arena-enterprise "$JOB_NAME" -n stoa-system
 
 echo ""
@@ -86,7 +112,7 @@ if kubectl wait --for=condition=complete "job/$JOB_NAME" -n stoa-system --timeou
   echo "Deploy complete. Next steps:"
   echo "  1. Check Pushgateway: kubectl exec -n monitoring deploy/pushgateway -- wget -qO- localhost:9091/metrics | grep enterprise"
   echo "  2. Import Grafana dashboard: docker/observability/grafana/dashboards/gateway-arena-historical.json"
-  echo "  3. OpenSearch Dashboards: stoa-bench-dashboards.ndjson (auto-imported in step 5)"
+  echo "  3. OpenSearch Dashboards: https://opensearch.gostoa.dev (OIDC via Keycloak)"
   echo "  4. Cleanup: kubectl delete job $JOB_NAME -n stoa-system"
 else
   echo "Job did not complete in 15m. Check logs:"

--- a/k8s/network-policies/10-stoa-system.yaml
+++ b/k8s/network-policies/10-stoa-system.yaml
@@ -82,7 +82,7 @@ spec:
         - protocol: TCP
           port: 20184
 ---
-# API → OpenSearch (log shipping)
+# API + Arena → OpenSearch (log shipping + benchmark persistence)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -93,8 +93,12 @@ metadata:
     security.stoa.dev/policy: cab-1401
 spec:
   podSelector:
-    matchLabels:
-      app: stoa-control-plane-api
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - stoa-control-plane-api
+          - gateway-arena-enterprise
   policyTypes:
     - Egress
   egress:

--- a/scripts/traffic/arena/run-arena-enterprise.py
+++ b/scripts/traffic/arena/run-arena-enterprise.py
@@ -344,15 +344,19 @@ def export_to_opensearch(dimension_docs: list[dict]) -> None:
     (stoa-bench-{yyyy.MM}). Uses stdlib urllib only (no requests/httpx dependency).
 
     Env vars:
-      OPENSEARCH_URL — OpenSearch base URL (default: http://opensearch.stoa-system.svc:9200)
+      OPENSEARCH_URL — OpenSearch base URL (default: http://opensearch.opensearch.svc:9200)
+      OPENSEARCH_USER — Basic auth username (default: admin)
+      OPENSEARCH_PASSWORD — Basic auth password (default: empty, no auth)
       OPENSEARCH_ENABLED — set to "false" to skip export (default: true)
     """
     if os.environ.get("OPENSEARCH_ENABLED", "true").lower() == "false":
         return
 
     base_url = os.environ.get(
-        "OPENSEARCH_URL", "http://opensearch.stoa-system.svc:9200"
+        "OPENSEARCH_URL", "http://opensearch.opensearch.svc:9200"
     )
+    os_user = os.environ.get("OPENSEARCH_USER", "admin")
+    os_password = os.environ.get("OPENSEARCH_PASSWORD", "")
     now = datetime.now(timezone.utc)
     index = f"stoa-bench-{now.strftime('%Y.%m')}"
     timestamp = now.isoformat()
@@ -384,10 +388,18 @@ def export_to_opensearch(dimension_docs: list[dict]) -> None:
 
     try:
         payload = ("\n".join(bulk_lines) + "\n").encode("utf-8")
+        headers: dict[str, str] = {"Content-Type": "application/x-ndjson"}
+        if os_password:
+            import base64
+
+            credentials = base64.b64encode(
+                f"{os_user}:{os_password}".encode()
+            ).decode()
+            headers["Authorization"] = f"Basic {credentials}"
         req = urllib.request.Request(
             f"{base_url}/_bulk",
             data=payload,
-            headers={"Content-Type": "application/x-ndjson"},
+            headers=headers,
             method="POST",
         )
         with urllib.request.urlopen(req, timeout=10) as resp:


### PR DESCRIPTION
## Summary
- Fix OpenSearch URL from `opensearch.stoa-system.svc` to `opensearch.opensearch.svc` (correct namespace) in cronjob, deploy script, Python scorer, and Grafana datasource
- Add basic auth support (`OPENSEARCH_USER`/`OPENSEARCH_PASSWORD` env vars) since OpenSearch security plugin is enabled
- Update NetworkPolicy `allow-api-to-opensearch` to include `gateway-arena-enterprise` pods
- Improve deploy script: K8s Secret creation, cross-namespace connectivity check, reliable OSD import via `kubectl cp`

## Test plan
- [ ] Deploy script creates `opensearch-credentials` K8s Secret
- [ ] NetworkPolicy allows arena pods → OpenSearch port 9200
- [ ] Smoke test job completes and persists docs to `stoa-bench-*` index
- [ ] OpenSearch Dashboards accessible at https://opensearch.gostoa.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)