### PR TITLE
fix(api): honor github catalog repo for override lookup (CAB-1889)

### DIFF
--- a/control-plane-api/src/services/git_provider.py
+++ b/control-plane-api/src/services/git_provider.py
@@ -181,9 +181,11 @@ class GitProvider(ABC):
         """
         import yaml
 
-        project_id = getattr(settings, "GITLAB_PROJECT_ID", None) or (
-            f"{getattr(settings, 'GITHUB_ORG', '')}/{getattr(settings, 'GITHUB_CATALOG_REPO', '')}"
-        )
+        provider = getattr(settings, "GIT_PROVIDER", "gitlab").lower()
+        if provider == "github":
+            project_id = f"{getattr(settings, 'GITHUB_ORG', '')}/{getattr(settings, 'GITHUB_CATALOG_REPO', '')}"
+        else:
+            project_id = getattr(settings, "GITLAB_PROJECT_ID", None)
         file_path = f"tenants/{tenant_id}/apis/{api_id}/overrides/{environment}.yaml"
         try:
             content = await self.get_file_content(str(project_id), file_path)

--- a/control-plane-api/tests/test_github_service_catalog_parity.py
+++ b/control-plane-api/tests/test_github_service_catalog_parity.py
@@ -1,6 +1,7 @@
 """Focused parity tests for GitHubService catalog reads."""
 
 from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import patch
 
 from src.services.github_service import GitHubService
 
@@ -109,3 +110,21 @@ spec:
         ]
         repo.get_contents.assert_called_once_with("tenants/demo/mcp-servers", ref="main")
         svc.get_mcp_server.assert_awaited_once_with("demo", "banking-demo")
+
+    async def test_get_api_override_uses_github_catalog_repo_even_if_gitlab_id_is_present(self):
+        svc = GitHubService()
+        svc.get_file_content = AsyncMock(return_value="rateLimit: 25\n")
+
+        with patch("src.services.git_provider.settings") as mock_settings:
+            mock_settings.GIT_PROVIDER = "github"
+            mock_settings.GITLAB_PROJECT_ID = "12345"
+            mock_settings.GITHUB_ORG = "stoa-platform"
+            mock_settings.GITHUB_CATALOG_REPO = "stoa-catalog"
+
+            override = await svc.get_api_override("banking-demo", "fapi-banking", "prod")
+
+        assert override == {"rateLimit": 25}
+        svc.get_file_content.assert_awaited_once_with(
+            "stoa-platform/stoa-catalog",
+            "tenants/banking-demo/apis/fapi-banking/overrides/prod.yaml",
+        )

--- a/control-plane-api/tests/test_regression_cab_1889_github_override_lookup.py
+++ b/control-plane-api/tests/test_regression_cab_1889_github_override_lookup.py
@@ -1,0 +1,26 @@
+"""Regression coverage for CAB-1889 GitHub override lookup."""
+
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+from src.services.github_service import GitHubService
+
+
+async def test_regression_cab_1889_github_override_lookup_uses_catalog_repo():
+    """GitHub mode must not fall back to the injected GitLab project id."""
+    svc = GitHubService()
+    svc.get_file_content = AsyncMock(return_value="rateLimit: 25\n")
+
+    with patch("src.services.git_provider.settings") as mock_settings:
+        mock_settings.GIT_PROVIDER = "github"
+        mock_settings.GITLAB_PROJECT_ID = "12345"
+        mock_settings.GITHUB_ORG = "stoa-platform"
+        mock_settings.GITHUB_CATALOG_REPO = "stoa-catalog"
+
+        override = await svc.get_api_override("banking-demo", "fapi-banking", "prod")
+
+    assert override == {"rateLimit": 25}
+    svc.get_file_content.assert_awaited_once_with(
+        "stoa-platform/stoa-catalog",
+        "tenants/banking-demo/apis/fapi-banking/overrides/prod.yaml",
+    )


### PR DESCRIPTION
Summary
- fix GitProvider.get_api_override so the catalog project is chosen from GIT_PROVIDER instead of always preferring GITLAB_PROJECT_ID
- unblock GitHub catalog sync when rollback-oriented GitLab env vars are still injected in prod
- add a regression test for the exact prod case: GIT_PROVIDER=github while GITLAB_PROJECT_ID is still present

Prod evidence
- control-plane is live on the GitHub cutover image dev-0c01ba31
- tenant sync for banking-demo connects to GitHub successfully
- sync then fails with a 404 on banking-demo/fapi-banking because override lookup resolves the wrong project id

Test plan
- pytest -q control-plane-api/tests/test_catalog_sync_service.py control-plane-api/tests/test_github_service_catalog_parity.py control-plane-api/tests/test_mcp_gitops_router.py control-plane-api/tests/test_dual_provider_smoke.py