### PR TITLE
feat(ci): council-review.sh Step 4 — tests + doc (CAB-2047)

### DIFF
--- a/.claude/rules/council-s3.md
+++ b/.claude/rules/council-s3.md
@@ -1,0 +1,215 @@
+---
+description: Council Stage 3 — automated 4-axis code review gate (scripts/council-review.sh)
+globs: "scripts/council-review.sh,scripts/council-prompts/**,tests/bats/council-review.bats,.claude/skills/council/SKILL.md,.github/workflows/council-gate.yml"
+---
+
+# Council Stage 3 — Automated Code Review
+
+## Overview
+
+Stage 3 is the **post-code-change** Council gate. While S1 validates ticket pertinence and S2 validates the implementation plan, **S3 validates the actual diff** before it reaches main.
+
+It runs `scripts/council-review.sh`, which evaluates a git diff via 4 independent Anthropic API calls and returns a binary verdict.
+
+```
+S1 (ticket pertinence)  →  S2 (plan validation)  →  implementation  →  S3 (code review)  →  merge
+     council:ticket-*           council:plan-*                         council-review.sh         PR merged
+```
+
+S3 is the **only Council stage that reads code instead of prose**. It is the last checkpoint before `git push` / PR merge.
+
+## Invocation
+
+```bash
+# Review the default range (origin/main..HEAD)
+scripts/council-review.sh --ticket CAB-XXXX
+
+# Review an arbitrary range
+scripts/council-review.sh --diff origin/main..feat/my-branch --ticket CAB-XXXX
+
+# Include a Trivy report to enrich the attack_surface axis
+scripts/council-review.sh --ticket CAB-XXXX --trivy-report trivy.json
+
+# Mock mode (no API calls, uses fixtures in scripts/council-prompts/fixtures/)
+MOCK_API=1 scripts/council-review.sh --ticket CAB-XXXX
+```
+
+See `scripts/council-review.sh --help` for the full CLI.
+
+## Exit Codes
+
+| Code | Meaning | Next action |
+|------|---------|-------------|
+| **0** | `APPROVED` — global score >= 8.0 (or empty diff) | Proceed to push / merge |
+| **1** | `REWORK` — global score < 8.0 | Address the blockers/warnings listed per axis, re-run |
+| **2** | Technical failure — missing deps, gitleaks block, >= 2 axes errored, etc. | Fix the infra/env issue, re-run |
+
+Exit 2 is **never a verdict**, always an operational failure. Treat it like a CI outage.
+
+## The 4 Axes
+
+Each axis is a dedicated Anthropic call with its own prompt in `scripts/council-prompts/<axis>.md`. The axes run **in parallel** (Step 3c orchestration), each scoring 0–10 with `blockers`, `warnings`, `summary`.
+
+| Axis | Role | Prompt file |
+|------|------|-------------|
+| `conformance` | Code respects repo conventions (style, naming, structure) | `scripts/council-prompts/conformance.md` |
+| `debt` | No shortcuts, TODOs, test gaps, premature abstractions | `scripts/council-prompts/debt.md` |
+| `attack_surface` | Security: input validation, authn/z, secrets, SSRF, PII, CORS, deps | `scripts/council-prompts/attack_surface.md` |
+| `contract_impact` | Cross-component contracts (API/CRD/events) — **skipped** if `docs/stoa-impact.db` is stale | `scripts/council-prompts/contract_impact.md` |
+
+### Scoring
+
+1. Each axis returns `score` ∈ {0..10}
+2. `aggregate_scores` averages the non-errored axes
+3. Result:
+   - `APPROVED` if `avg >= 8.0` and `errors < 2`
+   - `REWORK` if `avg < 8.0` and `errors < 2`
+   - `error` (exit 2) if `errors >= 2` or all axes failed
+
+### contract_impact skip logic
+
+If `docs/stoa-impact.db` is missing or older than `DB_STALE_DAYS` (default **7 days**), the `contract_impact` axis is **skipped** and `expected_count=3`. The verdict is then averaged over the 3 remaining axes and the JSONL history entry sets `db_fresh: false`.
+
+All other axes are **always expected** — a missing or empty result file for `conformance`, `debt`, or `attack_surface` counts as an error (never a silent skip).
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ANTHROPIC_API_KEY` | — | Required for real API calls (unset when `MOCK_API=1`) |
+| `ANTHROPIC_MODEL` | `claude-sonnet-4-5` | Model used for all 4 axes |
+| `ANTHROPIC_MAX_TOKENS` | `1024` | Per-call response cap |
+| `ANTHROPIC_TIMEOUT_S` | `30` | Per-call HTTP timeout |
+| `LINEAR_API_KEY` | — | Optional — enables `--ticket CAB-XXXX` context fetch from Linear GraphQL |
+| `LINEAR_TIMEOUT_S` | `10` | Linear GraphQL HTTP timeout |
+| `MOCK_API` | — | Set to `1` to use fixtures in `scripts/council-prompts/fixtures/` — no network |
+| `COUNCIL_DISABLE` | — | Set to `1` to short-circuit to APPROVED with `status: BYPASSED` (kill-switch) |
+| `COUNCIL_DAILY_CAP_EUR` | `5` | Hard daily budget from `council-history.jsonl` — exit 2 when reached |
+| `COUNCIL_FORCE_DEDUP` | — | Set to `1` to skip SHA dedup (force fresh review of an already-seen diff) |
+| `COUNCIL_HISTORY_FILE` | `<repo>/council-history.jsonl` | Append-only audit + dedup + cost ledger |
+| `TMPDIR` | `/tmp` | Parent of the per-run temp directory |
+
+All Anthropic/Linear credentials come from Vault (`stoa/shared/linear_token`, `stoa/k8s/anthropic_api_key`) in production. Never commit them.
+
+## JSONL History Schema
+
+Each run appends one line to `council-history.jsonl`:
+
+```json
+{
+  "timestamp": "2026-04-11T18:30:00Z",
+  "ticket": "CAB-2047",
+  "status": "APPROVED",
+  "global_score": 8.75,
+  "axes_evaluated": 4,
+  "db_fresh": true,
+  "model": "claude-sonnet-4-5",
+  "tokens": 14230,
+  "input_tokens": 12100,
+  "output_tokens": 2130,
+  "cost_eur": 0.062724,
+  "diff_lines": 412,
+  "diff_truncated": false,
+  "duration_ms": 4821,
+  "diff_sha": "a1b2c3d4e5f6..."
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `status` | string | `APPROVED` \| `REWORK` \| `error` \| `BYPASSED` |
+| `global_score` | number | Average of valid axes (0 when `status=error`) |
+| `axes_evaluated` | integer | 0–4 (3 when DB stale) |
+| `db_fresh` | bool | `false` when `contract_impact` was skipped |
+| `tokens` | integer | `input_tokens + output_tokens` (0 in MOCK_API mode) |
+| `cost_eur` | number | Sonnet 4.5 pricing: €2.76/MTok in, €13.80/MTok out |
+| `diff_lines` | integer | Lines in the diff (post-truncation if applied) |
+| `diff_truncated` | bool | `true` when the diff exceeded `MAX_DIFF_LINES` (10000) |
+| `duration_ms` | integer | Wall-clock time from start to verdict |
+| `diff_sha` | string | SHA-256 of the canonical diff — used for dedup |
+
+The file is append-only. Rotation is handled in CAB-2050.
+
+## Cost Guardrails
+
+Three independent safeguards, all introduced in Step 2a:
+
+1. **`COUNCIL_DISABLE=1`** — emergency kill-switch. Script exits 0 with `status: BYPASSED`, logs to history, **does not call the API**.
+2. **Daily cap** (`COUNCIL_DAILY_CAP_EUR`, default €5) — before each run, the script sums `cost_eur` across today's UTC entries in `council-history.jsonl`. If the sum exceeds the cap, the run exits **2** with an explanatory log line and never calls the API.
+3. **SHA dedup** — the script computes SHA-256 of the diff and checks history for an existing entry with the same `diff_sha`. On a hit, it replays the prior verdict (exit 0/1) and does **not** re-call the API. Bypass with `COUNCIL_FORCE_DEDUP=1`.
+
+All three are verified by the Step 2a commit and protected by bats tests (Step 4). In MOCK_API mode, cost is always 0 and the guardrails are no-ops.
+
+## Pre-flight
+
+Before any API call, S3 runs these **Étape 0** checks (Step 1):
+
+1. Required deps present: `git`, `jq`, `curl`, `sqlite3`, `gitleaks`, `shasum`/`sha256sum`
+2. `gitleaks detect --no-banner --staged=false --source=<tmpdiff>` — **any** secret in the diff → exit 2
+3. Portable `stat` helper (GNU vs BSD)
+4. `git diff --numstat` — count lines, compare against `MAX_DIFF_LINES`=10000
+5. Truncation: diffs > 10k lines are truncated at 10k lines, `diff_truncated=true` in history
+
+A gitleaks hit is a **hard stop**. Never bypass — fix the secret or use `.gitleaks.toml` allowlist.
+
+## Tests
+
+Unit tests live in `tests/bats/council-review.bats` and use bats-core. They source `council-review.sh` directly (guarded by `[[ "${BASH_SOURCE[0]}" == "${0}" ]]`) and call the pure helpers against fixture tmpdirs.
+
+Coverage:
+
+| Helper | Scenarios |
+|--------|-----------|
+| `aggregate_scores` | APPROVED (avg >= 8), REWORK (avg < 8), 3 ok + 1 error, 2 errors → exit 2, `contract_impact` skipped, all-errored, score exactly 8.0, missing `conformance` counts as error |
+| `sum_usage_tokens` | 4 raws summed, no raws → `0 0`, malformed raw → 0 |
+| `compute_cost_eur` | 1M input, 1M output, realistic (12k/2k), zero |
+
+Run:
+
+```bash
+bats tests/bats/council-review.bats
+```
+
+See `tests/bats/README.md` for the bats convention.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `exit 2` + `gitleaks: secret detected` | Real secret or false positive in diff | Remove the secret or update `.gitleaks.toml` allowlist |
+| `exit 2` + `daily cap reached` | `cost_eur` sum today ≥ `COUNCIL_DAILY_CAP_EUR` | Wait for UTC midnight, or raise cap intentionally in CI `vars` |
+| `exit 0` but no API call in logs | SHA dedup hit on an existing `council-history.jsonl` entry | Expected. `COUNCIL_FORCE_DEDUP=1` to force a fresh review |
+| `axes_evaluated: 3` and `db_fresh: false` | `docs/stoa-impact.db` missing or older than 7 days | Run `docs/scripts/post-change-learn.sh` to refresh, or accept — it's a designed skip |
+| `exit 2` + `>=2 axes failed` | API outage, prompt parse error, or rate-limit | Check `${tmpdir}/<axis>.raw` files — re-run after upstream is healthy |
+| Wrong verdict on a real diff | Prompt tuning needed | Edit `scripts/council-prompts/<axis>.md`, re-run against the same diff with `COUNCIL_FORCE_DEDUP=1` |
+| MOCK_API returns unexpected score | Stale fixtures | Update `scripts/council-prompts/fixtures/<axis>.json` |
+| History file fills disk | Not yet rotated | CAB-2050 implements rotation — for now, truncate after review |
+
+## FAQ
+
+**Q: Does S3 replace S1/S2?**
+No. S1 checks whether the ticket is worth doing at all (pertinence). S2 checks whether the plan is sound (design). S3 checks whether the code delivers the plan cleanly (implementation). All three are composable and complementary.
+
+**Q: Is my code sent to Anthropic?**
+Yes, the diff content is posted to the Messages API. Per Anthropic ToS, API traffic is **not used for training**. For extra safety, gitleaks runs pre-flight to block any secret from leaving the machine.
+
+**Q: Why 4 axes and not 1 big prompt?**
+Isolation. Independent axes produce more reliable scores, parallelize cleanly, and let you tune one prompt without affecting the others. The `contract_impact` axis in particular is opt-in based on DB freshness.
+
+**Q: Can I override the 8.0 threshold?**
+Not without changing the script. The threshold is hard-coded in `aggregate_scores` so the verdict is binary and reproducible. Calibration happens through prompt tuning, not threshold drift.
+
+**Q: What if I disagree with the verdict?**
+Read the per-axis `blockers` and `warnings` in the run output. If they're spurious, tune the prompt (`scripts/council-prompts/<axis>.md`) and re-run with `COUNCIL_FORCE_DEDUP=1`. If you still disagree, override at the PR level with a human review — S3 is a gate, not an oracle.
+
+**Q: Can I run S3 locally before pushing?**
+Yes — that's the intended flow for CAB-2048 (pre-push hook extension). Today you can invoke `scripts/council-review.sh` manually on any branch.
+
+## References
+
+- Skill: `.claude/skills/council/SKILL.md` — S1/S2 workflow
+- Script: `scripts/council-review.sh` — v0.7.0 (Step 4)
+- Prompts: `scripts/council-prompts/{conformance,debt,attack_surface,contract_impact}.md`
+- Tests: `tests/bats/council-review.bats`
+- Impact DB: `docs/stoa-impact.db` (`docs/DEPENDENCIES.md`, `docs/SCENARIOS.md`)
+- Tickets: CAB-2046 (MEGA) → CAB-2047 (script) / CAB-2048 (pre-push) / CAB-2049 (CI) / CAB-2050 (rotation) / CAB-2051 (shadow)

--- a/.claude/skills/council/SKILL.md
+++ b/.claude/skills/council/SKILL.md
@@ -6,6 +6,16 @@ argument-hint: "<description of what to build>"
 
 # Council Validation — $ARGUMENTS
 
+## Three-Stage Council
+
+This skill drives **Stage 1 (ticket pertinence)** and **Stage 2 (plan validation)** — both prose-based, 4-persona scoring.
+
+**Stage 3 (code review)** runs **after implementation** on the actual diff, via `scripts/council-review.sh` (4-axis: conformance, debt, attack_surface, contract_impact). It is **not** invoked by this skill — it is wired to the pre-push hook (CAB-2048) and `council-gate.yml` CI workflow (CAB-2049). See `.claude/rules/council-s3.md` for full docs.
+
+```
+S1 (this skill, prose)  →  S2 (this skill, plan)  →  implementation  →  S3 (council-review.sh, diff)  →  merge
+```
+
 ## Step 1: Gather Context
 
 Read and understand the feature/ADR/change description. Gather context from:
@@ -271,6 +281,29 @@ Linear: <URL>
 plan.md: updated
 Next: say "go" to start implementation, or "adjust <feedback>" to revise
 ```
+
+## Step 4c: Stage 3 — Automated Code Review (post-implementation)
+
+Stage 3 is **not run by this skill**. It runs automatically against the diff once implementation is complete, via `scripts/council-review.sh`. Shape:
+
+| Axis | Role |
+|------|------|
+| `conformance` | Repo conventions, style, naming, structure |
+| `debt` | Shortcuts, TODOs, test gaps, premature abstractions |
+| `attack_surface` | Input validation, authn/z, secrets, SSRF, PII, CORS, deps |
+| `contract_impact` | Cross-component contracts (skipped when `docs/stoa-impact.db` is stale) |
+
+Exit codes: `0` APPROVED (avg >= 8.0), `1` REWORK, `2` technical failure.
+
+Trigger points (when wired):
+
+| Level | Trigger | How |
+|-------|---------|-----|
+| Local pre-push | `git push` | Pre-push hook extension (CAB-2048) |
+| CI | PR opened | `.github/workflows/council-gate.yml` feature-flagged via `vars.COUNCIL_S3_ENABLED` (CAB-2049) |
+| Manual | Any diff | `scripts/council-review.sh --ticket CAB-XXXX --diff <range>` |
+
+When S3 returns REWORK, address the per-axis blockers/warnings and re-run. Full documentation: `.claude/rules/council-s3.md`.
 
 ## Rules
 

--- a/scripts/council-review.sh
+++ b/scripts/council-review.sh
@@ -25,6 +25,7 @@
 # CAB-2047 Step 3a: externalize prompts to scripts/council-prompts/*.md.
 # CAB-2047 Step 3b: fetch_linear_ticket + fetch_db_context + evaluate_axis context injection.
 # CAB-2047 Step 3c: parallel 4-axis orchestration + aggregate_scores + council-history.jsonl.
+# CAB-2047 Step 4: source guard for bats test suite + .claude/rules/council-s3.md + skill update.
 
 set -euo pipefail
 
@@ -32,7 +33,7 @@ set -euo pipefail
 # Script metadata
 # =============================================================================
 
-VERSION="0.6.0-step3c-parallel"
+VERSION="0.7.0-step4-tests-doc"
 SCRIPT_NAME="council-review.sh"
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 
@@ -1275,4 +1276,8 @@ main() {
     esac
 }
 
-main "$@"
+# Only run main when executed directly. When sourced (e.g. from bats tests),
+# function definitions load without side effects.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/bats/README.md
+++ b/tests/bats/README.md
@@ -1,0 +1,39 @@
+# Bats Tests
+
+Bash unit tests for shell scripts in `scripts/`, using [bats-core](https://bats-core.readthedocs.io/).
+
+## Install
+
+```bash
+# macOS
+brew install bats-core
+
+# Ubuntu / CI
+sudo apt-get install -y bats
+```
+
+## Run
+
+```bash
+# All bats tests
+bats tests/bats/
+
+# Single file
+bats tests/bats/council-review.bats
+```
+
+## Suites
+
+| File | Covers |
+|------|--------|
+| `council-review.bats` | `scripts/council-review.sh` helpers (CAB-2047): `aggregate_scores`, `sum_usage_tokens`, `compute_cost_eur` |
+
+## Conventions
+
+- Each `.bats` file sources the script under test. Scripts must guard their entrypoint
+  with `[[ "${BASH_SOURCE[0]}" == "${0}" ]] && main "$@"` so sourcing does not run `main`.
+- Use `setup()` / `teardown()` to create and clean up per-test tmpdirs.
+- Helpers for fixture construction belong at the top of the file.
+- No network calls — fixtures only. For Anthropic/Linear-backed scripts, use `MOCK_API=1`.
+
+See `.claude/rules/council-s3.md` for the Council S3 specification.

--- a/tests/bats/council-review.bats
+++ b/tests/bats/council-review.bats
@@ -1,0 +1,259 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 STOA Platform
+#
+# council-review.bats — unit tests for scripts/council-review.sh
+#
+# CAB-2047 Step 4: covers the pure helpers extracted in Step 3c —
+#   - aggregate_scores <tmpdir> <failed_count> <expected_count>
+#   - sum_usage_tokens <tmpdir>
+#   - compute_cost_eur <input_tokens> <output_tokens>
+#
+# Tests source council-review.sh directly. The script guards `main "$@"`
+# behind `BASH_SOURCE[0] == $0`, so sourcing loads functions without
+# executing main.
+#
+# Run: bats tests/bats/council-review.bats
+
+SCRIPT_PATH="${BATS_TEST_DIRNAME}/../../scripts/council-review.sh"
+
+setup() {
+    # shellcheck source=/dev/null
+    source "$SCRIPT_PATH"
+
+    TEST_TMPDIR=$(mktemp -d)
+}
+
+teardown() {
+    if [ -n "${TEST_TMPDIR:-}" ] && [ -d "$TEST_TMPDIR" ]; then
+        rm -rf "$TEST_TMPDIR"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Fixture helpers
+# -----------------------------------------------------------------------------
+
+# Write a valid axis result JSON with the given score.
+write_axis_result() {
+    local axis="$1"
+    local score="$2"
+    cat > "${TEST_TMPDIR}/${axis}.json" <<EOF
+{
+  "score": ${score},
+  "blockers": [],
+  "warnings": [],
+  "summary": "fixture axis ${axis} score ${score}"
+}
+EOF
+}
+
+# Write an invalid/empty axis result (simulates an errored axis).
+write_empty_axis_result() {
+    local axis="$1"
+    : > "${TEST_TMPDIR}/${axis}.json"
+}
+
+# Write a usage raw (Anthropic response shape) for token sum tests.
+write_usage_raw() {
+    local axis="$1"
+    local input="$2"
+    local output="$3"
+    cat > "${TEST_TMPDIR}/${axis}.raw" <<EOF
+{
+  "content": [{"type": "text", "text": "stub"}],
+  "usage": {"input_tokens": ${input}, "output_tokens": ${output}}
+}
+EOF
+}
+
+# =============================================================================
+# aggregate_scores — 5 canonical DoD scenarios (CAB-2047 Adj #9)
+# =============================================================================
+
+@test "aggregate_scores: 4 axes all ok, avg >= 8.0 → APPROVED exit 0" {
+    write_axis_result conformance 9
+    write_axis_result debt 8
+    write_axis_result attack_surface 9
+    write_axis_result contract_impact 8
+
+    run aggregate_scores "$TEST_TMPDIR" 0 4
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"status":"APPROVED"'* ]]
+    [[ "$output" == *'"count":4'* ]]
+    [[ "$output" == *'"errors":0'* ]]
+    # Average is (9+8+9+8)/4 = 8.50
+    [[ "$output" == *'"score":8.5'* ]]
+}
+
+@test "aggregate_scores: 4 axes all ok, avg < 8.0 → REWORK exit 1" {
+    write_axis_result conformance 7
+    write_axis_result debt 7
+    write_axis_result attack_surface 8
+    write_axis_result contract_impact 7
+
+    run aggregate_scores "$TEST_TMPDIR" 0 4
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"status":"REWORK"'* ]]
+    [[ "$output" == *'"count":4'* ]]
+    [[ "$output" == *'"errors":0'* ]]
+    # Average is (7+7+8+7)/4 = 7.25
+    [[ "$output" == *'"score":7.25'* ]]
+}
+
+@test "aggregate_scores: 3 axes ok + 1 errored → averaged over 3, count=3 errors=1" {
+    write_axis_result conformance 9
+    write_axis_result debt 9
+    write_axis_result attack_surface 9
+    write_empty_axis_result contract_impact
+
+    run aggregate_scores "$TEST_TMPDIR" 0 4
+
+    # 1 error is below the >=2 threshold — verdict still computed over 3 axes.
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"status":"APPROVED"'* ]]
+    [[ "$output" == *'"count":3'* ]]
+    [[ "$output" == *'"errors":1'* ]]
+    [[ "$output" == *'"score":9'* ]]
+}
+
+@test "aggregate_scores: 2 axes errored → exit 2 technical failure" {
+    write_axis_result conformance 9
+    write_axis_result debt 9
+    write_empty_axis_result attack_surface
+    write_empty_axis_result contract_impact
+
+    run aggregate_scores "$TEST_TMPDIR" 2 4
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'"status":"error"'* ]]
+    [[ "$output" == *'"errors":2'* ]]
+    [[ "$output" == *'"count":2'* ]]
+    [[ "$output" == *'"failed":2'* ]]
+}
+
+@test "aggregate_scores: contract_impact skipped (expected_count=3) → avg over 3" {
+    write_axis_result conformance 8
+    write_axis_result debt 8
+    write_axis_result attack_surface 9
+    # contract_impact intentionally absent — DB stale, so expected_count=3.
+
+    run aggregate_scores "$TEST_TMPDIR" 0 3
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"status":"APPROVED"'* ]]
+    [[ "$output" == *'"count":3'* ]]
+    [[ "$output" == *'"errors":0'* ]]
+    # Average is (8+8+9)/3 ≈ 8.33
+    [[ "$output" == *'"score":8.33'* ]]
+}
+
+# =============================================================================
+# Additional edge cases — defensive coverage
+# =============================================================================
+
+@test "aggregate_scores: all 4 axes errored → exit 2, count=0" {
+    write_empty_axis_result conformance
+    write_empty_axis_result debt
+    write_empty_axis_result attack_surface
+    write_empty_axis_result contract_impact
+
+    run aggregate_scores "$TEST_TMPDIR" 4 4
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'"status":"error"'* ]]
+    [[ "$output" == *'"errors":4'* ]]
+    [[ "$output" == *'"count":0'* ]]
+}
+
+@test "aggregate_scores: score exactly 8.0 → APPROVED" {
+    write_axis_result conformance 8
+    write_axis_result debt 8
+    write_axis_result attack_surface 8
+    write_axis_result contract_impact 8
+
+    run aggregate_scores "$TEST_TMPDIR" 0 4
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"status":"APPROVED"'* ]]
+    [[ "$output" == *'"score":8'* ]]
+}
+
+@test "aggregate_scores: missing conformance (expected) counts as error, not silent skip" {
+    # conformance is in the expected_axes list, so its absence should be
+    # counted — not silently skipped.
+    write_axis_result debt 9
+    write_axis_result attack_surface 9
+    write_axis_result contract_impact 9
+
+    run aggregate_scores "$TEST_TMPDIR" 0 4
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"errors":1'* ]]
+    [[ "$output" == *'"count":3'* ]]
+}
+
+# =============================================================================
+# sum_usage_tokens — token aggregation across axis .raw files
+# =============================================================================
+
+@test "sum_usage_tokens: sums input and output across all .raw files" {
+    write_usage_raw conformance 1000 500
+    write_usage_raw debt 800 400
+    write_usage_raw attack_surface 1200 600
+    write_usage_raw contract_impact 900 450
+
+    run sum_usage_tokens "$TEST_TMPDIR"
+
+    [ "$status" -eq 0 ]
+    # Expected: 1000+800+1200+900 = 3900 input ; 500+400+600+450 = 1950 output
+    [ "$output" = "3900 1950" ]
+}
+
+@test "sum_usage_tokens: no .raw files → 0 0" {
+    run sum_usage_tokens "$TEST_TMPDIR"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "0 0" ]
+}
+
+@test "sum_usage_tokens: malformed .raw file → treated as 0" {
+    echo "not json" > "${TEST_TMPDIR}/conformance.raw"
+    write_usage_raw debt 100 50
+
+    run sum_usage_tokens "$TEST_TMPDIR"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "100 50" ]
+}
+
+# =============================================================================
+# compute_cost_eur — Sonnet 4.5 pricing (€2.76/MTok in, €13.80/MTok out)
+# =============================================================================
+
+@test "compute_cost_eur: 1M input / 0 output → 2.760000 EUR" {
+    run compute_cost_eur 1000000 0
+    [ "$status" -eq 0 ]
+    [ "$output" = "2.760000" ]
+}
+
+@test "compute_cost_eur: 0 input / 1M output → 13.800000 EUR" {
+    run compute_cost_eur 0 1000000
+    [ "$status" -eq 0 ]
+    [ "$output" = "13.800000" ]
+}
+
+@test "compute_cost_eur: realistic 4-axis call (12k in, 2k out) → under 0.10 EUR" {
+    run compute_cost_eur 12000 2000
+    [ "$status" -eq 0 ]
+    # Expected: 12000*2.76/1e6 + 2000*13.80/1e6 = 0.03312 + 0.02760 = 0.060720
+    [ "$output" = "0.060720" ]
+}
+
+@test "compute_cost_eur: zero tokens → 0.000000" {
+    run compute_cost_eur 0 0
+    [ "$status" -eq 0 ]
+    [ "$output" = "0.000000" ]
+}


### PR DESCRIPTION
## Summary

Step 4 of CAB-2047 — the `scripts/council-review.sh` saga. **No script logic changes** — only a source-guard plus unit tests, documentation, and skill cross-reference.

- `scripts/council-review.sh` v0.7.0 — guards `main \"\$@\"` behind `[[ \"\${BASH_SOURCE[0]}\" == \"\${0}\" ]]` so bats can source without triggering main.
- `tests/bats/council-review.bats` — 15 unit tests on `aggregate_scores`, `sum_usage_tokens`, `compute_cost_eur`, covering the 5 DoD scenarios (Adj #9) + 3 edge cases.
- `.claude/rules/council-s3.md` — scoped (via globs) rule documenting the 4-axis model, exit codes, env vars, JSONL schema, cost guardrails, pre-flight checks, troubleshooting, FAQ.
- `.claude/skills/council/SKILL.md` — cross-reference S3 (this skill drives S1+S2 only; S3 runs post-implementation on the diff).
- `tests/bats/README.md` — install + run convention, source-guard pattern for bats-sourced scripts.

## DoD Coverage (CAB-2047 Adj #9)

```
bats tests/bats/council-review.bats
1..15
ok 1 aggregate_scores: 4 axes all ok, avg >= 8.0 → APPROVED exit 0
ok 2 aggregate_scores: 4 axes all ok, avg < 8.0 → REWORK exit 1
ok 3 aggregate_scores: 3 axes ok + 1 errored → averaged over 3, count=3 errors=1
ok 4 aggregate_scores: 2 axes errored → exit 2 technical failure
ok 5 aggregate_scores: contract_impact skipped (expected_count=3) → avg over 3
ok 6 aggregate_scores: all 4 axes errored → exit 2, count=0
ok 7 aggregate_scores: score exactly 8.0 → APPROVED
ok 8 aggregate_scores: missing conformance (expected) counts as error, not silent skip
ok 9 sum_usage_tokens: sums input and output across all .raw files
ok 10 sum_usage_tokens: no .raw files → 0 0
ok 11 sum_usage_tokens: malformed .raw file → treated as 0
ok 12 compute_cost_eur: 1M input / 0 output → 2.760000 EUR
ok 13 compute_cost_eur: 0 input / 1M output → 13.800000 EUR
ok 14 compute_cost_eur: realistic 4-axis call (12k in, 2k out) → under 0.10 EUR
ok 15 compute_cost_eur: zero tokens → 0.000000
```

Shellcheck clean on `scripts/council-review.sh`. CLI still works (`bash scripts/council-review.sh --version` → `0.7.0-step4-tests-doc`).

## Test plan

- [x] `bats tests/bats/council-review.bats` — 15/15 green locally (bats-core 1.13.0)
- [x] `shellcheck scripts/council-review.sh` — clean
- [x] `bash scripts/council-review.sh --help` — help renders (main still runs when executed directly)
- [x] `bash -c 'source scripts/council-review.sh'` — sources without executing main
- [x] Rules budget lint — new rule is scoped (globs present), no always-loaded budget impact
- [ ] CI green (License, SBOM, Signed Commits, Regression Guard)

## References

- CAB-2047 Step 4 scope (DoD Adj #9)
- Parent MEGA: CAB-2046 (Council Stage 3)
- Prior steps: #2303, #2304, #2306, #2307, #2308, #2310