### PR TITLE
fix(ui): Gateway Dashboard Inconsistencies — unified status, remove mocks, aggregated multi-gateway overview (CAB-1887)

### DIFF
--- a/control-plane-api/src/routers/platform.py
+++ b/control-plane-api/src/routers/platform.py
@@ -132,7 +132,13 @@ async def get_platform_status(
         # Check if ArgoCD service is configured
         if not argocd_service.is_connected:
             logger.warning("ArgoCD service not configured")
-            return _get_mock_status()
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "error": "deployments_unavailable",
+                    "detail": "ArgoCD service not configured",
+                },
+            )
 
         # CAB-687: Check in-memory cache first (Council obligation #3)
         cached = await _platform_status_cache.get("platform:status")
@@ -150,12 +156,24 @@ async def get_platform_status(
         # Handle health check failure
         if isinstance(health_result, Exception) or not health_result:
             logger.warning("ArgoCD health check failed")
-            return _get_mock_status(error="ArgoCD not reachable")
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "error": "deployments_unavailable",
+                    "detail": "ArgoCD not reachable",
+                },
+            )
 
         # Handle status fetch failure
         if isinstance(status_data, Exception):
             logger.error(f"Failed to get platform status: {status_data}")
-            return _get_mock_status(error=str(status_data))
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "error": "deployments_unavailable",
+                    "detail": str(status_data),
+                },
+            )
 
         # Build events from already-fetched app data (no extra API calls)
         events = []
@@ -200,10 +218,17 @@ async def get_platform_status(
 
         return response
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Failed to get platform status: {e}")
-        # Return degraded status on error
-        return _get_mock_status(error=str(e))
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": "deployments_unavailable",
+                "detail": str(e),
+            },
+        ) from e
 
 
 @router.get("/components", response_model=list[ComponentStatus])
@@ -390,69 +415,5 @@ async def get_component_diff(
 # ============================================================================
 # Helper Functions
 # ============================================================================
-
-
-def _get_mock_status(error: str | None = None) -> PlatformStatusResponse:
-    """
-    Return mock status when ArgoCD is not available.
-
-    Used for development/testing or when ArgoCD connection fails.
-    """
-    now = datetime.utcnow().isoformat() + "Z"
-
-    # Default components for mock status
-    components = [
-        ComponentStatus(
-            name="stoa-control-plane",
-            display_name="Control Plane API",
-            sync_status="Unknown" if error else "Synced",
-            health_status="Unknown" if error else "Healthy",
-            revision="HEAD",
-            last_sync=now,
-            message=error if error else None,
-        ),
-        ComponentStatus(
-            name="stoa-console",
-            display_name="Console UI",
-            sync_status="Unknown" if error else "Synced",
-            health_status="Unknown" if error else "Healthy",
-            revision="HEAD",
-            last_sync=now,
-            message=None,
-        ),
-        ComponentStatus(
-            name="stoa-portal",
-            display_name="Developer Portal",
-            sync_status="Unknown" if error else "Synced",
-            health_status="Unknown" if error else "Healthy",
-            revision="HEAD",
-            last_sync=now,
-            message=None,
-        ),
-        ComponentStatus(
-            name="stoa-gateway",
-            display_name="STOA Gateway",
-            sync_status="Unknown" if error else "Synced",
-            health_status="Unknown" if error else "Healthy",
-            revision="HEAD",
-            last_sync=now,
-            message=None,
-        ),
-    ]
-
-    return PlatformStatusResponse(
-        gitops=GitOpsStatus(
-            status="unknown" if error else "healthy",
-            components=components,
-            checked_at=now,
-        ),
-        events=[],
-        external_links=ExternalLinks(
-            argocd=settings.ARGOCD_EXTERNAL_URL,
-            grafana=settings.GRAFANA_URL,
-            prometheus=settings.PROMETHEUS_URL,
-            logs=settings.LOGS_URL,
-        ),
-        timestamp=now,
-        demo_mode=True,
-    )
+# Mock fallback removed (CAB-1887 G7): on failure, endpoints now return
+# 503 with structured error body {error, detail} instead of fake data.

--- a/control-plane-api/tests/test_platform_router.py
+++ b/control-plane-api/tests/test_platform_router.py
@@ -51,8 +51,8 @@ def _mock_status_data():
 class TestPlatformStatus:
     """Tests for GET /v1/platform/status."""
 
-    def test_status_mock_when_argocd_not_connected(self, client_as_cpi_admin: TestClient):
-        """Returns mock status when ArgoCD is not configured."""
+    def test_status_503_when_argocd_not_connected(self, client_as_cpi_admin: TestClient):
+        """Returns 503 with structured error when ArgoCD is not configured (CAB-1887 G7)."""
         mock_argocd = MagicMock()
         mock_argocd.is_connected = False
 
@@ -65,10 +65,10 @@ class TestPlatformStatus:
                 headers={"Authorization": "Bearer test-token"},
             )
 
-        assert resp.status_code == 200
+        assert resp.status_code == 503
         data = resp.json()
-        assert "gitops" in data
-        assert "events" in data
+        assert data["detail"]["error"] == "deployments_unavailable"
+        assert "detail" in data["detail"]
 
     def test_status_success_with_argocd(self, client_as_cpi_admin: TestClient):
         """Returns real status when ArgoCD is connected."""

--- a/control-plane-api/tests/test_regression_bugfixes.py
+++ b/control-plane-api/tests/test_regression_bugfixes.py
@@ -299,9 +299,24 @@ class TestRegression_PlatformExternalURL:
         )
 
     def test_platform_status_uses_external_url(self, client_as_cpi_admin: TestClient):
-        """Platform status response must use external URL, not internal K8s URL."""
+        """Platform status response must use external URL, not internal K8s URL.
+
+        Post CAB-1887 G7: mock fallback removed, so we simulate a successful
+        ArgoCD response and assert external_links still use external URLs.
+        """
+        from unittest.mock import AsyncMock
+
         mock_argocd = MagicMock()
-        mock_argocd.is_connected = False
+        mock_argocd.is_connected = True
+        mock_argocd.health_check = AsyncMock(return_value=True)
+        mock_argocd.get_platform_status = AsyncMock(
+            return_value={
+                "status": "healthy",
+                "components": [],
+                "checked_at": "2026-04-15T00:00:00Z",
+                "events": {},
+            }
+        )
 
         mock_settings = MagicMock()
         mock_settings.ARGOCD_URL = "http://argocd-server.argocd.svc:8080"

--- a/control-plane-ui/src/components/gateway/SloMetricTile.tsx
+++ b/control-plane-ui/src/components/gateway/SloMetricTile.tsx
@@ -1,0 +1,45 @@
+import { memo } from 'react';
+import { usePrometheusQuery, scalarValue } from '../../hooks/usePrometheus';
+
+/**
+ * Inline metric tile: renders loading skeleton / error / formatted value
+ * from a Prometheus query. Extracted in CAB-1887 G5 so it can be reused
+ * per-gateway in the aggregated Overview.
+ */
+export const SloMetricTile = memo(function SloMetricTile({
+  label,
+  query,
+  unit,
+  digits = 2,
+  testId,
+}: {
+  label: string;
+  query: string;
+  unit: string;
+  digits?: number;
+  testId: string;
+}) {
+  const { data, loading, error } = usePrometheusQuery(query);
+  const value = scalarValue(data);
+  return (
+    <div className="flex-1 min-w-0" data-testid={testId}>
+      <p className="text-xs text-neutral-500 dark:text-neutral-400">{label}</p>
+      {loading ? (
+        <div className="animate-pulse mt-1 h-7 w-20 rounded bg-neutral-100 dark:bg-neutral-700" />
+      ) : error ? (
+        <p className="mt-1 text-sm text-red-600 dark:text-red-400" title={error}>
+          Unavailable
+        </p>
+      ) : value === null ? (
+        <p className="mt-1 text-sm text-neutral-400 dark:text-neutral-500">—</p>
+      ) : (
+        <p className="mt-1 text-xl font-semibold text-neutral-900 dark:text-white">
+          {value.toFixed(digits)}
+          <span className="text-sm font-normal text-neutral-500 dark:text-neutral-400 ml-1">
+            {unit}
+          </span>
+        </p>
+      )}
+    </div>
+  );
+});

--- a/control-plane-ui/src/hooks/useGatewayStatus.ts
+++ b/control-plane-ui/src/hooks/useGatewayStatus.ts
@@ -13,7 +13,9 @@ export function useGatewayStatus() {
     queryFn: getGatewayStatus,
     refetchInterval: 30000,
     staleTime: 10000,
-    retry: false, // getGatewayStatus never throws; no need to retry
+    // CAB-1887 G2: getGatewayStatus now throws when all endpoints fail.
+    // React Query surfaces the error; callers render an explicit error state.
+    retry: 1,
   });
 }
 

--- a/control-plane-ui/src/pages/GatewayStatus.tsx
+++ b/control-plane-ui/src/pages/GatewayStatus.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useGatewayPlatformInfo } from '../hooks/useGatewayStatus';
 import { useGatewayHealthSummary, useGatewayInstances } from '../hooks/usePlatformMetrics';
+import { usePrometheusQuery, scalarValue } from '../hooks/usePrometheus';
 import { config } from '../config';
 import { observabilityPath, logsPath } from '../utils/navigation';
 import { SubNav } from '../components/SubNav';
@@ -18,6 +19,7 @@ import {
   BarChart3,
   Search,
   ShieldAlert,
+  Info,
   Loader2,
   Target,
   Gauge,
@@ -91,6 +93,55 @@ const StatsCard = memo(function StatsCard({
           <p className="text-2xl font-semibold text-neutral-900 dark:text-white">{value}</p>
         </div>
       </div>
+    </div>
+  );
+});
+
+// PromQL queries for the STOA gateway SLO row (aligned with PlatformMetricsDashboard)
+const SLO_QUERIES = {
+  availability:
+    '(1 - (sum(rate(stoa_http_requests_total{status=~"5.."}[1h])) or vector(0)) / (sum(rate(stoa_http_requests_total[1h])) or vector(1))) * 100',
+  p95Latency:
+    'histogram_quantile(0.95, sum(rate(stoa_http_request_duration_seconds_bucket[5m])) by (le)) * 1000',
+  errorRate:
+    'sum(rate(stoa_http_requests_total{status=~"5.."}[5m])) / sum(rate(stoa_http_requests_total[5m])) * 100',
+} as const;
+
+/** Inline metric tile: renders loading skeleton / error / formatted value from a Prometheus query. */
+const SloMetricTile = memo(function SloMetricTile({
+  label,
+  query,
+  unit,
+  digits = 2,
+  testId,
+}: {
+  label: string;
+  query: string;
+  unit: string;
+  digits?: number;
+  testId: string;
+}) {
+  const { data, loading, error } = usePrometheusQuery(query);
+  const value = scalarValue(data);
+  return (
+    <div className="flex-1 min-w-0" data-testid={testId}>
+      <p className="text-xs text-neutral-500 dark:text-neutral-400">{label}</p>
+      {loading ? (
+        <div className="animate-pulse mt-1 h-7 w-20 rounded bg-neutral-100 dark:bg-neutral-700" />
+      ) : error ? (
+        <p className="mt-1 text-sm text-red-600 dark:text-red-400" title={error}>
+          Unavailable
+        </p>
+      ) : value === null ? (
+        <p className="mt-1 text-sm text-neutral-400 dark:text-neutral-500">—</p>
+      ) : (
+        <p className="mt-1 text-xl font-semibold text-neutral-900 dark:text-white">
+          {value.toFixed(digits)}
+          <span className="text-sm font-normal text-neutral-500 dark:text-neutral-400 ml-1">
+            {unit}
+          </span>
+        </p>
+      )}
     </div>
   );
 });
@@ -333,40 +384,59 @@ export default function GatewayStatus() {
         </div>
       )}
 
-      {/* SLO Compliance Row */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm p-5">
-          <div className="flex items-center mb-4">
-            <div className="p-2 bg-neutral-100 dark:bg-neutral-700 rounded-lg">
-              <Target className="w-5 h-5 text-neutral-500 dark:text-neutral-400" />
-            </div>
-            <h3 className="ml-3 text-sm font-semibold text-neutral-900 dark:text-white">
-              SLO Compliance
-            </h3>
+      {/* SLO Compliance Row — live Prometheus metrics for STOA fleet, fallback for 3rd-party */}
+      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm p-5">
+        <div className="flex items-center mb-4">
+          <div className="p-2 bg-neutral-100 dark:bg-neutral-700 rounded-lg">
+            <Target className="w-5 h-5 text-neutral-500 dark:text-neutral-400" />
           </div>
-          <div className="text-center py-4">
+          <h3 className="ml-3 text-sm font-semibold text-neutral-900 dark:text-white">
+            STOA Gateway SLOs
+          </h3>
+          {stats.thirdPartyCount > 0 && (
+            <span
+              className="ml-2 inline-flex items-center text-xs text-neutral-400 dark:text-neutral-500"
+              title="3rd-party gateway metrics require a separate exporter — tracked as a follow-up ticket."
+              data-testid="slo-third-party-tooltip"
+            >
+              <Info className="w-3.5 h-3.5 mr-1" />
+              {stats.thirdPartyCount} 3rd-party excluded
+            </span>
+          )}
+        </div>
+        {stats.stoaCount > 0 ? (
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4" data-testid="slo-metrics-stoa">
+            <SloMetricTile
+              label="Availability (1h)"
+              query={SLO_QUERIES.availability}
+              unit="%"
+              digits={3}
+              testId="slo-availability"
+            />
+            <SloMetricTile
+              label="Latency p95 (5m)"
+              query={SLO_QUERIES.p95Latency}
+              unit="ms"
+              digits={0}
+              testId="slo-latency-p95"
+            />
+            <SloMetricTile
+              label="Error rate (5m)"
+              query={SLO_QUERIES.errorRate}
+              unit="%"
+              digits={2}
+              testId="slo-error-rate"
+            />
+          </div>
+        ) : (
+          <div className="text-center py-4" data-testid="slo-metrics-fallback">
+            <Gauge className="w-5 h-5 mx-auto text-neutral-400 dark:text-neutral-500 mb-2" />
             <p className="text-sm text-neutral-500 dark:text-neutral-400">No metrics available</p>
             <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1">
-              Connect Prometheus to enable SLO tracking
+              3rd-party gateway metrics require a separate exporter — follow-up ticket.
             </p>
           </div>
-        </div>
-        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm p-5">
-          <div className="flex items-center mb-4">
-            <div className="p-2 bg-neutral-100 dark:bg-neutral-700 rounded-lg">
-              <Gauge className="w-5 h-5 text-neutral-500 dark:text-neutral-400" />
-            </div>
-            <h3 className="ml-3 text-sm font-semibold text-neutral-900 dark:text-white">
-              Error Budget
-            </h3>
-          </div>
-          <div className="text-center py-4">
-            <p className="text-sm text-neutral-500 dark:text-neutral-400">No metrics available</p>
-            <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1">
-              Connect Prometheus to enable error budget tracking
-            </p>
-          </div>
-        </div>
+        )}
       </div>
 
       {/* Extension Cards (CAB-1023) */}

--- a/control-plane-ui/src/pages/GatewayStatus.tsx
+++ b/control-plane-ui/src/pages/GatewayStatus.tsx
@@ -2,17 +2,16 @@ import { memo, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useGatewayPlatformInfo } from '../hooks/useGatewayStatus';
 import { useGatewayHealthSummary, useGatewayInstances } from '../hooks/usePlatformMetrics';
-import { usePrometheusQuery, scalarValue } from '../hooks/usePrometheus';
 import { config } from '../config';
 import { observabilityPath, logsPath } from '../utils/navigation';
 import { SubNav } from '../components/SubNav';
 import { gatewayTabs } from '../components/subNavGroups';
+import { SloMetricTile } from '../components/gateway/SloMetricTile';
 import type { GatewayInstance, GatewayInstanceStatus } from '../types';
 import {
   Server,
   Activity,
   RefreshCw,
-  CheckCircle2,
   XCircle,
   ExternalLink,
   GitCommit,
@@ -21,7 +20,6 @@ import {
   ShieldAlert,
   Info,
   Loader2,
-  Target,
   Gauge,
   Zap,
 } from 'lucide-react';
@@ -54,93 +52,193 @@ function isStoa(type: string): boolean {
   return type.startsWith('stoa');
 }
 
-function timeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
+// PromQL queries for per-STOA-gateway SLO tiles. Each query is scoped to the
+// gateway's `job` label so each card reflects its own fleet slice. Aligned
+// with PlatformMetricsDashboard recording rules.
+function sloQueriesForGateway(job: string) {
+  const j = job.replace(/"/g, '\\"');
+  return {
+    availability: `(1 - (sum(rate(stoa_http_requests_total{job="${j}",status=~"5.."}[1h])) or vector(0)) / (sum(rate(stoa_http_requests_total{job="${j}"}[1h])) or vector(1))) * 100`,
+    p95Latency: `histogram_quantile(0.95, sum(rate(stoa_http_request_duration_seconds_bucket{job="${j}"}[5m])) by (le)) * 1000`,
+    errorRate: `sum(rate(stoa_http_requests_total{job="${j}",status=~"5.."}[5m])) / sum(rate(stoa_http_requests_total{job="${j}"}[5m])) * 100`,
+  } as const;
 }
 
-const statsColorClasses = {
-  blue: 'bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400',
-  green: 'bg-green-50 dark:bg-green-900/30 text-green-600 dark:text-green-400',
-  purple: 'bg-purple-50 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400',
-  orange: 'bg-orange-50 dark:bg-orange-900/30 text-orange-600 dark:text-orange-400',
-} as const;
-
-const StatsCard = memo(function StatsCard({
-  title,
-  value,
-  icon: Icon,
-  color = 'blue',
+/** Fleet summary header: totals + status breakdown + type breakdown. */
+const FleetSummaryHeader = memo(function FleetSummaryHeader({
+  total,
+  online,
+  offline,
+  degraded,
+  maintenance,
+  stoaCount,
+  thirdPartyCount,
 }: {
-  title: string;
-  value: number | string;
-  icon: React.ElementType;
-  color?: keyof typeof statsColorClasses;
+  total: number;
+  online: number;
+  offline: number;
+  degraded: number;
+  maintenance: number;
+  stoaCount: number;
+  thirdPartyCount: number;
 }) {
   return (
-    <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 p-4">
-      <div className="flex items-center">
-        <div className={`p-2 rounded-lg ${statsColorClasses[color]}`}>
-          <Icon className="w-5 h-5" />
+    <div
+      data-testid="fleet-summary"
+      className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm p-5"
+    >
+      <div className="flex items-center justify-between flex-wrap gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+            Fleet
+          </p>
+          <p
+            data-testid="fleet-total-count"
+            className="text-3xl font-bold text-neutral-900 dark:text-white"
+          >
+            {total}
+          </p>
+          <p className="text-xs text-neutral-500 dark:text-neutral-400">Registered gateways</p>
         </div>
-        <div className="ml-3">
-          <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">{title}</p>
-          <p className="text-2xl font-semibold text-neutral-900 dark:text-white">{value}</p>
+        <div className="flex gap-6 flex-wrap">
+          <FleetCounter
+            label="Online"
+            value={online}
+            testId="fleet-status-online-count"
+            dotClass="bg-green-500"
+          />
+          <FleetCounter
+            label="Offline"
+            value={offline}
+            testId="fleet-status-offline-count"
+            dotClass="bg-neutral-400"
+          />
+          <FleetCounter
+            label="Degraded"
+            value={degraded}
+            testId="fleet-status-degraded-count"
+            dotClass="bg-yellow-500"
+          />
+          <FleetCounter
+            label="Maintenance"
+            value={maintenance}
+            testId="fleet-status-maintenance-count"
+            dotClass="bg-blue-500"
+          />
+        </div>
+        <div className="flex gap-6">
+          <FleetCounter label="STOA" value={stoaCount} testId="fleet-type-stoa-count" />
+          <FleetCounter
+            label="3rd-party"
+            value={thirdPartyCount}
+            testId="fleet-type-thirdparty-count"
+          />
         </div>
       </div>
     </div>
   );
 });
 
-// PromQL queries for the STOA gateway SLO row (aligned with PlatformMetricsDashboard)
-const SLO_QUERIES = {
-  availability:
-    '(1 - (sum(rate(stoa_http_requests_total{status=~"5.."}[1h])) or vector(0)) / (sum(rate(stoa_http_requests_total[1h])) or vector(1))) * 100',
-  p95Latency:
-    'histogram_quantile(0.95, sum(rate(stoa_http_request_duration_seconds_bucket[5m])) by (le)) * 1000',
-  errorRate:
-    'sum(rate(stoa_http_requests_total{status=~"5.."}[5m])) / sum(rate(stoa_http_requests_total[5m])) * 100',
-} as const;
-
-/** Inline metric tile: renders loading skeleton / error / formatted value from a Prometheus query. */
-const SloMetricTile = memo(function SloMetricTile({
+function FleetCounter({
   label,
-  query,
-  unit,
-  digits = 2,
+  value,
   testId,
+  dotClass,
 }: {
   label: string;
-  query: string;
-  unit: string;
-  digits?: number;
+  value: number;
   testId: string;
+  dotClass?: string;
 }) {
-  const { data, loading, error } = usePrometheusQuery(query);
-  const value = scalarValue(data);
   return (
-    <div className="flex-1 min-w-0" data-testid={testId}>
-      <p className="text-xs text-neutral-500 dark:text-neutral-400">{label}</p>
-      {loading ? (
-        <div className="animate-pulse mt-1 h-7 w-20 rounded bg-neutral-100 dark:bg-neutral-700" />
-      ) : error ? (
-        <p className="mt-1 text-sm text-red-600 dark:text-red-400" title={error}>
-          Unavailable
-        </p>
-      ) : value === null ? (
-        <p className="mt-1 text-sm text-neutral-400 dark:text-neutral-500">—</p>
+    <div className="text-center">
+      <div className="flex items-center justify-center gap-1.5">
+        {dotClass && <span className={`w-2 h-2 rounded-full ${dotClass}`} />}
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">{label}</p>
+      </div>
+      <p data-testid={testId} className="text-xl font-semibold text-neutral-900 dark:text-white">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+/** Per-gateway card: name, type badge, status pill, SLO tiles (STOA) or "No metrics" (3rd-party). */
+const GatewayCard = memo(function GatewayCard({ gw }: { gw: GatewayInstance }) {
+  const sc = STATUS_COLORS[gw.status];
+  const stoa = isStoa(gw.gateway_type);
+  const queries = useMemo(() => sloQueriesForGateway(`stoa-gateway-${gw.name}`), [gw.name]);
+  return (
+    <div
+      data-testid={`gateway-card-${gw.id}`}
+      className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm p-5"
+    >
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <div
+            className={`w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 ${
+              stoa ? 'bg-indigo-100 dark:bg-indigo-900/30' : 'bg-neutral-100 dark:bg-neutral-700'
+            }`}
+          >
+            {stoa ? (
+              <Zap className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />
+            ) : (
+              <Server className="w-4 h-4 text-neutral-500 dark:text-neutral-400" />
+            )}
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-neutral-900 dark:text-white truncate">
+              {gw.display_name}
+            </p>
+            <p className="text-xs text-neutral-500 dark:text-neutral-400 truncate">
+              <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-neutral-100 dark:bg-neutral-700 font-mono text-[10px] mr-1">
+                {gw.gateway_type}
+              </span>
+              · {gw.environment}
+            </p>
+          </div>
+        </div>
+        <span
+          data-testid={`gateway-card-status-${gw.id}`}
+          className={`inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-full flex-shrink-0 ${sc.badge}`}
+        >
+          <span className={`w-1.5 h-1.5 rounded-full ${sc.dot}`} />
+          {sc.label}
+        </span>
+      </div>
+      {stoa ? (
+        <div className="grid grid-cols-3 gap-3 pt-3 border-t border-neutral-100 dark:border-neutral-700">
+          <SloMetricTile
+            label="Availability"
+            query={queries.availability}
+            unit="%"
+            digits={3}
+            testId={`gateway-card-slo-availability-${gw.id}`}
+          />
+          <SloMetricTile
+            label="p95 latency"
+            query={queries.p95Latency}
+            unit="ms"
+            digits={0}
+            testId={`gateway-card-slo-latency-${gw.id}`}
+          />
+          <SloMetricTile
+            label="Error rate"
+            query={queries.errorRate}
+            unit="%"
+            digits={2}
+            testId={`gateway-card-slo-error-${gw.id}`}
+          />
+        </div>
       ) : (
-        <p className="mt-1 text-xl font-semibold text-neutral-900 dark:text-white">
-          {value.toFixed(digits)}
-          <span className="text-sm font-normal text-neutral-500 dark:text-neutral-400 ml-1">
-            {unit}
-          </span>
-        </p>
+        <div
+          className="pt-3 border-t border-neutral-100 dark:border-neutral-700 flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400"
+          title="3rd-party gateway metrics require a separate exporter — follow-up ticket."
+          data-testid={`gateway-card-no-metrics-${gw.id}`}
+        >
+          <Info className="w-3.5 h-3.5" />
+          No metrics available
+        </div>
       )}
     </div>
   );
@@ -228,9 +326,18 @@ export default function GatewayStatus() {
     const online = gateways.filter((g) => g.status === 'online').length;
     const offline = gateways.filter((g) => g.status === 'offline').length;
     const degraded = gateways.filter((g) => g.status === 'degraded').length;
+    const maintenance = gateways.filter((g) => g.status === 'maintenance').length;
     const stoaCount = gateways.filter((g) => isStoa(g.gateway_type)).length;
     const thirdPartyCount = gateways.length - stoaCount;
-    return { online, offline, degraded, total: gateways.length, stoaCount, thirdPartyCount };
+    return {
+      online,
+      offline,
+      degraded,
+      maintenance,
+      total: gateways.length,
+      stoaCount,
+      thirdPartyCount,
+    };
   }, [gateways]);
 
   if (isLoading) {
@@ -294,150 +401,41 @@ export default function GatewayStatus() {
       {/* Contextual sub-navigation (CAB-1785) */}
       <SubNav tabs={gatewayTabs} />
 
-      {/* Stats Summary */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <StatsCard title="Total Gateways" value={stats.total} icon={Server} color="blue" />
-        <StatsCard title="Online" value={stats.online} icon={CheckCircle2} color="green" />
-        <StatsCard title="STOA Gateways" value={stats.stoaCount} icon={Zap} color="purple" />
-        <StatsCard
-          title="Third-Party"
-          value={stats.thirdPartyCount}
-          icon={Activity}
-          color="orange"
-        />
-      </div>
+      {/* Fleet summary header — totals + status/type breakdown */}
+      <FleetSummaryHeader
+        total={stats.total}
+        online={stats.online}
+        offline={stats.offline}
+        degraded={stats.degraded}
+        maintenance={stats.maintenance}
+        stoaCount={stats.stoaCount}
+        thirdPartyCount={stats.thirdPartyCount}
+      />
 
-      {/* Gateway Instance List */}
-      {gateways.length > 0 && (
-        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm">
-          <div className="px-6 py-4 border-b border-neutral-200 dark:border-neutral-700">
-            <div className="flex items-center justify-between">
-              <h2 className="text-sm font-semibold text-neutral-900 dark:text-white">
-                All Gateways
-              </h2>
-              <button
-                onClick={() => navigate('/gateways')}
-                className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300"
-              >
-                View Registry →
-              </button>
-            </div>
-          </div>
-          <div className="divide-y divide-neutral-100 dark:divide-neutral-700/50">
-            {gateways.slice(0, 10).map((gw) => {
-              const sc = STATUS_COLORS[gw.status];
-              return (
-                <div
-                  key={gw.id}
-                  className="flex items-center gap-4 px-6 py-3 hover:bg-neutral-50 dark:hover:bg-neutral-750 cursor-pointer"
-                  onClick={() => navigate('/gateways')}
-                >
-                  <div className="flex-shrink-0 relative">
-                    <div
-                      className={`w-8 h-8 rounded-lg flex items-center justify-center ${
-                        isStoa(gw.gateway_type)
-                          ? 'bg-indigo-100 dark:bg-indigo-900/30'
-                          : 'bg-neutral-100 dark:bg-neutral-700'
-                      }`}
-                    >
-                      {isStoa(gw.gateway_type) ? (
-                        <Zap className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />
-                      ) : (
-                        <Server className="w-4 h-4 text-neutral-500 dark:text-neutral-400" />
-                      )}
-                    </div>
-                    <span
-                      className={`absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-white dark:border-neutral-800 ${sc.dot}`}
-                    />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <span className="text-sm font-medium text-neutral-900 dark:text-white truncate block">
-                      {gw.display_name}
-                    </span>
-                    <span className="text-xs text-neutral-500 dark:text-neutral-400">
-                      {gw.gateway_type} · {gw.environment}
-                    </span>
-                  </div>
-                  <span
-                    className={`inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-full ${sc.badge}`}
-                  >
-                    <span className={`w-1.5 h-1.5 rounded-full ${sc.dot}`} />
-                    {sc.label}
-                  </span>
-                  <span className="text-xs text-neutral-400 dark:text-neutral-500 w-16 text-right">
-                    {gw.last_health_check ? timeAgo(gw.last_health_check) : 'never'}
-                  </span>
-                </div>
-              );
-            })}
-            {gateways.length > 10 && (
-              <div className="px-6 py-3 text-center">
-                <button
-                  onClick={() => navigate('/gateways')}
-                  className="text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-800"
-                >
-                  View all {gateways.length} gateways →
-                </button>
-              </div>
-            )}
-          </div>
+      {/* Per-gateway cards grid — aggregated multi-gateway view (CAB-1887 G5) */}
+      {gateways.length > 0 ? (
+        <div
+          data-testid="gateway-cards-grid"
+          className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4"
+        >
+          {gateways.map((gw) => (
+            <GatewayCard key={gw.id} gw={gw} />
+          ))}
+        </div>
+      ) : (
+        <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm p-8 text-center">
+          <Server className="w-8 h-8 mx-auto text-neutral-400 dark:text-neutral-500 mb-2" />
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">
+            No gateways registered yet.
+          </p>
+          <button
+            onClick={() => navigate('/gateways')}
+            className="mt-3 text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-800"
+          >
+            Go to Gateway Registry →
+          </button>
         </div>
       )}
-
-      {/* SLO Compliance Row — live Prometheus metrics for STOA fleet, fallback for 3rd-party */}
-      <div className="bg-white dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 shadow-sm p-5">
-        <div className="flex items-center mb-4">
-          <div className="p-2 bg-neutral-100 dark:bg-neutral-700 rounded-lg">
-            <Target className="w-5 h-5 text-neutral-500 dark:text-neutral-400" />
-          </div>
-          <h3 className="ml-3 text-sm font-semibold text-neutral-900 dark:text-white">
-            STOA Gateway SLOs
-          </h3>
-          {stats.thirdPartyCount > 0 && (
-            <span
-              className="ml-2 inline-flex items-center text-xs text-neutral-400 dark:text-neutral-500"
-              title="3rd-party gateway metrics require a separate exporter — tracked as a follow-up ticket."
-              data-testid="slo-third-party-tooltip"
-            >
-              <Info className="w-3.5 h-3.5 mr-1" />
-              {stats.thirdPartyCount} 3rd-party excluded
-            </span>
-          )}
-        </div>
-        {stats.stoaCount > 0 ? (
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4" data-testid="slo-metrics-stoa">
-            <SloMetricTile
-              label="Availability (1h)"
-              query={SLO_QUERIES.availability}
-              unit="%"
-              digits={3}
-              testId="slo-availability"
-            />
-            <SloMetricTile
-              label="Latency p95 (5m)"
-              query={SLO_QUERIES.p95Latency}
-              unit="ms"
-              digits={0}
-              testId="slo-latency-p95"
-            />
-            <SloMetricTile
-              label="Error rate (5m)"
-              query={SLO_QUERIES.errorRate}
-              unit="%"
-              digits={2}
-              testId="slo-error-rate"
-            />
-          </div>
-        ) : (
-          <div className="text-center py-4" data-testid="slo-metrics-fallback">
-            <Gauge className="w-5 h-5 mx-auto text-neutral-400 dark:text-neutral-500 mb-2" />
-            <p className="text-sm text-neutral-500 dark:text-neutral-400">No metrics available</p>
-            <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1">
-              3rd-party gateway metrics require a separate exporter — follow-up ticket.
-            </p>
-          </div>
-        )}
-      </div>
 
       {/* Extension Cards (CAB-1023) */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/control-plane-ui/src/pages/Operations/OperationsDashboard.test.tsx
+++ b/control-plane-ui/src/pages/Operations/OperationsDashboard.test.tsx
@@ -116,7 +116,7 @@ describe('OperationsDashboard', () => {
   it('renders the subtitle', async () => {
     renderComponent();
     expect(
-      await screen.findByText('SLO metrics, ArgoCD status, and deployment overview')
+      await screen.findByText('SLO metrics, Infrastructure Sync, and deployment overview')
     ).toBeInTheDocument();
   });
 
@@ -146,10 +146,10 @@ describe('OperationsDashboard', () => {
     expect(screen.queryByTestId('grafana-panel')).not.toBeInTheDocument();
   });
 
-  it('renders ArgoCD Components section', async () => {
+  it('renders Infrastructure Sync section (CAB-1887 G4)', async () => {
     renderComponent();
     await waitFor(() => {
-      expect(screen.getByText('ArgoCD Components')).toBeInTheDocument();
+      expect(screen.getAllByText('Infrastructure Sync').length).toBeGreaterThanOrEqual(1);
     });
     expect(screen.getByText('control-plane-api')).toBeInTheDocument();
     expect(screen.getAllByText('stoa-gateway').length).toBeGreaterThanOrEqual(1);

--- a/control-plane-ui/src/pages/Operations/OperationsDashboard.tsx
+++ b/control-plane-ui/src/pages/Operations/OperationsDashboard.tsx
@@ -153,17 +153,23 @@ export function OperationsDashboard() {
 
   const loadData = useCallback(async () => {
     try {
-      const status = await apiService
-        .get<PlatformStatusResponse>('/v1/platform/status')
-        .then((r) => r.data)
-        .catch(() => null);
-
-      setPlatformStatus(status);
+      const { data } = await apiService.get<PlatformStatusResponse>('/v1/platform/status');
+      setPlatformStatus(data);
       setError(null);
       setLastRefresh(new Date());
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { detail?: string } } };
-      setError(axiosErr.response?.data?.detail || 'Failed to load operations data');
+      // CAB-1887 G7: 503 from API → surface as error, no silent mock fallback
+      const axiosErr = err as {
+        response?: { status?: number; data?: { detail?: { error?: string; detail?: string } } };
+      };
+      const status = axiosErr.response?.status;
+      const payload = axiosErr.response?.data?.detail;
+      if (status === 503 && payload?.error === 'deployments_unavailable') {
+        setError(`Infrastructure Sync unavailable: ${payload.detail || 'unknown reason'}`);
+      } else {
+        setError('Failed to load operations data');
+      }
+      setPlatformStatus(null);
     } finally {
       setLoading(false);
     }
@@ -216,7 +222,7 @@ export function OperationsDashboard() {
             Operations Dashboard
           </h1>
           <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
-            SLO metrics, ArgoCD status, and deployment overview
+            SLO metrics, Infrastructure Sync, and deployment overview
           </p>
         </div>
         <div className="flex items-center gap-3">
@@ -322,11 +328,11 @@ export function OperationsDashboard() {
             </div>
           </section>
 
-          {/* Platform Health — ArgoCD status */}
+          {/* Platform Health — Infrastructure Sync (ArgoCD) */}
           <section>
             <div className="flex items-center justify-between mb-3">
               <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase">
-                ArgoCD Components
+                Infrastructure Sync
               </h2>
               <button
                 onClick={() => navigate(observabilityPath(dashboards.platformHealth))}
@@ -340,7 +346,7 @@ export function OperationsDashboard() {
               <div className="flex items-center gap-2 mb-4">
                 <Shield className="h-4 w-4 text-neutral-500" />
                 <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
-                  ArgoCD Components — {platformHealth}% Healthy
+                  Infrastructure Sync — {platformHealth}% Healthy
                 </h3>
               </div>
               {platformStatus?.gitops?.components ? (
@@ -375,7 +381,7 @@ export function OperationsDashboard() {
                 </div>
               ) : (
                 <p className="text-sm text-neutral-500 dark:text-neutral-400 text-center py-4">
-                  ArgoCD status unavailable
+                  Infrastructure Sync unavailable
                 </p>
               )}
             </div>

--- a/control-plane-ui/src/services/gatewayApi.ts
+++ b/control-plane-ui/src/services/gatewayApi.ts
@@ -46,33 +46,43 @@ export async function getGatewayApplications(): Promise<GatewayApplicationRespon
   return data;
 }
 
+/**
+ * Fetch full gateway status (health + APIs + applications).
+ *
+ * Contract (CAB-1887 G2): this function surfaces errors instead of silently
+ * returning empty data. If ALL three endpoints fail, it throws so callers
+ * (React Query) can render an explicit error state with a retry button.
+ * If at least one endpoint succeeds, the response is returned and failed
+ * slices are marked via `health.error` / `apis === null` / `applications === null`.
+ */
 export async function getGatewayStatus(): Promise<GatewayStatusResponse> {
   const fallbackHealth: GatewayHealthResponse = { status: 'unhealthy', proxy_mode: false };
 
-  try {
-    const [healthResult, apisResult, appsResult] = await Promise.allSettled([
-      getGatewayHealth(),
-      getGatewayAPIs(),
-      getGatewayApplications(),
-    ]);
+  const [healthResult, apisResult, appsResult] = await Promise.allSettled([
+    getGatewayHealth(),
+    getGatewayAPIs(),
+    getGatewayApplications(),
+  ]);
 
-    return {
-      health:
-        healthResult.status === 'fulfilled'
-          ? healthResult.value
-          : { ...fallbackHealth, error: String((healthResult as PromiseRejectedResult).reason) },
-      apis: apisResult.status === 'fulfilled' ? apisResult.value : null,
-      applications: appsResult.status === 'fulfilled' ? appsResult.value : null,
-      fetchedAt: new Date().toISOString(),
-    };
-  } catch {
-    // Defensive: should never reach here with Promise.allSettled,
-    // but guarantees the dashboard always renders.
-    return {
-      health: fallbackHealth,
-      apis: null,
-      applications: null,
-      fetchedAt: new Date().toISOString(),
-    };
+  const allFailed =
+    healthResult.status === 'rejected' &&
+    apisResult.status === 'rejected' &&
+    appsResult.status === 'rejected';
+
+  if (allFailed) {
+    const reason = (healthResult as PromiseRejectedResult).reason;
+    throw new Error(
+      `Failed to load gateway status: ${reason instanceof Error ? reason.message : String(reason)}`
+    );
   }
+
+  return {
+    health:
+      healthResult.status === 'fulfilled'
+        ? healthResult.value
+        : { ...fallbackHealth, error: String((healthResult as PromiseRejectedResult).reason) },
+    apis: apisResult.status === 'fulfilled' ? apisResult.value : null,
+    applications: appsResult.status === 'fulfilled' ? appsResult.value : null,
+    fetchedAt: new Date().toISOString(),
+  };
 }


### PR DESCRIPTION
## Summary

Fixes CAB-1887 (MEGA, P0-Urgent, Council 9.00/10 validated). Removes contradictory data across 4 Gateway module pages in the Console.

**Phases delivered** (5 commits):
- `0b6219ae` — G2: replace silent empty-array fallback with error state in `gatewayApi.ts`
- `bc734a34` — G3: wire live Prometheus SLO metrics for STOA gateway variants, graceful "No metrics available" fallback for 3rd-party (Kong/Gravitee/webMethods/Apigee/AWS/Azure)
- `2f019755` — G7: remove `_get_mock_status()` helper in `platform.py`, return `503 {error, detail}` on failure
- `e70667dc` — G4: rename "ArgoCD Components" widget to "Infrastructure Sync" + wire 503 error state
- `3b3e6487` — G5: aggregated multi-gateway Overview (per-gateway cards grid + fleet summary), extract `SloMetricTile` to `components/gateway/`

**Pre-shipped** (no commit needed): G1 (unified status enum already landed), G6 (drift `gateway_type` filter shipped in PR #1892).

## Intentional Breaking Changes

These are the explicit goal of the MEGA (Council Linear 9.00/10, DoD items):

- `GET /v1/platform/status` now returns 503 on failure instead of 200 with mock data. Frontend updated in same branch (`OperationsDashboard.tsx` handles 503 → error banner + retry).
- `gatewayApi.getGatewayStatus()` throws when all three endpoints fail (partial failure still returns tagged data). Consumer updated (`useGatewayStatus` enables retry: 1).

## DoD

- [x] Gateway statuses consistent between Overview and Registry (single enum — G1)
- [x] No hardcoded mock/seed data in any gateway dashboard
- [x] Overview displays aggregated multi-gateway view
- [x] Failed API calls show error state, not silent zeros
- [x] Drift Detection filterable by gateway type (pre-shipped)
- [x] ArgoCD widget labeled "Infrastructure Sync"
- [x] Tests passing (300 pytest, 16 vitest)
- [x] Pre-push quality gate passed (opsec, ruff, eslint, prettier, tsc, axe)

## Test plan
- [x] Backend: `pytest -k "platform or deployment"` → 300 passed
- [x] Frontend: `vitest run OperationsDashboard.test.tsx` → 16 passed
- [x] Frontend: lint (90 warnings < 100 cap), format:check clean, tsc clean
- [ ] CI green
- [ ] CD verified post-merge

## Canary Context

This PR is the Phase 1 canary for **CAB-2065** (Agent Teams workflow validation). Executed via 4 parallel subagent teammates. Chrono: ~14min wall-clock vs baseline ~5h for MEGA 21pts single-session. Scope shrinkage ~40% (3/5 phases had pre-existing work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)