### PR TITLE
fix(api): make migration 035 idempotent for pre-existing columns (CAB-1601)

### DIFF
--- a/control-plane-api/alembic/versions/035_add_ttl_extension_fields.py
+++ b/control-plane-api/alembic/versions/035_add_ttl_extension_fields.py
@@ -17,15 +17,29 @@ branch_labels = None
 depends_on = None
 
 
+def _column_exists(table: str, column: str) -> bool:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = :table AND column_name = :col)"
+        ),
+        {"table": table, "col": column},
+    )
+    return bool(result.scalar())
+
+
 def upgrade() -> None:
-    op.add_column(
-        "subscriptions",
-        sa.Column("ttl_extension_count", sa.Integer(), nullable=False, server_default="0"),
-    )
-    op.add_column(
-        "subscriptions",
-        sa.Column("ttl_total_extended_days", sa.Integer(), nullable=False, server_default="0"),
-    )
+    if not _column_exists("subscriptions", "ttl_extension_count"):
+        op.add_column(
+            "subscriptions",
+            sa.Column("ttl_extension_count", sa.Integer(), nullable=False, server_default="0"),
+        )
+    if not _column_exists("subscriptions", "ttl_total_extended_days"):
+        op.add_column(
+            "subscriptions",
+            sa.Column("ttl_total_extended_days", sa.Integer(), nullable=False, server_default="0"),
+        )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary
- Add column existence checks in migration 035 before `ALTER TABLE ADD COLUMN`
- Columns `ttl_extension_count` and `ttl_total_extended_days` already exist in production from a previous broken migration run where explicit `COMMIT` in migration 026 broke transactional DDL boundaries

## Context
Production DB is at revision 025. After PR #1279 (026 fix) and PR #1285 (postgresql.ENUM fix), migrations 026-034 run successfully. Migration 035 then fails because these 2 columns already exist from a prior partial run.

## Test plan
- [ ] CI green
- [ ] Deploy and run `alembic upgrade head` on production (025 → 048)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>