### PR TITLE
fix(api): auto-reconnect Keycloak admin on stale token

### DIFF
--- a/control-plane-api/src/services/keycloak_service.py
+++ b/control-plane-api/src/services/keycloak_service.py
@@ -1,5 +1,6 @@
 """Keycloak service for authentication and client management"""
 
+import functools
 import logging
 
 import httpx
@@ -8,6 +9,29 @@ from keycloak import KeycloakAdmin, KeycloakOpenIDConnection
 from ..config import settings
 
 logger = logging.getLogger(__name__)
+
+
+def _auto_reconnect(func):
+    """Retry once after re-establishing the Keycloak connection on stale-token errors.
+
+    The python-keycloak library sets ``self.token = None`` when a refresh fails,
+    then crashes with ``AttributeError: 'NoneType' object has no attribute 'get'``
+    on the next admin call. This decorator catches that specific failure,
+    reconnects (which obtains a fresh token), and retries the call once.
+    """
+
+    @functools.wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        try:
+            return await func(self, *args, **kwargs)
+        except AttributeError:
+            if self._admin is None:
+                raise
+            logger.warning("Keycloak admin token stale in %s, reconnecting", func.__name__)
+            await self.connect()
+            return await func(self, *args, **kwargs)
+
+    return wrapper
 
 
 class KeycloakService:
@@ -37,6 +61,7 @@ class KeycloakService:
         self._admin = None
 
     # User operations
+    @_auto_reconnect
     async def get_users(self, tenant_id: str | None = None) -> list[dict]:
         """Get users, optionally filtered by tenant"""
         if not self._admin:
@@ -50,6 +75,7 @@ class KeycloakService:
 
         return users
 
+    @_auto_reconnect
     async def get_user(self, user_id: str) -> dict | None:
         """Get user by ID"""
         if not self._admin:
@@ -60,6 +86,7 @@ class KeycloakService:
         except Exception:
             return None
 
+    @_auto_reconnect
     async def create_user(
         self,
         username: str,
@@ -104,6 +131,7 @@ class KeycloakService:
         logger.info(f"Created user {username} with roles {roles}")
         return user_id
 
+    @_auto_reconnect
     async def update_user(self, user_id: str, updates: dict) -> bool:
         """Update user attributes"""
         if not self._admin:
@@ -112,6 +140,7 @@ class KeycloakService:
         self._admin.update_user(user_id, updates)
         return True
 
+    @_auto_reconnect
     async def delete_user(self, user_id: str) -> bool:
         """Delete a user"""
         if not self._admin:
@@ -122,6 +151,7 @@ class KeycloakService:
         return True
 
     # Role operations
+    @_auto_reconnect
     async def get_roles(self) -> list[dict]:
         """Get all realm roles"""
         if not self._admin:
@@ -129,6 +159,7 @@ class KeycloakService:
 
         return self._admin.get_realm_roles()
 
+    @_auto_reconnect
     async def assign_role(self, user_id: str, role_name: str) -> bool:
         """Assign a role to a user"""
         if not self._admin:
@@ -138,6 +169,7 @@ class KeycloakService:
         self._admin.assign_realm_roles(user_id, [role])
         return True
 
+    @_auto_reconnect
     async def remove_role(self, user_id: str, role_name: str) -> bool:
         """Remove a role from a user"""
         if not self._admin:
@@ -148,6 +180,7 @@ class KeycloakService:
         return True
 
     # Client (Application) operations
+    @_auto_reconnect
     async def get_clients(self, tenant_id: str | None = None) -> list[dict]:
         """Get all clients, optionally filtered by tenant"""
         if not self._admin:
@@ -166,6 +199,7 @@ class KeycloakService:
 
         return clients
 
+    @_auto_reconnect
     async def get_client(self, client_id: str) -> dict | None:
         """Get client by client_id"""
         if not self._admin:
@@ -177,6 +211,7 @@ class KeycloakService:
                 return client
         return None
 
+    @_auto_reconnect
     async def get_client_by_id(self, client_uuid: str) -> dict | None:
         """Get client by Keycloak internal UUID."""
         if not self._admin:
@@ -186,6 +221,7 @@ class KeycloakService:
         except Exception:
             return None
 
+    @_auto_reconnect
     async def create_client(
         self, tenant_id: str, name: str, display_name: str, redirect_uris: list[str], description: str = ""
     ) -> dict:
@@ -237,6 +273,7 @@ class KeycloakService:
             "id": client_uuid,
         }
 
+    @_auto_reconnect
     async def update_client(self, client_uuid: str, updates: dict) -> bool:
         """Update client configuration"""
         if not self._admin:
@@ -245,6 +282,7 @@ class KeycloakService:
         self._admin.update_client(client_uuid, updates)
         return True
 
+    @_auto_reconnect
     async def delete_client(self, client_uuid: str) -> bool:
         """Delete a client"""
         if not self._admin:
@@ -254,6 +292,7 @@ class KeycloakService:
         logger.info(f"Deleted client {client_uuid}")
         return True
 
+    @_auto_reconnect
     async def regenerate_client_secret(self, client_uuid: str) -> str:
         """Regenerate client secret"""
         if not self._admin:
@@ -263,6 +302,7 @@ class KeycloakService:
         return secret_data.get("value")
 
     # Consumer client operations (CAB-1121 Phase 2)
+    @_auto_reconnect
     async def create_consumer_client(
         self,
         tenant_slug: str,
@@ -397,6 +437,7 @@ class KeycloakService:
             "id": client_uuid,
         }
 
+    @_auto_reconnect
     async def create_consumer_client_with_cert(
         self,
         tenant_slug: str,
@@ -499,6 +540,7 @@ class KeycloakService:
             "id": client_uuid,
         }
 
+    @_auto_reconnect
     async def update_consumer_client_cnf(
         self,
         client_id: str,
@@ -545,6 +587,7 @@ class KeycloakService:
         logger.info(f"Updated cnf mapper for client {client_id}")
         return True
 
+    @_auto_reconnect
     async def disable_consumer_client(self, client_id: str) -> bool:
         """
         Disable a consumer's Keycloak client (CAB-864).
@@ -621,6 +664,7 @@ class KeycloakService:
         logger.info(f"Token exchange succeeded for client {client_id}")
         return result
 
+    @_auto_reconnect
     async def delete_consumer_client(self, client_id: str) -> bool:
         """Delete a consumer's Keycloak client by client_id."""
         if not self._admin:
@@ -636,6 +680,7 @@ class KeycloakService:
         return True
 
     # Service Account operations (for MCP access)
+    @_auto_reconnect
     async def create_service_account(
         self,
         user_id: str,
@@ -755,6 +800,7 @@ class KeycloakService:
             "name": name,
         }
 
+    @_auto_reconnect
     async def list_user_service_accounts(self, user_id: str) -> list[dict]:
         """List all service accounts owned by a user"""
         if not self._admin:
@@ -779,6 +825,7 @@ class KeycloakService:
 
         return user_accounts
 
+    @_auto_reconnect
     async def delete_service_account(self, client_uuid: str, user_id: str) -> bool:
         """Delete a service account (only if owned by user)"""
         if not self._admin:
@@ -798,6 +845,7 @@ class KeycloakService:
         return True
 
     # Tenant realm provisioning (CAB-1547)
+    @_auto_reconnect
     async def create_realm(self, realm_name: str, display_name: str) -> str:
         """Create a Keycloak realm for a tenant.
 
@@ -818,6 +866,7 @@ class KeycloakService:
         return realm_name
 
     # Tenant setup
+    @_auto_reconnect
     async def setup_tenant_group(self, tenant_id: str, tenant_name: str) -> str:
         """Create a Keycloak group for the tenant"""
         if not self._admin:
@@ -834,6 +883,7 @@ class KeycloakService:
         logger.info(f"Created group for tenant {tenant_id}")
         return group_id
 
+    @_auto_reconnect
     async def add_user_to_tenant(self, user_id: str, tenant_id: str) -> bool:
         """Add user to tenant group and set tenant_id attribute"""
         if not self._admin:
@@ -851,6 +901,7 @@ class KeycloakService:
 
         return True
 
+    @_auto_reconnect
     async def remove_user_from_group(self, user_id: str, tenant_id: str) -> bool:
         """Remove user from tenant group (idempotent)."""
         if not self._admin:
@@ -867,6 +918,7 @@ class KeycloakService:
                 return False
         return True
 
+    @_auto_reconnect
     async def delete_tenant_group(self, tenant_id: str) -> bool:
         """Delete tenant group from Keycloak (idempotent)."""
         if not self._admin:
@@ -885,6 +937,7 @@ class KeycloakService:
             return False
         return True
 
+    @_auto_reconnect
     async def get_user_roles(self, user_id: str) -> list[str]:
         """Get realm roles for a user, filtering out system roles."""
         if not self._admin:
@@ -894,6 +947,7 @@ class KeycloakService:
         roles = self._admin.get_realm_roles_of_user(user_id)
         return [r["name"] for r in roles if r["name"] not in system_roles]
 
+    @_auto_reconnect
     async def exchange_federation_token(
         self,
         client_id: str,
@@ -945,6 +999,7 @@ class KeycloakService:
             logger.warning("Federation token exchange failed for client '%s': %s", client_id, e)
             return None
 
+    @_auto_reconnect
     async def setup_federation_client(
         self,
         sub_account_id: str,

--- a/control-plane-api/tests/test_keycloak_service.py
+++ b/control-plane-api/tests/test_keycloak_service.py
@@ -747,3 +747,73 @@ class TestSetupFederationClient:
         svc._admin.create_client.side_effect = Exception("KC down")
         result = await svc.setup_federation_client("sub-id-12345678", "master", "acme")
         assert result is None
+
+
+# ── Auto-Reconnect Decorator ──
+
+
+class TestAutoReconnect:
+    """Tests for the _auto_reconnect decorator that handles stale Keycloak tokens."""
+
+    async def test_reconnects_on_attribute_error(self, svc):
+        """When admin call raises AttributeError (stale token), decorator reconnects and retries."""
+        call_count = 0
+
+        def get_users_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise AttributeError("'NoneType' object has no attribute 'get'")
+            return [{"id": "u1"}]
+
+        svc._admin.get_users.side_effect = get_users_side_effect
+
+        with patch("src.services.keycloak_service.KeycloakOpenIDConnection"), \
+             patch("src.services.keycloak_service.KeycloakAdmin") as mock_admin_cls:
+            mock_admin_cls.return_value = svc._admin
+            users = await svc.get_users()
+
+        assert len(users) == 1
+        assert call_count == 2  # first call failed, retry succeeded
+
+    async def test_disconnected_still_raises_runtime_error(self, disconnected_svc):
+        """When _admin is None (never connected), RuntimeError propagates — not caught by decorator."""
+        with pytest.raises(RuntimeError, match="not connected"):
+            await disconnected_svc.get_users()
+
+    async def test_retry_failure_propagates(self, svc):
+        """If the retry also raises AttributeError, it propagates to caller."""
+        svc._admin.get_clients.side_effect = AttributeError("stale token")
+
+        with patch("src.services.keycloak_service.KeycloakOpenIDConnection"), \
+             patch("src.services.keycloak_service.KeycloakAdmin") as mock_admin_cls:
+            mock_admin_cls.return_value = svc._admin
+            with pytest.raises(AttributeError):
+                await svc.get_clients()
+
+    async def test_non_attribute_errors_not_caught(self, svc):
+        """Non-AttributeError exceptions (e.g., KeycloakError) propagate immediately."""
+        svc._admin.get_realm_roles.side_effect = RuntimeError("Keycloak 503")
+        with pytest.raises(RuntimeError, match="503"):
+            await svc.get_roles()
+
+    async def test_reconnect_called_once(self, svc):
+        """Decorator calls connect() exactly once on stale-token error."""
+        call_count = 0
+
+        def get_roles_side_effect():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise AttributeError("stale")
+            return [{"name": "admin"}]
+
+        svc._admin.get_realm_roles.side_effect = get_roles_side_effect
+
+        with patch("src.services.keycloak_service.KeycloakOpenIDConnection") as mock_conn, \
+             patch("src.services.keycloak_service.KeycloakAdmin") as mock_admin_cls:
+            mock_admin_cls.return_value = svc._admin
+            roles = await svc.get_roles()
+
+        assert len(roles) == 1
+        mock_conn.assert_called_once()  # connect() called exactly once


### PR DESCRIPTION
## Summary
- Fix 500 errors on Console Applications page caused by Keycloak admin token expiration
- `python-keycloak` sets `self.token = None` when refresh fails, then crashes with `AttributeError: 'NoneType' object has no attribute 'get'` on the next admin call
- Browser reports CORS error because FastAPI's 500 response doesn't include CORS headers
- Add `_auto_reconnect` decorator that catches `AttributeError`, reconnects (fresh token), and retries once
- Applied to all 31 methods that use `self._admin`
- 5 unit tests for the decorator covering: reconnect success, disconnected state, retry failure propagation, non-AttributeError passthrough, single reconnect verification

## Test plan
- [x] 83/83 keycloak_service tests pass
- [x] Full suite: 6428 passed, 90.85% coverage
- [x] Lint clean (ruff + black)
- [ ] CI green
- [ ] Deploy to production, verify Console Applications page loads without 500/CORS

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>