### PR TITLE
fix(api,gateway): send API key in body to bypass PII middleware (CAB-1601)

### DIFF
--- a/control-plane-api/src/routers/subscriptions.py
+++ b/control-plane-api/src/routers/subscriptions.py
@@ -7,6 +7,7 @@ import uuid as uuid_mod
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import User, get_current_user
@@ -744,9 +745,16 @@ async def reactivate_subscription(
 # ============== API Key Validation Endpoint (Gateway) ==============
 
 
+class _ValidateKeyBody(BaseModel):
+    """Request body for API key validation (preferred over query param)."""
+
+    api_key: str
+
+
 @router.post("/validate-key")
 async def validate_api_key(
-    api_key: str,
+    body: _ValidateKeyBody | None = None,
+    api_key: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -755,14 +763,23 @@ async def validate_api_key(
     This is an internal endpoint for the API Gateway to validate
     incoming API keys and get subscription details.
 
+    Accepts key via JSON body (preferred) or query param (legacy).
+    Body is preferred because the PII middleware masks query params
+    named ``api_key``.
+
     Supports grace period: during key rotation, both old and new keys are valid.
     """
+    # Body takes precedence (query params are masked by PII middleware)
+    key = (body.api_key if body else None) or api_key
+    if not key:
+        raise HTTPException(status_code=400, detail="api_key required in body or query")
+
     # Validate format
-    if not APIKeyService.validate_format(api_key):
+    if not APIKeyService.validate_format(key):
         raise HTTPException(status_code=401, detail="Invalid API key format")
 
     # Hash and lookup
-    api_key_hash = APIKeyService.hash_key(api_key)
+    api_key_hash = APIKeyService.hash_key(key)
 
     repo = SubscriptionRepository(db)
 

--- a/control-plane-api/tests/test_subscriptions.py
+++ b/control-plane-api/tests/test_subscriptions.py
@@ -492,6 +492,44 @@ class TestSubscriptionsRouter:
 
         app.dependency_overrides.clear()
 
+    def test_validate_key_via_body(
+        self, app, mock_db_session, sample_subscription_data
+    ):
+        """Test POST /validate-key with JSON body (preferred, PII-safe)."""
+        from src.database import get_db
+
+        mock_sub = self._create_mock_subscription(sample_subscription_data)
+        mock_sub.status = SubscriptionStatus.ACTIVE
+        mock_sub.expires_at = None
+        mock_sub.previous_key_expires_at = None
+
+        async def override_get_db():
+            yield mock_db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        with patch("src.routers.subscriptions.SubscriptionRepository") as MockRepo, \
+             patch("src.routers.subscriptions.APIKeyService") as MockKeyService:
+            mock_repo_instance = MockRepo.return_value
+            mock_repo_instance.get_by_api_key_hash = AsyncMock(return_value=mock_sub)
+            mock_repo_instance.get_by_previous_key_hash = AsyncMock(return_value=None)
+
+            MockKeyService.validate_format.return_value = True
+            MockKeyService.hash_key.return_value = "hashed_key_test_123"
+
+            with TestClient(app) as client:
+                response = client.post(
+                    "/v1/subscriptions/validate-key",
+                    json={"api_key": "stoa_sk_test1234567890abcdef12345678"},
+                )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["valid"] is True
+            assert data["subscription_id"] == str(sample_subscription_data["id"])
+
+        app.dependency_overrides.clear()
+
     # ============== Phase 2: Suspend/Reactivate Tests ==============
 
     def test_suspend_subscription_success(

--- a/stoa-gateway/src/auth/api_key.rs
+++ b/stoa-gateway/src/auth/api_key.rs
@@ -87,7 +87,7 @@ impl ApiKeyValidator {
         let response = self
             .http_client
             .post(&url)
-            .query(&[("api_key", api_key)])
+            .json(&serde_json::json!({"api_key": api_key}))
             .timeout(Duration::from_secs(5))
             .send()
             .await


### PR DESCRIPTION
## Summary
- **Root cause**: `PIIMaskingMiddleware` masks query params named `api_key` with `[REDACTED]` before FastAPI parses them. The gateway sends the key as a query param, so the `validate-key` handler receives `[REDACTED]` instead of the actual key.
- **Fix (gateway)**: Send API key in POST body (JSON) instead of query parameter — the PII middleware only masks query strings, not request bodies.
- **Fix (CP API)**: Accept key from both JSON body (preferred) and query param (legacy backward compat).
- Added test for body-based validation.

## Test plan
- [x] All 39 subscription tests pass (6 existing query-param + 1 new body test)
- [x] `cargo clippy` clean, `cargo test` clean
- [x] `ruff check` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>