### PR TITLE
feat(keycloak): add stoactl public client w/ device-auth grant (CAB-2103)

### DIFF
--- a/charts/stoa-platform/templates/bootstrap-job.yaml
+++ b/charts/stoa-platform/templates/bootstrap-job.yaml
@@ -206,6 +206,24 @@ data:
     }"
 
     # ---------------------------------------------------------------
+    # stoactl CLI — public client, OAuth2 device authorization grant
+    # CAB-2103: required by `stoactl auth login` (hardcoded clientID)
+    # ---------------------------------------------------------------
+    create_client "stoactl" "{
+      \"clientId\": \"stoactl\",
+      \"name\": \"STOA CLI (stoactl)\",
+      \"enabled\": true,
+      \"publicClient\": true,
+      \"standardFlowEnabled\": false,
+      \"directAccessGrantsEnabled\": false,
+      \"serviceAccountsEnabled\": false,
+      \"attributes\": {
+        \"oauth2.device.authorization.grant.enabled\": \"true\"
+      },
+      \"defaultClientScopes\": [\"openid\", \"profile\", \"email\", \"stoa:read\", \"stoa:write\"]
+    }"
+
+    # ---------------------------------------------------------------
     # Create admin user (if adminEmail provided)
     # ---------------------------------------------------------------
     if [ -n "${ADMIN_EMAIL}" ]; then


### PR DESCRIPTION
## Summary

- `stoactl auth login` currently fails with `400 invalid_client` against prod — the `stoa` realm has no `stoactl` OIDC client.
- Adds a 5th entry to the idempotent `create_client` block in the Helm bootstrap-job: public client, OAuth2 device authorization grant, default scopes `openid/profile/email/stoa:read/stoa:write`.
- Mirror in `stoa-infra` CR path: PotoMitan/stoa-infra#TBD (realm-import.yaml, dormant operator.enabled=true path).

## Context

- Direct probe: `POST auth.gostoa.dev/realms/stoa/protocol/openid-connect/auth/device client_id=stoactl` → `400 invalid_client`.
- stoactl hardcodes `clientID = "stoactl"` (`stoactl/internal/cli/cmd/auth/login.go:22-26`).
- Realm bootstrap only provisions 4 clients — Console, Portal, Gateway, CP-API. No CLI public client, no device-auth grant anywhere.
- `create_client` is create-only (409 treated as OK). Existing 4 clients are untouched.
- Keycloak 26.5.3 on prod → device-auth grant supported (requires ≥25).

## Rollout gotcha

Bootstrap-job is a Helm `post-install` hook, not `post-upgrade`. After merge:

1. `helm upgrade` alone **won't** run the job.
2. Operator must either:
   - `kubectl -n stoa-system delete job <bootstrap-job-name>` and re-run the hook manually, **or**
   - POST the new client via `kcadm.sh` against prod KC directly.

## Test plan

- [x] `helm lint charts/stoa-platform` clean
- [ ] Local k3d (Tilt): bootstrap-job re-run, probe `POST auth/device client_id=stoactl` → 200 with device_code
- [ ] `stoactl auth login` on k3d-local context completes device flow → token in keychain
- [ ] Prod post-rollout: same probe + `stoactl auth login` against stoa-prod context
- [ ] `stoactl tenants list` with user token → 200 (validates end-to-end w/ CAB-2095 tenant-scoped paths)

## Refs

- Linear: [CAB-2103](https://linear.app/hlfh-workspace/issue/CAB-2103)
- Unblocks: CAB-2088 démo act 1 (user-token flow on prod)
- Sibling: CAB-2094 (issuer drift, already merged as PR #2399)

🤖 Generated with [Claude Code](https://claude.com/claude-code)