### PR TITLE
feat(api): demo seed fixtures (CAB-2149 a/3)

### DIFF
--- a/control-plane-api/src/seed/__init__.py
+++ b/control-plane-api/src/seed/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic demo seed fixtures (CAB-2149)."""

--- a/control-plane-api/src/seed/demo_fixtures.py
+++ b/control-plane-api/src/seed/demo_fixtures.py
@@ -1,0 +1,128 @@
+"""Deterministic demo fixtures for the multi-client Customer API scenario (CAB-2149).
+
+Backbone of CAB-2148 Phase 1. Single source of truth consumed by
+``src.db.reset_service`` and ``scripts.demo.reset``. Neutral placeholder
+tenants (``tenant-a/b/c/d``) — client identities are injected at presentation
+time via narrative, never here (pre-push OpSec scanner rejects identifying
+phrases). All identifiers are derived so two cold runs produce identical rows.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+DEMO_TENANTS: tuple[dict[str, str], ...] = (
+    {"id": "tenant-a", "name": "Tenant A", "description": "Demo tenant A (placeholder)."},
+    {"id": "tenant-b", "name": "Tenant B", "description": "Demo tenant B (placeholder)."},
+    {"id": "tenant-c", "name": "Tenant C", "description": "Demo tenant C (placeholder)."},
+    {"id": "tenant-d", "name": "Tenant D", "description": "Demo tenant D (placeholder)."},
+)
+
+# Neutral Customer API scenario — replicated identically across every tenant
+# to demonstrate UAC "Define Once, Expose Everywhere".
+CUSTOMER_API_ID = "customer-api-v1"
+CUSTOMER_API_NAME = "Customer API"
+CUSTOMER_API_VERSION = "1.0.0"
+CUSTOMER_API_CATEGORY = "reference-data"
+CUSTOMER_API_TAGS: tuple[str, ...] = ("customer", "referentiel", "uac-demo")
+CUSTOMER_API_AUDIENCE = "internal"
+CUSTOMER_API_DESCRIPTION = (
+    "Neutral customer reference-data API used by the UAC 5-step demo scenario. "
+    "Identical definition replicated across every demo tenant."
+)
+
+
+@dataclass(frozen=True)
+class DemoAPIFixture:
+    """One Customer API catalog row, scoped to a single tenant."""
+
+    tenant_id: str
+    api_id: str
+    api_name: str
+    version: str
+    category: str
+    audience: str
+    tags: tuple[str, ...]
+    description: str
+
+    @property
+    def deterministic_uuid(self) -> UUID:
+        """Stable UUID derived from ``(tenant_id, api_id, version)``.
+
+        SHA-256 of the identity tuple, truncated to 16 bytes. Collision
+        probability is negligible in a 4-tenant catalogue.
+        """
+        seed = f"demo:{self.tenant_id}:{self.api_id}:{self.version}".encode()
+        return UUID(bytes=hashlib.sha256(seed).digest()[:16], version=5)
+
+    def metadata(self) -> dict[str, Any]:
+        """JSON-serialisable metadata payload for the catalog row."""
+        return {
+            "source": "demo-seeder",
+            "scenario": "customer-api-uac-demo",
+            "name": self.api_name,
+            "version": self.version,
+            "description": self.description,
+            "backend_url": f"https://api.gostoa.dev/demo/{self.tenant_id}/customers",
+            "auth_type": "none",
+        }
+
+
+@dataclass(frozen=True)
+class DemoTenantFixture:
+    """Tenant definition + its attached Customer API row."""
+
+    id: str
+    name: str
+    description: str
+    api: DemoAPIFixture
+
+
+def _build_demo_fixtures() -> tuple[DemoTenantFixture, ...]:
+    """Build the deterministic fixture tuple. Pure function — no I/O, no clock."""
+    rows = [
+        DemoTenantFixture(
+            id=tenant["id"],
+            name=tenant["name"],
+            description=tenant["description"],
+            api=DemoAPIFixture(
+                tenant_id=tenant["id"],
+                api_id=CUSTOMER_API_ID,
+                api_name=CUSTOMER_API_NAME,
+                version=CUSTOMER_API_VERSION,
+                category=CUSTOMER_API_CATEGORY,
+                audience=CUSTOMER_API_AUDIENCE,
+                tags=CUSTOMER_API_TAGS,
+                description=CUSTOMER_API_DESCRIPTION,
+            ),
+        )
+        for tenant in DEMO_TENANTS
+    ]
+    # Lock ordering so byte-identical snapshots are reproducible.
+    rows.sort(key=lambda t: t.id)
+    return tuple(rows)
+
+
+DEMO_FIXTURES: tuple[DemoTenantFixture, ...] = _build_demo_fixtures()
+
+
+@dataclass(frozen=True)
+class DemoFixtureBundle:
+    """Immutable envelope around the full demo catalogue."""
+
+    tenants: tuple[DemoTenantFixture, ...] = field(default_factory=_build_demo_fixtures)
+
+    @property
+    def tenant_ids(self) -> tuple[str, ...]:
+        return tuple(t.id for t in self.tenants)
+
+    def apis_for(self, tenant_id: str) -> tuple[DemoAPIFixture, ...]:
+        return tuple(t.api for t in self.tenants if t.id == tenant_id)
+
+
+def default_bundle() -> DemoFixtureBundle:
+    """Return the canonical immutable demo bundle."""
+    return DemoFixtureBundle()

--- a/control-plane-api/tests/demo/__init__.py
+++ b/control-plane-api/tests/demo/__init__.py
@@ -1,0 +1,1 @@
+"""Demo reset/seed tests (CAB-2149)."""

--- a/control-plane-api/tests/demo/test_demo_fixtures.py
+++ b/control-plane-api/tests/demo/test_demo_fixtures.py
@@ -1,0 +1,74 @@
+"""Invariant tests for the deterministic demo fixtures (CAB-2149).
+
+These tests guard the pure-Python contract of
+:mod:`src.seed.demo_fixtures` — no DB involved. They protect the downstream
+reset service (PR B) and CLI (PR C) from fixture regressions that would
+break byte-identical cold-run snapshots.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from src.seed.demo_fixtures import (
+    CUSTOMER_API_ID,
+    CUSTOMER_API_NAME,
+    CUSTOMER_API_VERSION,
+    DEMO_FIXTURES,
+    DEMO_TENANTS,
+    default_bundle,
+)
+
+
+class TestDemoFixtureInvariants:
+    """Guard the deterministic contract of the fixture module."""
+
+    def test_four_tenants_placeholders_only(self) -> None:
+        ids = [t["id"] for t in DEMO_TENANTS]
+        assert ids == ["tenant-a", "tenant-b", "tenant-c", "tenant-d"]
+
+    def test_fixtures_sorted_by_tenant_id(self) -> None:
+        ids = [t.id for t in DEMO_FIXTURES]
+        assert ids == sorted(ids)
+
+    def test_every_tenant_has_customer_api(self) -> None:
+        for tenant in DEMO_FIXTURES:
+            assert tenant.api.api_id == CUSTOMER_API_ID
+            assert tenant.api.version == CUSTOMER_API_VERSION
+
+    def test_deterministic_uuid_stable_across_builds(self) -> None:
+        first = default_bundle().tenants[0].api.deterministic_uuid
+        second = default_bundle().tenants[0].api.deterministic_uuid
+        assert first == second
+
+    def test_deterministic_uuid_differs_per_tenant(self) -> None:
+        uuids = {t.api.deterministic_uuid for t in DEMO_FIXTURES}
+        assert len(uuids) == len(DEMO_FIXTURES)
+
+    def test_metadata_is_json_serialisable(self) -> None:
+        for tenant in DEMO_FIXTURES:
+            payload = json.dumps(tenant.api.metadata(), sort_keys=True)
+            assert CUSTOMER_API_NAME in payload
+            assert "demo-seeder" in payload
+
+    def test_bundle_tenant_ids_stable(self) -> None:
+        bundle = default_bundle()
+        assert bundle.tenant_ids == ("tenant-a", "tenant-b", "tenant-c", "tenant-d")
+        # apis_for is tenant-scoped and returns the Customer API row.
+        apis = bundle.apis_for("tenant-a")
+        assert len(apis) == 1
+        assert apis[0].api_id == CUSTOMER_API_ID
+
+    def test_fixture_tuples_are_immutable(self) -> None:
+        # Tuple vs list guard — downstream snapshot stability depends on this.
+        assert isinstance(DEMO_FIXTURES, tuple)
+        assert isinstance(DEMO_FIXTURES[0].api.tags, tuple)
+
+    def test_fixtures_carry_no_wallclock_timestamps(self) -> None:
+        # Fixture dataclasses must not embed datetime fields — the reset
+        # service owns the single frozen epoch. Catching drift here prevents
+        # silent snapshot divergence.
+        for tenant in DEMO_FIXTURES:
+            for value in (tenant.id, tenant.name, tenant.description, tenant.api):
+                assert not isinstance(value, datetime)


### PR DESCRIPTION
## Summary

First of three stacked PRs splitting the demo reset/seed backbone (CAB-2149 — Phase 1 of CAB-2148 demo-multi-client kernel). This PR lands **only the deterministic fixture module and its invariant tests**.

Tracks CAB-2149.

## Stack

| Order | PR | Scope |
|---|---|---|
| a/3 (this PR) | this | Fixtures + invariant tests |
| b/3 | `feat/cab-2149-b-reset-service` | `DemoResetService` + DB-backed regression tests |
| c/3 | `feat/cab-2149-c-cli` | `scripts/demo/reset.py` CLI entry point |

b/3 branches from a/3, c/3 branches from b/3. Merge a → b → c.

## What lands

- `src/seed/demo_fixtures.py` (128 LOC) — neutral Customer API scenario replicated across four placeholder tenants (`tenant-a/b/c/d`). Pure Python, no I/O, no wall-clock reads at import time. Identifiers derived via SHA-256 of `(tenant_id, api_id, version)`. Tuples sorted for reproducible byte-level snapshots.
- `tests/demo/test_demo_fixtures.py` (74 LOC) — 9 invariant guards: placeholder slugs only, sort order, stable deterministic UUID, per-tenant UUID uniqueness, metadata shape, tuple immutability, no embedded timestamps, bundle `tenant_ids` + `apis_for` lookup.

## LOC breakdown

- Source: 129 LOC (`src/seed/` — 1 + 128)
- Tests: 75 LOC (`tests/demo/` — 1 + 74)
- **Total: 204 LOC** (hard cap 300)

## Test plan

- [x] `pytest tests/demo/ -q` → 9 passed in 0.07s
- [x] `ruff check` + `black --check` + `mypy --strict` clean

## Supersedes

Supersedes #2464 (squashed single-PR attempt breached 300 LOC cap; split into a/b/c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)