### PR TITLE
fix(ci): exclude .md from e2e path triggers

### DIFF
--- a/.github/workflows/e2e-a11y-gate.yml
+++ b/.github/workflows/e2e-a11y-gate.yml
@@ -18,6 +18,8 @@ on:
       - 'e2e/smoke-mock/**'
       - 'e2e/fixtures/axe-helper*'
       - '.github/workflows/e2e-a11y-gate.yml'
+      - '!control-plane-ui/**/*.md'
+      - '!shared/**/*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,6 +10,9 @@ on:
       - 'portal/**'
       - 'control-plane-ui/**'
       - '.github/workflows/e2e-tests.yml'
+      - '!e2e/**/*.md'
+      - '!portal/**/*.md'
+      - '!control-plane-ui/**/*.md'
 
   pull_request:
     branches:
@@ -19,6 +22,9 @@ on:
       - 'e2e/**'
       - 'portal/**'
       - 'control-plane-ui/**'
+      - '!e2e/**/*.md'
+      - '!portal/**/*.md'
+      - '!control-plane-ui/**/*.md'
 
   # Run daily at 6 AM UTC
   schedule:

--- a/.github/workflows/e2e-visual-regression.yml
+++ b/.github/workflows/e2e-visual-regression.yml
@@ -19,6 +19,9 @@ on:
       - 'e2e/visual/**'
       - 'e2e/golden/**'
       - '.github/workflows/e2e-visual-regression.yml'
+      - '!control-plane-ui/**/*.md'
+      - '!portal/**/*.md'
+      - '!shared/**/*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

E2E workflows (e2e-tests, e2e-visual-regression, e2e-a11y-gate) triggeraient sur toute modif dans `portal/**`, `control-plane-ui/**`, `e2e/**` — y compris les .md (CLAUDE.md, README, docs AI Factory). Résultat: tests E2E avec infra live qui échouent sur des PRs doc-only.

Fix: negation globs `!**/*.md` dans les `paths:` filters.

Exemple de faux positif: PR #2363 (refacto CLAUDE.md) a déclenché E2E + Visual Regression à cause des éditions dans `portal/CLAUDE.md`, `control-plane-ui/CLAUDE.md`, `e2e/CLAUDE.md`.

## Test plan
- [x] Pre-push gate passé
- [ ] PR doc-only future dans portal/CLAUDE.md ne déclenche plus E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)