### PR TITLE
feat(ci): STOA PR Guardian (ADR-065)

### DIFF
--- a/.claude/skills/pr-guardian/SKILL.md
+++ b/.claude/skills/pr-guardian/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: pr-guardian
+description: STOA PR Guardian — advisory three-axis review (ADR compliance, security, AI code smell) with binary GO/NO-GO verdict + confidence. Never approves, never blocks merge.
+argument-hint: "<PR_number>"
+allowed-tools: Read, Glob, Grep, Bash(gh:*), Bash(curl:*), Bash(jq:*), Bash(./\.claude/skills/pr-guardian/adr-loader\.sh:*), Bash(wc:*), Bash(head:*), Bash(sed:*)
+---
+
+# STOA PR Guardian — $ARGUMENTS
+
+Advisory-only review. Three axes, binary verdict, idempotent comments. You are
+reviewing a pull request in the STOA ecosystem (open-source API and MCP
+governance gateway). Your job is to catch issues BEFORE human review, not to
+replace it.
+
+**ADR**: [ADR-065](https://github.com/stoa-platform/stoa-docs/blob/main/docs/architecture/adr/adr-065-pr-guardian.md)
+**Policy**: [`docs/ai/pr-guardian-policy.md`](../../../docs/ai/pr-guardian-policy.md)
+**Runbook**: [`docs/ai/pr-guardian-runbook.md`](../../../docs/ai/pr-guardian-runbook.md)
+
+---
+
+## Hard rules (enforced — do not deviate)
+
+- **Never approve.** Never submit a GitHub review with state `APPROVE` or `REQUEST_CHANGES`. Use `gh pr comment` (summary) and `gh api` (inline) only.
+- **Never block merge.** You are advisory. You signal risk; humans decide.
+- **Terse comments.** Max 4 lines each. No preamble ("Great PR!"), no emoji, no trailing summary.
+- **No follow-ups injected.** Do not write `TODO`/`FIXME` into the reviewed code. Do not open issues.
+- **English in GitHub comments.** French is fine in Slack if it matches the team tone.
+- **Summary comment MUST begin with** `<!-- stoa-pr-guardian -->` on its own line.
+
+---
+
+## Step 1 — Load context
+
+PR number: $ARGUMENTS (also available as `$PR_NUMBER` env var in CI).
+
+Pull the PR metadata, diff, and linked issue:
+
+```bash
+PR="${PR_NUMBER:-$ARGUMENTS}"
+REPO="${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+
+gh pr view "$PR" --json title,body,author,headRefName,baseRefName,files,labels \
+  > /tmp/guardian-pr-meta.json
+
+gh pr diff "$PR" --patch > /tmp/guardian-pr-diff.patch
+
+DIFF_LINES=$(wc -l < /tmp/guardian-pr-diff.patch | tr -d ' ')
+echo "Diff lines: $DIFF_LINES (cap 1000)"
+```
+
+If the workflow already short-circuited on the 1000-line guard, this step will
+not run; when invoked locally on an oversize PR, stop and emit the same "diff
+too large" comment the workflow would have posted.
+
+---
+
+## Step 2 — Detect stack
+
+Map changed files to stacks. A PR can span multiple stacks.
+
+| Path pattern | Stack |
+|---|---|
+| `control-plane-api/` or `*.py` + `pyproject.toml` | Control Plane |
+| `stoa-gateway/` or `*.rs` + `Cargo.toml` | Gateway |
+| `portal/` or `control-plane-ui/` + `*.tsx`/`*.ts` + `package.json` | Portal / Console |
+| `stoa-go/` or `*.go` + `go.mod` | stoactl / stoa-connect |
+| `charts/` + `*.yaml` | Helm |
+| `e2e/` + `*.feature`/`*.ts` | E2E |
+
+Output: one of `Control Plane`, `Gateway`, `Portal`, `Console`, `mixed`.
+Treat Portal and Console separately for ADR-055 checks.
+
+---
+
+## Step 3 — Load ADRs
+
+Run the loader. It fetches raw markdown from `stoa-platform/stoa-docs` and
+falls back with a sentinel on failure.
+
+```bash
+# Static base — always load
+bash .claude/skills/pr-guardian/adr-loader.sh 012 041 > /tmp/guardian-adrs.md
+
+# Conditional — Portal or Console touched
+if grep -qE '^(portal|control-plane-ui)/' /tmp/guardian-pr-meta.json; then
+  bash .claude/skills/pr-guardian/adr-loader.sh 055 >> /tmp/guardian-adrs.md
+fi
+
+# Dynamic — any ADR-XXX mentioned in title, body, or commit messages
+DYNAMIC=$(jq -r '.title + "\n" + .body' /tmp/guardian-pr-meta.json \
+  | grep -oE 'ADR-[0-9]+' | sed 's/ADR-//' | sort -u | head -6)
+for n in $DYNAMIC; do
+  bash .claude/skills/pr-guardian/adr-loader.sh "$n" >> /tmp/guardian-adrs.md
+done
+
+# Cap at 6 total ADRs loaded. If the fetch sentinel appears, record it.
+FETCH_FAILED=false
+if grep -q 'ADR_LOADER_FETCH_FAILED' /tmp/guardian-adrs.md; then
+  FETCH_FAILED=true
+fi
+```
+
+If `FETCH_FAILED=true`, proceed with axes 2 and 3 only and note the partial
+load in the summary confidence field.
+
+---
+
+## Step 4 — Apply the three axes
+
+Read the rubric from `docs/ai/pr-guardian-policy.md` and apply it line by line
+against the diff. **Do not invent rules.** Stick to the policy pack.
+
+For each issue found, emit an inline comment on the exact file and line. Use
+this exact shape:
+
+```
+[AXIS] Short title
+
+Why this matters: 1 sentence.
+Suggested fix: 1–2 lines of code or a clear instruction.
+```
+
+Where `[AXIS]` is one of: `[ADR-XXX]`, `[SEC]`, `[SMELL]`.
+Four lines max. No preamble. No emoji.
+
+Post inline comments via:
+
+```bash
+gh api "repos/${REPO}/pulls/${PR}/comments" \
+  -f body="..." -f commit_id="$HEAD_SHA" -f path="$FILE" -F line=$LINE -f side=RIGHT
+```
+
+If inline positioning fails (renamed file, outside diff hunk), fall back to
+a file-level PR comment: `gh pr comment "$PR" --body "..."`.
+
+---
+
+## Step 5 — Compute verdict + confidence
+
+**Verdict (from policy pack):**
+- Any `[SEC]` flag → `NO-GO`
+- ≥ 3 combined `[ADR-XXX]` + `[SMELL]` flags → `NO-GO`
+- Otherwise → `GO`
+
+**Confidence (from policy pack):**
+- `high` — full diff analyzed, all ADRs loaded, stack unambiguous
+- `medium` — partial ADR load, mixed-stack PR, or diff in 500-1000 range
+- `low` — ADR fetch failed, diff near cap, or unusual file patterns
+
+---
+
+## Step 6 — Post summary comment (idempotent)
+
+The workflow deletes any previous Guardian comment before your run. Post a
+fresh one starting with the marker. Use exactly this structure:
+
+**GO case:**
+
+```
+<!-- stoa-pr-guardian -->
+**STOA PR Guardian — GO ✅**
+
+Stack: <detected>
+ADRs checked: <list or "none loaded — fetch failed">
+Confidence: <high|medium|low> <optional: short reason>
+
+Findings:
+- [ADR-XXX] N issues
+- [SEC] N issues
+- [SMELL] N issues
+
+LGTM — proceed to human review.
+```
+
+**NO-GO case:**
+
+```
+<!-- stoa-pr-guardian -->
+**STOA PR Guardian — NO-GO 🛑**
+
+Stack: <detected>
+ADRs checked: <list>
+Confidence: <high|medium|low> <optional: short reason>
+
+Findings:
+- [SEC] N issues
+- [ADR-XXX] N issues
+- [SMELL] N issues
+
+Blockers:
+- <max 3 bullets, one line each>
+```
+
+Post:
+
+```bash
+gh pr comment "$PR" --body "$(cat <<'EOF'
+<!-- stoa-pr-guardian -->
+... (assembled verdict)
+EOF
+)"
+```
+
+The GO/NO-GO marker and the `<!-- stoa-pr-guardian -->` line are **required**.
+Downstream automation greps for them.
+
+---
+
+## Step 7 — Slack alert (NO-GO only)
+
+On `NO-GO`, post to the webhook in `$SLACK_WEBHOOK_STOA_REVIEWS`. If the env
+var is empty, log a warning and skip — never error.
+
+```bash
+if [ "$VERDICT" = "NO-GO" ] && [ -n "${SLACK_WEBHOOK_STOA_REVIEWS:-}" ]; then
+  REPO_SHORT=$(echo "$REPO" | cut -d/ -f2)
+  TITLE=$(jq -r .title /tmp/guardian-pr-meta.json)
+  AUTHOR=$(jq -r .author.login /tmp/guardian-pr-meta.json)
+  BLOCKERS_LINE="<one-line summary of the top blockers>"
+  PAYLOAD=$(jq -cn \
+    --arg text "🛑 NO-GO sur ${REPO_SHORT}#${PR} — « ${TITLE} »" \
+    --arg author "@${AUTHOR}" \
+    --arg blockers "$BLOCKERS_LINE" \
+    --arg link "${PR_URL:-https://github.com/${REPO}/pull/${PR}}" \
+    '{text: $text, attachments: [{color: "danger", fields: [
+       {title: "Auteur", value: $author, short: true},
+       {title: "Blockers", value: $blockers, short: false},
+       {title: "Lien", value: $link, short: false}
+     ]}]}')
+  curl -sS -X POST -H 'Content-Type: application/json' \
+    --data "$PAYLOAD" "$SLACK_WEBHOOK_STOA_REVIEWS" >/dev/null || true
+fi
+```
+
+On `GO`, do nothing in Slack. No news is good news.
+
+---
+
+## Local invocation
+
+```bash
+# From the stoa repo root. PR must be a number in stoa-platform/stoa.
+# You need GH_TOKEN (or authenticated gh) and optional SLACK_WEBHOOK_STOA_REVIEWS.
+claude-code chat "/pr-guardian 2378"
+```
+
+For dry-run without Slack: `SLACK_WEBHOOK_STOA_REVIEWS= /pr-guardian 2378`.
+For replay on merged PRs: use the PR number, diff is still fetchable.
+
+---
+
+## Failure modes — do NOT swallow
+
+If any step fails (ADR loader, inline comment post, diff fetch), log it and
+continue to the next step. The final summary comment MUST still be posted
+with reduced confidence. Silent failure is the worst outcome: it makes the
+Guardian look trustworthy when it is not.
+
+If the summary comment itself cannot be posted (permissions error, API down),
+the workflow will detect the non-zero exit and fall back to the "Guardian
+unavailable" sentinel comment + ops Slack alert. Do not try to route around
+the workflow fallback — raise the error cleanly.

--- a/.claude/skills/pr-guardian/adr-loader.sh
+++ b/.claude/skills/pr-guardian/adr-loader.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# adr-loader.sh — fetch ADRs from stoa-platform/stoa-docs for the PR Guardian.
+#
+# Usage: adr-loader.sh <number> [<number> ...]
+#        Emits concatenated markdown on stdout. One `## ADR-XXX` header per ADR.
+#
+# Fallback contract: on any fetch failure, echoes a sentinel line that the
+# skill greps for ("ADR_LOADER_FETCH_FAILED"). Never exits non-zero when called
+# with valid arguments — the skill decides how to degrade confidence.
+
+set -u
+# Note: deliberately no `-e` so partial failures still emit the sentinel and
+# continue to the next ADR.
+
+REPO_OWNER="${ADR_REPO_OWNER:-stoa-platform}"
+REPO_NAME="${ADR_REPO_NAME:-stoa-docs}"
+BRANCH="${ADR_BRANCH:-main}"
+ADR_DIR="docs/architecture/adr"
+
+# Prefer raw.githubusercontent.com; fall back to gh api if available.
+fetch_adr() {
+  local n="$1"
+  local padded
+  padded=$(printf "%03d" "$n" 2>/dev/null || echo "$n")
+  local slug_pattern="adr-${padded}-"
+
+  # Ask stoa-docs for the filename matching adr-XXX-*.md via GitHub API.
+  # This lets us fetch the ADR without hardcoding its slug.
+  local filename=""
+  if command -v gh >/dev/null 2>&1; then
+    filename=$(gh api "repos/${REPO_OWNER}/${REPO_NAME}/contents/${ADR_DIR}?ref=${BRANCH}" \
+      --jq ".[] | select(.name | startswith(\"${slug_pattern}\")) | .name" 2>/dev/null | head -1)
+  fi
+
+  if [ -z "$filename" ]; then
+    # Fallback: try plain-curl directory listing via the REST API.
+    filename=$(curl -sS -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents/${ADR_DIR}?ref=${BRANCH}" 2>/dev/null \
+      | jq -r ".[] | select(.name | startswith(\"${slug_pattern}\")) | .name" 2>/dev/null | head -1)
+  fi
+
+  if [ -z "$filename" ]; then
+    echo "<!-- ADR_LOADER_FETCH_FAILED: could not resolve filename for ADR-${padded} -->"
+    return
+  fi
+
+  local url="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${BRANCH}/${ADR_DIR}/${filename}"
+  local body
+  body=$(curl -sSfL --max-time 10 "$url" 2>/dev/null || echo "")
+
+  if [ -z "$body" ]; then
+    echo "<!-- ADR_LOADER_FETCH_FAILED: fetch error on ${url} -->"
+    return
+  fi
+
+  echo ""
+  echo "## ADR-${padded} (source: ${filename})"
+  echo ""
+  echo "$body"
+  echo ""
+  echo "---"
+}
+
+if [ $# -eq 0 ]; then
+  echo "Usage: $0 <number> [<number> ...]" >&2
+  exit 2
+fi
+
+for arg in "$@"; do
+  # Accept both "12" and "012"; normalize to integer.
+  n=$(echo "$arg" | sed 's/^0*//')
+  [ -z "$n" ] && n=0
+  fetch_adr "$n"
+done

--- a/.github/workflows/pr-guardian.yml
+++ b/.github/workflows/pr-guardian.yml
@@ -1,0 +1,184 @@
+# STOA PR Guardian — advisory AI review on every PR
+# ADR-065 (stoa-docs). Binary GO/NO-GO verdict + confidence. Fail-visible.
+#
+# Kill-switch: repo variable DISABLE_PR_GUARDIAN=true disables all runs.
+# Per-PR skip:  label `skip-guardian` or `wip`, or convert PR to draft.
+#
+# Complementary to claude-review.yml (generic Ship/Show/Ask). Not a replacement.
+
+name: STOA PR Guardian
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+
+concurrency:
+  group: guardian-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  guardian:
+    # Skip: kill-switch, bot authors, draft PRs, opt-out labels, fork PRs (secrets protection)
+    if: |
+      vars.DISABLE_PR_GUARDIAN != 'true' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !endsWith(github.actor, '[bot]') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-guardian') &&
+      !contains(github.event.pull_request.labels.*.name, 'wip')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # ------------------------------------------------------------------
+      # Pre-flight: compute diff size, short-circuit if over 1000 lines
+      # ------------------------------------------------------------------
+      - name: Diff size guard (1000-line cap)
+        id: diff-guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          DIFF_LINES=$(gh pr diff "$PR_NUM" --patch 2>/dev/null | wc -l | tr -d ' ')
+          echo "diff_lines=${DIFF_LINES}" >> "$GITHUB_OUTPUT"
+          echo "PR #${PR_NUM} diff: ${DIFF_LINES} lines"
+
+          if [ "${DIFF_LINES:-0}" -gt 1000 ]; then
+            echo "too_large=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "too_large=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Remove previous Guardian comment (idempotence)
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          # Find and delete any previous Guardian summary comment so we can post a fresh one.
+          # This is simpler than editing; the marker ensures we only touch our own comments.
+          REPO="${{ github.repository }}"
+          COMMENT_IDS=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments" \
+            --jq '.[] | select(.body | contains("<!-- stoa-pr-guardian -->")) | .id' 2>/dev/null || echo "")
+          for id in $COMMENT_IDS; do
+            gh api -X DELETE "repos/${REPO}/issues/comments/${id}" >/dev/null 2>&1 || true
+          done
+
+      - name: Post oversize notice and exit
+        if: steps.diff-guard.outputs.too_large == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUM" --body "$(cat <<'EOF'
+          <!-- stoa-pr-guardian -->
+          **STOA PR Guardian — skipped**
+
+          Diff too large for guardian review (${{ steps.diff-guard.outputs.diff_lines }} lines > 1000 cap).
+          Human review required. Consider splitting this PR per CLAUDE.md rule.
+          EOF
+          )"
+          echo "::notice::Guardian skipped on PR #${PR_NUM} — diff ${{ steps.diff-guard.outputs.diff_lines }} lines"
+
+      # ------------------------------------------------------------------
+      # Guardian run (only if within diff cap)
+      # ------------------------------------------------------------------
+      - name: Run STOA PR Guardian
+        id: guardian
+        if: steps.diff-guard.outputs.too_large != 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            IMPORTANT: You are running in CI. Skip session-startup protocol entirely.
+            Do NOT read memory.md, plan.md, or operations.log for session state.
+            Focus exclusively on the task below.
+
+            Run the STOA PR Guardian on PR #${{ github.event.pull_request.number }}.
+
+            PR metadata:
+              Title: ${{ github.event.pull_request.title }}
+              Author: ${{ github.event.pull_request.user.login }}
+              Base: ${{ github.event.pull_request.base.ref }}
+              Head: ${{ github.event.pull_request.head.sha }}
+              URL: ${{ github.event.pull_request.html_url }}
+
+            Steps:
+              1. Read the skill `.claude/skills/pr-guardian/SKILL.md`.
+              2. Read the policy pack `docs/ai/pr-guardian-policy.md`.
+              3. Follow the skill's instructions to the letter.
+              4. Post inline comments via `gh pr review --comment` or `gh api` if inline
+                 positioning is needed. Summary comment via `gh pr comment`.
+              5. If verdict = NO-GO, POST Slack notification via the webhook in env
+                 $SLACK_WEBHOOK_STOA_REVIEWS (curl). If the env var is empty, log
+                 `::warning::Slack webhook missing` and continue.
+
+            Hard rules (from the skill, restated):
+              - Never approve. Never request changes via API. Comment only.
+              - Comments max 4 lines, no preamble, no emoji, no TODO injection.
+              - English in GitHub comments. French OK in Slack alert.
+              - All summary comments MUST start with the literal marker `<!-- stoa-pr-guardian -->`.
+          # Sonnet 4.6 per CLAUDE.md CI policy. Bash/Read/Glob/Grep + gh/curl are enough.
+          claude_args: "--model claude-sonnet-4-6 --max-turns 20 --allowedTools Read,Glob,Grep,Bash"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          REPO: ${{ github.repository }}
+          SLACK_WEBHOOK_STOA_REVIEWS: ${{ secrets.SLACK_WEBHOOK_STOA_REVIEWS }}
+
+      # ------------------------------------------------------------------
+      # Failure mode: never silent
+      # ------------------------------------------------------------------
+      - name: Post fallback comment on Guardian failure
+        if: steps.guardian.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUM" --body "$(cat <<'EOF'
+          <!-- stoa-pr-guardian -->
+          **STOA PR Guardian — unavailable**
+
+          Guardian could not analyze this PR. Non-blocking. Human review still required.
+
+          Possible causes: API rate limit, transient error, ADR fetch failure.
+          Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EOF
+          )" || true
+
+      - name: Alert ops on Guardian failure
+        if: steps.guardian.outcome == 'failure'
+        env:
+          SLACK_WEBHOOK_GUARDIAN_ALERTS: ${{ secrets.SLACK_WEBHOOK_GUARDIAN_ALERTS }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_GUARDIAN_ALERTS}" ]; then
+            echo "::warning::SLACK_WEBHOOK_GUARDIAN_ALERTS not set — ops alert skipped"
+            exit 0
+          fi
+          payload=$(jq -cn \
+            --arg text "⚠️ STOA PR Guardian failed on ${PR_TITLE}" \
+            --arg pr "${PR_URL}" \
+            --arg run "${RUN_URL}" \
+            '{text: $text, attachments: [{color: "warning", fields: [{title: "PR", value: $pr, short: false}, {title: "Run", value: $run, short: false}]}]}')
+          curl -sS -X POST -H 'Content-Type: application/json' \
+            --data "$payload" "${SLACK_WEBHOOK_GUARDIAN_ALERTS}" >/dev/null || true
+
+      - name: Log token usage
+        if: always()
+        run: |
+          echo "::notice title=AI Factory::Job=${{ github.job }}, Workflow=${{ github.workflow }}, Model=sonnet-4-6, Stage=pr-guardian, PR=${{ github.event.pull_request.number }}, Outcome=${{ steps.guardian.outcome }}"

--- a/docs/ai/pr-guardian-policy.md
+++ b/docs/ai/pr-guardian-policy.md
@@ -1,0 +1,152 @@
+# STOA PR Guardian — Policy Pack
+
+This is the **rubric** the Guardian applies. The skill enforces the shape
+(verdict, confidence, comment format). This file defines the content (what
+counts as a flag, how flags combine into a verdict). Edit this file to tune
+the rubric — no workflow change, no skill change required.
+
+- **Advisory only.** Guardian never blocks merge.
+- **Binary verdict** + confidence.
+- **Fail-visible, never silent.**
+
+Related:
+- ADR-065 — decision record in stoa-docs.
+- `.claude/skills/pr-guardian/SKILL.md` — the skill source.
+- `docs/ai/pr-guardian-runbook.md` — operational surface.
+
+---
+
+## The three axes
+
+Every flag carries a prefix. Inline comments lead with the prefix; the
+summary comment aggregates counts per prefix.
+
+### Axis 1 — ADR compliance → `[ADR-XXX]`
+
+Load context: ADR-012 (RBAC), ADR-041 (Community / Enterprise), and — if the
+PR touches Portal or Console — ADR-055 (Portal/Console governance). Add any
+ADR referenced in the PR title, body, or commit messages (regex `ADR-\d+`),
+capped at 6 loaded ADRs total.
+
+For each changed file:
+
+| Check | Fires when |
+|---|---|
+| **ADR-012 bypass** | A new HTTP route or FastAPI endpoint lacks `Depends(require_scope(...))`, or a Rust axum handler lacks the equivalent middleware/guard, or a React route is not wrapped in the scoped guard component. |
+| **ADR-041 boundary leak** | Community code imports a module or crate tagged `enterprise-only`, or vice-versa. File-level `// @community` / `// @enterprise` markers or directory conventions (`src/enterprise/`) are authoritative. |
+| **ADR-055 Portal/Console leak** | Portal code (`portal/`) imports from Console-only modules, or renders a Provider-scoped feature (API creation, subscription approval, gateway mgmt, webhooks, credentials, contracts). |
+| **Dynamic ADR ref** | The PR cites `ADR-XXX` and the diff reads inconsistent with the decision described in that ADR. |
+
+Flag shape:
+
+```
+[ADR-055] Portal importing Console-only module
+
+Why this matters: breaks Portal=Consumer/Console=Provider split; confuses RBAC.
+Suggested fix: move this hook to `control-plane-ui/` or route via the public API.
+```
+
+### Axis 2 — Security regression → `[SEC]`
+
+Any `[SEC]` flag promotes the verdict to `NO-GO`. Be conservative: if in
+doubt, the reviewer can overrule. False negatives are worse than false
+positives on this axis.
+
+| Check | Fires when |
+|---|---|
+| **Hardcoded secret** | Literal API key, JWT, Bearer token, private key, or credential in source, tests, fixtures, or migrations. Patterns: entropy > 3.5 on 20+ char strings, `AKIA...`, `sk_live_`, PEM headers, `eyJ...`. Exclude documented examples in `*.example.*`, `README`, and `docs/`. |
+| **Auth bypass — Python** | New FastAPI route (`@router.get/post/...`) without `Depends(require_scope(...))` or equivalent. Applies to `control-plane-api/` and `mcp-gateway/` (legacy). |
+| **Auth bypass — Rust** | New axum handler added without a middleware layer that enforces scope. Remember: `.layer()` only applies to routes registered BEFORE it. |
+| **Auth bypass — React** | New Portal/Console route registered without a scoped guard (e.g. `<Protected scopes={...}>`). |
+| **Unsafe deserialization** | Eval-like parsing (`eval`, `pickle.loads`, `yaml.load` without `SafeLoader`, `serde_json::from_value` on untrusted single-item arrays, JSONPath matches that silently return a single element when a list is expected — see webMethods JSONPath bug). |
+| **SQL / NoSQL injection** | String concatenation or f-string interpolation into a query instead of parameterized binding. Applies to raw SQL, SQLAlchemy text(), MongoDB filter dicts built from user input. |
+| **CORS / CSP loosening** | `Access-Control-Allow-Origin: *` added, CSP `unsafe-inline`/`unsafe-eval` added, without a justification comment tied to a ticket. |
+| **Secret in log / response** | Log statement or HTTP response body containing a token, password, api key, or session cookie. Includes structured logging fields named `token`, `secret`, `authorization`, `password`. |
+
+Flag shape:
+
+```
+[SEC] Route bypasses RBAC — missing scope guard
+
+Why this matters: exposes the endpoint to any authenticated user.
+Suggested fix: add `Depends(require_scope("stoa:write"))` to the signature.
+```
+
+### Axis 3 — AI-generated code smell → `[SMELL]`
+
+~85% of STOA code is AI co-authored. Look for failure modes typical of LLM
+generation. This is the axis that decays fastest — tune aggressively.
+
+| Check | Fires when |
+|---|---|
+| **Dead code** | Unused import, unused variable, unused function, unreachable branch. Trust the linter — fire only when the linter is not covering this file. |
+| **Over-abstraction** | Single-call wrapper adds no value (rename, parameter reorder, same signature). One-file helper imported once. Premature interface with a single implementer. |
+| **Duplicated logic** | Same function logic reimplemented in a sibling file with minor variation. Heuristic: two functions with identical signatures and 80%+ overlapping bodies. |
+| **Inconsistent naming** | New symbol deviates from the codebase convention (snake_case vs camelCase, `get_*` vs `fetch_*`, `Client` vs `Service`). Cross-reference 3+ existing symbols in the same module before flagging. |
+| **Tests that test mocks** | Assertions verify what the mock was called with but no assertion on the real output or side effect under test. Common with `AsyncMock`, `httpx.MockTransport` used against the code under test instead of a boundary. |
+| **WHAT-not-WHY comments** | Comment restates what the line does (`# increment counter`) instead of explaining a non-obvious constraint, invariant, or reason. |
+| **Leftover markers** | `TODO`, `FIXME`, `XXX`, `HACK` in the diff (not in files outside the diff). |
+| **Swallowed exceptions** | `except: pass`, `except Exception: pass` without logging, `.unwrap()` on fallible Rust Result/Option in non-test code, empty `catch {}` in TS, `|_|` ignored errors in Rust without a reason. |
+
+Flag shape:
+
+```
+[SMELL] Swallowed exception hides storage failure
+
+Why this matters: `except: pass` turns a DB timeout into silent data loss.
+Suggested fix: log at WARN and re-raise, or catch the specific exception class.
+```
+
+---
+
+## Verdict computation
+
+Apply in order. First match wins.
+
+1. **Any `[SEC]` flag → `NO-GO`.**
+2. **`[ADR-XXX]` + `[SMELL]` combined count ≥ 3 → `NO-GO`.**
+3. Otherwise → `GO`.
+
+Count rule: a single file with three independent SMELLs counts as three. A
+single SMELL referenced across five files counts as one (it is the same
+issue). Use human judgment — the Guardian is advisory.
+
+---
+
+## Confidence computation
+
+| Level | Fires when |
+|---|---|
+| `high` | Full diff analyzed (≤ 500 lines), all requested ADRs loaded, stack is unambiguous (single-stack PR). |
+| `medium` | ONE of: diff in 500-1000 range, mixed-stack PR, one or more ADR requests partially loaded, unusual file layout. |
+| `low` | TWO or more medium triggers, ADR loader returned the `ADR_LOADER_FETCH_FAILED` sentinel for any requested ADR, or diff is within 100 lines of the 1000-line cap. |
+
+State the confidence and its primary reason in the summary. Example:
+`Confidence: medium (mixed-stack PR)`.
+
+---
+
+## What the Guardian does NOT do
+
+The following are explicitly out of scope. They belong to other tools or
+to human reviewers:
+
+- **Style/format nits** — ruff, black, prettier, clippy, eslint already cover these. The Guardian does not duplicate.
+- **Test coverage thresholds** — coverage gates live in the per-stack CI workflows (ADR-031).
+- **Build/test failures** — CI tells you. Guardian does not re-check.
+- **Performance regressions** — out of scope; dedicated benchmarks handle this.
+- **Prescription of fix** — Guardian suggests, humans decide. A `[SMELL]` with two possible fixes offers both; does not pick one.
+- **Issue creation, Linear sync, task tracking** — Guardian is read-only beyond the PR comment surface.
+
+---
+
+## Policy evolution
+
+Edits to this file land on `main` via PR. The Guardian picks up the new
+rubric on its **next run** — no workflow restart, no skill redeploy. Expect
+two sprints of advisory data before promoting any rule from "tune" to
+"enforce" (see ADR-065 rollout plan).
+
+When adding a rule: include a one-line "Fires when" cell in the relevant
+axis table, a concrete flag example, and — if the rule has a historical
+incident behind it — a reference (ticket ID, commit SHA).

--- a/docs/ai/pr-guardian-runbook.md
+++ b/docs/ai/pr-guardian-runbook.md
@@ -1,0 +1,206 @@
+# STOA PR Guardian — Runbook
+
+Operational surface for the PR Guardian: how to disable, skip, test, iterate,
+debug. Anything requiring a decision beyond "run the playbook" belongs in
+ADR-065 (stoa-docs), not here.
+
+- **Workflow**: `.github/workflows/pr-guardian.yml`
+- **Skill**: `.claude/skills/pr-guardian/SKILL.md`
+- **Policy**: `docs/ai/pr-guardian-policy.md`
+- **ADR**: [ADR-065](https://github.com/stoa-platform/stoa-docs/blob/main/docs/architecture/adr/adr-065-pr-guardian.md)
+
+---
+
+## Disable globally
+
+Set the repository variable `DISABLE_PR_GUARDIAN=true` on the GitHub repo.
+
+```bash
+gh variable set DISABLE_PR_GUARDIAN --body "true" --repo stoa-platform/stoa
+```
+
+Effect: workflow triggers on PR events but every job exits early. Visible in
+the Actions tab as "skipped". Re-enable by setting the variable to `false`
+or deleting it:
+
+```bash
+gh variable delete DISABLE_PR_GUARDIAN --repo stoa-platform/stoa
+```
+
+Propagation: instant on the next PR event.
+
+## Skip a specific PR
+
+Three ways, pick one:
+
+| Method | When to use |
+|---|---|
+| Label `skip-guardian` | You disagree with the Guardian on this PR, but keep it enabled elsewhere. |
+| Label `wip` | PR is work-in-progress, feedback not useful yet. |
+| Convert PR to draft | You want CI to skip reviews entirely, including `claude-review.yml`. |
+
+Add a label:
+
+```bash
+gh pr edit <PR_NUM> --add-label skip-guardian
+```
+
+Remove the label (or mark PR ready for review) and the Guardian runs again
+on the next `synchronize` event, or trigger a manual `gh pr ready`.
+
+## Bot authors — skipped automatically
+
+The workflow condition excludes any author whose login ends with `[bot]`:
+Dependabot, Renovate, release-please, github-actions. No action required.
+
+## Fork PRs — skipped automatically
+
+Secrets (ANTHROPIC_API_KEY, Slack webhooks) are not available to fork
+workflows by GitHub policy. The Guardian skips fork PRs with a workflow
+condition, no comment posted. Internal reviewer owns the call on fork PRs.
+
+## Large diffs — handled automatically
+
+Any PR whose diff exceeds 1000 lines triggers a single comment:
+
+> **STOA PR Guardian — skipped**
+> Diff too large for guardian review (N lines > 1000 cap). Human review
+> required. Consider splitting this PR per CLAUDE.md rule.
+
+No Slack alert. The split recommendation is the actionable step.
+
+---
+
+## Test locally
+
+You can dry-run the Guardian on any accessible PR without triggering the
+workflow. Useful for policy tuning and historical PR replay.
+
+Requirements:
+
+- `gh` authenticated as a user with read access to the repo
+- Optional `SLACK_WEBHOOK_STOA_REVIEWS` if you want to test the Slack path
+- Claude Code CLI with the skill loaded (it is, if you are on `main`)
+
+Invocation:
+
+```bash
+cd ~/hlfh-repos/stoa
+claude-code chat "/pr-guardian 2378"
+```
+
+Dry-run without Slack (safe default):
+
+```bash
+SLACK_WEBHOOK_STOA_REVIEWS= claude-code chat "/pr-guardian 2378"
+```
+
+The skill will fetch the PR diff, run the three axes, and emit comments
+to your terminal. It will NOT post to GitHub unless you confirm via the
+shell prompt.
+
+### Replay on a merged PR
+
+Historical PRs still have fetchable diffs via `gh pr diff`. Replay works
+identically — useful when tuning the policy against real past decisions.
+
+```bash
+claude-code chat "/pr-guardian 2378"
+# Where 2378 is any PR number, open or merged.
+```
+
+### Three-PR calibration run
+
+When the policy changes, run the Guardian on three reference PRs to
+verify it still behaves as expected:
+
+| PR shape | Expected verdict |
+|---|---|
+| Small refactor, no secrets, no ADR-touching files | `GO` |
+| Known historical security regression | `NO-GO` on `[SEC]` |
+| PR with ≥ 3 AI code smell flags (loose fixtures, swallowed exceptions) | `NO-GO` on `[SMELL]` threshold |
+
+Record the verdicts in the PR description of whatever policy change you
+are proposing.
+
+---
+
+## Iterate on the policy
+
+The rubric lives in one file: `docs/ai/pr-guardian-policy.md`.
+
+1. Edit the policy file on a branch.
+2. Open a PR. The Guardian runs on that PR using the OLD policy (from
+   `main`), not the PR version — this is intentional: policy changes are
+   reviewed by humans, not self-reviewed.
+3. Run the three-PR calibration locally (see above) using the PR branch
+   to see how the new policy behaves.
+4. Merge. Next PR event picks up the new policy automatically.
+
+No workflow restart, no secret rotation, no infra change.
+
+---
+
+## Known failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Comment says "Guardian unavailable" | Claude action failed (API rate limit, transient 5xx, secret missing) | Check Actions logs; wait for next `synchronize` or push a trivial commit to retry |
+| No Guardian comment on a PR that should have one | Kill-switch on, PR is draft, label `skip-guardian`/`wip` present, author is bot, PR is from a fork | Check the job condition in Actions logs; the `if:` evaluated to false |
+| Duplicate Guardian comments | `Remove previous Guardian comment` step failed (rate limit, permissions) | Delete the stale one manually; the idempotence step runs best-effort |
+| NO-GO posted but no Slack alert | `SLACK_WEBHOOK_STOA_REVIEWS` secret missing or empty | Set the secret; skill logs `::warning::Slack webhook missing` |
+| "ADR_LOADER_FETCH_FAILED" in summary | GitHub rate limit, stoa-docs outage, or branch rename | Confidence drops to `low`; verdict still computed from available data |
+| Guardian flags a file that was not in the diff | Stale cache or skill bug | Re-run via empty push; if persistent, open an issue against this repo |
+
+## Inspect a run
+
+Actions tab → STOA PR Guardian → pick the PR number in the concurrency group.
+
+Useful fields in the run log:
+
+- Step `Diff size guard` → the computed diff line count
+- Step `Run STOA PR Guardian` → the Claude invocation output (execution file)
+- Step `Post fallback comment on Guardian failure` → only runs on failure
+- `::notice::AI Factory` line → model, outcome, PR number
+
+Raw Claude execution:
+
+```bash
+gh run view <RUN_ID> --log | grep -A 200 'Run STOA PR Guardian'
+```
+
+---
+
+## Costs
+
+Per PR run:
+
+- Sonnet 4.6, max 20 turns, `--allowedTools Read,Glob,Grep,Bash`
+- Typical run: one PR, ≤ 1000-line diff, three ADRs loaded
+- Expected cost: low-single-digit cents per PR (monitor via `/token-report`)
+
+Cost controls already in place:
+
+- Concurrency cancel on resync (no duplicate runs for quick pushes)
+- Bot/draft/fork skip (no wasted runs on auto-PRs)
+- 1000-line diff guard (oversize diffs do not invoke Claude at all)
+
+If token cost trends concerning:
+
+1. Tighten the `max-turns` in the workflow (start: 20, floor: 10)
+2. Switch the static ADR list to just the one the diff touches
+3. Disable during active refactor sprints via `DISABLE_PR_GUARDIAN=true`
+
+---
+
+## Relationship to other workflows
+
+| Workflow | Relationship |
+|---|---|
+| `claude-review.yml` | Complementary. Generic vibe check. No plan to retire. |
+| `council-gate.yml` | Upstream of the Guardian — runs Stage 3 diff review at push time (pre-PR). Guardian runs at PR time (post-push). Different surfaces, different latencies. |
+| `context-compiler-learn.yml` | Independent. Runs on post-merge, not PR-time. |
+
+The Guardian is **one layer** of the review stack. It is not the last line
+of defence and it is not the first — it catches a narrow set of failure
+modes cheaply, and hands off to humans on everything else.


### PR DESCRIPTION
## Summary

Implements the four-artefact STOA PR Guardian design from **ADR-065** (stoa-docs PR [#161](https://github.com/stoa-platform/stoa-docs/pull/161), status Proposed).

Advisory-only PR review automation. Binary GO/NO-GO verdict + confidence. Idempotent comments via HTML marker. Fail-visible (never silent). No merge gate.

**Depends on**: [stoa-docs#161](https://github.com/stoa-platform/stoa-docs/pull/161) (merge first → Accepted → merge this).

## Artefacts

| File | Role |
|---|---|
| `.github/workflows/pr-guardian.yml` | `pull_request` trigger; kill-switch `DISABLE_PR_GUARDIAN`; 1000-line diff guard; concurrency cancel-in-progress; fallback comment + ops Slack on failure |
| `.claude/skills/pr-guardian/SKILL.md` | Three-axis review prompt; binary verdict + confidence; invocable locally as `/pr-guardian <PR#>` |
| `.claude/skills/pr-guardian/adr-loader.sh` | Fetches ADRs from stoa-docs with `ADR_LOADER_FETCH_FAILED` sentinel |
| `docs/ai/pr-guardian-policy.md` | The rubric — three axes `[ADR-XXX]` / `[SEC]` / `[SMELL]`; verdict + confidence rules |
| `docs/ai/pr-guardian-runbook.md` | Kill-switch, per-PR skip, local test, policy iteration, failure modes |

## Design (recap from ADR-065)

- **Advisory only** — no merge gate. Prevents workaround culture.
- **Binary GO/NO-GO + confidence** — readable in < 5 seconds.
- **Fail-visible** — Guardian outages never hide (fallback comment + ops Slack alert).
- **Separated policy pack** — the rubric evolves faster than the skill; policy changes are one-file PRs.
- **Not Anthropic Routines** — fitness for purpose: GH Actions wins on audit trail (DORA), portability (self-hosted parity), policy PR review, per-repo kill-switch.

## Skip / disable rules

| Scenario | Behaviour |
|---|---|
| Repo var `DISABLE_PR_GUARDIAN=true` | All runs skip |
| Author `*[bot]` | Skip |
| Draft PR | Skip |
| Label `skip-guardian` or `wip` | Skip |
| Fork PR | Skip (secrets protection) |
| Diff > 1000 lines | One "diff too large" comment, skip Claude |

## Verdict / confidence rules (from policy pack)

- Any `[SEC]` flag → **NO-GO**
- ≥ 3 combined `[ADR-XXX]` + `[SMELL]` → **NO-GO**
- Otherwise → **GO**

Confidence: `high` (full diff, all ADRs loaded, single stack) → `medium` (partial load OR mixed-stack OR 500-1000 diff) → `low` (ADR fetch failed OR near diff cap).

## Validation

| Check | Status |
|---|---|
| `actionlint .github/workflows/pr-guardian.yml` | ✅ clean |
| `shellcheck -S warning .claude/skills/pr-guardian/adr-loader.sh` | ✅ clean |
| `bash -n adr-loader.sh` | ✅ clean |
| Skill discoverable by Claude Code CLI | ✅ listed as `pr-guardian` |
| 3-PR dry-run (GO / NO-GO SEC / NO-GO SMELL) | ⏳ **deferred** — requires merge of [stoa-docs#161](https://github.com/stoa-platform/stoa-docs/pull/161) so the ADR loader can fetch the live ADR-065 record. Will run on the Guardian's own PR as first live test once both land. |
| Kill-switch (`DISABLE_PR_GUARDIAN=true`) | ⏳ deferred — not set on repo yet; verified in code path via `if:` condition |

## Rollout

- **Phase 1 — Advisory (from merge)**: workflow runs on every non-bot, non-draft, non-fork PR. No merge gate. Collect 2 sprints of signal quality.
- **Phase 2 — Calibration**: review false-positive rate + NO-GO acceptance rate; tune policy; decide whether to promote. No date.

## Secrets required (repo)

| Secret | Purpose | Already present? |
|---|---|---|
| `ANTHROPIC_API_KEY` | Claude invocation | ✅ yes (shared with `claude-review.yml`) |
| `SLACK_WEBHOOK_STOA_REVIEWS` | NO-GO notifications to `#stoa-reviews` | ⏳ **to provision** |
| `SLACK_WEBHOOK_GUARDIAN_ALERTS` | Workflow-failure alerts to `#stoa-ops` | ⏳ **to provision** |

Missing Slack webhooks degrade gracefully — the skill logs `::warning::Slack webhook missing` and continues.

## Test plan

- [ ] Merge [stoa-docs#161](https://github.com/stoa-platform/stoa-docs/pull/161) (ADR-065 Proposed → Accepted)
- [ ] Mark this PR ready-for-review; verify Guardian self-reviews cleanly
- [ ] Provision `SLACK_WEBHOOK_STOA_REVIEWS` + `SLACK_WEBHOOK_GUARDIAN_ALERTS`
- [ ] Dry-run on 3 historical PRs (GO / NO-GO SEC / NO-GO SMELL) — capture verdicts in a follow-up comment
- [ ] Flip `DISABLE_PR_GUARDIAN=true`, confirm next PR skips workflow; flip back
- [ ] Observe 2 sprints of signal; review false-positive rate

## Related

- ADR-065 (stoa-docs#161) — decision record
- `claude-review.yml` — existing generic PR review (not retired; complementary)
- `council-gate.yml` — upstream S3 review at push time

## Not in this PR (out of scope)

- Merge-blocking required check (ADR-065 Phase 2, conditional)
- Weekly review digests / metrics dashboards
- `guardian: ignore` inline comment syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)