### PR TITLE
feat(local): Tilt + k3d local environment + Alembic migration fixes

### DIFF
--- a/.claude/rules/seo-content.md
+++ b/.claude/rules/seo-content.md
@@ -50,9 +50,29 @@ Rules: every spoke links to hub, every hub links to all spokes, cross-pillar enc
 
 10 checks: build clean, front-matter complete, word count met, min 3 internal links, hub link present, content compliance (no P0/P1), last-verified tag on comparisons, valid tags, no broken links, answer-first format. Pre-commit: `cd stoa-docs && npm run build 2>&1 | grep -E "broken|error|warning"` → must be empty.
 
+## Blog Validation Process (MANDATORY)
+
+Every blog article MUST pass these gates before merge:
+
+```
+1. Write article (docs-writer or manual)
+2. npm run build (link validation)
+3. content-reviewer audit (ALWAYS — not just when competitors mentioned)
+4. scripts/audit-content-compliance.sh (automated P0/P1 scan)
+5. CI: docs-audit.yml runs both client-names + content-compliance jobs
+```
+
+**Gate enforcement**:
+- `audit-content-compliance.sh` runs in CI on every PR touching `blog/**`
+- P0 = merge blocked (competitor pricing, certification claims, client names)
+- P1 = warning in PR comment (unsourced claims, missing disclaimers, negative characterizations)
+- Local pre-check: `cd stoa-docs && ./scripts/audit-content-compliance.sh`
+
+**content-reviewer subagent is ALWAYS required** — not just when competitors are mentioned. Cost claims, regulatory language, and positioning can violate P1 even without naming competitors.
+
 ## Subagent Pattern
 
-Blog post flow: choose topic → research → prepare context for `docs-writer` (front-matter, valid link list, hub, word count, compliance rules) → generate → `npm run build` (ALWAYS — subagents guess wrong links) → `content-reviewer` if competitors mentioned → fix → commit.
+Blog post flow: choose topic → research → prepare context for `docs-writer` (front-matter, valid link list, hub, word count, compliance rules) → generate → `npm run build` (ALWAYS — subagents guess wrong links) → **`content-reviewer` (ALWAYS)** → `audit-content-compliance.sh` → fix → commit.
 
 ## Search Optimization
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,94 @@
+# -*- mode: Python -*-
+# =============================================================================
+# STOA Platform — Tilt Local Development
+# =============================================================================
+#
+# Prerequisites:
+#   brew install tilt k3d
+#   k3d cluster create --config ../stoa-infra/deploy/tilt/k3d-config.yaml
+#   cp deploy/docker-compose/.env.example deploy/docker-compose/.env
+#   docker compose -f ../stoa-infra/deploy/tilt/docker-compose-stateful.yml \
+#     --env-file deploy/docker-compose/.env up -d
+#
+# Usage:
+#   tilt up        # start k8s workloads (stateful services must be running)
+#   tilt down      # stop k8s workloads
+#
+# Architecture:
+#   Docker Compose (manual): postgres, keycloak, redpanda
+#   k3d (via Tilt):          control-plane-api, control-plane-ui, portal, stoa-gateway
+#
+# =============================================================================
+
+INFRA_REPO = '../stoa-infra'
+K3D_CLUSTER = 'stoa-dev'
+
+allow_k8s_contexts('k3d-stoa-dev')
+default_registry('localhost:5111')
+
+# ── Stub secrets (needed by Helm chart envFrom) ──────────────────────────────
+k8s_yaml(blob("""
+apiVersion: v1
+kind: Secret
+metadata:
+  name: stoa-local-secrets
+type: Opaque
+stringData:
+  token: "unused"
+  project-id: "0"
+  webhook-secret: "unused"
+"""))
+
+# ── Image builds ─────────────────────────────────────────────────────────────
+
+docker_build(
+    'stoa-platform/control-plane-api',
+    context='control-plane-api',
+    dockerfile='control-plane-api/Dockerfile',
+)
+
+docker_build(
+    'stoa-platform/control-plane-ui',
+    context='.',
+    dockerfile='control-plane-ui/Dockerfile.dev',
+    only=['control-plane-ui/', 'shared/', 'tsconfig.base.json'],
+)
+
+docker_build(
+    'stoa-platform/portal',
+    context='.',
+    dockerfile='portal/Dockerfile.dev',
+    only=['portal/', 'shared/', 'tsconfig.base.json'],
+)
+
+docker_build(
+    'stoa-platform/stoa-gateway',
+    context='stoa-gateway',
+    dockerfile='stoa-gateway/Dockerfile',
+)
+
+# ── Helm Charts ──────────────────────────────────────────────────────────────
+
+k8s_yaml(helm(
+    INFRA_REPO + '/charts/control-plane-api',
+    values=[INFRA_REPO + '/deploy/tilt/values-local/control-plane-api.yaml'],
+))
+k8s_resource('stoa-control-plane-api', port_forwards=['8000:8000'], labels=['workloads'])
+
+k8s_yaml(helm(
+    INFRA_REPO + '/charts/control-plane-ui',
+    values=[INFRA_REPO + '/deploy/tilt/values-local/control-plane-ui.yaml'],
+))
+k8s_resource('control-plane-ui', port_forwards=['5173:5173'], labels=['workloads'])
+
+k8s_yaml(helm(
+    INFRA_REPO + '/charts/stoa-portal',
+    values=[INFRA_REPO + '/deploy/tilt/values-local/stoa-portal.yaml'],
+))
+k8s_resource('stoa-portal', port_forwards=['5174:5174'], labels=['workloads'])
+
+k8s_yaml(helm(
+    INFRA_REPO + '/charts/stoa-gateway',
+    values=[INFRA_REPO + '/deploy/tilt/values-local/stoa-gateway.yaml'],
+))
+k8s_resource('stoa-gateway', port_forwards=['8081:8080'], labels=['workloads'])

--- a/Tiltfile
+++ b/Tiltfile
@@ -20,8 +20,8 @@
 #
 # =============================================================================
 
-INFRA_REPO = '../stoa-infra'
-K3D_CLUSTER = 'stoa-dev'
+infra_repo = '../stoa-infra'
+k3d_cluster = 'stoa-dev'
 
 allow_k8s_contexts('k3d-stoa-dev')
 default_registry('localhost:5111')
@@ -70,25 +70,25 @@ docker_build(
 # ── Helm Charts ──────────────────────────────────────────────────────────────
 
 k8s_yaml(helm(
-    INFRA_REPO + '/charts/control-plane-api',
-    values=[INFRA_REPO + '/deploy/tilt/values-local/control-plane-api.yaml'],
+    infra_repo + '/charts/control-plane-api',
+    values=[infra_repo + '/deploy/tilt/values-local/control-plane-api.yaml'],
 ))
 k8s_resource('stoa-control-plane-api', port_forwards=['8000:8000'], labels=['workloads'])
 
 k8s_yaml(helm(
-    INFRA_REPO + '/charts/control-plane-ui',
-    values=[INFRA_REPO + '/deploy/tilt/values-local/control-plane-ui.yaml'],
+    infra_repo + '/charts/control-plane-ui',
+    values=[infra_repo + '/deploy/tilt/values-local/control-plane-ui.yaml'],
 ))
 k8s_resource('control-plane-ui', port_forwards=['5173:5173'], labels=['workloads'])
 
 k8s_yaml(helm(
-    INFRA_REPO + '/charts/stoa-portal',
-    values=[INFRA_REPO + '/deploy/tilt/values-local/stoa-portal.yaml'],
+    infra_repo + '/charts/stoa-portal',
+    values=[infra_repo + '/deploy/tilt/values-local/stoa-portal.yaml'],
 ))
 k8s_resource('stoa-portal', port_forwards=['5174:5174'], labels=['workloads'])
 
 k8s_yaml(helm(
-    INFRA_REPO + '/charts/stoa-gateway',
-    values=[INFRA_REPO + '/deploy/tilt/values-local/stoa-gateway.yaml'],
+    infra_repo + '/charts/stoa-gateway',
+    values=[infra_repo + '/deploy/tilt/values-local/stoa-gateway.yaml'],
 ))
 k8s_resource('stoa-gateway', port_forwards=['8081:8080'], labels=['workloads'])

--- a/control-plane-api/alembic/env.py
+++ b/control-plane-api/alembic/env.py
@@ -58,6 +58,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        version_num_width=128,
     )
 
     with context.begin_transaction():
@@ -75,7 +76,8 @@ def run_migrations_online() -> None:
     with connectable.connect() as connection:
         context.configure(
             connection=connection,
-            target_metadata=target_metadata
+            target_metadata=target_metadata,
+            version_num_width=128,
         )
 
         with context.begin_transaction():

--- a/control-plane-api/alembic/versions/017_add_gateway_mode_column.py
+++ b/control-plane-api/alembic/versions/017_add_gateway_mode_column.py
@@ -29,7 +29,8 @@ def upgrade() -> None:
     op.create_index('ix_gw_instances_mode', 'gateway_instances', ['mode'])
 
     # Add new enum values for STOA modes (ADR-024)
-    # Using raw SQL since Alembic doesn't have direct enum value addition
+    # Must commit before ADD VALUE — Postgres requires it outside a transaction block
+    op.execute("COMMIT")
     op.execute("ALTER TYPE gateway_type_enum ADD VALUE IF NOT EXISTS 'stoa_edge_mcp'")
     op.execute("ALTER TYPE gateway_type_enum ADD VALUE IF NOT EXISTS 'stoa_sidecar'")
     op.execute("ALTER TYPE gateway_type_enum ADD VALUE IF NOT EXISTS 'stoa_proxy'")

--- a/control-plane-api/alembic/versions/022_add_gravitee_gateway_type.py
+++ b/control-plane-api/alembic/versions/022_add_gravitee_gateway_type.py
@@ -20,6 +20,7 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     """Add gravitee to gateway_type_enum."""
+    op.execute("COMMIT")
     op.execute("ALTER TYPE gateway_type_enum ADD VALUE IF NOT EXISTS 'gravitee'")
 
 

--- a/control-plane-api/alembic/versions/037_add_azure_apim_gateway_type.py
+++ b/control-plane-api/alembic/versions/037_add_azure_apim_gateway_type.py
@@ -20,6 +20,7 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     """Add azure_apim to gateway_type_enum."""
+    op.execute("COMMIT")
     op.execute("ALTER TYPE gateway_type_enum ADD VALUE IF NOT EXISTS 'azure_apim'")
 
 

--- a/control-plane-api/alembic/versions/039_extend_error_category.py
+++ b/control-plane-api/alembic/versions/039_extend_error_category.py
@@ -19,6 +19,7 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    op.execute("COMMIT")
     op.execute("ALTER TYPE errorcategory ADD VALUE IF NOT EXISTS 'network'")
     op.execute("ALTER TYPE errorcategory ADD VALUE IF NOT EXISTS 'certificate'")
     op.execute("ALTER TYPE errorcategory ADD VALUE IF NOT EXISTS 'policy'")

--- a/control-plane-api/alembic/versions/053_add_rejected_subscription_status.py
+++ b/control-plane-api/alembic/versions/053_add_rejected_subscription_status.py
@@ -16,6 +16,7 @@ depends_on = None
 
 def upgrade() -> None:
     # Add 'rejected' value to the subscriptionstatus enum
+    op.execute("COMMIT")
     op.execute("ALTER TYPE subscriptionstatus ADD VALUE IF NOT EXISTS 'rejected'")
 
     # Add rejected_by and rejected_at columns

--- a/control-plane-api/alembic/versions/083_cleanup_phantom_gateway_instances.py
+++ b/control-plane-api/alembic/versions/083_cleanup_phantom_gateway_instances.py
@@ -29,6 +29,10 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    # Add DELETING enum value if missing (needed for WHERE clause below)
+    op.execute("COMMIT")
+    op.execute("ALTER TYPE deployment_sync_status_enum ADD VALUE IF NOT EXISTS 'DELETING'")
+
     # Soft-delete gateway instances where:
     # 1. source is NOT 'self_register' (manually created or imported)
     # 2. already not soft-deleted (deleted_at IS NULL)

--- a/control-plane-api/alembic/versions/093_add_security_posture_tables.py
+++ b/control-plane-api/alembic/versions/093_add_security_posture_tables.py
@@ -1,7 +1,7 @@
 """add security_findings, security_scans, security_baselines tables
 
 Revision ID: 093
-Revises: 092
+Revises: 091_add_is_platform_and_seed_gateway
 Create Date: 2026-04-08
 
 CAB-2008: tables for Security Posture dashboard — scanner findings,
@@ -13,8 +13,8 @@ from alembic import op
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 
-revision = "093"
-down_revision = "092"
+revision = "093_add_security_posture_tables"
+down_revision = "091_add_is_platform_and_seed_gateway"
 branch_labels = None
 depends_on = None
 

--- a/control-plane-api/alembic/versions/094_seed_gateway_deployments.py
+++ b/control-plane-api/alembic/versions/094_seed_gateway_deployments.py
@@ -22,8 +22,8 @@ import json
 import sqlalchemy as sa
 from alembic import op
 
-revision = "094"
-down_revision = "093"
+revision = "094_seed_gateway_deployments"
+down_revision = "093_add_security_posture_tables"
 branch_labels = None
 depends_on = None
 

--- a/control-plane-ui/Dockerfile.dev
+++ b/control-plane-ui/Dockerfile.dev
@@ -1,0 +1,30 @@
+# Dev Dockerfile — Vite dev server with HMR (no nginx)
+# Build context: repo root
+# Usage: docker build -f control-plane-ui/Dockerfile.dev -t stoa-platform/control-plane-ui:local .
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install shared deps
+COPY shared/package*.json ./shared/
+RUN cd shared && npm ci --ignore-scripts --legacy-peer-deps
+
+# Install main deps
+COPY control-plane-ui/package*.json ./control-plane-ui/
+WORKDIR /app/control-plane-ui
+RUN npm ci
+
+# Copy source
+WORKDIR /app
+COPY tsconfig.base.json ./
+COPY shared/ ./shared/
+COPY control-plane-ui/ ./control-plane-ui/
+
+WORKDIR /app/control-plane-ui
+
+# Ensure node_modules writable by any UID (K8s securityContext may override user)
+RUN chmod -R 777 /app/control-plane-ui/node_modules /app/shared/node_modules
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/control-plane-ui/vite.config.ts
+++ b/control-plane-ui/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+    allowedHosts: true,
     proxy: {
       '/api': {
         target: 'http://localhost:8000',

--- a/portal/Dockerfile.dev
+++ b/portal/Dockerfile.dev
@@ -1,0 +1,30 @@
+# Dev Dockerfile — Vite dev server with HMR (no nginx)
+# Build context: repo root
+# Usage: docker build -f portal/Dockerfile.dev -t stoa-platform/portal:local .
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install shared deps
+COPY shared/package*.json ./shared/
+RUN cd shared && npm ci --ignore-scripts --legacy-peer-deps
+
+# Install main deps
+COPY portal/package*.json ./portal/
+WORKDIR /app/portal
+RUN npm ci --legacy-peer-deps
+
+# Copy source
+WORKDIR /app
+COPY tsconfig.base.json ./
+COPY shared/ ./shared/
+COPY portal/ ./portal/
+
+WORKDIR /app/portal
+
+# Ensure node_modules writable by any UID (K8s securityContext may override user)
+RUN chmod -R 777 /app/portal/node_modules /app/shared/node_modules
+
+EXPOSE 5174
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5174"]

--- a/portal/src/services/governance.ts
+++ b/portal/src/services/governance.ts
@@ -92,17 +92,30 @@ export const governanceService = {
    * Aggregates data from multiple endpoints
    */
   getStats: async (tenantId: string): Promise<GovernanceStats> => {
-    const [pendingResponse, apisResponse] = await Promise.all([
-      apiSubscriptionsService.listPendingForTenant(tenantId, { page_size: 1 }),
-      apiClient
-        .get<{ items: { status: string }[] }>('/v1/portal/apis', {
-          params: { page_size: 200 },
-        })
-        .then((r) => r.data),
-    ]);
+    const pendingResponse = await apiSubscriptionsService.listPendingForTenant(tenantId, {
+      page_size: 1,
+    });
+
+    // Fetch all APIs with pagination (API max page_size is 100)
+    const allApis: { status: string }[] = [];
+    let page = 1;
+    let total = Infinity;
+    while (allApis.length < total) {
+      const response = await apiClient.get<{
+        apis: { status: string }[];
+        total: number;
+        page: number;
+        page_size: number;
+      }>('/v1/portal/apis', {
+        params: { page, page_size: 100 },
+      });
+      allApis.push(...response.data.apis);
+      total = response.data.total;
+      page++;
+    }
 
     const apisByStatus: Record<string, number> = {};
-    for (const api of apisResponse.items) {
+    for (const api of allApis) {
       apisByStatus[api.status] = (apisByStatus[api.status] || 0) + 1;
     }
 

--- a/portal/src/services/governance.ts
+++ b/portal/src/services/governance.ts
@@ -12,6 +12,9 @@
  */
 
 import { apiClient } from './api';
+
+/** Maximum page_size accepted by the portal/apis endpoint */
+const API_MAX_PAGE_SIZE = 100;
 import type {
   GovernanceStats,
   GovernanceApproval,
@@ -107,7 +110,7 @@ export const governanceService = {
         page: number;
         page_size: number;
       }>('/v1/portal/apis', {
-        params: { page, page_size: 100 },
+        params: { page, page_size: API_MAX_PAGE_SIZE },
       });
       allApis.push(...response.data.apis);
       total = response.data.total;

--- a/portal/src/services/governance.ts
+++ b/portal/src/services/governance.ts
@@ -100,10 +100,11 @@ export const governanceService = {
     });
 
     // Fetch all APIs with pagination (API max page_size is 100)
+    const maxPages = 50; // safeguard against infinite loop
     const allApis: { status: string }[] = [];
     let page = 1;
     let total = Infinity;
-    while (allApis.length < total) {
+    while (allApis.length < total && page <= maxPages) {
       const response = await apiClient.get<{
         apis: { status: string }[];
         total: number;


### PR DESCRIPTION
## Summary
- **Portal pagination fix**: `governance.ts` called `/v1/portal/apis` with `page_size=200` (API max is 100 → 422). Now paginates correctly with safeguard against infinite loops.
- **Alembic migration fixes**: 6 migrations had `ALTER TYPE ADD VALUE` inside transactions (Postgres rejects this). Added `COMMIT` before each. Fixed missing migration 092 by rechaining 093→091.
- **Tilt local dev**: `Tiltfile` + `Dockerfile.dev` for Console/Portal (Vite HMR) + Makefile targets. Requires `stoa-infra` deploy/tilt/ configs (separate PR).
- **Vite `allowedHosts: true`**: needed for k8s readiness probes that use pod IP as Host header.

## Test plan
- [x] Pre-push quality gate passed (8 checks)
- [x] Playwright E2E: OIDC login + API calls → 0 errors, 0 fails
- [x] `alembic upgrade head` on fresh DB passes all 94 migrations
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>