### PR TITLE
feat(cli): support Tool kind in stoactl apply + global --namespace flag

### DIFF
--- a/stoa-go/internal/cli/cmd/apply/apply.go
+++ b/stoa-go/internal/cli/cmd/apply/apply.go
@@ -291,7 +291,7 @@ func applyTool(c *client.Client, resource types.Resource) error {
 func decodeToolSpec(raw any) (types.ToolSpec, error) {
 	var spec types.ToolSpec
 	if raw == nil {
-		return spec, fmt.Errorf("Tool spec is empty")
+		return spec, fmt.Errorf("tool spec is empty")
 	}
 	b, err := yaml.Marshal(raw)
 	if err != nil {

--- a/stoa-go/internal/cli/cmd/apply/apply.go
+++ b/stoa-go/internal/cli/cmd/apply/apply.go
@@ -22,6 +22,19 @@ var (
 	dryRun   bool
 )
 
+// namespaceOverrideFn is the callback used by apply to read the root-level
+// --namespace flag without importing the cmd package (which would create an
+// import cycle). The root package wires this at init time.
+var namespaceOverrideFn = func() string { return "" }
+
+// SetNamespaceOverrideFn wires the --namespace override accessor. Called by
+// the root package during init.
+func SetNamespaceOverrideFn(fn func() string) {
+	if fn != nil {
+		namespaceOverrideFn = fn
+	}
+}
+
 // NewApplyCmd creates the apply command
 func NewApplyCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -33,7 +46,7 @@ The resource will be created if it doesn't exist, or updated if it does.
 This command is idempotent and safe to run multiple times.
 
 Supported kinds: API, Tenant, Gateway, Subscription, Consumer, Contract,
-MCPServer, ServiceAccount, Plan, Webhook.
+MCPServer, ServiceAccount, Plan, Webhook, Tool.
 
 Examples:
   # Apply an API definition
@@ -186,8 +199,12 @@ func applyFile(c *client.Client, path string) error {
 		if err := applyGeneric(c, fmt.Sprintf("/v1/tenants/%s/webhooks", tenant), resource); err != nil {
 			return fmt.Errorf("failed to apply %s/%s: %w", resource.Kind, resource.Metadata.Name, err)
 		}
+	case "Tool":
+		if err := applyTool(c, resource); err != nil {
+			return fmt.Errorf("failed to apply %s/%s: %w", resource.Kind, resource.Metadata.Name, err)
+		}
 	default:
-		return fmt.Errorf("unsupported resource kind: %s", resource.Kind)
+		return fmt.Errorf("unsupported resource kind: %s (supported: API, Tenant, Gateway, Subscription, Consumer, Contract, MCPServer, ServiceAccount, Plan, Webhook, Tool)", resource.Kind)
 	}
 
 	output.Success("%s/%s configured", resource.Kind, resource.Metadata.Name)
@@ -231,10 +248,93 @@ func buildApplyBody(resource types.Resource) map[string]any {
 	return body
 }
 
-// tenantFromResource returns the tenant from metadata.namespace or falls back to the client's configured tenant.
+// tenantFromResource resolves the tenant for a resource with precedence:
+// --namespace flag > metadata.namespace > client's configured tenant.
 func tenantFromResource(c *client.Client, resource types.Resource) string {
+	if ns := namespaceOverrideFn(); ns != "" {
+		return ns
+	}
 	if resource.Metadata.Namespace != "" {
 		return resource.Metadata.Namespace
 	}
 	return c.TenantID()
+}
+
+// applyTool registers a Tool CRD under its parent MCP server.
+// Parent server is resolved from (in order): metadata.labels["mcp-server"],
+// spec.apiRef.name + "-mcp", or an explicit error. If the server does not
+// exist, it is auto-created to match `stoactl bridge --apply` semantics.
+func applyTool(c *client.Client, resource types.Resource) error {
+	spec, err := decodeToolSpec(resource.Spec)
+	if err != nil {
+		return err
+	}
+
+	serverName := mcpServerForTool(resource, spec)
+	if serverName == "" {
+		return fmt.Errorf("cannot resolve parent MCP server: add metadata.labels[\"mcp-server\"] or spec.apiRef.name")
+	}
+
+	serverID, created, err := findOrCreateMCPServer(c, serverName, resource)
+	if err != nil {
+		return err
+	}
+	if created {
+		output.Info("  created MCP server %q (id=%s)", serverName, serverID)
+	}
+
+	return c.AddToolToServer(serverID, resource.Metadata.Name, spec)
+}
+
+// decodeToolSpec converts a raw resource.Spec (typically map[string]any from YAML)
+// into the strongly-typed ToolSpec expected by the CP API client.
+func decodeToolSpec(raw any) (types.ToolSpec, error) {
+	var spec types.ToolSpec
+	if raw == nil {
+		return spec, fmt.Errorf("Tool spec is empty")
+	}
+	b, err := yaml.Marshal(raw)
+	if err != nil {
+		return spec, fmt.Errorf("failed to re-marshal Tool spec: %w", err)
+	}
+	if err := yaml.Unmarshal(b, &spec); err != nil {
+		return spec, fmt.Errorf("invalid Tool spec: %w", err)
+	}
+	return spec, nil
+}
+
+// mcpServerForTool resolves the parent MCP server name for a Tool CRD.
+// Precedence: metadata.labels["mcp-server"] > spec.apiRef.name + "-mcp".
+func mcpServerForTool(r types.Resource, spec types.ToolSpec) string {
+	if v := r.Metadata.Labels["mcp-server"]; v != "" {
+		return v
+	}
+	if spec.APIRef != nil && spec.APIRef.Name != "" {
+		return spec.APIRef.Name + "-mcp"
+	}
+	return ""
+}
+
+// findOrCreateMCPServer looks up an MCP server by name. If missing, it creates
+// one and returns the new ID. The second return value is true when the server
+// was created by this call.
+func findOrCreateMCPServer(c *client.Client, name string, r types.Resource) (string, bool, error) {
+	list, err := c.ListMCPServers()
+	if err != nil {
+		return "", false, fmt.Errorf("failed to list MCP servers: %w", err)
+	}
+	for _, srv := range list.Servers {
+		if srv.Name == name {
+			return srv.ID, false, nil
+		}
+	}
+	desc := "Auto-created by stoactl apply"
+	if r.Metadata.Namespace != "" {
+		desc = fmt.Sprintf("Auto-created by stoactl apply (namespace=%s)", r.Metadata.Namespace)
+	}
+	id, err := c.CreateMCPServer(name, name, desc)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to create MCP server %q: %w", name, err)
+	}
+	return id, true, nil
 }

--- a/stoa-go/internal/cli/cmd/apply/apply_test.go
+++ b/stoa-go/internal/cli/cmd/apply/apply_test.go
@@ -205,6 +205,101 @@ func searchSubstr(s, substr string) bool {
 	return false
 }
 
+func TestMCPServerForTool_Label(t *testing.T) {
+	r := types.Resource{
+		Metadata: types.Metadata{
+			Labels: map[string]string{"mcp-server": "custom-mcp"},
+		},
+	}
+	spec := types.ToolSpec{APIRef: &types.APIRef{Name: "openapi"}}
+	if got := mcpServerForTool(r, spec); got != "custom-mcp" {
+		t.Errorf("label should win; got %q, want %q", got, "custom-mcp")
+	}
+}
+
+func TestMCPServerForTool_APIRefFallback(t *testing.T) {
+	r := types.Resource{Metadata: types.Metadata{}}
+	spec := types.ToolSpec{APIRef: &types.APIRef{Name: "petstore"}}
+	if got := mcpServerForTool(r, spec); got != "petstore-mcp" {
+		t.Errorf("apiRef fallback; got %q, want %q", got, "petstore-mcp")
+	}
+}
+
+func TestMCPServerForTool_NoHint(t *testing.T) {
+	r := types.Resource{Metadata: types.Metadata{}}
+	spec := types.ToolSpec{}
+	if got := mcpServerForTool(r, spec); got != "" {
+		t.Errorf("no hint should return empty; got %q", got)
+	}
+}
+
+func TestDecodeToolSpec_FromYAMLMap(t *testing.T) {
+	raw := map[string]any{
+		"displayName": "Get balance",
+		"endpoint":    "https://api.bank.fr/balance",
+		"method":      "GET",
+		"apiRef": map[string]any{
+			"name":        "openapi",
+			"operationId": "getBalance",
+		},
+	}
+	spec, err := decodeToolSpec(raw)
+	if err != nil {
+		t.Fatalf("decodeToolSpec() err = %v", err)
+	}
+	if spec.DisplayName != "Get balance" {
+		t.Errorf("displayName = %q", spec.DisplayName)
+	}
+	if spec.APIRef == nil || spec.APIRef.Name != "openapi" {
+		t.Errorf("apiRef not decoded: %+v", spec.APIRef)
+	}
+	if spec.APIRef.OperationID != "getBalance" {
+		t.Errorf("operationId = %q", spec.APIRef.OperationID)
+	}
+}
+
+func TestDecodeToolSpec_NilRejected(t *testing.T) {
+	if _, err := decodeToolSpec(nil); err == nil {
+		t.Error("decodeToolSpec(nil) should error")
+	}
+}
+
+func TestTenantFromResource_NamespaceOverrideWins(t *testing.T) {
+	prev := namespaceOverrideFn
+	defer func() { namespaceOverrideFn = prev }()
+	namespaceOverrideFn = func() string { return "flag-tenant" }
+
+	r := types.Resource{Metadata: types.Metadata{Namespace: "yaml-tenant"}}
+	if got := tenantFromResource(nil, r); got != "flag-tenant" {
+		t.Errorf("--namespace should override metadata.namespace; got %q", got)
+	}
+}
+
+func TestApplyFile_ToolMissingServerHint(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "orphan-tool.yaml")
+	content := `apiVersion: gostoa.dev/v1alpha1
+kind: Tool
+metadata:
+  name: orphan-tool
+  namespace: demo
+spec:
+  displayName: Orphan
+  endpoint: https://example.com
+  method: GET
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := applyFile(nil, path)
+	if err == nil {
+		t.Fatal("Tool without server hint should error before network call")
+	}
+	if !contains(err.Error(), "parent MCP server") {
+		t.Errorf("error should mention 'parent MCP server'; got %q", err.Error())
+	}
+}
+
 func TestRunApply_MissingFile(t *testing.T) {
 	filePath = "/nonexistent/path/file.yaml"
 	dryRun = false

--- a/stoa-go/internal/cli/cmd/root.go
+++ b/stoa-go/internal/cli/cmd/root.go
@@ -38,6 +38,15 @@ var (
 // AdminMode indicates whether --admin was passed (service account context).
 var AdminMode bool
 
+// NamespaceOverride holds the value of the persistent --namespace flag.
+// When non-empty, commands should prefer this over metadata.namespace / the
+// configured tenant.
+var NamespaceOverride string
+
+// Namespace returns the namespace override set via the --namespace flag,
+// or an empty string when the flag was not provided.
+func Namespace() string { return NamespaceOverride }
+
 var rootCmd = &cobra.Command{
 	Use:   "stoactl",
 	Short: "STOA Platform CLI",
@@ -66,6 +75,12 @@ func Execute() error {
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&AdminMode, "admin", false, "Use service account token instead of user OIDC token")
+	// `-n` intentionally omitted: the `bridge` command already defines a
+	// local `-n` shortcut, and shadowing it globally would break existing
+	// scripts. Long form only; users still get kubectl-like UX.
+	rootCmd.PersistentFlags().StringVar(&NamespaceOverride, "namespace", "", "Target namespace (overrides metadata.namespace in manifests)")
+
+	apply.SetNamespaceOverrideFn(Namespace)
 
 	rootCmd.AddCommand(catalogcmd.NewCatalogCmd())
 	rootCmd.AddCommand(auditcmd.NewAuditCmd())


### PR DESCRIPTION
## Summary

- Adds `case "Tool"` to `stoactl apply`. Bridge-generated `./tools/*.yaml` now apply cleanly — previously they hit `unsupported resource kind: Tool` even though `stoactl bridge` advertises them as "ready for `stoactl apply -f`".
- Adds persistent `--namespace` flag to root. Avoids `Error: unknown flag: --namespace` when users reach for kubectl muscle memory, and lets CI/GitOps pipelines override `metadata.namespace` from the command line.
- Precedence: `--namespace` > `metadata.namespace` > context tenant.

## Resolution logic (Tool)

Parent MCP server resolved from, in order:
1. `metadata.labels["mcp-server"]` (explicit)
2. `spec.apiRef.name + "-mcp"` (bridge convention)
3. Error with clear hint

If the server doesn't exist, it is auto-created (matches `stoactl bridge --apply` semantics).

## Test plan

- [x] `go test ./...` green (all packages)
- [x] 7 new unit tests in `apply_test.go` covering:
      - Server name resolution (label, apiRef fallback, no-hint)
      - ToolSpec decoding (map + nil rejected)
      - `--namespace` override wins over `metadata.namespace`
      - Tool without server hint errors before any network call
- [ ] Manual verify on stoa-demo tenant post-merge (`stoactl --admin apply -f ./tools/`)

## Notes

- `-n` shortcut intentionally omitted on root to avoid shadowing the local `-n` on `stoactl bridge`.
- Callback pattern (`SetNamespaceOverrideFn`) used to wire the root flag into `apply` without introducing an import cycle.
- No Linear ticket assigned yet — happy to label post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)