### PR TITLE
feat(api,ui): wire FloatingChat to chat backend API (CAB-286)

### DIFF
--- a/control-plane-api/src/routers/chat.py
+++ b/control-plane-api/src/routers/chat.py
@@ -26,6 +26,7 @@ from ..auth import User, get_current_user, require_tenant_access
 from ..config import settings
 from ..database import get_db
 from ..repositories.chat_token_usage_repository import ChatTokenUsageRepository
+from ..auth.rbac import require_role
 from ..schemas.chat import (
     ChatTenantUsageResponse,
     ChatUsageResponse,
@@ -36,6 +37,7 @@ from ..schemas.chat import (
     ConversationResponse,
     ConversationUpdate,
     MessageSend,
+    ProviderKeySet,
     TokenBudgetStatusResponse,
     TokenUsageStatsResponse,
 )
@@ -253,9 +255,11 @@ async def send_message(
 ) -> EventSourceResponse:
     api_key = request.headers.get("X-Provider-Api-Key", "")
     if not api_key:
+        api_key = await svc.get_tenant_api_key(tenant_id) or ""
+    if not api_key:
         raise HTTPException(
             status_code=400,
-            detail="Missing X-Provider-Api-Key header",
+            detail="No API key: set X-Provider-Api-Key header or configure tenant key via PUT /provider-key",
         )
 
     async def event_generator():  # type: ignore[return]
@@ -348,3 +352,26 @@ async def get_usage_stats(
     repo = ChatTokenUsageRepository(db)
     stats = await repo.get_usage_stats(tenant_id, days=days)
     return TokenUsageStatsResponse(**stats)
+
+
+# ---------------------------------------------------------------------------
+# Provider key management (admin)
+# ---------------------------------------------------------------------------
+
+
+@router.put(
+    "/provider-key",
+    status_code=204,
+    summary="Set the tenant-level chat provider API key (admin)",
+)
+@require_tenant_access
+@require_role(["cpi-admin", "tenant-admin"])
+async def set_provider_key(
+    tenant_id: str,
+    body: ProviderKeySet,
+    user: User = Depends(get_current_user),
+    svc: ChatService = Depends(_service),
+) -> None:
+    ok = await svc.set_tenant_api_key(tenant_id, body.api_key)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Tenant not found")

--- a/control-plane-api/src/schemas/chat.py
+++ b/control-plane-api/src/schemas/chat.py
@@ -58,6 +58,12 @@ class MessageSend(BaseModel):
     content: str = Field(..., min_length=1, max_length=100000)
 
 
+class ProviderKeySet(BaseModel):
+    """Set the tenant-level provider API key (admin-only)."""
+
+    api_key: str = Field(..., min_length=10, max_length=500)
+
+
 # ---------------------------------------------------------------------------
 # Response schemas
 # ---------------------------------------------------------------------------

--- a/control-plane-api/src/services/chat_service.py
+++ b/control-plane-api/src/services/chat_service.py
@@ -477,6 +477,33 @@ class ChatService:
         data = decrypt_auth_config(encrypted)
         return data.get("api_key", "")
 
+    async def get_tenant_api_key(self, tenant_id: str) -> str | None:
+        """Read the encrypted chat provider API key from tenant settings."""
+        from ..models.tenant import Tenant
+
+        q = select(Tenant).where(Tenant.id == tenant_id)
+        tenant = (await self.session.execute(q)).scalar_one_or_none()
+        if tenant is None:
+            return None
+        encrypted = (tenant.settings or {}).get("chat_provider_api_key")
+        if not encrypted:
+            return None
+        return self.decrypt_api_key(encrypted)
+
+    async def set_tenant_api_key(self, tenant_id: str, api_key: str) -> bool:
+        """Encrypt and store the chat provider API key in tenant settings."""
+        from ..models.tenant import Tenant
+
+        q = select(Tenant).where(Tenant.id == tenant_id)
+        tenant = (await self.session.execute(q)).scalar_one_or_none()
+        if tenant is None:
+            return False
+        settings = dict(tenant.settings or {})
+        settings["chat_provider_api_key"] = self.encrypt_api_key(api_key)
+        tenant.settings = settings
+        await self.session.flush()
+        return True
+
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------

--- a/control-plane-ui/src/App.tsx
+++ b/control-plane-ui/src/App.tsx
@@ -5,6 +5,7 @@ import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { EnvironmentProvider } from './contexts/EnvironmentContext';
 import { Layout } from './components/Layout';
 import { FloatingChat } from './components/FloatingChat';
+import { useChatService } from './hooks/useChatService';
 import { PlatformStatus } from './components/PlatformStatus';
 import { TokenUsageWidget } from './components/chat/TokenUsageWidget';
 import { quickLinks } from './config';
@@ -404,6 +405,11 @@ const QuickActionCard = memo(function QuickActionCard({
   );
 });
 
+function ConnectedFloatingChat() {
+  const { sendMessage } = useChatService();
+  return <FloatingChat onSendMessage={(msg) => sendMessage(msg)} />;
+}
+
 function ProtectedRoutes() {
   const { isAuthenticated, isLoading } = useAuth();
 
@@ -482,7 +488,7 @@ function ProtectedRoutes() {
         </Layout>
       </CommandPaletteProvider>
       {/* CAB-285: Floating AI assistant — rendered above Layout so it persists across page navigation */}
-      <FloatingChat />
+      <ConnectedFloatingChat />
     </EnvironmentProvider>
   );
 }

--- a/control-plane-ui/src/hooks/useChatService.ts
+++ b/control-plane-ui/src/hooks/useChatService.ts
@@ -1,0 +1,87 @@
+/**
+ * useChatService — manages chat conversation lifecycle and SSE message streaming.
+ *
+ * Lazy-creates a conversation on first message, then sends messages via
+ * fetch() + ReadableStream (not EventSource — we need the Authorization header).
+ * Accumulates content_delta events and returns the full assembled response (V1).
+ */
+import { useCallback, useRef } from 'react';
+
+import { config } from '@/config';
+import { useAuth } from '@/contexts/AuthContext';
+import { apiService } from '@/services/api';
+
+export function useChatService() {
+  const { user } = useAuth();
+  const conversationId = useRef<string | null>(null);
+
+  const sendMessage = useCallback(
+    async (message: string): Promise<string> => {
+      const tenantId = user?.tenant_id;
+      if (!tenantId) throw new Error('No tenant selected');
+
+      const token = apiService.getAuthToken();
+      if (!token) throw new Error('Not authenticated');
+
+      // Lazy-create conversation on first message
+      if (!conversationId.current) {
+        const conv = await apiService.createChatConversation(tenantId);
+        conversationId.current = conv.id;
+      }
+
+      const url = `${config.api.baseUrl}/v1/tenants/${tenantId}/chat/conversations/${conversationId.current}/messages`;
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ content: message }),
+      });
+
+      if (!res.ok) {
+        const detail = await res.text();
+        throw new Error(`Chat request failed (${res.status}): ${detail}`);
+      }
+
+      // Read SSE stream and accumulate content_delta text
+      const reader = res.body?.getReader();
+      if (!reader) throw new Error('No response body');
+
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let result = '';
+
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Parse SSE frames: "event: <type>\ndata: <json>\n\n"
+        const frames = buffer.split('\n\n');
+        buffer = frames.pop() ?? '';
+
+        for (const frame of frames) {
+          const dataLine = frame.split('\n').find((l) => l.startsWith('data:'));
+          if (!dataLine) continue;
+
+          try {
+            const payload = JSON.parse(dataLine.slice(5).trim());
+            if (payload.delta !== undefined) {
+              result += payload.delta;
+            }
+          } catch {
+            // skip malformed frames
+          }
+        }
+      }
+
+      return result || '(no response)';
+    },
+    [user?.tenant_id]
+  );
+
+  return { sendMessage };
+}

--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -136,6 +136,10 @@ class ApiService {
     this.client.defaults.headers.common['Authorization'] = `Bearer ${token}`;
   }
 
+  getAuthToken(): string | null {
+    return this.authToken;
+  }
+
   clearAuthToken() {
     this.authToken = null;
     delete this.client.defaults.headers.common['Authorization'];
@@ -797,6 +801,16 @@ class ApiService {
   async getChatUsageStats(tenantId: string, days = 30): Promise<TokenUsageStats> {
     const { data } = await this.client.get(`/v1/tenants/${tenantId}/chat/usage/metering`, {
       params: { days },
+    });
+    return data;
+  }
+
+  async createChatConversation(
+    tenantId: string,
+    title = 'New conversation'
+  ): Promise<{ id: string }> {
+    const { data } = await this.client.post(`/v1/tenants/${tenantId}/chat/conversations`, {
+      title,
     });
     return data;
   }


### PR DESCRIPTION
## Summary
- **Backend**: tenant-level API key storage via encrypted `tenant.settings` JSON column (no migration needed), with `PUT /provider-key` admin endpoint and fallback in `send_message` when `X-Provider-Api-Key` header is missing
- **Frontend**: `useChatService` hook manages conversation lifecycle, sends messages via `fetch()` + `ReadableStream` SSE (V1 full response assembly), lazy-creates conversation on first message
- **Frontend**: `ConnectedFloatingChat` wrapper in App.tsx replaces the stub `<FloatingChat />`

## Test plan
- [ ] Backend: `CHAT_ENABLED=True` + `PUT /provider-key` stores encrypted key in tenant settings
- [ ] Backend: `POST .../messages` falls back to tenant key when header is missing
- [ ] Frontend: `npm run lint && npm run format:check && npx tsc -p tsconfig.app.json --noEmit` passes
- [ ] E2E: open console, click chat bubble, type "Hello", verify response from Anthropic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>