### PR TITLE
fix(security): follow-up to CAB-2052 — 3 remaining leaks + ArgoCD spam

### DIFF
--- a/control-plane-api/src/workers/gateway_reconciler.py
+++ b/control-plane-api/src/workers/gateway_reconciler.py
@@ -97,7 +97,10 @@ class GatewayReconciler:
 
     async def _reconcile(self) -> None:
         """Main reconciliation: list ArgoCD apps → upsert/prune gateway_instances."""
-        # Fetch all ArgoCD applications using static token (no user token needed)
+        # Skip when no static token is configured (typical local dev without ArgoCD).
+        # Without a token, httpx would reject the empty "Bearer " header on every cycle.
+        if not settings.ARGOCD_TOKEN:
+            return
         try:
             all_apps = await argocd_service.get_applications(auth_token="")
         except Exception as e:

--- a/control-plane-api/tests/test_gateway_reconciler.py
+++ b/control-plane-api/tests/test_gateway_reconciler.py
@@ -206,6 +206,11 @@ class TestPruneStaleEntries:
 class TestReconcileEndToEnd:
     """Test the full reconcile cycle."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_argocd_token(self, monkeypatch):
+        # Reconciler short-circuits when no token; tests need it configured.
+        monkeypatch.setattr("src.workers.gateway_reconciler.settings.ARGOCD_TOKEN", "test-token")
+
     @pytest.mark.asyncio
     @patch("src.workers.gateway_reconciler.argocd_service")
     @patch("src.workers.gateway_reconciler._get_session_factory")
@@ -250,6 +255,18 @@ class TestReconcileEndToEnd:
 
         # Should not raise — logs warning and returns
         await reconciler._reconcile()
+
+    @pytest.mark.asyncio
+    @patch("src.workers.gateway_reconciler.argocd_service")
+    async def test_reconcile_skips_when_no_token(self, mock_argocd, monkeypatch):
+        monkeypatch.setattr("src.workers.gateway_reconciler.settings.ARGOCD_TOKEN", "")
+        reconciler = GatewayReconciler()
+        mock_argocd.get_applications = AsyncMock(return_value=[])
+
+        await reconciler._reconcile()
+
+        # ArgoCD should NOT be queried when token is absent
+        mock_argocd.get_applications.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("src.workers.gateway_reconciler.argocd_service")

--- a/control-plane-api/tests/test_regression_cab_2052_argocd_spam.py
+++ b/control-plane-api/tests/test_regression_cab_2052_argocd_spam.py
@@ -1,0 +1,55 @@
+"""Regression test for CAB-2052 follow-up — ArgoCD reconcile spam.
+
+When ARGOCD_TOKEN is empty (typical local dev without ArgoCD), the gateway
+reconciler used to call `argocd_service.get_applications(auth_token="")` on
+every cycle, which httpx would reject with `Illegal header value b"Bearer "`.
+The fix short-circuits `_reconcile` early when no token is configured.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.workers.gateway_reconciler import GatewayReconciler
+
+
+class TestRegression_ArgoCDReconcileSpam:
+    """Guards gateway_reconciler._reconcile early-return when token is empty."""
+
+    @pytest.mark.asyncio
+    @patch("src.workers.gateway_reconciler.argocd_service")
+    async def test_regression_cab_2052_reconcile_skips_when_no_token(
+        self, mock_argocd, monkeypatch
+    ):
+        monkeypatch.setattr("src.workers.gateway_reconciler.settings.ARGOCD_TOKEN", "")
+        reconciler = GatewayReconciler()
+        mock_argocd.get_applications = AsyncMock(return_value=[])
+
+        await reconciler._reconcile()
+
+        # ArgoCD must NOT be queried when token is absent — prevents log spam.
+        mock_argocd.get_applications.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("src.workers.gateway_reconciler.argocd_service")
+    @patch("src.workers.gateway_reconciler._get_session_factory")
+    async def test_regression_cab_2052_reconcile_runs_when_token_set(
+        self, mock_factory, mock_argocd, monkeypatch
+    ):
+        monkeypatch.setattr("src.workers.gateway_reconciler.settings.ARGOCD_TOKEN", "stub-token")
+        reconciler = GatewayReconciler()
+        mock_argocd.get_applications = AsyncMock(return_value=[])
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_session.execute.return_value = mock_result
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_factory.return_value = MagicMock(return_value=mock_cm)
+
+        await reconciler._reconcile()
+
+        # When a token is present, reconcile proceeds normally.
+        mock_argocd.get_applications.assert_called_once_with(auth_token="")

--- a/deploy/docker-compose/config/opensearch-dashboards/opensearch_dashboards.yml
+++ b/deploy/docker-compose/config/opensearch-dashboards/opensearch_dashboards.yml
@@ -15,7 +15,7 @@ server.rewriteBasePath: true
 opensearch.hosts: ["https://opensearch:9200"]
 opensearch.ssl.verificationMode: none
 opensearch.username: "kibanaserver"
-opensearch.password: "kibanaserver"
+# opensearch.password injected at runtime via OPENSEARCH_PASSWORD env var (set in docker-compose.yml)
 opensearch.requestHeadersAllowlist: ["Authorization", "securitytenant"]
 
 # ---------------------------------------------------------------------------
@@ -25,7 +25,8 @@ opensearch_security.auth.type: ["basicauth", "openid"]
 opensearch_security.auth.multiple_auth_enabled: true
 opensearch_security.openid.connect_url: "http://keycloak:8080/realms/stoa/.well-known/openid-configuration"
 opensearch_security.openid.client_id: "opensearch-dashboards"
-opensearch_security.openid.client_secret: "opensearch-dashboards-dev-secret"
+# opensearch_security.openid.client_secret injected at runtime via
+# OPENSEARCH_SECURITY_OPENID_CLIENT_SECRET env var (set in docker-compose.yml)
 opensearch_security.openid.scope: "openid"
 opensearch_security.openid.base_redirect_url: "http://keycloak:5601/logs"
 opensearch_security.openid.logout_url: "http://keycloak:8080/realms/stoa/protocol/openid-connect/logout?redirect_uri=http://keycloak:5601/logs"


### PR DESCRIPTION
## Summary

PR #2296 (CAB-2052) removed most hardcoded credentials but a full-repo scan surfaced 3 items that slipped through.

- **opensearch_dashboards.yml** — still contained legacy `opensearch.password: "kibanaserver"` and hardcoded `opensearch_security.openid.client_secret: "opensearch-dashboards-dev-secret"`. Both now injected at runtime via env vars that are already set in `docker-compose.yml` (OPENSEARCH_PASSWORD, OPENSEARCH_SECURITY_OPENID_CLIENT_SECRET).
- **gateway_reconciler._reconcile** — when `ARGOCD_TOKEN` is empty (typical local dev), httpx was rejecting the empty `Bearer ` header every cycle, spamming logs with `Illegal header value b'Bearer '`. Now short-circuits early and never calls `argocd_service.get_applications`. Added regression test.
- **tests** — `TestReconcileEndToEnd` gets an autouse fixture to stub the token (so existing cases still exercise the reconcile path) + explicit `test_reconcile_skips_when_no_token`.

Scope is intentionally small: this PR only patches what PR #2296 missed. It does not revisit anything #2296 already shipped.

## Test plan

- [x] `pytest tests/test_gateway_reconciler.py` → 18/18 green locally
- [ ] CI green
- [ ] No new gitleaks findings on `opensearch_dashboards.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)