### PR TITLE
chore(claude): enforce rewrite-vs-patch policy to mitigate context rot

### DIFF
--- a/.claude/docs/rewrite-vs-patch.md
+++ b/.claude/docs/rewrite-vs-patch.md
@@ -1,0 +1,69 @@
+# Rewrite vs Patch — Context rot mitigation
+
+> **Règle binaire dans CLAUDE.md.** Ce fichier est le protocole détaillé (lu on-demand).
+
+## Pourquoi cette règle existe
+
+Recherche 2023-2026 sur l'efficacité des approches d'édition LLM :
+
+- **Aider benchmarks** : search/replace échoue sur 20-30% des tentatives sur codebases évoluées. Pattern matching fragile.
+- **Unified diff vs search/replace** : unified diff a rendu GPT-4 Turbo 3× moins paresseux (laziness score 20% → 61%). Le format compte autant que le choix patch-vs-rewrite.
+- **Liu et al. "Lost in the Middle" (2023)** : la performance dégrade sévèrement dès que le contexte dépasse 50% de remplissage. Les tokens du milieu "se perdent".
+- **Databricks Mosaic (2025)** : correctness des agents chute après 32K tokens. Agents favorisent actions répétitives issues de leur historique.
+- **Veseli et al. (2025)** : au-delà de 50% de contexte, dégradation par distance depuis la fin (récents > milieu > anciens). Les tokens anciens de CLAUDE.md deviennent moins influents que les dernières erreurs.
+
+Effet combiné : chaque Edit raté laisse des traces (tool calls échoués, corrections, assumptions fausses) qui polluent le contexte et biaisent les décisions suivantes. Après 2-3 Edits ratés sur le même fichier, l'agent tourne en rond — il "voit" le fichier à travers une accumulation de fausses versions.
+
+## Décisions binaires (seuils)
+
+| Signal | Action |
+|--------|--------|
+| 1 Edit échoué | Re-lire le fichier, corriger le pattern, retry une fois |
+| **2 Edits échoués consécutifs sur même fichier** | **STOP. Write (rewrite complet) ou subagent.** |
+| 3+ itérations sur même fichier en session | `/clear` ou délégation subagent (contexte pollué) |
+| Diff estimé >30% du fichier | Write direct dès le départ (pas de série d'Edit) |
+| Fichier >1500 lignes | Ne pas rewrite inline — split ou subagent |
+| Contexte session >70% | Subagent même pour rewrite simple (pollution bias) |
+
+## Enforcement
+
+**3 niveaux actifs** :
+
+1. **Documenté** : CLAUDE.md section "Rewrite vs Patch" (auto-chargé) + `feedback_rewrite_after_fail.md` (persiste cross-sessions)
+2. **Détecté** : hook `post-edit-failure-tracker.sh` (PostToolUse Edit)
+   - Tracke fails par fichier dans `.claude/state/edit-attempts.json`
+   - Injecte `systemMessage` à ≥2 fails consécutifs
+   - Second warning à ≥5 Edit total même fichier (risque pollution)
+   - Reset sur SessionStart + PostCompact
+3. **Exécuté** : skill `/rewrite <file> <intent>` force le Write propre
+
+## Signals de failure (ce que le hook détecte)
+
+Le hook lit `tool_response` post-Edit et flag error si :
+- `tool_response.is_error == true`
+- `tool_response.error` non vide
+- String response contient `error|failed|not found|does not match` (case-insensitive)
+
+Faux positifs possibles mais rares (le hook n'est qu'advisory, `exit 0` toujours).
+
+## Bypass
+
+Pas de kill-switch dédié. Si besoin d'un bypass ponctuel :
+- Ignorer le systemMessage (il est advisory, pas bloquant)
+- Ou reset manuel : `echo '{}' > .claude/state/edit-attempts.json`
+
+Si tu te retrouves à bypasser régulièrement, c'est un signal que le seuil est mal calibré — ajuster dans le hook plutôt que router autour.
+
+## Interaction avec les autres règles
+
+- **Context budget (60/80/90)** : complémentaire. Le budget mesure le volume, cette règle mesure la qualité (échecs répétés). Un contexte à 40% mais avec 3 Edits ratés est aussi pollué qu'un contexte à 80% propre.
+- **PR >300 LOC interdit** : un rewrite peut pousser un fichier au-delà. Si le rewrite lui-même fait >300 LOC de diff, c'est le signal qu'il fallait un subagent, pas un rewrite inline.
+- **Test-first (fix/feat)** : un rewrite doit passer les tests existants. Si non, c'est du refactor déguisé — séparer.
+
+## Sources
+
+- [Aider — Unified diffs make GPT-4 Turbo 3X less lazy](https://aider.chat/docs/unified-diffs.html)
+- [Aider — Edit formats benchmarks](https://aider.chat/docs/benchmarks.html)
+- [Liu et al. 2023 — Lost in the Middle](https://arxiv.org/abs/2307.03172)
+- [Diff-XYZ benchmark (arXiv 2510.12487)](https://arxiv.org/html/2510.12487v1)
+- [Context Rot: Why AI Gets Worse the Longer You Chat](https://www.producttalk.org/context-rot/)

--- a/.claude/hooks/post-edit-failure-tracker.sh
+++ b/.claude/hooks/post-edit-failure-tracker.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# PostToolUse hook: track Edit failures per file to detect context rot.
+#
+# When the model patches the same file ≥2 times and keeps failing, the context
+# accumulates failed attempts, wrong assumptions, and retry noise. Research
+# (Liu et al. "Lost in the Middle", Databricks Mosaic) shows this degrades
+# performance. This hook injects a systemMessage telling the model to switch
+# to Write (rewrite) or delegate to a subagent.
+#
+# State: .claude/state/edit-attempts.json (session-scoped, reset on /clear via
+# the PostCompact hook and on SessionStart).
+#
+# Thresholds:
+#   - 2 consecutive Edit failures same file → "switch to Write or subagent"
+#   - 5 Edit calls same file in session (even successful) → "consider rewrite"
+#
+# Exit 0 always (advisory, never blocks).
+
+set -u
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# Only track Edit (not Write — Write is already the rewrite path)
+[ "$TOOL_NAME" != "Edit" ] && exit 0
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+[ -z "$FILE_PATH" ] && exit 0
+
+# Detect failure: tool_response has error indicator
+# Claude Code marks failed tool calls via .tool_response.is_error or .error fields
+IS_ERROR=$(echo "$INPUT" | jq -r '
+  if (.tool_response.is_error // false) then "true"
+  elif (.tool_response.error // "") != "" then "true"
+  elif (.tool_response | type) == "string" and (.tool_response | test("Error|error|failed|not found|does not match"; "i")) then "true"
+  else "false"
+  end
+' 2>/dev/null)
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+STATE_DIR="$PROJECT_DIR/.claude/state"
+STATE_FILE="$STATE_DIR/edit-attempts.json"
+
+mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+[ ! -f "$STATE_FILE" ] && echo '{}' > "$STATE_FILE"
+
+# Use a short hash of the file path as key (avoids JSON escaping issues)
+FILE_KEY=$(echo -n "$FILE_PATH" | shasum -a 1 | awk '{print $1}' | cut -c1-16)
+
+# Atomic update via jq — increment counters
+TMP=$(mktemp)
+jq --arg key "$FILE_KEY" \
+   --arg path "$FILE_PATH" \
+   --arg err "$IS_ERROR" \
+   '
+   .[$key] = {
+     path: $path,
+     total: ((.[$key].total // 0) + 1),
+     consecutive_fails: (
+       if $err == "true" then ((.[$key].consecutive_fails // 0) + 1)
+       else 0
+       end
+     ),
+     last_error: ($err == "true")
+   }
+   ' "$STATE_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$STATE_FILE" || { rm -f "$TMP"; exit 0; }
+
+# Read back to decide if we warn
+FAILS=$(jq -r --arg key "$FILE_KEY" '.[$key].consecutive_fails // 0' "$STATE_FILE" 2>/dev/null)
+TOTAL=$(jq -r --arg key "$FILE_KEY" '.[$key].total // 0' "$STATE_FILE" 2>/dev/null)
+
+BASENAME=$(basename "$FILE_PATH")
+
+if [ "${FAILS:-0}" -ge 2 ]; then
+  MSG="Edit failed ${FAILS}× consecutively on ${BASENAME}. Context rot risk: STOP patching. Read the current file, then use Write (full rewrite) or delegate to a subagent with fresh context. See feedback_rewrite_after_fail.md."
+  echo "$MSG" | jq -Rs '{"systemMessage": .}'
+elif [ "${TOTAL:-0}" -ge 5 ]; then
+  MSG="Edit called ${TOTAL}× on ${BASENAME} this session. Consider switching to Write (rewrite) or subagent — accumulated patches pollute context and bias future decisions."
+  echo "$MSG" | jq -Rs '{"systemMessage": .}'
+else
+  echo '{}'
+fi
+
+exit 0

--- a/.claude/hooks/session-reset-edit-tracker.sh
+++ b/.claude/hooks/session-reset-edit-tracker.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# SessionStart + PostCompact hook: reset the edit-attempts state.
+# Fresh session or post-/compact = clean slate for the failure counter.
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+STATE_FILE="$PROJECT_DIR/.claude/state/edit-attempts.json"
+
+[ -f "$STATE_FILE" ] && echo '{}' > "$STATE_FILE"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,10 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-init.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-reset-edit-tracker.sh\""
           }
         ]
       }
@@ -82,6 +86,15 @@
         ]
       },
       {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-edit-failure-tracker.sh\""
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write|Bash|Read|Grep|Glob",
         "hooks": [
           {
@@ -134,6 +147,10 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-compact-state.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-reset-edit-tracker.sh\""
           }
         ]
       }

--- a/.claude/skills/rewrite/SKILL.md
+++ b/.claude/skills/rewrite/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: rewrite
+description: Force a full-file rewrite (Write) instead of patch (Edit) when Edit keeps failing or diff is large. Context rot mitigation — use when Edit has failed ≥2× on same file, or when estimated diff >30% of file size.
+argument-hint: "<file_path> [intent — what should change]"
+---
+
+# Rewrite — $ARGUMENTS
+
+> Invoked when Edit (patch) is the wrong tool. Research shows search/replace fails 20-30% on evolved code, and accumulated failed patches poison the context (Liu et al. "Lost in the Middle"; Databricks Mosaic). See `feedback_rewrite_after_fail.md`.
+
+## When to use this skill
+
+Triggered automatically via the hook `post-edit-failure-tracker.sh` at 2 consecutive Edit failures. Also invoke manually when:
+- Diff estimated >30% of the file size
+- Refactoring where structure changes, not just content
+- File is small-to-medium (≤800 lines) and a clean rewrite is cheaper than hunting for correct search/replace anchors
+- User says "just rewrite it"
+
+**Do NOT use** for:
+- Single-line changes (use Edit)
+- Files >1500 lines (split first, or delegate to subagent)
+- Files you haven't read yet in this session (read first, understand first)
+
+## Workflow
+
+### Step 1 — Parse arguments
+Split `$ARGUMENTS` into:
+- `FILE_PATH` (first token, absolute path)
+- `INTENT` (remainder — what the rewrite should accomplish)
+
+If `INTENT` is empty, ask the user: "What should the rewrite accomplish? (e.g. 'fix the auth middleware bug', 'add tenant filtering')". Do NOT guess the intent from context alone.
+
+### Step 2 — Read the current file
+Always `Read` the full file before rewriting. If >1500 lines, stop and suggest splitting or subagent delegation instead.
+
+### Step 3 — Check pollution signal
+```bash
+jq --arg path "$FILE_PATH" '[.[] | select(.path == $path)] | .[0]' .claude/state/edit-attempts.json
+```
+If `consecutive_fails ≥ 2`, the rewrite is warranted. If `total ≥ 5` but `consecutive_fails < 2`, consider whether a subagent with fresh context would be better than an inline rewrite (Main context already has noise).
+
+### Step 4 — Rewrite strategy
+
+Preserve by default:
+- Public API surface (exported symbols, function signatures if referenced elsewhere)
+- Import structure and file-level conventions
+- Comments that explain non-obvious WHY (delete comments that explain WHAT)
+- Type annotations, docstrings where they exist
+
+Change per INTENT:
+- Fix the bug described
+- Refactor the internal logic
+- Simplify control flow
+
+### Step 5 — Write the file
+Use the `Write` tool with the full new content. Never emit partial content or placeholders like `// ... rest unchanged`.
+
+### Step 6 — Verify
+Run the relevant check for the file type:
+- `.py`: `ruff check <file> && ruff format --check <file>` (or let the post-edit-format hook run)
+- `.rs`: `rustfmt --check <file>` + `cargo check -p <crate>` if feasible
+- `.ts|.tsx|.js|.jsx`: `npx prettier --check <file>`
+- `.go`: `go vet ./... && gofmt -l <file>`
+
+If the file has tests nearby (`*_test.*`, `*.test.*`, `*.spec.*`), run them.
+
+### Step 7 — Reset the tracker
+```bash
+jq --arg path "$FILE_PATH" 'del(.[] | select(.path == $path))' .claude/state/edit-attempts.json > /tmp/et.json && mv /tmp/et.json .claude/state/edit-attempts.json
+```
+Removes the failure counter for this file so the next session starts clean.
+
+## Anti-patterns
+
+- Do NOT rewrite a file whose purpose you don't understand. Read + grep callers first.
+- Do NOT rewrite while the main context is >70% full — delegate to a subagent instead (the pollution bias applies to rewrites too).
+- Do NOT bundle unrelated changes into the rewrite. Stick to the stated INTENT.
+- Do NOT remove comments that carry historical/compliance context (e.g. "kept for backwards compat with X", "regression for CAB-XXXX") — these have load-bearing information.
+- Do NOT rewrite test files without running them after — silent test deletion is a known failure mode.

--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,9 @@ backups/
 # Git worktrees (parallel Claude sessions)
 .claude/worktrees/
 
+# Ephemeral hook state (edit-attempts tracker, session-scoped)
+.claude/state/
+
 # Infisical
 .infisical.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,13 @@ Règles binaires GO/NOGO. Détail on-demand dans `.claude/docs/<rule>.md`.
 - Coverage: cp-api ≥70%, mcp-gateway ≥40%. Jamais descendre.
 - Ne jamais mocker la boundary sous test (httpx.MockTransport, MSW, pas AsyncMock).
 
+### Rewrite vs Patch (context rot mitigation)
+- 2 Edit échecs consécutifs même fichier → **Write (rewrite complet) ou subagent**. Pas de 3e tentative Edit.
+- Diff estimé >30% du fichier → Write direct. Pas de série d'Edit qui dérive.
+- >3 itérations de fix sur même fichier dans la même session → `/clear` ou délégation subagent (contexte frais).
+- Skill `/rewrite <path>` disponible pour forcer rewrite propre quand Edit échoue.
+- Détail: `.claude/docs/rewrite-vs-patch.md`. Hook: `post-edit-failure-tracker.sh`.
+
 ### Git & Merge
 - Toujours `--squash` + `--delete-branch`. Jamais push direct sur `main`.
 - `--force`, `git reset --hard`, suppression branche tiers = demander avant.


### PR DESCRIPTION
## Summary

Three-level enforcement of a rewrite-over-patch policy for the Claude Code harness, to mitigate context rot when Edit (search/replace) keeps failing on the same file.

**Research basis** (documented in `.claude/docs/rewrite-vs-patch.md`):
- Aider benchmarks: search/replace fails 20-30% on evolved codebases
- Liu et al. "Lost in the Middle" (2023): performance degrades past 50% context fill
- Databricks Mosaic (2025): agent correctness drops after 32K tokens
- Each failed Edit accumulates in the context (failed tool calls, retries, wrong assumptions) and biases subsequent decisions

## Changes

- **N1 — Documented**: `CLAUDE.md` section "Rewrite vs Patch" (binary GO/NOGO) + `.claude/docs/rewrite-vs-patch.md` (on-demand protocol) + `memory/feedback_rewrite_after_fail.md` (cross-session)
- **N2 — Detected**: `post-edit-failure-tracker.sh` PostToolUse hook
  - Tracks Edit failures per file in `.claude/state/edit-attempts.json`
  - Injects `systemMessage` at >=2 consecutive fails on the same path
  - Second warning at >=5 total Edit calls same file (pollution risk)
  - Advisory-only (`exit 0`), never blocks
  - Resets on SessionStart + PostCompact
- **N3 — Executed**: `/rewrite <path> [intent]` skill (`.claude/skills/rewrite/SKILL.md`)
  - Forces Write with preserved API surface, runs lint/format/tests, resets the file's failure counter
- `.gitignore`: adds `.claude/state/` (ephemeral, session-scoped)

## Test plan

- [x] Hook unit-tested with simulated PostToolUse payloads (success → silent; 1st fail → silent; 2nd consecutive fail → systemMessage injected; success → consecutive counter resets)
- [x] Session-reset hook verified (clears `edit-attempts.json` on SessionStart + PostCompact)
- [x] `/rewrite` skill registered (visible in skill list)
- [x] Commitlint: scope `claude` raises a level-1 warning (non-blocking per `commitlint.config.js`)
- [ ] CI: post-push verification

## Footprint

- 7 files, +268/-0 LOC (well under the 300-LOC PR limit)
- No production code touched. No Linear ticket — pure harness tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)