### PR TITLE
feat(gateway): tool-expansion observability + runbook (CAB-2113 PR3)

### DIFF
--- a/control-plane-api/src/routers/portal.py
+++ b/control-plane-api/src/routers/portal.py
@@ -209,7 +209,9 @@ async def internal_list_apis_expanded(
     """Expand published APIs into per-operation MCP tool descriptors.
 
     Internal endpoint — same auth model and gateway scoping as ``/apis``.
-    Consumed by ``stoa-gateway`` when ``STOA_TOOL_EXPANSION_MODE=per_operation``.
+    Consumed by ``stoa-gateway`` when ``STOA_TOOL_EXPANSION_MODE=per-op``
+    (canonical kebab-case; ``per_operation`` still accepted as a deprecated
+    alias for one release, see CAB-2113 PR3).
 
     Falls back to a single coarse tool per API when ``openapi_spec`` is missing
     so switching the gateway flag is safe even on a partially-specced catalog.

--- a/docs/runbooks/tool-expansion-mode.md
+++ b/docs/runbooks/tool-expansion-mode.md
@@ -1,0 +1,116 @@
+# Runbook: Gateway Tool Expansion Mode
+
+> **Severity**: Medium (flag flip, reversible within one refresh cycle)
+> **Last updated**: 2026-04-19
+> **Owner**: Platform Team
+> **Linear Issue**: CAB-2113
+
+Covers `STOA_TOOL_EXPANSION_MODE` — the CAB-2113 Phase 0 runtime overlay that controls how the gateway exposes catalog APIs as MCP tools. Phase 0.5 (CAB-2116) gates further evolution.
+
+---
+
+## 1. What the flag does
+
+| Value | Canonical | Gateway behaviour |
+|-------|-----------|-------------------|
+| `coarse` (default) | kebab | One `{action, params}` tool per API. Consumes `GET /v1/internal/catalog/apis`. Legacy behaviour. |
+| `per-op` | kebab | One MCP tool per OpenAPI operation. Consumes `GET /v1/internal/catalog/apis/expanded`. Input schema is the per-op params + requestBody; path params substituted server-side by `DynamicTool`. |
+| `per_operation` | **deprecated alias** | Same as `per-op`. Accepted for one release to bridge the pre-2026-04-19 doc drift. Emit a warning in your own tooling and migrate to `per-op`. |
+
+Flipping is safe in both directions: the change takes effect at the next refresh tick (≤60s, see `API_TOOL_REFRESH_INTERVAL` in `api_bridge.rs`). Existing `tools/list` results for the previous mode stop being served; in-flight calls finish on whatever tool was registered when the call started.
+
+---
+
+## 2. How to flip per gateway / per tenant
+
+### 2.1 Canary one gateway
+
+Helm value (`values.yaml` for that gateway release only):
+
+```yaml
+env:
+  - name: STOA_TOOL_EXPANSION_MODE
+    value: per-op
+```
+
+Roll the deployment — no restart required beyond the usual Helm upgrade. On OVH prod:
+
+```bash
+helm -n stoa-system upgrade stoa-gateway charts/stoa-gateway \
+  --reuse-values --set env[0].name=STOA_TOOL_EXPANSION_MODE --set env[0].value=per-op
+```
+
+Watch `stoa_gateway_tool_expansion_refresh_total{mode="per-op",result="ok"}` tick up within 60s, and `stoa_gateway_tool_expansion_ops_registered{mode="per-op"}` populate with the expected per-op count.
+
+### 2.2 Per-tenant flip
+
+Not directly supported in Phase 0 — the flag is gateway-wide. For a tenant-scoped trial, deploy a dedicated gateway pool for the tenant and set the flag on that pool only. Tenant-scoped flipping is a Phase 1 question, gated on the CAB-2116 outcome.
+
+### 2.3 Rollback
+
+Set the env back to `coarse` (or remove the env — default is coarse) and redeploy. The next refresh tick repopulates the registry with the coarse shape. No pod restart required beyond the Helm upgrade.
+
+```bash
+helm -n stoa-system upgrade stoa-gateway charts/stoa-gateway \
+  --reuse-values --set env[0].value=coarse
+```
+
+Full rollback window: ≤60s (next refresh) from the env change taking effect on the running pod.
+
+---
+
+## 3. Observability
+
+Three Prometheus metrics introduced in CAB-2113 PR3. Scraped from the gateway `/metrics` endpoint (see `charts/stoa-gateway/templates/servicemonitor.yaml`).
+
+| Metric | Type | Labels | Use |
+|--------|------|--------|-----|
+| `stoa_gateway_tool_expansion_refresh_total` | Counter | `mode`, `result` | Rate of successful / failed refresh cycles per mode. |
+| `stoa_gateway_tool_expansion_ops_registered` | Gauge | `mode` | Tools newly registered at the last refresh cycle (0 in steady state once all ops are already registered). |
+| `stoa_gateway_tool_expansion_errors_total` | Counter | `reason` | Categorised errors: `transport`, `upstream_status`, `parse`. Pinpoints CP-API vs network vs schema-shape issues. |
+
+### PromQL examples
+
+Refresh success rate per mode (last hour):
+
+```promql
+sum by (mode) (rate(stoa_gateway_tool_expansion_refresh_total{result="ok"}[1h]))
+/
+sum by (mode) (rate(stoa_gateway_tool_expansion_refresh_total[1h]))
+```
+
+Error budget — spike on `upstream_status` typically means CP-API is returning 5xx on `/apis/expanded`:
+
+```promql
+sum by (reason) (rate(stoa_gateway_tool_expansion_errors_total[5m]))
+```
+
+Tool-count drift — gauge goes back to 0 once registry is steady:
+
+```promql
+stoa_gateway_tool_expansion_ops_registered{mode="per-op"}
+```
+
+### Alerting
+
+No hard alert wired today. Phase 0.5 harness (CAB-2116) will exercise the metrics; alert rules land with Phase 1 if that gate goes GREEN.
+
+---
+
+## 4. Known limitations
+
+- **Path-param vs body-param collision**: when an OpenAPI spec has a parameter with the same name both in the URL path and in the request body (rare in practice), `DynamicTool` routes it to the path and drops it from the body. No disambiguation yet. Track via a dedicated ticket if you hit this on a real spec — not observed on banking-services-v1-2, payment-api, or fapi-accounts as of 2026-04-19.
+- **Tool-count scalability** beyond ~200 ops is unmeasured. CAB-2116 Phase 0.5 will test 50/100/200 explicitly; do not run `per-op` on a gateway serving >200 ops in prod until the scalability subset is green.
+- **Same-action across APIs**: the `per-op` mode uses `{tenant}:{api}:{op_id}` as tool name, so two APIs sharing the same `operationId` don't collide. `coarse` mode names tools by API slug, so two APIs with the same slug in different tenants is already broken regardless of this flag.
+- **Auth translation**: `DynamicTool` forwards the caller's Bearer token. Upstreams requiring X-API-Key / Basic auth (e.g., banking-mock in the demo) need an auth-translation policy layered separately — not part of this flag's behaviour.
+
+---
+
+## 5. Related
+
+- CAB-2113 Phase 0 PR1 (#2415) — CP-API `/apis/expanded` endpoint
+- CAB-2113 Phase 0 PR2 (#2420) — gateway consumer + `ExpansionMode` enum + `DynamicTool` path-pattern substitution
+- CAB-2113 Phase 0 PR3 (this runbook) — observability + docstring drift fix + `per_operation` serde alias
+- CAB-2116 — Phase 0.5 LLM tool-selection benchmark (gate before catalog CRDs)
+- CAB-2117 — `stoactl --tenant` vs `--namespace` separation (surfaced during Phase 0 investigation)
+- ADR-024 — Gateway 4-mode architecture (edge-mcp, sidecar, proxy, shadow)

--- a/stoa-gateway/src/config.rs
+++ b/stoa-gateway/src/config.rs
@@ -1259,6 +1259,11 @@ fn default_tool_max_staleness_secs() -> u64 {
 }
 
 /// Catalog tool expansion mode (CAB-2113 Phase 0).
+///
+/// `per-op` is the canonical kebab-case value; `per_operation` is accepted as
+/// a deprecated alias so existing docs / manifests keep parsing (PR3 doc drift
+/// fix: `control-plane-api/src/routers/portal.py` pre-2026-04-19 used the
+/// snake form). Prefer the canonical form in new configs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum ExpansionMode {
@@ -1266,6 +1271,7 @@ pub enum ExpansionMode {
     #[default]
     Coarse,
     /// One tool per OpenAPI operation via `/apis/expanded`.
+    #[serde(alias = "per_operation")]
     PerOp,
 }
 
@@ -1948,5 +1954,20 @@ mod tests {
             config.keycloak_backend_url(),
             Some("http://keycloak.stoa-system.svc.cluster.local:8080")
         );
+    }
+
+    #[test]
+    fn expansion_mode_accepts_kebab_and_snake_alias() {
+        // Canonical kebab-case value (CAB-2113 Phase 0).
+        let kebab: ExpansionMode = serde_json::from_str("\"per-op\"").unwrap();
+        assert_eq!(kebab, ExpansionMode::PerOp);
+
+        // Deprecated snake-case alias — kept only for the PR3 doc-drift window
+        // on `control-plane-api/src/routers/portal.py`. Drop with Release N+1.
+        let snake: ExpansionMode = serde_json::from_str("\"per_operation\"").unwrap();
+        assert_eq!(snake, ExpansionMode::PerOp);
+
+        // Default stays coarse — flipping to per-op must be explicit.
+        assert_eq!(ExpansionMode::default(), ExpansionMode::Coarse);
     }
 }

--- a/stoa-gateway/src/mcp/tools/api_bridge.rs
+++ b/stoa-gateway/src/mcp/tools/api_bridge.rs
@@ -362,18 +362,54 @@ pub fn start_api_tool_refresh_task(
                 }
             };
 
+            let mode_label = expansion_mode_label(mode);
             match result {
                 Ok(count) => {
+                    crate::metrics::TOOL_EXPANSION_REFRESH_TOTAL
+                        .with_label_values(&[mode_label, "ok"])
+                        .inc();
+                    crate::metrics::TOOL_EXPANSION_OPS_REGISTERED
+                        .with_label_values(&[mode_label])
+                        .set(count as f64);
                     if count > 0 {
                         info!(count, mode = ?mode, "New API tools discovered from catalog");
                     }
                 }
                 Err(e) => {
+                    crate::metrics::TOOL_EXPANSION_REFRESH_TOTAL
+                        .with_label_values(&[mode_label, "err"])
+                        .inc();
+                    crate::metrics::TOOL_EXPANSION_ERRORS_TOTAL
+                        .with_label_values(&[classify_refresh_error(&e)])
+                        .inc();
                     debug!(error = %e, mode = ?mode, "API tool refresh failed (keeping existing tools)");
                 }
             }
         }
     });
+}
+
+/// Stable Prometheus label for an `ExpansionMode`. Kept as a free fn so tests
+/// can assert the label surface without touching the metric registry.
+fn expansion_mode_label(mode: ExpansionMode) -> &'static str {
+    match mode {
+        ExpansionMode::Coarse => "coarse",
+        ExpansionMode::PerOp => "per-op",
+    }
+}
+
+/// Coarse categorisation of refresh error strings for the
+/// `stoa_gateway_tool_expansion_errors_total{reason=...}` counter. The matching
+/// order matters: parse errors come from `resp.json()` after a successful HTTP
+/// status, so they must be checked before the generic transport bucket.
+fn classify_refresh_error(err: &str) -> &'static str {
+    if err.contains("Failed to parse") {
+        "parse"
+    } else if err.contains("returned") {
+        "upstream_status"
+    } else {
+        "transport"
+    }
 }
 
 #[cfg(test)]
@@ -801,5 +837,27 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.contains("500"), "got: {err}");
+    }
+
+    #[test]
+    fn expansion_mode_label_is_kebab_canonical() {
+        assert_eq!(expansion_mode_label(ExpansionMode::Coarse), "coarse");
+        assert_eq!(expansion_mode_label(ExpansionMode::PerOp), "per-op");
+    }
+
+    #[test]
+    fn classify_refresh_error_buckets_parse_upstream_transport() {
+        assert_eq!(
+            classify_refresh_error("Failed to parse CP expanded catalog response: eof"),
+            "parse"
+        );
+        assert_eq!(
+            classify_refresh_error("CP expanded catalog returned 503: unavailable"),
+            "upstream_status"
+        );
+        assert_eq!(
+            classify_refresh_error("CP expanded catalog request failed: connection refused"),
+            "transport"
+        );
     }
 }

--- a/stoa-gateway/src/metrics.rs
+++ b/stoa-gateway/src/metrics.rs
@@ -88,6 +88,40 @@ pub static MCP_SESSIONS_ACTIVE: Lazy<Gauge> = Lazy::new(|| {
         .expect("Failed to create stoa_mcp_sessions_active metric")
 });
 
+// === Tool Expansion Metrics (CAB-2113 Phase 0) ===
+
+/// Counter of catalog tool refresh cycles by expansion mode and outcome.
+/// `mode` = `coarse` | `per-op`. `result` = `ok` | `err`.
+pub static TOOL_EXPANSION_REFRESH_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        "stoa_gateway_tool_expansion_refresh_total",
+        "Total catalog tool refresh cycles by expansion mode and outcome",
+        &["mode", "result"]
+    )
+    .expect("Failed to create stoa_gateway_tool_expansion_refresh_total metric")
+});
+
+/// Gauge of tools registered by the most recent refresh, by expansion mode.
+pub static TOOL_EXPANSION_OPS_REGISTERED: Lazy<GaugeVec> = Lazy::new(|| {
+    register_gauge_vec!(
+        "stoa_gateway_tool_expansion_ops_registered",
+        "Tools registered at last refresh cycle, by expansion mode",
+        &["mode"]
+    )
+    .expect("Failed to create stoa_gateway_tool_expansion_ops_registered metric")
+});
+
+/// Counter of expansion refresh errors by coarse reason category.
+/// `reason` = `transport` | `parse` | `upstream_status` | `empty_catalog`.
+pub static TOOL_EXPANSION_ERRORS_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        "stoa_gateway_tool_expansion_errors_total",
+        "Total expansion refresh errors by coarse reason",
+        &["reason"]
+    )
+    .expect("Failed to create stoa_gateway_tool_expansion_errors_total metric")
+});
+
 // === TCP Early Filter Metrics (CAB-1830) ===
 
 /// Counter of TCP connections rejected before HTTP processing.


### PR DESCRIPTION
## Summary

CAB-2113 Phase 0 PR3 — observability + docs to make `STOA_TOOL_EXPANSION_MODE` actually flippable in production. Follows PR #2415 (CP-API endpoint) and PR #2420 (gateway consumer).

- **3 Prometheus metrics** on the refresh task: `stoa_gateway_tool_expansion_refresh_total{mode,result}`, `stoa_gateway_tool_expansion_ops_registered{mode}`, `stoa_gateway_tool_expansion_errors_total{reason}`. Error reasons coarse-bucketed (transport / upstream_status / parse).
- **Serde alias** `per_operation` on `ExpansionMode::PerOp` — bridges the pre-2026-04-19 doc drift (CP-API docstring documented the snake form while the gateway enum was kebab-only). Canonical value stays `per-op`; alias tested both ways.
- **Docstring fix** in `control-plane-api/src/routers/portal.py:212` to document the canonical `per-op`.
- **New runbook** `docs/runbooks/tool-expansion-mode.md`: how to flip per gateway, canary/rollback, PromQL examples, known limitations (path/body collision, tool-count scalability — both gated on CAB-2116 Phase 0.5).

## Diff size

232 insertions, 1 deletion. Impl ~75 LOC (metrics + helpers + alias + docstring), tests ~42 LOC, runbook 116 lines. Well under the 300-LOC ceiling after PR2's overshoot.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — 3 new tests green (`expansion_mode_accepts_kebab_and_snake_alias`, `expansion_mode_label_is_kebab_canonical`, `classify_refresh_error_buckets_parse_upstream_transport`). All 26 CAB-2113 related tests pass.
- [x] `ruff check` + `black --check` on portal.py — clean
- [ ] Post-merge: flip `STOA_TOOL_EXPANSION_MODE=per-op` on a gateway canary and verify `stoa_gateway_tool_expansion_refresh_total{mode="per-op",result="ok"}` ticks up within 60s.

## Related

- Closes the Phase 0 runway for CAB-2113. Phase 0.5 (LLM bench gate) tracked as [CAB-2116](https://linear.app/hlfh-workspace/issue/CAB-2116). CLI divergence spin-off as [CAB-2117](https://linear.app/hlfh-workspace/issue/CAB-2117).

🤖 Generated with [Claude Code](https://claude.com/claude-code)