### PR TITLE
feat(api): MCP connector catalog with OAuth flow (Phase 1)

### DIFF
--- a/control-plane-api/alembic/versions/052_mcp_connector_catalog.py
+++ b/control-plane-api/alembic/versions/052_mcp_connector_catalog.py
@@ -1,0 +1,211 @@
+"""MCP Connector Catalog — pre-configured OAuth connectors (App Store pattern).
+
+Creates:
+- mcp_connector_templates: seed data catalog of pre-configured providers
+- oauth_pending_sessions: ephemeral CSRF-protected OAuth state
+- Adds connector_template_id FK to external_mcp_servers
+
+Seeds 5 connector templates: Linear, GitHub, Notion, Slack, Sentry.
+
+Revision ID: 052_mcp_connector_catalog
+Revises: 051_unique_personal_tenant_owner
+Create Date: 2026-03-02
+"""
+
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "052_mcp_connector_catalog"
+down_revision = "051_unique_personal_tenant_owner"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- mcp_connector_templates ---
+    op.create_table(
+        "mcp_connector_templates",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("slug", sa.String(100), unique=True, nullable=False),
+        sa.Column("display_name", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("icon_url", sa.String(500), nullable=True),
+        sa.Column("category", sa.String(100), nullable=False),
+        sa.Column("mcp_base_url", sa.String(500), nullable=False),
+        sa.Column("transport", sa.String(20), nullable=False, server_default="sse"),
+        sa.Column("oauth_authorize_url", sa.String(500), nullable=False),
+        sa.Column("oauth_token_url", sa.String(500), nullable=False),
+        sa.Column("oauth_scopes", sa.String(500), nullable=True),
+        sa.Column("oauth_pkce_required", sa.Boolean, nullable=False, server_default="false"),
+        sa.Column("documentation_url", sa.String(500), nullable=True),
+        sa.Column("is_featured", sa.Boolean, nullable=False, server_default="false"),
+        sa.Column("enabled", sa.Boolean, nullable=False, server_default="true"),
+        sa.Column("sort_order", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_mcp_connector_templates_slug", "mcp_connector_templates", ["slug"], unique=True)
+    op.create_index("ix_mcp_connector_templates_category", "mcp_connector_templates", ["category"])
+    op.create_index("ix_mcp_connector_templates_enabled", "mcp_connector_templates", ["enabled"])
+
+    # --- oauth_pending_sessions ---
+    op.create_table(
+        "oauth_pending_sessions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("state", sa.String(255), unique=True, nullable=False),
+        sa.Column(
+            "connector_template_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("mcp_connector_templates.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("user_id", sa.String(255), nullable=False),
+        sa.Column("tenant_id", sa.String(255), nullable=True),
+        sa.Column("code_verifier", sa.String(128), nullable=True),
+        sa.Column("redirect_after", sa.String(500), nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column("expires_at", sa.DateTime, nullable=False),
+    )
+    op.create_index("ix_oauth_pending_sessions_state", "oauth_pending_sessions", ["state"], unique=True)
+    op.create_index("ix_oauth_pending_sessions_expires", "oauth_pending_sessions", ["expires_at"])
+
+    # --- Add connector_template_id FK to external_mcp_servers ---
+    op.add_column(
+        "external_mcp_servers",
+        sa.Column(
+            "connector_template_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("mcp_connector_templates.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+    # --- Seed 5 connector templates ---
+    templates = [
+        {
+            "id": str(uuid.uuid4()),
+            "slug": "linear",
+            "display_name": "Linear",
+            "description": "Project management and issue tracking for software teams",
+            "icon_url": "https://linear.app/favicon.ico",
+            "category": "project-management",
+            "mcp_base_url": "https://mcp.linear.app/sse",
+            "transport": "sse",
+            "oauth_authorize_url": "https://linear.app/oauth/authorize",
+            "oauth_token_url": "https://api.linear.app/oauth/token",
+            "oauth_scopes": "read write",
+            "oauth_pkce_required": True,
+            "documentation_url": "https://developers.linear.app/docs/oauth",
+            "is_featured": True,
+            "enabled": True,
+            "sort_order": 1,
+        },
+        {
+            "id": str(uuid.uuid4()),
+            "slug": "github",
+            "display_name": "GitHub",
+            "description": "Code hosting, pull requests, and CI/CD for developers",
+            "icon_url": "https://github.com/favicon.ico",
+            "category": "development",
+            "mcp_base_url": "https://api.githubcopilot.com/mcp/",
+            "transport": "http",
+            "oauth_authorize_url": "https://github.com/login/oauth/authorize",
+            "oauth_token_url": "https://github.com/login/oauth/access_token",
+            "oauth_scopes": "repo read:org",
+            "oauth_pkce_required": False,
+            "documentation_url": "https://docs.github.com/en/apps/oauth-apps",
+            "is_featured": True,
+            "enabled": True,
+            "sort_order": 2,
+        },
+        {
+            "id": str(uuid.uuid4()),
+            "slug": "notion",
+            "display_name": "Notion",
+            "description": "All-in-one workspace for notes, docs, and knowledge management",
+            "icon_url": "https://www.notion.so/favicon.ico",
+            "category": "project-management",
+            "mcp_base_url": "https://mcp.notion.so/sse",
+            "transport": "sse",
+            "oauth_authorize_url": "https://api.notion.com/v1/oauth/authorize",
+            "oauth_token_url": "https://api.notion.com/v1/oauth/token",
+            "oauth_scopes": "",
+            "oauth_pkce_required": False,
+            "documentation_url": "https://developers.notion.com/docs/authorization",
+            "is_featured": True,
+            "enabled": True,
+            "sort_order": 3,
+        },
+        {
+            "id": str(uuid.uuid4()),
+            "slug": "slack",
+            "display_name": "Slack",
+            "description": "Team messaging, channels, and integrations for collaboration",
+            "icon_url": "https://slack.com/favicon.ico",
+            "category": "communication",
+            "mcp_base_url": "https://mcp.slack.com/sse",
+            "transport": "sse",
+            "oauth_authorize_url": "https://slack.com/oauth/v2/authorize",
+            "oauth_token_url": "https://slack.com/api/oauth.v2.access",
+            "oauth_scopes": "channels:read chat:write",
+            "oauth_pkce_required": False,
+            "documentation_url": "https://api.slack.com/authentication/oauth-v2",
+            "is_featured": False,
+            "enabled": True,
+            "sort_order": 4,
+        },
+        {
+            "id": str(uuid.uuid4()),
+            "slug": "sentry",
+            "display_name": "Sentry",
+            "description": "Error tracking and performance monitoring for applications",
+            "icon_url": "https://sentry.io/favicon.ico",
+            "category": "monitoring",
+            "mcp_base_url": "https://mcp.sentry.dev/sse",
+            "transport": "sse",
+            "oauth_authorize_url": "https://sentry.io/oauth/authorize/",
+            "oauth_token_url": "https://sentry.io/oauth/token/",
+            "oauth_scopes": "project:read event:read",
+            "oauth_pkce_required": False,
+            "documentation_url": "https://docs.sentry.io/api/auth/",
+            "is_featured": False,
+            "enabled": True,
+            "sort_order": 5,
+        },
+    ]
+
+    mct = sa.table(
+        "mcp_connector_templates",
+        sa.column("id", postgresql.UUID),
+        sa.column("slug", sa.String),
+        sa.column("display_name", sa.String),
+        sa.column("description", sa.Text),
+        sa.column("icon_url", sa.String),
+        sa.column("category", sa.String),
+        sa.column("mcp_base_url", sa.String),
+        sa.column("transport", sa.String),
+        sa.column("oauth_authorize_url", sa.String),
+        sa.column("oauth_token_url", sa.String),
+        sa.column("oauth_scopes", sa.String),
+        sa.column("oauth_pkce_required", sa.Boolean),
+        sa.column("documentation_url", sa.String),
+        sa.column("is_featured", sa.Boolean),
+        sa.column("enabled", sa.Boolean),
+        sa.column("sort_order", sa.Integer),
+    )
+
+    op.bulk_insert(mct, templates)
+
+
+def downgrade() -> None:
+    op.drop_column("external_mcp_servers", "connector_template_id")
+    op.drop_index("ix_oauth_pending_sessions_expires", table_name="oauth_pending_sessions")
+    op.drop_index("ix_oauth_pending_sessions_state", table_name="oauth_pending_sessions")
+    op.drop_table("oauth_pending_sessions")
+    op.drop_index("ix_mcp_connector_templates_enabled", table_name="mcp_connector_templates")
+    op.drop_index("ix_mcp_connector_templates_category", table_name="mcp_connector_templates")
+    op.drop_index("ix_mcp_connector_templates_slug", table_name="mcp_connector_templates")
+    op.drop_table("mcp_connector_templates")

--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -1123,6 +1123,58 @@
         "title": "AuthTypeEnum",
         "type": "string"
       },
+      "AuthorizeRequest": {
+        "description": "Request to initiate an OAuth authorization flow.",
+        "properties": {
+          "redirect_after": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "UI URL to redirect after callback",
+            "title": "Redirect After"
+          },
+          "tenant_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Tenant to connect for (null = personal)",
+            "title": "Tenant Id"
+          }
+        },
+        "title": "AuthorizeRequest",
+        "type": "object"
+      },
+      "AuthorizeResponse": {
+        "description": "Response with the OAuth authorize URL to redirect the user to.",
+        "properties": {
+          "authorize_url": {
+            "description": "Full OAuth authorize URL with state, scope, etc.",
+            "title": "Authorize Url",
+            "type": "string"
+          },
+          "state": {
+            "description": "CSRF state token (for reference)",
+            "title": "State",
+            "type": "string"
+          }
+        },
+        "required": [
+          "authorize_url",
+          "state"
+        ],
+        "title": "AuthorizeResponse",
+        "type": "object"
+      },
       "BackendApiAuthTypeEnum": {
         "description": "Authentication type for the backend API.",
         "enum": [
@@ -1897,6 +1949,73 @@
         "title": "CallStatus",
         "type": "string"
       },
+      "CallbackRequest": {
+        "description": "Request from the OAuth callback (code + state exchange).",
+        "properties": {
+          "code": {
+            "description": "Authorization code from the provider",
+            "title": "Code",
+            "type": "string"
+          },
+          "state": {
+            "description": "CSRF state token to validate",
+            "title": "State",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "state"
+        ],
+        "title": "CallbackRequest",
+        "type": "object"
+      },
+      "CallbackResponse": {
+        "description": "Response after successful OAuth callback \u2014 the created server.",
+        "properties": {
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "redirect_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Redirect Url"
+          },
+          "server_id": {
+            "format": "uuid",
+            "title": "Server Id",
+            "type": "string"
+          },
+          "server_name": {
+            "title": "Server Name",
+            "type": "string"
+          },
+          "slug": {
+            "title": "Slug",
+            "type": "string"
+          },
+          "tools_sync_triggered": {
+            "default": false,
+            "title": "Tools Sync Triggered",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "server_id",
+          "server_name",
+          "display_name",
+          "slug"
+        ],
+        "title": "CallbackResponse",
+        "type": "object"
+      },
       "CatalogSeedAPIEntry": {
         "description": "Single API entry for direct catalog seeding.",
         "properties": {
@@ -2509,6 +2628,160 @@
           "status"
         ],
         "title": "ConnectivityStage",
+        "type": "object"
+      },
+      "ConnectorCatalogResponse": {
+        "description": "Response for the connector catalog listing.",
+        "properties": {
+          "connectors": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectorTemplateResponse"
+            },
+            "title": "Connectors",
+            "type": "array"
+          },
+          "total_count": {
+            "title": "Total Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "connectors",
+          "total_count"
+        ],
+        "title": "ConnectorCatalogResponse",
+        "type": "object"
+      },
+      "ConnectorTemplateResponse": {
+        "description": "A pre-configured MCP connector template.",
+        "properties": {
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "connected_server_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Connected Server Id"
+          },
+          "connection_health": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Connection Health"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "documentation_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Documentation Url"
+          },
+          "enabled": {
+            "default": true,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "icon_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icon Url"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "is_connected": {
+            "default": false,
+            "title": "Is Connected",
+            "type": "boolean"
+          },
+          "is_featured": {
+            "default": false,
+            "title": "Is Featured",
+            "type": "boolean"
+          },
+          "mcp_base_url": {
+            "title": "Mcp Base Url",
+            "type": "string"
+          },
+          "oauth_pkce_required": {
+            "default": false,
+            "title": "Oauth Pkce Required",
+            "type": "boolean"
+          },
+          "oauth_scopes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Oauth Scopes"
+          },
+          "slug": {
+            "title": "Slug",
+            "type": "string"
+          },
+          "sort_order": {
+            "default": 0,
+            "title": "Sort Order",
+            "type": "integer"
+          },
+          "transport": {
+            "title": "Transport",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "slug",
+          "display_name",
+          "category",
+          "mcp_base_url",
+          "transport"
+        ],
+        "title": "ConnectorTemplateResponse",
         "type": "object"
       },
       "ConsumerCreate": {
@@ -5217,6 +5490,37 @@
           "disabled_at"
         ],
         "title": "DisableBindingResponse",
+        "type": "object"
+      },
+      "DisconnectResponse": {
+        "description": "Response after disconnecting a connector.",
+        "properties": {
+          "disconnected": {
+            "default": true,
+            "title": "Disconnected",
+            "type": "boolean"
+          },
+          "server_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Server Id"
+          },
+          "slug": {
+            "title": "Slug",
+            "type": "string"
+          }
+        },
+        "required": [
+          "slug"
+        ],
+        "title": "DisconnectResponse",
         "type": "object"
       },
       "DocsSearchResponse": {
@@ -25204,6 +25508,295 @@
         ]
       }
     },
+    "/v1/admin/mcp-connectors": {
+      "get": {
+        "description": "List the connector catalog with per-tenant connection status.",
+        "operationId": "list_connectors_v1_admin_mcp_connectors_get",
+        "parameters": [
+          {
+            "description": "Tenant to check connection status for",
+            "in": "query",
+            "name": "tenant_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Tenant to check connection status for",
+              "title": "Tenant Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorCatalogResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Connectors",
+        "tags": [
+          "MCP Connectors - Catalog"
+        ]
+      }
+    },
+    "/v1/admin/mcp-connectors/callback": {
+      "post": {
+        "description": "Handle the OAuth callback \u2014 exchange code for tokens and create the MCP server.\n\nThis endpoint does NOT require authentication because it is called by the\nbrowser redirect from the OAuth provider. The CSRF state token provides\nsecurity by linking the callback to the original authorized session.",
+        "operationId": "oauth_callback_v1_admin_mcp_connectors_callback_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CallbackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallbackResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Oauth Callback",
+        "tags": [
+          "MCP Connectors - Catalog"
+        ]
+      }
+    },
+    "/v1/admin/mcp-connectors/{slug}": {
+      "get": {
+        "description": "Get a single connector template with connection status.",
+        "operationId": "get_connector_v1_admin_mcp_connectors__slug__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant to check connection status for",
+            "in": "query",
+            "name": "tenant_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Tenant to check connection status for",
+              "title": "Tenant Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorTemplateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Connector",
+        "tags": [
+          "MCP Connectors - Catalog"
+        ]
+      }
+    },
+    "/v1/admin/mcp-connectors/{slug}/authorize": {
+      "post": {
+        "description": "Initiate OAuth authorization for a connector.\n\nReturns the authorize URL to redirect the user to the provider's consent page.",
+        "operationId": "authorize_connector_v1_admin_mcp_connectors__slug__authorize_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthorizeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Authorize Connector",
+        "tags": [
+          "MCP Connectors - Catalog"
+        ]
+      }
+    },
+    "/v1/admin/mcp-connectors/{slug}/disconnect": {
+      "delete": {
+        "description": "Disconnect a connector \u2014 remove the server and Vault credentials.",
+        "operationId": "disconnect_connector_v1_admin_mcp_connectors__slug__disconnect_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant to disconnect for",
+            "in": "query",
+            "name": "tenant_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Tenant to disconnect for",
+              "title": "Tenant Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DisconnectResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Disconnect Connector",
+        "tags": [
+          "MCP Connectors - Catalog"
+        ]
+      }
+    },
     "/v1/admin/mcp/servers": {
       "get": {
         "description": "List all MCP servers (admin view).\n\nShows all servers regardless of visibility configuration.",
@@ -32930,7 +33523,7 @@
     },
     "/v1/monitoring/transactions": {
       "get": {
-        "description": "List recent API transactions.\n\nReturns transaction summaries for efficient list display.",
+        "description": "List recent API transactions.\n\nReturns transaction summaries for efficient list display.\nUses real OpenSearch data when available, falls back to demo data.",
         "operationId": "list_transactions_v1_monitoring_transactions_get",
         "parameters": [
           {
@@ -32943,22 +33536,6 @@
               "minimum": 1,
               "title": "Limit",
               "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "tenant_id",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Tenant Id"
             }
           },
           {
@@ -32991,6 +33568,20 @@
                 }
               ],
               "title": "Status"
+            }
+          },
+          {
+            "description": "Time range in minutes",
+            "in": "query",
+            "name": "time_range",
+            "required": false,
+            "schema": {
+              "default": 60,
+              "description": "Time range in minutes",
+              "maximum": 1440,
+              "minimum": 1,
+              "title": "Time Range",
+              "type": "integer"
             }
           }
         ],
@@ -33027,8 +33618,24 @@
     },
     "/v1/monitoring/transactions/stats": {
       "get": {
-        "description": "Get API transaction statistics.\n\nReturns aggregated metrics about API calls.",
+        "description": "Get API transaction statistics.\n\nReturns aggregated metrics about API calls.\nUses real OpenSearch data when available, falls back to demo data.",
         "operationId": "get_transaction_stats_v1_monitoring_transactions_stats_get",
+        "parameters": [
+          {
+            "description": "Time range in minutes",
+            "in": "query",
+            "name": "time_range",
+            "required": false,
+            "schema": {
+              "default": 60,
+              "description": "Time range in minutes",
+              "maximum": 1440,
+              "minimum": 1,
+              "title": "Time Range",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -33037,6 +33644,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "security": [
@@ -33052,7 +33669,7 @@
     },
     "/v1/monitoring/transactions/{transaction_id}": {
       "get": {
-        "description": "Get detailed information about a specific transaction.\n\nIncludes all spans with timing and metadata.",
+        "description": "Get detailed information about a specific transaction.\n\nIncludes all spans with timing and metadata.\nUses real OpenSearch data when available, falls back to demo data.",
         "operationId": "get_transaction_v1_monitoring_transactions__transaction_id__get",
         "parameters": [
           {

--- a/control-plane-api/src/main.py
+++ b/control-plane-api/src/main.py
@@ -66,6 +66,7 @@ from .routers import (
     health,
     llm_budget,
     llm_usage,
+    mcp_connectors,
     mcp_gitops,
     mcp_policy_proxy,
     mcp_proxy,
@@ -624,6 +625,9 @@ app.include_router(mcp_admin_servers_router)
 # External MCP Servers (Linear, GitHub, etc.)
 app.include_router(external_mcp_servers_admin_router)
 app.include_router(external_mcp_servers_internal_router)
+
+# MCP Connector Catalog — App Store pattern (pre-configured OAuth connectors)
+app.include_router(mcp_connectors.router)
 
 # Tenant-scoped MCP Servers — developer self-service (CAB-1319)
 app.include_router(tenant_mcp_servers_router)

--- a/control-plane-api/src/models/external_mcp_server.py
+++ b/control-plane-api/src/models/external_mcp_server.py
@@ -5,6 +5,7 @@ Models for registering and managing external MCP servers
 
 Reference: External MCP Server Registration Plan
 """
+
 import enum
 import uuid
 from datetime import datetime
@@ -28,29 +29,33 @@ from src.database import Base
 
 class ExternalMCPTransport(enum.StrEnum):
     """Transport protocol for external MCP server."""
-    SSE = "sse"           # Server-Sent Events (Claude Desktop compatible)
-    HTTP = "http"         # HTTP JSON-RPC
+
+    SSE = "sse"  # Server-Sent Events (Claude Desktop compatible)
+    HTTP = "http"  # HTTP JSON-RPC
     WEBSOCKET = "websocket"  # WebSocket
 
 
 class ExternalMCPAuthType(enum.StrEnum):
     """Authentication type for external MCP server."""
-    NONE = "none"              # No authentication
-    API_KEY = "api_key"        # API key in header
+
+    NONE = "none"  # No authentication
+    API_KEY = "api_key"  # API key in header
     BEARER_TOKEN = "bearer_token"  # Bearer token
-    OAUTH2 = "oauth2"          # OAuth2 flow
+    OAUTH2 = "oauth2"  # OAuth2 flow
 
 
 class ExternalMCPHealthStatus(enum.StrEnum):
     """Health status of external MCP server."""
-    UNKNOWN = "unknown"     # Not yet checked
-    HEALTHY = "healthy"     # Connection successful
-    DEGRADED = "degraded"   # Partial issues
+
+    UNKNOWN = "unknown"  # Not yet checked
+    HEALTHY = "healthy"  # Connection successful
+    DEGRADED = "degraded"  # Partial issues
     UNHEALTHY = "unhealthy"  # Connection failed
 
 
 class ExternalMCPServer(Base):
     """External MCP Server model - registered external servers like Linear, GitHub."""
+
     __tablename__ = "external_mcp_servers"
 
     # Primary key
@@ -58,7 +63,7 @@ class ExternalMCPServer(Base):
 
     # Server identity
     name = Column(String(255), unique=True, nullable=False)  # Slug, e.g., "linear"
-    display_name = Column(String(255), nullable=False)       # "Linear"
+    display_name = Column(String(255), nullable=False)  # "Linear"
     description = Column(Text, nullable=True)
     icon = Column(String(500), nullable=True)  # URL to icon
 
@@ -67,14 +72,14 @@ class ExternalMCPServer(Base):
     transport = Column(
         SQLEnum(ExternalMCPTransport, values_callable=lambda x: [e.value for e in x]),
         nullable=False,
-        default=ExternalMCPTransport.SSE
+        default=ExternalMCPTransport.SSE,
     )
 
     # Authentication configuration
     auth_type = Column(
         SQLEnum(ExternalMCPAuthType, values_callable=lambda x: [e.value for e in x]),
         nullable=False,
-        default=ExternalMCPAuthType.NONE
+        default=ExternalMCPAuthType.NONE,
     )
     credential_vault_path = Column(String(500), nullable=True)  # Path to credentials in Vault
 
@@ -86,7 +91,7 @@ class ExternalMCPServer(Base):
     health_status = Column(
         SQLEnum(ExternalMCPHealthStatus, values_callable=lambda x: [e.value for e in x]),
         nullable=False,
-        default=ExternalMCPHealthStatus.UNKNOWN
+        default=ExternalMCPHealthStatus.UNKNOWN,
     )
     last_health_check = Column(DateTime, nullable=True)
     last_sync_at = Column(DateTime, nullable=True)
@@ -100,17 +105,18 @@ class ExternalMCPServer(Base):
     updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
     created_by = Column(String(255), nullable=True)  # Admin user ID
 
-    # Relationships
-    tools = relationship(
-        "ExternalMCPServerTool",
-        back_populates="server",
-        cascade="all, delete-orphan"
+    # Connector catalog link (null = manually configured server)
+    connector_template_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("mcp_connector_templates.id", ondelete="SET NULL"),
+        nullable=True,
     )
 
+    # Relationships
+    tools = relationship("ExternalMCPServerTool", back_populates="server", cascade="all, delete-orphan")
+
     # Indexes
-    __table_args__ = (
-        Index('ix_external_mcp_servers_tenant_enabled', 'tenant_id', 'enabled'),
-    )
+    __table_args__ = (Index("ix_external_mcp_servers_tenant_enabled", "tenant_id", "enabled"),)
 
     def __repr__(self) -> str:
         return f"<ExternalMCPServer {self.name} url={self.base_url}>"
@@ -118,17 +124,14 @@ class ExternalMCPServer(Base):
 
 class ExternalMCPServerTool(Base):
     """Tool discovered from an external MCP server."""
+
     __tablename__ = "external_mcp_server_tools"
 
     # Primary key
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 
     # Server reference
-    server_id = Column(
-        UUID(as_uuid=True),
-        ForeignKey("external_mcp_servers.id", ondelete="CASCADE"),
-        nullable=False
-    )
+    server_id = Column(UUID(as_uuid=True), ForeignKey("external_mcp_servers.id", ondelete="CASCADE"), nullable=False)
 
     # Tool identity
     name = Column(String(255), nullable=False)  # Original name from external server
@@ -148,8 +151,8 @@ class ExternalMCPServerTool(Base):
 
     # Indexes
     __table_args__ = (
-        Index('ix_external_mcp_server_tools_server_name', 'server_id', 'name', unique=True),
-        Index('ix_external_mcp_server_tools_namespaced', 'namespaced_name'),
+        Index("ix_external_mcp_server_tools_server_name", "server_id", "name", unique=True),
+        Index("ix_external_mcp_server_tools_namespaced", "namespaced_name"),
     )
 
     def __repr__(self) -> str:

--- a/control-plane-api/src/models/mcp_connector_template.py
+++ b/control-plane-api/src/models/mcp_connector_template.py
@@ -1,0 +1,72 @@
+"""MCP Connector Template and OAuth Pending Session models.
+
+Pre-configured connector catalog for one-click OAuth integrations
+(App Store pattern: browse, click Connect, authorize, done).
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+
+from src.database import Base
+
+
+class MCPConnectorTemplate(Base):
+    """Pre-configured MCP connector template (seed data for the catalog)."""
+
+    __tablename__ = "mcp_connector_templates"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    slug = Column(String(100), unique=True, nullable=False, index=True)
+    display_name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    icon_url = Column(String(500), nullable=True)
+    category = Column(String(100), nullable=False)
+
+    # MCP connection
+    mcp_base_url = Column(String(500), nullable=False)
+    transport = Column(String(20), nullable=False, default="sse")
+
+    # OAuth configuration
+    oauth_authorize_url = Column(String(500), nullable=False)
+    oauth_token_url = Column(String(500), nullable=False)
+    oauth_scopes = Column(String(500), nullable=True)
+    oauth_pkce_required = Column(Boolean, nullable=False, default=False)
+
+    # Metadata
+    documentation_url = Column(String(500), nullable=True)
+    is_featured = Column(Boolean, nullable=False, default=False)
+    enabled = Column(Boolean, nullable=False, default=True)
+    sort_order = Column(Integer, nullable=False, default=0)
+
+    # Timestamps
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def __repr__(self) -> str:
+        return f"<MCPConnectorTemplate {self.slug}>"
+
+
+class OAuthPendingSession(Base):
+    """Ephemeral OAuth session for CSRF protection during the authorize flow."""
+
+    __tablename__ = "oauth_pending_sessions"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    state = Column(String(255), unique=True, nullable=False, index=True)
+    connector_template_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("mcp_connector_templates.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id = Column(String(255), nullable=False)
+    tenant_id = Column(String(255), nullable=True)
+    code_verifier = Column(String(128), nullable=True)
+    redirect_after = Column(String(500), nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    expires_at = Column(DateTime, nullable=False)
+
+    def __repr__(self) -> str:
+        return f"<OAuthPendingSession state={self.state[:8]}...>"

--- a/control-plane-api/src/repositories/mcp_connector.py
+++ b/control-plane-api/src/repositories/mcp_connector.py
@@ -1,0 +1,112 @@
+"""Repository for MCP Connector Template and OAuth Pending Session operations."""
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import and_, delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.external_mcp_server import ExternalMCPServer
+from src.models.mcp_connector_template import MCPConnectorTemplate, OAuthPendingSession
+
+
+class ConnectorTemplateRepository:
+    """Repository for MCP Connector Template database operations."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def list_all(self, enabled_only: bool = True) -> list[MCPConnectorTemplate]:
+        """List all connector templates, ordered by sort_order."""
+        query = select(MCPConnectorTemplate).order_by(MCPConnectorTemplate.sort_order)
+        if enabled_only:
+            query = query.where(MCPConnectorTemplate.enabled.is_(True))
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def get_by_slug(self, slug: str) -> MCPConnectorTemplate | None:
+        """Get a connector template by slug."""
+        result = await self.session.execute(select(MCPConnectorTemplate).where(MCPConnectorTemplate.slug == slug))
+        return result.scalar_one_or_none()
+
+    async def get_by_id(self, template_id: UUID) -> MCPConnectorTemplate | None:
+        """Get a connector template by ID."""
+        result = await self.session.execute(select(MCPConnectorTemplate).where(MCPConnectorTemplate.id == template_id))
+        return result.scalar_one_or_none()
+
+
+class OAuthSessionRepository:
+    """Repository for OAuth Pending Session operations."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(self, pending_session: OAuthPendingSession) -> OAuthPendingSession:
+        """Create a new OAuth pending session."""
+        self.session.add(pending_session)
+        await self.session.flush()
+        await self.session.refresh(pending_session)
+        return pending_session
+
+    async def get_by_state(self, state: str) -> OAuthPendingSession | None:
+        """Get a pending session by state token."""
+        result = await self.session.execute(select(OAuthPendingSession).where(OAuthPendingSession.state == state))
+        return result.scalar_one_or_none()
+
+    async def delete(self, pending_session: OAuthPendingSession) -> None:
+        """Delete a pending session (single-use after callback)."""
+        await self.session.delete(pending_session)
+        await self.session.flush()
+
+    async def cleanup_expired(self) -> int:
+        """Delete expired sessions. Returns count of deleted rows."""
+        now = datetime.utcnow()
+        result = await self.session.execute(delete(OAuthPendingSession).where(OAuthPendingSession.expires_at < now))
+        await self.session.flush()
+        return result.rowcount
+
+
+class ConnectorServerRepository:
+    """Repository for querying ExternalMCPServer by connector_template_id."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_by_template_and_tenant(
+        self,
+        template_id: UUID,
+        tenant_id: str | None,
+    ) -> ExternalMCPServer | None:
+        """Find an existing server connected via a specific template for a tenant."""
+        conditions = [ExternalMCPServer.connector_template_id == template_id]
+        if tenant_id is not None:
+            conditions.append(ExternalMCPServer.tenant_id == tenant_id)
+        else:
+            conditions.append(ExternalMCPServer.tenant_id.is_(None))
+
+        result = await self.session.execute(select(ExternalMCPServer).where(and_(*conditions)))
+        return result.scalar_one_or_none()
+
+    async def list_connected_template_ids(
+        self,
+        tenant_id: str | None,
+    ) -> dict[UUID, tuple[UUID, str]]:
+        """Get a mapping of connected template_id -> (server_id, health_status) for a tenant."""
+        conditions = [ExternalMCPServer.connector_template_id.isnot(None)]
+        if tenant_id is not None:
+            conditions.append(ExternalMCPServer.tenant_id == tenant_id)
+        else:
+            conditions.append(ExternalMCPServer.tenant_id.is_(None))
+
+        result = await self.session.execute(
+            select(
+                ExternalMCPServer.connector_template_id,
+                ExternalMCPServer.id,
+                ExternalMCPServer.health_status,
+            ).where(and_(*conditions))
+        )
+
+        mapping: dict[UUID, tuple[UUID, str]] = {}
+        for row in result.all():
+            mapping[row[0]] = (row[1], row[2].value if hasattr(row[2], "value") else str(row[2]))
+        return mapping

--- a/control-plane-api/src/routers/mcp_connectors.py
+++ b/control-plane-api/src/routers/mcp_connectors.py
@@ -1,0 +1,265 @@
+"""MCP Connector Catalog Router — App Store pattern for pre-configured OAuth connectors.
+
+Endpoints:
+- GET    /v1/admin/mcp-connectors              — List catalog with connection status
+- GET    /v1/admin/mcp-connectors/{slug}        — Template detail
+- POST   /v1/admin/mcp-connectors/{slug}/authorize  — Initiate OAuth flow
+- POST   /v1/admin/mcp-connectors/callback      — OAuth callback (code+state exchange)
+- DELETE /v1/admin/mcp-connectors/{slug}/disconnect  — Disconnect connector
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth import User, get_current_user
+from ..config import settings
+from ..database import get_db
+from ..repositories.external_mcp_server import ExternalMCPServerRepository
+from ..repositories.mcp_connector import (
+    ConnectorServerRepository,
+    ConnectorTemplateRepository,
+    OAuthSessionRepository,
+)
+from ..schemas.mcp_connector import (
+    AuthorizeRequest,
+    AuthorizeResponse,
+    CallbackRequest,
+    CallbackResponse,
+    ConnectorCatalogResponse,
+    ConnectorTemplateResponse,
+    DisconnectResponse,
+)
+from ..services.connector_oauth import ConnectorOAuthError, ConnectorOAuthService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/admin/mcp-connectors", tags=["MCP Connectors - Catalog"])
+
+
+def _require_admin(user: User) -> None:
+    """Check if user has admin access."""
+    if "cpi-admin" not in user.roles and "tenant-admin" not in user.roles:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+
+def _get_tenant_id(user: User, explicit_tenant_id: str | None = None) -> str | None:
+    """Resolve the effective tenant_id for the request."""
+    if "cpi-admin" in user.roles:
+        return explicit_tenant_id
+    return user.tenant_id
+
+
+def _build_oauth_service(db: AsyncSession) -> ConnectorOAuthService:
+    """Build ConnectorOAuthService with all repositories."""
+    return ConnectorOAuthService(
+        template_repo=ConnectorTemplateRepository(db),
+        session_repo=OAuthSessionRepository(db),
+        connector_server_repo=ConnectorServerRepository(db),
+        server_repo=ExternalMCPServerRepository(db),
+    )
+
+
+def _build_redirect_uri() -> str:
+    """Build the OAuth callback redirect URI from settings."""
+    return f"https://console.{settings.BASE_DOMAIN}/mcp-connectors/callback"
+
+
+@router.get("", response_model=ConnectorCatalogResponse)
+async def list_connectors(
+    tenant_id: str | None = Query(None, description="Tenant to check connection status for"),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List the connector catalog with per-tenant connection status."""
+    _require_admin(user)
+
+    effective_tenant_id = _get_tenant_id(user, tenant_id)
+
+    template_repo = ConnectorTemplateRepository(db)
+    connector_server_repo = ConnectorServerRepository(db)
+
+    templates = await template_repo.list_all(enabled_only=True)
+
+    # Get connection status for the tenant
+    connected_map = await connector_server_repo.list_connected_template_ids(effective_tenant_id)
+
+    result = []
+    for t in templates:
+        connected_info = connected_map.get(t.id)
+        result.append(
+            ConnectorTemplateResponse(
+                id=t.id,
+                slug=t.slug,
+                display_name=t.display_name,
+                description=t.description,
+                icon_url=t.icon_url,
+                category=t.category,
+                mcp_base_url=t.mcp_base_url,
+                transport=t.transport,
+                oauth_scopes=t.oauth_scopes,
+                oauth_pkce_required=t.oauth_pkce_required,
+                documentation_url=t.documentation_url,
+                is_featured=t.is_featured,
+                enabled=t.enabled,
+                sort_order=t.sort_order,
+                is_connected=connected_info is not None,
+                connected_server_id=connected_info[0] if connected_info else None,
+                connection_health=connected_info[1] if connected_info else None,
+            )
+        )
+
+    return ConnectorCatalogResponse(connectors=result, total_count=len(result))
+
+
+@router.get("/{slug}", response_model=ConnectorTemplateResponse)
+async def get_connector(
+    slug: str,
+    tenant_id: str | None = Query(None, description="Tenant to check connection status for"),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get a single connector template with connection status."""
+    _require_admin(user)
+
+    effective_tenant_id = _get_tenant_id(user, tenant_id)
+
+    template_repo = ConnectorTemplateRepository(db)
+    template = await template_repo.get_by_slug(slug)
+    if not template:
+        raise HTTPException(status_code=404, detail=f"Connector '{slug}' not found")
+
+    connector_server_repo = ConnectorServerRepository(db)
+    connected_map = await connector_server_repo.list_connected_template_ids(effective_tenant_id)
+    connected_info = connected_map.get(template.id)
+
+    return ConnectorTemplateResponse(
+        id=template.id,
+        slug=template.slug,
+        display_name=template.display_name,
+        description=template.description,
+        icon_url=template.icon_url,
+        category=template.category,
+        mcp_base_url=template.mcp_base_url,
+        transport=template.transport,
+        oauth_scopes=template.oauth_scopes,
+        oauth_pkce_required=template.oauth_pkce_required,
+        documentation_url=template.documentation_url,
+        is_featured=template.is_featured,
+        enabled=template.enabled,
+        sort_order=template.sort_order,
+        is_connected=connected_info is not None,
+        connected_server_id=connected_info[0] if connected_info else None,
+        connection_health=connected_info[1] if connected_info else None,
+    )
+
+
+@router.post("/{slug}/authorize", response_model=AuthorizeResponse)
+async def authorize_connector(
+    slug: str,
+    request: AuthorizeRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Initiate OAuth authorization for a connector.
+
+    Returns the authorize URL to redirect the user to the provider's consent page.
+    """
+    _require_admin(user)
+
+    effective_tenant_id = _get_tenant_id(user, request.tenant_id)
+
+    template_repo = ConnectorTemplateRepository(db)
+    template = await template_repo.get_by_slug(slug)
+    if not template:
+        raise HTTPException(status_code=404, detail=f"Connector '{slug}' not found")
+
+    if not template.enabled:
+        raise HTTPException(status_code=400, detail=f"Connector '{slug}' is disabled")
+
+    service = _build_oauth_service(db)
+    redirect_uri = _build_redirect_uri()
+
+    try:
+        authorize_url, state = await service.initiate_authorize(
+            template=template,
+            user_id=user.id,
+            tenant_id=effective_tenant_id,
+            redirect_after=request.redirect_after,
+            redirect_uri=redirect_uri,
+        )
+        await db.commit()
+    except ConnectorOAuthError as e:
+        if e.status_code == 409:
+            raise HTTPException(status_code=409, detail=e.message)
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+
+    return AuthorizeResponse(authorize_url=authorize_url, state=state)
+
+
+@router.post("/callback", response_model=CallbackResponse)
+async def oauth_callback(
+    request: CallbackRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Handle the OAuth callback — exchange code for tokens and create the MCP server.
+
+    This endpoint does NOT require authentication because it is called by the
+    browser redirect from the OAuth provider. The CSRF state token provides
+    security by linking the callback to the original authorized session.
+    """
+    service = _build_oauth_service(db)
+    redirect_uri = _build_redirect_uri()
+
+    try:
+        server, redirect_after = await service.handle_callback(
+            code=request.code,
+            state=request.state,
+            redirect_uri=redirect_uri,
+        )
+        await db.commit()
+    except ConnectorOAuthError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+
+    return CallbackResponse(
+        server_id=server.id,
+        server_name=server.name,
+        display_name=server.display_name,
+        slug=server.tool_prefix or server.name,
+        redirect_url=redirect_after,
+    )
+
+
+@router.delete("/{slug}/disconnect", response_model=DisconnectResponse)
+async def disconnect_connector(
+    slug: str,
+    tenant_id: str | None = Query(None, description="Tenant to disconnect for"),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Disconnect a connector — remove the server and Vault credentials."""
+    _require_admin(user)
+
+    effective_tenant_id = _get_tenant_id(user, tenant_id)
+
+    template_repo = ConnectorTemplateRepository(db)
+    template = await template_repo.get_by_slug(slug)
+    if not template:
+        raise HTTPException(status_code=404, detail=f"Connector '{slug}' not found")
+
+    service = _build_oauth_service(db)
+
+    try:
+        server_id = await service.disconnect(template, effective_tenant_id)
+        await db.commit()
+    except ConnectorOAuthError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+
+    if not server_id:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Connector '{slug}' is not connected for this tenant",
+        )
+
+    return DisconnectResponse(slug=slug, disconnected=True, server_id=server_id)

--- a/control-plane-api/src/schemas/mcp_connector.py
+++ b/control-plane-api/src/schemas/mcp_connector.py
@@ -1,0 +1,93 @@
+"""Pydantic schemas for MCP Connector Catalog endpoints.
+
+App Store pattern: browse catalog, authorize via OAuth, auto-configure server.
+"""
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# ============== Template Schemas ==============
+
+
+class ConnectorTemplateResponse(BaseModel):
+    """A pre-configured MCP connector template."""
+
+    id: UUID
+    slug: str
+    display_name: str
+    description: str | None = None
+    icon_url: str | None = None
+    category: str
+    mcp_base_url: str
+    transport: str
+    oauth_scopes: str | None = None
+    oauth_pkce_required: bool = False
+    documentation_url: str | None = None
+    is_featured: bool = False
+    enabled: bool = True
+    sort_order: int = 0
+    # Connection status (populated per-request based on tenant)
+    is_connected: bool = False
+    connected_server_id: UUID | None = None
+    connection_health: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ConnectorCatalogResponse(BaseModel):
+    """Response for the connector catalog listing."""
+
+    connectors: list[ConnectorTemplateResponse]
+    total_count: int
+
+
+# ============== Authorize Schemas ==============
+
+
+class AuthorizeRequest(BaseModel):
+    """Request to initiate an OAuth authorization flow."""
+
+    tenant_id: str | None = Field(None, description="Tenant to connect for (null = personal)")
+    redirect_after: str | None = Field(None, description="UI URL to redirect after callback")
+
+
+class AuthorizeResponse(BaseModel):
+    """Response with the OAuth authorize URL to redirect the user to."""
+
+    authorize_url: str = Field(..., description="Full OAuth authorize URL with state, scope, etc.")
+    state: str = Field(..., description="CSRF state token (for reference)")
+
+
+# ============== Callback Schemas ==============
+
+
+class CallbackRequest(BaseModel):
+    """Request from the OAuth callback (code + state exchange)."""
+
+    code: str = Field(..., description="Authorization code from the provider")
+    state: str = Field(..., description="CSRF state token to validate")
+
+
+class CallbackResponse(BaseModel):
+    """Response after successful OAuth callback — the created server."""
+
+    server_id: UUID
+    server_name: str
+    display_name: str
+    slug: str
+    tools_sync_triggered: bool = False
+    redirect_url: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# ============== Disconnect Schema ==============
+
+
+class DisconnectResponse(BaseModel):
+    """Response after disconnecting a connector."""
+
+    slug: str
+    disconnected: bool = True
+    server_id: UUID | None = None

--- a/control-plane-api/src/services/connector_oauth.py
+++ b/control-plane-api/src/services/connector_oauth.py
@@ -1,0 +1,361 @@
+"""Connector OAuth Service — handles the OAuth authorization flow for MCP connectors.
+
+Flow:
+1. initiate_authorize: build OAuth URL, save CSRF state in DB
+2. handle_callback: exchange code for tokens, create ExternalMCPServer, store tokens in Vault
+3. disconnect: remove server + Vault credentials
+"""
+
+import base64
+import hashlib
+import logging
+import secrets
+import uuid
+from datetime import datetime, timedelta
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+from hvac.exceptions import InvalidPath
+
+from src.models.external_mcp_server import (
+    ExternalMCPAuthType,
+    ExternalMCPServer,
+    ExternalMCPTransport,
+)
+from src.models.mcp_connector_template import MCPConnectorTemplate, OAuthPendingSession
+from src.repositories.external_mcp_server import ExternalMCPServerRepository
+from src.repositories.mcp_connector import (
+    ConnectorServerRepository,
+    ConnectorTemplateRepository,
+    OAuthSessionRepository,
+)
+from src.services.vault_client import get_vault_client
+
+logger = logging.getLogger(__name__)
+
+# OAuth state token expires after 10 minutes
+STATE_EXPIRY_MINUTES = 10
+
+
+class ConnectorOAuthError(Exception):
+    """Raised when the OAuth flow encounters an error."""
+
+    def __init__(self, message: str, status_code: int = 400):
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+
+class ConnectorOAuthService:
+    """Handles the full OAuth lifecycle for MCP connector integrations."""
+
+    def __init__(
+        self,
+        template_repo: ConnectorTemplateRepository,
+        session_repo: OAuthSessionRepository,
+        connector_server_repo: ConnectorServerRepository,
+        server_repo: ExternalMCPServerRepository,
+    ):
+        self.template_repo = template_repo
+        self.session_repo = session_repo
+        self.connector_server_repo = connector_server_repo
+        self.server_repo = server_repo
+
+    async def initiate_authorize(
+        self,
+        template: MCPConnectorTemplate,
+        user_id: str,
+        tenant_id: str | None,
+        redirect_after: str | None = None,
+        redirect_uri: str = "",
+    ) -> tuple[str, str]:
+        """Build the OAuth authorize URL and save CSRF state.
+
+        Args:
+            template: The connector template to authorize
+            user_id: Current user ID
+            tenant_id: Tenant to connect for (None = platform-wide)
+            redirect_after: UI URL to redirect after callback
+            redirect_uri: The callback URL registered with the provider
+
+        Returns:
+            Tuple of (authorize_url, state_token)
+
+        Raises:
+            ConnectorOAuthError: If already connected (409) or provider credentials missing
+        """
+        # Check not already connected
+        existing = await self.connector_server_repo.get_by_template_and_tenant(template.id, tenant_id)
+        if existing:
+            raise ConnectorOAuthError(
+                f"Connector '{template.slug}' is already connected for this tenant",
+                status_code=409,
+            )
+
+        # Retrieve provider client_id from Vault
+        provider_creds = await self._get_provider_credentials(template.slug)
+        client_id = provider_creds.get("client_id", "")
+        if not client_id:
+            raise ConnectorOAuthError(
+                f"Provider credentials not configured for '{template.slug}'",
+                status_code=503,
+            )
+
+        # Generate CSRF state
+        state = secrets.token_urlsafe(32)
+
+        # Generate PKCE if required
+        code_verifier = None
+        code_challenge = None
+        if template.oauth_pkce_required:
+            code_verifier = secrets.token_urlsafe(96)[:128]
+            code_challenge = self._generate_code_challenge(code_verifier)
+
+        # Save pending session
+        pending = OAuthPendingSession(
+            id=uuid.uuid4(),
+            state=state,
+            connector_template_id=template.id,
+            user_id=user_id,
+            tenant_id=tenant_id,
+            code_verifier=code_verifier,
+            redirect_after=redirect_after,
+            created_at=datetime.utcnow(),
+            expires_at=datetime.utcnow() + timedelta(minutes=STATE_EXPIRY_MINUTES),
+        )
+        await self.session_repo.create(pending)
+
+        # Build authorize URL
+        params: dict[str, str] = {
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "state": state,
+        }
+        if template.oauth_scopes:
+            params["scope"] = template.oauth_scopes
+        if code_challenge:
+            params["code_challenge"] = code_challenge
+            params["code_challenge_method"] = "S256"
+
+        authorize_url = f"{template.oauth_authorize_url}?{urlencode(params)}"
+
+        # Cleanup expired sessions (piggyback, non-blocking)
+        await self.session_repo.cleanup_expired()
+
+        return authorize_url, state
+
+    async def handle_callback(
+        self,
+        code: str,
+        state: str,
+        redirect_uri: str = "",
+    ) -> tuple[ExternalMCPServer, str | None]:
+        """Exchange authorization code for tokens and create the MCP server.
+
+        Args:
+            code: Authorization code from the provider
+            state: CSRF state token for validation
+            redirect_uri: The callback URL used during authorize
+
+        Returns:
+            Tuple of (created_server, redirect_after_url)
+
+        Raises:
+            ConnectorOAuthError: On invalid/expired state, or token exchange failure
+        """
+        # Validate state
+        pending = await self.session_repo.get_by_state(state)
+        if not pending:
+            raise ConnectorOAuthError("Invalid or expired state token")
+
+        # Check expiry
+        if datetime.utcnow() > pending.expires_at:
+            await self.session_repo.delete(pending)
+            raise ConnectorOAuthError("OAuth state has expired, please try again")
+
+        # Get template
+        template = await self.template_repo.get_by_id(pending.connector_template_id)
+        if not template:
+            await self.session_repo.delete(pending)
+            raise ConnectorOAuthError("Connector template not found", status_code=404)
+
+        redirect_after = pending.redirect_after
+        code_verifier = pending.code_verifier
+        user_id = pending.user_id
+        tenant_id = pending.tenant_id
+
+        # Delete session immediately (single-use)
+        await self.session_repo.delete(pending)
+
+        # Get provider credentials
+        provider_creds = await self._get_provider_credentials(template.slug)
+        client_id = provider_creds.get("client_id", "")
+        client_secret = provider_creds.get("client_secret", "")
+
+        # Exchange code for tokens
+        tokens = await self._exchange_code_for_tokens(
+            token_url=template.oauth_token_url,
+            code=code,
+            client_id=client_id,
+            client_secret=client_secret,
+            redirect_uri=redirect_uri,
+            code_verifier=code_verifier,
+        )
+
+        # Create ExternalMCPServer
+        tenant_suffix = f"-{tenant_id[:8]}" if tenant_id else ""
+        server_name = f"{template.slug}{tenant_suffix}"
+
+        server = ExternalMCPServer(
+            id=uuid.uuid4(),
+            name=server_name,
+            display_name=template.display_name,
+            description=template.description,
+            icon=template.icon_url,
+            base_url=template.mcp_base_url,
+            transport=ExternalMCPTransport(template.transport),
+            auth_type=ExternalMCPAuthType.OAUTH2,
+            tool_prefix=template.slug,
+            tenant_id=tenant_id,
+            created_by=user_id,
+            connector_template_id=template.id,
+        )
+
+        # Store user tokens in Vault (separate from provider app credentials)
+        vault_data = {
+            "access_token": tokens.get("access_token", ""),
+            "refresh_token": tokens.get("refresh_token"),
+            "expires_at": tokens.get("expires_at"),
+            "token_url": template.oauth_token_url,
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+        try:
+            vault = get_vault_client()
+            vault_path = await vault.store_credential(str(server.id), vault_data)
+            server.credential_vault_path = vault_path
+        except Exception as e:
+            logger.error(f"Failed to store tokens in Vault for connector '{template.slug}': {e}")
+            raise ConnectorOAuthError("Failed to store credentials securely", status_code=500)
+
+        server = await self.server_repo.create(server)
+
+        logger.info(
+            f"Connected connector '{template.slug}' as server '{server.name}'",
+            extra={"server_id": str(server.id), "user_id": user_id},
+        )
+
+        return server, redirect_after
+
+    async def disconnect(
+        self,
+        template: MCPConnectorTemplate,
+        tenant_id: str | None,
+    ) -> uuid.UUID | None:
+        """Disconnect a connector: delete server + Vault credentials.
+
+        Returns:
+            The deleted server's ID, or None if not found.
+        """
+        server = await self.connector_server_repo.get_by_template_and_tenant(template.id, tenant_id)
+        if not server:
+            return None
+
+        server_id = server.id
+
+        # Delete from Vault
+        if server.credential_vault_path:
+            try:
+                vault = get_vault_client()
+                await vault.delete_credential(str(server.id))
+            except Exception as e:
+                logger.warning(f"Failed to delete Vault credentials for connector '{template.slug}': {e}")
+
+        # Delete server (cascades to tools)
+        await self.server_repo.delete(server)
+
+        logger.info(
+            f"Disconnected connector '{template.slug}'",
+            extra={"server_id": str(server_id)},
+        )
+
+        return server_id
+
+    async def _get_provider_credentials(self, slug: str) -> dict[str, Any]:
+        """Retrieve provider app credentials (client_id/secret) from Vault.
+
+        Provider credentials are stored at: secret/data/mcp-connector-templates/{slug}
+        (separate path from user tokens at external-mcp-servers/{server_id}).
+        """
+        try:
+            vault = get_vault_client()
+            vault._ensure_unsealed()
+            client = vault._get_client()
+            path = f"mcp-connector-templates/{slug}"
+            response = client.secrets.kv.v2.read_secret_version(
+                path=path,
+                mount_point=vault.mount_point,
+            )
+            if response and "data" in response and "data" in response["data"]:
+                return response["data"]["data"]
+            return {}
+        except InvalidPath:
+            logger.warning(f"Provider credentials not found in Vault for '{slug}'")
+            return {}
+        except Exception as e:
+            logger.error(f"Failed to retrieve provider credentials for '{slug}': {e}")
+            return {}
+
+    async def _exchange_code_for_tokens(
+        self,
+        token_url: str,
+        code: str,
+        client_id: str,
+        client_secret: str,
+        redirect_uri: str,
+        code_verifier: str | None = None,
+    ) -> dict[str, Any]:
+        """Exchange an authorization code for access/refresh tokens."""
+        data: dict[str, str] = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": client_id,
+        }
+        if client_secret:
+            data["client_secret"] = client_secret
+        if code_verifier:
+            data["code_verifier"] = code_verifier
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                token_url,
+                data=data,
+                headers={"Accept": "application/json"},
+            )
+
+        if response.status_code != 200:
+            logger.error(
+                f"Token exchange failed: {response.status_code} {response.text[:200]}",
+                extra={"token_url": token_url},
+            )
+            raise ConnectorOAuthError(
+                f"Failed to exchange authorization code (HTTP {response.status_code})",
+                status_code=502,
+            )
+
+        tokens = response.json()
+
+        # Compute expires_at if expires_in is present
+        if "expires_in" in tokens and "expires_at" not in tokens:
+            tokens["expires_at"] = (datetime.utcnow() + timedelta(seconds=int(tokens["expires_in"]))).isoformat()
+
+        return tokens
+
+    @staticmethod
+    def _generate_code_challenge(code_verifier: str) -> str:
+        """Generate a S256 PKCE code challenge from a code verifier."""
+        digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+        return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")

--- a/control-plane-api/tests/test_mcp_connectors.py
+++ b/control-plane-api/tests/test_mcp_connectors.py
@@ -1,0 +1,782 @@
+"""Tests for MCP Connector Catalog Router — App Store pattern.
+
+Endpoints:
+- GET    /v1/admin/mcp-connectors              — List catalog with connection status
+- GET    /v1/admin/mcp-connectors/{slug}        — Template detail
+- POST   /v1/admin/mcp-connectors/{slug}/authorize  — Initiate OAuth flow
+- POST   /v1/admin/mcp-connectors/callback      — OAuth callback (code+state exchange)
+- DELETE /v1/admin/mcp-connectors/{slug}/disconnect  — Disconnect connector
+
+Auth: get_current_user + _require_admin (cpi-admin or tenant-admin).
+Exception: /callback has NO auth (CSRF state token provides security).
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Patch paths (where objects are looked up at runtime in the router)
+TEMPLATE_REPO_PATH = "src.routers.mcp_connectors.ConnectorTemplateRepository"
+SESSION_REPO_PATH = "src.routers.mcp_connectors.OAuthSessionRepository"
+CONNECTOR_SERVER_REPO_PATH = "src.routers.mcp_connectors.ConnectorServerRepository"
+EXT_SERVER_REPO_PATH = "src.routers.mcp_connectors.ExternalMCPServerRepository"
+OAUTH_SERVICE_PATH = "src.routers.mcp_connectors.ConnectorOAuthService"
+SETTINGS_PATH = "src.routers.mcp_connectors.settings"
+
+BASE = "/v1/admin/mcp-connectors"
+
+
+def _mock_template(**overrides):
+    """Create a mock MCPConnectorTemplate."""
+    mock = MagicMock()
+    defaults = {
+        "id": uuid4(),
+        "slug": "linear",
+        "display_name": "Linear",
+        "description": "Linear issue tracking MCP server",
+        "icon_url": "https://linear.app/icon.png",
+        "category": "project-management",
+        "mcp_base_url": "https://mcp.linear.app/sse",
+        "transport": "sse",
+        "oauth_authorize_url": "https://linear.app/oauth/authorize",
+        "oauth_token_url": "https://api.linear.app/oauth/token",
+        "oauth_scopes": "read write",
+        "oauth_pkce_required": True,
+        "documentation_url": "https://developers.linear.app",
+        "is_featured": True,
+        "enabled": True,
+        "sort_order": 10,
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+        "updated_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    for k, v in {**defaults, **overrides}.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _mock_server(**overrides):
+    """Create a mock ExternalMCPServer for connector tests."""
+    mock = MagicMock()
+    defaults = {
+        "id": uuid4(),
+        "name": "linear-abcd1234",
+        "display_name": "Linear",
+        "description": "Linear issue tracking MCP server",
+        "icon": "https://linear.app/icon.png",
+        "base_url": "https://mcp.linear.app/sse",
+        "transport": "sse",
+        "auth_type": "oauth2",
+        "tool_prefix": "linear",
+        "tenant_id": "acme",
+        "created_by": "admin-user-id",
+        "connector_template_id": uuid4(),
+        "credential_vault_path": "external-mcp-servers/some-uuid",
+    }
+    for k, v in {**defaults, **overrides}.items():
+        setattr(mock, k, v)
+    return mock
+
+
+# ============== List Connectors ==============
+
+
+class TestListConnectors:
+    """GET /v1/admin/mcp-connectors"""
+
+    def test_list_connectors_cpi_admin(self, app_with_cpi_admin, mock_db_session):
+        """CPI admin sees full catalog with connection status."""
+        templates = [_mock_template(), _mock_template(slug="github", display_name="GitHub")]
+
+        with (
+            patch(TEMPLATE_REPO_PATH) as MockTemplateRepo,
+            patch(CONNECTOR_SERVER_REPO_PATH) as MockConnServerRepo,
+        ):
+            MockTemplateRepo.return_value.list_all = AsyncMock(return_value=templates)
+            MockConnServerRepo.return_value.list_connected_template_ids = AsyncMock(return_value={})
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get(BASE)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_count"] == 2
+        assert len(data["connectors"]) == 2
+        assert data["connectors"][0]["slug"] == "linear"
+        assert data["connectors"][0]["is_connected"] is False
+
+    def test_list_connectors_with_connected(self, app_with_cpi_admin, mock_db_session):
+        """Connected templates show is_connected=True and server_id."""
+        template = _mock_template()
+        server_id = uuid4()
+        connected_map = {template.id: (server_id, "healthy")}
+
+        with (
+            patch(TEMPLATE_REPO_PATH) as MockTemplateRepo,
+            patch(CONNECTOR_SERVER_REPO_PATH) as MockConnServerRepo,
+        ):
+            MockTemplateRepo.return_value.list_all = AsyncMock(return_value=[template])
+            MockConnServerRepo.return_value.list_connected_template_ids = AsyncMock(return_value=connected_map)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get(BASE)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["connectors"][0]["is_connected"] is True
+        assert data["connectors"][0]["connected_server_id"] == str(server_id)
+        assert data["connectors"][0]["connection_health"] == "healthy"
+
+    def test_list_connectors_tenant_admin(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admin can list connectors (uses own tenant_id)."""
+        with (
+            patch(TEMPLATE_REPO_PATH) as MockTemplateRepo,
+            patch(CONNECTOR_SERVER_REPO_PATH) as MockConnServerRepo,
+        ):
+            MockTemplateRepo.return_value.list_all = AsyncMock(return_value=[])
+            MockConnServerRepo.return_value.list_connected_template_ids = AsyncMock(return_value={})
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.get(BASE)
+
+        assert response.status_code == 200
+
+    def test_list_connectors_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        """Viewer (no admin role) gets 403."""
+        with TestClient(app_with_no_tenant_user) as client:
+            response = client.get(BASE)
+
+        assert response.status_code == 403
+
+    def test_list_connectors_cpi_admin_with_tenant_filter(self, app_with_cpi_admin, mock_db_session):
+        """CPI admin can filter by explicit tenant_id."""
+        with (
+            patch(TEMPLATE_REPO_PATH) as MockTemplateRepo,
+            patch(CONNECTOR_SERVER_REPO_PATH) as MockConnServerRepo,
+        ):
+            MockTemplateRepo.return_value.list_all = AsyncMock(return_value=[])
+            MockConnServerRepo.return_value.list_connected_template_ids = AsyncMock(return_value={})
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get(f"{BASE}?tenant_id=other-tenant")
+
+        assert response.status_code == 200
+
+
+# ============== Get Connector Detail ==============
+
+
+class TestGetConnector:
+    """GET /v1/admin/mcp-connectors/{slug}"""
+
+    def test_get_connector_found(self, app_with_cpi_admin, mock_db_session):
+        """Returns connector template detail."""
+        template = _mock_template()
+
+        with (
+            patch(TEMPLATE_REPO_PATH) as MockTemplateRepo,
+            patch(CONNECTOR_SERVER_REPO_PATH) as MockConnServerRepo,
+        ):
+            MockTemplateRepo.return_value.get_by_slug = AsyncMock(return_value=template)
+            MockConnServerRepo.return_value.list_connected_template_ids = AsyncMock(return_value={})
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get(f"{BASE}/linear")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["slug"] == "linear"
+        assert data["display_name"] == "Linear"
+        assert data["category"] == "project-management"
+
+    def test_get_connector_not_found(self, app_with_cpi_admin, mock_db_session):
+        """Returns 404 for unknown slug."""
+        with patch(TEMPLATE_REPO_PATH) as MockTemplateRepo:
+            MockTemplateRepo.return_value.get_by_slug = AsyncMock(return_value=None)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get(f"{BASE}/nonexistent")
+
+        assert response.status_code == 404
+
+    def test_get_connector_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        """Viewer gets 403."""
+        with TestClient(app_with_no_tenant_user) as client:
+            response = client.get(f"{BASE}/linear")
+
+        assert response.status_code == 403
+
+
+# ============== Authorize ==============
+
+
+class TestAuthorize:
+    """POST /v1/admin/mcp-connectors/{slug}/authorize"""
+
+    def test_authorize_success(self, app_with_cpi_admin, mock_db_session):
+        """Initiates OAuth flow and returns authorize URL + state."""
+        template = _mock_template()
+        authorize_url = "https://linear.app/oauth/authorize?client_id=xxx&state=abc"
+        state = "csrf-state-token"
+
+        with (
+            patch(TEMPLATE_REPO_PATH) as MockTemplateRepo,
+            patch(CONNECTOR_SERVER_REPO_PATH),
+            patch(SESSION_REPO_PATH),
+            patch(EXT_SERVER_REPO_PATH),
+            patch(OAUTH_SERVICE_PATH) as MockOAuthService,
+        ):
+            MockTemplateRepo.return_value.get_by_slug = AsyncMock(return_value=template)
+            mock_service = MockOAuthService.return_value
+            mock_service.initiate_authorize = AsyncMock(return_value=(authorize_url, state))
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(
+                    f"{BASE}/linear/authorize",
+                    json={"tenant_id": "acme"},
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["authorize_url"] == authorize_url
+        assert data["state"] == state
+
+    def test_authorize_template_not_found(self, app_with_cpi_admin, mock_db_session):
+        """Returns 404 when slug not found."""
+        with patch(TEMPLATE_REPO_PATH) as MockTemplateRepo:
+            MockTemplateRepo.return_value.get_by_slug = AsyncMock(return_value=None)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(
+                    f"{BASE}/nonexistent/authorize",
+                    json={},
+                )
+
+        assert response.status_code == 404
+
+    def test_authorize_template_disabled(self, app_with_cpi_admin, mock_db_session):
+        """Returns 400 when template is disabled."""
+        template = _mock_template(enabled=False)
+
+        with patch(TEMPLATE_REPO_PATH) as MockTemplateRepo:
+            MockTemplateRepo.return_value.get_by_slug = AsyncMock(return_value=template)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(
+                    f"{BASE}/linear/authorize",
+                    json={},
+                )
+
+        assert response.status_code == 400
+
+    def test_authorize_already_connected_409(self, app_with_cpi_admin, mock_db_session):
+        """Returns 409 when connector already connected for tenant."""
+        from src.services.connector_oauth import ConnectorOAuthError
+
+        template = _mock_template()
+
+        with (
+            patch(TEMPLATE_REPO_PATH) as MockTemplateRepo,
+            patch(CONNECTOR_SERVER_REPO_PATH),
+            patch(SESSION_REPO_PATH),
+            patch(EXT_SERVER_REPO_PATH),
+            patch(OAUTH_SERVICE_PATH) as MockOAuthService,
+        ):
+            MockTemplateRepo.return_value.get_by_slug = AsyncMock(return_value=template)
+            mock_service = MockOAuthService.return_value
+            mock_service.initiate_authorize = AsyncMock(
+                side_effect=ConnectorOAuthError(
+                    "Connector 'linear' is already connected for this tenant",
+                    status_code=409,
+                )
+            )
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(
+                    f"{BASE}/linear/authorize",
+                    json={"tenant_id": "acme"},
+                )
+
+        assert response.status_code == 409
+
+    def test_authorize_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        """Viewer gets 403."""
+        with TestClient(app_with_no_tenant_user) as client:
+            response = client.post(
+                f"{BASE}/linear/authorize",
+                json={},
+            )
+
+        assert response.status_code == 403
+
+    def test_authorize_tenant_admin_uses_own_tenant(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admin ignores explicit tenant_id and uses own."""
+        template = _mock_template()
+        authorize_url = "https://linear.app/oauth/authorize?state=xyz"
+        state = "xyz"
+
+        with (
+            patch(TEMPLATE_REPO_PATH) as MockTemplateRepo,
+            patch(CONNECTOR_SERVER_REPO_PATH),
+            patch(SESSION_REPO_PATH),
+            patch(EXT_SERVER_REPO_PATH),
+            patch(OAUTH_SERVICE_PATH) as MockOAuthService,
+        ):
+            MockTemplateRepo.return_value.get_by_slug = AsyncMock(return_value=template)
+            mock_service = MockOAuthService.return_value
+            mock_service.initiate_authorize = AsyncMock(return_value=(authorize_url, state))
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.post(
+                    f"{BASE}/linear/authorize",
+                    json={"tenant_id": "other-tenant"},
+                )
+
+        assert response.status_code == 200
+        # Verify initiate_authorize was called with tenant_admin's tenant, not the override
+        call_kwargs = mock_service.initiate_authorize.call_args
+        assert call_kwargs.kwargs.get("tenant_id") == "acme" or (
+            len(call_kwargs.args) >= 3 and call_kwargs.args[2] == "acme"
+        )
+
+
+# ============== Callback ==============
+
+
+class TestCallback:
+    """POST /v1/admin/mcp-connectors/callback"""
+
+    def test_callback_success(self, app, mock_db_session):
+        """Exchanges code+state for tokens and creates server."""
+        from src.database import get_db
+
+        async def override_get_db():
+            yield mock_db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            server = _mock_server()
+            redirect_after = "/mcp-connectors"
+
+            with (
+                patch(TEMPLATE_REPO_PATH),
+                patch(SESSION_REPO_PATH),
+                patch(CONNECTOR_SERVER_REPO_PATH),
+                patch(EXT_SERVER_REPO_PATH),
+                patch(OAUTH_SERVICE_PATH) as MockOAuthService,
+            ):
+                mock_service = MockOAuthService.return_value
+                mock_service.handle_callback = AsyncMock(return_value=(server, redirect_after))
+
+                with TestClient(app) as client:
+                    response = client.post(
+                        f"{BASE}/callback",
+                        json={"code": "auth-code-123", "state": "csrf-state"},
+                    )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["server_id"] == str(server.id)
+            assert data["server_name"] == server.name
+            assert data["redirect_url"] == redirect_after
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_callback_invalid_state(self, app, mock_db_session):
+        """Returns 400 for invalid/expired state token."""
+        from src.database import get_db
+        from src.services.connector_oauth import ConnectorOAuthError
+
+        async def override_get_db():
+            yield mock_db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            with (
+                patch(TEMPLATE_REPO_PATH),
+                patch(SESSION_REPO_PATH),
+                patch(CONNECTOR_SERVER_REPO_PATH),
+                patch(EXT_SERVER_REPO_PATH),
+                patch(OAUTH_SERVICE_PATH) as MockOAuthService,
+            ):
+                mock_service = MockOAuthService.return_value
+                mock_service.handle_callback = AsyncMock(
+                    side_effect=ConnectorOAuthError("Invalid or expired state token")
+                )
+
+                with TestClient(app) as client:
+                    response = client.post(
+                        f"{BASE}/callback",
+                        json={"code": "auth-code", "state": "bad-state"},
+                    )
+
+            assert response.status_code == 400
+            assert "Invalid or expired state token" in response.json()["detail"]
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_callback_expired_state(self, app, mock_db_session):
+        """Returns 400 for expired state token."""
+        from src.database import get_db
+        from src.services.connector_oauth import ConnectorOAuthError
+
+        async def override_get_db():
+            yield mock_db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            with (
+                patch(TEMPLATE_REPO_PATH),
+                patch(SESSION_REPO_PATH),
+                patch(CONNECTOR_SERVER_REPO_PATH),
+                patch(EXT_SERVER_REPO_PATH),
+                patch(OAUTH_SERVICE_PATH) as MockOAuthService,
+            ):
+                mock_service = MockOAuthService.return_value
+                mock_service.handle_callback = AsyncMock(
+                    side_effect=ConnectorOAuthError("OAuth state has expired, please try again")
+                )
+
+                with TestClient(app) as client:
+                    response = client.post(
+                        f"{BASE}/callback",
+                        json={"code": "auth-code", "state": "expired-state"},
+                    )
+
+            assert response.status_code == 400
+            assert "expired" in response.json()["detail"]
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_callback_token_exchange_failure(self, app, mock_db_session):
+        """Returns 502 when token exchange with provider fails."""
+        from src.database import get_db
+        from src.services.connector_oauth import ConnectorOAuthError
+
+        async def override_get_db():
+            yield mock_db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            with (
+                patch(TEMPLATE_REPO_PATH),
+                patch(SESSION_REPO_PATH),
+                patch(CONNECTOR_SERVER_REPO_PATH),
+                patch(EXT_SERVER_REPO_PATH),
+                patch(OAUTH_SERVICE_PATH) as MockOAuthService,
+            ):
+                mock_service = MockOAuthService.return_value
+                mock_service.handle_callback = AsyncMock(
+                    side_effect=ConnectorOAuthError(
+                        "Failed to exchange authorization code (HTTP 401)",
+                        status_code=502,
+                    )
+                )
+
+                with TestClient(app) as client:
+                    response = client.post(
+                        f"{BASE}/callback",
+                        json={"code": "bad-code", "state": "valid-state"},
+                    )
+
+            assert response.status_code == 502
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_callback_no_auth_required(self, app, mock_db_session):
+        """Callback endpoint works WITHOUT authentication (browser redirect)."""
+        from src.database import get_db
+
+        async def override_get_db():
+            yield mock_db_session
+
+        # Explicitly do NOT override get_current_user — callback has no auth dep
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            server = _mock_server()
+
+            with (
+                patch(TEMPLATE_REPO_PATH),
+                patch(SESSION_REPO_PATH),
+                patch(CONNECTOR_SERVER_REPO_PATH),
+                patch(EXT_SERVER_REPO_PATH),
+                patch(OAUTH_SERVICE_PATH) as MockOAuthService,
+            ):
+                mock_service = MockOAuthService.return_value
+                mock_service.handle_callback = AsyncMock(return_value=(server, None))
+
+                with TestClient(app) as client:
+                    response = client.post(
+                        f"{BASE}/callback",
+                        json={"code": "code", "state": "state"},
+                    )
+
+            assert response.status_code == 200
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_callback_missing_fields(self, app, mock_db_session):
+        """Returns 422 when required fields are missing."""
+        from src.database import get_db
+
+        async def override_get_db():
+            yield mock_db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            with TestClient(app) as client:
+                response = client.post(
+                    f"{BASE}/callback",
+                    json={"code": "auth-code"},  # Missing 'state'
+                )
+
+            assert response.status_code == 422
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ============== Disconnect ==============
+
+
+class TestDisconnect:
+    """DELETE /v1/admin/mcp-connectors/{slug}/disconnect"""
+
+    def test_disconnect_success(self, app_with_cpi_admin, mock_db_session):
+        """Disconnects connector and returns server_id."""
+        template = _mock_template()
+        server_id = uuid4()
+
+        with (
+            patch(TEMPLATE_REPO_PATH) as MockTemplateRepo,
+            patch(CONNECTOR_SERVER_REPO_PATH),
+            patch(SESSION_REPO_PATH),
+            patch(EXT_SERVER_REPO_PATH),
+            patch(OAUTH_SERVICE_PATH) as MockOAuthService,
+        ):
+            MockTemplateRepo.return_value.get_by_slug = AsyncMock(return_value=template)
+            mock_service = MockOAuthService.return_value
+            mock_service.disconnect = AsyncMock(return_value=server_id)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.delete(f"{BASE}/linear/disconnect")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["slug"] == "linear"
+        assert data["disconnected"] is True
+        assert data["server_id"] == str(server_id)
+
+    def test_disconnect_not_connected(self, app_with_cpi_admin, mock_db_session):
+        """Returns 404 when connector is not connected for this tenant."""
+        template = _mock_template()
+
+        with (
+            patch(TEMPLATE_REPO_PATH) as MockTemplateRepo,
+            patch(CONNECTOR_SERVER_REPO_PATH),
+            patch(SESSION_REPO_PATH),
+            patch(EXT_SERVER_REPO_PATH),
+            patch(OAUTH_SERVICE_PATH) as MockOAuthService,
+        ):
+            MockTemplateRepo.return_value.get_by_slug = AsyncMock(return_value=template)
+            mock_service = MockOAuthService.return_value
+            mock_service.disconnect = AsyncMock(return_value=None)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.delete(f"{BASE}/linear/disconnect")
+
+        assert response.status_code == 404
+        assert "not connected" in response.json()["detail"]
+
+    def test_disconnect_template_not_found(self, app_with_cpi_admin, mock_db_session):
+        """Returns 404 when slug not found."""
+        with patch(TEMPLATE_REPO_PATH) as MockTemplateRepo:
+            MockTemplateRepo.return_value.get_by_slug = AsyncMock(return_value=None)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.delete(f"{BASE}/nonexistent/disconnect")
+
+        assert response.status_code == 404
+
+    def test_disconnect_403_viewer(self, app_with_no_tenant_user, mock_db_session):
+        """Viewer gets 403."""
+        with TestClient(app_with_no_tenant_user) as client:
+            response = client.delete(f"{BASE}/linear/disconnect")
+
+        assert response.status_code == 403
+
+    def test_disconnect_tenant_admin(self, app_with_tenant_admin, mock_db_session):
+        """Tenant admin can disconnect their own connectors."""
+        template = _mock_template()
+        server_id = uuid4()
+
+        with (
+            patch(TEMPLATE_REPO_PATH) as MockTemplateRepo,
+            patch(CONNECTOR_SERVER_REPO_PATH),
+            patch(SESSION_REPO_PATH),
+            patch(EXT_SERVER_REPO_PATH),
+            patch(OAUTH_SERVICE_PATH) as MockOAuthService,
+        ):
+            MockTemplateRepo.return_value.get_by_slug = AsyncMock(return_value=template)
+            mock_service = MockOAuthService.return_value
+            mock_service.disconnect = AsyncMock(return_value=server_id)
+
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.delete(f"{BASE}/linear/disconnect")
+
+        assert response.status_code == 200
+
+
+# ============== Service Unit Tests ==============
+
+
+class TestConnectorOAuthService:
+    """Unit tests for ConnectorOAuthService business logic."""
+
+    def test_initiate_authorize_builds_url(self):
+        """initiate_authorize returns a valid authorize URL with state."""
+        import asyncio
+
+        from src.services.connector_oauth import ConnectorOAuthService
+
+        template = _mock_template()
+        template_repo = MagicMock()
+        session_repo = MagicMock()
+        session_repo.create = AsyncMock()
+        session_repo.cleanup_expired = AsyncMock()
+        connector_server_repo = MagicMock()
+        connector_server_repo.get_by_template_and_tenant = AsyncMock(return_value=None)
+        server_repo = MagicMock()
+
+        service = ConnectorOAuthService(
+            template_repo=template_repo,
+            session_repo=session_repo,
+            connector_server_repo=connector_server_repo,
+            server_repo=server_repo,
+        )
+
+        with patch.object(
+            service,
+            "_get_provider_credentials",
+            new=AsyncMock(return_value={"client_id": "test-client-id", "client_secret": "secret"}),
+        ):
+            url, state = asyncio.get_event_loop().run_until_complete(
+                service.initiate_authorize(
+                    template=template,
+                    user_id="user-1",
+                    tenant_id="acme",
+                    redirect_after="/connectors",
+                    redirect_uri="https://console.gostoa.dev/mcp-connectors/callback",
+                )
+            )
+
+        assert "linear.app/oauth/authorize" in url
+        assert "client_id=test-client-id" in url
+        assert "state=" in url
+        assert "code_challenge=" in url  # PKCE enabled for Linear
+        assert "code_challenge_method=S256" in url
+        assert len(state) > 20
+
+    def test_initiate_authorize_already_connected(self):
+        """initiate_authorize raises 409 when already connected."""
+        import asyncio
+
+        from src.services.connector_oauth import ConnectorOAuthError, ConnectorOAuthService
+
+        template = _mock_template()
+        connector_server_repo = MagicMock()
+        connector_server_repo.get_by_template_and_tenant = AsyncMock(return_value=_mock_server())
+
+        service = ConnectorOAuthService(
+            template_repo=MagicMock(),
+            session_repo=MagicMock(),
+            connector_server_repo=connector_server_repo,
+            server_repo=MagicMock(),
+        )
+
+        with pytest.raises(ConnectorOAuthError) as exc_info:
+            asyncio.get_event_loop().run_until_complete(
+                service.initiate_authorize(template=template, user_id="u", tenant_id="acme")
+            )
+        assert exc_info.value.status_code == 409
+
+    def test_initiate_authorize_no_pkce_when_not_required(self):
+        """No PKCE params when oauth_pkce_required=False."""
+        import asyncio
+
+        from src.services.connector_oauth import ConnectorOAuthService
+
+        template = _mock_template(oauth_pkce_required=False, slug="github")
+        session_repo = MagicMock()
+        session_repo.create = AsyncMock()
+        session_repo.cleanup_expired = AsyncMock()
+        connector_server_repo = MagicMock()
+        connector_server_repo.get_by_template_and_tenant = AsyncMock(return_value=None)
+
+        service = ConnectorOAuthService(
+            template_repo=MagicMock(),
+            session_repo=session_repo,
+            connector_server_repo=connector_server_repo,
+            server_repo=MagicMock(),
+        )
+
+        with patch.object(
+            service,
+            "_get_provider_credentials",
+            new=AsyncMock(return_value={"client_id": "gh-id"}),
+        ):
+            url, _state = asyncio.get_event_loop().run_until_complete(
+                service.initiate_authorize(
+                    template=template,
+                    user_id="u",
+                    tenant_id="t",
+                    redirect_uri="https://example.com/callback",
+                )
+            )
+
+        assert "code_challenge" not in url
+        assert "code_challenge_method" not in url
+
+    def test_disconnect_returns_none_when_not_connected(self):
+        """disconnect returns None when no server found."""
+        import asyncio
+
+        from src.services.connector_oauth import ConnectorOAuthService
+
+        template = _mock_template()
+        connector_server_repo = MagicMock()
+        connector_server_repo.get_by_template_and_tenant = AsyncMock(return_value=None)
+
+        service = ConnectorOAuthService(
+            template_repo=MagicMock(),
+            session_repo=MagicMock(),
+            connector_server_repo=connector_server_repo,
+            server_repo=MagicMock(),
+        )
+
+        result = asyncio.get_event_loop().run_until_complete(service.disconnect(template, "acme"))
+
+        assert result is None
+
+    def test_generate_code_challenge_s256(self):
+        """PKCE S256 code challenge is correctly generated."""
+        import base64
+        import hashlib
+
+        from src.services.connector_oauth import ConnectorOAuthService
+
+        verifier = "test-code-verifier-string"
+        challenge = ConnectorOAuthService._generate_code_challenge(verifier)
+
+        # Manually verify S256
+        digest = hashlib.sha256(verifier.encode("ascii")).digest()
+        expected = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+        assert challenge == expected


### PR DESCRIPTION
## Summary
- **App Store pattern** for pre-configured MCP connectors (Linear, GitHub, Notion, Slack, Sentry)
- Full OAuth 2.0 Authorization Code flow with CSRF state protection and optional PKCE (S256)
- 5 API endpoints: catalog listing, detail, authorize, callback, disconnect
- Credential storage in Vault (provider creds separate from user tokens)
- 30 tests covering catalog, OAuth flow, PKCE, RBAC, and edge cases

## Changes
- **Migration 052**: `mcp_connector_templates` table (5 seed providers) + `oauth_pending_sessions` (CSRF)
- **Models**: `MCPConnectorTemplate`, `OAuthPendingSession` + FK `connector_template_id` on `ExternalMCPServer`
- **Service**: `ConnectorOAuthService` — initiate_authorize, handle_callback, disconnect
- **Router**: `GET /v1/admin/mcp-connectors`, `GET /{slug}`, `POST /{slug}/authorize`, `POST /callback`, `DELETE /{slug}/disconnect`
- **Schemas**: 7 Pydantic v2 schemas (request + response)
- **OpenAPI snapshot** updated

## Test plan
- [x] 30 unit tests pass (0.79s)
- [x] Full suite: 6491 passed, coverage 89.97% (threshold 70%)
- [x] Ruff + Black clean
- [x] OpenAPI contract tests updated and passing
- [ ] CI green (3 required checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)