### PR TITLE
feat(cli): unified schema registry gostoa.dev/v1beta1 (CAB-2053 phase 4)

### DIFF
--- a/charts/stoa-platform/schemas/api.schema.json
+++ b/charts/stoa-platform/schemas/api.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.gostoa.dev/schemas/api.schema.json",
+  "title": "STOA API Resource",
+  "description": "Schema for stoactl apply -f with kind: API",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "gostoa.dev/v1beta1",
+      "description": "STOA API version"
+    },
+    "kind": {
+      "type": "string",
+      "const": "API",
+      "description": "Resource kind"
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Resource name (unique within tenant)"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Tenant ID (optional, falls back to CLI context)"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Key-value labels"
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "$defs": {
+        "BackendApiAuthTypeEnum": {
+          "description": "Authentication type for the backend API.",
+          "enum": [
+            "none",
+            "api_key",
+            "bearer",
+            "basic",
+            "oauth2_cc"
+          ],
+          "title": "BackendApiAuthTypeEnum",
+          "type": "string"
+        }
+      },
+      "description": "Schema for registering a new backend API.",
+      "example": {
+        "auth_config": {
+          "header_name": "X-API-Key",
+          "header_value": "secret123"
+        },
+        "auth_type": "api_key",
+        "backend_url": "https://petstore.swagger.io/v2",
+        "description": "Sample Petstore backend",
+        "display_name": "Petstore API",
+        "name": "petstore-api",
+        "openapi_spec_url": "https://petstore.swagger.io/v2/swagger.json"
+      },
+      "properties": {
+        "name": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Display Name"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "backend_url": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Backend Url",
+          "type": "string"
+        },
+        "openapi_spec_url": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Openapi Spec Url"
+        },
+        "auth_type": {
+          "$ref": "#/$defs/BackendApiAuthTypeEnum",
+          "default": "none"
+        },
+        "auth_config": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Backend credentials (api_key, bearer token, basic user/pass, oauth2 client_id/secret+token_url)",
+          "title": "Auth Config"
+        }
+      },
+      "required": [
+        "name",
+        "backend_url"
+      ],
+      "title": "BackendApiCreate",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/charts/stoa-platform/schemas/consumer.schema.json
+++ b/charts/stoa-platform/schemas/consumer.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.gostoa.dev/schemas/consumer.schema.json",
+  "title": "STOA Consumer Resource",
+  "description": "Schema for stoactl apply -f with kind: Consumer",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "gostoa.dev/v1beta1",
+      "description": "STOA API version"
+    },
+    "kind": {
+      "type": "string",
+      "const": "Consumer",
+      "description": "Resource kind"
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Resource name (unique within tenant)"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Tenant ID (optional, falls back to CLI context)"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Key-value labels"
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "description": "Schema for creating a new consumer.",
+      "example": {
+        "company": "ACME Corporation",
+        "description": "Strategic API partner",
+        "email": "api@acme.com",
+        "external_id": "partner-acme-001",
+        "name": "ACME Corp"
+      },
+      "properties": {
+        "external_id": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "External Id",
+          "type": "string"
+        },
+        "name": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "email": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Email",
+          "type": "string"
+        },
+        "company": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Company"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "keycloak_user_id": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Keycloak User Id"
+        },
+        "consumer_metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Consumer Metadata"
+        }
+      },
+      "required": [
+        "external_id",
+        "name",
+        "email"
+      ],
+      "title": "ConsumerCreate",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/charts/stoa-platform/schemas/contract.schema.json
+++ b/charts/stoa-platform/schemas/contract.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.gostoa.dev/schemas/contract.schema.json",
+  "title": "STOA Contract Resource",
+  "description": "Schema for stoactl apply -f with kind: Contract",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "gostoa.dev/v1beta1",
+      "description": "STOA API version"
+    },
+    "kind": {
+      "type": "string",
+      "const": "Contract",
+      "description": "Resource kind"
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Resource name (unique within tenant)"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Tenant ID (optional, falls back to CLI context)"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Key-value labels"
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "description": "Request to create a new contract.",
+      "example": {
+        "description": "API for processing payments",
+        "display_name": "Payment Service API",
+        "name": "payment-service",
+        "openapi_spec_url": "https://specs.example.com/payment-service/openapi.yaml",
+        "version": "2.0.0"
+      },
+      "properties": {
+        "name": {
+          "description": "Unique contract name",
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-friendly name",
+          "title": "Display Name"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Contract description",
+          "title": "Description"
+        },
+        "version": {
+          "default": "1.0.0",
+          "description": "Contract version",
+          "maxLength": 50,
+          "title": "Version",
+          "type": "string"
+        },
+        "openapi_spec_url": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "URL to OpenAPI spec",
+          "title": "Openapi Spec Url"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "ContractCreate",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/charts/stoa-platform/schemas/gateway.schema.json
+++ b/charts/stoa-platform/schemas/gateway.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.gostoa.dev/schemas/gateway.schema.json",
+  "title": "STOA Gateway Resource",
+  "description": "Schema for stoactl apply -f with kind: Gateway",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "gostoa.dev/v1beta1",
+      "description": "STOA API version"
+    },
+    "kind": {
+      "type": "string",
+      "const": "Gateway",
+      "description": "Resource kind"
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Resource name (unique within tenant)"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Tenant ID (optional, falls back to CLI context)"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Key-value labels"
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "description": "Schema for creating a new gateway instance.",
+      "properties": {
+        "name": {
+          "description": "Unique identifier (e.g. 'webmethods-prod')",
+          "maxLength": 255,
+          "title": "Name",
+          "type": "string"
+        },
+        "display_name": {
+          "maxLength": 255,
+          "title": "Display Name",
+          "type": "string"
+        },
+        "gateway_type": {
+          "description": "webmethods, kong, apigee, aws_apigateway, stoa",
+          "title": "Gateway Type",
+          "type": "string"
+        },
+        "environment": {
+          "description": "dev, staging, prod",
+          "maxLength": 50,
+          "title": "Environment",
+          "type": "string"
+        },
+        "tenant_id": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "null = platform-wide",
+          "title": "Tenant Id"
+        },
+        "base_url": {
+          "description": "Admin API URL",
+          "maxLength": 500,
+          "title": "Base Url",
+          "type": "string"
+        },
+        "auth_config": {
+          "additionalProperties": true,
+          "description": "Auth config: {type, vault_path, ...}",
+          "title": "Auth Config",
+          "type": "object"
+        },
+        "capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Capabilities",
+          "type": "array"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Tags",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "display_name",
+        "gateway_type",
+        "environment",
+        "base_url"
+      ],
+      "title": "GatewayInstanceCreate",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/charts/stoa-platform/schemas/mcpserver.schema.json
+++ b/charts/stoa-platform/schemas/mcpserver.schema.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.gostoa.dev/schemas/mcpserver.schema.json",
+  "title": "STOA MCPServer Resource",
+  "description": "Schema for stoactl apply -f with kind: MCPServer",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "gostoa.dev/v1beta1",
+      "description": "STOA API version"
+    },
+    "kind": {
+      "type": "string",
+      "const": "MCPServer",
+      "description": "Resource kind"
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Resource name (unique within tenant)"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Tenant ID (optional, falls back to CLI context)"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Key-value labels"
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "$defs": {
+        "MCPServerCategoryEnum": {
+          "description": "MCP Server category for API responses.",
+          "enum": [
+            "platform",
+            "tenant",
+            "public"
+          ],
+          "title": "MCPServerCategoryEnum",
+          "type": "string"
+        },
+        "MCPServerVisibility": {
+          "description": "Visibility configuration for MCP Servers.",
+          "properties": {
+            "roles": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Required roles to see this server",
+              "title": "Roles"
+            },
+            "exclude_roles": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Roles that cannot see this server",
+              "title": "Exclude Roles"
+            },
+            "public": {
+              "default": true,
+              "description": "If true, visible to all authenticated users",
+              "title": "Public",
+              "type": "boolean"
+            }
+          },
+          "title": "MCPServerVisibility",
+          "type": "object"
+        }
+      },
+      "description": "Schema for creating a new MCP Server (admin only).",
+      "example": {
+        "category": "public",
+        "description": "Get weather data from various sources",
+        "display_name": "Weather API",
+        "name": "weather-api",
+        "requires_approval": false,
+        "visibility": {
+          "public": true
+        }
+      },
+      "properties": {
+        "name": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "display_name": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Display Name",
+          "type": "string"
+        },
+        "description": {
+          "minLength": 1,
+          "title": "Description",
+          "type": "string"
+        },
+        "icon": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Icon"
+        },
+        "category": {
+          "$ref": "#/$defs/MCPServerCategoryEnum",
+          "default": "public"
+        },
+        "tenant_id": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tenant Id"
+        },
+        "visibility": {
+          "$ref": "#/$defs/MCPServerVisibility",
+          "default": {
+            "roles": null,
+            "exclude_roles": null,
+            "public": true
+          }
+        },
+        "requires_approval": {
+          "default": false,
+          "title": "Requires Approval",
+          "type": "boolean"
+        },
+        "auto_approve_roles": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Auto Approve Roles"
+        },
+        "version": {
+          "anyOf": [
+            {
+              "maxLength": 50,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Version"
+        },
+        "documentation_url": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Documentation Url"
+        }
+      },
+      "required": [
+        "name",
+        "display_name",
+        "description"
+      ],
+      "title": "MCPServerCreate",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/charts/stoa-platform/schemas/plan.schema.json
+++ b/charts/stoa-platform/schemas/plan.schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.gostoa.dev/schemas/plan.schema.json",
+  "title": "STOA Plan Resource",
+  "description": "Schema for stoactl apply -f with kind: Plan",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "gostoa.dev/v1beta1",
+      "description": "STOA API version"
+    },
+    "kind": {
+      "type": "string",
+      "const": "Plan",
+      "description": "Resource kind"
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Resource name (unique within tenant)"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Tenant ID (optional, falls back to CLI context)"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Key-value labels"
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "description": "Schema for creating a new subscription plan.",
+      "example": {
+        "daily_request_limit": 1000000,
+        "description": "High-volume plan for production workloads",
+        "monthly_request_limit": 30000000,
+        "name": "Gold Plan",
+        "rate_limit_per_minute": 5000,
+        "rate_limit_per_second": 100,
+        "requires_approval": true,
+        "slug": "gold"
+      },
+      "properties": {
+        "slug": {
+          "maxLength": 100,
+          "minLength": 1,
+          "pattern": "^[a-z0-9-]+$",
+          "title": "Slug",
+          "type": "string"
+        },
+        "name": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "rate_limit_per_second": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rate Limit Per Second"
+        },
+        "rate_limit_per_minute": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rate Limit Per Minute"
+        },
+        "daily_request_limit": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Daily Request Limit"
+        },
+        "monthly_request_limit": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Monthly Request Limit"
+        },
+        "burst_limit": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Burst Limit"
+        },
+        "requires_approval": {
+          "default": false,
+          "title": "Requires Approval",
+          "type": "boolean"
+        },
+        "auto_approve_roles": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Auto Approve Roles"
+        },
+        "pricing_metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pricing Metadata"
+        }
+      },
+      "required": [
+        "slug",
+        "name"
+      ],
+      "title": "PlanCreate",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/charts/stoa-platform/schemas/registry.json
+++ b/charts/stoa-platform/schemas/registry.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.gostoa.dev/schemas/registry.json",
+  "title": "STOA Schema Registry",
+  "description": "Registry of all 10 stoactl resource kinds at gostoa.dev/v1beta1",
+  "apiVersion": "gostoa.dev/v1beta1",
+  "kinds": {
+    "API": {
+      "schema": "api.schema.json",
+      "description": "STOA API resource"
+    },
+    "Consumer": {
+      "schema": "consumer.schema.json",
+      "description": "STOA Consumer resource"
+    },
+    "Contract": {
+      "schema": "contract.schema.json",
+      "description": "STOA Contract resource"
+    },
+    "Gateway": {
+      "schema": "gateway.schema.json",
+      "description": "STOA Gateway resource"
+    },
+    "MCPServer": {
+      "schema": "mcpserver.schema.json",
+      "description": "STOA MCPServer resource"
+    },
+    "Plan": {
+      "schema": "plan.schema.json",
+      "description": "STOA Plan resource"
+    },
+    "ServiceAccount": {
+      "schema": "serviceaccount.schema.json",
+      "description": "STOA ServiceAccount resource"
+    },
+    "Subscription": {
+      "schema": "subscription.schema.json",
+      "description": "STOA Subscription resource"
+    },
+    "Tenant": {
+      "schema": "tenant.schema.json",
+      "description": "STOA Tenant resource"
+    },
+    "Webhook": {
+      "schema": "webhook.schema.json",
+      "description": "STOA Webhook resource"
+    }
+  }
+}

--- a/charts/stoa-platform/schemas/serviceaccount.schema.json
+++ b/charts/stoa-platform/schemas/serviceaccount.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.gostoa.dev/schemas/serviceaccount.schema.json",
+  "title": "STOA ServiceAccount Resource",
+  "description": "Schema for stoactl apply -f with kind: ServiceAccount",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "gostoa.dev/v1beta1",
+      "description": "STOA API version"
+    },
+    "kind": {
+      "type": "string",
+      "const": "ServiceAccount",
+      "description": "Resource kind"
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Resource name (unique within tenant)"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Tenant ID (optional, falls back to CLI context)"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Key-value labels"
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "description": "Request to create a new service account",
+      "example": {
+        "description": "Service account for Claude Desktop MCP access",
+        "name": "claude-desktop"
+      },
+      "properties": {
+        "name": {
+          "description": "Name for the service account (e.g., 'claude-desktop', 'cursor-ide')",
+          "maxLength": 50,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "maxLength": 200,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional description",
+          "title": "Description"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "ServiceAccountCreate",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/charts/stoa-platform/schemas/subscription.schema.json
+++ b/charts/stoa-platform/schemas/subscription.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.gostoa.dev/schemas/subscription.schema.json",
+  "title": "STOA Subscription Resource",
+  "description": "Schema for stoactl apply -f with kind: Subscription",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "gostoa.dev/v1beta1",
+      "description": "STOA API version"
+    },
+    "kind": {
+      "type": "string",
+      "const": "Subscription",
+      "description": "Resource kind"
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Resource name (unique within tenant)"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Tenant ID (optional, falls back to CLI context)"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Key-value labels"
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "description": "Schema for creating a new subscription request",
+      "example": {
+        "api_id": "api-456",
+        "api_name": "Weather API",
+        "api_version": "1.0",
+        "application_id": "app-123",
+        "application_name": "My App",
+        "plan_id": "basic",
+        "plan_name": "Basic Plan",
+        "tenant_id": "acme"
+      },
+      "properties": {
+        "application_id": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Application Id",
+          "type": "string"
+        },
+        "application_name": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Application Name",
+          "type": "string"
+        },
+        "api_id": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Api Id",
+          "type": "string"
+        },
+        "api_name": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Api Name",
+          "type": "string"
+        },
+        "api_version": {
+          "maxLength": 50,
+          "minLength": 1,
+          "title": "Api Version",
+          "type": "string"
+        },
+        "tenant_id": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Tenant Id",
+          "type": "string"
+        },
+        "plan_id": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Plan Id"
+        },
+        "plan_name": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "default",
+          "title": "Plan Name"
+        }
+      },
+      "required": [
+        "application_id",
+        "application_name",
+        "api_id",
+        "api_name",
+        "api_version",
+        "tenant_id"
+      ],
+      "title": "SubscriptionCreate",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/charts/stoa-platform/schemas/tenant.schema.json
+++ b/charts/stoa-platform/schemas/tenant.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.gostoa.dev/schemas/tenant.schema.json",
+  "title": "STOA Tenant Resource",
+  "description": "Schema for stoactl apply -f with kind: Tenant",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "gostoa.dev/v1beta1",
+      "description": "STOA API version"
+    },
+    "kind": {
+      "type": "string",
+      "const": "Tenant",
+      "description": "Resource kind"
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Resource name (unique within tenant)"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Tenant ID (optional, falls back to CLI context)"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Key-value labels"
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "display_name": {
+          "title": "Display Name",
+          "type": "string"
+        },
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "owner_email": {
+          "title": "Owner Email",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "display_name",
+        "owner_email"
+      ],
+      "title": "TenantCreate",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/charts/stoa-platform/schemas/webhook.schema.json
+++ b/charts/stoa-platform/schemas/webhook.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.gostoa.dev/schemas/webhook.schema.json",
+  "title": "STOA Webhook Resource",
+  "description": "Schema for stoactl apply -f with kind: Webhook",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "gostoa.dev/v1beta1",
+      "description": "STOA API version"
+    },
+    "kind": {
+      "type": "string",
+      "const": "Webhook",
+      "description": "Resource kind"
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Resource name (unique within tenant)"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Tenant ID (optional, falls back to CLI context)"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Key-value labels"
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "description": "Schema for creating a new webhook",
+      "example": {
+        "events": [
+          "subscription.created",
+          "subscription.approved"
+        ],
+        "headers": {
+          "X-Custom-Header": "custom-value"
+        },
+        "name": "Slack Notifications",
+        "secret": "my-super-secret-key-min16chars",
+        "url": "https://hooks.slack.com/services/xxx/yyy/zzz"
+      },
+      "properties": {
+        "name": {
+          "description": "Human-readable name for this webhook",
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL to send webhook events to",
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Url",
+          "type": "string"
+        },
+        "events": {
+          "description": "List of events to subscribe to, or ['*'] for all events",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Events",
+          "type": "array"
+        },
+        "secret": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "minLength": 16,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Secret for HMAC signature verification (min 16 chars)",
+          "title": "Secret"
+        },
+        "headers": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Custom headers to include in webhook requests",
+          "title": "Headers"
+        }
+      },
+      "required": [
+        "name",
+        "url",
+        "events"
+      ],
+      "title": "WebhookCreate",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/generate-schemas.py
+++ b/scripts/generate-schemas.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Generate JSON Schema registry from Pydantic models.
+
+Exports one JSON Schema file per stoactl Kind into charts/stoa-platform/schemas/.
+These schemas are the single source of truth for resource validation in stoactl.
+
+Usage:
+    cd control-plane-api && python ../scripts/generate-schemas.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# Ensure control-plane-api/src is importable
+CP_API_SRC = Path(__file__).resolve().parent.parent / "control-plane-api"
+sys.path.insert(0, str(CP_API_SRC))
+
+from src.schemas.backend_api import BackendApiCreate  # noqa: E402
+from src.schemas.consumer import ConsumerCreate  # noqa: E402
+from src.schemas.contract import ContractCreate  # noqa: E402
+from src.schemas.gateway import GatewayInstanceCreate  # noqa: E402
+from src.schemas.mcp_subscription import MCPServerCreate  # noqa: E402
+from src.schemas.plan import PlanCreate  # noqa: E402
+from src.schemas.subscription import SubscriptionCreate  # noqa: E402
+from src.schemas.tenant import TenantCreate  # noqa: E402
+from src.schemas.webhook import WebhookCreate  # noqa: E402
+
+# ServiceAccountCreate is defined inline in routers — import it
+from src.routers.service_accounts import ServiceAccountCreate  # noqa: E402
+
+# ── Kind → Pydantic model mapping ──────────────────────────────────────────
+API_VERSION = "gostoa.dev/v1beta1"
+
+KIND_MAP: dict[str, type] = {
+    "API": BackendApiCreate,
+    "Tenant": TenantCreate,
+    "Gateway": GatewayInstanceCreate,
+    "Subscription": SubscriptionCreate,
+    "Consumer": ConsumerCreate,
+    "Contract": ContractCreate,
+    "MCPServer": MCPServerCreate,
+    "ServiceAccount": ServiceAccountCreate,
+    "Plan": PlanCreate,
+    "Webhook": WebhookCreate,
+}
+
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / "charts" / "stoa-platform" / "schemas"
+
+
+def generate_schema(kind: str, model: type) -> dict:
+    """Generate a JSON Schema for a stoactl resource kind."""
+    schema = model.model_json_schema()
+
+    # Wrap in the stoactl resource envelope
+    resource_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": f"https://docs.gostoa.dev/schemas/{kind.lower()}.schema.json",
+        "title": f"STOA {kind} Resource",
+        "description": f"Schema for stoactl apply -f with kind: {kind}",
+        "type": "object",
+        "required": ["apiVersion", "kind", "metadata", "spec"],
+        "properties": {
+            "apiVersion": {
+                "type": "string",
+                "const": API_VERSION,
+                "description": "STOA API version",
+            },
+            "kind": {
+                "type": "string",
+                "const": kind,
+                "description": "Resource kind",
+            },
+            "metadata": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Resource name (unique within tenant)",
+                    },
+                    "namespace": {
+                        "type": "string",
+                        "description": "Tenant ID (optional, falls back to CLI context)",
+                    },
+                    "labels": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                        "description": "Key-value labels",
+                    },
+                },
+                "additionalProperties": False,
+            },
+            "spec": schema,
+        },
+        "additionalProperties": False,
+    }
+
+    return resource_schema
+
+
+def generate_registry(kinds: list[str]) -> dict:
+    """Generate the registry index listing all available schemas."""
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://docs.gostoa.dev/schemas/registry.json",
+        "title": "STOA Schema Registry",
+        "description": f"Registry of all {len(kinds)} stoactl resource kinds at {API_VERSION}",
+        "apiVersion": API_VERSION,
+        "kinds": {
+            kind: {
+                "schema": f"{kind.lower()}.schema.json",
+                "description": f"STOA {kind} resource",
+            }
+            for kind in sorted(kinds)
+        },
+    }
+
+
+def main() -> None:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    generated = []
+    for kind, model in sorted(KIND_MAP.items()):
+        schema = generate_schema(kind, model)
+        output_path = OUTPUT_DIR / f"{kind.lower()}.schema.json"
+        output_path.write_text(json.dumps(schema, indent=2) + "\n")
+        generated.append(kind)
+        print(f"  ✓ {kind:20s} → {output_path.relative_to(OUTPUT_DIR.parent.parent.parent)}")
+
+    # Write registry index
+    registry = generate_registry(generated)
+    registry_path = OUTPUT_DIR / "registry.json"
+    registry_path.write_text(json.dumps(registry, indent=2) + "\n")
+    print(f"  ✓ {'registry':20s} → {registry_path.relative_to(OUTPUT_DIR.parent.parent.parent)}")
+
+    print(f"\n✅ Generated {len(generated)} schemas + registry at {API_VERSION}")
+
+
+if __name__ == "__main__":
+    main()

--- a/stoa-go/internal/cli/cmd/apply/apply.go
+++ b/stoa-go/internal/cli/cmd/apply/apply.go
@@ -119,6 +119,14 @@ func applyFile(c *client.Client, path string) error {
 		return fmt.Errorf("invalid resource in %s: missing metadata.name", path)
 	}
 
+	// Validate apiVersion — accept legacy versions with a deprecation warning
+	if !types.IsAcceptedAPIVersion(resource.APIVersion) {
+		return fmt.Errorf("unsupported apiVersion %q in %s (expected %s)", resource.APIVersion, path, types.CanonicalAPIVersion)
+	}
+	if resource.APIVersion != types.CanonicalAPIVersion {
+		output.Warn("apiVersion %q is deprecated, use %q instead", resource.APIVersion, types.CanonicalAPIVersion)
+	}
+
 	// Dry run
 	if dryRun {
 		if err := c.ValidateResource(&resource); err != nil {

--- a/stoa-go/internal/cli/cmd/apply/apply_test.go
+++ b/stoa-go/internal/cli/cmd/apply/apply_test.go
@@ -149,6 +149,62 @@ metadata:
 	}
 }
 
+func TestApplyFile_UnsupportedAPIVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad-version.yaml")
+	content := `apiVersion: unknown.io/v99
+kind: Tenant
+metadata:
+  name: test
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := applyFile(nil, path)
+	if err == nil {
+		t.Error("applyFile() with unsupported apiVersion should return error")
+	}
+	if err != nil && !contains(err.Error(), "unsupported apiVersion") {
+		t.Errorf("error = %q, want it to contain 'unsupported apiVersion'", err.Error())
+	}
+}
+
+func TestApplyFile_CanonicalAPIVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "v1beta1.yaml")
+	content := `apiVersion: gostoa.dev/v1beta1
+kind: UnknownThing
+metadata:
+  name: test
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should pass apiVersion validation but fail on unsupported kind
+	err := applyFile(nil, path)
+	if err == nil {
+		t.Error("applyFile() should fail on unsupported kind")
+	}
+	if err != nil && contains(err.Error(), "unsupported apiVersion") {
+		t.Error("canonical v1beta1 should not trigger apiVersion error")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchSubstr(s, substr)
+}
+
+func searchSubstr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
 func TestRunApply_MissingFile(t *testing.T) {
 	filePath = "/nonexistent/path/file.yaml"
 	dryRun = false

--- a/stoa-go/pkg/output/output.go
+++ b/stoa-go/pkg/output/output.go
@@ -120,3 +120,8 @@ func Error(format string, args ...any) {
 func Info(format string, args ...any) {
 	fmt.Printf(format+"\n", args...)
 }
+
+// Warn prints a warning message to stderr
+func Warn(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "Warning: "+format+"\n", args...)
+}

--- a/stoa-go/pkg/types/types.go
+++ b/stoa-go/pkg/types/types.go
@@ -2,6 +2,28 @@
 // Copyright 2024-2026 CAB Ingénierie / Christophe ABOULICAM
 package types
 
+// CanonicalAPIVersion is the target version for all STOA resources.
+const CanonicalAPIVersion = "gostoa.dev/v1beta1"
+
+// AcceptedAPIVersions lists all apiVersions that stoactl will accept.
+// Older versions are transparently upgraded to CanonicalAPIVersion.
+var AcceptedAPIVersions = []string{
+	"gostoa.dev/v1beta1", // canonical (Phase 4)
+	"gostoa.dev/v1",       // MCPServer legacy
+	"gostoa.dev/v1alpha1", // CRD legacy (Tool, ToolSet, Skill)
+	"stoa.io/v1",          // early prototype — deprecated
+}
+
+// IsAcceptedAPIVersion returns true if the given apiVersion is recognized.
+func IsAcceptedAPIVersion(v string) bool {
+	for _, accepted := range AcceptedAPIVersions {
+		if v == accepted {
+			return true
+		}
+	}
+	return false
+}
+
 // Resource represents a STOA resource (API, Subscription, etc.)
 type Resource struct {
 	APIVersion string   `yaml:"apiVersion" json:"apiVersion"`

--- a/stoa-go/pkg/types/types_test.go
+++ b/stoa-go/pkg/types/types_test.go
@@ -490,6 +490,41 @@ func TestRegression_CAB2006_GatewayHealthFields(t *testing.T) {
 	}
 }
 
+// TestIsAcceptedAPIVersion validates the apiVersion acceptance logic
+func TestIsAcceptedAPIVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"gostoa.dev/v1beta1", true},   // canonical
+		{"gostoa.dev/v1", true},         // MCPServer legacy
+		{"gostoa.dev/v1alpha1", true},   // CRD legacy
+		{"stoa.io/v1", true},            // deprecated prototype
+		{"gostoa.dev/v2", false},        // unknown
+		{"", false},                     // empty
+		{"kubernetes/v1", false},        // unrelated
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			got := IsAcceptedAPIVersion(tt.version)
+			if got != tt.want {
+				t.Errorf("IsAcceptedAPIVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCanonicalAPIVersion ensures the constant is set correctly
+func TestCanonicalAPIVersion(t *testing.T) {
+	if CanonicalAPIVersion != "gostoa.dev/v1beta1" {
+		t.Errorf("CanonicalAPIVersion = %q, want %q", CanonicalAPIVersion, "gostoa.dev/v1beta1")
+	}
+	if !IsAcceptedAPIVersion(CanonicalAPIVersion) {
+		t.Error("CanonicalAPIVersion should be accepted")
+	}
+}
+
 // TestEmptyAPIListResponse tests empty list response
 func TestEmptyAPIListResponse(t *testing.T) {
 	jsonData := `{"items": [], "totalCount": 0}`


### PR DESCRIPTION
## Summary
- Generate 10 JSON schemas from Pydantic v2 models (`charts/stoa-platform/schemas/`) + registry index
- Add `CanonicalAPIVersion = gostoa.dev/v1beta1` to stoactl types with backward-compat for v1/v1alpha1/stoa.io/v1
- Apply command now validates apiVersion: canonical passes clean, legacy emits deprecation warning, unknown rejected
- Schema generation script (`scripts/generate-schemas.py`) as single source of truth

## CAB-2053 Phase 4 DoD
- [x] `apiVersion` unified on `gostoa.dev/v1beta1` via accept list + deprecation path
- [x] JSON Schema registry published in `charts/stoa-platform/schemas/` (10 kinds + registry.json)
- [x] `stoactl` types.go has canonical version constant + validation
- [x] Schema generation from Pydantic models (single source)
- [x] All Go tests pass (4 new tests for version validation)

## Test plan
- [x] `go test ./...` — all packages pass
- [x] New tests: `TestIsAcceptedAPIVersion`, `TestCanonicalAPIVersion`, `TestApplyFile_UnsupportedAPIVersion`, `TestApplyFile_CanonicalAPIVersion`
- [x] Schema generation: `cd control-plane-api && python3 ../scripts/generate-schemas.py`
- [ ] CI green (3 required checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)