### PR TITLE
feat(api): add cache token columns to usage metering (CAB-1601)

### DIFF
--- a/control-plane-api/alembic/versions/049_add_cache_token_columns.py
+++ b/control-plane-api/alembic/versions/049_add_cache_token_columns.py
@@ -1,0 +1,44 @@
+"""Add cache token columns to usage_summaries (CAB-1601).
+
+Adds input_tokens, output_tokens, cache_creation_input_tokens, and
+cache_read_input_tokens to the usage_summaries table for Anthropic
+prompt caching support.
+
+Revision ID: 049_cache_token_columns
+Revises: 048_seed_chat_completions
+Create Date: 2026-03-01
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "049_cache_token_columns"
+down_revision = "048_seed_chat_completions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "usage_summaries",
+        sa.Column("input_tokens", sa.BigInteger(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "usage_summaries",
+        sa.Column("output_tokens", sa.BigInteger(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "usage_summaries",
+        sa.Column("cache_creation_input_tokens", sa.BigInteger(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "usage_summaries",
+        sa.Column("cache_read_input_tokens", sa.BigInteger(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("usage_summaries", "cache_read_input_tokens")
+    op.drop_column("usage_summaries", "cache_creation_input_tokens")
+    op.drop_column("usage_summaries", "output_tokens")
+    op.drop_column("usage_summaries", "input_tokens")

--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -20567,6 +20567,20 @@
       "UsageRecordRequest": {
         "description": "Gateway-submitted usage event (CAB-1568: LLM proxy metering).",
         "properties": {
+          "cache_creation_input_tokens": {
+            "default": 0,
+            "description": "Anthropic cache creation tokens",
+            "minimum": 0.0,
+            "title": "Cache Creation Input Tokens",
+            "type": "integer"
+          },
+          "cache_read_input_tokens": {
+            "default": 0,
+            "description": "Anthropic cache read tokens",
+            "minimum": 0.0,
+            "title": "Cache Read Input Tokens",
+            "type": "integer"
+          },
           "endpoint": {
             "default": "/v1/messages",
             "description": "API endpoint called",
@@ -20853,6 +20867,16 @@
             "title": "Api Id",
             "type": "string"
           },
+          "cache_creation_input_tokens": {
+            "default": 0,
+            "title": "Cache Creation Input Tokens",
+            "type": "integer"
+          },
+          "cache_read_input_tokens": {
+            "default": 0,
+            "title": "Cache Read Input Tokens",
+            "type": "integer"
+          },
           "consumer_id": {
             "anyOf": [
               {
@@ -20879,6 +20903,16 @@
             "format": "uuid",
             "title": "Id",
             "type": "string"
+          },
+          "input_tokens": {
+            "default": 0,
+            "title": "Input Tokens",
+            "type": "integer"
+          },
+          "output_tokens": {
+            "default": 0,
+            "title": "Output Tokens",
+            "type": "integer"
           },
           "p99_latency_ms": {
             "anyOf": [

--- a/control-plane-api/src/models/usage_summary.py
+++ b/control-plane-api/src/models/usage_summary.py
@@ -37,6 +37,10 @@ class UsageSummary(Base):
 
     # Token usage (for LLM/MCP tool calls)
     total_tokens = Column(BigInteger, nullable=False, default=0)
+    input_tokens = Column(BigInteger, nullable=False, default=0, server_default="0")
+    output_tokens = Column(BigInteger, nullable=False, default=0, server_default="0")
+    cache_creation_input_tokens = Column(BigInteger, nullable=False, default=0, server_default="0")
+    cache_read_input_tokens = Column(BigInteger, nullable=False, default=0, server_default="0")
 
     # Timestamps
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)

--- a/control-plane-api/src/repositories/usage_metering.py
+++ b/control-plane-api/src/repositories/usage_metering.py
@@ -113,6 +113,10 @@ class UsageMeteringRepository:
         total_latency_ms: int = 0,
         p99_latency_ms: int | None = None,
         total_tokens: int = 0,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cache_creation_input_tokens: int = 0,
+        cache_read_input_tokens: int = 0,
         consumer_id: uuid.UUID | None = None,
     ) -> UsageSummary:
         """Insert or update a usage summary record (upsert on tenant+api+period+period_start)."""
@@ -143,6 +147,10 @@ class UsageMeteringRepository:
                     total_latency_ms=UsageSummary.total_latency_ms + total_latency_ms,
                     p99_latency_ms=p99_latency_ms if p99_latency_ms is not None else existing.p99_latency_ms,
                     total_tokens=UsageSummary.total_tokens + total_tokens,
+                    input_tokens=UsageSummary.input_tokens + input_tokens,
+                    output_tokens=UsageSummary.output_tokens + output_tokens,
+                    cache_creation_input_tokens=UsageSummary.cache_creation_input_tokens + cache_creation_input_tokens,
+                    cache_read_input_tokens=UsageSummary.cache_read_input_tokens + cache_read_input_tokens,
                     updated_at=datetime.utcnow(),
                 )
             )
@@ -165,6 +173,10 @@ class UsageMeteringRepository:
             total_latency_ms=total_latency_ms,
             p99_latency_ms=p99_latency_ms,
             total_tokens=total_tokens,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
         )
         self.session.add(new_record)
         await self.session.flush()

--- a/control-plane-api/src/routers/usage_metering.py
+++ b/control-plane-api/src/routers/usage_metering.py
@@ -106,6 +106,10 @@ async def record_usage(
         request_count=payload.request_count,
         total_latency_ms=payload.total_latency_ms,
         total_tokens=payload.total_tokens,
+        input_tokens=payload.input_tokens,
+        output_tokens=payload.output_tokens,
+        cache_creation_input_tokens=payload.cache_creation_input_tokens,
+        cache_read_input_tokens=payload.cache_read_input_tokens,
     )
     await db.commit()
 

--- a/control-plane-api/src/schemas/usage_metering.py
+++ b/control-plane-api/src/schemas/usage_metering.py
@@ -22,6 +22,10 @@ class UsageSummaryResponse(BaseModel):
     total_latency_ms: int = 0
     p99_latency_ms: int | None = None
     total_tokens: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
     created_at: datetime
     updated_at: datetime
 
@@ -45,6 +49,8 @@ class UsageRecordRequest(BaseModel):
     total_tokens: int = Field(default=0, ge=0, description="Total tokens (input + output)")
     input_tokens: int = Field(default=0, ge=0, description="Input tokens")
     output_tokens: int = Field(default=0, ge=0, description="Output tokens")
+    cache_creation_input_tokens: int = Field(default=0, ge=0, description="Anthropic cache creation tokens")
+    cache_read_input_tokens: int = Field(default=0, ge=0, description="Anthropic cache read tokens")
     total_latency_ms: int = Field(default=0, ge=0, description="Request latency in ms")
 
 

--- a/control-plane-api/src/services/usage_metering.py
+++ b/control-plane-api/src/services/usage_metering.py
@@ -76,6 +76,10 @@ class UsageMeteringService:
         total_latency_ms: int = 0,
         p99_latency_ms: int | None = None,
         total_tokens: int = 0,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cache_creation_input_tokens: int = 0,
+        cache_read_input_tokens: int = 0,
         consumer_id: uuid.UUID | None = None,
     ) -> UsageSummaryResponse:
         """Record (upsert) a usage event into the summaries table."""
@@ -89,6 +93,10 @@ class UsageMeteringService:
             total_latency_ms=total_latency_ms,
             p99_latency_ms=p99_latency_ms,
             total_tokens=total_tokens,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
             consumer_id=consumer_id,
         )
         return UsageSummaryResponse.model_validate(record)


### PR DESCRIPTION
## Summary

- Add `cache_creation_input_tokens` and `cache_read_input_tokens` to usage metering schema, model, repository, service, and router
- Add `input_tokens` and `output_tokens` columns for granular token tracking
- Migration 049 adds 4 new BigInteger columns with `server_default=0` (backward compatible)
- OpenAPI snapshot updated to reflect new fields

Companion to PR #1292 (Rust gateway cache field extraction).

## Test plan

- [x] `ruff check .` — clean
- [x] `black --check .` — clean
- [x] `pytest tests/ --cov=src --cov-fail-under=70 --ignore=tests/test_opensearch.py` — 6408 passed (3 pre-existing failures on main)
- [x] OpenAPI snapshot regenerated and test passes
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)