### PR TITLE
chore(gitignore): ignore local agent/tool state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,11 @@ kubeconfig*
 # Ephemeral agent/tool state
 .playwright-mcp/
 .claude/scheduled_tasks.lock
+.claude/agent-memory/
+.codex/
+.agents/skills/
+tools/phase05-harness/report.json
+tools/phase05-harness/runs.jsonl
 
 # Council S3 (CAB-2047) — history + metrics, never commit
 council-history.jsonl


### PR DESCRIPTION
## Summary

Surgical .gitignore additions for local agent/tool state that has been leaking into untracked lists across worktrees.

## Patterns added (under existing "Ephemeral agent/tool state" block)

| Pattern | Why |
|---------|-----|
| `.claude/agent-memory/` | Per-agent runtime state (e.g. `docs-writer/`) |
| `.codex/` | Codex CLI per-repo config (`config.toml`), user-specific |
| `.agents/skills/` | Local skills mirror — canonical source is `.claude/skills/` |
| `tools/phase05-harness/report.json` | Bench output, not source — README + code stay tracked |
| `tools/phase05-harness/runs.jsonl` | Bench output, same |

Note: `.agents/skills/` is targeted (not `.agents/` entirely) to leave room for tracked content if added later. `tools/phase05-harness/` directory itself stays open — only the two output files are ignored, README.md / build_enriched.py / run_bench.py / score.py / specs/ / tests/ remain tracked.

## Test plan

- [x] `git check-ignore -v` confirms each path matches the intended rule
- [x] `tools/phase05-harness/README.md` is NOT ignored (sanity check)
- [x] No tracked file affected (commit is +5 / -0 on `.gitignore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)