### PR TITLE
feat(cli): add full resource CRUD to stoactl (CAB-2053 phase 3)

### DIFF
--- a/.claude/rules/stoactl-usage.md
+++ b/.claude/rules/stoactl-usage.md
@@ -15,7 +15,7 @@ globs: "stoa-go/**,scripts/ops/**,control-plane-api/src/routers/**"
 - Build: `cd stoa-go && go build -o bin/stoactl ./cmd/stoactl/`
 - If `stoactl` not in PATH, use `stoa-go/bin/stoactl` directly
 
-## Available Commands (Phase 0+1)
+## Available Commands (Phase 0+1+3)
 
 | Operation | stoactl command | Replaces |
 |-----------|----------------|----------|
@@ -24,12 +24,31 @@ globs: "stoa-go/**,scripts/ops/**,control-plane-api/src/routers/**"
 | Audit log export | `stoactl audit export --tenant X --since 7d` | `curl /v1/audit` |
 | Audit compliance CSV | `stoactl audit export --tenant X --since 30d --output csv` | Manual API + jq |
 | API listing | `stoactl get apis` | `curl /v1/tenants/{t}/apis` |
-| Apply resource | `stoactl apply -f api.yaml` | `curl -X POST /v1/...` |
+| Apply resource | `stoactl apply -f <file>` | `curl -X POST /v1/...` |
 | Gateway health | `stoactl gateway health` | `curl /health` |
 | MCP tools list | `stoactl mcp list-tools` | `curl /mcp/tools/list` |
 | Bridge OpenAPI→MCP | `stoactl bridge -f openapi.yaml` | Manual conversion |
 | Auth status | `stoactl auth status` | `curl /v1/auth/me` |
 | System diagnostics | `stoactl doctor` | Manual checks |
+| Consumer listing | `stoactl get consumers` | `curl /v1/consumers/{t}` |
+| Contract listing | `stoactl get contracts` | `curl /v1/tenants/{t}/contracts` |
+| Service account listing | `stoactl get service-accounts` | `curl /v1/service-accounts` |
+| Environment listing | `stoactl get environments` | `curl /v1/environments` |
+| Plan listing | `stoactl get plans` | `curl /v1/plans/{t}` |
+| Webhook listing | `stoactl get webhooks` | `curl /v1/tenants/{t}/webhooks` |
+| Delete any resource | `stoactl delete <kind> <id>` | `curl -X DELETE /v1/...` |
+
+### Apply Supported Kinds (Phase 3)
+
+`stoactl apply -f` supports: **API**, **Tenant**, **Gateway**, **Subscription**, **Consumer**, **Contract**, **MCPServer**, **ServiceAccount**, **Plan**, **Webhook**.
+
+### Get Supported Resources (Phase 3)
+
+`stoactl get` supports: **apis**, **tenants**, **subscriptions**, **gateways**, **consumers**, **contracts**, **service-accounts**, **environments**, **plans**, **webhooks**.
+
+### Delete Supported Resources (Phase 3)
+
+`stoactl delete` supports: **api**, **tenant**, **gateway**, **subscription**, **consumer**, **contract**, **service-account**, **plan**, **webhook**.
 
 ## When to Use in AI Factory
 

--- a/stoa-go/internal/cli/cmd/apply/apply.go
+++ b/stoa-go/internal/cli/cmd/apply/apply.go
@@ -4,6 +4,8 @@ package apply
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 
@@ -30,9 +32,15 @@ func NewApplyCmd() *cobra.Command {
 The resource will be created if it doesn't exist, or updated if it does.
 This command is idempotent and safe to run multiple times.
 
+Supported kinds: API, Tenant, Gateway, Subscription, Consumer, Contract,
+MCPServer, ServiceAccount, Plan, Webhook.
+
 Examples:
   # Apply an API definition
   stoactl apply -f api.yaml
+
+  # Apply a consumer
+  stoactl apply -f consumer.yaml
 
   # Apply multiple resources from a directory
   stoactl apply -f ./manifests/
@@ -127,10 +135,98 @@ func applyFile(c *client.Client, path string) error {
 		if err := c.CreateOrUpdateAPI(&resource); err != nil {
 			return fmt.Errorf("failed to apply %s/%s: %w", resource.Kind, resource.Metadata.Name, err)
 		}
+	case "Tenant":
+		if err := applyGeneric(c, "/v1/tenants", resource); err != nil {
+			return fmt.Errorf("failed to apply %s/%s: %w", resource.Kind, resource.Metadata.Name, err)
+		}
+	case "Gateway":
+		if err := applyGeneric(c, "/v1/admin/gateways", resource); err != nil {
+			return fmt.Errorf("failed to apply %s/%s: %w", resource.Kind, resource.Metadata.Name, err)
+		}
+	case "Subscription":
+		if err := applyGeneric(c, "/v1/subscriptions", resource); err != nil {
+			return fmt.Errorf("failed to apply %s/%s: %w", resource.Kind, resource.Metadata.Name, err)
+		}
+	case "Consumer":
+		tenant := tenantFromResource(c, resource)
+		if err := applyGeneric(c, fmt.Sprintf("/v1/consumers/%s", tenant), resource); err != nil {
+			return fmt.Errorf("failed to apply %s/%s: %w", resource.Kind, resource.Metadata.Name, err)
+		}
+	case "Contract":
+		tenant := tenantFromResource(c, resource)
+		if err := applyGeneric(c, fmt.Sprintf("/v1/tenants/%s/contracts", tenant), resource); err != nil {
+			return fmt.Errorf("failed to apply %s/%s: %w", resource.Kind, resource.Metadata.Name, err)
+		}
+	case "MCPServer":
+		spec, _ := resource.Spec.(map[string]any)
+		displayName, _ := spec["displayName"].(string)
+		description, _ := spec["description"].(string)
+		if _, err := c.CreateMCPServer(resource.Metadata.Name, displayName, description); err != nil {
+			return fmt.Errorf("failed to apply %s/%s: %w", resource.Kind, resource.Metadata.Name, err)
+		}
+	case "ServiceAccount":
+		if err := applyGeneric(c, "/v1/service-accounts", resource); err != nil {
+			return fmt.Errorf("failed to apply %s/%s: %w", resource.Kind, resource.Metadata.Name, err)
+		}
+	case "Plan":
+		tenant := tenantFromResource(c, resource)
+		if err := applyGeneric(c, fmt.Sprintf("/v1/plans/%s", tenant), resource); err != nil {
+			return fmt.Errorf("failed to apply %s/%s: %w", resource.Kind, resource.Metadata.Name, err)
+		}
+	case "Webhook":
+		tenant := tenantFromResource(c, resource)
+		if err := applyGeneric(c, fmt.Sprintf("/v1/tenants/%s/webhooks", tenant), resource); err != nil {
+			return fmt.Errorf("failed to apply %s/%s: %w", resource.Kind, resource.Metadata.Name, err)
+		}
 	default:
 		return fmt.Errorf("unsupported resource kind: %s", resource.Kind)
 	}
 
 	output.Success("%s/%s configured", resource.Kind, resource.Metadata.Name)
 	return nil
+}
+
+// applyGeneric sends a POST to the given path with the resource spec merged with metadata.
+// The API endpoint is expected to handle create-or-update semantics.
+func applyGeneric(c *client.Client, path string, resource types.Resource) error {
+	body := buildApplyBody(resource)
+
+	resp, err := c.Do("POST", path, body)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return nil
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("API error (%d): %s", resp.StatusCode, string(respBody))
+}
+
+// buildApplyBody merges resource metadata.name into the spec map for the API payload.
+func buildApplyBody(resource types.Resource) map[string]any {
+	body := make(map[string]any)
+	body["name"] = resource.Metadata.Name
+
+	if specMap, ok := resource.Spec.(map[string]any); ok {
+		for k, v := range specMap {
+			body[k] = v
+		}
+	}
+
+	if len(resource.Metadata.Labels) > 0 {
+		body["labels"] = resource.Metadata.Labels
+	}
+
+	return body
+}
+
+// tenantFromResource returns the tenant from metadata.namespace or falls back to the client's configured tenant.
+func tenantFromResource(c *client.Client, resource types.Resource) string {
+	if resource.Metadata.Namespace != "" {
+		return resource.Metadata.Namespace
+	}
+	return c.TenantID()
 }

--- a/stoa-go/internal/cli/cmd/apply/apply_test.go
+++ b/stoa-go/internal/cli/cmd/apply/apply_test.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2026 CAB Ingénierie / Christophe ABOULICAM
+package apply
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stoa-platform/stoa-go/pkg/types"
+)
+
+func TestBuildApplyBody_WithSpec(t *testing.T) {
+	resource := types.Resource{
+		APIVersion: "stoa.io/v1",
+		Kind:       "Consumer",
+		Metadata: types.Metadata{
+			Name:      "my-consumer",
+			Namespace: "acme",
+			Labels:    map[string]string{"env": "prod"},
+		},
+		Spec: map[string]any{
+			"email":        "user@example.com",
+			"display_name": "My Consumer",
+		},
+	}
+
+	body := buildApplyBody(resource)
+
+	if body["name"] != "my-consumer" {
+		t.Errorf("body[name] = %q, want %q", body["name"], "my-consumer")
+	}
+	if body["email"] != "user@example.com" {
+		t.Errorf("body[email] = %q, want %q", body["email"], "user@example.com")
+	}
+	if body["display_name"] != "My Consumer" {
+		t.Errorf("body[display_name] = %q, want %q", body["display_name"], "My Consumer")
+	}
+	labels, ok := body["labels"].(map[string]string)
+	if !ok {
+		t.Fatal("body[labels] is not map[string]string")
+	}
+	if labels["env"] != "prod" {
+		t.Errorf("body[labels][env] = %q, want %q", labels["env"], "prod")
+	}
+}
+
+func TestBuildApplyBody_NoSpec(t *testing.T) {
+	resource := types.Resource{
+		APIVersion: "stoa.io/v1",
+		Kind:       "Tenant",
+		Metadata:   types.Metadata{Name: "acme"},
+		Spec:       nil,
+	}
+
+	body := buildApplyBody(resource)
+
+	if body["name"] != "acme" {
+		t.Errorf("body[name] = %q, want %q", body["name"], "acme")
+	}
+	// Should only have "name" key when spec is nil
+	if len(body) != 1 {
+		t.Errorf("body has %d keys, want 1 (name only)", len(body))
+	}
+}
+
+func TestBuildApplyBody_SpecNotMap(t *testing.T) {
+	resource := types.Resource{
+		APIVersion: "stoa.io/v1",
+		Kind:       "Tenant",
+		Metadata:   types.Metadata{Name: "acme"},
+		Spec:       "invalid-spec",
+	}
+
+	body := buildApplyBody(resource)
+
+	// Should still have name even when spec is not a map
+	if body["name"] != "acme" {
+		t.Errorf("body[name] = %q, want %q", body["name"], "acme")
+	}
+}
+
+func TestApplyFile_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(path, []byte(":::invalid:::"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := applyFile(nil, path)
+	if err == nil {
+		t.Error("applyFile() with invalid YAML should return error")
+	}
+}
+
+func TestApplyFile_MissingKind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "no-kind.yaml")
+	content := `apiVersion: stoa.io/v1
+metadata:
+  name: test
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := applyFile(nil, path)
+	if err == nil {
+		t.Error("applyFile() with missing kind should return error")
+	}
+}
+
+func TestApplyFile_MissingName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "no-name.yaml")
+	content := `apiVersion: stoa.io/v1
+kind: Tenant
+metadata: {}
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := applyFile(nil, path)
+	if err == nil {
+		t.Error("applyFile() with missing name should return error")
+	}
+}
+
+func TestApplyFile_UnsupportedKind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unsupported.yaml")
+	content := `apiVersion: stoa.io/v1
+kind: UnknownThing
+metadata:
+  name: test
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Will fail because client is nil, but should reach the kind switch first
+	// for validation tests that don't need a server. However since applyFile
+	// requires a non-nil client for non-dry-run, and UnsupportedKind would
+	// need to reach the switch, let's just verify the error message pattern.
+	err := applyFile(nil, path)
+	if err == nil {
+		t.Error("applyFile() with unsupported kind should return error")
+	}
+}
+
+func TestRunApply_MissingFile(t *testing.T) {
+	filePath = "/nonexistent/path/file.yaml"
+	dryRun = false
+
+	err := runApply(nil, nil)
+	if err == nil {
+		t.Error("runApply() with nonexistent file should return error")
+	}
+}
+
+func TestRunApply_EmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	filePath = dir
+	dryRun = false
+
+	err := runApply(nil, nil)
+	if err == nil {
+		t.Error("runApply() with empty directory should return error")
+	}
+}

--- a/stoa-go/internal/cli/cmd/delete/delete.go
+++ b/stoa-go/internal/cli/cmd/delete/delete.go
@@ -16,17 +16,31 @@ func NewDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete resources",
-		Long: `Delete resources by name.
+		Long: `Delete resources by name or ID.
 
 Examples:
   # Delete an API
   stoactl delete api billing-api
 
   # Delete multiple APIs
-  stoactl delete api billing-api payments-api`,
+  stoactl delete api billing-api payments-api
+
+  # Delete a consumer
+  stoactl delete consumer abc-123
+
+  # Delete a contract
+  stoactl delete contract my-contract-id`,
 	}
 
 	cmd.AddCommand(newDeleteAPICmd())
+	cmd.AddCommand(newDeleteTenantCmd())
+	cmd.AddCommand(newDeleteGatewayCmd())
+	cmd.AddCommand(newDeleteSubscriptionCmd())
+	cmd.AddCommand(newDeleteConsumerCmd())
+	cmd.AddCommand(newDeleteContractCmd())
+	cmd.AddCommand(newDeleteServiceAccountCmd())
+	cmd.AddCommand(newDeletePlanCmd())
+	cmd.AddCommand(newDeleteWebhookCmd())
 
 	return cmd
 }
@@ -60,6 +74,154 @@ func runDeleteAPI(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		output.Success("api %q deleted", name)
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("%d resource(s) failed to delete", len(errors))
+	}
+
+	return nil
+}
+
+func newDeleteTenantCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "tenant <id> [id...]",
+		Aliases: []string{"tenants"},
+		Short:   "Delete one or more tenants",
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := client.New()
+			if err != nil {
+				return err
+			}
+			return deleteResources(args, "tenant", c.DeleteTenant)
+		},
+	}
+}
+
+func newDeleteGatewayCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "gateway <id> [id...]",
+		Aliases: []string{"gateways", "gw"},
+		Short:   "Delete one or more gateway instances",
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := client.New()
+			if err != nil {
+				return err
+			}
+			return deleteResources(args, "gateway", c.DeleteGateway)
+		},
+	}
+}
+
+func newDeleteSubscriptionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "subscription <id> [id...]",
+		Aliases: []string{"subscriptions", "sub", "subs"},
+		Short:   "Delete one or more subscriptions",
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := client.New()
+			if err != nil {
+				return err
+			}
+			return deleteResources(args, "subscription", c.DeleteSubscription)
+		},
+	}
+}
+
+func newDeleteConsumerCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "consumer <id> [id...]",
+		Aliases: []string{"consumers"},
+		Short:   "Delete one or more consumers",
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := client.New()
+			if err != nil {
+				return err
+			}
+			return deleteResources(args, "consumer", c.DeleteConsumer)
+		},
+	}
+}
+
+func newDeleteContractCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "contract <id> [id...]",
+		Aliases: []string{"contracts", "uac"},
+		Short:   "Delete one or more contracts",
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := client.New()
+			if err != nil {
+				return err
+			}
+			return deleteResources(args, "contract", c.DeleteContract)
+		},
+	}
+}
+
+func newDeleteServiceAccountCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "service-account <id> [id...]",
+		Aliases: []string{"service-accounts", "sa"},
+		Short:   "Delete one or more service accounts",
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := client.New()
+			if err != nil {
+				return err
+			}
+			return deleteResources(args, "service-account", c.DeleteServiceAccount)
+		},
+	}
+}
+
+func newDeletePlanCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "plan <id> [id...]",
+		Aliases: []string{"plans"},
+		Short:   "Delete one or more subscription plans",
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := client.New()
+			if err != nil {
+				return err
+			}
+			return deleteResources(args, "plan", c.DeletePlan)
+		},
+	}
+}
+
+func newDeleteWebhookCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "webhook <id> [id...]",
+		Aliases: []string{"webhooks", "wh"},
+		Short:   "Delete one or more webhooks",
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := client.New()
+			if err != nil {
+				return err
+			}
+			return deleteResources(args, "webhook", c.DeleteWebhook)
+		},
+	}
+}
+
+// deleteResources is a generic batch-delete helper. It iterates over IDs,
+// calls the deleteFn for each, accumulates errors, and returns a summary error.
+func deleteResources(ids []string, kind string, deleteFn func(string) error) error {
+	var errors []error
+	for _, id := range ids {
+		if err := deleteFn(id); err != nil {
+			output.Error("Failed to delete %s %q: %v", kind, id, err)
+			errors = append(errors, err)
+			continue
+		}
+		output.Success("%s %q deleted", kind, id)
 	}
 
 	if len(errors) > 0 {

--- a/stoa-go/internal/cli/cmd/delete/delete_test.go
+++ b/stoa-go/internal/cli/cmd/delete/delete_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2026 CAB Ingénierie / Christophe ABOULICAM
+package delete
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNewDeleteCmd_HasAllSubcommands(t *testing.T) {
+	cmd := NewDeleteCmd()
+
+	expected := []string{
+		"api",
+		"tenant",
+		"gateway",
+		"subscription",
+		"consumer",
+		"contract",
+		"service-account",
+		"plan",
+		"webhook",
+	}
+
+	commands := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		// Use field may include args (e.g., "api <name> [name...]"), extract first word
+		use := sub.Use
+		for i, ch := range use {
+			if ch == ' ' {
+				use = use[:i]
+				break
+			}
+		}
+		commands[use] = true
+	}
+
+	for _, name := range expected {
+		if !commands[name] {
+			t.Errorf("delete command missing %q subcommand", name)
+		}
+	}
+}
+
+func TestDeleteResources_AllSucceed(t *testing.T) {
+	deleted := []string{}
+	deleteFn := func(id string) error {
+		deleted = append(deleted, id)
+		return nil
+	}
+
+	err := deleteResources([]string{"a", "b", "c"}, "test", deleteFn)
+	if err != nil {
+		t.Fatalf("deleteResources() error = %v, want nil", err)
+	}
+	if len(deleted) != 3 {
+		t.Errorf("deleteResources() deleted %d items, want 3", len(deleted))
+	}
+}
+
+func TestDeleteResources_SomeFail(t *testing.T) {
+	deleteFn := func(id string) error {
+		if id == "bad" {
+			return fmt.Errorf("not found")
+		}
+		return nil
+	}
+
+	err := deleteResources([]string{"good", "bad", "also-good"}, "test", deleteFn)
+	if err == nil {
+		t.Error("deleteResources() error = nil, want error when some fail")
+	}
+}
+
+func TestDeleteResources_AllFail(t *testing.T) {
+	deleteFn := func(id string) error {
+		return fmt.Errorf("fail")
+	}
+
+	err := deleteResources([]string{"a", "b"}, "test", deleteFn)
+	if err == nil {
+		t.Error("deleteResources() error = nil, want error when all fail")
+	}
+}
+
+func TestDeleteTenantCmd_RequiresArgs(t *testing.T) {
+	cmd := newDeleteTenantCmd()
+	err := cmd.Args(cmd, []string{})
+	if err == nil {
+		t.Error("delete tenant should require at least 1 argument")
+	}
+}
+
+func TestDeleteConsumerCmd_RequiresArgs(t *testing.T) {
+	cmd := newDeleteConsumerCmd()
+	err := cmd.Args(cmd, []string{})
+	if err == nil {
+		t.Error("delete consumer should require at least 1 argument")
+	}
+}
+
+func TestDeleteContractCmd_Aliases(t *testing.T) {
+	cmd := newDeleteContractCmd()
+	aliases := make(map[string]bool)
+	for _, a := range cmd.Aliases {
+		aliases[a] = true
+	}
+	if !aliases["contracts"] {
+		t.Error("delete contract missing 'contracts' alias")
+	}
+	if !aliases["uac"] {
+		t.Error("delete contract missing 'uac' alias")
+	}
+}
+
+func TestDeleteGatewayCmd_Aliases(t *testing.T) {
+	cmd := newDeleteGatewayCmd()
+	aliases := make(map[string]bool)
+	for _, a := range cmd.Aliases {
+		aliases[a] = true
+	}
+	if !aliases["gw"] {
+		t.Error("delete gateway missing 'gw' alias")
+	}
+}

--- a/stoa-go/internal/cli/cmd/get/get.go
+++ b/stoa-go/internal/cli/cmd/get/get.go
@@ -47,6 +47,12 @@ Examples:
 	cmd.AddCommand(newGetTenantsCmd())
 	cmd.AddCommand(newGetSubscriptionsCmd())
 	cmd.AddCommand(newGetGatewaysCmd())
+	cmd.AddCommand(newGetConsumersCmd())
+	cmd.AddCommand(newGetContractsCmd())
+	cmd.AddCommand(newGetServiceAccountsCmd())
+	cmd.AddCommand(newGetEnvironmentsCmd())
+	cmd.AddCommand(newGetPlansCmd())
+	cmd.AddCommand(newGetWebhooksCmd())
 
 	return cmd
 }
@@ -386,6 +392,377 @@ func newGetGatewaysCmd() *cobra.Command {
 				var rows [][]string
 				for _, g := range resp.Items {
 					rows = append(rows, []string{g.ID, g.Name, g.GatewayType, g.Status, g.BaseURL})
+				}
+				printer.PrintTable(headers, rows)
+			}
+
+			return nil
+		},
+	}
+}
+
+func newGetConsumersCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "consumers [id]",
+		Aliases: []string{"consumer"},
+		Short:   "Display consumers",
+		Args:    cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := client.New()
+			if err != nil {
+				return err
+			}
+
+			format := output.ParseFormat(outputFormat)
+			printer := output.NewPrinter(format)
+
+			if len(args) == 1 {
+				consumer, err := c.GetConsumer(args[0])
+				if err != nil {
+					return err
+				}
+				switch printer.Format {
+				case output.FormatJSON:
+					return printer.PrintJSON(consumer)
+				case output.FormatYAML:
+					return printer.PrintYAML(consumer)
+				default:
+					headers := []string{"ID", "NAME", "EMAIL", "STATUS", "TENANT"}
+					rows := [][]string{{consumer.ID, consumer.Name, consumer.Email, consumer.Status, consumer.TenantID}}
+					printer.PrintTable(headers, rows)
+				}
+				return nil
+			}
+
+			resp, err := c.ListConsumers()
+			if err != nil {
+				return err
+			}
+
+			if len(resp.Items) == 0 {
+				output.Info("No consumers found.")
+				return nil
+			}
+
+			switch printer.Format {
+			case output.FormatJSON:
+				return printer.PrintJSON(resp.Items)
+			case output.FormatYAML:
+				return printer.PrintYAML(resp.Items)
+			case output.FormatWide:
+				headers := []string{"ID", "NAME", "DISPLAY NAME", "EMAIL", "STATUS", "TENANT", "CREATED"}
+				var rows [][]string
+				for _, cs := range resp.Items {
+					rows = append(rows, []string{
+						cs.ID, cs.Name, cs.DisplayName, cs.Email, cs.Status, cs.TenantID, cs.CreatedAt,
+					})
+				}
+				printer.PrintTable(headers, rows)
+			default:
+				headers := []string{"ID", "NAME", "EMAIL", "STATUS"}
+				var rows [][]string
+				for _, cs := range resp.Items {
+					rows = append(rows, []string{cs.ID, cs.Name, cs.Email, cs.Status})
+				}
+				printer.PrintTable(headers, rows)
+			}
+
+			return nil
+		},
+	}
+}
+
+func newGetContractsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "contracts [id]",
+		Aliases: []string{"contract", "uac"},
+		Short:   "Display Universal API Contracts",
+		Args:    cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := client.New()
+			if err != nil {
+				return err
+			}
+
+			format := output.ParseFormat(outputFormat)
+			printer := output.NewPrinter(format)
+
+			if len(args) == 1 {
+				contract, err := c.GetContract(args[0])
+				if err != nil {
+					return err
+				}
+				switch printer.Format {
+				case output.FormatJSON:
+					return printer.PrintJSON(contract)
+				case output.FormatYAML:
+					return printer.PrintYAML(contract)
+				default:
+					headers := []string{"ID", "NAME", "VERSION", "STATUS", "TENANT"}
+					rows := [][]string{{contract.ID, contract.Name, contract.Version, contract.Status, contract.TenantID}}
+					printer.PrintTable(headers, rows)
+				}
+				return nil
+			}
+
+			resp, err := c.ListContracts()
+			if err != nil {
+				return err
+			}
+
+			if len(resp.Items) == 0 {
+				output.Info("No contracts found.")
+				return nil
+			}
+
+			switch printer.Format {
+			case output.FormatJSON:
+				return printer.PrintJSON(resp.Items)
+			case output.FormatYAML:
+				return printer.PrintYAML(resp.Items)
+			case output.FormatWide:
+				headers := []string{"ID", "NAME", "DISPLAY NAME", "VERSION", "STATUS", "TENANT", "CREATED"}
+				var rows [][]string
+				for _, ct := range resp.Items {
+					rows = append(rows, []string{
+						ct.ID, ct.Name, ct.DisplayName, ct.Version, ct.Status, ct.TenantID, ct.CreatedAt,
+					})
+				}
+				printer.PrintTable(headers, rows)
+			default:
+				headers := []string{"ID", "NAME", "VERSION", "STATUS"}
+				var rows [][]string
+				for _, ct := range resp.Items {
+					rows = append(rows, []string{ct.ID, ct.Name, ct.Version, ct.Status})
+				}
+				printer.PrintTable(headers, rows)
+			}
+
+			return nil
+		},
+	}
+}
+
+func newGetServiceAccountsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "service-accounts",
+		Aliases: []string{"service-account", "sa"},
+		Short:   "Display service accounts",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := client.New()
+			if err != nil {
+				return err
+			}
+
+			format := output.ParseFormat(outputFormat)
+			printer := output.NewPrinter(format)
+
+			accounts, err := c.ListServiceAccounts()
+			if err != nil {
+				return err
+			}
+
+			if len(accounts) == 0 {
+				output.Info("No service accounts found.")
+				return nil
+			}
+
+			switch printer.Format {
+			case output.FormatJSON:
+				return printer.PrintJSON(accounts)
+			case output.FormatYAML:
+				return printer.PrintYAML(accounts)
+			default:
+				headers := []string{"ID", "NAME", "CLIENT ID", "STATUS", "CREATED"}
+				var rows [][]string
+				for _, sa := range accounts {
+					rows = append(rows, []string{sa.ID, sa.Name, sa.ClientID, sa.Status, sa.CreatedAt})
+				}
+				printer.PrintTable(headers, rows)
+			}
+
+			return nil
+		},
+	}
+}
+
+func newGetEnvironmentsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "environments",
+		Aliases: []string{"environment", "env", "envs"},
+		Short:   "Display environments",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := client.New()
+			if err != nil {
+				return err
+			}
+
+			format := output.ParseFormat(outputFormat)
+			printer := output.NewPrinter(format)
+
+			resp, err := c.ListEnvironments()
+			if err != nil {
+				return err
+			}
+
+			if len(resp.Items) == 0 {
+				output.Info("No environments found.")
+				return nil
+			}
+
+			switch printer.Format {
+			case output.FormatJSON:
+				return printer.PrintJSON(resp.Items)
+			case output.FormatYAML:
+				return printer.PrintYAML(resp.Items)
+			default:
+				headers := []string{"ID", "NAME", "TYPE", "URL", "STATUS"}
+				var rows [][]string
+				for _, e := range resp.Items {
+					rows = append(rows, []string{e.ID, e.Name, e.Type, e.URL, e.Status})
+				}
+				printer.PrintTable(headers, rows)
+			}
+
+			return nil
+		},
+	}
+}
+
+func newGetPlansCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "plans [id]",
+		Aliases: []string{"plan"},
+		Short:   "Display subscription plans",
+		Args:    cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := client.New()
+			if err != nil {
+				return err
+			}
+
+			format := output.ParseFormat(outputFormat)
+			printer := output.NewPrinter(format)
+
+			if len(args) == 1 {
+				plan, err := c.GetPlan(args[0])
+				if err != nil {
+					return err
+				}
+				switch printer.Format {
+				case output.FormatJSON:
+					return printer.PrintJSON(plan)
+				case output.FormatYAML:
+					return printer.PrintYAML(plan)
+				default:
+					headers := []string{"ID", "NAME", "SLUG", "STATUS", "TENANT"}
+					rows := [][]string{{plan.ID, plan.Name, plan.Slug, plan.Status, plan.TenantID}}
+					printer.PrintTable(headers, rows)
+				}
+				return nil
+			}
+
+			resp, err := c.ListPlans()
+			if err != nil {
+				return err
+			}
+
+			if len(resp.Items) == 0 {
+				output.Info("No plans found.")
+				return nil
+			}
+
+			switch printer.Format {
+			case output.FormatJSON:
+				return printer.PrintJSON(resp.Items)
+			case output.FormatYAML:
+				return printer.PrintYAML(resp.Items)
+			case output.FormatWide:
+				headers := []string{"ID", "NAME", "SLUG", "DISPLAY NAME", "STATUS", "TENANT", "CREATED"}
+				var rows [][]string
+				for _, p := range resp.Items {
+					rows = append(rows, []string{
+						p.ID, p.Name, p.Slug, p.DisplayName, p.Status, p.TenantID, p.CreatedAt,
+					})
+				}
+				printer.PrintTable(headers, rows)
+			default:
+				headers := []string{"ID", "NAME", "SLUG", "STATUS"}
+				var rows [][]string
+				for _, p := range resp.Items {
+					rows = append(rows, []string{p.ID, p.Name, p.Slug, p.Status})
+				}
+				printer.PrintTable(headers, rows)
+			}
+
+			return nil
+		},
+	}
+}
+
+func newGetWebhooksCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "webhooks [id]",
+		Aliases: []string{"webhook", "wh"},
+		Short:   "Display webhook configurations",
+		Args:    cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := client.New()
+			if err != nil {
+				return err
+			}
+
+			format := output.ParseFormat(outputFormat)
+			printer := output.NewPrinter(format)
+
+			if len(args) == 1 {
+				wh, err := c.GetWebhook(args[0])
+				if err != nil {
+					return err
+				}
+				switch printer.Format {
+				case output.FormatJSON:
+					return printer.PrintJSON(wh)
+				case output.FormatYAML:
+					return printer.PrintYAML(wh)
+				default:
+					enabled := "false"
+					if wh.Enabled {
+						enabled = "true"
+					}
+					headers := []string{"ID", "NAME", "URL", "ENABLED", "TENANT"}
+					rows := [][]string{{wh.ID, wh.Name, wh.URL, enabled, wh.TenantID}}
+					printer.PrintTable(headers, rows)
+				}
+				return nil
+			}
+
+			resp, err := c.ListWebhooks()
+			if err != nil {
+				return err
+			}
+
+			if len(resp.Items) == 0 {
+				output.Info("No webhooks found.")
+				return nil
+			}
+
+			switch printer.Format {
+			case output.FormatJSON:
+				return printer.PrintJSON(resp.Items)
+			case output.FormatYAML:
+				return printer.PrintYAML(resp.Items)
+			default:
+				headers := []string{"ID", "NAME", "URL", "ENABLED"}
+				var rows [][]string
+				for _, wh := range resp.Items {
+					enabled := "false"
+					if wh.Enabled {
+						enabled = "true"
+					}
+					rows = append(rows, []string{wh.ID, wh.Name, wh.URL, enabled})
 				}
 				printer.PrintTable(headers, rows)
 			}

--- a/stoa-go/internal/cli/cmd/get/get_test.go
+++ b/stoa-go/internal/cli/cmd/get/get_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2026 CAB Ingénierie / Christophe ABOULICAM
+package get
+
+import (
+	"testing"
+)
+
+func TestNewGetCmd_HasAllSubcommands(t *testing.T) {
+	cmd := NewGetCmd()
+
+	expected := []string{
+		"apis",
+		"tenants",
+		"subscriptions",
+		"gateways",
+		"consumers",
+		"contracts",
+		"service-accounts",
+		"environments",
+		"plans",
+		"webhooks",
+	}
+
+	commands := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		commands[sub.Use] = true
+	}
+
+	for _, name := range expected {
+		// Commands may have args in Use (e.g., "apis [name]"), check prefix
+		found := false
+		for use := range commands {
+			if len(use) >= len(name) && use[:len(name)] == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("get command missing %q subcommand", name)
+		}
+	}
+}
+
+func TestNewGetCmd_HasOutputFlag(t *testing.T) {
+	cmd := NewGetCmd()
+	flag := cmd.PersistentFlags().Lookup("output")
+	if flag == nil {
+		t.Error("get command missing --output persistent flag")
+	}
+	if flag.DefValue != "table" {
+		t.Errorf("--output default = %q, want %q", flag.DefValue, "table")
+	}
+}
+
+func TestGetConsumersCmd_Aliases(t *testing.T) {
+	cmd := newGetConsumersCmd()
+	if len(cmd.Aliases) == 0 {
+		t.Error("consumers command has no aliases, want 'consumer'")
+	}
+	found := false
+	for _, a := range cmd.Aliases {
+		if a == "consumer" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("consumers command missing 'consumer' alias")
+	}
+}
+
+func TestGetContractsCmd_Aliases(t *testing.T) {
+	cmd := newGetContractsCmd()
+	aliases := make(map[string]bool)
+	for _, a := range cmd.Aliases {
+		aliases[a] = true
+	}
+	if !aliases["contract"] {
+		t.Error("contracts command missing 'contract' alias")
+	}
+	if !aliases["uac"] {
+		t.Error("contracts command missing 'uac' alias")
+	}
+}
+
+func TestGetServiceAccountsCmd_Aliases(t *testing.T) {
+	cmd := newGetServiceAccountsCmd()
+	aliases := make(map[string]bool)
+	for _, a := range cmd.Aliases {
+		aliases[a] = true
+	}
+	if !aliases["sa"] {
+		t.Error("service-accounts command missing 'sa' alias")
+	}
+}
+
+func TestGetEnvironmentsCmd_Aliases(t *testing.T) {
+	cmd := newGetEnvironmentsCmd()
+	aliases := make(map[string]bool)
+	for _, a := range cmd.Aliases {
+		aliases[a] = true
+	}
+	if !aliases["env"] {
+		t.Error("environments command missing 'env' alias")
+	}
+	if !aliases["envs"] {
+		t.Error("environments command missing 'envs' alias")
+	}
+}
+
+func TestGetPlansCmd_Aliases(t *testing.T) {
+	cmd := newGetPlansCmd()
+	found := false
+	for _, a := range cmd.Aliases {
+		if a == "plan" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("plans command missing 'plan' alias")
+	}
+}
+
+func TestGetWebhooksCmd_Aliases(t *testing.T) {
+	cmd := newGetWebhooksCmd()
+	aliases := make(map[string]bool)
+	for _, a := range cmd.Aliases {
+		aliases[a] = true
+	}
+	if !aliases["webhook"] {
+		t.Error("webhooks command missing 'webhook' alias")
+	}
+	if !aliases["wh"] {
+		t.Error("webhooks command missing 'wh' alias")
+	}
+}

--- a/stoa-go/internal/cli/cmd/get/get_test.go
+++ b/stoa-go/internal/cli/cmd/get/get_test.go
@@ -46,7 +46,7 @@ func TestNewGetCmd_HasOutputFlag(t *testing.T) {
 	cmd := NewGetCmd()
 	flag := cmd.PersistentFlags().Lookup("output")
 	if flag == nil {
-		t.Error("get command missing --output persistent flag")
+		t.Fatal("get command missing --output persistent flag")
 	}
 	if flag.DefValue != "table" {
 		t.Errorf("--output default = %q, want %q", flag.DefValue, "table")

--- a/stoa-go/pkg/client/resources.go
+++ b/stoa-go/pkg/client/resources.go
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2026 CAB Ingénierie / Christophe ABOULICAM
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/stoa-platform/stoa-go/pkg/types"
+)
+
+// ---- Consumer Methods (CAB-2053) ----
+
+// ListConsumers fetches all consumers for the current tenant
+func (c *Client) ListConsumers() (*types.ConsumerListResponse, error) {
+	resp, err := c.do("GET", fmt.Sprintf("/v1/consumers/%s", c.tenant), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var result types.ConsumerListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetConsumer fetches a single consumer by ID
+func (c *Client) GetConsumer(id string) (*types.Consumer, error) {
+	resp, err := c.do("GET", fmt.Sprintf("/v1/consumers/%s/%s", c.tenant, id), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("consumer %q not found", id)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var result types.Consumer
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeleteConsumer deletes a consumer by ID
+func (c *Client) DeleteConsumer(id string) error {
+	resp, err := c.do("DELETE", fmt.Sprintf("/v1/consumers/%s/%s", c.tenant, id), nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("consumer %q not found", id)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// ---- Contract Methods (CAB-2053) ----
+
+// ListContracts fetches all contracts for the current tenant
+func (c *Client) ListContracts() (*types.ContractListResponse, error) {
+	resp, err := c.do("GET", fmt.Sprintf("/v1/tenants/%s/contracts", c.tenant), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var result types.ContractListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetContract fetches a single contract by ID
+func (c *Client) GetContract(id string) (*types.Contract, error) {
+	resp, err := c.do("GET", fmt.Sprintf("/v1/tenants/%s/contracts/%s", c.tenant, id), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("contract %q not found", id)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var result types.Contract
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeleteContract deletes a contract by ID
+func (c *Client) DeleteContract(id string) error {
+	resp, err := c.do("DELETE", fmt.Sprintf("/v1/tenants/%s/contracts/%s", c.tenant, id), nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("contract %q not found", id)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// ---- Service Account Methods (CAB-2053) ----
+
+// ListServiceAccounts fetches all service accounts for the current user
+func (c *Client) ListServiceAccounts() ([]types.ServiceAccount, error) {
+	resp, err := c.do("GET", "/v1/service-accounts", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var result []types.ServiceAccount
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return result, nil
+}
+
+// DeleteServiceAccount deletes a service account by ID
+func (c *Client) DeleteServiceAccount(id string) error {
+	resp, err := c.do("DELETE", fmt.Sprintf("/v1/service-accounts/%s", id), nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("service account %q not found", id)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// ---- Environment Methods (CAB-2053) ----
+
+// ListEnvironments fetches all environments
+func (c *Client) ListEnvironments() (*types.EnvironmentListResponse, error) {
+	resp, err := c.do("GET", "/v1/environments", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var result types.EnvironmentListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ---- Plan Methods (CAB-2053) ----
+
+// ListPlans fetches all plans for the current tenant
+func (c *Client) ListPlans() (*types.PlanListResponse, error) {
+	resp, err := c.do("GET", fmt.Sprintf("/v1/plans/%s", c.tenant), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var result types.PlanListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetPlan fetches a single plan by ID
+func (c *Client) GetPlan(id string) (*types.Plan, error) {
+	resp, err := c.do("GET", fmt.Sprintf("/v1/plans/%s/%s", c.tenant, id), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("plan %q not found", id)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var result types.Plan
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeletePlan deletes a plan by ID
+func (c *Client) DeletePlan(id string) error {
+	resp, err := c.do("DELETE", fmt.Sprintf("/v1/plans/%s/%s", c.tenant, id), nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("plan %q not found", id)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// ---- Webhook Methods (CAB-2053) ----
+
+// ListWebhooks fetches all webhooks for the current tenant
+func (c *Client) ListWebhooks() (*types.WebhookListResponse, error) {
+	resp, err := c.do("GET", fmt.Sprintf("/v1/tenants/%s/webhooks", c.tenant), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var result types.WebhookListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetWebhook fetches a single webhook by ID
+func (c *Client) GetWebhook(id string) (*types.Webhook, error) {
+	resp, err := c.do("GET", fmt.Sprintf("/v1/tenants/%s/webhooks/%s", c.tenant, id), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("webhook %q not found", id)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var result types.Webhook
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeleteWebhook deletes a webhook by ID
+func (c *Client) DeleteWebhook(id string) error {
+	resp, err := c.do("DELETE", fmt.Sprintf("/v1/tenants/%s/webhooks/%s", c.tenant, id), nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("webhook %q not found", id)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// ---- Gateway Delete (CAB-2053) ----
+
+// DeleteGateway deletes a gateway instance by ID
+func (c *Client) DeleteGateway(id string) error {
+	resp, err := c.do("DELETE", fmt.Sprintf("/v1/admin/gateways/%s", id), nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("gateway %q not found", id)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// DeleteSubscription deletes a subscription by ID
+func (c *Client) DeleteSubscription(id string) error {
+	resp, err := c.do("DELETE", fmt.Sprintf("/v1/subscriptions/%s", id), nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("subscription %q not found", id)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}

--- a/stoa-go/pkg/client/resources_test.go
+++ b/stoa-go/pkg/client/resources_test.go
@@ -1,0 +1,492 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2026 CAB Ingénierie / Christophe ABOULICAM
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stoa-platform/stoa-go/pkg/types"
+)
+
+// ---- Consumer Tests ----
+
+func TestListConsumers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/consumers/test-tenant" {
+			t.Errorf("Expected path /v1/consumers/test-tenant, got %s", r.URL.Path)
+		}
+
+		resp := types.ConsumerListResponse{
+			Items: []types.Consumer{
+				{ID: "c1", Name: "consumer-1", Email: "c1@test.com", Status: "active"},
+				{ID: "c2", Name: "consumer-2", Email: "c2@test.com", Status: "suspended"},
+			},
+			Total: 2,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	result, err := c.ListConsumers()
+	if err != nil {
+		t.Fatalf("ListConsumers() error = %v", err)
+	}
+	if len(result.Items) != 2 {
+		t.Errorf("ListConsumers() got %d items, want 2", len(result.Items))
+	}
+	if result.Items[0].Name != "consumer-1" {
+		t.Errorf("ListConsumers()[0].Name = %q, want %q", result.Items[0].Name, "consumer-1")
+	}
+}
+
+func TestGetConsumer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/consumers/test-tenant/c1" {
+			t.Errorf("Expected path /v1/consumers/test-tenant/c1, got %s", r.URL.Path)
+		}
+
+		resp := types.Consumer{ID: "c1", Name: "consumer-1", Email: "c1@test.com", Status: "active"}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	result, err := c.GetConsumer("c1")
+	if err != nil {
+		t.Fatalf("GetConsumer() error = %v", err)
+	}
+	if result.Name != "consumer-1" {
+		t.Errorf("GetConsumer().Name = %q, want %q", result.Name, "consumer-1")
+	}
+}
+
+func TestGetConsumer_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	_, err := c.GetConsumer("missing")
+	if err == nil {
+		t.Error("GetConsumer() error = nil, want error for 404")
+	}
+}
+
+func TestDeleteConsumer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/consumers/test-tenant/c1" {
+			t.Errorf("Expected path /v1/consumers/test-tenant/c1, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	err := c.DeleteConsumer("c1")
+	if err != nil {
+		t.Fatalf("DeleteConsumer() error = %v", err)
+	}
+}
+
+// ---- Contract Tests ----
+
+func TestListContracts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/tenants/test-tenant/contracts" {
+			t.Errorf("Expected path /v1/tenants/test-tenant/contracts, got %s", r.URL.Path)
+		}
+
+		resp := types.ContractListResponse{
+			Items: []types.Contract{
+				{ID: "ct1", Name: "billing-contract", Version: "1.0", Status: "published"},
+			},
+			Total: 1,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	result, err := c.ListContracts()
+	if err != nil {
+		t.Fatalf("ListContracts() error = %v", err)
+	}
+	if len(result.Items) != 1 {
+		t.Errorf("ListContracts() got %d items, want 1", len(result.Items))
+	}
+	if result.Items[0].Name != "billing-contract" {
+		t.Errorf("ListContracts()[0].Name = %q, want %q", result.Items[0].Name, "billing-contract")
+	}
+}
+
+func TestGetContract(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/tenants/test-tenant/contracts/ct1" {
+			t.Errorf("Expected path /v1/tenants/test-tenant/contracts/ct1, got %s", r.URL.Path)
+		}
+
+		resp := types.Contract{ID: "ct1", Name: "billing-contract", Version: "1.0", Status: "published"}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	result, err := c.GetContract("ct1")
+	if err != nil {
+		t.Fatalf("GetContract() error = %v", err)
+	}
+	if result.Name != "billing-contract" {
+		t.Errorf("GetContract().Name = %q, want %q", result.Name, "billing-contract")
+	}
+}
+
+func TestDeleteContract(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	err := c.DeleteContract("ct1")
+	if err != nil {
+		t.Fatalf("DeleteContract() error = %v", err)
+	}
+}
+
+// ---- Service Account Tests ----
+
+func TestListServiceAccounts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/service-accounts" {
+			t.Errorf("Expected path /v1/service-accounts, got %s", r.URL.Path)
+		}
+
+		resp := []types.ServiceAccount{
+			{ID: "sa1", Name: "ci-bot", ClientID: "client-123", Status: "active"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	result, err := c.ListServiceAccounts()
+	if err != nil {
+		t.Fatalf("ListServiceAccounts() error = %v", err)
+	}
+	if len(result) != 1 {
+		t.Errorf("ListServiceAccounts() got %d items, want 1", len(result))
+	}
+	if result[0].Name != "ci-bot" {
+		t.Errorf("ListServiceAccounts()[0].Name = %q, want %q", result[0].Name, "ci-bot")
+	}
+}
+
+func TestDeleteServiceAccount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/service-accounts/sa1" {
+			t.Errorf("Expected path /v1/service-accounts/sa1, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	err := c.DeleteServiceAccount("sa1")
+	if err != nil {
+		t.Fatalf("DeleteServiceAccount() error = %v", err)
+	}
+}
+
+// ---- Environment Tests ----
+
+func TestListEnvironments(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/environments" {
+			t.Errorf("Expected path /v1/environments, got %s", r.URL.Path)
+		}
+
+		resp := types.EnvironmentListResponse{
+			Items: []types.Environment{
+				{ID: "e1", Name: "production", Type: "prod", URL: "https://api.example.com", Status: "active"},
+				{ID: "e2", Name: "staging", Type: "staging", URL: "https://staging.example.com", Status: "active"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	result, err := c.ListEnvironments()
+	if err != nil {
+		t.Fatalf("ListEnvironments() error = %v", err)
+	}
+	if len(result.Items) != 2 {
+		t.Errorf("ListEnvironments() got %d items, want 2", len(result.Items))
+	}
+}
+
+// ---- Plan Tests ----
+
+func TestListPlans(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/plans/test-tenant" {
+			t.Errorf("Expected path /v1/plans/test-tenant, got %s", r.URL.Path)
+		}
+
+		resp := types.PlanListResponse{
+			Items: []types.Plan{
+				{ID: "p1", Name: "free", Slug: "free", Status: "active"},
+				{ID: "p2", Name: "pro", Slug: "pro", Status: "active"},
+			},
+			Total: 2,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	result, err := c.ListPlans()
+	if err != nil {
+		t.Fatalf("ListPlans() error = %v", err)
+	}
+	if len(result.Items) != 2 {
+		t.Errorf("ListPlans() got %d items, want 2", len(result.Items))
+	}
+}
+
+func TestGetPlan(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/plans/test-tenant/p1" {
+			t.Errorf("Expected path /v1/plans/test-tenant/p1, got %s", r.URL.Path)
+		}
+
+		resp := types.Plan{ID: "p1", Name: "free", Slug: "free", Status: "active"}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	result, err := c.GetPlan("p1")
+	if err != nil {
+		t.Fatalf("GetPlan() error = %v", err)
+	}
+	if result.Name != "free" {
+		t.Errorf("GetPlan().Name = %q, want %q", result.Name, "free")
+	}
+}
+
+func TestDeletePlan(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/plans/test-tenant/p1" {
+			t.Errorf("Expected path /v1/plans/test-tenant/p1, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	err := c.DeletePlan("p1")
+	if err != nil {
+		t.Fatalf("DeletePlan() error = %v", err)
+	}
+}
+
+// ---- Webhook Tests ----
+
+func TestListWebhooks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/tenants/test-tenant/webhooks" {
+			t.Errorf("Expected path /v1/tenants/test-tenant/webhooks, got %s", r.URL.Path)
+		}
+
+		resp := types.WebhookListResponse{
+			Items: []types.Webhook{
+				{ID: "wh1", Name: "deploy-hook", URL: "https://hooks.example.com/deploy", Enabled: true},
+			},
+			Total: 1,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	result, err := c.ListWebhooks()
+	if err != nil {
+		t.Fatalf("ListWebhooks() error = %v", err)
+	}
+	if len(result.Items) != 1 {
+		t.Errorf("ListWebhooks() got %d items, want 1", len(result.Items))
+	}
+	if !result.Items[0].Enabled {
+		t.Error("ListWebhooks()[0].Enabled = false, want true")
+	}
+}
+
+func TestGetWebhook(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/tenants/test-tenant/webhooks/wh1" {
+			t.Errorf("Expected path /v1/tenants/test-tenant/webhooks/wh1, got %s", r.URL.Path)
+		}
+
+		resp := types.Webhook{ID: "wh1", Name: "deploy-hook", URL: "https://hooks.example.com/deploy", Enabled: true}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	result, err := c.GetWebhook("wh1")
+	if err != nil {
+		t.Fatalf("GetWebhook() error = %v", err)
+	}
+	if result.Name != "deploy-hook" {
+		t.Errorf("GetWebhook().Name = %q, want %q", result.Name, "deploy-hook")
+	}
+}
+
+func TestDeleteWebhook(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	err := c.DeleteWebhook("wh1")
+	if err != nil {
+		t.Fatalf("DeleteWebhook() error = %v", err)
+	}
+}
+
+// ---- Gateway/Subscription Delete Tests ----
+
+func TestDeleteGateway(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/admin/gateways/gw1" {
+			t.Errorf("Expected path /v1/admin/gateways/gw1, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	err := c.DeleteGateway("gw1")
+	if err != nil {
+		t.Fatalf("DeleteGateway() error = %v", err)
+	}
+}
+
+func TestDeleteGateway_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	err := c.DeleteGateway("missing")
+	if err == nil {
+		t.Error("DeleteGateway() error = nil, want error for 404")
+	}
+}
+
+func TestDeleteSubscription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/subscriptions/sub1" {
+			t.Errorf("Expected path /v1/subscriptions/sub1, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	err := c.DeleteSubscription("sub1")
+	if err != nil {
+		t.Fatalf("DeleteSubscription() error = %v", err)
+	}
+}
+
+// ---- Error Handling Tests ----
+
+func TestListConsumers_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	_, err := c.ListConsumers()
+	if err == nil {
+		t.Error("ListConsumers() error = nil, want error for 500")
+	}
+}
+
+func TestListContracts_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	_, err := c.ListContracts()
+	if err == nil {
+		t.Error("ListContracts() error = nil, want error for 500")
+	}
+}
+
+func TestDeleteConsumer_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-tenant", "test-token")
+	err := c.DeleteConsumer("missing")
+	if err == nil {
+		t.Error("DeleteConsumer() error = nil, want error for 404")
+	}
+}

--- a/stoa-go/pkg/types/types.go
+++ b/stoa-go/pkg/types/types.go
@@ -303,3 +303,112 @@ type AuditListResponse struct {
 	PageSize int          `json:"page_size"`
 	HasMore  bool         `json:"has_more"`
 }
+
+// ---- Consumer Types (CAB-2053) ----
+
+// Consumer represents a consumer from the STOA API
+type Consumer struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name,omitempty"`
+	Email       string `json:"email,omitempty"`
+	TenantID    string `json:"tenant_id,omitempty"`
+	Status      string `json:"status,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty"`
+}
+
+// ConsumerListResponse represents the response from listing consumers
+type ConsumerListResponse struct {
+	Items []Consumer `json:"items"`
+	Total int        `json:"total"`
+}
+
+// ---- Contract Types (CAB-2053) ----
+
+// Contract represents a Universal API Contract from the STOA API
+type Contract struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Version     string `json:"version,omitempty"`
+	Status      string `json:"status,omitempty"`
+	TenantID    string `json:"tenant_id,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty"`
+}
+
+// ContractListResponse represents the response from listing contracts
+type ContractListResponse struct {
+	Items []Contract `json:"items"`
+	Total int        `json:"total"`
+}
+
+// ---- Service Account Types (CAB-2053) ----
+
+// ServiceAccount represents a service account from the STOA API
+type ServiceAccount struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	ClientID  string `json:"client_id,omitempty"`
+	Status    string `json:"status,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+// ---- Environment Types (CAB-2053) ----
+
+// Environment represents an environment from the STOA API
+type Environment struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name,omitempty"`
+	Type        string `json:"type,omitempty"`
+	URL         string `json:"url,omitempty"`
+	Status      string `json:"status,omitempty"`
+}
+
+// EnvironmentListResponse represents the response from listing environments
+type EnvironmentListResponse struct {
+	Items []Environment `json:"items"`
+}
+
+// ---- Plan Types (CAB-2053) ----
+
+// Plan represents a subscription plan from the STOA API
+type Plan struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Slug        string `json:"slug,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
+	Description string `json:"description,omitempty"`
+	TenantID    string `json:"tenant_id,omitempty"`
+	Status      string `json:"status,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty"`
+}
+
+// PlanListResponse represents the response from listing plans
+type PlanListResponse struct {
+	Items []Plan `json:"items"`
+	Total int    `json:"total"`
+}
+
+// ---- Webhook Types (CAB-2053) ----
+
+// Webhook represents a webhook configuration from the STOA API
+type Webhook struct {
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	URL       string   `json:"url"`
+	Events    []string `json:"events,omitempty"`
+	TenantID  string   `json:"tenant_id,omitempty"`
+	Enabled   bool     `json:"enabled"`
+	CreatedAt string   `json:"created_at,omitempty"`
+}
+
+// WebhookListResponse represents the response from listing webhooks
+type WebhookListResponse struct {
+	Items []Webhook `json:"items"`
+	Total int       `json:"total"`
+}


### PR DESCRIPTION
## Summary
- **apply -f**: 10 kinds (was 1) — API, Tenant, Gateway, Subscription, Consumer, Contract, MCPServer, ServiceAccount, Plan, Webhook
- **get**: 10 resources (was 4) — +consumers, contracts, service-accounts, environments, plans, webhooks
- **delete**: 9 resources (was 1) — +tenant, gateway, subscription, consumer, contract, service-account, plan, webhook
- 55 new tests (httptest mocks, YAML validation, command structure, batch delete logic)

Phase 3 close gate: `stoactl apply -f` no longer returns "unsupported resource kind" for any CP API resource type.

## Test plan
- [x] `go build ./...` — clean compile
- [x] `go test ./...` — 55 new tests pass, all existing pass
- [x] `stoactl apply --help` lists all 10 kinds
- [x] `stoactl get --help` lists all 10 resources
- [x] `stoactl delete --help` lists all 9 resources
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>