### PR TITLE
fix(ci): align E2E workflow on dedicated gha-stoa-e2e Vault role

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -92,8 +92,10 @@ jobs:
           # broke silently because `continue-on-error: true` masked the 404.
           url: https://hcvault.gostoa.dev
           method: jwt
-          role: github-actions
-          jwtGithubAudience: sigstore
+          # Dedicated role (separated from gha-stoa-deploy for privilege isolation).
+          # Created by stoa-infra: deploy/vps/vault/setup-gha-e2e-oidc.sh.
+          role: gha-stoa-e2e
+          jwtGithubAudience: https://github.com/stoa-platform/stoa
           exportEnv: true
           secrets: |
             secret/data/e2e/urls PORTAL_URL | E2E_PORTAL_URL ;


### PR DESCRIPTION
## Summary

Fix the 403 permission denied blocking PR #2450 E2E shards by pointing the workflow at a dedicated, properly scoped Vault JWT role.

## What was wrong

The workflow sent `role: github-actions` with `jwtGithubAudience: sigstore`. Neither value matches anything actually configured on `hcvault.gostoa.dev`. `setup-gha-oidc.sh` only creates the `gha-stoa-deploy` role (audience `https://github.com/stoa-platform/stoa`). The 403 happens at `auth/jwt/login` — before any secret read.

## What this changes

`.github/workflows/e2e-tests.yml`:
- `role: github-actions` → `role: gha-stoa-e2e`
- `jwtGithubAudience: sigstore` → `jwtGithubAudience: https://github.com/stoa-platform/stoa`

Plus an inline comment pointing at the stoa-infra setup script so the next maintainer can trace the role back to its Vault-side config.

## Paired change

**stoa-infra PR**: https://github.com/PotoMitan/stoa-infra/pull/50 — adds the `gha-stoa-e2e` role + `gha-e2e` policy (read-only on `secret/data/e2e/*`). Kept separate from `gha-stoa-deploy` for privilege isolation.

## Merge sequence (human-coordinated)

1. Merge PotoMitan/stoa-infra#50
2. Run `VAULT_TOKEN=<admin> ./deploy/vps/vault/setup-gha-e2e-oidc.sh` on the hcvault VPS
3. Verify `secret/data/e2e/*` is populated (urls + personas) — if not, populate
4. Merge this PR
5. Update-branch on PR #2450 → E2E shards should pass

Step 4 will surface a secondary failure if step 3 wasn't done (E2E login still fails for lack of persona creds), but the Vault auth itself will succeed.

## Test plan

- [ ] CI lint green (no test changes)
- [ ] Post-merge: `auth/jwt/login` succeeds on an E2E run (logs should show `Retrieving Vault token` + `Vault secrets exported`)
- [ ] Post-merge: PR #2450 E2E shards pass

Linear: Phase 2 CAB-2079 stabilization

🤖 Generated with [Claude Code](https://claude.com/claude-code)