### PR TITLE
fix(api): prevent duplicate personal tenants via unique index + row lock

### DIFF
--- a/control-plane-api/alembic/versions/051_unique_personal_tenant_owner.py
+++ b/control-plane-api/alembic/versions/051_unique_personal_tenant_owner.py
@@ -1,0 +1,55 @@
+"""Add unique index on personal tenant owner to prevent duplicates.
+
+Race condition in POST /v1/me/tenant allowed concurrent requests to create
+multiple personal tenants for the same user. This migration:
+1. Deduplicates existing personal tenants (keeps oldest, archives others)
+2. Adds a partial unique index on settings->>'owner_user_id' for personal tenants
+
+Revision ID: 051_unique_personal_tenant_owner
+Revises: 050_llm_spend_events
+Create Date: 2026-03-02
+"""
+
+from alembic import op
+
+revision = "051_unique_personal_tenant_owner"
+down_revision = "050_llm_spend_events"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Step 1: Archive duplicate personal tenants (keep the oldest per owner)
+    op.execute("""
+        UPDATE tenants
+        SET status = 'archived'
+        WHERE id IN (
+            SELECT t.id
+            FROM tenants t
+            INNER JOIN (
+                SELECT settings->>'owner_user_id' AS owner_id,
+                       MIN(created_at) AS first_created
+                FROM tenants
+                WHERE settings->>'personal' = 'true'
+                  AND status != 'archived'
+                  AND settings->>'owner_user_id' IS NOT NULL
+                GROUP BY settings->>'owner_user_id'
+                HAVING COUNT(*) > 1
+            ) dups ON t.settings->>'owner_user_id' = dups.owner_id
+                  AND t.created_at > dups.first_created
+            WHERE t.settings->>'personal' = 'true'
+              AND t.status != 'archived'
+        )
+    """)
+
+    # Step 2: Add partial unique index (only for active/suspended personal tenants)
+    op.execute("""
+        CREATE UNIQUE INDEX ix_tenants_personal_owner_unique
+        ON tenants ((settings->>'owner_user_id'))
+        WHERE settings->>'personal' = 'true'
+          AND status != 'archived'
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_tenants_personal_owner_unique")

--- a/control-plane-api/src/repositories/tenant.py
+++ b/control-plane-api/src/repositories/tenant.py
@@ -62,14 +62,23 @@ class TenantRepository:
 
         return []
 
-    async def get_personal_tenant_by_owner(self, user_id: str) -> Tenant | None:
-        """Find a personal tenant by owner user ID (stored in settings JSON)."""
-        result = await self.session.execute(
-            select(Tenant).where(
-                Tenant.settings["owner_user_id"].as_string() == user_id,
-                Tenant.status != TenantStatus.ARCHIVED.value,
-            )
+    async def get_personal_tenant_by_owner(
+        self, user_id: str, *, for_update: bool = False
+    ) -> Tenant | None:
+        """Find a personal tenant by owner user ID (stored in settings JSON).
+
+        Args:
+            user_id: Keycloak user ID to search for.
+            for_update: If True, acquires a row lock (SELECT FOR UPDATE)
+                to prevent race conditions during tenant provisioning.
+        """
+        query = select(Tenant).where(
+            Tenant.settings["owner_user_id"].as_string() == user_id,
+            Tenant.status != TenantStatus.ARCHIVED.value,
         )
+        if for_update:
+            query = query.with_for_update()
+        result = await self.session.execute(query)
         return result.scalars().first()
 
     async def update(self, tenant: Tenant) -> Tenant:

--- a/control-plane-api/src/routers/users.py
+++ b/control-plane-api/src/routers/users.py
@@ -295,9 +295,12 @@ async def provision_personal_tenant(
             )
 
     # Idempotent check 2: DB lookup for existing personal tenant owned by this user.
+    # Uses SELECT FOR UPDATE to serialize concurrent requests — prevents duplicates.
     # The JWT tenant_id claim is only set AFTER token refresh (post KC group assignment),
     # so between signup and refresh every call would bypass check 1 and create duplicates.
-    existing_personal = await repo.get_personal_tenant_by_owner(current_user.id)
+    existing_personal = await repo.get_personal_tenant_by_owner(
+        current_user.id, for_update=True
+    )
     if existing_personal:
         return PersonalTenantResponse(
             tenant_id=existing_personal.id,
@@ -318,7 +321,9 @@ async def provision_personal_tenant(
     else:
         raise HTTPException(status_code=409, detail="Could not generate unique tenant ID")
 
-    # Create tenant in DB
+    # Create tenant in DB — unique index ix_tenants_personal_owner_unique
+    # provides a database-level guard against duplicates in addition to
+    # the SELECT FOR UPDATE above.
     tenant = Tenant(
         id=tenant_id,
         name=f"{current_user.username}'s workspace",
@@ -330,7 +335,21 @@ async def provision_personal_tenant(
             "owner_email": current_user.email,
         },
     )
-    tenant = await repo.create(tenant)
+    try:
+        tenant = await repo.create(tenant)
+    except Exception as e:
+        if "ix_tenants_personal_owner_unique" in str(e):
+            # Race condition: another request created the tenant between
+            # our SELECT FOR UPDATE and INSERT. Return the existing one.
+            await db.rollback()
+            existing_personal = await repo.get_personal_tenant_by_owner(current_user.id)
+            if existing_personal:
+                return PersonalTenantResponse(
+                    tenant_id=existing_personal.id,
+                    display_name=existing_personal.name,
+                    created=False,
+                )
+        raise
 
     # Keycloak: create group + assign user + assign viewer role
     try:


### PR DESCRIPTION
## Summary
- Race condition in `POST /v1/me/tenant` allowed concurrent requests to create multiple personal tenants for the same user (e.g. "aech's workspace" appeared 3 times)
- Root cause: no database-level uniqueness constraint on `settings->>'owner_user_id'` for personal tenants
- Fix applies 3 layers of defense: Alembic migration (dedup + unique index), `SELECT FOR UPDATE` row lock, and unique constraint violation fallback

## Changes
- **Migration 051**: Archives duplicate personal tenants (keeps oldest), adds `ix_tenants_personal_owner_unique` partial unique index
- **`TenantRepository.get_personal_tenant_by_owner`**: Added `for_update` parameter for row-level locking
- **`POST /v1/me/tenant`**: Uses `for_update=True` on idempotency check + catches unique constraint violation as fallback

## Test plan
- [x] All 50 user/tenant tests pass
- [x] Full suite: 6423 passed, 90.84% coverage (2 pre-existing Kafka DNS failures)
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>