### PR TITLE
fix(gateway): correct insta redaction path for mcp-capabilities

### DIFF
--- a/stoa-gateway/tests/contract/discovery.rs
+++ b/stoa-gateway/tests/contract/discovery.rs
@@ -25,7 +25,9 @@ async fn test_mcp_capabilities_shape() {
     assert_eq!(status, axum::http::StatusCode::OK);
     let json: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
     assert_json_snapshot!("mcp-capabilities", json, {
-        ".server.version" => "[version]",
+        ".serverInfo.version" => "[version]",
+        ".serverInfo.protocolVersion" => "[protocol_version]",
+        ".protocolVersion" => "[protocol_version]",
     });
 }
 

--- a/stoa-gateway/tests/contract/snapshots/contract__discovery__mcp-capabilities.snap
+++ b/stoa-gateway/tests/contract/snapshots/contract__discovery__mcp-capabilities.snap
@@ -27,10 +27,10 @@ expression: json
       "listChanged": true
     }
   },
-  "protocolVersion": "2025-11-25",
+  "protocolVersion": "[protocol_version]",
   "serverInfo": {
     "name": "STOA Gateway",
-    "protocolVersion": "2025-11-25",
-    "version": "0.9.1"
+    "protocolVersion": "[protocol_version]",
+    "version": "[version]"
   }
 }


### PR DESCRIPTION
## Root cause

The redaction `.server.version` in `tests/contract/discovery.rs:28` never matched because `/mcp/capabilities` returns `serverInfo` (not `server`). The raw version string got baked into the stored snapshot. When release-please bumped `stoa-gateway` from 0.9.1 to 0.9.3 (#2291), the contract test `discovery::test_mcp_capabilities_shape` failed on main with a snapshot drift panic.

## Fix

- `tests/contract/discovery.rs`: replace `.server.version` with `.serverInfo.version`, `.serverInfo.protocolVersion`, and root `.protocolVersion`
- `tests/contract/snapshots/contract__discovery__mcp-capabilities.snap`: replace hardcoded `"0.9.1"` / `"2025-11-25"` with `[version]` / `[protocol_version]` placeholders

## Verification

Local: `cargo test --test contract discovery::test_mcp_capabilities_shape` → ok (1 passed).
cargo fmt --check → clean.
cargo clippy --tests -- -D warnings → clean.

## Impact

Unblocks STOA Gateway CI/CD on main → Docker build + GitOps dispatch → ArgoCD sync with new 0.9.3 image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>