### PR TITLE
fix(gateway): honor Accept: text/event-stream on /mcp/sse (CAB-2106)

### DIFF
--- a/stoa-gateway/src/mcp/sse.rs
+++ b/stoa-gateway/src/mcp/sse.rs
@@ -11,7 +11,7 @@ use axum::{
     response::{sse::Event, IntoResponse, Response, Sse},
     Json,
 };
-use futures::stream::Stream;
+use futures::stream::{self, Stream};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::{convert::Infallible, time::Duration};
@@ -377,8 +377,72 @@ pub async fn handle_sse_post(
         ),
     };
 
+    // Content negotiation (MCP Streamable HTTP spec 2025-03-26): if the
+    // client accepts `text/event-stream`, wrap the JSON-RPC response in an
+    // SSE frame; otherwise keep the legacy `application/json` body for
+    // back-compat with curl / claude-code CLI callers that omit Accept.
+    if accepts_event_stream(&headers) {
+        return build_sse_single_response(&session_id, &response);
+    }
+
     // Always return Mcp-Session-Id header (required by Streamable HTTP transport)
     let mut resp = Json(response).into_response();
+    if let Ok(header_value) = session_id.parse() {
+        resp.headers_mut().insert("Mcp-Session-Id", header_value);
+    }
+    resp
+}
+
+/// Does the client accept `text/event-stream` for this request?
+///
+/// Parses the `Accept` header as a comma-separated media-range list and
+/// checks for an explicit `text/event-stream` token (case-insensitive,
+/// tolerant of quality values like `;q=0.9`). Wildcards (`*/*`) do NOT
+/// count as acceptance — legacy HTTP clients like curl that send no
+/// Accept (or only `*/*`) keep the pre-existing JSON response so this fix
+/// stays strictly additive.
+pub fn accepts_event_stream(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .map(|accept| {
+            accept.split(',').any(|media_range| {
+                let mime = media_range.split(';').next().unwrap_or("").trim();
+                mime.eq_ignore_ascii_case("text/event-stream")
+            })
+        })
+        .unwrap_or(false)
+}
+
+/// Build the SSE response that carries a single JSON-RPC reply.
+///
+/// Emits one `event: message` frame with the serialized response and then
+/// closes the stream. The spec allows — and in fact recommends — closing
+/// after all correlated responses have been sent; clients that need
+/// server-initiated notifications open a long-lived `GET /mcp/sse`.
+fn build_sse_single_response(session_id: &str, response: &JsonRpcResponse) -> Response {
+    let data = serde_json::to_string(response).unwrap_or_else(|e| {
+        error!(error = %e, "SSE: failed to serialize JSON-RPC response");
+        json!({
+            "jsonrpc": "2.0",
+            "error": {"code": INTERNAL_ERROR, "message": "serialization failure"},
+            "id": Value::Null
+        })
+        .to_string()
+    });
+
+    let event = Event::default().event("message").data(data);
+    let one_event: Box<dyn Stream<Item = Result<Event, Infallible>> + Send + Unpin> =
+        Box::new(stream::iter(std::iter::once(Ok(event))));
+
+    let mut resp = Sse::new(one_event)
+        .keep_alive(
+            axum::response::sse::KeepAlive::new()
+                .interval(Duration::from_secs(15))
+                .text("ping"),
+        )
+        .into_response();
+
     if let Ok(header_value) = session_id.parse() {
         resp.headers_mut().insert("Mcp-Session-Id", header_value);
     }
@@ -1464,5 +1528,67 @@ mod tests {
         // Empty string is not a valid version, treated as unknown
         let result = negotiate_protocol_version(Some(""));
         assert_eq!(result, DEFAULT_PROTOCOL_VERSION);
+    }
+
+    // === Accept negotiation (CAB-2106 — claude.ai SSE fix) ===
+
+    fn accept(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(header::ACCEPT, value.parse().unwrap());
+        h
+    }
+
+    #[test]
+    fn test_accepts_event_stream_explicit() {
+        assert!(accepts_event_stream(&accept("text/event-stream")));
+    }
+
+    #[test]
+    fn test_accepts_event_stream_mcp_compliant_client() {
+        // Spec 2025-03-26 says clients MUST list both media types.
+        assert!(accepts_event_stream(&accept(
+            "application/json, text/event-stream"
+        )));
+    }
+
+    #[test]
+    fn test_accepts_event_stream_with_q_values() {
+        assert!(accepts_event_stream(&accept(
+            "application/json;q=0.8, text/event-stream;q=0.9"
+        )));
+    }
+
+    #[test]
+    fn test_accepts_event_stream_case_insensitive() {
+        assert!(accepts_event_stream(&accept("Text/Event-Stream")));
+    }
+
+    #[test]
+    fn test_accepts_event_stream_tolerates_whitespace() {
+        assert!(accepts_event_stream(&accept(
+            "  application/json ,  text/event-stream  "
+        )));
+    }
+
+    #[test]
+    fn test_accepts_event_stream_rejects_json_only() {
+        assert!(!accepts_event_stream(&accept("application/json")));
+    }
+
+    #[test]
+    fn test_accepts_event_stream_rejects_missing_header() {
+        assert!(!accepts_event_stream(&HeaderMap::new()));
+    }
+
+    #[test]
+    fn test_accepts_event_stream_rejects_bare_wildcard() {
+        // `*/*` is intentionally NOT accepted: curl / claude-code callers
+        // that omit Accept or send `*/*` keep the back-compat JSON body.
+        assert!(!accepts_event_stream(&accept("*/*")));
+    }
+
+    #[test]
+    fn test_accepts_event_stream_rejects_unrelated_types() {
+        assert!(!accepts_event_stream(&accept("text/plain, text/html")));
     }
 }

--- a/stoa-gateway/tests/contract/main.rs
+++ b/stoa-gateway/tests/contract/main.rs
@@ -13,4 +13,5 @@ mod errors;
 mod health;
 mod mcp_compliance;
 mod oauth;
+mod sse_accept;
 mod tools;

--- a/stoa-gateway/tests/contract/sse_accept.rs
+++ b/stoa-gateway/tests/contract/sse_accept.rs
@@ -61,8 +61,12 @@ fn content_type(headers: &axum::http::HeaderMap) -> String {
 // Accept: text/event-stream → SSE response
 // ===========================================================
 
+/// Regression for CAB-2106: claude.ai sent `Accept: text/event-stream` and
+/// the gateway returned `application/json`, causing the connector to abort
+/// the session every ~90 s. Any response that is not `text/event-stream`
+/// here reopens that bug.
 #[tokio::test]
-async fn initialize_returns_sse_when_accept_is_event_stream() {
+async fn regression_cab_2106_initialize_returns_sse_when_accept_is_event_stream() {
     let app = TestApp::new();
     let (status, headers, body) = app
         .post_raw(

--- a/stoa-gateway/tests/contract/sse_accept.rs
+++ b/stoa-gateway/tests/contract/sse_accept.rs
@@ -1,0 +1,295 @@
+//! Accept header content-negotiation tests for `POST /mcp/sse` (CAB-2106).
+//!
+//! MCP Streamable HTTP transport spec 2025-03-26 requires the server to
+//! respond with `text/event-stream` whenever the client accepts it, and to
+//! keep the back-compat `application/json` path for callers that do not.
+//!
+//! These tests lock down the Accept matrix × JSON-RPC method pairing plus
+//! the `Mcp-Session-Id` header contract.
+
+use serde_json::{json, Value};
+
+use crate::common::TestApp;
+
+const TEST_TOKEN: &str = "test-bearer-token";
+
+fn initialize_body(id: i64) -> String {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "claude-ai-test", "version": "1.0"}
+        }
+    })
+    .to_string()
+}
+
+fn tools_list_body(id: i64) -> String {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/list"
+    })
+    .to_string()
+}
+
+fn tools_call_unknown_body(id: i64) -> String {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": {
+            "name": "this-tool-does-not-exist",
+            "arguments": {}
+        }
+    })
+    .to_string()
+}
+
+fn content_type(headers: &axum::http::HeaderMap) -> String {
+    headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string()
+}
+
+// ===========================================================
+// Accept: text/event-stream → SSE response
+// ===========================================================
+
+#[tokio::test]
+async fn initialize_returns_sse_when_accept_is_event_stream() {
+    let app = TestApp::new();
+    let (status, headers, body) = app
+        .post_raw(
+            "/mcp/sse",
+            &initialize_body(1),
+            Some("text/event-stream"),
+            Some(TEST_TOKEN),
+        )
+        .await;
+
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert!(
+        content_type(&headers).starts_with("text/event-stream"),
+        "expected text/event-stream, got: {}",
+        content_type(&headers)
+    );
+    assert!(
+        body.contains("event: message"),
+        "body must include SSE message event, got: {}",
+        body
+    );
+    assert!(
+        body.contains("\"jsonrpc\":\"2.0\""),
+        "body must embed JSON-RPC response, got: {}",
+        body
+    );
+    assert!(
+        headers.get("mcp-session-id").is_some(),
+        "Mcp-Session-Id header must accompany SSE initialize response"
+    );
+}
+
+#[tokio::test]
+async fn initialize_returns_sse_when_accept_lists_both() {
+    let app = TestApp::new();
+    let (status, headers, body) = app
+        .post_raw(
+            "/mcp/sse",
+            &initialize_body(2),
+            Some("application/json, text/event-stream"),
+            Some(TEST_TOKEN),
+        )
+        .await;
+
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert!(
+        content_type(&headers).starts_with("text/event-stream"),
+        "MCP-compliant client (both media types) must get SSE; got: {}",
+        content_type(&headers)
+    );
+    assert!(body.contains("event: message"));
+}
+
+#[tokio::test]
+async fn initialize_returns_sse_with_q_values() {
+    let app = TestApp::new();
+    let (status, headers, _) = app
+        .post_raw(
+            "/mcp/sse",
+            &initialize_body(3),
+            Some("application/json;q=0.8, text/event-stream;q=0.9"),
+            Some(TEST_TOKEN),
+        )
+        .await;
+
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert!(
+        content_type(&headers).starts_with("text/event-stream"),
+        "q-value-annotated Accept must still route to SSE; got: {}",
+        content_type(&headers)
+    );
+}
+
+#[tokio::test]
+async fn initialize_case_insensitive_accept() {
+    let app = TestApp::new();
+    let (status, headers, _) = app
+        .post_raw(
+            "/mcp/sse",
+            &initialize_body(4),
+            Some("Text/Event-Stream"),
+            Some(TEST_TOKEN),
+        )
+        .await;
+
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert!(content_type(&headers).starts_with("text/event-stream"));
+}
+
+// ===========================================================
+// Accept without text/event-stream → JSON response (back-compat)
+// ===========================================================
+
+#[tokio::test]
+async fn initialize_returns_json_when_accept_is_json_only() {
+    let app = TestApp::new();
+    let (status, headers, body) = app
+        .post_raw(
+            "/mcp/sse",
+            &initialize_body(5),
+            Some("application/json"),
+            Some(TEST_TOKEN),
+        )
+        .await;
+
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert!(
+        content_type(&headers).starts_with("application/json"),
+        "Accept: application/json must keep back-compat JSON; got: {}",
+        content_type(&headers)
+    );
+    let parsed: Value = serde_json::from_str(&body).expect("body must parse as JSON");
+    assert_eq!(parsed["jsonrpc"], "2.0");
+    assert!(
+        headers.get("mcp-session-id").is_some(),
+        "Mcp-Session-Id must be present on JSON path too"
+    );
+}
+
+#[tokio::test]
+async fn initialize_returns_json_when_accept_absent() {
+    let app = TestApp::new();
+    let (status, headers, body) = app
+        .post_raw("/mcp/sse", &initialize_body(6), None, Some(TEST_TOKEN))
+        .await;
+
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert!(
+        content_type(&headers).starts_with("application/json"),
+        "absent Accept defaults to JSON (legacy clients); got: {}",
+        content_type(&headers)
+    );
+    let parsed: Value = serde_json::from_str(&body).expect("body must parse as JSON");
+    assert_eq!(parsed["jsonrpc"], "2.0");
+}
+
+// ===========================================================
+// Method coverage: tools/list, tools/call via SSE
+// ===========================================================
+
+#[tokio::test]
+async fn tools_list_sse_wraps_json_rpc_response() {
+    let app = TestApp::new();
+    let (status, headers, body) = app
+        .post_raw(
+            "/mcp/sse",
+            &tools_list_body(10),
+            Some("text/event-stream"),
+            Some(TEST_TOKEN),
+        )
+        .await;
+
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert!(content_type(&headers).starts_with("text/event-stream"));
+    assert!(body.contains("event: message"));
+    assert!(body.contains("\"tools\""));
+}
+
+#[tokio::test]
+async fn tools_call_sse_wraps_error_for_unknown_tool() {
+    let app = TestApp::new();
+    let (status, headers, body) = app
+        .post_raw(
+            "/mcp/sse",
+            &tools_call_unknown_body(11),
+            Some("text/event-stream"),
+            Some(TEST_TOKEN),
+        )
+        .await;
+
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert!(content_type(&headers).starts_with("text/event-stream"));
+    assert!(body.contains("event: message"));
+    assert!(
+        body.contains("-32601") || body.contains("not found"),
+        "unknown tool must surface METHOD_NOT_FOUND wrapped in SSE message, got: {}",
+        body
+    );
+}
+
+// ===========================================================
+// Session reuse
+// ===========================================================
+
+#[tokio::test]
+async fn session_reuse_does_not_create_new_session() {
+    let app = TestApp::new();
+
+    // First call: initialize, no session_id → server mints one
+    let (_, headers, _) = app
+        .post_raw(
+            "/mcp/sse",
+            &initialize_body(20),
+            Some("application/json"),
+            Some(TEST_TOKEN),
+        )
+        .await;
+    let session_id = headers
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .expect("initialize must return Mcp-Session-Id")
+        .to_string();
+    let count_after_first = app.state.session_manager.count();
+    assert_eq!(
+        count_after_first, 1,
+        "initialize must create exactly one session"
+    );
+
+    // Second call: tools/list with ?sessionId= → reuse, no new session
+    let uri = format!("/mcp/sse?sessionId={}", session_id);
+    let (status, headers, _) = app
+        .post_raw(
+            &uri,
+            &tools_list_body(21),
+            Some("application/json"),
+            Some(TEST_TOKEN),
+        )
+        .await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert_eq!(
+        headers.get("mcp-session-id").and_then(|v| v.to_str().ok()),
+        Some(session_id.as_str()),
+        "Mcp-Session-Id must echo the reused session"
+    );
+    assert_eq!(
+        app.state.session_manager.count(),
+        count_after_first,
+        "second request must NOT create a new session"
+    );
+}

--- a/stoa-gateway/tests/integration/common.rs
+++ b/stoa-gateway/tests/integration/common.rs
@@ -1,7 +1,7 @@
 //! Shared test helpers for integration tests.
 
 use axum::body::Body;
-use axum::http::{Request, StatusCode};
+use axum::http::{HeaderMap, Request, StatusCode};
 use axum::Router;
 use tower::ServiceExt;
 
@@ -127,6 +127,46 @@ impl TestApp {
             .await
             .expect("read body");
         (status, String::from_utf8_lossy(&body).to_string())
+    }
+
+    /// Send a POST request with JSON body + optional Accept/Authorization and
+    /// return the full `(status, headers, body)` tuple so callers can assert on
+    /// `Content-Type`, `Mcp-Session-Id`, etc.
+    #[allow(dead_code)] // only consumed from the `contract` test harness
+    pub async fn post_raw(
+        &self,
+        uri: &str,
+        json_body: &str,
+        accept: Option<&str>,
+        bearer: Option<&str>,
+    ) -> (StatusCode, HeaderMap, String) {
+        let mut builder = Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("Content-Type", "application/json");
+        if let Some(a) = accept {
+            builder = builder.header("Accept", a);
+        }
+        if let Some(t) = bearer {
+            builder = builder.header("Authorization", format!("Bearer {}", t));
+        }
+        let request = builder
+            .body(Body::from(json_body.to_string()))
+            .expect("valid request");
+
+        let response = self
+            .router
+            .clone()
+            .oneshot(request)
+            .await
+            .expect("router should not error");
+
+        let status = response.status();
+        let headers = response.headers().clone();
+        let body = axum::body::to_bytes(response.into_body(), 1_048_576)
+            .await
+            .expect("read body");
+        (status, headers, String::from_utf8_lossy(&body).to_string())
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix claude.ai remote MCP connector loop: `POST /mcp/sse` now returns `text/event-stream` when the client accepts it, keeping the `application/json` back-compat path untouched for curl / claude-code / healthchecks.
- MCP Streamable HTTP spec 2025-03-26 compliance: single-event SSE frame (`event: message`) with 15 s keep-alive ping, `Mcp-Session-Id` header on both response paths.
- Explicit scope: Accept-header content negotiation + session-reuse test. Soft-auth close / CORS / OTLP noise left for follow-up P1-P3 tickets listed in the handoff.

## Root cause

`handle_sse_post` always wrapped the JSON-RPC response in `Json(...).into_response()`, so claude.ai — which sends `Accept: text/event-stream` — rejected every `initialize` response and looped into DCR → token → initialize every ~90 s. Diagnosis is documented in `docs/audits/2026-04-17-mcp-claude-ai-connector/HANDOFF.md` (Anthropic error ref `ofid_d2fef633fa45878c`).

## What changed

- `stoa-gateway/src/mcp/sse.rs` — new `accepts_event_stream(&HeaderMap)` helper (case-insensitive, q-value tolerant, deliberately does NOT match bare `*/*`) + `build_sse_single_response(...)` + branch in `handle_sse_post`. Batch path and `GET /mcp/sse` long-poll untouched.
- `stoa-gateway/tests/contract/sse_accept.rs` (new) — 9 contract tests covering the Accept × method matrix (initialize / tools/list / tools/call × event-stream / both / q-values / case / JSON only / absent) + session reuse via `?sessionId=`.
- `stoa-gateway/tests/integration/common.rs` — new `post_raw` test helper returning `(status, headers, body)` so callers can assert on `Content-Type` and `Mcp-Session-Id`.
- `stoa-gateway/tests/contract/main.rs` — register the new `sse_accept` module.
- Inline unit tests in `src/mcp/sse.rs` — 9 cases for the Accept parser.

Production code ≈ 70 LOC; the rest of the diff is tests.

## Test plan

- [x] `cargo test -p stoa-gateway` — 2158 lib + 47 contract + 52 integration + 15 resilience + 26 security, all green.
- [x] `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] Local binary curl matrix (5 Accept variants) + `initialize → tools/list` session-reuse flow — all PASS. Evidence archived in `docs/audits/2026-04-17-mcp-claude-ai-connector/AUDIT-RESULTS.md`.
- [ ] Dev-vps / claude.ai end-to-end validation — Phase 2 follow-up, separate session.
- [ ] Chart version bump via release-please after merge — automated.

## Design choices worth flagging

- `*/*` intentionally does NOT trigger SSE. curl / claude-code CLI / mtls probes that omit Accept keep the JSON body they rely on.
- Single-event-then-close SSE stream. Spec 2025-03-26 explicitly permits closing after all correlated responses have been sent; server-push notifications keep using the existing long-lived `GET /mcp/sse`.
- `handle_streamable_http_post` (POST `/mcp`) delegates to `handle_sse_post` and picks up the fix automatically — no code duplication.

Refs: CAB-2106, `docs/audits/2026-04-17-mcp-claude-ai-connector/HANDOFF.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)