### PR TITLE
fix(ci): restore hcvault URL for E2E secret fetch

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -87,7 +87,10 @@ jobs:
         continue-on-error: true  # Gracefully fall back to GitHub secrets if Vault fails
         uses: hashicorp/vault-action@v3
         with:
-          url: https://vault.gostoa.dev
+          # vault.gostoa.dev = Infisical (different product) — E2E secrets live on
+          # the HashiCorp Vault instance at hcvault.gostoa.dev. Changing this URL
+          # broke silently because `continue-on-error: true` masked the 404.
+          url: https://hcvault.gostoa.dev
           method: jwt
           role: github-actions
           jwtGithubAudience: sigstore


### PR DESCRIPTION
## Summary

`e2e-tests.yml` was pointing `hashicorp/vault-action` at `vault.gostoa.dev`, which is **Infisical** (a different secrets product — see internal infra memory). HashiCorp's vault-action speaks the Vault API, so `POST /v1/auth/jwt/login` returns 404 on Infisical. The action's `continue-on-error: true` silently swallowed the failure, so every E2E shard started with empty persona secrets and cascaded into browser-level login failures (Chat Agent, Error Taxonomy, MCP Servers, API CRUD), all reported as code regressions.

## Evidence

Probed both endpoints just now:

```bash
$ curl -X POST https://hcvault.gostoa.dev/v1/auth/jwt/login
HTTP 403 — {"errors":["permission denied"]}                  # endpoint exists, just no creds

$ curl -X POST https://vault.gostoa.dev/v1/auth/jwt/login
HTTP 404 — {"message":"Route POST:/v1/auth/jwt/login not found", ...}
```

And `hcvault.gostoa.dev/v1/sys/health` returns Vault 1.18.4, initialized + unsealed.

## What changed

One line in `.github/workflows/e2e-tests.yml`:
`https://vault.gostoa.dev` → `https://hcvault.gostoa.dev`

Plus an inline comment so the next person doesn't reintroduce the same bug.

The other workflows that touch Vault (`arena-l0.yml:47`, `ops-scripts-deploy.yml:56`) already use `hcvault.gostoa.dev`. This aligns E2E with them.

## Test plan

- [ ] CI green (no test changes, just the URL)
- [ ] Post-merge: PR #2450 re-runs E2E and shards pass
- [ ] Post-merge: any subsequent E2E workflow run gets secrets correctly

## Context

Discovered while stabilizing Phase 2 of CAB-2079 (MEGA security hardening). PR #2450 (CAB-2142, CORS tighten) was blocked by this CI env issue — the failures looked scary on paper (Console flows red) but were all downstream of missing persona secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)