### PR TITLE
style(ui): format CAB-2159 Application alias with prettier

### DIFF
--- a/control-plane-ui/src/types/index.ts
+++ b/control-plane-ui/src/types/index.ts
@@ -71,10 +71,7 @@ export interface APICreate {
 // (BUG-1 is now fixed in the backend: the portal router owns the canonical
 // schema name). UI narrows two nullable fields (`client_id, tenant_id`) and
 // adds a UI-only `environment` field.
-export type Application = Omit<
-  Schemas['ApplicationResponse'],
-  'client_id' | 'tenant_id'
-> & {
+export type Application = Omit<Schemas['ApplicationResponse'], 'client_id' | 'tenant_id'> & {
   /** UI assumes always set (BUG-1: backend should make it required). */
   client_id: string;
   /** UI assumes always set in the contexts we render. */


### PR DESCRIPTION
## Summary
- Apply `prettier --write` to `control-plane-ui/src/types/index.ts`
- Unblocks `ci / Build and Test (control-plane-ui)` → `format:check` on main after #2476 merged with the `Application` alias unformatted
- 1 line reformat only, no functional change

## Why this mini-PR
#2476 was merged via admin bypass while `format:check` was failing. Main is currently red on cp-ui CI. This patch closes that.

Linear: [CAB-2159]

## Test plan
- [ ] CI `ci / Build and Test (control-plane-ui)` green
- [ ] No other checks regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)