### PR TITLE
refactor(ui): extract 5 domain clients (UI-2 S2b)

### DIFF
--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -68,6 +68,11 @@ import { sessionClient } from './api/session';
 import { adminClient } from './api/admin';
 import { toolPermissionsClient } from './api/toolPermissions';
 import { workflowsClient } from './api/workflows';
+import { subscriptionsClient } from './api/subscriptions';
+import { webhooksClient } from './api/webhooks';
+import { credentialMappingsClient } from './api/credentialMappings';
+import { contractsClient } from './api/contracts';
+import { promotionsClient } from './api/promotions';
 
 // =============================================================================
 // Façade ApiService — agrège le core transport (services/http) et les méthodes
@@ -439,13 +444,11 @@ class ApiService {
       page_size?: number;
     }
   ): Promise<PromotionListResponse> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/promotions`, { params });
-    return data;
+    return promotionsClient.list(tenantId, params);
   }
 
   async getPromotion(tenantId: string, promotionId: string): Promise<Promotion> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/promotions/${promotionId}`);
-    return data;
+    return promotionsClient.get(tenantId, promotionId);
   }
 
   async createPromotion(
@@ -453,22 +456,15 @@ class ApiService {
     apiId: string,
     request: Schemas['PromotionCreate']
   ): Promise<Promotion> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/promotions/${apiId}`, request);
-    return data;
+    return promotionsClient.create(tenantId, apiId, request);
   }
 
   async approvePromotion(tenantId: string, promotionId: string): Promise<Promotion> {
-    const { data } = await httpClient.post(
-      `/v1/tenants/${tenantId}/promotions/${promotionId}/approve`
-    );
-    return data;
+    return promotionsClient.approve(tenantId, promotionId);
   }
 
   async completePromotion(tenantId: string, promotionId: string): Promise<Promotion> {
-    const { data } = await httpClient.post(
-      `/v1/tenants/${tenantId}/promotions/${promotionId}/complete`
-    );
-    return data;
+    return promotionsClient.complete(tenantId, promotionId);
   }
 
   async rollbackPromotion(
@@ -476,19 +472,14 @@ class ApiService {
     promotionId: string,
     request: Schemas['PromotionRollbackRequest']
   ): Promise<Promotion> {
-    const { data } = await httpClient.post(
-      `/v1/tenants/${tenantId}/promotions/${promotionId}/rollback`,
-      request
-    );
-    return data;
+    return promotionsClient.rollback(tenantId, promotionId, request);
   }
 
   async getPromotionDiff(
     tenantId: string,
     promotionId: string
   ): Promise<Schemas['PromotionDiffResponse']> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/promotions/${promotionId}/diff`);
-    return data;
+    return promotionsClient.getDiff(tenantId, promotionId);
   }
 
   // ── Environment Status ────────────────────────────────────────────────────
@@ -1161,10 +1152,7 @@ class ApiService {
     pageSize = 20,
     environment?: string
   ): Promise<SubscriptionListResponse> {
-    const { data } = await httpClient.get(`/v1/subscriptions/tenant/${tenantId}`, {
-      params: { status, page, page_size: pageSize, environment },
-    });
-    return data;
+    return subscriptionsClient.list(tenantId, status, page, pageSize, environment);
   }
 
   async getPendingSubscriptions(
@@ -1172,51 +1160,39 @@ class ApiService {
     page = 1,
     pageSize = 20
   ): Promise<SubscriptionListResponse> {
-    const { data } = await httpClient.get(`/v1/subscriptions/tenant/${tenantId}/pending`, {
-      params: { page, page_size: pageSize },
-    });
-    return data;
+    return subscriptionsClient.listPending(tenantId, page, pageSize);
   }
 
   async getSubscriptionStats(tenantId: string): Promise<SubscriptionStats> {
-    const { data } = await httpClient.get(`/v1/subscriptions/tenant/${tenantId}/stats`);
-    return data;
+    return subscriptionsClient.getStats(tenantId);
   }
 
   async approveSubscription(id: string, expiresAt?: string): Promise<Subscription> {
-    const { data } = await httpClient.post(`/v1/subscriptions/${id}/approve`, {
-      expires_at: expiresAt || null,
-    });
-    return data;
+    return subscriptionsClient.approve(id, expiresAt);
   }
 
   async rejectSubscription(id: string, reason: string): Promise<Subscription> {
-    const { data } = await httpClient.post(`/v1/subscriptions/${id}/reject`, { reason });
-    return data;
+    return subscriptionsClient.reject(id, reason);
   }
 
   async bulkSubscriptionAction(
     payload: Schemas['BulkSubscriptionAction']
   ): Promise<Schemas['BulkActionResult']> {
-    const { data } = await httpClient.post('/v1/subscriptions/bulk', payload);
-    return data;
+    return subscriptionsClient.bulkAction(payload);
   }
 
   // ============ Webhook Management (CAB-1647) ============
 
   async getWebhooks(tenantId: string): Promise<WebhookListResponse> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/webhooks`);
-    return data;
+    return webhooksClient.list(tenantId);
   }
 
   async getWebhook(tenantId: string, webhookId: string): Promise<TenantWebhook> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/webhooks/${webhookId}`);
-    return data;
+    return webhooksClient.get(tenantId, webhookId);
   }
 
   async createWebhook(tenantId: string, payload: Schemas['WebhookCreate']): Promise<TenantWebhook> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/webhooks`, payload);
-    return data;
+    return webhooksClient.create(tenantId, payload);
   }
 
   async updateWebhook(
@@ -1224,22 +1200,15 @@ class ApiService {
     webhookId: string,
     payload: Schemas['WebhookUpdate']
   ): Promise<TenantWebhook> {
-    const { data } = await httpClient.patch(
-      `/v1/tenants/${tenantId}/webhooks/${webhookId}`,
-      payload
-    );
-    return data;
+    return webhooksClient.update(tenantId, webhookId, payload);
   }
 
   async deleteWebhook(tenantId: string, webhookId: string): Promise<void> {
-    await httpClient.delete(`/v1/tenants/${tenantId}/webhooks/${webhookId}`);
+    return webhooksClient.remove(tenantId, webhookId);
   }
 
   async testWebhook(tenantId: string, webhookId: string): Promise<Schemas['WebhookTestResponse']> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/webhooks/${webhookId}/test`, {
-      event_type: 'subscription.created',
-    });
-    return data;
+    return webhooksClient.test(tenantId, webhookId);
   }
 
   async getWebhookDeliveries(
@@ -1247,11 +1216,7 @@ class ApiService {
     webhookId: string,
     limit = 50
   ): Promise<WebhookDeliveryListResponse> {
-    const { data } = await httpClient.get(
-      `/v1/tenants/${tenantId}/webhooks/${webhookId}/deliveries`,
-      { params: { limit } }
-    );
-    return data;
+    return webhooksClient.listDeliveries(tenantId, webhookId, limit);
   }
 
   async retryWebhookDelivery(
@@ -1259,24 +1224,20 @@ class ApiService {
     webhookId: string,
     deliveryId: string
   ): Promise<void> {
-    await httpClient.post(
-      `/v1/tenants/${tenantId}/webhooks/${webhookId}/deliveries/${deliveryId}/retry`
-    );
+    return webhooksClient.retryDelivery(tenantId, webhookId, deliveryId);
   }
 
   // ============ Credential Mappings (CAB-1648) ============
 
   async getCredentialMappings(tenantId: string): Promise<CredentialMappingListResponse> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/credential-mappings`);
-    return data;
+    return credentialMappingsClient.list(tenantId);
   }
 
   async createCredentialMapping(
     tenantId: string,
     payload: Schemas['CredentialMappingCreate']
   ): Promise<CredentialMapping> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/credential-mappings`, payload);
-    return data;
+    return credentialMappingsClient.create(tenantId, payload);
   }
 
   async updateCredentialMapping(
@@ -1284,39 +1245,29 @@ class ApiService {
     mappingId: string,
     payload: Schemas['CredentialMappingUpdate']
   ): Promise<CredentialMapping> {
-    const { data } = await httpClient.put(
-      `/v1/tenants/${tenantId}/credential-mappings/${mappingId}`,
-      payload
-    );
-    return data;
+    return credentialMappingsClient.update(tenantId, mappingId, payload);
   }
 
   async deleteCredentialMapping(tenantId: string, mappingId: string): Promise<void> {
-    await httpClient.delete(`/v1/tenants/${tenantId}/credential-mappings/${mappingId}`);
+    return credentialMappingsClient.remove(tenantId, mappingId);
   }
 
   // ============ Contracts / UAC (CAB-1649) ============
 
   async getContracts(tenantId: string): Promise<ContractListResponse> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/contracts`);
-    return data;
+    return contractsClient.list(tenantId);
   }
 
   async getContract(tenantId: string, contractId: string): Promise<Contract> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/contracts/${contractId}`);
-    return data;
+    return contractsClient.get(tenantId, contractId);
   }
 
   async createContract(tenantId: string, payload: ContractCreate): Promise<Contract> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/contracts`, payload);
-    return data;
+    return contractsClient.create(tenantId, payload);
   }
 
   async publishContract(tenantId: string, contractId: string): Promise<PublishContractResponse> {
-    const { data } = await httpClient.post(
-      `/v1/tenants/${tenantId}/contracts/${contractId}/publish`
-    );
-    return data;
+    return contractsClient.publish(tenantId, contractId);
   }
 
   async updateContract(
@@ -1324,22 +1275,15 @@ class ApiService {
     contractId: string,
     payload: Schemas['ContractUpdate']
   ): Promise<Contract> {
-    const { data } = await httpClient.patch(
-      `/v1/tenants/${tenantId}/contracts/${contractId}`,
-      payload
-    );
-    return data;
+    return contractsClient.update(tenantId, contractId, payload);
   }
 
   async deleteContract(tenantId: string, contractId: string): Promise<void> {
-    await httpClient.delete(`/v1/tenants/${tenantId}/contracts/${contractId}`);
+    return contractsClient.remove(tenantId, contractId);
   }
 
   async getContractBindings(tenantId: string, contractId: string): Promise<ProtocolBinding[]> {
-    const { data } = await httpClient.get(
-      `/v1/tenants/${tenantId}/contracts/${contractId}/bindings`
-    );
-    return data;
+    return contractsClient.listBindings(tenantId, contractId);
   }
 
   async enableBinding(
@@ -1347,15 +1291,11 @@ class ApiService {
     contractId: string,
     protocol: string
   ): Promise<ProtocolBinding> {
-    const { data } = await httpClient.post(
-      `/v1/tenants/${tenantId}/contracts/${contractId}/bindings`,
-      { protocol }
-    );
-    return data;
+    return contractsClient.enableBinding(tenantId, contractId, protocol);
   }
 
   async disableBinding(tenantId: string, contractId: string, protocol: string): Promise<void> {
-    await httpClient.delete(`/v1/tenants/${tenantId}/contracts/${contractId}/bindings/${protocol}`);
+    return contractsClient.disableBinding(tenantId, contractId, protocol);
   }
 
   // ============ Monitoring / Call Flow (CAB-1869) ============

--- a/control-plane-ui/src/services/api/contracts.ts
+++ b/control-plane-ui/src/services/api/contracts.ts
@@ -1,0 +1,72 @@
+import { httpClient } from '../http';
+import type { Schemas } from '@stoa/shared/api-types';
+import type {
+  Contract,
+  ContractCreate,
+  ContractListResponse,
+  ProtocolBinding,
+  PublishContractResponse,
+} from '../../types';
+
+export const contractsClient = {
+  async list(tenantId: string): Promise<ContractListResponse> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/contracts`);
+    return data;
+  },
+
+  async get(tenantId: string, contractId: string): Promise<Contract> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/contracts/${contractId}`);
+    return data;
+  },
+
+  async create(tenantId: string, payload: ContractCreate): Promise<Contract> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/contracts`, payload);
+    return data;
+  },
+
+  async publish(tenantId: string, contractId: string): Promise<PublishContractResponse> {
+    const { data } = await httpClient.post(
+      `/v1/tenants/${tenantId}/contracts/${contractId}/publish`
+    );
+    return data;
+  },
+
+  async update(
+    tenantId: string,
+    contractId: string,
+    payload: Schemas['ContractUpdate']
+  ): Promise<Contract> {
+    const { data } = await httpClient.patch(
+      `/v1/tenants/${tenantId}/contracts/${contractId}`,
+      payload
+    );
+    return data;
+  },
+
+  async remove(tenantId: string, contractId: string): Promise<void> {
+    await httpClient.delete(`/v1/tenants/${tenantId}/contracts/${contractId}`);
+  },
+
+  async listBindings(tenantId: string, contractId: string): Promise<ProtocolBinding[]> {
+    const { data } = await httpClient.get(
+      `/v1/tenants/${tenantId}/contracts/${contractId}/bindings`
+    );
+    return data;
+  },
+
+  async enableBinding(
+    tenantId: string,
+    contractId: string,
+    protocol: string
+  ): Promise<ProtocolBinding> {
+    const { data } = await httpClient.post(
+      `/v1/tenants/${tenantId}/contracts/${contractId}/bindings`,
+      { protocol }
+    );
+    return data;
+  },
+
+  async disableBinding(tenantId: string, contractId: string, protocol: string): Promise<void> {
+    await httpClient.delete(`/v1/tenants/${tenantId}/contracts/${contractId}/bindings/${protocol}`);
+  },
+};

--- a/control-plane-ui/src/services/api/credentialMappings.ts
+++ b/control-plane-ui/src/services/api/credentialMappings.ts
@@ -1,0 +1,34 @@
+import { httpClient } from '../http';
+import type { Schemas } from '@stoa/shared/api-types';
+import type { CredentialMapping, CredentialMappingListResponse } from '../../types';
+
+export const credentialMappingsClient = {
+  async list(tenantId: string): Promise<CredentialMappingListResponse> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/credential-mappings`);
+    return data;
+  },
+
+  async create(
+    tenantId: string,
+    payload: Schemas['CredentialMappingCreate']
+  ): Promise<CredentialMapping> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/credential-mappings`, payload);
+    return data;
+  },
+
+  async update(
+    tenantId: string,
+    mappingId: string,
+    payload: Schemas['CredentialMappingUpdate']
+  ): Promise<CredentialMapping> {
+    const { data } = await httpClient.put(
+      `/v1/tenants/${tenantId}/credential-mappings/${mappingId}`,
+      payload
+    );
+    return data;
+  },
+
+  async remove(tenantId: string, mappingId: string): Promise<void> {
+    await httpClient.delete(`/v1/tenants/${tenantId}/credential-mappings/${mappingId}`);
+  },
+};

--- a/control-plane-ui/src/services/api/promotions.ts
+++ b/control-plane-ui/src/services/api/promotions.ts
@@ -1,0 +1,64 @@
+import { httpClient } from '../http';
+import type { Schemas } from '@stoa/shared/api-types';
+import type { Promotion, PromotionListResponse } from '../../types';
+
+export const promotionsClient = {
+  async list(
+    tenantId: string,
+    params?: {
+      api_id?: string;
+      status?: string;
+      target_environment?: string;
+      page?: number;
+      page_size?: number;
+    }
+  ): Promise<PromotionListResponse> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/promotions`, { params });
+    return data;
+  },
+
+  async get(tenantId: string, promotionId: string): Promise<Promotion> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/promotions/${promotionId}`);
+    return data;
+  },
+
+  async create(
+    tenantId: string,
+    apiId: string,
+    request: Schemas['PromotionCreate']
+  ): Promise<Promotion> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/promotions/${apiId}`, request);
+    return data;
+  },
+
+  async approve(tenantId: string, promotionId: string): Promise<Promotion> {
+    const { data } = await httpClient.post(
+      `/v1/tenants/${tenantId}/promotions/${promotionId}/approve`
+    );
+    return data;
+  },
+
+  async complete(tenantId: string, promotionId: string): Promise<Promotion> {
+    const { data } = await httpClient.post(
+      `/v1/tenants/${tenantId}/promotions/${promotionId}/complete`
+    );
+    return data;
+  },
+
+  async rollback(
+    tenantId: string,
+    promotionId: string,
+    request: Schemas['PromotionRollbackRequest']
+  ): Promise<Promotion> {
+    const { data } = await httpClient.post(
+      `/v1/tenants/${tenantId}/promotions/${promotionId}/rollback`,
+      request
+    );
+    return data;
+  },
+
+  async getDiff(tenantId: string, promotionId: string): Promise<Schemas['PromotionDiffResponse']> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/promotions/${promotionId}/diff`);
+    return data;
+  },
+};

--- a/control-plane-ui/src/services/api/subscriptions.ts
+++ b/control-plane-ui/src/services/api/subscriptions.ts
@@ -1,0 +1,49 @@
+import { httpClient } from '../http';
+import type { Schemas } from '@stoa/shared/api-types';
+import type { Subscription, SubscriptionListResponse, SubscriptionStats } from '../../types';
+
+export const subscriptionsClient = {
+  async list(
+    tenantId: string,
+    status?: string,
+    page = 1,
+    pageSize = 20,
+    environment?: string
+  ): Promise<SubscriptionListResponse> {
+    const { data } = await httpClient.get(`/v1/subscriptions/tenant/${tenantId}`, {
+      params: { status, page, page_size: pageSize, environment },
+    });
+    return data;
+  },
+
+  async listPending(tenantId: string, page = 1, pageSize = 20): Promise<SubscriptionListResponse> {
+    const { data } = await httpClient.get(`/v1/subscriptions/tenant/${tenantId}/pending`, {
+      params: { page, page_size: pageSize },
+    });
+    return data;
+  },
+
+  async getStats(tenantId: string): Promise<SubscriptionStats> {
+    const { data } = await httpClient.get(`/v1/subscriptions/tenant/${tenantId}/stats`);
+    return data;
+  },
+
+  async approve(id: string, expiresAt?: string): Promise<Subscription> {
+    const { data } = await httpClient.post(`/v1/subscriptions/${id}/approve`, {
+      expires_at: expiresAt || null,
+    });
+    return data;
+  },
+
+  async reject(id: string, reason: string): Promise<Subscription> {
+    const { data } = await httpClient.post(`/v1/subscriptions/${id}/reject`, { reason });
+    return data;
+  },
+
+  async bulkAction(
+    payload: Schemas['BulkSubscriptionAction']
+  ): Promise<Schemas['BulkActionResult']> {
+    const { data } = await httpClient.post('/v1/subscriptions/bulk', payload);
+    return data;
+  },
+};

--- a/control-plane-ui/src/services/api/webhooks.ts
+++ b/control-plane-ui/src/services/api/webhooks.ts
@@ -1,0 +1,61 @@
+import { httpClient } from '../http';
+import type { Schemas } from '@stoa/shared/api-types';
+import type { TenantWebhook, WebhookListResponse, WebhookDeliveryListResponse } from '../../types';
+
+export const webhooksClient = {
+  async list(tenantId: string): Promise<WebhookListResponse> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/webhooks`);
+    return data;
+  },
+
+  async get(tenantId: string, webhookId: string): Promise<TenantWebhook> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/webhooks/${webhookId}`);
+    return data;
+  },
+
+  async create(tenantId: string, payload: Schemas['WebhookCreate']): Promise<TenantWebhook> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/webhooks`, payload);
+    return data;
+  },
+
+  async update(
+    tenantId: string,
+    webhookId: string,
+    payload: Schemas['WebhookUpdate']
+  ): Promise<TenantWebhook> {
+    const { data } = await httpClient.patch(
+      `/v1/tenants/${tenantId}/webhooks/${webhookId}`,
+      payload
+    );
+    return data;
+  },
+
+  async remove(tenantId: string, webhookId: string): Promise<void> {
+    await httpClient.delete(`/v1/tenants/${tenantId}/webhooks/${webhookId}`);
+  },
+
+  async test(tenantId: string, webhookId: string): Promise<Schemas['WebhookTestResponse']> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/webhooks/${webhookId}/test`, {
+      event_type: 'subscription.created',
+    });
+    return data;
+  },
+
+  async listDeliveries(
+    tenantId: string,
+    webhookId: string,
+    limit = 50
+  ): Promise<WebhookDeliveryListResponse> {
+    const { data } = await httpClient.get(
+      `/v1/tenants/${tenantId}/webhooks/${webhookId}/deliveries`,
+      { params: { limit } }
+    );
+    return data;
+  },
+
+  async retryDelivery(tenantId: string, webhookId: string, deliveryId: string): Promise<void> {
+    await httpClient.post(
+      `/v1/tenants/${tenantId}/webhooks/${webhookId}/deliveries/${deliveryId}/retry`
+    );
+  },
+};

--- a/control-plane-ui/src/test/services/api/ui2-s2b-clients.test.ts
+++ b/control-plane-ui/src/test/services/api/ui2-s2b-clients.test.ts
@@ -41,9 +41,9 @@ describe('UI-2 S2b domain clients', () => {
       .mockResolvedValueOnce({ data: subscription })
       .mockResolvedValueOnce({ data: bulkResult });
 
-    await expect(
-      subscriptionsClient.list('tenant-1', 'approved', 2, 50, 'prod')
-    ).resolves.toBe(list);
+    await expect(subscriptionsClient.list('tenant-1', 'approved', 2, 50, 'prod')).resolves.toBe(
+      list
+    );
     await expect(subscriptionsClient.listPending('tenant-1', 3, 25)).resolves.toBe(pending);
     await expect(subscriptionsClient.getStats('tenant-1')).resolves.toBe(stats);
     await expect(subscriptionsClient.approve('sub-1', '2026-04-30')).resolves.toBe(subscription);
@@ -125,10 +125,7 @@ describe('UI-2 S2b domain clients', () => {
     ).resolves.toBeUndefined();
 
     expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/webhooks');
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
-      2,
-      '/v1/tenants/tenant-1/webhooks/wh-1'
-    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/tenants/tenant-1/webhooks/wh-1');
     expect(mockHttpClient.post).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/webhooks', {
       name: 'Ops',
       url: 'https://example.com/hook',
@@ -182,13 +179,10 @@ describe('UI-2 S2b domain clients', () => {
     await expect(credentialMappingsClient.remove('tenant-1', 'map-1')).resolves.toBeUndefined();
 
     expect(mockHttpClient.get).toHaveBeenCalledWith('/v1/tenants/tenant-1/credential-mappings');
-    expect(mockHttpClient.post).toHaveBeenCalledWith(
-      '/v1/tenants/tenant-1/credential-mappings',
-      {
-        provider: 'vault',
-        remote_key: 'secret/data/foo',
-      }
-    );
+    expect(mockHttpClient.post).toHaveBeenCalledWith('/v1/tenants/tenant-1/credential-mappings', {
+      provider: 'vault',
+      remote_key: 'secret/data/foo',
+    });
     expect(mockHttpClient.put).toHaveBeenCalledWith(
       '/v1/tenants/tenant-1/credential-mappings/map-1',
       {
@@ -240,10 +234,7 @@ describe('UI-2 S2b domain clients', () => {
     ).resolves.toBeUndefined();
 
     expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/contracts');
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
-      2,
-      '/v1/tenants/tenant-1/contracts/ct-1'
-    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/tenants/tenant-1/contracts/ct-1');
     expect(mockHttpClient.post).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/contracts', {
       name: 'Payments',
       version: '1.0.0',
@@ -255,10 +246,7 @@ describe('UI-2 S2b domain clients', () => {
     expect(mockHttpClient.patch).toHaveBeenCalledWith('/v1/tenants/tenant-1/contracts/ct-1', {
       description: 'Updated',
     });
-    expect(mockHttpClient.delete).toHaveBeenNthCalledWith(
-      1,
-      '/v1/tenants/tenant-1/contracts/ct-1'
-    );
+    expect(mockHttpClient.delete).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/contracts/ct-1');
     expect(mockHttpClient.get).toHaveBeenNthCalledWith(
       3,
       '/v1/tenants/tenant-1/contracts/ct-1/bindings'

--- a/control-plane-ui/src/test/services/api/ui2-s2b-clients.test.ts
+++ b/control-plane-ui/src/test/services/api/ui2-s2b-clients.test.ts
@@ -1,0 +1,340 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockHttpClient } = vi.hoisted(() => ({
+  mockHttpClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../../../services/http', () => ({
+  httpClient: mockHttpClient,
+}));
+
+import { subscriptionsClient } from '../../../services/api/subscriptions';
+import { webhooksClient } from '../../../services/api/webhooks';
+import { credentialMappingsClient } from '../../../services/api/credentialMappings';
+import { contractsClient } from '../../../services/api/contracts';
+import { promotionsClient } from '../../../services/api/promotions';
+
+describe('UI-2 S2b domain clients', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('covers subscriptionsClient request delegation', async () => {
+    const list = { items: [] };
+    const pending = { items: [] };
+    const stats = { active: 1 };
+    const subscription = { id: 'sub-1' };
+    const bulkResult = { success_count: 1, failure_count: 0 };
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: list })
+      .mockResolvedValueOnce({ data: pending })
+      .mockResolvedValueOnce({ data: stats });
+    mockHttpClient.post
+      .mockResolvedValueOnce({ data: subscription })
+      .mockResolvedValueOnce({ data: subscription })
+      .mockResolvedValueOnce({ data: bulkResult });
+
+    await expect(
+      subscriptionsClient.list('tenant-1', 'approved', 2, 50, 'prod')
+    ).resolves.toBe(list);
+    await expect(subscriptionsClient.listPending('tenant-1', 3, 25)).resolves.toBe(pending);
+    await expect(subscriptionsClient.getStats('tenant-1')).resolves.toBe(stats);
+    await expect(subscriptionsClient.approve('sub-1', '2026-04-30')).resolves.toBe(subscription);
+    await expect(subscriptionsClient.reject('sub-1', 'missing docs')).resolves.toBe(subscription);
+    await expect(
+      subscriptionsClient.bulkAction({
+        subscription_ids: ['sub-1'],
+        action: 'approve',
+      })
+    ).resolves.toBe(bulkResult);
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/subscriptions/tenant/tenant-1', {
+      params: {
+        status: 'approved',
+        page: 2,
+        page_size: 50,
+        environment: 'prod',
+      },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      2,
+      '/v1/subscriptions/tenant/tenant-1/pending',
+      {
+        params: { page: 3, page_size: 25 },
+      }
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      3,
+      '/v1/subscriptions/tenant/tenant-1/stats'
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(1, '/v1/subscriptions/sub-1/approve', {
+      expires_at: '2026-04-30',
+    });
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(2, '/v1/subscriptions/sub-1/reject', {
+      reason: 'missing docs',
+    });
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(3, '/v1/subscriptions/bulk', {
+      subscription_ids: ['sub-1'],
+      action: 'approve',
+    });
+  });
+
+  it('covers webhooksClient request delegation', async () => {
+    const webhookList = { items: [] };
+    const webhook = { id: 'wh-1' };
+    const testResponse = { delivered: true };
+    const deliveries = { items: [] };
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: webhookList })
+      .mockResolvedValueOnce({ data: webhook })
+      .mockResolvedValueOnce({ data: deliveries });
+    mockHttpClient.post
+      .mockResolvedValueOnce({ data: webhook })
+      .mockResolvedValueOnce({ data: testResponse })
+      .mockResolvedValueOnce({});
+    mockHttpClient.patch.mockResolvedValueOnce({ data: webhook });
+    mockHttpClient.delete.mockResolvedValueOnce({});
+
+    await expect(webhooksClient.list('tenant-1')).resolves.toBe(webhookList);
+    await expect(webhooksClient.get('tenant-1', 'wh-1')).resolves.toBe(webhook);
+    await expect(
+      webhooksClient.create('tenant-1', {
+        name: 'Ops',
+        url: 'https://example.com/hook',
+        events: ['subscription.created'],
+      })
+    ).resolves.toBe(webhook);
+    await expect(
+      webhooksClient.update('tenant-1', 'wh-1', {
+        name: 'Ops v2',
+      })
+    ).resolves.toBe(webhook);
+    await expect(webhooksClient.remove('tenant-1', 'wh-1')).resolves.toBeUndefined();
+    await expect(webhooksClient.test('tenant-1', 'wh-1')).resolves.toBe(testResponse);
+    await expect(webhooksClient.listDeliveries('tenant-1', 'wh-1', 15)).resolves.toBe(deliveries);
+    await expect(
+      webhooksClient.retryDelivery('tenant-1', 'wh-1', 'delivery-1')
+    ).resolves.toBeUndefined();
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/webhooks');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/webhooks/wh-1'
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/webhooks', {
+      name: 'Ops',
+      url: 'https://example.com/hook',
+      events: ['subscription.created'],
+    });
+    expect(mockHttpClient.patch).toHaveBeenCalledWith('/v1/tenants/tenant-1/webhooks/wh-1', {
+      name: 'Ops v2',
+    });
+    expect(mockHttpClient.delete).toHaveBeenCalledWith('/v1/tenants/tenant-1/webhooks/wh-1');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/webhooks/wh-1/test',
+      {
+        event_type: 'subscription.created',
+      }
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      3,
+      '/v1/tenants/tenant-1/webhooks/wh-1/deliveries',
+      {
+        params: { limit: 15 },
+      }
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      3,
+      '/v1/tenants/tenant-1/webhooks/wh-1/deliveries/delivery-1/retry'
+    );
+  });
+
+  it('covers credentialMappingsClient request delegation', async () => {
+    const list = { items: [] };
+    const mapping = { id: 'map-1' };
+
+    mockHttpClient.get.mockResolvedValueOnce({ data: list });
+    mockHttpClient.post.mockResolvedValueOnce({ data: mapping });
+    mockHttpClient.put.mockResolvedValueOnce({ data: mapping });
+    mockHttpClient.delete.mockResolvedValueOnce({});
+
+    await expect(credentialMappingsClient.list('tenant-1')).resolves.toBe(list);
+    await expect(
+      credentialMappingsClient.create('tenant-1', {
+        provider: 'vault',
+        remote_key: 'secret/data/foo',
+      })
+    ).resolves.toBe(mapping);
+    await expect(
+      credentialMappingsClient.update('tenant-1', 'map-1', {
+        remote_key: 'secret/data/bar',
+      })
+    ).resolves.toBe(mapping);
+    await expect(credentialMappingsClient.remove('tenant-1', 'map-1')).resolves.toBeUndefined();
+
+    expect(mockHttpClient.get).toHaveBeenCalledWith('/v1/tenants/tenant-1/credential-mappings');
+    expect(mockHttpClient.post).toHaveBeenCalledWith(
+      '/v1/tenants/tenant-1/credential-mappings',
+      {
+        provider: 'vault',
+        remote_key: 'secret/data/foo',
+      }
+    );
+    expect(mockHttpClient.put).toHaveBeenCalledWith(
+      '/v1/tenants/tenant-1/credential-mappings/map-1',
+      {
+        remote_key: 'secret/data/bar',
+      }
+    );
+    expect(mockHttpClient.delete).toHaveBeenCalledWith(
+      '/v1/tenants/tenant-1/credential-mappings/map-1'
+    );
+  });
+
+  it('covers contractsClient request delegation', async () => {
+    const list = { items: [] };
+    const contract = { id: 'ct-1' };
+    const publishResponse = { artifact_url: 'https://example.com/uac.json' };
+    const bindings = [{ protocol: 'mcp' }];
+    const binding = { protocol: 'mcp' };
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: list })
+      .mockResolvedValueOnce({ data: contract })
+      .mockResolvedValueOnce({ data: bindings });
+    mockHttpClient.post
+      .mockResolvedValueOnce({ data: contract })
+      .mockResolvedValueOnce({ data: publishResponse })
+      .mockResolvedValueOnce({ data: binding });
+    mockHttpClient.patch.mockResolvedValueOnce({ data: contract });
+    mockHttpClient.delete.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+
+    await expect(contractsClient.list('tenant-1')).resolves.toBe(list);
+    await expect(contractsClient.get('tenant-1', 'ct-1')).resolves.toBe(contract);
+    await expect(
+      contractsClient.create('tenant-1', {
+        name: 'Payments',
+        version: '1.0.0',
+      })
+    ).resolves.toBe(contract);
+    await expect(contractsClient.publish('tenant-1', 'ct-1')).resolves.toBe(publishResponse);
+    await expect(
+      contractsClient.update('tenant-1', 'ct-1', {
+        description: 'Updated',
+      })
+    ).resolves.toBe(contract);
+    await expect(contractsClient.remove('tenant-1', 'ct-1')).resolves.toBeUndefined();
+    await expect(contractsClient.listBindings('tenant-1', 'ct-1')).resolves.toBe(bindings);
+    await expect(contractsClient.enableBinding('tenant-1', 'ct-1', 'mcp')).resolves.toBe(binding);
+    await expect(
+      contractsClient.disableBinding('tenant-1', 'ct-1', 'mcp')
+    ).resolves.toBeUndefined();
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/contracts');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/contracts/ct-1'
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/contracts', {
+      name: 'Payments',
+      version: '1.0.0',
+    });
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/contracts/ct-1/publish'
+    );
+    expect(mockHttpClient.patch).toHaveBeenCalledWith('/v1/tenants/tenant-1/contracts/ct-1', {
+      description: 'Updated',
+    });
+    expect(mockHttpClient.delete).toHaveBeenNthCalledWith(
+      1,
+      '/v1/tenants/tenant-1/contracts/ct-1'
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      3,
+      '/v1/tenants/tenant-1/contracts/ct-1/bindings'
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      3,
+      '/v1/tenants/tenant-1/contracts/ct-1/bindings',
+      { protocol: 'mcp' }
+    );
+    expect(mockHttpClient.delete).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/contracts/ct-1/bindings/mcp'
+    );
+  });
+
+  it('covers promotionsClient request delegation', async () => {
+    const list = { items: [] };
+    const promotion = { id: 'promo-1' };
+    const diff = { resources: [] };
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: list })
+      .mockResolvedValueOnce({ data: promotion })
+      .mockResolvedValueOnce({ data: diff });
+    mockHttpClient.post
+      .mockResolvedValueOnce({ data: promotion })
+      .mockResolvedValueOnce({ data: promotion })
+      .mockResolvedValueOnce({ data: promotion })
+      .mockResolvedValueOnce({ data: promotion });
+
+    await expect(
+      promotionsClient.list('tenant-1', { api_id: 'api-1', status: 'pending' })
+    ).resolves.toBe(list);
+    await expect(promotionsClient.get('tenant-1', 'promo-1')).resolves.toBe(promotion);
+    await expect(
+      promotionsClient.create('tenant-1', 'api-1', {
+        target_environment: 'prod',
+      })
+    ).resolves.toBe(promotion);
+    await expect(promotionsClient.approve('tenant-1', 'promo-1')).resolves.toBe(promotion);
+    await expect(promotionsClient.complete('tenant-1', 'promo-1')).resolves.toBe(promotion);
+    await expect(
+      promotionsClient.rollback('tenant-1', 'promo-1', { reason: 'rollback' })
+    ).resolves.toBe(promotion);
+    await expect(promotionsClient.getDiff('tenant-1', 'promo-1')).resolves.toBe(diff);
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/promotions', {
+      params: { api_id: 'api-1', status: 'pending' },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/promotions/promo-1'
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      1,
+      '/v1/tenants/tenant-1/promotions/api-1',
+      {
+        target_environment: 'prod',
+      }
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/promotions/promo-1/approve'
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      3,
+      '/v1/tenants/tenant-1/promotions/promo-1/complete'
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      4,
+      '/v1/tenants/tenant-1/promotions/promo-1/rollback',
+      { reason: 'rollback' }
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      3,
+      '/v1/tenants/tenant-1/promotions/promo-1/diff'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Part 3/8 of UI-2 axios split. Extracts 5 additional domain clients into `services/<domain>/`.

**Stack base**: S2a (part of #2481 chain).

## Size

+319/-99 across 6 files. Slightly above 300 cap (pure mechanical moves, no logic).

## Test plan

- [x] `npm run typecheck` green
- [x] `npm run lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)