### PR TITLE
feat(ci): council-review.sh Step 3c — parallel 4-axis orchestration (CAB-2047)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,7 @@ kubeconfig*
 # Ephemeral agent/tool state
 .playwright-mcp/
 .claude/scheduled_tasks.lock
+
+# Council S3 (CAB-2047) — history + metrics, never commit
+council-history.jsonl
+council-history-*.jsonl

--- a/memory.md
+++ b/memory.md
@@ -1,6 +1,6 @@
 # STOA Memory
 
-> Derniere MAJ: 2026-04-03 (CAB-1953 gateway ui_url)
+> Derniere MAJ: 2026-04-11 (CAB-2047 Step 3b merged, handoff for Step 3c)
 
 ## ✅ DONE
 
@@ -78,11 +78,13 @@
 
 CAB-2046: [MEGA] Council Stage 3 — Automated Code Review (21 pts) — Council S1 8.125/10, S2 8.5/10 Go
 - Decomposed into 5 sub-issues (CAB-2047 through CAB-2051), 3-phase DAG
-- CAB-2047 (13 pts): council-review.sh — Steps 1 + 2a merged, **Step 2b next**
+- CAB-2047 (13 pts): council-review.sh — Steps 1+2a+2b+3a+3b merged, **Step 3c next**
   - ✅ Step 1: skeleton + Étape 0 pre-checks (deps, gitleaks pre-flight, portable stat, numstat, truncation 10k) — PR #2303, commit `e98e88c0`, 333 LOC
   - ✅ Step 2a: cost guardrails (COUNCIL_DISABLE kill-switch, COUNCIL_DAILY_CAP_EUR default €5, SHA dedup) — PR #2304, commit `fd8c7d66`, +134/-5 → 462 LOC
-  - ⏳ Step 2b: anthropic_call() + evaluate_axis(conformance) + MOCK_API fixtures — next session
-  - ⏳ Steps 3a/3b/3c/4/5 pending (prompts externalisés, fetchers, parallel orchestration, aggregate_scores + bats, docs)
+  - ✅ Step 2b: anthropic_call() + evaluate_axis(conformance) + MOCK_API fixtures — PR #2306, commit `9fb4a235`
+  - ✅ Step 3a: prompts externalisés → `scripts/council-prompts/{conformance,debt,attack_surface,contract_impact}.md`, `load_prompt(axis)` loader, v0.4.0 — PR #2307, merge `c7108607`, +152/-41. Only conformance invoked in main() — other 3 axes are content-only until Step 3c.
+  - ✅ Step 3b: `fetch_linear_ticket` (GraphQL issueSearch → TICKET_CONTEXT) + `fetch_db_context` (sqlite3 -readonly, match repo_path, cross-component contracts → DB_CONTEXT) + `evaluate_axis` 4th arg `extra_context` wrapped in `<context>…</context>`/`<diff>…</diff>`. TICKET_CONTEXT passed to conformance; DB_CONTEXT computed but wired in 3c. v0.5.0 — PR #2308, merge `423641f7`, +263/-7 → 949 LOC.
+  - ⏳ Steps 3c/4/5 pending (parallel 4-axis orchestration with incremental PID capture Adj #1, aggregate_scores + JSONL + bats, docs + skill integration)
 - CAB-2048 (2 pts): pre-push hook extension — blocked by CAB-2047
 - CAB-2049 (3 pts): council-gate.yml CI workflow + feature flag vars.COUNCIL_S3_ENABLED — blocked by CAB-2047
 - CAB-2050 (1 pt): council-history.jsonl rotation + gitignore — blocked by CAB-2047
@@ -90,7 +92,25 @@ CAB-2046: [MEGA] Council Stage 3 — Automated Code Review (21 pts) — Council 
 - Claim file: `.claude/claims/CAB-2046.json` — Phase 1 released for handoff (owner=null)
 - Cost guardrails active on main: €5/day hard cap, SHA dedup, COUNCIL_DISABLE kill-switch
 - Audit base: `audit-results.md` (root) — pre-implementation audit of existing Council infra
-- **Next session handoff**: read CAB-2047 Linear comments for full Council S1/S2 history + 13 adjustments v2
+- **Next session handoff (Step 3c — parallel 4-axis orchestration)**:
+  - Read CAB-2047 Linear comments for Council S1/S2 history + 13 adjustments v2
+  - Start from `scripts/council-review.sh` v0.5.0 on main (`423641f7`)
+  - Wire `DB_CONTEXT` into `contract_impact` axis call (pattern: `evaluate_axis contract_impact "$out" "$diff_content" "$DB_CONTEXT"`)
+  - Wire Trivy report into `attack_surface` (load JSON from `$TRIVY_REPORT`, pass as extra_context if present)
+  - `debt` axis: diff-only (no extra context per ticket spec)
+  - Launch 4 axes in parallel subshells with **incremental PID capture** (Adj #1 — `$!` only returns LAST PID):
+    ```
+    evaluate_axis conformance "$TMPDIR/conformance.json" "$diff" "$TICKET_CONTEXT" & PID_CONF=$!
+    evaluate_axis debt        "$TMPDIR/debt.json"        "$diff" &                   PID_DEBT=$!
+    evaluate_axis attack_surface "$TMPDIR/attack_surface.json" "$diff" "$TRIVY_CTX" & PID_ATTK=$!
+    [ "$axes_count" -eq 4 ] && { evaluate_axis contract_impact "$TMPDIR/contract_impact.json" "$diff" "$DB_CONTEXT" & PID_CTR=$!; }
+    ```
+  - Use `wait $PID` per pid with exit-code capture → increment FAILED counter on non-zero
+  - Route result files to Step 4's `aggregate_scores` function (not yet implemented)
+  - Keep conformance-only gate as fallback (e.g., via `COUNCIL_AXES_ONLY=conformance` env) until aggregate_scores lands in Step 4
+  - MOCK_API must still work: parallel subshells cp fixtures in parallel (race-free via distinct output paths)
+  - Target PR size: <300 LOC (Stripe micro-PR standard), shellcheck clean, bump version to `0.6.0-step3c-parallel-orchestration`
+- **Session log**: Step 3b completed 2026-04-11, PR #2308 merged `423641f7`, +263/-7. `council-review.sh` now 949 LOC. Context fetchers verified against HEAD~50..HEAD~40 (4 components matched, 1681-byte DB_CONTEXT).
 
 CAB-1938: fix(api) upsert conflict clauses with partial indexes — branch `fix/cab-1938-upsert-partial-index`
 - PRs #2106, #2109, #2111 merged

--- a/scripts/council-review.sh
+++ b/scripts/council-review.sh
@@ -24,6 +24,7 @@
 # CAB-2047 Step 2b: anthropic_call + evaluate_axis(conformance) + MOCK_API.
 # CAB-2047 Step 3a: externalize prompts to scripts/council-prompts/*.md.
 # CAB-2047 Step 3b: fetch_linear_ticket + fetch_db_context + evaluate_axis context injection.
+# CAB-2047 Step 3c: parallel 4-axis orchestration + aggregate_scores + council-history.jsonl.
 
 set -euo pipefail
 
@@ -31,7 +32,7 @@ set -euo pipefail
 # Script metadata
 # =============================================================================
 
-VERSION="0.5.0-step3b-context-fetchers"
+VERSION="0.6.0-step3c-parallel"
 SCRIPT_NAME="council-review.sh"
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 
@@ -74,6 +75,19 @@ log_info()  { echo "info  $*" >&2; }
 log_warn()  { echo "warn  $*" >&2; }
 log_error() { echo "error $*" >&2; }
 log_ok()    { echo "ok    $*" >&2; }
+
+# Portable monotonic-ish millisecond timestamp. GNU date supports %3N for ms,
+# but BSD date (macOS) treats the format literally and returns the seconds
+# epoch with a trailing "N". Fall back to seconds*1000 in that case.
+now_ms() {
+    local ms
+    ms=$(date +%s%3N 2>/dev/null)
+    if [[ "$ms" =~ ^[0-9]+$ ]]; then
+        echo "$ms"
+    else
+        echo $(($(date +%s) * 1000))
+    fi
+}
 
 # =============================================================================
 # Help
@@ -814,6 +828,213 @@ ${diff_content}
 }
 
 # =============================================================================
+# Step 3c: aggregate_scores — pure function over the tempdir.
+#
+# Reads $tmpdir/{conformance,debt,attack_surface,contract_impact}.json, parses
+# `.score`, and emits a single JSON verdict on stdout:
+#
+#   {"status":"APPROVED|REWORK|error","score":<avg>,"count":<n>,"errors":<e>}
+#
+# Return codes:
+#   0 — APPROVED (avg >= 8.0 over the valid axes)
+#   1 — REWORK   (avg < 8.0)
+#   2 — error    (>= 2 axes failed OR 0 valid axes)
+#
+# Skipped axes (missing file, e.g. contract_impact when DB is stale) are
+# silently ignored — the average is taken only over the ready axes.
+#
+# Designed to be testable in isolation: no globals, no side effects beyond
+# stdout.
+#
+# Arguments:
+#   $1 — tmpdir (absolute path)
+#   $2 — failed_count from the parallel wait (diagnostic)
+#   $3 — expected_count (3 when contract_impact is skipped, 4 otherwise)
+# =============================================================================
+
+aggregate_scores() {
+    local tmpdir="$1"
+    local failed_count="${2:-0}"
+    local expected_count="${3:-4}"
+    local total=0 count=0 errors=0 score
+    local axis file
+
+    # Canonical order + contract_impact appended only when expected.
+    local expected_axes=("conformance" "debt" "attack_surface")
+    if [ "$expected_count" -ge 4 ]; then
+        expected_axes+=("contract_impact")
+    fi
+
+    for axis in "${expected_axes[@]}"; do
+        file="${tmpdir}/${axis}.json"
+        # A missing or empty file for an EXPECTED axis is an error — not a
+        # silent skip. Silent skip is reserved for contract_impact when the
+        # DB is stale (expected_count=3, so the loop never visits it).
+        if [ ! -f "$file" ] || [ ! -s "$file" ]; then
+            errors=$((errors + 1))
+            continue
+        fi
+        score=$(jq -r '.score // empty' "$file" 2>/dev/null)
+        if [ -z "$score" ] || ! [[ "$score" =~ ^[0-9]+$ ]]; then
+            errors=$((errors + 1))
+            continue
+        fi
+        total=$((total + score))
+        count=$((count + 1))
+    done
+
+    # Technical failure: >=2 errored axes, or no valid axis at all.
+    if [ "$errors" -ge 2 ] || [ "$count" -eq 0 ]; then
+        jq -n -c \
+            --arg reason ">=2 axes failed or no valid result" \
+            --argjson errors "$errors" \
+            --argjson count "$count" \
+            --argjson failed "$failed_count" \
+            '{status:"error", reason:$reason, errors:$errors, count:$count, failed:$failed}'
+        return 2
+    fi
+
+    local avg
+    avg=$(awk -v t="$total" -v c="$count" 'BEGIN {printf "%.2f", t/c}')
+
+    if awk -v a="$avg" 'BEGIN {exit !(a >= 8.0)}'; then
+        jq -n -c \
+            --argjson score "$avg" \
+            --argjson count "$count" \
+            --argjson errors "$errors" \
+            '{status:"APPROVED", score:$score, count:$count, errors:$errors}'
+        return 0
+    else
+        jq -n -c \
+            --argjson score "$avg" \
+            --argjson count "$count" \
+            --argjson errors "$errors" \
+            '{status:"REWORK", score:$score, count:$count, errors:$errors}'
+        return 1
+    fi
+}
+
+# =============================================================================
+# Step 3c: sum_usage_tokens — total input/output tokens across all axis raws.
+# Anthropic responses are cached by anthropic_call() at ${out}.raw, so we just
+# glob $tmpdir/*.raw and sum the .usage fields. Missing raws (MOCK_API mode)
+# yield 0 tokens.
+#
+# Prints: "<input_tokens> <output_tokens>" on stdout.
+# =============================================================================
+
+sum_usage_tokens() {
+    local tmpdir="$1"
+    local in=0 out=0 raw i o
+    for raw in "$tmpdir"/*.raw; do
+        [ -f "$raw" ] || continue
+        i=$(jq -r '.usage.input_tokens // 0' "$raw" 2>/dev/null || echo 0)
+        o=$(jq -r '.usage.output_tokens // 0' "$raw" 2>/dev/null || echo 0)
+        [[ "$i" =~ ^[0-9]+$ ]] || i=0
+        [[ "$o" =~ ^[0-9]+$ ]] || o=0
+        in=$((in + i))
+        out=$((out + o))
+    done
+    echo "${in} ${out}"
+}
+
+# =============================================================================
+# Step 3c: compute_cost_eur — Sonnet 4.5 API pricing converted to EUR.
+#   input:  $3 /MTok → €2.76/MTok  (assuming 1 USD ≈ €0.92)
+#   output: $15/MTok → €13.80/MTok
+# Printed with 6 decimals (micro-euro granularity for daily-cap aggregation).
+# =============================================================================
+
+compute_cost_eur() {
+    local input_tokens="$1"
+    local output_tokens="$2"
+    awk -v i="$input_tokens" -v o="$output_tokens" \
+        'BEGIN {printf "%.6f", (i * 2.76 / 1e6) + (o * 13.80 / 1e6)}'
+}
+
+# =============================================================================
+# Step 3c: write_history — append one JSONL entry to council-history.jsonl.
+# Fields match the spec in CAB-2047 description. All numeric fields are real
+# JSON numbers (via --argjson), booleans are real JSON booleans, strings are
+# real JSON strings. Never fails the script — a history write error just logs
+# a warning, since the review verdict has already been computed.
+#
+# Arguments (positional, all required):
+#   $1  status           APPROVED | REWORK | error | BYPASSED
+#   $2  global_score     float (0 if status=error)
+#   $3  axes_evaluated   integer (0-4)
+#   $4  db_fresh         true | false
+#   $5  input_tokens     integer
+#   $6  output_tokens    integer
+#   $7  cost_eur         decimal string
+#   $8  diff_lines       integer
+#   $9  duration_ms      integer
+# =============================================================================
+
+write_history() {
+    local status="$1"
+    local global_score="$2"
+    local axes_evaluated="$3"
+    local db_fresh="$4"
+    local input_tokens="$5"
+    local output_tokens="$6"
+    local cost_eur="$7"
+    local diff_lines="$8"
+    local duration_ms="$9"
+
+    local timestamp
+    timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+    local total_tokens=$((input_tokens + output_tokens))
+
+    # jq builds the entry, guaranteeing valid JSON regardless of shell quoting.
+    local entry
+    entry=$(jq -n -c \
+        --arg ts "$timestamp" \
+        --arg ticket "${TICKET:-}" \
+        --arg status "$status" \
+        --argjson score "${global_score:-0}" \
+        --argjson axes "$axes_evaluated" \
+        --argjson db_fresh "$db_fresh" \
+        --arg model "$ANTHROPIC_MODEL" \
+        --argjson tokens "$total_tokens" \
+        --argjson input_tokens "$input_tokens" \
+        --argjson output_tokens "$output_tokens" \
+        --argjson cost_eur "${cost_eur:-0}" \
+        --argjson diff_lines "$diff_lines" \
+        --argjson diff_truncated "$DIFF_TRUNCATED" \
+        --argjson duration_ms "$duration_ms" \
+        --arg diff_sha "${DIFF_SHA:-unknown}" \
+        '{
+            timestamp: $ts,
+            ticket: $ticket,
+            status: $status,
+            global_score: $score,
+            axes_evaluated: $axes,
+            db_fresh: $db_fresh,
+            model: $model,
+            tokens: $tokens,
+            input_tokens: $input_tokens,
+            output_tokens: $output_tokens,
+            cost_eur: $cost_eur,
+            diff_lines: $diff_lines,
+            diff_truncated: $diff_truncated,
+            duration_ms: $duration_ms,
+            diff_sha: $diff_sha
+        }' 2>/dev/null) || {
+        log_warn "write_history: jq failed to build entry — skipping"
+        return 0
+    }
+
+    if ! echo "$entry" >> "$COUNCIL_HISTORY_FILE" 2>/dev/null; then
+        log_warn "write_history: cannot write to ${COUNCIL_HISTORY_FILE} — skipping"
+        return 0
+    fi
+
+    log_info "History appended: ${COUNCIL_HISTORY_FILE} (status=${status} score=${global_score} tokens=${total_tokens} cost=€${cost_eur})"
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -910,40 +1131,148 @@ main() {
     log_info "  mock_api=${MOCK_API:-0}"
     log_info "------------------------------------------------------------"
 
-    log_info "Evaluating axis=conformance (Step 3b — context-aware, conformance-only gate)"
+    # --- 8. Step 3c: parallel orchestration of all axes -------------------
+    log_info "Evaluating ${axes_count} axes in parallel (Step 3c)"
+
     local conformance_out="${COUNCIL_TMPDIR}/conformance.json"
-    if ! evaluate_axis conformance "$conformance_out" "$diff_content" "$TICKET_CONTEXT"; then
-        log_error "conformance axis evaluation failed"
-        exit 2
+    local debt_out="${COUNCIL_TMPDIR}/debt.json"
+    local attack_out="${COUNCIL_TMPDIR}/attack_surface.json"
+    local contract_out="${COUNCIL_TMPDIR}/contract_impact.json"
+
+    # Best-effort Trivy context for attack_surface (cap at 8KB to avoid
+    # inflating the prompt beyond what the axis actually uses).
+    local trivy_context=""
+    if [ "$trivy_loaded" = "yes" ]; then
+        trivy_context=$(head -c 8192 "$TRIVY_REPORT")
     fi
 
-    local score feedback blockers_count
-    score=$(jq -r '.score // empty' "$conformance_out")
-    feedback=$(jq -r '.feedback // empty' "$conformance_out")
-    blockers_count=$(jq -r '.blockers | length' "$conformance_out" 2>/dev/null || echo 0)
+    # Start wall-clock timer (ms resolution where supported; fallback to s*1000).
+    local start_ts end_ts duration_ms
+    start_ts=$(now_ms)
 
-    if [ -z "$score" ]; then
-        log_error "conformance result missing 'score' field"
-        log_error "Response: $(cat "$conformance_out")"
-        exit 2
+    # Launch each axis as an independent subshell writing to its own output file.
+    # PIDs are captured INCREMENTALLY (Adj #1 — $! only returns the most recent
+    # background PID, so we must grab it right after each &).
+    evaluate_axis conformance "$conformance_out" "$diff_content" "$TICKET_CONTEXT" \
+        > "${COUNCIL_TMPDIR}/conformance.stdout" \
+        2> "${COUNCIL_TMPDIR}/conformance.stderr" &
+    local pid_conformance=$!
+
+    evaluate_axis debt "$debt_out" "$diff_content" "" \
+        > "${COUNCIL_TMPDIR}/debt.stdout" \
+        2> "${COUNCIL_TMPDIR}/debt.stderr" &
+    local pid_debt=$!
+
+    evaluate_axis attack_surface "$attack_out" "$diff_content" "$trivy_context" \
+        > "${COUNCIL_TMPDIR}/attack_surface.stdout" \
+        2> "${COUNCIL_TMPDIR}/attack_surface.stderr" &
+    local pid_attack=$!
+
+    local axis_pids="$pid_conformance $pid_debt $pid_attack"
+
+    if [ "$axes_count" -eq 4 ]; then
+        evaluate_axis contract_impact "$contract_out" "$diff_content" "$DB_CONTEXT" \
+            > "${COUNCIL_TMPDIR}/contract_impact.stdout" \
+            2> "${COUNCIL_TMPDIR}/contract_impact.stderr" &
+        local pid_contract=$!
+        axis_pids="${axis_pids} ${pid_contract}"
     fi
 
-    log_ok "conformance: score=${score}/10 blockers=${blockers_count}"
-    log_info "feedback: ${feedback}"
-
-    # Step 2b binary gate on conformance only. Step 4 will aggregate over all 4 axes.
-    if [ "$score" -ge 8 ]; then
-        log_ok "conformance APPROVED (score >= 8)"
-        exit 0
-    else
-        log_warn "conformance REWORK (score < 8)"
-        if [ "$blockers_count" -gt 0 ]; then
-            jq -r '.blockers[]' "$conformance_out" | while IFS= read -r b; do
-                log_warn "  blocker: ${b}"
-            done
+    # Wait for every axis. `wait <pid>` is not disabled by `set -e` in bash 4+,
+    # but we guard with `|| true` to keep counting failures across all PIDs.
+    local failed=0 pid
+    for pid in $axis_pids; do
+        if ! wait "$pid"; then
+            failed=$((failed + 1))
         fi
-        exit 1
+    done
+
+    end_ts=$(now_ms)
+    duration_ms=$((end_ts - start_ts))
+
+    log_info "Parallel run complete: failed=${failed}/${axes_count} duration=${duration_ms}ms"
+
+    # --- 9. Per-axis summary (best-effort, before aggregation) ------------
+    local axis f axis_score axis_blockers
+    for axis in conformance debt attack_surface contract_impact; do
+        f="${COUNCIL_TMPDIR}/${axis}.json"
+        if [ -f "$f" ] && [ -s "$f" ]; then
+            axis_score=$(jq -r '.score // "?"' "$f" 2>/dev/null || echo "?")
+            axis_blockers=$(jq -r '.blockers | length' "$f" 2>/dev/null || echo 0)
+            log_ok "  ${axis}: score=${axis_score}/10 blockers=${axis_blockers}"
+        elif [ "$axis" = "contract_impact" ] && [ "$axes_count" -eq 3 ]; then
+            log_info "  ${axis}: SKIPPED (db stale/missing)"
+        else
+            log_warn "  ${axis}: NO RESULT (see ${axis}.stderr)"
+            if [ -f "${COUNCIL_TMPDIR}/${axis}.stderr" ] && [ -s "${COUNCIL_TMPDIR}/${axis}.stderr" ]; then
+                sed 's/^/    /' "${COUNCIL_TMPDIR}/${axis}.stderr" >&2 || true
+            fi
+        fi
+    done
+
+    # --- 10. Aggregate scores → verdict ------------------------------------
+    # aggregate_scores return code mirrors the verdict (0/1/2) but we parse
+    # the JSON `status` field to decide the exit — it carries strictly more
+    # information (score, count, errors) and is easier to log. `|| true`
+    # prevents set -e from killing us on REWORK (rc=1) or error (rc=2).
+    local verdict
+    verdict=$(aggregate_scores "$COUNCIL_TMPDIR" "$failed" "$axes_count" || true)
+
+    local status global_score axes_used
+    status=$(echo "$verdict" | jq -r '.status')
+    global_score=$(echo "$verdict" | jq -r '.score // 0')
+    axes_used=$(echo "$verdict" | jq -r '.count // 0')
+
+    # --- 11. Usage + cost accounting (zero under MOCK_API) ----------------
+    local tokens_line input_tokens output_tokens cost_eur
+    tokens_line=$(sum_usage_tokens "$COUNCIL_TMPDIR")
+    input_tokens=${tokens_line% *}
+    output_tokens=${tokens_line#* }
+    cost_eur=$(compute_cost_eur "$input_tokens" "$output_tokens")
+
+    local db_fresh=true
+    if [ "$axes_count" -ne 4 ]; then
+        db_fresh=false
     fi
+
+    # --- 12. Append history entry (never fails the script) ----------------
+    write_history \
+        "$status" \
+        "$global_score" \
+        "$axes_used" \
+        "$db_fresh" \
+        "$input_tokens" \
+        "$output_tokens" \
+        "$cost_eur" \
+        "$diff_lines" \
+        "$duration_ms"
+
+    # --- 13. Final verdict + blockers dump --------------------------------
+    case "$status" in
+        APPROVED)
+            log_ok "VERDICT: APPROVED (score=${global_score}/10 over ${axes_used} axes)"
+            exit 0
+            ;;
+        REWORK)
+            log_warn "VERDICT: REWORK (score=${global_score}/10 over ${axes_used} axes)"
+            for axis in conformance debt attack_surface contract_impact; do
+                f="${COUNCIL_TMPDIR}/${axis}.json"
+                [ -f "$f" ] && [ -s "$f" ] || continue
+                axis_blockers=$(jq -r '.blockers | length' "$f" 2>/dev/null || echo 0)
+                if [ "$axis_blockers" -gt 0 ]; then
+                    log_warn "  ${axis} blockers:"
+                    jq -r '.blockers[]' "$f" 2>/dev/null | while IFS= read -r b; do
+                        log_warn "    - ${b}"
+                    done
+                fi
+            done
+            exit 1
+            ;;
+        error|*)
+            log_error "VERDICT: technical failure — verdict=${verdict}"
+            exit 2
+            ;;
+    esac
 }
 
 main "$@"

--- a/tests/fixtures/council/attack_surface.json
+++ b/tests/fixtures/council/attack_surface.json
@@ -1,0 +1,5 @@
+{
+  "score": 9,
+  "feedback": "No new network endpoints. No new secret reads. curl calls are already bounded by TIMEOUT_CMD. Gitleaks pre-flight remains the strongest guardrail. sqlite3 is invoked with -readonly and comp_id interpolation is whitelisted to [a-zA-Z0-9_-].",
+  "blockers": []
+}

--- a/tests/fixtures/council/contract_impact.json
+++ b/tests/fixtures/council/contract_impact.json
@@ -1,0 +1,5 @@
+{
+  "score": 8,
+  "feedback": "Pure addition to scripts/council-review.sh + scripts/council-prompts/*, no consumer of the shell API outside CAB-2048 pre-push hook. No DB schema change, no cross-component contract break. council-history.jsonl format is append-only additive.",
+  "blockers": []
+}

--- a/tests/fixtures/council/debt.json
+++ b/tests/fixtures/council/debt.json
@@ -1,0 +1,5 @@
+{
+  "score": 8,
+  "feedback": "Low tech debt: no new TODO comments, no dead code, no duplicated blocks >20 LOC. One borderline: the aggregate_scores function is reaching 40 LOC, consider extracting score parsing if a 5th axis is added later.",
+  "blockers": []
+}


### PR DESCRIPTION
## Summary

Step 3c of CAB-2047 — wires the 4 Council axes (conformance, debt, attack_surface, contract_impact) in parallel subshells, aggregates scores into a single verdict, and appends one JSONL entry per review to `council-history.jsonl`. Replaces the Step 2b conformance-only gate.

- `aggregate_scores()` — pure function, 3 exit codes (0 APPROVED, 1 REWORK, 2 error), explicit `expected_count` so a missing file for an expected axis counts as an error (closes the silent-skip gap that let partial failures slip through as APPROVED).
- `sum_usage_tokens` / `compute_cost_eur` — parse `.usage` from each axis `${out}.raw`, convert to EUR via Sonnet 4.5 pricing for the daily-cap ledger.
- `write_history()` — append one JSONL line with all CAB-2047 DoD fields (status, global_score, axes_evaluated, db_fresh, model, tokens, cost_eur, diff_lines, diff_truncated, duration_ms, diff_sha). Never fails the script on write error.
- `now_ms()` — portable millisecond timer (GNU `date +%s%3N` on CI/Linux, `seconds*1000` fallback on macOS where BSD date returns the format literal).
- `main()` — incremental PID capture per Adj #1, wait loop tallying failures, per-axis summary, aggregate → history → final verdict.

Also: 3 missing MOCK_API fixtures (debt.json, attack_surface.json, contract_impact.json) and .gitignore entries for council-history.jsonl.

## Test plan

Tested locally with MOCK_API=1 (zero API cost):

- [x] APPROVED: 4 axes score [9, 8, 9, 8] → avg 8.50 → rc=0
- [x] REWORK: conformance swapped to rework fixture (score 5) → avg 7.50 → rc=1
- [x] ERROR: debt.json + attack_surface.json deleted → 2 failed axes → rc=2
- [x] 3-axis path: docs/stoa-impact.db moved away → axes_count=3, db_fresh=false, avg 8.67 → rc=0
- [x] JSONL history correctly written in all 4 cases (verified via jq)
- [x] Shellcheck clean on full 1278-line script
- [x] Pre-push quality gate green
- [ ] CI green

## CAB-2047 DoD deltas

- [x] 4 fonctions evaluate_axis isolées, appels parallèles via subshells + tempfiles
- [x] PIDs capturés incrémentalement (PID_X=\$! après chaque &) — Adj #1
- [x] aggregate_scores: moyenne axes ok, skip axes skipped, exit 2 si ≥2 errors
- [x] council-history.jsonl écrit avec tous les champs documentés (+ diff_sha + input_tokens/output_tokens split for future accounting)
- [x] MOCK_API=1 env var désactive les appels réels, uses fixtures — Adj #10
- [x] Shellcheck clean

Remaining for Step 4 (not in scope): bats-core test suite on aggregate_scores, .claude/rules/council-s3.md documentation.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>