### PR TITLE
fix(docs): add Domain N/A baseline rule to council skill (CAB-2054)

### DIFF
--- a/.claude/skills/council/SKILL.md
+++ b/.claude/skills/council/SKILL.md
@@ -49,6 +49,8 @@ If `build-context.sh` or `stoa-impact.db` is not available, skip this step with 
 
 Evaluate $ARGUMENTS through each of the 8 canonical personas. **All 8 are mandatory** — no subset selection, no quick mode. The canonical roster is defined in `hegemon/patterns/validation/HEG-PAT-003-team-coca-adversarial-validation.md`.
 
+**Domain N/A baseline (calibration rule from CAB-2054 Phase 4)**: when a ticket does not touch a persona's domain (e.g., a backend infra ticket has no webapp surface for N3m0), score the persona at **8/10** (neutral-positive: "no concern detected"), not 6-7. Lower scores must be backed by an actual identified concern. This rule keeps the 8-persona average stable vs the historical 4-persona baseline (calibration drift < ±0.3 on 4/5 historic tickets).
+
 ### 1. Chucky (Devil's Advocate) — Score /10
 - Challenges assumptions and finds weaknesses
 - Questions: Is this really needed? What could go wrong? What's the hidden complexity? How would I break this?


### PR DESCRIPTION
## Summary

Phase 4 calibration tuning. Adds explicit "Domain N/A → 8/10 baseline" rule to the Council Step 2 header so that personas without a concern in their domain don't drag the 8-persona average down.

## Why

Phase 4 calibration on 5 historic tickets (CAB-2046, 2010, 2009, 1989, 2054) found that the 8-persona scoring drifts -0.46 average vs the historical 4-persona baseline because the 4 new personas (N3m0, Gh0st, Pr1nc3ss, Gekk0) score 6-7 by default for tickets out of their domain.

| Round | Within ±0.3 | Pass rate |
|-------|-------------|-----------|
| 1 (no rule) | 1/5 | FAIL |
| 2 (with rule) | 4/5 | PASS (≥3/5) |

This is iteration 2 of 2 (cap from plan adjustment a). Calibration converges; full report posted as comment on CAB-2054.

## Test plan

- [x] Calibration round 2 passes (4/5 within ±0.3)
- [x] Single 2-line addition, no other behavioral change
- [ ] CI green
- [ ] Smoke test on next /council invocation

## References

- CAB-2054 Phase 4 calibration report (Linear comment)
- Phase 3 (8-persona rewrite): merged in #2327
- Plan adjustment (a): 2-iteration cap with user escalation if still drifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)