### PR TITLE
fix(gateway): drop non-dict experimental.transports from InitializeResult (CAB-2112)

### DIFF
--- a/stoa-gateway/src/mcp/sse.rs
+++ b/stoa-gateway/src/mcp/sse.rs
@@ -833,11 +833,18 @@ async fn handle_initialize(
                 "levels": ["none", "moderate", "aggressive"]
             },
             // Advertise elicitation support (Phase 5)
-            "elicitation": {},
-            // Advertise supported transports (CAB-1345 Phase 3)
-            "experimental": {
-                "transports": ["sse", "websocket"]
-            }
+            "elicitation": {}
+            // CAB-2110: `experimental.transports` used to be advertised as
+            // `{"transports": ["sse", "websocket"]}` but MCP 2025-11-25 / the
+            // Anthropic Toolbox validator expect every value under
+            // `capabilities.experimental` to be a dict (per-feature config
+            // object), not an array. Claude.ai failed initialize with:
+            //   ValidationError: capabilities.experimental.transports
+            //   Input should be a valid dictionary
+            // HTTP-level transport is negotiated via URL + Accept anyway;
+            // advertising it in the JSON-RPC capabilities block was purely
+            // informational and outside the spec. Drop it entirely rather
+            // than reshape it into a dummy dict.
         },
         "serverInfo": {
             "name": "STOA Gateway",

--- a/stoa-gateway/tests/contract/initialize_schema.rs
+++ b/stoa-gateway/tests/contract/initialize_schema.rs
@@ -1,0 +1,122 @@
+//! MCP `InitializeResult` shape conformance (CAB-2110).
+//!
+//! Anthropic's Toolbox validates the `initialize` response against
+//! Pydantic schemas. Under `capabilities.experimental`, every value MUST
+//! be a dict (per-feature config object), never an array. Claude.ai
+//! rejected the connector with:
+//!
+//!     ValidationError: 1 validation error for InitializeResult
+//!     capabilities.experimental.transports
+//!       Input should be a valid dictionary [type=dict_type]
+//!
+//! This test freezes the contract so no one ever advertises a list under
+//! `experimental` again.
+
+use serde_json::{json, Value};
+
+use crate::common::TestApp;
+
+#[tokio::test]
+async fn regression_cab_2110_experimental_entries_are_all_dicts() {
+    let app = TestApp::new();
+
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "cab-2110", "version": "1.0"}
+        }
+    })
+    .to_string();
+
+    let (status, _headers, text) = app
+        .post_raw("/mcp/sse", &body, Some("application/json"), None)
+        .await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    let parsed: Value = serde_json::from_str(&text).expect("body must parse as JSON");
+    let result = parsed
+        .get("result")
+        .expect("initialize must return a result object");
+    let caps = result
+        .get("capabilities")
+        .and_then(|v| v.as_object())
+        .expect("capabilities must be an object");
+
+    // The `experimental` block, if present, must map feature-name → object.
+    if let Some(exp) = caps.get("experimental") {
+        let exp_obj = exp
+            .as_object()
+            .expect("capabilities.experimental must itself be a JSON object");
+        for (feature, value) in exp_obj {
+            assert!(
+                value.is_object(),
+                "capabilities.experimental.{} MUST be a JSON object, got {:?} — \
+                 re-advertising an array here would re-break the claude.ai connector \
+                 (Pydantic validator rejects dict_type).",
+                feature,
+                value
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn regression_cab_2110_initialize_result_shape_matches_spec() {
+    let app = TestApp::new();
+
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "cab-2110", "version": "1.0"}
+        }
+    })
+    .to_string();
+
+    let (_status, _headers, text) = app
+        .post_raw("/mcp/sse", &body, Some("application/json"), None)
+        .await;
+    let parsed: Value = serde_json::from_str(&text).expect("body must parse as JSON");
+    let result = parsed.get("result").expect("result required");
+
+    // Required scalar fields
+    assert!(
+        result
+            .get("protocolVersion")
+            .and_then(|v| v.as_str())
+            .is_some(),
+        "result.protocolVersion must be a string"
+    );
+    let server_info = result
+        .get("serverInfo")
+        .and_then(|v| v.as_object())
+        .expect("result.serverInfo must be an object");
+    assert!(server_info.get("name").and_then(|v| v.as_str()).is_some());
+    assert!(server_info
+        .get("version")
+        .and_then(|v| v.as_str())
+        .is_some());
+
+    // capabilities block must be an object; each standard sub-key must be
+    // either absent or an object (never an array).
+    let caps = result
+        .get("capabilities")
+        .and_then(|v| v.as_object())
+        .expect("result.capabilities must be an object");
+    for key in ["tools", "resources", "prompts", "logging", "elicitation"] {
+        if let Some(v) = caps.get(key) {
+            assert!(
+                v.is_object(),
+                "capabilities.{} must be an object, got {:?}",
+                key,
+                v
+            );
+        }
+    }
+}

--- a/stoa-gateway/tests/contract/main.rs
+++ b/stoa-gateway/tests/contract/main.rs
@@ -11,6 +11,7 @@ mod common;
 mod discovery;
 mod errors;
 mod health;
+mod initialize_schema;
 mod mcp_compliance;
 mod mcp_public_methods;
 mod oauth;


### PR DESCRIPTION
## Summary

The actual root cause for `claude.ai` Chrome connector rejecting `mcp.gostoa.dev`. Browser-side error (captured by the user):

```
Network error connecting to MCP server.
ValidationError: 1 validation error for InitializeResult
capabilities.experimental.transports
  Input should be a valid dictionary [type=dict_type]
```

`handle_initialize` advertised `"experimental": { "transports": ["sse", "websocket"] }` — but MCP 2025-11-25 (and the Anthropic Toolbox Pydantic schema) requires every value under `capabilities.experimental` to be a feature-config dict, never an array. Anthropic rejected the whole `InitializeResult`, claude.ai surfaced it as the generic "Authorization with the MCP server failed" (`ofid_d2fef633fa45878c` / `ofid_5f1fcc086cd04144`).

## Fix

Drop the non-standard `experimental.transports` field entirely. Transport is negotiated at the HTTP layer (URL + Accept header); this capability was purely informational and outside the spec.

## Test plan

- [x] `tests/contract/initialize_schema.rs` adds two regression tests: one walks `capabilities.experimental` and refuses non-object values (pins the claude.ai contract), one locks required fields in `InitializeResult`.
- [x] `cargo test` — 2158 lib + 52 contract + 52 integration + 15 resilience + 26 security, all green.
- [x] `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings` + `cargo fmt --check` clean.
- [ ] Post-rollout: `curl https://mcp.gostoa.dev/mcp/sse` initialize response no longer contains `experimental.transports`.
- [ ] claude.ai connector shows "Connected", tools list, one tool call succeeds. `ofid_*` no longer reproduces.

## Out of scope

- The broken `chat-completions-gpt4o` tool with its DNS-less upstream `stoa-aoai.openai.azure.com` trips the per-tool circuit breaker when actually invoked. Unrelated to the claude.ai initialize error; separate tool-registry cleanup.
- Shipped on top of CAB-2106 (Accept) and CAB-2109 (public_methods), both already live on 0.9.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)