### PR TITLE
fix(api): exclude CHANGELOG.md from Parzival literal scan (CAB-2083)

### DIFF
--- a/control-plane-api/tests/test_regression_cab_2083_no_hardcoded_parzival.py
+++ b/control-plane-api/tests/test_regression_cab_2083_no_hardcoded_parzival.py
@@ -28,8 +28,19 @@ def test_parzival_password_is_never_hardcoded() -> None:
     # `git ls-files | xargs grep` is faster than a Python walk and honors
     # .gitignore automatically, so vendored copies in node_modules, venv,
     # target, etc. don't leak into the scan.
+    # CHANGELOG files are release-please-generated history of commit titles.
+    # A past commit message that legitimately quoted the literal (e.g. the
+    # very fix that removed it) is not a regression.
     result = subprocess.run(  # noqa: S603 — fixed args, no user input
-        ["git", "grep", "-n", "--fixed-strings", FORBIDDEN_LITERAL],  # noqa: S607
+        [  # noqa: S607
+            "git",
+            "grep",
+            "-n",
+            "--fixed-strings",
+            FORBIDDEN_LITERAL,
+            "--",
+            ":!**/CHANGELOG.md",
+        ],
         capture_output=True,
         text=True,
         cwd=REPO_ROOT,


### PR DESCRIPTION
## Summary

Follow-up to #2394. The regression test `test_parzival_password_is_never_hardcoded` scanned the whole repo including `CHANGELOG.md`, which is release-please-generated and contains past commit titles. After #2394 merged, the cp-api 1.5.0 changelog quoted the literal from the very fix that removed it, flagging it as a regression.

## Fix

Narrow the `git grep` pathspec with `:!**/CHANGELOG.md`. History files are not source code and cannot reintroduce a secret.

## Unblocks

- #2384 release-please `control-plane-api 1.5.0` — required check `ci / Lint and Test (cp-api)` currently red because of this.

## Test

Ran `pytest tests/test_regression_cab_2083_no_hardcoded_parzival.py` locally → green with the fix, would stay green on the release-please branch with CHANGELOG updated.