### PR TITLE
fix(ci): resolve Helm lint and ESLint SAST pre-existing failures (CAB-2053)

### DIFF
--- a/charts/stoa-platform/.helmignore
+++ b/charts/stoa-platform/.helmignore
@@ -17,8 +17,6 @@
 .claude/
 
 # Development
-*.md
-!README.md
 CLAUDE.md
 
 # Build artifacts

--- a/control-plane-ui/src/test/i18n-keys.test.ts
+++ b/control-plane-ui/src/test/i18n-keys.test.ts
@@ -32,7 +32,7 @@ function loadLocaleKeys(locale: string): string[] {
 /** Recursively scan .ts/.tsx source files for nav.* i18n keys in string literals */
 function scanNavKeysInSource(dir: string): Set<string> {
   const keys = new Set<string>();
-  const keyPattern = /['"]([\w]+(?:\.[\w]+){1,10})['"]/g;
+  const keyPattern = /['"](\w[\w.]*\w)['"]/g;
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const fullPath = join(dir, entry.name);
     if (entry.isDirectory() && entry.name !== 'node_modules') {


### PR DESCRIPTION
## Summary
- **Helm lint**: remove `!README.md` negation pattern from `.helmignore` — the `!` negation breaks Helm's chart loader, causing spurious "Chart.yaml file is missing" errors. Replace `*.md` + `!README.md` with just `CLAUDE.md`.
- **ESLint SAST**: simplify i18n key regex from nested quantifier `[\w]+(?:\.[\w]+){1,10}` to `\w[\w.]*\w` — avoids triggering `security/detect-unsafe-regex` false positive. All 4 test assertions pass.

## Root cause
- **Helm**: The `!pattern` negation in `.helmignore` is broken in Helm (tested v3.14.0 and v4.1.3). It causes the chart loader to fail finding `Chart.yaml` in subdirectories. This has been failing on every CI run since charts/ was last touched.
- **ESLint**: The regex `[\w]+(?:\.[\w]+){1,10})` has nested quantifiers that trigger the conservative `detect-unsafe-regex` rule, even though the `{1,10}` bound prevents actual ReDoS.

## Test plan
- [x] `helm lint charts/stoa-platform` passes locally
- [x] `vitest run src/test/i18n-keys.test.ts` — 4/4 pass
- [x] ESLint security gate (detect-unsafe-regex) passes on the simplified regex
- [ ] CI: Helm Lint job passes (was always failing before)
- [ ] CI: SAST JavaScript (ESLint) (control-plane-ui) passes (was always failing before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)