### PR TITLE
feat(helm): add stoactl-admin Keycloak SA client with cpi-admin role (CAB-2108)

### DIFF
--- a/charts/stoa-platform/templates/bootstrap-job.yaml
+++ b/charts/stoa-platform/templates/bootstrap-job.yaml
@@ -224,6 +224,75 @@ data:
     }"
 
     # ---------------------------------------------------------------
+    # stoactl-admin — confidential SA client with cpi-admin role.
+    # Lets CI/CD and `stoactl --admin` obtain a JWT via client_credentials
+    # without any human-in-the-loop.
+    #
+    # Security posture:
+    # - MFA does not apply to the client_credentials grant (machine auth).
+    #   Mitigation: the client secret lives in Infisical (RBAC-protected)
+    #   and is rotated every 90 days via the runbook.
+    # - The bootstrap job does NOT retrieve the auto-generated client_secret
+    #   — it lacks Infisical write credentials and running the job with them
+    #   would broaden the blast radius. Retrieval + Infisical write are a
+    #   separate operator step: see runbook
+    #   docs/runbooks/cab-2108-stoactl-admin-kc-client.md.
+    # - Client + role names kept hardcoded to match the convention used
+    #   for stoa-mcp-gateway / control-plane-api above; follow-up ticket
+    #   if we ever want these chart-configurable uniformly.
+    # ---------------------------------------------------------------
+    STOACTL_ADMIN_CLIENT=stoactl-admin
+    STOACTL_ADMIN_ROLE=cpi-admin
+    # access.token.lifespan=300 caps JWTs to 5 minutes regardless of realm
+    # default, limiting blast radius of a leaked admin token.
+    create_client "$STOACTL_ADMIN_CLIENT" "{
+      \"clientId\": \"${STOACTL_ADMIN_CLIENT}\",
+      \"name\": \"STOA CLI Admin (service account)\",
+      \"enabled\": true,
+      \"publicClient\": false,
+      \"serviceAccountsEnabled\": true,
+      \"standardFlowEnabled\": false,
+      \"directAccessGrantsEnabled\": false,
+      \"attributes\": {
+        \"access.token.lifespan\": \"300\",
+        \"client_credentials.use_refresh_token\": \"false\"
+      }
+    }"
+
+    # Assign the admin realm role to the service-account user. KC returns
+    # the target entity's `id` first in its JSON responses; `head -1` on
+    # the sed extraction therefore always picks the correct UUID even if
+    # sub-objects carry their own `id` fields. jq would be cleaner but is
+    # not available in the curlimages/curl base image.
+    SA_CLIENT_UUID=$(curl -sf "${KEYCLOAK_URL}/admin/realms/${REALM}/clients?clientId=${STOACTL_ADMIN_CLIENT}" \
+      -H "${AUTH}" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p' | head -1)
+    SA_USER_ID=""
+    ROLE_ID=""
+    if [ -n "$SA_CLIENT_UUID" ]; then
+      SA_USER_ID=$(curl -sf "${KEYCLOAK_URL}/admin/realms/${REALM}/clients/${SA_CLIENT_UUID}/service-account-user" \
+        -H "${AUTH}" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p' | head -1)
+      ROLE_ID=$(curl -sf "${KEYCLOAK_URL}/admin/realms/${REALM}/roles/${STOACTL_ADMIN_ROLE}" \
+        -H "${AUTH}" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+    fi
+    if [ -n "$SA_USER_ID" ] && [ -n "$ROLE_ID" ]; then
+      STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        "${KEYCLOAK_URL}/admin/realms/${REALM}/users/${SA_USER_ID}/role-mappings/realm" \
+        -H "${AUTH}" -H "Content-Type: application/json" \
+        -d "[{\"id\": \"${ROLE_ID}\", \"name\": \"${STOACTL_ADMIN_ROLE}\"}]")
+      case "$STATUS" in
+        204|200) log "Assigned ${STOACTL_ADMIN_ROLE} role to ${STOACTL_ADMIN_CLIENT} service account" ;;
+        409)     log "${STOACTL_ADMIN_ROLE} role already on ${STOACTL_ADMIN_CLIENT} SA (OK)" ;;
+        *)       log "WARN: ${STOACTL_ADMIN_CLIENT} role-mapping returned ${STATUS}" ;;
+      esac
+    else
+      log "WARN: could not resolve ${STOACTL_ADMIN_CLIENT} SA user (uuid=${SA_CLIENT_UUID:-?} user=${SA_USER_ID:-?}) or ${STOACTL_ADMIN_ROLE} role (id=${ROLE_ID:-?})"
+    fi
+
+    # Remind the operator that the client_secret still needs to be harvested
+    # and pushed to Infisical. The job intentionally does not do this itself.
+    log "NOTE: run docs/runbooks/cab-2108-stoactl-admin-kc-client.md step 4-5 to push STOACTL_ADMIN_CLIENT_SECRET to Infisical"
+
+    # ---------------------------------------------------------------
     # Create admin user (if adminEmail provided)
     # ---------------------------------------------------------------
     if [ -n "${ADMIN_EMAIL}" ]; then

--- a/docs/runbooks/cab-2108-stoactl-admin-kc-client.md
+++ b/docs/runbooks/cab-2108-stoactl-admin-kc-client.md
@@ -1,0 +1,165 @@
+# Runbook: provision `stoactl-admin` Keycloak client on existing cluster
+
+> **Severity**: Operational — no downtime
+> **Last updated**: 2026-04-17
+> **Linear Issue**: [CAB-2108](https://linear.app/hlfh-workspace/issue/CAB-2108)
+
+---
+
+## Context
+
+The Helm chart now defines a `stoactl-admin` confidential Keycloak client with the `cpi-admin` realm role assigned to its service-account user, so `stoactl --admin` and CI can obtain admin JWTs via `client_credentials`.
+
+The bootstrap job that creates these clients runs as a `post-install` Helm
+hook — `helm.sh/hook: post-install`. Helm **does not re-run it on
+`helm upgrade`**, and `create_client` in the script short-circuits on 409.
+So on any cluster that was deployed before this change (prod included), the
+operator must provision the client manually with the `curl`-based flow
+below (or delete the existing job + `helm upgrade` to re-trigger the hook).
+
+## Prerequisites
+
+- Shell access to a pod or workstation with `curl` + `jq`
+- Keycloak admin credentials (Infisical: `prod/keycloak/ADMIN_PASSWORD`)
+- Infisical write access (to push the generated secret)
+
+**Before you start**, prevent secrets from hitting your shell history:
+
+```bash
+# zsh
+setopt HIST_IGNORE_SPACE     # lines starting with a space are not saved
+# bash (already default with HISTCONTROL)
+export HISTCONTROL=ignorespace:erasedups
+# Prefix every command in this runbook with a leading space.
+```
+
+Exports below use `read -s` for the admin password so it's never on the
+command line:
+
+```bash
+export KC=https://auth.gostoa.dev
+export REALM=stoa
+export ADMIN_USER=admin
+# Fetch via infisical (uses cached session creds, not on argv):
+ADMIN_PASS=$(infisical secrets get ADMIN_PASSWORD --env prod --path /keycloak --plain)
+```
+
+## Steps
+
+### 1. Get a master-realm admin token
+
+```bash
+TOKEN=$(curl -sf -X POST "$KC/realms/master/protocol/openid-connect/token" \
+  -d grant_type=password -d client_id=admin-cli \
+  -d "username=$ADMIN_USER" -d "password=$ADMIN_PASS" | jq -r .access_token)
+```
+
+### 2. Create the client (idempotent — 409 if exists)
+
+```bash
+curl -sf -X POST "$KC/admin/realms/$REALM/clients" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "clientId": "stoactl-admin",
+    "name": "STOA CLI Admin (service account)",
+    "enabled": true,
+    "publicClient": false,
+    "serviceAccountsEnabled": true,
+    "standardFlowEnabled": false,
+    "directAccessGrantsEnabled": false
+  }'
+```
+
+### 3. Assign `cpi-admin` to the service-account user
+
+```bash
+CLIENT_UUID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
+  "$KC/admin/realms/$REALM/clients?clientId=stoactl-admin" | jq -r '.[0].id')
+
+SA_USER_ID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
+  "$KC/admin/realms/$REALM/clients/$CLIENT_UUID/service-account-user" | jq -r .id)
+
+ROLE=$(curl -sf -H "Authorization: Bearer $TOKEN" \
+  "$KC/admin/realms/$REALM/roles/cpi-admin")
+
+curl -sf -X POST "$KC/admin/realms/$REALM/users/$SA_USER_ID/role-mappings/realm" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "[$ROLE]"
+```
+
+### 4. Retrieve the generated client secret
+
+```bash
+# Capture into a variable without echoing. Do not run `set -x` in this shell.
+SECRET=$(curl -sf -H "Authorization: Bearer $TOKEN" \
+  "$KC/admin/realms/$REALM/clients/$CLIENT_UUID/client-secret" | jq -r .value)
+[ -n "$SECRET" ] || { echo "ERR: failed to retrieve secret" >&2; exit 1; }
+```
+
+### 5. Push secret to Infisical
+
+```bash
+infisical secrets set STOACTL_ADMIN_CLIENT_SECRET="$SECRET" \
+  --env prod --path /gateway --type shared
+unset SECRET   # clear from shell history / environment
+```
+
+## Verification
+
+The steps below pass the secret via stdin (`--data-binary @-`) rather than as
+a `-d` flag value, so it never appears in the process listing or shell
+history. The generated JWT is short-lived (5 min) and is decoded into a
+variable instead of being printed directly:
+
+```bash
+# a) Obtain an admin token via client_credentials (secret via stdin)
+JWT=$(printf 'grant_type=client_credentials&client_id=stoactl-admin&client_secret=%s' "$SECRET" \
+  | curl -sf -X POST "$KC/realms/$REALM/protocol/openid-connect/token" \
+      -H "Content-Type: application/x-www-form-urlencoded" \
+      --data-binary @- | jq -r .access_token)
+
+# b) Confirm cpi-admin is in the token without logging the JWT itself
+ROLES=$(printf '%s' "$JWT" | cut -d. -f2 | base64 -d 2>/dev/null | jq -r '.realm_access.roles | join(",")')
+echo "roles: $ROLES"   # → expect a comma-separated list containing cpi-admin
+
+# c) Admin endpoint should return 200, not 403
+curl -s -o /dev/null -w "%{http_code}\n" \
+  -H "Authorization: Bearer $JWT" \
+  https://api.gostoa.dev/v1/admin/mcp/servers
+# → 200
+
+# d) stoactl end-to-end (read-only check)
+STOA_ADMIN_KEY="$JWT" stoactl get apis --admin
+unset JWT
+```
+
+## Secret handling + rotation
+
+- **Never** pass the secret via `-d "key=$SECRET"` on the command line: on
+  shared hosts it appears in `ps auxe` for the lifetime of the curl process.
+  Use stdin with `--data-binary @-` or a file with `--data-urlencode @file`
+  and delete the file afterward.
+- **Never** log the secret (no `echo "$SECRET"`, no `set -x`).
+- **Rotation policy**: rotate the secret every 90 days, and immediately on
+  suspected compromise or whenever a team member with access leaves.
+  Rotation procedure:
+  ```bash
+  # Regenerate in Keycloak (invalidates the old value)
+  NEW=$(curl -sf -X POST -H "Authorization: Bearer $TOKEN" \
+    "$KC/admin/realms/$REALM/clients/$CLIENT_UUID/client-secret" | jq -r .value)
+  # Update Infisical (consumers pick up on next read — no restart)
+  infisical secrets set STOACTL_ADMIN_CLIENT_SECRET="$NEW" \
+    --env prod --path /gateway --type shared
+  unset NEW
+  ```
+
+## Rollback
+
+If the new client misbehaves, delete it (SA and role-mapping are cascaded):
+
+```bash
+curl -sf -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "$KC/admin/realms/$REALM/clients/$CLIENT_UUID"
+```
+
+Consumers of `STOACTL_ADMIN_CLIENT_SECRET` will start getting 401 — coordinate before deleting.


### PR DESCRIPTION
## Summary

Closes [CAB-2108](https://linear.app/hlfh-workspace/issue/CAB-2108). The STOA realm had **no Keycloak client capable of issuing admin-scoped JWTs non-interactively**: `stoa-mcp-gateway`'s SA lacks `cpi-admin`, `stoactl` (CAB-2103) is device-auth only, and `control-plane-api` is bearer-only. So `stoactl --admin` (CAB-2107 plumbed the flag) had no token source — even with a valid gateway SA JWT → 403 "Admin access required" on `/v1/admin/*`. Empirically verified 2026-04-17.

## What the chart adds

- New confidential client `stoactl-admin` in the bootstrap job (`serviceAccountsEnabled: true`, no standard flow, no DAG)
- `access.token.lifespan=300` + `client_credentials.use_refresh_token=false` on the client → JWTs capped at 5 min, no refresh
- `cpi-admin` realm role assigned to the auto-generated service-account user
- Idempotent status logging (409 = already exists, logged as OK)

## What happens after merge

- **Fresh clusters**: new deploys pick it up automatically via the `post-install` Helm hook
- **Existing clusters (prod)**: bootstrap job is `post-install` only (won't re-run on `helm upgrade` — memory note `gotcha_bootstrap_job_post_install_hook`). Operator runs [docs/runbooks/cab-2108-stoactl-admin-kc-client.md](docs/runbooks/cab-2108-stoactl-admin-kc-client.md): create client + assign role via `curl`, fetch generated secret, push to Infisical at `/gateway/STOACTL_ADMIN_CLIENT_SECRET`.

## Test plan

- [x] `helm lint charts/stoa-platform` → clean
- [ ] **Manual (post-merge)**: run runbook on prod, verify:
  - `curl -X POST $KC/realms/stoa/protocol/openid-connect/token -d grant_type=client_credentials -d client_id=stoactl-admin -d client_secret=$SECRET` → JWT with `realm_access.roles` containing `cpi-admin`
  - `curl -H "Authorization: Bearer $JWT" api.gostoa.dev/v1/admin/mcp/servers` → 200
  - `STOA_ADMIN_KEY=$JWT stoactl get apis --admin` → works

## ⚠ Council S3 bypass (explicit)

The pre-push Council gate stayed in REWORK for 4 consecutive iterations (scores **7.5 → 6.5 → 7.25 → 6.75**, threshold is 8.0). Each round surfaced new or re-raised theoretical blockers that are **structural to the existing `bootstrap-job.yaml` pattern** and out of scope for a 35-line chart addition:

| Council blocker | Why not addressed in this PR |
|---|---|
| Full automated rotation (ESO + Vault dynamic secrets) | Infra-wide initiative, own ticket |
| Test harness for shell-in-YAML bootstrap | Applies to the whole 300-LOC job, not this delta |
| IP allowlisting + rate limiting on KC | Network-layer concern, Envoy/NetworkPolicy ticket |
| `sed`-based JSON parsing | Existing pattern (base image = `curlimages/curl:8.7.1`, no `jq`) |
| Hardcoded client/role names | Matches existing convention (`stoa-mcp-gateway`, `control-plane-api` etc.) |
| Secrets in shell variables (runbook) | Mitigated: `HISTCONTROL`, `--data-binary @-` via stdin, `unset` after use — further hardening requires kernel keyring, out of scope |

What the PR **does** deliver in response to Council feedback:
- Explicit rotation policy (90-day + on-compromise) with regen commands
- Token TTL capped at 5 min (`access.token.lifespan=300`)
- No refresh token on `client_credentials` grant
- Secret handling via stdin, never `-d "key=$VAR"` on the command line
- Shell-history prevention (`HISTCONTROL=ignorespace`) documented in the runbook prereq
- Explicit log line reminding the operator to run the post-install runbook step

Bypass approved by @PotoMitan (session 2026-04-17). Human review determines whether the trade-off is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)