### PR TITLE
fix(api): update OpenAPI snapshot for validate-key body param (CAB-1601)

### DIFF
--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -21594,6 +21594,20 @@
         "title": "WebhookUpdate",
         "type": "object"
       },
+      "_ValidateKeyBody": {
+        "description": "Request body for API key validation (preferred over query param).",
+        "properties": {
+          "api_key": {
+            "title": "Api Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "api_key"
+        ],
+        "title": "_ValidateKeyBody",
+        "type": "object"
+      },
       "src__routers__applications__ApplicationResponse": {
         "properties": {
           "api_subscriptions": {
@@ -36156,19 +36170,43 @@
     },
     "/v1/subscriptions/validate-key": {
       "post": {
-        "description": "Validate an API key (used by the Gateway).\n\nThis is an internal endpoint for the API Gateway to validate\nincoming API keys and get subscription details.\n\nSupports grace period: during key rotation, both old and new keys are valid.",
+        "description": "Validate an API key (used by the Gateway).\n\nThis is an internal endpoint for the API Gateway to validate\nincoming API keys and get subscription details.\n\nAccepts key via JSON body (preferred) or query param (legacy).\nBody is preferred because the PII middleware masks query params\nnamed ``api_key``.\n\nSupports grace period: during key rotation, both old and new keys are valid.",
         "operationId": "validate_api_key_v1_subscriptions_validate_key_post",
         "parameters": [
           {
             "in": "query",
             "name": "api_key",
-            "required": true,
+            "required": false,
             "schema": {
-              "title": "Api Key",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Api Key"
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/_ValidateKeyBody"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Body"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "content": {


### PR DESCRIPTION
## Summary
- Regenerates OpenAPI snapshot after PR #1250 added `_ValidateKeyBody` model to the validate-key endpoint.
- Fixes `test_openapi_schemas_match_snapshot` CI failure that blocked CP API deployment.

## Test plan
- [x] `pytest tests/test_openapi_contract.py` — all 6 tests pass
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>