### PR TITLE
docs(audits): archive evidence — claude.ai connector + CAB-2120/2122/2123

### DIFF
--- a/docs/audits/2026-04-17-mcp-claude-ai-connector/AUDIT-RESULTS.md
+++ b/docs/audits/2026-04-17-mcp-claude-ai-connector/AUDIT-RESULTS.md
@@ -1,0 +1,163 @@
+# AUDIT-RESULTS — claude.ai remote MCP connector fix (CAB-2106)
+
+**Audit date**: 2026-04-17
+**Scope**: Phase 1 (code + tests) + Phase 2 step 1 (local curl matrix on running binary).
+**Under test**: `stoa-gateway` built from worktree `.claude/worktrees/gateway-mcp-fix`, commit `b8f56b04`, branch `fix/cab-2106-gateway-mcp-sse-accept`.
+
+## Phase 1 — Code + tests — PASS
+
+| Gate | Command | Result |
+|------|---------|--------|
+| Unit tests | `cargo test --lib mcp::sse` | 39 passed / 0 failed (9 new for `accepts_event_stream`) |
+| Full test suite | `cargo test` | 2158 lib + 47 contract + 52 integration + 15 resilience + 26 security, all green |
+| Clippy strict | `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings` | clean |
+| Rustfmt | `cargo fmt --check` | clean |
+| PR size | `git diff --cached --stat` | 464 insertions / 2 deletions across 4 files (production ≈70 LOC) |
+
+## Phase 2 step 1 — Local binary curl matrix — PASS
+
+### Setup
+- Gateway launched from the worktree with `STOA_PORT=8765 STOA_JWT_VALIDATION_DISABLED=true STOA_OTEL_ENDPOINT="" cargo run`.
+- `/health` returned `200` before the matrix started.
+
+### Accept matrix
+
+| # | Accept header | Expected Content-Type | Observed Content-Type | Body shape | Mcp-Session-Id |
+|---|---------------|------------------------|------------------------|------------|----------------|
+| A | `text/event-stream` (claude.ai pattern) | `text/event-stream` | `text/event-stream` | `event: message\ndata: {"jsonrpc":"2.0",...}` | present |
+| B | `application/json, text/event-stream` (MCP-compliant client) | `text/event-stream` | `text/event-stream` | SSE frame as above | present |
+| C | `application/json` (legacy) | `application/json` | `application/json` | JSON body, `content-length: 412` | present |
+| D | *absent* (curl default) | `application/json` | `application/json` | JSON body | present |
+| E | `*/*` | `application/json` (back-compat) | `application/json` | JSON body | present |
+
+### Full claude.ai-style flow
+
+1. `POST /mcp/sse` with `Accept: text/event-stream`, body = `initialize` → `200`, `content-type: text/event-stream`, `mcp-session-id: cc3fd415-aa6c-42b1-be24-dbfc185be52e`, SSE `event: message` with the initialize response.
+2. `POST /mcp/sse?sessionId=cc3fd415-...` with `Accept: text/event-stream`, body = `tools/list` → `200`, `content-type: text/event-stream`, same `mcp-session-id` echoed, SSE frame with the full tools array (15 tools: `stoa_api_spec`, `stoa_cache_invalidate`, `stoa_tenants`, `stoa_alerts`, `stoa_uac`, `stoa_platform_health`, `stoa_subscription`, `stoa_catalog`, `stoa_cache_load`, `stoa_tools`, `stoa_cache_get`, `stoa_logs`, `stoa_security`, `stoa_platform_info`, `stoa_metrics`).
+3. `transfer-encoding: chunked` confirmed on the SSE responses.
+
+Pre-fix observation (reproduced earlier against prod `mcp.gostoa.dev`): identical curl against the unpatched binary returned `content-type: application/json` regardless of Accept, which is what the claude.ai connector rejected.
+
+### Evidence artefacts
+Raw curl output captured under `/tmp/sse_*.{hdr,body}` during the run (not copied into git to keep the audit note short). Reproduce with:
+```bash
+cargo run  # in worktree stoa-gateway/
+for H in 'text/event-stream' 'application/json, text/event-stream' 'application/json'; do
+  curl -sS -D - --max-time 3 -X POST http://127.0.0.1:8765/mcp/sse \
+    -H "Accept: $H" -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}'
+done
+```
+
+## Phase 4 — InitializeResult shape hotfix (CAB-2112) — PASS
+
+### Actual root cause for the claude.ai UI error
+
+User-captured Anthropic Toolbox / Pydantic error (the generic `ofid_*` refs came from this):
+
+```
+Network error connecting to MCP server.
+ValidationError: 1 validation error for InitializeResult
+capabilities.experimental.transports
+  Input should be a valid dictionary [type=dict_type]
+```
+
+`handle_initialize` was emitting `"experimental": { "transports": ["sse", "websocket"] }`. MCP 2025-11-25 / the Anthropic Pydantic schema require every value under `capabilities.experimental` to be a feature-config **dict**. Shipping an array rejected the whole `InitializeResult`, which claude.ai surfaced as the opaque "Authorization with the MCP server failed".
+
+### Fix + deploy
+
+- **PR #2414** (CAB-2112) — drops the non-standard `experimental.transports` field entirely; 2 regression tests lock the contract (`regression_cab_2110_experimental_entries_are_all_dicts`, `regression_cab_2110_initialize_result_shape_matches_spec`).
+- **PR #2416** — release-please `stoa-gateway 0.9.8`, merged.
+- ArgoCD rolled `ghcr.io/stoa-platform/stoa-gateway:dev-3570f39193c85ae803c2fc72f3234093e061a1eb` on OVH MKS.
+
+### Post-deploy validation
+
+`curl POST https://mcp.gostoa.dev/mcp/sse initialize` response capabilities keys: `elicitation, logging, prompts, resources, tokenOptimization, tools`. `experimental` absent.
+
+Same curl flow returned the broken array shape before 0.9.8. Pydantic no longer has a surface to reject.
+
+## Lessons learned
+
+- **Extrapolating a "full chain validation" from MCP Inspector + Claude Code CLI was the wrong call**. Inspector used streamable-http happy-path with a generous JSON-schema validator; Anthropic's Toolbox uses Pydantic which is stricter. The claude.ai GUI error message only surfaced the actual validation failure when the user captured and shared the browser-level error.
+- **Always drive the real client of record** (claude.ai in Chrome, not MCP Inspector CLI) when closing a "works on prod" audit.
+- **Three root causes in series**:
+  1. Accept header never honoured → CAB-2106
+  2. Discovery methods 401 during capability negotiation → CAB-2109
+  3. `experimental.transports` shape breaks Pydantic `InitializeResult` → CAB-2112
+- Adjacent but unrelated prod bugs surfaced in logs during the hunt: broken `chat-completions-gpt4o` tool (DNS-less `stoa-aoai.openai.azure.com`) trips the per-tool circuit breaker; ~5 UUID-named stale tools clutter `tools/list`; OTLP `BatchSpanProcessor` saturation. Not blocking claude.ai once CAB-2112 landed.
+
+## Phase 3 — public_methods hotfix (CAB-2109) — PASS
+
+### Second root cause found after CAB-2106 deploy
+
+`claude.ai` connector kept failing with Anthropic ref `ofid_5f1fcc086cd04144` even though the Accept-header fix was live. Root cause confirmed via MCP Inspector (`--transport streamable-http`):
+
+```
+POST /mcp/sse initialize                → 200 ✓
+POST /mcp/sse notifications/initialized → 204 ✓
+POST /mcp/sse tools/list                → 200 ✓
+POST /mcp/sse logging/setLevel          → 401 ✗
+POST /mcp/sse resources/list            → 401 ✗
+POST /mcp/sse prompts/list              → 401 ✗
+```
+
+`public_methods` only whitelisted `initialize`, `ping`, `tools/list`, `notifications/initialized`, `notifications/cancelled`. The remaining discovery methods advertised in the `initialize` capabilities response (logging, resources, prompts, etc.) were gated behind auth, breaking capability negotiation before the OAuth flow attaches a Bearer token.
+
+### Fix + deploy
+
+- **PR #2411** (CAB-2109) merged `fb082f8c` — factored `PUBLIC_METHODS` into a shared const (both `handle_sse_post` and `process_single_request`), extended whitelist with 8 read-only discovery methods, added 3 regression tests.
+- **PR #2412** (release-please `stoa-gateway 0.9.7`) merged `400ae970`.
+- ArgoCD rolled `ghcr.io/stoa-platform/stoa-gateway:dev-fb082f8cfac6c5eb5bcf6b48249653653c7beebe` on OVH MKS, 2/2 pods Running.
+
+### Prod matrix validation on 0.9.7
+
+All 11 discovery methods anonymous (no Bearer):
+
+| Method | Status |
+|--------|--------|
+| `ping` | 200 |
+| `tools/list` | 200 |
+| `resources/list` | 200 |
+| `resources/templates/list` | 200 |
+| `resources/read` | 200 |
+| `prompts/list` | 200 |
+| `prompts/get` | 200 |
+| `completion/complete` | 200 |
+| `roots/list` | 200 |
+| `logging/setLevel` | 200 |
+| `notifications/initialized` | 204 |
+| `tools/call` (still must 401) | 401 + `WWW-Authenticate: Bearer` |
+
+Tool surface remains protected. MCP Inspector `--cli --transport streamable-http` now lists the full 15-tool catalog without `Authentication required` error.
+
+## Phase 2 — prod deploy + curl validation — PASS
+
+### Deploy chain
+- PR #2404 merged `a738ff25` — unblocked Gateway CI on main (pre-existing `/tmp` tee failure on self-hosted runner).
+- PR #2402 (CAB-2106) merged `bd286867` — rebased onto fresh main.
+- Release-please opened PR #2405 (`chore(main): release stoa-gateway 0.9.6`) automatically, then merged `bb5046f6`.
+- ArgoCD / image-updater on OVH MKS picked up the new image within minutes. Running pods on the `stoa-system` namespace at validation time:
+  - `stoa-gateway-7684665f49-rmpqx` / `stoa-gateway-7684665f49-tz7vd`
+  - image: `ghcr.io/stoa-platform/stoa-gateway:dev-bd2868675d744e9aa34969630a110690e5fbbe40`
+  - status: `1/1 Running`, age 18 min.
+
+### Production curl matrix (`mcp.gostoa.dev`)
+
+| # | Accept header | Observed Content-Type | Body |
+|---|---------------|------------------------|------|
+| A | `text/event-stream` (claude.ai) | `text/event-stream` | `event: message\ndata: {"jsonrpc":"2.0","result":{"capabilities":{...` |
+| B | `application/json, text/event-stream` | `text/event-stream` | SSE frame |
+| C | `application/json` | `application/json` | `{"jsonrpc":"2.0","result":...}` (content-length 412) |
+
+Mcp-Session-Id header present on all 3. HTTP/2 200 everywhere. No redirect loop, no 401.
+
+### Remaining (manual / GUI-bound, out of Claude Code scope)
+
+- [ ] Attach a claude.ai test connector at `https://mcp.gostoa.dev/mcp/sse`; confirm "Connected" + tools list + single tool call succeeds. Expected: Anthropic error ref `ofid_d2fef633fa45878c` no longer reproduces.
+- [ ] Capture screenshot of claude.ai UI + `kubectl -n stoa-system logs -l app=stoa-gateway` showing one-shot `initialize → tools/list → tools/call` sequence (no DCR retry loop).
+
+## Phase 3+ — scope of separate tickets
+
+- **Soft-auth close on `/mcp/*`** — P1 follow-up (`gotcha_gateway_soft_auth_mcp.md`).
+- **CORS annotations on ingress** — P2 (dual-repo chart sync).
+- **OTLP `BatchSpanProcessor` saturation** — P3 log noise.

--- a/docs/audits/2026-04-17-mcp-claude-ai-connector/HANDOFF.md
+++ b/docs/audits/2026-04-17-mcp-claude-ai-connector/HANDOFF.md
@@ -125,7 +125,7 @@ Tâches :
 ### Phase 2 — P0 Validation canary puis prod
 
 1. Tilt k3d local : re-tester `POST /mcp/sse` avec curl matrix + MCP Inspector (`npx @modelcontextprotocol/inspector`). Gotcha Tilt k3d en mémoire (`gotcha_tilt_local.md`) — lire avant.
-2. Dev VPS (`dev-vps` 94.23.107.107 — Docker Compose, pas K8s) : déployer build.
+2. Dev VPS (`dev-vps` <dev-vps-ip> — Docker Compose, pas K8s) : déployer build.
 3. Configurer un connecteur MCP claude.ai de test pointant sur l'URL dev (ex : `https://dev-mcp.gostoa.dev` si existe, sinon prod avec feature flag — à clarifier).
 4. Observer les logs dev : séquence `DCR → token → initialize → tools/list → tools/call` sans boucle.
 5. Bump version chart gateway (patch) + release PR automatique (release-please).

--- a/docs/audits/2026-04-17-mcp-claude-ai-connector/HANDOFF.md
+++ b/docs/audits/2026-04-17-mcp-claude-ai-connector/HANDOFF.md
@@ -1,0 +1,271 @@
+# Handoff — Fix claude.ai remote MCP connector vs stoa-gateway
+
+**Date diagnostic** : 2026-04-17
+**Branche au moment du diag** : `feat/cab-2095-stoactl-api-tenant-scope` (hors scope, ne pas mélanger)
+**Cible prod cassée** : `https://mcp.gostoa.dev`
+**Symptôme utilisateur** : claude.ai → "Authorization with the MCP server failed" (ref côté Anthropic `ofid_d2fef633fa45878c`).
+
+Ce document est **self-contained**. Une session fraîche doit pouvoir l'exécuter sans contexte conversationnel.
+
+---
+
+## 0bis. Progression
+
+| Phase | Ticket | Statut | Artefacts |
+|-------|--------|--------|-----------|
+| 1 — Fix Accept/SSE | [CAB-2106](https://linear.app/hlfh-workspace/issue/CAB-2106) | **Merged** `bd286867` (PR #2402) | — |
+| 2 — Canary + prod validation (Accept) | [CAB-2106](https://linear.app/hlfh-workspace/issue/CAB-2106) | **Prod curl matrix PASS** on 0.9.6 (PR #2405 merged `bb5046f6`). ArgoCD rolled `dev-bd286867`. Insufficient — see Phase 3. | `AUDIT-RESULTS.md` |
+| 3 — public_methods hotfix | [CAB-2109](https://linear.app/hlfh-workspace/issue/CAB-2109) | **Merged** `fb082f8c` (PR #2411), release 0.9.7 merged `400ae970` (PR #2412). Prod rollout `dev-fb082f8c` live on OVH MKS 2/2 pods. Discovery matrix + tools/call 401 contract all green on prod. | `AUDIT-RESULTS.md` |
+| 3 — Enforce auth on /mcp/* | — | Pending | — |
+| 4 — CORS ingress | — | Pending | — |
+| 5 — OTLP saturation | — | Pending | — |
+
+Phase 1 DoD:
+- [x] `cargo test -p stoa-gateway` — 2158 lib + 47 contract + 52 integration + 15 resilience + 26 security, all green.
+- [x] `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings` — clean.
+- [x] Unit tests `accepts_event_stream` — 9 cases.
+- [x] Contract tests Accept × method — 9 cases on /mcp/sse (initialize, tools/list, tools/call × explicit SSE / both / q-values / case / JSON-only / absent + session reuse).
+- [x] Manual curl reproduction against a running binary — PASS, recorded in `AUDIT-RESULTS.md`.
+- [ ] PR opened — awaiting push authorization.
+
+## 0. Contexte minimal
+
+- `stoa-gateway` = binaire Rust, `stoa-system` ns sur cluster OVH MKS. Deux pods `stoa-gateway-5976d6b6f7-*`.
+- Kubeconfig prod : `~/.kube/config-stoa-ovh`.
+- Ingress nginx + ACME (cert-manager). Domaine `mcp.gostoa.dev` → service `stoa-gateway:80`.
+- Keycloak = `https://auth.gostoa.dev/realms/stoa`. Le gateway agit comme AS-relais (DCR proxy) + RS (valide JWT).
+- Deployment mode : `edge-mcp` (ADR-024).
+
+---
+
+## 1. Diagnostic validé (preuves)
+
+### A. OAuth fonctionne
+- `/.well-known/oauth-protected-resource` → 200
+- `/.well-known/oauth-authorization-server` → 200 (issuer `auth.gostoa.dev`, registration_endpoint `mcp.gostoa.dev/oauth/register`)
+- `POST /oauth/register` → 201 (DCR proxy Keycloak)
+- `POST /oauth/token` → 200
+- JWT validé côté gateway (logs `JWT validated — user authenticated`, user_id `2fefc656-8725-4761-95bb-1ae2e24db96e`, scopes `openid, profile, email, stoa:read, stoa:write, stoa:admin`)
+
+### B. BUG P0 — Accept: text/event-stream non honoré
+Le handler `POST /mcp/sse` retourne **toujours** `Content-Type: application/json` quel que soit le `Accept`. Spec Streamable HTTP MCP 2025-03-26 exige de retourner `text/event-stream` si le client l'accepte, et de maintenir le flux ouvert.
+
+Reproduction :
+```
+curl -sS -D - -X POST https://mcp.gostoa.dev/mcp/sse \
+  -H 'Accept: text/event-stream' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}' \
+  --max-time 5
+```
+Observé : `HTTP/2 200`, `content-type: application/json`, body JSON complet + `mcp-session-id` dans les headers, connexion close.
+Attendu : `content-type: text/event-stream`, frame SSE `event: message\ndata: {...}\n\n`, flux maintenu.
+
+### C. Conséquence observée côté Claude
+Boucle ~90 s : `POST /oauth/register` → `POST /oauth/token` → `POST /mcp/sse` initialize → **nouvelle session à chaque coup** (`session_id:"None"` entrant systématiquement). Aucun `tools/list` ni `tools/call` jamais déclenché. Le connecteur abandonne et redémarre à zéro.
+
+### D. Bugs secondaires découverts
+
+1. **Soft-auth sur `/mcp/*`** (gotcha déjà en mémoire `gotcha_gateway_soft_auth_mcp.md`) : un POST sans `Authorization` renvoie 200 + scope anon `stoa:read` au lieu de `401 WWW-Authenticate: Bearer resource_metadata=…`. Avec bearer invalide, le 401 est correct → preuve que le code `require_auth` existe mais n'est pas branché sur le chemin anonyme.
+2. **CORS absent** : ingress `stoa-gateway` n'a aucune annotation `nginx.ingress.kubernetes.io/cors-*` (alors que `stoa-control-plane-api` en a). Pas bloquant pour claude.ai remote (backend Anthropic, UA `Claude-User`), mais cassera tout client MCP in-browser (Inspector local, Portal, etc.).
+3. **OTLP saturé** : logs spam `BatchSpanProcessor.Flush.ExportError: sending queue is full`. Collector sous-dimensionné ou HS. Pollue le debug.
+
+---
+
+## 2. Fichiers à éditer (repérage)
+
+Repo : `github.com/stoa-platform/stoa`, répertoire `stoa-gateway/`.
+
+- `stoa-gateway/src/mcp/sse.rs`
+  - `handle_sse_post` (l. ~158)
+  - `handle_streamable_http_post` (l. ~393) — peut déjà contenir une logique à factoriser
+  - `handle_sse_get` (l. ~412), `handle_sse_delete` (l. ~494)
+  - `extract_bearer_token` (l. ~1131)
+- `stoa-gateway/src/mcp/session.rs` (587 LOC) — gestion `mcp-session-id`
+- `stoa-gateway/src/mcp/handlers.rs` (1598 LOC) — handlers par méthode JSON-RPC
+- Tests existants dans `sse.rs` à partir de l. ~1162 (module `mod tests`)
+
+Pour le chart :
+- `charts/stoa-platform/templates/ingress.yaml` (ou sous-chart `stoa-gateway`)
+- Miroir `stoa-infra/charts/` à synchroniser (règle CLAUDE.md #6)
+
+---
+
+## 3. Phases d'exécution
+
+### Phase 1 — P0 Fix Accept / SSE (1 PR, ≤ 300 LOC)
+
+**Branche** : `fix/cab-XXXX-gateway-mcp-sse-accept-negotiation` (créer ticket Linear avant, cf §6).
+
+Tâches :
+1. Parser `Accept` (utiliser `mime` crate ou parse simple) dans `handle_sse_post`.
+2. Si `text/event-stream` acceptable :
+   - Répondre avec `Content-Type: text/event-stream`, `Transfer-Encoding: chunked`.
+   - Émettre la réponse JSON-RPC sous `event: message\ndata: <json>\n\n`.
+   - Conserver l'écriture ouverte via `axum::response::sse::Sse` (déjà utilisé si `handle_sse_get` existe) ou stream manuel.
+   - Garder le flux ouvert (keepalive ping toutes les 15 s) jusqu'à disconnect client ou `DELETE /mcp/sse`.
+3. Si `application/json` uniquement : comportement actuel inchangé (back-compat).
+4. Ne pas re-créer de session si `mcp-session-id` entrant est valide et présent → router vers la session existante. Si invalide → 404 `Mcp-Session-Not-Found`.
+5. Tests unitaires à ajouter :
+   - Accept matrix × method : `initialize`, `tools/list`, `tools/call` × Accept {json only, event-stream only, both, none}.
+   - Session reuse : second POST avec `mcp-session-id` ne doit pas créer nouvelle session.
+6. Vérifier que `handle_streamable_http_post` n'est pas un alias oublié — soit l'aligner soit le supprimer si mort.
+
+**Contrainte** :
+- Pas de `--no-verify`, pre-push green (lint-before-commit rule).
+- Conventional commit `fix(gateway): honor Accept: text/event-stream on /mcp/sse (CAB-XXXX)`.
+- Squash merge + delete branch.
+
+**DoD Phase 1** :
+- `cargo test -p stoa-gateway` vert.
+- `cargo clippy --all-targets -- -D warnings` vert.
+- Reproduction manuelle curl : Accept event-stream → réponse SSE, JSON only → JSON.
+- Test Accept matrix : ≥ 8 cas verts.
+
+### Phase 2 — P0 Validation canary puis prod
+
+1. Tilt k3d local : re-tester `POST /mcp/sse` avec curl matrix + MCP Inspector (`npx @modelcontextprotocol/inspector`). Gotcha Tilt k3d en mémoire (`gotcha_tilt_local.md`) — lire avant.
+2. Dev VPS (`dev-vps` 94.23.107.107 — Docker Compose, pas K8s) : déployer build.
+3. Configurer un connecteur MCP claude.ai de test pointant sur l'URL dev (ex : `https://dev-mcp.gostoa.dev` si existe, sinon prod avec feature flag — à clarifier).
+4. Observer les logs dev : séquence `DCR → token → initialize → tools/list → tools/call` sans boucle.
+5. Bump version chart gateway (patch) + release PR automatique (release-please).
+6. Post-merge : ArgoCD sync auto. Vérifier rollout (`kubectl -n stoa-system rollout status deploy/stoa-gateway --kubeconfig ~/.kube/config-stoa-ovh`).
+7. Capture écran claude.ai OK + `kubectl logs` montrant `tools/list` → archivage `docs/audits/2026-04-17-mcp-claude-ai-connector/AUDIT-RESULTS.md`.
+
+**DoD Phase 2** : claude.ai connecteur listé "Connected", tools apparaissent, appel d'outil réussit. Evidence archive remplie.
+
+### Phase 3 — P1 Soft-auth close (PR séparée)
+
+**Branche** : `fix/cab-YYYY-gateway-enforce-auth-mcp`
+
+Tâches :
+1. Identifier le code `require_auth` existant (déjà mentionné comme "code mort").
+2. Brancher sur toutes les routes `/mcp/*` sauf `GET /mcp` (ping anon) si existant.
+3. POST sans `Authorization` → `401` + `WWW-Authenticate: Bearer resource_metadata="/.well-known/oauth-protected-resource"`.
+4. Tests contract : anonymous, invalid bearer, expired bearer, valid bearer → 401/401/401/200.
+5. Supprimer le fallback `[stoa:read]` anonyme.
+
+**DoD** : tous les tests contract verts, reproduction curl sans header Authorization renvoie 401 avec challenge.
+
+### Phase 4 — P2 CORS ingress (PR séparée, dual-repo)
+
+1. Ajouter annotations dans `charts/stoa-platform/templates/ingress.yaml` pour le gateway (ou sous-chart dédié) :
+   ```
+   nginx.ingress.kubernetes.io/enable-cors: "true"
+   nginx.ingress.kubernetes.io/cors-allow-origin: "https://claude.ai, https://*.claude.ai, https://console.gostoa.dev, https://portal.gostoa.dev"
+   nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, OPTIONS, DELETE"
+   nginx.ingress.kubernetes.io/cors-allow-headers: "Authorization, Content-Type, mcp-session-id, mcp-protocol-version, Accept"
+   nginx.ingress.kubernetes.io/cors-expose-headers: "mcp-session-id"
+   ```
+2. Rendre configurables via `values.yaml` (`gateway.ingress.cors.allowedOrigins: []`).
+3. Sync miroir `stoa-infra/charts/`.
+4. Test post-deploy : `curl -X OPTIONS https://mcp.gostoa.dev/mcp/sse -H 'Origin: https://claude.ai' -H 'Access-Control-Request-Method: POST'` → 200 + headers CORS attendus.
+
+### Phase 5 — P3 OTLP (ticket séparé, hors scope immédiat)
+
+1. Vérifier santé `otel-collector` / tempo (ns `monitoring` ou `logging`).
+2. Tuner `BatchSpanProcessor` : augmenter `max_queue_size`, réduire `scheduled_delay`, ou baisser sampling.
+3. Ticket dédié, pas bloquant.
+
+---
+
+## 4. Commandes de référence
+
+Toutes prod = `KUBECONFIG=~/.kube/config-stoa-ovh`.
+
+```
+# Pods gateway
+kubectl -n stoa-system get pods -l app=stoa-gateway
+
+# Logs en tail (filtrer bruit OTEL)
+kubectl -n stoa-system logs -l app=stoa-gateway --tail=500 \
+  | grep -v "BatchSpanProcessor\|opentelemetry\|acme-challenge"
+
+# Access logs Claude-User
+kubectl -n stoa-system logs -l app=stoa-gateway --tail=5000 \
+  | grep -E "access_log" | grep -E "Claude-User|Claude/"
+
+# Trace OAuth → initialize d'une session
+kubectl -n stoa-system logs -l app=stoa-gateway --tail=10000 \
+  | grep -E "oauth/register|oauth/token|/mcp/sse" | grep "access_log"
+
+# Rollout
+kubectl -n stoa-system rollout status deploy/stoa-gateway
+```
+
+Test externe :
+```
+curl -sS -D - -X POST https://mcp.gostoa.dev/mcp/sse \
+  -H 'Accept: text/event-stream' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <kc-token>' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}'
+```
+
+Récup token Keycloak (user test) : via Portal OIDC session cookie, ou `stoactl auth login --oidc` si dispo, ou flow client_credentials avec un client admin de test.
+
+---
+
+## 5. Règles projet à respecter
+
+- **CLAUDE.md** : 1 chose à la fois, test-first `fix()`, PR ≤ 300 LOC, `--squash`+`--delete-branch`, conventional commits, Ticket ID sur 1er commit, lint avant commit, pas de `--no-verify`.
+- **Dual-repo** : chart gateway modifié doit être synchronisé `stoa/charts/` ↔ `stoa-infra/charts/`.
+- **Evidence archive** obligatoire après test Playwright / validation claude.ai : `docs/audits/2026-04-17-mcp-claude-ai-connector/AUDIT-RESULTS.md` + captures.
+- **Pas de reset password** Keycloak si token expiré — utiliser creds `.env`.
+- **Pre-push hook** obligatoire.
+- **Tests qui échouent AVANT le code** (test-first).
+- Pas mocker la boundary sous test (pas de `AsyncMock` sur HTTP ; utiliser `httpx.MockTransport` ou un serveur réel).
+
+---
+
+## 6. Ticketing Linear (à faire AVANT de coder)
+
+Team Linear STOA : `624a9948-a160-4e47-aba5-7f9404d23506`.
+
+Créer 4 tickets :
+
+| Ticket | Titre | Priorité | Pts | Phase |
+|--------|-------|----------|-----|-------|
+| CAB-NEW-A | fix(gateway): honor Accept: text/event-stream on /mcp/sse | P0 | 5 | 1+2 |
+| CAB-NEW-B | fix(gateway): enforce 401 on unauthenticated /mcp/* (close soft-auth) | P1 | 3 | 3 |
+| CAB-NEW-C | feat(chart): CORS annotations on stoa-gateway ingress | P2 | 2 | 4 |
+| CAB-NEW-D | chore(gateway): fix OTLP batch processor saturation | P3 | 2 | 5 |
+
+Impact Score probable ≥ HIGH (touche auth + prod client-facing) → vérifier si Council requis (seuil 16+). Utiliser `docs/scripts/build-context.sh --component stoa-gateway --ticket CAB-NEW-A` pour générer le context pack avant code.
+
+---
+
+## 7. Mémoires/Gotchas à lire AVANT de coder
+
+Dans `/Users/torpedo/.claude/projects/-Users-torpedo-hlfh-repos-stoa/memory/` :
+
+- `gotcha_gateway_soft_auth_mcp.md` — bug soft-auth, directement en lien avec Phase 3.
+- `gotcha_gateway_chart_baseDomain_hardcode.md` — chart gateway hardcode `baseDomain` sur `templates/deployment.yaml:62`. Pertinent pour Phase 4 (edits du chart).
+- `gotcha_tilt_local.md` — k3d local HTTPS pour OIDC, Helm overridable.
+- `feedback_evidence_archive.md` — archive obligatoire après test.
+- `feedback_lint_before_commit.md` — lint avant `git add`.
+- `feedback_linear_in_review.md` — "In Review" seulement si PR existe.
+
+---
+
+## 8. Pièges connus à éviter
+
+- **Pas de ré-déclenchement de DCR** côté serveur : Claude.ai spamme `/oauth/register`. Ne pas confondre cause et symptôme.
+- **mcp-session-id** : le header doit être à la fois renvoyé sur la réponse initialize ET accepté sur les requêtes suivantes. Ne pas oublier `Access-Control-Expose-Headers` si CORS activé (Phase 4).
+- **Streamable HTTP spec 2025-03-26** : https://modelcontextprotocol.io/specification/2025-03-26/basic/transports — à relire, notamment section "Sending Messages to the Server".
+- **Ne pas mélanger** avec la branche `feat/cab-2095-stoactl-api-tenant-scope` en cours — créer worktree dédié : `git worktree add .claude/worktrees/gateway-mcp-fix -b fix/cab-XXXX-gateway-mcp-sse-accept main`.
+- **Tests gateway** : `cargo test --all-features` requiert cmake (cf MEMORY.md). Local : `cargo test -p stoa-gateway`.
+
+---
+
+## 9. Critère global de succès
+
+Binaire, non négociable :
+
+1. ✅ Sur claude.ai web, ajouter un connecteur MCP "STOA" pointant vers `https://mcp.gostoa.dev/mcp/sse`, login OAuth réussi.
+2. ✅ Le connecteur liste les tools (`stoa_tenants`, `stoa_platform_health`, etc.) sans boucle DCR.
+3. ✅ Invocation d'un tool (ex : `stoa_platform_health`) retourne une réponse utilisable dans une conversation claude.ai.
+4. ✅ Logs gateway prod montrent la séquence complète : `initialize` (1×) → `tools/list` → `tools/call` → `notifications/*`.
+5. ✅ Aucune régression sur `claude-code` CLI (`GET /mcp/sse` avec UA `claude-code/x.y.z` continue de fonctionner).
+
+Si les 5 ne sont pas verts en prod, le handoff n'est pas clôturé.

--- a/docs/audits/2026-04-19-cab-2120-post-merge-rollout.md
+++ b/docs/audits/2026-04-19-cab-2120-post-merge-rollout.md
@@ -1,0 +1,106 @@
+# CAB-2120 Post-Merge Rollout Verification
+
+- UTC timestamp: `2026-04-19T16:02:00Z`
+- Local repo: `stoa`
+- Local HEAD: `c73fd58b21f23eaf6074c9f3e5d7c24245c57ebe`
+- Infra change: `PotoMitan/stoa-infra#45`
+- Verification scope: live state after merge and gateway rollout of `STOA_TOOL_EXPANSION_MODE=per-op`
+
+## Verdict
+
+`PARTIAL GO`
+
+The prod gateway rollout for `per-op` is live and verified.
+
+What is confirmed:
+
+- new gateway pods are running
+- the deployment now injects `STOA_TOOL_EXPANSION_MODE=per-op`
+- the rollout completed successfully
+
+What is still missing:
+
+- authenticated `tools/list` with a real `stoa-demo` JWT
+- authenticated invoke of `get-customer-by-number`
+
+`CAB-2120` is therefore **not closed yet**, but the deployment-side blocker is lifted.
+
+## Independently verified live evidence
+
+### 1. Gateway rollout
+
+Observed live pods:
+
+- `stoa-gateway-59b7f479c6-57vsp` — `Running`, `0` restarts
+- `stoa-gateway-59b7f479c6-zkwl6` — `Running`, `0` restarts
+
+Rollout status:
+
+```text
+deployment "stoa-gateway" successfully rolled out
+```
+
+### 2. Deployment env injection
+
+The live deployment now includes:
+
+```text
+STOA_TOOL_EXPANSION_MODE=per-op
+```
+
+This confirms the chart change is no longer just in Git; it is present in the running deployment spec.
+
+### 3. Live gateway image
+
+Current deployed image:
+
+```text
+ghcr.io/stoa-platform/stoa-gateway:dev-cd9941741c234f3b6fd0b6bde4afad480615aa27
+```
+
+This is consistent with the CAB-2113 code path previously identified.
+
+## Operator-reported but not independently re-verified in this pass
+
+The following signal was reported by the operator run after merge:
+
+- gateway logs include:
+  - `"API catalog tools registered","count":74,"mode":"PerOp"`
+  - followed by a warning fallback:
+    - `"No expanded tools found for gateway — falling back to unfiltered catalog"`
+    - `gateway_id="c97f041a-7916-4508-85cf-4e8bed8bf965"`
+
+I did not independently re-capture this log line in this pass.
+
+Interpretation if accurate:
+
+- `per-op` is active
+- gateway-scoped expansion may be empty for this gateway id
+- fallback still serves expanded tools from the unfiltered catalog
+- this is a follow-up concern, not yet proof of demo failure
+
+## Current blocking condition
+
+The remaining blocker is now purely **audience-path verification**:
+
+1. get a real `stoa-demo` JWT
+2. run authenticated `tools/list`
+3. run authenticated invoke of `get-customer-by-number` with `CUST-2026-0001`
+
+Until that happens:
+
+- deployment status = green
+- demo path status = partial
+
+## Next step
+
+Run these checks immediately with a real `stoa-demo` token:
+
+1. authenticated `GET /mcp/v1/tools`
+2. authenticated invoke of `get-customer-by-number`
+
+Decision rule:
+
+- `tools/list` green + invoke green -> `CAB-2120` can move toward done
+- `tools/list` green + invoke fails upstream -> investigate upstream/auth path, not chart wiring
+- `tools/list` missing expected tool -> investigate the fallback warning / gateway assignment path

--- a/docs/audits/2026-04-19-cab-2120-rollout-verification.md
+++ b/docs/audits/2026-04-19-cab-2120-rollout-verification.md
@@ -1,0 +1,96 @@
+# CAB-2120 Rollout Verification
+
+- UTC timestamp: `2026-04-19T15:54:46Z`
+- Local repo: `stoa`
+- Local HEAD: `c73fd58b21f23eaf6074c9f3e5d7c24245c57ebe`
+- Target infra PR: `PotoMitan/stoa-infra#45`
+- Verification scope: post-PR live state of the prod gateway rollout for `STOA_TOOL_EXPANSION_MODE=per-op`
+
+## Verdict
+
+`BLOCKED`
+
+The runtime verification cannot proceed yet because the infra change is **not deployed**:
+
+- PR `#45` is still `open`
+- `merged=false`
+- the live deployment does **not** expose `STOA_TOOL_EXPANSION_MODE`
+- the gateway is still serving the pre-change coarse tool shape
+
+This is a deployment-state blocker, not a runtime failure of the `per-op` path.
+
+## Evidence
+
+### 1. Infra PR status
+
+GitHub state at verification time:
+
+- PR: `https://github.com/PotoMitan/stoa-infra/pull/45`
+- state: `open`
+- merged: `false`
+- mergeable: `true`
+- head SHA: `4c98d6a459f2645f7d023892d3767c36c460ff70`
+
+### 2. Live gateway deployment
+
+Observed live deployment state:
+
+- rollout status: `deployment "stoa-gateway" successfully rolled out`
+- deployment generation: `486`
+- observedGeneration: `486`
+- image: `ghcr.io/stoa-platform/stoa-gateway:dev-cd9941741c234f3b6fd0b6bde4afad480615aa27`
+
+Targeted deployment inspection shows no injected `STOA_TOOL_EXPANSION_MODE` env var. The only matching deployment snippet found was the image line:
+
+```text
+132:        image: ghcr.io/stoa-platform/stoa-gateway:dev-cd9941741c234f3b6fd0b6bde4afad480615aa27
+```
+
+### 3. Live gateway pods
+
+Current pods at verification time:
+
+- `stoa-gateway-fcdd94774-mqllz` — `Running`, `0` restarts
+- `stoa-gateway-fcdd94774-rf246` — `Running`, `0` restarts
+
+This confirms the gateway is healthy, but it does **not** confirm the `per-op` overlay was applied.
+
+### 4. Current tool shape on the public MCP endpoint
+
+Anonymous `GET https://mcp.gostoa.dev/mcp/v1/tools` still exposes coarse banking/catalog entries such as:
+
+- `banking-services-v1-2`
+- `customer-360-api`
+
+No `get-customer-by-number` name was observed during this verification pass.
+
+This is consistent with the gateway still serving the pre-flip coarse expansion mode.
+
+## What was intentionally not attempted
+
+Authenticated checks were **not** executed in this pass:
+
+- authenticated `tools/list`
+- invoke `get-customer-by-number`
+
+Reason:
+
+- PR `#45` is not merged yet, so the rollout target state is absent
+- running auth-dependent checks now would only reconfirm the old state and muddy the report
+
+## Operational conclusion
+
+The next valid step is:
+
+1. merge `PotoMitan/stoa-infra#45`
+2. allow ArgoCD to sync the `stoa-gateway` application
+3. re-run verification in this order:
+   - confirm `STOA_TOOL_EXPANSION_MODE=per-op` is injected
+   - check rollout health
+   - authenticated `tools/list`
+   - authenticated invoke `get-customer-by-number`
+
+## Go / No-Go
+
+- `NO-GO` for claiming CAB-2120 is fixed
+- `GO` to merge PR `#45` and continue with post-rollout verification immediately after sync

--- a/docs/audits/2026-04-19-cab-2123-post-merge-verification/AUDIT-RESULTS.md
+++ b/docs/audits/2026-04-19-cab-2123-post-merge-verification/AUDIT-RESULTS.md
@@ -1,0 +1,54 @@
+# CAB-2123 — Post-merge verification
+
+- **Date**: 2026-04-19
+- **PR**: https://github.com/stoa-platform/stoa/pull/2426
+- **Squash commit**: `3a0614bc`
+- **Cluster**: OVH MKS GRA9 (`config-stoa-ovh`)
+- **Deployment**: `stoa-system/stoa-gateway`
+
+## Rollout confirmation
+
+- Image on live deployment: `ghcr.io/stoa-platform/stoa-gateway:dev-3a0614bcadb86b032eb487d03be7f57512db1c34`
+- `observedGeneration` / `generation`: `488 / 488`
+- Pods post-rollout: `stoa-gateway-9dc9bcd77-8zr4r`, `stoa-gateway-9dc9bcd77-gf42s` — both `Running 1/1`, `0` restarts
+
+## Baseline (pre-merge, anonymous call)
+
+```
+$ curl -sS https://mcp.gostoa.dev/mcp/v1/tools | jq '.tools | length'
+15
+```
+
+All 15 tools were `stoa_*` platform tools. Zero banking tools visible.
+
+## Post-merge (anonymous call, same endpoint)
+
+```
+$ curl -sS https://mcp.gostoa.dev/mcp/v1/tools | jq '.tools | length'
+89
+```
+
+7/7 banking per-op tools now visible via standard discovery:
+
+- `demo:banking-services-v1-2:getaccountbalance`
+- `demo:banking-services-v1-2:getaccounttransactions`
+- `demo:banking-services-v1-2:getcustomerbynumber`
+- `demo:banking-services-v1-2:gettransferstatus`
+- `demo:banking-services-v1-2:initiateinternationaltransfer`
+- `demo:banking-services-v1-2:initiatesepatransfer`
+- `demo:banking-services-v1-2:listaccountsbycustomer`
+
+## DoD
+
+| Criterion | Status |
+|---|---|
+| `into_public()` tool → `definition().tenant_id == None` | PASS (regression_cab_2123_public_dynamic_tool_has_no_tenant_in_definition) |
+| `registry.list(Some("any-tenant"))` includes public DynamicTool | PASS (regression_cab_2123_registry_list_includes_public_dynamic_tool_for_any_tenant) |
+| Non-public DynamicTool stays tenant-scoped | PASS (regression_cab_2123_registry_list_keeps_private_dynamic_tool_tenant_scoped) |
+| api_bridge per-op integration shape | PASS (regression_cab_2123_public_per_op_tool_surfaces_via_standard_list) |
+| `cargo clippy --all-targets -- -D warnings` green | PASS |
+| Post-merge prod: banking tools visible via standard discovery | **PASS — 7/7 tools visible** |
+
+## Conclusion
+
+CAB-2088 demo acte 1 standard-client path unblocked. Generic MCP clients (Claude Connector, Codex Custom MCP) can now discover the banking catalog through `tools/list` without relying on the bricolé `stoa_tools action=list` path.

--- a/docs/audits/2026-04-19-demo-readiness-prod-check.md
+++ b/docs/audits/2026-04-19-demo-readiness-prod-check.md
@@ -1,0 +1,249 @@
+# Demo Readiness Report — 2026-04-19
+
+UTC timestamp: `2026-04-19T12:40:54Z`
+
+Local HEAD at run time: `ce11d0ac8018d1312da9eb3fa06cc29a7697d949`
+
+`main` HEAD at run time: `3e57435dff98c6d75f0c3789a54c8242c90f2ac4`
+
+Observed production gateway artifact:
+- Deployed image: `ghcr.io/stoa-platform/stoa-gateway:dev-cd9941741c234f3b6fd0b6bde4afad480615aa27`
+- Namespace: `stoa-system`
+- Pods observed: `stoa-gateway-fcdd94774-mqllz`, `stoa-gateway-fcdd94774-rf246`
+
+## Scope
+
+This report covers read-only production checks run from the local repo against `*.gostoa.dev` and the OVH kubeconfig. It is intentionally split between:
+- observed production state
+- verification script regressions
+- items requiring Claude Code confirmation or follow-up
+
+## Executive Summary
+
+The `edge-mcp` production path is live enough for demo preparation: Console, Portal, CP API, Gateway health, Gateway OIDC discovery, and Grafana behind `console.gostoa.dev` all responded successfully during the run.
+
+The main confirmed red on the current demo path is OpenSearch Dashboards, which returned `HTTP 503` with body `OpenSearch Dashboards server is not ready yet`. Two security/observability gaps also remain confirmed in prod: anonymous `GET /mcp/v1/tools` returns a full tool list, and public `GET /metrics` returns `200` with `gateway_otel_spans_exported_total 0`.
+
+Three verification scripts are currently unreliable as audit artifacts because they stop too early or have config drift. They still provide signal, but not a complete matrix.
+
+## Commands Run
+
+### Scripted checks
+
+1. `bash scripts/demo/smoke-test-production.sh`
+2. `bash scripts/demo/demo-dry-run.sh`
+3. `bash scripts/demo/pre-demo-check.sh`
+
+### Manual follow-up checks
+
+1. `curl https://console.gostoa.dev/`
+2. `curl https://portal.gostoa.dev/`
+3. `curl https://api.gostoa.dev/health`
+4. `curl https://mcp.gostoa.dev/health`
+5. `curl https://mcp.gostoa.dev/mcp/v1/tools`
+6. `curl -X POST https://mcp.gostoa.dev/mcp/tools/call`
+7. `curl https://mcp.gostoa.dev/metrics`
+8. `curl https://opensearch.gostoa.dev/`
+9. `curl https://console.gostoa.dev/grafana/api/health`
+10. `KUBECONFIG=$HOME/.kube/config-stoa-ovh kubectl cluster-info`
+11. `KUBECONFIG=$HOME/.kube/config-stoa-ovh kubectl get ns`
+12. `KUBECONFIG=$HOME/.kube/config-stoa-ovh kubectl get pods -A | rg 'gateway|mcp|stoa-gateway'`
+
+## Results
+
+### 1. Gaps confirmed vs supposed
+
+#### Confirmed
+
+- `mcp.gostoa.dev/health` returned healthy.
+- `GET /mcp/v1/tools` is anonymously accessible in prod and returned a list of `41` tools.
+- `POST /mcp/tools/call` without auth reached execution and returned:
+
+```text
+HTTP 500
+{"content":[{"type":"text","text":"Execution failed: HTTP request failed: error sending request for url (http://fapi-echo:8889/)"}],"isError":true}
+```
+
+- `GET /admin/health` returned `401`.
+- `GET /metrics` is publicly accessible and returned `200`.
+- `gateway_otel_spans_exported_total` is still `0` in the public metrics output.
+- `console.gostoa.dev/grafana/api/health` returned `200`.
+- `opensearch.gostoa.dev/` returned:
+
+```text
+HTTP/2 503
+OpenSearch Dashboards server is not ready yet
+```
+
+- OVH kube access works with explicit kubeconfig.
+- Production gateway pods are running in `stoa-system`.
+
+#### Not confirmed in this run
+
+- Authenticated MCP invoke with tenant/demo JWTs.
+- Federation flows requiring `FEDERATION_SECRET_*` and `DEMO_PASSWORD`.
+- Whether the exact webMethods/Axway demo tools are visible to the authenticated `stoa-demo` audience.
+- Whether CP-API writes are immediately reflected in the gateway catalog for the demo tenant.
+
+#### Nuance
+
+- The anonymous tool list did contain banking-related names:
+  - `account-management-api`
+  - `banking-services-v1-2`
+  - `fapi-accounts`
+  - `customer-360-api`
+  - `fapi-transfers`
+- The specific local CRD tool names from `tools/` such as `get-customer-by-number` were not found in the anonymous list during this run.
+
+### 2. Regressions recent or newly surfaced by this run
+
+#### Confirmed production regression
+
+- OpenSearch Dashboards is currently not ready in prod. This is not a script artifact; it was reproduced directly with `curl`.
+
+#### Script regressions or config drift
+
+- `scripts/demo/smoke-test-production.sh` exits on the first failure because `set -e` combines badly with `check()` returning non-zero. It did not complete the full matrix after the OpenSearch `503`.
+- `scripts/demo/demo-dry-run.sh` is operational enough to produce signal, but it hard-stops in Act 6 when `FEDERATION_SECRET_ALPHA` is unset.
+- `scripts/demo/pre-demo-check.sh` is not currently reliable as a prod readiness artifact:
+  - it uses the default kube context, which failed, while the explicit OVH kubeconfig worked
+  - it defaults `GRAFANA_URL` to `https://grafana.gostoa.dev`, which did not resolve in this run
+  - it exits on first `FAIL`, so it does not yield a complete GO/NO-GO matrix
+
+### 3. Demo blockers for 2026-04-28
+
+#### Red blockers on the critical path
+
+- OpenSearch Dashboards `503`.
+  - If the demo uses OpenSearch directly or relies on Dashboards for the investigation act, this is a real blocker.
+  - If the demo can stay on Grafana-only observability, this is downgradable to yellow.
+
+#### Yellow blockers or high-risk prerequisites
+
+- Anonymous MCP discovery is still open.
+  - This is not necessarily a blocker for the demo narrative, but it is a real audit exposure if someone explores live.
+
+- Anonymous `tools/call` reaches execution and fails inside a backend call.
+  - This confirms the defense-in-depth story only partially.
+  - It also confirms an auth gap: the gateway is not hard-denying the request early.
+
+- `gateway_otel_spans_exported_total 0`.
+  - Not a functional gateway blocker.
+  - A blocker if the demo depends on this exact metric in dashboards or narration.
+
+- Demo/federation scripts cannot complete from this machine because required env vars are unset:
+  - `ART3MIS_PASSWORD`
+  - `PARZIVAL_PASSWORD`
+  - `FEDERATION_SECRET_ALPHA`
+  - `FEDERATION_SECRET_BETA`
+  - `FEDERATION_SECRET_GAMMA`
+  - `DEMO_PASSWORD`
+  - `INFISICAL_TOKEN`
+
+- mTLS section in `demo-dry-run.sh` failed with `invalid_client` even though `credentials.json` and `fingerprints.csv` existed.
+  - This is a real finding until disproved.
+  - It may be a drift between seeded demo credentials and current Keycloak/client state.
+
+#### Green on the current path
+
+- Console reachable
+- Portal reachable
+- CP API health
+- Gateway health
+- Gateway OIDC discovery
+- Grafana behind console
+- OVH kube API reachable with explicit config
+- Production gateway pods running
+
+### 4. Tickets to create or update before the demo
+
+#### Existing tickets already justified by this run
+
+- `CAB-2092` — public `/metrics`
+  - confirmed
+
+- `CAB-2093` — `gateway_otel_spans_exported_total 0`
+  - confirmed
+
+#### Likely missing tickets or runbook fixes
+
+- Fix `scripts/demo/smoke-test-production.sh` so it produces a full report even when one check fails.
+- Fix `scripts/demo/pre-demo-check.sh`:
+  - explicit OVH kubeconfig support
+  - current Grafana URL/path
+  - non-fatal aggregation instead of first-fail exit
+- Fix `scripts/demo/demo-dry-run.sh` so missing secrets degrade cleanly into `SKIP` instead of aborting the whole run.
+- OpenSearch Dashboards readiness incident or bug ticket if none exists yet.
+- Demo readiness ticket for verifying the live visibility and invocation path of the webMethods/Axway banking tools as seen by `stoa-demo`.
+- Demo readiness ticket for the mTLS `invalid_client` drift if this act is still in scope.
+
+## Raw Script Signal
+
+### `smoke-test-production.sh`
+
+Observed before abort:
+- PASS Console HTTPS reachable
+- PASS CP API health
+- PASS Portal HTTPS reachable
+- PASS Gateway `/health`
+- PASS Gateway OIDC discovery
+- PASS Grafana reachable
+- PASS Grafana login
+- FAIL OpenSearch Dashboards HTTPS
+
+Abort reason:
+- script stopped on first fail
+
+### `demo-dry-run.sh`
+
+Observed before abort:
+- PASS Console accessible
+- PASS API health
+- PASS Keycloak reachable
+- PASS OIDC discovery
+- FAIL Token issuance (`art3mis`) — no token returned
+- PASS Portal accessible
+- PASS Gateway health
+- PASS credentials.json present
+- PASS fingerprints.csv present
+- FAIL mTLS token acquisition — `invalid_client`
+- PASS Grafana health
+- FAIL OpenSearch Dashboards — `HTTP 503`
+
+Abort reason:
+- missing `FEDERATION_SECRET_ALPHA`
+
+### `pre-demo-check.sh`
+
+Observed before abort:
+- FAIL Kubernetes cluster unreachable
+
+Manual follow-up disproved the service assumption:
+- kube API is reachable with `KUBECONFIG=$HOME/.kube/config-stoa-ovh`
+
+## Claude Verification Checklist
+
+Claude Code should verify these items in priority order:
+
+1. Confirm whether OpenSearch `503` is a current prod incident or an expected transient bootstrap state.
+2. Confirm whether the demo can run Grafana-only if OpenSearch remains unavailable.
+3. Re-run MCP checks with valid `stoa-demo` credentials and record:
+   - authenticated tool count
+   - presence of the webMethods/Axway banking tools
+   - one successful end-to-end invoke on the demo tenant
+4. Confirm whether the anonymous `tools/call` path should be treated as a blocker or a known gap with acceptable demo workaround.
+5. Verify the mTLS `invalid_client` finding with current seeded credentials and Keycloak client state.
+6. Fix the three verification scripts so the next run produces a complete artifact without manual salvage.
+7. Check whether the gateway catalog source gap affects the exact demo write/read flow.
+
+## Current Verdict
+
+Verdict at `2026-04-19T12:40:54Z`:
+- Core edge gateway path: `GREEN`
+- Demo environment automation/runbooks: `YELLOW`
+- Security posture on MCP discovery and metrics: `YELLOW/RED`
+- OpenSearch observability path: `RED`
+
+If the April 28 demo depends on OpenSearch Dashboards or on a live authenticated banking-tool invoke that has not yet been revalidated with real secrets, the demo is not ready to call `GO` without follow-up.
+
+If the demo can stay on Console + Gateway + Grafana and the banking-tool invoke is revalidated quickly with proper credentials, the current state is recoverable.


### PR DESCRIPTION
## Summary

Per the **evidence-archive-mandatory** rule, archive recent audit evidence currently sitting untracked on local workspace. All paths are under `docs/audits/<YYYY-MM-DD>-<topic>/` per convention.

## Archived

| Path | Coverage |
|------|----------|
| `2026-04-17-mcp-claude-ai-connector/AUDIT-RESULTS.md` + `HANDOFF.md` | Triple regression fix on Claude.ai MCP connector — CAB-2106 (Accept header), CAB-2109 (public_methods matrix), CAB-2112 (experimental dict). Live on gateway 0.9.8. |
| `2026-04-19-cab-2120-post-merge-rollout.md` | CAB-2120 post-merge rollout report |
| `2026-04-19-cab-2120-rollout-verification.md` | CAB-2120 verification (binary pass/fail) |
| `2026-04-19-cab-2123-post-merge-verification/AUDIT-RESULTS.md` | CAB-2123 verification — anonymous `/mcp/v1/tools` went 15→89 tools, 7/7 banking per-op surfaced |
| `2026-04-19-demo-readiness-prod-check.md` | Codex prod audit → 4 follow-up tickets (CAB-2119/2120/2121/2122) |

## Test plan

- [x] All paths follow `docs/audits/<date>-<topic>/` convention
- [x] No code change, +939 LOC docs only
- [ ] CI doc-only checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)