### PR TITLE
fix(api): enforce JWT issuer + cache Keycloak public key (CAB-2082)

### DIFF
--- a/control-plane-api/src/auth/dependencies.py
+++ b/control-plane-api/src/auth/dependencies.py
@@ -2,7 +2,10 @@
 
 CAB-330: Enhanced debug logging for authentication troubleshooting.
 CAB-438: Sender-constrained token validation (RFC 8705/9449).
+CAB-2082: JWT issuer validation + Keycloak public-key cache (Security P0-01).
 """
+
+import time
 
 import httpx
 from fastapi import Depends, HTTPException, Request, status
@@ -17,6 +20,21 @@ from .sender_constrained import validate_sender_constrained_token
 logger = get_logger(__name__)
 security = HTTPBearer(auto_error=False)
 
+# CAB-2082: cache the Keycloak realm public key in-memory (TTL 5 min).
+# Prior behavior refetched on every request — DoS vector if Keycloak slow,
+# and no pinning/cache meant MITM could substitute the key freely.
+_KC_PUBLIC_KEY_CACHE: dict[str, tuple[str, float]] = {}
+_KC_PUBLIC_KEY_TTL_SEC = 300.0
+_KC_HTTP_TIMEOUT_SEC = 3.0
+
+
+def _kc_realm_url() -> str:
+    return f"{settings.KEYCLOAK_URL}/realms/{settings.KEYCLOAK_REALM}"
+
+
+def _clear_keycloak_public_key_cache() -> None:
+    _KC_PUBLIC_KEY_CACHE.clear()
+
 
 class User(BaseModel):
     id: str
@@ -26,14 +44,24 @@ class User(BaseModel):
     tenant_id: str | None = None
 
 
-async def get_keycloak_public_key():
-    """Fetch Keycloak realm public key"""
-    url = f"{settings.KEYCLOAK_URL}/realms/{settings.KEYCLOAK_REALM}"
-    async with httpx.AsyncClient() as client:
+async def get_keycloak_public_key() -> str:
+    """Fetch Keycloak realm public key, cached in-memory for 5 minutes."""
+    url = _kc_realm_url()
+    now = time.monotonic()
+    cached = _KC_PUBLIC_KEY_CACHE.get(url)
+    if cached is not None and now - cached[1] < _KC_PUBLIC_KEY_TTL_SEC:
+        return cached[0]
+
+    async with httpx.AsyncClient(timeout=_KC_HTTP_TIMEOUT_SEC) as client:
         response = await client.get(url)
+        response.raise_for_status()
         data = response.json()
-        public_key = data.get("public_key")
-        return f"-----BEGIN PUBLIC KEY-----\n{public_key}\n-----END PUBLIC KEY-----"
+    public_key = data.get("public_key")
+    if not public_key:
+        raise httpx.HTTPError("Keycloak realm endpoint returned no public_key")
+    pem = f"-----BEGIN PUBLIC KEY-----\n{public_key}\n-----END PUBLIC KEY-----"
+    _KC_PUBLIC_KEY_CACHE[url] = (pem, now)
+    return pem
 
 
 async def get_current_user(
@@ -83,8 +111,16 @@ async def get_current_user(
     try:
         public_key = await get_keycloak_public_key()
 
-        # Decode without audience validation first
-        payload = jwt.decode(token, public_key, algorithms=["RS256"], options={"verify_aud": False})
+        # CAB-2082: enforce issuer. Audience is validated manually below to
+        # support legacy clients still mapping azp instead of aud.
+        expected_issuer = _kc_realm_url()
+        payload = jwt.decode(
+            token,
+            public_key,
+            algorithms=["RS256"],
+            issuer=expected_issuer,
+            options={"verify_aud": False, "verify_iss": True},
+        )
 
         # Debug: log payload structure (not values) for troubleshooting
         if settings.LOG_DEBUG_AUTH_PAYLOAD:
@@ -137,9 +173,7 @@ async def get_current_user(
         # after all clients have migrated (target: Q2 2026).
         legacy_audiences = {"control-plane-ui", "stoa-portal"}
         primary_audience = {settings.KEYCLOAK_CLIENT_ID}
-        if any(aud in legacy_audiences for aud in token_aud) and not any(
-            aud in primary_audience for aud in token_aud
-        ):
+        if any(aud in legacy_audiences for aud in token_aud) and not any(aud in primary_audience for aud in token_aud):
             logger.warning(
                 "DEPRECATION: Token uses legacy audience, migrate to Audience Mapper",
                 token_aud=token_aud,
@@ -177,11 +211,7 @@ async def get_current_user(
         roles = normalize_roles(payload.get("realm_access", {}).get("roles", []))
         # Handle tenant_id as either string or list (from group membership mapper)
         raw_tenant_id = payload.get("tenant_id")
-        tenant_id = (
-            (raw_tenant_id[0] if raw_tenant_id else None)
-            if isinstance(raw_tenant_id, list)
-            else raw_tenant_id
-        )
+        tenant_id = (raw_tenant_id[0] if raw_tenant_id else None) if isinstance(raw_tenant_id, list) else raw_tenant_id
 
         # Get user ID from 'sub' claim (Keycloak UUID)
         # The 'sub' claim is mandatory in OIDC access tokens — if missing, the
@@ -252,9 +282,7 @@ async def get_current_user(
             error=str(e),
             error_type=type(e).__name__,
         )
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail=f"Invalid token: {e!s}"
-        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=f"Invalid token: {e!s}")
     except httpx.HTTPError as e:
         logger.error(
             "Failed to fetch Keycloak public key",

--- a/control-plane-api/tests/test_regression_cab_2082_jwt_issuer.py
+++ b/control-plane-api/tests/test_regression_cab_2082_jwt_issuer.py
@@ -1,0 +1,164 @@
+"""Regression tests for CAB-2082 (Security P0-01).
+
+Before the fix:
+- `jwt.decode` was called with `verify_iss` disabled — any token whose signing
+  key matched (e.g. leaked/rotated public key from another Keycloak realm or a
+  MITM-injected public key) would be accepted.
+- The Keycloak realm public key was refetched over HTTP on every request, with
+  no timeout and no cache — a slow Keycloak turned into API-wide latency.
+
+After the fix:
+- `jwt.decode` enforces `issuer=<keycloak_url>/realms/<realm>`.
+- The public key is cached in-memory for 5 minutes; the httpx call has a 3 s
+  timeout.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from jose import JWTError
+
+from src.auth.dependencies import (
+    User,
+    _clear_keycloak_public_key_cache,
+    get_current_user,
+    get_keycloak_public_key,
+)
+
+
+def _make_app():
+    app = FastAPI()
+
+    @app.get("/me")
+    async def me(user: User = pytest.importorskip("fastapi").Depends(get_current_user)):
+        return {"id": user.id}
+
+    return app
+
+
+def _base_payload(**overrides):
+    base = {
+        "sub": "user-123",
+        "email": "user@acme.com",
+        "preferred_username": "testuser",
+        "realm_access": {"roles": ["viewer"]},
+        "tenant_id": "acme",
+        "aud": ["control-plane-api"],
+        "azp": "control-plane-ui",
+        "iss": "https://auth.gostoa.dev/realms/stoa",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def mock_settings():
+    with patch("src.auth.dependencies.settings") as m:
+        m.KEYCLOAK_URL = "https://auth.gostoa.dev"
+        m.KEYCLOAK_REALM = "stoa"
+        m.KEYCLOAK_CLIENT_ID = "control-plane-api"
+        m.gateway_api_keys_list = []
+        m.LOG_DEBUG_AUTH_TOKENS = False
+        m.LOG_DEBUG_AUTH_PAYLOAD = False
+        yield m
+
+
+@pytest.fixture
+def mock_kc_key():
+    with patch("src.auth.dependencies.get_keycloak_public_key", new_callable=AsyncMock) as m:
+        m.return_value = "-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----"
+        yield m
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    _clear_keycloak_public_key_cache()
+    yield
+    _clear_keycloak_public_key_cache()
+
+
+class TestIssuerValidation:
+    """The JWT decode call must enforce the issuer claim."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_issuer_rejected_as_401(self, mock_settings, mock_kc_key):
+        # Simulate python-jose raising on issuer mismatch (what happens for real
+        # when verify_iss=True and iss != expected).
+        with patch(
+            "src.auth.dependencies.jwt.decode",
+            side_effect=JWTError("Invalid issuer"),
+        ):
+            app = _make_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                resp = await c.get("/me", headers={"Authorization": "Bearer forged"})
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_decode_receives_expected_issuer(self, mock_settings, mock_kc_key):
+        captured: dict = {}
+
+        def fake_decode(token, key, algorithms, issuer=None, options=None, **kw):
+            captured["issuer"] = issuer
+            captured["options"] = options
+            return _base_payload()
+
+        with patch("src.auth.dependencies.jwt.decode", side_effect=fake_decode):
+            app = _make_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                resp = await c.get("/me", headers={"Authorization": "Bearer ok"})
+        assert resp.status_code == 200
+        assert captured["issuer"] == "https://auth.gostoa.dev/realms/stoa"
+        assert captured["options"]["verify_iss"] is True
+
+
+class TestPublicKeyCache:
+    """The realm public key must be cached; network call timeout must be set."""
+
+    @pytest.mark.asyncio
+    async def test_public_key_cached_between_calls(self):
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(200, json={"public_key": "MIIBIj..."})
+
+        transport = httpx.MockTransport(handler)
+
+        class _FakeClient(httpx.AsyncClient):
+            def __init__(self, *a, **kw):
+                super().__init__(*a, transport=transport, **kw)
+
+        with (
+            patch("src.auth.dependencies.httpx.AsyncClient", _FakeClient),
+            patch("src.auth.dependencies.settings") as m,
+        ):
+            m.KEYCLOAK_URL = "https://auth.test"
+            m.KEYCLOAK_REALM = "stoa"
+            pem1 = await get_keycloak_public_key()
+            pem2 = await get_keycloak_public_key()
+
+        assert pem1 == pem2
+        assert calls["n"] == 1, "second call must hit the cache"
+
+    @pytest.mark.asyncio
+    async def test_missing_public_key_raises(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"public_key": None})
+
+        transport = httpx.MockTransport(handler)
+
+        class _FakeClient(httpx.AsyncClient):
+            def __init__(self, *a, **kw):
+                super().__init__(*a, transport=transport, **kw)
+
+        with (
+            patch("src.auth.dependencies.httpx.AsyncClient", _FakeClient),
+            patch("src.auth.dependencies.settings") as m,
+        ):
+            m.KEYCLOAK_URL = "https://auth.test"
+            m.KEYCLOAK_REALM = "stoa"
+            with pytest.raises(httpx.HTTPError):
+                await get_keycloak_public_key()


### PR DESCRIPTION
## Summary

Security **P0-01** from audit 2026-04-16.

- `jwt.decode` now enforces `issuer=<KEYCLOAK_URL>/realms/<REALM>` with `verify_iss: True`. Previously disabled — forged tokens signed with a matching public key (leaked key, MITM-injected key, sibling realm) would be accepted.
- `get_keycloak_public_key` caches the PEM in-memory for 5 minutes and times out after 3 s. Previously refetched on every request with no timeout.

## Context

Audit surfaced two issues in `control-plane-api/src/auth/dependencies.py`:

1. `jwt.decode(..., options={"verify_aud": False})` never set `verify_iss`, so issuer was trusted implicitly.
2. `get_keycloak_public_key` opened a fresh `httpx.AsyncClient()` per request with no timeout/cache. Any slow-or-hostile path to Keycloak impacted all auth.

## Changes

- `src/auth/dependencies.py`: module-level PEM cache (dict URL→(pem, timestamp)), 300 s TTL, 3 s `httpx` timeout, `_clear_...` helper for tests. `jwt.decode` now passes `issuer=...` and `options={"verify_iss": True, "verify_aud": False}` — audience stays validated manually to preserve legacy `azp`/`aud` mapping handling.
- `tests/test_regression_cab_2082_jwt_issuer.py`: 4 new tests covering issuer rejection, decode kwargs, cache hit, and missing `public_key` field.

## Test plan

- [x] `pytest tests/test_regression_cab_2082_jwt_issuer.py tests/test_jwt_validation.py` → 16/16 green locally
- [x] `ruff check` + `black --check` pass on changed files
- [ ] CI green (control-plane-api-ci, mypy, coverage ≥ 70%)
- [ ] Playwright OIDC smoke (Console + Portal) post-deploy

Refs [CAB-2079](https://linear.app/hlfh-workspace/issue/CAB-2079) (MEGA Auth/RBAC hardening)
Closes CAB-2082