### PR TITLE
fix(ui): chown /usr/share/nginx/html for sed -i index.html

### DIFF
--- a/control-plane-ui/Dockerfile
+++ b/control-plane-ui/Dockerfile
@@ -134,9 +134,10 @@ COPY control-plane-ui/nginx.conf.template /etc/nginx/custom-templates/default.co
 # Copy built app
 COPY --from=builder /app/control-plane-ui/dist /usr/share/nginx/html
 
-# Allow nginx user to write runtime-config.js at startup
+# Allow nginx user to write runtime-config.js and sed -i index.html at startup.
+# sed -i creates a temp file in the same directory, so the dir itself must be writable.
 USER root
-RUN chown nginx:nginx /usr/share/nginx/html/runtime-config.js
+RUN chown -R nginx:nginx /usr/share/nginx/html
 USER nginx
 
 # nginx-unprivileged listens on 8080


### PR DESCRIPTION
## Summary
- New cp-ui pods crashloop on `sed: can't create temp file '/usr/share/nginx/html/index.htmlXXXXXX': Permission denied`
- Root cause: cache-bust `sed -i index.html` added in #2294 needs the parent directory writable; `Dockerfile` only chowned `runtime-config.js`
- Fix: `chown -R nginx:nginx /usr/share/nginx/html` so UID 101 can create the `sed -i` tempfile

## Observed failure
Seen on prod (OVH MKS GRA9) today post cp-ui 1.3.0 rollout (PR #2371). Deployment stuck Progressing in ArgoCD; traffic still served by older ReplicaSet (1.2.2). Same symptom had appeared on an orphan pod before today's merge.

## Test plan
- [x] Dockerfile diff is 1 line change (chown targets dir, not single file)
- [ ] Image rebuild via Control Plane UI CI/CD workflow
- [ ] After merge: confirm new cp-ui pod on `dev-<sha>` reaches Ready on prod (`kubectl -n stoa-system get pods -l app=control-plane-ui`)
- [ ] ArgoCD `control-plane-ui` app returns Healthy
- [ ] `curl https://console.gostoa.dev` still 200 (no regression)

## Risk
Very low. Only widens chown scope; no code, no nginx config, no runtime behavior change. `readOnlyRootFilesystem: false` already in Helm values, so chown effective.