### PR TITLE
feat(api): wire OTel distributed tracing with per-tenant spans (CAB-1635)

### DIFF
--- a/charts/stoa-platform/values.yaml
+++ b/charts/stoa-platform/values.yaml
@@ -81,7 +81,7 @@ stoaGateway:
   logFormat: json
   # OpenTelemetry Collector endpoint (Grafana Alloy in stoa-monitoring namespace)
   # Set to enable distributed tracing export via OTLP gRPC
-  otelEndpoint: ""  # e.g. "http://stoa-alloy-otlp.stoa-monitoring:4317"
+  otelEndpoint: "http://stoa-alloy-otlp.stoa-monitoring:4317"
 
   # Resources
   resources:

--- a/control-plane-api/k8s/deployment.yaml
+++ b/control-plane-api/k8s/deployment.yaml
@@ -32,6 +32,9 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
+          env:
+            - name: LOG_TRACE_EXPORT_ENDPOINT
+              value: "http://stoa-alloy-otlp.stoa-monitoring:4317"
           envFrom:
             - configMapRef:
                 name: stoa-control-plane-api-config

--- a/control-plane-api/src/tracing_config.py
+++ b/control-plane-api/src/tracing_config.py
@@ -10,14 +10,46 @@ to Grafana Alloy, which forwards them to Tempo. Grafana then provides:
 - Metrics-to-Traces correlation (via exemplars)
 """
 
-import logging
+from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING
+
+import structlog
 from opentelemetry import trace
 from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
+if TYPE_CHECKING:
+    from opentelemetry.context import Context
+    from opentelemetry.sdk.trace import ReadableSpan, Span
+
 logger = logging.getLogger(__name__)
+
+
+class TenantSpanProcessor(SpanProcessor):
+    """Enrich every span with tenant_id from structlog request context.
+
+    Auth middleware binds tenant_id via structlog.contextvars.bind_contextvars().
+    This processor reads it and sets the ``tenant.id`` span attribute so traces
+    can be filtered per-tenant in Grafana Tempo.
+    """
+
+    def on_start(self, span: Span, parent_context: Context | None = None) -> None:
+        ctx = structlog.contextvars.get_contextvars()
+        tenant_id = ctx.get("tenant_id")
+        if tenant_id:
+            span.set_attribute("tenant.id", tenant_id)
+
+    def on_end(self, span: ReadableSpan) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
 
 
 def configure_tracing(app, settings) -> None:
@@ -31,17 +63,20 @@ def configure_tracing(app, settings) -> None:
         logger.info("OTel tracing disabled (LOG_TRACE_EXPORT_ENDPOINT not set)")
         return
 
-    resource = Resource.create({
-        "service.name": "control-plane-api",
-        "service.version": settings.VERSION,
-        "deployment.environment": settings.ENVIRONMENT,
-    })
+    resource = Resource.create(
+        {
+            "service.name": "control-plane-api",
+            "service.version": settings.VERSION,
+            "deployment.environment": settings.ENVIRONMENT,
+        }
+    )
 
     provider = TracerProvider(resource=resource)
 
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 
     exporter = OTLPSpanExporter(endpoint=endpoint, insecure=True)
+    provider.add_span_processor(TenantSpanProcessor())
     provider.add_span_processor(BatchSpanProcessor(exporter))
     trace.set_tracer_provider(provider)
 

--- a/control-plane-api/tests/test_tenant_span_processor.py
+++ b/control-plane-api/tests/test_tenant_span_processor.py
@@ -1,0 +1,85 @@
+"""Tests for TenantSpanProcessor — enriches OTel spans with tenant_id."""
+
+from unittest.mock import MagicMock, patch
+
+import structlog
+
+from src.tracing_config import TenantSpanProcessor, configure_tracing
+
+
+class TestTenantSpanProcessor:
+    """TenantSpanProcessor reads tenant_id from structlog contextvars."""
+
+    def setup_method(self):
+        structlog.contextvars.clear_contextvars()
+        self.processor = TenantSpanProcessor()
+
+    def teardown_method(self):
+        structlog.contextvars.clear_contextvars()
+
+    def test_on_start_sets_tenant_id_when_present(self):
+        structlog.contextvars.bind_contextvars(tenant_id="acme-corp")
+        span = MagicMock()
+
+        self.processor.on_start(span)
+
+        span.set_attribute.assert_called_once_with("tenant.id", "acme-corp")
+
+    def test_on_start_no_op_when_no_tenant(self):
+        span = MagicMock()
+
+        self.processor.on_start(span)
+
+        span.set_attribute.assert_not_called()
+
+    def test_on_start_ignores_other_context_vars(self):
+        structlog.contextvars.bind_contextvars(request_id="req-123", user_id="u-1")
+        span = MagicMock()
+
+        self.processor.on_start(span)
+
+        span.set_attribute.assert_not_called()
+
+    def test_force_flush_returns_true(self):
+        assert self.processor.force_flush() is True
+
+    def test_shutdown_is_noop(self):
+        self.processor.shutdown()  # should not raise
+
+    def test_on_end_is_noop(self):
+        span = MagicMock()
+        self.processor.on_end(span)  # should not raise
+
+
+class TestConfigureTracingIntegration:
+    """Verify configure_tracing wires TenantSpanProcessor into the provider."""
+
+    def test_provider_has_tenant_processor(self):
+        from opentelemetry import trace as otel_trace
+
+        settings = MagicMock()
+        settings.LOG_TRACE_EXPORT_ENDPOINT = "http://localhost:4317"
+        settings.VERSION = "test"
+        settings.ENVIRONMENT = "test"
+
+        app = MagicMock()
+
+        with (
+            patch(
+                "opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter",
+                return_value=MagicMock(),
+            ),
+            patch("opentelemetry.instrumentation.fastapi.FastAPIInstrumentor"),
+            patch("opentelemetry.instrumentation.httpx.HTTPXClientInstrumentor"),
+            patch("opentelemetry.instrumentation.sqlalchemy.SQLAlchemyInstrumentor"),
+        ):
+            configure_tracing(app, settings)
+
+        provider = otel_trace.get_tracer_provider()
+        # Provider should have both TenantSpanProcessor and BatchSpanProcessor
+        processor_types = [type(sp).__name__ for sp in provider._active_span_processor._span_processors]
+        assert "TenantSpanProcessor" in processor_types
+        assert "BatchSpanProcessor" in processor_types
+
+        # Cleanup: reset global tracer provider
+        otel_trace.set_tracer_provider(None)


### PR DESCRIPTION
## Summary
- Add `TenantSpanProcessor` to `tracing_config.py` that reads `tenant_id` from structlog contextvars and sets `tenant.id` span attribute for per-tenant trace filtering in Grafana Tempo
- Set `LOG_TRACE_EXPORT_ENDPOINT` in CP API k8s manifest to activate tracing export to Alloy (`stoa-alloy-otlp.stoa-monitoring:4317`)
- Set `stoaGateway.otelEndpoint` in Helm values to activate Rust gateway OTel export
- 7 tests (6 unit + 1 integration) for TenantSpanProcessor

Phase 3 of Full Gateway Observability (Phase 1: PR #1366, Phase 2: PR #1368). Wires existing infrastructure — Tempo, Alloy, and Grafana datasources already deployed via `charts/stoa-observability/`.

## Test plan
- [x] `pytest tests/test_tenant_span_processor.py -v` — 7/7 passed
- [x] `ruff check` + `black --check` — clean
- [x] Full test suite: 6553 passed, coverage 90.08% (≥70%)
- [ ] CI green (3 required checks)
- [ ] Post-deploy: verify `kubectl logs deploy/control-plane-api | grep "OTel tracing"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)