### PR TITLE
feat(ci): Council S3 conditional in pre-push hook (CAB-2048)

### DIFF
--- a/.claude/hooks/pre-push-quality-gate.sh
+++ b/.claude/hooks/pre-push-quality-gate.sh
@@ -5,6 +5,8 @@
 #
 # Kill switch: DISABLE_PRE_PUSH_GATE=1
 # Skip for specific push: SKIP_QUALITY_GATE=1 git push ...
+# Council S3 kill-switch: DISABLE_COUNCIL_GATE=1 (skip council-review.sh only)
+# Council S3 threshold: COUNCIL_MIN_DIFF_LINES=20 (below = CI-only)
 
 set -euo pipefail
 
@@ -130,4 +132,31 @@ fi
 if [ "$CHECKS_RUN" -gt 0 ]; then
   echo "✅ Pre-push quality gate passed ($CHECKS_RUN checks)" >&2
 fi
+
+# --- Council Stage 3 (CAB-2046 / CAB-2048) ---
+# Conditional on diff size: small diffs go through CI (council-gate.yml) only.
+COUNCIL_HISTORY_FILE="${COUNCIL_HISTORY_FILE:-${REPO_ROOT}/council-history.jsonl}"
+COUNCIL_MIN_DIFF_LINES="${COUNCIL_MIN_DIFF_LINES:-20}"
+COUNCIL_DIFF_LINES=$(git diff --numstat "${MERGE_BASE}" HEAD 2>/dev/null \
+  | awk '{sum+=$1+$2} END {print sum+0}')
+
+if [ "${DISABLE_COUNCIL_GATE:-}" = "1" ]; then
+  echo "⏭️  Council S3 BYPASSED (DISABLE_COUNCIL_GATE=1)" >&2
+  printf '{"timestamp":"%s","status":"BYPASSED","reason":"local_kill_switch","diff_lines":%s}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$COUNCIL_DIFF_LINES" >> "$COUNCIL_HISTORY_FILE"
+elif [ "$COUNCIL_DIFF_LINES" -lt "$COUNCIL_MIN_DIFF_LINES" ]; then
+  echo "⏭️  Council S3 SKIPPED (diff $COUNCIL_DIFF_LINES lines < $COUNCIL_MIN_DIFF_LINES — CI-only)" >&2
+elif [ ! -x "$REPO_ROOT/scripts/council-review.sh" ]; then
+  echo "⏭️  Council S3 SKIPPED (scripts/council-review.sh missing or not executable)" >&2
+else
+  echo "⏳ [council:s3] running ($COUNCIL_DIFF_LINES diff lines)..." >&2
+  if ! "$REPO_ROOT/scripts/council-review.sh" --diff "${MERGE_BASE}..HEAD" 1>&2; then
+    echo "" >&2
+    echo "🚫 Council S3 REWORK — address blockers above, then push again" >&2
+    echo "To bypass (emergency): DISABLE_COUNCIL_GATE=1 git push ..." >&2
+    exit 2
+  fi
+  echo "✅ [council:s3] APPROVED" >&2
+fi
+
 exit 0


### PR DESCRIPTION
## Summary
- Extends `.claude/hooks/pre-push-quality-gate.sh` to run `scripts/council-review.sh` after existing lint/format/compile/a11y checks when the diff is large enough to warrant review.
- Threshold `COUNCIL_MIN_DIFF_LINES` (default 20) keeps small diffs fast (~60s pre-push) — they still get reviewed by CI (`council-gate.yml`, CAB-2049).
- Local kill-switch `DISABLE_COUNCIL_GATE=1` emits a `BYPASSED` entry to `council-history.jsonl` and exits 0, so emergency pushes stay unblocked and auditable.
- Graceful SKIPPED fallback when `scripts/council-review.sh` is missing/non-executable, so partial checkouts don't brick `git push`.

## Logic
```
diff < 20 lines                           → SKIPPED (CI-only)
DISABLE_COUNCIL_GATE=1                    → BYPASSED (logged to jsonl)
council-review.sh missing                 → SKIPPED (fallback)
council-review.sh exit 0                  → APPROVED, push proceeds
council-review.sh exit 1 or 2             → exit 2 (push blocked)
```

## Test plan
Manually exercised all 4 branches on a probe commit (30 lines outside every component dir) using mocked PreToolUse stdin:

- [x] **A — BYPASSED**: `DISABLE_COUNCIL_GATE=1` → exit 0, jsonl entry written: `{"status":"BYPASSED","reason":"local_kill_switch","diff_lines":59}`
- [x] **B — threshold SKIPPED**: `COUNCIL_MIN_DIFF_LINES=9999` → exit 0, no API call, clear SKIPPED log
- [x] **C — missing script fallback**: `mv scripts/council-review.sh ...bak` → exit 0, "missing or not executable" message
- [x] **D — Council invoked**: diff ≥ 20 lines, `council-review.sh --diff MERGE_BASE..HEAD` runs, exits 2 when verdict is REWORK or technical error, prints bypass hint
- [x] No regression on existing checks (lint/format/tsc/axe) — classification and run_check blocks untouched
- [x] shellcheck clean on new code (pre-existing SC2294 on `eval` unchanged)
- [x] LOC: +29 (target was 30-50, hard cap 100)

## Invariants preserved
- Hook stays a Claude Code PreToolUse hook (exit 2 = block tool call)
- Reuses existing `MERGE_BASE` and `REPO_ROOT` — no duplicate git plumbing
- `COUNCIL_HISTORY_FILE` env var matches `council-review.sh` default (`${REPO_ROOT}/council-history.jsonl`)
- Works from any PWD (the hook `cd`s into `REPO_ROOT` earlier)

Refs: CAB-2046 (MEGA), CAB-2047 (council-review.sh script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)