### PR TITLE
docs: plan validation convention (docs/plans + docs/decisions)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — STOA Platform
+# AGENTS.md — STOA Platform
 
 ## Project
 **STOA Platform** — "The European Agent Gateway"
@@ -70,7 +70,7 @@ STOA Go: stoactl CLI + stoa-connect agent (ADR-057). stoactl = GitOps CLI, stoa-
 
 ## AI Factory
 
-### Subagents (`.claude/agents/`)
+### Subagents (`.Codex/agents/`)
 | Agent | Specialite | Mode |
 |-------|-----------|------|
 | `security-reviewer` | OWASP, secrets, RBAC, deps vulns | Read-only (plan) |
@@ -81,7 +81,7 @@ STOA Go: stoactl CLI + stoa-connect agent (ADR-057). stoactl = GitOps CLI, stoa-
 | `verify-app` | Post-deploy SRE verification (9 checks) | Read-only (plan) |
 | `competitive-analyst` | AI coding tools competitive intelligence | Read-only (plan) |
 
-### MCP Integrations (Claude.ai Native)
+### MCP Integrations (Codex.ai Native)
 | Service | Use For | Key Actions |
 |---------|---------|-------------|
 | **Linear** | Ticket lifecycle | `get_issue` (DoD), `update_issue` (Done), `create_comment` (PR link) |
@@ -90,21 +90,21 @@ STOA Go: stoactl CLI + stoa-connect agent (ADR-057). stoactl = GitOps CLI, stoa-
 | **Notion** | Knowledge search | `notion-search`, `notion-fetch` |
 | **n8n** | Workflow automation | `execute_workflow` |
 
-Full reference on-demand: `.claude/docs/mcp-integrations.md`
+Full reference on-demand: `.Codex/docs/mcp-integrations.md`
 
-### Quand lire `.claude/docs/`
+### Quand lire `.Codex/docs/`
 
-`CLAUDE.md` (racine + par service) = décisions GO/NOGO auto-chargées. `.claude/docs/<topic>.md` = protocoles détaillés, exemples, tables de gotchas — **jamais auto-chargés**.
+`AGENTS.md` (racine + par service) = décisions GO/NOGO auto-chargées. `.Codex/docs/<topic>.md` = protocoles détaillés, exemples, tables de gotchas — **jamais auto-chargés**.
 
 Lire `docs/<topic>.md` quand:
 - Tu touches un domaine spécifique (ex: modifier le gateway → lire `code-style-rust.md` + `mcp-oauth.md`)
-- Un CLAUDE.md référence explicitement un fichier docs/
+- Un AGENTS.md référence explicitement un fichier docs/
 - Tu écris un skill/command qui automatise un protocole (crash-recovery, council-s3, phase-ownership)
-- Une règle CLAUDE.md mentionne un seuil sans le détailler
+- Une règle AGENTS.md mentionne un seuil sans le détailler
 
-**Règle**: décisions binaires → CLAUDE.md. Protocoles, exemples, tables → `.claude/docs/`. Jamais dupliquer.
+**Règle**: décisions binaires → AGENTS.md. Protocoles, exemples, tables → `.Codex/docs/`. Jamais dupliquer.
 
-### Skills (`.claude/skills/`)
+### Skills (`.Codex/skills/`)
 - 8 legacy: `implement-feature`, `fix-bug`, `review-pr`, `audit-component`, `create-adr`, `e2e-test`, `refactor`, `update-memory`
 - 2 modernes: `/ci-debug [PR|run-url]` (fork), `/parallel-review [PR|path]` (inline)
 - 3 MCP-powered: `/council` (4-persona validation → Linear), `/sync-plan` (plan.md ↔ Linear), `/decompose` (MEGA → component-scoped sub-issues + DAG)
@@ -112,7 +112,7 @@ Lire `docs/<topic>.md` quand:
 - 2 sprint: `/fill-cycle` (capacity gap analysis), `/generate-backlog` (MEGA backlog generation)
 - 1 visibility: `/roadmap` (strategic progress snapshot — themes, milestones, velocity)
 
-### Slash Commands (`.claude/commands/`)
+### Slash Commands (`.Codex/commands/`)
 - `/status` — quick project snapshot (git, PRs, CI, pods, tokens)
 - `/deploy-check` — post-merge CD verification
 - `/token-report` — 7-day token cost analysis
@@ -122,7 +122,7 @@ Lire `docs/<topic>.md` quand:
 Prerequis: `brew install tmux` + `export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
 
 ### Parallel Sessions (git worktrees)
-Named worktrees in `.claude/worktrees/` for concurrent Claude Code sessions:
+Named worktrees in `.Codex/worktrees/` for concurrent Codex sessions:
 ```bash
 za   # analysis worktree (read-only exploration)
 zf   # feature session (main repo)
@@ -139,9 +139,9 @@ zh   # hotfix worktree (ephemeral, from main)
 
 | Hook | Workflow | Trigger | What |
 |------|----------|---------|------|
-| Pre-coding | `claude-linear-dispatch.yml` | `/go` on ticket | Generates context pack, alerts on CRITICAL |
+| Pre-coding | `Codex-linear-dispatch.yml` | `/go` on ticket | Generates context pack, alerts on CRITICAL |
 | Post-merge | `context-compiler-learn.yml` | Push to main | Compares predicted vs actual, enriches DB |
-| Weekly | `claude-self-improve.yml` | Friday 18:00 UTC | Co-change discovery, dashboard, doc regen |
+| Weekly | `Codex-self-improve.yml` | Friday 18:00 UTC | Co-change discovery, dashboard, doc regen |
 
 Kill-switch: `DISABLE_CONTEXT_COMPILER=true` (GitHub repo variable) disables all hooks.
 
@@ -153,7 +153,7 @@ Kill-switch: `DISABLE_CONTEXT_COMPILER=true` (GitHub repo variable) disables all
 
 ## Règles
 
-Règles binaires GO/NOGO. Détail on-demand dans `.claude/docs/<rule>.md`.
+Règles binaires GO/NOGO. Détail on-demand dans `.Codex/docs/<rule>.md`.
 
 ### Workflow & Sessions
 - 1 MEGA par session. `/clear` entre chaque.
@@ -182,7 +182,7 @@ Règles binaires GO/NOGO. Détail on-demand dans `.claude/docs/<rule>.md`.
 - Council S1/S2/S3: seuil ≥ 8.0/10. <8 = rework, pas de contournement.
 - MEGA jamais marqué Done directement. Toujours `/verify-mega` (5 gates).
 - Sub-ticket Done sans comment "PR #N" = gate 1 échoue.
-- **Decision Challenge Gate** (HLFH-wide) avant exécution d'un plan matchant ≥1 trigger: (a) temps Claude > 5h, (b) impact business direct (GTM/pricing/positioning/contenu stratégique/partenariat/roadmap lourde), (c) irréversible (données/contrats/branding). Rappeler le gate et exiger contre-analyse d'un challenger externe non-aligné (GPT ou autre, PAS Claude). Framework + logs: `stoa-docs/HEGEMON/DECISION_GATE.md`.
+- **Decision Challenge Gate** (HLFH-wide) avant exécution d'un plan matchant ≥1 trigger: (a) temps Codex > 5h, (b) impact business direct (GTM/pricing/positioning/contenu stratégique/partenariat/roadmap lourde), (c) irréversible (données/contrats/branding). Rappeler le gate et exiger contre-analyse d'un challenger externe non-aligné (GPT ou autre, PAS Codex). Framework + logs: `stoa-docs/HEGEMON/DECISION_GATE.md`.
 - **Plan validation workflow** (convention, pas de hook): plan taggé `triggers: [...]` → fichier canonique dans `docs/plans/YYYY-MM-DD-<slug>.md` avec frontmatter `validation_status: draft|challenged|validated|rejected`. Verdict du challenger lié dans `docs/decisions/YYYY-MM-DD-<slug>.md` (`plan_ref` + `verdict`). **Pas d'exécution tant que `validation_status != validated`**. Templates: `docs/plans/_template.md`, `docs/decisions/_template-plan-validation.md`. Exemple canonique: `docs/plans/2026-04-19-dev-tools-gateway.md` (rejected, log #7).
 
 ### Sécurité
@@ -198,12 +198,12 @@ Règles binaires GO/NOGO. Détail on-demand dans `.claude/docs/<rule>.md`.
 - Jamais dupliquer un guide entre stoa et stoa-docs.
 
 ### Outillage
-- stoactl > curl/bash. Lire `.claude/context/cli-reference.md` avant de scanner src/.
+- stoactl > curl/bash. Lire `.Codex/context/cli-reference.md` avant de scanner src/.
 - Linear MCP = state changes. Local files = context. Batch reads, minimize writes.
 - Context7 avant de deviner une API de lib.
 
 ### Phase Ownership (multi-instance)
-- Claim via `.claude/claims/<ID>.json` + `mkdir` atomic lock.
+- Claim via `.Codex/claims/<ID>.json` + `mkdir` atomic lock.
 - End-to-end ownership: qui claim finit la phase.
 - Claim stale = 2h sans activité → auto-release.
 

--- a/docs/decisions/2026-04-19-dev-tools-gateway.md
+++ b/docs/decisions/2026-04-19-dev-tools-gateway.md
@@ -1,0 +1,50 @@
+---
+id: decision-2026-04-19-dev-tools-gateway
+plan_ref: docs/plans/2026-04-19-dev-tools-gateway.md
+challenger: "GPT-5 (Codex, background exec)"
+verdict: NO-GO
+decision_gate_log: "#7"
+---
+
+# Decision — 3 tools dev via gateway STOA locale
+
+## Challenger prompt
+
+See the verbatim prompt at `stoa-docs/HEGEMON/DECISION_GATE.md` log #7. Prompt structure: context (STOA platform + active C15 cycle state) + plan verbatim + mandate (5 blocks: hidden flaw, under-priced costs, ignored alternatives, metric gaps, brutal verdict) + hard constraints (600 words, French, no disclaimers, no reflexive validation).
+
+## Challenger output
+
+**Hidden flaw.** The plan frames this as a transport/MCP tooling problem when it is actually a workflow-discipline + artefact-format problem. Claude Code and Codex already perform plan/review/status natively. The gateway would interpose a layer between two tools that already work. If the assumption falls, the "unique artefact format" is a fiction (plan/review/status don't have the same needs), and the Go/No-Go criterion is biased (agents will bypass the tool as soon as it adds friction).
+
+**Under-priced costs.**
+- **Schemas:** not "x2" but at minimum 3 tools × I/O × 2 clients + artefact compat — silent wording drift = worst bug class
+- **Auth:** "minimal" is a lie — CAB-2121 not even committed, so Keycloak + scopes + policy mapping + fallback + 401/403 + rotation + debug to design
+- **Latency:** direct CLI is local process; gateway adds MCP discovery + auth + serialization + network hop + wrapper
+- **Ops debt:** who fixes k3d/Tilt/gateway/Keycloak when they break? Who versions the artefact when `dev-review` needs a new field?
+- **Opportunity cost:** frontal collision with CAB-2088 demo (J-6), CAB-2121 (not secured), CAB-2116 (cost fallout), CAB-2109 (pending) — "1 MEGA per session" rule makes this a collision, not a side quest
+
+**Ignored alternatives.**
+1. `stoactl dev plan|review|status` CLI invoked via Bash (2–4 days, 80% of value, zero gateway drift)
+2. Shared prompt contract + repo script (1–2 days, tests real demand cheaply)
+3. Observe native usage first, instrument nothing (< 1 day, establishes baseline)
+
+**Metric gaps.** No baseline on comparable tickets. No quantified thresholds ("less human routing" = 20%? 50%?). No token/latency cost tracking for the gateway. No quality metrics (false findings, unusable plans, stale statuses, manual workaround rate). No stop-loss (if phase 2 runs X days over, if phase 3 depends on CAB-2121, if Claude/Codex diverge on 1 of 3 tools — when do we stop?).
+
+**Verdict: NO-GO.** Reopen only if three signals exist: CAB-2088 shipped + CAB-2121 merged stable + CAB-2116 fallout absorbed; a no-gateway pilot proves real demand on 10+ tickets; the gateway locale has demonstrated auth/discovery stability on a less fragile use case first.
+
+## Arbitrage
+
+- **Verdict:** NO-GO
+- **Rejected because:** the plan mis-frames a workflow-discipline problem as an MCP transport problem, and under-prices auth + ops-debt + opportunity cost against active C15 priorities.
+
+## Reopen conditions
+
+Revisit in 1–3 months only if **all three** hold:
+
+1. CAB-2088 demo shipped, CAB-2121 MCP auth gate merged stable, CAB-2116 cost fallout absorbed
+2. A no-gateway pilot (alternative 1 or 2 above) proves real demand on 10+ tickets, with a measured drop in human routing
+3. The STOA gateway locale has demonstrated auth + discovery stability on a less fragile use case than the dev workflow itself
+
+## Meta-signal
+
+The Claude → Codex challenge itself was executed during this gate via `codex exec --skip-git-repo-check` + `run_in_background: true` — proving the intended use case (cross-LLM challenge for plan validation) is already achievable with **zero new MCP surface**.

--- a/docs/decisions/2026-04-19-dev-tools-gateway.md
+++ b/docs/decisions/2026-04-19-dev-tools-gateway.md
@@ -4,33 +4,149 @@ plan_ref: docs/plans/2026-04-19-dev-tools-gateway.md
 challenger: "GPT-5 (Codex, background exec)"
 verdict: NO-GO
 decision_gate_log: "#7"
+decision_gate_log_url: "https://github.com/stoa-platform/stoa-docs/blob/0f6022b/HEGEMON/DECISION_GATE.md"
 ---
 
 # Decision — 3 tools dev via gateway STOA locale
 
-## Challenger prompt
+## Challenger prompt (verbatim)
 
-See the verbatim prompt at `stoa-docs/HEGEMON/DECISION_GATE.md` log #7. Prompt structure: context (STOA platform + active C15 cycle state) + plan verbatim + mandate (5 blocks: hidden flaw, under-priced costs, ignored alternatives, metric gaps, brutal verdict) + hard constraints (600 words, French, no disclaimers, no reflexive validation).
+````markdown
+# Décision Challenge — Plan "3 tools dev via gateway STOA locale"
 
-## Challenger output
+Tu es le challenger externe non-aligné pour un Decision Gate HEGEMON (framework STOA). Mission: **défoncer le plan ci-dessous**, pas le valider. Objectif: exposer les blindspots avant que l'équipe n'engage des points de sprint dessus.
 
-**Hidden flaw.** The plan frames this as a transport/MCP tooling problem when it is actually a workflow-discipline + artefact-format problem. Claude Code and Codex already perform plan/review/status natively. The gateway would interpose a layer between two tools that already work. If the assumption falls, the "unique artefact format" is a fiction (plan/review/status don't have the same needs), and the Go/No-Go criterion is biased (agents will bypass the tool as soon as it adds friction).
+## Contexte plateforme (à prendre en compte avant de challenger)
 
-**Under-priced costs.**
-- **Schemas:** not "x2" but at minimum 3 tools × I/O × 2 clients + artefact compat — silent wording drift = worst bug class
-- **Auth:** "minimal" is a lie — CAB-2121 not even committed, so Keycloak + scopes + policy mapping + fallback + 401/403 + rotation + debug to design
-- **Latency:** direct CLI is local process; gateway adds MCP discovery + auth + serialization + network hop + wrapper
-- **Ops debt:** who fixes k3d/Tilt/gateway/Keycloak when they break? Who versions the artefact when `dev-review` needs a new field?
-- **Opportunity cost:** frontal collision with CAB-2088 demo (J-6), CAB-2121 (not secured), CAB-2116 (cost fallout), CAB-2109 (pending) — "1 MEGA per session" rule makes this a collision, not a side quest
+- **STOA Platform** = "European Agent Gateway" — API Management AI-Native. Kill feature: UAC (Universal API Contract) via MCP Gateway (`stoa-gateway`, Rust).
+- **Flux de travail actuel des devs** (humain + IA): Claude Code (CLI Anthropic) et Codex (CLI OpenAI) sont utilisés directement dans le repo, sans gateway intermédiaire. Chacun a son propre contexte via CLAUDE.md / .codex/config.toml et MCP servers (Linear, Notion, etc.).
+- **État actif cycle C15 (2026-04-19)**:
+  - CAB-2088 démo committee arch EU en préparation (J-6, dry-run #2 vendredi 25).
+  - CAB-2116 Phase 0.5 bench vient de sortir **RED/RED sur le coût**: per-op expansion +703% tokens, enriched-single +68%. Décision: Phase 1 CRDs per-op annulée, contract scenario abandonné. Log Decision Gate #6 publié.
+  - CAB-2121 MCP auth gate **pas encore commité** (sur mauvaise branche), CAB-2109 contract matrix pending.
+  - CAB-2113 Phase 0 complete mais admin-API visibility bug encore ouvert.
+  - CAB-2123 public DynamicTool discovery shipped (15→89 tools anonymes, banking API per-op visibles).
+- **Gateway locale**: k3d + Tilt, gateway tourne via `stoa-gateway` image + chart. Auth Keycloak. Découverte via `/mcp/v1/tools`.
+- **Règle "1 MEGA par session"**: ajouter un nouveau MEGA dilue les priorités actives (démo + auth gate + audit catalog).
+- **Décision Gate framework (HEGEMON)**: triggers = (a) Claude > 5h, (b) impact business direct, (c) irréversible. Challenger externe non-aligné obligatoire.
 
-**Ignored alternatives.**
-1. `stoactl dev plan|review|status` CLI invoked via Bash (2–4 days, 80% of value, zero gateway drift)
-2. Shared prompt contract + repo script (1–2 days, tests real demand cheaply)
-3. Observe native usage first, instrument nothing (< 1 day, establishes baseline)
+## Plan proposé
 
-**Metric gaps.** No baseline on comparable tickets. No quantified thresholds ("less human routing" = 20%? 50%?). No token/latency cost tracking for the gateway. No quality metrics (false findings, unusable plans, stale statuses, manual workaround rate). No stop-loss (if phase 2 runs X days over, if phase 3 depends on CAB-2121, if Claude/Codex diverge on 1 of 3 tools — when do we stop?).
+**Objectif**: exposer un workflow dev minimal via la gateway STOA locale, consommable par Claude Code et Codex, sans lancer un nouvel orchestrateur.
 
-**Verdict: NO-GO.** Reopen only if three signals exist: CAB-2088 shipped + CAB-2121 merged stable + CAB-2116 fallout absorbed; a no-gateway pilot proves real demand on 10+ tickets; the gateway locale has demonstrated auth/discovery stability on a less fragile use case first.
+**Scope**:
+- 3 tools MCP: `dev-plan(ticket|brief) -> plan + artefact`, `dev-review(diff|pr_ref) -> verdict + findings + score`, `dev-status(ticket|run_id) -> état + next step`
+- Transport: gateway STOA locale
+- Clients: Claude Code + Codex
+- Hors scope: `execute`, `ship`, auto-merge, auto-Done Linear, remote MCP dédié
+
+**Phases**:
+1. Contrat (3 tools I/O + format artefact unique + métriques succès)
+2. Core local (wrapper existant contexte+review, tests unit+smoke, core marche sans agent)
+3. Exposition via gateway STOA locale (auth/policy min, découverte MCP, stoactl mcp comme debug)
+4. Consommation Claude/Codex (3 parcours: plan, review, status)
+5. Canary 3-5 tickets réels, mesures: temps→plan, retouches manuelles, temps→1er diff, tool mismatch
+6. Décision: si adoption → stabiliser + `stoactl dev ...`; sinon → abandonner execute/ship
+
+**Go/No-Go**: Go si 3 tools utilisés par Claude+Codex sur tickets réels avec moins de routing humain. No-Go si valeur dépend d'un orchestrateur multi-stage.
+
+## Ton mandat
+
+Challenge dur. Pas de politesse, pas de "c'est un bon plan mais...". Structure ta réponse en 5 blocs:
+
+### 1. Le vice caché
+Quelle est l'hypothèse *non formulée* qui tient tout le plan debout ? Si elle tombe, qu'est-ce qui casse ?
+
+### 2. Les coûts que le plan ne chiffre pas
+- Maintenance des schémas MCP (x2 clients, x2 schémas à synchroniser)
+- Auth/policy sur la gateway locale qui n'existe pas (pas juste "minimales")
+- Latence ajoutée vs appel CLI direct
+- Dette: qu'est-ce qu'on doit maintenir quand la gateway crash, quand Claude/Codex bumpent leur MCP spec, quand les artefacts format change ?
+- Quel est le **coût d'opportunité** vs les priorités actives (démo CAB-2088, auth gate CAB-2121, bench fallout CAB-2116) ?
+
+### 3. L'alternative que le plan n'explore pas
+Propose au moins **2 alternatives** qui atteignent le même objectif sans gateway. Par exemple:
+- Un CLI local simple (`stoactl dev plan|review|status`) appelé par Claude et Codex via Bash tool (pas MCP)
+- Un template de prompt partagé + script hook post-commit
+- Ou laisser Claude/Codex faire nativement ce qu'ils font déjà
+
+Pour chaque alternative: effort, risque, valeur comparée.
+
+### 4. Les trous dans les métriques
+Phase 5 mesure "temps→plan acceptable", "gain net ou parité", "fréquence d'échec". Qu'est-ce qui manque ?
+- Baseline avant phase 1 ?
+- Seuils chiffrés ?
+- Mesure du coût token/latence ajouté par la gateway ?
+- Critère d'arrêt explicite si phase 2 ou 3 dérape ?
+
+### 5. Le verdict brutal
+- **GO / NO-GO / REFRAME** ?
+- Si REFRAME: en 3 bullets max, quelle est la forme la plus petite qui mérite d'être tentée ?
+- Si NO-GO: quel est le signal qui devrait faire revenir ce plan dans 1-3 mois ?
+
+## Contraintes de sortie
+
+- Max 600 mots.
+- Pas de disclaimers.
+- Pas de reformulation du plan.
+- Français.
+- Ne valide **rien** par défaut. Ton job est de trouver pourquoi ça échouerait.
+````
+
+## Challenger output (verbatim)
+
+Executed via `codex exec --skip-git-repo-check` (OpenAI Codex v0.121.0, model `gpt-5.4`, reasoning effort `xhigh`). Tokens used: 88 563. Session id: `019da744-3050-7220-a1b3-fcb8abd2b2d1`.
+
+````markdown
+### 1. Le vice caché
+
+L'hypothèse non dite: **le problème est un problème de transport/outillage MCP**, alors qu'il ressemble surtout à un problème de **discipline de workflow et de format de sortie**. Claude Code et Codex savent déjà faire plan/review/status dans le repo avec leur contexte natif. Le plan suppose qu'un habillage gateway rendra ces comportements plus fiables et plus adoptés.
+
+Si cette hypothèse tombe, tout casse:
+- la gateway ne crée aucune valeur, elle **interpose** juste une couche entre deux outils qui fonctionnent déjà ;
+- le "format artefact unique" devient une fiction, parce que plan/review/status n'ont pas les mêmes besoins et Claude/Codex ne consomment pas pareil ;
+- le critère Go/No-Go est biaisé: les agents contourneront le tool dès qu'il ralentit ou rigidifie.
+
+### 2. Les coûts que le plan ne chiffre pas
+
+- **Schémas**: ce n'est pas "x2". C'est au minimum **3 tools x input/output x 2 clients**, plus la compatibilité de l'artefact. À la moindre dérive de wording, un client dégrade sans casser franchement: le pire type de bug.
+- **Auth/policy locale**: "minimales" est un mensonge. CAB-2121 n'est même pas commité. Donc il faut concevoir, brancher, tester et documenter: Keycloak, scopes, policy mapping, fallback local, erreurs 401/403, rotation, debug.
+- **Latence**: direct CLI = process local. Gateway = discovery MCP, auth, sérialisation, hop réseau local, wrapper, réponse structurée. Vous ajoutez du délai sur des actions à forte fréquence et faible tolérance au frictionnel.
+- **Dette d'exploitation**: qui dépanne quand k3d/Tilt/gateway/Keycloak cassent ? Qui tient la matrice de smoke tests Claude/Codex après bump MCP spec ? Qui versionne l'artefact quand `dev-review` a besoin d'un nouveau champ ?
+- **Coût d'opportunité**: vous ouvrez un nouveau front alors que le cycle est déjà saturé: CAB-2088 à J-6, CAB-2121 non sécurisé, CAB-2116 vient de prouver que les intuitions "contract-first/per-op" explosent au coût, CAB-2109 pending. Avec la règle "1 MEGA par session", ce plan n'est pas un side quest, c'est une collision frontale.
+
+### 3. L'alternative que le plan n'explore pas
+
+- **CLI local `stoactl dev plan|review|status`**
+  - Effort: 2-4 jours.
+  - Risque: faible.
+  - Valeur: 80% de l'objectif sans gateway, sans auth, sans MCP drift. Claude et Codex peuvent l'appeler via shell et récupérer un JSON stable.
+- **Prompt contract partagé + script repo**
+  - Effort: 1-2 jours.
+  - Risque: faible à moyen.
+  - Valeur: moyenne, mais excellente pour tester si le besoin est réel. Un template strict + un parseur de sortie suffit pour mesurer adoption/qualité.
+- **Ne rien interposer, observer l'existant**
+  - Effort: <1 jour.
+  - Risque: minimal.
+  - Valeur: potentiellement supérieure, parce que vous mesurez le vrai usage natif avant d'inventer une couche.
+
+### 4. Les trous dans les métriques
+
+- Aucune **baseline** sur tickets comparables avant phase 1.
+- Aucun **seuil chiffré**: "moins de routing humain" ne veut rien dire. Combien: 20%, 50% ?
+- Aucun suivi explicite de **coût token/latence** ajouté par la gateway.
+- Rien sur la **qualité**: taux de faux findings en review, plans inutilisables, statuts obsolètes, taux de contournement manuel.
+- Aucun **stop-loss**: si phase 2 dépasse X jours, si phase 3 dépend de CAB-2121, si Claude/Codex divergent sur 1 tool sur 3, on arrête quand ?
+
+### 5. Le verdict brutal
+
+**NO-GO.**
+
+À reconsidérer dans 1-3 mois seulement si trois signaux existent:
+- CAB-2088 est passé, CAB-2121 est mergé et stable, le fallout CAB-2116 est absorbé.
+- Un pilote **sans gateway** prouve une demande réelle sur 10+ tickets avec baisse mesurée du routing humain.
+- La gateway locale a déjà démontré sa stabilité auth/discovery sur un use case moins fragile que le workflow dev.
+````
 
 ## Arbitrage
 
@@ -48,3 +164,7 @@ Revisit in 1–3 months only if **all three** hold:
 ## Meta-signal
 
 The Claude → Codex challenge itself was executed during this gate via `codex exec --skip-git-repo-check` + `run_in_background: true` — proving the intended use case (cross-LLM challenge for plan validation) is already achievable with **zero new MCP surface**.
+
+## External index
+
+Registered in `stoa-docs/HEGEMON/DECISION_GATE.md` as log #7 (merged in commit [`0f6022b`](https://github.com/stoa-platform/stoa-docs/blob/0f6022b/HEGEMON/DECISION_GATE.md) on 2026-04-19) as a one-line entry. **This file in `docs/decisions/` is the self-contained source of truth**; the stoa-docs log is the cross-repo index.

--- a/docs/decisions/_template-plan-validation.md
+++ b/docs/decisions/_template-plan-validation.md
@@ -1,0 +1,27 @@
+---
+id: decision-YYYY-MM-DD-<slug>
+plan_ref: docs/plans/YYYY-MM-DD-<slug>.md
+challenger: "GPT-5 (Codex)"            # or other non-Claude LLM
+verdict: GO | NO-GO | REFRAME
+decision_gate_log: "#N"                # index in stoa-docs/HEGEMON/DECISION_GATE.md
+---
+
+# Decision — <title>
+
+## Challenger prompt
+
+> (paste the full prompt sent to the challenger, for reproducibility)
+
+## Challenger output
+
+> (paste the verbatim response, or a faithful summary with a link to the raw capture)
+
+## Arbitrage
+
+- **Verdict:** GO | NO-GO | REFRAME
+- **Reframe applied:** (if REFRAME) what changed in the plan
+- **Rejected because:** (if NO-GO) one-line reason
+
+## Reopen conditions
+
+(If NO-GO) What signals would justify revisiting this plan in 1–3 months?

--- a/docs/plans/2026-04-19-dev-tools-gateway.md
+++ b/docs/plans/2026-04-19-dev-tools-gateway.md
@@ -1,0 +1,41 @@
+---
+id: plan-2026-04-19-dev-tools-gateway
+triggers: [a, b]
+validation_status: rejected
+challenge_ref: docs/decisions/2026-04-19-dev-tools-gateway.md
+---
+
+# Plan — 3 tools dev via gateway STOA locale
+
+## Objectif
+
+Exposer un workflow dev minimal (`dev-plan`, `dev-review`, `dev-status`) via la gateway STOA locale, consommable par Claude Code et Codex, sans lancer un nouvel orchestrateur.
+
+## Scope
+
+- **In:**
+  - 3 MCP tools: `dev-plan(ticket|brief) -> plan + artefact`, `dev-review(diff|pr_ref) -> verdict + findings + score`, `dev-status(ticket|run_id) -> état + next step`
+  - Transport: gateway STOA locale (k3d + Tilt)
+  - Clients: Claude Code + Codex
+- **Out:** `execute`, `ship`, auto-merge, auto-Done Linear, remote MCP dédié
+
+## Phases
+
+1. Contrat (3 tools I/O + format artefact unique + métriques succès)
+2. Core local (wrapper existant contexte+review, tests unit+smoke, core marche sans agent)
+3. Exposition via gateway STOA locale (auth/policy min, découverte MCP, `stoactl mcp` comme debug)
+4. Consommation Claude/Codex (3 parcours: plan, review, status)
+5. Canary 3–5 tickets réels, mesures: temps→plan, retouches manuelles, temps→1er diff, tool mismatch
+6. Décision: si adoption → stabiliser + `stoactl dev ...`; sinon → abandonner `execute/ship`
+
+## Go / No-Go criteria
+
+- **Go** si 3 tools utilisés par Claude+Codex sur tickets réels avec moins de routing humain
+- **No-Go** si valeur dépend d'un orchestrateur multi-stage
+
+## Assumptions
+
+- Le problème est un problème de transport/outillage MCP (→ stress-testé par le challenger, **invalidé**)
+- Les artefacts plan/review/status ont un format commun viable
+- L'auth locale "minimale" est un effort mineur (→ **invalidé**: CAB-2121 non commité, dette réelle)
+- La gateway locale est stable en usage quotidien (→ **invalidé**: k3d/Tilt/KC stack fragile)

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,55 @@
+# Plans — Canonical Plan Registry
+
+Canonical location for plans that match the **Decision Challenge Gate** triggers (see `stoa-docs/HEGEMON/DECISION_GATE.md`).
+
+## When to create a plan file here
+
+Create a plan file here **before starting execution** if the plan matches **≥ 1** trigger:
+
+- **(a)** Estimated agent time > 5 h (≈ 2 Linear pts).
+- **(b)** Direct business impact: GTM, pricing, positioning, strategic content, partnership, heavy roadmap.
+- **(c)** Irreversible: data, contracts, branding, trademark, public commitments.
+
+Plans that do **not** match any trigger stay in chat or `plan.md` — no canonical file required.
+
+## Naming
+
+`YYYY-MM-DD-<slug>.md` — ISO date + short kebab slug.
+
+## Required frontmatter
+
+```yaml
+---
+id: plan-YYYY-MM-DD-<slug>
+triggers: [a, b, c]                    # list of trigger letters matched
+validation_status: draft               # draft | challenged | validated | rejected
+challenge_ref: docs/decisions/YYYY-MM-DD-<slug>.md   # set once challenged
+---
+```
+
+## Validation status lifecycle
+
+| Status | Meaning |
+|--------|---------|
+| `draft` | Plan written, challenger not yet invoked |
+| `challenged` | External challenger verdict produced, arbitrage pending |
+| `validated` | Arbitrage acted, reframe applied if needed, other gates satisfied |
+| `rejected` | Plan abandoned |
+
+## Enforcement
+
+**Convention, not code.** No pre-execution hook. Discipline enforced by CLAUDE.md / AGENTS.md rule: *no execution of a plan with `triggers: [...]` until `validation_status: validated`.*
+
+If discipline breaks ≥ 3 times in 30 days, promote to pre-commit / PreToolUse hook (P2).
+
+## Linked verdict
+
+Every plan in `challenged` / `validated` / `rejected` state **must** reference a verdict file in `docs/decisions/` via `challenge_ref`. The verdict file carries the challenger's reasoning and the final arbitrage.
+
+## Template
+
+See `_template.md`.
+
+## Canonical example
+
+`2026-04-19-dev-tools-gateway.md` — first retroactive application, resulting in `rejected` (Decision Gate log #7).

--- a/docs/plans/_template.md
+++ b/docs/plans/_template.md
@@ -1,0 +1,31 @@
+---
+id: plan-YYYY-MM-DD-<slug>
+triggers: []                           # letters among a (>5h), b (business), c (irreversible)
+validation_status: draft               # draft | challenged | validated | rejected
+challenge_ref: ""                      # docs/decisions/YYYY-MM-DD-<slug>.md once challenged
+---
+
+# Plan — <title>
+
+## Objectif
+
+One sentence. What outcome does this plan produce? Who benefits?
+
+## Scope
+
+- In: …
+- Out: …
+
+## Phases
+
+1. …
+2. …
+
+## Go / No-Go criteria
+
+- Go if: …
+- No-Go if: …
+
+## Assumptions
+
+What must be true for this plan to work? List the non-obvious ones — they are what the challenger will stress-test.


### PR DESCRIPTION
## Summary

Adds the formal **plan-validation workflow** referenced by the Decision Challenge Gate (`stoa-docs/HEGEMON/DECISION_GATE.md`). Convention only — **no hook**, no automated enforcement.

Closes the governance gap identified in Decision Gate log #7: the gate covered the *contradictory challenge* of plans but not the *formal validation workflow* (canonical artefact, status field, plan ↔ verdict linkage, execution block).

## Changes

- `docs/plans/` — canonical plan files for plans matching ≥1 gate trigger (agent time > 5h / business impact / irreversible), with frontmatter:
  ```yaml
  ---
  id: plan-YYYY-MM-DD-<slug>
  triggers: [a, b, c]
  validation_status: draft | challenged | validated | rejected
  challenge_ref: docs/decisions/YYYY-MM-DD-<slug>.md
  ---
  ```
- `docs/decisions/` — linked challenger verdict files with `plan_ref` and `verdict: GO | NO-GO | REFRAME`
- `CLAUDE.md` + `AGENTS.md` — new rule: **no execution until `validation_status: validated`**
- `AGENTS.md` — promoted from untracked draft to tracked (mirrors CLAUDE.md with Claude↔Codex substitutions)
- Canonical retroactive example: `docs/plans/2026-04-19-dev-tools-gateway.md` (rejected, linked to Decision Gate log #7)

## Enforcement

**Convention + discipline only.** Pre-commit or PreToolUse hook deferred to P2 — promote only if discipline breaks ≥ 3 times in 30 days.

## Test plan

- [x] Templates have valid YAML frontmatter
- [x] Retroactive canonical case (`#7`) demonstrates the full lifecycle (draft → challenged → rejected)
- [x] CLAUDE.md + AGENTS.md rule references the correct paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)