### PR TITLE
feat(gateway): wire AI Factory through STOA Gateway LLM proxy (CAB-1633)

### DIFF
--- a/deploy/vps/hegemon/setup-claude.sh
+++ b/deploy/vps/hegemon/setup-claude.sh
@@ -71,6 +71,9 @@ ssh_cmd 'cat > ~/.env.hegemon << "ENVEOF"
 # Path: /anthropic/ANTHROPIC_API_KEY
 export ANTHROPIC_API_KEY=""
 
+# Route Claude API calls through STOA Gateway for metering/budget/kill-switch
+export ANTHROPIC_BASE_URL="https://mcp.gostoa.dev"
+
 # Path: /slack/SLACK_WEBHOOK_URL
 export SLACK_WEBHOOK_URL=""
 

--- a/hegemon/daemon/infisical-loader.sh
+++ b/hegemon/daemon/infisical-loader.sh
@@ -100,6 +100,9 @@ _hegemon_load_secrets() {
   _val=$(_infisical_fetch "/n8n" "GITHUB_PAT")
   [ -n "$_val" ] && export GH_TOKEN="$_val"
 
+  # Route Claude API calls through STOA Gateway (metering, budget gate, kill-switch)
+  export ANTHROPIC_BASE_URL="${ANTHROPIC_BASE_URL:-https://mcp.gostoa.dev}"
+
   # Clear token from memory
   unset _HEGEMON_TOKEN
 

--- a/scripts/ai-ops/stoa-dogfood.sh
+++ b/scripts/ai-ops/stoa-dogfood.sh
@@ -266,6 +266,26 @@ if 'cache_creation_input_tokens' in usage:
     fi
 }
 
+cmd_status() {
+    echo "=== STOA Dogfood Status ==="
+    if [[ -f "$PID_FILE" ]]; then
+        local pid
+        pid=$(cat "$PID_FILE")
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "  Status:  RUNNING"
+            echo "  PID:     $pid"
+            echo "  Port:    $GATEWAY_PORT"
+            echo "  Logs:    /tmp/stoa-dogfood.log"
+            echo "  Health:  $(curl -sf "http://localhost:${GATEWAY_PORT}/health" 2>/dev/null || echo 'unreachable')"
+        else
+            echo "  Status:  STOPPED (stale PID file)"
+            echo "  PID:     $pid (not running)"
+        fi
+    else
+        echo "  Status:  STOPPED (no PID file)"
+    fi
+}
+
 cmd_setup() {
     echo "=== STOA Dogfood Setup ==="
     echo ""
@@ -296,6 +316,7 @@ cmd_setup() {
 # --- Main ---
 case "${1:-}" in
     --stop)     cmd_stop ;;
+    --status)   cmd_status ;;
     --env)      cmd_env ;;
     --hegemon)  cmd_hegemon ;;
     --verify)   cmd_verify ;;
@@ -308,6 +329,7 @@ case "${1:-}" in
         echo "  (default)   Start the gateway locally"
         echo "  --start     Start the gateway locally"
         echo "  --stop      Stop the gateway"
+        echo "  --status    Show gateway status (PID, port, health)"
         echo "  --env       Print env vars for local tmux panes"
         echo "  --hegemon   Print env vars for HEGEMON workers (Contabo VPS)"
         echo "  --verify    Run health + passthrough + cache metrics checks"

--- a/scripts/parallel/stoa-parallel
+++ b/scripts/parallel/stoa-parallel
@@ -97,6 +97,8 @@ for arg in "$@"; do
     --kill)
       echo "Killing session $SESSION..."
       tmux kill-session -t "$SESSION" 2>/dev/null || echo "No session to kill."
+      # Stop local gateway if running
+      "$STOA_DIR/scripts/ai-ops/stoa-dogfood.sh" --stop 2>/dev/null || true
       # Cleanup generated files
       for role in orchestre backend frontend auth mcp qa; do
         rm -f "$INSTANCES_DIR/${role}.local.md"
@@ -446,6 +448,10 @@ sleep 0.5
 tmux send-keys -t "$SESSION:workspace.1" "stoa-gc" Enter
 
 if [[ "$LAUNCH_CLAUDE" == "true" ]]; then
+  # ── Auto-start local gateway for LLM proxy metering ──
+  "$STOA_DIR/scripts/ai-ops/stoa-dogfood.sh" --start 2>/dev/null || \
+    echo "WARNING: Gateway start failed. Claude will call api.anthropic.com directly."
+
   # ── Ensure auto-merge is enabled on the repo ──
   # Without this, `stoa-merge` and `gh pr merge --auto` fail silently.
   # Only check once per session (idempotent, non-blocking).
@@ -560,6 +566,8 @@ CONFIGEOF
   echo "Launching 6 Claude instances (${max_count} Max + ${api_count} API)..."
 
   # ── ORCHESTRE (pane 0, always Max) ──
+  tmux send-keys -t "$SESSION:workspace.0" "export ANTHROPIC_BASE_URL=http://localhost:${GATEWAY_PORT:-8080}" Enter
+  sleep 0.3
   tmux send-keys -t "$SESSION:workspace.0" "claude" Enter
 
   # ── Specialist instances (panes 2-6) ──
@@ -568,10 +576,10 @@ CONFIGEOF
 
     if is_max_pane "$p"; then
       # Max pane: uses ~/.claude/ (has subscription credentials)
-      tmux send-keys -t "$SESSION:workspace.$p" "export STOA_INSTANCE=${role}" Enter
+      tmux send-keys -t "$SESSION:workspace.$p" "export STOA_INSTANCE=${role} ANTHROPIC_BASE_URL=http://localhost:${GATEWAY_PORT:-8080}" Enter
     else
       # API pane: CLAUDE_CONFIG_DIR points to dir WITHOUT Max credentials
-      tmux send-keys -t "$SESSION:workspace.$p" "export STOA_INSTANCE=${role} ANTHROPIC_API_KEY='${API_KEY}' CLAUDE_CONFIG_DIR='${API_CONFIG_DIR}'" Enter
+      tmux send-keys -t "$SESSION:workspace.$p" "export STOA_INSTANCE=${role} ANTHROPIC_API_KEY='${API_KEY}' CLAUDE_CONFIG_DIR='${API_CONFIG_DIR}' ANTHROPIC_BASE_URL=http://localhost:${GATEWAY_PORT:-8080}" Enter
     fi
     # Small delay to ensure env export is processed before claude launch
     sleep 0.3

--- a/stoa-gateway/k8s/deployment.yaml
+++ b/stoa-gateway/k8s/deployment.yaml
@@ -64,6 +64,14 @@ spec:
               value: "true"
             - name: STOA_KAFKA_BROKERS
               value: "redpanda.stoa-system.svc.cluster.local:9092"
+            - name: STOA_LLM_PROXY_ENABLED
+              value: "true"
+            - name: STOA_LLM_PROXY_UPSTREAM_URL
+              value: "https://api.anthropic.com"
+            - name: STOA_LLM_PROXY_TIMEOUT_SECS
+              value: "300"
+            - name: STOA_LLM_PROXY_METERING_URL
+              value: "http://stoa-control-plane-api.stoa-system.svc.cluster.local:80"
           # REQUIRED for auto-registration (ADR-028):
           # The Secret `stoa-gateway-secrets` MUST contain:
           #   STOA_CONTROL_PLANE_API_KEY - API key matching one entry in


### PR DESCRIPTION
## Summary
- Enable LLM proxy on production gateway K8s deployment (4 env vars)
- Wire stoa-parallel to auto-start/stop local gateway and inject `ANTHROPIC_BASE_URL` for all panes
- Wire HEGEMON workers to route through `mcp.gostoa.dev` via env template and Infisical loader
- Add `--status` command to `stoa-dogfood.sh` for quick health checks

## Test plan
- [ ] `grep STOA_LLM_PROXY stoa-gateway/k8s/deployment.yaml` shows 4 env vars
- [ ] `grep ANTHROPIC_BASE_URL scripts/parallel/stoa-parallel` shows 3 injection points
- [ ] `grep ANTHROPIC_BASE_URL deploy/vps/hegemon/setup-claude.sh` shows env template entry
- [ ] `grep ANTHROPIC_BASE_URL hegemon/daemon/infisical-loader.sh` shows export with default
- [ ] `stoa-dogfood.sh --status` reports PID/port/health
- [ ] Gateway failure gracefully falls back to direct Anthropic API

🤖 Generated with [Claude Code](https://claude.com/claude-code)