### PR TITLE
chore(deps): block major npm version bumps in dependabot (CAB-2053 phase 2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 3
+    # Block major bumps — too many breaking incidents (Vite 8, Tailwind 4, ESLint 10). Major upgrades via dedicated tickets.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-portal:
         patterns: ["*"]
@@ -41,6 +45,10 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 3
+    # Block major bumps — too many breaking incidents (Vite 8, Tailwind 4, ESLint 10). Major upgrades via dedicated tickets.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-ui:
         patterns: ["*"]


### PR DESCRIPTION
## Summary
- Add `ignore` rules to block major version bumps (`version-update:semver-major`) for npm ecosystems in `control-plane-ui` and `portal` directories
- Prevents repeat incidents where Dependabot auto-bumped major versions (Vite 8, Tailwind 4, ESLint 10, TypeScript 6, react-is peer deps) and broke builds
- Minor and patch bumps continue to flow normally

## Test plan
- [ ] CI green (required checks: License Compliance, SBOM Generation, Verify Signed Commits)
- [ ] Verify next Dependabot run does not propose major bumps for portal/control-plane-ui

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>