### PR TITLE
fix(ci): pre-push hook scope api linting to src/ (CAB-2053 phase 2)

### DIFF
--- a/.claude/hooks/pre-push-quality-gate.sh
+++ b/.claude/hooks/pre-push-quality-gate.sh
@@ -87,8 +87,13 @@ run_check() {
 
 # Python (control-plane-api)
 if [ "$HAS_PYTHON_API" = "true" ]; then
-  run_check "api:ruff" "cd $REPO_ROOT/control-plane-api && ruff check ."
-  run_check "api:black" "cd $REPO_ROOT/control-plane-api && black --check ."
+  # Scope: src/ only — matches CI exactly (reusable-python-ci.yml runs ruff check src/).
+  # tests/ has pre-existing violations out of CI scope; linting them here blocked pushes
+  # on unrelated legacy debt (CAB-2053 Phase 2 bug class #7).
+  # black removed: CI does NOT run black (reusable-python-ci.yml only runs ruff + mypy).
+  # src/ has 83 pre-existing black violations that CI tolerates — hook should not be
+  # stricter than CI.
+  run_check "api:ruff" "cd $REPO_ROOT/control-plane-api && ruff check src/"
 fi
 
 # Console (control-plane-ui)


### PR DESCRIPTION
## Summary

Docs/config Ship-mode PR. Fixes CAB-2053 Phase 2 bug class #7 (pre-push hook stricter than CI).

### Problem

\`.claude/hooks/pre-push-quality-gate.sh\` was running:
\`\`\`
cd control-plane-api && ruff check .
cd control-plane-api && black --check .
\`\`\`

Both include \`tests/\` which has **667 pre-existing ruff violations** and **229 pre-existing black violations**. CI only runs \`ruff check src/\` + \`mypy src/\` (source of truth: \`.github/workflows/reusable-python-ci.yml:70,76\`). The hook was therefore stricter than CI and blocked legitimate pushes on unrelated legacy debt.

### Fix

- \`ruff check .\` → \`ruff check src/\` (match CI scope)
- \`black --check .\` → **removed entirely** (CI does not run black; src/ has 83 pre-existing black violations, hook cannot be stricter than CI)

### Observed impact

Blocked PR #2329 (mypy fixes) earlier this session — had to bypass with \`SKIP_QUALITY_GATE=1\`. Documented bypass in #2329 body.

### Test plan
- [x] \`ruff check src/\` clean locally
- [ ] CI green (docs-only, no component triggers)
- [ ] Next push attempt on a Python-touching PR goes through without bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)