### PR TITLE
chore: refresh session-brief + plan backlog (CAB-2069, CAB-2070)

### DIFF
--- a/.claude/session-brief.json
+++ b/.claude/session-brief.json
@@ -1,27 +1,27 @@
 {
-  "generated_at": "2026-04-04T16:48:43Z",
+  "generated_at": "2026-04-16T08:03:14Z",
   "project": "stoa",
   "sessions": [
     {
-      "instance_id": "t14961-3397",
+      "instance_id": "t21295-dfda",
       "role": "interactive",
-      "ticket": "CAB-1978",
-      "step": "paused",
-      "pr": 2197
-    },
-    {
-      "instance_id": "t15785-ed2f",
-      "role": "interactive",
-      "ticket": "CAB-1979",
+      "ticket": "CAB-1930",
       "step": "merged",
-      "pr": 2201
+      "pr": 2371
     },
     {
-      "instance_id": "t19792-d73d",
+      "instance_id": "t23494-8715",
       "role": "interactive",
-      "ticket": "CAB-1980",
-      "step": "coding",
-      "pr": 2202
+      "ticket": "CAB-2066",
+      "step": "merged",
+      "pr": 2377
+    },
+    {
+      "instance_id": "t26584-e931",
+      "role": "interactive",
+      "ticket": "CAB-1917",
+      "step": "claimed",
+      "pr": null
     }
   ],
   "tickets": [
@@ -101,64 +101,64 @@
   "claims": [],
   "recent_milestones": [
     {
-      "ticket": "CAB-1980",
-      "step": "coding",
-      "pr": null,
-      "created_at": "2026-04-04T16:46:42Z"
-    },
-    {
-      "ticket": "CAB-1980",
-      "step": "pr-created",
-      "pr": 2202,
-      "created_at": "2026-04-04T16:35:06Z"
-    },
-    {
-      "ticket": "CAB-1980",
-      "step": "coding",
-      "pr": null,
-      "created_at": "2026-04-04T16:34:55Z"
-    },
-    {
-      "ticket": "CAB-1980",
+      "ticket": "CAB-1917",
       "step": "claimed",
       "pr": null,
-      "created_at": "2026-04-04T16:23:12Z"
+      "created_at": "2026-04-16T08:03:04Z"
     },
     {
-      "ticket": "CAB-1979",
+      "ticket": "CAB-2066",
       "step": "merged",
-      "pr": 2201,
-      "created_at": "2026-04-04T16:23:01Z"
+      "pr": 2377,
+      "created_at": "2026-04-16T07:46:23Z"
     },
     {
-      "ticket": "CAB-1979",
-      "step": "pr-created",
-      "pr": 2201,
-      "created_at": "2026-04-04T16:15:24Z"
-    },
-    {
-      "ticket": "CAB-1979",
-      "step": "coding",
-      "pr": null,
-      "created_at": "2026-04-04T16:15:12Z"
-    },
-    {
-      "ticket": "CAB-1979",
+      "ticket": "CAB-2066",
       "step": "merged",
-      "pr": 2198,
-      "created_at": "2026-04-04T16:10:44Z"
+      "pr": 156,
+      "created_at": "2026-04-16T07:29:37Z"
     },
     {
-      "ticket": "CAB-1979",
-      "step": "coding",
-      "pr": null,
-      "created_at": "2026-04-04T15:44:38Z"
-    },
-    {
-      "ticket": "CAB-1979",
+      "ticket": "CAB-2066",
       "step": "paused",
       "pr": null,
-      "created_at": "2026-04-04T15:34:01Z"
+      "created_at": "2026-04-16T07:28:40Z"
+    },
+    {
+      "ticket": "CAB-2066",
+      "step": "paused",
+      "pr": null,
+      "created_at": "2026-04-16T07:27:39Z"
+    },
+    {
+      "ticket": "CAB-2066",
+      "step": "pr-created",
+      "pr": 2377,
+      "created_at": "2026-04-16T07:26:08Z"
+    },
+    {
+      "ticket": "CAB-2066",
+      "step": "coding",
+      "pr": null,
+      "created_at": "2026-04-16T07:25:03Z"
+    },
+    {
+      "ticket": "CAB-2066",
+      "step": "merged",
+      "pr": 2375,
+      "created_at": "2026-04-16T07:16:38Z"
+    },
+    {
+      "ticket": "CAB-2066",
+      "step": "paused",
+      "pr": null,
+      "created_at": "2026-04-16T07:15:01Z"
+    },
+    {
+      "ticket": "CAB-2066",
+      "step": "paused",
+      "pr": null,
+      "created_at": "2026-04-16T07:12:11Z"
     }
   ]
 }

--- a/plan.md
+++ b/plan.md
@@ -50,6 +50,8 @@ Voir Linear (queue typiquement ~40 tickets mais drainée à 0 en Phase 1 CAB-205
 - [ ] CAB-2043 Benchmark gateway STOA vs concurrents (P2)
 - [~] CAB-2054 Council 8 personas (13 pts) — 3/4 phases merged, P2 ADR-061 stoa-docs PR #151 awaiting review
 - [~] CAB-2065 Baseline + Agent Teams canary — Phase 0 done (PR #2362)
+- [ ] CAB-2069 Fix TCO fabriqué build-vs-buy article + extend audit script (5 pts, P1) — Council 7.88/10 Fix
+- [ ] CAB-2070 Audit SaaS Playbook + migration guides TCO fabrication (13 pts, P2) — Council 7.88/10 Fix, blocked by CAB-2069
 
 ## Milestones
 


### PR DESCRIPTION
## Summary

- **session-brief.json**: auto-refresh to 2026-04-16 state — CAB-1930 merged (#2371), CAB-2066 merged (#2377), CAB-1917 claimed for SDD spec work (PR #2378).
- **plan.md**: add two new backlog entries for TCO fabrication remediation — CAB-2069 (P1, 5pts, already In Review on #157) and CAB-2070 (P2, 13pts, blocked by CAB-2069).

Pure metadata / doc changes. No code.

## Test plan

- [ ] CI green (markdown + JSON, no runtime).
- [ ] Merge in any order — no coupling with open PRs.

Refs CAB-2069 CAB-2070

🤖 Generated with [Claude Code](https://claude.com/claude-code)