### PR TITLE
refactor(api): close GitProvider abstraction leak (CAB-1889 CP-1)

### DIFF
--- a/control-plane-api/REWRITE-BUGS.md
+++ b/control-plane-api/REWRITE-BUGS.md
@@ -1,0 +1,61 @@
+# REWRITE-BUGS — CAB-1889 CP-1
+
+Bugs and smells surfaced while rewriting the GitProvider abstraction. Not fixed in CP-1 — tracked here for future tickets.
+
+---
+
+## BUG-01 — `_project` leak in `iam_sync_service.py`
+
+**File** : `src/services/iam_sync_service.py:205-209`
+**Nature** : same abstraction leak pattern as the router, but in a service layer:
+```python
+if not git_service._project:
+    ...
+tree = git_service._project.repository_tree(path="tenants", ref="main")
+```
+**Why it matters** : `iam_sync_service` goes through `git_service` (the singleton). If `GIT_PROVIDER=github` is active, `git_service` is a `GitHubService` with **no** `_project` attribute — this branch is silently dead. The sync never runs for GitHub-backed deployments.
+**Fix** : swap to `await git_service.list_tree("tenants", ref="main")` (CP-1 added the method). No new capability needed.
+
+---
+
+## BUG-02 — `_project` leak in `deployment_orchestration_service.py`
+
+**File** : `src/services/deployment_orchestration_service.py:102, 122`
+**Nature** : same leak, reads `git_service._project.commits.list(ref_name="main", per_page=1)`.
+**Why it matters** : same as BUG-01 — the head-commit lookup is GitLab-only. GitHub returns the `_project is None` branch.
+**Fix** : swap to `await git_service.get_head_commit_sha(ref="main")` (already in the ABC).
+
+---
+
+## BUG-03 — Semaphore bypass on `GitLabService.create_file/update_file/delete_file`
+
+**File** : `src/services/git_service.py:621-663`
+**Nature** : `create_file`, `update_file`, `delete_file`, `batch_commit` call `self._gl.projects.get(project_id)` bypassing the `_fetch_with_protection` semaphore+retry wrapper (CAB-688 obligation #1).
+**Why it matters** : under parallel load, write ops can blow past the 10-connection ceiling and trigger 429s with no retry.
+**Fix** : wrap inside `_fetch_with_protection` or sleep the wrapper into the method body.
+
+---
+
+## BUG-04 — Provider-aware logic in base ABC
+
+**File** : `src/services/git_provider.py:175-194` (`get_api_override` default impl).
+**Nature** : the base class inspects `settings.GIT_PROVIDER` to pick a `project_id` format. That's leaky — the base class shouldn't know about concrete providers.
+**Fix** : push the `project_id` resolution to the subclass (each provider already has `_catalog_project_id` / `settings.GITLAB_PROJECT_ID`).
+
+---
+
+## BUG-05 — `write_file` consolidation flips POST semantics silently (CP-1 introduced)
+
+**File** : `src/routers/git.py:166-184` (POST `/files/{path}`).
+**Nature** : before CP-1, the router ran `get_file` + `files.get(...).save(...)` for updates — two round-trips. After CP-1, it calls `write_file` which does `get_file` + `files.get(...).save(...)` inside the provider — same semantics, but a caller inspecting GitLab logs sees the second `files.get()` attributed to `write_file` instead of the endpoint handler.
+**Why it matters** : diagnostic only — no functional change, no user-visible change. Worth noting in the CP-1 commit message for log-grepping oncall folks.
+**Fix** : none required.
+
+---
+
+## BUG-06 — `list_path_commits` in GitHub returns up to `limit` via Python slicing (CP-1 introduced)
+
+**File** : `src/services/github_service.py` (new `list_path_commits` method).
+**Nature** : PyGithub's `get_commits(path=...)` is paginated; `[:limit]` pulls pages until `limit` is satisfied. Unlike GitLab's `per_page=limit`, GitHub's implementation may fetch more than one page when `limit > 30`. No API-level cap enforcement.
+**Why it matters** : minor efficiency, not correctness. Call sites in the router cap `limit <= 100` (Query constraint).
+**Fix** : `itertools.islice(repo.get_commits(...), limit)` for iterator-friendly cap, or accept current behavior.

--- a/control-plane-api/REWRITE-PLAN.md
+++ b/control-plane-api/REWRITE-PLAN.md
@@ -1,0 +1,245 @@
+# REWRITE-PLAN — Git Provider abstraction (CP-1 / CAB-1889)
+
+**Scope** : `src/routers/git.py`, `src/services/git_provider.py`, `src/services/git_service.py`, `src/services/github_service.py`, tests associés.
+**Métrique binaire de succès** : zéro accès `_project` ou `_gh` depuis `src/routers/git.py`.
+
+---
+
+## A. Carte des fuites (`src/routers/git.py`)
+
+Fichier actuel : 388 LOC. 45 tests. **17 accès directs aux internals** (tous `_project`), regroupés en **6 domaines métier** :
+
+| # | Ligne | Opération métier | Accès interne | Méthode ABC actuelle | Statut |
+|---|-------|------------------|---------------|----------------------|--------|
+| 1 | 115 | Lister les commits d'un chemin | `git.list_commits(...)` | ❌ absent de l'ABC (présent sur `GitLabService`, absent de `GitHubService`) | **ABSENT** |
+| 2 | 135, 183 | Lire le contenu d'un fichier (None si absent) | `git.get_file(...)` | ❌ `get_file_content` existe mais **raise** FileNotFoundError | **MISMATCH sémantique** |
+| 3 | 152, 156 | Vérifier connexion + lister un dossier | `git._project` + `repository_tree(path, ref)` | ❌ `list_files` existe mais retourne `list[str]` (pas `[{name, type, path}]`) | **ABSENT (tree shape)** |
+| 4 | 176, 192-198 | Créer un fichier | `git._project.files.create({...})` | ✅ `create_file(project_id, path, content, msg, branch)` existe | **NON UTILISÉ** |
+| 5 | 186-189 | Update via file object | `git._project.files.get(...).save(...)` | ✅ `update_file(...)` existe | **NON UTILISÉ** |
+| 6 | 219, 226-228 | Supprimer un fichier | `git._project.files.delete(...)` | ✅ `delete_file(...)` existe | **NON UTILISÉ** |
+| 7 | 246, 250 | Lister merge requests (state) | `git._project.mergerequests.list(state=...)` | ❌ absent | **ABSENT** |
+| 8 | 281, 286-293 | Créer une merge request | `git._project.mergerequests.create({...})` | ❌ absent | **ABSENT** |
+| 9 | 321, 325-326 | Merger une merge request (by iid) | `git._project.mergerequests.get(iid).merge()` | ❌ absent | **ABSENT** |
+| 10 | 342, 346 | Lister les branches | `git._project.branches.list()` | ❌ absent | **ABSENT** |
+| 11 | 370, 375-380 | Créer une branche | `git._project.branches.create({branch, ref})` | ❌ absent | **ABSENT** |
+
+**Constat** :
+1. L'ABC existante est inconsistante : `create_file`, `update_file`, `delete_file`, `get_file_content`, `list_files`, `batch_commit` sont définis mais **le router ne les utilise pas** pour les ops fichiers (3 contournements alors que l'API est dispo).
+2. 8 opérations métier (tree, commits, get_file nullable, MRs x3, branches x2) ne sont **pas dans l'ABC** — c'est la fuite structurelle.
+3. `is_connected()` existe déjà sur la base class (`git_provider.py:196-198`) — utilisable pour remplacer tous les `if not git._project`.
+4. Semantic drift `get_file` vs `get_file_content` : l'un retourne `None`, l'autre `raise`. Les callers du router veulent la variante `None`.
+
+**Hors périmètre strict, mais même pattern à documenter** : `src/services/iam_sync_service.py:205-209` et `src/services/deployment_orchestration_service.py:102,122` leak aussi `_project` → 4 accès à sortir dans un suivi (pas dans ce rewrite).
+
+**Responsabilités mélangées dans `git.py`** :
+- Routing FastAPI + décorateurs RBAC
+- Construction du `scoped_path` (préfixe tenant) — **à garder dans le router** (c'est une règle de scoping tenant)
+- Mapping objet provider → Pydantic response (MR, Branch, Commit) — **à descendre dans l'interface** (retour d'objets déjà normalisés)
+- Error fallback (return `[]`, return `503`, return `500`) — **à garder dans le router** (c'est la politique HTTP)
+
+---
+
+## B. Nouvelle interface `GitProvider`
+
+Méthodes ajoutées (toutes `async`, type hints complets). Les modèles de retour sont des `dataclass` frozen (colocalisés dans `git_provider.py`) pour éviter le leak PyGitLab/PyGithub.
+
+### Nouveaux types valeur (colocalisés dans `git_provider.py`)
+
+```python
+@dataclass(frozen=True)
+class TreeEntry:
+    name: str
+    type: Literal["tree", "blob"]
+    path: str
+
+@dataclass(frozen=True)
+class CommitRef:
+    sha: str
+    message: str
+    author: str
+    date: str
+
+@dataclass(frozen=True)
+class BranchRef:
+    name: str
+    commit_sha: str
+    protected: bool
+
+@dataclass(frozen=True)
+class MergeRequestRef:
+    id: int
+    iid: int              # GitLab iid / GitHub pr_number
+    title: str
+    description: str
+    state: str            # opened | merged | closed
+    source_branch: str
+    target_branch: str
+    web_url: str
+    created_at: str
+    author: str
+```
+
+### Méthodes ajoutées à `GitProvider` (ABC)
+
+```python
+# Connectivity
+def is_connected(self) -> bool: ...   # déjà présent, on s'appuie dessus
+
+# Reads
+async def list_tree(self, path: str, ref: str = "main") -> list[TreeEntry]: ...
+async def read_file(self, path: str, ref: str = "main") -> str | None:
+    """Return file content or None if missing. Does not raise on 404."""
+async def list_path_commits(self, path: str | None, limit: int = 20) -> list[CommitRef]: ...
+
+# Files (already exist — use them, kill the _project.files.* leak)
+# create_file / update_file / delete_file existent déjà — à signature près (project_id arg).
+# → nouvelle surcharge sans project_id qui tape le repo "catalog par défaut" du provider.
+async def write_file(self, path: str, content: str, commit_message: str, branch: str = "main") -> None:
+    """Create-or-update file on the provider's default catalog repo. Implemented on top of existing create_file/update_file."""
+async def remove_file(self, path: str, commit_message: str, branch: str = "main") -> None: ...
+
+# Branches
+async def list_branches(self) -> list[BranchRef]: ...
+async def create_branch(self, name: str, ref: str = "main") -> BranchRef: ...
+
+# Merge requests / Pull requests
+async def list_merge_requests(self, state: str = "opened") -> list[MergeRequestRef]: ...
+async def create_merge_request(
+    self, title: str, description: str, source_branch: str, target_branch: str = "main"
+) -> MergeRequestRef: ...
+async def merge_merge_request(self, iid: int) -> MergeRequestRef: ...
+```
+
+Contrat sémantique :
+- `iid` pour GitLab = `iid`, pour GitHub = `pr.number`. Mapping documenté dans chaque impl.
+- Les nouvelles méthodes opèrent sur **le repo catalog du provider** (GitLab `GITLAB_PROJECT_ID`, GitHub `GITHUB_ORG/GITHUB_CATALOG_REPO`). Le router n'a jamais besoin de passer un `project_id`.
+- Ne raise pas de 404 implicite → le router ne fait plus le mapping. `read_file` renvoie `None`, `list_tree` renvoie `[]` si le chemin est absent.
+
+### Ce qui ne change pas
+
+- `connect` / `disconnect` / `clone_repo` / `get_file_content` / `list_files` / `create_webhook` / `delete_webhook` / `get_repo_info` / `create_file` / `update_file` / `delete_file` / `batch_commit` / catalog methods (`get_tenant`, `list_tenants`, `get_api`, `list_apis`, `get_api_openapi_spec`, `list_mcp_servers`, …) — **inchangés** (utilisés par `git_sync_worker`, `catalog_admin`, `mcp_gitops`, `tenants`, `deployments`, `apis`, `portal`, `health`, `iam_sync_service`).
+
+---
+
+## C. Découpage fichier
+
+État actuel (LOC) :
+
+| Fichier | LOC | Split dans CP-1 ? |
+|---------|-----|-------------------|
+| `src/routers/git.py` | 388 | **NON** — sous seuil après cleanup attendu ~280 LOC |
+| `src/services/git_provider.py` | 303 | **NON** — grossit ~+80 LOC (types + méthodes ABC) → ~380 |
+| `src/services/git_service.py` (GitLab) | 992 | **DIFFÉRÉ** — Phase 2 séparée |
+| `src/services/github_service.py` | 898 | **DIFFÉRÉ** — Phase 2 séparée |
+
+**Décision** : le split des deux services est un rewrite à part entière (restructuration fichiers + mixins + backcompat imports). Il n'appartient pas au noyau CP-1 « fermer la fuite d'abstraction ». Il est **sorti de ce plan** et tracé comme Phase 2 CAB-1889 dédiée (voir section **Phase 2 (séparée, hors CP-1)** plus bas).
+
+Dans CP-1 on accepte temporairement que `git_service.py` et `github_service.py` dépassent 500 LOC — ils grossissent un peu plus (les nouvelles méthodes d'interface s'y ajoutent). C'est le prix pour garder CP-1 focalisé sur le contrat.
+
+**Schemas du router** : `git.py` garde ses Pydantic inline (on ne touche pas au shape OpenAPI). Pas de déplacement.
+
+---
+
+## D. Plan d'exécution (bottom-up)
+
+### Étape 0 — baseline (ne code rien)
+- [ ] Snapshot OpenAPI : `python -c "from src.main import app; import json; print(json.dumps(app.openapi(), indent=2, sort_keys=True))" > /tmp/openapi-before.json`
+- [ ] `pytest tests/test_git_router.py tests/test_git_provider.py tests/test_git_service.py tests/test_github_service.py -q` — note les compteurs (255 tests total, 45 router).
+- [ ] `wc -l src/routers/git.py src/services/git_provider.py src/services/git_service.py src/services/github_service.py` — note les tailles.
+- **Commit 0** : rien (baseline, outputs archivés dans `/tmp/`).
+
+### Étape 1 — enrichir l'ABC
+- [ ] Dans `git_provider.py` : ajouter les dataclasses (`TreeEntry`, `CommitRef`, `BranchRef`, `MergeRequestRef`).
+- [ ] Ajouter les méthodes `list_tree`, `read_file`, `list_path_commits`, `write_file`, `remove_file`, `list_branches`, `create_branch`, `list_merge_requests`, `create_merge_request`, `merge_merge_request` — chacune `async` abstraite (raise `NotImplementedError` côté base pour éviter l'ABCError forçant toutes les impls à bouger d'un coup ; `@abstractmethod` seulement sur ce qui est hard-required).
+- [ ] Tests : **Étape 1.5** on ajoute `tests/test_git_provider_contract.py` qui fait tourner un contrat minimal (chaque impl doit produire les mêmes dataclasses).
+- [ ] `pytest tests/test_git_provider.py -q` : pass.
+- **Commit 1** : `refactor(git): extend GitProvider with tree/branches/MR interface (CAB-1889)`.
+
+### Étape 2 — implémenter côté `GitLabService`
+- [ ] Ajouter dans `git_service.py` (monolithe toujours) les implémentations des nouvelles méthodes, en mappant sur `self._project.branches/mergerequests/files/commits/repository_tree`. Utiliser les dataclasses pour le retour.
+- [ ] `read_file` = wrap de `get_file` existant (déjà nullable).
+- [ ] `list_path_commits` = wrap de `list_commits` existant.
+- [ ] Unit tests : `tests/test_git_service.py` — ajouter les cas mismatch (`read_file` returns None, `list_tree` returns `[]`).
+- [ ] `pytest tests/test_git_service.py -q` : pass.
+- **Commit 2** : `feat(git): GitLab impl for tree/branches/MR abstraction (CAB-1889)`.
+
+### Étape 3 — implémenter côté `GitHubService`
+- [ ] Ajouter dans `github_service.py` les implémentations (PyGithub). `MergeRequestRef.iid` ← `pr.number`. `list_tree` via `repo.get_contents(path)`. `read_file` = wrap de `get_file_content` qui catch `FileNotFoundError` → `None`. `list_path_commits` via `repo.get_commits(path=...)`.
+- [ ] Unit tests : `tests/test_github_service.py` — mêmes cas.
+- [ ] `pytest tests/test_github_service.py -q` : pass.
+- **Commit 3** : `feat(git): GitHub impl for tree/branches/MR abstraction (CAB-1889)`.
+
+### Étape 4 — réécrire le router `git.py`
+- [ ] Remplacer tous les `if not git._project` par `if not git.is_connected()`.
+- [ ] Remplacer chaque bloc `_project.xxx` par l'appel interface correspondant :
+  - tree → `git.list_tree(scoped_path, ref)`
+  - create/update file → `git.write_file(scoped_path, ...)` (consolide les 2 endpoints POST)
+  - delete file → `git.remove_file(scoped_path, ...)`
+  - MRs → `git.list_merge_requests / create_merge_request / merge_merge_request`
+  - branches → `git.list_branches / create_branch`
+  - commits → `git.list_path_commits(...)` (remplace `list_commits`)
+  - get_file → `git.read_file(...)` (remplace `get_file`)
+- [ ] Le mapping dataclass → Pydantic (`BranchInfo(**asdict(b))`) est fait au niveau du router → aucun champ de response model ne bouge.
+- [ ] Vérifier que chaque endpoint conserve status code + response schema identique.
+- [ ] `grep -n "\._project\|\._gh\|\._repo" src/routers/git.py` → attendu **0**.
+- **Commit 4** : `refactor(git): route git.py through GitProvider interface only (CAB-1889)`.
+
+### Étape 5 — rewriter `tests/test_git_router.py`
+- [ ] Les tests existants mockent `_project.*` — invalides désormais. Réécrire chaque test pour mocker la méthode d'interface (`mock_git.list_tree.return_value = [...]`, etc.).
+- [ ] Les tests de **comportement** (status codes, RBAC, response shape) restent **identiques dans leurs assertions** — seules les setups changent.
+- [ ] Compteur de tests ≥ 45 (ajouter 2-3 cas : `is_connected=False`, provider-agnostic GitHub-like MR via `iid`).
+- [ ] `pytest tests/test_git_router.py -q` : pass.
+- **Commit 5** : `test(git): mock GitProvider interface instead of internals (CAB-1889)`.
+
+### Étape 6 — validation finale
+- [ ] `grep -n "\._project\|\._gh\|\._repo\|_internal\|_private" src/routers/git.py` → **0**.
+- [ ] `grep -rn "github_service\|gitlab_service" src/routers/git.py` → **0**.
+- [ ] `pytest --cov=src --cov-fail-under=70 -q` → green, coverage ≥ 70.
+- [ ] `ruff check src/` → 0 issue.
+- [ ] `mypy src/services/git_provider.py src/services/git_service.py src/services/github_service.py src/routers/git.py` → 0 nouvelle erreur.
+- [ ] `wc -l src/routers/git.py src/services/git_provider.py` → tous les **fichiers touchés dans le périmètre CP-1** < 500. `git_service.py` / `github_service.py` restent > 500 → tracé Phase 2.
+- [ ] OpenAPI diff : `diff /tmp/openapi-before.json /tmp/openapi-after.json` → **vide**.
+
+---
+
+## E. Risques identifiés
+
+| # | Risque | Impact | Mitigation |
+|---|--------|--------|------------|
+| R1 | `test_git_router.py` actuel asserte `_project.xxx.assert_called_once()` → 30+ tests à réécrire | Moyen — dette visible, invalide la "non-régression" des tests actuels | Étape 5 dédiée. Les **assertions sur response body + status code** restent des specs. Les **assertions sur `_project.xxx`** sont reconnues comme testant l'implémentation et légitimement réécrites. |
+| R2 | GitHub PR vs GitLab MR : sémantique `iid` ≠ `pr.number` | Moyen | Mapping explicite `iid ← pr.number` documenté dans `GitHubService`. Tests contrat dans `test_git_provider_contract.py`. |
+| R3 | `GitHubService` n'a pas de `_project` → `test_git_router.py` mocks casseront en dev local si on switch GIT_PROVIDER=github | Faible | `is_connected()` abstrait cette bifurcation. Les tests n'utilisent plus `_project` après étape 5. |
+| R4 | Les callers externes (`iam_sync_service`, `deployment_orchestration_service`) leakent aussi `_project` | Faible (hors périmètre strict) | Documenter dans `REWRITE-BUGS.md`, ticket suivi CAB-1889-follow-up. Ne pas fixer dans ce rewrite. |
+| R5 | La méthode `GitLabService._gl.projects.get(project_id)` dans `create_file`/`update_file`/`delete_file` ignore la semaphore `_fetch_with_protection` | Moyen (déjà présent — pas introduit par le rewrite) | Documenter dans `REWRITE-BUGS.md`. Le rewrite n'aggrave pas. |
+| R6 | Le bootstrap `git_service = git_provider_factory()` au module-load (`git.py:43`) est un workaround pour le patching de tests (conftest `_git_di_bridge`). Il peut casser si on change l'ordre d'import | Faible | Garder le shim tant que conftest l'utilise. Vérifier à l'étape 4. |
+| R7 | `git_service.py` / `github_service.py` dépassent déjà 500 LOC et grossissent encore (~+80 LOC / fichier) dans CP-1 | Faible | Accepté — traité dans Phase 2 séparée. Documenté ici pour que le dépassement soit conscient et borné. |
+| R8 | `get_api_override` (git_provider.py:175) a une logique provider-aware dans la base class (regarde `settings.GIT_PROVIDER`) — smell. | Très faible | Hors périmètre. Noter dans `REWRITE-BUGS.md`. |
+
+**Budget estimé CP-1** : 5-7h IA (revu à la baisse — le split était le gros morceau). Étape 5 (rewrite tests) = le plus long (~3h).
+
+---
+
+## Livrables à chaque commit
+
+Chaque commit a un message conventionnel + référence `CAB-1889`. Tests verts entre chaque. Ruff/mypy verts entre chaque. Aucun changement de comportement observable (OpenAPI spec identique). Les tests de comportement restent des specs de non-régression ; les tests implementation-detail sont réécrits explicitement.
+
+---
+
+## Phase 2 (séparée, hors CP-1)
+
+**Objectif** : découper `git_service.py` (~1070 LOC après CP-1) et `github_service.py` (~980 LOC après CP-1) en modules par domaine.
+
+**Prérequis** : CP-1 mergé. Interface `GitProvider` stable. Tous les callers router passent par l'interface.
+
+**Esquisse du split** (ré-évaluation au moment du kick-off — à ne pas graver ici) :
+```
+src/services/git/
+├── gitlab/  { client, rate_limit, reads, writes, branches, merge_requests, catalog, mcp }
+├── github/  { structure identique }
+└── schemas.py  # dataclasses déjà créées en CP-1
+```
+Pattern : mixins composés dans `GitLabService` / `GitHubService`. `git_service.py` et `github_service.py` deviennent des shims backcompat (re-export) — on ne casse pas les imports `iam_sync_service`, `git_sync_worker`, `main.py`, `apis.py`, `tenants.py`, `deployments.py`, `portal.py`, `health.py`, `catalog_admin.py`, `mcp_gitops.py`.
+
+**Livrable attendu** : un `PHASE2-SPLIT-PLAN.md` dédié au moment où on ouvre la Phase 2 (pas maintenant).
+
+**STOP CP-1 ici — attends validation avant d'exécuter les étapes 1-6.**

--- a/control-plane-api/src/routers/git.py
+++ b/control-plane-api/src/routers/git.py
@@ -1,6 +1,7 @@
-"""Git router - provider-agnostic GitOps operations (CAB-1890)"""
+"""Git router - provider-agnostic GitOps operations (CAB-1890, CAB-1889 CP-1)."""
 
 import logging
+from dataclasses import asdict
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -100,6 +101,11 @@ def _tenant_path(tenant_id: str, path: str = "") -> str:
     return f"{base}/{path}" if path else base
 
 
+def _require_connected(git: GitProvider) -> None:
+    if not git.is_connected():
+        raise HTTPException(status_code=503, detail="Git provider not connected")
+
+
 @router.get("/commits", response_model=list[CommitInfo])
 @require_tenant_access
 async def list_commits(
@@ -112,10 +118,8 @@ async def list_commits(
     """List recent commits for tenant repository"""
     scoped_path = _tenant_path(tenant_id, path) if path else _tenant_path(tenant_id)
     try:
-        commits = await git.list_commits(
-            path=scoped_path, limit=limit
-        )  # TODO(CAB-1889): add list_commits to GitProvider ABC
-        return [CommitInfo(**c) for c in commits]
+        commits = await git.list_path_commits(path=scoped_path, limit=limit)
+        return [CommitInfo(**asdict(c)) for c in commits]
     except Exception as e:
         logger.error(f"Failed to list commits for tenant {tenant_id}: {e}")
         return []
@@ -132,7 +136,7 @@ async def get_file(
 ):
     """Get file content from git provider"""
     scoped_path = _tenant_path(tenant_id, file_path)
-    content = await git.get_file(scoped_path, ref=ref)  # TODO(CAB-1889): add get_file to GitProvider ABC
+    content = await git.read_file(scoped_path, ref=ref)
     if content is None:
         raise HTTPException(status_code=404, detail="File not found")
     return FileContent(path=file_path, content=content)
@@ -148,14 +152,11 @@ async def get_tree(
     git: GitProvider = Depends(get_git_provider),
 ):
     """Get directory tree from git provider"""
+    _require_connected(git)
     scoped_path = _tenant_path(tenant_id, path) if path else _tenant_path(tenant_id)
-    if not git._project:  # TODO(CAB-1889): abstract _project access
-        raise HTTPException(status_code=503, detail="Git provider not connected")
-
     try:
-        tree = git._project.repository_tree(path=scoped_path, ref=ref)  # TODO(CAB-1889): abstract _project access
-        items = [TreeItem(name=item["name"], type=item["type"], path=item["path"]) for item in tree]
-        return TreeListResponse(items=items)
+        entries = await git.list_tree(scoped_path, ref=ref)
+        return TreeListResponse(items=[TreeItem(**asdict(e)) for e in entries])
     except Exception:
         return TreeListResponse(items=[])
 
@@ -173,35 +174,17 @@ async def create_or_update_file(
     git: GitProvider = Depends(get_git_provider),
 ):
     """Create or update a file in git provider"""
-    if not git._project:  # TODO(CAB-1889): abstract _project access
-        raise HTTPException(status_code=503, detail="Git provider not connected")
-
+    _require_connected(git)
     scoped_path = _tenant_path(tenant_id, file_path)
     msg = commit_message or f"Update {file_path} for tenant {tenant_id}"
 
-    # Try to get existing file to determine create vs update
-    existing = await git.get_file(scoped_path, ref=branch)  # TODO(CAB-1889): add get_file to GitProvider ABC
     try:
-        if existing is not None:
-            # TODO(CAB-1889): abstract _project access
-            file_obj = git._project.files.get(scoped_path, ref=branch)
-            file_obj.content = body.content
-            file_obj.save(branch=branch, commit_message=msg)
-        else:
-            # TODO(CAB-1889): abstract _project access
-            git._project.files.create(
-                {
-                    "file_path": scoped_path,
-                    "branch": branch,
-                    "content": body.content,
-                    "commit_message": msg,
-                }
-            )
+        action = await git.write_file(scoped_path, body.content, commit_message=msg, branch=branch)
     except Exception as e:
         logger.error(f"Failed to create/update file {scoped_path}: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to save file: {e}")
 
-    return {"path": file_path, "action": "updated" if existing else "created"}
+    return {"path": file_path, "action": action}
 
 
 @router.delete("/files/{file_path:path}", response_model=MessageResponse)
@@ -216,16 +199,12 @@ async def delete_file(
     git: GitProvider = Depends(get_git_provider),
 ):
     """Delete a file from git provider"""
-    if not git._project:  # TODO(CAB-1889): abstract _project access
-        raise HTTPException(status_code=503, detail="Git provider not connected")
-
+    _require_connected(git)
     scoped_path = _tenant_path(tenant_id, file_path)
     msg = commit_message or f"Delete {file_path} for tenant {tenant_id}"
 
     try:
-        git._project.files.delete(
-            file_path=scoped_path, commit_message=msg, branch=branch
-        )  # TODO(CAB-1889): abstract _project access
+        await git.remove_file(scoped_path, commit_message=msg, branch=branch)
     except Exception as e:
         logger.error(f"Failed to delete file {scoped_path}: {e}")
         raise HTTPException(status_code=404, detail="File not found")
@@ -243,26 +222,10 @@ async def list_merge_requests(
     git: GitProvider = Depends(get_git_provider),
 ):
     """List merge requests"""
-    if not git._project:  # TODO(CAB-1889): abstract _project access
-        raise HTTPException(status_code=503, detail="Git provider not connected")
-
+    _require_connected(git)
     try:
-        mrs = git._project.mergerequests.list(state=state)  # TODO(CAB-1889): abstract _project access
-        return [
-            MergeRequestResponse(
-                id=mr.id,
-                iid=mr.iid,
-                title=mr.title,
-                description=mr.description or "",
-                state=mr.state,
-                source_branch=mr.source_branch,
-                target_branch=mr.target_branch,
-                web_url=mr.web_url,
-                created_at=mr.created_at,
-                author=mr.author.get("name", "") if isinstance(mr.author, dict) else str(mr.author),
-            )
-            for mr in mrs
-        ]
+        mrs = await git.list_merge_requests(state=state)
+        return [MergeRequestResponse(**asdict(mr)) for mr in mrs]
     except Exception as e:
         logger.error(f"Failed to list merge requests: {e}")
         return []
@@ -278,31 +241,15 @@ async def create_merge_request(
     git: GitProvider = Depends(get_git_provider),
 ):
     """Create a merge request"""
-    if not git._project:  # TODO(CAB-1889): abstract _project access
-        raise HTTPException(status_code=503, detail="Git provider not connected")
-
+    _require_connected(git)
     try:
-        # TODO(CAB-1889): abstract _project access
-        new_mr = git._project.mergerequests.create(
-            {
-                "title": mr.title,
-                "description": mr.description,
-                "source_branch": mr.source_branch,
-                "target_branch": mr.target_branch,
-            }
+        new_mr = await git.create_merge_request(
+            title=mr.title,
+            description=mr.description,
+            source_branch=mr.source_branch,
+            target_branch=mr.target_branch,
         )
-        return MergeRequestResponse(
-            id=new_mr.id,
-            iid=new_mr.iid,
-            title=new_mr.title,
-            description=new_mr.description or "",
-            state=new_mr.state,
-            source_branch=new_mr.source_branch,
-            target_branch=new_mr.target_branch,
-            web_url=new_mr.web_url,
-            created_at=new_mr.created_at,
-            author=new_mr.author.get("name", "") if isinstance(new_mr.author, dict) else str(new_mr.author),
-        )
+        return MergeRequestResponse(**asdict(new_mr))
     except Exception as e:
         logger.error(f"Failed to create merge request: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to create merge request: {e}")
@@ -318,12 +265,9 @@ async def merge_request(
     git: GitProvider = Depends(get_git_provider),
 ):
     """Merge a merge request"""
-    if not git._project:  # TODO(CAB-1889): abstract _project access
-        raise HTTPException(status_code=503, detail="Git provider not connected")
-
+    _require_connected(git)
     try:
-        mr = git._project.mergerequests.get(mr_iid)  # TODO(CAB-1889): abstract _project access
-        mr.merge()
+        await git.merge_merge_request(mr_iid)
         return {"message": "Merge request merged", "iid": mr_iid}
     except Exception as e:
         logger.error(f"Failed to merge MR !{mr_iid}: {e}")
@@ -339,19 +283,10 @@ async def list_branches(
     git: GitProvider = Depends(get_git_provider),
 ):
     """List branches"""
-    if not git._project:  # TODO(CAB-1889): abstract _project access
-        raise HTTPException(status_code=503, detail="Git provider not connected")
-
+    _require_connected(git)
     try:
-        branches = git._project.branches.list()  # TODO(CAB-1889): abstract _project access
-        return [
-            BranchInfo(
-                name=b.name,
-                commit_sha=b.commit["id"] if isinstance(b.commit, dict) else str(b.commit),
-                protected=getattr(b, "protected", False),
-            )
-            for b in branches
-        ]
+        branches = await git.list_branches()
+        return [BranchInfo(**asdict(b)) for b in branches]
     except Exception as e:
         logger.error(f"Failed to list branches: {e}")
         return []
@@ -367,22 +302,10 @@ async def create_branch(
     git: GitProvider = Depends(get_git_provider),
 ):
     """Create a new branch"""
-    if not git._project:  # TODO(CAB-1889): abstract _project access
-        raise HTTPException(status_code=503, detail="Git provider not connected")
-
+    _require_connected(git)
     try:
-        # TODO(CAB-1889): abstract _project access
-        branch = git._project.branches.create(
-            {
-                "branch": body.name,
-                "ref": body.ref,
-            }
-        )
-        return BranchInfo(
-            name=branch.name,
-            commit_sha=branch.commit["id"] if isinstance(branch.commit, dict) else str(branch.commit),
-            protected=getattr(branch, "protected", False),
-        )
+        branch = await git.create_branch(name=body.name, ref=body.ref)
+        return BranchInfo(**asdict(branch))
     except Exception as e:
         logger.error(f"Failed to create branch {body.name}: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to create branch: {e}")

--- a/control-plane-api/src/services/git_provider.py
+++ b/control-plane-api/src/services/git_provider.py
@@ -6,11 +6,59 @@ Implementations: GitLabService (existing), GitHubService (Wave 2).
 
 import asyncio
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from ..config import settings
+
+
+@dataclass(frozen=True)
+class TreeEntry:
+    """A single entry in a repository tree listing."""
+
+    name: str
+    type: Literal["tree", "blob"]
+    path: str
+
+
+@dataclass(frozen=True)
+class CommitRef:
+    """Provider-agnostic commit reference."""
+
+    sha: str
+    message: str
+    author: str
+    date: str
+
+
+@dataclass(frozen=True)
+class BranchRef:
+    """Provider-agnostic branch reference."""
+
+    name: str
+    commit_sha: str
+    protected: bool
+
+
+@dataclass(frozen=True)
+class MergeRequestRef:
+    """Provider-agnostic merge request / pull request reference.
+
+    On GitHub, ``iid`` is the PR number. On GitLab, ``iid`` is the project-scoped iid.
+    """
+
+    id: int
+    iid: int
+    title: str
+    description: str
+    state: str
+    source_branch: str
+    target_branch: str
+    web_url: str
+    created_at: str
+    author: str
 
 
 class GitProvider(ABC):
@@ -264,6 +312,69 @@ class GitProvider(ABC):
         Returns:
             Commit metadata (sha, url).
         """
+
+    # ============================================================
+    # CAB-1889 CP-1: provider-agnostic surface used by routers.
+    # Operates on the provider's default catalog repository — the
+    # router never needs to know about project_id / org-repo.
+    # ============================================================
+
+    async def list_tree(self, path: str, ref: str = "main") -> list[TreeEntry]:
+        """List immediate children of ``path`` in the catalog repo.
+
+        Returns an empty list when the path is absent. Never raises on 404.
+        """
+        raise NotImplementedError("list_tree() must be implemented by the provider")
+
+    async def read_file(self, path: str, ref: str = "main") -> str | None:
+        """Return file content from the catalog repo, or ``None`` if missing.
+
+        Unlike :meth:`get_file_content`, this method never raises FileNotFoundError.
+        """
+        raise NotImplementedError("read_file() must be implemented by the provider")
+
+    async def list_path_commits(self, path: str | None, limit: int = 20) -> list[CommitRef]:
+        """List recent commits touching ``path`` (or the whole catalog if None)."""
+        raise NotImplementedError("list_path_commits() must be implemented by the provider")
+
+    async def write_file(
+        self, path: str, content: str, commit_message: str, branch: str = "main"
+    ) -> Literal["created", "updated"]:
+        """Create-or-update a file on the catalog repo.
+
+        Returns ``"created"`` if the file did not exist before, ``"updated"`` otherwise.
+        """
+        raise NotImplementedError("write_file() must be implemented by the provider")
+
+    async def remove_file(self, path: str, commit_message: str, branch: str = "main") -> bool:
+        """Delete a file from the catalog repo. Raises FileNotFoundError if missing."""
+        raise NotImplementedError("remove_file() must be implemented by the provider")
+
+    async def list_branches(self) -> list[BranchRef]:
+        """List branches on the catalog repo."""
+        raise NotImplementedError("list_branches() must be implemented by the provider")
+
+    async def create_branch(self, name: str, ref: str = "main") -> BranchRef:
+        """Create a branch named ``name`` pointing at ``ref`` on the catalog repo."""
+        raise NotImplementedError("create_branch() must be implemented by the provider")
+
+    async def list_merge_requests(self, state: str = "opened") -> list[MergeRequestRef]:
+        """List merge requests / pull requests on the catalog repo."""
+        raise NotImplementedError("list_merge_requests() must be implemented by the provider")
+
+    async def create_merge_request(
+        self,
+        title: str,
+        description: str,
+        source_branch: str,
+        target_branch: str = "main",
+    ) -> MergeRequestRef:
+        """Open a merge request / pull request on the catalog repo."""
+        raise NotImplementedError("create_merge_request() must be implemented by the provider")
+
+    async def merge_merge_request(self, iid: int) -> MergeRequestRef:
+        """Merge a merge request / pull request by its ``iid`` (GitHub: PR number)."""
+        raise NotImplementedError("merge_merge_request() must be implemented by the provider")
 
 
 def git_provider_factory() -> GitProvider:

--- a/control-plane-api/src/services/git_service.py
+++ b/control-plane-api/src/services/git_service.py
@@ -6,14 +6,14 @@ import re
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import gitlab
 import yaml
 from gitlab.v4.objects import Project
 
 from ..config import settings
-from .git_provider import GitProvider
+from .git_provider import BranchRef, CommitRef, GitProvider, MergeRequestRef, TreeEntry
 
 logger = logging.getLogger(__name__)
 
@@ -986,6 +986,125 @@ settings:
         except Exception as e:
             logger.error(f"Failed to delete MCP server: {e}")
             raise
+
+    # ============================================================
+    # CAB-1889 CP-1: provider-agnostic surface (GitProvider ABC).
+    # Operates on the connected catalog project (self._project).
+    # ============================================================
+
+    async def list_tree(self, path: str, ref: str = "main") -> list[TreeEntry]:
+        if not self._project:
+            raise RuntimeError("GitLab not connected")
+        try:
+            tree = self._project.repository_tree(path=path, ref=ref)
+        except gitlab.exceptions.GitlabGetError:
+            return []
+        return [TreeEntry(name=item["name"], type=item["type"], path=item["path"]) for item in tree]
+
+    async def read_file(self, path: str, ref: str = "main") -> str | None:
+        return await self.get_file(path, ref=ref)
+
+    async def list_path_commits(self, path: str | None, limit: int = 20) -> list[CommitRef]:
+        raw = await self.list_commits(path=path, limit=limit)
+        return [CommitRef(sha=c["sha"], message=c["message"], author=c["author"], date=c["date"]) for c in raw]
+
+    async def write_file(
+        self, path: str, content: str, commit_message: str, branch: str = "main"
+    ) -> Literal["created", "updated"]:
+        if not self._project:
+            raise RuntimeError("GitLab not connected")
+        existing = await self.get_file(path, ref=branch)
+        if existing is not None:
+            file_obj = self._project.files.get(path, ref=branch)
+            file_obj.content = content
+            file_obj.save(branch=branch, commit_message=commit_message)
+            return "updated"
+        self._project.files.create(
+            {
+                "file_path": path,
+                "branch": branch,
+                "content": content,
+                "commit_message": commit_message,
+            }
+        )
+        return "created"
+
+    async def remove_file(self, path: str, commit_message: str, branch: str = "main") -> bool:
+        if not self._project:
+            raise RuntimeError("GitLab not connected")
+        self._project.files.delete(file_path=path, commit_message=commit_message, branch=branch)
+        return True
+
+    async def list_branches(self) -> list[BranchRef]:
+        if not self._project:
+            raise RuntimeError("GitLab not connected")
+        branches = self._project.branches.list()
+        return [
+            BranchRef(
+                name=b.name,
+                commit_sha=b.commit["id"] if isinstance(b.commit, dict) else str(b.commit),
+                protected=getattr(b, "protected", False),
+            )
+            for b in branches
+        ]
+
+    async def create_branch(self, name: str, ref: str = "main") -> BranchRef:
+        if not self._project:
+            raise RuntimeError("GitLab not connected")
+        b = self._project.branches.create({"branch": name, "ref": ref})
+        return BranchRef(
+            name=b.name,
+            commit_sha=b.commit["id"] if isinstance(b.commit, dict) else str(b.commit),
+            protected=getattr(b, "protected", False),
+        )
+
+    @staticmethod
+    def _mr_to_ref(mr: Any) -> MergeRequestRef:
+        author = mr.author.get("name", "") if isinstance(mr.author, dict) else str(mr.author)
+        return MergeRequestRef(
+            id=mr.id,
+            iid=mr.iid,
+            title=mr.title,
+            description=mr.description or "",
+            state=mr.state,
+            source_branch=mr.source_branch,
+            target_branch=mr.target_branch,
+            web_url=mr.web_url,
+            created_at=mr.created_at,
+            author=author,
+        )
+
+    async def list_merge_requests(self, state: str = "opened") -> list[MergeRequestRef]:
+        if not self._project:
+            raise RuntimeError("GitLab not connected")
+        mrs = self._project.mergerequests.list(state=state)
+        return [self._mr_to_ref(mr) for mr in mrs]
+
+    async def create_merge_request(
+        self,
+        title: str,
+        description: str,
+        source_branch: str,
+        target_branch: str = "main",
+    ) -> MergeRequestRef:
+        if not self._project:
+            raise RuntimeError("GitLab not connected")
+        mr = self._project.mergerequests.create(
+            {
+                "title": title,
+                "description": description,
+                "source_branch": source_branch,
+                "target_branch": target_branch,
+            }
+        )
+        return self._mr_to_ref(mr)
+
+    async def merge_merge_request(self, iid: int) -> MergeRequestRef:
+        if not self._project:
+            raise RuntimeError("GitLab not connected")
+        mr = self._project.mergerequests.get(iid)
+        mr.merge()
+        return self._mr_to_ref(mr)
 
 
 # Global instance

--- a/control-plane-api/src/services/github_service.py
+++ b/control-plane-api/src/services/github_service.py
@@ -10,13 +10,13 @@ import logging
 import re
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 from github import Auth, Github, GithubException, InputGitTreeElement
 
 from ..config import settings
-from .git_provider import GitProvider
+from .git_provider import BranchRef, CommitRef, GitProvider, MergeRequestRef, TreeEntry
 
 logger = logging.getLogger(__name__)
 
@@ -896,3 +896,122 @@ class GitHubService(GitProvider):
 
         logger.info("Deleted MCP server %s", server_name)
         return True
+
+    # ============================================================
+    # CAB-1889 CP-1: provider-agnostic surface (GitProvider ABC).
+    # Operates on the catalog repo resolved via _catalog_project_id().
+    # ============================================================
+
+    async def list_tree(self, path: str, ref: str = "main") -> list[TreeEntry]:
+        repo = self._get_repo(self._catalog_project_id())
+        try:
+            contents = repo.get_contents(path, ref=ref)
+        except GithubException as exc:
+            if exc.status == 404:
+                return []
+            raise
+        if not isinstance(contents, list):
+            contents = [contents]
+        return [
+            TreeEntry(
+                name=item.name,
+                type="tree" if item.type == "dir" else "blob",
+                path=item.path,
+            )
+            for item in contents
+        ]
+
+    async def read_file(self, path: str, ref: str = "main") -> str | None:
+        try:
+            return await self.get_file_content(self._catalog_project_id(), path, ref=ref)
+        except FileNotFoundError:
+            return None
+
+    async def list_path_commits(self, path: str | None, limit: int = 20) -> list[CommitRef]:
+        repo = self._get_repo(self._catalog_project_id())
+        kwargs: dict[str, Any] = {}
+        if path:
+            kwargs["path"] = path
+        commits = repo.get_commits(**kwargs)[:limit]
+        refs: list[CommitRef] = []
+        for c in commits:
+            author = ""
+            if c.author and getattr(c.author, "login", None):
+                author = c.author.login
+            elif c.commit and c.commit.author and c.commit.author.name:
+                author = c.commit.author.name
+            date = c.commit.author.date.isoformat() if c.commit and c.commit.author and c.commit.author.date else ""
+            refs.append(CommitRef(sha=c.sha, message=c.commit.message if c.commit else "", author=author, date=date))
+        return refs
+
+    async def write_file(
+        self, path: str, content: str, commit_message: str, branch: str = "main"
+    ) -> Literal["created", "updated"]:
+        project_id = self._catalog_project_id()
+        if await self._file_exists(project_id, path, ref=branch):
+            await self.update_file(project_id, path, content, commit_message, branch=branch)
+            return "updated"
+        await self.create_file(project_id, path, content, commit_message, branch=branch)
+        return "created"
+
+    async def remove_file(self, path: str, commit_message: str, branch: str = "main") -> bool:
+        return await self.delete_file(self._catalog_project_id(), path, commit_message, branch=branch)
+
+    async def list_branches(self) -> list[BranchRef]:
+        repo = self._get_repo(self._catalog_project_id())
+        return [
+            BranchRef(name=b.name, commit_sha=b.commit.sha, protected=getattr(b, "protected", False))
+            for b in repo.get_branches()
+        ]
+
+    async def create_branch(self, name: str, ref: str = "main") -> BranchRef:
+        repo = self._get_repo(self._catalog_project_id())
+        base_ref = repo.get_git_ref(f"heads/{ref}")
+        repo.create_git_ref(f"refs/heads/{name}", base_ref.object.sha)
+        branch = repo.get_branch(name)
+        return BranchRef(
+            name=branch.name, commit_sha=branch.commit.sha, protected=getattr(branch, "protected", False)
+        )
+
+    @staticmethod
+    def _pr_to_ref(pr: Any) -> MergeRequestRef:
+        author = pr.user.login if pr.user and getattr(pr.user, "login", None) else ""
+        created_at = pr.created_at.isoformat() if getattr(pr, "created_at", None) else ""
+        return MergeRequestRef(
+            id=pr.id,
+            iid=pr.number,
+            title=pr.title,
+            description=pr.body or "",
+            state=pr.state,
+            source_branch=pr.head.ref if pr.head else "",
+            target_branch=pr.base.ref if pr.base else "",
+            web_url=pr.html_url,
+            created_at=created_at,
+            author=author,
+        )
+
+    @staticmethod
+    def _map_mr_state_to_github(state: str) -> str:
+        return {"opened": "open", "closed": "closed", "merged": "closed", "all": "all"}.get(state, state)
+
+    async def list_merge_requests(self, state: str = "opened") -> list[MergeRequestRef]:
+        repo = self._get_repo(self._catalog_project_id())
+        gh_state = self._map_mr_state_to_github(state)
+        return [self._pr_to_ref(pr) for pr in repo.get_pulls(state=gh_state)]
+
+    async def create_merge_request(
+        self,
+        title: str,
+        description: str,
+        source_branch: str,
+        target_branch: str = "main",
+    ) -> MergeRequestRef:
+        repo = self._get_repo(self._catalog_project_id())
+        pr = repo.create_pull(title=title, body=description, head=source_branch, base=target_branch)
+        return self._pr_to_ref(pr)
+
+    async def merge_merge_request(self, iid: int) -> MergeRequestRef:
+        repo = self._get_repo(self._catalog_project_id())
+        pr = repo.get_pull(iid)
+        pr.merge()
+        return self._pr_to_ref(repo.get_pull(iid))

--- a/control-plane-api/tests/test_git_router.py
+++ b/control-plane-api/tests/test_git_router.py
@@ -1,9 +1,16 @@
-"""Tests for git router — GitLab-backed operations."""
+"""Tests for git router — provider-agnostic (CAB-1889 CP-1).
+
+The router must talk only to the GitProvider interface. These tests mock the
+interface methods (list_tree, write_file, list_merge_requests, ...) — they do
+NOT mock provider internals like _project/_gh. That is the whole point of CP-1.
+"""
 
 from unittest.mock import AsyncMock, MagicMock
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+from src.services.git_provider import BranchRef, CommitRef, MergeRequestRef, TreeEntry
 
 _ADMIN_USER = MagicMock()
 _ADMIN_USER.id = "admin-1"
@@ -41,9 +48,10 @@ def _build_test_app(user=None, mock_git=None):
     return app
 
 
-def _make_mock_git(**attrs):
-    """Return a MagicMock with given attributes pre-set."""
+def _make_mock_git(connected: bool = True, **attrs):
+    """Return a MagicMock simulating a connected GitProvider by default."""
     m = MagicMock()
+    m.is_connected = MagicMock(return_value=connected)
     for k, v in attrs.items():
         setattr(m, k, v)
     return m
@@ -57,7 +65,7 @@ BASE = f"/v1/tenants/{TENANT}/git"
 
 
 def test_list_commits_empty():
-    mock_git = _make_mock_git(list_commits=AsyncMock(return_value=[]))
+    mock_git = _make_mock_git(list_path_commits=AsyncMock(return_value=[]))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/commits")
     assert resp.status_code == 200
@@ -66,8 +74,8 @@ def test_list_commits_empty():
 
 def test_list_commits_with_data():
     mock_git = _make_mock_git(
-        list_commits=AsyncMock(
-            return_value=[{"sha": "abc123", "message": "init", "author": "dev", "date": "2026-01-01T00:00:00"}]
+        list_path_commits=AsyncMock(
+            return_value=[CommitRef(sha="abc123", message="init", author="dev", date="2026-01-01T00:00:00")]
         )
     )
     client = TestClient(_build_test_app(mock_git=mock_git))
@@ -78,51 +86,45 @@ def test_list_commits_with_data():
 
 
 def test_list_commits_with_path():
-    mock_git = _make_mock_git(list_commits=AsyncMock(return_value=[]))
+    mock_git = _make_mock_git(list_path_commits=AsyncMock(return_value=[]))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/commits?path=apis")
     assert resp.status_code == 200
-    mock_git.list_commits.assert_called_once_with(path="tenants/acme/apis", limit=20)
+    mock_git.list_path_commits.assert_called_once_with(path="tenants/acme/apis", limit=20)
 
 
 # ---- Files ----
 
 
 def test_get_file_success():
-    mock_git = _make_mock_git(get_file=AsyncMock(return_value="file content here"))
+    mock_git = _make_mock_git(read_file=AsyncMock(return_value="file content here"))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/files/apis/test.yaml")
     assert resp.status_code == 200
     assert resp.json()["content"] == "file content here"
-    mock_git.get_file.assert_called_once_with("tenants/acme/apis/test.yaml", ref="main")
+    mock_git.read_file.assert_called_once_with("tenants/acme/apis/test.yaml", ref="main")
 
 
 def test_get_file_not_found():
-    mock_git = _make_mock_git(get_file=AsyncMock(return_value=None))
+    mock_git = _make_mock_git(read_file=AsyncMock(return_value=None))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/files/nonexistent.yaml")
     assert resp.status_code == 404
 
 
 def test_create_file():
-    mock_git = _make_mock_git(
-        _project=MagicMock(),
-        get_file=AsyncMock(return_value=None),  # file doesn't exist
-    )
-    mock_git._project.files.create = MagicMock()
+    mock_git = _make_mock_git(write_file=AsyncMock(return_value="created"))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/files/new.yaml", json={"content": "hello"})
     assert resp.status_code == 201
     assert resp.json()["action"] == "created"
+    mock_git.write_file.assert_called_once()
+    _, kwargs = mock_git.write_file.call_args
+    assert kwargs == {"commit_message": "Update new.yaml for tenant acme", "branch": "main"}
 
 
 def test_update_file():
-    file_obj = MagicMock()
-    mock_git = _make_mock_git(
-        _project=MagicMock(),
-        get_file=AsyncMock(return_value="old content"),  # file exists
-    )
-    mock_git._project.files.get = MagicMock(return_value=file_obj)
+    mock_git = _make_mock_git(write_file=AsyncMock(return_value="updated"))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/files/existing.yaml", json={"content": "new content"})
     assert resp.status_code == 201
@@ -130,8 +132,7 @@ def test_update_file():
 
 
 def test_delete_file():
-    mock_git = _make_mock_git(_project=MagicMock())
-    mock_git._project.files.delete = MagicMock()
+    mock_git = _make_mock_git(remove_file=AsyncMock(return_value=True))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.delete(f"{BASE}/files/old.yaml")
     assert resp.status_code == 200
@@ -142,12 +143,13 @@ def test_delete_file():
 
 
 def test_tree_success():
-    mock_git = _make_mock_git(_project=MagicMock())
-    mock_git._project.repository_tree = MagicMock(
-        return_value=[
-            {"name": "apis", "type": "tree", "path": "tenants/acme/apis"},
-            {"name": "tenant.yaml", "type": "blob", "path": "tenants/acme/tenant.yaml"},
-        ]
+    mock_git = _make_mock_git(
+        list_tree=AsyncMock(
+            return_value=[
+                TreeEntry(name="apis", type="tree", path="tenants/acme/apis"),
+                TreeEntry(name="tenant.yaml", type="blob", path="tenants/acme/tenant.yaml"),
+            ]
+        )
     )
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/tree")
@@ -156,8 +158,7 @@ def test_tree_success():
 
 
 def test_tree_empty():
-    mock_git = _make_mock_git(_project=MagicMock())
-    mock_git._project.repository_tree = MagicMock(side_effect=Exception("not found"))
+    mock_git = _make_mock_git(list_tree=AsyncMock(side_effect=Exception("not found")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/tree")
     assert resp.status_code == 200
@@ -168,28 +169,33 @@ def test_tree_empty():
 
 
 def test_list_merge_requests_empty():
-    mock_git = _make_mock_git(_project=MagicMock())
-    mock_git._project.mergerequests.list = MagicMock(return_value=[])
+    mock_git = _make_mock_git(list_merge_requests=AsyncMock(return_value=[]))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/merge-requests")
     assert resp.status_code == 200
     assert resp.json() == []
 
 
+def _mr_ref(**overrides):
+    defaults = {
+        "id": 1,
+        "iid": 1,
+        "title": "Test MR",
+        "description": "desc",
+        "state": "opened",
+        "source_branch": "feat/x",
+        "target_branch": "main",
+        "web_url": "https://gitlab.com/mr/1",
+        "created_at": "2026-01-01T00:00:00",
+        "author": "dev",
+    }
+    defaults.update(overrides)
+    return MergeRequestRef(**defaults)
+
+
 def test_create_merge_request():
-    mock_git = _make_mock_git(_project=MagicMock())
-    mr_mock = MagicMock()
-    mr_mock.id = 1
-    mr_mock.iid = 1
-    mr_mock.title = "Test MR"
-    mr_mock.description = "desc"
-    mr_mock.state = "opened"
-    mr_mock.source_branch = "feat/x"
-    mr_mock.target_branch = "main"
-    mr_mock.web_url = "https://gitlab.com/mr/1"
-    mr_mock.created_at = "2026-01-01T00:00:00"
-    mr_mock.author = {"name": "dev"}
-    mock_git._project.mergerequests.create = MagicMock(return_value=mr_mock)
+    mr = _mr_ref()
+    mock_git = _make_mock_git(create_merge_request=AsyncMock(return_value=mr))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(
         f"{BASE}/merge-requests",
@@ -205,25 +211,20 @@ def test_create_merge_request():
 
 
 def test_merge_merge_request():
-    mock_git = _make_mock_git(_project=MagicMock())
-    mr_mock = MagicMock()
-    mock_git._project.mergerequests.get = MagicMock(return_value=mr_mock)
+    mock_git = _make_mock_git(merge_merge_request=AsyncMock(return_value=_mr_ref(state="merged")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/merge-requests/1/merge")
     assert resp.status_code == 200
-    mr_mock.merge.assert_called_once()
+    mock_git.merge_merge_request.assert_called_once_with(1)
 
 
 # ---- Branches ----
 
 
 def test_list_branches():
-    mock_git = _make_mock_git(_project=MagicMock())
-    branch_mock = MagicMock()
-    branch_mock.name = "main"
-    branch_mock.commit = {"id": "abc123"}
-    branch_mock.protected = True
-    mock_git._project.branches.list = MagicMock(return_value=[branch_mock])
+    mock_git = _make_mock_git(
+        list_branches=AsyncMock(return_value=[BranchRef(name="main", commit_sha="abc123", protected=True)])
+    )
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/branches")
     assert resp.status_code == 200
@@ -232,76 +233,74 @@ def test_list_branches():
 
 
 def test_create_branch():
-    mock_git = _make_mock_git(_project=MagicMock())
-    branch_mock = MagicMock()
-    branch_mock.name = "feat/new"
-    branch_mock.commit = {"id": "def456"}
-    branch_mock.protected = False
-    mock_git._project.branches.create = MagicMock(return_value=branch_mock)
+    mock_git = _make_mock_git(
+        create_branch=AsyncMock(return_value=BranchRef(name="feat/new", commit_sha="def456", protected=False))
+    )
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/branches", json={"name": "feat/new", "ref": "main"})
     assert resp.status_code == 201
     assert resp.json()["name"] == "feat/new"
+    mock_git.create_branch.assert_called_once_with(name="feat/new", ref="main")
 
 
 # ---- RBAC ----
 
 
 def test_viewer_can_read():
-    mock_git = _make_mock_git(list_commits=AsyncMock(return_value=[]))
+    mock_git = _make_mock_git(list_path_commits=AsyncMock(return_value=[]))
     client = TestClient(_build_test_app(user=_VIEWER_USER, mock_git=mock_git))
     resp = client.get(f"{BASE}/commits")
     assert resp.status_code == 200
 
 
 def test_viewer_cannot_create_file():
-    mock_git = _make_mock_git(_project=MagicMock())
+    mock_git = _make_mock_git()
     client = TestClient(_build_test_app(user=_VIEWER_USER, mock_git=mock_git))
     resp = client.post(f"{BASE}/files/test.yaml", json={"content": "x"})
     assert resp.status_code == 403
 
 
 def test_viewer_cannot_delete_file():
-    mock_git = _make_mock_git(_project=MagicMock())
+    mock_git = _make_mock_git()
     client = TestClient(_build_test_app(user=_VIEWER_USER, mock_git=mock_git))
     resp = client.delete(f"{BASE}/files/test.yaml")
     assert resp.status_code == 403
 
 
-# ---- 503 when _project is None ----
+# ---- 503 when provider is not connected ----
 
 
-def test_tree_503_when_project_none():
-    mock_git = _make_mock_git(_project=None)
+def test_tree_503_when_disconnected():
+    mock_git = _make_mock_git(connected=False)
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/tree")
     assert resp.status_code == 503
     assert "Git provider not connected" in resp.json()["detail"]
 
 
-def test_create_file_503_when_project_none():
-    mock_git = _make_mock_git(_project=None)
+def test_create_file_503_when_disconnected():
+    mock_git = _make_mock_git(connected=False)
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/files/new.yaml", json={"content": "x"})
     assert resp.status_code == 503
 
 
-def test_delete_file_503_when_project_none():
-    mock_git = _make_mock_git(_project=None)
+def test_delete_file_503_when_disconnected():
+    mock_git = _make_mock_git(connected=False)
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.delete(f"{BASE}/files/old.yaml")
     assert resp.status_code == 503
 
 
-def test_list_merge_requests_503_when_project_none():
-    mock_git = _make_mock_git(_project=None)
+def test_list_merge_requests_503_when_disconnected():
+    mock_git = _make_mock_git(connected=False)
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/merge-requests")
     assert resp.status_code == 503
 
 
-def test_create_merge_request_503_when_project_none():
-    mock_git = _make_mock_git(_project=None)
+def test_create_merge_request_503_when_disconnected():
+    mock_git = _make_mock_git(connected=False)
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(
         f"{BASE}/merge-requests",
@@ -310,22 +309,22 @@ def test_create_merge_request_503_when_project_none():
     assert resp.status_code == 503
 
 
-def test_merge_request_503_when_project_none():
-    mock_git = _make_mock_git(_project=None)
+def test_merge_request_503_when_disconnected():
+    mock_git = _make_mock_git(connected=False)
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/merge-requests/1/merge")
     assert resp.status_code == 503
 
 
-def test_list_branches_503_when_project_none():
-    mock_git = _make_mock_git(_project=None)
+def test_list_branches_503_when_disconnected():
+    mock_git = _make_mock_git(connected=False)
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/branches")
     assert resp.status_code == 503
 
 
-def test_create_branch_503_when_project_none():
-    mock_git = _make_mock_git(_project=None)
+def test_create_branch_503_when_disconnected():
+    mock_git = _make_mock_git(connected=False)
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/branches", json={"name": "feat/new", "ref": "main"})
     assert resp.status_code == 503
@@ -335,7 +334,7 @@ def test_create_branch_503_when_project_none():
 
 
 def test_list_commits_exception_returns_empty():
-    mock_git = _make_mock_git(list_commits=AsyncMock(side_effect=Exception("gitlab timeout")))
+    mock_git = _make_mock_git(list_path_commits=AsyncMock(side_effect=Exception("gitlab timeout")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/commits")
     assert resp.status_code == 200
@@ -343,11 +342,7 @@ def test_list_commits_exception_returns_empty():
 
 
 def test_create_file_exception_returns_500():
-    mock_git = _make_mock_git(
-        _project=MagicMock(),
-        get_file=AsyncMock(return_value=None),
-    )
-    mock_git._project.files.create = MagicMock(side_effect=Exception("write failed"))
+    mock_git = _make_mock_git(write_file=AsyncMock(side_effect=Exception("write failed")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/files/new.yaml", json={"content": "x"})
     assert resp.status_code == 500
@@ -355,21 +350,14 @@ def test_create_file_exception_returns_500():
 
 
 def test_update_file_exception_returns_500():
-    file_obj = MagicMock()
-    file_obj.save = MagicMock(side_effect=Exception("save failed"))
-    mock_git = _make_mock_git(
-        _project=MagicMock(),
-        get_file=AsyncMock(return_value="old content"),
-    )
-    mock_git._project.files.get = MagicMock(return_value=file_obj)
+    mock_git = _make_mock_git(write_file=AsyncMock(side_effect=Exception("save failed")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/files/existing.yaml", json={"content": "new"})
     assert resp.status_code == 500
 
 
 def test_delete_file_exception_returns_404():
-    mock_git = _make_mock_git(_project=MagicMock())
-    mock_git._project.files.delete = MagicMock(side_effect=Exception("not found"))
+    mock_git = _make_mock_git(remove_file=AsyncMock(side_effect=Exception("not found")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.delete(f"{BASE}/files/missing.yaml")
     assert resp.status_code == 404
@@ -377,8 +365,7 @@ def test_delete_file_exception_returns_404():
 
 
 def test_list_merge_requests_exception_returns_empty():
-    mock_git = _make_mock_git(_project=MagicMock())
-    mock_git._project.mergerequests.list = MagicMock(side_effect=Exception("gitlab error"))
+    mock_git = _make_mock_git(list_merge_requests=AsyncMock(side_effect=Exception("gitlab error")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/merge-requests")
     assert resp.status_code == 200
@@ -386,8 +373,7 @@ def test_list_merge_requests_exception_returns_empty():
 
 
 def test_create_merge_request_exception_returns_500():
-    mock_git = _make_mock_git(_project=MagicMock())
-    mock_git._project.mergerequests.create = MagicMock(side_effect=Exception("create failed"))
+    mock_git = _make_mock_git(create_merge_request=AsyncMock(side_effect=Exception("create failed")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(
         f"{BASE}/merge-requests",
@@ -398,8 +384,7 @@ def test_create_merge_request_exception_returns_500():
 
 
 def test_merge_merge_request_exception_returns_500():
-    mock_git = _make_mock_git(_project=MagicMock())
-    mock_git._project.mergerequests.get = MagicMock(side_effect=Exception("merge failed"))
+    mock_git = _make_mock_git(merge_merge_request=AsyncMock(side_effect=Exception("merge failed")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/merge-requests/1/merge")
     assert resp.status_code == 500
@@ -407,8 +392,7 @@ def test_merge_merge_request_exception_returns_500():
 
 
 def test_list_branches_exception_returns_empty():
-    mock_git = _make_mock_git(_project=MagicMock())
-    mock_git._project.branches.list = MagicMock(side_effect=Exception("gitlab error"))
+    mock_git = _make_mock_git(list_branches=AsyncMock(side_effect=Exception("gitlab error")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/branches")
     assert resp.status_code == 200
@@ -416,8 +400,7 @@ def test_list_branches_exception_returns_empty():
 
 
 def test_create_branch_exception_returns_500():
-    mock_git = _make_mock_git(_project=MagicMock())
-    mock_git._project.branches.create = MagicMock(side_effect=Exception("create failed"))
+    mock_git = _make_mock_git(create_branch=AsyncMock(side_effect=Exception("create failed")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/branches", json={"name": "feat/err", "ref": "main"})
     assert resp.status_code == 500
@@ -428,27 +411,26 @@ def test_create_branch_exception_returns_500():
 
 
 def test_list_commits_with_custom_limit():
-    mock_git = _make_mock_git(list_commits=AsyncMock(return_value=[]))
+    mock_git = _make_mock_git(list_path_commits=AsyncMock(return_value=[]))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/commits?limit=50")
     assert resp.status_code == 200
-    mock_git.list_commits.assert_called_once_with(path="tenants/acme", limit=50)
+    mock_git.list_path_commits.assert_called_once_with(path="tenants/acme", limit=50)
 
 
 def test_list_merge_requests_with_data():
-    mock_git = _make_mock_git(_project=MagicMock())
-    mr_mock = MagicMock()
-    mr_mock.id = 10
-    mr_mock.iid = 5
-    mr_mock.title = "Fix bug"
-    mr_mock.description = None  # test None description
-    mr_mock.state = "merged"
-    mr_mock.source_branch = "fix/bug"
-    mr_mock.target_branch = "main"
-    mr_mock.web_url = "https://gitlab.com/mr/5"
-    mr_mock.created_at = "2026-01-15T00:00:00"
-    mr_mock.author = "dev-string"  # test non-dict author
-    mock_git._project.mergerequests.list = MagicMock(return_value=[mr_mock])
+    mr = _mr_ref(
+        id=10,
+        iid=5,
+        title="Fix bug",
+        description="",
+        state="merged",
+        source_branch="fix/bug",
+        web_url="https://gitlab.com/mr/5",
+        created_at="2026-01-15T00:00:00",
+        author="dev-string",
+    )
+    mock_git = _make_mock_git(list_merge_requests=AsyncMock(return_value=[mr]))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/merge-requests")
     assert resp.status_code == 200
@@ -459,34 +441,31 @@ def test_list_merge_requests_with_data():
 
 
 def test_create_file_with_custom_commit_message():
-    mock_git = _make_mock_git(
-        _project=MagicMock(),
-        get_file=AsyncMock(return_value=None),
-    )
-    mock_git._project.files.create = MagicMock()
+    mock_git = _make_mock_git(write_file=AsyncMock(return_value="created"))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/files/new.yaml?commit_message=custom+msg", json={"content": "data"})
     assert resp.status_code == 201
+    _, kwargs = mock_git.write_file.call_args
+    assert kwargs["commit_message"] == "custom msg"
 
 
 def test_get_tree_with_path_param():
-    mock_git = _make_mock_git(_project=MagicMock())
-    mock_git._project.repository_tree = MagicMock(return_value=[])
+    mock_git = _make_mock_git(list_tree=AsyncMock(return_value=[]))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/tree?path=apis")
     assert resp.status_code == 200
-    mock_git._project.repository_tree.assert_called_once_with(path="tenants/acme/apis", ref="main")
+    mock_git.list_tree.assert_called_once_with("tenants/acme/apis", ref="main")
 
 
 def test_viewer_cannot_create_branch():
-    mock_git = _make_mock_git(_project=MagicMock())
+    mock_git = _make_mock_git()
     client = TestClient(_build_test_app(user=_VIEWER_USER, mock_git=mock_git))
     resp = client.post(f"{BASE}/branches", json={"name": "feat/x", "ref": "main"})
     assert resp.status_code == 403
 
 
 def test_viewer_cannot_create_merge_request():
-    mock_git = _make_mock_git(_project=MagicMock())
+    mock_git = _make_mock_git()
     client = TestClient(_build_test_app(user=_VIEWER_USER, mock_git=mock_git))
     resp = client.post(
         f"{BASE}/merge-requests",
@@ -496,7 +475,49 @@ def test_viewer_cannot_create_merge_request():
 
 
 def test_viewer_cannot_merge_request():
-    mock_git = _make_mock_git(_project=MagicMock())
+    mock_git = _make_mock_git()
     client = TestClient(_build_test_app(user=_VIEWER_USER, mock_git=mock_git))
     resp = client.post(f"{BASE}/merge-requests/1/merge")
     assert resp.status_code == 403
+
+
+# ---- GitHub-style PR mapped as merge request (iid ← pr_number) ----
+
+
+def test_merge_merge_request_maps_iid_for_github():
+    """Router passes mr_iid unchanged — GitHubService translates iid → pr.number internally.
+
+    This regression-guards the interface contract: routers speak in iid terms.
+    """
+    merged = _mr_ref(id=99, iid=42, state="merged", web_url="https://github.com/org/repo/pull/42")
+    mock_git = _make_mock_git(merge_merge_request=AsyncMock(return_value=merged))
+    client = TestClient(_build_test_app(mock_git=mock_git))
+    resp = client.post(f"{BASE}/merge-requests/42/merge")
+    assert resp.status_code == 200
+    assert resp.json() == {"message": "Merge request merged", "iid": 42}
+    mock_git.merge_merge_request.assert_called_once_with(42)
+
+
+def test_router_does_not_touch_provider_internals():
+    """CP-1 metric: the router must never access _project or _gh.
+
+    Regression guard — if someone reintroduces a ``git._project`` / ``git._gh``
+    access in the router, this test fails loudly.
+    """
+    import inspect
+
+    from src.routers import git as git_router
+
+    source = inspect.getsource(git_router)
+    forbidden = ["._project", "._gh ", "._gh.", "._gh)", "._repo", "_internal"]
+    for token in forbidden:
+        assert token not in source, f"Router leaks provider internal: {token!r} found"
+
+
+def test_list_merge_requests_filters_by_state():
+    """Router forwards ?state= to provider.list_merge_requests verbatim."""
+    mock_git = _make_mock_git(list_merge_requests=AsyncMock(return_value=[]))
+    client = TestClient(_build_test_app(mock_git=mock_git))
+    resp = client.get(f"{BASE}/merge-requests?state=merged")
+    assert resp.status_code == 200
+    mock_git.list_merge_requests.assert_called_once_with(state="merged")


### PR DESCRIPTION
## Summary
- Close the `git._project.xxx` abstraction leak in `routers/git.py` (17 direct accesses → 0).
- Extend `GitProvider` ABC with 4 dataclasses + 10 provider-agnostic methods; implement on `GitLabService` + `GitHubService`.
- Rewrite `test_git_router.py` (45 tests) to mock the interface; add regression guard `test_router_does_not_touch_provider_internals`.

Full rewrite plan & smell inventory: `control-plane-api/REWRITE-PLAN.md` + `control-plane-api/REWRITE-BUGS.md`.

## What ships vs defers
- **Ships**: router no longer touches provider internals; ABC is no longer a façade.
- **Defers (Phase 2)**: split of `git_service.py` (992 → 1111 LOC) and `github_service.py` (898 → 1017 LOC) via mixins — keeps this PR under the micro-PR budget and behavior-preserving.
- **Defers (follow-up PR)**: fix BUG-01 + BUG-02 in `iam_sync_service.py` and `deployment_orchestration_service.py` — same leak pattern, ~5 LOC each, silently dead on GitHub today; now fixable via the new ABC methods.

## Test plan
- [x] `pytest tests/test_git_router.py` — 45/45 green
- [x] `pytest tests/test_git_*.py tests/test_github_*.py tests/test_*gitops*` (302 tests) — all green
- [x] `ruff check` on scope — clean
- [x] `mypy` on scope — 20 errors eliminated, 0 new
- [x] OpenAPI diff before/after — 0 lines changed
- [ ] CI green on this PR
- [ ] Guardian advisory review

## Notes
- Scope `api` (not `cp-api`) to match repo commitlint enum and prior CAB-1889 PRs (#2439, #2445).
- Pre-existing unrelated failures in `tests/test_provisioning*.py` (12 tests) reproduce on `main` — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)