### PR TITLE
ci: deploy to dev first, require approval for prod promotion

### DIFF
--- a/.github/workflows/control-plane-api-ci.yml
+++ b/.github/workflows/control-plane-api-ci.yml
@@ -129,7 +129,7 @@ jobs:
       attestations: write
     secrets: inherit
 
-  # === GitOps Deploy: dispatch to stoa-infra → ArgoCD syncs ===
+  # === GitOps Deploy to Dev: dispatch to stoa-infra → ArgoCD syncs ===
   deploy:
     needs: docker
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -137,32 +137,45 @@ jobs:
     with:
       component: control-plane-api
       image-tag: ${{ needs.docker.outputs.image-tag }}
-      environment: ${{ github.event.inputs.environment || 'dev' }}
-      environment-url: https://api.gostoa.dev
-      verify-endpoint: https://api.gostoa.dev/health
+      environment: dev
+      environment-url: https://dev-api.gostoa.dev
+      verify-endpoint: https://dev-api.gostoa.dev/health
     secrets: inherit
 
   # === Smoke Test: health checks after deploy (Tier 1) ===
-  # Full E2E with personas runs nightly (e2e-nightly.yml)
   smoke-test:
     needs: deploy
     if: needs.deploy.result == 'success'
     uses: ./.github/workflows/reusable-health-smoke.yml
     with:
       component: control-plane-api
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: dev
     permissions:
       contents: read
 
+  # === Promote to Prod: requires manual approval via GitHub Environment ===
+  promote-to-prod:
+    needs: [docker, smoke-test]
+    if: |
+      always() &&
+      needs.smoke-test.result == 'success' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    uses: ./.github/workflows/reusable-promote.yml
+    with:
+      component: control-plane-api
+      image-name: control-plane-api
+      sha: ${{ github.sha }}
+    secrets: inherit
+
   # === Notify: Slack ===
   notify:
-    needs: [ci, docker, deploy, smoke-test]
+    needs: [ci, docker, deploy, smoke-test, promote-to-prod]
     if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/reusable-notify.yml
     with:
       component: Control Plane API
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ needs.promote-to-prod.result == 'success' && 'prod' || 'dev' }}
       ci-result: ${{ needs.ci.outputs.test-result }}
-      deploy-result: ${{ needs.deploy.result }}
+      deploy-result: ${{ needs.promote-to-prod.result }}
       smoke-result: ${{ needs.smoke-test.result }}
     secrets: inherit

--- a/.github/workflows/control-plane-api-ci.yml
+++ b/.github/workflows/control-plane-api-ci.yml
@@ -156,10 +156,7 @@ jobs:
   # === Promote to Prod: requires manual approval via GitHub Environment ===
   promote-to-prod:
     needs: [docker, smoke-test]
-    if: |
-      always() &&
-      needs.smoke-test.result == 'success' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: needs.smoke-test.result == 'success'
     uses: ./.github/workflows/reusable-promote.yml
     with:
       component: control-plane-api
@@ -174,8 +171,8 @@ jobs:
     uses: ./.github/workflows/reusable-notify.yml
     with:
       component: Control Plane API
-      environment: ${{ needs.promote-to-prod.result == 'success' && 'prod' || 'dev' }}
+      environment: dev
       ci-result: ${{ needs.ci.outputs.test-result }}
-      deploy-result: ${{ needs.promote-to-prod.result }}
+      deploy-result: ${{ needs.deploy.result }}
       smoke-result: ${{ needs.smoke-test.result }}
     secrets: inherit

--- a/.github/workflows/control-plane-ui-ci.yml
+++ b/.github/workflows/control-plane-ui-ci.yml
@@ -121,10 +121,7 @@ jobs:
   # === Promote to Prod: requires manual approval via GitHub Environment ===
   promote-to-prod:
     needs: [docker, smoke-test]
-    if: |
-      always() &&
-      needs.smoke-test.result == 'success' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: needs.smoke-test.result == 'success'
     uses: ./.github/workflows/reusable-promote.yml
     with:
       component: control-plane-ui
@@ -139,8 +136,8 @@ jobs:
     uses: ./.github/workflows/reusable-notify.yml
     with:
       component: Control Plane UI
-      environment: ${{ needs.promote-to-prod.result == 'success' && 'prod' || 'dev' }}
+      environment: dev
       ci-result: ${{ needs.ci.outputs.test-result }}
-      deploy-result: ${{ needs.promote-to-prod.result }}
+      deploy-result: ${{ needs.deploy.result }}
       smoke-result: ${{ needs.smoke-test.result }}
     secrets: inherit

--- a/.github/workflows/control-plane-ui-ci.yml
+++ b/.github/workflows/control-plane-ui-ci.yml
@@ -94,7 +94,7 @@ jobs:
       attestations: write
     secrets: inherit
 
-  # === GitOps Deploy: dispatch to stoa-infra → ArgoCD syncs ===
+  # === GitOps Deploy to Dev: dispatch to stoa-infra → ArgoCD syncs ===
   deploy:
     needs: docker
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -102,32 +102,45 @@ jobs:
     with:
       component: control-plane-ui
       image-tag: ${{ needs.docker.outputs.image-tag }}
-      environment: ${{ github.event.inputs.environment || 'dev' }}
-      environment-url: https://console.gostoa.dev
-      verify-endpoint: https://console.gostoa.dev
+      environment: dev
+      environment-url: https://dev-console.gostoa.dev
+      verify-endpoint: https://dev-console.gostoa.dev
     secrets: inherit
 
   # === Smoke Test: health checks after deploy (Tier 1) ===
-  # Full E2E with personas runs nightly (e2e-nightly.yml)
   smoke-test:
     needs: deploy
     if: needs.deploy.result == 'success'
     uses: ./.github/workflows/reusable-health-smoke.yml
     with:
       component: control-plane-ui
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: dev
     permissions:
       contents: read
 
+  # === Promote to Prod: requires manual approval via GitHub Environment ===
+  promote-to-prod:
+    needs: [docker, smoke-test]
+    if: |
+      always() &&
+      needs.smoke-test.result == 'success' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    uses: ./.github/workflows/reusable-promote.yml
+    with:
+      component: control-plane-ui
+      image-name: control-plane-ui
+      sha: ${{ github.sha }}
+    secrets: inherit
+
   # === Notify: Slack ===
   notify:
-    needs: [ci, docker, deploy, smoke-test]
+    needs: [ci, docker, deploy, smoke-test, promote-to-prod]
     if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/reusable-notify.yml
     with:
       component: Control Plane UI
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ needs.promote-to-prod.result == 'success' && 'prod' || 'dev' }}
       ci-result: ${{ needs.ci.outputs.test-result }}
-      deploy-result: ${{ needs.deploy.result }}
+      deploy-result: ${{ needs.promote-to-prod.result }}
       smoke-result: ${{ needs.smoke-test.result }}
     secrets: inherit

--- a/.github/workflows/stoa-gateway-ci.yml
+++ b/.github/workflows/stoa-gateway-ci.yml
@@ -81,7 +81,7 @@ jobs:
       attestations: write
     secrets: inherit
 
-  # === GitOps Deploy: dispatch to stoa-infra → ArgoCD syncs ===
+  # === GitOps Deploy to Dev: dispatch to stoa-infra → ArgoCD syncs ===
   deploy:
     needs: docker
     if: |
@@ -92,33 +92,46 @@ jobs:
     with:
       component: stoa-gateway
       image-tag: ${{ needs.docker.outputs.image-tag }}
-      environment: ${{ github.event.inputs.environment || 'dev' }}
-      environment-url: https://mcp.gostoa.dev
-      verify-endpoint: https://mcp.gostoa.dev/health/ready
+      environment: dev
+      environment-url: https://dev-mcp.gostoa.dev
+      verify-endpoint: https://dev-mcp.gostoa.dev/health/ready
       verify-timeout: 300
     secrets: inherit
 
   # === Smoke Test: health checks after deploy (Tier 1) ===
-  # Full E2E with personas runs nightly (e2e-nightly.yml)
   smoke-test:
     needs: deploy
     if: needs.deploy.result == 'success'
     uses: ./.github/workflows/reusable-health-smoke.yml
     with:
       component: stoa-gateway
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: dev
     permissions:
       contents: read
 
+  # === Promote to Prod: requires manual approval via GitHub Environment ===
+  promote-to-prod:
+    needs: [docker, smoke-test]
+    if: |
+      always() &&
+      needs.smoke-test.result == 'success' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    uses: ./.github/workflows/reusable-promote.yml
+    with:
+      component: stoa-gateway
+      image-name: stoa-gateway
+      sha: ${{ github.sha }}
+    secrets: inherit
+
   # === Notify: Slack ===
   notify:
-    needs: [ci, docker, deploy, smoke-test]
+    needs: [ci, docker, deploy, smoke-test, promote-to-prod]
     if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/reusable-notify.yml
     with:
       component: STOA Gateway
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ needs.promote-to-prod.result == 'success' && 'prod' || 'dev' }}
       ci-result: ${{ needs.ci.outputs.test-result }}
-      deploy-result: ${{ needs.deploy.result }}
+      deploy-result: ${{ needs.promote-to-prod.result }}
       smoke-result: ${{ needs.smoke-test.result }}
     secrets: inherit

--- a/.github/workflows/stoa-gateway-ci.yml
+++ b/.github/workflows/stoa-gateway-ci.yml
@@ -112,10 +112,7 @@ jobs:
   # === Promote to Prod: requires manual approval via GitHub Environment ===
   promote-to-prod:
     needs: [docker, smoke-test]
-    if: |
-      always() &&
-      needs.smoke-test.result == 'success' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: needs.smoke-test.result == 'success'
     uses: ./.github/workflows/reusable-promote.yml
     with:
       component: stoa-gateway
@@ -130,8 +127,8 @@ jobs:
     uses: ./.github/workflows/reusable-notify.yml
     with:
       component: STOA Gateway
-      environment: ${{ needs.promote-to-prod.result == 'success' && 'prod' || 'dev' }}
+      environment: dev
       ci-result: ${{ needs.ci.outputs.test-result }}
-      deploy-result: ${{ needs.promote-to-prod.result }}
+      deploy-result: ${{ needs.deploy.result }}
       smoke-result: ${{ needs.smoke-test.result }}
     secrets: inherit

--- a/.github/workflows/stoa-portal-ci.yml
+++ b/.github/workflows/stoa-portal-ci.yml
@@ -95,7 +95,7 @@ jobs:
       attestations: write
     secrets: inherit
 
-  # === GitOps Deploy: dispatch to stoa-infra → ArgoCD syncs ===
+  # === GitOps Deploy to Dev: dispatch to stoa-infra → ArgoCD syncs ===
   deploy:
     needs: docker
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -103,32 +103,45 @@ jobs:
     with:
       component: stoa-portal
       image-tag: ${{ needs.docker.outputs.image-tag }}
-      environment: ${{ github.event.inputs.environment || 'dev' }}
-      environment-url: https://portal.gostoa.dev
-      verify-endpoint: https://portal.gostoa.dev
+      environment: dev
+      environment-url: https://dev-portal.gostoa.dev
+      verify-endpoint: https://dev-portal.gostoa.dev
     secrets: inherit
 
   # === Smoke Test: health checks after deploy (Tier 1) ===
-  # Full E2E with personas runs nightly (e2e-nightly.yml)
   smoke-test:
     needs: deploy
     if: needs.deploy.result == 'success'
     uses: ./.github/workflows/reusable-health-smoke.yml
     with:
       component: stoa-portal
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: dev
     permissions:
       contents: read
 
+  # === Promote to Prod: requires manual approval via GitHub Environment ===
+  promote-to-prod:
+    needs: [docker, smoke-test]
+    if: |
+      always() &&
+      needs.smoke-test.result == 'success' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    uses: ./.github/workflows/reusable-promote.yml
+    with:
+      component: stoa-portal
+      image-name: portal
+      sha: ${{ github.sha }}
+    secrets: inherit
+
   # === Notify: Slack ===
   notify:
-    needs: [ci, docker, deploy, smoke-test]
+    needs: [ci, docker, deploy, smoke-test, promote-to-prod]
     if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/reusable-notify.yml
     with:
       component: STOA Portal
-      environment: ${{ github.event.inputs.environment || 'dev' }}
+      environment: ${{ needs.promote-to-prod.result == 'success' && 'prod' || 'dev' }}
       ci-result: ${{ needs.ci.outputs.test-result }}
-      deploy-result: ${{ needs.deploy.result }}
+      deploy-result: ${{ needs.promote-to-prod.result }}
       smoke-result: ${{ needs.smoke-test.result }}
     secrets: inherit

--- a/.github/workflows/stoa-portal-ci.yml
+++ b/.github/workflows/stoa-portal-ci.yml
@@ -122,10 +122,7 @@ jobs:
   # === Promote to Prod: requires manual approval via GitHub Environment ===
   promote-to-prod:
     needs: [docker, smoke-test]
-    if: |
-      always() &&
-      needs.smoke-test.result == 'success' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: needs.smoke-test.result == 'success'
     uses: ./.github/workflows/reusable-promote.yml
     with:
       component: stoa-portal
@@ -140,8 +137,8 @@ jobs:
     uses: ./.github/workflows/reusable-notify.yml
     with:
       component: STOA Portal
-      environment: ${{ needs.promote-to-prod.result == 'success' && 'prod' || 'dev' }}
+      environment: dev
       ci-result: ${{ needs.ci.outputs.test-result }}
-      deploy-result: ${{ needs.promote-to-prod.result }}
+      deploy-result: ${{ needs.deploy.result }}
       smoke-result: ${{ needs.smoke-test.result }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- All 4 component CI/CD workflows now deploy to **dev** (`dev-*.gostoa.dev`) on merge to main
- Smoke tests run against dev endpoints before promotion
- New `promote-to-prod` job requires **manual approval** via GitHub Environment protection (PotoMitan)
- Uses existing `reusable-promote.yml` — same image promoted, no rebuild

## Context
Dev environment bootstrapped on OVH MKS (1x B2-15, GRA9):
- `dev-api.gostoa.dev` ✅
- `dev-console.gostoa.dev` ✅  
- `dev-portal.gostoa.dev` ✅
- `dev-auth.gostoa.dev` ✅

## Pipeline flow
```
merge → CI → Docker → Deploy DEV → Smoke → ⏸️ Approve → Promote PROD
```

## Test plan
- [x] Pre-push quality gate passed
- [ ] CI green (required checks)
- [ ] Verify workflow YAML syntax valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)