### PR TITLE
chore(docs): refresh session-brief with canary milestones

### DIFF
--- a/.claude/session-brief.json
+++ b/.claude/session-brief.json
@@ -1,29 +1,7 @@
 {
-  "generated_at": "2026-04-04T16:48:43Z",
+  "generated_at": "2026-04-16T06:29:33Z",
   "project": "stoa",
-  "sessions": [
-    {
-      "instance_id": "t14961-3397",
-      "role": "interactive",
-      "ticket": "CAB-1978",
-      "step": "paused",
-      "pr": 2197
-    },
-    {
-      "instance_id": "t15785-ed2f",
-      "role": "interactive",
-      "ticket": "CAB-1979",
-      "step": "merged",
-      "pr": 2201
-    },
-    {
-      "instance_id": "t19792-d73d",
-      "role": "interactive",
-      "ticket": "CAB-1980",
-      "step": "coding",
-      "pr": 2202
-    }
-  ],
+  "sessions": [],
   "tickets": [
     {
       "id": "CAB-1582",
@@ -101,64 +79,64 @@
   "claims": [],
   "recent_milestones": [
     {
-      "ticket": "CAB-1980",
-      "step": "coding",
-      "pr": null,
-      "created_at": "2026-04-04T16:46:42Z"
-    },
-    {
-      "ticket": "CAB-1980",
-      "step": "pr-created",
-      "pr": 2202,
-      "created_at": "2026-04-04T16:35:06Z"
-    },
-    {
-      "ticket": "CAB-1980",
-      "step": "coding",
-      "pr": null,
-      "created_at": "2026-04-04T16:34:55Z"
-    },
-    {
-      "ticket": "CAB-1980",
-      "step": "claimed",
-      "pr": null,
-      "created_at": "2026-04-04T16:23:12Z"
-    },
-    {
-      "ticket": "CAB-1979",
+      "ticket": "CAB-1989",
       "step": "merged",
-      "pr": 2201,
-      "created_at": "2026-04-04T16:23:01Z"
+      "pr": 2367,
+      "created_at": "2026-04-15T20:54:23Z"
     },
     {
-      "ticket": "CAB-1979",
-      "step": "pr-created",
-      "pr": 2201,
-      "created_at": "2026-04-04T16:15:24Z"
-    },
-    {
-      "ticket": "CAB-1979",
-      "step": "coding",
-      "pr": null,
-      "created_at": "2026-04-04T16:15:12Z"
-    },
-    {
-      "ticket": "CAB-1979",
+      "ticket": "CAB-1989",
       "step": "merged",
-      "pr": 2198,
-      "created_at": "2026-04-04T16:10:44Z"
+      "pr": 2367,
+      "created_at": "2026-04-15T20:34:13Z"
     },
     {
-      "ticket": "CAB-1979",
-      "step": "coding",
-      "pr": null,
-      "created_at": "2026-04-04T15:44:38Z"
+      "ticket": "CAB-1989",
+      "step": "merged",
+      "pr": 2372,
+      "created_at": "2026-04-15T20:24:12Z"
     },
     {
-      "ticket": "CAB-1979",
+      "ticket": "CAB-1989",
       "step": "paused",
       "pr": null,
-      "created_at": "2026-04-04T15:34:01Z"
+      "created_at": "2026-04-15T20:24:07Z"
+    },
+    {
+      "ticket": "CAB-1989",
+      "step": "paused",
+      "pr": null,
+      "created_at": "2026-04-15T20:21:54Z"
+    },
+    {
+      "ticket": "CAB-1989",
+      "step": "paused",
+      "pr": null,
+      "created_at": "2026-04-15T20:21:49Z"
+    },
+    {
+      "ticket": "CAB-1989",
+      "step": "coding",
+      "pr": null,
+      "created_at": "2026-04-15T20:21:45Z"
+    },
+    {
+      "ticket": "CAB-1989",
+      "step": "paused",
+      "pr": null,
+      "created_at": "2026-04-15T20:00:15Z"
+    },
+    {
+      "ticket": "CAB-1989",
+      "step": "paused",
+      "pr": null,
+      "created_at": "2026-04-15T19:59:55Z"
+    },
+    {
+      "ticket": "CAB-1989",
+      "step": "coding",
+      "pr": null,
+      "created_at": "2026-04-15T19:59:33Z"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Auto-regenerated `.claude/session-brief.json` with latest state
- Clears stale Apr 4 sessions (CAB-1978/1979/1980 paused/merged/coding)
- Adds CAB-1989 canary #2 merge (PR #2367) to recent_milestones

## Test plan
- [x] Pre-push quality gate (no code, skipped)
- [ ] Required checks green