### PR TITLE
fix(api): alembic merge migration 095 to reconcile heads 092 + 094 (CAB-1977)

### DIFF
--- a/control-plane-api/alembic/versions/095_merge_heads.py
+++ b/control-plane-api/alembic/versions/095_merge_heads.py
@@ -1,0 +1,30 @@
+"""merge heads 092 (drop execution_logs) and 094 (seed gateway_deployments)
+
+Revision ID: 095_merge_heads
+Revises: 092, 094_seed_gateway_deployments
+Create Date: 2026-04-16
+
+Two migration chains both branched off 091_add_is_platform_and_seed_gateway:
+
+- 091 -> 092                                        (CAB-1977, drop execution_logs)
+- 091 -> 093_add_security_posture_tables -> 094_seed_gateway_deployments  (CAB-2008 + CAB-2034)
+
+They merged to main independently, leaving alembic with two heads and
+blocking `alembic upgrade head` in prod (prod stuck at 090). This no-op
+migration reconciles the heads so future upgrades can proceed linearly.
+
+No schema change; pure lineage merge.
+"""
+
+revision = "095_merge_heads"
+down_revision = ("092", "094_seed_gateway_deployments")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/control-plane-api/tests/test_regression_cab_1977_alembic_heads.py
+++ b/control-plane-api/tests/test_regression_cab_1977_alembic_heads.py
@@ -1,0 +1,32 @@
+"""
+Regression test for CAB-1977 — alembic must never have multiple heads.
+
+After PR #2297 (migration 092, drop execution_logs) landed alongside
+093_add_security_posture_tables + 094_seed_gateway_deployments that had
+independently branched off 091, alembic had two concurrent heads on main.
+`alembic upgrade head` errored with "Multiple head revisions are present"
+and prod stayed stuck at 090 — migration 092 (the whole point of #2297)
+could not run.
+
+PR #2386 added 095_merge_heads (no-op merge migration) to collapse the
+graph back to one head. This test asserts the same property at CI time
+so the next divergence is caught before it hits prod.
+"""
+
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+def test_regression_cab_1977_single_alembic_head():
+    """Alembic migration tree must have exactly one head."""
+    repo_root = Path(__file__).resolve().parents[1]
+    cfg = Config(str(repo_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(repo_root / "alembic"))
+    script = ScriptDirectory.from_config(cfg)
+    heads = script.get_heads()
+    assert len(heads) == 1, (
+        f"alembic has {len(heads)} heads ({heads!r}); expected exactly 1. "
+        "Add a merge migration listing all heads as down_revision tuple to reconcile."
+    )


### PR DESCRIPTION
## Summary

Alembic had **two concurrent heads** on `main` after [#2297](https://github.com/stoa-platform/stoa/pull/2297) (CAB-1977, drop execution_logs) merged alongside CAB-2008 + CAB-2034 migrations that had independently branched from the same parent:

- `091_add_is_platform_and_seed_gateway → 092` (drop execution_logs)
- `091_add_is_platform_and_seed_gateway → 093_add_security_posture_tables → 094_seed_gateway_deployments`

Result: prod is **stuck at 090**. `alembic upgrade head` fails with *Multiple head revisions are present*. Migration 092 (the whole point of #2297) is inert until the heads are reconciled.

This PR adds a **no-op merge migration** `095_merge_heads` that declares both `092` and `094_seed_gateway_deployments` as `down_revision`, collapsing the graph back to a single head.

## Test plan

- [x] Injected the file into a live prod cp-api pod (`kubectl cp` → `/app/alembic/versions/095_merge_heads.py`), ran `alembic heads` → single head `095_merge_heads` ✅
- [x] Removed test file from pod, re-ran `alembic heads` → two heads again (confirms the migration is what reconciles) ✅
- [ ] `alembic upgrade head` on a staging DB from rev `090` — should apply `091, 092, 093, 094, 095` in order and drop `execution_logs` for real
- [ ] Post-merge: run `alembic upgrade head` in prod

## Detection

Surfaced by `/deploy-check` after #2297 merge. See [CAB-1977](https://linear.app/hlfh-workspace/issue/CAB-1977).

## Follow-up (not in scope here)

CD pipeline has no migration init-container or job in `stoa-system`. Hence the 091-094 gap in prod even before the divergence. A separate ticket should add automatic migration execution on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)