### PR TITLE
fix(api): split Keycloak public vs internal URL (CAB-2094)

### DIFF
--- a/control-plane-api/src/auth/dependencies.py
+++ b/control-plane-api/src/auth/dependencies.py
@@ -3,6 +3,7 @@
 CAB-330: Enhanced debug logging for authentication troubleshooting.
 CAB-438: Sender-constrained token validation (RFC 8705/9449).
 CAB-2082: JWT issuer validation + Keycloak public-key cache (Security P0-01).
+CAB-2094: Split issuer (public KEYCLOAK_URL) from JWKS fetch (KEYCLOAK_INTERNAL_URL).
 """
 
 import time
@@ -28,8 +29,14 @@ _KC_PUBLIC_KEY_TTL_SEC = 300.0
 _KC_HTTP_TIMEOUT_SEC = 3.0
 
 
-def _kc_realm_url() -> str:
+def _kc_issuer_url() -> str:
+    """Expected `iss` claim — must match what Keycloak embeds in tokens."""
     return f"{settings.KEYCLOAK_URL}/realms/{settings.KEYCLOAK_REALM}"
+
+
+def _kc_public_key_url() -> str:
+    """URL for fetching the realm public key (internal service URL when set)."""
+    return f"{settings.keycloak_internal_url}/realms/{settings.KEYCLOAK_REALM}"
 
 
 def _clear_keycloak_public_key_cache() -> None:
@@ -46,7 +53,7 @@ class User(BaseModel):
 
 async def get_keycloak_public_key() -> str:
     """Fetch Keycloak realm public key, cached in-memory for 5 minutes."""
-    url = _kc_realm_url()
+    url = _kc_public_key_url()
     now = time.monotonic()
     cached = _KC_PUBLIC_KEY_CACHE.get(url)
     if cached is not None and now - cached[1] < _KC_PUBLIC_KEY_TTL_SEC:
@@ -113,7 +120,9 @@ async def get_current_user(
 
         # CAB-2082: enforce issuer. Audience is validated manually below to
         # support legacy clients still mapping azp instead of aud.
-        expected_issuer = _kc_realm_url()
+        # CAB-2094: issuer comes from the PUBLIC URL regardless of where we
+        # fetched the public key (which may be the internal SVC URL).
+        expected_issuer = _kc_issuer_url()
         payload = jwt.decode(
             token,
             public_key,
@@ -287,7 +296,7 @@ async def get_current_user(
         logger.error(
             "Failed to fetch Keycloak public key",
             error=str(e),
-            keycloak_url=settings.KEYCLOAK_URL,
+            keycloak_url=settings.keycloak_internal_url,
             realm=settings.KEYCLOAK_REALM,
         )
         raise HTTPException(

--- a/control-plane-api/src/config.py
+++ b/control-plane-api/src/config.py
@@ -24,11 +24,26 @@ class Settings(BaseSettings):
     BASE_DOMAIN: str = _BASE_DOMAIN
 
     # Keycloak Authentication
+    # KEYCLOAK_URL is the PUBLIC URL Keycloak embeds in token `iss` claims
+    # (e.g. https://auth.gostoa.dev). Must match what clients see — used for
+    # issuer validation and for the `token_endpoint` returned to external
+    # consumers. CAB-2094: previously set to the in-cluster svc URL in prod,
+    # which broke issuer validation for every user token.
+    # KEYCLOAK_INTERNAL_URL is the in-cluster service URL used for backend-to-KC
+    # calls (admin API, token exchange, JWKS fetch). Avoids hairpin NAT on
+    # OVH MKS and similar cloud providers. Falls back to KEYCLOAK_URL when
+    # unset. Mirrors the stoa-gateway STOA_KEYCLOAK_URL / _INTERNAL_URL pattern.
     KEYCLOAK_URL: str = f"https://auth.{_BASE_DOMAIN}"
+    KEYCLOAK_INTERNAL_URL: str = ""
     KEYCLOAK_REALM: str = "stoa"
     KEYCLOAK_CLIENT_ID: str = "control-plane-api"
     KEYCLOAK_CLIENT_SECRET: str = ""
     KEYCLOAK_VERIFY_SSL: bool = True
+
+    @property
+    def keycloak_internal_url(self) -> str:
+        """Return internal URL for backend-to-KC calls, falling back to public URL."""
+        return self.KEYCLOAK_INTERNAL_URL or self.KEYCLOAK_URL
 
     # Keycloak Admin API (for Service Account management)
     # Uses a dedicated admin client with realm-management roles

--- a/control-plane-api/src/services/keycloak_service.py
+++ b/control-plane-api/src/services/keycloak_service.py
@@ -49,8 +49,10 @@ class KeycloakService:
         for client/user management.
         """
         try:
+            # CAB-2094: admin API uses the internal SVC URL when configured,
+            # avoiding hairpin NAT on OVH MKS.
             conn = KeycloakOpenIDConnection(
-                server_url=settings.KEYCLOAK_URL,
+                server_url=settings.keycloak_internal_url,
                 realm_name="master",
                 client_id=settings.KEYCLOAK_ADMIN_CLIENT_ID,
                 username="admin",
@@ -696,7 +698,8 @@ class KeycloakService:
             httpx.HTTPStatusError: If Keycloak returns an error
             RuntimeError: If Keycloak is unreachable
         """
-        token_url = f"{settings.KEYCLOAK_URL}/realms/{settings.KEYCLOAK_REALM}" f"/protocol/openid-connect/token"
+        # CAB-2094: server-side token exchange uses the internal SVC URL.
+        token_url = f"{settings.keycloak_internal_url}/realms/{settings.KEYCLOAK_REALM}/protocol/openid-connect/token"
 
         data = {
             "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
@@ -1035,7 +1038,11 @@ class KeycloakService:
                 logger.warning("Federation token exchange: no secret for client '%s'", client_id)
                 return None
 
-            token_url = f"{settings.KEYCLOAK_URL}/realms/{settings.KEYCLOAK_REALM}" "/protocol/openid-connect/token"
+            # CAB-2094: federation token exchange is a backend call.
+            token_url = (
+                f"{settings.keycloak_internal_url}/realms/{settings.KEYCLOAK_REALM}"
+                "/protocol/openid-connect/token"
+            )
             async with httpx.AsyncClient(timeout=10.0) as http:
                 resp = await http.post(
                     token_url,

--- a/control-plane-api/tests/test_jwt_validation.py
+++ b/control-plane-api/tests/test_jwt_validation.py
@@ -38,6 +38,7 @@ def _base_payload(**overrides):
 def mock_settings():
     with patch("src.auth.dependencies.settings") as m:
         m.KEYCLOAK_URL = "https://auth.gostoa.dev"
+        m.keycloak_internal_url = "https://auth.gostoa.dev"
         m.KEYCLOAK_REALM = "stoa"
         m.KEYCLOAK_CLIENT_ID = "control-plane-api"
         m.gateway_api_keys_list = []
@@ -131,6 +132,7 @@ class TestJwtValidation:
     @pytest.mark.asyncio
     async def test_jwt_decode_error_401(self, mock_settings, mock_kc_key):
         from jose import JWTError
+
         with patch("src.auth.dependencies.jwt.decode", side_effect=JWTError("bad token")):
             app = _make_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
@@ -179,8 +181,12 @@ class TestJwtValidation:
     @pytest.mark.asyncio
     async def test_keycloak_unreachable_503(self, mock_settings):
         import httpx
-        with patch("src.auth.dependencies.get_keycloak_public_key", new_callable=AsyncMock,
-                    side_effect=httpx.ConnectError("Connection refused")):
+
+        with patch(
+            "src.auth.dependencies.get_keycloak_public_key",
+            new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("Connection refused"),
+        ):
             app = _make_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
                 resp = await c.get("/me", headers={"Authorization": "Bearer any"})

--- a/control-plane-api/tests/test_regression_cab_2082_jwt_issuer.py
+++ b/control-plane-api/tests/test_regression_cab_2082_jwt_issuer.py
@@ -58,6 +58,7 @@ def _base_payload(**overrides):
 def mock_settings():
     with patch("src.auth.dependencies.settings") as m:
         m.KEYCLOAK_URL = "https://auth.gostoa.dev"
+        m.keycloak_internal_url = "https://auth.gostoa.dev"
         m.KEYCLOAK_REALM = "stoa"
         m.KEYCLOAK_CLIENT_ID = "control-plane-api"
         m.gateway_api_keys_list = []
@@ -136,6 +137,7 @@ class TestPublicKeyCache:
             patch("src.auth.dependencies.settings") as m,
         ):
             m.KEYCLOAK_URL = "https://auth.test"
+            m.keycloak_internal_url = "https://auth.test"
             m.KEYCLOAK_REALM = "stoa"
             pem1 = await get_keycloak_public_key()
             pem2 = await get_keycloak_public_key()
@@ -159,6 +161,7 @@ class TestPublicKeyCache:
             patch("src.auth.dependencies.settings") as m,
         ):
             m.KEYCLOAK_URL = "https://auth.test"
+            m.keycloak_internal_url = "https://auth.test"
             m.KEYCLOAK_REALM = "stoa"
             with pytest.raises(httpx.HTTPError):
                 await get_keycloak_public_key()

--- a/control-plane-api/tests/test_regression_cab_2094_issuer_internal_url.py
+++ b/control-plane-api/tests/test_regression_cab_2094_issuer_internal_url.py
@@ -1,0 +1,102 @@
+"""Regression tests for CAB-2094.
+
+Before the fix:
+- `KEYCLOAK_URL` was overloaded: used both for issuer validation and for
+  backend-to-KC calls (admin API, JWKS fetch, token exchange).
+- Prod set `KEYCLOAK_URL=http://keycloak.stoa-system.svc.cluster.local` so the
+  backend could reach Keycloak without hairpin NAT, but Keycloak still embedded
+  `iss=https://auth.gostoa.dev/realms/stoa` in every token — so
+  `jwt.decode(issuer=expected_issuer)` rejected every real user token with
+  "Invalid issuer".
+
+After the fix:
+- `KEYCLOAK_URL` is the public URL (authoritative for `iss` claims).
+- `KEYCLOAK_INTERNAL_URL` is optional, used for backend-to-KC calls only.
+- `settings.keycloak_internal_url` falls back to `KEYCLOAK_URL` when unset so
+  local/dev setups keep working.
+"""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from src.auth.dependencies import (
+    _clear_keycloak_public_key_cache,
+    _kc_issuer_url,
+    _kc_public_key_url,
+    get_keycloak_public_key,
+)
+from src.config import Settings
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    _clear_keycloak_public_key_cache()
+    yield
+    _clear_keycloak_public_key_cache()
+
+
+class TestKeycloakInternalUrlFallback:
+    """`keycloak_internal_url` must fall back to `KEYCLOAK_URL` when unset."""
+
+    def test_falls_back_to_public_when_empty(self):
+        s = Settings(
+            KEYCLOAK_URL="https://auth.gostoa.dev",
+            KEYCLOAK_INTERNAL_URL="",
+        )
+        assert s.keycloak_internal_url == "https://auth.gostoa.dev"
+
+    def test_prefers_internal_when_set(self):
+        s = Settings(
+            KEYCLOAK_URL="https://auth.gostoa.dev",
+            KEYCLOAK_INTERNAL_URL="http://keycloak.stoa-system.svc.cluster.local",
+        )
+        assert s.keycloak_internal_url == "http://keycloak.stoa-system.svc.cluster.local"
+
+
+class TestIssuerUsesPublicUrl:
+    """`iss` match must use the public URL, even when internal URL is set."""
+
+    def test_issuer_uses_public_url_even_when_internal_diverges(self):
+        with patch("src.auth.dependencies.settings") as m:
+            m.KEYCLOAK_URL = "https://auth.gostoa.dev"
+            m.keycloak_internal_url = "http://keycloak.stoa-system.svc.cluster.local"
+            m.KEYCLOAK_REALM = "stoa"
+            assert _kc_issuer_url() == "https://auth.gostoa.dev/realms/stoa"
+
+    def test_public_key_url_uses_internal_when_set(self):
+        with patch("src.auth.dependencies.settings") as m:
+            m.KEYCLOAK_URL = "https://auth.gostoa.dev"
+            m.keycloak_internal_url = "http://keycloak.stoa-system.svc.cluster.local"
+            m.KEYCLOAK_REALM = "stoa"
+            assert _kc_public_key_url() == "http://keycloak.stoa-system.svc.cluster.local/realms/stoa"
+
+
+class TestPublicKeyFetchHitsInternalUrl:
+    """JWKS fetch must target the internal URL when configured."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_targets_internal_url(self):
+        captured: dict = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            return httpx.Response(200, json={"public_key": "MIIBIj..."})
+
+        transport = httpx.MockTransport(handler)
+
+        class _FakeClient(httpx.AsyncClient):
+            def __init__(self, *a, **kw):
+                super().__init__(*a, transport=transport, **kw)
+
+        with (
+            patch("src.auth.dependencies.httpx.AsyncClient", _FakeClient),
+            patch("src.auth.dependencies.settings") as m,
+        ):
+            m.KEYCLOAK_URL = "https://auth.gostoa.dev"
+            m.keycloak_internal_url = "http://keycloak.stoa-system.svc.cluster.local"
+            m.KEYCLOAK_REALM = "stoa"
+            await get_keycloak_public_key()
+
+        assert captured["url"] == "http://keycloak.stoa-system.svc.cluster.local/realms/stoa"


### PR DESCRIPTION
## Summary

P0 bug from CAB-2082 rollout: `GET /v1/tenants` on `api.gostoa.dev` returns 401 `Invalid issuer` for every real user token. CAB-2082 enforces `iss` match against `{KEYCLOAK_URL}/realms/{REALM}`, but prod sets `KEYCLOAK_URL` to the in-cluster SVC URL (`http://keycloak.stoa-system.svc.cluster.local`, used to bypass hairpin NAT on OVH MKS), while tokens carry `iss=https://auth.gostoa.dev/realms/stoa`. Nothing caught it because only `/v1/internal/*` and `/health` were hit post-rollout.

## Fix

Mirror the `stoa-gateway` dual-URL pattern:

- `KEYCLOAK_URL` = PUBLIC URL (authoritative for `iss` match + `token_endpoint` returned to external consumers)
- `KEYCLOAK_INTERNAL_URL` = optional in-cluster SVC URL used for backend-to-KC calls only (admin API, JWKS fetch, server-side token exchange). Falls back to `KEYCLOAK_URL` when unset so local/dev keeps working.

### Files touched

- `control-plane-api/src/config.py` — new setting + `keycloak_internal_url` property
- `control-plane-api/src/auth/dependencies.py` — `_kc_issuer_url()` (public) vs `_kc_public_key_url()` (internal)
- `control-plane-api/src/services/keycloak_service.py` — admin connect + 2 token-exchange calls
- `control-plane-api/routers/consumers.py:405` — untouched (returns public URL to external consumers, correct)

### Regression coverage

New: `tests/test_regression_cab_2094_issuer_internal_url.py` (5 tests)
- fallback when internal URL unset
- issuer uses public URL even when internal diverges
- JWKS fetch targets internal URL

Updated fixtures in `test_regression_cab_2082_jwt_issuer.py` + `test_jwt_validation.py` to set `keycloak_internal_url` on the mock.

## Chart wiring

Separate PR on `stoa-infra`: `charts/control-plane-api/values.yaml` and `templates/deployment.yaml` expose both env vars (values explicit for prod, empty default for dev).

## Test plan

- [x] `pytest tests/test_regression_cab_2094_issuer_internal_url.py` → 5/5
- [x] `pytest tests/test_regression_cab_2082_jwt_issuer.py tests/test_jwt_validation.py tests/test_token_exchange.py` → 26/26
- [x] `ruff check` clean on touched files
- [x] `black --check` clean on touched code (pre-existing violations elsewhere left alone to keep diff tight)
- [x] `mypy` no new errors on touched files
- [ ] Deploy stoa + stoa-infra PRs together, then curl `GET /v1/tenants` with fresh user JWT → 200
- [ ] Verify tenant create flow (backend admin-API path) still works

## Acceptance criteria mapping

- [x] Fresh user JWT from `auth.gostoa.dev` accepted by `api.gostoa.dev` → verify post-deploy
- [x] Backend-to-KC calls keep working → internal URL now explicit, admin path unchanged semantically
- [x] Regression test added
- [x] Local k3d uses dev-mode fallback (`KEYCLOAK_INTERNAL_URL=""` → falls back to `KEYCLOAK_URL`)

Linear: https://linear.app/hlfh-workspace/issue/CAB-2094

🤖 Generated with [Claude Code](https://claude.com/claude-code)