### PR TITLE
chore(skills): sanitize sensitive data in skill files for public repo (CAB-1632)

### DIFF
--- a/.claude/skills/analytics/SKILL.md
+++ b/.claude/skills/analytics/SKILL.md
@@ -30,7 +30,7 @@ psql "$DB_URL" -c "<QUERY>"
 
 Fallback (direct):
 ```bash
-psql "postgresql://avnadmin:<password>@postgresql-1a861124-o65d47357.database.cloud.ovh.net:20184/stoa_production?sslmode=require"
+psql "<POSTGRES_CONNECTION_STRING>"
 ```
 
 ### Token Observatory

--- a/.claude/skills/council/SKILL.md
+++ b/.claude/skills/council/SKILL.md
@@ -102,9 +102,9 @@ If Council passes (Go or Fix-then-confirmed), create the ticket using Linear MCP
 linear.create_issue(
   title: "<type>(scope): <short description>",
   description: <see template below>,
-  team: "624a9948-a160-4e47-aba5-7f9404d23506",
-  project: "227427af-6844-484d-bb4a-dedeffc68825",
-  assignee: "0543749d-ecde-4edf-aec1-6f372aafafce",
+  team: "<LINEAR_TEAM_ID>",
+  project: "<LINEAR_PROJECT_ID>",
+  assignee: "<LINEAR_ASSIGNEE_ID>",
   estimate: <fibonacci points>,
   priority: <1=Urgent, 2=High, 3=Normal, 4=Low>,
   labels: [<type label>, <priority label>, "hlfh:validated", "council:ticket-go|fix", "instance:<detected-instance>"],

--- a/.claude/skills/decompose/SKILL.md
+++ b/.claude/skills/decompose/SKILL.md
@@ -38,14 +38,14 @@ Analyze the feature and map to STOA components:
 
 | Component | Path | Linear Label ID | Tech | Instance Label |
 |-----------|------|-----------------|------|----------------|
-| **cp-api** | `control-plane-api/` | `3d9dcfcc-2578-447f-ab94-0b00b73022f0` | Python, FastAPI | `instance:backend` |
-| **cp-ui** | `control-plane-ui/` | `1c4d11ff-da26-466d-a2ac-e49786bac927` | React, Console | `instance:frontend` |
-| **portal** | `portal/` | `df33f1d3-bb93-463d-bf60-7d602a6add10` | React, Portal | `instance:frontend` |
-| **gateway** | `stoa-gateway/` | `b14f839d-cde8-4fee-9f1c-894431143b35` | Rust, axum | `instance:mcp` |
+| **cp-api** | `control-plane-api/` | `<LABEL_ID_CP_API>` | Python, FastAPI | `instance:backend` |
+| **cp-ui** | `control-plane-ui/` | `<LABEL_ID_CP_UI>` | React, Console | `instance:frontend` |
+| **portal** | `portal/` | `<LABEL_ID_PORTAL>` | React, Portal | `instance:frontend` |
+| **gateway** | `stoa-gateway/` | `<LABEL_ID_GATEWAY>` | Rust, axum | `instance:mcp` |
 | **operator** | `stoa-operator/` | _(create if needed)_ | Python, kopf | `instance:backend` |
 | **e2e** | `e2e/` | _(create if needed)_ | Playwright | `instance:qa` |
-| **docs** | `stoa-docs` (separate repo) | `8a23f909-d1fb-45be-9516-4e33a72998e1` | Docusaurus | `instance:backend` |
-| **infra** | `charts/`, `k8s/` | `ad81cb7f-31a7-4b9c-ac1f-fe0827bfea03` | Helm, K8s | `instance:backend` |
+| **docs** | `stoa-docs` (separate repo) | `<LABEL_ID_DOCS>` | Docusaurus | `instance:backend` |
+| **infra** | `charts/`, `k8s/` | `<LABEL_ID_INFRA>` | Helm, K8s | `instance:backend` |
 | **keycloak** | `keycloak/`, OAuth/IAM | _(use auth label)_ | Keycloak | `instance:auth` |
 
 ### Instance Dispatch Mapping
@@ -133,9 +133,9 @@ For each component-issue, create a Linear sub-issue:
 linear.create_issue(
   title: "[<component>] <action verb> <what> (<parent-ticket-id>)",
   description: <see template below>,
-  team: "624a9948-a160-4e47-aba5-7f9404d23506",
-  project: "227427af-6844-484d-bb4a-dedeffc68825",
-  assignee: "0543749d-ecde-4edf-aec1-6f372aafafce",
+  team: "<LINEAR_TEAM_ID>",
+  project: "<LINEAR_PROJECT_ID>",
+  assignee: "<LINEAR_ASSIGNEE_ID>",
   parentId: "<parent-issue-id>",
   estimate: <component-specific points>,
   priority: <inherit from parent>,
@@ -150,11 +150,11 @@ Every sub-issue MUST receive an `instance:*` label. Resolve from the component u
 
 | Component | Instance Label ID to add |
 |-----------|--------------------------|
-| `cp-api`, `operator`, `infra`, `docs` | `b60c32eb-3374-4a53-a487-b409bfed2d61` (`instance:backend`) |
-| `cp-ui`, `portal` | `e9434a2f-f313-4223-a042-598185718c7b` (`instance:frontend`) |
-| `keycloak` | `c4bb2546-7bbc-45d9-b5ab-384fd7065d48` (`instance:auth`) |
-| `gateway` | `19497340-8712-45d0-8728-a77c96c592a7` (`instance:mcp`) |
-| `e2e` | `00ba65ee-81e3-40e8-b2d2-38f340617b2f` (`instance:qa`) |
+| `cp-api`, `operator`, `infra`, `docs` | `<LABEL_ID_INSTANCE_BACKEND>` (`instance:backend`) |
+| `cp-ui`, `portal` | `<LABEL_ID_INSTANCE_FRONTEND>` (`instance:frontend`) |
+| `keycloak` | `<LABEL_ID_INSTANCE_AUTH>` (`instance:auth`) |
+| `gateway` | `<LABEL_ID_INSTANCE_MCP>` (`instance:mcp`) |
+| `e2e` | `<LABEL_ID_INSTANCE_QA>` (`instance:qa`) |
 
 **Rules**:
 - Never create a sub-issue without an instance label — the parallel dispatch system depends on it
@@ -269,7 +269,7 @@ linear.create_comment(
 
 Add `needs-split` label removal if it was present:
 ```
-linear.update_issue(parentId, removeLabelIds: ["768f96b2-69f0-4ed3-83de-538f657dd001"])
+linear.update_issue(parentId, removeLabelIds: ["<LABEL_ID_NEEDS_SPLIT>"])
 ```
 
 ## Step 9: Initialize Claim File
@@ -377,30 +377,30 @@ Next steps:
 
 | Component | Label ID |
 |-----------|----------|
-| cp-api | `3d9dcfcc-2578-447f-ab94-0b00b73022f0` |
-| cp-ui | `1c4d11ff-da26-466d-a2ac-e49786bac927` |
-| portal (ui) | `df33f1d3-bb93-463d-bf60-7d602a6add10` |
-| gateway | `b14f839d-cde8-4fee-9f1c-894431143b35` |
-| docs | `8a23f909-d1fb-45be-9516-4e33a72998e1` |
-| infra | `ad81cb7f-31a7-4b9c-ac1f-fe0827bfea03` |
-| flow-ready | `6692a52b-126d-4fce-b480-3fac19751ecb` |
-| mega-ticket | `97f7371c-8ac3-44e6-a0a0-412e81bc959e` |
-| needs-split | `768f96b2-69f0-4ed3-83de-538f657dd001` |
+| cp-api | `<LABEL_ID_CP_API>` |
+| cp-ui | `<LABEL_ID_CP_UI>` |
+| portal (ui) | `<LABEL_ID_PORTAL>` |
+| gateway | `<LABEL_ID_GATEWAY>` |
+| docs | `<LABEL_ID_DOCS>` |
+| infra | `<LABEL_ID_INFRA>` |
+| flow-ready | `<LABEL_ID_FLOW_READY>` |
+| mega-ticket | `<LABEL_ID_MEGA_TICKET>` |
+| needs-split | `<LABEL_ID_NEEDS_SPLIT>` |
 
 ## Instance Label IDs (cached — for parallel dispatch)
 
 | Instance | Label ID |
 |----------|----------|
-| `instance:backend` | `b60c32eb-3374-4a53-a487-b409bfed2d61` |
-| `instance:frontend` | `e9434a2f-f313-4223-a042-598185718c7b` |
-| `instance:auth` | `c4bb2546-7bbc-45d9-b5ab-384fd7065d48` |
-| `instance:mcp` | `19497340-8712-45d0-8728-a77c96c592a7` |
-| `instance:qa` | `00ba65ee-81e3-40e8-b2d2-38f340617b2f` |
+| `instance:backend` | `<LABEL_ID_INSTANCE_BACKEND>` |
+| `instance:frontend` | `<LABEL_ID_INSTANCE_FRONTEND>` |
+| `instance:auth` | `<LABEL_ID_INSTANCE_AUTH>` |
+| `instance:mcp` | `<LABEL_ID_INSTANCE_MCP>` |
+| `instance:qa` | `<LABEL_ID_INSTANCE_QA>` |
 
 ## Linear IDs (cached)
 
 | Entity | ID |
 |--------|----|
-| Team (CAB-ING) | `624a9948-a160-4e47-aba5-7f9404d23506` |
-| Project (STOA Platform) | `227427af-6844-484d-bb4a-dedeffc68825` |
-| Assignee (Christophe) | `0543749d-ecde-4edf-aec1-6f372aafafce` |
+| Team (CAB-ING) | `<LINEAR_TEAM_ID>` |
+| Project (STOA Platform) | `<LINEAR_PROJECT_ID>` |
+| Assignee (<PRIMARY_ASSIGNEE>) | `<LINEAR_ASSIGNEE_ID>` |

--- a/.claude/skills/fill-cycle/SKILL.md
+++ b/.claude/skills/fill-cycle/SKILL.md
@@ -15,12 +15,12 @@ Target: $ARGUMENTS
 
 | Label | ID |
 |-------|-----|
-| `roadmap` (parent group — NOT assignable to issues) | `922e1f2d-c839-4b8b-9eba-6c2ba4365a8c` |
-| `roadmap:gateway` | `82e07bcd-69fa-4fc5-a2e1-d4d7fa0fad70` |
-| `roadmap:dx` | `9f4356e1-f3bc-49a5-b28a-fa1077a6e326` |
-| `roadmap:platform` | `c819ff92-c9cf-453d-a0f9-451840f6f8cc` |
-| `roadmap:community` | `2de713f1-47a9-49a0-9e84-a7bd947eb707` |
-| `roadmap:observability` | `d4ce6487-92fe-4f12-a5f3-8d682e03623f` |
+| `roadmap` (parent group — NOT assignable to issues) | `<LABEL_ID_ROADMAP>` |
+| `roadmap:gateway` | `<LABEL_ID_ROADMAP_GATEWAY>` |
+| `roadmap:dx` | `<LABEL_ID_ROADMAP_DX>` |
+| `roadmap:platform` | `<LABEL_ID_ROADMAP_PLATFORM>` |
+| `roadmap:community` | `<LABEL_ID_ROADMAP_COMMUNITY>` |
+| `roadmap:observability` | `<LABEL_ID_ROADMAP_OBSERVABILITY>` |
 
 ## Step 0: Determine Mode
 
@@ -34,7 +34,7 @@ Target: $ARGUMENTS
 ## Step 1: Fetch Current Cycle from Linear
 
 ```
-linear.list_cycles(teamId: "624a9948-a160-4e47-aba5-7f9404d23506")
+linear.list_cycles(teamId: "<LINEAR_TEAM_ID>")
 ```
 
 Identify the **current** cycle (type `"current"` or date range containing today).
@@ -44,7 +44,7 @@ Then fetch all issues in the cycle:
 
 ```
 linear.list_issues(
-  team: "624a9948-a160-4e47-aba5-7f9404d23506",
+  team: "<LINEAR_TEAM_ID>",
   cycle: "<cycle_id>",
   first: 50
 )
@@ -81,7 +81,7 @@ Scan 4 sources for candidate items. Each source contributes candidates with meta
 
 ```
 linear.list_issues(
-  team: "624a9948-a160-4e47-aba5-7f9404d23506",
+  team: "<LINEAR_TEAM_ID>",
   first: 50
 )
 ```

--- a/.claude/skills/generate-backlog/SKILL.md
+++ b/.claude/skills/generate-backlog/SKILL.md
@@ -19,30 +19,30 @@ Target: $ARGUMENTS
 
 | Entity | ID |
 |--------|----|
-| Team (CAB-ING) | `624a9948-a160-4e47-aba5-7f9404d23506` |
-| Project (STOA Platform) | `227427af-6844-484d-bb4a-dedeffc68825` |
-| Assignee (Christophe) | `0543749d-ecde-4edf-aec1-6f372aafafce` |
+| Team (CAB-ING) | `<LINEAR_TEAM_ID>` |
+| Project (STOA Platform) | `<LINEAR_PROJECT_ID>` |
+| Assignee (<PRIMARY_ASSIGNEE>) | `<LINEAR_ASSIGNEE_ID>` |
 
 ### Label IDs
 
 | Label | ID |
 |-------|-----|
-| `roadmap` (parent — NOT assignable) | `922e1f2d-c839-4b8b-9eba-6c2ba4365a8c` |
-| `roadmap:gateway` | `82e07bcd-69fa-4fc5-a2e1-d4d7fa0fad70` |
-| `roadmap:dx` | `9f4356e1-f3bc-49a5-b28a-fa1077a6e326` |
-| `roadmap:platform` | `c819ff92-c9cf-453d-a0f9-451840f6f8cc` |
-| `roadmap:community` | `2de713f1-47a9-49a0-9e84-a7bd947eb707` |
-| `roadmap:observability` | `d4ce6487-92fe-4f12-a5f3-8d682e03623f` |
+| `roadmap` (parent — NOT assignable) | `<LABEL_ID_ROADMAP>` |
+| `roadmap:gateway` | `<LABEL_ID_ROADMAP_GATEWAY>` |
+| `roadmap:dx` | `<LABEL_ID_ROADMAP_DX>` |
+| `roadmap:platform` | `<LABEL_ID_ROADMAP_PLATFORM>` |
+| `roadmap:community` | `<LABEL_ID_ROADMAP_COMMUNITY>` |
+| `roadmap:observability` | `<LABEL_ID_ROADMAP_OBSERVABILITY>` |
 
 ### Instance Label IDs (parallel dispatch)
 
 | Label | ID | Components |
 |-------|-----|-----------|
-| `instance:backend` | `b60c32eb-3374-4a53-a487-b409bfed2d61` | cp-api, operator, infra, docs |
-| `instance:frontend` | `e9434a2f-f313-4223-a042-598185718c7b` | cp-ui, portal, shared |
-| `instance:auth` | `c4bb2546-7bbc-45d9-b5ab-384fd7065d48` | keycloak, IAM |
-| `instance:mcp` | `19497340-8712-45d0-8728-a77c96c592a7` | stoa-gateway |
-| `instance:qa` | `00ba65ee-81e3-40e8-b2d2-38f340617b2f` | e2e, tests |
+| `instance:backend` | `<LABEL_ID_INSTANCE_BACKEND>` | cp-api, operator, infra, docs |
+| `instance:frontend` | `<LABEL_ID_INSTANCE_FRONTEND>` | cp-ui, portal, shared |
+| `instance:auth` | `<LABEL_ID_INSTANCE_AUTH>` | keycloak, IAM |
+| `instance:mcp` | `<LABEL_ID_INSTANCE_MCP>` | stoa-gateway |
+| `instance:qa` | `<LABEL_ID_INSTANCE_QA>` | e2e, tests |
 
 ## Step 0: Determine Mode
 
@@ -60,7 +60,7 @@ Fetch all backlog issues (no cycle) from Linear:
 
 ```
 linear.list_issues(
-  team: "624a9948-a160-4e47-aba5-7f9404d23506",
+  team: "<LINEAR_TEAM_ID>",
   first: 100
 )
 ```
@@ -261,9 +261,9 @@ For each MEGA (up to 15):
 linear.create_issue(
   title: "[MEGA] <Theme>: <Description>",
   description: <see template below>,
-  team: "624a9948-a160-4e47-aba5-7f9404d23506",
-  project: "227427af-6844-484d-bb4a-dedeffc68825",
-  assignee: "0543749d-ecde-4edf-aec1-6f372aafafce",
+  team: "<LINEAR_TEAM_ID>",
+  project: "<LINEAR_PROJECT_ID>",
+  assignee: "<LINEAR_ASSIGNEE_ID>",
   estimate: <pts from Step 3>,
   priority: 3,
   labels: ["roadmap:<theme>", "instance:<lead-instance>"],

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -25,7 +25,7 @@ Query each `roadmap:*` label to count Done vs Total issues:
 ```
 For each theme in [gateway, platform, dx, security, community, observability]:
   linear.list_issues(
-    team: "624a9948-a160-4e47-aba5-7f9404d23506",
+    team: "<LINEAR_TEAM_ID>",
     labels: ["roadmap:<theme>"],
     first: 250
   )
@@ -36,30 +36,30 @@ For each theme in [gateway, platform, dx, security, community, observability]:
 
 | Theme | Label | ID |
 |-------|-------|----|
-| Gateway | `roadmap:gateway` | `82e07bcd-69fa-4fc5-a2e1-d4d7fa0fad70` |
-| Platform | `roadmap:platform` | `c819ff92-c9cf-453d-a0f9-451840f6f8cc` |
-| DX | `roadmap:dx` | `9f4356e1-f3bc-49a5-b28a-fa1077a6e326` |
-| Security | `roadmap:security` | `365e859a-9306-44ae-8a59-fe02f8fdc5ad` |
-| Community | `roadmap:community` | `2de713f1-47a9-49a0-9e84-a7bd947eb707` |
-| Observability | `roadmap:observability` | `d4ce6487-92fe-4f12-a5f3-8d682e03623f` |
+| Gateway | `roadmap:gateway` | `<LABEL_ID_ROADMAP_GATEWAY>` |
+| Platform | `roadmap:platform` | `<LABEL_ID_ROADMAP_PLATFORM>` |
+| DX | `roadmap:dx` | `<LABEL_ID_ROADMAP_DX>` |
+| Security | `roadmap:security` | `<LABEL_ID_ROADMAP_SECURITY>` |
+| Community | `roadmap:community` | `<LABEL_ID_ROADMAP_COMMUNITY>` |
+| Observability | `roadmap:observability` | `<LABEL_ID_ROADMAP_OBSERVABILITY>` |
 
 **Important**: Theme percentages depend on `roadmap:*` labels being applied to issues. If a theme shows 0/0, it means no issues have been tagged with that label yet. Run a backfill session to tag historical issues.
 
 ## Step 2: Fetch Milestones (1 query)
 
 ```
-linear.list_milestones(project: "227427af-6844-484d-bb4a-dedeffc68825")
+linear.list_milestones(project: "<LINEAR_PROJECT_ID>")
 ```
 
 ### Milestone IDs (cached)
 
 | Milestone | ID | Target Date |
 |-----------|----|-------------|
-| Demo MVP Ready | `b70d6b9b-e7f8-4e60-8e37-67f60eba8d11` | 2026-02-17 |
-| Demo Day | `111a34ba-7662-42b2-a07b-8f5c4467d1a6` | 2026-03-17 |
-| Private Beta | `4cacb62a-af54-4abc-8bf4-560d9cbf71f3` | 2026-04-30 |
-| RC1 Public Beta | `a2d5acf5-a21b-4980-ba88-aef174daaaf2` | 2026-06-30 |
-| v1.0 GA | `8e352939-eb7d-46d1-9d22-d35789549ca6` | 2026-07-31 |
+| Demo MVP Ready | `<MILESTONE_DEMO_MVP>` | 2026-02-17 |
+| Demo Day | `<MILESTONE_DEMO_DAY>` | 2026-03-17 |
+| Private Beta | `<MILESTONE_PRIVATE_BETA>` | 2026-04-30 |
+| RC1 Public Beta | `<MILESTONE_RC1>` | 2026-06-30 |
+| v1.0 GA | `<MILESTONE_V1_GA>` | 2026-07-31 |
 
 For each milestone, compute:
 - **Status**: Done (target date < today AND progress 100%), Active (target date > today), Overdue (target date < today AND progress < 100%)
@@ -78,7 +78,7 @@ Extract:
 ## Step 4: Fetch Current Cycle (1 query)
 
 ```
-linear.list_cycles(teamId: "624a9948-a160-4e47-aba5-7f9404d23506", type: "current")
+linear.list_cycles(teamId: "<LINEAR_TEAM_ID>", type: "current")
 ```
 
 Extract: cycle name, scope (total pts), done (pts), issue count.

--- a/.claude/skills/sync-plan/SKILL.md
+++ b/.claude/skills/sync-plan/SKILL.md
@@ -25,7 +25,7 @@ Target: $ARGUMENTS
 Always start by discovering the active cycles:
 
 ```
-linear.list_cycles(teamId: "624a9948-a160-4e47-aba5-7f9404d23506")
+linear.list_cycles(teamId: "<LINEAR_TEAM_ID>")
 ```
 
 Identify:
@@ -40,7 +40,7 @@ For each active cycle (current + next):
 
 ```
 linear.list_issues(
-  team: "624a9948-a160-4e47-aba5-7f9404d23506",
+  team: "<LINEAR_TEAM_ID>",
   cycle: "<cycle_id>",
   first: 50
 )

--- a/.claude/skills/verify-mega/SKILL.md
+++ b/.claude/skills/verify-mega/SKILL.md
@@ -35,7 +35,7 @@ If no children → report: "CAB-XXXX is not a MEGA (no children). Use standard c
 
 ```
 linear.list_issues(
-  teamId: "624a9948-a160-4e47-aba5-7f9404d23506",
+  teamId: "<LINEAR_TEAM_ID>",
   filter: { state: { name: { eq: "Done" } }, updatedAt: { gte: "<7 days ago>" } }
 )
 ```


### PR DESCRIPTION
## Summary
- Replace 59 sensitive data points across 8 `.claude/skills/` files with `<PLACEHOLDER>` tokens
- Covers: Linear UUIDs (team, project, assignee, 6 roadmap labels, 5 instance labels, 6 component labels, 3 workflow labels, 5 milestones), personal name, PostgreSQL connection string
- Consistent with PR #1331 convention for `.claude/rules/` sanitization
- Completes the CAB-1632 public repo preparation for `.claude/` directory

## Files changed (8)
| File | Edits | Types |
|------|-------|-------|
| `decompose/SKILL.md` | 18 | Team/Project/Assignee IDs, 6 component labels, 3 workflow labels, 5 instance labels, personal name |
| `generate-backlog/SKILL.md` | 15 | Team/Project/Assignee IDs, 6 roadmap labels, 5 instance labels, personal name |
| `fill-cycle/SKILL.md` | 9 | Team ID (3x), 6 roadmap labels |
| `roadmap/SKILL.md` | 13 | Team/Project IDs, 6 roadmap labels, 5 milestone UUIDs |
| `council/SKILL.md` | 3 | Team/Project/Assignee IDs |
| `sync-plan/SKILL.md` | 2 | Team ID (2x) |
| `verify-mega/SKILL.md` | 1 | Team ID |
| `analytics/SKILL.md` | 1 | PostgreSQL connection string |

## Verification
```bash
# Zero UUIDs remaining
grep -rn '[0-9a-f]\{8\}-[0-9a-f]\{4\}' .claude/skills/  # empty

# Zero personal names
grep -rn 'Christophe' .claude/skills/  # empty

# Zero connection strings
grep -rn 'avnadmin\|ovh\.net' .claude/skills/  # empty
```

## Test plan
- [x] All 59 edits verified — zero raw UUIDs, names, or connection strings remain
- [x] Placeholder naming consistent with PR #1331 convention
- [ ] CI green (security scan, no component code changed)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>