### PR TITLE
feat(api): demo reset CLI entry point (CAB-2149 c/3)

### DIFF
--- a/control-plane-api/scripts/demo/__init__.py
+++ b/control-plane-api/scripts/demo/__init__.py
@@ -1,0 +1,1 @@
+"""Demo harness entry points (CAB-2149)."""

--- a/control-plane-api/scripts/demo/reset.py
+++ b/control-plane-api/scripts/demo/reset.py
@@ -1,0 +1,85 @@
+"""Deterministic demo reset/seed CLI entry point (CAB-2149).
+
+Usage::
+
+    DATABASE_URL=postgresql+asyncpg://... python -m scripts.demo.reset
+    DATABASE_URL=postgresql+asyncpg://... python -m scripts.demo.reset --check
+
+Purges the four demo tenants (``tenant-a/b/c/d``) and re-seeds the neutral
+Customer API fixtures. Two consecutive runs produce byte-identical catalogue
+state — see ``tests/demo/test_reset_isolation.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="stoa-demo-reset",
+        description="Deterministic demo reset/seed (multi-client UAC scenario).",
+    )
+    parser.add_argument("--check", action="store_true", help="Print snapshot and exit (no mutation).")
+    parser.add_argument("--reset-only", action="store_true", help="Reset without re-seeding.")
+    return parser.parse_args(argv)
+
+
+async def _main(args: argparse.Namespace) -> int:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    from src.db.reset_service import DemoResetService
+
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        print("ERROR: DATABASE_URL environment variable is required", file=sys.stderr)
+        return 1
+
+    engine = create_async_engine(database_url, echo=False)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    start = time.perf_counter()
+    try:
+        async with factory() as session, session.begin():
+            service = DemoResetService(session)
+            if args.check:
+                snapshot = await service.snapshot()
+                print(f"demo snapshot: {len(snapshot)} rows across {len(service.bundle.tenant_ids)} tenants")
+                for row in snapshot:
+                    print(f"  {row['tenant_id']}/{row['api_id']}@{row['version']}")
+                return 0
+            if args.reset_only:
+                result = await service.reset()
+                print(f"demo reset: tenants_deleted={result.tenants_deleted} apis_deleted={result.apis_deleted}")
+                return 0
+            result = await service.run_cycle()
+            elapsed = time.perf_counter() - start
+            print(
+                f"demo reset+seed: tenants_deleted={result.tenants_deleted} "
+                f"apis_deleted={result.apis_deleted} "
+                f"tenants_created={result.tenants_created} "
+                f"apis_created={result.apis_created} "
+                f"elapsed={elapsed:.2f}s"
+            )
+            return 0
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        await engine.dispose()
+
+
+def cli() -> None:
+    sys.exit(asyncio.run(_main(parse_args())))
+
+
+if __name__ == "__main__":
+    cli()

--- a/control-plane-api/tests/demo/test_reset_cli.py
+++ b/control-plane-api/tests/demo/test_reset_cli.py
@@ -1,0 +1,35 @@
+"""Unit tests for the demo reset CLI entry point (CAB-2149 c/3).
+
+Boundaries tested without a real database: argument parsing + the
+missing-``DATABASE_URL`` guard. End-to-end DB validation is performed
+when the CLI is wired into the Phase 2 demo harness.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from scripts.demo.reset import _main, parse_args
+
+
+class TestParseArgs:
+    def test_defaults_are_full_cycle(self) -> None:
+        args = parse_args([])
+        assert args.check is False
+        assert args.reset_only is False
+
+    def test_check_flag(self) -> None:
+        args = parse_args(["--check"])
+        assert args.check is True
+
+    def test_reset_only_flag(self) -> None:
+        args = parse_args(["--reset-only"])
+        assert args.reset_only is True
+
+
+class TestMissingDatabaseUrl:
+    def test_regression_cab_2149_cli_exits_1_without_database_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        exit_code = asyncio.run(_main(parse_args([])))
+        assert exit_code == 1

--- a/control-plane-api/tests/demo/test_reset_cli.py
+++ b/control-plane-api/tests/demo/test_reset_cli.py
@@ -7,8 +7,6 @@ when the CLI is wired into the Phase 2 demo harness.
 
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 from scripts.demo.reset import _main, parse_args
 
@@ -29,7 +27,11 @@ class TestParseArgs:
 
 
 class TestMissingDatabaseUrl:
-    def test_regression_cab_2149_cli_exits_1_without_database_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_regression_cab_2149_cli_exits_1_without_database_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Must be async: a sync test calling asyncio.run() nulls set_event_loop
+        # and poisons the session-scoped event_loop fixture for every later test.
         monkeypatch.delenv("DATABASE_URL", raising=False)
-        exit_code = asyncio.run(_main(parse_args([])))
+        exit_code = await _main(parse_args([]))
         assert exit_code == 1


### PR DESCRIPTION
## Summary

Third of three stacked PRs for CAB-2149 (Phase 1 of CAB-2148 demo-multi-client kernel). Wraps the reset service from PR b/3 in a CLI that the Phase 2 demo harness (CAB-2150) will invoke before every cold run.

Tracks CAB-2149. **Base is `feat/cab-2149-b-reset-service` (PR #2467) — merge a/3 then b/3 first.**

## Stack

| Order | PR | Scope |
|---|---|---|
| a/3 | #2466 | Fixtures + invariant tests |
| b/3 | #2467 | `DemoResetService` + DB-backed regression tests |
| c/3 (this PR) | this | `scripts/demo/reset.py` CLI entry point |

## What lands

- `scripts/demo/reset.py` (85 LOC) — CLI with `--check` (snapshot only), `--reset-only` (purge without reseed), and default full reset+seed cycle. Reads `DATABASE_URL` from env. Bounds the reset within a single SQLAlchemy transaction (`session.begin()` + factory commit).
- `tests/demo/test_reset_cli.py` (35 LOC) — 4 unit tests covering argparse defaults/flags + the `test_regression_cab_2149_cli_exits_1_without_database_url` guard so missing env never silently turns into a reset-everything disaster.

End-to-end DB validation is performed when this CLI is wired into CAB-2150 — out of scope for this stack.

## LOC breakdown

- Source: 86 LOC (`scripts/demo/` — 1 + 85)
- Tests: 35 LOC
- **Total: 121 LOC** (hard cap 300)

## Test plan

- [x] `pytest tests/demo/ -q` from this branch → 20 passed in 0.15s (9 fixture + 7 DB-backed + 4 CLI)
- [x] `ruff check` + `black --check` + `mypy --strict` clean
- [ ] End-to-end CLI invocation with real PostgreSQL — deferred to CAB-2150 harness bring-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)