### PR TITLE
fix(api): use postgresql.ENUM for create_type=False in migrations (CAB-1601)

### DIFF
--- a/control-plane-api/alembic/versions/032_create_skills_table.py
+++ b/control-plane-api/alembic/versions/032_create_skills_table.py
@@ -7,6 +7,7 @@ Create Date: 2026-02-18
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import UUID
 
 revision = "032"
@@ -17,7 +18,7 @@ depends_on = None
 
 def upgrade() -> None:
     # Create enum type first
-    skill_scope_enum = sa.Enum("global", "tenant", "tool", "user", name="skill_scope_enum", create_type=False)
+    skill_scope_enum = postgresql.ENUM("global", "tenant", "tool", "user", name="skill_scope_enum", create_type=False)
     skill_scope_enum.create(op.get_bind(), checkfirst=True)
 
     op.create_table(
@@ -51,4 +52,4 @@ def downgrade() -> None:
     op.drop_index("ix_skills_tenant_scope", table_name="skills")
     op.drop_index("ix_skills_tenant_id", table_name="skills")
     op.drop_table("skills")
-    sa.Enum(name="skill_scope_enum").drop(op.get_bind(), checkfirst=True)
+    postgresql.ENUM(name="skill_scope_enum").drop(op.get_bind(), checkfirst=True)

--- a/control-plane-api/alembic/versions/034_create_execution_logs.py
+++ b/control-plane-api/alembic/versions/034_create_execution_logs.py
@@ -9,6 +9,7 @@ CAB-1318: Consumer execution view with error taxonomy.
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision = "034"
 down_revision = "033"
@@ -18,8 +19,8 @@ depends_on = None
 
 def upgrade() -> None:
     # Create enums
-    executionstatus = sa.Enum("success", "error", "timeout", name="executionstatus", create_type=False)
-    errorcategory = sa.Enum(
+    executionstatus = postgresql.ENUM("success", "error", "timeout", name="executionstatus", create_type=False)
+    errorcategory = postgresql.ENUM(
         "auth", "rate_limit", "backend", "timeout", "validation", name="errorcategory", create_type=False
     )
     executionstatus.create(op.get_bind(), checkfirst=True)
@@ -56,5 +57,5 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("execution_logs")
-    op.execute("DROP TYPE IF EXISTS executionstatus")
-    op.execute("DROP TYPE IF EXISTS errorcategory")
+    postgresql.ENUM(name="executionstatus").drop(op.get_bind(), checkfirst=True)
+    postgresql.ENUM(name="errorcategory").drop(op.get_bind(), checkfirst=True)

--- a/control-plane-api/alembic/versions/042_create_usage_summaries.py
+++ b/control-plane-api/alembic/versions/042_create_usage_summaries.py
@@ -7,6 +7,7 @@ Create Date: 2026-02-24
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import UUID
 
 revision = "042_usage_summaries"
@@ -17,7 +18,7 @@ depends_on = None
 
 def upgrade() -> None:
     # Create the enum type first
-    usage_period_enum = sa.Enum("daily", "monthly", name="usage_period_enum", create_type=False)
+    usage_period_enum = postgresql.ENUM("daily", "monthly", name="usage_period_enum", create_type=False)
     usage_period_enum.create(op.get_bind(), checkfirst=True)
 
     op.create_table(
@@ -56,4 +57,4 @@ def downgrade() -> None:
     op.drop_table("usage_summaries")
 
     # Drop the enum type
-    sa.Enum(name="usage_period_enum").drop(op.get_bind(), checkfirst=True)
+    postgresql.ENUM(name="usage_period_enum").drop(op.get_bind(), checkfirst=True)

--- a/control-plane-api/alembic/versions/043_create_department_budgets.py
+++ b/control-plane-api/alembic/versions/043_create_department_budgets.py
@@ -7,6 +7,7 @@ Create Date: 2026-02-24
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import UUID
 
 revision = "043_department_budgets"
@@ -17,7 +18,7 @@ depends_on = None
 
 def upgrade() -> None:
     # Create enforcement enum
-    enforcement_enum = sa.Enum(
+    enforcement_enum = postgresql.ENUM(
         "enabled", "disabled", "warn_only",
         name="budget_enforcement_enum",
         create_type=False,
@@ -56,4 +57,4 @@ def downgrade() -> None:
     op.drop_index("ix_dept_budgets_tenant_dept")
     op.drop_table("department_budgets")
 
-    sa.Enum(name="budget_enforcement_enum").drop(op.get_bind(), checkfirst=True)
+    postgresql.ENUM(name="budget_enforcement_enum").drop(op.get_bind(), checkfirst=True)

--- a/control-plane-api/alembic/versions/046_add_llm_budget_tables.py
+++ b/control-plane-api/alembic/versions/046_add_llm_budget_tables.py
@@ -7,6 +7,7 @@ Create Date: 2026-02-26
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import UUID
 
 revision = "046_llm_budget_tables"
@@ -17,7 +18,7 @@ depends_on = None
 
 def upgrade() -> None:
     # Create enum explicitly with checkfirst to avoid double-create in create_table
-    llm_status_enum = sa.Enum("active", "inactive", "rate_limited", name="llm_provider_status_enum", create_type=False)
+    llm_status_enum = postgresql.ENUM("active", "inactive", "rate_limited", name="llm_provider_status_enum", create_type=False)
     llm_status_enum.create(op.get_bind(), checkfirst=True)
 
     op.create_table(
@@ -65,4 +66,4 @@ def downgrade() -> None:
     op.drop_index("ix_llm_providers_tenant_provider", table_name="llm_providers")
     op.drop_index("ix_llm_providers_tenant_id", table_name="llm_providers")
     op.drop_table("llm_providers")
-    op.execute("DROP TYPE IF EXISTS llm_provider_status_enum")
+    postgresql.ENUM(name="llm_provider_status_enum").drop(op.get_bind(), checkfirst=True)


### PR DESCRIPTION
## Summary
- Replace `sa.Enum(create_type=False)` with `postgresql.ENUM(create_type=False)` in 5 Alembic migrations (032, 034, 042, 043, 046)
- In SQLAlchemy 2.0.46, `sa.Enum` silently ignores `create_type=False` — the attribute only exists on `postgresql.ENUM`
- This caused "type already exists" errors during `alembic upgrade head` on production (stuck at rev 025)

## Root Cause
`sa.Enum._on_table_create` delegates to `dialect_impl()` which creates a `postgresql.ENUM`. But `create_type=False` is never transferred because it's a `postgresql.ENUM`-specific attribute. The dialect impl defaults to `create_type=True`, so `CREATE TYPE` fires again after the explicit `.create(checkfirst=True)` call.

## Test plan
- [ ] CI green (ruff lint passes)
- [ ] Deploy to production and run `alembic upgrade head` (025 → 048)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>