### PR TITLE
feat(gateway): add LLM completion cache + subscription-aware routing (CAB-1615)

### DIFF
--- a/stoa-gateway/src/config.rs
+++ b/stoa-gateway/src/config.rs
@@ -510,6 +510,22 @@ pub struct Config {
     /// Env: STOA_LLM_PROXY_MISTRAL_UPSTREAM_URL
     #[serde(default = "default_llm_proxy_mistral_upstream_url")]
     pub llm_proxy_mistral_upstream_url: String,
+
+    // === LLM Completion Cache (CAB-1615) ===
+    /// Enable LLM completion cache for non-streaming responses (default: false).
+    /// Env: STOA_LLM_CACHE_ENABLED
+    #[serde(default)]
+    pub llm_cache_enabled: bool,
+
+    /// Max entries in LLM completion cache (default: 1000).
+    /// Env: STOA_LLM_CACHE_MAX_ENTRIES
+    #[serde(default = "default_llm_cache_max_entries")]
+    pub llm_cache_max_entries: u64,
+
+    /// TTL in seconds for cached LLM completions (default: 300 = 5 min).
+    /// Env: STOA_LLM_CACHE_TTL_SECS
+    #[serde(default = "default_llm_cache_ttl_secs")]
+    pub llm_cache_ttl_secs: u64,
 }
 
 /// LLM provider router configuration (CAB-1487)
@@ -898,6 +914,14 @@ fn default_llm_proxy_mistral_upstream_url() -> String {
     "https://api.mistral.ai".to_string()
 }
 
+fn default_llm_cache_max_entries() -> u64 {
+    1_000
+}
+
+fn default_llm_cache_ttl_secs() -> u64 {
+    300
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -999,6 +1023,9 @@ impl Default for Config {
             llm_proxy_provider: None,
             llm_proxy_mistral_api_key: None,
             llm_proxy_mistral_upstream_url: default_llm_proxy_mistral_upstream_url(),
+            llm_cache_enabled: false,
+            llm_cache_max_entries: default_llm_cache_max_entries(),
+            llm_cache_ttl_secs: default_llm_cache_ttl_secs(),
         }
     }
 }

--- a/stoa-gateway/src/llm/cache.rs
+++ b/stoa-gateway/src/llm/cache.rs
@@ -1,0 +1,447 @@
+//! LLM Completion Cache (CAB-1615)
+//!
+//! Caches non-streaming LLM completion responses by content hash.
+//! Avoids redundant upstream calls for identical prompts within the TTL window.
+//!
+//! Cache key: `{subscription_id}:{model}:{hash(messages + temperature)}`
+//!
+//! Only caches:
+//! - Non-streaming responses (streaming = no cache)
+//! - Successful responses (HTTP 2xx)
+//! - Responses with `stream: false` or no `stream` field in the request body
+
+use moka::future::Cache;
+use serde::Deserialize;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use tracing::{debug, info};
+
+/// Cached LLM completion response.
+#[derive(Debug, Clone)]
+pub struct CachedCompletion {
+    /// HTTP response body bytes.
+    pub body: Vec<u8>,
+    /// Content-Type header value.
+    pub content_type: String,
+    /// HTTP status code.
+    pub status: u16,
+}
+
+/// Configuration for the LLM completion cache.
+#[derive(Debug, Clone)]
+pub struct LlmCacheConfig {
+    /// Maximum number of cached entries.
+    pub max_entries: u64,
+    /// Default TTL for cached completions.
+    pub default_ttl: Duration,
+    /// Whether caching is enabled.
+    pub enabled: bool,
+}
+
+impl Default for LlmCacheConfig {
+    fn default() -> Self {
+        Self {
+            max_entries: 1_000,
+            default_ttl: Duration::from_secs(300), // 5 minutes
+            enabled: false,
+        }
+    }
+}
+
+/// LLM completion cache statistics.
+#[derive(Debug, Clone)]
+pub struct LlmCacheStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub entry_count: u64,
+    pub hit_rate: f64,
+}
+
+/// Partial request body for extracting cache-relevant fields.
+#[derive(Debug, Deserialize)]
+struct ChatRequestFields {
+    model: Option<String>,
+    messages: Option<serde_json::Value>,
+    temperature: Option<f64>,
+    stream: Option<bool>,
+}
+
+/// LLM completion cache backed by moka.
+pub struct LlmCompletionCache {
+    cache: Cache<String, CachedCompletion>,
+    enabled: bool,
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+impl LlmCompletionCache {
+    /// Create a new LLM completion cache.
+    pub fn new(config: LlmCacheConfig) -> Self {
+        let cache = Cache::builder()
+            .max_capacity(config.max_entries)
+            .time_to_live(config.default_ttl)
+            .build();
+
+        if config.enabled {
+            info!(
+                max_entries = config.max_entries,
+                ttl_secs = config.default_ttl.as_secs(),
+                "LLM completion cache initialized"
+            );
+        }
+
+        Self {
+            cache,
+            enabled: config.enabled,
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+        }
+    }
+
+    /// Check if the request body is cacheable (non-streaming).
+    pub fn is_cacheable(body: &[u8]) -> bool {
+        match serde_json::from_slice::<ChatRequestFields>(body) {
+            Ok(fields) => !fields.stream.unwrap_or(false),
+            Err(_) => false,
+        }
+    }
+
+    /// Build cache key from subscription context and request body.
+    ///
+    /// Key format: `llm:{subscription_id}:{model}:{hash(messages+temperature)}`
+    pub fn cache_key(subscription_id: &str, body: &[u8]) -> Option<String> {
+        let fields: ChatRequestFields = serde_json::from_slice(body).ok()?;
+        let model = fields.model.as_deref().unwrap_or("default");
+        let messages = fields.messages.as_ref()?;
+
+        let mut hasher = DefaultHasher::new();
+        let messages_str = serde_json::to_string(messages).unwrap_or_default();
+        messages_str.hash(&mut hasher);
+        // Include temperature in hash (different temperatures = different results)
+        let temp_bits = fields.temperature.unwrap_or(1.0).to_bits();
+        temp_bits.hash(&mut hasher);
+        let content_hash = hasher.finish();
+
+        Some(format!(
+            "llm:{}:{}:{:016x}",
+            subscription_id, model, content_hash
+        ))
+    }
+
+    /// Get a cached completion.
+    pub async fn get(&self, subscription_id: &str, body: &[u8]) -> Option<CachedCompletion> {
+        if !self.enabled {
+            return None;
+        }
+
+        let key = Self::cache_key(subscription_id, body)?;
+
+        match self.cache.get(&key).await {
+            Some(cached) => {
+                self.hits.fetch_add(1, Ordering::Relaxed);
+                debug!(key = %key, "LLM cache hit");
+                Some(cached)
+            }
+            None => {
+                self.misses.fetch_add(1, Ordering::Relaxed);
+                debug!(key = %key, "LLM cache miss");
+                None
+            }
+        }
+    }
+
+    /// Store a completion in the cache.
+    pub async fn put(
+        &self,
+        subscription_id: &str,
+        request_body: &[u8],
+        response_body: Vec<u8>,
+        content_type: String,
+        status: u16,
+    ) {
+        if !self.enabled {
+            return;
+        }
+
+        // Only cache successful responses
+        if !(200..300).contains(&status) {
+            return;
+        }
+
+        let key = match Self::cache_key(subscription_id, request_body) {
+            Some(k) => k,
+            None => return,
+        };
+
+        let cached = CachedCompletion {
+            body: response_body,
+            content_type,
+            status,
+        };
+
+        self.cache.insert(key.clone(), cached).await;
+        debug!(key = %key, "LLM completion cached");
+    }
+
+    /// Get cache statistics.
+    pub fn stats(&self) -> LlmCacheStats {
+        let hits = self.hits.load(Ordering::Relaxed);
+        let misses = self.misses.load(Ordering::Relaxed);
+        let total = hits + misses;
+
+        LlmCacheStats {
+            hits,
+            misses,
+            entry_count: self.cache.entry_count(),
+            hit_rate: if total > 0 {
+                hits as f64 / total as f64
+            } else {
+                0.0
+            },
+        }
+    }
+
+    /// Whether caching is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn cache_key_deterministic() {
+        let body = serde_json::to_vec(&json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "temperature": 0.7
+        }))
+        .unwrap();
+
+        let key1 = LlmCompletionCache::cache_key("sub-alpha", &body);
+        let key2 = LlmCompletionCache::cache_key("sub-alpha", &body);
+        assert_eq!(key1, key2);
+        assert!(key1.unwrap().starts_with("llm:sub-alpha:gpt-4o:"));
+    }
+
+    #[test]
+    fn cache_key_different_subscriptions() {
+        let body = serde_json::to_vec(&json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}]
+        }))
+        .unwrap();
+
+        let key_a = LlmCompletionCache::cache_key("sub-alpha", &body).unwrap();
+        let key_b = LlmCompletionCache::cache_key("sub-beta", &body).unwrap();
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn cache_key_different_messages() {
+        let body1 = serde_json::to_vec(&json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}]
+        }))
+        .unwrap();
+        let body2 = serde_json::to_vec(&json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Goodbye"}]
+        }))
+        .unwrap();
+
+        let key1 = LlmCompletionCache::cache_key("sub-1", &body1).unwrap();
+        let key2 = LlmCompletionCache::cache_key("sub-1", &body2).unwrap();
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn cache_key_different_temperatures() {
+        let body1 = serde_json::to_vec(&json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "temperature": 0.0
+        }))
+        .unwrap();
+        let body2 = serde_json::to_vec(&json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "temperature": 1.0
+        }))
+        .unwrap();
+
+        let key1 = LlmCompletionCache::cache_key("sub-1", &body1).unwrap();
+        let key2 = LlmCompletionCache::cache_key("sub-1", &body2).unwrap();
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn cache_key_missing_messages_returns_none() {
+        let body = serde_json::to_vec(&json!({"model": "gpt-4o"})).unwrap();
+        assert!(LlmCompletionCache::cache_key("sub-1", &body).is_none());
+    }
+
+    #[test]
+    fn cache_key_invalid_json_returns_none() {
+        assert!(LlmCompletionCache::cache_key("sub-1", b"not json").is_none());
+    }
+
+    #[test]
+    fn is_cacheable_non_streaming() {
+        let body = serde_json::to_vec(&json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hi"}]
+        }))
+        .unwrap();
+        assert!(LlmCompletionCache::is_cacheable(&body));
+    }
+
+    #[test]
+    fn is_cacheable_explicit_false() {
+        let body = serde_json::to_vec(&json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "stream": false
+        }))
+        .unwrap();
+        assert!(LlmCompletionCache::is_cacheable(&body));
+    }
+
+    #[test]
+    fn not_cacheable_streaming() {
+        let body = serde_json::to_vec(&json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "stream": true
+        }))
+        .unwrap();
+        assert!(!LlmCompletionCache::is_cacheable(&body));
+    }
+
+    #[test]
+    fn not_cacheable_invalid_json() {
+        assert!(!LlmCompletionCache::is_cacheable(b"garbage"));
+    }
+
+    #[tokio::test]
+    async fn cache_put_get_hit() {
+        let cache = LlmCompletionCache::new(LlmCacheConfig {
+            enabled: true,
+            ..LlmCacheConfig::default()
+        });
+
+        let body = serde_json::to_vec(&json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}]
+        }))
+        .unwrap();
+
+        // Miss
+        assert!(cache.get("sub-1", &body).await.is_none());
+
+        // Put
+        cache
+            .put(
+                "sub-1",
+                &body,
+                b"response".to_vec(),
+                "application/json".into(),
+                200,
+            )
+            .await;
+
+        // Hit
+        let cached = cache.get("sub-1", &body).await.unwrap();
+        assert_eq!(cached.body, b"response");
+        assert_eq!(cached.status, 200);
+        assert_eq!(cached.content_type, "application/json");
+    }
+
+    #[tokio::test]
+    async fn cache_skips_error_responses() {
+        let cache = LlmCompletionCache::new(LlmCacheConfig {
+            enabled: true,
+            ..LlmCacheConfig::default()
+        });
+
+        let body = serde_json::to_vec(&json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}]
+        }))
+        .unwrap();
+
+        // Put with error status — should not cache
+        cache
+            .put(
+                "sub-1",
+                &body,
+                b"error".to_vec(),
+                "application/json".into(),
+                429,
+            )
+            .await;
+
+        assert!(cache.get("sub-1", &body).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn cache_disabled_returns_none() {
+        let cache = LlmCompletionCache::new(LlmCacheConfig::default()); // enabled: false
+
+        let body = serde_json::to_vec(&json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}]
+        }))
+        .unwrap();
+
+        cache
+            .put(
+                "sub-1",
+                &body,
+                b"response".to_vec(),
+                "application/json".into(),
+                200,
+            )
+            .await;
+        assert!(cache.get("sub-1", &body).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn cache_stats() {
+        let cache = LlmCompletionCache::new(LlmCacheConfig {
+            enabled: true,
+            ..LlmCacheConfig::default()
+        });
+
+        let body = serde_json::to_vec(&json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}]
+        }))
+        .unwrap();
+
+        // 1 miss
+        let _ = cache.get("sub-1", &body).await;
+        // Put + 2 hits
+        cache
+            .put(
+                "sub-1",
+                &body,
+                b"ok".to_vec(),
+                "application/json".into(),
+                200,
+            )
+            .await;
+        let _ = cache.get("sub-1", &body).await;
+        let _ = cache.get("sub-1", &body).await;
+
+        let stats = cache.stats();
+        assert_eq!(stats.hits, 2);
+        assert_eq!(stats.misses, 1);
+        assert!((stats.hit_rate - 0.666).abs() < 0.01);
+    }
+}

--- a/stoa-gateway/src/llm/mod.rs
+++ b/stoa-gateway/src/llm/mod.rs
@@ -21,6 +21,7 @@
 //! ```
 
 pub mod azure;
+pub mod cache;
 pub mod cost;
 pub mod providers;
 pub mod router;
@@ -29,6 +30,7 @@ pub use azure::{
     build_chat_completions_url, build_headers as azure_headers, transform_request, AzureRequest,
     AzureTransformError,
 };
+pub use cache::{CachedCompletion, LlmCacheConfig, LlmCompletionCache};
 pub use cost::{
     record_fallback, record_latency, BudgetDecision, BudgetGate, CostCalculator, CostResult,
     TokenUsage, LLM_COST_TOTAL, LLM_FALLBACK_TOTAL, LLM_LATENCY_SECONDS,

--- a/stoa-gateway/src/proxy/llm_proxy.rs
+++ b/stoa-gateway/src/proxy/llm_proxy.rs
@@ -19,6 +19,7 @@ use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 
+use crate::llm::{LlmCompletionCache, LlmProvider};
 use crate::state::AppState;
 
 /// Dedicated HTTP client for LLM proxy (long timeouts, large bodies).
@@ -53,49 +54,6 @@ pub async fn llm_proxy_handler(State(state): State<AppState>, request: Request<B
     let request_path = request.uri().path().to_string();
     let api_format = LlmApiFormat::from_path(&request_path);
 
-    // Resolve upstream URL and API key based on format
-    let (upstream_base_url, upstream_api_key) = match api_format {
-        LlmApiFormat::OpenAiCompat => {
-            // OpenAI-compatible: use Mistral-specific config, fallback to default
-            let key = state
-                .config
-                .llm_proxy_mistral_api_key
-                .clone()
-                .or_else(|| state.config.llm_proxy_api_key.clone());
-            let url = if state.config.llm_proxy_mistral_api_key.is_some() {
-                // Mistral API key is set → use Mistral upstream URL
-                state.config.llm_proxy_mistral_upstream_url.clone()
-            } else {
-                // Fallback to default upstream for OpenAI-compat with no Mistral-specific config
-                state.config.llm_proxy_upstream_url.clone()
-            };
-            (url, key)
-        }
-        LlmApiFormat::Anthropic => (
-            state.config.llm_proxy_upstream_url.clone(),
-            state.config.llm_proxy_api_key.clone(),
-        ),
-    };
-
-    let upstream_api_key = match upstream_api_key {
-        Some(key) if !key.is_empty() => key,
-        _ => {
-            let provider = match api_format {
-                LlmApiFormat::OpenAiCompat => "OpenAI-compat/Mistral",
-                LlmApiFormat::Anthropic => "Anthropic",
-            };
-            error!(
-                provider = provider,
-                "LLM proxy: upstream API key not configured"
-            );
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                "LLM proxy upstream not configured",
-            )
-                .into_response();
-        }
-    };
-
     // Step 1: Extract consumer API key from request
     let consumer_key = extract_api_key(request.headers());
     let consumer_key = match consumer_key {
@@ -128,13 +86,107 @@ pub async fn llm_proxy_handler(State(state): State<AppState>, request: Request<B
         "LLM proxy: consumer authenticated"
     );
 
+    // Step 2b: Resolve upstream via subscription routing (CAB-1615)
+    // Try LlmRouter subscription mapping first, fall back to static config.
+    let routed_provider = state.llm_router.as_ref().and_then(|router| {
+        router
+            .select_for_subscription(
+                &subscription_id,
+                &state.config.llm_router.subscription_mapping,
+            )
+            .cloned()
+    });
+
+    let (upstream_base_url, upstream_api_key, is_azure) =
+        if let Some(ref provider_cfg) = routed_provider {
+            // Subscription has a routed backend — use its config
+            let is_azure = provider_cfg.provider == LlmProvider::AzureOpenAi;
+            let url = provider_cfg.base_url.clone();
+            // Resolve API key from environment variable name stored in config
+            let key = provider_cfg
+                .api_key_env
+                .as_ref()
+                .and_then(|env_name| std::env::var(env_name).ok());
+            debug!(
+                subscription_id = %subscription_id,
+                backend_id = ?provider_cfg.backend_id,
+                provider = ?provider_cfg.provider,
+                "LLM proxy: subscription routed to provider"
+            );
+            (url, key, is_azure)
+        } else {
+            // Fallback to static config (existing behavior)
+            let (url, key) = match api_format {
+                LlmApiFormat::OpenAiCompat => {
+                    let key = state
+                        .config
+                        .llm_proxy_mistral_api_key
+                        .clone()
+                        .or_else(|| state.config.llm_proxy_api_key.clone());
+                    let url = if state.config.llm_proxy_mistral_api_key.is_some() {
+                        state.config.llm_proxy_mistral_upstream_url.clone()
+                    } else {
+                        state.config.llm_proxy_upstream_url.clone()
+                    };
+                    (url, key)
+                }
+                LlmApiFormat::Anthropic => (
+                    state.config.llm_proxy_upstream_url.clone(),
+                    state.config.llm_proxy_api_key.clone(),
+                ),
+            };
+            (url, key, false)
+        };
+
+    let upstream_api_key = match upstream_api_key {
+        Some(key) if !key.is_empty() => key,
+        _ => {
+            let provider = match api_format {
+                LlmApiFormat::OpenAiCompat => "OpenAI-compat/Mistral",
+                LlmApiFormat::Anthropic => "Anthropic",
+            };
+            error!(
+                provider = provider,
+                "LLM proxy: upstream API key not configured"
+            );
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "LLM proxy upstream not configured",
+            )
+                .into_response();
+        }
+    };
+
     // Step 3: Build upstream request
-    // Trim trailing slash from base URL to avoid double-slash issues
-    let upstream_url = format!(
-        "{}{}",
-        upstream_base_url.trim_end_matches('/'),
-        request_path
-    );
+    // For Azure OpenAI, use the Azure URL builder; otherwise, simple concatenation.
+    let upstream_url = if is_azure {
+        if let Some(ref provider_cfg) = routed_provider {
+            match crate::llm::build_chat_completions_url(provider_cfg) {
+                Ok(url) => url,
+                Err(e) => {
+                    error!(error = %e, "LLM proxy: failed to build Azure URL");
+                    return (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        format!("Azure OpenAI config error: {e}"),
+                    )
+                        .into_response();
+                }
+            }
+        } else {
+            format!(
+                "{}{}",
+                upstream_base_url.trim_end_matches('/'),
+                request_path
+            )
+        }
+    } else {
+        // Trim trailing slash from base URL to avoid double-slash issues
+        format!(
+            "{}{}",
+            upstream_base_url.trim_end_matches('/'),
+            request_path
+        )
+    };
 
     let timeout = Duration::from_secs(state.config.llm_proxy_timeout_secs);
     let client = llm_client(timeout);
@@ -149,44 +201,86 @@ pub async fn llm_proxy_handler(State(state): State<AppState>, request: Request<B
         }
     };
 
-    // Build upstream headers (format-aware)
+    // Build upstream headers (format-aware + Azure support)
     let mut upstream_headers = HeaderMap::new();
-    match api_format {
-        LlmApiFormat::Anthropic => {
-            // Anthropic: forward anthropic-specific headers, use x-api-key
-            for key in &[
-                "anthropic-version",
-                "anthropic-beta",
-                "content-type",
-                "accept",
-            ] {
-                if let Some(val) = parts.headers.get(*key) {
-                    if let Ok(name) = header::HeaderName::from_bytes(key.as_bytes()) {
-                        upstream_headers.insert(name, val.clone());
-                    }
+    if is_azure {
+        // Azure OpenAI: use api-key header, forward content-type/accept
+        for key in &["content-type", "accept"] {
+            if let Some(val) = parts.headers.get(*key) {
+                if let Ok(name) = header::HeaderName::from_bytes(key.as_bytes()) {
+                    upstream_headers.insert(name, val.clone());
                 }
             }
-            upstream_headers.insert(
-                "x-api-key",
-                HeaderValue::from_str(&upstream_api_key)
-                    .unwrap_or_else(|_| HeaderValue::from_static("")),
-            );
         }
-        LlmApiFormat::OpenAiCompat => {
-            // OpenAI-compatible: forward content-type/accept, use Authorization: Bearer
-            for key in &["content-type", "accept"] {
-                if let Some(val) = parts.headers.get(*key) {
-                    if let Ok(name) = header::HeaderName::from_bytes(key.as_bytes()) {
-                        upstream_headers.insert(name, val.clone());
+        upstream_headers.insert(
+            "api-key",
+            HeaderValue::from_str(&upstream_api_key)
+                .unwrap_or_else(|_| HeaderValue::from_static("")),
+        );
+    } else {
+        match api_format {
+            LlmApiFormat::Anthropic => {
+                // Anthropic: forward anthropic-specific headers, use x-api-key
+                for key in &[
+                    "anthropic-version",
+                    "anthropic-beta",
+                    "content-type",
+                    "accept",
+                ] {
+                    if let Some(val) = parts.headers.get(*key) {
+                        if let Ok(name) = header::HeaderName::from_bytes(key.as_bytes()) {
+                            upstream_headers.insert(name, val.clone());
+                        }
                     }
                 }
+                upstream_headers.insert(
+                    "x-api-key",
+                    HeaderValue::from_str(&upstream_api_key)
+                        .unwrap_or_else(|_| HeaderValue::from_static("")),
+                );
             }
-            let bearer = format!("Bearer {}", upstream_api_key);
-            upstream_headers.insert(
-                header::AUTHORIZATION,
-                HeaderValue::from_str(&bearer)
-                    .unwrap_or_else(|_| HeaderValue::from_static("Bearer ")),
+            LlmApiFormat::OpenAiCompat => {
+                // OpenAI-compatible: forward content-type/accept, use Authorization: Bearer
+                for key in &["content-type", "accept"] {
+                    if let Some(val) = parts.headers.get(*key) {
+                        if let Ok(name) = header::HeaderName::from_bytes(key.as_bytes()) {
+                            upstream_headers.insert(name, val.clone());
+                        }
+                    }
+                }
+                let bearer = format!("Bearer {}", upstream_api_key);
+                upstream_headers.insert(
+                    header::AUTHORIZATION,
+                    HeaderValue::from_str(&bearer)
+                        .unwrap_or_else(|_| HeaderValue::from_static("Bearer ")),
+                );
+            }
+        }
+    }
+
+    // Check LLM completion cache for non-streaming requests (CAB-1615)
+    let is_cacheable = LlmCompletionCache::is_cacheable(&body_bytes);
+    if is_cacheable {
+        if let Some(cached) = state
+            .llm_completion_cache
+            .get(&subscription_id, &body_bytes)
+            .await
+        {
+            debug!(
+                subscription_id = %subscription_id,
+                "LLM proxy: serving from completion cache"
             );
+            let mut response = Response::new(Body::from(cached.body));
+            *response.status_mut() = StatusCode::from_u16(cached.status).unwrap_or(StatusCode::OK);
+            response.headers_mut().insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_str(&cached.content_type)
+                    .unwrap_or_else(|_| HeaderValue::from_static("application/json")),
+            );
+            response
+                .headers_mut()
+                .insert("x-stoa-cache", HeaderValue::from_static("hit"));
+            return response;
         }
     }
 
@@ -331,7 +425,7 @@ pub async fn llm_proxy_handler(State(state): State<AppState>, request: Request<B
         response
     } else {
         // Non-streaming: read full body, extract usage, return
-        let body_bytes = match upstream_resp.bytes().await {
+        let resp_bytes = match upstream_resp.bytes().await {
             Ok(b) => b,
             Err(e) => {
                 error!(error = %e, "LLM proxy: failed to read upstream response");
@@ -341,9 +435,34 @@ pub async fn llm_proxy_handler(State(state): State<AppState>, request: Request<B
         };
 
         let elapsed = start.elapsed();
+        let status_code = upstream_status.as_u16();
+
+        // Store in LLM completion cache if cacheable (CAB-1615)
+        if is_cacheable {
+            let content_type = response_headers
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("application/json")
+                .to_string();
+            let cache = state.llm_completion_cache.clone();
+            let cache_sub = subscription_id.clone();
+            let cache_body = body_bytes.to_vec();
+            let cache_resp = resp_bytes.to_vec();
+            tokio::spawn(async move {
+                cache
+                    .put(
+                        &cache_sub,
+                        &cache_body,
+                        cache_resp,
+                        content_type,
+                        status_code,
+                    )
+                    .await;
+            });
+        }
 
         // Extract usage from JSON response
-        if let Some(usage) = extract_json_usage(&body_bytes) {
+        if let Some(usage) = extract_json_usage(&resp_bytes) {
             info!(
                 tenant_id = %tenant_id,
                 subscription_id = %subscription_id,
@@ -377,9 +496,9 @@ pub async fn llm_proxy_handler(State(state): State<AppState>, request: Request<B
             });
         }
 
-        let mut response = Response::new(Body::from(body_bytes));
+        let mut response = Response::new(Body::from(resp_bytes));
         *response.status_mut() =
-            StatusCode::from_u16(upstream_status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+            StatusCode::from_u16(status_code).unwrap_or(StatusCode::BAD_GATEWAY);
         *response.headers_mut() = response_headers;
         response
     }

--- a/stoa-gateway/src/state.rs
+++ b/stoa-gateway/src/state.rs
@@ -119,6 +119,11 @@ pub struct AppState {
     /// Pre-serialized MCP capabilities JSON (CAB-1558 arena optimization).
     /// Built once at startup — avoids per-request serde + allocation overhead.
     pub capabilities_json: Vec<u8>,
+    /// LLM provider router for subscription-based backend selection (CAB-1610/1615).
+    /// None when the LLM router is disabled or has no providers configured.
+    pub llm_router: Option<Arc<crate::llm::LlmRouter>>,
+    /// LLM completion cache for non-streaming responses (CAB-1615).
+    pub llm_completion_cache: Arc<crate::llm::LlmCompletionCache>,
 }
 
 impl AppState {
@@ -459,6 +464,37 @@ impl AppState {
             serde_json::to_vec(&crate::mcp::discovery::build_capabilities_response())
                 .expect("capabilities response must serialize");
 
+        // Initialize LLM provider router (CAB-1610/1615)
+        let llm_router = if config.llm_router.enabled && !config.llm_router.providers.is_empty() {
+            let provider_registry = Arc::new(crate::llm::ProviderRegistry::new(
+                config.llm_router.providers.clone(),
+            ));
+            let router = Arc::new(crate::llm::LlmRouter::new(
+                provider_registry,
+                circuit_breakers.clone(),
+                config.llm_router.default_strategy,
+            ));
+            tracing::info!(
+                providers = config.llm_router.providers.len(),
+                strategy = ?config.llm_router.default_strategy,
+                "LLM provider router initialized"
+            );
+            Some(router)
+        } else {
+            tracing::info!(
+                "LLM provider router disabled (no providers or STOA_LLM_ROUTER_ENABLED=false)"
+            );
+            None
+        };
+
+        // Initialize LLM completion cache (CAB-1615)
+        let llm_cache_config = crate::llm::LlmCacheConfig {
+            max_entries: config.llm_cache_max_entries,
+            default_ttl: std::time::Duration::from_secs(config.llm_cache_ttl_secs),
+            enabled: config.llm_cache_enabled,
+        };
+        let llm_completion_cache = Arc::new(crate::llm::LlmCompletionCache::new(llm_cache_config));
+
         let start_time = Instant::now();
 
         Self {
@@ -501,6 +537,8 @@ impl AppState {
             admin_token_cache,
             mcp_discovery,
             capabilities_json,
+            llm_router,
+            llm_completion_cache,
         }
     }
 


### PR DESCRIPTION
## Summary
- Add moka-backed `LlmCompletionCache` for non-streaming LLM responses (keyed by subscription+model+message hash)
- Wire `LlmRouter.select_for_subscription()` into the LLM proxy handler for Azure OpenAI namespace routing
- Resolve API keys from environment variables via `ProviderConfig.api_key_env` (not hardcoded)
- Build Azure-specific URLs using `build_chat_completions_url(&ProviderConfig)` from CAB-1610
- Fall back to static config (existing behavior) when no subscription mapping exists
- Add 3 config fields: `llm_cache_enabled`, `llm_cache_max_entries`, `llm_cache_ttl_secs`
- 13 unit tests for the cache module

## Files changed
- `src/llm/cache.rs` — new: LLM completion cache (moka, TTL, stats)
- `src/llm/mod.rs` — export cache types
- `src/config.rs` — 3 new cache config fields with defaults
- `src/state.rs` — wire LlmRouter + LlmCompletionCache into AppState
- `src/proxy/llm_proxy.rs` — subscription routing + Azure URL/headers + cache check/store

## Test plan
- [x] `cargo check` — clean
- [x] `cargo clippy` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] `cargo test` — 1571 passed, 0 failed
- [ ] CI green (3 required checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)