### PR TITLE
ci(release-please): dispatch release-published event to stoa-docs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -125,3 +125,21 @@ jobs:
     with:
       tag: ${{ needs.release-please.outputs.stoa_go_tag_name }}
       version: ${{ needs.release-please.outputs.stoa_go_version }}
+
+  trigger-docs-changelog-sync:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.any_release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch release-published event to stoa-docs
+        env:
+          GH_TOKEN: ${{ secrets.STOA_DOCS_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "STOA_DOCS_DISPATCH_TOKEN not set — skipping docs changelog sync. Daily cron will catch up."
+            exit 0
+          fi
+          gh api repos/stoa-platform/stoa-docs/dispatches \
+            -X POST \
+            -f event_type=release-published \
+            -F 'client_payload[services]=${{ needs.release-please.outputs.released_services }}'


### PR DESCRIPTION
## Summary
Replaces #2355 (had stale CAB-2057 commits already merged via #2353, causing 50+ file conflicts).

Adds a `trigger-docs-changelog-sync` job to `release-please.yml` that dispatches a `release-published` event to stoa-docs after any release. Gracefully skips if `STOA_DOCS_DISPATCH_TOKEN` secret is absent.

## Test plan
- [x] Cherry-pick clean on current main
- [ ] CI green
- [ ] Next release-please merge triggers stoa-docs workflow

Closes #2355

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>