### PR TITLE
chore(docs): cab-2053 phase 1 closeout — plan.md sync

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -478,9 +478,9 @@ _(none — all active items either Done or In Review)_
 ### Todo
 
 **🚨 FREEZE ACTIVE — Council-validated 2026-04-11 8.0/10 Go**:
-- [~] CAB-2053: [MEGA] Feature freeze + CLI-first stabilization — break the 3-week loop (21 pts, P1-High) — Phase 0 started 2026-04-11
-  - **Phase 0** [~] — Feature freeze policy declared in memory.md + plan.md
-  - **Phase 1** [owner: —] — Drain In Review queue (39 tickets C15)
+- [~] CAB-2053: [MEGA] Feature freeze + CLI-first stabilization — break the 3-week loop (21 pts, P1-High) — **Phase 1 done 2026-04-12**
+  - **Phase 0** [x] — Feature freeze policy declared in memory.md + plan.md (PR #2318)
+  - **Phase 1** [x] — In Review queue drained 43→0 (25 Done, 3 Canceled, 15 Todo)
   - **Phase 2** [owner: —] — Bug recurrence root cause (1 fix par classe, pas par symptôme)
   - **Phase 3** [owner: —] — stoactl completeness 100% (apply -f tous les kinds + get/delete/list manquants) — **coeur du MEGA**
   - **Phase 4** [owner: —] — Schema registry unifié gostoa.dev/v1beta1 (conversion webhook)
@@ -540,6 +540,7 @@ _(none — all active items either Done or In Review)_
 - [ ] CAB-2041: Dossier technique — Réponses instances d'archi post-démo (P2)
 - [ ] CAB-2042: Présentation — Comité d'architecture STOA (P2)
 - [ ] CAB-2043: Benchmark gateway — STOA vs concurrents, backend co-localisé VPS (P2)
+- [ ] CAB-2054: [MEGA] feat(council): align S1/S2 to 8 personas per HEG-PAT-003 (13 pts) — Council 8.5/10 Go
 
 ---
 


### PR DESCRIPTION
## Summary

Ship-mode docs-only PR — closes out CAB-2053 Phase 1 on plan.md.

Phase 1 (In Review queue drain) completed 2026-04-12:
- **25 tickets → Done** (state drift, PRs already merged)
- **3 tickets → Canceled** (superseded by CAB-2053 Phase 3)
- **15 tickets → Todo** (legitimate WIP + re-evaluation)

Also embarks one orphan addition from a parallel session: `CAB-2054` ticket entry added to the P3 backlog list.

Note: `memory.md` Phase 1 section was already synced via PR #2325 (parallel handoff session merged while this session was triaging). Only `plan.md` needed this commit.

Linear breakdown posted on CAB-2053 as a dedicated comment (methodology + observations + next Phase 2 candidates).

## Test plan
- [x] Pre-push quality gate (docs-only, skipped)
- [ ] CI green (Required: License, SBOM, Signed Commits, Regression Test Guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)