### PR TITLE
feat(api): replace demo monitoring with OpenSearch-backed analytics

### DIFF
--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -33571,13 +33571,11 @@
             }
           },
           {
-            "description": "Time range in minutes",
             "in": "query",
             "name": "time_range",
             "required": false,
             "schema": {
               "default": 60,
-              "description": "Time range in minutes",
               "maximum": 1440,
               "minimum": 1,
               "title": "Time Range",
@@ -33622,13 +33620,11 @@
         "operationId": "get_transaction_stats_v1_monitoring_transactions_stats_get",
         "parameters": [
           {
-            "description": "Time range in minutes",
             "in": "query",
             "name": "time_range",
             "required": false,
             "schema": {
               "default": 60,
-              "description": "Time range in minutes",
               "maximum": 1440,
               "minimum": 1,
               "title": "Time Range",

--- a/control-plane-api/src/routers/monitoring.py
+++ b/control-plane-api/src/routers/monitoring.py
@@ -5,9 +5,15 @@ import random
 from datetime import datetime, timedelta
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel
 
 from ..auth import User, get_current_user
+from ..schemas.monitoring import (
+    APITransaction,
+    APITransactionStats,
+    APITransactionSummary,
+    TransactionSpan,
+)
+from ..services.monitoring_service import MonitoringService
 
 logger = logging.getLogger(__name__)
 
@@ -15,66 +21,25 @@ router = APIRouter(prefix="/v1/monitoring", tags=["Monitoring"])
 
 
 # =============================================================================
-# MODELS
+# OPENSEARCH SERVICE DEPENDENCY
 # =============================================================================
 
 
-class TransactionSpan(BaseModel):
-    name: str
-    service: str
-    start_offset_ms: int
-    duration_ms: int
-    status: str  # success, error
-    metadata: dict = {}
+def _get_monitoring_service() -> MonitoringService | None:
+    """Return a MonitoringService if OpenSearch is available, else None."""
+    try:
+        from ..opensearch.opensearch_integration import OpenSearchService
 
-
-class APITransactionSummary(BaseModel):
-    id: str
-    trace_id: str
-    api_name: str
-    method: str
-    path: str
-    status_code: int
-    status: str  # success, error, timeout, pending
-    started_at: str
-    total_duration_ms: int
-    spans_count: int
-
-
-class APITransaction(BaseModel):
-    id: str
-    trace_id: str
-    api_name: str
-    tenant_id: str
-    method: str
-    path: str
-    status_code: int
-    status: str
-    client_ip: str | None = None
-    user_id: str | None = None
-    started_at: str
-    total_duration_ms: int
-    spans: list[TransactionSpan]
-    request_headers: dict | None = None
-    response_headers: dict | None = None
-    error_message: str | None = None
-
-
-class APITransactionStats(BaseModel):
-    total_requests: int
-    success_count: int
-    error_count: int
-    timeout_count: int
-    avg_latency_ms: float
-    p95_latency_ms: float
-    p99_latency_ms: float
-    requests_per_minute: float
-    by_api: dict
-    by_status_code: dict
+        instance = OpenSearchService.get_instance()
+        if instance and instance.client:
+            return MonitoringService(instance.client)
+    except Exception:
+        logger.debug("OpenSearch not available, will use demo data")
+    return None
 
 
 # =============================================================================
-# DEMO DATA GENERATOR
+# DEMO DATA GENERATORS (fallback when OpenSearch is unavailable)
 # =============================================================================
 
 
@@ -263,26 +228,40 @@ def generate_stats() -> APITransactionStats:
 @router.get("/transactions")
 async def list_transactions(
     limit: int = Query(50, ge=1, le=200),
-    tenant_id: str | None = None,
     api_name: str | None = None,
     status: str | None = None,
+    time_range: int = Query(60, ge=1, le=1440),
     user: User = Depends(get_current_user),
 ):
     """
     List recent API transactions.
 
     Returns transaction summaries for efficient list display.
+    Uses real OpenSearch data when available, falls back to demo data.
     """
-    # Use user's tenant if not CPI admin
-    effective_tenant = tenant_id or user.tenant_id or "demo"
+    tenant_id = user.tenant_id or "demo"
 
-    transactions = generate_demo_transactions(limit, effective_tenant)
+    # Try real data from OpenSearch
+    svc = _get_monitoring_service()
+    if svc:
+        result = await svc.list_transactions(
+            tenant_id=tenant_id,
+            limit=limit,
+            api_name=api_name,
+            status=status,
+            time_range_minutes=time_range,
+        )
+        if result is not None:
+            return {
+                "transactions": [t.model_dump() for t in result],
+                "total": len(result),
+                "demo_mode": False,
+            }
 
-    # Filter by api_name if provided
+    # Fallback to demo data
+    transactions = generate_demo_transactions(limit, tenant_id)
     if api_name:
         transactions = [t for t in transactions if t.api_name == api_name]
-
-    # Filter by status if provided
     if status:
         transactions = [t for t in transactions if t.status == status]
 
@@ -295,13 +274,25 @@ async def list_transactions(
 
 @router.get("/transactions/stats")
 async def get_transaction_stats(
+    time_range: int = Query(60, ge=1, le=1440),
     user: User = Depends(get_current_user),
 ):
     """
     Get API transaction statistics.
 
     Returns aggregated metrics about API calls.
+    Uses real OpenSearch data when available, falls back to demo data.
     """
+    tenant_id = user.tenant_id or "demo"
+
+    # Try real data from OpenSearch
+    svc = _get_monitoring_service()
+    if svc:
+        result = await svc.get_transaction_stats(tenant_id=tenant_id, time_range_minutes=time_range)
+        if result is not None:
+            return {**result.model_dump(), "demo_mode": False}
+
+    # Fallback to demo data
     return {**generate_stats().model_dump(), "demo_mode": True}
 
 
@@ -314,7 +305,17 @@ async def get_transaction(
     Get detailed information about a specific transaction.
 
     Includes all spans with timing and metadata.
+    Uses real OpenSearch data when available, falls back to demo data.
     """
     tenant_id = user.tenant_id or "demo"
+
+    # Try real data from OpenSearch
+    svc = _get_monitoring_service()
+    if svc:
+        result = await svc.get_transaction(event_id=transaction_id, tenant_id=tenant_id)
+        if result is not None:
+            return {**result.model_dump(), "demo_mode": False}
+
+    # Fallback to demo data
     transaction = generate_transaction_detail(transaction_id, tenant_id)
     return {**transaction.model_dump(), "demo_mode": True}

--- a/control-plane-api/src/schemas/monitoring.py
+++ b/control-plane-api/src/schemas/monitoring.py
@@ -1,0 +1,57 @@
+"""Pydantic schemas for monitoring endpoints."""
+
+from pydantic import BaseModel
+
+
+class TransactionSpan(BaseModel):
+    name: str
+    service: str
+    start_offset_ms: int
+    duration_ms: int
+    status: str  # success, error
+    metadata: dict = {}
+
+
+class APITransactionSummary(BaseModel):
+    id: str
+    trace_id: str
+    api_name: str
+    method: str
+    path: str
+    status_code: int
+    status: str  # success, error, timeout, pending
+    started_at: str
+    total_duration_ms: int
+    spans_count: int
+
+
+class APITransaction(BaseModel):
+    id: str
+    trace_id: str
+    api_name: str
+    tenant_id: str
+    method: str
+    path: str
+    status_code: int
+    status: str
+    client_ip: str | None = None
+    user_id: str | None = None
+    started_at: str
+    total_duration_ms: int
+    spans: list[TransactionSpan]
+    request_headers: dict | None = None
+    response_headers: dict | None = None
+    error_message: str | None = None
+
+
+class APITransactionStats(BaseModel):
+    total_requests: int
+    success_count: int
+    error_count: int
+    timeout_count: int
+    avg_latency_ms: float
+    p95_latency_ms: float
+    p99_latency_ms: float
+    requests_per_minute: float
+    by_api: dict
+    by_status_code: dict

--- a/control-plane-api/src/services/monitoring_service.py
+++ b/control-plane-api/src/services/monitoring_service.py
@@ -1,0 +1,253 @@
+"""Monitoring service — queries audit-* index in OpenSearch for real transaction data."""
+
+import logging
+
+from opensearchpy import AsyncOpenSearch
+
+from ..schemas.monitoring import (
+    APITransaction,
+    APITransactionStats,
+    APITransactionSummary,
+    TransactionSpan,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _status_from_code(code: int) -> str:
+    """Derive transaction status from HTTP status code."""
+    if code == 504:
+        return "timeout"
+    if code >= 400:
+        return "error"
+    return "success"
+
+
+def _extract_api_name(path: str) -> str:
+    """Extract API name from request path (first segment after /v1/)."""
+    parts = path.strip("/").split("/")
+    try:
+        idx = parts.index("v1")
+        if idx + 1 < len(parts):
+            return parts[idx + 1]
+    except ValueError:
+        pass
+    # Fallback: use first meaningful segment
+    return parts[0] if parts else "unknown"
+
+
+class MonitoringService:
+    """Queries OpenSearch audit-* index for transaction analytics."""
+
+    def __init__(self, client: AsyncOpenSearch):
+        self.client = client
+
+    async def list_transactions(
+        self,
+        tenant_id: str,
+        limit: int = 50,
+        api_name: str | None = None,
+        status: str | None = None,
+        time_range_minutes: int = 60,
+    ) -> list[APITransactionSummary] | None:
+        """List recent transactions from audit index."""
+        try:
+            filters: list[dict] = [
+                {"term": {"tenant_id": tenant_id}},
+                {"range": {"@timestamp": {"gte": f"now-{time_range_minutes}m"}}},
+            ]
+            if api_name:
+                filters.append({"wildcard": {"request.path": f"*/{api_name}/*"}})
+            if status:
+                if status == "timeout":
+                    filters.append({"term": {"response.status_code": 504}})
+                elif status == "error":
+                    filters.append({"range": {"response.status_code": {"gte": 400, "lt": 504}}})
+                elif status == "success":
+                    filters.append({"range": {"response.status_code": {"lt": 400}}})
+
+            body = {
+                "query": {"bool": {"filter": filters}},
+                "sort": [{"@timestamp": {"order": "desc"}}],
+                "size": limit,
+            }
+
+            resp = await self.client.search(index="audit-*", body=body)
+            hits = resp.get("hits", {}).get("hits", [])
+
+            transactions = []
+            for hit in hits:
+                src = hit["_source"]
+                req = src.get("request", {})
+                res = src.get("response", {})
+                code = res.get("status_code", 0)
+                path = req.get("path", "")
+
+                transactions.append(
+                    APITransactionSummary(
+                        id=src.get("event_id", hit["_id"]),
+                        trace_id=src.get("correlation_id", ""),
+                        api_name=_extract_api_name(path),
+                        method=req.get("method", "GET"),
+                        path=path,
+                        status_code=code,
+                        status=_status_from_code(code),
+                        started_at=src.get("@timestamp", ""),
+                        total_duration_ms=int(res.get("latency_ms", 0)),
+                        spans_count=1,
+                    )
+                )
+            return transactions
+
+        except Exception:
+            logger.exception("Failed to list transactions from OpenSearch")
+            return None
+
+    async def get_transaction_stats(
+        self,
+        tenant_id: str,
+        time_range_minutes: int = 60,
+    ) -> APITransactionStats | None:
+        """Get aggregated transaction statistics from audit index."""
+        try:
+            body = {
+                "size": 0,
+                "query": {
+                    "bool": {
+                        "filter": [
+                            {"term": {"tenant_id": tenant_id}},
+                            {"range": {"@timestamp": {"gte": f"now-{time_range_minutes}m"}}},
+                        ]
+                    }
+                },
+                "aggs": {
+                    "success_count": {"filter": {"range": {"response.status_code": {"lt": 400}}}},
+                    "error_count": {
+                        "filter": {
+                            "bool": {
+                                "filter": [
+                                    {"range": {"response.status_code": {"gte": 400}}},
+                                    {"range": {"response.status_code": {"lt": 504}}},
+                                ]
+                            }
+                        }
+                    },
+                    "timeout_count": {"filter": {"term": {"response.status_code": 504}}},
+                    "latency_stats": {"stats": {"field": "response.latency_ms"}},
+                    "latency_percentiles": {
+                        "percentiles": {
+                            "field": "response.latency_ms",
+                            "percents": [95, 99],
+                        }
+                    },
+                    "by_api": {
+                        "terms": {"field": "request.path", "size": 20},
+                        "aggs": {
+                            "avg_latency": {"avg": {"field": "response.latency_ms"}},
+                            "errors": {"filter": {"range": {"response.status_code": {"gte": 400}}}},
+                        },
+                    },
+                    "by_status_code": {"terms": {"field": "response.status_code", "size": 20}},
+                },
+            }
+
+            resp = await self.client.search(index="audit-*", body=body)
+            total = resp["hits"]["total"]["value"]
+            aggs = resp["aggregations"]
+
+            percentiles = aggs["latency_percentiles"]["values"]
+
+            # Build by_api dict
+            by_api: dict = {}
+            for bucket in aggs["by_api"]["buckets"]:
+                name = _extract_api_name(bucket["key"])
+                entry = by_api.get(name, {"total": 0, "success": 0, "errors": 0, "avg_latency_ms": 0})
+                entry["total"] += bucket["doc_count"]
+                entry["errors"] += bucket["errors"]["doc_count"]
+                entry["success"] = entry["total"] - entry["errors"]
+                entry["avg_latency_ms"] = round(bucket["avg_latency"]["value"] or 0, 1)
+                by_api[name] = entry
+
+            # Build by_status_code dict
+            by_status_code: dict = {}
+            for bucket in aggs["by_status_code"]["buckets"]:
+                by_status_code[bucket["key"]] = bucket["doc_count"]
+
+            return APITransactionStats(
+                total_requests=total,
+                success_count=aggs["success_count"]["doc_count"],
+                error_count=aggs["error_count"]["doc_count"],
+                timeout_count=aggs["timeout_count"]["doc_count"],
+                avg_latency_ms=round(aggs["latency_stats"]["avg"] or 0, 2),
+                p95_latency_ms=round(percentiles.get("95.0", 0), 2),
+                p99_latency_ms=round(percentiles.get("99.0", 0), 2),
+                requests_per_minute=round(total / max(time_range_minutes, 1), 2),
+                by_api=by_api,
+                by_status_code=by_status_code,
+            )
+
+        except Exception:
+            logger.exception("Failed to get transaction stats from OpenSearch")
+            return None
+
+    async def get_transaction(
+        self,
+        event_id: str,
+        tenant_id: str,
+    ) -> APITransaction | None:
+        """Get detailed transaction by event_id."""
+        try:
+            body = {
+                "query": {
+                    "bool": {
+                        "filter": [
+                            {"term": {"event_id": event_id}},
+                            {"term": {"tenant_id": tenant_id}},
+                        ]
+                    }
+                },
+                "size": 1,
+            }
+
+            resp = await self.client.search(index="audit-*", body=body)
+            hits = resp.get("hits", {}).get("hits", [])
+            if not hits:
+                return None
+
+            src = hits[0]["_source"]
+            req = src.get("request", {})
+            res = src.get("response", {})
+            actor = src.get("actor", {})
+            code = res.get("status_code", 0)
+            latency = int(res.get("latency_ms", 0))
+            path = req.get("path", "")
+
+            span = TransactionSpan(
+                name="api_request",
+                service="control-plane-api",
+                start_offset_ms=0,
+                duration_ms=latency,
+                status=_status_from_code(code),
+                metadata={"correlation_id": src.get("correlation_id", "")},
+            )
+
+            return APITransaction(
+                id=src.get("event_id", hits[0]["_id"]),
+                trace_id=src.get("correlation_id", ""),
+                api_name=_extract_api_name(path),
+                tenant_id=src.get("tenant_id", tenant_id),
+                method=req.get("method", "GET"),
+                path=path,
+                status_code=code,
+                status=_status_from_code(code),
+                client_ip=actor.get("ip_address"),
+                user_id=actor.get("id"),
+                started_at=src.get("@timestamp", ""),
+                total_duration_ms=latency,
+                spans=[span],
+                error_message=src.get("details", {}).get("error") if code >= 400 else None,
+            )
+
+        except Exception:
+            logger.exception("Failed to get transaction detail from OpenSearch")
+            return None

--- a/control-plane-api/tests/test_monitoring_service.py
+++ b/control-plane-api/tests/test_monitoring_service.py
@@ -1,0 +1,277 @@
+"""Tests for MonitoringService — OpenSearch-backed transaction analytics."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.services.monitoring_service import MonitoringService, _extract_api_name, _status_from_code
+
+# =============================================================================
+# Unit tests for helpers
+# =============================================================================
+
+
+class TestStatusFromCode:
+    def test_success_200(self):
+        assert _status_from_code(200) == "success"
+
+    def test_success_201(self):
+        assert _status_from_code(201) == "success"
+
+    def test_success_204(self):
+        assert _status_from_code(204) == "success"
+
+    def test_success_301(self):
+        assert _status_from_code(301) == "success"
+
+    def test_error_400(self):
+        assert _status_from_code(400) == "error"
+
+    def test_error_401(self):
+        assert _status_from_code(401) == "error"
+
+    def test_error_404(self):
+        assert _status_from_code(404) == "error"
+
+    def test_error_500(self):
+        assert _status_from_code(500) == "error"
+
+    def test_timeout_504(self):
+        assert _status_from_code(504) == "timeout"
+
+
+class TestExtractApiName:
+    def test_v1_path(self):
+        assert _extract_api_name("/v1/tenants/123") == "tenants"
+
+    def test_v1_apis(self):
+        assert _extract_api_name("/v1/apis/my-api") == "apis"
+
+    def test_no_v1_prefix(self):
+        assert _extract_api_name("/health") == "health"
+
+    def test_empty_path(self):
+        assert _extract_api_name("/") == ""
+
+    def test_deep_path(self):
+        assert _extract_api_name("/v1/monitoring/transactions/tx-123") == "monitoring"
+
+
+# =============================================================================
+# MonitoringService tests
+# =============================================================================
+
+
+def _make_os_hit(
+    event_id: str = "evt-1",
+    method: str = "GET",
+    path: str = "/v1/apis",
+    status_code: int = 200,
+    latency_ms: float = 42.5,
+    tenant_id: str = "tenant-1",
+    correlation_id: str = "corr-1",
+    timestamp: str = "2026-03-02T10:00:00Z",
+) -> dict:
+    """Build a realistic OpenSearch audit hit."""
+    return {
+        "_id": f"os-{event_id}",
+        "_source": {
+            "@timestamp": timestamp,
+            "event_id": event_id,
+            "correlation_id": correlation_id,
+            "tenant_id": tenant_id,
+            "request": {"method": method, "path": path},
+            "response": {"status_code": status_code, "latency_ms": latency_ms},
+            "actor": {"id": "user-1", "ip_address": "10.0.0.1"},
+            "details": {},
+        },
+    }
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    client.search = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def service(mock_client):
+    return MonitoringService(mock_client)
+
+
+class TestListTransactions:
+    @pytest.mark.asyncio
+    async def test_maps_audit_events(self, service, mock_client):
+        mock_client.search.return_value = {
+            "hits": {
+                "hits": [
+                    _make_os_hit(event_id="e1", path="/v1/apis", status_code=200, latency_ms=35),
+                    _make_os_hit(event_id="e2", path="/v1/tenants/t1", status_code=404, latency_ms=12),
+                ],
+            },
+        }
+
+        result = await service.list_transactions(tenant_id="tenant-1", limit=10)
+
+        assert result is not None
+        assert len(result) == 2
+        assert result[0].id == "e1"
+        assert result[0].api_name == "apis"
+        assert result[0].status == "success"
+        assert result[0].total_duration_ms == 35
+        assert result[1].id == "e2"
+        assert result[1].status == "error"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_error(self, service, mock_client):
+        mock_client.search.side_effect = Exception("connection refused")
+
+        result = await service.list_transactions(tenant_id="t1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_filters_by_status_success(self, service, mock_client):
+        mock_client.search.return_value = {"hits": {"hits": []}}
+
+        await service.list_transactions(tenant_id="t1", status="success")
+
+        call_body = mock_client.search.call_args[1]["body"]
+        filters = call_body["query"]["bool"]["filter"]
+        # Should have tenant_id, time_range, and status_code range filter
+        assert len(filters) == 3
+        assert {"range": {"response.status_code": {"lt": 400}}} in filters
+
+    @pytest.mark.asyncio
+    async def test_filters_by_status_timeout(self, service, mock_client):
+        mock_client.search.return_value = {"hits": {"hits": []}}
+
+        await service.list_transactions(tenant_id="t1", status="timeout")
+
+        call_body = mock_client.search.call_args[1]["body"]
+        filters = call_body["query"]["bool"]["filter"]
+        assert {"term": {"response.status_code": 504}} in filters
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self, service, mock_client):
+        mock_client.search.return_value = {"hits": {"hits": []}}
+
+        result = await service.list_transactions(tenant_id="t1")
+        assert result is not None
+        assert result == []
+
+
+class TestGetTransactionStats:
+    @pytest.mark.asyncio
+    async def test_aggregations_mapped(self, service, mock_client):
+        mock_client.search.return_value = {
+            "hits": {"total": {"value": 1000}},
+            "aggregations": {
+                "success_count": {"doc_count": 900},
+                "error_count": {"doc_count": 90},
+                "timeout_count": {"doc_count": 10},
+                "latency_stats": {"avg": 85.5, "count": 1000, "min": 5, "max": 3000, "sum": 85500},
+                "latency_percentiles": {"values": {"95.0": 250.0, "99.0": 800.0}},
+                "by_api": {
+                    "buckets": [
+                        {
+                            "key": "/v1/apis",
+                            "doc_count": 500,
+                            "avg_latency": {"value": 60.0},
+                            "errors": {"doc_count": 20},
+                        },
+                        {
+                            "key": "/v1/tenants/t1",
+                            "doc_count": 300,
+                            "avg_latency": {"value": 120.0},
+                            "errors": {"doc_count": 50},
+                        },
+                    ]
+                },
+                "by_status_code": {
+                    "buckets": [
+                        {"key": 200, "doc_count": 800},
+                        {"key": 404, "doc_count": 90},
+                        {"key": 504, "doc_count": 10},
+                    ]
+                },
+            },
+        }
+
+        result = await service.get_transaction_stats(tenant_id="t1", time_range_minutes=60)
+
+        assert result is not None
+        assert result.total_requests == 1000
+        assert result.success_count == 900
+        assert result.error_count == 90
+        assert result.timeout_count == 10
+        assert result.avg_latency_ms == 85.5
+        assert result.p95_latency_ms == 250.0
+        assert result.p99_latency_ms == 800.0
+        assert result.requests_per_minute == pytest.approx(1000 / 60, rel=0.01)
+        assert "apis" in result.by_api
+        assert result.by_api["apis"]["total"] == 500
+        assert result.by_api["apis"]["errors"] == 20
+        assert result.by_status_code[200] == 800
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_error(self, service, mock_client):
+        mock_client.search.side_effect = Exception("timeout")
+
+        result = await service.get_transaction_stats(tenant_id="t1")
+        assert result is None
+
+
+class TestGetTransaction:
+    @pytest.mark.asyncio
+    async def test_maps_single_event(self, service, mock_client):
+        mock_client.search.return_value = {
+            "hits": {
+                "hits": [
+                    _make_os_hit(
+                        event_id="evt-42",
+                        method="POST",
+                        path="/v1/apis",
+                        status_code=201,
+                        latency_ms=150,
+                    )
+                ],
+            },
+        }
+
+        result = await service.get_transaction(event_id="evt-42", tenant_id="tenant-1")
+
+        assert result is not None
+        assert result.id == "evt-42"
+        assert result.method == "POST"
+        assert result.status == "success"
+        assert result.total_duration_ms == 150
+        assert len(result.spans) == 1
+        assert result.spans[0].name == "api_request"
+        assert result.spans[0].duration_ms == 150
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, service, mock_client):
+        mock_client.search.return_value = {"hits": {"hits": []}}
+
+        result = await service.get_transaction(event_id="nope", tenant_id="t1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_error(self, service, mock_client):
+        mock_client.search.side_effect = Exception("connection error")
+
+        result = await service.get_transaction(event_id="e1", tenant_id="t1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_error_message_populated_on_failure(self, service, mock_client):
+        hit = _make_os_hit(event_id="err-1", status_code=500)
+        hit["_source"]["details"] = {"error": "Internal failure"}
+        mock_client.search.return_value = {"hits": {"hits": [hit]}}
+
+        result = await service.get_transaction(event_id="err-1", tenant_id="tenant-1")
+
+        assert result is not None
+        assert result.status == "error"
+        assert result.error_message == "Internal failure"


### PR DESCRIPTION
## Summary
- Add `MonitoringService` that queries the `audit-*` OpenSearch index for real transaction data
- Rewire monitoring endpoints to try real data first, falling back to demo generators when OpenSearch is unavailable
- Extract Pydantic models to `schemas/monitoring.py` (follows codebase convention)
- Add `time_range` query parameter (1-1440 min) for stats and list endpoints
- Add `demo_mode: bool` to all responses indicating data source

## Changes
| File | Action |
|------|--------|
| `src/schemas/monitoring.py` | New — 4 Pydantic models |
| `src/services/monitoring_service.py` | New — OpenSearch query service (3 methods) |
| `src/routers/monitoring.py` | Modified — import schemas, add service dependency, demo fallback |
| `tests/test_monitoring_service.py` | New — 25 unit tests |
| `openapi-snapshot.json` | Regenerated |

## Test plan
- [x] 25 new unit tests pass (`pytest tests/test_monitoring_service.py -v`)
- [x] 6 OpenAPI contract tests pass
- [x] Coverage >= 70%
- [x] Lint (ruff) + format (black) clean
- [x] Graceful fallback: when OpenSearch is down, endpoints return demo data with `demo_mode: True`
- [x] Real mode: when OpenSearch is up, endpoints return mapped data with `demo_mode: False`
- [x] Frontend contract unchanged (same response shape)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>