### PR TITLE
feat(ui): wire role display names in Console sidebar (CAB-1634)

### DIFF
--- a/control-plane-ui/src/components/Layout.tsx
+++ b/control-plane-ui/src/components/Layout.tsx
@@ -777,7 +777,7 @@ export function Layout({ children }: LayoutProps) {
                     {user.name}
                   </p>
                   <p className="truncate text-xs text-neutral-500 dark:text-neutral-400">
-                    {user.roles.join(', ')}
+                    {user.roles.map((r) => user.role_display_names?.[r] || r).join(', ')}
                   </p>
                 </>
               ) : (

--- a/control-plane-ui/src/contexts/AuthContext.tsx
+++ b/control-plane-ui/src/contexts/AuthContext.tsx
@@ -131,6 +131,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [isReady, setIsReady] = useState(false);
   const prevTokenRef = useRef<string | null>(null);
+  const fetchingMeRef = useRef(false);
 
   useEffect(() => {
     if (oidc.user) {
@@ -148,6 +149,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           queryFn: () => apiService.getTenants(),
           staleTime: 5 * 60 * 1000, // 5 minutes
         });
+        // Fetch /v1/me for role display names (CAB-1634)
+        if (!fetchingMeRef.current) {
+          fetchingMeRef.current = true;
+          apiService
+            .getMe()
+            .then((meData) => {
+              setUser((prev) =>
+                prev ? { ...prev, role_display_names: meData.role_display_names } : prev
+              );
+            })
+            .catch((err) => {
+              console.warn('[AuthContext] Failed to fetch /v1/me for display names', err);
+            })
+            .finally(() => {
+              fetchingMeRef.current = false;
+            });
+        }
       } else if (!token) {
         setUser(extractUserFromToken(oidc.user));
       }

--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -853,6 +853,20 @@ class ApiService {
     return data;
   }
 
+  async getMe(): Promise<{
+    user_id: string;
+    email: string;
+    username: string;
+    tenant_id: string | null;
+    roles: string[];
+    permissions: string[];
+    effective_scopes: string[];
+    role_display_names: Record<string, string>;
+  }> {
+    const { data } = await this.client.get('/v1/me');
+    return data;
+  }
+
   // =========================================================================
   // LLM Usage & Cost Monitoring (CAB-1487)
   // =========================================================================

--- a/control-plane-ui/src/types/index.ts
+++ b/control-plane-ui/src/types/index.ts
@@ -6,6 +6,7 @@ export interface User {
   roles: string[];
   tenant_id?: string;
   permissions: string[];
+  role_display_names?: Record<string, string>;
 }
 
 export type Role = 'cpi-admin' | 'tenant-admin' | 'devops' | 'viewer';


### PR DESCRIPTION
## Summary
- Fetch `/v1/me` in Console AuthContext to get `role_display_names` (same pattern as Portal PR #1353)
- Show human-readable role labels in sidebar instead of raw slugs (`Platform Admin` instead of `cpi-admin`)
- Graceful fallback: if `/v1/me` fails, raw role slugs still displayed

## Changes
- `types/index.ts`: Add `role_display_names?: Record<string, string>` to `User`
- `services/api.ts`: Add `getMe()` method
- `contexts/AuthContext.tsx`: Fetch `/v1/me` after token set (non-blocking)
- `components/Layout.tsx`: Map roles to display names in sidebar

## Test plan
- [x] TSC clean
- [x] ESLint: 103 warnings (under 105 max)
- [x] Prettier: clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)