### PR TITLE
fix(cli): plumb --admin flag through all stoactl commands (CAB-2107)

### DIFF
--- a/stoa-go/internal/cli/cmd/apply/apply.go
+++ b/stoa-go/internal/cli/cmd/apply/apply.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/cmdflags"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 	"github.com/stoa-platform/stoa-go/pkg/types"
@@ -72,7 +73,7 @@ Examples:
 }
 
 func runApply(cmd *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := client.NewForMode(cmdflags.AdminMode)
 	if err != nil {
 		return err
 	}

--- a/stoa-go/internal/cli/cmd/audit/audit.go
+++ b/stoa-go/internal/cli/cmd/audit/audit.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/cmdflags"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	auditpkg "github.com/stoa-platform/stoa-go/pkg/client/audit"
 	"github.com/stoa-platform/stoa-go/pkg/output"
@@ -76,7 +77,7 @@ Time range can be relative (7d, 30d, 24h) or absolute (2026-01-01).`,
 }
 
 func runExport(_ *cobra.Command, _ []string) error {
-	c, err := client.New()
+	c, err := client.NewForMode(cmdflags.AdminMode)
 	if err != nil {
 		return err
 	}

--- a/stoa-go/internal/cli/cmd/bridge/bridge.go
+++ b/stoa-go/internal/cli/cmd/bridge/bridge.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	bridgelib "github.com/stoa-platform/stoa-go/internal/cli/bridge"
+	"github.com/stoa-platform/stoa-go/internal/cli/cmdflags"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 	"github.com/stoa-platform/stoa-go/pkg/types"
@@ -130,7 +131,7 @@ func runBridge(cmd *cobra.Command, args []string) error {
 
 	// --apply mode: create MCP server + register tools via CP API
 	if apply {
-		c, err := client.New()
+		c, err := client.NewForMode(cmdflags.AdminMode)
 		if err != nil {
 			return fmt.Errorf("failed to create API client: %w", err)
 		}

--- a/stoa-go/internal/cli/cmd/delete/delete.go
+++ b/stoa-go/internal/cli/cmd/delete/delete.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/cmdflags"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 )
@@ -61,7 +62,7 @@ Examples:
 }
 
 func runDeleteAPI(cmd *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := client.NewForMode(cmdflags.AdminMode)
 	if err != nil {
 		return err
 	}
@@ -90,7 +91,7 @@ func newDeleteTenantCmd() *cobra.Command {
 		Short:   "Delete one or more tenants",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -106,7 +107,7 @@ func newDeleteGatewayCmd() *cobra.Command {
 		Short:   "Delete one or more gateway instances",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -122,7 +123,7 @@ func newDeleteSubscriptionCmd() *cobra.Command {
 		Short:   "Delete one or more subscriptions",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -138,7 +139,7 @@ func newDeleteConsumerCmd() *cobra.Command {
 		Short:   "Delete one or more consumers",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -154,7 +155,7 @@ func newDeleteContractCmd() *cobra.Command {
 		Short:   "Delete one or more contracts",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -170,7 +171,7 @@ func newDeleteServiceAccountCmd() *cobra.Command {
 		Short:   "Delete one or more service accounts",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -186,7 +187,7 @@ func newDeletePlanCmd() *cobra.Command {
 		Short:   "Delete one or more subscription plans",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -202,7 +203,7 @@ func newDeleteWebhookCmd() *cobra.Command {
 		Short:   "Delete one or more webhooks",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}

--- a/stoa-go/internal/cli/cmd/deploy/deploy.go
+++ b/stoa-go/internal/cli/cmd/deploy/deploy.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/cmdflags"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/config"
 	"github.com/stoa-platform/stoa-go/pkg/output"
@@ -79,7 +80,7 @@ func runDeployFromFile(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--env is required (e.g. --env production)")
 	}
 
-	c, err := client.New()
+	c, err := client.NewForMode(cmdflags.AdminMode)
 	if err != nil {
 		return err
 	}
@@ -193,7 +194,7 @@ Examples:
 }
 
 func runDeployCreate(cmd *cobra.Command, _ []string) error {
-	c, err := client.New()
+	c, err := client.NewForMode(cmdflags.AdminMode)
 	if err != nil {
 		return err
 	}
@@ -221,7 +222,7 @@ func runDeployCreate(cmd *cobra.Command, _ []string) error {
 }
 
 func runDeployList(_ *cobra.Command, _ []string) error {
-	c, err := client.New()
+	c, err := client.NewForMode(cmdflags.AdminMode)
 	if err != nil {
 		return err
 	}
@@ -280,7 +281,7 @@ func runDeployList(_ *cobra.Command, _ []string) error {
 }
 
 func runDeployGet(_ *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := client.NewForMode(cmdflags.AdminMode)
 	if err != nil {
 		return err
 	}
@@ -336,7 +337,7 @@ func runDeployGet(_ *cobra.Command, args []string) error {
 }
 
 func runDeployRollback(_ *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := client.NewForMode(cmdflags.AdminMode)
 	if err != nil {
 		return err
 	}

--- a/stoa-go/internal/cli/cmd/gateway/gateway.go
+++ b/stoa-go/internal/cli/cmd/gateway/gateway.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/cmdflags"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 )
@@ -41,7 +42,7 @@ func newGatewayListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List all gateway instances",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -94,7 +95,7 @@ func newGatewayGetCmd() *cobra.Command {
 		Short: "Get a gateway instance by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -129,7 +130,7 @@ func newGatewayHealthCmd() *cobra.Command {
 		Short: "Check gateway health",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}

--- a/stoa-go/internal/cli/cmd/get/get.go
+++ b/stoa-go/internal/cli/cmd/get/get.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/cmdflags"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 	"github.com/stoa-platform/stoa-go/pkg/types"
@@ -75,7 +76,7 @@ Examples:
 }
 
 func runGetAPIs(cmd *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := client.NewForMode(cmdflags.AdminMode)
 	if err != nil {
 		return err
 	}
@@ -194,7 +195,7 @@ func newGetTenantsCmd() *cobra.Command {
 		Short:   "Display tenants",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -266,7 +267,7 @@ func newGetSubscriptionsCmd() *cobra.Command {
 		Short:   "Display subscriptions",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -338,7 +339,7 @@ func newGetGatewaysCmd() *cobra.Command {
 		Short:   "Display gateway instances",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -410,7 +411,7 @@ func newGetConsumersCmd() *cobra.Command {
 		Short:   "Display consumers",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -481,7 +482,7 @@ func newGetContractsCmd() *cobra.Command {
 		Short:   "Display Universal API Contracts",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -552,7 +553,7 @@ func newGetServiceAccountsCmd() *cobra.Command {
 		Short:   "Display service accounts",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -596,7 +597,7 @@ func newGetEnvironmentsCmd() *cobra.Command {
 		Short:   "Display environments",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -640,7 +641,7 @@ func newGetPlansCmd() *cobra.Command {
 		Short:   "Display subscription plans",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -711,7 +712,7 @@ func newGetWebhooksCmd() *cobra.Command {
 		Short:   "Display webhook configurations",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}

--- a/stoa-go/internal/cli/cmd/logs/logs.go
+++ b/stoa-go/internal/cli/cmd/logs/logs.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/cmdflags"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 )
@@ -44,7 +45,7 @@ Examples:
 func runLogs(_ *cobra.Command, args []string) error {
 	apiName := args[0]
 
-	c, err := client.New()
+	c, err := client.NewForMode(cmdflags.AdminMode)
 	if err != nil {
 		return err
 	}

--- a/stoa-go/internal/cli/cmd/mcp/mcp.go
+++ b/stoa-go/internal/cli/cmd/mcp/mcp.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/cmdflags"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 	"github.com/stoa-platform/stoa-go/pkg/types"
@@ -58,7 +59,7 @@ func newListServersCmd() *cobra.Command {
 		Use:   "list-servers",
 		Short: "List registered MCP servers",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -116,7 +117,7 @@ Examples:
 				return listToolsFromGateway(gatewayURL)
 			}
 
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -229,7 +230,7 @@ Examples:
 				return fmt.Errorf("--server is required (specify MCP server name)")
 			}
 
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -282,7 +283,7 @@ Examples:
 				return healthFromGateway(gatewayURL)
 			}
 
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}

--- a/stoa-go/internal/cli/cmd/root.go
+++ b/stoa-go/internal/cli/cmd/root.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stoa-platform/stoa-go/internal/cli/cmd/apply"
 	auditcmd "github.com/stoa-platform/stoa-go/internal/cli/cmd/audit"
 	"github.com/stoa-platform/stoa-go/internal/cli/cmd/auth"
-	catalogcmd "github.com/stoa-platform/stoa-go/internal/cli/cmd/catalog"
 	bridgecmd "github.com/stoa-platform/stoa-go/internal/cli/cmd/bridge"
+	catalogcmd "github.com/stoa-platform/stoa-go/internal/cli/cmd/catalog"
 	"github.com/stoa-platform/stoa-go/internal/cli/cmd/completion"
 	"github.com/stoa-platform/stoa-go/internal/cli/cmd/config"
 	connectcmd "github.com/stoa-platform/stoa-go/internal/cli/cmd/connect"
@@ -26,6 +26,7 @@ import (
 	"github.com/stoa-platform/stoa-go/internal/cli/cmd/subscription"
 	"github.com/stoa-platform/stoa-go/internal/cli/cmd/tenant"
 	"github.com/stoa-platform/stoa-go/internal/cli/cmd/token_usage"
+	"github.com/stoa-platform/stoa-go/internal/cli/cmdflags"
 )
 
 var (
@@ -34,9 +35,6 @@ var (
 	// Commit is set at build time
 	Commit = "none"
 )
-
-// AdminMode indicates whether --admin was passed (service account context).
-var AdminMode bool
 
 // NamespaceOverride holds the value of the persistent --namespace flag.
 // When non-empty, commands should prefer this over metadata.namespace / the
@@ -74,7 +72,7 @@ func Execute() error {
 }
 
 func init() {
-	rootCmd.PersistentFlags().BoolVar(&AdminMode, "admin", false, "Use service account token instead of user OIDC token")
+	rootCmd.PersistentFlags().BoolVar(&cmdflags.AdminMode, "admin", false, "Use service account token instead of user OIDC token")
 	// `-n` intentionally omitted: the `bridge` command already defines a
 	// local `-n` shortcut, and shadowing it globally would break existing
 	// scripts. Long form only; users still get kubectl-like UX.
@@ -114,13 +112,13 @@ var versionCmd = &cobra.Command{
 
 // ExitCode constants following ADR-001
 const (
-	ExitSuccess           = 0
-	ExitGeneralError      = 1
-	ExitMisuse            = 2
-	ExitAuthFailed        = 3
-	ExitResourceNotFound  = 4
-	ExitConflict          = 5
-	ExitValidationError   = 6
+	ExitSuccess          = 0
+	ExitGeneralError     = 1
+	ExitMisuse           = 2
+	ExitAuthFailed       = 3
+	ExitResourceNotFound = 4
+	ExitConflict         = 5
+	ExitValidationError  = 6
 )
 
 // Exit exits with the specified code

--- a/stoa-go/internal/cli/cmd/subscription/subscription.go
+++ b/stoa-go/internal/cli/cmd/subscription/subscription.go
@@ -5,6 +5,7 @@ package subscription
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/cmdflags"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 )
@@ -43,7 +44,7 @@ func newSubListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List subscriptions",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -100,7 +101,7 @@ func newSubGetCmd() *cobra.Command {
 		Short: "Get a subscription by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -135,7 +136,7 @@ func newSubApproveCmd() *cobra.Command {
 		Short: "Approve a pending subscription",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -156,7 +157,7 @@ func newSubRevokeCmd() *cobra.Command {
 		Short: "Revoke an active subscription",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}

--- a/stoa-go/internal/cli/cmd/tenant/tenant.go
+++ b/stoa-go/internal/cli/cmd/tenant/tenant.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/cmdflags"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 	"github.com/stoa-platform/stoa-go/pkg/types"
@@ -56,7 +57,7 @@ Example:
 }
 
 func runTenantStatus(cmd *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := client.NewForMode(cmdflags.AdminMode)
 	if err != nil {
 		return err
 	}
@@ -121,7 +122,7 @@ func newTenantCreateCmd() *cobra.Command {
 				displayName = name
 			}
 
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -157,7 +158,7 @@ func newTenantDeleteCmd() *cobra.Command {
 		Short: "Delete a tenant",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New()
+			c, err := client.NewForMode(cmdflags.AdminMode)
 			if err != nil {
 				return err
 			}
@@ -173,7 +174,7 @@ func newTenantDeleteCmd() *cobra.Command {
 }
 
 func runTenantList(cmd *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := client.NewForMode(cmdflags.AdminMode)
 	if err != nil {
 		return err
 	}
@@ -220,7 +221,7 @@ func runTenantList(cmd *cobra.Command, args []string) error {
 }
 
 func runTenantGet(cmd *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := client.NewForMode(cmdflags.AdminMode)
 	if err != nil {
 		return err
 	}

--- a/stoa-go/internal/cli/cmd/token_usage/token_usage.go
+++ b/stoa-go/internal/cli/cmd/token_usage/token_usage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stoa-platform/stoa-go/internal/cli/cmdflags"
 	"github.com/stoa-platform/stoa-go/pkg/client"
 	"github.com/stoa-platform/stoa-go/pkg/output"
 )
@@ -73,7 +74,7 @@ Examples:
 }
 
 func runTokenUsage(cmd *cobra.Command, args []string) error {
-	c, err := client.New()
+	c, err := client.NewForMode(cmdflags.AdminMode)
 	if err != nil {
 		return err
 	}

--- a/stoa-go/internal/cli/cmdflags/flags.go
+++ b/stoa-go/internal/cli/cmdflags/flags.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2026 CAB Ingénierie / Christophe ABOULICAM
+
+// Package cmdflags holds persistent CLI flag state shared between root.go
+// (which binds the flags) and subcommand packages (which read them).
+// It exists because `internal/cli/cmd` imports every subcommand package for
+// registration, so subcommands cannot import `cmd` back without creating an
+// import cycle.
+package cmdflags
+
+// AdminMode indicates whether --admin was passed. Subcommands pass this to
+// client.NewForMode to select between the user OIDC token and the service
+// account token.
+var AdminMode bool

--- a/stoa-go/pkg/client/client.go
+++ b/stoa-go/pkg/client/client.go
@@ -110,6 +110,18 @@ func New() (*Client, error) {
 	return client, nil
 }
 
+// NewForMode returns a client configured for the mode selected by the global
+// --admin CLI flag. When admin is true it delegates to NewAdmin (service
+// account token, resolved from STOA_ADMIN_KEY or the "<context>-admin" keychain
+// entry); otherwise it delegates to New (user OIDC token). Callers should pass
+// cmdflags.AdminMode so --admin plumbs through end-to-end (CAB-2107).
+func NewForMode(admin bool) (*Client, error) {
+	if admin {
+		return NewAdmin()
+	}
+	return New()
+}
+
 // NewWithConfig creates a client with specific config
 func NewWithConfig(baseURL, tenant, token string) *Client {
 	return &Client{

--- a/stoa-go/pkg/client/client_test.go
+++ b/stoa-go/pkg/client/client_test.go
@@ -77,8 +77,8 @@ func TestNewForMode_Admin(t *testing.T) {
 }
 
 // TestNewForMode_Admin_MissingToken surfaces the explicit "no admin token
-// found" error (the main DoD of CAB-2107) instead of falling through to an
-// unauthenticated 401. regression for CAB-2107.
+// found" error instead of falling through to an unauthenticated 401.
+// regression for CAB-2107
 func TestNewForMode_Admin_MissingToken(t *testing.T) {
 	seedTestContext(t)
 	t.Setenv("STOA_API_KEY", "")

--- a/stoa-go/pkg/client/client_test.go
+++ b/stoa-go/pkg/client/client_test.go
@@ -6,10 +6,92 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/stoa-platform/stoa-go/pkg/config"
 	"github.com/stoa-platform/stoa-go/pkg/types"
 )
+
+// seedTestContext writes a minimal stoactl config in a temp HOME so that
+// config.Load + GetCurrentContext succeed without touching the user's real
+// ~/.stoa directory. Returns the context name, which is unique per test so
+// that keychain lookups against "<name>-admin" reliably miss.
+func seedTestContext(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	name := "test-ctx-" + t.Name()
+	cfg := &config.Config{
+		APIVersion:     "stoa.io/v1",
+		Kind:           "Config",
+		CurrentContext: name,
+		Contexts: []config.Context{
+			{
+				Name: name,
+				Context: config.ContextDetail{
+					Server: "https://api.test.invalid",
+					Tenant: "test-tenant",
+				},
+			},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	return name
+}
+
+// TestNewForMode_User routes to New() when admin=false and honours STOA_API_KEY.
+func TestNewForMode_User(t *testing.T) {
+	seedTestContext(t)
+	t.Setenv("STOA_API_KEY", "user-env-token")
+	t.Setenv("STOA_ADMIN_KEY", "")
+
+	c, err := NewForMode(false)
+	if err != nil {
+		t.Fatalf("NewForMode(false) error = %v", err)
+	}
+	if !c.IsAuthenticated() {
+		t.Error("NewForMode(false) should load STOA_API_KEY")
+	}
+	if c.token != "user-env-token" {
+		t.Errorf("token = %q, want %q", c.token, "user-env-token")
+	}
+}
+
+// TestNewForMode_Admin routes to NewAdmin() when admin=true and honours STOA_ADMIN_KEY.
+func TestNewForMode_Admin(t *testing.T) {
+	seedTestContext(t)
+	t.Setenv("STOA_API_KEY", "")
+	t.Setenv("STOA_ADMIN_KEY", "admin-env-token")
+
+	c, err := NewForMode(true)
+	if err != nil {
+		t.Fatalf("NewForMode(true) error = %v", err)
+	}
+	if c.token != "admin-env-token" {
+		t.Errorf("token = %q, want %q", c.token, "admin-env-token")
+	}
+}
+
+// TestNewForMode_Admin_MissingToken surfaces the explicit "no admin token
+// found" error (the main DoD of CAB-2107) instead of falling through to an
+// unauthenticated 401.
+func TestNewForMode_Admin_MissingToken(t *testing.T) {
+	seedTestContext(t)
+	t.Setenv("STOA_API_KEY", "")
+	t.Setenv("STOA_ADMIN_KEY", "")
+
+	_, err := NewForMode(true)
+	if err == nil {
+		t.Fatal("NewForMode(true) without admin token: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no admin token found") {
+		t.Errorf("error = %v, want to mention 'no admin token found'", err)
+	}
+}
 
 // TestNewWithConfig tests client creation with specific config
 func TestNewWithConfig(t *testing.T) {

--- a/stoa-go/pkg/client/client_test.go
+++ b/stoa-go/pkg/client/client_test.go
@@ -78,7 +78,7 @@ func TestNewForMode_Admin(t *testing.T) {
 
 // TestNewForMode_Admin_MissingToken surfaces the explicit "no admin token
 // found" error (the main DoD of CAB-2107) instead of falling through to an
-// unauthenticated 401.
+// unauthenticated 401. regression for CAB-2107.
 func TestNewForMode_Admin_MissingToken(t *testing.T) {
 	seedTestContext(t)
 	t.Setenv("STOA_API_KEY", "")


### PR DESCRIPTION
## Summary

- `--admin` was bound globally in `cmd/root.go` but only `catalog` honoured it. All 44 other call sites (plus one the ticket missed in `logs/`) called `client.New()` directly, so the flag was silently ignored and expired user tokens surfaced as bare 401s.
- Added `client.NewForMode(admin bool)` helper that dispatches to `NewAdmin` (service account) or `New` (user OIDC). Godoc references the `--admin` flag.
- Moved `AdminMode` to new leaf `internal/cli/cmdflags` package so subcommands can read it without an import cycle (`cmd` already imports every subcommand).
- Migrated 45 `client.New()` call sites across 12 files to `client.NewForMode(cmdflags.AdminMode)`.

## Scope note — 45 sites, not 44

The ticket listed 11 files / 44 sites. `logs/logs.go` was missed; included for consistency so `stoactl logs --admin` behaves like every other command. `catalog/catalog.go` keeps its unconditional `NewAdmin()` call per ticket instruction (always-admin semantic).

## Acceptance criteria

- [x] `client.NewForMode` exists + godoc references `--admin`
- [x] 45 call sites migrated; `go build ./...`, `go vet ./...`, `gofmt -l` clean on touched files
- [x] Unit tests cover admin-mode token, user-mode token, admin-mode missing-token → explicit "no admin token found" error
- [x] `stoactl get apis --admin` without an admin token now returns "no admin token found. Set STOA_ADMIN_KEY or run 'stoactl auth login --admin'" instead of a 401 (covered by `TestNewForMode_Admin_MissingToken`)
- [x] `stoactl get apis` (no flag) still routes through `New()` (covered by `TestNewForMode_User`)
- [x] PR < 300 LOC (~220 net)

## Test plan

- [x] `go test ./pkg/client/... ./internal/cli/...` passes locally
- [x] `go build ./...` clean
- [ ] CI green
- [ ] Smoke test on stoa-prod after merge (pair with CAB-2108 service-account client)

## Related

- Unblocks CAB-2108 (stoactl-admin KC client — PR #2410)
- Related: CAB-2103 (KC realm gaps — AC-A shipped), CAB-2111, CAB-2110

🤖 Generated with [Claude Code](https://claude.com/claude-code)