### PR TITLE
fix(security): gate sensitive debug flags on prod boot (CAB-2145)

### DIFF
--- a/control-plane-api/src/config.py
+++ b/control-plane-api/src/config.py
@@ -5,12 +5,28 @@ For Kubernetes deployments, set these in ConfigMaps/Secrets.
 """
 
 import json
+import logging
 import os
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
 
 # Base domain - used to construct default URLs
 _BASE_DOMAIN = os.getenv("BASE_DOMAIN", "gostoa.dev")
+
+_logger = logging.getLogger(__name__)
+
+# CAB-2145: flags that emit credential-grade data (raw JWT tokens, decoded
+# JWT payload, Authorization/Cookie headers, raw request bodies). They must
+# never be `True` in production. Adding a new flag to this list is enough to
+# make the startup validator enforce the gate.
+SENSITIVE_DEBUG_FLAGS_IN_PROD: tuple[str, ...] = (
+    "LOG_DEBUG_AUTH_TOKENS",
+    "LOG_DEBUG_AUTH_HEADERS",
+    "LOG_DEBUG_AUTH_PAYLOAD",
+    "LOG_DEBUG_HTTP_BODY",
+    "LOG_DEBUG_HTTP_HEADERS",
+)
 
 
 class Settings(BaseSettings):
@@ -387,6 +403,33 @@ class Settings(BaseSettings):
         if not self.GATEWAY_API_KEYS:
             return []
         return [key.strip() for key in self.GATEWAY_API_KEYS.split(",") if key.strip()]
+
+    @model_validator(mode="after")
+    def _gate_sensitive_debug_flags_in_prod(self) -> "Settings":
+        """CAB-2145: fail fast if a credential-leaking debug flag is enabled in prod.
+
+        Raises on `ENVIRONMENT=production`; logs a warning in any other env so
+        developers still see the foot-gun during local debugging.
+        """
+        offenders = [flag for flag in SENSITIVE_DEBUG_FLAGS_IN_PROD if getattr(self, flag, False)]
+        if not offenders:
+            return self
+
+        joined = ", ".join(offenders)
+        if self.ENVIRONMENT == "production":
+            raise ValueError(
+                f"Refusing to boot: sensitive debug flag(s) {joined} are True while "
+                f"ENVIRONMENT=production. These flags leak JWT tokens, Authorization "
+                f"headers, or request bodies into logs. Unset them in your Helm override."
+            )
+
+        _logger.warning(
+            "Sensitive debug flag(s) %s are True (ENVIRONMENT=%s). "
+            "These MUST be False in production — do not deploy this config.",
+            joined,
+            self.ENVIRONMENT,
+        )
+        return self
 
     class Config:
         env_file = ".env"

--- a/control-plane-api/tests/test_regression_cab_2145_debug_flag_env_gating.py
+++ b/control-plane-api/tests/test_regression_cab_2145_debug_flag_env_gating.py
@@ -1,0 +1,95 @@
+"""Regression tests for CAB-2145 (Security MEGA CAB-2079 — debug flag env gating).
+
+Before the fix:
+- `LOG_DEBUG_AUTH_TOKENS`, `LOG_DEBUG_AUTH_PAYLOAD`, `LOG_DEBUG_AUTH_HEADERS`,
+  `LOG_DEBUG_HTTP_BODY`, and `LOG_DEBUG_HTTP_HEADERS` were plain booleans on
+  `Settings`. Nothing stopped them being flipped to `True` in a prod Helm
+  override — in which case live JWT bearer tokens and request bodies ended up
+  in stdout logs and OpenSearch indices.
+- The config-drift audit (CAB-2140 / PR #2448) verified prod has them all
+  False today, but there was no mechanism to keep them that way.
+
+After the fix:
+- A Pydantic model validator fails fast at app startup when `ENVIRONMENT
+  == "production"` and ANY flag in `SENSITIVE_DEBUG_FLAGS_IN_PROD` is `True`.
+  The traceback names the flag(s) so the operator can find the Helm override
+  quickly.
+- In dev/staging the validator emits a loud warning but does not crash, so
+  local debugging workflows keep working.
+"""
+
+# regression for CAB-2079
+import logging
+
+import pytest
+
+from src.config import SENSITIVE_DEBUG_FLAGS_IN_PROD, Settings
+
+
+class TestProductionRejectsDebugFlags:
+    """Every sensitive flag, combined with ENVIRONMENT=production, must raise."""
+
+    @pytest.mark.parametrize("flag", SENSITIVE_DEBUG_FLAGS_IN_PROD)
+    def test_flag_true_in_prod_raises(self, flag: str):
+        with pytest.raises(ValueError) as exc:
+            Settings(ENVIRONMENT="production", **{flag: True})
+        # The flag name must appear in the error so the operator knows what to flip.
+        assert flag in str(exc.value)
+
+    def test_all_flags_false_in_prod_boots(self):
+        # Canary: the validator must not be overly aggressive and reject a clean prod boot.
+        s = Settings(ENVIRONMENT="production")
+        assert s.ENVIRONMENT == "production"
+        for flag in SENSITIVE_DEBUG_FLAGS_IN_PROD:
+            assert getattr(s, flag) is False
+
+    def test_multiple_flags_all_reported(self):
+        with pytest.raises(ValueError) as exc:
+            Settings(
+                ENVIRONMENT="production",
+                LOG_DEBUG_AUTH_TOKENS=True,
+                LOG_DEBUG_HTTP_BODY=True,
+            )
+        msg = str(exc.value)
+        assert "LOG_DEBUG_AUTH_TOKENS" in msg
+        assert "LOG_DEBUG_HTTP_BODY" in msg
+
+
+class TestDevAndStagingOnlyWarn:
+    """Dev and staging should log a warning, never crash."""
+
+    @pytest.mark.parametrize("env", ["dev", "staging"])
+    def test_flag_true_in_non_prod_does_not_raise(self, env: str, caplog):
+        caplog.set_level(logging.WARNING)
+        s = Settings(ENVIRONMENT=env, LOG_DEBUG_AUTH_TOKENS=True)
+        assert env == s.ENVIRONMENT
+        assert s.LOG_DEBUG_AUTH_TOKENS is True
+        # Operator-visible warning must mention the flag.
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("LOG_DEBUG_AUTH_TOKENS" in r.getMessage() for r in warnings)
+
+    def test_silent_when_no_flag_set(self, caplog):
+        caplog.set_level(logging.WARNING)
+        Settings(ENVIRONMENT="dev")
+        warnings = [r for r in caplog.records if "LOG_DEBUG" in r.getMessage()]
+        assert warnings == []
+
+
+class TestSensitiveListCoverage:
+    """The sensitive list must include the auth-token + payload + body flags
+    that actually leak credential-grade data in prod. Guard against someone
+    renaming a field and forgetting to update the allow-list."""
+
+    def test_auth_tokens_flag_is_covered(self):
+        assert "LOG_DEBUG_AUTH_TOKENS" in SENSITIVE_DEBUG_FLAGS_IN_PROD
+
+    def test_auth_payload_flag_is_covered(self):
+        assert "LOG_DEBUG_AUTH_PAYLOAD" in SENSITIVE_DEBUG_FLAGS_IN_PROD
+
+    def test_http_body_flag_is_covered(self):
+        assert "LOG_DEBUG_HTTP_BODY" in SENSITIVE_DEBUG_FLAGS_IN_PROD
+
+    def test_all_listed_flags_exist_on_settings(self):
+        s = Settings()
+        for flag in SENSITIVE_DEBUG_FLAGS_IN_PROD:
+            assert hasattr(s, flag), f"SENSITIVE_DEBUG_FLAGS_IN_PROD references {flag}, which is not a Settings field"


### PR DESCRIPTION
## Summary

Add a fail-fast gate so a Helm override that flips a credential-leaking debug flag on in prod crashes the app at boot instead of silently shipping live JWTs / request bodies to logs.

### Why now
The CAB-2140 rollout audit (PR #2448) verified that prod cp-api today has every `LOG_DEBUG_AUTH_*` and `LOG_DEBUG_HTTP_BODY` flag set to False. Nothing in the code enforced that — a future values.yaml edit could silently undo it.

## What changed

| File | Change |
|---|---|
| `control-plane-api/src/config.py` | New `SENSITIVE_DEBUG_FLAGS_IN_PROD` tuple + `@model_validator(mode="after")` that raises on prod, warns on dev/staging |
| `control-plane-api/tests/test_regression_cab_2145_debug_flag_env_gating.py` | 14 cases: parametrized prod-rejection, multi-offender error, dev/staging warning, sensitive-list coverage |

### Sensitive flags gated
- `LOG_DEBUG_AUTH_TOKENS` (raw JWTs)
- `LOG_DEBUG_AUTH_HEADERS` (Authorization / Cookie)
- `LOG_DEBUG_AUTH_PAYLOAD` (decoded JWT payload)
- `LOG_DEBUG_HTTP_BODY` (raw request/response bodies)
- `LOG_DEBUG_HTTP_HEADERS` (leaks auth headers too)

Less-sensitive `LOG_DEBUG_SQL_*` / `LOG_DEBUG_KAFKA_*` / `LOG_DEBUG_HTTP_REQUESTS` are intentionally not in the list — they log shape, not content.

## Diff
2 files, +138 / -0 LOC. Well under budget.

## Tests
- `pytest tests/test_regression_cab_2145_debug_flag_env_gating.py` → 14/14 green
- `pytest tests/ -k "config or settings"` → 164 passed, 0 failed

## Test plan
- [ ] CI green (pytest + ruff + black)
- [ ] Manual: set `ENVIRONMENT=production LOG_DEBUG_AUTH_TOKENS=true` locally → uvicorn crashes at startup with clear message
- [ ] Manual: set `ENVIRONMENT=dev LOG_DEBUG_AUTH_TOKENS=true` → app boots, warning in logs

### Related
Independent of #2449 (rate-limit keying) and #2450 (CORS tighten). All three PRs touch different files and can merge in any order.

Linear: [CAB-2145]

🤖 Generated with [Claude Code](https://claude.com/claude-code)