### PR TITLE
fix(api): use CAST() instead of :: for jsonb/json in migration 048 (CAB-1601)

### DIFF
--- a/control-plane-api/alembic/versions/048_seed_chat_completions_api.py
+++ b/control-plane-api/alembic/versions/048_seed_chat_completions_api.py
@@ -37,8 +37,8 @@ def upgrade() -> None:
                                      portal_published, audience, metadata, openapi_spec, target_gateways)
             VALUES (
                 :id, :tenant_id, :api_id, :api_name, :version, :status, :category,
-                :tags::jsonb, :portal_published, :audience, :metadata::jsonb,
-                :openapi_spec::jsonb, :target_gateways::jsonb
+                CAST(:tags AS jsonb), :portal_published, :audience, CAST(:metadata AS jsonb),
+                CAST(:openapi_spec AS jsonb), CAST(:target_gateways AS jsonb)
             )
             ON CONFLICT (tenant_id, api_id) DO UPDATE SET
                 api_name = EXCLUDED.api_name,
@@ -139,8 +139,8 @@ def upgrade() -> None:
                                status, pricing_metadata, created_by)
             VALUES (
                 :id, :slug, :name, :description, :tenant_id,
-                :rate_limit_per_minute, :requires_approval, :auto_approve_roles::json,
-                :status, :pricing_metadata::json, :created_by
+                :rate_limit_per_minute, :requires_approval, CAST(:auto_approve_roles AS json),
+                :status, CAST(:pricing_metadata AS json), :created_by
             )
             ON CONFLICT (tenant_id, slug) DO UPDATE SET
                 name = EXCLUDED.name,
@@ -170,8 +170,8 @@ def upgrade() -> None:
                                status, pricing_metadata, created_by)
             VALUES (
                 :id, :slug, :name, :description, :tenant_id,
-                :rate_limit_per_minute, :requires_approval, :auto_approve_roles::json,
-                :status, :pricing_metadata::json, :created_by
+                :rate_limit_per_minute, :requires_approval, CAST(:auto_approve_roles AS json),
+                :status, CAST(:pricing_metadata AS json), :created_by
             )
             ON CONFLICT (tenant_id, slug) DO UPDATE SET
                 name = EXCLUDED.name,


### PR DESCRIPTION
## Summary
- Replace `::jsonb` / `::json` PostgreSQL cast syntax with `CAST(:param AS jsonb)` in migration 048
- `sa.text()` interprets `:tags` as a bind parameter but `::jsonb` breaks the parser — causing `psycopg2.errors.SyntaxError`
- Affects 8 cast expressions across 3 INSERT statements (api_catalog + 2 plans)

## Context
Fourth fix in the CAB-1601 production migration series:
- PR #1285: `postgresql.ENUM(create_type=False)` for 5 migrations
- PR #1286: idempotent `_column_exists()` for migration 035
- PR #1287: index rename collision in migration 041
- PR #1288: `conn.execute()` instead of `op.execute()` for migration 048
- **This PR**: CAST() syntax for migration 048's jsonb/json columns

## Test plan
- [x] Python syntax valid
- [x] ruff clean
- [ ] CI green
- [ ] `alembic upgrade head` succeeds on production (025 → 048)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>