### PR TITLE
fix(api): preserve spec.tags and spec.category in catalog normalization (CAB-2135)

### DIFF
--- a/control-plane-api/src/services/github_service.py
+++ b/control-plane-api/src/services/github_service.py
@@ -37,6 +37,8 @@ def _normalize_api_data(raw_data: dict) -> dict:
             "description": spec.get("description", ""),
             "backend_url": backend.get("url", ""),
             "status": spec.get("status", "draft"),
+            "category": spec.get("category"),
+            "tags": spec.get("tags", []),
             "deployments": {
                 "dev": deployments.get("dev", False),
                 "staging": deployments.get("staging", False),

--- a/control-plane-api/tests/test_github_service_catalog_parity.py
+++ b/control-plane-api/tests/test_github_service_catalog_parity.py
@@ -1,7 +1,6 @@
 """Focused parity tests for GitHubService catalog reads."""
 
-from unittest.mock import AsyncMock, MagicMock
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.services.github_service import GitHubService
 
@@ -49,9 +48,12 @@ class TestGitHubServiceCatalogParity:
         repo.get_contents.assert_called_once_with("tenants", ref="main")
 
     async def test_get_api_normalizes_kubernetes_style_yaml(self):
+        # regression for CAB-2135: spec.tags and spec.category must survive
+        # normalization — without them the sync downstream leaves
+        # portal_published=False on every Kind=API manifest (the tag set
+        # drives the portal promotion flag).
         svc = GitHubService()
-        svc.get_file_content = AsyncMock(
-            return_value="""
+        svc.get_file_content = AsyncMock(return_value="""
 apiVersion: gostoa.dev/v1
 kind: API
 metadata:
@@ -60,13 +62,16 @@ metadata:
 spec:
   displayName: Banking Services
   description: Banking API
+  category: banking
+  tags:
+    - portal:published
+    - banking
   backend:
     url: http://banking-mock.demo-banking-mock.svc.cluster.local:8080/api/v1
   deployments:
     dev: true
     staging: false
-"""
-        )
+""")
 
         api = await svc.get_api("demo", "banking-services-v1-2")
 
@@ -78,6 +83,8 @@ spec:
             "description": "Banking API",
             "backend_url": "http://banking-mock.demo-banking-mock.svc.cluster.local:8080/api/v1",
             "status": "draft",
+            "category": "banking",
+            "tags": ["portal:published", "banking"],
             "deployments": {"dev": True, "staging": False},
         }
 

--- a/control-plane-api/tests/test_regression_cab_2135_api_tags_category_normalization.py
+++ b/control-plane-api/tests/test_regression_cab_2135_api_tags_category_normalization.py
@@ -1,0 +1,61 @@
+"""Regression test for CAB-2135: spec.tags and spec.category must survive
+normalization of Kind=API manifests.
+
+Prior to the fix, ``_normalize_api_data`` dropped both fields, which made
+``catalog_sync_service._upsert_api`` compute ``portal_published=False`` for
+every new-kind API (the promotion flag keys off the ``portal:published`` tag).
+That in turn hid banking-demo/fapi-banking from
+``GET /v1/internal/catalog/apis/expanded``.
+"""
+
+from unittest.mock import AsyncMock
+
+from src.services.github_service import GitHubService
+
+
+class TestRegressionCab2135ApiTagsCategoryNormalization:
+    async def test_normalization_preserves_spec_tags_and_category(self):
+        svc = GitHubService()
+        svc.get_file_content = AsyncMock(return_value="""
+apiVersion: gostoa.dev/v1
+kind: API
+metadata:
+  name: fapi-banking
+  version: 1.2.0
+spec:
+  displayName: FAPI Banking Demo
+  description: Regulated EU banking demo API
+  category: banking
+  tags:
+    - portal:published
+    - banking
+    - regulated-eu
+  backend:
+    url: http://banking-mock.demo-banking-mock.svc.cluster.local:8080
+  deployments:
+    dev: true
+    staging: false
+""")
+
+        api = await svc.get_api("banking-demo", "fapi-banking")
+
+        assert api["category"] == "banking"
+        assert api["tags"] == ["portal:published", "banking", "regulated-eu"]
+
+    async def test_normalization_defaults_tags_to_empty_list_when_absent(self):
+        svc = GitHubService()
+        svc.get_file_content = AsyncMock(return_value="""
+apiVersion: gostoa.dev/v1
+kind: API
+metadata:
+  name: no-tags-api
+spec:
+  displayName: No Tags API
+  backend:
+    url: https://example.com
+""")
+
+        api = await svc.get_api("demo", "no-tags-api")
+
+        assert api["tags"] == []
+        assert api["category"] is None


### PR DESCRIPTION
## Summary
- `_normalize_api_data` now copies `spec.tags` and `spec.category` when flattening `Kind=API` manifests from stoa-catalog. Without them the downstream sync computed `portal_published=False` for every new-kind manifest, hiding `banking-demo/fapi-banking` from `GET /v1/internal/catalog/apis/expanded` even though its `api.yaml` carried `portal:published`.
- Extended the existing parity test to assert both fields survive normalization.
- Added `test_regression_cab_2135_api_tags_category_normalization.py` so regression-guard recognises the pattern (workflow greps `test_regression_` in filename for Python).

Tech-debt marker already present in banking-demo's `api.yaml` metadata labels (`tech-debt: CAB-2135`).

## Post-merge validation
1. Re-trigger `POST /v1/admin/catalog/sync/tenant/banking-demo` with a `cpi-admin` JWT.
2. `GET https://api.gostoa.dev/v1/internal/catalog/apis/expanded` should now include `banking-demo` tools.
3. `portal_promoted=true` on `GET /v1/tenants/banking-demo/apis` items carrying the `portal:published` tag.

Out of scope: `spec.gateways` normalization, the cosmetic `GitLab connected` log at `main.py:196`, and the missing `STOA_TOOL_EXPANSION_MODE` env var in prod.

## Test plan
- [x] `pytest tests/test_github_service_catalog_parity.py tests/test_regression_cab_2135_*.py` — 7 green locally
- [x] `ruff check` + `black --check` on the three touched files
- [ ] Post-merge: sync `banking-demo`, confirm it appears in `/apis/expanded`

Linear: [CAB-2135](https://linear.app/stoa-platform/issue/CAB-2135)

🤖 Generated with [Claude Code](https://claude.com/claude-code)