### PR TITLE
fix(api): alembic 094 paramstyle — CAST(:desired_state AS JSONB) (CAB-1977)

### DIFF
--- a/control-plane-api/alembic/versions/094_seed_gateway_deployments.py
+++ b/control-plane-api/alembic/versions/094_seed_gateway_deployments.py
@@ -90,7 +90,7 @@ def upgrade() -> None:
                          desired_at, sync_status, sync_attempts)
                     VALUES
                         (gen_random_uuid(), :api_catalog_id, :gateway_id,
-                         :desired_state::jsonb, NOW(), 'pending', 0)
+                         CAST(:desired_state AS JSONB), NOW(), 'pending', 0)
                     ON CONFLICT ON CONSTRAINT uq_deployment_api_gateway DO NOTHING
                 """),
                 {

--- a/control-plane-api/tests/test_regression_cab_1977_094_paramstyle.py
+++ b/control-plane-api/tests/test_regression_cab_1977_094_paramstyle.py
@@ -1,0 +1,55 @@
+"""
+Regression test for CAB-1977 / migration 094_seed_gateway_deployments.
+
+The original SQL in migration 094 mixed SQLAlchemy bind syntax with a
+PostgreSQL cast (`:desired_state::jsonb`). SQLAlchemy's regex parser
+cannot disambiguate `:name::type` and emits a literal `:name` into the
+final psycopg2 query, which then rejects it:
+
+    sqlalchemy.exc.ProgrammingError: (psycopg2.errors.SyntaxError)
+    syntax error at or near ":"
+
+Fix: use `CAST(:desired_state AS JSONB)` which is unambiguous.
+
+This test compiles the offending statement under the live postgresql+
+psycopg2 dialect with `literal_binds=False` (what alembic actually
+uses) and asserts no stray `:`-prefixed bind survives into the
+rendered SQL.
+"""
+
+import re
+
+from sqlalchemy import text
+from sqlalchemy.dialects import postgresql
+
+
+# Kept identical to the SQL in
+# control-plane-api/alembic/versions/094_seed_gateway_deployments.py.
+# If the migration changes, update this block in lockstep.
+INSERT_SQL = """
+    INSERT INTO gateway_deployments
+        (id, api_catalog_id, gateway_instance_id, desired_state,
+         desired_at, sync_status, sync_attempts)
+    VALUES
+        (gen_random_uuid(), :api_catalog_id, :gateway_id,
+         CAST(:desired_state AS JSONB), NOW(), 'pending', 0)
+    ON CONFLICT ON CONSTRAINT uq_deployment_api_gateway DO NOTHING
+"""
+
+
+def test_regression_cab_1977_094_paramstyle_compiles():
+    """Migration 094's INSERT must compile under postgresql+psycopg2 without stray `:` bindparams."""
+    stmt = text(INSERT_SQL)
+    compiled = stmt.compile(dialect=postgresql.dialect())
+    rendered = str(compiled)
+
+    # Every named bind should have been rewritten to %(name)s pyformat.
+    # A surviving `:name` would indicate the old paramstyle-mix bug.
+    assert not re.search(r":\w+", rendered), (
+        f"migration 094 SQL still contains unbound `:name` placeholders; "
+        f"rendered: {rendered!r}"
+    )
+    assert "%(api_catalog_id)s" in rendered
+    assert "%(gateway_id)s" in rendered
+    assert "%(desired_state)s" in rendered
+    assert "CAST(%(desired_state)s AS JSONB)" in rendered


### PR DESCRIPTION
## Summary

Migration `094_seed_gateway_deployments` has been unrunnable since its merge (CAB-2034). The INSERT mixed SQLAlchemy bindparam syntax (`:name`) with a PostgreSQL cast suffix (`::jsonb`):

```python
VALUES (gen_random_uuid(), :api_catalog_id, :gateway_id,
        :desired_state::jsonb, NOW(), 'pending', 0)
```

SQLAlchemy's regex parser can't disambiguate `:desired_state::jsonb`, so the bind is never rewritten to `%(desired_state)s` and psycopg2 rejects the query:

```
psycopg2.errors.SyntaxError: syntax error at or near ":"
LINE 7: ...:desired_state::jsonb, NOW(), 'pending', 0)
```

Surfaced today when `alembic upgrade head` was attempted in prod for the first time after [#2386](https://github.com/stoa-platform/stoa/pull/2386) unblocked the multi-head state. Transaction DDL rolled back cleanly; prod stayed at 090.

## The fix

One SQL edit: `:desired_state::jsonb` → `CAST(:desired_state AS JSONB)`. Unambiguous, SQLAlchemy renders it correctly, psycopg2 accepts it.

## Safety of editing 094 in place

`alembic_version` in prod is `090_add_tenant_tool_permissions`. No other environment has ever run 094 (evidence: the bug triggers on the first row and is deterministic; any successful run would have advanced alembic_version past 094 somewhere). Editing 094 in-place is safe — no applied state to reconcile.

## Test plan

- [x] `test_regression_cab_1977_094_paramstyle_compiles` — compiles the INSERT under `postgresql` dialect and asserts no stray `:name` survives after bindparam rewrite. Validated live: FIXED passes, BROKEN (old code) fails.
- [ ] Post-merge: redeploy → `alembic upgrade head` in prod (applies 091→092→093→094→095 in order, dropping `execution_logs` for real per CAB-1977/CAB-2034)

## Links

- [CAB-1977](https://linear.app/hlfh-workspace/issue/CAB-1977)
- Related PRs: [#2297](https://github.com/stoa-platform/stoa/pull/2297) (migration 092), [#2386](https://github.com/stoa-platform/stoa/pull/2386) (095 merge heads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)