### PR TITLE
fix(ci): remove package-name to fix Release Please component mismatch

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,8 +18,6 @@
     {"type": "ci", "section": "CI/CD", "hidden": true}
   ],
   "packages": {
-    ".": {
-      "package-name": "stoa-platform"
-    }
+    ".": {}
   }
 }


### PR DESCRIPTION
## Summary
- Removes `package-name: "stoa-platform"` from `release-please-config.json`
- Fixes the "untagged, merged release PRs outstanding" abort that prevented automatic tagging after merging a release PR
- Root cause: Release Please v17 uses `package-name` as the component for PR title matching, but the default title pattern `chore: release main` has `component=undefined`, causing a mismatch

## Context
v2.2.0 release was created manually because of this bug. This fix ensures v2.3.0+ will be fully automated.

## Test plan
- [ ] CI green
- [ ] Next Release Please run doesn't show `PR component: undefined does not match configured component` warning

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>