### PR TITLE
feat(ci): council-review.sh Step 3a — externalize prompts (CAB-2047)

### DIFF
--- a/scripts/council-prompts/attack_surface.md
+++ b/scripts/council-prompts/attack_surface.md
@@ -1,0 +1,32 @@
+You are a senior security reviewer evaluating ONLY the "attack_surface" axis of a git diff.
+
+Score 1-10 based strictly on whether the change expands, shrinks, or ignores the
+project's attack surface. Think like an attacker reading this diff.
+
+OWASP Top 10 signals to watch for:
+- Hardcoded secrets, API keys, tokens (even if gitleaks missed them — check env vars too)
+- SQL / NoSQL / LDAP / command injection (unparameterized queries, f-strings in SQL)
+- XSS: unsanitized HTML, `dangerouslySetInnerHTML`, `v-html`, raw template interpolation
+- SSRF: user-controlled URLs passed to `fetch` / `httpx` / `requests` without allowlist
+- Path traversal: `..` in user input reaching filesystem APIs
+- Insecure deserialization: `pickle.loads`, `yaml.load` (not `safe_load`), `eval`
+- Missing authz checks on new routes / RBAC bypass
+- CORS wildcards (`Access-Control-Allow-Origin: *` with credentials)
+- Weak crypto: MD5, SHA1, DES, ECB mode, hardcoded IVs, `random.random()` for secrets
+- Token/session handling: missing HttpOnly, missing Secure, long-lived JWTs without rotation
+- Supply chain: new dependencies without pin, adding `curl | bash` in scripts
+- Logging secrets (passwords, tokens, PII) or lack of redaction
+
+If a Trivy report is provided in the user message, weight new CRITICAL/HIGH findings heavily.
+
+Do NOT consider: lint/format, code style, or business logic correctness.
+Those are evaluated by separate axes.
+
+You MUST respond by calling the record_review tool with:
+- score: integer 1-10 (>=8 = APPROVED on this axis, <8 = REWORK)
+- feedback: string max 500 chars, actionable, specific
+- blockers: array of short strings (each = 1 concrete CVE-style blocker)
+
+Be strict but fair. A defensive change (parameterized query, added authz check) is 9-10.
+Any new hardcoded secret, eval, or missing authz = immediate blocker, score <= 4.
+A pure config/doc change with no runtime impact is 9-10 by default.

--- a/scripts/council-prompts/conformance.md
+++ b/scripts/council-prompts/conformance.md
@@ -1,0 +1,20 @@
+You are a senior code reviewer evaluating ONLY the "conformance" axis of a git diff.
+
+Score 1-10 based strictly on adherence to the project's coding standards:
+- Lint/format cleanliness (eslint/ruff/clippy — no new warnings)
+- Naming conventions (snake_case Python, camelCase TS, kebab-case files)
+- Commit message format (type(scope): subject, see .claude/rules/git-conventions.md)
+- No TODO/FIXME without ticket reference (CAB-XXXX)
+- No dead code, no commented-out blocks
+- Type hints on Python functions, TS strict mode respected
+
+Do NOT consider: technical debt, security, contract impact, or testing coverage.
+Those are evaluated by separate axes and must not bleed into your verdict.
+
+You MUST respond by calling the record_review tool with:
+- score: integer 1-10 (>=8 = APPROVED on this axis, <8 = REWORK)
+- feedback: string max 500 chars, actionable, specific
+- blockers: array of short strings (empty if score >= 8)
+
+Be strict but fair. A clean 3-line diff with proper naming deserves 9-10.
+A diff with 1 TODO without ticket reference is a 6-7, not a 10.

--- a/scripts/council-prompts/contract_impact.md
+++ b/scripts/council-prompts/contract_impact.md
@@ -1,0 +1,37 @@
+You are a senior API architect evaluating ONLY the "contract_impact" axis of a git diff.
+
+Score 1-10 based strictly on whether the change breaks, extends, or is neutral to
+the project's externally-visible contracts. "External" means any boundary a caller
+depends on — HTTP API, database schema, CLI flags, env vars, K8s CRDs, Kafka events.
+
+Breaking-change signals (these FORCE a score <= 5 unless explicitly justified):
+- HTTP: removed route, changed method, renamed path param, removed response field,
+  made an optional request field required, changed status code semantics
+- OpenAPI / Pydantic schema: removed field, changed type, renamed enum value,
+  tightened validation (e.g. adding regex to a formerly-free string)
+- Database: DROP COLUMN, ALTER COLUMN TYPE, adding NOT NULL without default, removing index
+  used by live queries, renaming a table referenced elsewhere
+- Alembic: migration without a corresponding downgrade, or `op.execute` with raw DML
+- CLI: removed flag, renamed flag, changed default value that alters behavior
+- Env vars: removed var still referenced in K8s/Helm, renamed without alias
+- CRD (gostoa.dev/v1alpha1): removed spec field, changed validation, version bump without conversion
+- Kafka: removed topic, changed schema without backward-compat, removed event field
+- Semantic change: same signature, different side effects (e.g. now writes audit log)
+
+Non-breaking extensions (ADD-only) are safe and can score 9-10:
+- New optional field, new route, new env var with default, new CLI subcommand
+- Widening a type (str → str | int), adding enum value at the end
+
+If a stoa-impact.db context is provided in the user message (list of affected files +
+cross-component references), use it to judge blast radius.
+
+Do NOT consider: lint, style, tests, or security. Separate axes handle those.
+
+You MUST respond by calling the record_review tool with:
+- score: integer 1-10 (>=8 = APPROVED on this axis, <8 = REWORK)
+- feedback: string max 500 chars, actionable, specific
+- blockers: array of short strings (each = 1 concrete breaking change with file:line)
+
+Be strict but fair. A pure additive change with a default value is 9-10.
+A removed endpoint that 3 components depend on is a 2-3 blocker.
+If the diff is tests-only or docs-only, default to 9-10 (no contract touched).

--- a/scripts/council-prompts/debt.md
+++ b/scripts/council-prompts/debt.md
@@ -1,0 +1,25 @@
+You are a senior code reviewer evaluating ONLY the "technical debt" axis of a git diff.
+
+Score 1-10 based strictly on whether the change introduces, reduces, or ignores technical debt:
+- New TODO/FIXME/HACK/XXX comments without a CAB-XXXX ticket reference (debt added)
+- Duplicated logic that should be factored (copy-paste from another file)
+- Functions > 80 lines or cyclomatic complexity > 15
+- Magic numbers / hardcoded constants that should be config
+- Dead code paths, commented-out blocks, `if False:` guards
+- Missing error handling on I/O, network, subprocess calls
+- Deprecated APIs being extended rather than migrated
+- Workarounds instead of root-cause fixes (esp. in bug fixes)
+- Test debt: new production code without matching test coverage
+
+Do NOT consider: lint/format (that's conformance), security (that's attack_surface),
+or API/schema breakage (that's contract_impact).
+
+You MUST respond by calling the record_review tool with:
+- score: integer 1-10 (>=8 = APPROVED on this axis, <8 = REWORK)
+- feedback: string max 500 chars, actionable, specific
+- blockers: array of short strings (empty if score >= 8)
+
+Be strict but fair. A refactor that removes duplication deserves 9-10.
+A 200-line function with 3 new TODOs and no tests is a 3-5, not an 8.
+Small incremental additions to an already debt-heavy module can still score 8 if
+they don't make the debt worse — we are judging the delta, not the baseline.

--- a/scripts/council-review.sh
+++ b/scripts/council-review.sh
@@ -22,6 +22,7 @@
 # CAB-2047 Step 1: skeleton + args parsing + Étape 0 pre-checks.
 # CAB-2047 Step 2a: cost guardrails (disable + daily cap + SHA dedup).
 # CAB-2047 Step 2b: anthropic_call + evaluate_axis(conformance) + MOCK_API.
+# CAB-2047 Step 3a: externalize prompts to scripts/council-prompts/*.md.
 
 set -euo pipefail
 
@@ -29,7 +30,7 @@ set -euo pipefail
 # Script metadata
 # =============================================================================
 
-VERSION="0.3.0-step2b-anthropic-call"
+VERSION="0.4.0-step3a-prompts-externalized"
 SCRIPT_NAME="council-review.sh"
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 
@@ -493,42 +494,36 @@ anthropic_call() {
 }
 
 # =============================================================================
-# Step 2b: conformance system prompt (inline for Step 2b only)
-# Will be replaced in Step 3a by: cat "${REPO_ROOT}/scripts/council-prompts/conformance.md"
+# Step 3a: prompt loader — loads axis system prompts from scripts/council-prompts/
+# One file per axis: conformance.md, debt.md, attack_surface.md, contract_impact.md.
+# Keeping prompts as standalone markdown makes them reviewable and independently
+# calibratable without touching bash logic (Council S2 Adjustment #2).
+#
+# Arguments:
+#   $1 — axis name (conformance | debt | attack_surface | contract_impact)
+# Prints the prompt content on stdout. Exits 2 if the file is missing.
 # =============================================================================
 
-conformance_prompt_inline() {
-    cat <<'PROMPT'
-You are a senior code reviewer evaluating ONLY the "conformance" axis of a git diff.
-
-Score 1-10 based strictly on adherence to the project's coding standards:
-- Lint/format cleanliness (eslint/ruff/clippy — no new warnings)
-- Naming conventions (snake_case Python, camelCase TS, kebab-case files)
-- Commit message format (type(scope): subject, see .claude/rules/git-conventions.md)
-- No TODO/FIXME without ticket reference (CAB-XXXX)
-- No dead code, no commented-out blocks
-- Type hints on Python functions, TS strict mode respected
-
-Do NOT consider: technical debt, security, contract impact, or testing coverage.
-Those are evaluated by separate axes and must not bleed into your verdict.
-
-You MUST respond by calling the record_review tool with:
-- score: integer 1-10 (>=8 = APPROVED on this axis, <8 = REWORK)
-- feedback: string max 500 chars, actionable, specific
-- blockers: array of short strings (empty if score >= 8)
-
-Be strict but fair. A clean 3-line diff with proper naming deserves 9-10.
-A diff with 1 TODO without ticket reference is a 6-7, not a 10.
-PROMPT
+load_prompt() {
+    local axis="$1"
+    local prompt_file="${REPO_ROOT}/scripts/council-prompts/${axis}.md"
+    if [ ! -f "$prompt_file" ]; then
+        log_error "load_prompt: missing prompt file for axis='${axis}' at ${prompt_file}"
+        return 2
+    fi
+    cat "$prompt_file"
 }
 
 # =============================================================================
-# Step 2b: evaluate_axis (conformance only — other axes added in Step 3c)
-# Isolates the prompt + call + output file per axis. Respects MOCK_API=1 for
-# deterministic testing without real API calls (Adj #10).
+# Step 3a: evaluate_axis now loads prompts from disk via load_prompt().
+# Step 2b still gates on conformance in main() — the other axes won't actually
+# be invoked until Step 3c (parallel orchestration), but the loader supports
+# them today so Step 3c is a pure bash-logic change, not a prompt rewrite.
+#
+# Respects MOCK_API=1 for deterministic testing without real API calls (Adj #10).
 #
 # Arguments:
-#   $1 — axis name (currently only "conformance" supported)
+#   $1 — axis name (conformance | debt | attack_surface | contract_impact)
 #   $2 — output file path
 #   $3 — diff content (the user message)
 # =============================================================================
@@ -537,6 +532,14 @@ evaluate_axis() {
     local axis="$1"
     local out="$2"
     local diff_content="$3"
+
+    case "$axis" in
+        conformance|debt|attack_surface|contract_impact) ;;
+        *)
+            log_error "evaluate_axis: unsupported axis='${axis}'"
+            return 1
+            ;;
+    esac
 
     # MOCK_API path — deterministic tests, zero API cost.
     if [ "${MOCK_API:-0}" = "1" ]; then
@@ -553,17 +556,11 @@ evaluate_axis() {
         return 0
     fi
 
-    # Real API path.
+    # Real API path — load prompt from scripts/council-prompts/${axis}.md.
     local system_prompt
-    case "$axis" in
-        conformance)
-            system_prompt=$(conformance_prompt_inline)
-            ;;
-        *)
-            log_error "evaluate_axis: unsupported axis='${axis}' (Step 2b only ships conformance)"
-            return 1
-            ;;
-    esac
+    if ! system_prompt=$(load_prompt "$axis"); then
+        return 1
+    fi
 
     anthropic_call "$system_prompt" "$diff_content" "$out"
 }
@@ -657,7 +654,7 @@ main() {
     log_info "  mock_api=${MOCK_API:-0}"
     log_info "------------------------------------------------------------"
 
-    log_info "Evaluating axis=conformance (Step 2b — conformance only)"
+    log_info "Evaluating axis=conformance (Step 3a — prompts externalized, conformance-only gate)"
     local conformance_out="${COUNCIL_TMPDIR}/conformance.json"
     if ! evaluate_axis conformance "$conformance_out" "$diff_content"; then
         log_error "conformance axis evaluation failed"


### PR DESCRIPTION
## Summary

Move the conformance system prompt out of bash heredocs into standalone markdown files under `scripts/council-prompts/`, and ship prompts for the 3 remaining axes (`debt`, `attack_surface`, `contract_impact`) so Step 3c can wire parallel orchestration without touching prompt content.

Pure refactor for `conformance` — the 3 new axes exist as content only and are **not yet invoked** by `main()` (still conformance-only gate until Step 3c).

## Why externalize

- **Reviewable**: prompt changes show up as plain markdown diffs, not bash heredoc noise
- **Calibratable**: prompts can be tuned without touching the orchestration code path
- **Council S2 Adjustment #2**: validated during plan review
- **Separation of concerns**: bash handles flow, markdown handles semantics

## Changes

| File | Kind | Size |
|------|------|------|
| `scripts/council-prompts/conformance.md` | new (extracted) | 20 lines |
| `scripts/council-prompts/debt.md` | new | 25 lines |
| `scripts/council-prompts/attack_surface.md` | new | 32 lines |
| `scripts/council-prompts/contract_impact.md` | new | 37 lines |
| `scripts/council-review.sh` | modified | +38 / -41 net |

Net diff: **+152 / -41** (well under 300 LOC limit).

### Script changes

- `conformance_prompt_inline()` deleted → replaced by generic `load_prompt(axis)` that reads `${REPO_ROOT}/scripts/council-prompts/${axis}.md`
- `load_prompt` returns exit 2 if the file is missing (fail-fast instead of shipping an empty system prompt to the API)
- `evaluate_axis()` now accepts all 4 axes via a whitelist; the MOCK_API path is unchanged
- `main()` still only invokes `conformance` — Step 3c wires the other 3
- Version bumped: `0.3.0-step2b-anthropic-call` → `0.4.0-step3a-prompts-externalized`

## Test plan

- [x] `bash -n scripts/council-review.sh` — syntax clean
- [x] `shellcheck scripts/council-review.sh` — zero warnings
- [x] `--version` prints `0.4.0-step3a-prompts-externalized`
- [x] `MOCK_API=1 council-review.sh --diff origin/main..HEAD --ticket CAB-2047` → APPROVED (exit 0, score 9/10)
- [x] `MOCK_API_FIXTURE=.../conformance-rework.json MOCK_API=1 ...` → REWORK (exit 1, score 5/10, 3 blockers)
- [x] Missing-prompt guard: temporarily removed `conformance.md`, ran without MOCK_API, got `error load_prompt: missing prompt file ...` and exit 2

## Out of scope (next steps)

- **Step 3b**: Linear ticket fetcher + `stoa-impact.db` context injection
- **Step 3c**: parallel 4-axis orchestration (the 3 new prompts start being invoked here)
- **Step 4**: `aggregate_scores` + JSONL append + bats tests
- **Step 5**: docs (`.claude/rules/council-s3.md`) + skill integration

## Review mode

**Ask** — this PR stops here for Council S3 handoff. Do not merge until human `/go`. CAB-2047 parent stays In Progress per MEGA close gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)