### PR TITLE
feat(docs): add verification matrix and Helm post-upgrade notes (CAB-1622)

### DIFF
--- a/charts/stoa-platform/templates/NOTES.txt
+++ b/charts/stoa-platform/templates/NOTES.txt
@@ -1,0 +1,66 @@
+
+=============================================================
+  STOA Platform — {{ .Chart.Name }} {{ .Chart.Version }}
+  App Version: {{ .Chart.AppVersion }}
+=============================================================
+
+Your STOA Platform release "{{ .Release.Name }}" has been deployed
+to namespace "{{ .Release.Namespace }}".
+
+--------------------------------------------------------------
+  POST-UPGRADE VERIFICATION
+--------------------------------------------------------------
+
+Run the automated verification script:
+
+  ./scripts/release/verify-upgrade.sh \
+    --base-domain {{ .Values.baseDomain | default "<YOUR_DOMAIN>" }} \
+    --namespace {{ .Release.Namespace }}
+
+Or verify manually:
+
+  1. API Health:
+     curl -sf https://api.{{ .Values.baseDomain | default "<YOUR_DOMAIN>" }}/v1/health
+
+  2. Gateway Health:
+     curl -sf https://mcp.{{ .Values.baseDomain | default "<YOUR_DOMAIN>" }}/health
+
+  3. Auth (Keycloak):
+     curl -sf https://auth.{{ .Values.baseDomain | default "<YOUR_DOMAIN>" }}/realms/stoa/.well-known/openid-configuration
+
+  4. Console UI:
+     curl -sf -o /dev/null -w '%{http_code}' https://console.{{ .Values.baseDomain | default "<YOUR_DOMAIN>" }}
+
+  5. Portal:
+     curl -sf -o /dev/null -w '%{http_code}' https://portal.{{ .Values.baseDomain | default "<YOUR_DOMAIN>" }}
+
+  6. Pod Status:
+     kubectl get pods -n {{ .Release.Namespace }}
+
+{{- if .Values.stoaGateway.enabled }}
+
+  7. MCP Discovery:
+     curl -sf https://mcp.{{ .Values.baseDomain | default "<YOUR_DOMAIN>" }}/mcp/capabilities
+{{- end }}
+
+--------------------------------------------------------------
+  BREAKING CHANGES
+--------------------------------------------------------------
+
+Check for breaking changes before going to production:
+
+  cat docs/releases/breaking-changes.md
+
+Or visit: https://docs.gostoa.dev/guides/migration/
+
+--------------------------------------------------------------
+  ROLLBACK
+--------------------------------------------------------------
+
+If any check fails, rollback with:
+
+  helm rollback {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Full upgrade guide:
+  docs/releases/_template/upgrade-guide.md
+

--- a/docs/releases/_template/upgrade-guide.md
+++ b/docs/releases/_template/upgrade-guide.md
@@ -72,24 +72,35 @@ kubectl set image deployment/stoa-gateway \
 Run the automated verification:
 
 ```bash
+# Full verification (HTTP + Kubernetes + ArgoCD)
 ./scripts/release/verify-upgrade.sh
+
+# HTTP-only (no kubectl required)
+./scripts/release/verify-upgrade.sh --skip-k8s
+
+# With version confirmation
+./scripts/release/verify-upgrade.sh --expected-version vX.Y.Z
+
+# Single component
+./scripts/release/verify-upgrade.sh --component api
+
+# Machine-readable output
+./scripts/release/verify-upgrade.sh --json
 ```
 
-Or verify manually — **all checks must pass**:
+Or verify manually — see the full [Verification Matrix](./verification-matrix.md) for all checks.
 
-### Verification Matrix
+### Quick Manual Checks
 
-| # | Component | What to Test | Command | Pass Criteria |
-|---|-----------|-------------|---------|---------------|
-| 1 | API Health | Service responds | `curl -sf ${STOA_API_URL}/v1/health` | HTTP 200, `{"status":"healthy"}` |
-| 2 | Gateway Health | Service responds | `curl -sf ${STOA_GATEWAY_URL}/health` | HTTP 200 |
-| 3 | Auth Chain | Token endpoint works | `curl -sf -X POST ${STOA_AUTH_URL}/realms/stoa/protocol/openid-connect/token -d 'grant_type=client_credentials&client_id=...'` | HTTP 200, `access_token` present |
-| 4 | MCP Discovery | MCP capabilities | `curl -sf ${STOA_GATEWAY_URL}/mcp/capabilities` | HTTP 200, valid JSON |
-| 5 | Console UI | Frontend loads | `curl -sf ${STOA_CONSOLE_URL} -o /dev/null -w '%{http_code}'` | HTTP 200 |
-| 6 | Portal | Frontend loads | `curl -sf ${STOA_PORTAL_URL} -o /dev/null -w '%{http_code}'` | HTTP 200 |
-| 7 | Pod Status | No restarts | `kubectl get pods -n stoa-system --no-headers \| grep -v Running` | Empty output |
-| 8 | ArgoCD Sync | Apps synced | `kubectl get applications -n argocd -o jsonpath='{range .items[*]}{.metadata.name}: {.status.sync.status}\n{end}'` | All "Synced" |
-| 9 | Logs Clean | No errors post-upgrade | `kubectl logs -n stoa-system deploy/control-plane-api --since=5m \| grep -c ERROR` | 0 |
+| # | Component | Command | Pass Criteria |
+|---|-----------|---------|---------------|
+| 1 | API | `curl -sf ${STOA_API_URL}/v1/health` | HTTP 200 |
+| 2 | Gateway | `curl -sf ${STOA_GATEWAY_URL}/health` | HTTP 200 |
+| 3 | Auth | `curl -sf ${STOA_AUTH_URL}/realms/stoa/.well-known/openid-configuration` | `"issuer"` present |
+| 4 | Console | `curl -sf -o /dev/null -w '%{http_code}' ${STOA_CONSOLE_URL}` | `200` |
+| 5 | Portal | `curl -sf -o /dev/null -w '%{http_code}' ${STOA_PORTAL_URL}` | `200` |
+| 6 | MCP | `curl -sf ${STOA_GATEWAY_URL}/mcp/capabilities` | Valid JSON |
+| 7 | Pods | `kubectl get pods -n stoa-system --no-headers \| grep -v Running` | Empty |
 
 ### New Features to Test (vX.Y.Z specific)
 

--- a/docs/releases/_template/verification-matrix.md
+++ b/docs/releases/_template/verification-matrix.md
@@ -1,0 +1,88 @@
+# Verification Matrix — STOA Platform vX.Y.Z
+
+> Use this matrix after every upgrade. Every row MUST pass before declaring the upgrade successful.
+> Automated version: `./scripts/release/verify-upgrade.sh`
+
+## Environment Variables
+
+```bash
+export STOA_API_URL=https://api.<YOUR_DOMAIN>
+export STOA_GATEWAY_URL=https://mcp.<YOUR_DOMAIN>
+export STOA_AUTH_URL=https://auth.<YOUR_DOMAIN>
+export STOA_CONSOLE_URL=https://console.<YOUR_DOMAIN>
+export STOA_PORTAL_URL=https://portal.<YOUR_DOMAIN>
+```
+
+## Core Health (must pass on every upgrade)
+
+| # | Component | Check | Command | Pass Criteria |
+|---|-----------|-------|---------|---------------|
+| 1 | Control Plane API | HTTP health | `curl -sf ${STOA_API_URL}/v1/health` | HTTP 200, JSON contains `"healthy"` |
+| 2 | STOA Gateway | HTTP health | `curl -sf ${STOA_GATEWAY_URL}/health` | HTTP 200 |
+| 3 | Keycloak | OIDC discovery | `curl -sf ${STOA_AUTH_URL}/realms/stoa/.well-known/openid-configuration` | HTTP 200, JSON contains `"issuer"` |
+| 4 | Console UI | Frontend loads | `curl -sf -o /dev/null -w '%{http_code}' ${STOA_CONSOLE_URL}` | HTTP 200 |
+| 5 | Portal | Frontend loads | `curl -sf -o /dev/null -w '%{http_code}' ${STOA_PORTAL_URL}` | HTTP 200 |
+
+## MCP Protocol (must pass if gateway changed)
+
+| # | Component | Check | Command | Pass Criteria |
+|---|-----------|-------|---------|---------------|
+| 6 | MCP Discovery | Capabilities endpoint | `curl -sf ${STOA_GATEWAY_URL}/mcp/capabilities` | HTTP 200, valid JSON |
+| 7 | MCP Tools | Tool listing | `curl -sf -X POST ${STOA_GATEWAY_URL}/mcp/tools/list` | HTTP 200, JSON with `tools` array |
+| 8 | OAuth Discovery | Protected resource | `curl -sf ${STOA_GATEWAY_URL}/.well-known/oauth-protected-resource` | HTTP 200, JSON with `authorization_servers` |
+
+## Auth Chain (must pass if auth/gateway changed)
+
+| # | Component | Check | Command | Pass Criteria |
+|---|-----------|-------|---------|---------------|
+| 9 | Token Endpoint | Client credentials grant | `curl -sf -X POST ${STOA_AUTH_URL}/realms/stoa/protocol/openid-connect/token -d 'grant_type=client_credentials&client_id=<CLIENT>&client_secret=<SECRET>'` | HTTP 200, `access_token` in response |
+| 10 | Authenticated API | Token-protected endpoint | `curl -sf -H "Authorization: Bearer <TOKEN>" ${STOA_API_URL}/v1/tenants` | HTTP 200 or 403 (not 401) |
+
+## Kubernetes (must pass on every upgrade)
+
+| # | Component | Check | Command | Pass Criteria |
+|---|-----------|-------|---------|---------------|
+| 11 | Pod Status | All pods running | `kubectl get pods -n stoa-system --no-headers \| grep -v Running` | Empty output |
+| 12 | No CrashLoops | Zero crash loops | `kubectl get pods -n stoa-system --no-headers \| grep CrashLoopBackOff` | Empty output |
+| 13 | Recent Restarts | No excessive restarts | `kubectl get pods -n stoa-system -o jsonpath='{range .items[*]}{.metadata.name} {.status.containerStatuses[0].restartCount}{"\n"}{end}' \| awk '$2 > 3'` | Empty output |
+| 14 | ArgoCD Sync | Apps synced | `kubectl get applications -n argocd -o custom-columns='NAME:.metadata.name,SYNC:.status.sync.status'` | All rows show "Synced" |
+
+## Version Confirmation (must pass on every upgrade)
+
+| # | Component | Check | Command | Pass Criteria |
+|---|-----------|-------|---------|---------------|
+| 15 | API Version | Correct image tag | `kubectl get deploy/control-plane-api -n stoa-system -o jsonpath='{.spec.template.spec.containers[0].image}'` | Contains expected version tag |
+| 16 | Gateway Version | Correct image tag | `kubectl get deploy/stoa-gateway -n stoa-system -o jsonpath='{.spec.template.spec.containers[0].image}'` | Contains expected version tag |
+| 17 | Helm Release | Correct chart version | `helm list -n stoa-system -o json \| jq '.[0].chart'` | Shows expected chart version |
+
+## Error Rate (check 15 min post-upgrade)
+
+| # | Component | Check | Command | Pass Criteria |
+|---|-----------|-------|---------|---------------|
+| 18 | API Logs | No error spike | `kubectl logs -n stoa-system deploy/control-plane-api --since=15m \| grep -c ERROR` | < 5 errors |
+| 19 | Gateway Logs | No error spike | `kubectl logs -n stoa-system deploy/stoa-gateway --since=15m \| grep -c ERROR` | < 5 errors |
+
+## Version-Specific Tests (vX.Y.Z)
+
+<!-- Add rows for features/changes introduced in this specific version. -->
+<!-- Copy from the "What's New" document and add verification commands. -->
+
+| # | Feature | Check | Command | Pass Criteria |
+|---|---------|-------|---------|---------------|
+| — | _Example: New /v1/foo endpoint_ | _Endpoint responds_ | `curl -sf ${STOA_API_URL}/v1/foo` | _HTTP 200_ |
+
+## Quick Automated Check
+
+```bash
+# Full verification (HTTP + K8s + ArgoCD)
+./scripts/release/verify-upgrade.sh
+
+# HTTP-only (no kubectl required)
+./scripts/release/verify-upgrade.sh --skip-k8s
+
+# Custom domain
+./scripts/release/verify-upgrade.sh --base-domain example.com
+
+# Specific version check
+./scripts/release/verify-upgrade.sh --expected-version v2.1.0
+```

--- a/docs/releases/v2.1.0/upgrade-guide.md
+++ b/docs/releases/v2.1.0/upgrade-guide.md
@@ -90,7 +90,14 @@ helm upgrade stoa-platform ./charts/stoa-platform \
 ### Automated Verification
 
 ```bash
+# Full verification
 ./scripts/release/verify-upgrade.sh
+
+# With version confirmation
+./scripts/release/verify-upgrade.sh --expected-version v2.1.0
+
+# Machine-readable output
+./scripts/release/verify-upgrade.sh --json
 ```
 
 ## Step 5 — Post-Upgrade

--- a/scripts/release/verify-upgrade.sh
+++ b/scripts/release/verify-upgrade.sh
@@ -4,10 +4,13 @@
 # Exit 0 = all checks pass, Exit 1 = at least one check failed.
 #
 # Usage:
-#   ./scripts/release/verify-upgrade.sh                    # Use env vars
-#   ./scripts/release/verify-upgrade.sh --base-domain gostoa.dev  # Override domain
-#   ./scripts/release/verify-upgrade.sh --namespace stoa-system    # Override namespace
-#   ./scripts/release/verify-upgrade.sh --skip-k8s                 # Skip kubectl checks
+#   ./scripts/release/verify-upgrade.sh                              # Use env vars
+#   ./scripts/release/verify-upgrade.sh --base-domain gostoa.dev     # Override domain
+#   ./scripts/release/verify-upgrade.sh --namespace stoa-system       # Override namespace
+#   ./scripts/release/verify-upgrade.sh --skip-k8s                    # Skip kubectl checks
+#   ./scripts/release/verify-upgrade.sh --expected-version v2.1.0     # Check image versions
+#   ./scripts/release/verify-upgrade.sh --component api               # Test single component
+#   ./scripts/release/verify-upgrade.sh --json                        # Machine-readable output
 
 set -euo pipefail
 
@@ -15,6 +18,9 @@ set -euo pipefail
 BASE_DOMAIN="${BASE_DOMAIN:-gostoa.dev}"
 NAMESPACE="${NAMESPACE:-stoa-system}"
 SKIP_K8S="${SKIP_K8S:-false}"
+EXPECTED_VERSION=""
+COMPONENT_FILTER=""
+JSON_OUTPUT=false
 TIMEOUT=10
 
 # Parse arguments
@@ -23,7 +29,22 @@ while [[ $# -gt 0 ]]; do
     --base-domain) BASE_DOMAIN="$2"; shift 2 ;;
     --namespace) NAMESPACE="$2"; shift 2 ;;
     --skip-k8s) SKIP_K8S=true; shift ;;
-    --help) echo "Usage: $0 [--base-domain DOMAIN] [--namespace NS] [--skip-k8s]"; exit 0 ;;
+    --expected-version) EXPECTED_VERSION="$2"; shift 2 ;;
+    --component) COMPONENT_FILTER="$2"; shift 2 ;;
+    --json) JSON_OUTPUT=true; shift ;;
+    --help)
+      echo "Usage: $0 [OPTIONS]"
+      echo ""
+      echo "Options:"
+      echo "  --base-domain DOMAIN     Base domain (default: gostoa.dev)"
+      echo "  --namespace NS           K8s namespace (default: stoa-system)"
+      echo "  --skip-k8s               Skip kubectl checks"
+      echo "  --expected-version VER   Check deployed image versions match VER"
+      echo "  --component NAME         Test single component (api|gateway|auth|console|portal|mcp)"
+      echo "  --json                   Machine-readable JSON output"
+      echo "  --help                   Show this help"
+      exit 0
+      ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 done
@@ -37,116 +58,248 @@ STOA_PORTAL_URL="${STOA_PORTAL_URL:-https://portal.${BASE_DOMAIN}}"
 # --- State ---
 PASS=0
 FAIL=0
+SKIP=0
 TOTAL=0
 RESULTS=()
+JSON_RESULTS=()
+START_TIME=$(date +%s)
 
 # --- Helpers ---
 check() {
-  local name="$1"
-  local cmd="$2"
-  local expected="$3"
+  local component="$1"
+  local name="$2"
+  local cmd="$3"
+  local expected="$4"
+
+  # Apply component filter
+  if [[ -n "$COMPONENT_FILTER" ]] && [[ "$component" != "$COMPONENT_FILTER" ]]; then
+    SKIP=$((SKIP + 1))
+    return
+  fi
+
   TOTAL=$((TOTAL + 1))
 
   local output
   local status=0
+  local start
+  start=$(date +%s%N 2>/dev/null || date +%s)
   output=$(eval "$cmd" 2>&1) || status=$?
+  local end
+  end=$(date +%s%N 2>/dev/null || date +%s)
+  local duration_ms=$(( (end - start) / 1000000 ))
 
   if [[ $status -eq 0 ]] && echo "$output" | grep -qE "$expected"; then
     PASS=$((PASS + 1))
-    RESULTS+=("PASS  $name")
-    printf "  \033[32mPASS\033[0m  %s\n" "$name"
+    RESULTS+=("PASS  [$component] $name (${duration_ms}ms)")
+    JSON_RESULTS+=("{\"component\":\"$component\",\"check\":\"$name\",\"status\":\"pass\",\"duration_ms\":$duration_ms}")
+    if [[ "$JSON_OUTPUT" != "true" ]]; then
+      printf "  \033[32mPASS\033[0m  [%-8s] %s (%dms)\n" "$component" "$name" "$duration_ms"
+    fi
   else
     FAIL=$((FAIL + 1))
-    RESULTS+=("FAIL  $name — got: ${output:0:120}")
-    printf "  \033[31mFAIL\033[0m  %s\n" "$name"
-    printf "        %s\n" "${output:0:200}"
+    local snippet="${output:0:120}"
+    snippet="${snippet//$'\n'/ }"
+    RESULTS+=("FAIL  [$component] $name — got: $snippet")
+    JSON_RESULTS+=("{\"component\":\"$component\",\"check\":\"$name\",\"status\":\"fail\",\"duration_ms\":$duration_ms,\"output\":\"$snippet\"}")
+    if [[ "$JSON_OUTPUT" != "true" ]]; then
+      printf "  \033[31mFAIL\033[0m  [%-8s] %s\n" "$component" "$name"
+      printf "        %s\n" "${output:0:200}"
+    fi
   fi
 }
 
 # --- Banner ---
-echo ""
-echo "================================================"
-echo "  STOA Platform — Post-Upgrade Verification"
-echo "================================================"
-echo "  Domain:    ${BASE_DOMAIN}"
-echo "  Namespace: ${NAMESPACE}"
-echo "  Skip K8s:  ${SKIP_K8S}"
-echo "  Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-echo "================================================"
-echo ""
+if [[ "$JSON_OUTPUT" != "true" ]]; then
+  echo ""
+  echo "================================================"
+  echo "  STOA Platform — Post-Upgrade Verification"
+  echo "================================================"
+  echo "  Domain:    ${BASE_DOMAIN}"
+  echo "  Namespace: ${NAMESPACE}"
+  echo "  Skip K8s:  ${SKIP_K8S}"
+  if [[ -n "$EXPECTED_VERSION" ]]; then
+    echo "  Expected:  ${EXPECTED_VERSION}"
+  fi
+  if [[ -n "$COMPONENT_FILTER" ]]; then
+    echo "  Component: ${COMPONENT_FILTER}"
+  fi
+  echo "  Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "================================================"
+  echo ""
+fi
 
-# --- HTTP Health Checks ---
-echo "HTTP Health Checks"
-echo "------------------"
+# --- Section: Core Health ---
+if [[ "$JSON_OUTPUT" != "true" ]]; then
+  echo "Core Health"
+  echo "-----------"
+fi
 
-check "API Health" \
+check "api" "API Health" \
   "curl -sf --max-time ${TIMEOUT} ${STOA_API_URL}/v1/health" \
   "healthy\|ok\|200"
 
-check "Gateway Health" \
+check "gateway" "Gateway Health" \
   "curl -sf --max-time ${TIMEOUT} ${STOA_GATEWAY_URL}/health" \
   "healthy\|ok\|200"
 
-check "Auth (Keycloak) Health" \
+check "auth" "Keycloak OIDC Discovery" \
   "curl -sf --max-time ${TIMEOUT} ${STOA_AUTH_URL}/realms/stoa/.well-known/openid-configuration" \
   "issuer"
 
-check "MCP Discovery" \
-  "curl -sf --max-time ${TIMEOUT} ${STOA_GATEWAY_URL}/mcp/capabilities" \
-  "capabilities\|tools\|version"
-
-check "Console UI" \
+check "console" "Console UI" \
   "curl -sf --max-time ${TIMEOUT} -o /dev/null -w '%{http_code}' ${STOA_CONSOLE_URL}" \
   "200"
 
-check "Portal" \
+check "portal" "Portal" \
   "curl -sf --max-time ${TIMEOUT} -o /dev/null -w '%{http_code}' ${STOA_PORTAL_URL}" \
   "200"
 
-# --- Kubernetes Checks ---
-if [[ "$SKIP_K8S" != "true" ]]; then
+# --- Section: MCP Protocol ---
+if [[ "$JSON_OUTPUT" != "true" ]]; then
   echo ""
-  echo "Kubernetes Checks"
-  echo "-----------------"
+  echo "MCP Protocol"
+  echo "------------"
+fi
 
-  check "Pods Running" \
+check "mcp" "MCP Discovery" \
+  "curl -sf --max-time ${TIMEOUT} ${STOA_GATEWAY_URL}/mcp/capabilities" \
+  "capabilities\|tools\|version"
+
+check "mcp" "MCP Tools List" \
+  "curl -sf --max-time ${TIMEOUT} -X POST ${STOA_GATEWAY_URL}/mcp/tools/list -H 'Content-Type: application/json' -d '{}'" \
+  "tools"
+
+check "mcp" "OAuth Protected Resource" \
+  "curl -sf --max-time ${TIMEOUT} ${STOA_GATEWAY_URL}/.well-known/oauth-protected-resource" \
+  "authorization_servers\|resource"
+
+# --- Section: Kubernetes ---
+if [[ "$SKIP_K8S" != "true" ]]; then
+  if [[ "$JSON_OUTPUT" != "true" ]]; then
+    echo ""
+    echo "Kubernetes"
+    echo "----------"
+  fi
+
+  check "k8s" "Pods Running" \
     "kubectl get pods -n ${NAMESPACE} --no-headers 2>&1 | grep -cv Running || echo 0" \
     "^0$"
 
-  check "No CrashLoopBackOff" \
+  check "k8s" "No CrashLoopBackOff" \
     "kubectl get pods -n ${NAMESPACE} --no-headers 2>&1 | grep -c CrashLoopBackOff || echo 0" \
     "^0$"
 
-  check "No Recent Restarts (>3)" \
+  check "k8s" "No Excessive Restarts (>3)" \
     "kubectl get pods -n ${NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name} {.status.containerStatuses[0].restartCount}{\"\\n\"}{end}' 2>&1 | awk '\$2 > 3 {count++} END {print count+0}'" \
     "^0$"
 
-  # ArgoCD check (optional — only if argocd namespace exists)
+  # ArgoCD check (optional)
   if kubectl get namespace argocd &>/dev/null; then
-    check "ArgoCD Apps Synced" \
+    check "k8s" "ArgoCD Apps Synced" \
       "kubectl get applications -n argocd -o jsonpath='{range .items[*]}{.status.sync.status}{\"\\n\"}{end}' 2>&1 | grep -cv Synced || echo 0" \
       "^0$"
   fi
+
+  # --- Section: Version Confirmation ---
+  if [[ -n "$EXPECTED_VERSION" ]]; then
+    if [[ "$JSON_OUTPUT" != "true" ]]; then
+      echo ""
+      echo "Version Confirmation"
+      echo "--------------------"
+    fi
+
+    check "api" "API Image Version" \
+      "kubectl get deploy/control-plane-api -n ${NAMESPACE} -o jsonpath='{.spec.template.spec.containers[0].image}' 2>&1" \
+      "${EXPECTED_VERSION}"
+
+    check "gateway" "Gateway Image Version" \
+      "kubectl get deploy/stoa-gateway -n ${NAMESPACE} -o jsonpath='{.spec.template.spec.containers[0].image}' 2>&1" \
+      "${EXPECTED_VERSION}"
+
+    check "console" "Console Image Version" \
+      "kubectl get deploy/control-plane-ui -n ${NAMESPACE} -o jsonpath='{.spec.template.spec.containers[0].image}' 2>&1" \
+      "${EXPECTED_VERSION}"
+
+    check "portal" "Portal Image Version" \
+      "kubectl get deploy/stoa-portal -n ${NAMESPACE} -o jsonpath='{.spec.template.spec.containers[0].image}' 2>&1" \
+      "${EXPECTED_VERSION}"
+  fi
+
+  # --- Section: Error Rate ---
+  if [[ "$JSON_OUTPUT" != "true" ]]; then
+    echo ""
+    echo "Error Rate (last 5 min)"
+    echo "-----------------------"
+  fi
+
+  check "api" "API Error Rate" \
+    "kubectl logs -n ${NAMESPACE} deploy/control-plane-api --since=5m 2>&1 | grep -c ERROR || echo 0" \
+    "^[0-4]$"
+
+  check "gateway" "Gateway Error Rate" \
+    "kubectl logs -n ${NAMESPACE} deploy/stoa-gateway --since=5m 2>&1 | grep -c ERROR || echo 0" \
+    "^[0-4]$"
 fi
 
 # --- Summary ---
-echo ""
-echo "================================================"
-echo "  Results: ${PASS}/${TOTAL} passed, ${FAIL} failed"
-echo "================================================"
-echo ""
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
 
-for r in "${RESULTS[@]}"; do
-  echo "  $r"
-done
-
-echo ""
-
-if [[ $FAIL -gt 0 ]]; then
-  echo "VERIFICATION FAILED — ${FAIL} check(s) need attention."
-  echo "See upgrade guide: docs/releases/_template/upgrade-guide.md"
-  exit 1
+if [[ "$JSON_OUTPUT" == "true" ]]; then
+  # JSON output
+  echo "{"
+  echo "  \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\","
+  echo "  \"domain\": \"${BASE_DOMAIN}\","
+  echo "  \"namespace\": \"${NAMESPACE}\","
+  if [[ -n "$EXPECTED_VERSION" ]]; then
+    echo "  \"expected_version\": \"${EXPECTED_VERSION}\","
+  fi
+  echo "  \"duration_seconds\": ${DURATION},"
+  echo "  \"summary\": {\"total\": ${TOTAL}, \"pass\": ${PASS}, \"fail\": ${FAIL}, \"skip\": ${SKIP}},"
+  echo "  \"verdict\": \"$([ $FAIL -eq 0 ] && echo 'PASS' || echo 'FAIL')\","
+  echo "  \"checks\": ["
+  local first=true
+  for jr in "${JSON_RESULTS[@]}"; do
+    if [[ "$first" == "true" ]]; then
+      echo "    $jr"
+      first=false
+    else
+      echo "    ,$jr"
+    fi
+  done
+  echo "  ]"
+  echo "}"
 else
-  echo "ALL CHECKS PASSED — upgrade verified successfully."
-  exit 0
+  echo ""
+  echo "================================================"
+  printf "  Results: %d/%d passed, %d failed" "$PASS" "$TOTAL" "$FAIL"
+  if [[ $SKIP -gt 0 ]]; then
+    printf ", %d skipped" "$SKIP"
+  fi
+  echo ""
+  echo "  Duration: ${DURATION}s"
+  echo "================================================"
+  echo ""
+
+  for r in "${RESULTS[@]}"; do
+    echo "  $r"
+  done
+
+  echo ""
+
+  if [[ $FAIL -gt 0 ]]; then
+    echo "VERIFICATION FAILED — ${FAIL} check(s) need attention."
+    echo ""
+    echo "Troubleshooting:"
+    echo "  - Check pod logs:    kubectl logs -n ${NAMESPACE} deploy/<component> --tail=50"
+    echo "  - Check pod events:  kubectl describe pod -n ${NAMESPACE} -l app=<component>"
+    echo "  - Check ArgoCD:      kubectl get applications -n argocd"
+    echo "  - Rollback:          helm rollback stoa-platform -n ${NAMESPACE}"
+    echo ""
+    echo "See upgrade guide: docs/releases/_template/upgrade-guide.md"
+    exit 1
+  else
+    echo "ALL CHECKS PASSED — upgrade verified successfully."
+    exit 0
+  fi
 fi


### PR DESCRIPTION
## Summary
- Create standalone verification matrix template with 19 checks across 6 categories (core health, MCP protocol, auth chain, kubernetes, version confirmation, error rate)
- Enhance `verify-upgrade.sh` with `--component`, `--expected-version`, `--json` flags for per-component granularity
- Add Helm `NOTES.txt` with post-upgrade verification commands shown after `helm upgrade`
- Update upgrade-guide templates to reference new matrix and script options

## Linear Ticket
CAB-1622

## Test plan
- [ ] `bash -n scripts/release/verify-upgrade.sh` passes (syntax check)
- [ ] `./scripts/release/verify-upgrade.sh --help` shows usage
- [ ] `./scripts/release/verify-upgrade.sh --skip-k8s` runs HTTP checks only
- [ ] Helm NOTES.txt renders (verified by chart deploy or template)
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>