### PR TITLE
fix(arena): add echo route to Kong VPS declarative config

### DIFF
--- a/deploy/vps/kong/docker-compose.yml
+++ b/deploy/vps/kong/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  kong:
+    image: kong/kong-gateway:3.9
+    container_name: kong-gateway
+    restart: unless-stopped
+    environment:
+      KONG_DATABASE: "off"
+      KONG_DECLARATIVE_CONFIG: /kong/kong.yml
+      KONG_PROXY_LISTEN: "0.0.0.0:8000"
+      KONG_ADMIN_LISTEN: "0.0.0.0:8001"
+      KONG_ADMIN_GUI_LISTEN: "off"
+      KONG_LOG_LEVEL: info
+    volumes:
+      - ./kong.yml:/kong/kong.yml:ro
+    ports:
+      - "8000:8000"
+      - "8001:8001"
+    healthcheck:
+      test: ["CMD", "kong", "health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3

--- a/deploy/vps/kong/kong.yml
+++ b/deploy/vps/kong/kong.yml
@@ -1,0 +1,56 @@
+# Kong Declarative Configuration (DB-less mode)
+# 3 demo services + 1 echo backend for Arena benchmarks.
+_format_version: "3.0"
+
+services:
+  # --- Echo backend (Arena benchmark) ---
+  - name: echo-backend
+    url: http://echo-local:8888
+    routes:
+      - name: echo-route
+        paths:
+          - /echo
+        strip_path: false
+
+  # --- Demo Service 1: httpbin (HTTP testing) ---
+  - name: demo-httpbin
+    url: https://httpbin.org
+    routes:
+      - name: demo-httpbin-route
+        paths:
+          - /apis/demo/httpbin
+        methods:
+          - GET
+          - POST
+          - PUT
+          - DELETE
+        strip_path: true
+    plugins:
+      - name: rate-limiting
+        config:
+          minute: 60
+          policy: local
+
+  # --- Demo Service 2: JSONPlaceholder (REST mock) ---
+  - name: demo-jsonplaceholder
+    url: https://jsonplaceholder.typicode.com
+    routes:
+      - name: demo-jsonplaceholder-route
+        paths:
+          - /apis/demo/jsonplaceholder
+        methods:
+          - GET
+          - POST
+        strip_path: true
+
+  # --- Demo Service 3: ReqRes (user API mock) ---
+  - name: demo-reqres
+    url: https://reqres.in/api
+    routes:
+      - name: demo-reqres-route
+        paths:
+          - /apis/demo/reqres
+        methods:
+          - GET
+          - POST
+        strip_path: true


### PR DESCRIPTION
## Summary
- Kong VPS (`<KONG_VPS_IP>`) was missing the `echo-backend` service/route in `kong.yml`, causing `/echo/get` to return 404
- Arena L0 score jumped from **74.9 → 91.3** (+16.4 pts) after adding the route
- Tracks Kong VPS config in repo for the first time (`deploy/vps/kong/`)

## Test plan
- [x] Route tested live: `curl http://<KONG_VPS_IP>:8000/echo/get` → HTTP 200
- [x] Existing demo routes still work (httpbin, jsonplaceholder)
- [x] Arena L0 sidecar run confirmed new score on Pushgateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)
