### PR TITLE
fix(api): exclude CHANGELOG.md from Parzival regression scan (CAB-2083)

### DIFF
--- a/control-plane-api/tests/test_regression_cab_2083_no_hardcoded_parzival.py
+++ b/control-plane-api/tests/test_regression_cab_2083_no_hardcoded_parzival.py
@@ -28,8 +28,19 @@ def test_parzival_password_is_never_hardcoded() -> None:
     # `git ls-files | xargs grep` is faster than a Python walk and honors
     # .gitignore automatically, so vendored copies in node_modules, venv,
     # target, etc. don't leak into the scan.
+    # CHANGELOG files are release-please-generated history of commit titles.
+    # A past commit message that legitimately quoted the literal (e.g. the
+    # very fix that removed it) is not a regression.
     result = subprocess.run(  # noqa: S603 — fixed args, no user input
-        ["git", "grep", "-n", "--fixed-strings", FORBIDDEN_LITERAL],  # noqa: S607
+        [  # noqa: S607
+            "git",
+            "grep",
+            "-n",
+            "--fixed-strings",
+            FORBIDDEN_LITERAL,
+            "--",
+            ":!**/CHANGELOG.md",
+        ],
         capture_output=True,
         text=True,
         cwd=REPO_ROOT,


### PR DESCRIPTION
## Summary
- Regression test `tests/test_regression_cab_2083_no_hardcoded_parzival.py` scanned the whole repo via `git grep`, including release-please-generated `CHANGELOG.md`.
- After merge of #2394, cp-api 1.5.0 changelog quoted the commit title that killed the hardcoded fallback — flagging its own fix as a regression.
- Narrow the pathspec to exclude `**/CHANGELOG.md`. History files are not source code and cannot reintroduce a secret.

## Test plan
- [x] Pytest: `pytest control-plane-api/tests/test_regression_cab_2083_no_hardcoded_parzival.py`
- [ ] CI: regression-guard job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)