### PR TITLE
fix(ci): write cov-summary to $RUNNER_TEMP instead of /tmp

### DIFF
--- a/.github/workflows/reusable-rust-ci.yml
+++ b/.github/workflows/reusable-rust-ci.yml
@@ -107,12 +107,12 @@ jobs:
       - name: Run coverage
         env:
           RUSTC_WRAPPER: ''
-        run: cargo llvm-cov ${{ inputs.cargo-features }} --summary-only 2>&1 | tee /tmp/cov-summary.txt
+        run: cargo llvm-cov ${{ inputs.cargo-features }} --summary-only 2>&1 | tee "${RUNNER_TEMP}/cov-summary.txt"
 
       - name: Extract coverage percentage
         id: extract-cov
         run: |
-          COV_PCT=$(grep -oP 'TOTAL\s+\d+\s+\d+\s+\K[\d.]+' /tmp/cov-summary.txt || echo "0")
+          COV_PCT=$(grep -oP 'TOTAL\s+\d+\s+\d+\s+\K[\d.]+' "${RUNNER_TEMP}/cov-summary.txt" || echo "0")
           echo "coverage_pct=$COV_PCT" >> $GITHUB_OUTPUT
           echo "Coverage: $COV_PCT%"
 
@@ -160,5 +160,5 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage-report
-          path: /tmp/cov-summary.txt
+          path: ${{ runner.temp }}/cov-summary.txt
           retention-days: 30


### PR DESCRIPTION
## Summary

- Unblock Gateway CI on main and all Rust PRs. `/tmp` is not writable by the `debian` service account on `contabo-runner-1`, so `cargo llvm-cov ... | tee /tmp/cov-summary.txt` exits with code 1 under `bash -e -o pipefail`, even when coverage itself runs to completion (observed 81.24 % on PR #2402).
- Switch the 3 path usages (tee, grep, upload-artifact) to `$RUNNER_TEMP` / `${{ runner.temp }}`, which is the GitHub-Actions-provided writable temp directory on any runner.

## Evidence

Observed on PR #2402 (commit `73215d78`, Rust CI run `24585553075`):

```
tee: /tmp/cov-summary.txt: Permission denied
... (coverage output, TOTAL 81.24 %) ...
##[error]Process completed with exit code 1.
```

Same pattern on release PR `#2392` (chore: release stoa-gateway 0.9.5) and every Gateway CI run on main since 2026-04-16 (after PR #2388 introduced the coverage step).

## Test plan

- [x] Rust CI on this PR runs successfully and publishes coverage report — validates the /tmp → RUNNER_TEMP switch on the same self-hosted runner.
- [ ] Release-please Gateway CI goes green on next release PR.
- [ ] PR #2402 (CAB-2106, gateway Accept fix) becomes mergeable after rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)