### PR TITLE
docs: SDD spec for MEGA-CAB-1917 API creation pipeline

### DIFF
--- a/.sdlc/specs/MEGA-CAB-1917/requirement.md
+++ b/.sdlc/specs/MEGA-CAB-1917/requirement.md
@@ -1,0 +1,116 @@
+---
+mega_id: CAB-1917
+title: Fix API creation and deployment pipeline end-to-end
+owner: "@PotoMitan"
+state: council-validated
+impact_level: HIGH
+council_score: 8.25       # S1, 2026-03-26
+adrs: []
+created_at: 2026-04-16
+shipped_at: null
+---
+# Fix API creation and deployment pipeline end-to-end
+
+## Problem
+
+Deep audit of the STOA API creation and deployment flow found the core
+pipeline broken in multiple places:
+
+- Two parallel, disconnected API models (GitOps APIs + Backend APIs) that
+  were never unified.
+- Two parallel deployment tracking systems (legacy `deployments` table
+  vs. modern `gateway_deployments` table).
+- The legacy deployment endpoint publishes to a Kafka topic with no
+  consumer (dead end).
+- `RegisterApiModal` submit button is rendered outside the `<form>`
+  element, so it is non-functional — users cannot register a Backend API
+  at all.
+- `auto_deploy_on_promotion()` is dead code; promotion approvals never
+  trigger deployments.
+- Policy enforcement on the proxy path is soft-mode only.
+
+Canonical architecture decision taken during Council:
+`DeploymentOrchestrationService` → `GatewayDeploymentService` →
+`SyncEngine` is THE canonical deployment path. The legacy `Deployment`
+table and `deploy-requests` Kafka topic are deprecated.
+
+## Out of scope
+
+- UAC classification graduation (soft → hard mode) — separate ticket.
+- Unifying GitOps APIs and Backend APIs into a single model.
+- E2E Playwright tests for the OAuth flow.
+- `datetime.utcnow()` replacement — mechanical chore, separate ticket.
+- Dead code cleanup for `ToolRegistry` and `handlers/health.rs`.
+
+## Architecture touchpoints
+
+Impact verified via `stoa-impact` MCP (see `.sdlc/context/architecture.md`).
+
+- `control-plane-api` — API + promotion endpoints, OpenAPI validation,
+  orchestration service, legacy deprecation.
+- `control-plane-ui` — `RegisterApiModal` fix, Backend API
+  detail/edit view, gateway admin input validation, deploy dialog.
+- `portal` — catalog error handling.
+- `stoa-gateway` — consumers of policy config keys (read-only;
+  normalization happens server-side).
+- Adapters (7) — Kong, Gravitee, webMethods, Azure APIM, Apigee, AWS
+  API Gateway, WSO2 — policy config key normalization.
+
+## Acceptance criteria (binary DoD)
+
+Phase 1 — API creation works end-to-end:
+
+- [ ] `RegisterApiModal` submit button triggers form submission; vitest
+      unit test + manual Playwright scenario cover it.
+- [ ] Legacy `POST /deployments` returns `Deprecation` + `Sunset`
+      response headers; contract test asserts header presence.
+- [ ] `auto_deploy_on_promotion()` is wired to promotion approval; a
+      promotion approval produces a `GatewayDeployment` row.
+- [ ] Invalid OpenAPI spec on API create returns `422` with a
+      structured error, not `500`.
+- [ ] `list_apis` returns `503` on GitLab connector errors (not an
+      empty list).
+
+Phase 2 — deployment reliability:
+
+- [ ] Canonical policy config schema committed to
+      `control-plane-api/docs/policy-config-schema.md`.
+- [ ] `build_desired_state()` emits HTTP methods per API; assertion in
+      existing desired-state test.
+- [ ] Policy config keys identical across all 7 adapters; one
+      table-driven test covers all.
+- [ ] GitLab delete is a single commit (atomic); integration test
+      covers rollback on failure.
+- [ ] `GatewayDeployment.policy_sync_status` column populated on every
+      sync; DB migration shipped.
+- [ ] Drift detector reports drift when `spec_hash` is empty (today it
+      silently skips).
+- [ ] `SyncEngine` retry counter increments on inline sync failure; unit
+      test asserts counter value.
+
+Phase 3 — UI completeness:
+
+- [ ] Console shows Backend API detail + edit view (`/apis/backend/:id`).
+- [ ] Portal catalog page shows an error state on fetch failure (not a
+      blank grid).
+- [ ] Gateway admin rejects `backend_url` failing SSRF pre-check
+      (private IP ranges, `localhost`, link-local) with `400`.
+- [ ] Deploy API dialog supports search by name/tag.
+
+Cross-cutting:
+
+- [ ] Each phase ships as separate PRs. No PR > 300 LOC.
+- [ ] Every `fix()` commit has a regression test that fails before the
+      fix and passes after.
+- [ ] `/deploy-check` green after each phase merges.
+
+## Tasks
+
+See `tasks/`. Order is `T-001` → `T-002` → `T-003`. Within each task,
+sub-items follow the Linear ticket's phase order.
+
+## References
+
+- Linear: https://linear.app/hlfh-workspace/issue/CAB-1917
+- Council decision: inline in Linear description (S1, 8.25/10, 2026-03-26)
+- Related MEGA: CAB-1977 (observability) — independent, same project

--- a/.sdlc/specs/MEGA-CAB-1917/tasks/T-001-phase-1-api-creation.md
+++ b/.sdlc/specs/MEGA-CAB-1917/tasks/T-001-phase-1-api-creation.md
@@ -1,0 +1,69 @@
+---
+task_id: T-001
+mega_id: CAB-1917
+title: Phase 1 — Make API creation work end-to-end
+owner: "@PotoMitan"
+state: pending
+blocked_by: []
+pr: null
+created_at: 2026-04-16
+completed_at: null
+---
+# Phase 1 — Make API creation work end-to-end
+
+## Goal
+
+Fix the five bugs that currently prevent Backend API creation and
+promotion from reaching a deployed state. Covers Phase 1 ACs of
+`requirement.md`.
+
+Council adjustment: each sub-item is a separate PR (micro-PR strategy).
+This task file tracks the five PRs as one logical phase.
+
+## Approach
+
+Sub-PRs in dependency order:
+
+1. **RegisterApiModal submit button** — FIRST COMMIT.
+   - Files: `control-plane-ui/src/.../RegisterApiModal.tsx`.
+   - Move submit button inside the `<form>` element; add vitest.
+   - ~10 LOC.
+2. **Deprecate legacy `POST /deployments`** with `Deprecation` +
+   `Sunset` headers.
+   - Files: `control-plane-api/.../routers/deployments.py`.
+   - Contract test first (red), then header.
+   - ~30 LOC.
+3. **Wire `auto_deploy_on_promotion()` to promotion approval**.
+   - Files: `control-plane-api/.../services/promotion_service.py`.
+   - Regression test: approve promotion → GatewayDeployment row.
+   - ~20 LOC.
+4. **OpenAPI spec validation on API create** — reject invalid spec
+   with `422` + structured error.
+   - Files: `control-plane-api/.../routers/apis.py`.
+   - Use existing `openapi-spec-validator`; add to requirements if
+     missing.
+   - ~50 LOC.
+5. **Fix `list_apis` error swallowing** — propagate `503` from GitLab
+   connector.
+   - Files: `control-plane-api/.../services/gitops_api_service.py`.
+   - Unit test with `httpx.MockTransport`.
+   - ~10 LOC.
+
+Commands to run before each PR:
+
+- `cd control-plane-api && uv run pytest -q && uv run mypy .`
+- `cd control-plane-ui && npm test -- --run && npm run lint`
+
+## Done when
+
+- [ ] All five PRs merged to `main` via squash, each referenced above.
+- [ ] CI green on every PR (no pre-existing flakes attributed).
+- [ ] Regression test committed for each `fix()` commit.
+- [ ] Post-merge `/deploy-check` green.
+
+## Notes
+
+- RegisterApiModal is the P0 user-visible bug — ship it first on its
+  own tiny PR so it can backport-merge without waiting on the phase.
+- Contract test for (2) is mandatory before shipping the deprecation
+  header; it is the regression guard once the endpoint is removed.

--- a/.sdlc/specs/MEGA-CAB-1917/tasks/T-002-phase-2-deployment-reliability.md
+++ b/.sdlc/specs/MEGA-CAB-1917/tasks/T-002-phase-2-deployment-reliability.md
@@ -1,0 +1,67 @@
+---
+task_id: T-002
+mega_id: CAB-1917
+title: Phase 2 — Deployment reliability
+owner: "@PotoMitan"
+state: pending
+blocked_by: [T-001]
+pr: null
+created_at: 2026-04-16
+completed_at: null
+---
+# Phase 2 — Deployment reliability
+
+## Goal
+
+Stabilise `GatewayDeploymentService` + `SyncEngine` so that every
+promotion approved in Phase 1 lands on the target gateway with the
+correct policy and is observable. Covers Phase 2 ACs of
+`requirement.md`.
+
+## Approach
+
+Ordered sub-PRs:
+
+1. **Canonical policy config schema doc** — prerequisite for
+   normalisation.
+   - File: `control-plane-api/docs/policy-config-schema.md`.
+   - Owner of the source of truth for 7 adapters.
+2. **`build_desired_state()` emits HTTP methods** per API.
+   - Files: `control-plane-api/.../services/desired_state.py`.
+   - ~30 LOC.
+3. **Normalise policy config keys across 7 adapters** —
+   table-driven test.
+   - Files: `control-plane-api/.../adapters/{kong,gravitee,webmethods,...}_adapter.py`.
+   - ~50 LOC.
+4. **Atomic GitLab delete** — one commit with all deletions.
+   - Files: `control-plane-api/.../connectors/gitlab_connector.py`.
+   - Integration test covers rollback.
+   - ~20 LOC.
+5. **Track `policy_sync_status` on `GatewayDeployment`**.
+   - Files: Alembic migration + model + service writes.
+   - Migration COMMIT before `ADD VALUE` (local gotcha per MEMORY).
+   - ~40 LOC.
+6. **Drift detection handles empty `spec_hash`**.
+   - Files: `control-plane-api/.../services/drift_service.py`.
+   - Unit test asserts drift reported.
+   - ~20 LOC.
+7. **SyncEngine retry counter on inline failure**.
+   - Files: `control-plane-api/.../services/sync_engine.py`.
+   - Unit test.
+   - ~5 LOC.
+
+## Done when
+
+- [ ] All seven sub-items merged; each references a PR above.
+- [ ] `GET /v1/gateway/deployments/{id}` response includes
+      `policy_sync_status`.
+- [ ] Adapter conformance test is green for all 7 adapters.
+- [ ] Post-merge `/deploy-check` green.
+
+## Notes
+
+- Phase 2 blocked by T-001 because Phase 1 wires the canonical
+  deployment path; Phase 2 hardens it. Merging Phase 2 without Phase 1
+  would touch dead code.
+- Alembic migration gotcha (MEMORY): `COMMIT` between
+  `CREATE TYPE` and `ADD VALUE`. Tilt local verifies this.

--- a/.sdlc/specs/MEGA-CAB-1917/tasks/T-003-phase-3-ui-completeness.md
+++ b/.sdlc/specs/MEGA-CAB-1917/tasks/T-003-phase-3-ui-completeness.md
@@ -1,0 +1,62 @@
+---
+task_id: T-003
+mega_id: CAB-1917
+title: Phase 3 — UI completeness
+owner: "@PotoMitan"
+state: pending
+blocked_by: [T-002]
+pr: null
+created_at: 2026-04-16
+completed_at: null
+---
+# Phase 3 — UI completeness
+
+## Goal
+
+Close the UX gaps around the now-functional pipeline: Backend API
+detail/edit view, Portal catalog error handling, Gateway admin input
+validation with SSRF pre-check, Deploy dialog search. Covers Phase 3
+ACs of `requirement.md`.
+
+## Approach
+
+Ordered sub-PRs:
+
+1. **Backend API detail + edit view** — new Console page.
+   - Files: `control-plane-ui/src/pages/apis/BackendApiDetail.tsx` +
+     routing, form, vitest.
+   - ~200 LOC — the largest sub-PR of the MEGA. Stay under 300 LOC by
+     deferring bulk-edit to a follow-up if needed.
+2. **Portal catalog error state** — replace blank grid with error UI
+   on fetch failure.
+   - Files: `portal/src/.../CatalogPage.tsx`.
+   - MSW test for fetch failure path.
+   - ~30 LOC.
+3. **Gateway admin SSRF pre-check** — reject private IP ranges,
+   `localhost`, link-local in `backend_url`.
+   - Files: `control-plane-api/.../schemas/gateway_admin.py` +
+     validator.
+   - Use `ipaddress` module; cover IPv4 + IPv6.
+   - Unit tests for each rejected class.
+   - ~40 LOC.
+4. **Deploy API dialog search** — filter list by name/tag.
+   - Files: `control-plane-ui/src/.../DeployApiDialog.tsx`.
+   - Client-side filter; no new API endpoint.
+   - ~20 LOC.
+
+## Done when
+
+- [ ] All four sub-items merged; each references a PR above.
+- [ ] Playwright smoke: log in as tenant-admin, register Backend API,
+      edit it, see it in Deploy dialog via search → evidence archived
+      in `docs/audits/2026-04-<dd>-cab-1917/`.
+- [ ] Post-merge `/deploy-check` green.
+- [ ] MEGA DoD checklist in `requirement.md` fully checked.
+
+## Notes
+
+- (3) is a security fix — MUST land with a regression test even though
+  it lives in Phase 3. SSRF pre-check predates this MEGA but was never
+  wired on the admin path.
+- After this task's PRs merge, run `/verify-mega CAB-1917` to close
+  out. Do not mark Linear Done manually.


### PR DESCRIPTION
## Summary

- First **real** MEGA formalized under the SDD L1 convention introduced by CAB-2066 / PR #2377.
- Pure greenfield spec: CAB-1917 is Todo, Council-validated (8.25/10, 2026-03-26), zero sub-tickets created yet, zero code written.
- Adds `.sdlc/specs/MEGA-CAB-1917/` = `requirement.md` + 3 task files (one per phase), 314 lines of markdown, no code change.

## Why now

`.sdlc/KILL-CRITERIA.md` trigger #1 checks on 2026-04-30 whether a second real MEGA (not the CAB-2066 dogfood) has a spec. Without this PR the trigger fires and SDD L1 gets deleted. This PR gives the trial real-world data to evaluate against.

## Design choices

- **Pointer-style** — references Linear + Council decision instead of duplicating them. If this spec duplicates Linear or ADRs, that is a trigger #3 signal.
- **One task = one phase, not one task = one PR** — CAB-1917 has 16 planned sub-PRs; 16 task files would turn the spec into a kanban board. Task files group sub-PRs by phase with explicit dependency ordering.
- **Spec state `council-validated`, not `in_progress`** — code has not started. Trigger #2 (staleness) cannot fire until implementation begins.

## Test plan

- [ ] Reviewer confirms spec does not duplicate content already in Linear CAB-1917 or an existing ADR.
- [ ] YAML frontmatter parses cleanly (validated locally; no CI parser yet).
- [ ] Task `blocked_by` chain reads correctly (T-002 blocked_by T-001, T-003 blocked_by T-002).
- [ ] All 18 acceptance criteria in `requirement.md` are binary (checkable), not qualitative.

## References

- Linear MEGA being specced: https://linear.app/hlfh-workspace/issue/CAB-1917
- Kill-review driving this: https://linear.app/hlfh-workspace/issue/CAB-2068
- SDD L1 origin: PR #2377 (`551d330e`), ADR-063 in stoa-docs (`2ab1e9f7`)

Refs CAB-1917 CAB-2068

🤖 Generated with [Claude Code](https://claude.com/claude-code)