### PR TITLE
feat(ui): MCP connector catalog gallery with OAuth flow (Phase 2)

### DIFF
--- a/control-plane-ui/public/locales/en/common.json
+++ b/control-plane-ui/public/locales/en/common.json
@@ -10,6 +10,7 @@
     "apis": "APIs",
     "aiTools": "AI Tools",
     "externalMcpServers": "External MCP Servers",
+    "mcpConnectors": "MCP Connectors",
     "applications": "Applications",
     "consumers": "Consumers",
     "saas": "SaaS",

--- a/control-plane-ui/public/locales/fr/common.json
+++ b/control-plane-ui/public/locales/fr/common.json
@@ -9,6 +9,7 @@
     "tenants": "Tenants",
     "apis": "APIs",
     "aiTools": "Outils IA",
+    "mcpConnectors": "Connecteurs MCP",
     "externalMcpServers": "Serveurs MCP externes",
     "applications": "Applications",
     "consumers": "Consommateurs",

--- a/control-plane-ui/src/App.tsx
+++ b/control-plane-ui/src/App.tsx
@@ -20,6 +20,7 @@ import { ErrorBoundary } from '@stoa/shared/components/ErrorBoundary';
 // Consolidated imports — single module loader per multi-export file
 const aiToolsModule = () => import('./pages/AITools');
 const externalMcpModule = () => import('./pages/ExternalMCPServers');
+const mcpConnectorsModule = () => import('./pages/MCPConnectors');
 const gatewaysModule = () => import('./pages/Gateways');
 
 const Tenants = lazy(() => import('./pages/Tenants').then((m) => ({ default: m.Tenants })));
@@ -46,6 +47,12 @@ const ExternalMCPServersList = lazy(() =>
 );
 const ExternalMCPServerDetail = lazy(() =>
   externalMcpModule().then((m) => ({ default: m.ExternalMCPServerDetail }))
+);
+const ConnectorCatalog = lazy(() =>
+  mcpConnectorsModule().then((m) => ({ default: m.ConnectorCatalog }))
+);
+const ConnectorCallback = lazy(() =>
+  mcpConnectorsModule().then((m) => ({ default: m.ConnectorCallback }))
 );
 const AdminProspects = lazy(() =>
   import('./pages/AdminProspects').then((m) => ({ default: m.AdminProspects }))
@@ -440,6 +447,8 @@ function ProtectedRoutes() {
                 <Route path="/errors" element={<ErrorSnapshots />} />
                 <Route path="/external-mcp-servers" element={<ExternalMCPServersList />} />
                 <Route path="/external-mcp-servers/:id" element={<ExternalMCPServerDetail />} />
+                <Route path="/mcp-connectors" element={<ConnectorCatalog />} />
+                <Route path="/mcp-connectors/callback" element={<ConnectorCallback />} />
                 <Route path="/gateway" element={<GatewayStatus />} />
                 <Route path="/gateways/modes" element={<GatewayModes />} />
                 <Route path="/gateways" element={<GatewayRegistry />} />

--- a/control-plane-ui/src/components/Layout.tsx
+++ b/control-plane-ui/src/components/Layout.tsx
@@ -54,6 +54,7 @@ import {
   Stethoscope,
   Settings,
   DollarSign,
+  Puzzle,
 } from 'lucide-react';
 import { clsx } from 'clsx';
 import { useApiConnectivity } from '../hooks/useApiConnectivity';
@@ -124,6 +125,13 @@ const navigationSections: NavSection[] = [
         permission: 'apis:read',
         shortcut: ['g', 'w'],
         badge: 'STOA',
+      },
+      {
+        name: 'nav.mcpConnectors',
+        href: '/mcp-connectors',
+        icon: Puzzle,
+        permission: 'admin:servers',
+        badge: 'NEW',
       },
       {
         name: 'nav.externalMcpServers',

--- a/control-plane-ui/src/pages/MCPConnectors/ConnectorCallback.test.tsx
+++ b/control-plane-ui/src/pages/MCPConnectors/ConnectorCallback.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const mockHandleCallback = vi.fn();
+vi.mock('../../services/mcpConnectorsApi', () => ({
+  mcpConnectorsService: {
+    handleCallback: (...args: unknown[]) => mockHandleCallback(...args),
+  },
+}));
+
+const mockToast = { success: vi.fn(), error: vi.fn(), info: vi.fn() };
+vi.mock('@stoa/shared/components/Toast', () => ({
+  useToastActions: () => mockToast,
+}));
+
+vi.mock('@stoa/shared/components/StoaLoader', () => ({
+  StoaLoader: () => <div data-testid="loader" />,
+}));
+
+import { ConnectorCallback } from './ConnectorCallback';
+
+function renderWithParams(search: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/mcp-connectors/callback${search}`]}>
+      <ConnectorCallback />
+    </MemoryRouter>
+  );
+}
+
+describe('ConnectorCallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading spinner on mount', () => {
+    mockHandleCallback.mockReturnValue(new Promise(() => {}));
+    renderWithParams('?code=abc&state=xyz');
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+    expect(screen.getByText('Connecting...')).toBeInTheDocument();
+  });
+
+  it('calls handleCallback with code and state from URL', async () => {
+    mockHandleCallback.mockResolvedValue({
+      server_id: 'srv-1',
+      server_name: 'linear-mcp',
+      display_name: 'Linear',
+      slug: 'linear',
+      tools_sync_triggered: true,
+    });
+
+    renderWithParams('?code=test-code&state=test-state');
+
+    await waitFor(() => {
+      expect(mockHandleCallback).toHaveBeenCalledWith({
+        code: 'test-code',
+        state: 'test-state',
+      });
+    });
+  });
+
+  it('navigates to server detail on success', async () => {
+    mockHandleCallback.mockResolvedValue({
+      server_id: 'srv-1',
+      server_name: 'linear-mcp',
+      display_name: 'Linear',
+      slug: 'linear',
+      tools_sync_triggered: true,
+    });
+
+    renderWithParams('?code=abc&state=xyz');
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/external-mcp-servers/srv-1', { replace: true });
+    });
+    expect(mockToast.success).toHaveBeenCalledWith('Connected', 'Linear has been connected');
+  });
+
+  it('uses redirect_url from response when present', async () => {
+    mockHandleCallback.mockResolvedValue({
+      server_id: 'srv-1',
+      server_name: 'linear-mcp',
+      display_name: 'Linear',
+      slug: 'linear',
+      tools_sync_triggered: true,
+      redirect_url: '/mcp-connectors',
+    });
+
+    renderWithParams('?code=abc&state=xyz');
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/mcp-connectors', { replace: true });
+    });
+  });
+
+  it('shows error toast and navigates on API error', async () => {
+    mockHandleCallback.mockRejectedValue(new Error('Token exchange failed'));
+
+    renderWithParams('?code=abc&state=xyz');
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith('Connection failed', 'Token exchange failed');
+      expect(mockNavigate).toHaveBeenCalledWith('/mcp-connectors', { replace: true });
+    });
+  });
+
+  it('handles OAuth error param', async () => {
+    renderWithParams('?error=access_denied&error_description=User+denied+access');
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith('Connection failed', 'User denied access');
+      expect(mockNavigate).toHaveBeenCalledWith('/mcp-connectors', { replace: true });
+    });
+  });
+
+  it('handles missing code/state params', async () => {
+    renderWithParams('?code=abc');
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith(
+        'Connection failed',
+        'Missing authorization parameters'
+      );
+      expect(mockNavigate).toHaveBeenCalledWith('/mcp-connectors', { replace: true });
+    });
+  });
+});

--- a/control-plane-ui/src/pages/MCPConnectors/ConnectorCallback.tsx
+++ b/control-plane-ui/src/pages/MCPConnectors/ConnectorCallback.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { mcpConnectorsService } from '../../services/mcpConnectorsApi';
+import { useToastActions } from '@stoa/shared/components/Toast';
+import { StoaLoader } from '@stoa/shared/components/StoaLoader';
+
+export function ConnectorCallback() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const toast = useToastActions();
+  const calledRef = useRef(false);
+
+  useEffect(() => {
+    if (calledRef.current) return;
+    calledRef.current = true;
+
+    const error = searchParams.get('error');
+    if (error) {
+      const description = searchParams.get('error_description') || 'Authorization was denied';
+      toast.error('Connection failed', description);
+      navigate('/mcp-connectors', { replace: true });
+      return;
+    }
+
+    const code = searchParams.get('code');
+    const state = searchParams.get('state');
+
+    if (!code || !state) {
+      toast.error('Connection failed', 'Missing authorization parameters');
+      navigate('/mcp-connectors', { replace: true });
+      return;
+    }
+
+    mcpConnectorsService
+      .handleCallback({ code, state })
+      .then((response) => {
+        toast.success('Connected', `${response.display_name} has been connected`);
+        if (response.redirect_url) {
+          navigate(response.redirect_url, { replace: true });
+        } else {
+          navigate(`/external-mcp-servers/${response.server_id}`, { replace: true });
+        }
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : 'Failed to complete authorization';
+        toast.error('Connection failed', message);
+        navigate('/mcp-connectors', { replace: true });
+      });
+  }, [searchParams, navigate, toast]);
+
+  return (
+    <div className="flex items-center justify-center min-h-[60vh]">
+      <div className="text-center space-y-4">
+        <StoaLoader variant="inline" />
+        <p className="text-neutral-500 dark:text-neutral-400">Connecting...</p>
+      </div>
+    </div>
+  );
+}

--- a/control-plane-ui/src/pages/MCPConnectors/ConnectorCatalog.test.tsx
+++ b/control-plane-ui/src/pages/MCPConnectors/ConnectorCatalog.test.tsx
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { PersonaRole } from '../../test/helpers';
+import { createAuthMock } from '../../test/helpers';
+import { useAuth } from '../../contexts/AuthContext';
+
+const mockListConnectors = vi.fn();
+const mockAuthorize = vi.fn();
+const mockDisconnect = vi.fn();
+
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+vi.mock('../../services/mcpConnectorsApi', () => ({
+  mcpConnectorsService: {
+    listConnectors: (...args: unknown[]) => mockListConnectors(...args),
+    authorize: (...args: unknown[]) => mockAuthorize(...args),
+    disconnect: (...args: unknown[]) => mockDisconnect(...args),
+  },
+}));
+
+const mockToast = { success: vi.fn(), error: vi.fn(), info: vi.fn() };
+vi.mock('@stoa/shared/components/Toast', () => ({
+  useToastActions: () => mockToast,
+}));
+
+const mockConfirm = vi.fn().mockResolvedValue(false);
+vi.mock('@stoa/shared/components/ConfirmDialog', () => ({
+  useConfirm: () => [mockConfirm, () => null],
+}));
+
+vi.mock('@stoa/shared/components/EmptyState', () => ({
+  EmptyState: ({ title }: { title?: string }) => <div data-testid="empty-state">{title}</div>,
+}));
+
+vi.mock('@stoa/shared/components/Skeleton', () => ({
+  CardSkeleton: () => <div data-testid="card-skeleton" />,
+}));
+
+import { ConnectorCatalog } from './ConnectorCatalog';
+
+const mockConnectors = [
+  {
+    id: '1',
+    slug: 'linear',
+    display_name: 'Linear',
+    description: 'Project management for modern teams',
+    icon_url: 'https://example.com/linear.png',
+    category: 'project_management',
+    mcp_base_url: 'https://mcp.linear.app',
+    transport: 'sse',
+    oauth_scopes: 'read write',
+    oauth_pkce_required: true,
+    documentation_url: 'https://linear.app/docs',
+    is_featured: true,
+    enabled: true,
+    sort_order: 1,
+    is_connected: true,
+    connected_server_id: 'srv-1',
+    connection_health: 'healthy',
+  },
+  {
+    id: '2',
+    slug: 'github',
+    display_name: 'GitHub',
+    description: 'Code hosting and collaboration',
+    icon_url: null,
+    category: 'development',
+    mcp_base_url: 'https://mcp.github.com',
+    transport: 'streamable_http',
+    oauth_scopes: 'repo',
+    oauth_pkce_required: false,
+    documentation_url: null,
+    is_featured: true,
+    enabled: true,
+    sort_order: 2,
+    is_connected: false,
+    connected_server_id: null,
+    connection_health: null,
+  },
+  {
+    id: '3',
+    slug: 'slack',
+    display_name: 'Slack',
+    description: 'Team communication',
+    icon_url: null,
+    category: 'communication',
+    mcp_base_url: 'https://mcp.slack.com',
+    transport: 'sse',
+    oauth_scopes: null,
+    oauth_pkce_required: false,
+    documentation_url: null,
+    is_featured: false,
+    enabled: true,
+    sort_order: 3,
+    is_connected: false,
+    connected_server_id: null,
+    connection_health: null,
+  },
+  {
+    id: '4',
+    slug: 'datadog',
+    display_name: 'Datadog',
+    description: 'Monitoring and analytics',
+    icon_url: null,
+    category: 'monitoring',
+    mcp_base_url: 'https://mcp.datadog.com',
+    transport: 'sse',
+    oauth_scopes: null,
+    oauth_pkce_required: false,
+    documentation_url: null,
+    is_featured: false,
+    enabled: true,
+    sort_order: 4,
+    is_connected: false,
+    connected_server_id: null,
+    connection_health: null,
+  },
+  {
+    id: '5',
+    slug: 'sentry',
+    display_name: 'Sentry',
+    description: 'Error tracking',
+    icon_url: null,
+    category: 'monitoring',
+    mcp_base_url: 'https://mcp.sentry.io',
+    transport: 'sse',
+    oauth_scopes: null,
+    oauth_pkce_required: false,
+    documentation_url: null,
+    is_featured: false,
+    enabled: true,
+    sort_order: 5,
+    is_connected: false,
+    connected_server_id: null,
+    connection_health: null,
+  },
+];
+
+function renderComponent() {
+  return render(
+    <MemoryRouter>
+      <ConnectorCatalog />
+    </MemoryRouter>
+  );
+}
+
+describe('ConnectorCatalog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+    mockListConnectors.mockResolvedValue({
+      connectors: mockConnectors,
+      total_count: mockConnectors.length,
+    });
+  });
+
+  it('renders loading skeletons initially', () => {
+    mockListConnectors.mockReturnValue(new Promise(() => {}));
+    renderComponent();
+    expect(screen.getAllByTestId('card-skeleton')).toHaveLength(6);
+  });
+
+  it('displays connector cards after loading', async () => {
+    renderComponent();
+    // Featured connectors appear in both Featured and All sections
+    await waitFor(() => {
+      expect(screen.getAllByText('Linear').length).toBeGreaterThanOrEqual(1);
+    });
+    expect(screen.getAllByText('GitHub').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Slack')).toBeInTheDocument();
+    expect(screen.getByText('Datadog')).toBeInTheDocument();
+    expect(screen.getByText('Sentry')).toBeInTheDocument();
+  });
+
+  it('shows category badges on cards', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getAllByText('Linear').length).toBeGreaterThanOrEqual(1);
+    });
+    expect(screen.getAllByText('Project Management').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Development').length).toBeGreaterThan(0);
+  });
+
+  it('shows Connected badge for connected connectors', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getAllByText('Connected').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('shows Connect button for disconnected connectors', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getAllByText('Linear').length).toBeGreaterThanOrEqual(1);
+    });
+    // GitHub appears in Featured + All = 2 Connect buttons for GitHub
+    // Slack, Datadog, Sentry = 3 Connect buttons (non-featured)
+    // Total: 2 (GitHub) + 3 (non-featured) = 5
+    const connectButtons = screen.getAllByText('Connect');
+    expect(connectButtons.length).toBe(5);
+  });
+
+  it('shows Disconnect button for connected connectors', async () => {
+    renderComponent();
+    await waitFor(() => {
+      // Linear is connected and appears in Featured + All = 2 Disconnect buttons
+      expect(screen.getAllByText('Disconnect').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('renders featured section', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('Featured')).toBeInTheDocument();
+    });
+  });
+
+  it('filters by category', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getAllByText('Linear').length).toBeGreaterThanOrEqual(1);
+    });
+    // "Monitoring" text appears as both category badge and filter button
+    fireEvent.click(screen.getByRole('button', { name: 'Monitoring' }));
+    // Category filter hides Featured section, so Linear is gone completely
+    expect(screen.getByText('Datadog')).toBeInTheDocument();
+    expect(screen.getByText('Sentry')).toBeInTheDocument();
+    expect(screen.queryByText('Linear')).not.toBeInTheDocument();
+  });
+
+  it('calls authorize API on connect click', async () => {
+    mockAuthorize.mockResolvedValue({ authorize_url: 'https://auth.example.com', state: 'xyz' });
+
+    // Mock window.location.href assignment
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...originalLocation, href: 'http://localhost/' },
+    });
+
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getAllByText('GitHub').length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Click first Connect button (featured GitHub card)
+    const connectButtons = screen.getAllByText('Connect');
+    fireEvent.click(connectButtons[0]);
+
+    await waitFor(() => {
+      expect(mockAuthorize).toHaveBeenCalledWith('github', {
+        redirect_after: 'http://localhost/',
+      });
+    });
+
+    Object.defineProperty(window, 'location', { writable: true, value: originalLocation });
+  });
+
+  it('calls disconnect with confirm dialog', async () => {
+    mockConfirm.mockResolvedValue(true);
+    mockDisconnect.mockResolvedValue(undefined);
+    mockListConnectors.mockResolvedValue({
+      connectors: mockConnectors,
+      total_count: mockConnectors.length,
+    });
+
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getAllByText('Disconnect').length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Click first Disconnect button (featured Linear card)
+    fireEvent.click(screen.getAllByText('Disconnect')[0]);
+
+    await waitFor(() => {
+      expect(mockConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Disconnect Linear?',
+          variant: 'danger',
+        })
+      );
+    });
+  });
+
+  it('shows error state', async () => {
+    mockListConnectors.mockRejectedValue(new Error('Network error'));
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no connectors match filter', async () => {
+    mockListConnectors.mockResolvedValue({ connectors: [], total_count: 0 });
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    });
+  });
+
+  describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
+    '%s persona',
+    (role) => {
+      it('renders the page without crashing', async () => {
+        vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
+        renderComponent();
+        await waitFor(() => {
+          expect(screen.getByText('MCP Connectors')).toBeInTheDocument();
+        });
+      });
+    }
+  );
+});

--- a/control-plane-ui/src/pages/MCPConnectors/ConnectorCatalog.tsx
+++ b/control-plane-ui/src/pages/MCPConnectors/ConnectorCatalog.tsx
@@ -1,0 +1,346 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Puzzle, RefreshCw, ExternalLink, CheckCircle, XCircle } from 'lucide-react';
+import { mcpConnectorsService } from '../../services/mcpConnectorsApi';
+import { useAuth } from '../../contexts/AuthContext';
+import { useToastActions } from '@stoa/shared/components/Toast';
+import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
+import { EmptyState } from '@stoa/shared/components/EmptyState';
+import { CardSkeleton } from '@stoa/shared/components/Skeleton';
+import type { ConnectorTemplate } from '../../types';
+
+const categoryLabels: Record<string, string> = {
+  project_management: 'Project Management',
+  development: 'Development',
+  communication: 'Communication',
+  monitoring: 'Monitoring',
+  analytics: 'Analytics',
+  security: 'Security',
+  data: 'Data',
+};
+
+const transportLabels: Record<string, string> = {
+  sse: 'SSE',
+  streamable_http: 'Streamable HTTP',
+  stdio: 'Stdio',
+};
+
+const ALL_CATEGORY = '__all__';
+
+export function ConnectorCatalog() {
+  const { isReady } = useAuth();
+  const toast = useToastActions();
+  const [confirm, ConfirmDialog] = useConfirm();
+  const mountedRef = useRef(true);
+
+  const [connectors, setConnectors] = useState<ConnectorTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState(ALL_CATEGORY);
+  const [connectingSlug, setConnectingSlug] = useState<string | null>(null);
+  const [disconnectingSlug, setDisconnectingSlug] = useState<string | null>(null);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    if (isReady) {
+      loadConnectors();
+    }
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [isReady]);
+
+  async function loadConnectors() {
+    try {
+      setLoading(true);
+      const response = await mcpConnectorsService.listConnectors();
+      if (!mountedRef.current) return;
+      setConnectors(response.connectors);
+      setError(null);
+    } catch (err: unknown) {
+      if (!mountedRef.current) return;
+      const message = err instanceof Error ? err.message : 'Failed to load connectors';
+      setError(message);
+    } finally {
+      if (mountedRef.current) setLoading(false);
+    }
+  }
+
+  const handleConnect = useCallback(
+    async (slug: string) => {
+      try {
+        setConnectingSlug(slug);
+        const response = await mcpConnectorsService.authorize(slug, {
+          redirect_after: window.location.href,
+        });
+        window.location.href = response.authorize_url;
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Failed to start authorization';
+        toast.error('Connection failed', message);
+        setConnectingSlug(null);
+      }
+    },
+    [toast]
+  );
+
+  const handleDisconnect = useCallback(
+    async (connector: ConnectorTemplate) => {
+      const confirmed = await confirm({
+        title: `Disconnect ${connector.display_name}?`,
+        message:
+          'This will remove the connected server and its tools. You can reconnect at any time.',
+        confirmLabel: 'Disconnect',
+        variant: 'danger',
+      });
+      if (!confirmed) return;
+
+      try {
+        setDisconnectingSlug(connector.slug);
+        await mcpConnectorsService.disconnect(connector.slug);
+        toast.success('Disconnected', `${connector.display_name} has been disconnected`);
+        await loadConnectors();
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Failed to disconnect';
+        toast.error('Disconnect failed', message);
+      } finally {
+        if (mountedRef.current) setDisconnectingSlug(null);
+      }
+    },
+    [confirm, toast]
+  );
+
+  // Derive categories from data
+  const categories = [
+    ALL_CATEGORY,
+    ...Array.from(new Set(connectors.map((c) => c.category))).sort(),
+  ];
+
+  const featured = connectors.filter((c) => c.is_featured);
+  const filtered =
+    categoryFilter === ALL_CATEGORY
+      ? connectors
+      : connectors.filter((c) => c.category === categoryFilter);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="flex justify-between items-center">
+          <div className="h-8 w-64 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
+          <div className="h-10 w-24 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">MCP Connectors</h1>
+          <p className="text-neutral-500 dark:text-neutral-400 mt-1">
+            Connect third-party services to STOA with one click via OAuth
+          </p>
+        </div>
+        <button
+          onClick={loadConnectors}
+          className="flex items-center gap-2 px-4 py-2 text-sm border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-800 text-neutral-700 dark:text-neutral-300"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 px-4 py-3 rounded-lg">
+          {error}
+          <button onClick={() => setError(null)} className="float-right font-bold">
+            &times;
+          </button>
+        </div>
+      )}
+
+      {/* Featured section */}
+      {featured.length > 0 && categoryFilter === ALL_CATEGORY && (
+        <div>
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-white mb-3">Featured</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {featured.map((connector) => (
+              <ConnectorCard
+                key={connector.id}
+                connector={connector}
+                onConnect={handleConnect}
+                onDisconnect={handleDisconnect}
+                connectingSlug={connectingSlug}
+                disconnectingSlug={disconnectingSlug}
+                featured
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Category filter tabs */}
+      {categories.length > 2 && (
+        <div className="flex gap-2 flex-wrap">
+          {categories.map((cat) => (
+            <button
+              key={cat}
+              onClick={() => setCategoryFilter(cat)}
+              className={`px-3 py-1.5 text-sm rounded-full transition-colors ${
+                categoryFilter === cat
+                  ? 'bg-primary-600 text-white'
+                  : 'bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-700'
+              }`}
+            >
+              {cat === ALL_CATEGORY ? 'All' : categoryLabels[cat] || cat}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Connector grid */}
+      {filtered.length === 0 ? (
+        <div className="bg-white dark:bg-neutral-800 rounded-lg shadow">
+          <EmptyState
+            variant="default"
+            title="No connectors available"
+            description="No connector templates match your filter. Try selecting a different category."
+          />
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filtered.map((connector) => (
+            <ConnectorCard
+              key={connector.id}
+              connector={connector}
+              onConnect={handleConnect}
+              onDisconnect={handleDisconnect}
+              connectingSlug={connectingSlug}
+              disconnectingSlug={disconnectingSlug}
+            />
+          ))}
+        </div>
+      )}
+
+      {ConfirmDialog}
+    </div>
+  );
+}
+
+interface ConnectorCardProps {
+  connector: ConnectorTemplate;
+  onConnect: (slug: string) => void;
+  onDisconnect: (connector: ConnectorTemplate) => void;
+  connectingSlug: string | null;
+  disconnectingSlug: string | null;
+  featured?: boolean;
+}
+
+function ConnectorCard({
+  connector,
+  onConnect,
+  onDisconnect,
+  connectingSlug,
+  disconnectingSlug,
+  featured,
+}: ConnectorCardProps) {
+  const isConnecting = connectingSlug === connector.slug;
+  const isDisconnecting = disconnectingSlug === connector.slug;
+
+  return (
+    <div
+      className={`bg-white dark:bg-neutral-800 rounded-lg shadow p-6 hover:shadow-md transition-shadow ${
+        featured ? 'ring-2 ring-primary-200 dark:ring-primary-800' : ''
+      }`}
+    >
+      {/* Header */}
+      <div className="flex items-start gap-3 mb-4">
+        {connector.icon_url ? (
+          <img src={connector.icon_url} alt="" className="w-10 h-10 rounded flex-shrink-0" />
+        ) : (
+          <div className="w-10 h-10 bg-neutral-100 dark:bg-neutral-700 rounded flex items-center justify-center flex-shrink-0">
+            <Puzzle className="h-5 w-5 text-neutral-500 dark:text-neutral-400" />
+          </div>
+        )}
+        <div className="flex-1 min-w-0">
+          <h3 className="text-lg font-semibold text-neutral-900 dark:text-white truncate">
+            {connector.display_name}
+          </h3>
+          {connector.description && (
+            <p className="text-sm text-neutral-500 dark:text-neutral-400 line-clamp-2 mt-0.5">
+              {connector.description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Badges */}
+      <div className="flex flex-wrap gap-2 mb-4">
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300">
+          {categoryLabels[connector.category] || connector.category}
+        </span>
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300">
+          {transportLabels[connector.transport] || connector.transport}
+        </span>
+        {connector.is_connected && (
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300">
+            <CheckCircle className="h-3 w-3" />
+            Connected
+          </span>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-2 pt-4 border-t dark:border-neutral-700">
+        {connector.is_connected ? (
+          <>
+            <button
+              onClick={() => onDisconnect(connector)}
+              disabled={isDisconnecting}
+              className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 text-sm border border-red-200 dark:border-red-800 text-red-600 dark:text-red-400 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50"
+            >
+              <XCircle className="h-4 w-4" />
+              {isDisconnecting ? 'Disconnecting...' : 'Disconnect'}
+            </button>
+            {connector.documentation_url && (
+              <a
+                href={connector.documentation_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center px-3 py-2 text-sm border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300"
+              >
+                <ExternalLink className="h-4 w-4" />
+              </a>
+            )}
+          </>
+        ) : (
+          <>
+            <button
+              onClick={() => onConnect(connector.slug)}
+              disabled={isConnecting}
+              className="flex-1 px-3 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50"
+            >
+              {isConnecting ? 'Connecting...' : 'Connect'}
+            </button>
+            {connector.documentation_url && (
+              <a
+                href={connector.documentation_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center px-3 py-2 text-sm border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300"
+              >
+                <ExternalLink className="h-4 w-4" />
+              </a>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/control-plane-ui/src/pages/MCPConnectors/index.ts
+++ b/control-plane-ui/src/pages/MCPConnectors/index.ts
@@ -1,0 +1,2 @@
+export { ConnectorCatalog } from './ConnectorCatalog';
+export { ConnectorCallback } from './ConnectorCallback';

--- a/control-plane-ui/src/services/mcpConnectorsApi.ts
+++ b/control-plane-ui/src/services/mcpConnectorsApi.ts
@@ -1,0 +1,54 @@
+/**
+ * MCP Connector Catalog API Service
+ *
+ * Client for the connector catalog — browse templates, authorize via OAuth,
+ * and manage connected MCP servers.
+ */
+
+import { apiService } from './api';
+import type { ConnectorCatalogResponse, AuthorizeResponse, CallbackResponse } from '../types';
+
+class MCPConnectorsService {
+  /**
+   * List all connector templates with connection status.
+   * Endpoint: GET /v1/admin/mcp-connectors
+   */
+  async listConnectors(tenantId?: string): Promise<ConnectorCatalogResponse> {
+    const { data } = await apiService.get('/v1/admin/mcp-connectors', {
+      params: tenantId ? { tenant_id: tenantId } : undefined,
+    });
+    return data;
+  }
+
+  /**
+   * Initiate OAuth authorization for a connector.
+   * Endpoint: POST /v1/admin/mcp-connectors/{slug}/authorize
+   */
+  async authorize(
+    slug: string,
+    body: { tenant_id?: string; redirect_after?: string }
+  ): Promise<AuthorizeResponse> {
+    const { data } = await apiService.post(`/v1/admin/mcp-connectors/${slug}/authorize`, body);
+    return data;
+  }
+
+  /**
+   * Exchange OAuth code for tokens and create the server.
+   * Endpoint: POST /v1/admin/mcp-connectors/callback
+   */
+  async handleCallback(body: { code: string; state: string }): Promise<CallbackResponse> {
+    const { data } = await apiService.post('/v1/admin/mcp-connectors/callback', body);
+    return data;
+  }
+
+  /**
+   * Disconnect a connector (remove the linked server).
+   * Endpoint: DELETE /v1/admin/mcp-connectors/{slug}/disconnect
+   */
+  async disconnect(slug: string, tenantId?: string): Promise<void> {
+    const params = tenantId ? `?tenant_id=${encodeURIComponent(tenantId)}` : '';
+    await apiService.delete(`/v1/admin/mcp-connectors/${slug}/disconnect${params}`);
+  }
+}
+
+export const mcpConnectorsService = new MCPConnectorsService();

--- a/control-plane-ui/src/types/index.ts
+++ b/control-plane-ui/src/types/index.ts
@@ -1407,3 +1407,46 @@ export interface RoleListResponse {
   roles: RoleDefinition[];
   total: number;
 }
+
+// =============================================================================
+// MCP Connector Catalog Types (Phase 2 UI)
+// =============================================================================
+
+export interface ConnectorTemplate {
+  id: string;
+  slug: string;
+  display_name: string;
+  description?: string;
+  icon_url?: string;
+  category: string;
+  mcp_base_url: string;
+  transport: string;
+  oauth_scopes?: string;
+  oauth_pkce_required: boolean;
+  documentation_url?: string;
+  is_featured: boolean;
+  enabled: boolean;
+  sort_order: number;
+  is_connected: boolean;
+  connected_server_id?: string;
+  connection_health?: string;
+}
+
+export interface ConnectorCatalogResponse {
+  connectors: ConnectorTemplate[];
+  total_count: number;
+}
+
+export interface AuthorizeResponse {
+  authorize_url: string;
+  state: string;
+}
+
+export interface CallbackResponse {
+  server_id: string;
+  server_name: string;
+  display_name: string;
+  slug: string;
+  tools_sync_triggered: boolean;
+  redirect_url?: string;
+}


### PR DESCRIPTION
## Summary
- Add MCP Connectors gallery page with card grid, category filtering, and featured section
- Add OAuth callback handler page for code/state exchange after provider redirect
- Add API service, TypeScript types, lazy-loaded routes, nav entry with NEW badge
- 23 tests covering catalog display, connect/disconnect flows, error states, and 4 RBAC personas

Follows Phase 1 (API) merged in #1356.

## Test plan
- [x] Local quality gate: lint (103/105), format, tsc, vitest (1621 pass)
- [ ] CI green (3 required checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)