### PR TITLE
fix(api): rename mcp_generated_tools indexes to avoid collision (CAB-1601)

### DIFF
--- a/control-plane-api/alembic/versions/041_create_mcp_generated_tools.py
+++ b/control-plane-api/alembic/versions/041_create_mcp_generated_tools.py
@@ -5,8 +5,8 @@ Revises: 040b
 Create Date: 2026-02-24
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 revision = "041_mcp_generated_tools"
@@ -36,10 +36,10 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["contract_id"], ["contracts.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index("ix_mcp_tools_tenant", "mcp_generated_tools", ["tenant_id"])
-    op.create_index("ix_mcp_tools_contract", "mcp_generated_tools", ["contract_id"])
+    op.create_index("ix_mcp_gen_tools_tenant", "mcp_generated_tools", ["tenant_id"])
+    op.create_index("ix_mcp_gen_tools_contract", "mcp_generated_tools", ["contract_id"])
     op.create_index(
-        "ix_mcp_tools_name",
+        "ix_mcp_gen_tools_name",
         "mcp_generated_tools",
         ["tenant_id", "tool_name"],
         unique=True,
@@ -47,7 +47,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index("ix_mcp_tools_name", table_name="mcp_generated_tools")
-    op.drop_index("ix_mcp_tools_contract", table_name="mcp_generated_tools")
-    op.drop_index("ix_mcp_tools_tenant", table_name="mcp_generated_tools")
+    op.drop_index("ix_mcp_gen_tools_name", table_name="mcp_generated_tools")
+    op.drop_index("ix_mcp_gen_tools_contract", table_name="mcp_generated_tools")
+    op.drop_index("ix_mcp_gen_tools_tenant", table_name="mcp_generated_tools")
     op.drop_table("mcp_generated_tools")

--- a/control-plane-api/src/models/contract.py
+++ b/control-plane-api/src/models/contract.py
@@ -196,9 +196,9 @@ class McpGeneratedTool(Base):
     contract = relationship("Contract")
 
     __table_args__ = (
-        Index("ix_mcp_tools_tenant", "tenant_id"),
-        Index("ix_mcp_tools_contract", "contract_id"),
-        Index("ix_mcp_tools_name", "tenant_id", "tool_name", unique=True),
+        Index("ix_mcp_gen_tools_tenant", "tenant_id"),
+        Index("ix_mcp_gen_tools_contract", "contract_id"),
+        Index("ix_mcp_gen_tools_name", "tenant_id", "tool_name", unique=True),
     )
 
     def __repr__(self):


### PR DESCRIPTION
## Summary
- Rename indexes in migration 041 from `ix_mcp_tools_*` to `ix_mcp_gen_tools_*` to avoid naming collision with existing `ix_mcp_tools_tenant` index on `mcp_tools_catalog` (created by migration 009)
- Update SQLAlchemy model `McpGeneratedTool` to match new index names
- Fixes `DuplicateTable: relation "ix_mcp_tools_tenant" already exists` error during `alembic upgrade head`

## Test plan
- [ ] CI green (lint, tests)
- [ ] Deploy to OVH prod
- [ ] Run `alembic upgrade head` — migrations 026-048 complete

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>