### PR TITLE
feat(cp-api): /v1/internal/catalog/apis/expanded overlay (CAB-2113)

### DIFF
--- a/control-plane-api/src/routers/portal.py
+++ b/control-plane-api/src/routers/portal.py
@@ -24,6 +24,7 @@ from ..database import get_db as get_async_db
 from ..models.mcp_subscription import MCPServer, MCPServerCategory, MCPServerStatus, MCPServerTool
 from ..repositories.catalog import CatalogRepository, escape_like, get_allowed_audiences
 from ..schemas.portal import APIListItem, MCPServerListItem
+from ..services.mcp_tool_expander import expand_api
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/portal", tags=["Portal"])
@@ -175,6 +176,78 @@ async def internal_list_apis(
     except Exception as e:
         logger.error(f"Failed to list internal APIs: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to list APIs: {e!s}")
+
+
+class InternalExpandedTool(BaseModel):
+    """One MCP tool descriptor emitted by the expander (CAB-2113 Phase 0)."""
+
+    name: str
+    description: str
+    input_schema: dict | None = None
+    backend_url: str
+    http_method: str
+    tenant_id: str
+    path_pattern: str | None = None
+
+
+class InternalExpandedToolsResponse(BaseModel):
+    """Runtime-overlay tool list for the gateway API bridge.
+
+    Drop-in alternative to ``/apis`` that emits per-operation tools when an
+    ``openapi_spec`` is available on the catalog row, and the legacy coarse
+    ``{action, params}`` tool otherwise.
+    """
+
+    tools: list[InternalExpandedTool]
+
+
+@internal_router.get("/apis/expanded", response_model=InternalExpandedToolsResponse)
+async def internal_list_apis_expanded(
+    gateway_id: UUID | None = Query(None, description="Filter APIs assigned to this gateway (CAB-1940)"),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """Expand published APIs into per-operation MCP tool descriptors.
+
+    Internal endpoint — same auth model and gateway scoping as ``/apis``.
+    Consumed by ``stoa-gateway`` when ``STOA_TOOL_EXPANSION_MODE=per_operation``.
+
+    Falls back to a single coarse tool per API when ``openapi_spec`` is missing
+    so switching the gateway flag is safe even on a partially-specced catalog.
+    """
+    try:
+        repo = CatalogRepository(db)
+        apis, _total = await repo.get_portal_apis(page=1, page_size=100, gateway_id=gateway_id)
+
+        tools: list[InternalExpandedTool] = []
+        for api in apis:
+            metadata: dict = api.api_metadata or {}
+            backend_url: str = metadata.get("backend_url") or ""
+            if not backend_url:
+                continue
+            expanded = expand_api(
+                api_id=str(api.api_id),
+                tenant_id=str(api.tenant_id),
+                api_name=str(api.api_name or api.api_id),
+                backend_url=backend_url,
+                openapi_spec=api.openapi_spec if isinstance(api.openapi_spec, dict) else None,
+            )
+            for t in expanded:
+                tools.append(
+                    InternalExpandedTool(
+                        name=t.name,
+                        description=t.description,
+                        input_schema=t.input_schema,
+                        backend_url=t.backend_url,
+                        http_method=t.http_method,
+                        tenant_id=t.tenant_id,
+                        path_pattern=t.path_pattern,
+                    )
+                )
+        return InternalExpandedToolsResponse(tools=tools)
+
+    except Exception as e:
+        logger.error(f"Failed to expand internal APIs: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to expand APIs: {e!s}")
 
 
 class PortalMCPServerResponse(BaseModel):

--- a/control-plane-api/src/services/mcp_tool_expander.py
+++ b/control-plane-api/src/services/mcp_tool_expander.py
@@ -1,0 +1,229 @@
+"""MCP tool expander (CAB-2113 Phase 0).
+
+Turns a catalog API into a list of MCP tool descriptors ready to be consumed by
+``stoa-gateway`` over ``GET /v1/internal/catalog/apis/expanded``. Two modes:
+
+1. **Per-operation** (``openapi_spec`` provided): one tool per
+   ``paths[].operations`` entry, with input schema merged from path params,
+   query params and request body. Tool name follows the existing
+   ``{tenant}:{api}:{operation}`` convention used by ``UacToolGenerator``.
+2. **Coarse fallback** (``openapi_spec is None``): one tool with the legacy
+   ``{action, params}`` schema — matches today's hardcoded gateway behaviour in
+   ``stoa-gateway/src/mcp/tools/api_bridge.rs`` so ``/apis/expanded`` stays a
+   drop-in replacement for ``/apis`` when a spec isn't available.
+
+Pure function — no DB access, no I/O. Designed to be called from the
+``/v1/internal/catalog/apis/expanded`` router once per request and is cheap
+enough to not need caching at this stage.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+_HTTP_METHODS: tuple[str, ...] = ("get", "post", "put", "patch", "delete", "head", "options")
+
+
+@dataclass(frozen=True)
+class ExpandedTool:
+    """MCP tool descriptor emitted by the expander.
+
+    Immutable (``frozen=True``) so background refresh loops on the gateway
+    side can't accidentally mutate registry state across ticks.
+    """
+
+    name: str
+    description: str
+    input_schema: dict[str, Any] | None
+    backend_url: str
+    http_method: str
+    tenant_id: str
+    path_pattern: str | None = None
+
+
+def expand_api(
+    api_id: str,
+    tenant_id: str,
+    api_name: str,
+    backend_url: str,
+    openapi_spec: dict[str, Any] | None,
+) -> list[ExpandedTool]:
+    """Expand a single catalog API into one or more MCP tool descriptors."""
+    if openapi_spec is None:
+        return [_coarse_tool(api_id, api_name, backend_url, tenant_id)]
+
+    paths = openapi_spec.get("paths") or {}
+    if not isinstance(paths, dict):
+        return []
+
+    tools: list[ExpandedTool] = []
+    for path, path_item in paths.items():
+        if not isinstance(path_item, dict):
+            continue
+        for method in _HTTP_METHODS:
+            operation = path_item.get(method)
+            if not isinstance(operation, dict):
+                continue
+            tools.append(
+                _operation_to_tool(
+                    api_id=api_id,
+                    tenant_id=tenant_id,
+                    backend_url=backend_url,
+                    path=path,
+                    method=method.upper(),
+                    operation=operation,
+                )
+            )
+    return tools
+
+
+def _operation_to_tool(
+    *,
+    api_id: str,
+    tenant_id: str,
+    backend_url: str,
+    path: str,
+    method: str,
+    operation: dict[str, Any],
+) -> ExpandedTool:
+    op_id = operation.get("operationId")
+    name = _build_tool_name(tenant_id, api_id, op_id, path, method)
+    description = _build_description(operation, path, method)
+    input_schema = _build_input_schema(operation, path)
+
+    return ExpandedTool(
+        name=name,
+        description=description,
+        input_schema=input_schema,
+        backend_url=backend_url,
+        http_method=method,
+        tenant_id=tenant_id,
+        path_pattern=path,
+    )
+
+
+def _coarse_tool(api_id: str, api_name: str, backend_url: str, tenant_id: str) -> ExpandedTool:
+    """Single coarse tool, matching today's ``api_bridge.rs`` behaviour verbatim."""
+    description = api_name or api_id
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "description": "API action to perform (e.g. get-status, list, create)",
+            },
+            "params": {
+                "type": "object",
+                "description": "Additional parameters for the API call",
+            },
+        },
+        "required": [],
+    }
+    return ExpandedTool(
+        name=api_id,
+        description=description,
+        input_schema=input_schema,
+        backend_url=backend_url,
+        http_method="POST",
+        tenant_id=tenant_id,
+    )
+
+
+def _build_tool_name(
+    tenant_id: str,
+    api_id: str,
+    operation_id: str | None,
+    path: str,
+    method: str,
+) -> str:
+    """Return ``{tenant}:{api}:{operation_slug}``.
+
+    Slug rules mirror ``UacToolGenerator._build_tool_name`` so the naming stays
+    consistent with tools coming from the UAC contract pipeline.
+    """
+    if operation_id:
+        slug = re.sub(r"[^a-zA-Z0-9_]", "_", operation_id).lower()
+    else:
+        path_slug = re.sub(r"[{}]", "", path)
+        path_slug = re.sub(r"[^a-zA-Z0-9/]", "_", path_slug).strip("/_").replace("/", "_")
+        slug = f"{method.lower()}_{path_slug}"
+    return f"{tenant_id}:{api_id}:{slug}"
+
+
+def _build_description(operation: dict[str, Any], path: str, method: str) -> str:
+    summary = operation.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        return summary.strip()
+    desc = operation.get("description")
+    if isinstance(desc, str) and desc.strip():
+        return desc.strip()
+    return f"{method} {path}"
+
+
+def _build_input_schema(operation: dict[str, Any], path: str) -> dict[str, Any] | None:
+    """Merge path + query parameters with requestBody into a single JSON Schema.
+
+    Path-param substitution at call time happens gateway-side; we simply surface
+    them as required string properties so the LLM knows to supply them.
+    """
+    properties: dict[str, dict[str, Any]] = {}
+    required: list[str] = []
+
+    for param in operation.get("parameters") or []:
+        if not isinstance(param, dict):
+            continue
+        location = param.get("in")
+        if location not in ("path", "query"):
+            continue
+        name = param.get("name")
+        if not isinstance(name, str):
+            continue
+        raw_schema = param.get("schema")
+        schema: dict[str, Any] = raw_schema if isinstance(raw_schema, dict) else {"type": "string"}
+        prop: dict[str, Any] = dict(schema)
+        if description := param.get("description"):
+            prop["description"] = description
+        properties[name] = prop
+        if param.get("required") or location == "path":
+            required.append(name)
+
+    body_schema = _extract_request_body_schema(operation)
+    if body_schema and isinstance(body_schema.get("properties"), dict):
+        for name, prop in body_schema["properties"].items():
+            if name not in properties:
+                properties[name] = prop
+        for name in body_schema.get("required") or []:
+            if name in properties and name not in required:
+                required.append(name)
+    elif body_schema:
+        properties["body"] = body_schema
+
+    # Fallback to path-only parameters if nothing was captured (matches
+    # UacToolGenerator._build_input_schema behaviour).
+    if not properties:
+        path_params = re.findall(r"\{(\w+)\}", path)
+        if not path_params:
+            return None
+        return {
+            "type": "object",
+            "properties": {p: {"type": "string", "description": f"Path parameter: {p}"} for p in path_params},
+            "required": path_params,
+        }
+
+    return {"type": "object", "properties": properties, "required": required}
+
+
+def _extract_request_body_schema(operation: dict[str, Any]) -> dict[str, Any] | None:
+    request_body = operation.get("requestBody")
+    if not isinstance(request_body, dict):
+        return None
+    content = request_body.get("content")
+    if not isinstance(content, dict):
+        return None
+    json_content = content.get("application/json")
+    if not isinstance(json_content, dict):
+        return None
+    schema = json_content.get("schema")
+    return schema if isinstance(schema, dict) else None

--- a/control-plane-api/tests/test_mcp_tool_expander.py
+++ b/control-plane-api/tests/test_mcp_tool_expander.py
@@ -1,0 +1,229 @@
+"""Tests for MCP tool expander (CAB-2113 Phase 0).
+
+The expander turns a catalog API (with optional OpenAPI spec) into a list of
+MCP tool descriptors. Two modes:
+- Per-operation: iterate OpenAPI paths, emit one tool per operation.
+- Coarse fallback (no openapi_spec): emit one tool with the legacy
+  ``{action, params}`` schema so the expanded endpoint stays a drop-in
+  replacement for ``/v1/internal/catalog/apis`` when a spec isn't available.
+
+Router integration test lives below and exercises
+``GET /v1/internal/catalog/apis/expanded`` end-to-end through a TestClient
+with the CatalogRepository boundary mocked.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.mcp_tool_expander import ExpandedTool, expand_api
+
+BANKING_OPENAPI: dict[str, Any] = {
+    "openapi": "3.0.3",
+    "info": {"title": "Banking", "version": "1.0.0"},
+    "paths": {
+        "/customers": {
+            "get": {
+                "operationId": "listCustomers",
+                "summary": "List all customers",
+                "responses": {"200": {"description": "ok"}},
+            },
+            "post": {
+                "operationId": "createCustomer",
+                "summary": "Create a customer",
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {"name": {"type": "string"}},
+                                "required": ["name"],
+                            }
+                        }
+                    },
+                },
+                "responses": {"201": {"description": "created"}},
+            },
+        },
+        "/customers/{number}": {
+            "get": {
+                "operationId": "getCustomerByNumber",
+                "summary": "Get a customer by number",
+                "parameters": [
+                    {"name": "number", "in": "path", "required": True, "schema": {"type": "string"}},
+                ],
+                "responses": {"200": {"description": "ok"}},
+            },
+        },
+    },
+}
+
+
+class TestExpandApiPerOperation:
+    """Per-operation expansion when openapi_spec is present."""
+
+    def test_emits_one_tool_per_operation(self) -> None:
+        tools = expand_api(
+            api_id="banking",
+            tenant_id="oasis",
+            api_name="Banking API",
+            backend_url="http://banking.svc:8080",
+            openapi_spec=BANKING_OPENAPI,
+        )
+        assert len(tools) == 3
+        names = {t.name for t in tools}
+        assert "oasis:banking:listcustomers" in names
+        assert "oasis:banking:createcustomer" in names
+        assert "oasis:banking:getcustomerbynumber" in names
+
+    def test_tool_carries_http_method(self) -> None:
+        tools = {t.name: t for t in expand_api("banking", "oasis", "Banking", "http://b", BANKING_OPENAPI)}
+        assert tools["oasis:banking:listcustomers"].http_method == "GET"
+        assert tools["oasis:banking:createcustomer"].http_method == "POST"
+
+    def test_path_pattern_surfaces_params(self) -> None:
+        tools = {t.name: t for t in expand_api("banking", "oasis", "Banking", "http://b", BANKING_OPENAPI)}
+        by_number = tools["oasis:banking:getcustomerbynumber"]
+        assert by_number.path_pattern == "/customers/{number}"
+        assert by_number.input_schema is not None
+        assert "number" in (by_number.input_schema.get("properties") or {})
+
+    def test_tenant_id_propagated(self) -> None:
+        tools = expand_api("banking", "oasis", "Banking", "http://b", BANKING_OPENAPI)
+        assert all(t.tenant_id == "oasis" for t in tools)
+
+    def test_backend_url_in_every_tool(self) -> None:
+        tools = expand_api("banking", "oasis", "Banking", "http://banking.svc:8080", BANKING_OPENAPI)
+        # Backend URL is the API-level base; path info travels via path_pattern.
+        assert all(t.backend_url == "http://banking.svc:8080" for t in tools)
+
+    def test_scales_to_fifty_operations(self) -> None:
+        """CAB-2113 challenger callout: sanity-check on a ≥50-op spec."""
+        paths: dict[str, Any] = {}
+        for i in range(50):
+            paths[f"/op{i}"] = {
+                "get": {
+                    "operationId": f"op{i}",
+                    "summary": f"Operation {i}",
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        spec = {"openapi": "3.0.3", "info": {"title": "Large", "version": "1"}, "paths": paths}
+
+        tools = expand_api("large", "oasis", "Large", "http://x", spec)
+
+        assert len(tools) == 50
+        assert len({t.name for t in tools}) == 50, "tool names must be unique"
+
+    def test_empty_paths_yields_empty_list(self) -> None:
+        spec = {"openapi": "3.0.3", "info": {"title": "Empty", "version": "1"}, "paths": {}}
+        assert expand_api("empty", "oasis", "Empty", "http://x", spec) == []
+
+
+class TestExpandApiCoarseFallback:
+    """Fallback when openapi_spec is missing — mirrors today's gateway coarse tool."""
+
+    def test_emits_single_coarse_tool_when_spec_is_none(self) -> None:
+        tools = expand_api(
+            api_id="petstore",
+            tenant_id="oasis",
+            api_name="Petstore",
+            backend_url="http://petstore.svc:80",
+            openapi_spec=None,
+        )
+        assert len(tools) == 1
+
+    def test_coarse_tool_has_legacy_action_params_schema(self) -> None:
+        """Ship-safe fallback must preserve the today's gateway input shape so
+        MCP clients seeing a mix of coarse + expanded tools don't observe a
+        regression on APIs that lack a spec."""
+        (coarse,) = expand_api("petstore", "oasis", "Petstore", "http://x", None)
+        assert coarse.input_schema is not None
+        props = coarse.input_schema.get("properties") or {}
+        assert "action" in props
+        assert "params" in props
+
+    def test_coarse_tool_name_is_plain_api_id(self) -> None:
+        """Matches api_bridge.rs today — tool name == api slug."""
+        (coarse,) = expand_api("petstore", "oasis", "Petstore", "http://x", None)
+        assert coarse.name == "petstore"
+
+
+class TestInternalCatalogExpandedRouter:
+    """Router smoke test for GET /v1/internal/catalog/apis/expanded."""
+
+    @pytest.fixture
+    def mock_repo(self):
+        """Mock CatalogRepository but keep the expander real — boundary integrity."""
+        with patch("src.routers.portal.CatalogRepository") as cls:
+            repo = MagicMock()
+            repo.get_portal_apis = AsyncMock(return_value=([], 0))
+            cls.return_value = repo
+            yield repo
+
+    def test_empty_catalog_returns_empty_tool_list(self, client, mock_repo) -> None:
+        resp = client.get("/v1/internal/catalog/apis/expanded")
+        assert resp.status_code == 200
+        assert resp.json() == {"tools": []}
+
+    def test_catalog_with_spec_expands_to_per_operation_tools(self, client, mock_repo) -> None:
+        api = MagicMock()
+        api.api_id = "banking"
+        api.api_name = "Banking API"
+        api.tenant_id = "oasis"
+        api.version = "1.0.0"
+        api.api_metadata = {"backend_url": "http://banking.svc:8080"}
+        api.openapi_spec = BANKING_OPENAPI
+        mock_repo.get_portal_apis = AsyncMock(return_value=([api], 1))
+
+        resp = client.get("/v1/internal/catalog/apis/expanded")
+
+        assert resp.status_code == 200
+        names = [t["name"] for t in resp.json()["tools"]]
+        assert "oasis:banking:listcustomers" in names
+        assert "oasis:banking:createcustomer" in names
+        assert "oasis:banking:getcustomerbynumber" in names
+
+    def test_catalog_without_spec_falls_back_to_coarse_tool(self, client, mock_repo) -> None:
+        api = MagicMock()
+        api.api_id = "petstore"
+        api.api_name = "Petstore"
+        api.tenant_id = "oasis"
+        api.version = "1.0.0"
+        api.api_metadata = {"backend_url": "http://petstore.svc:80"}
+        api.openapi_spec = None
+        mock_repo.get_portal_apis = AsyncMock(return_value=([api], 1))
+
+        resp = client.get("/v1/internal/catalog/apis/expanded")
+
+        assert resp.status_code == 200
+        tools = resp.json()["tools"]
+        assert len(tools) == 1
+        assert tools[0]["name"] == "petstore"
+
+    def test_gateway_id_filter_passed_through(self, client, mock_repo) -> None:
+        import uuid as _uuid
+
+        gw = _uuid.uuid4()
+        client.get(f"/v1/internal/catalog/apis/expanded?gateway_id={gw}")
+        kwargs = mock_repo.get_portal_apis.await_args.kwargs
+        assert kwargs.get("gateway_id") == gw
+
+
+def test_expanded_tool_is_immutable() -> None:
+    """Regression guard against mutable tool defs leaking state across refreshes."""
+    t = ExpandedTool(
+        name="x",
+        description="y",
+        input_schema=None,
+        backend_url="http://z",
+        http_method="GET",
+        tenant_id="oasis",
+    )
+    with pytest.raises(FrozenInstanceError):
+        t.name = "other"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Phase 0 of the CAB-2113 Decision-Gate-patched plan: runtime overlay that expands each catalog API into per-operation MCP tool descriptors, zero catalog schema change, additive endpoint.
- New `mcp_tool_expander.expand_api` pure function + `GET /v1/internal/catalog/apis/expanded` internal endpoint.
- Ship-safe fallback to the legacy coarse `{action, params}` shape when an API has no `openapi_spec` — switching the gateway over in PR2 is safe on a partially-specced catalog.

## Context

CAB-2113 started as a suspected Kafka-sync bug between admin-API writes and the gateway tool registry. Investigation showed the gateway's tool registry is hydrated from `GET /v1/internal/catalog/apis` (API-level metadata only), and `stoa-gateway/src/mcp/tools/api_bridge.rs` hardcodes a single coarse `{action, params}` tool per API. Admin-API writes to `mcp_servers` / `mcp_tools` never reach the gateway because that path isn't wired.

The reframed plan (Option B, extend the catalog to hold granular Tool CRDs) was challenged via the HLFH Decision Gate (log #5, GPT-5 VALID 5/5, erreur évitée = Y) — shipping catalog CRDs before measuring whether per-operation MCP tools actually improve LLM selection would have frozen an unvalidated interaction model into the product surface. This PR implements the patched Phase 0: a runtime overlay that lets us wire up per-operation tools without any catalog schema commitment, so Phase 0.5 can measure (coarse vs per-op vs enriched single tool) and only then decide whether to persist granular tools in the catalog.

## What this PR does

- New module `control-plane-api/src/services/mcp_tool_expander.py`:
  - `expand_api(api_id, tenant_id, api_name, backend_url, openapi_spec) -> list[ExpandedTool]`
  - Per-operation mode walks `paths[].operations`, merges path + query + `requestBody` into one JSON Schema per operation
  - Coarse fallback matches the `{action, params}` shape emitted today by `api_bridge.rs:107-128` so no-spec APIs keep working when the gateway flips the flag
  - Tool names follow `{tenant}:{api}:{op}`, the convention already used by `UacToolGenerator`
  - `ExpandedTool` is a frozen dataclass (prevents accidental mutation across refresh ticks on the consumer side)
- New endpoint in `control-plane-api/src/routers/portal.py`:
  - `GET /v1/internal/catalog/apis/expanded?gateway_id=…`
  - Same internal (no-JWT) auth model and gateway scoping as the existing `/apis`
  - Skips APIs without a `backend_url` (same behaviour as `/apis`)

## What this PR does NOT do

- No change to the existing `/v1/internal/catalog/apis` endpoint
- No DB migration, no catalog schema change, no new CRD kind
- No gateway change yet — the `STOA_TOOL_EXPANSION_MODE` env flag, `api_bridge.rs` branch, path-param substitution in `DynamicTool`, and the runbook land in PR2

## Test plan

- [x] 15/15 unit + router tests pass locally (`pytest tests/test_mcp_tool_expander.py`)
  - 7 per-operation tests including a 50-operation scalability check (CAB-2113 challenger callout)
  - 3 coarse-fallback tests confirming parity with today's gateway shape
  - 4 router tests via `TestClient` with a mocked `CatalogRepository` (boundary integrity: expander under test is real)
  - 1 immutability regression test on `ExpandedTool`
- [x] Existing `tests/test_portal_apis.py` + `tests/test_regression_cab_1940.py` green (no regression)
- [x] `ruff check` + `black --check --line-length 120` + `mypy` clean on the three touched files
- [ ] CI to confirm on green branch
- [ ] Post-merge: Phase 0.5 harness (separate ticket) will hit `/expanded` and compare LLM selection accuracy against the current coarse path before we decide on catalog persistence

## Related

- Ticket: CAB-2113
- Decision Gate log: `stoa-docs/HEGEMON/DECISION_GATE.md#5`
- Follow-ups: PR2 (gateway flag + consumer + DynamicTool path-param substitution + runbook), CAB-211x (`stoactl bridge --namespace` semantic divergence flagged during investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)