### PR TITLE
fix(cli): plumb --admin flag through all stoactl commands (CAB-2107)

### DIFF
--- a/stoa-go/internal/cli/clientx/clientx.go
+++ b/stoa-go/internal/cli/clientx/clientx.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2026 CAB Ingénierie / Christophe ABOULICAM
+
+// Package clientx wraps pkg/client construction with cobra-aware helpers so
+// command packages can honor the persistent --admin flag uniformly.
+package clientx
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/stoa-platform/stoa-go/pkg/client"
+)
+
+// New returns a STOA API client scoped to the user OIDC token, or to the
+// admin service-account token when the persistent --admin flag is set on
+// the given command (or any of its ancestors). A nil cmd falls back to
+// user-scope — useful in unit tests that exercise command handlers directly
+// without a real cobra command tree.
+func New(cmd *cobra.Command) (*client.Client, error) {
+	var admin bool
+	if cmd != nil {
+		admin, _ = cmd.Flags().GetBool("admin")
+	}
+	return client.NewForMode(admin)
+}

--- a/stoa-go/internal/cli/clientx/clientx_test.go
+++ b/stoa-go/internal/cli/clientx/clientx_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2026 CAB Ingénierie / Christophe ABOULICAM
+package clientx
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func writeTestStoaConfig(t *testing.T) {
+	t.Helper()
+	dir := filepath.Join(os.Getenv("HOME"), ".stoa")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	cfg := `apiVersion: stoa.io/v1
+kind: Config
+current-context: test
+contexts:
+  - name: test
+    context:
+      server: https://api.test.invalid
+      tenant: test-tenant
+`
+	if err := os.WriteFile(filepath.Join(dir, "config"), []byte(cfg), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+// newCmdWithAdminFlag builds a root-like *cobra.Command exposing the --admin
+// persistent flag, mirroring the wiring in internal/cli/cmd/root.go.
+func newCmdWithAdminFlag() *cobra.Command {
+	root := &cobra.Command{Use: "stoactl-test"}
+	var admin bool
+	root.PersistentFlags().BoolVar(&admin, "admin", false, "admin mode")
+	sub := &cobra.Command{Use: "sub", RunE: func(_ *cobra.Command, _ []string) error { return nil }}
+	root.AddCommand(sub)
+	return sub
+}
+
+func TestNew_FlagAbsent_UsesUserPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("STOA_API_KEY", "user-tok")
+	t.Setenv("STOA_ADMIN_KEY", "")
+	writeTestStoaConfig(t)
+
+	sub := newCmdWithAdminFlag()
+	// Simulate invocation without --admin.
+	sub.Root().SetArgs([]string{"sub"})
+	if err := sub.Root().Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	c, err := New(sub)
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil", err)
+	}
+	if !c.IsAuthenticated() {
+		t.Error("IsAuthenticated() = false, want true")
+	}
+}
+
+func TestNew_FlagSet_UsesAdminPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("STOA_API_KEY", "")
+	t.Setenv("STOA_ADMIN_KEY", "admin-tok")
+	writeTestStoaConfig(t)
+
+	sub := newCmdWithAdminFlag()
+	sub.Root().SetArgs([]string{"sub", "--admin"})
+	if err := sub.Root().Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	c, err := New(sub)
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil", err)
+	}
+	if !c.IsAuthenticated() {
+		t.Error("IsAuthenticated() = false, want true")
+	}
+}
+
+func TestNew_AdminFlag_NoToken_ReturnsClearError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("STOA_API_KEY", "")
+	t.Setenv("STOA_ADMIN_KEY", "")
+	writeTestStoaConfig(t)
+
+	sub := newCmdWithAdminFlag()
+	sub.Root().SetArgs([]string{"sub", "--admin"})
+	if err := sub.Root().Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	_, err := New(sub)
+	if err == nil {
+		t.Fatal("New() error = nil, want error about missing admin token")
+	}
+	if !strings.Contains(err.Error(), "no admin token found") {
+		t.Errorf("error = %q, want message containing 'no admin token found'", err.Error())
+	}
+}

--- a/stoa-go/internal/cli/cmd/apply/apply.go
+++ b/stoa-go/internal/cli/cmd/apply/apply.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/clientx"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 	"github.com/stoa-platform/stoa-go/pkg/types"
@@ -72,7 +73,7 @@ Examples:
 }
 
 func runApply(cmd *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := clientx.New(cmd)
 	if err != nil {
 		return err
 	}

--- a/stoa-go/internal/cli/cmd/audit/audit.go
+++ b/stoa-go/internal/cli/cmd/audit/audit.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/stoa-platform/stoa-go/pkg/client"
+	"github.com/stoa-platform/stoa-go/internal/cli/clientx"
 	auditpkg "github.com/stoa-platform/stoa-go/pkg/client/audit"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 	"github.com/stoa-platform/stoa-go/pkg/redact"
@@ -75,8 +75,8 @@ Time range can be relative (7d, 30d, 24h) or absolute (2026-01-01).`,
 	return cmd
 }
 
-func runExport(_ *cobra.Command, _ []string) error {
-	c, err := client.New()
+func runExport(cmd *cobra.Command, _ []string) error {
+	c, err := clientx.New(cmd)
 	if err != nil {
 		return err
 	}

--- a/stoa-go/internal/cli/cmd/bridge/bridge.go
+++ b/stoa-go/internal/cli/cmd/bridge/bridge.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	bridgelib "github.com/stoa-platform/stoa-go/internal/cli/bridge"
-	"github.com/stoa-platform/stoa-go/pkg/client"
+	"github.com/stoa-platform/stoa-go/internal/cli/clientx"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 	"github.com/stoa-platform/stoa-go/pkg/types"
 )
@@ -130,7 +130,7 @@ func runBridge(cmd *cobra.Command, args []string) error {
 
 	// --apply mode: create MCP server + register tools via CP API
 	if apply {
-		c, err := client.New()
+		c, err := clientx.New(cmd)
 		if err != nil {
 			return fmt.Errorf("failed to create API client: %w", err)
 		}

--- a/stoa-go/internal/cli/cmd/delete/delete.go
+++ b/stoa-go/internal/cli/cmd/delete/delete.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/stoa-platform/stoa-go/pkg/client"
+	"github.com/stoa-platform/stoa-go/internal/cli/clientx"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 )
 
@@ -61,7 +61,7 @@ Examples:
 }
 
 func runDeleteAPI(cmd *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := clientx.New(cmd)
 	if err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func newDeleteTenantCmd() *cobra.Command {
 		Short:   "Delete one or more tenants",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -106,7 +106,7 @@ func newDeleteGatewayCmd() *cobra.Command {
 		Short:   "Delete one or more gateway instances",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -122,7 +122,7 @@ func newDeleteSubscriptionCmd() *cobra.Command {
 		Short:   "Delete one or more subscriptions",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -138,7 +138,7 @@ func newDeleteConsumerCmd() *cobra.Command {
 		Short:   "Delete one or more consumers",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -154,7 +154,7 @@ func newDeleteContractCmd() *cobra.Command {
 		Short:   "Delete one or more contracts",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -170,7 +170,7 @@ func newDeleteServiceAccountCmd() *cobra.Command {
 		Short:   "Delete one or more service accounts",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -186,7 +186,7 @@ func newDeletePlanCmd() *cobra.Command {
 		Short:   "Delete one or more subscription plans",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -202,7 +202,7 @@ func newDeleteWebhookCmd() *cobra.Command {
 		Short:   "Delete one or more webhooks",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}

--- a/stoa-go/internal/cli/cmd/deploy/deploy.go
+++ b/stoa-go/internal/cli/cmd/deploy/deploy.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/clientx"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/config"
 	"github.com/stoa-platform/stoa-go/pkg/output"
@@ -79,7 +80,7 @@ func runDeployFromFile(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--env is required (e.g. --env production)")
 	}
 
-	c, err := client.New()
+	c, err := clientx.New(cmd)
 	if err != nil {
 		return err
 	}
@@ -193,7 +194,7 @@ Examples:
 }
 
 func runDeployCreate(cmd *cobra.Command, _ []string) error {
-	c, err := client.New()
+	c, err := clientx.New(cmd)
 	if err != nil {
 		return err
 	}
@@ -220,8 +221,8 @@ func runDeployCreate(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func runDeployList(_ *cobra.Command, _ []string) error {
-	c, err := client.New()
+func runDeployList(cmd *cobra.Command, _ []string) error {
+	c, err := clientx.New(cmd)
 	if err != nil {
 		return err
 	}
@@ -279,8 +280,8 @@ func runDeployList(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func runDeployGet(_ *cobra.Command, args []string) error {
-	c, err := client.New()
+func runDeployGet(cmd *cobra.Command, args []string) error {
+	c, err := clientx.New(cmd)
 	if err != nil {
 		return err
 	}
@@ -335,8 +336,8 @@ func runDeployGet(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func runDeployRollback(_ *cobra.Command, args []string) error {
-	c, err := client.New()
+func runDeployRollback(cmd *cobra.Command, args []string) error {
+	c, err := clientx.New(cmd)
 	if err != nil {
 		return err
 	}

--- a/stoa-go/internal/cli/cmd/gateway/gateway.go
+++ b/stoa-go/internal/cli/cmd/gateway/gateway.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/stoa-platform/stoa-go/pkg/client"
+	"github.com/stoa-platform/stoa-go/internal/cli/clientx"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 )
 
@@ -41,7 +41,7 @@ func newGatewayListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List all gateway instances",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -94,7 +94,7 @@ func newGatewayGetCmd() *cobra.Command {
 		Short: "Get a gateway instance by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -129,7 +129,7 @@ func newGatewayHealthCmd() *cobra.Command {
 		Short: "Check gateway health",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}

--- a/stoa-go/internal/cli/cmd/get/get.go
+++ b/stoa-go/internal/cli/cmd/get/get.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/clientx"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 	"github.com/stoa-platform/stoa-go/pkg/types"
@@ -75,7 +76,7 @@ Examples:
 }
 
 func runGetAPIs(cmd *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := clientx.New(cmd)
 	if err != nil {
 		return err
 	}
@@ -194,7 +195,7 @@ func newGetTenantsCmd() *cobra.Command {
 		Short:   "Display tenants",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -266,7 +267,7 @@ func newGetSubscriptionsCmd() *cobra.Command {
 		Short:   "Display subscriptions",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -338,7 +339,7 @@ func newGetGatewaysCmd() *cobra.Command {
 		Short:   "Display gateway instances",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -410,7 +411,7 @@ func newGetConsumersCmd() *cobra.Command {
 		Short:   "Display consumers",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -481,7 +482,7 @@ func newGetContractsCmd() *cobra.Command {
 		Short:   "Display Universal API Contracts",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -552,7 +553,7 @@ func newGetServiceAccountsCmd() *cobra.Command {
 		Short:   "Display service accounts",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -596,7 +597,7 @@ func newGetEnvironmentsCmd() *cobra.Command {
 		Short:   "Display environments",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -640,7 +641,7 @@ func newGetPlansCmd() *cobra.Command {
 		Short:   "Display subscription plans",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -711,7 +712,7 @@ func newGetWebhooksCmd() *cobra.Command {
 		Short:   "Display webhook configurations",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}

--- a/stoa-go/internal/cli/cmd/mcp/mcp.go
+++ b/stoa-go/internal/cli/cmd/mcp/mcp.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/clientx"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 	"github.com/stoa-platform/stoa-go/pkg/types"
@@ -58,7 +59,7 @@ func newListServersCmd() *cobra.Command {
 		Use:   "list-servers",
 		Short: "List registered MCP servers",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -116,7 +117,7 @@ Examples:
 				return listToolsFromGateway(gatewayURL)
 			}
 
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -229,7 +230,7 @@ Examples:
 				return fmt.Errorf("--server is required (specify MCP server name)")
 			}
 
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -282,7 +283,7 @@ Examples:
 				return healthFromGateway(gatewayURL)
 			}
 
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}

--- a/stoa-go/internal/cli/cmd/subscription/subscription.go
+++ b/stoa-go/internal/cli/cmd/subscription/subscription.go
@@ -5,7 +5,7 @@ package subscription
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/stoa-platform/stoa-go/pkg/client"
+	"github.com/stoa-platform/stoa-go/internal/cli/clientx"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 )
 
@@ -43,7 +43,7 @@ func newSubListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List subscriptions",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -100,7 +100,7 @@ func newSubGetCmd() *cobra.Command {
 		Short: "Get a subscription by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -135,7 +135,7 @@ func newSubApproveCmd() *cobra.Command {
 		Short: "Approve a pending subscription",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -156,7 +156,7 @@ func newSubRevokeCmd() *cobra.Command {
 		Short: "Revoke an active subscription",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}

--- a/stoa-go/internal/cli/cmd/tenant/tenant.go
+++ b/stoa-go/internal/cli/cmd/tenant/tenant.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/stoa-platform/stoa-go/pkg/client"
+	"github.com/stoa-platform/stoa-go/internal/cli/clientx"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 	"github.com/stoa-platform/stoa-go/pkg/types"
 )
@@ -56,7 +56,7 @@ Example:
 }
 
 func runTenantStatus(cmd *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := clientx.New(cmd)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func newTenantCreateCmd() *cobra.Command {
 				displayName = name
 			}
 
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -157,7 +157,7 @@ func newTenantDeleteCmd() *cobra.Command {
 		Short: "Delete a tenant",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := clientx.New(cmd)
 			if err != nil {
 				return err
 			}
@@ -173,7 +173,7 @@ func newTenantDeleteCmd() *cobra.Command {
 }
 
 func runTenantList(cmd *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := clientx.New(cmd)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func runTenantList(cmd *cobra.Command, args []string) error {
 }
 
 func runTenantGet(cmd *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := clientx.New(cmd)
 	if err != nil {
 		return err
 	}

--- a/stoa-go/internal/cli/cmd/token_usage/token_usage.go
+++ b/stoa-go/internal/cli/cmd/token_usage/token_usage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/clientx"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 )
@@ -73,7 +74,7 @@ Examples:
 }
 
 func runTokenUsage(cmd *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := clientx.New(cmd)
 	if err != nil {
 		return err
 	}

--- a/stoa-go/pkg/client/client.go
+++ b/stoa-go/pkg/client/client.go
@@ -26,6 +26,16 @@ type Client struct {
 	httpClient *http.Client
 }
 
+// NewForMode returns an admin-scoped client when admin is true, otherwise a
+// user-scoped client. It exists so commands can honor the global --admin flag
+// uniformly without branching at every call site.
+func NewForMode(admin bool) (*Client, error) {
+	if admin {
+		return NewAdmin()
+	}
+	return New()
+}
+
 // NewAdmin creates a client using the admin service account token.
 // Resolution: STOA_ADMIN_KEY env > keychain "stoactl-admin" context.
 func NewAdmin() (*Client, error) {

--- a/stoa-go/pkg/client/new_for_mode_test.go
+++ b/stoa-go/pkg/client/new_for_mode_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2026 CAB Ingénierie / Christophe ABOULICAM
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTestConfig stages a ~/.stoa/config file under the given HOME with a
+// single "test" context set as current. The keychain is not touched; callers
+// must drive token resolution via STOA_API_KEY / STOA_ADMIN_KEY env vars.
+func writeTestConfig(t *testing.T, home string) {
+	t.Helper()
+	dir := filepath.Join(home, ".stoa")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	cfg := `apiVersion: stoa.io/v1
+kind: Config
+current-context: test
+contexts:
+  - name: test
+    context:
+      server: https://api.test.invalid
+      tenant: test-tenant
+`
+	if err := os.WriteFile(filepath.Join(dir, "config"), []byte(cfg), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func TestNewForMode_User_WithEnvToken(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("STOA_API_KEY", "user-token-xyz")
+	t.Setenv("STOA_ADMIN_KEY", "")
+	writeTestConfig(t, os.Getenv("HOME"))
+
+	c, err := NewForMode(false)
+	if err != nil {
+		t.Fatalf("NewForMode(false) error = %v, want nil", err)
+	}
+	if !c.IsAuthenticated() {
+		t.Error("IsAuthenticated() = false, want true")
+	}
+	if c.TenantID() != "test-tenant" {
+		t.Errorf("TenantID() = %q, want %q", c.TenantID(), "test-tenant")
+	}
+}
+
+func TestNewForMode_Admin_WithEnvToken(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("STOA_API_KEY", "")
+	t.Setenv("STOA_ADMIN_KEY", "admin-sa-token-abc")
+	writeTestConfig(t, os.Getenv("HOME"))
+
+	c, err := NewForMode(true)
+	if err != nil {
+		t.Fatalf("NewForMode(true) error = %v, want nil", err)
+	}
+	if !c.IsAuthenticated() {
+		t.Error("IsAuthenticated() = false, want true")
+	}
+}
+
+func TestNewForMode_Admin_NoToken_ReturnsClearError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("STOA_API_KEY", "")
+	t.Setenv("STOA_ADMIN_KEY", "")
+	writeTestConfig(t, os.Getenv("HOME"))
+
+	_, err := NewForMode(true)
+	if err == nil {
+		t.Fatal("NewForMode(true) error = nil, want error about missing admin token")
+	}
+	if !strings.Contains(err.Error(), "no admin token found") {
+		t.Errorf("error = %q, want message containing 'no admin token found'", err.Error())
+	}
+}
+
+func TestNewForMode_DispatchMatchesDirectCalls(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("STOA_API_KEY", "user-token")
+	t.Setenv("STOA_ADMIN_KEY", "admin-token")
+	writeTestConfig(t, os.Getenv("HOME"))
+
+	userViaMode, err := NewForMode(false)
+	if err != nil {
+		t.Fatalf("NewForMode(false): %v", err)
+	}
+	userDirect, err := New()
+	if err != nil {
+		t.Fatalf("New(): %v", err)
+	}
+	if userViaMode.GetBaseURL() != userDirect.GetBaseURL() {
+		t.Errorf("NewForMode(false) and New() returned different base URLs: %q vs %q",
+			userViaMode.GetBaseURL(), userDirect.GetBaseURL())
+	}
+
+	adminViaMode, err := NewForMode(true)
+	if err != nil {
+		t.Fatalf("NewForMode(true): %v", err)
+	}
+	adminDirect, err := NewAdmin()
+	if err != nil {
+		t.Fatalf("NewAdmin(): %v", err)
+	}
+	if adminViaMode.GetBaseURL() != adminDirect.GetBaseURL() {
+		t.Errorf("NewForMode(true) and NewAdmin() returned different base URLs: %q vs %q",
+			adminViaMode.GetBaseURL(), adminDirect.GetBaseURL())
+	}
+}


### PR DESCRIPTION
## Summary

- Closes [CAB-2107](https://linear.app/hlfh-workspace/issue/CAB-2107). The `--admin` global flag was bound on `rootCmd` but only honored by `catalog`; every other command called `client.New()` and silently fell back to the user OIDC token, surfacing in prod as `401 Not authenticated` instead of the expected `no admin token found. Set STOA_ADMIN_KEY or run 'stoactl auth login --admin'`.
- Adds `pkg/client.NewForMode(admin bool)` + `internal/cli/clientx.New(cmd *cobra.Command)` helpers. The clientx wrapper reads the persistent `--admin` flag off any cobra command so sub-commands don't couple to a root-package global (which would create an import cycle).
- Migrates all 44 call sites across 11 command files (`apply`, `audit`, `bridge`, `delete`, `deploy`, `gateway`, `get`, `mcp`, `subscription`, `tenant`, `token_usage`). `catalog` already calls `NewAdmin()` directly and is untouched.
- `clientx.New` tolerates a `nil *cobra.Command` so existing unit tests that invoke handlers with `runApply(nil, nil)` keep working.

## LOC breakdown

- Production code: ~148 LOC (helper + 44 one-line substitutions + 3 import tweaks)
- Tests: ~221 LOC (7 table-style tests across `pkg/client` and `internal/cli/clientx`)

Under the 300-LOC guidance once tests are excluded.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on all touched files (pre-existing formatting drift elsewhere left alone)
- [x] `go test ./...` — all packages pass, no regression in `apply_test.go`
- [x] New tests: `TestNewForMode_{User,Admin}_WithEnvToken`, `TestNewForMode_Admin_NoToken_ReturnsClearError`, `TestNewForMode_DispatchMatchesDirectCalls`, `TestNew_{FlagAbsent,FlagSet,AdminFlag_NoToken}_*`
- [x] Local smoke: rebuilt binary in `~/.local/bin/stoactl`
  - `stoactl get apis --admin` (no `STOA_ADMIN_KEY`) → `Error: no admin token found. Set STOA_ADMIN_KEY or run 'stoactl auth login --admin'` (was silent 401)
  - `stoactl get apis` (no flag) → still routes through user OIDC path

## Related

- Follow-up of CAB-2103 (stoactl Keycloak public client) AC-A. Orthogonal to AC-B/C which are backend-side (service-accounts 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)