### PR TITLE
fix(gateway): unblock /mcp/sse capability-negotiation discovery methods (CAB-2109)

### DIFF
--- a/stoa-gateway/src/mcp/sse.rs
+++ b/stoa-gateway/src/mcp/sse.rs
@@ -88,6 +88,32 @@ pub const METHOD_NOT_FOUND: i32 = -32601;
 pub const INVALID_PARAMS: i32 = -32602;
 pub const INTERNAL_ERROR: i32 = -32603;
 
+/// JSON-RPC methods that are part of the MCP capability-negotiation /
+/// discovery surface. MCP clients (claude.ai, MCP Inspector, claude-code)
+/// call these right after `initialize` — before any OAuth flow has
+/// attached a Bearer token — so 401-ing them breaks the whole handshake
+/// even when the server later advertises OAuth on protected operations.
+///
+/// Tool invocation (`tools/call`) is NOT listed here; authorisation for it
+/// goes through the UAC / OPA policy layer which already enforces scopes
+/// and tenant isolation. `notifications/*` are fire-and-forget client
+/// messages with no response body, equally safe to accept anonymously.
+const PUBLIC_METHODS: &[&str] = &[
+    "initialize",
+    "ping",
+    "tools/list",
+    "resources/list",
+    "resources/templates/list",
+    "resources/read",
+    "prompts/list",
+    "prompts/get",
+    "completion/complete",
+    "roots/list",
+    "logging/setLevel",
+    "notifications/initialized",
+    "notifications/cancelled",
+];
+
 // ============================================
 // MCP Protocol Version Negotiation (2025-11-25)
 // ============================================
@@ -212,18 +238,12 @@ pub async fn handle_sse_post(
     }
 
     // === OAuth 2.1 Auth Challenge (RFC 9728) ===
-    // Public methods that don't require authentication.
-    // tools/list is public to allow unauthenticated discovery (matches /mcp/tools/list behavior).
-    let public_methods = [
-        "initialize",
-        "ping",
-        "tools/list",
-        "notifications/initialized",
-        "notifications/cancelled",
-    ];
+    // Public methods = the MCP capability-negotiation / discovery surface;
+    // see `PUBLIC_METHODS` for the rationale. Tool invocation is gated by
+    // the UAC / OPA layer in `handle_tools_call`, not here.
     let has_auth = headers.get(header::AUTHORIZATION).is_some();
 
-    if !public_methods.contains(&request.method.as_str()) && !has_auth {
+    if !PUBLIC_METHODS.contains(&request.method.as_str()) && !has_auth {
         debug!(
             method = %request.method,
             "Unauthenticated request to protected method — returning 401"
@@ -665,16 +685,9 @@ pub async fn process_single_request(
 
     // For batch processing, we need simplified auth check
     // Full auth is handled in the main handler for single requests
-    let public_methods = [
-        "initialize",
-        "ping",
-        "tools/list",
-        "notifications/initialized",
-        "notifications/cancelled",
-    ];
     let has_auth = headers.get(header::AUTHORIZATION).is_some();
 
-    if !public_methods.contains(&request.method.as_str()) && !has_auth {
+    if !PUBLIC_METHODS.contains(&request.method.as_str()) && !has_auth {
         return JsonRpcResponse::error(request.id, -32001, "Authentication required");
     }
 

--- a/stoa-gateway/tests/contract/main.rs
+++ b/stoa-gateway/tests/contract/main.rs
@@ -12,6 +12,7 @@ mod discovery;
 mod errors;
 mod health;
 mod mcp_compliance;
+mod mcp_public_methods;
 mod oauth;
 mod sse_accept;
 mod tools;

--- a/stoa-gateway/tests/contract/mcp_public_methods.rs
+++ b/stoa-gateway/tests/contract/mcp_public_methods.rs
@@ -1,0 +1,153 @@
+//! MCP capability-negotiation public-method matrix (CAB-2109).
+//!
+//! Anonymous MCP clients (claude.ai, MCP Inspector, claude-code) call the
+//! discovery / metadata methods immediately after `initialize`, before any
+//! OAuth flow has attached a Bearer token. If any of those methods 401,
+//! the client never reaches `tools/call` and abandons the session — which
+//! is the exact failure mode reported as Anthropic error ref
+//! `ofid_5f1fcc086cd04144`.
+//!
+//! This test matrix locks the entire read-only / discovery surface as
+//! anonymously accessible. `tools/call` stays out of the list and is
+//! gated by the UAC/OPA policy layer (covered in `mcp_compliance.rs`).
+
+use serde_json::{json, Value};
+
+use crate::common::TestApp;
+
+/// Every read-only MCP method that an unauthenticated client is allowed
+/// to call during capability negotiation. Pair is `(method, params)`.
+fn discovery_methods() -> Vec<(&'static str, Value)> {
+    vec![
+        (
+            "initialize",
+            json!({
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "cap-nego", "version": "1.0"}
+            }),
+        ),
+        ("ping", json!({})),
+        ("tools/list", json!({})),
+        ("resources/list", json!({})),
+        ("resources/templates/list", json!({})),
+        ("resources/read", json!({"uri": "stoa://tools/nonexistent"})),
+        ("prompts/list", json!({})),
+        ("prompts/get", json!({"name": "nonexistent"})),
+        (
+            "completion/complete",
+            json!({
+                "ref": {"type": "ref/prompt", "name": "x"},
+                "argument": {"name": "a", "value": "b"}
+            }),
+        ),
+        ("roots/list", json!({})),
+        ("logging/setLevel", json!({"level": "info"})),
+    ]
+}
+
+/// Regression for CAB-2109: every discovery method above must be
+/// reachable without an `Authorization` header. 401 on any of them
+/// re-opens the claude.ai connector bug.
+#[tokio::test]
+async fn regression_cab_2109_discovery_methods_are_public() {
+    let app = TestApp::new();
+
+    for (method, params) in discovery_methods() {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params
+        })
+        .to_string();
+
+        let (status, _headers, text) = app
+            .post_raw("/mcp/sse", &body, Some("application/json"), None)
+            .await;
+
+        assert_eq!(
+            status,
+            axum::http::StatusCode::OK,
+            "method `{}` MUST be reachable anonymously; got {} with body {}",
+            method,
+            status,
+            text
+        );
+
+        // Any JSON-RPC error here should be a legitimate domain-level
+        // error (e.g. prompt/resource not found), NOT an auth error.
+        let parsed: Value = serde_json::from_str(&text).unwrap_or_else(|e| {
+            panic!(
+                "method `{}` returned non-JSON body: {} ({})",
+                method, text, e
+            )
+        });
+        if let Some(err) = parsed.get("error") {
+            let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(0);
+            assert_ne!(
+                code, -32001,
+                "method `{}` still returns -32001 Authentication required: {}",
+                method, err
+            );
+        }
+    }
+}
+
+/// `notifications/*` are fire-and-forget client messages — must stay
+/// accepted anonymously (HTTP 204, no JSON body) so the client can
+/// complete the handshake without auth.
+#[tokio::test]
+async fn regression_cab_2109_notifications_initialized_anonymous() {
+    let app = TestApp::new();
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized"
+    })
+    .to_string();
+
+    let (status, _headers, _body) = app
+        .post_raw("/mcp/sse", &body, Some("application/json"), None)
+        .await;
+
+    assert_eq!(
+        status,
+        axum::http::StatusCode::NO_CONTENT,
+        "notifications/initialized must accept anonymous posts with 204"
+    );
+}
+
+/// `tools/call` is intentionally NOT in the public list: without a
+/// Bearer token the gateway must still challenge with 401 +
+/// `WWW-Authenticate` so MCP clients trigger the OAuth flow.
+#[tokio::test]
+async fn regression_cab_2109_tools_call_still_requires_auth() {
+    let app = TestApp::new();
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 42,
+        "method": "tools/call",
+        "params": {"name": "stoa_platform_health", "arguments": {}}
+    })
+    .to_string();
+
+    let (status, headers, text) = app
+        .post_raw("/mcp/sse", &body, Some("application/json"), None)
+        .await;
+
+    assert_eq!(
+        status,
+        axum::http::StatusCode::UNAUTHORIZED,
+        "tools/call without Bearer must 401 (got body {})",
+        text
+    );
+    let www = headers
+        .get("www-authenticate")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    assert!(
+        www.contains("Bearer"),
+        "401 must carry a Bearer challenge header, got: {:?}",
+        www
+    );
+}


### PR DESCRIPTION
## Summary

- Follow-up to CAB-2106: claude.ai remote MCP connector still fails (Anthropic ref `ofid_5f1fcc086cd04144`) because the gateway 401s every read-only discovery method advertised in `initialize` capabilities.
- Extend the `public_methods` whitelist to the full MCP capability-negotiation surface (`logging/setLevel`, `resources/*`, `prompts/*`, `completion/complete`, `roots/list`). `tools/call` stays protected via UAC/OPA.
- Factor the whitelist into a shared `PUBLIC_METHODS` const so single-request + batch paths can never drift again.

## Reproduction

MCP Inspector on prod (`mcp.gostoa.dev`, gateway 0.9.6), 2026-04-17 22:28:

```
POST /mcp/sse initialize                → 200 ✓
POST /mcp/sse notifications/initialized → 204 ✓
POST /mcp/sse tools/list                → 200 ✓
POST /mcp/sse logging/setLevel          → 401 ✗
POST /mcp/sse resources/list            → 401 ✗
POST /mcp/sse prompts/list              → 401 ✗
```

## Test plan

- [x] New `tests/contract/mcp_public_methods.rs` with 3 regression tests covering (a) full 11-method discovery matrix anonymous, (b) `notifications/initialized` anonymous → 204, (c) `tools/call` anonymous → 401 + `WWW-Authenticate: Bearer` (makes sure the fix doesn't weaken the tool surface).
- [x] `cargo test` — 2158 lib + 50 contract + 52 integration + 15 resilience + 26 security, all green.
- [x] `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings` + `cargo fmt --check` clean.
- [ ] Post-deploy prod validation: re-run curl matrix + MCP Inspector `--transport streamable-http` → no 401 on discovery methods.
- [ ] claude.ai connector shows "Connected" + tools list.

## Related

- CAB-2106 (Accept-header fix) — merged.
- `docs/audits/2026-04-17-mcp-claude-ai-connector/AUDIT-RESULTS.md`.
- Separate gotcha `gateway_soft_auth_mcp` — about the inverse bug (anon 200 on `/mcp/*` with invalid JWT) — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)