### PR TITLE
fix(api): close GitProvider leaks in iam_sync + deployment orch (CAB-1889)

### DIFF
--- a/control-plane-api/src/services/deployment_orchestration_service.py
+++ b/control-plane-api/src/services/deployment_orchestration_service.py
@@ -99,7 +99,8 @@ class DeploymentOrchestrationService:
         try:
             from ..services.git_service import git_service
 
-            if not git_service._project:
+            # regression for CAB-1889: use provider-agnostic is_connected, not _project
+            if not git_service.is_connected():
                 await git_service.connect()
 
             api_data = await git_service.get_api(tenant_id, api_id)
@@ -117,11 +118,10 @@ class DeploymentOrchestrationService:
             with contextlib.suppress(Exception):
                 openapi_spec = await git_service.get_api_openapi_spec(tenant_id, api_id)
 
-            commit_sha = None
+            commit_sha: str | None = None
             with contextlib.suppress(Exception):
-                commits = git_service._project.commits.list(ref_name="main", per_page=1)
-                if commits:
-                    commit_sha = commits[0].id
+                # regression for CAB-1889: use provider-agnostic ABC, not _project
+                commit_sha = await git_service.get_head_commit_sha(ref="main")
 
             await sync_svc._upsert_api(tenant_id, api_id, api_data, openapi_spec, commit_sha)
             await self.db.commit()

--- a/control-plane-api/src/services/iam_sync_service.py
+++ b/control-plane-api/src/services/iam_sync_service.py
@@ -202,15 +202,16 @@ class IAMSyncService:
 
         try:
             # List all tenants from GitOps
-            if not git_service._project:
-                result["errors"] = ["GitLab not connected"]
+            # regression for CAB-1889: use provider-agnostic list_tree, not _project
+            if not git_service.is_connected():
+                result["errors"] = ["Git provider not connected"]
                 return result
 
-            tree = git_service._project.repository_tree(path="tenants", ref="main")
+            tree = await git_service.list_tree("tenants", ref="main")
 
             for item in tree:
-                if item["type"] == "tree":
-                    tenant_id = item["name"]
+                if item.type == "tree":
+                    tenant_id = item.name
                     tenant_result = await self.sync_tenant(tenant_id)
                     result["tenants"].append(tenant_result)
                     result["total_actions"] += len(tenant_result.get("actions", []))

--- a/control-plane-api/tests/test_deployment_orchestration_service.py
+++ b/control-plane-api/tests/test_deployment_orchestration_service.py
@@ -340,3 +340,44 @@ class TestDeploymentOrchestrationService:
             assert result[2]["environment"] == "production"
             assert result[2]["deployable"] is False
 
+
+class TestRegressionCab1889:
+    """regression for CAB-1889: _sync_api_from_git must use provider-agnostic ABC, not _project."""
+
+    async def test_regression_cab_1889_deployment_orch_uses_get_head_commit_sha(self):
+        """_sync_api_from_git must call is_connected + get_head_commit_sha, never _project."""
+        from src.services.deployment_orchestration_service import (
+            DeploymentOrchestrationService,
+        )
+
+        db = AsyncMock()
+        svc = DeploymentOrchestrationService(db)
+
+        # Stub the catalog upsert path so the test focuses on the git access pattern.
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = MagicMock()
+        db.execute.return_value = mock_result
+
+        with (
+            patch("src.services.git_service.git_service") as mock_git,
+            patch(
+                "src.services.catalog_sync_service.CatalogSyncService"
+            ) as mock_catalog_cls,
+        ):
+            mock_git.is_connected.return_value = True
+            mock_git.connect = AsyncMock()
+            mock_git.get_api = AsyncMock(return_value={"api_id": "payments", "version": "2.0.0"})
+            mock_git.get_api_openapi_spec = AsyncMock(return_value={"openapi": "3.0.0"})
+            mock_git.get_head_commit_sha = AsyncMock(return_value="sha123")
+            mock_catalog_cls.return_value._upsert_api = AsyncMock()
+
+            await svc._sync_api_from_git("acme", "payments")
+
+            mock_git.is_connected.assert_called()
+            mock_git.get_head_commit_sha.assert_awaited_once_with(ref="main")
+            # _project must never be touched — if it is, this attribute access would work on MagicMock
+            # so we assert that only the interface methods were called.
+            assert not any(
+                "_project" in str(call) for call in mock_git.mock_calls
+            ), f"_project leaked into calls: {mock_git.mock_calls}"
+

--- a/control-plane-api/tests/test_iam_sync_service.py
+++ b/control-plane-api/tests/test_iam_sync_service.py
@@ -1,8 +1,9 @@
 """Tests for IAMSyncService (CAB-1291 + CAB-1292)"""
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from src.services.git_provider import TreeEntry
 from src.services.iam_sync_service import IAMSyncService
 
 
@@ -213,20 +214,20 @@ class TestSyncAllTenants:
     async def test_git_not_connected(self):
         svc = IAMSyncService()
         with patch("src.services.iam_sync_service.git_service") as mock_git:
-            mock_git._project = None
+            mock_git.is_connected.return_value = False
             result = await svc.sync_all_tenants()
-        assert "GitLab not connected" in result.get("errors", [])
+        assert "Git provider not connected" in result.get("errors", [])
 
     async def test_syncs_each_tenant(self):
         svc = IAMSyncService()
         svc.sync_tenant = AsyncMock(return_value={"actions": ["a"], "errors": []})
         with patch("src.services.iam_sync_service.git_service") as mock_git:
-            mock_git._project = MagicMock()
-            mock_git._project.repository_tree.return_value = [
-                {"type": "tree", "name": "acme"},
-                {"type": "tree", "name": "corp"},
-                {"type": "blob", "name": ".gitkeep"},
-            ]
+            mock_git.is_connected.return_value = True
+            mock_git.list_tree = AsyncMock(return_value=[
+                TreeEntry(name="acme", type="tree", path="tenants/acme"),
+                TreeEntry(name="corp", type="tree", path="tenants/corp"),
+                TreeEntry(name=".gitkeep", type="blob", path="tenants/.gitkeep"),
+            ])
             result = await svc.sync_all_tenants()
         assert svc.sync_tenant.call_count == 2
         assert result["total_actions"] == 2
@@ -624,11 +625,26 @@ class TestSyncAllTenantsException:
         """sync_all_tenants() catches top-level exception and adds to result."""
         svc = IAMSyncService()
         with patch("src.services.iam_sync_service.git_service") as mock_git:
-            mock_git._project = MagicMock()
-            mock_git._project.repository_tree.side_effect = Exception("GitLab down")
+            mock_git.is_connected.return_value = True
+            mock_git.list_tree = AsyncMock(side_effect=Exception("Git down"))
             result = await svc.sync_all_tenants()
         assert "errors" in result
         assert len(result["errors"]) > 0
+
+
+class TestRegressionCab1889:
+    """regression for CAB-1889: external services must use provider-agnostic ABC, not _project."""
+
+    async def test_regression_cab_1889_iam_sync_uses_list_tree(self):
+        """sync_all_tenants must call list_tree + is_connected, never _project directly."""
+        svc = IAMSyncService()
+        svc.sync_tenant = AsyncMock(return_value={"actions": [], "errors": []})
+        with patch("src.services.iam_sync_service.git_service") as mock_git:
+            mock_git.is_connected.return_value = True
+            mock_git.list_tree = AsyncMock(return_value=[])
+            await svc.sync_all_tenants()
+            mock_git.is_connected.assert_called()
+            mock_git.list_tree.assert_awaited_once_with("tenants", ref="main")
 
 
 class TestHandleTenantEventUserRemovedNoEmail:

--- a/control-plane-api/tests/test_regression_cab_1889_external_git_leaks.py
+++ b/control-plane-api/tests/test_regression_cab_1889_external_git_leaks.py
@@ -1,0 +1,60 @@
+"""Regression coverage for CAB-1889 external GitProvider leak fixes."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.deployment_orchestration_service import DeploymentOrchestrationService
+from src.services.iam_sync_service import IAMSyncService
+
+
+@pytest.mark.asyncio
+async def test_regression_cab_1889_iam_sync_uses_provider_tree_listing():
+    """sync_all_tenants must use the provider interface, not GitLab's `_project`."""
+    svc = IAMSyncService()
+    svc.sync_tenant = AsyncMock(return_value={"actions": [], "errors": []})
+    tenant_dir = SimpleNamespace(type="tree", name="acme")
+
+    with patch("src.services.iam_sync_service.git_service") as mock_git:
+        mock_git.is_connected.return_value = True
+        mock_git.list_tree = AsyncMock(return_value=[tenant_dir])
+
+        await svc.sync_all_tenants()
+
+    mock_git.is_connected.assert_called_once_with()
+    mock_git.list_tree.assert_awaited_once_with("tenants", ref="main")
+    svc.sync_tenant.assert_awaited_once_with("acme")
+    assert not any("_project" in str(call) for call in mock_git.mock_calls), (
+        f"_project leaked into calls: {mock_git.mock_calls}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_regression_cab_1889_deployment_sync_uses_provider_head_lookup():
+    """_sync_api_from_git must fetch head SHA via GitProvider, not `_project`."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = MagicMock()
+    db.execute.return_value = mock_result
+
+    svc = DeploymentOrchestrationService(db)
+
+    with (
+        patch("src.services.git_service.git_service") as mock_git,
+        patch("src.services.catalog_sync_service.CatalogSyncService") as mock_catalog_cls,
+    ):
+        mock_git.is_connected.return_value = True
+        mock_git.connect = AsyncMock()
+        mock_git.get_api = AsyncMock(return_value={"api_id": "payments", "version": "2.0.0"})
+        mock_git.get_api_openapi_spec = AsyncMock(return_value={"openapi": "3.0.0"})
+        mock_git.get_head_commit_sha = AsyncMock(return_value="sha123")
+        mock_catalog_cls.return_value._upsert_api = AsyncMock()
+
+        await svc._sync_api_from_git("acme", "payments")
+
+    mock_git.is_connected.assert_called_once_with()
+    mock_git.get_head_commit_sha.assert_awaited_once_with(ref="main")
+    assert not any("_project" in str(call) for call in mock_git.mock_calls), (
+        f"_project leaked into calls: {mock_git.mock_calls}"
+    )


### PR DESCRIPTION
## Summary
Close two `git_service._project` leak sites that slipped past CP-1 (#2460) — both silently dead on GitHub-backed deployments today.

- **BUG-01** — `iam_sync_service.sync_all_tenants`: swap `_project.repository_tree("tenants", ref="main")` → `list_tree("tenants", ref="main")`; `if not _project` → `is_connected()`.
- **BUG-02** — `deployment_orchestration_service._sync_api_from_git`: swap `_project.commits.list(ref_name="main", per_page=1)` → `get_head_commit_sha(ref="main")`; `if not _project` → `is_connected()`.

Both methods live on `GitProvider` ABC (added in CP-1 for `list_tree`; pre-existing for `get_head_commit_sha`). No new capability.

## Stack
Stacked on **#2460 (CP-1)** — base is `refactor/cab-1889-cp1-git-abstraction`. Cannot merge until CP-1 is in. Rebase onto `main` after CP-1 merges.

## Test plan
- [x] `pytest tests/test_iam_sync_service.py tests/test_deployment_orchestration_service.py` — 64/64 green
- [x] `pytest tests/test_git_router.py tests/test_iam_sync_service.py tests/test_deployment_orchestration_service.py` — 109/109 green
- [x] `ruff check` on scope — clean
- [x] `mypy` on scope — no new errors (64 pre-existing `Column[T]` errors unrelated)
- [x] 2 regression tests added: `test_regression_cab_1889_iam_sync_uses_list_tree`, `test_regression_cab_1889_deployment_orch_uses_get_head_commit_sha`

## Why it matters
Before this PR, tenants with `GIT_PROVIDER=github` had:
- IAM sync permanently broken (ran the `_project is None` branch and returned with a "GitLab not connected" error).
- Deployment orchestration's on-demand API sync silently dropped the commit SHA.

These did not trip tests or metrics because the failure mode is a silent return, not an exception.

## Follow-ups
- REWRITE-BUGS.md tracks BUG-03 (semaphore bypass), BUG-04 (provider-aware logic in ABC base), BUG-05/06 (diagnostic notes). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)