### PR TITLE
fix(api): drop gitlab _project deref in catalog sync (CAB-1889)

### DIFF
--- a/control-plane-api/src/routers/mcp_gitops.py
+++ b/control-plane-api/src/routers/mcp_gitops.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth.dependencies import User, get_current_user
+from ..config import settings
 from ..database import get_db as get_async_db
 from ..services.git_provider import GitProvider, get_git_provider
 from ..services.mcp_sync_service import MCPSyncService
@@ -56,7 +57,7 @@ class GitHealthResponse(BaseModel):
 
     status: str
     project: str | None = None
-    project_id: int | None = None
+    project_id: str | int | None = None
     default_branch: str | None = None
     error: str | None = None
 
@@ -118,7 +119,7 @@ async def trigger_full_sync(
 
     try:
         # Ensure git provider connection
-        if not git._project:  # TODO(CAB-1889): abstract _project access
+        if not git.is_connected():
             await git.connect()
 
         # Run sync
@@ -157,7 +158,7 @@ async def trigger_tenant_sync(
     logger.info(f"User {user.username} triggered MCP sync for tenant {tenant_id}")
 
     try:
-        if not git._project:  # TODO(CAB-1889): abstract _project access
+        if not git.is_connected():
             await git.connect()
 
         sync_service = MCPSyncService(git, db)
@@ -194,7 +195,7 @@ async def trigger_server_sync(
     logger.info(f"User {user.username} triggered sync for MCP server {server_name}")
 
     try:
-        if not git._project:  # TODO(CAB-1889): abstract _project access
+        if not git.is_connected():
             await git.connect()
 
         sync_service = MCPSyncService(git, db)
@@ -272,17 +273,21 @@ async def get_git_health(
     Requires: cpi-admin role
     """
     try:
-        if not git._project:  # TODO(CAB-1889): abstract _project access
+        if not git.is_connected():
             await git.connect()
 
-        # Try to list root directory
-        git._project.repository_tree(ref="main", per_page=1)  # TODO(CAB-1889): abstract _project access
+        project_id: str | int
+        if settings.GIT_PROVIDER.lower() == "github":
+            project_id = f"{settings.GITHUB_ORG}/{settings.GITHUB_CATALOG_REPO}"
+        else:
+            project_id = settings.GITLAB_PROJECT_ID
+        repo = await git.get_repo_info(str(project_id))
 
         return {
             "status": "healthy",
-            "project": git._project.name,  # TODO(CAB-1889): abstract _project access
-            "project_id": git._project.id,  # TODO(CAB-1889): abstract _project access
-            "default_branch": "main",
+            "project": repo.get("name"),
+            "project_id": project_id,
+            "default_branch": repo.get("default_branch", "main"),
         }
 
     except Exception:
@@ -306,7 +311,7 @@ async def list_git_servers(
     Requires: cpi-admin role
     """
     try:
-        if not git._project:  # TODO(CAB-1889): abstract _project access
+        if not git.is_connected():
             await git.connect()
 
         servers = await git.list_all_mcp_servers()  # TODO(CAB-1889): add list_all_mcp_servers to GitProvider ABC

--- a/control-plane-api/src/services/catalog_sync_service.py
+++ b/control-plane-api/src/services/catalog_sync_service.py
@@ -4,7 +4,6 @@ import logging
 import time
 from datetime import UTC, datetime
 
-import yaml
 from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -65,8 +64,8 @@ class CatalogSyncService:
             apis_failed = 0
             errors = []
 
-            # Ensure GitLab connection
-            if not self.git._project:
+            # Ensure provider connection
+            if not self.git.is_connected():
                 await self.git.connect()
 
             # Get current commit SHA
@@ -152,8 +151,8 @@ class CatalogSyncService:
         await self.db.refresh(sync_status)
 
         try:
-            # Ensure GitLab connection
-            if not self.git._project:
+            # Ensure provider connection
+            if not self.git.is_connected():
                 await self.git.connect()
 
             commit_sha = await self._get_current_commit_sha()
@@ -180,20 +179,17 @@ class CatalogSyncService:
             raise
 
     async def _get_current_commit_sha(self) -> str | None:
-        """Get the current HEAD commit SHA from GitLab"""
+        """Get the current HEAD commit SHA from the configured git provider."""
         try:
-            commits = self.git._project.commits.list(ref_name="main", per_page=1)
-            if commits:
-                return commits[0].id
+            return await self.git.get_head_commit_sha()
         except Exception as e:
             logger.warning(f"Failed to get current commit SHA: {e}")
         return None
 
     async def _list_tenants(self) -> list[str]:
-        """List all tenant IDs from GitLab"""
+        """List all tenant IDs from the configured git provider."""
         try:
-            tree = self.git._project.repository_tree(path="tenants", ref="main")
-            return [item["name"] for item in tree if item["type"] == "tree"]
+            return await self.git.list_tenants()
         except Exception as e:
             logger.warning(f"Failed to list tenants: {e}")
             return []
@@ -209,11 +205,10 @@ class CatalogSyncService:
         if existing is not None:
             return False
 
-        # Read tenant.yaml from Git
+        # Read tenant.yaml from the provider
         tenant_meta = {}
         try:
-            file = self.git._project.files.get(f"tenants/{tenant_id}/tenant.yaml", ref="main")
-            tenant_meta = yaml.safe_load(file.decode()) or {}
+            tenant_meta = await self.git.get_tenant(tenant_id) or {}
         except Exception as e:
             logger.debug(f"No tenant.yaml for {tenant_id}: {e}")
 
@@ -504,8 +499,8 @@ class CatalogSyncService:
             "errors": [],
         }
 
-        # Ensure GitLab connection
-        if not self.git._project:
+        # Ensure provider connection
+        if not self.git.is_connected():
             await self.git.connect()
 
         commit_sha = await self._get_current_commit_sha()

--- a/control-plane-api/src/services/git_provider.py
+++ b/control-plane-api/src/services/git_provider.py
@@ -4,6 +4,7 @@ ABC that defines the contract for git-based catalog operations.
 Implementations: GitLabService (existing), GitHubService (Wave 2).
 """
 
+import asyncio
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from pathlib import Path
@@ -189,6 +190,55 @@ class GitProvider(ABC):
             return yaml.safe_load(content)
         except FileNotFoundError:
             return None
+
+    def is_connected(self) -> bool:
+        """Return True when the provider client is initialized."""
+        return bool(getattr(self, "_project", None) or getattr(self, "_gh", None))
+
+    async def get_head_commit_sha(self, ref: str = "main") -> str | None:
+        """Return the current HEAD commit SHA for the provider's catalog repo."""
+        raise NotImplementedError("get_head_commit_sha() must be implemented by the provider")
+
+    async def get_tenant(self, tenant_id: str) -> dict | None:
+        """Return tenant metadata from the provider's catalog repo."""
+        raise NotImplementedError("get_tenant() must be implemented by the provider")
+
+    async def list_tenants(self) -> list[str]:
+        """List tenant identifiers from the provider's catalog repo."""
+        raise NotImplementedError("list_tenants() must be implemented by the provider")
+
+    async def get_api(self, tenant_id: str, api_name: str) -> dict | None:
+        """Return normalized API metadata for a tenant API."""
+        raise NotImplementedError("get_api() must be implemented by the provider")
+
+    async def list_apis(self, tenant_id: str) -> list[dict]:
+        """List normalized APIs for a tenant."""
+        raise NotImplementedError("list_apis() must be implemented by the provider")
+
+    async def get_api_openapi_spec(self, tenant_id: str, api_name: str) -> dict | None:
+        """Return the parsed OpenAPI spec for a tenant API, if present."""
+        raise NotImplementedError("get_api_openapi_spec() must be implemented by the provider")
+
+    async def list_apis_parallel(self, tenant_id: str) -> list[dict]:
+        """Provider-agnostic fallback to sequential API listing."""
+        return await self.list_apis(tenant_id)
+
+    async def get_all_openapi_specs_parallel(self, tenant_id: str, api_ids: list[str]) -> dict[str, dict | None]:
+        """Provider-agnostic fallback to parallel OpenAPI spec fetches."""
+
+        async def fetch_spec(api_id: str) -> tuple[str, dict | None]:
+            return (api_id, await self.get_api_openapi_spec(tenant_id, api_id))
+
+        results = await asyncio.gather(*[fetch_spec(api_id) for api_id in api_ids])
+        return dict(results)
+
+    async def list_mcp_servers(self, tenant_id: str = "_platform") -> list[dict]:
+        """List MCP servers defined for a tenant or platform scope."""
+        raise NotImplementedError("list_mcp_servers() must be implemented by the provider")
+
+    async def list_all_mcp_servers(self) -> list[dict]:
+        """List MCP servers across platform and tenant scopes."""
+        raise NotImplementedError("list_all_mcp_servers() must be implemented by the provider")
 
     @abstractmethod
     async def batch_commit(

--- a/control-plane-api/src/services/git_service.py
+++ b/control-plane-api/src/services/git_service.py
@@ -119,6 +119,25 @@ class GitLabService(GitProvider):
         self._gl = None
         self._project = None
 
+    async def get_head_commit_sha(self, ref: str = "main") -> str | None:
+        """Return the current HEAD commit SHA from GitLab."""
+        if not self._project:
+            raise RuntimeError("GitLab not connected")
+        commits = self._project.commits.list(ref_name=ref, per_page=1)
+        if not commits:
+            return None
+        return commits[0].id
+
+    async def list_tenants(self) -> list[str]:
+        """List tenant IDs from the catalog repository."""
+        if not self._project:
+            raise RuntimeError("GitLab not connected")
+        try:
+            tree = self._project.repository_tree(path="tenants", ref="main")
+            return [item["name"] for item in tree if item["type"] == "tree"]
+        except gitlab.exceptions.GitlabGetError:
+            return []
+
     # ============================================================
     # GitProvider ABC implementations
     # ============================================================

--- a/control-plane-api/src/services/github_service.py
+++ b/control-plane-api/src/services/github_service.py
@@ -5,7 +5,9 @@ project_id format: "org/repo" (e.g. "stoa-platform/stoa-catalog").
 """
 
 import asyncio
+import json
 import logging
+import re
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -17,6 +19,86 @@ from ..config import settings
 from .git_provider import GitProvider
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_api_data(raw_data: dict) -> dict:
+    """Normalize API data from GitHub YAML to the catalog sync format."""
+    if "apiVersion" in raw_data and "kind" in raw_data:
+        metadata = raw_data.get("metadata", {})
+        spec = raw_data.get("spec", {})
+        backend = spec.get("backend", {})
+        deployments = spec.get("deployments", {})
+
+        return {
+            "id": metadata.get("name", ""),
+            "name": metadata.get("name", ""),
+            "display_name": spec.get("displayName", metadata.get("name", "")),
+            "version": metadata.get("version", "1.0.0"),
+            "description": spec.get("description", ""),
+            "backend_url": backend.get("url", ""),
+            "status": spec.get("status", "draft"),
+            "deployments": {
+                "dev": deployments.get("dev", False),
+                "staging": deployments.get("staging", False),
+            },
+        }
+
+    return raw_data
+
+
+def _normalize_mcp_server_data(raw_data: dict, git_path: str) -> dict:
+    """Normalize MCP server YAML to the existing catalog sync format."""
+    metadata = raw_data.get("metadata", {})
+    spec = raw_data.get("spec", {})
+    visibility = spec.get("visibility", {})
+    subscription = spec.get("subscription", {})
+    backend = spec.get("backend", {})
+
+    tools = []
+    for tool in spec.get("tools", []):
+        tools.append(
+            {
+                "name": tool.get("name"),
+                "display_name": tool.get("displayName", tool.get("name")),
+                "description": tool.get("description", ""),
+                "endpoint": tool.get("endpoint", ""),
+                "method": tool.get("method", "POST"),
+                "enabled": tool.get("enabled", True),
+                "requires_approval": tool.get("requiresApproval", False),
+                "input_schema": tool.get("inputSchema", {}),
+                "timeout": tool.get("timeout", "30s"),
+                "rate_limit": tool.get("rateLimit", {}).get("requestsPerMinute", 60),
+            }
+        )
+
+    return {
+        "name": metadata.get("name", ""),
+        "tenant_id": metadata.get("tenant", "_platform"),
+        "version": metadata.get("version", "1.0.0"),
+        "display_name": spec.get("displayName", metadata.get("name", "")),
+        "description": spec.get("description", ""),
+        "icon": spec.get("icon", ""),
+        "category": spec.get("category", "public"),
+        "status": spec.get("status", "active"),
+        "documentation_url": spec.get("documentationUrl", ""),
+        "visibility": {
+            "public": visibility.get("public", True),
+            "roles": visibility.get("roles", []),
+            "exclude_roles": visibility.get("excludeRoles", []),
+        },
+        "requires_approval": subscription.get("requiresApproval", False),
+        "auto_approve_roles": subscription.get("autoApproveRoles", []),
+        "default_plan": subscription.get("defaultPlan", "free"),
+        "tools": tools,
+        "backend": {
+            "base_url": backend.get("baseUrl", ""),
+            "auth_type": backend.get("auth", {}).get("type", "none"),
+            "secret_ref": backend.get("auth", {}).get("secretRef", ""),
+            "timeout": backend.get("timeout", "30s"),
+            "retries": backend.get("retries", 3),
+        },
+        "git_path": git_path,
+    }
 
 
 class GitHubService(GitProvider):
@@ -42,6 +124,10 @@ class GitHubService(GitProvider):
         if self._gh:
             self._gh.close()
         self._gh = None
+
+    def is_connected(self) -> bool:
+        """Return True when the PyGithub client is initialized."""
+        return self._gh is not None
 
     async def clone_repo(self, repo_url: str) -> Path:
         """Clone a GitHub repository to a temporary directory."""
@@ -145,6 +231,218 @@ class GitHubService(GitProvider):
             "url": repo.html_url,
             "visibility": "private" if repo.private else "public",
         }
+
+    async def get_head_commit_sha(self, ref: str = "main") -> str | None:
+        """Return the HEAD commit SHA for the catalog branch."""
+        repo = self._get_repo(self._catalog_project_id())
+        try:
+            branch = repo.get_branch(ref)
+        except GithubException as exc:
+            if exc.status == 404:
+                return None
+            raise
+        return branch.commit.sha
+
+    async def get_tenant(self, tenant_id: str) -> dict | None:
+        """Return tenant metadata from tenant.yaml if present."""
+        project_id = self._catalog_project_id()
+        file_path = f"{self._get_tenant_path(tenant_id)}/tenant.yaml"
+        try:
+            content = await self.get_file_content(project_id, file_path)
+        except FileNotFoundError:
+            return None
+
+        try:
+            return yaml.safe_load(content) or {}
+        except yaml.YAMLError as exc:
+            logger.error("Failed to parse tenant YAML for %s: %s", tenant_id, exc)
+            return None
+
+    async def list_tenants(self) -> list[str]:
+        """List tenants from the catalog repository."""
+        repo = self._get_repo(self._catalog_project_id())
+        try:
+            contents = repo.get_contents("tenants", ref="main")
+        except GithubException as exc:
+            if exc.status == 404:
+                return []
+            raise
+
+        if not isinstance(contents, list):
+            contents = [contents]
+
+        return [item.name for item in contents if item.type == "dir"]
+
+    async def get_api(self, tenant_id: str, api_name: str) -> dict | None:
+        """Return normalized API metadata from api.yaml."""
+        project_id = self._catalog_project_id()
+        file_path = f"{self._get_api_path(tenant_id, api_name)}/api.yaml"
+        try:
+            content = await self.get_file_content(project_id, file_path)
+        except FileNotFoundError:
+            return None
+
+        try:
+            raw_data = yaml.safe_load(content) or {}
+        except yaml.YAMLError as exc:
+            logger.error("Failed to parse API YAML for %s/%s: %s", tenant_id, api_name, exc)
+            return None
+
+        return _normalize_api_data(raw_data)
+
+    async def list_apis(self, tenant_id: str) -> list[dict]:
+        """List APIs for a tenant from GitHub."""
+        repo = self._get_repo(self._catalog_project_id())
+        base_path = f"{self._get_tenant_path(tenant_id)}/apis"
+        try:
+            contents = repo.get_contents(base_path, ref="main")
+        except GithubException as exc:
+            if exc.status == 404:
+                return []
+            raise
+
+        if not isinstance(contents, list):
+            contents = [contents]
+
+        apis: list[dict] = []
+        for item in contents:
+            if item.type != "dir" or item.name == ".gitkeep":
+                continue
+            api = await self.get_api(tenant_id, item.name)
+            if api:
+                apis.append(api)
+        return apis
+
+    async def list_apis_parallel(self, tenant_id: str) -> list[dict]:
+        """List tenant APIs with concurrent GitHub fetches."""
+        repo = self._get_repo(self._catalog_project_id())
+        base_path = f"{self._get_tenant_path(tenant_id)}/apis"
+        try:
+            contents = repo.get_contents(base_path, ref="main")
+        except GithubException as exc:
+            if exc.status == 404:
+                return []
+            raise
+
+        if not isinstance(contents, list):
+            contents = [contents]
+
+        api_names = [item.name for item in contents if item.type == "dir" and item.name != ".gitkeep"]
+        results = await asyncio.gather(*[self.get_api(tenant_id, api_name) for api_name in api_names])
+        return [api for api in results if api is not None]
+
+    async def get_api_openapi_spec(self, tenant_id: str, api_name: str) -> dict | None:
+        """Return the parsed OpenAPI spec for a tenant API."""
+        project_id = self._catalog_project_id()
+        base_path = self._get_api_path(tenant_id, api_name)
+
+        for filename in ("openapi.yaml", "openapi.yml", "openapi.json"):
+            try:
+                content = await self.get_file_content(project_id, f"{base_path}/{filename}")
+            except FileNotFoundError:
+                continue
+
+            try:
+                if filename.endswith(".json"):
+                    return json.loads(content)
+                return yaml.safe_load(content)
+            except (json.JSONDecodeError, yaml.YAMLError) as exc:
+                logger.error("Failed to parse OpenAPI spec for %s/%s (%s): %s", tenant_id, api_name, filename, exc)
+                return None
+
+        return None
+
+    async def get_all_openapi_specs_parallel(self, tenant_id: str, api_ids: list[str]) -> dict[str, dict | None]:
+        """Fetch OpenAPI specs for multiple APIs concurrently."""
+
+        async def fetch_spec(api_id: str) -> tuple[str, dict | None]:
+            return (api_id, await self.get_api_openapi_spec(tenant_id, api_id))
+
+        results = await asyncio.gather(*[fetch_spec(api_id) for api_id in api_ids])
+        return dict(results)
+
+    async def get_full_tree_recursive(self, path: str = "tenants") -> list[dict]:
+        """Return the recursive Git tree in the GitLab-compatible shape."""
+        repo = self._get_repo(self._catalog_project_id())
+        branch = repo.get_branch("main")
+        tree = repo.get_git_tree(branch.commit.sha, recursive=True).tree
+        prefix = f"{path}/"
+
+        items: list[dict] = []
+        for item in tree:
+            if item.path != path and not item.path.startswith(prefix):
+                continue
+            items.append(
+                {
+                    "id": item.sha,
+                    "name": Path(item.path).name,
+                    "type": "tree" if item.type == "tree" else "blob",
+                    "path": item.path,
+                }
+            )
+        return items
+
+    def parse_tree_to_tenant_apis(self, tree: list[dict]) -> dict[str, list[str]]:
+        """Parse a recursive tree into {tenant_id: [api_ids]}."""
+        tenant_apis: dict[str, list[str]] = {}
+        pattern = re.compile(r"^tenants/([^/]+)/apis/([^/]+)/api\.yaml$")
+
+        for item in tree:
+            if item["type"] != "blob":
+                continue
+            match = pattern.match(item["path"])
+            if not match:
+                continue
+            tenant_id, api_id = match.groups()
+            tenant_apis.setdefault(tenant_id, []).append(api_id)
+
+        return tenant_apis
+
+    async def get_mcp_server(self, tenant_id: str, server_name: str) -> dict | None:
+        """Return normalized MCP server metadata from server.yaml."""
+        project_id = self._catalog_project_id()
+        server_path = self._get_mcp_server_path(tenant_id, server_name)
+        try:
+            content = await self.get_file_content(project_id, f"{server_path}/server.yaml")
+        except FileNotFoundError:
+            return None
+
+        try:
+            raw_data = yaml.safe_load(content) or {}
+        except yaml.YAMLError as exc:
+            logger.error("Failed to parse MCP server YAML for %s/%s: %s", tenant_id, server_name, exc)
+            return None
+
+        return _normalize_mcp_server_data(raw_data, server_path)
+
+    async def list_mcp_servers(self, tenant_id: str = "_platform") -> list[dict]:
+        """List MCP servers for a tenant or platform scope."""
+        repo = self._get_repo(self._catalog_project_id())
+        if tenant_id == "_platform":
+            base_path = "platform/mcp-servers"
+        else:
+            base_path = f"{self._get_tenant_path(tenant_id)}/mcp-servers"
+
+        try:
+            contents = repo.get_contents(base_path, ref="main")
+        except GithubException as exc:
+            if exc.status == 404:
+                return []
+            raise
+
+        if not isinstance(contents, list):
+            contents = [contents]
+
+        server_names = [item.name for item in contents if item.type == "dir" and item.name != ".gitkeep"]
+        results = await asyncio.gather(*[self.get_mcp_server(tenant_id, server_name) for server_name in server_names])
+        return [server for server in results if server is not None]
+
+    async def list_all_mcp_servers(self) -> list[dict]:
+        """List all MCP servers across platform and tenant scopes."""
+        servers = await self.list_mcp_servers("_platform")
+        for tenant_id in await self.list_tenants():
+            servers.extend(await self.list_mcp_servers(tenant_id))
+        return servers
 
     # ============================================================
     # Write operations (CAB-2011: GitOps source of truth)

--- a/control-plane-api/tests/test_catalog_sync_service.py
+++ b/control-plane-api/tests/test_catalog_sync_service.py
@@ -43,7 +43,11 @@ def _make_git() -> MagicMock:
     """Return a minimal GitLabService mock with a truthy _project."""
     git = MagicMock()
     git._project = MagicMock()  # truthy → no auto-connect
+    git.is_connected = MagicMock(return_value=True)
     git.connect = AsyncMock()
+    git.get_head_commit_sha = AsyncMock(return_value=None)
+    git.list_tenants = AsyncMock(return_value=[])
+    git.get_tenant = AsyncMock(return_value=None)
     git.get_full_tree_recursive = AsyncMock(return_value=[])
     git.parse_tree_to_tenant_apis = MagicMock(return_value={})
     git.list_apis_parallel = AsyncMock(return_value=[])
@@ -52,6 +56,7 @@ def _make_git() -> MagicMock:
     git.get_api_openapi_spec = AsyncMock(return_value=None)
     git.get_api_override = AsyncMock(return_value=None)  # CAB-2015: no override by default
     git.list_mcp_servers = AsyncMock(return_value=[])
+    git.list_all_mcp_servers = AsyncMock(return_value=[])
     return git
 
 
@@ -122,10 +127,7 @@ class TestSyncAll:
         db = _make_db()
         git = _make_git()
 
-        # Simulate a commit SHA
-        commit = MagicMock()
-        commit.id = "abc123"
-        git._project.commits.list.return_value = [commit]
+        git.get_head_commit_sha.return_value = "abc123"
 
         # Two tenants, one API each
         git.parse_tree_to_tenant_apis.return_value = {
@@ -155,7 +157,8 @@ class TestSyncAll:
         """git.connect raises → status=FAILED, exception re-raised."""
         db = _make_db()
         git = _make_git()
-        git._project = None  # force connect
+        git._project = None  # legacy marker
+        git.is_connected.return_value = False
         git.connect.side_effect = ConnectionError("GitLab down")
 
         svc = CatalogSyncService(db, git)
@@ -173,9 +176,7 @@ class TestSyncAll:
         db = _make_db()
         git = _make_git()
 
-        commit = MagicMock()
-        commit.id = "sha999"
-        git._project.commits.list.return_value = [commit]
+        git.get_head_commit_sha.return_value = "sha999"
 
         git.parse_tree_to_tenant_apis.return_value = {
             "bad-tenant": ["api-1"],
@@ -209,9 +210,7 @@ class TestSyncAll:
         db = _make_db()
         git = _make_git()
 
-        commit = MagicMock()
-        commit.id = "deadbeef"
-        git._project.commits.list.return_value = [commit]
+        git.get_head_commit_sha.return_value = "deadbeef"
         git.parse_tree_to_tenant_apis.return_value = {}
 
         svc = CatalogSyncService(db, git, enable_gateway_reconciliation=False)
@@ -229,9 +228,7 @@ class TestSyncAll:
         db = _make_db()
         git = _make_git()
 
-        commit = MagicMock()
-        commit.id = "c0ffee"
-        git._project.commits.list.return_value = [commit]
+        git.get_head_commit_sha.return_value = "c0ffee"
         git.parse_tree_to_tenant_apis.return_value = {"acme": ["api-1"]}
 
         svc = CatalogSyncService(db, git, enable_gateway_reconciliation=False)
@@ -260,9 +257,7 @@ class TestSyncTenant:
         db = _make_db()
         git = _make_git()
 
-        commit = MagicMock()
-        commit.id = "sha-tenant"
-        git._project.commits.list.return_value = [commit]
+        git.get_head_commit_sha.return_value = "sha-tenant"
 
         svc = CatalogSyncService(db, git, enable_gateway_reconciliation=False)
 
@@ -273,11 +268,28 @@ class TestSyncTenant:
         assert status.items_synced == 3
         assert status.git_commit_sha == "sha-tenant"
 
+    async def test_success_without_private_project_attr_when_provider_connected(self):
+        """GitHub-like providers should sync without exposing a GitLab-style _project."""
+        db = _make_db()
+        git = _make_git()
+        git._project = None
+        git.is_connected.return_value = True
+        git.get_head_commit_sha.return_value = "sha-github"
+
+        svc = CatalogSyncService(db, git, enable_gateway_reconciliation=False)
+
+        with patch.object(svc, "_sync_tenant_apis", AsyncMock(return_value=2)):
+            status = await svc.sync_tenant("banking-demo")
+
+        git.connect.assert_not_called()
+        assert status.status == SyncStatus.SUCCESS.value
+        assert status.git_commit_sha == "sha-github"
+
     async def test_failure_raises_and_marks_failed(self):
         """Exception in _sync_tenant_apis → status=FAILED, exception re-raised."""
         db = _make_db()
         git = _make_git()
-        git._project.commits.list.return_value = [MagicMock(id="sha")]
+        git.get_head_commit_sha.return_value = "sha"
 
         svc = CatalogSyncService(db, git)
 
@@ -293,14 +305,13 @@ class TestSyncTenant:
         db = _make_db()
         git = _make_git()
         git._project = None
-        git._project = None  # stays None to trigger connect
-
-        commit = MagicMock()
-        commit.id = "xyz"
+        git._project = None  # legacy marker
+        git.is_connected.return_value = False
 
         async def fake_connect():
             git._project = MagicMock()
-            git._project.commits.list.return_value = [commit]
+            git.is_connected.return_value = True
+            git.get_head_commit_sha.return_value = "xyz"
 
         git.connect.side_effect = fake_connect
 
@@ -315,7 +326,7 @@ class TestSyncTenant:
         """CatalogSyncStatus created with sync_type=TENANT."""
         db = _make_db()
         git = _make_git()
-        git._project.commits.list.return_value = [MagicMock(id="s")]
+        git.get_head_commit_sha.return_value = "s"
 
         added_objects = []
         db.add.side_effect = lambda obj: added_objects.append(obj)
@@ -340,9 +351,7 @@ class TestGetCurrentCommitSha:
     async def test_returns_sha_from_first_commit(self):
         db = _make_db()
         git = _make_git()
-        commit = MagicMock()
-        commit.id = "1a2b3c4d"
-        git._project.commits.list.return_value = [commit]
+        git.get_head_commit_sha.return_value = "1a2b3c4d"
 
         svc = CatalogSyncService(db, git)
         sha = await svc._get_current_commit_sha()
@@ -352,17 +361,38 @@ class TestGetCurrentCommitSha:
     async def test_no_commits_returns_none(self):
         db = _make_db()
         git = _make_git()
-        git._project.commits.list.return_value = []
+        git.get_head_commit_sha.return_value = None
 
         svc = CatalogSyncService(db, git)
         sha = await svc._get_current_commit_sha()
 
         assert sha is None
 
+
+class TestEnsureTenantFromGit:
+    """_ensure_tenant_from_git() — tenant hydration via provider abstraction."""
+
+    async def test_reads_tenant_metadata_via_provider_method(self):
+        db = _make_db()
+        git = _make_git()
+        git.get_tenant.return_value = {
+            "metadata": {"displayName": "Banking Demo", "description": "Regulated tenant"},
+            "spec": {"settings": {"region": "eu"}},
+        }
+        db.execute.return_value = _exec_returning(scalar=None)
+
+        svc = CatalogSyncService(db, git, enable_gateway_reconciliation=False)
+
+        created = await svc._ensure_tenant_from_git("banking-demo")
+
+        assert created is True
+        git.get_tenant.assert_awaited_once_with("banking-demo")
+        db.add.assert_called_once()
+
     async def test_exception_returns_none(self):
         db = _make_db()
         git = _make_git()
-        git._project.commits.list.side_effect = Exception("GL down")
+        git.get_head_commit_sha.side_effect = Exception("GL down")
 
         svc = CatalogSyncService(db, git)
         sha = await svc._get_current_commit_sha()
@@ -791,7 +821,7 @@ class TestSyncMcpServers:
 
         commit = MagicMock()
         commit.id = "sha-mcp"
-        git._project.commits.list.return_value = [commit]
+        git.get_head_commit_sha.return_value = "sha-mcp"
 
         svc = CatalogSyncService(db, git)
 
@@ -808,7 +838,7 @@ class TestSyncMcpServers:
         """With tenant_id → only that tenant synced, no orphan check."""
         db = _make_db()
         git = _make_git()
-        git._project.commits.list.return_value = [MagicMock(id="sha")]
+        git.get_head_commit_sha.return_value = "sha"
 
         svc = CatalogSyncService(db, git)
 
@@ -825,7 +855,7 @@ class TestSyncMcpServers:
         """One tenant failing → continues, error recorded in stats."""
         db = _make_db()
         git = _make_git()
-        git._project.commits.list.return_value = [MagicMock(id="sha")]
+        git.get_head_commit_sha.return_value = "sha"
 
         svc = CatalogSyncService(db, git)
 
@@ -850,7 +880,7 @@ class TestSyncMcpServers:
         """Full sync calls _mark_orphan_mcp_servers at the end."""
         db = _make_db()
         git = _make_git()
-        git._project.commits.list.return_value = [MagicMock(id="sha")]
+        git.get_head_commit_sha.return_value = "sha"
 
         svc = CatalogSyncService(db, git)
         orphan_mock = AsyncMock(return_value=3)

--- a/control-plane-api/tests/test_github_service_catalog_parity.py
+++ b/control-plane-api/tests/test_github_service_catalog_parity.py
@@ -1,0 +1,111 @@
+"""Focused parity tests for GitHubService catalog reads."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from src.services.github_service import GitHubService
+
+
+def _content(name: str, path: str, item_type: str = "dir") -> MagicMock:
+    item = MagicMock()
+    item.name = name
+    item.path = path
+    item.type = item_type
+    return item
+
+
+class TestGitHubServiceCatalogParity:
+    async def test_get_head_commit_sha_uses_catalog_repo(self):
+        svc = GitHubService()
+        repo = MagicMock()
+        branch = MagicMock()
+        branch.commit.sha = "abc123"
+        repo.get_branch.return_value = branch
+
+        svc._gh = MagicMock()
+        svc._gh.get_repo.return_value = repo
+
+        sha = await svc.get_head_commit_sha()
+
+        assert sha == "abc123"
+        svc._gh.get_repo.assert_called_once_with("stoa-platform/stoa-catalog")
+        repo.get_branch.assert_called_once_with("main")
+
+    async def test_list_tenants_filters_to_directories(self):
+        svc = GitHubService()
+        repo = MagicMock()
+        repo.get_contents.return_value = [
+            _content("banking-demo", "tenants/banking-demo"),
+            _content("README.md", "tenants/README.md", item_type="file"),
+            _content("oasis", "tenants/oasis"),
+        ]
+
+        svc._gh = MagicMock()
+        svc._gh.get_repo.return_value = repo
+
+        tenants = await svc.list_tenants()
+
+        assert tenants == ["banking-demo", "oasis"]
+        repo.get_contents.assert_called_once_with("tenants", ref="main")
+
+    async def test_get_api_normalizes_kubernetes_style_yaml(self):
+        svc = GitHubService()
+        svc.get_file_content = AsyncMock(
+            return_value="""
+apiVersion: gostoa.dev/v1
+kind: API
+metadata:
+  name: banking-services-v1-2
+  version: 1.2.0
+spec:
+  displayName: Banking Services
+  description: Banking API
+  backend:
+    url: http://banking-mock.demo-banking-mock.svc.cluster.local:8080/api/v1
+  deployments:
+    dev: true
+    staging: false
+"""
+        )
+
+        api = await svc.get_api("demo", "banking-services-v1-2")
+
+        assert api == {
+            "id": "banking-services-v1-2",
+            "name": "banking-services-v1-2",
+            "display_name": "Banking Services",
+            "version": "1.2.0",
+            "description": "Banking API",
+            "backend_url": "http://banking-mock.demo-banking-mock.svc.cluster.local:8080/api/v1",
+            "status": "draft",
+            "deployments": {"dev": True, "staging": False},
+        }
+
+    async def test_list_mcp_servers_filters_dirs_and_reads_server_yaml(self):
+        svc = GitHubService()
+        repo = MagicMock()
+        repo.get_contents.return_value = [
+            _content("banking-demo", "tenants/demo/mcp-servers/banking-demo"),
+            _content(".gitkeep", "tenants/demo/mcp-servers/.gitkeep", item_type="file"),
+        ]
+
+        svc._gh = MagicMock()
+        svc._gh.get_repo.return_value = repo
+        svc.get_mcp_server = AsyncMock(
+            return_value={
+                "name": "banking-demo",
+                "tenant_id": "demo",
+                "display_name": "Banking Demo",
+            }
+        )
+
+        servers = await svc.list_mcp_servers("demo")
+
+        assert servers == [
+            {
+                "name": "banking-demo",
+                "tenant_id": "demo",
+                "display_name": "Banking Demo",
+            }
+        ]
+        repo.get_contents.assert_called_once_with("tenants/demo/mcp-servers", ref="main")
+        svc.get_mcp_server.assert_awaited_once_with("demo", "banking-demo")

--- a/control-plane-api/tests/test_mcp_gitops_router.py
+++ b/control-plane-api/tests/test_mcp_gitops_router.py
@@ -24,7 +24,16 @@ def mock_git_provider():
     """Create a mock GitProvider with _project attribute."""
     mock = MagicMock()
     mock._project = MagicMock()
+    mock.is_connected = MagicMock(return_value=True)
     mock.connect = AsyncMock()
+    mock.get_repo_info = AsyncMock(
+        return_value={
+            "name": "stoa-mcp-servers",
+            "default_branch": "main",
+            "url": "https://github.com/stoa-platform/stoa-catalog",
+            "visibility": "private",
+        }
+    )
     mock.list_all_mcp_servers = AsyncMock(return_value=[])
     return mock
 
@@ -76,6 +85,7 @@ class TestMCPGitOpsRouter:
         """POST /sync connects to git provider if not already connected."""
         mock_result = self._mock_sync_result()
         mock_git_provider._project = None
+        mock_git_provider.is_connected.return_value = False
 
         with patch("src.routers.mcp_gitops.MCPSyncService") as MockSyncSvc:
             MockSyncSvc.return_value.sync_all_servers = AsyncMock(return_value=mock_result)
@@ -173,10 +183,6 @@ class TestMCPGitOpsRouter:
 
     def test_git_health_success(self, app_with_git_provider, mock_git_provider):
         """GET /git/health returns healthy status."""
-        mock_git_provider._project.name = "stoa-mcp-servers"
-        mock_git_provider._project.id = 42
-        mock_git_provider._project.repository_tree.return_value = []
-
         with TestClient(app_with_git_provider) as client:
             response = client.get("/v1/mcp/gitops/git/health")
 
@@ -188,6 +194,7 @@ class TestMCPGitOpsRouter:
     def test_git_health_unhealthy(self, app_with_git_provider, mock_git_provider):
         """GET /git/health returns unhealthy when provider is down."""
         mock_git_provider._project = None
+        mock_git_provider.is_connected.return_value = False
         mock_git_provider.connect = AsyncMock(side_effect=Exception("Connection refused"))
 
         with TestClient(app_with_git_provider, raise_server_exceptions=False) as client:

--- a/control-plane-api/tests/test_regression_cab_1889_github_sync.py
+++ b/control-plane-api/tests/test_regression_cab_1889_github_sync.py
@@ -1,0 +1,84 @@
+"""Regression test for CAB-1889: catalog sync must not deref GitLab `_project`.
+
+PR: #2439
+Ticket: CAB-1889
+Root cause: `CatalogSyncService` and `MCP GitOps router` dereferenced
+  `git._project` (a `python-gitlab` Project object) regardless of provider.
+  After flipping `GIT_PROVIDER=github` on prod (via stoa-infra#46), every
+  catalog sync failed with `AttributeError: 'GitHubService' object has no
+  attribute '_project'`, blocking CAB-2088 banking-demo visibility.
+Invariant: provider-neutral methods (`is_connected`, `get_head_commit_sha`,
+  `get_tenant`, `list_tenants`) must be used instead of `_project` deref,
+  so `GIT_PROVIDER=github` works end-to-end.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.services.git_provider import GitProvider
+from src.services.github_service import GitHubService
+
+
+def _content(name: str, path: str, type_: str = "dir") -> MagicMock:
+    item = MagicMock()
+    item.name = name
+    item.path = path
+    item.type = type_
+    return item
+
+
+def test_regression_cab_1889_github_service_has_no_project_attr():
+    """GitHubService must not expose the GitLab-specific `_project` attribute.
+
+    Any caller still relying on `_project` needs to migrate to the provider-
+    neutral interface (is_connected / get_head_commit_sha / get_tenant /
+    list_tenants) — see scope boundary in PR #2439 description.
+    """
+    svc = GitHubService()
+    assert not hasattr(svc, "_project"), (
+        "GitHubService must not define `_project` (GitLab-only artefact). "
+        "If a code path needs it, add a provider-neutral method on GitProvider."
+    )
+
+
+def test_regression_cab_1889_provider_neutral_contract():
+    """GitProvider abstract must expose the provider-neutral methods."""
+    required = {
+        "is_connected",
+        "get_head_commit_sha",
+        "get_tenant",
+        "list_tenants",
+    }
+    missing = required - set(dir(GitProvider))
+    assert not missing, (
+        f"GitProvider abstract missing provider-neutral methods: {missing}. "
+        "These are required so CatalogSyncService / MCP GitOps router stay "
+        "provider-agnostic and CAB-1889 regression doesn't return."
+    )
+
+
+@pytest.mark.asyncio
+async def test_regression_cab_1889_github_list_tenants_no_project_deref():
+    """GitHubService.list_tenants must work without touching `_project`.
+
+    Validates the fix path: CatalogSyncService iterates tenants via
+    `list_tenants()`, not via `_project.repository_tree()`.
+    """
+    svc = GitHubService()
+    repo = MagicMock()
+    repo.get_contents.return_value = [
+        _content("banking-demo", "tenants/banking-demo"),
+        _content("oasis", "tenants/oasis"),
+        _content("tenant.yaml", "tenants/tenant.yaml", type_="file"),
+    ]
+    svc._gh = MagicMock()
+    svc._gh.get_repo.return_value = repo
+
+    tenants = await svc.list_tenants()
+    assert "banking-demo" in tenants
+    assert "oasis" in tenants
+    # file entries must not appear as tenants
+    assert "tenant.yaml" not in tenants


### PR DESCRIPTION
## Summary

Unblocks `GIT_PROVIDER=github` on prod by removing the GitLab-specific `_project` attribute dereference from the catalog sync and MCP GitOps paths.

Discovered end-to-end during the 2026-04-20 GitHub cutover session (stoa-infra#46): after flipping `GIT_PROVIDER=github`, every catalog sync failed with `AttributeError: 'GitHubService' object has no attribute '_project'`, blocking CAB-2088 banking-demo visibility.

## Changes

- **GitProvider** (abstract): adds `is_connected`, `get_head_commit_sha`, `get_tenant`, `list_tenants` provider-neutral methods
- **GitHubService**: implements the new contract — reads catalog via GitHub REST (tenants, api.yaml, openapi.yaml, recursive tree, MCP servers)
- **GitLabService**: implements parity methods against `python-gitlab`
- **CatalogSyncService**: routes through provider-neutral methods, no more `git._project` deref
- **MCP GitOps router**: connection + health checks without `_project`

## Test plan

- [x] `pytest` on 4 test modules (catalog_sync_service, github_service_catalog_parity, mcp_gitops_router, dual_provider_smoke) → **67 passed**
- [ ] CI full suite
- [ ] Post-merge: re-trigger `POST /v1/admin/catalog/sync/tenant/banking-demo` against prod, verify `git_commit_sha` is a GitHub SHA (starts with something other than `28a86242...`)
- [ ] Post-merge: `GET /v1/admin/catalog/apis?tenant_id=banking-demo` returns 1 API (`fapi-banking`) with 7 operations

## Scope boundary (explicit)

Fixes **catalog sync + MCP GitOps** only. Remaining gitlab-only paths (out of this PR):

- `routers/git.py` — `TODO(CAB-1889): abstract _project access`
- `services/iam_sync_service.py`
- `services/deployment_orchestration_service.py`

These are tracked as follow-up continuation of CAB-1889. They don't block CAB-2088 demo visibility, but any work touching those paths with `GIT_PROVIDER=github` will fail similarly.

## Dependencies

- Requires prior merge of `PotoMitan/stoa-infra#46` (already merged as `8d6ecc9`): flips `GIT_PROVIDER=github` + adds `GITHUB_ORG/CATALOG_REPO/GITOPS_REPO`
- Requires `GITHUB_TOKEN` + `GITHUB_WEBHOOK_SECRET` in `stoa-control-plane-api-secrets` (done 2026-04-20 + written to Infisical `/control-plane-api/` prod)

## Known debt

- CAB-1889 (continuation): finish provider-neutral abstraction for `routers/git.py`, `iam_sync_service.py`, `deployment_orchestration_service.py`
- CAB-2135: catalog format + repo convergence (monorepo bundle vs runtime tenant.yaml/api.yaml/openapi.yaml vs gateway `UacContractSpec`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)