### PR TITLE
fix(ci): use PAT for Release Please to bypass enterprise PR restriction

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,7 +31,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary
- Use `RELEASE_PLEASE_TOKEN` PAT instead of `GITHUB_TOKEN` for Release Please PR creation
- Falls back to `GITHUB_TOKEN` if the secret is not set

## Context
Enterprise policy blocks `GITHUB_TOKEN` write permissions: _"Write permissions for workflows are disabled by the enterprise"_ (HTTP 409). This prevents Release Please from creating PRs regardless of org or repo settings.

## Test plan
- [ ] After merge: Release Please run succeeds
- [ ] Release Please creates `chore(main): release 2.2.0` PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)