### PR TITLE
docs: update memory.md with arena LLM routing fix and scores

### DIFF
--- a/memory.md
+++ b/memory.md
@@ -1,6 +1,6 @@
 # STOA Memory
 
-> Derniere MAJ: 2026-03-01 (CAB-1601: Cache Token Tracking complete, PRs #1292, #1303, #1304, #1305)
+> Derniere MAJ: 2026-03-01 (Arena LLM routing fix PR #1317, llm_routing 39.9→91.5)
 
 ## ✅ DONE
 
@@ -15,6 +15,7 @@
   - PR #1305: Dogfood script — `--verify` (4 checks), `--hegemon` (VPS env), enhanced `--setup`
 - ✅ CAB-1614: Arena 20 Dimensions — Blue Ocean (21 pts) — PRs #1270, #1276 (12 new k6 scenarios, features gate, 4-category Grafana, VPS sidecar deploy)
 - ✅ CAB-1552: Lazy MCP Discovery + ADR-051 (5 pts) — PR #1209 (LazyMcpDiscovery struct, moka cache, 10 tests)
+- ✅ Arena LLM routing fix — PRs #1313, #1317 (Mistral/OpenAI-compat corpus + LLM_BASE_URL fix). Score: llm_routing 39.9→91.5, llm_cost ~40→84.8, composite 83.90
 
 ### Cycle 11 (Feb 27) — 152/152 pts, 8 tickets, 9 PRs, 3h wall clock
 - ✅ CAB-1539: Portal Unit Tests (21 pts) — PR #1181 (15 untested components)
@@ -141,6 +142,7 @@ CAB-1512: MCP Federation v2 (21 pts) — Council 5.50 → needs spec
 - C10 CLOSED: 193/193 pts, 13 tickets, 100%
 - C11 CLOSED: 152/152 pts, 8 tickets, 9 PRs, 3h wall clock, 4 parallel instances
 - **Cache token tracking** (CAB-1601): end-to-end Anthropic prompt cache monitoring. Gateway extracts cache_creation/read tokens → Prometheus counters → CP API stores in usage_summaries (migration 049) → Grafana dashboard (cache ratio, savings, per-tenant cost, model mix). Verify: `stoa-dogfood.sh --verify`
+- **Arena Enterprise scores** (2026-03-01): STOA 83.90 (CI95 [83.74, 84.00]) | Gravitee 46.72 | Kong 5.46. LLM routing fix: `LLM_BASE_URL = LLM_MOCK_URL || TARGET_URL` routes LLM calls to mock backend in arena mode (PRs #1313, #1317)
 - Test suite: 5700+ tests, 91% coverage (control-plane-api), 1330+ gateway tests
 - Session 2026-02-27: 9 PRs merged (#1181-#1191), parallel 4-pane dispatch, 152 pts in 3h
 - Session 2026-02-26: 25 PRs merged (#1111-#1135), parallel agents + inline implementation, 5 MEGAs completed + Go daemon


### PR DESCRIPTION
## Summary
- Updated MAJ line with arena LLM routing fix reference
- Added arena LLM routing fix (PRs #1313, #1317) to Cycle 12 DONE section
- Added enterprise arena scores to NOTES (STOA 83.90, Gravitee 46.72, Kong 5.46)

## Test plan
- [ ] CI green (docs-only change)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>