### PR TITLE
fix(security): rate-limit keying collapses all JWT users (CAB-2146)

### DIFF
--- a/control-plane-api/src/auth/dependencies.py
+++ b/control-plane-api/src/auth/dependencies.py
@@ -4,8 +4,10 @@ CAB-330: Enhanced debug logging for authentication troubleshooting.
 CAB-438: Sender-constrained token validation (RFC 8705/9449).
 CAB-2082: JWT issuer validation + Keycloak public-key cache (Security P0-01).
 CAB-2094: Split issuer (public KEYCLOAK_URL) from JWKS fetch (KEYCLOAK_INTERNAL_URL).
+CAB-2146: Expose operator-key fingerprint on request.state for per-key rate-limit.
 """
 
+import hashlib
 import time
 
 import httpx
@@ -82,7 +84,16 @@ async def get_current_user(
     # Service-to-service auth for internal operators (ADR-042)
     operator_key = request.headers.get("X-Operator-Key")
     if operator_key and operator_key in settings.gateway_api_keys_list:
-        logger.info("Operator authenticated via X-Operator-Key")
+        # CAB-2146: fingerprint the key so the rate-limit bucket is per-operator.
+        # Never log or store the raw key — only the sha256[:16] fingerprint.
+        fingerprint = hashlib.sha256(operator_key.encode("utf-8")).hexdigest()[:16]
+        request.state.operator_fingerprint = fingerprint
+        logger.info(
+            "Operator authenticated via X-Operator-Key",
+            fingerprint=fingerprint,
+            client_ip=request.client.host if request.client else None,
+            path=request.url.path,
+        )
         bind_request_context(user_id="stoa-operator")
         # Store on request.state for audit middleware (CAB-1793)
         request.state.user = {

--- a/control-plane-api/src/middleware/rate_limit.py
+++ b/control-plane-api/src/middleware/rate_limit.py
@@ -25,37 +25,38 @@ logger = structlog.get_logger(__name__)
 # Rate Limit Key Functions
 # =============================================================================
 
+
 def get_rate_limit_key(request: Request) -> str:
     """
     Generate rate limit key based on authentication context.
 
-    MVP: user_id or API key or IP
-    Future (CAB-459): tenant_id + user_id + product_roles
-
     Priority:
-    1. Authenticated user (JWT) -> tenant:xxx:user:yyy
-    2. API Key -> apikey:prefix
-    3. IP address -> ip:xxx.xxx.xxx.xxx
+    1. X-Operator-Key fingerprint (set by auth/dependencies.py) -> operator:<fp>
+    2. Authenticated user (JWT) -> tenant:xxx:user:yyy
+    3. API Key -> apikey:prefix
+    4. IP address -> ip:xxx.xxx.xxx.xxx
     """
-    # Check for authenticated user from JWT
-    user = getattr(request.state, "user", None)
-    if user:
-        # Prepare for multi-tenant: extract tenant_id when available
-        tenant_id = getattr(user, "tenant_id", None)
-        if not tenant_id:
-            # Try to extract from JWT claims
-            tenant_id = getattr(user, "azp", "default")  # azp = authorized party
+    # CAB-2146: operator-key gets its own bucket per key fingerprint so distinct
+    # operators don't share a single rate-limit bucket (previous keying collapsed
+    # every operator onto `tenant:default:user:stoa-operator`).
+    operator_fingerprint = getattr(request.state, "operator_fingerprint", None)
+    if operator_fingerprint:
+        return f"operator:{operator_fingerprint}"
 
-        user_id = getattr(user, "sub", "unknown")
+    # CAB-2146: `request.state.user` is stored as a dict in auth/dependencies.py,
+    # not an object. The previous `getattr(user, "sub", "unknown")` always hit
+    # the default because dicts don't expose keys as attributes — all JWT users
+    # collapsed to `tenant:default:user:unknown`.
+    user = getattr(request.state, "user", None)
+    if isinstance(user, dict):
+        tenant_id = user.get("tenant_id") or user.get("azp") or "default"
+        user_id = user.get("sub") or "unknown"
         return f"tenant:{tenant_id}:user:{user_id}"
 
-    # Check for API key authentication
     api_key = request.headers.get("X-API-Key")
     if api_key:
-        # Use first 16 chars as identifier (safe prefix)
         return f"apikey:{api_key[:16]}"
 
-    # Fallback to IP address
     return f"ip:{get_remote_address(request)}"
 
 
@@ -76,11 +77,11 @@ def get_strict_rate_limit_key(request: Request) -> str:
 
 # Default limits by authentication type
 DEFAULT_LIMITS = {
-    "authenticated": "100/minute",    # JWT users
-    "api_key": "200/minute",          # Service accounts with API keys
-    "anonymous": "30/minute",         # Anonymous/IP-based
-    "tool_invoke": "60/minute",       # Tool invocations (stricter)
-    "subscription": "30/minute",      # Subscription operations
+    "authenticated": "100/minute",  # JWT users
+    "api_key": "200/minute",  # Service accounts with API keys
+    "anonymous": "30/minute",  # Anonymous/IP-based
+    "tool_invoke": "60/minute",  # Tool invocations (stricter)
+    "subscription": "30/minute",  # Subscription operations
 }
 
 # Create the limiter instance
@@ -95,6 +96,7 @@ limiter = Limiter(
 # =============================================================================
 # Rate Limit Exception Handler
 # =============================================================================
+
 
 async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
     """
@@ -135,6 +137,7 @@ async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) 
 # =============================================================================
 # Convenience Decorators
 # =============================================================================
+
 
 def limit_authenticated(limit: str = DEFAULT_LIMITS["authenticated"]):
     """Rate limit for authenticated endpoints."""

--- a/control-plane-api/tests/test_rate_limit.py
+++ b/control-plane-api/tests/test_rate_limit.py
@@ -1,7 +1,16 @@
-"""Tests for rate limiting middleware (CAB-1291)"""
+"""Tests for rate limiting middleware (CAB-1291, CAB-2146).
+
+CAB-2146: `request.state.user` is a dict in prod (set by auth/dependencies.py),
+not a MagicMock/object. Previous tests inadvertently validated MagicMock
+attribute access semantics, which masked the prod bug where every JWT user
+collapsed onto `tenant:default:user:unknown`. These tests now use real
+Starlette Requests with dict users.
+"""
+
 from unittest.mock import MagicMock, patch
 
 import pytest
+from starlette.requests import Request
 
 from src.middleware.rate_limit import (
     DEFAULT_LIMITS,
@@ -11,48 +20,40 @@ from src.middleware.rate_limit import (
 )
 
 
-def _make_request(user=None, api_key=None, remote_addr="1.2.3.4", path="/v1/test"):
-    """Build a mock Request with given auth context."""
-    request = MagicMock()
-    request.state = MagicMock()
-    if user:
-        request.state.user = user
-    else:
-        request.state.user = None
-        # getattr(request.state, "user", None) should return None
-        del request.state.user
-
-    headers = {}
+def _make_request(
+    *,
+    user: dict | None = None,
+    api_key: str | None = None,
+    remote_addr: str = "1.2.3.4",
+    path: str = "/v1/test",
+) -> Request:
+    """Build a real Starlette Request with the given auth context."""
+    raw_headers: list[tuple[bytes, bytes]] = []
     if api_key:
-        headers["X-API-Key"] = api_key
-    request.headers = headers
-    request.url.path = path
-    request.method = "GET"
+        raw_headers.append((b"x-api-key", api_key.encode()))
 
-    # For get_remote_address fallback
-    request.client = MagicMock()
-    request.client.host = remote_addr
-
-    return request
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "query_string": b"",
+        "headers": raw_headers,
+        "client": (remote_addr, 12345),
+    }
+    req = Request(scope)
+    if user is not None:
+        req.state.user = user
+    return req
 
 
 class TestGetRateLimitKey:
     def test_authenticated_user_with_tenant(self):
-        user = MagicMock()
-        user.tenant_id = "acme"
-        user.sub = "user-123"
-        request = _make_request(user=user)
+        request = _make_request(user={"sub": "user-123", "tenant_id": "acme"})
         key = get_rate_limit_key(request)
         assert key == "tenant:acme:user:user-123"
 
     def test_authenticated_user_no_tenant_uses_azp(self):
-        user = MagicMock(spec=[])
-        user.tenant_id = None
-        user.sub = "user-456"
-        user.azp = "my-client"
-        # Simulate getattr behavior
-        request = MagicMock()
-        request.state.user = user
+        request = _make_request(user={"sub": "user-456", "tenant_id": None, "azp": "my-client"})
         key = get_rate_limit_key(request)
         assert key == "tenant:my-client:user:user-456"
 

--- a/control-plane-api/tests/test_rate_limit_middleware.py
+++ b/control-plane-api/tests/test_rate_limit_middleware.py
@@ -1,6 +1,9 @@
-"""Tests for rate_limit middleware helpers (CAB-1388)."""
+"""Tests for rate_limit middleware helpers (CAB-1388, CAB-2146).
 
-from unittest.mock import MagicMock
+CAB-2146: switched from MagicMock users to dict users to match prod behavior.
+"""
+
+from starlette.requests import Request
 
 from src.middleware.rate_limit import (
     get_rate_limit_key,
@@ -14,56 +17,54 @@ from src.middleware.rate_limit import (
 # ── get_rate_limit_key ──
 
 
-class TestGetRateLimitKey:
-    def _req(self, user=None, api_key=None, remote_addr="1.2.3.4"):
-        req = MagicMock()
-        req.state = MagicMock()
-        req.state.user = user
-        req.headers = MagicMock()
-        req.headers.get = MagicMock(return_value=api_key)
-        req.url = MagicMock()
-        req.url.path = "/api/test"
-        req.client = MagicMock()
-        req.client.host = remote_addr
-        return req
+def _req(
+    *,
+    user: dict | None = None,
+    api_key: str | None = None,
+    remote_addr: str = "1.2.3.4",
+    path: str = "/api/test",
+) -> Request:
+    headers: list[tuple[bytes, bytes]] = []
+    if api_key:
+        headers.append((b"x-api-key", api_key.encode()))
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "query_string": b"",
+        "headers": headers,
+        "client": (remote_addr, 12345),
+    }
+    r = Request(scope)
+    if user is not None:
+        r.state.user = user
+    return r
 
+
+class TestGetRateLimitKey:
     def test_authenticated_user_with_tenant(self):
-        user = MagicMock(tenant_id="acme", sub="u-1")
-        req = self._req(user=user)
-        key = get_rate_limit_key(req)
-        assert key == "tenant:acme:user:u-1"
+        req = _req(user={"sub": "u-1", "tenant_id": "acme"})
+        assert get_rate_limit_key(req) == "tenant:acme:user:u-1"
 
     def test_authenticated_user_without_tenant_uses_azp(self):
-        user = MagicMock(tenant_id=None, sub="u-2", azp="app-x")
-        req = self._req(user=user)
-        key = get_rate_limit_key(req)
-        assert key == "tenant:app-x:user:u-2"
+        req = _req(user={"sub": "u-2", "tenant_id": None, "azp": "app-x"})
+        assert get_rate_limit_key(req) == "tenant:app-x:user:u-2"
 
     def test_api_key_uses_prefix(self):
-        req = self._req(user=None, api_key="ABCDEFGHIJKLMNOP-extra")
-        key = get_rate_limit_key(req)
-        assert key == "apikey:ABCDEFGHIJKLMNOP"
+        req = _req(api_key="ABCDEFGHIJKLMNOP-extra")
+        assert get_rate_limit_key(req) == "apikey:ABCDEFGHIJKLMNOP"
 
     def test_fallback_to_ip(self):
-        req = self._req(user=None, api_key=None)
         from unittest.mock import patch
 
-        # get_remote_address reads from request.client.host or headers
+        req = _req()
         with patch("src.middleware.rate_limit.get_remote_address", return_value="1.2.3.4"):
-            key = get_rate_limit_key(req)
-        assert key == "ip:1.2.3.4"
+            assert get_rate_limit_key(req) == "ip:1.2.3.4"
 
 
 class TestGetStrictRateLimitKey:
     def test_includes_path(self):
-        user = MagicMock(tenant_id="t1", sub="u1")
-        req = MagicMock()
-        req.state = MagicMock()
-        req.state.user = user
-        req.headers = MagicMock()
-        req.headers.get = MagicMock(return_value=None)
-        req.url = MagicMock()
-        req.url.path = "/tools/invoke"
+        req = _req(user={"sub": "u1", "tenant_id": "t1"}, path="/tools/invoke")
         key = get_strict_rate_limit_key(req)
         assert "path:" in key
         assert "/tools/invoke" in key

--- a/control-plane-api/tests/test_regression_cab_2083_no_hardcoded_parzival.py
+++ b/control-plane-api/tests/test_regression_cab_2083_no_hardcoded_parzival.py
@@ -29,8 +29,8 @@ def test_parzival_password_is_never_hardcoded() -> None:
     # .gitignore automatically, so vendored copies in node_modules, venv,
     # target, etc. don't leak into the scan.
     # CHANGELOG files are release-please-generated history of commit titles.
-    # A past commit message that legitimately quoted the literal (e.g. the
-    # very fix that removed it) is not a regression.
+    # Audit archives under docs/audits/** are historical incident reports that
+    # legitimately quote the literal for traceability. Neither is a regression.
     result = subprocess.run(  # noqa: S603 — fixed args, no user input
         [  # noqa: S607
             "git",
@@ -40,6 +40,7 @@ def test_parzival_password_is_never_hardcoded() -> None:
             FORBIDDEN_LITERAL,
             "--",
             ":!**/CHANGELOG.md",
+            ":!docs/audits/**",
         ],
         capture_output=True,
         text=True,

--- a/control-plane-api/tests/test_regression_cab_2146_rate_limit_keying.py
+++ b/control-plane-api/tests/test_regression_cab_2146_rate_limit_keying.py
@@ -1,0 +1,183 @@
+"""Regression tests for CAB-2146 (Security MEGA CAB-2079 — rate-limit keying bug).
+
+Before the fix:
+- `src/auth/dependencies.py` sets `request.state.user` as a **dict**
+  (`{"sub": user_id, "tenant_id": ..., ...}`).
+- `src/middleware/rate_limit.py` reads it with `getattr(user, "sub", "unknown")`,
+  which always returns the default for dicts (dicts don't expose keys as
+  attributes). Same for `tenant_id` and `azp`.
+- Conséquence: every JWT user collapsed to the key
+  `tenant:default:user:unknown` → one noisy user rate-limits all others.
+- For `X-Operator-Key` requests, every operator collapsed to
+  `tenant:default:user:stoa-operator` → operators share a single bucket.
+
+After the fix:
+- `get_rate_limit_key` uses `user.get(...)` dict access and yields a distinct
+  key per (tenant, user) pair.
+- When `X-Operator-Key` is validated, `dependencies.py` exposes
+  `request.state.operator_fingerprint = sha256(key)[:16]`. The limiter branches
+  on it so each operator key gets its own bucket.
+"""
+
+# regression for CAB-2079
+import hashlib
+
+import pytest
+from starlette.requests import Request
+
+from src.middleware.rate_limit import get_rate_limit_key
+
+
+def _make_request(
+    *,
+    user: dict | None = None,
+    operator_fingerprint: str | None = None,
+    headers: dict[str, str] | None = None,
+    client_host: str = "10.0.0.1",
+) -> Request:
+    """Build a minimal Starlette Request with the given state + headers."""
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "query_string": b"",
+        "headers": raw_headers,
+        "client": (client_host, 12345),
+    }
+    req = Request(scope)
+    if user is not None:
+        req.state.user = user
+    if operator_fingerprint is not None:
+        req.state.operator_fingerprint = operator_fingerprint
+    return req
+
+
+class TestDictUserKeying:
+    """After the fix, dict-based `request.state.user` must yield distinct keys."""
+
+    def test_regression_no_collapse_on_unknown(self):
+        """The literal bug: dict user + getattr returned `user:unknown`."""
+        key = get_rate_limit_key(_make_request(user={"sub": "alice", "tenant_id": "acme"}))
+        assert key == "tenant:acme:user:alice"
+        assert "unknown" not in key
+
+    def test_distinct_users_same_tenant(self):
+        key_alice = get_rate_limit_key(_make_request(user={"sub": "alice", "tenant_id": "acme"}))
+        key_bob = get_rate_limit_key(_make_request(user={"sub": "bob", "tenant_id": "acme"}))
+        assert key_alice != key_bob
+
+    def test_distinct_tenants_same_user(self):
+        key_acme = get_rate_limit_key(_make_request(user={"sub": "alice", "tenant_id": "acme"}))
+        key_oasis = get_rate_limit_key(_make_request(user={"sub": "alice", "tenant_id": "oasis"}))
+        assert key_acme != key_oasis
+
+    def test_missing_tenant_falls_back_to_azp_then_default(self):
+        # No tenant_id → use azp; no azp → "default"
+        key_azp = get_rate_limit_key(_make_request(user={"sub": "alice", "tenant_id": None, "azp": "portal"}))
+        assert key_azp == "tenant:portal:user:alice"
+
+        key_default = get_rate_limit_key(_make_request(user={"sub": "alice", "tenant_id": None}))
+        assert key_default == "tenant:default:user:alice"
+
+
+class TestOperatorKeyFingerprint:
+    """X-Operator-Key requests must key on fingerprint, not `sub=stoa-operator`."""
+
+    def test_fingerprint_takes_precedence_over_user(self):
+        fp = hashlib.sha256(b"op-key-1").hexdigest()[:16]
+        key = get_rate_limit_key(
+            _make_request(
+                user={"sub": "stoa-operator", "tenant_id": None},
+                operator_fingerprint=fp,
+            )
+        )
+        assert key == f"operator:{fp}"
+        assert "stoa-operator" not in key
+
+    def test_distinct_operator_keys_distinct_buckets(self):
+        fp_a = hashlib.sha256(b"op-key-A").hexdigest()[:16]
+        fp_b = hashlib.sha256(b"op-key-B").hexdigest()[:16]
+        key_a = get_rate_limit_key(
+            _make_request(
+                user={"sub": "stoa-operator", "tenant_id": None},
+                operator_fingerprint=fp_a,
+            )
+        )
+        key_b = get_rate_limit_key(
+            _make_request(
+                user={"sub": "stoa-operator", "tenant_id": None},
+                operator_fingerprint=fp_b,
+            )
+        )
+        assert key_a != key_b
+
+
+class TestNonJwtFallbacks:
+    """API key and IP fallbacks must still work."""
+
+    def test_api_key_header_yields_apikey_prefix(self):
+        key = get_rate_limit_key(_make_request(headers={"X-API-Key": "sekret-key-value-1234567890"}))
+        assert key.startswith("apikey:")
+        # Prefix-only — the full key must not leak into the bucket id
+        assert "sekret-key-value-1234567890" not in key
+
+    def test_ip_fallback_when_anonymous(self):
+        key = get_rate_limit_key(_make_request(client_host="203.0.113.42"))
+        assert key.startswith("ip:")
+
+
+class TestOperatorFingerprintDerivation:
+    """The fingerprint must be stable for the same key and different across keys."""
+
+    def test_fingerprint_length_and_stability(self):
+        fp1 = hashlib.sha256(b"same-key").hexdigest()[:16]
+        fp2 = hashlib.sha256(b"same-key").hexdigest()[:16]
+        assert fp1 == fp2
+        assert len(fp1) == 16
+
+    def test_fingerprint_changes_across_keys(self):
+        fp1 = hashlib.sha256(b"key-1").hexdigest()[:16]
+        fp2 = hashlib.sha256(b"key-2").hexdigest()[:16]
+        assert fp1 != fp2
+
+
+@pytest.mark.asyncio
+async def test_dependencies_sets_operator_fingerprint_on_state(monkeypatch):
+    """Integration: when X-Operator-Key is valid, get_current_user must expose
+    `request.state.operator_fingerprint` so the limiter can key on it."""
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    from src.auth import dependencies as deps_module
+    from src.auth.dependencies import User, get_current_user
+
+    class _Settings:
+        KEYCLOAK_URL = "https://auth.test"
+        keycloak_internal_url = "https://auth.test"
+        KEYCLOAK_REALM = "stoa"
+        KEYCLOAK_CLIENT_ID = "control-plane-api"
+        gateway_api_keys_list = ["valid-operator-key"]
+        LOG_DEBUG_AUTH_TOKENS = False
+        LOG_DEBUG_AUTH_PAYLOAD = False
+        LOG_DEBUG_AUTH_HEADERS = False
+
+    monkeypatch.setattr(deps_module, "settings", _Settings)
+
+    app = FastAPI()
+
+    @app.get("/probe")
+    async def probe(request: Request, user: User = pytest.importorskip("fastapi").Depends(get_current_user)):
+        return {
+            "user_sub": user.id,
+            "fingerprint": getattr(request.state, "operator_fingerprint", None),
+        }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get("/probe", headers={"X-Operator-Key": "valid-operator-key"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["user_sub"] == "stoa-operator"
+    expected_fp = hashlib.sha256(b"valid-operator-key").hexdigest()[:16]
+    assert body["fingerprint"] == expected_fp


### PR DESCRIPTION
## Summary

Fix a silent P1 availability bug where the rate-limit middleware was keying every JWT user onto the shared bucket `tenant:default:user:unknown`, so one noisy user could rate-limit every other authenticated user on the platform. The same defect collapsed every `X-Operator-Key` operator onto `tenant:default:user:stoa-operator`.

### Root cause (regression for CAB-2079)
- `control-plane-api/src/auth/dependencies.py:260` stores `request.state.user` as a **dict**.
- `control-plane-api/src/middleware/rate_limit.py:41` was reading it with `getattr(user, "sub", "unknown")`, which always hits the default for dicts.

### Fix
1. Dict-access keying (`user.get(...)`) with `isinstance(user, dict)` guard.
2. Expose `request.state.operator_fingerprint = sha256(key)[:16]` on X-Operator-Key auth; limiter now branches on it so each operator key gets its own bucket.
3. Enrich operator-auth audit log with `{fingerprint, client_ip, path}` (raw key never logged).

### Tests
- New `tests/test_regression_cab_2146_rate_limit_keying.py` — 11 cases covering distinct-user, distinct-tenant, operator-fingerprint, fallbacks, and end-to-end `get_current_user` fingerprint exposure.
- Legacy `test_rate_limit.py` + `test_rate_limit_middleware.py` migrated from MagicMock users to dict users — they were silently validating a contract the code never delivered in prod.

### Collateral
Extend `test_regression_cab_2083` grep exclusion to `docs/audits/**` so the audit archive shipped in CAB-2140 (PR #2448) — which legitimately quotes the Parzival literal as historical context — doesn't trigger the regression guard on main.

### Operational note
Users that previously benefited from the collapsed bucket may start seeing 429s post-deploy if they cross 100/min. Monitor `rate_limit_exceeded` logs in the first 24h.

## Test plan
- [ ] CI green (all three regression tests + migrated legacy tests)
- [ ] Manual Prometheus spot-check: `sum by (key) (rate_limit_exceeded_total)` shows distinct keys post-deploy
- [ ] No 429 spike on console.gostoa.dev during the day after merge

Linear: [CAB-2146]

🤖 Generated with [Claude Code](https://claude.com/claude-code)