### PR TITLE
feat(gateway): Azure OpenAI multi-namespace subscription routing (CAB-1610)

### DIFF
--- a/stoa-gateway/src/config.rs
+++ b/stoa-gateway/src/config.rs
@@ -536,6 +536,12 @@ pub struct LlmRouterConfig {
     /// Provider configurations.
     #[serde(default)]
     pub providers: Vec<crate::llm::ProviderConfig>,
+
+    /// Subscription-to-backend routing map (CAB-1610).
+    /// Maps subscription IDs (or plan names) to backend IDs in the provider list.
+    /// Enables multi-namespace routing: same API contract, different backends per subscriber.
+    #[serde(default)]
+    pub subscription_mapping: crate::llm::SubscriptionMapping,
 }
 
 impl Default for LlmRouterConfig {
@@ -545,6 +551,7 @@ impl Default for LlmRouterConfig {
             default_strategy: crate::llm::RoutingStrategy::default(),
             budget_limit_usd: 0.0,
             providers: Vec::new(),
+            subscription_mapping: crate::llm::SubscriptionMapping::new(),
         }
     }
 }

--- a/stoa-gateway/src/llm/azure.rs
+++ b/stoa-gateway/src/llm/azure.rs
@@ -1,0 +1,272 @@
+//! Azure OpenAI Request Transformation (CAB-1610)
+//!
+//! Transforms standard OpenAI-format requests into Azure OpenAI format:
+//! - URL: `{endpoint}/openai/deployments/{deployment}/chat/completions?api-version={version}`
+//! - Auth: `api-key: {key}` header instead of `Authorization: Bearer {key}`
+//!
+//! The subscriber sends a standard OpenAI chat/completions request with STOA
+//! credentials. The gateway resolves the target Azure namespace from the
+//! subscription mapping and transforms the request before proxying.
+
+use super::providers::ProviderConfig;
+
+/// Errors that can occur during Azure OpenAI request transformation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AzureTransformError {
+    /// The provider config is missing the required `deployment` field.
+    MissingDeployment,
+    /// The provider config is missing the required `api_version` field.
+    MissingApiVersion,
+    /// The API key environment variable is not set or empty.
+    MissingApiKey,
+}
+
+impl std::fmt::Display for AzureTransformError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AzureTransformError::MissingDeployment => {
+                write!(f, "Azure OpenAI config missing 'deployment' field")
+            }
+            AzureTransformError::MissingApiVersion => {
+                write!(f, "Azure OpenAI config missing 'api_version' field")
+            }
+            AzureTransformError::MissingApiKey => {
+                write!(f, "Azure OpenAI API key not set")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AzureTransformError {}
+
+/// Result of transforming a request for Azure OpenAI.
+#[derive(Debug, Clone)]
+pub struct AzureRequest {
+    /// Full URL including deployment and api-version query parameter.
+    pub url: String,
+    /// Headers to set on the upstream request.
+    pub headers: Vec<(String, String)>,
+}
+
+/// Build the Azure OpenAI chat completions URL from a provider config.
+///
+/// Format: `{base_url}/openai/deployments/{deployment}/chat/completions?api-version={version}`
+pub fn build_chat_completions_url(config: &ProviderConfig) -> Result<String, AzureTransformError> {
+    let deployment = config
+        .deployment
+        .as_deref()
+        .ok_or(AzureTransformError::MissingDeployment)?;
+    let api_version = config
+        .api_version
+        .as_deref()
+        .ok_or(AzureTransformError::MissingApiVersion)?;
+
+    let base = config.base_url.trim_end_matches('/');
+    Ok(format!(
+        "{base}/openai/deployments/{deployment}/chat/completions?api-version={api_version}"
+    ))
+}
+
+/// Build Azure OpenAI headers. Azure uses `api-key` instead of `Authorization: Bearer`.
+pub fn build_headers(api_key: &str) -> Vec<(String, String)> {
+    vec![
+        ("api-key".to_string(), api_key.to_string()),
+        ("Content-Type".to_string(), "application/json".to_string()),
+    ]
+}
+
+/// Resolve the API key from the environment variable specified in the config.
+pub fn resolve_api_key(config: &ProviderConfig) -> Result<String, AzureTransformError> {
+    let env_name = config
+        .api_key_env
+        .as_deref()
+        .ok_or(AzureTransformError::MissingApiKey)?;
+    std::env::var(env_name).map_err(|_| AzureTransformError::MissingApiKey)
+}
+
+/// Transform a standard OpenAI request into Azure OpenAI format.
+///
+/// Resolves the API key from the environment, builds the Azure-specific URL,
+/// and returns headers with `api-key` authentication.
+pub fn transform_request(config: &ProviderConfig) -> Result<AzureRequest, AzureTransformError> {
+    let url = build_chat_completions_url(config)?;
+    let api_key = resolve_api_key(config)?;
+    let headers = build_headers(&api_key);
+    Ok(AzureRequest { url, headers })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::providers::{LlmProvider, ProviderConfig};
+
+    fn make_azure_config(
+        endpoint: &str,
+        deployment: &str,
+        api_version: &str,
+        api_key_env: &str,
+    ) -> ProviderConfig {
+        ProviderConfig {
+            provider: LlmProvider::AzureOpenAi,
+            backend_id: Some("test-backend".to_string()),
+            base_url: endpoint.to_string(),
+            api_key_env: Some(api_key_env.to_string()),
+            default_model: None,
+            max_concurrent: 50,
+            enabled: true,
+            cost_per_1m_input: 5.0,
+            cost_per_1m_output: 15.0,
+            priority: 1,
+            deployment: Some(deployment.to_string()),
+            api_version: Some(api_version.to_string()),
+        }
+    }
+
+    #[test]
+    fn build_url_standard() {
+        let config = make_azure_config(
+            "https://projet-alpha.openai.azure.com",
+            "gpt-4o",
+            "2024-12-01-preview",
+            "AZURE_ALPHA_KEY",
+        );
+        let url = build_chat_completions_url(&config).expect("should build URL");
+        assert_eq!(
+            url,
+            "https://projet-alpha.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-12-01-preview"
+        );
+    }
+
+    #[test]
+    fn build_url_trailing_slash() {
+        let config = make_azure_config(
+            "https://projet-alpha.openai.azure.com/",
+            "gpt-4o",
+            "2024-12-01-preview",
+            "AZURE_ALPHA_KEY",
+        );
+        let url = build_chat_completions_url(&config).expect("should build URL");
+        assert_eq!(
+            url,
+            "https://projet-alpha.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-12-01-preview"
+        );
+    }
+
+    #[test]
+    fn build_url_missing_deployment() {
+        let mut config = make_azure_config(
+            "https://example.openai.azure.com",
+            "gpt-4o",
+            "2024-12-01-preview",
+            "KEY",
+        );
+        config.deployment = None;
+        let err = build_chat_completions_url(&config).unwrap_err();
+        assert_eq!(err, AzureTransformError::MissingDeployment);
+    }
+
+    #[test]
+    fn build_url_missing_api_version() {
+        let mut config = make_azure_config(
+            "https://example.openai.azure.com",
+            "gpt-4o",
+            "2024-12-01-preview",
+            "KEY",
+        );
+        config.api_version = None;
+        let err = build_chat_completions_url(&config).unwrap_err();
+        assert_eq!(err, AzureTransformError::MissingApiVersion);
+    }
+
+    #[test]
+    fn build_headers_uses_api_key() {
+        let headers = build_headers("my-secret-key");
+        assert_eq!(headers.len(), 2);
+        assert_eq!(
+            headers[0],
+            ("api-key".to_string(), "my-secret-key".to_string())
+        );
+        assert_eq!(
+            headers[1],
+            ("Content-Type".to_string(), "application/json".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_api_key_from_env() {
+        let config = make_azure_config(
+            "https://test.openai.azure.com",
+            "gpt-4o",
+            "2024-12-01-preview",
+            "STOA_TEST_AZURE_KEY_CAB1610",
+        );
+
+        // Set env var for this test
+        std::env::set_var("STOA_TEST_AZURE_KEY_CAB1610", "test-key-value");
+        let key = resolve_api_key(&config).expect("should resolve key");
+        assert_eq!(key, "test-key-value");
+        std::env::remove_var("STOA_TEST_AZURE_KEY_CAB1610");
+    }
+
+    #[test]
+    fn resolve_api_key_missing_env() {
+        let config = make_azure_config(
+            "https://test.openai.azure.com",
+            "gpt-4o",
+            "2024-12-01-preview",
+            "STOA_MISSING_KEY_CAB1610",
+        );
+        // Don't set the env var
+        std::env::remove_var("STOA_MISSING_KEY_CAB1610");
+        let err = resolve_api_key(&config).unwrap_err();
+        assert_eq!(err, AzureTransformError::MissingApiKey);
+    }
+
+    #[test]
+    fn resolve_api_key_no_env_name() {
+        let mut config = make_azure_config(
+            "https://test.openai.azure.com",
+            "gpt-4o",
+            "2024-12-01-preview",
+            "KEY",
+        );
+        config.api_key_env = None;
+        let err = resolve_api_key(&config).unwrap_err();
+        assert_eq!(err, AzureTransformError::MissingApiKey);
+    }
+
+    #[test]
+    fn transform_request_full_flow() {
+        let config = make_azure_config(
+            "https://projet-beta.openai.azure.com",
+            "gpt-4o",
+            "2024-12-01-preview",
+            "STOA_TEST_BETA_KEY_CAB1610",
+        );
+
+        std::env::set_var("STOA_TEST_BETA_KEY_CAB1610", "beta-secret");
+        let req = transform_request(&config).expect("should transform");
+        assert_eq!(
+            req.url,
+            "https://projet-beta.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-12-01-preview"
+        );
+        assert_eq!(req.headers[0].1, "beta-secret");
+        std::env::remove_var("STOA_TEST_BETA_KEY_CAB1610");
+    }
+
+    #[test]
+    fn error_display() {
+        assert_eq!(
+            AzureTransformError::MissingDeployment.to_string(),
+            "Azure OpenAI config missing 'deployment' field"
+        );
+        assert_eq!(
+            AzureTransformError::MissingApiVersion.to_string(),
+            "Azure OpenAI config missing 'api_version' field"
+        );
+        assert_eq!(
+            AzureTransformError::MissingApiKey.to_string(),
+            "Azure OpenAI API key not set"
+        );
+    }
+}

--- a/stoa-gateway/src/llm/cost.rs
+++ b/stoa-gateway/src/llm/cost.rs
@@ -195,6 +195,7 @@ mod tests {
         ProviderRegistry::new(vec![
             ProviderConfig {
                 provider: LlmProvider::OpenAi,
+                backend_id: None,
                 base_url: "https://api.openai.com/v1".to_string(),
                 api_key_env: None,
                 default_model: Some("gpt-4o".to_string()),
@@ -203,9 +204,12 @@ mod tests {
                 cost_per_1m_input: 5.0,
                 cost_per_1m_output: 15.0,
                 priority: 1,
+                deployment: None,
+                api_version: None,
             },
             ProviderConfig {
                 provider: LlmProvider::Anthropic,
+                backend_id: None,
                 base_url: "https://api.anthropic.com/v1".to_string(),
                 api_key_env: None,
                 default_model: Some("claude-sonnet-4-20250514".to_string()),
@@ -214,6 +218,8 @@ mod tests {
                 cost_per_1m_input: 3.0,
                 cost_per_1m_output: 15.0,
                 priority: 2,
+                deployment: None,
+                api_version: None,
             },
         ])
         .into_shared()

--- a/stoa-gateway/src/llm/mod.rs
+++ b/stoa-gateway/src/llm/mod.rs
@@ -20,13 +20,18 @@
 //!                     BudgetGate --> 429 + X-Stoa-Budget-Exceeded
 //! ```
 
+pub mod azure;
 pub mod cost;
 pub mod providers;
 pub mod router;
 
+pub use azure::{
+    build_chat_completions_url, build_headers as azure_headers, transform_request, AzureRequest,
+    AzureTransformError,
+};
 pub use cost::{
     record_fallback, record_latency, BudgetDecision, BudgetGate, CostCalculator, CostResult,
     TokenUsage, LLM_COST_TOTAL, LLM_FALLBACK_TOTAL, LLM_LATENCY_SECONDS,
 };
 pub use providers::{LlmProvider, ProviderConfig, ProviderRegistry};
-pub use router::{LlmRouter, RoutingStrategy};
+pub use router::{LlmRouter, RoutingStrategy, SubscriptionMapping};

--- a/stoa-gateway/src/llm/providers.rs
+++ b/stoa-gateway/src/llm/providers.rs
@@ -17,6 +17,7 @@ pub enum LlmProvider {
     Google,
     Mistral,
     Local,
+    AzureOpenAi,
 }
 
 impl fmt::Display for LlmProvider {
@@ -27,6 +28,7 @@ impl fmt::Display for LlmProvider {
             LlmProvider::Google => write!(f, "google"),
             LlmProvider::Mistral => write!(f, "mistral"),
             LlmProvider::Local => write!(f, "local"),
+            LlmProvider::AzureOpenAi => write!(f, "azure_openai"),
         }
     }
 }
@@ -40,6 +42,7 @@ impl LlmProvider {
             "google" | "gemini" => Some(LlmProvider::Google),
             "mistral" => Some(LlmProvider::Mistral),
             "local" | "ollama" | "vllm" => Some(LlmProvider::Local),
+            "azure_openai" | "azure-openai" | "azureopenai" => Some(LlmProvider::AzureOpenAi),
             _ => None,
         }
     }
@@ -52,6 +55,12 @@ impl LlmProvider {
             LlmProvider::OpenAi | LlmProvider::Mistral | LlmProvider::Local
         )
     }
+
+    /// Returns true if this provider uses the OpenAI response/request schema
+    /// but may have different auth or URL patterns (e.g. Azure OpenAI).
+    pub fn uses_openai_schema(&self) -> bool {
+        self.is_openai_compatible() || matches!(self, LlmProvider::AzureOpenAi)
+    }
 }
 
 /// Configuration for a single LLM provider endpoint.
@@ -59,6 +68,12 @@ impl LlmProvider {
 pub struct ProviderConfig {
     /// Provider type.
     pub provider: LlmProvider,
+
+    /// Unique backend identifier for subscription-based routing.
+    /// When multiple backends share the same provider type (e.g. two Azure OpenAI
+    /// namespaces), this ID distinguishes them in subscription → backend mappings.
+    #[serde(default)]
+    pub backend_id: Option<String>,
 
     /// Base URL for API requests (e.g. `https://api.openai.com/v1`).
     pub base_url: String,
@@ -90,6 +105,14 @@ pub struct ProviderConfig {
     /// Routing priority (lower = higher priority, 0 = highest).
     #[serde(default = "default_priority")]
     pub priority: u32,
+
+    /// Azure OpenAI deployment name (e.g. `gpt-4o`). Only used when provider is AzureOpenAi.
+    #[serde(default)]
+    pub deployment: Option<String>,
+
+    /// Azure OpenAI API version (e.g. `2024-10-21`). Only used when provider is AzureOpenAi.
+    #[serde(default)]
+    pub api_version: Option<String>,
 }
 
 fn default_max_concurrent() -> u32 {
@@ -127,6 +150,14 @@ impl ProviderRegistry {
     /// Get a provider config by type. Returns the first matching enabled provider.
     pub fn get(&self, provider: LlmProvider) -> Option<&ProviderConfig> {
         self.providers.iter().find(|p| p.provider == provider)
+    }
+
+    /// Get a provider config by backend ID. Used for subscription-based routing
+    /// where the subscription plan maps to a specific backend identifier.
+    pub fn get_by_backend_id(&self, backend_id: &str) -> Option<&ProviderConfig> {
+        self.providers
+            .iter()
+            .find(|p| p.backend_id.as_deref() == Some(backend_id))
     }
 
     /// Get all enabled providers sorted by priority (lowest number first).
@@ -180,6 +211,7 @@ mod tests {
     ) -> ProviderConfig {
         ProviderConfig {
             provider,
+            backend_id: None,
             base_url: format!("https://{}.example.com", provider),
             api_key_env: None,
             default_model: None,
@@ -188,6 +220,8 @@ mod tests {
             cost_per_1m_input: cost_input,
             cost_per_1m_output: cost_input * 3.0,
             priority,
+            deployment: None,
+            api_version: None,
         }
     }
 
@@ -248,6 +282,7 @@ mod tests {
         assert_eq!(LlmProvider::Google.to_string(), "google");
         assert_eq!(LlmProvider::Mistral.to_string(), "mistral");
         assert_eq!(LlmProvider::Local.to_string(), "local");
+        assert_eq!(LlmProvider::AzureOpenAi.to_string(), "azure_openai");
     }
 
     #[test]
@@ -272,6 +307,18 @@ mod tests {
             LlmProvider::from_str_opt("ollama"),
             Some(LlmProvider::Local)
         );
+        assert_eq!(
+            LlmProvider::from_str_opt("azure_openai"),
+            Some(LlmProvider::AzureOpenAi)
+        );
+        assert_eq!(
+            LlmProvider::from_str_opt("azure-openai"),
+            Some(LlmProvider::AzureOpenAi)
+        );
+        assert_eq!(
+            LlmProvider::from_str_opt("azureopenai"),
+            Some(LlmProvider::AzureOpenAi)
+        );
         assert_eq!(LlmProvider::from_str_opt("unknown"), None);
     }
 
@@ -282,5 +329,45 @@ mod tests {
         assert!(LlmProvider::Local.is_openai_compatible());
         assert!(!LlmProvider::Anthropic.is_openai_compatible());
         assert!(!LlmProvider::Google.is_openai_compatible());
+        assert!(!LlmProvider::AzureOpenAi.is_openai_compatible());
+    }
+
+    #[test]
+    fn uses_openai_schema() {
+        assert!(LlmProvider::OpenAi.uses_openai_schema());
+        assert!(LlmProvider::Mistral.uses_openai_schema());
+        assert!(LlmProvider::Local.uses_openai_schema());
+        assert!(LlmProvider::AzureOpenAi.uses_openai_schema());
+        assert!(!LlmProvider::Anthropic.uses_openai_schema());
+        assert!(!LlmProvider::Google.uses_openai_schema());
+    }
+
+    #[test]
+    fn get_by_backend_id() {
+        let mut alpha = make_provider(LlmProvider::AzureOpenAi, true, 1, 5.0);
+        alpha.backend_id = Some("projet-alpha".to_string());
+        alpha.base_url = "https://projet-alpha.openai.azure.com".to_string();
+
+        let mut beta = make_provider(LlmProvider::AzureOpenAi, true, 2, 5.0);
+        beta.backend_id = Some("projet-beta".to_string());
+        beta.base_url = "https://projet-beta.openai.azure.com".to_string();
+
+        let registry = ProviderRegistry::new(vec![alpha, beta]);
+
+        let found = registry.get_by_backend_id("projet-alpha");
+        assert!(found.is_some());
+        assert_eq!(
+            found.expect("should find alpha").base_url,
+            "https://projet-alpha.openai.azure.com"
+        );
+
+        let found_beta = registry.get_by_backend_id("projet-beta");
+        assert!(found_beta.is_some());
+        assert_eq!(
+            found_beta.expect("should find beta").base_url,
+            "https://projet-beta.openai.azure.com"
+        );
+
+        assert!(registry.get_by_backend_id("unknown").is_none());
     }
 }

--- a/stoa-gateway/src/llm/router.rs
+++ b/stoa-gateway/src/llm/router.rs
@@ -5,6 +5,7 @@
 //! and supports automatic fallback when a provider is unhealthy.
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -142,6 +143,79 @@ impl LlmRouter {
     fn parse_provider(&self, name: &str) -> Option<LlmProvider> {
         LlmProvider::from_str_opt(name)
     }
+
+    /// Select a provider by subscription ID using a subscription-to-backend mapping.
+    ///
+    /// This enables multi-namespace routing: the same API contract is served by
+    /// different backends depending on the subscriber's plan. For example, two Azure
+    /// OpenAI namespaces (`projet-alpha`, `projet-beta`) can be routed to based on
+    /// which plan the subscriber is on.
+    ///
+    /// Returns `None` if the subscription has no mapping or the mapped backend is
+    /// not found / unhealthy.
+    pub fn select_for_subscription(
+        &self,
+        subscription_id: &str,
+        mapping: &SubscriptionMapping,
+    ) -> Option<&ProviderConfig> {
+        let backend_id = mapping.get_backend(subscription_id)?;
+        let config = self.registry.get_by_backend_id(backend_id)?;
+        if self.is_healthy(config.provider) {
+            Some(config)
+        } else {
+            None
+        }
+    }
+}
+
+/// Maps subscription IDs (or plan names) to backend IDs in the provider registry.
+///
+/// # Example
+///
+/// ```text
+/// Plan "Projet Alpha" → backend_id "projet-alpha" → Azure OpenAI namespace alpha
+/// Plan "Projet Beta"  → backend_id "projet-beta"  → Azure OpenAI namespace beta
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SubscriptionMapping {
+    /// subscription_id → backend_id
+    map: HashMap<String, String>,
+}
+
+impl SubscriptionMapping {
+    /// Create an empty mapping.
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    /// Create a mapping from a list of (subscription_id, backend_id) pairs.
+    pub fn from_pairs(pairs: impl IntoIterator<Item = (String, String)>) -> Self {
+        Self {
+            map: pairs.into_iter().collect(),
+        }
+    }
+
+    /// Add a subscription → backend mapping.
+    pub fn insert(&mut self, subscription_id: String, backend_id: String) {
+        self.map.insert(subscription_id, backend_id);
+    }
+
+    /// Look up which backend a subscription maps to.
+    pub fn get_backend(&self, subscription_id: &str) -> Option<&str> {
+        self.map.get(subscription_id).map(|s| s.as_str())
+    }
+
+    /// Number of mappings.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Whether the mapping is empty.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
 }
 
 #[cfg(test)]
@@ -156,6 +230,7 @@ mod tests {
     ) -> super::super::providers::ProviderConfig {
         super::super::providers::ProviderConfig {
             provider,
+            backend_id: None,
             base_url: format!("https://{}.example.com", provider),
             api_key_env: None,
             default_model: None,
@@ -164,6 +239,33 @@ mod tests {
             cost_per_1m_input: cost_input,
             cost_per_1m_output: cost_input * 3.0,
             priority,
+            deployment: None,
+            api_version: None,
+        }
+    }
+
+    fn make_azure_backend(
+        backend_id: &str,
+        endpoint: &str,
+        deployment: &str,
+        priority: u32,
+    ) -> super::super::providers::ProviderConfig {
+        super::super::providers::ProviderConfig {
+            provider: LlmProvider::AzureOpenAi,
+            backend_id: Some(backend_id.to_string()),
+            base_url: endpoint.to_string(),
+            api_key_env: Some(format!(
+                "AZURE_{}_KEY",
+                backend_id.to_uppercase().replace('-', "_")
+            )),
+            default_model: None,
+            max_concurrent: 50,
+            enabled: true,
+            cost_per_1m_input: 5.0,
+            cost_per_1m_output: 15.0,
+            priority,
+            deployment: Some(deployment.to_string()),
+            api_version: Some("2024-12-01-preview".to_string()),
         }
     }
 
@@ -291,5 +393,136 @@ mod tests {
         let router = LlmRouter::new(registry, cb_registry, RoutingStrategy::RoundRobin);
 
         assert!(router.select(None, None).is_none());
+    }
+
+    // --- Subscription routing tests (CAB-1610) ---
+
+    #[test]
+    fn subscription_routes_to_correct_backend() {
+        let router = make_router(
+            vec![
+                make_azure_backend(
+                    "projet-alpha",
+                    "https://projet-alpha.openai.azure.com",
+                    "gpt-4o",
+                    1,
+                ),
+                make_azure_backend(
+                    "projet-beta",
+                    "https://projet-beta.openai.azure.com",
+                    "gpt-4o",
+                    2,
+                ),
+            ],
+            RoutingStrategy::RoundRobin,
+        );
+
+        let mapping = SubscriptionMapping::from_pairs(vec![
+            ("sub-alpha-001".to_string(), "projet-alpha".to_string()),
+            ("sub-beta-001".to_string(), "projet-beta".to_string()),
+        ]);
+
+        // Same contract, different subscriptions → different backends
+        let alpha = router
+            .select_for_subscription("sub-alpha-001", &mapping)
+            .expect("should route to alpha");
+        assert_eq!(alpha.base_url, "https://projet-alpha.openai.azure.com");
+        assert_eq!(alpha.backend_id.as_deref(), Some("projet-alpha"));
+
+        let beta = router
+            .select_for_subscription("sub-beta-001", &mapping)
+            .expect("should route to beta");
+        assert_eq!(beta.base_url, "https://projet-beta.openai.azure.com");
+        assert_eq!(beta.backend_id.as_deref(), Some("projet-beta"));
+    }
+
+    #[test]
+    fn subscription_unknown_returns_none() {
+        let router = make_router(
+            vec![make_azure_backend(
+                "projet-alpha",
+                "https://projet-alpha.openai.azure.com",
+                "gpt-4o",
+                1,
+            )],
+            RoutingStrategy::RoundRobin,
+        );
+
+        let mapping = SubscriptionMapping::from_pairs(vec![(
+            "sub-alpha-001".to_string(),
+            "projet-alpha".to_string(),
+        )]);
+
+        // Unknown subscription → None (caller returns 401)
+        assert!(router
+            .select_for_subscription("sub-unknown", &mapping)
+            .is_none());
+    }
+
+    #[test]
+    fn subscription_unhealthy_backend_returns_none() {
+        let router = make_router(
+            vec![make_azure_backend(
+                "projet-alpha",
+                "https://projet-alpha.openai.azure.com",
+                "gpt-4o",
+                1,
+            )],
+            RoutingStrategy::RoundRobin,
+        );
+
+        let mapping = SubscriptionMapping::from_pairs(vec![(
+            "sub-alpha-001".to_string(),
+            "projet-alpha".to_string(),
+        )]);
+
+        // Trip circuit breaker for AzureOpenAi
+        for _ in 0..6 {
+            router.record_failure(LlmProvider::AzureOpenAi);
+        }
+
+        // Backend is unhealthy → None
+        assert!(router
+            .select_for_subscription("sub-alpha-001", &mapping)
+            .is_none());
+    }
+
+    #[test]
+    fn subscription_mapping_to_missing_backend_returns_none() {
+        let router = make_router(
+            vec![make_azure_backend(
+                "projet-alpha",
+                "https://projet-alpha.openai.azure.com",
+                "gpt-4o",
+                1,
+            )],
+            RoutingStrategy::RoundRobin,
+        );
+
+        // Mapping points to a backend that doesn't exist in registry
+        let mapping = SubscriptionMapping::from_pairs(vec![(
+            "sub-gamma-001".to_string(),
+            "projet-gamma".to_string(),
+        )]);
+
+        assert!(router
+            .select_for_subscription("sub-gamma-001", &mapping)
+            .is_none());
+    }
+
+    #[test]
+    fn subscription_mapping_operations() {
+        let mut mapping = SubscriptionMapping::new();
+        assert!(mapping.is_empty());
+        assert_eq!(mapping.len(), 0);
+
+        mapping.insert("sub-1".to_string(), "backend-a".to_string());
+        mapping.insert("sub-2".to_string(), "backend-b".to_string());
+
+        assert!(!mapping.is_empty());
+        assert_eq!(mapping.len(), 2);
+        assert_eq!(mapping.get_backend("sub-1"), Some("backend-a"));
+        assert_eq!(mapping.get_backend("sub-2"), Some("backend-b"));
+        assert_eq!(mapping.get_backend("sub-3"), None);
     }
 }


### PR DESCRIPTION
## Summary
- Add subscription-based routing for Azure OpenAI backends — same API contract, different Azure namespaces per subscriber plan
- New `backend_id` field on `ProviderConfig` for multi-backend identification within the same provider type
- New `SubscriptionMapping` type maps subscription IDs to backend IDs
- `LlmRouter.select_for_subscription()` resolves subscription → backend → provider config with circuit breaker health check
- New `azure.rs` module: URL builder (`/openai/deployments/{deployment}/chat/completions?api-version=...`) + `api-key` header transformation
- `LlmRouterConfig` extended with `subscription_mapping` for YAML/env configuration

## Test plan
- [x] 45 LLM module tests pass (10 new)
- [x] Subscription routes to correct backend (2 namespaces, 2 subscriptions)
- [x] Unknown subscription returns None (caller returns 401)
- [x] Unhealthy backend returns None (circuit breaker integration)
- [x] Missing backend ID in mapping returns None
- [x] Azure URL builder: standard, trailing slash, missing deployment, missing api_version
- [x] Azure headers: api-key instead of Authorization Bearer
- [x] API key resolution from env var (present, missing, no env name)
- [x] Full transform flow (URL + headers)
- [x] `cargo fmt --check` clean
- [x] `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>