### PR TITLE
fix(api): isolate Kafka consumers from test boot path (CAB-2085)

### DIFF
--- a/.github/workflows/control-plane-api-ci.yml
+++ b/.github/workflows/control-plane-api-ci.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Run adapter boundary tests (CAB-1951)
         working-directory: control-plane-api
         env:
+          STOA_ENABLE_KAFKA_CONSUMERS: 'false'  # CAB-2085
           ENABLE_DEPLOYMENT_WORKER: 'false'
           ENABLE_SNAPSHOT_CONSUMER: 'false'
         run: |
@@ -99,6 +100,7 @@ jobs:
         working-directory: control-plane-api
         env:
           DATABASE_URL: postgresql+asyncpg://stoa_test:stoa_test@localhost:5432/stoa_test
+          STOA_ENABLE_KAFKA_CONSUMERS: 'false'  # CAB-2085
           ENABLE_DEPLOYMENT_WORKER: 'false'
           ENABLE_SNAPSHOT_CONSUMER: 'false'
         run: |

--- a/control-plane-api/src/main.py
+++ b/control-plane-api/src/main.py
@@ -154,15 +154,26 @@ configure_logging()
 logger = get_logger(__name__)
 
 # Flag to control worker startup (can be disabled for dev/testing)
-ENABLE_DEPLOYMENT_NOTIFIER = os.getenv("ENABLE_DEPLOYMENT_NOTIFIER", "true").lower() == "true"
-ENABLE_SNAPSHOT_CONSUMER = os.getenv("ENABLE_SNAPSHOT_CONSUMER", "true").lower() == "true"
-ENABLE_SYNC_ENGINE = os.getenv("ENABLE_SYNC_ENGINE", "true").lower() == "true"
+# CAB-2085: master gate for Kafka-backed consumers. Default true so production
+# behaviour is unchanged; tests flip it to false in conftest.py so the lifespan
+# never spawns threads that try to reach `redpanda.stoa-system.svc.cluster.local`.
+KAFKA_CONSUMERS_ENABLED = os.getenv("STOA_ENABLE_KAFKA_CONSUMERS", "true").lower() == "true"
+
+ENABLE_DEPLOYMENT_NOTIFIER = (
+    KAFKA_CONSUMERS_ENABLED and os.getenv("ENABLE_DEPLOYMENT_NOTIFIER", "true").lower() == "true"
+)
+ENABLE_SNAPSHOT_CONSUMER = KAFKA_CONSUMERS_ENABLED and os.getenv("ENABLE_SNAPSHOT_CONSUMER", "true").lower() == "true"
+ENABLE_SYNC_ENGINE = KAFKA_CONSUMERS_ENABLED and os.getenv("ENABLE_SYNC_ENGINE", "true").lower() == "true"
 ENABLE_GATEWAY_HEALTH_WORKER = os.getenv("ENABLE_GATEWAY_HEALTH_WORKER", "true").lower() == "true"
-ENABLE_CHAT_METERING_CONSUMER = os.getenv("ENABLE_CHAT_METERING_CONSUMER", "true").lower() == "true"
-ENABLE_BILLING_METERING_CONSUMER = os.getenv("ENABLE_BILLING_METERING_CONSUMER", "true").lower() == "true"
+ENABLE_CHAT_METERING_CONSUMER = (
+    KAFKA_CONSUMERS_ENABLED and os.getenv("ENABLE_CHAT_METERING_CONSUMER", "true").lower() == "true"
+)
+ENABLE_BILLING_METERING_CONSUMER = (
+    KAFKA_CONSUMERS_ENABLED and os.getenv("ENABLE_BILLING_METERING_CONSUMER", "true").lower() == "true"
+)
 ENABLE_TELEMETRY_WORKER = os.getenv("ENABLE_TELEMETRY_WORKER", "true").lower() == "true"
 ENABLE_GATEWAY_RECONCILER = os.getenv("ENABLE_GATEWAY_RECONCILER", "true").lower() == "true"
-ENABLE_GIT_SYNC_WORKER = os.getenv("ENABLE_GIT_SYNC_WORKER", "true").lower() == "true"
+ENABLE_GIT_SYNC_WORKER = KAFKA_CONSUMERS_ENABLED and os.getenv("ENABLE_GIT_SYNC_WORKER", "true").lower() == "true"
 
 
 @asynccontextmanager

--- a/control-plane-api/tests/conftest.py
+++ b/control-plane-api/tests/conftest.py
@@ -31,6 +31,9 @@ import os
 
 # Set environment variables to disable workers before any imports
 os.environ["ENABLE_SNAPSHOT_CONSUMER"] = "false"
+# CAB-2085: master gate that disables every Kafka-backed consumer during tests.
+# Keeps the FastAPI lifespan from spawning threads that try to reach the broker.
+os.environ["STOA_ENABLE_KAFKA_CONSUMERS"] = "false"
 
 # Explicit GIT_PROVIDER for test determinism (CAB-1890 dual-provider).
 # Tests that need GIT_PROVIDER=github override this via monkeypatch.setenv().

--- a/control-plane-api/tests/test_regression_kafka_boot.py
+++ b/control-plane-api/tests/test_regression_kafka_boot.py
@@ -1,0 +1,74 @@
+"""Regression: app boots cleanly without a Kafka broker (CAB-2085).
+
+Before the fix, `consumers.deployment_consumer`, `consumers.promotion_deploy_consumer`,
+`workers.git_sync_worker`, `workers.sync_engine`, and the metering consumers
+instantiated `kafka.KafkaConsumer` at lifespan start. On CI runners (no broker
+reachable) this produced noisy `NoBrokersAvailable` logs plus secondary
+`ValueError: I/O operation on closed file` from threads logging after pytest
+closed stdout.
+
+After the fix, the master `STOA_ENABLE_KAFKA_CONSUMERS` flag gates every
+Kafka-dependent consumer. Tests set it to `false` in `conftest.py`, so the
+lifespan must complete without touching the broker.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+FORBIDDEN_LOG_FRAGMENTS = (
+    "NoBrokersAvailable",
+    "I/O operation on closed file",
+    "DNS lookup failed for redpanda",
+)
+
+
+def test_master_gate_defaults_disabled_in_test_env() -> None:
+    """conftest.py must set the master gate to false before src.main is imported."""
+    assert os.environ.get("STOA_ENABLE_KAFKA_CONSUMERS") == "false", (
+        "conftest.py should set STOA_ENABLE_KAFKA_CONSUMERS=false before importing "
+        "src.main so Kafka consumers never start during tests."
+    )
+
+
+def test_per_consumer_flags_respect_master_gate() -> None:
+    """When the master gate is off, every Kafka-backed consumer flag must be False."""
+    from src import main
+
+    assert main.KAFKA_CONSUMERS_ENABLED is False
+
+    kafka_backed_flags = (
+        "ENABLE_DEPLOYMENT_NOTIFIER",
+        "ENABLE_SNAPSHOT_CONSUMER",
+        "ENABLE_SYNC_ENGINE",
+        "ENABLE_CHAT_METERING_CONSUMER",
+        "ENABLE_BILLING_METERING_CONSUMER",
+        "ENABLE_GIT_SYNC_WORKER",
+    )
+    for flag in kafka_backed_flags:
+        assert (
+            getattr(main, flag) is False
+        ), f"{flag} must AND with KAFKA_CONSUMERS_ENABLED so the master gate turns it off."
+
+
+def test_app_lifespan_emits_no_kafka_errors(caplog: pytest.LogCaptureFixture) -> None:
+    """Running the full lifespan must not surface any Kafka broker lookup."""
+    from src.main import app
+
+    caplog.set_level(logging.WARNING)
+
+    with TestClient(app):
+        pass
+
+    leaked = [
+        record.getMessage()
+        for record in caplog.records
+        if any(token in record.getMessage() for token in FORBIDDEN_LOG_FRAGMENTS)
+    ]
+    assert not leaked, (
+        "Kafka consumer leaked past the STOA_ENABLE_KAFKA_CONSUMERS gate; " f"offending log lines: {leaked}"
+    )


### PR DESCRIPTION
## Summary

- Adds `STOA_ENABLE_KAFKA_CONSUMERS` master gate that AND-guards every Kafka-backed consumer started from the FastAPI lifespan (deployment, promotion-deploy, snapshot, sync-engine, chat-metering, billing-metering, git-sync-worker).
- Tests + the `Integration Tests` CI job set the gate to `false`, so app import no longer reaches `redpanda.stoa-system.svc.cluster.local:9092`. Production default stays `true` — no stoa-infra change needed.
- Regression: `tests/test_regression_kafka_boot.py` proves (a) conftest seeds the gate off, (b) each per-consumer flag composes with the gate, (c) lifespan emits no `NoBrokersAvailable` / closed-file / redpanda-DNS log lines.

Linear: CAB-2085.

## Acceptance criteria

- [x] `pytest control-plane-api/tests -q` (unit suite) boots the app with no Kafka broker on network. Regression test passes locally (3/3).
- [x] No `NoBrokersAvailable` log line during test run — asserted by `test_app_lifespan_emits_no_kafka_errors`.
- [x] Regression test in `control-plane-api/tests/test_regression_kafka_boot.py` covers clean import without broker.
- [ ] `Integration Tests` job green on `main` for 3 consecutive merges (post-merge observation).
- [ ] CP API pods in `dev` pick up the new image (post-merge `/deploy-check`).

## Design notes / deviation from ticket

The ticket proposed `default=false` with Helm enabling prod. I kept `default=true` because `cp-api`'s Deployment lives in `stoa-infra` (standalone manifest, not in `stoa/charts/`) and a default-false flip requires a coordinated stoa-infra + timing change. Default-true + explicit `false` in tests/CI is the lighter isolation that fully satisfies ACs 1/4/5 without any infra coupling. If a future runtime wants opt-out, it can set `STOA_ENABLE_KAFKA_CONSUMERS=false` at the deployment env level.

## What is NOT fixed here

The failing `Integration Tests` job on main (run 24519776164) is primarily red because of DB schema/seeder issues introduced by migrations 090→095:
- `relation "tenants" does not exist` / `relation "prospects" does not exist`
- `null value in column "provisioning_attempts" violates not-null constraint` in the seeder

These are out of scope for CAB-2085 and need a follow-up ticket.

## Test plan

- [x] Run `pytest control-plane-api/tests/test_regression_kafka_boot.py -v` — 3/3 green.
- [x] Sanity: `pytest tests/test_openapi_contract.py tests/test_deployment_consumer.py tests/test_worker_sync_engine.py -q` — 49 passed, 2 pre-existing skips.
- [x] Lint: `ruff check src/main.py tests/test_regression_kafka_boot.py` — clean.
- [x] Verified gate behaviour: with `STOA_ENABLE_KAFKA_CONSUMERS=true` the per-consumer flags flip back to True.
- [ ] Post-merge: observe 3 consecutive green `Integration Tests` runs on main (blocked on the separate seeder/schema fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)