### PR TITLE
feat(demo): rewrite demo harness scripts reset/check/dry-run (CAB-2150)

### DIFF
--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -18,6 +18,39 @@ Scripts for the "ESB is Dead, AI Agents Are Here" live demo (24 fev 2026).
 | `check-health.sh` | Verify all Docker Compose services are healthy | ~5s |
 | `test-opensearch.sh` | Verify OpenSearch pipeline end-to-end | ~15s |
 | `opensearch-live-demo.sh` | 2-min presenter-friendly error correlation demo | ~90s |
+| `reset-demo.sh` | Idempotent harness — invokes cp-api demo reset (CAB-2149 contract) | ~10s |
+| `pre-demo-check.sh` | Binary preflight gate (health + seed + audience claim + tenant count) | ~5s |
+| `demo-dry-run.sh` | Cold full-path dry-run; emits timestamped artifacts under `docs/audits/demo-dryrun-<UTC>/` | ~20s |
+
+## Demo Harness Runbook (CAB-2148)
+
+Invocation sequence for a cold demo rehearsal:
+
+```bash
+export STOA_API_URL="https://api.gostoa.dev"
+export STOA_GATEWAY_URL="https://mcp.gostoa.dev"
+export STOA_API_TOKEN="..."         # demo-admin bearer
+export STOA_DEMO_MIN_TENANTS=4      # optional, default 4
+
+# Full cold run (reset + preflight) with evidence capture
+./scripts/demo/demo-dry-run.sh
+
+# Or step by step:
+./scripts/demo/reset-demo.sh
+./scripts/demo/pre-demo-check.sh
+```
+
+Exit-code contract (binary, no warning state):
+
+| Script | Exit 0 means |
+|--------|--------------|
+| `reset-demo.sh` | cp-api returned `status=reset_complete` — reset fully applied |
+| `pre-demo-check.sh` | every check passed (any FAIL = exit 1) |
+| `demo-dry-run.sh` | reset (unless `--skip-reset`) AND preflight passed; artifacts written |
+
+Artifact archive (`demo-dry-run.sh` only): `docs/audits/demo-dryrun-<UTC>/` contains `summary.md`, `metadata.json`, and per-step logs. Commit the archive as evidence per the repo audit rule.
+
+**Contract dependency**: `reset-demo.sh` and the seed-state probe in `pre-demo-check.sh` assume the cp-api endpoints delivered by CAB-2149 (`POST /api/v1/demo/reset`, `GET /api/v1/demo/status`). Until CAB-2149 merges, the scripts will fail fast with a non-zero exit and a diagnostic on stderr — that is the intended behavior.
 
 ## Quick Start
 

--- a/scripts/demo/demo-dry-run.sh
+++ b/scripts/demo/demo-dry-run.sh
@@ -1,655 +1,104 @@
 #!/usr/bin/env bash
 # =============================================================================
-# CAB-802: Demo Dry-Run — Act-by-Act Validation
+# CAB-2150 (parent CAB-2148): Cold full-path dry-run.
 # =============================================================================
-# Validates all 8 demo acts against production in <60s.
-# Tests: Auth, API, Console, Portal, Gateway, mTLS, OpenSearch, Federation,
-#        MCP Bridge, AI Factory.
-# Output: Colored PASS/FAIL report with per-act timing + GO/NO-GO verdict.
+# Executes the full demo harness in order (reset -> check) with per-step
+# timing and captures all output + metadata into a timestamped evidence
+# archive under docs/audits/demo-dryrun-<UTC>/.
 #
-# Usage: ./demo-dry-run.sh [--base-domain gostoa.dev] [--include-act5]
+# Exits 0 ONLY if every step succeeded.
 #
-# Act 5 (OpenSearch Dashboards) is OUT OF SCOPE by default — CAB-2119 ouvert
-# (HTTP 503). Pass --include-act5 to opt-in once OpenSearch is fixed.
+# Usage: ./demo-dry-run.sh [--skip-reset]
+# Env (inherited by sub-scripts):
+#   STOA_API_URL, STOA_API_TOKEN, STOA_GATEWAY_URL, STOA_DEMO_MIN_TENANTS
 # =============================================================================
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# Argument parsing
-BASE_DOMAIN="gostoa.dev"
-INCLUDE_ACT5="false"
+SKIP_RESET=0
 while [ $# -gt 0 ]; do
     case "$1" in
-        --base-domain)
-            BASE_DOMAIN="${2:-gostoa.dev}"
-            shift 2
-            ;;
-        --include-act5)
-            INCLUDE_ACT5="true"
-            shift
-            ;;
-        *)
-            # Backward-compat: first positional arg = base domain
-            BASE_DOMAIN="$1"
-            shift
-            ;;
+        --skip-reset) SKIP_RESET=1; shift ;;
+        -h|--help) sed -n '2,14p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
     esac
 done
 
-API_URL="https://api.${BASE_DOMAIN}"
-PORTAL_URL="https://portal.${BASE_DOMAIN}"
-CONSOLE_URL="https://console.${BASE_DOMAIN}"
-MCP_URL="https://mcp.${BASE_DOMAIN}"
-AUTH_URL="https://auth.${BASE_DOMAIN}"
-GRAFANA_URL="https://console.${BASE_DOMAIN}/grafana"
-OPENSEARCH_URL="https://opensearch.${BASE_DOMAIN}"
-CERTS_DIR="${MTLS_CERTS_DIR:-$SCRIPT_DIR/certs}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+ARTIFACT_DIR="${REPO_ROOT}/docs/audits/demo-dryrun-${STAMP}"
+mkdir -p "$ARTIFACT_DIR"
 
-# Demo persona passwords — sourced from Infisical vault (e2e-personas)
-# Fallback to env vars if Infisical unavailable
-INFISICAL_PROJECT_ID="97972ffc-990b-4d28-9c4d-0664d217f03b"
-_get_persona_password() {
-    local name="$1"
-    local secret_name
-    secret_name="$(echo "${name}_PASSWORD" | tr '[:lower:]' '[:upper:]')"
-    # Try env var first (CI injects these)
-    eval "local env_val=\"\${${secret_name}:-}\""
-    if [ -n "$env_val" ]; then echo "$env_val"; return; fi
-    # Try Infisical
-    local token="${INFISICAL_TOKEN:-$(infisical-token --raw 2>/dev/null || true)}"
-    if [ -n "$token" ]; then
-        INFISICAL_TOKEN="$token" infisical secrets get "$secret_name" \
-            --env=prod --path="/e2e-personas" \
-            --projectId="$INFISICAL_PROJECT_ID" \
-            --plain 2>/dev/null && return
-    fi
-    echo ""
-}
-ART3MIS_PASSWORD="$(_get_persona_password art3mis)"
-PARZIVAL_PASSWORD="$(_get_persona_password parzival)"
+SUMMARY="${ARTIFACT_DIR}/summary.md"
+META="${ARTIFACT_DIR}/metadata.json"
 
-if [ -z "$ART3MIS_PASSWORD" ]; then
-    echo -e "${YELLOW}[WARN]${NC} Could not fetch art3mis password from Infisical or env. Token checks will fail."
-fi
+TOTAL_START=$(date +%s)
+STATUS="success"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
-
-# Counters
-PASSED=0
-FAILED=0
-SKIPPED=0
-TOTAL_START=$(date +%s%N)
-REPORT=""
-
-# --------------------------------------------------------------------------
-# Helpers
-# --------------------------------------------------------------------------
-
-check() {
-    local name="$1"
-    local status="$2"
-    local duration_ms="$3"
-    local detail="${4:-}"
-
-    if [ "$status" = "PASS" ]; then
-        echo -e "  ${GREEN}[PASS]${NC} ${name} (${duration_ms}ms)"
-        REPORT+="| ${name} | PASS | ${duration_ms}ms | ${detail} |\n"
-        PASSED=$((PASSED + 1))
-    elif [ "$status" = "SKIP" ]; then
-        echo -e "  ${YELLOW}[SKIP]${NC} ${name} ${detail}"
-        REPORT+="| ${name} | SKIP | — | ${detail} |\n"
-        SKIPPED=$((SKIPPED + 1))
+run_step() {
+    local name="$1"; shift
+    local logfile="${ARTIFACT_DIR}/${name}.log"
+    local step_start step_end elapsed rc
+    step_start=$(date +%s)
+    printf '\n=== [%s] starting ===\n' "$name"
+    rc=0
+    "$@" > "$logfile" 2>&1 || rc=$?
+    step_end=$(date +%s)
+    elapsed=$((step_end - step_start))
+    if [ "$rc" -eq 0 ]; then
+        printf '=== [%s] OK (%ds) ===\n' "$name" "$elapsed"
+        printf -- '- %s: PASS (%ds)\n' "$name" "$elapsed" >> "$SUMMARY"
     else
-        echo -e "  ${RED}[FAIL]${NC} ${name} (${duration_ms}ms) ${detail}"
-        REPORT+="| ${name} | FAIL | ${duration_ms}ms | ${detail} |\n"
-        FAILED=$((FAILED + 1))
+        printf '=== [%s] FAIL rc=%d (%ds) ===\n' "$name" "$rc" "$elapsed" >&2
+        printf -- '- %s: FAIL rc=%d (%ds)\n' "$name" "$rc" "$elapsed" >> "$SUMMARY"
+        STATUS="failed"
     fi
+    return "$rc"
 }
 
-timed_curl() {
-    local url="$1"
-    local method="${2:-GET}"
-    local extra_args=("${@:3}")
+{
+    printf '# Demo dry-run — %s\n\n' "$STAMP"
+    printf '## Steps\n\n'
+} > "$SUMMARY"
 
-    local start_ms=$(date +%s%N)
-    local http_code
-    http_code=$(curl -s -o /dev/null -w "%{http_code}" -X "$method" \
-        --max-time 10 ${extra_args[@]+"${extra_args[@]}"} "$url" 2>/dev/null || echo "000")
-    local end_ms=$(date +%s%N)
-    local duration_ms=$(( (end_ms - start_ms) / 1000000 ))
+# Step 1: reset (optional skip for read-only dry runs)
+if [ "$SKIP_RESET" -eq 0 ]; then
+    run_step reset "${SCRIPT_DIR}/reset-demo.sh" || true
+else
+    printf -- '- reset: SKIPPED (--skip-reset)\n' >> "$SUMMARY"
+fi
 
-    echo "$http_code $duration_ms"
+# Step 2: preflight binary gate (only if reset passed or was skipped)
+if [ "$STATUS" = "success" ]; then
+    run_step pre-demo-check "${SCRIPT_DIR}/pre-demo-check.sh" || true
+else
+    printf -- '- pre-demo-check: SKIPPED (upstream failure)\n' >> "$SUMMARY"
+fi
+
+TOTAL_END=$(date +%s)
+TOTAL_ELAPSED=$((TOTAL_END - TOTAL_START))
+
+{
+    printf '\n## Result\n\n'
+    printf -- '- status: **%s**\n' "$STATUS"
+    printf -- '- elapsed: %ds\n' "$TOTAL_ELAPSED"
+    printf -- '- skip_reset: %s\n' "$SKIP_RESET"
+} >> "$SUMMARY"
+
+cat > "$META" <<EOF
+{
+  "ticket": "CAB-2150",
+  "parent": "CAB-2148",
+  "timestamp_utc": "${STAMP}",
+  "status": "${STATUS}",
+  "elapsed_seconds": ${TOTAL_ELAPSED},
+  "skip_reset": ${SKIP_RESET},
+  "api_url": "${STOA_API_URL:-}",
+  "gateway_url": "${STOA_GATEWAY_URL:-}"
 }
-
-act_header() {
-    local act="$1"
-    local title="$2"
-    echo ""
-    echo -e "${CYAN}${BOLD}Act ${act}: ${title}${NC}"
-    echo "──────────────────────────────────────────"
-    ACT_START=$(date +%s%N)
-}
-
-act_footer() {
-    local act_end=$(date +%s%N)
-    local act_ms=$(( (act_end - ACT_START) / 1000000 ))
-    echo -e "  ${CYAN}(${act_ms}ms)${NC}"
-}
-
-# --------------------------------------------------------------------------
-# Header
-# --------------------------------------------------------------------------
-
-echo ""
-echo -e "${CYAN}=====================================================================${NC}"
-echo -e "${CYAN}  STOA Demo Dry-Run — $(date -Iseconds)${NC}"
-echo -e "${CYAN}  Base domain: ${BASE_DOMAIN}${NC}"
-echo -e "${CYAN}  8 acts, GO/NO-GO verdict${NC}"
-echo -e "${CYAN}=====================================================================${NC}"
-
-REPORT="# Demo Dry-Run Report\n\n"
-REPORT+="**Date**: $(date -Iseconds)\n"
-REPORT+="**Base domain**: ${BASE_DOMAIN}\n\n"
-REPORT+="| Check | Status | Duration | Notes |\n"
-REPORT+="|-------|--------|----------|-------|\n"
-
-# --------------------------------------------------------------------------
-# Act 1 — Console: Create Tenant + Publish API
-# --------------------------------------------------------------------------
-
-act_header "1" "Console + API Health"
-
-# Console health
-read -r code ms <<< "$(timed_curl "${CONSOLE_URL}")"
-if [ "$code" = "200" ]; then
-    check "Console accessible" "PASS" "$ms"
-else
-    check "Console accessible" "FAIL" "$ms" "HTTP ${code}"
-fi
-
-# API health
-read -r code ms <<< "$(timed_curl "${API_URL}/health/ready")"
-if [ "$code" = "200" ]; then
-    check "API health" "PASS" "$ms"
-else
-    check "API health" "FAIL" "$ms" "HTTP ${code}"
-fi
-
-# Keycloak reachable (realm endpoint — /health/ready not exposed via ingress)
-read -r code ms <<< "$(timed_curl "${AUTH_URL}/realms/stoa")"
-if [ "$code" = "200" ]; then
-    check "Keycloak reachable" "PASS" "$ms"
-else
-    check "Keycloak reachable" "FAIL" "$ms" "HTTP ${code}"
-fi
-
-# OIDC discovery
-read -r code ms <<< "$(timed_curl "${AUTH_URL}/realms/stoa/.well-known/openid-configuration")"
-if [ "$code" = "200" ]; then
-    check "OIDC discovery" "PASS" "$ms"
-else
-    check "OIDC discovery" "FAIL" "$ms" "HTTP ${code}"
-fi
-
-# Token issuance (art3mis — used throughout)
-TOKEN_START=$(date +%s%N)
-TOKEN_RESPONSE=$(curl -s -X POST "${AUTH_URL}/realms/stoa/protocol/openid-connect/token" \
-    -d "grant_type=password&client_id=control-plane-api&client_secret=api-dev-secret&username=art3mis&password=${ART3MIS_PASSWORD}" \
-    --max-time 10 2>/dev/null || echo '{}')
-TOKEN_END=$(date +%s%N)
-TOKEN_MS=$(( (TOKEN_END - TOKEN_START) / 1000000 ))
-
-ACCESS_TOKEN=$(echo "$TOKEN_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null || echo "")
-if [ -n "$ACCESS_TOKEN" ] && [ "$ACCESS_TOKEN" != "None" ]; then
-    check "Token issuance (art3mis)" "PASS" "$TOKEN_MS"
-else
-    check "Token issuance (art3mis)" "FAIL" "$TOKEN_MS" "No token returned"
-    ACCESS_TOKEN=""
-fi
-
-# API catalog list (authenticated)
-if [ -n "$ACCESS_TOKEN" ]; then
-    read -r code ms <<< "$(timed_curl "${API_URL}/v1/portal/apis" "GET" -H "Authorization: Bearer ${ACCESS_TOKEN}")"
-    if [ "$code" = "200" ]; then
-        check "API catalog list" "PASS" "$ms"
-    else
-        check "API catalog list" "FAIL" "$ms" "HTTP ${code}"
-    fi
-else
-    check "API catalog list" "SKIP" "0" "No auth token"
-fi
-
-act_footer
-
-# --------------------------------------------------------------------------
-# Act 2 — Portal: Consumer Flow
-# --------------------------------------------------------------------------
-
-act_header "2" "Portal + Consumer Flow"
-
-# Portal health
-read -r code ms <<< "$(timed_curl "${PORTAL_URL}")"
-if [ "$code" = "200" ]; then
-    check "Portal accessible" "PASS" "$ms"
-else
-    check "Portal accessible" "FAIL" "$ms" "HTTP ${code}"
-fi
-
-# Consumer API reachable (any non-timeout response = API is alive)
-if [ -n "$ACCESS_TOKEN" ]; then
-    read -r code ms <<< "$(timed_curl "${API_URL}/v1/consumers" "GET" -H "Authorization: Bearer ${ACCESS_TOKEN}")"
-    if [ "$code" != "000" ]; then
-        check "Consumer API reachable" "PASS" "$ms" "HTTP ${code}"
-    else
-        check "Consumer API reachable" "FAIL" "$ms" "Connection failed"
-    fi
-else
-    check "Consumer API reachable" "SKIP" "0" "No auth token"
-fi
-
-act_footer
-
-# --------------------------------------------------------------------------
-# Act 3 — Rust Gateway: API Call, JWT
-# --------------------------------------------------------------------------
-
-act_header "3" "Rust Gateway"
-
-# Gateway health
-read -r code ms <<< "$(timed_curl "${MCP_URL}/health")"
-if [ "$code" = "200" ]; then
-    check "Gateway health" "PASS" "$ms"
-else
-    check "Gateway health" "FAIL" "$ms" "HTTP ${code}"
-fi
-
-# Authenticated tool invoke
-if [ -n "$ACCESS_TOKEN" ]; then
-    INVOKE_START=$(date +%s%N)
-    INVOKE_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-        -X POST "${MCP_URL}/mcp/v1/tools/invoke" \
-        -H "Content-Type: application/json" \
-        -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-        -d '{"tool":"petstore","arguments":{"action":"list-pets"}}' \
-        --max-time 10 2>/dev/null || echo "000")
-    INVOKE_END=$(date +%s%N)
-    INVOKE_MS=$(( (INVOKE_END - INVOKE_START) / 1000000 ))
-
-    # 200 = success, 404 = tool not found, 401 = auth enforced — all prove gateway alive
-    if [ "$INVOKE_CODE" = "200" ] || [ "$INVOKE_CODE" = "404" ] || [ "$INVOKE_CODE" = "401" ]; then
-        check "Gateway tool invoke" "PASS" "$INVOKE_MS" "HTTP ${INVOKE_CODE}"
-    else
-        check "Gateway tool invoke" "FAIL" "$INVOKE_MS" "HTTP ${INVOKE_CODE}"
-    fi
-else
-    check "Gateway tool invoke" "SKIP" "0" "No auth token"
-fi
-
-act_footer
-
-# --------------------------------------------------------------------------
-# Act 3b — mTLS: Enterprise Certificate Binding
-# --------------------------------------------------------------------------
-
-act_header "3b" "mTLS Certificate Binding"
-
-# Check prerequisites
-MTLS_READY=true
-
-if [ -f "$CERTS_DIR/credentials.json" ]; then
-    CRED_COUNT=$(python3 -c "
-import json
-d=json.load(open('$CERTS_DIR/credentials.json'))
-c=d.get('credentials',d) if isinstance(d,dict) else d
-print(len(c))
-" 2>/dev/null || echo "0")
-    check "credentials.json" "PASS" "0" "${CRED_COUNT} consumers"
-else
-    check "credentials.json" "FAIL" "0" "Missing — run seed-mtls-demo.py"
-    MTLS_READY=false
-fi
-
-if [ -f "$CERTS_DIR/fingerprints.csv" ]; then
-    FP_COUNT=$(wc -l < "$CERTS_DIR/fingerprints.csv" | tr -d ' ')
-    FP_COUNT=$((FP_COUNT - 1))  # minus header
-    check "fingerprints.csv" "PASS" "0" "${FP_COUNT} certs"
-else
-    check "fingerprints.csv" "FAIL" "0" "Missing — run generate-mtls-certs.sh"
-    MTLS_READY=false
-fi
-
-if [ "$MTLS_READY" = true ]; then
-    # Load first consumer credentials
-    CLIENT_ID=$(python3 -c "
-import json
-d=json.load(open('$CERTS_DIR/credentials.json'))
-c=d.get('credentials',d) if isinstance(d,dict) else d
-print(c[0]['client_id'])
-" 2>/dev/null || echo "")
-
-    CLIENT_SECRET=$(python3 -c "
-import json
-d=json.load(open('$CERTS_DIR/credentials.json'))
-c=d.get('credentials',d) if isinstance(d,dict) else d
-print(c[0]['client_secret'])
-" 2>/dev/null || echo "")
-
-    FINGERPRINT=$(awk -F',' 'NR==2{print $2}' "$CERTS_DIR/fingerprints.csv")
-
-    # Get mTLS client_credentials token
-    MTLS_TOKEN_START=$(date +%s%N)
-    MTLS_TOKEN_RESP=$(curl -s -X POST "${AUTH_URL}/realms/stoa/protocol/openid-connect/token" \
-        -d "grant_type=client_credentials" \
-        -d "client_id=${CLIENT_ID}" \
-        -d "client_secret=${CLIENT_SECRET}" \
-        --max-time 10 2>/dev/null || echo '{}')
-    MTLS_TOKEN_END=$(date +%s%N)
-    MTLS_TOKEN_MS=$(( (MTLS_TOKEN_END - MTLS_TOKEN_START) / 1000000 ))
-
-    MTLS_TOKEN=$(echo "$MTLS_TOKEN_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null || echo "")
-
-    if [ -n "$MTLS_TOKEN" ] && [ "$MTLS_TOKEN" != "None" ] && [ "$MTLS_TOKEN" != "" ]; then
-        check "mTLS token acquisition" "PASS" "$MTLS_TOKEN_MS"
-
-        # Verify cnf claim
-        CNF_START=$(date +%s%N)
-        HAS_CNF=$(echo "$MTLS_TOKEN" | python3 -c "
-import sys, json, base64
-token = sys.stdin.read().strip()
-payload = token.split('.')[1]
-payload += '=' * (4 - len(payload) % 4)
-claims = json.loads(base64.urlsafe_b64decode(payload))
-cnf = claims.get('cnf', {})
-print('yes' if 'x5t#S256' in cnf else 'no')
-" 2>/dev/null || echo "no")
-        CNF_END=$(date +%s%N)
-        CNF_MS=$(( (CNF_END - CNF_START) / 1000000 ))
-
-        if [ "$HAS_CNF" = "yes" ]; then
-            check "JWT cnf.x5t#S256 claim" "PASS" "$CNF_MS"
-        else
-            check "JWT cnf.x5t#S256 claim" "PASS" "$CNF_MS" "Not configured (non-fatal)"
-        fi
-
-        # Scenario A: Correct cert → expect 200 or 404
-        CORRECT_START=$(date +%s%N)
-        CORRECT_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            -X POST "${MCP_URL}/mcp/v1/tools/invoke" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${MTLS_TOKEN}" \
-            -H "X-SSL-Client-Verify: SUCCESS" \
-            -H "X-SSL-Client-Fingerprint: ${FINGERPRINT}" \
-            -H "X-SSL-Client-S-DN: CN=api-consumer-001,OU=tenant-acme,O=Acme Corp,C=FR" \
-            -H "X-SSL-Client-I-DN: CN=STOA Demo CA,O=STOA Platform,C=FR" \
-            -d '{"tool":"petstore","arguments":{"action":"list-pets"}}' \
-            --max-time 10 2>/dev/null || echo "000")
-        CORRECT_END=$(date +%s%N)
-        CORRECT_MS=$(( (CORRECT_END - CORRECT_START) / 1000000 ))
-
-        if [ "$CORRECT_CODE" = "200" ] || [ "$CORRECT_CODE" = "404" ]; then
-            check "mTLS correct cert → access" "PASS" "$CORRECT_MS" "HTTP ${CORRECT_CODE}"
-        else
-            check "mTLS correct cert → access" "FAIL" "$CORRECT_MS" "HTTP ${CORRECT_CODE}"
-        fi
-
-        # Scenario B: Wrong cert → expect 403 (if cnf bound) or 200 (if cnf not configured)
-        WRONG_FP="0000000000000000000000000000000000000000000000000000000000000000"
-        WRONG_START=$(date +%s%N)
-        WRONG_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            -X POST "${MCP_URL}/mcp/v1/tools/invoke" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${MTLS_TOKEN}" \
-            -H "X-SSL-Client-Verify: SUCCESS" \
-            -H "X-SSL-Client-Fingerprint: ${WRONG_FP}" \
-            -H "X-SSL-Client-S-DN: CN=attacker,OU=evil-corp,O=Evil Inc,C=XX" \
-            -H "X-SSL-Client-I-DN: CN=STOA Demo CA,O=STOA Platform,C=FR" \
-            -d '{"tool":"petstore","arguments":{"action":"list-pets"}}' \
-            --max-time 10 2>/dev/null || echo "000")
-        WRONG_END=$(date +%s%N)
-        WRONG_MS=$(( (WRONG_END - WRONG_START) / 1000000 ))
-
-        if [ "$WRONG_CODE" = "403" ]; then
-            check "mTLS wrong cert → rejected" "PASS" "$WRONG_MS" "403 (cnf enforced)"
-        elif [ "$WRONG_CODE" = "200" ] || [ "$WRONG_CODE" = "404" ]; then
-            # Gateway doesn't enforce fingerprint binding yet — non-fatal
-            check "mTLS wrong cert → rejected" "PASS" "$WRONG_MS" "HTTP ${WRONG_CODE} (enforcement pending)"
-        else
-            check "mTLS wrong cert → rejected" "FAIL" "$WRONG_MS" "HTTP ${WRONG_CODE}"
-        fi
-    else
-        MTLS_ERROR=$(echo "$MTLS_TOKEN_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error','unknown'))" 2>/dev/null || echo "unknown")
-        check "mTLS token acquisition" "FAIL" "$MTLS_TOKEN_MS" "$MTLS_ERROR"
-        check "JWT cnf.x5t#S256 claim" "SKIP" "0" "No token"
-        check "mTLS correct cert → access" "SKIP" "0" "No token"
-        check "mTLS wrong cert → 403" "SKIP" "0" "No token"
-    fi
-else
-    check "mTLS token acquisition" "SKIP" "0" "Prerequisites missing"
-    check "JWT cnf.x5t#S256 claim" "SKIP" "0" "Prerequisites missing"
-    check "mTLS correct cert → access" "SKIP" "0" "Prerequisites missing"
-    check "mTLS wrong cert → 403" "SKIP" "0" "Prerequisites missing"
-fi
-
-act_footer
-
-# --------------------------------------------------------------------------
-# Act 4 — Grafana: Live Dashboards
-# --------------------------------------------------------------------------
-
-act_header "4" "Grafana Dashboards"
-
-read -r code ms <<< "$(timed_curl "${GRAFANA_URL}/api/health")"
-if [ "$code" = "200" ]; then
-    check "Grafana health" "PASS" "$ms"
-else
-    check "Grafana health" "FAIL" "$ms" "HTTP ${code}"
-fi
-
-act_footer
-
-# --------------------------------------------------------------------------
-# Act 5 — OpenSearch: Error Snapshots (HORS SCOPE par défaut, opt-in --include-act5)
-# --------------------------------------------------------------------------
-
-if [ "$INCLUDE_ACT5" = "true" ]; then
-    act_header "5" "OpenSearch"
-
-    # OpenSearch Dashboards is behind OIDC — expect 200 or 302 (redirect to login)
-    read -r code ms <<< "$(timed_curl "${OPENSEARCH_URL}")"
-    if [ "$code" = "200" ] || [ "$code" = "302" ]; then
-        check "OpenSearch Dashboards" "PASS" "$ms" "HTTP ${code}"
-    else
-        check "OpenSearch Dashboards" "FAIL" "$ms" "HTTP ${code}"
-    fi
-
-    act_footer
-else
-    echo ""
-    echo "Act 5 — OpenSearch: SKIPPED (out of scope by default — CAB-2119 ouvert)."
-    echo "        Pass --include-act5 to opt-in once OpenSearch is fixed."
-fi
-
-# --------------------------------------------------------------------------
-# Act 6 — Federation: Cross-Realm Token Isolation
-# --------------------------------------------------------------------------
-
-act_header "6" "Federation Cross-Realm"
-
-# Token from demo-org-alpha
-ALPHA_START=$(date +%s%N)
-ALPHA_RESP=$(curl -s -X POST "${AUTH_URL}/realms/demo-org-alpha/protocol/openid-connect/token" \
-    -d "grant_type=password&client_id=federation-demo&client_secret=${FEDERATION_SECRET_ALPHA:?Set FEDERATION_SECRET_ALPHA}&username=demo-alpha&password=${DEMO_PASSWORD:?Set DEMO_PASSWORD}" \
-    --max-time 10 2>/dev/null || echo '{}')
-ALPHA_END=$(date +%s%N)
-ALPHA_MS=$(( (ALPHA_END - ALPHA_START) / 1000000 ))
-
-ALPHA_TOKEN=$(echo "$ALPHA_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null || echo "")
-if [ -n "$ALPHA_TOKEN" ] && [ "$ALPHA_TOKEN" != "None" ] && [ "$ALPHA_TOKEN" != "" ]; then
-    check "Alpha realm token" "PASS" "$ALPHA_MS"
-else
-    check "Alpha realm token" "FAIL" "$ALPHA_MS" "No token"
-fi
-
-# Token from demo-org-beta
-BETA_START=$(date +%s%N)
-BETA_RESP=$(curl -s -X POST "${AUTH_URL}/realms/demo-org-beta/protocol/openid-connect/token" \
-    -d "grant_type=password&client_id=federation-demo&client_secret=${FEDERATION_SECRET_BETA:?Set FEDERATION_SECRET_BETA}&username=demo-beta&password=${DEMO_PASSWORD:?Set DEMO_PASSWORD}" \
-    --max-time 10 2>/dev/null || echo '{}')
-BETA_END=$(date +%s%N)
-BETA_MS=$(( (BETA_END - BETA_START) / 1000000 ))
-
-BETA_TOKEN=$(echo "$BETA_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null || echo "")
-if [ -n "$BETA_TOKEN" ] && [ "$BETA_TOKEN" != "None" ] && [ "$BETA_TOKEN" != "" ]; then
-    check "Beta realm token" "PASS" "$BETA_MS"
-else
-    check "Beta realm token" "FAIL" "$BETA_MS" "No token"
-fi
-
-# Verify different issuers
-if [ -n "$ALPHA_TOKEN" ] && [ "$ALPHA_TOKEN" != "None" ] && [ "$ALPHA_TOKEN" != "" ] && \
-   [ -n "$BETA_TOKEN" ] && [ "$BETA_TOKEN" != "None" ] && [ "$BETA_TOKEN" != "" ]; then
-    ISS_START=$(date +%s%N)
-    ISS_CHECK=$(python3 -c "
-import json, base64, sys
-def decode(t):
-    p = t.split('.')[1]
-    p += '=' * (4 - len(p) % 4)
-    return json.loads(base64.urlsafe_b64decode(p))
-a = decode('$ALPHA_TOKEN')
-b = decode('$BETA_TOKEN')
-iss_a = a.get('iss','')
-iss_b = b.get('iss','')
-realm_a = a.get('stoa_realm', a.get('azp',''))
-realm_b = b.get('stoa_realm', b.get('azp',''))
-if iss_a != iss_b:
-    print(f'PASS|{iss_a}|{iss_b}')
-else:
-    print(f'FAIL|{iss_a}|{iss_b}')
-" 2>/dev/null || echo "FAIL||")
-    ISS_END=$(date +%s%N)
-    ISS_MS=$(( (ISS_END - ISS_START) / 1000000 ))
-
-    ISS_STATUS=$(echo "$ISS_CHECK" | cut -d'|' -f1)
-    ISS_A=$(echo "$ISS_CHECK" | cut -d'|' -f2)
-    ISS_B=$(echo "$ISS_CHECK" | cut -d'|' -f3)
-
-    if [ "$ISS_STATUS" = "PASS" ]; then
-        check "Issuers differ (alpha ≠ beta)" "PASS" "$ISS_MS"
-    else
-        check "Issuers differ (alpha ≠ beta)" "FAIL" "$ISS_MS" "Same issuer"
-    fi
-else
-    check "Issuers differ (alpha ≠ beta)" "SKIP" "0" "Missing tokens"
-fi
-
-act_footer
-
-# --------------------------------------------------------------------------
-# Act 7 — MCP Bridge: OpenAPI → MCP
-# --------------------------------------------------------------------------
-
-act_header "7" "MCP Bridge + Tool Discovery"
-
-# MCP tool list (with auth if available)
-TOOLS_START=$(date +%s%N)
-if [ -n "$ACCESS_TOKEN" ]; then
-    TOOLS_RESPONSE=$(curl -s "${MCP_URL}/mcp/v1/tools" \
-        -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-        --max-time 10 2>/dev/null || echo '{}')
-else
-    TOOLS_RESPONSE=$(curl -s "${MCP_URL}/mcp/v1/tools" --max-time 10 2>/dev/null || echo '{}')
-fi
-TOOLS_END=$(date +%s%N)
-TOOLS_MS=$(( (TOOLS_END - TOOLS_START) / 1000000 ))
-
-TOOL_COUNT=$(echo "$TOOLS_RESPONSE" | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-if isinstance(data, dict):
-    tools = data.get('tools', [])
-elif isinstance(data, list):
-    tools = data
-else:
-    tools = []
-print(len(tools))
-" 2>/dev/null || echo "0")
-
-if [ "$TOOL_COUNT" -ge 1 ]; then
-    check "MCP tools registered" "PASS" "$TOOLS_MS" "${TOOL_COUNT} tools"
-else
-    # 0 tools = not synced yet, non-fatal for dry-run
-    check "MCP tools registered" "PASS" "$TOOLS_MS" "0 tools (sync needed)"
-fi
-
-act_footer
-
-# --------------------------------------------------------------------------
-# Act 8 — Born GitOps + AI Factory
-# --------------------------------------------------------------------------
-
-act_header "8" "AI Factory (git velocity)"
-
-GIT_START=$(date +%s%N)
-COMMIT_COUNT=$(git -C "$SCRIPT_DIR/../.." log --oneline --since="2026-02-09" 2>/dev/null | wc -l | tr -d ' ')
-GIT_END=$(date +%s%N)
-GIT_MS=$(( (GIT_END - GIT_START) / 1000000 ))
-
-if [ "$COMMIT_COUNT" -gt 0 ]; then
-    check "Commits since Feb 9" "PASS" "$GIT_MS" "${COMMIT_COUNT} commits"
-else
-    check "Commits since Feb 9" "FAIL" "$GIT_MS" "0 commits"
-fi
-
-act_footer
-
-# --------------------------------------------------------------------------
-# Summary
-# --------------------------------------------------------------------------
-
-TOTAL_END=$(date +%s%N)
-TOTAL_MS=$(( (TOTAL_END - TOTAL_START) / 1000000 ))
-TOTAL_S=$(( TOTAL_MS / 1000 ))
-TOTAL=$((PASSED + FAILED + SKIPPED))
-
-echo ""
-echo -e "${CYAN}=====================================================================${NC}"
-echo ""
-echo -e "  ${BOLD}Results${NC}: ${GREEN}${PASSED} passed${NC}, ${RED}${FAILED} failed${NC}, ${YELLOW}${SKIPPED} skipped${NC}"
-echo -e "  ${BOLD}Checks${NC}:  ${TOTAL} total in ${TOTAL_S}s (${TOTAL_MS}ms)"
-echo ""
-
-REPORT+="\n## Summary\n\n"
-REPORT+="- **Passed**: ${PASSED}\n"
-REPORT+="- **Failed**: ${FAILED}\n"
-REPORT+="- **Skipped**: ${SKIPPED}\n"
-REPORT+="- **Total**: ${TOTAL} checks in ${TOTAL_MS}ms\n"
-
-if [ "$FAILED" -eq 0 ]; then
-    echo -e "  ${GREEN}${BOLD}GO${NC} ${GREEN}— All critical checks passed. Ready for demo.${NC}"
-    REPORT+="\n**Verdict**: GO\n"
-else
-    echo -e "  ${RED}${BOLD}NO-GO${NC} ${RED}— ${FAILED} check(s) failed. Fix before demo.${NC}"
-    REPORT+="\n**Verdict**: NO-GO — ${FAILED} check(s) need attention\n"
-fi
-
-echo ""
-echo -e "${CYAN}=====================================================================${NC}"
-echo ""
-
-# Print markdown report if piped
-if [ ! -t 1 ]; then
-    echo -e "$REPORT"
-fi
-
-# Exit with failure if any check failed
-if [ "$FAILED" -gt 0 ]; then
-    exit 1
-fi
+EOF
+
+printf '\nArtifacts: %s\n' "$ARTIFACT_DIR"
+[ "$STATUS" = "success" ] || exit 1
+exit 0

--- a/scripts/demo/pre-demo-check.sh
+++ b/scripts/demo/pre-demo-check.sh
@@ -1,336 +1,102 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # =============================================================================
-# CAB-1104: Pre-Demo Checklist Script
+# CAB-2150 (parent CAB-2148): Pre-demo binary gate.
 # =============================================================================
-# Comprehensive GO/NO-GO check before the demo.
-# Validates all components are ready:
-# - Kubernetes cluster health
-# - API connectivity
-# - Grafana dashboards
-# - MCP tools availability
-# - Cache warmth
+# Preflight checks for the demo environment. Prints a PASS/FAIL line per check
+# and exits non-zero on ANY red signal (binary gate — no "warning" state).
 #
-# Returns exit code 0 (GO) or 1 (NO-GO)
+# Checks (all MUST pass):
+#   1. Control Plane /healthz reachable, returns 200
+#   2. Gateway /healthz reachable, returns 200
+#   3. Demo seed integrity: GET /api/v1/demo/status reports 'seeded'
+#   4. Audience claim present on a fresh token from the demo client
+#   5. Tenant count: at least ${STOA_DEMO_MIN_TENANTS:-4} tenants exposed
 #
-# Usage: ./pre-demo-check.sh [--verbose]
+# Usage: ./pre-demo-check.sh
+# Env:
+#   STOA_API_URL            (required)
+#   STOA_GATEWAY_URL        (required)
+#   STOA_API_TOKEN          (required) Bearer token used to read demo status
+#   STOA_DEMO_MIN_TENANTS   (optional, default 4)
 # =============================================================================
 
-set -e
+set -euo pipefail
 
-# Configuration
-CONTROL_PLANE_URL="${CONTROL_PLANE_URL:-https://api.gostoa.dev}"
-GATEWAY_URL="${GATEWAY_URL:-https://mcp.gostoa.dev}"
-GRAFANA_URL="${GRAFANA_URL:-https://console.gostoa.dev/grafana}"
-KEYCLOAK_URL="${KEYCLOAK_URL:-https://auth.gostoa.dev}"
-VERBOSE="${1:-}"
+: "${STOA_API_URL:?STOA_API_URL must be set}"
+: "${STOA_GATEWAY_URL:?STOA_GATEWAY_URL must be set}"
+: "${STOA_API_TOKEN:?STOA_API_TOKEN must be set}"
+MIN_TENANTS="${STOA_DEMO_MIN_TENANTS:-4}"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-# Counters
-PASSED=0
-FAILED=0
-WARNINGS=0
-
-# Check function
-check() {
-    local name="$1"
-    local result="$2"
-    local critical="${3:-true}"
-
-    if [ "$result" = "pass" ]; then
-        echo -e "  ${GREEN}[PASS]${NC} $name"
-        PASSED=$((PASSED + 1))
-    elif [ "$result" = "warn" ]; then
-        echo -e "  ${YELLOW}[WARN]${NC} $name"
-        WARNINGS=$((WARNINGS + 1))
+PASS=0
+FAIL=0
+report() {
+    local status="$1" name="$2" detail="${3:-}"
+    if [ "$status" = "PASS" ]; then
+        printf '[PASS] %s\n' "$name"
+        PASS=$((PASS + 1))
     else
-        if [ "$critical" = "true" ]; then
-            echo -e "  ${RED}[FAIL]${NC} $name"
-            FAILED=$((FAILED + 1))
-        else
-            echo -e "  ${YELLOW}[SKIP]${NC} $name (non-critical)"
-            WARNINGS=$((WARNINGS + 1))
-        fi
+        printf '[FAIL] %s — %s\n' "$name" "$detail" >&2
+        FAIL=$((FAIL + 1))
     fi
 }
 
-echo ""
-echo -e "${BLUE}╔════════════════════════════════════════════════════════════╗${NC}"
-echo -e "${BLUE}║           STOA Demo Pre-Flight Checklist                   ║${NC}"
-echo -e "${BLUE}╚════════════════════════════════════════════════════════════╝${NC}"
-echo ""
-echo -e "Timestamp: $(date -Iseconds)"
-echo ""
+http_code() {
+    curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$@" || echo "000"
+}
 
-# =============================================================================
-# Infrastructure Checks
-# =============================================================================
-echo -e "${CYAN}Infrastructure${NC}"
-echo "─────────────────────────────────────────"
+http_get_body() {
+    curl -sS --max-time 10 \
+        -H "Authorization: Bearer ${STOA_API_TOKEN}" \
+        -H 'Accept: application/json' \
+        "$@" || true
+}
 
-# Kubernetes cluster
-if command -v kubectl &> /dev/null; then
-    if kubectl cluster-info &> /dev/null; then
-        NODE_COUNT=$(kubectl get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')
-        if [ "$NODE_COUNT" -gt 0 ]; then
-            check "Kubernetes cluster ($NODE_COUNT nodes)" "pass"
-        else
-            check "Kubernetes cluster (no nodes ready)" "fail"
-        fi
-    else
-        check "Kubernetes cluster unreachable" "fail"
-    fi
+# 1. Control Plane health
+code="$(http_code "${STOA_API_URL%/}/healthz")"
+if [ "$code" = "200" ]; then
+    report PASS "control-plane /healthz"
 else
-    check "kubectl not available" "warn" "false"
+    report FAIL "control-plane /healthz" "HTTP ${code}"
 fi
 
-# MCP Gateway pods
-if command -v kubectl &> /dev/null; then
-    GATEWAY_READY=$(kubectl get pods -n stoa-system -l app=mcp-gateway --no-headers 2>/dev/null | grep -c "Running" || echo "0")
-    if [ "$GATEWAY_READY" -gt 0 ]; then
-        check "MCP Gateway pods ($GATEWAY_READY running)" "pass"
-    else
-        check "MCP Gateway pods (none running)" "fail"
-    fi
+# 2. Gateway health
+code="$(http_code "${STOA_GATEWAY_URL%/}/healthz")"
+if [ "$code" = "200" ]; then
+    report PASS "gateway /healthz"
 else
-    check "MCP Gateway pods" "warn" "false"
+    report FAIL "gateway /healthz" "HTTP ${code}"
 fi
 
-# Control Plane pods
-if command -v kubectl &> /dev/null; then
-    CP_READY=$(kubectl get pods -n stoa-system -l app=control-plane-api --no-headers 2>/dev/null | grep -c "Running" || echo "0")
-    if [ "$CP_READY" -gt 0 ]; then
-        check "Control Plane pods ($CP_READY running)" "pass"
-    else
-        check "Control Plane pods (none running)" "warn" "false"
-    fi
+# 3. Demo seed integrity (contract from CAB-2149)
+body="$(http_get_body "${STOA_API_URL%/}/api/v1/demo/status")"
+if printf '%s' "$body" | grep -q '"seed_state"[[:space:]]*:[[:space:]]*"seeded"'; then
+    report PASS "demo seed integrity"
 else
-    check "Control Plane pods" "warn" "false"
+    report FAIL "demo seed integrity" "expected seed_state=seeded, got: ${body:-<empty>}"
 fi
 
-echo ""
-
-# =============================================================================
-# Service Health Checks
-# =============================================================================
-echo -e "${CYAN}Service Health${NC}"
-echo "─────────────────────────────────────────"
-
-# Gateway health
-GATEWAY_HEALTH=$(curl -s -o /dev/null -w "%{http_code}" "$GATEWAY_URL/health" --max-time 5 2>/dev/null || echo "000")
-if [ "$GATEWAY_HEALTH" = "200" ]; then
-    check "MCP Gateway health ($GATEWAY_URL)" "pass"
+# 4. Audience claim present in JWT (inspect payload of STOA_API_TOKEN)
+jwt_payload="$(printf '%s' "$STOA_API_TOKEN" | awk -F. '{print $2}')"
+# Base64URL decode (pad to multiple of 4)
+pad=$(( (4 - ${#jwt_payload} % 4) % 4 ))
+padded="${jwt_payload}$(printf '%*s' "$pad" '' | tr ' ' '=')"
+decoded="$(printf '%s' "$padded" | tr '_-' '/+' | base64 -d 2>/dev/null || true)"
+if printf '%s' "$decoded" | grep -q '"aud"'; then
+    report PASS "audience claim present"
 else
-    check "MCP Gateway health (HTTP $GATEWAY_HEALTH)" "fail"
+    report FAIL "audience claim present" "no 'aud' in token payload"
 fi
 
-# Control Plane health
-CP_HEALTH=$(curl -s -o /dev/null -w "%{http_code}" "$CONTROL_PLANE_URL/health" --max-time 5 2>/dev/null || echo "000")
-if [ "$CP_HEALTH" = "200" ]; then
-    check "Control Plane health ($CONTROL_PLANE_URL)" "pass"
+# 5. Tenant count
+body="$(http_get_body "${STOA_API_URL%/}/api/v1/tenants")"
+# Count "id" fields as a lower bound on tenant entries; avoids jq dep.
+count="$(printf '%s' "$body" | grep -o '"id"[[:space:]]*:' | wc -l | tr -d ' ')"
+if [ "${count:-0}" -ge "$MIN_TENANTS" ]; then
+    report PASS "tenant count >= ${MIN_TENANTS} (got ${count})"
 else
-    check "Control Plane health (HTTP $CP_HEALTH)" "warn" "false"
+    report FAIL "tenant count" "expected >= ${MIN_TENANTS}, got ${count:-0}"
 fi
 
-# Grafana health
-GRAFANA_HEALTH=$(curl -s -o /dev/null -w "%{http_code}" "$GRAFANA_URL/api/health" --max-time 5 2>/dev/null || echo "000")
-if [ "$GRAFANA_HEALTH" = "200" ]; then
-    check "Grafana health ($GRAFANA_URL)" "pass"
-else
-    check "Grafana health (HTTP $GRAFANA_HEALTH)" "warn" "false"
-fi
-
-# Keycloak health
-KC_HEALTH=$(curl -s -o /dev/null -w "%{http_code}" "$KEYCLOAK_URL/health/ready" --max-time 5 2>/dev/null || echo "000")
-if [ "$KC_HEALTH" = "200" ]; then
-    check "Keycloak health ($KEYCLOAK_URL)" "pass"
-else
-    check "Keycloak health (HTTP $KC_HEALTH)" "warn" "false"
-fi
-
-echo ""
-
-# =============================================================================
-# External APIs Checks
-# =============================================================================
-echo -e "${CYAN}External APIs${NC}"
-echo "─────────────────────────────────────────"
-
-# CoinGecko
-COINGECKO=$(curl -s -o /dev/null -w "%{http_code}" "https://api.coingecko.com/api/v3/ping" --max-time 5 2>/dev/null || echo "000")
-if [ "$COINGECKO" = "200" ]; then
-    check "CoinGecko API (crypto prices)" "pass"
-else
-    check "CoinGecko API (HTTP $COINGECKO)" "warn" "false"
-fi
-
-# Open-Meteo
-OPEN_METEO=$(curl -s -o /dev/null -w "%{http_code}" "https://api.open-meteo.com/v1/forecast?latitude=48.85&longitude=2.35&current_weather=true" --max-time 5 2>/dev/null || echo "000")
-if [ "$OPEN_METEO" = "200" ]; then
-    check "Open-Meteo API (weather)" "pass"
-else
-    check "Open-Meteo API (HTTP $OPEN_METEO)" "warn" "false"
-fi
-
-# JSONPlaceholder
-JSONPLACEHOLDER=$(curl -s -o /dev/null -w "%{http_code}" "https://jsonplaceholder.typicode.com/posts/1" --max-time 5 2>/dev/null || echo "000")
-if [ "$JSONPLACEHOLDER" = "200" ]; then
-    check "JSONPlaceholder API (CRUD demo)" "pass"
-else
-    check "JSONPlaceholder API (HTTP $JSONPLACEHOLDER)" "warn" "false"
-fi
-
-# DummyJSON
-DUMMYJSON=$(curl -s -o /dev/null -w "%{http_code}" "https://dummyjson.com/users/1" --max-time 5 2>/dev/null || echo "000")
-if [ "$DUMMYJSON" = "200" ]; then
-    check "DummyJSON API (CRM demo)" "pass"
-else
-    check "DummyJSON API (HTTP $DUMMYJSON)" "warn" "false"
-fi
-
-# httpbin
-HTTPBIN=$(curl -s -o /dev/null -w "%{http_code}" "https://httpbin.org/get" --max-time 5 2>/dev/null || echo "000")
-if [ "$HTTPBIN" = "200" ]; then
-    check "httpbin API (legacy mock)" "pass"
-else
-    check "httpbin API (HTTP $HTTPBIN)" "warn" "false"
-fi
-
-echo ""
-
-# =============================================================================
-# MCP Tools Checks
-# =============================================================================
-echo -e "${CYAN}MCP Tools${NC}"
-echo "─────────────────────────────────────────"
-
-# List tools via gateway. Post CAB-2121 (PR #2433), anon discovery returns 401
-# by design — claude.ai connector authenticates via OAuth before calling tools/list.
-# Use AUTH_TOKEN env if available, else accept 401 anon as expected.
-if [ -n "$AUTH_TOKEN" ]; then
-    TOOLS_RESPONSE=$(curl -s -H "Authorization: Bearer $AUTH_TOKEN" "$GATEWAY_URL/mcp/v1/tools" --max-time 10 2>/dev/null || echo '{"error": "failed"}')
-else
-    TOOLS_RESPONSE=$(curl -s "$GATEWAY_URL/mcp/v1/tools" --max-time 10 2>/dev/null || echo '{"error": "failed"}')
-fi
-if echo "$TOOLS_RESPONSE" | grep -q '"tools"'; then
-    TOOL_COUNT=$(echo "$TOOLS_RESPONSE" | grep -o '"name"' | wc -l | tr -d ' ')
-    if [ "$TOOL_COUNT" -ge 5 ]; then
-        check "MCP tools registered ($TOOL_COUNT tools)" "pass"
-    else
-        check "MCP tools registered ($TOOL_COUNT tools - low)" "warn"
-    fi
-elif echo "$TOOLS_RESPONSE" | grep -q '"unauthorized"'; then
-    check "MCP discovery anon → 401 (CAB-2121 expected; set AUTH_TOKEN to test fully)" "pass"
-else
-    check "MCP tools list failed" "warn" "false"
-fi
-
-# Check K8s Tool CRDs
-if command -v kubectl &> /dev/null; then
-    CRD_COUNT=$(kubectl get tools -A --no-headers 2>/dev/null | wc -l | tr -d ' ' || echo "0")
-    if [ "$CRD_COUNT" -ge 10 ]; then
-        check "Tool CRDs in cluster ($CRD_COUNT tools)" "pass"
-    else
-        check "Tool CRDs in cluster ($CRD_COUNT tools)" "warn"
-    fi
-else
-    check "Tool CRDs" "warn" "false"
-fi
-
-echo ""
-
-# =============================================================================
-# Tenant Checks
-# =============================================================================
-echo -e "${CYAN}Tenants${NC}"
-echo "─────────────────────────────────────────"
-
-# Demo tenants exist
-if command -v kubectl &> /dev/null; then
-    for tenant in "high-five" "ioi" "oasis"; do
-        NS_EXISTS=$(kubectl get namespace "tenant-$tenant" --no-headers 2>/dev/null | wc -l | tr -d ' ' || echo "0")
-        if [ "$NS_EXISTS" -gt 0 ]; then
-            check "Tenant namespace: tenant-$tenant" "pass"
-        else
-            check "Tenant namespace: tenant-$tenant" "warn" "false"
-        fi
-    done
-else
-    check "Tenant namespaces (kubectl not available)" "warn" "false"
-fi
-
-echo ""
-
-# =============================================================================
-# Grafana Dashboards Check
-# =============================================================================
-echo -e "${CYAN}Grafana Dashboards${NC}"
-echo "─────────────────────────────────────────"
-
-DASHBOARDS=("stoa-platform-overview" "stoa-mcp-tools" "stoa-security-events")
-
-for dashboard in "${DASHBOARDS[@]}"; do
-    DASH_CHECK=$(curl -s -o /dev/null -w "%{http_code}" "$GRAFANA_URL/api/dashboards/uid/$dashboard" --max-time 5 2>/dev/null || echo "000")
-    if [ "$DASH_CHECK" = "200" ]; then
-        check "Dashboard: $dashboard" "pass"
-    else
-        check "Dashboard: $dashboard (not found)" "warn" "false"
-    fi
-done
-
-echo ""
-
-# =============================================================================
-# Summary
-# =============================================================================
-TOTAL=$((PASSED + FAILED + WARNINGS))
-
-echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
-echo ""
-echo -e "Summary: ${GREEN}$PASSED passed${NC}, ${RED}$FAILED failed${NC}, ${YELLOW}$WARNINGS warnings${NC}"
-echo ""
-
-if [ "$FAILED" -eq 0 ]; then
-    echo -e "  ╔═══════════════════════════════════════╗"
-    echo -e "  ║                                       ║"
-    echo -e "  ║   ${GREEN}██████╗  ██████╗ ${NC}                  ║"
-    echo -e "  ║   ${GREEN}██╔════╝ ██╔═══██╗${NC}                  ║"
-    echo -e "  ║   ${GREEN}██║  ███╗██║   ██║${NC}                  ║"
-    echo -e "  ║   ${GREEN}██║   ██║██║   ██║${NC}                  ║"
-    echo -e "  ║   ${GREEN}╚██████╔╝╚██████╔╝${NC}                  ║"
-    echo -e "  ║   ${GREEN} ╚═════╝  ╚═════╝ ${NC}                  ║"
-    echo -e "  ║                                       ║"
-    echo -e "  ║   ${GREEN}All critical checks passed!${NC}         ║"
-    echo -e "  ║   Ready to start the demo.            ║"
-    echo -e "  ║                                       ║"
-    echo -e "  ╚═══════════════════════════════════════╝"
-    echo ""
-    exit 0
-else
-    echo -e "  ╔═══════════════════════════════════════╗"
-    echo -e "  ║                                       ║"
-    echo -e "  ║   ${RED}███╗   ██╗ ██████╗ ${NC}                 ║"
-    echo -e "  ║   ${RED}████╗  ██║██╔═══██╗${NC}                 ║"
-    echo -e "  ║   ${RED}██╔██╗ ██║██║   ██║${NC}                 ║"
-    echo -e "  ║   ${RED}██║╚██╗██║██║   ██║${NC}                 ║"
-    echo -e "  ║   ${RED}██║ ╚████║╚██████╔╝${NC}                 ║"
-    echo -e "  ║   ${RED}╚═╝  ╚═══╝ ╚═════╝ ${NC}-GO              ║"
-    echo -e "  ║                                       ║"
-    echo -e "  ║   ${RED}$FAILED critical checks failed!${NC}       ║"
-    echo -e "  ║   Fix issues before starting demo.    ║"
-    echo -e "  ║                                       ║"
-    echo -e "  ╚═══════════════════════════════════════╝"
-    echo ""
-    echo "Recommended actions:"
-    echo "  1. Check failed components"
-    echo "  2. Run: ./reset-demo.sh"
-    echo "  3. Re-run this check"
-    echo ""
-    exit 1
-fi
+printf '\nResult: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/scripts/demo/reset-demo.sh
+++ b/scripts/demo/reset-demo.sh
@@ -1,176 +1,75 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # =============================================================================
-# CAB-1104: Demo Reset Script
+# CAB-2150 (parent CAB-2148): Demo reset harness.
 # =============================================================================
-# Resets the demo environment to a clean state in < 30 seconds
-# - Flush semantic cache
-# - Reset rate limit counters
-# - Clear audit trail (demo data only)
-# - Re-seed demo data
-# - Warm semantic cache
-# - Restart traffic generator
+# Calls the cp-api demo reset endpoint (CAB-2149 contract) to return the
+# platform to a known demo-ready state. Idempotent by contract: server
+# guarantees safe replay. Exits 0 ONLY if reset fully completed.
 #
-# Usage: ./reset-demo.sh [--quick]
+# Contract assumption (CAB-2149, not yet merged):
+#   POST ${STOA_API_URL}/api/v1/demo/reset
+#     Authorization: Bearer ${STOA_API_TOKEN}
+#   -> 200 {"status": "reset_complete", "tenants": N, "duration_ms": M}
+#   -> any other status = non-zero exit + stderr diagnostic
+#
+# Usage: ./reset-demo.sh [--timeout SECONDS]
+# Env:
+#   STOA_API_URL     (required) Control Plane API base URL
+#   STOA_API_TOKEN   (required) Bearer token with demo-admin scope
 # =============================================================================
 
-set -e
+set -euo pipefail
 
-# Configuration
-CONTROL_PLANE_URL="${CONTROL_PLANE_URL:-https://api.gostoa.dev}"
-GATEWAY_URL="${GATEWAY_URL:-https://mcp.gostoa.dev}"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-QUICK_MODE="${1:-}"
+TIMEOUT=60
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --timeout) TIMEOUT="${2:?--timeout needs a value}"; shift 2 ;;
+        -h|--help) sed -n '2,17p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+: "${STOA_API_URL:?STOA_API_URL must be set (e.g. https://api.gostoa.dev)}"
+: "${STOA_API_TOKEN:?STOA_API_TOKEN must be set (bearer token, demo-admin scope)}"
 
-# Timer
-START_TIME=$(date +%s)
+log() { printf '[reset-demo] %s\n' "$*"; }
+fail() { printf '[reset-demo] FAIL: %s\n' "$*" >&2; exit 1; }
 
-echo -e "${BLUE}========================================${NC}"
-echo -e "${BLUE}STOA Demo Reset Script${NC}"
-echo -e "${BLUE}========================================${NC}"
-echo ""
+log "POST ${STOA_API_URL}/api/v1/demo/reset (timeout=${TIMEOUT}s)"
 
-# =============================================================================
-# Step 1: Flush semantic cache
-# =============================================================================
-echo -e "${YELLOW}[1/6] Flushing semantic cache...${NC}"
-CACHE_RESULT=$(curl -s -X DELETE "${GATEWAY_URL}/api/v1/cache/flush" \
-    -H "Content-Type: application/json" \
-    2>/dev/null || echo '{"status": "skipped", "note": "endpoint not available"}')
+TMP_BODY="$(mktemp)"
+trap 'rm -f "$TMP_BODY"' EXIT
 
-if echo "$CACHE_RESULT" | grep -q "cleared\|success\|ok"; then
-    echo -e "${GREEN}  Cache flushed successfully${NC}"
-else
-    echo -e "${YELLOW}  Cache flush skipped (endpoint may not be available)${NC}"
+HTTP_CODE="$(
+    curl -sS --max-time "$TIMEOUT" \
+        -o "$TMP_BODY" \
+        -w '%{http_code}' \
+        -X POST \
+        -H "Authorization: Bearer ${STOA_API_TOKEN}" \
+        -H 'Content-Type: application/json' \
+        -H 'Accept: application/json' \
+        "${STOA_API_URL%/}/api/v1/demo/reset" \
+    || true
+)"
+
+if [ -z "$HTTP_CODE" ]; then
+    fail "curl produced no HTTP status (network or DNS failure)"
 fi
 
-# =============================================================================
-# Step 2: Reset rate limit counters
-# =============================================================================
-echo -e "${YELLOW}[2/6] Resetting rate limit counters...${NC}"
-RATE_RESULT=$(curl -s -X POST "${CONTROL_PLANE_URL}/api/v1/admin/reset-rate-limits" \
-    -H "Content-Type: application/json" \
-    2>/dev/null || echo '{"status": "skipped"}')
-
-if echo "$RATE_RESULT" | grep -q "reset\|success\|ok"; then
-    echo -e "${GREEN}  Rate limits reset successfully${NC}"
-else
-    echo -e "${YELLOW}  Rate limit reset skipped (using in-memory reset)${NC}"
-    # Fallback: restart the gateway to reset in-memory rate limits
-    if command -v kubectl &> /dev/null; then
-        kubectl rollout restart deployment/mcp-gateway -n stoa-system 2>/dev/null || true
-    fi
+if [ "$HTTP_CODE" != "200" ]; then
+    log "response body:"
+    cat "$TMP_BODY" >&2 || true
+    fail "unexpected HTTP ${HTTP_CODE}"
 fi
 
-# =============================================================================
-# Step 3: Clear audit trail (demo data only)
-# =============================================================================
-echo -e "${YELLOW}[3/6] Clearing demo audit data...${NC}"
-AUDIT_RESULT=$(curl -s -X DELETE "${CONTROL_PLANE_URL}/api/v1/audit?scope=demo" \
-    -H "Content-Type: application/json" \
-    2>/dev/null || echo '{"status": "skipped"}')
+STATUS="$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$TMP_BODY" \
+    | head -n1 | sed 's/.*"\([^"]*\)"$/\1/' || true)"
 
-if echo "$AUDIT_RESULT" | grep -q "cleared\|success\|deleted"; then
-    echo -e "${GREEN}  Audit data cleared successfully${NC}"
-else
-    echo -e "${YELLOW}  Audit clear skipped (demo data preserved)${NC}"
+if [ "$STATUS" != "reset_complete" ]; then
+    log "response body:"
+    cat "$TMP_BODY" >&2 || true
+    fail "server returned status='${STATUS:-<missing>}', expected 'reset_complete'"
 fi
 
-# =============================================================================
-# Step 4: Re-seed demo data
-# =============================================================================
-echo -e "${YELLOW}[4/6] Re-seeding demo data...${NC}"
-
-if [ -f "$SCRIPT_DIR/seed-rpo-demo.py" ]; then
-    if [ "$QUICK_MODE" = "--quick" ]; then
-        python3 "$SCRIPT_DIR/seed-rpo-demo.py" --quick 2>/dev/null || true
-    else
-        python3 "$SCRIPT_DIR/seed-rpo-demo.py" 2>/dev/null || true
-    fi
-    echo -e "${GREEN}  Demo data seeded${NC}"
-else
-    echo -e "${YELLOW}  Seed script not found, skipping${NC}"
-fi
-
-# Apply K8s resources if available
-if command -v kubectl &> /dev/null && [ -d "$SCRIPT_DIR/../../deploy/demo-rpo" ]; then
-    kubectl apply -k "$SCRIPT_DIR/../../deploy/demo-rpo" 2>/dev/null || true
-    echo -e "${GREEN}  K8s demo resources applied${NC}"
-fi
-
-# =============================================================================
-# Step 5: Warm semantic cache
-# =============================================================================
-echo -e "${YELLOW}[5/6] Warming semantic cache...${NC}"
-
-if [ -f "$SCRIPT_DIR/warm-cache.sh" ]; then
-    bash "$SCRIPT_DIR/warm-cache.sh" 2>/dev/null || true
-    echo -e "${GREEN}  Cache warmed with 10 entries${NC}"
-else
-    # Inline cache warming
-    WARM_QUERIES=(
-        '{"tool": "stoa_catalog_list", "arguments": {}}'
-        '{"tool": "high-five__crypto__get_prices", "arguments": {"coins": ["bitcoin"]}}'
-        '{"tool": "high-five__crypto__get_prices", "arguments": {"coins": ["ethereum"]}}'
-        '{"tool": "high-five__weather__forecast", "arguments": {"latitude": 48.85, "longitude": 2.35}}'
-        '{"tool": "stoa_ml_sentiment", "arguments": {"inputs": "This is great!"}}'
-    )
-
-    for query in "${WARM_QUERIES[@]}"; do
-        curl -s -X POST "${GATEWAY_URL}/mcp/v1/tools/call" \
-            -H "Content-Type: application/json" \
-            -H "X-Tenant-ID: high-five" \
-            -d "$query" \
-            > /dev/null 2>&1 || true
-    done
-    echo -e "${GREEN}  Cache warmed with ${#WARM_QUERIES[@]} entries${NC}"
-fi
-
-# =============================================================================
-# Step 6: Restart traffic generator
-# =============================================================================
-echo -e "${YELLOW}[6/6] Restarting traffic generator...${NC}"
-
-# Kill any existing traffic generator
-pkill -f "traffic-generator.py" 2>/dev/null || true
-
-# Start new traffic generator in background
-if [ -f "$SCRIPT_DIR/traffic-generator.py" ]; then
-    nohup python3 "$SCRIPT_DIR/traffic-generator.py" --duration 3600 \
-        > /tmp/traffic-generator.log 2>&1 &
-    echo -e "${GREEN}  Traffic generator started (PID: $!)${NC}"
-else
-    echo -e "${YELLOW}  Traffic generator script not found${NC}"
-fi
-
-# =============================================================================
-# Summary
-# =============================================================================
-END_TIME=$(date +%s)
-ELAPSED=$((END_TIME - START_TIME))
-
-echo ""
-echo -e "${BLUE}========================================${NC}"
-echo -e "${GREEN}Demo Reset Complete!${NC}"
-echo -e "${BLUE}========================================${NC}"
-echo ""
-echo -e "Time elapsed: ${GREEN}${ELAPSED}s${NC}"
-
-if [ "$ELAPSED" -le 30 ]; then
-    echo -e "Status: ${GREEN}Within target (< 30s)${NC}"
-else
-    echo -e "Status: ${YELLOW}Exceeded target (> 30s)${NC}"
-fi
-
-echo ""
-echo "Next steps:"
-echo "  1. Open Grafana: https://grafana.gostoa.dev"
-echo "  2. Check dashboards have live data"
-echo "  3. Run pre-demo check: ./pre-demo-check.sh"
-echo ""
+log "reset complete ($(cat "$TMP_BODY"))"
+exit 0


### PR DESCRIPTION
## Summary

Rewrite the three demo harness scripts to align with the CAB-2148 demo kernel contract. Strict, binary, artifact-producing — no "warning" state.

Parent: CAB-2148 (Phase 1, parallel). Sub-issue: CAB-2150.

- `reset-demo.sh` — single POST to cp-api `/api/v1/demo/reset`, exits 0 only on `status=reset_complete`. Server guarantees idempotency.
- `pre-demo-check.sh` — 5-check binary gate: cp-api health, gateway health, seed integrity (`/api/v1/demo/status`), JWT audience claim present, tenant count >= `STOA_DEMO_MIN_TENANTS` (default 4). Any red = exit 1.
- `demo-dry-run.sh` — cold full-path run with per-step timing, writes logs + `summary.md` + `metadata.json` to `docs/audits/demo-dryrun-<UTC>/` for the evidence archive rule.
- `README.md` — operator runbook (env vars, invocation, exit-code contract, contract dependency note).

## Contract assumption (CAB-2149, not yet merged)

The scripts depend on two cp-api endpoints delivered by CAB-2149:

- `POST /api/v1/demo/reset` → `200 {"status": "reset_complete", ...}`
- `GET /api/v1/demo/status` → body contains `"seed_state": "seeded"`

Until CAB-2149 merges, the scripts fail fast with a diagnostic on stderr — that is the intended behavior for the binary gate.

## DoD checklist

- [x] `reset-demo.sh` idempotent, exits 0 only if reset fully completed
- [x] `pre-demo-check.sh` exits non-zero on any red signal (binary gate)
- [x] `demo-dry-run.sh` emits timestamped artifacts to `docs/audits/demo-dryrun-<UTC>/`
- [x] All three scripts pass `shellcheck` clean
- [x] `set -euo pipefail` everywhere; `set -e + ((x++))` gotcha avoided
- [x] Operator runbook updated with invocation sequence + exit-code contract
- [x] PR under 300 LOC (251 additions, 1104 deletions in `scripts/demo/`)
- [ ] CI green (pending)

## Test plan

- [x] `shellcheck scripts/demo/{reset-demo,pre-demo-check,demo-dry-run}.sh` passes
- [x] `--help` prints usage for `reset-demo.sh` and `demo-dry-run.sh`
- [x] Missing required env var causes fast exit 1 with diagnostic
- [ ] Integration test deferred to CAB-2155 (e2e cold runs) once CAB-2149 lands

## Scope respected

- Only `scripts/demo/` touched + the runbook
- No changes to `control-plane-api/`, `portal/`, `control-plane-ui/`, `stoa-gateway/`
- Does NOT auto-close CAB-2148 (references ticket as plain text)

Ref: CAB-2150