### PR TITLE
fix(ui): align Application alias with regenerated schema (CAB-2159)

### DIFF
--- a/control-plane-ui/src/__tests__/regression/CAB-2159-application-schema-alias.test.ts
+++ b/control-plane-ui/src/__tests__/regression/CAB-2159-application-schema-alias.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type { Schemas } from '@stoa/shared/api-types';
+import type { Application } from '../../types';
+
+/**
+ * Regression for CAB-2159 — the UI Application alias must track the canonical
+ * OpenAPI schema key after type regeneration.
+ */
+describe('regression/CAB-2159', () => {
+  it('keeps Application aligned with the canonical generated schema', () => {
+    expectTypeOf<Application>().toMatchTypeOf<Schemas['ApplicationResponse']>();
+    expectTypeOf<Application['api_subscriptions']>().toEqualTypeOf<
+      Schemas['ApplicationResponse']['api_subscriptions']
+    >();
+    expect(true).toBe(true);
+  });
+});

--- a/control-plane-ui/src/types/index.ts
+++ b/control-plane-ui/src/types/index.ts
@@ -67,12 +67,12 @@ export interface APICreate {
 }
 
 // ---- Application ------------------------------------------------------------
-// Wire = `Schemas['src__routers__portal_applications__ApplicationResponse']`
-// (long Pydantic-namespaced name because BUG-1 — backend never extracted
-// a clean `ApplicationResponse` schema). UI narrows two nullable fields
-// (`client_id, tenant_id`) and adds a UI-only `environment` field.
+// Wire = `Schemas['ApplicationResponse']`
+// (BUG-1 is now fixed in the backend: the portal router owns the canonical
+// schema name). UI narrows two nullable fields (`client_id, tenant_id`) and
+// adds a UI-only `environment` field.
 export type Application = Omit<
-  Schemas['src__routers__portal_applications__ApplicationResponse'],
+  Schemas['ApplicationResponse'],
   'client_id' | 'tenant_id'
 > & {
   /** UI assumes always set (BUG-1: backend should make it required). */


### PR DESCRIPTION
## Summary
- switch the UI Application alias to the canonical OpenAPI schema key introduced by CAB-2159
- remove the stale namespaced schema reference left from the pre-regeneration shape
- unblock control-plane-ui builds that started failing after #2473 merged

## Verification
- reproduced the failure locally before the change: missing Schemas['src__routers__portal_applications__ApplicationResponse'] and implicit any on app.api_subscriptions.map
- after the change, TypeScript progressed past those errors; local build then stopped later on a separate local Rollup optional-dependency issue (@rollup/rollup-darwin-arm64), which is unrelated to this code change