### PR TITLE
fix(api): use conn.execute for parameterized seed migration (CAB-1601)

### DIFF
--- a/control-plane-api/alembic/versions/048_seed_chat_completions_api.py
+++ b/control-plane-api/alembic/versions/048_seed_chat_completions_api.py
@@ -28,8 +28,10 @@ API_NAME = "IA \u2014 Chat Completions (GPT-4o)"
 
 
 def upgrade() -> None:
+    conn = op.get_bind()
+
     # 1. Insert API catalog entry
-    op.execute(
+    conn.execute(
         sa.text("""
             INSERT INTO api_catalog (id, tenant_id, api_id, api_name, version, status, category, tags,
                                      portal_published, audience, metadata, openapi_spec, target_gateways)
@@ -130,7 +132,7 @@ def upgrade() -> None:
     )
 
     # 2. Insert Plan: Alpha — Exploration (1000 tokens/min)
-    op.execute(
+    conn.execute(
         sa.text("""
             INSERT INTO plans (id, slug, name, description, tenant_id,
                                rate_limit_per_minute, requires_approval, auto_approve_roles,
@@ -161,7 +163,7 @@ def upgrade() -> None:
     )
 
     # 3. Insert Plan: Beta — Production (5000 tokens/min)
-    op.execute(
+    conn.execute(
         sa.text("""
             INSERT INTO plans (id, slug, name, description, tenant_id,
                                rate_limit_per_minute, requires_approval, auto_approve_roles,
@@ -193,11 +195,12 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(
+    conn = op.get_bind()
+    conn.execute(
         sa.text("DELETE FROM plans WHERE id IN (:alpha_id, :beta_id)"),
         {"alpha_id": PLAN_ALPHA_ID, "beta_id": PLAN_BETA_ID},
     )
-    op.execute(
+    conn.execute(
         sa.text("DELETE FROM api_catalog WHERE id = :id"),
         {"id": API_CATALOG_ID},
     )


### PR DESCRIPTION
## Summary
- Migration 048 used `op.execute(sa.text(...), params)` which fails in SQLAlchemy 2.0 — `op.execute()` only accepts a single argument
- Changed to `op.get_bind().execute()` for all 3 parameterized INSERT statements and 2 DELETE statements
- This is the last blocker for `alembic upgrade head` on production (migrations 026-047 now pass)

## Test plan
- [ ] CI green
- [ ] Deploy to OVH prod
- [ ] Run `alembic upgrade head` — all 23 migrations (026-048) complete

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>