### PR TITLE
refactor(ui): extract tenants/apis/applications/consumers (UI-2 S2c)

### DIFF
--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -73,6 +73,10 @@ import { webhooksClient } from './api/webhooks';
 import { credentialMappingsClient } from './api/credentialMappings';
 import { contractsClient } from './api/contracts';
 import { promotionsClient } from './api/promotions';
+import { tenantsClient } from './api/tenants';
+import { apisClient } from './api/apis';
+import { applicationsClient } from './api/applications';
+import { consumersClient } from './api/consumers';
 
 // =============================================================================
 // Façade ApiService — agrège le core transport (services/http) et les méthodes
@@ -138,27 +142,23 @@ class ApiService {
 
   // Tenants
   async getTenants(): Promise<Tenant[]> {
-    const { data } = await httpClient.get('/v1/tenants');
-    return data;
+    return tenantsClient.list();
   }
 
   async getTenant(tenantId: string): Promise<Tenant> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}`);
-    return data;
+    return tenantsClient.get(tenantId);
   }
 
   async createTenant(tenant: TenantCreate): Promise<Tenant> {
-    const { data } = await httpClient.post('/v1/tenants', tenant);
-    return data;
+    return tenantsClient.create(tenant);
   }
 
   async updateTenant(tenantId: string, tenant: Partial<TenantCreate>): Promise<Tenant> {
-    const { data } = await httpClient.put(`/v1/tenants/${tenantId}`, tenant);
-    return data;
+    return tenantsClient.update(tenantId, tenant);
   }
 
   async deleteTenant(tenantId: string): Promise<void> {
-    await httpClient.delete(`/v1/tenants/${tenantId}`);
+    return tenantsClient.remove(tenantId);
   }
 
   // Environments (ADR-040)
@@ -168,36 +168,27 @@ class ApiService {
 
   // APIs
   async getApis(tenantId: string, environment?: Environment): Promise<API[]> {
-    const params: Record<string, unknown> = { page: 1, page_size: 100 };
-    if (environment) params.environment = environment;
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/apis`, { params });
-    return data.items ?? data;
+    return apisClient.list(tenantId, environment);
   }
 
   async getAdminApis(page = 1, pageSize = 100): Promise<API[]> {
-    const { data } = await httpClient.get('/v1/admin/catalog/apis', {
-      params: { page, page_size: pageSize },
-    });
-    return data.items ?? data;
+    return apisClient.listAdmin(page, pageSize);
   }
 
   async getApi(tenantId: string, apiId: string): Promise<API> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/apis/${apiId}`);
-    return data;
+    return apisClient.get(tenantId, apiId);
   }
 
   async createApi(tenantId: string, api: APICreate): Promise<API> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/apis`, api);
-    return data;
+    return apisClient.create(tenantId, api);
   }
 
   async updateApi(tenantId: string, apiId: string, api: Partial<APICreate>): Promise<API> {
-    const { data } = await httpClient.put(`/v1/tenants/${tenantId}/apis/${apiId}`, api);
-    return data;
+    return apisClient.update(tenantId, apiId, api);
   }
 
   async deleteApi(tenantId: string, apiId: string): Promise<void> {
-    await httpClient.delete(`/v1/tenants/${tenantId}/apis/${apiId}`);
+    return apisClient.remove(tenantId, apiId);
   }
 
   async getApiVersions(
@@ -205,10 +196,7 @@ class ApiService {
     apiId: string,
     limit = 20
   ): Promise<Schemas['APIVersionEntry'][]> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/apis/${apiId}/versions`, {
-      params: { limit },
-    });
-    return data;
+    return apisClient.listVersions(tenantId, apiId, limit);
   }
 
   async updateApiAudience(
@@ -216,32 +204,24 @@ class ApiService {
     apiId: string,
     audience: string
   ): Promise<{ api_id: string; tenant_id: string; audience: string; updated_by: string }> {
-    const { data } = await httpClient.patch(`/v1/admin/catalog/${tenantId}/${apiId}/audience`, {
-      audience,
-    });
-    return data;
+    return apisClient.updateAudience(tenantId, apiId, audience);
   }
 
   async triggerCatalogSync(tenantId: string): Promise<void> {
-    await httpClient.post(`/v1/admin/catalog/sync/tenant/${tenantId}`);
+    return apisClient.triggerCatalogSync(tenantId);
   }
 
   // Applications
   async getApplications(tenantId: string): Promise<Application[]> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/applications`, {
-      params: { page: 1, page_size: 100 },
-    });
-    return data.items ?? data;
+    return applicationsClient.list(tenantId);
   }
 
   async getApplication(tenantId: string, appId: string): Promise<Application> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/applications/${appId}`);
-    return data;
+    return applicationsClient.get(tenantId, appId);
   }
 
   async createApplication(tenantId: string, app: ApplicationCreate): Promise<Application> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/applications`, app);
-    return data;
+    return applicationsClient.create(tenantId, app);
   }
 
   async updateApplication(
@@ -249,39 +229,32 @@ class ApiService {
     appId: string,
     app: Partial<ApplicationCreate>
   ): Promise<Application> {
-    const { data } = await httpClient.put(`/v1/tenants/${tenantId}/applications/${appId}`, app);
-    return data;
+    return applicationsClient.update(tenantId, appId, app);
   }
 
   async deleteApplication(tenantId: string, appId: string): Promise<void> {
-    await httpClient.delete(`/v1/tenants/${tenantId}/applications/${appId}`);
+    return applicationsClient.remove(tenantId, appId);
   }
 
   // Consumers (CAB-864 — mTLS Self-Service)
   async getConsumers(tenantId: string, environment?: string): Promise<Consumer[]> {
-    const { data } = await httpClient.get(`/v1/consumers/${tenantId}`, {
-      params: { page: 1, page_size: 100, environment },
-    });
-    return data.items ?? data;
+    return consumersClient.list(tenantId, environment);
   }
 
   async getConsumer(tenantId: string, consumerId: string): Promise<Consumer> {
-    const { data } = await httpClient.get(`/v1/consumers/${tenantId}/${consumerId}`);
-    return data;
+    return consumersClient.get(tenantId, consumerId);
   }
 
   async suspendConsumer(tenantId: string, consumerId: string): Promise<Consumer> {
-    const { data } = await httpClient.post(`/v1/consumers/${tenantId}/${consumerId}/suspend`);
-    return data;
+    return consumersClient.suspend(tenantId, consumerId);
   }
 
   async activateConsumer(tenantId: string, consumerId: string): Promise<Consumer> {
-    const { data } = await httpClient.post(`/v1/consumers/${tenantId}/${consumerId}/activate`);
-    return data;
+    return consumersClient.activate(tenantId, consumerId);
   }
 
   async deleteConsumer(tenantId: string, consumerId: string): Promise<void> {
-    await httpClient.delete(`/v1/consumers/${tenantId}/${consumerId}`);
+    return consumersClient.remove(tenantId, consumerId);
   }
 
   async rotateCertificate(
@@ -290,23 +263,20 @@ class ApiService {
     certificatePem: string,
     gracePeriodHours: number = 24
   ): Promise<Consumer> {
-    const { data } = await httpClient.post(
-      `/v1/consumers/${tenantId}/${consumerId}/certificate/rotate`,
-      { certificate_pem: certificatePem, grace_period_hours: gracePeriodHours }
+    return consumersClient.rotateCertificate(
+      tenantId,
+      consumerId,
+      certificatePem,
+      gracePeriodHours
     );
-    return data;
   }
 
   async revokeCertificate(tenantId: string, consumerId: string): Promise<Consumer> {
-    const { data } = await httpClient.post(
-      `/v1/consumers/${tenantId}/${consumerId}/certificate/revoke`
-    );
-    return data;
+    return consumersClient.revokeCertificate(tenantId, consumerId);
   }
 
   async blockConsumer(tenantId: string, consumerId: string): Promise<Consumer> {
-    const { data } = await httpClient.post(`/v1/consumers/${tenantId}/${consumerId}/block`);
-    return data;
+    return consumersClient.block(tenantId, consumerId);
   }
 
   // Certificate Lifecycle (CAB-872)
@@ -315,41 +285,30 @@ class ApiService {
     consumerId: string,
     certificatePem: string
   ): Promise<Consumer> {
-    const { data } = await httpClient.post(`/v1/consumers/${tenantId}/${consumerId}/certificate`, {
-      certificate_pem: certificatePem,
-    });
-    return data;
+    return consumersClient.bindCertificate(tenantId, consumerId, certificatePem);
   }
 
   async getExpiringCertificates(
     tenantId: string,
     days: number = 30
   ): Promise<Schemas['CertificateExpiryResponse']> {
-    const { data } = await httpClient.get(`/v1/consumers/${tenantId}/certificates/expiring`, {
-      params: { days },
-    });
-    return data;
+    return consumersClient.getExpiringCertificates(tenantId, days);
   }
 
   async bulkRevokeCertificates(
     tenantId: string,
     consumerIds: string[]
   ): Promise<Schemas['BulkRevokeResponse']> {
-    const { data } = await httpClient.post(`/v1/consumers/${tenantId}/certificates/bulk-revoke`, {
-      consumer_ids: consumerIds,
-    });
-    return data;
+    return consumersClient.bulkRevokeCertificates(tenantId, consumerIds);
   }
 
   // Tenant CA (CAB-1787/1788 — per-tenant CA management)
   async getTenantCA(tenantId: string): Promise<TenantCAInfo> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/ca`);
-    return data;
+    return tenantsClient.getCA(tenantId);
   }
 
   async generateTenantCA(tenantId: string): Promise<TenantCAInfo> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/ca/generate`);
-    return data;
+    return tenantsClient.generateCA(tenantId);
   }
 
   async signCSR(
@@ -357,29 +316,22 @@ class ApiService {
     csrPem: string,
     validityDays: number = 365
   ): Promise<Schemas['CSRSignResponse']> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/ca/sign`, {
-      csr_pem: csrPem,
-      validity_days: validityDays,
-    });
-    return data;
+    return tenantsClient.signCSR(tenantId, csrPem, validityDays);
   }
 
   async revokeTenantCA(tenantId: string): Promise<void> {
-    await httpClient.delete(`/v1/tenants/${tenantId}/ca`);
+    return tenantsClient.revokeCA(tenantId);
   }
 
   async listIssuedCertificates(
     tenantId: string,
     status?: string
   ): Promise<IssuedCertificateListResponse> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/ca/certificates`, {
-      params: status ? { status } : undefined,
-    });
-    return data;
+    return tenantsClient.listIssuedCertificates(tenantId, status);
   }
 
   async revokeIssuedCertificate(tenantId: string, certId: string): Promise<void> {
-    await httpClient.post(`/v1/tenants/${tenantId}/ca/certificates/${certId}/revoke`);
+    return tenantsClient.revokeIssuedCertificate(tenantId, certId);
   }
 
   // Deployments (CAB-1353 lifecycle API)

--- a/control-plane-ui/src/services/api/apis.ts
+++ b/control-plane-ui/src/services/api/apis.ts
@@ -1,0 +1,64 @@
+import { httpClient } from '../http';
+import type { Schemas } from '@stoa/shared/api-types';
+import type { API, APICreate, Environment } from '../../types';
+
+export const apisClient = {
+  async list(tenantId: string, environment?: Environment): Promise<API[]> {
+    const params: Record<string, unknown> = { page: 1, page_size: 100 };
+    if (environment) params.environment = environment;
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/apis`, { params });
+    return data.items ?? data;
+  },
+
+  async listAdmin(page = 1, pageSize = 100): Promise<API[]> {
+    const { data } = await httpClient.get('/v1/admin/catalog/apis', {
+      params: { page, page_size: pageSize },
+    });
+    return data.items ?? data;
+  },
+
+  async get(tenantId: string, apiId: string): Promise<API> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/apis/${apiId}`);
+    return data;
+  },
+
+  async create(tenantId: string, api: APICreate): Promise<API> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/apis`, api);
+    return data;
+  },
+
+  async update(tenantId: string, apiId: string, api: Partial<APICreate>): Promise<API> {
+    const { data } = await httpClient.put(`/v1/tenants/${tenantId}/apis/${apiId}`, api);
+    return data;
+  },
+
+  async remove(tenantId: string, apiId: string): Promise<void> {
+    await httpClient.delete(`/v1/tenants/${tenantId}/apis/${apiId}`);
+  },
+
+  async listVersions(
+    tenantId: string,
+    apiId: string,
+    limit = 20
+  ): Promise<Schemas['APIVersionEntry'][]> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/apis/${apiId}/versions`, {
+      params: { limit },
+    });
+    return data;
+  },
+
+  async updateAudience(
+    tenantId: string,
+    apiId: string,
+    audience: string
+  ): Promise<{ api_id: string; tenant_id: string; audience: string; updated_by: string }> {
+    const { data } = await httpClient.patch(`/v1/admin/catalog/${tenantId}/${apiId}/audience`, {
+      audience,
+    });
+    return data;
+  },
+
+  async triggerCatalogSync(tenantId: string): Promise<void> {
+    await httpClient.post(`/v1/admin/catalog/sync/tenant/${tenantId}`);
+  },
+};

--- a/control-plane-ui/src/services/api/applications.ts
+++ b/control-plane-ui/src/services/api/applications.ts
@@ -1,0 +1,34 @@
+import { httpClient } from '../http';
+import type { Application, ApplicationCreate } from '../../types';
+
+export const applicationsClient = {
+  async list(tenantId: string): Promise<Application[]> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/applications`, {
+      params: { page: 1, page_size: 100 },
+    });
+    return data.items ?? data;
+  },
+
+  async get(tenantId: string, appId: string): Promise<Application> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/applications/${appId}`);
+    return data;
+  },
+
+  async create(tenantId: string, app: ApplicationCreate): Promise<Application> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/applications`, app);
+    return data;
+  },
+
+  async update(
+    tenantId: string,
+    appId: string,
+    patch: Partial<ApplicationCreate>
+  ): Promise<Application> {
+    const { data } = await httpClient.put(`/v1/tenants/${tenantId}/applications/${appId}`, patch);
+    return data;
+  },
+
+  async remove(tenantId: string, appId: string): Promise<void> {
+    await httpClient.delete(`/v1/tenants/${tenantId}/applications/${appId}`);
+  },
+};

--- a/control-plane-ui/src/services/api/consumers.ts
+++ b/control-plane-ui/src/services/api/consumers.ts
@@ -1,0 +1,88 @@
+import { httpClient } from '../http';
+import type { Schemas } from '@stoa/shared/api-types';
+import type { Consumer } from '../../types';
+
+export const consumersClient = {
+  async list(tenantId: string, environment?: string): Promise<Consumer[]> {
+    const { data } = await httpClient.get(`/v1/consumers/${tenantId}`, {
+      params: { page: 1, page_size: 100, environment },
+    });
+    return data.items ?? data;
+  },
+
+  async get(tenantId: string, consumerId: string): Promise<Consumer> {
+    const { data } = await httpClient.get(`/v1/consumers/${tenantId}/${consumerId}`);
+    return data;
+  },
+
+  async suspend(tenantId: string, consumerId: string): Promise<Consumer> {
+    const { data } = await httpClient.post(`/v1/consumers/${tenantId}/${consumerId}/suspend`);
+    return data;
+  },
+
+  async activate(tenantId: string, consumerId: string): Promise<Consumer> {
+    const { data } = await httpClient.post(`/v1/consumers/${tenantId}/${consumerId}/activate`);
+    return data;
+  },
+
+  async remove(tenantId: string, consumerId: string): Promise<void> {
+    await httpClient.delete(`/v1/consumers/${tenantId}/${consumerId}`);
+  },
+
+  async rotateCertificate(
+    tenantId: string,
+    consumerId: string,
+    certificatePem: string,
+    gracePeriodHours: number = 24
+  ): Promise<Consumer> {
+    const { data } = await httpClient.post(
+      `/v1/consumers/${tenantId}/${consumerId}/certificate/rotate`,
+      { certificate_pem: certificatePem, grace_period_hours: gracePeriodHours }
+    );
+    return data;
+  },
+
+  async revokeCertificate(tenantId: string, consumerId: string): Promise<Consumer> {
+    const { data } = await httpClient.post(
+      `/v1/consumers/${tenantId}/${consumerId}/certificate/revoke`
+    );
+    return data;
+  },
+
+  async block(tenantId: string, consumerId: string): Promise<Consumer> {
+    const { data } = await httpClient.post(`/v1/consumers/${tenantId}/${consumerId}/block`);
+    return data;
+  },
+
+  // Certificate Lifecycle (CAB-872)
+  async bindCertificate(
+    tenantId: string,
+    consumerId: string,
+    certificatePem: string
+  ): Promise<Consumer> {
+    const { data } = await httpClient.post(`/v1/consumers/${tenantId}/${consumerId}/certificate`, {
+      certificate_pem: certificatePem,
+    });
+    return data;
+  },
+
+  async getExpiringCertificates(
+    tenantId: string,
+    days: number = 30
+  ): Promise<Schemas['CertificateExpiryResponse']> {
+    const { data } = await httpClient.get(`/v1/consumers/${tenantId}/certificates/expiring`, {
+      params: { days },
+    });
+    return data;
+  },
+
+  async bulkRevokeCertificates(
+    tenantId: string,
+    consumerIds: string[]
+  ): Promise<Schemas['BulkRevokeResponse']> {
+    const { data } = await httpClient.post(`/v1/consumers/${tenantId}/certificates/bulk-revoke`, {
+      consumer_ids: consumerIds,
+    });
+    return data;
+  },
+};

--- a/control-plane-ui/src/services/api/tenants.ts
+++ b/control-plane-ui/src/services/api/tenants.ts
@@ -1,0 +1,75 @@
+import { httpClient } from '../http';
+import type { Schemas } from '@stoa/shared/api-types';
+import type {
+  Tenant,
+  TenantCreate,
+  TenantCAInfo,
+  IssuedCertificateListResponse,
+} from '../../types';
+
+export const tenantsClient = {
+  async list(): Promise<Tenant[]> {
+    const { data } = await httpClient.get('/v1/tenants');
+    return data;
+  },
+
+  async get(tenantId: string): Promise<Tenant> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}`);
+    return data;
+  },
+
+  async create(tenant: TenantCreate): Promise<Tenant> {
+    const { data } = await httpClient.post('/v1/tenants', tenant);
+    return data;
+  },
+
+  async update(tenantId: string, patch: Partial<TenantCreate>): Promise<Tenant> {
+    const { data } = await httpClient.put(`/v1/tenants/${tenantId}`, patch);
+    return data;
+  },
+
+  async remove(tenantId: string): Promise<void> {
+    await httpClient.delete(`/v1/tenants/${tenantId}`);
+  },
+
+  // Tenant CA (CAB-1787/1788)
+  async getCA(tenantId: string): Promise<TenantCAInfo> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/ca`);
+    return data;
+  },
+
+  async generateCA(tenantId: string): Promise<TenantCAInfo> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/ca/generate`);
+    return data;
+  },
+
+  async signCSR(
+    tenantId: string,
+    csrPem: string,
+    validityDays: number = 365
+  ): Promise<Schemas['CSRSignResponse']> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/ca/sign`, {
+      csr_pem: csrPem,
+      validity_days: validityDays,
+    });
+    return data;
+  },
+
+  async revokeCA(tenantId: string): Promise<void> {
+    await httpClient.delete(`/v1/tenants/${tenantId}/ca`);
+  },
+
+  async listIssuedCertificates(
+    tenantId: string,
+    status?: string
+  ): Promise<IssuedCertificateListResponse> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/ca/certificates`, {
+      params: status ? { status } : undefined,
+    });
+    return data;
+  },
+
+  async revokeIssuedCertificate(tenantId: string, certId: string): Promise<void> {
+    await httpClient.post(`/v1/tenants/${tenantId}/ca/certificates/${certId}/revoke`);
+  },
+};

--- a/control-plane-ui/src/test/services/api/ui2-s2c-clients.test.ts
+++ b/control-plane-ui/src/test/services/api/ui2-s2c-clients.test.ts
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockHttpClient } = vi.hoisted(() => ({
+  mockHttpClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../../../services/http', () => ({
+  httpClient: mockHttpClient,
+}));
+
+import { tenantsClient } from '../../../services/api/tenants';
+import { apisClient } from '../../../services/api/apis';
+import { applicationsClient } from '../../../services/api/applications';
+import { consumersClient } from '../../../services/api/consumers';
+
+describe('UI-2 S2c domain clients', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('covers tenantsClient request delegation', async () => {
+    const tenantList = [{ id: 'tenant-1' }];
+    const tenant = { id: 'tenant-1', name: 'Acme' };
+    const ca = { issuer: 'stoa-root' };
+    const signResponse = { certificate_pem: 'cert', serial_number: '123' };
+    const issuedCertificates = { items: [{ id: 'cert-1' }] };
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: tenantList })
+      .mockResolvedValueOnce({ data: tenant })
+      .mockResolvedValueOnce({ data: ca })
+      .mockResolvedValueOnce({ data: issuedCertificates });
+    mockHttpClient.post
+      .mockResolvedValueOnce({ data: tenant })
+      .mockResolvedValueOnce({ data: ca })
+      .mockResolvedValueOnce({ data: signResponse })
+      .mockResolvedValueOnce({});
+    mockHttpClient.put.mockResolvedValueOnce({ data: tenant });
+    mockHttpClient.delete.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+
+    await expect(tenantsClient.list()).resolves.toBe(tenantList);
+    await expect(tenantsClient.get('tenant-1')).resolves.toBe(tenant);
+    await expect(
+      tenantsClient.create({
+        name: 'Acme',
+        slug: 'acme',
+      } as never)
+    ).resolves.toBe(tenant);
+    await expect(
+      tenantsClient.update('tenant-1', {
+        name: 'Acme 2',
+      } as never)
+    ).resolves.toBe(tenant);
+    await expect(tenantsClient.remove('tenant-1')).resolves.toBeUndefined();
+    await expect(tenantsClient.getCA('tenant-1')).resolves.toBe(ca);
+    await expect(tenantsClient.generateCA('tenant-1')).resolves.toBe(ca);
+    await expect(tenantsClient.signCSR('tenant-1', 'csr-pem', 90)).resolves.toBe(signResponse);
+    await expect(tenantsClient.revokeCA('tenant-1')).resolves.toBeUndefined();
+    await expect(tenantsClient.listIssuedCertificates('tenant-1', 'active')).resolves.toBe(
+      issuedCertificates
+    );
+    await expect(
+      tenantsClient.revokeIssuedCertificate('tenant-1', 'cert-1')
+    ).resolves.toBeUndefined();
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/tenants');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/tenants/tenant-1');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(1, '/v1/tenants', {
+      name: 'Acme',
+      slug: 'acme',
+    });
+    expect(mockHttpClient.put).toHaveBeenCalledWith('/v1/tenants/tenant-1', {
+      name: 'Acme 2',
+    });
+    expect(mockHttpClient.delete).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(3, '/v1/tenants/tenant-1/ca');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(2, '/v1/tenants/tenant-1/ca/generate');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(3, '/v1/tenants/tenant-1/ca/sign', {
+      csr_pem: 'csr-pem',
+      validity_days: 90,
+    });
+    expect(mockHttpClient.delete).toHaveBeenNthCalledWith(2, '/v1/tenants/tenant-1/ca');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      4,
+      '/v1/tenants/tenant-1/ca/certificates',
+      {
+        params: { status: 'active' },
+      }
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      4,
+      '/v1/tenants/tenant-1/ca/certificates/cert-1/revoke'
+    );
+  });
+
+  it('covers apisClient request delegation', async () => {
+    const apiList = { items: [{ id: 'api-1' }] };
+    const api = { id: 'api-1', name: 'Payments' };
+    const adminList = { items: [{ id: 'api-2' }] };
+    const versions = [{ version: '1.0.0' }];
+    const audienceUpdate = {
+      api_id: 'api-1',
+      tenant_id: 'tenant-1',
+      audience: 'payments',
+      updated_by: 'admin',
+    };
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: apiList })
+      .mockResolvedValueOnce({ data: adminList })
+      .mockResolvedValueOnce({ data: api })
+      .mockResolvedValueOnce({ data: versions });
+    mockHttpClient.post
+      .mockResolvedValueOnce({ data: api })
+      .mockResolvedValueOnce({});
+    mockHttpClient.put.mockResolvedValueOnce({ data: api });
+    mockHttpClient.patch.mockResolvedValueOnce({ data: audienceUpdate });
+    mockHttpClient.delete.mockResolvedValueOnce({});
+
+    await expect(apisClient.list('tenant-1', 'prod')).resolves.toEqual(apiList.items);
+    await expect(apisClient.listAdmin(2, 25)).resolves.toEqual(adminList.items);
+    await expect(apisClient.get('tenant-1', 'api-1')).resolves.toBe(api);
+    await expect(
+      apisClient.create('tenant-1', {
+        name: 'Payments',
+      } as never)
+    ).resolves.toBe(api);
+    await expect(
+      apisClient.update('tenant-1', 'api-1', {
+        description: 'Updated',
+      } as never)
+    ).resolves.toBe(api);
+    await expect(apisClient.remove('tenant-1', 'api-1')).resolves.toBeUndefined();
+    await expect(apisClient.listVersions('tenant-1', 'api-1', 50)).resolves.toBe(versions);
+    await expect(
+      apisClient.updateAudience('tenant-1', 'api-1', 'payments')
+    ).resolves.toBe(audienceUpdate);
+    await expect(apisClient.triggerCatalogSync('tenant-1')).resolves.toBeUndefined();
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/apis', {
+      params: { page: 1, page_size: 100, environment: 'prod' },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/admin/catalog/apis', {
+      params: { page: 2, page_size: 25 },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(3, '/v1/tenants/tenant-1/apis/api-1');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/apis', {
+      name: 'Payments',
+    });
+    expect(mockHttpClient.put).toHaveBeenCalledWith('/v1/tenants/tenant-1/apis/api-1', {
+      description: 'Updated',
+    });
+    expect(mockHttpClient.delete).toHaveBeenCalledWith('/v1/tenants/tenant-1/apis/api-1');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      4,
+      '/v1/tenants/tenant-1/apis/api-1/versions',
+      {
+        params: { limit: 50 },
+      }
+    );
+    expect(mockHttpClient.patch).toHaveBeenCalledWith(
+      '/v1/admin/catalog/tenant-1/api-1/audience',
+      {
+        audience: 'payments',
+      }
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(2, '/v1/admin/catalog/sync/tenant/tenant-1');
+  });
+
+  it('covers applicationsClient request delegation', async () => {
+    const list = { items: [{ id: 'app-1' }] };
+    const app = { id: 'app-1', name: 'Console' };
+
+    mockHttpClient.get.mockResolvedValueOnce({ data: list }).mockResolvedValueOnce({ data: app });
+    mockHttpClient.post.mockResolvedValueOnce({ data: app });
+    mockHttpClient.put.mockResolvedValueOnce({ data: app });
+    mockHttpClient.delete.mockResolvedValueOnce({});
+
+    await expect(applicationsClient.list('tenant-1')).resolves.toEqual(list.items);
+    await expect(applicationsClient.get('tenant-1', 'app-1')).resolves.toBe(app);
+    await expect(
+      applicationsClient.create('tenant-1', {
+        name: 'Console',
+      } as never)
+    ).resolves.toBe(app);
+    await expect(
+      applicationsClient.update('tenant-1', 'app-1', {
+        description: 'Updated',
+      } as never)
+    ).resolves.toBe(app);
+    await expect(applicationsClient.remove('tenant-1', 'app-1')).resolves.toBeUndefined();
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/applications', {
+      params: { page: 1, page_size: 100 },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/applications/app-1'
+    );
+    expect(mockHttpClient.post).toHaveBeenCalledWith('/v1/tenants/tenant-1/applications', {
+      name: 'Console',
+    });
+    expect(mockHttpClient.put).toHaveBeenCalledWith(
+      '/v1/tenants/tenant-1/applications/app-1',
+      {
+        description: 'Updated',
+      }
+    );
+    expect(mockHttpClient.delete).toHaveBeenCalledWith(
+      '/v1/tenants/tenant-1/applications/app-1'
+    );
+  });
+
+  it('covers consumersClient request delegation', async () => {
+    const list = { items: [{ id: 'consumer-1' }] };
+    const consumer = { id: 'consumer-1', status: 'active' };
+    const expiring = { items: [{ id: 'consumer-1' }] };
+    const bulkRevoke = { success_count: 1, failure_count: 0 };
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: list })
+      .mockResolvedValueOnce({ data: consumer })
+      .mockResolvedValueOnce({ data: expiring });
+    mockHttpClient.post
+      .mockResolvedValueOnce({ data: consumer })
+      .mockResolvedValueOnce({ data: consumer })
+      .mockResolvedValueOnce({ data: consumer })
+      .mockResolvedValueOnce({ data: consumer })
+      .mockResolvedValueOnce({ data: consumer })
+      .mockResolvedValueOnce({ data: consumer })
+      .mockResolvedValueOnce({ data: bulkRevoke });
+    mockHttpClient.delete.mockResolvedValueOnce({});
+
+    await expect(consumersClient.list('tenant-1', 'prod')).resolves.toEqual(list.items);
+    await expect(consumersClient.get('tenant-1', 'consumer-1')).resolves.toBe(consumer);
+    await expect(consumersClient.suspend('tenant-1', 'consumer-1')).resolves.toBe(consumer);
+    await expect(consumersClient.activate('tenant-1', 'consumer-1')).resolves.toBe(consumer);
+    await expect(consumersClient.remove('tenant-1', 'consumer-1')).resolves.toBeUndefined();
+    await expect(
+      consumersClient.rotateCertificate('tenant-1', 'consumer-1', 'cert-pem', 12)
+    ).resolves.toBe(consumer);
+    await expect(
+      consumersClient.revokeCertificate('tenant-1', 'consumer-1')
+    ).resolves.toBe(consumer);
+    await expect(consumersClient.block('tenant-1', 'consumer-1')).resolves.toBe(consumer);
+    await expect(
+      consumersClient.bindCertificate('tenant-1', 'consumer-1', 'cert-pem')
+    ).resolves.toBe(consumer);
+    await expect(consumersClient.getExpiringCertificates('tenant-1', 14)).resolves.toBe(expiring);
+    await expect(
+      consumersClient.bulkRevokeCertificates('tenant-1', ['consumer-1'])
+    ).resolves.toBe(bulkRevoke);
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/consumers/tenant-1', {
+      params: { page: 1, page_size: 100, environment: 'prod' },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/consumers/tenant-1/consumer-1');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      1,
+      '/v1/consumers/tenant-1/consumer-1/suspend'
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      2,
+      '/v1/consumers/tenant-1/consumer-1/activate'
+    );
+    expect(mockHttpClient.delete).toHaveBeenCalledWith('/v1/consumers/tenant-1/consumer-1');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      3,
+      '/v1/consumers/tenant-1/consumer-1/certificate/rotate',
+      {
+        certificate_pem: 'cert-pem',
+        grace_period_hours: 12,
+      }
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      4,
+      '/v1/consumers/tenant-1/consumer-1/certificate/revoke'
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      5,
+      '/v1/consumers/tenant-1/consumer-1/block'
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      6,
+      '/v1/consumers/tenant-1/consumer-1/certificate',
+      {
+        certificate_pem: 'cert-pem',
+      }
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      3,
+      '/v1/consumers/tenant-1/certificates/expiring',
+      {
+        params: { days: 14 },
+      }
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      7,
+      '/v1/consumers/tenant-1/certificates/bulk-revoke',
+      {
+        consumer_ids: ['consumer-1'],
+      }
+    );
+  });
+});

--- a/control-plane-ui/src/test/services/api/ui2-s2c-clients.test.ts
+++ b/control-plane-ui/src/test/services/api/ui2-s2c-clients.test.ts
@@ -86,13 +86,9 @@ describe('UI-2 S2c domain clients', () => {
       validity_days: 90,
     });
     expect(mockHttpClient.delete).toHaveBeenNthCalledWith(2, '/v1/tenants/tenant-1/ca');
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
-      4,
-      '/v1/tenants/tenant-1/ca/certificates',
-      {
-        params: { status: 'active' },
-      }
-    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(4, '/v1/tenants/tenant-1/ca/certificates', {
+      params: { status: 'active' },
+    });
     expect(mockHttpClient.post).toHaveBeenNthCalledWith(
       4,
       '/v1/tenants/tenant-1/ca/certificates/cert-1/revoke'
@@ -116,9 +112,7 @@ describe('UI-2 S2c domain clients', () => {
       .mockResolvedValueOnce({ data: adminList })
       .mockResolvedValueOnce({ data: api })
       .mockResolvedValueOnce({ data: versions });
-    mockHttpClient.post
-      .mockResolvedValueOnce({ data: api })
-      .mockResolvedValueOnce({});
+    mockHttpClient.post.mockResolvedValueOnce({ data: api }).mockResolvedValueOnce({});
     mockHttpClient.put.mockResolvedValueOnce({ data: api });
     mockHttpClient.patch.mockResolvedValueOnce({ data: audienceUpdate });
     mockHttpClient.delete.mockResolvedValueOnce({});
@@ -138,9 +132,9 @@ describe('UI-2 S2c domain clients', () => {
     ).resolves.toBe(api);
     await expect(apisClient.remove('tenant-1', 'api-1')).resolves.toBeUndefined();
     await expect(apisClient.listVersions('tenant-1', 'api-1', 50)).resolves.toBe(versions);
-    await expect(
-      apisClient.updateAudience('tenant-1', 'api-1', 'payments')
-    ).resolves.toBe(audienceUpdate);
+    await expect(apisClient.updateAudience('tenant-1', 'api-1', 'payments')).resolves.toBe(
+      audienceUpdate
+    );
     await expect(apisClient.triggerCatalogSync('tenant-1')).resolves.toBeUndefined();
 
     expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/apis', {
@@ -164,13 +158,13 @@ describe('UI-2 S2c domain clients', () => {
         params: { limit: 50 },
       }
     );
-    expect(mockHttpClient.patch).toHaveBeenCalledWith(
-      '/v1/admin/catalog/tenant-1/api-1/audience',
-      {
-        audience: 'payments',
-      }
+    expect(mockHttpClient.patch).toHaveBeenCalledWith('/v1/admin/catalog/tenant-1/api-1/audience', {
+      audience: 'payments',
+    });
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      2,
+      '/v1/admin/catalog/sync/tenant/tenant-1'
     );
-    expect(mockHttpClient.post).toHaveBeenNthCalledWith(2, '/v1/admin/catalog/sync/tenant/tenant-1');
   });
 
   it('covers applicationsClient request delegation', async () => {
@@ -206,15 +200,10 @@ describe('UI-2 S2c domain clients', () => {
     expect(mockHttpClient.post).toHaveBeenCalledWith('/v1/tenants/tenant-1/applications', {
       name: 'Console',
     });
-    expect(mockHttpClient.put).toHaveBeenCalledWith(
-      '/v1/tenants/tenant-1/applications/app-1',
-      {
-        description: 'Updated',
-      }
-    );
-    expect(mockHttpClient.delete).toHaveBeenCalledWith(
-      '/v1/tenants/tenant-1/applications/app-1'
-    );
+    expect(mockHttpClient.put).toHaveBeenCalledWith('/v1/tenants/tenant-1/applications/app-1', {
+      description: 'Updated',
+    });
+    expect(mockHttpClient.delete).toHaveBeenCalledWith('/v1/tenants/tenant-1/applications/app-1');
   });
 
   it('covers consumersClient request delegation', async () => {
@@ -245,17 +234,17 @@ describe('UI-2 S2c domain clients', () => {
     await expect(
       consumersClient.rotateCertificate('tenant-1', 'consumer-1', 'cert-pem', 12)
     ).resolves.toBe(consumer);
-    await expect(
-      consumersClient.revokeCertificate('tenant-1', 'consumer-1')
-    ).resolves.toBe(consumer);
+    await expect(consumersClient.revokeCertificate('tenant-1', 'consumer-1')).resolves.toBe(
+      consumer
+    );
     await expect(consumersClient.block('tenant-1', 'consumer-1')).resolves.toBe(consumer);
     await expect(
       consumersClient.bindCertificate('tenant-1', 'consumer-1', 'cert-pem')
     ).resolves.toBe(consumer);
     await expect(consumersClient.getExpiringCertificates('tenant-1', 14)).resolves.toBe(expiring);
-    await expect(
-      consumersClient.bulkRevokeCertificates('tenant-1', ['consumer-1'])
-    ).resolves.toBe(bulkRevoke);
+    await expect(consumersClient.bulkRevokeCertificates('tenant-1', ['consumer-1'])).resolves.toBe(
+      bulkRevoke
+    );
 
     expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/consumers/tenant-1', {
       params: { page: 1, page_size: 100, environment: 'prod' },


### PR DESCRIPTION
## Summary

Part 4/8 of UI-2 axios split. Extracts 4 core platform clients (tenants, apis, applications, consumers) into `services/<domain>/`.

**Stack base**: S2b.

## Size

+305/-92 across 5 files. Marginally above 300 cap (mechanical moves).

## Test plan

- [x] `npm run typecheck` green
- [x] `npm run lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)