### PR TITLE
refactor(ui): extract deployments/traces/gateways/gatewayDeployments (UI-2 S2d)

### DIFF
--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -77,6 +77,10 @@ import { tenantsClient } from './api/tenants';
 import { apisClient } from './api/apis';
 import { applicationsClient } from './api/applications';
 import { consumersClient } from './api/consumers';
+import { deploymentsClient } from './api/deployments';
+import { tracesClient } from './api/traces';
+import { gatewaysClient } from './api/gateways';
+import { gatewayDeploymentsClient } from './api/gatewayDeployments';
 
 // =============================================================================
 // Façade ApiService — agrège le core transport (services/http) et les méthodes
@@ -345,18 +349,15 @@ class ApiService {
       page_size?: number;
     }
   ): Promise<DeploymentListResponse> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/deployments`, { params });
-    return data;
+    return deploymentsClient.list(tenantId, params);
   }
 
   async getDeployment(tenantId: string, deploymentId: string): Promise<Deployment> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/deployments/${deploymentId}`);
-    return data;
+    return deploymentsClient.get(tenantId, deploymentId);
   }
 
   async createDeployment(tenantId: string, request: DeploymentCreate): Promise<Deployment> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/deployments`, request);
-    return data;
+    return deploymentsClient.create(tenantId, request);
   }
 
   async rollbackDeployment(
@@ -364,11 +365,7 @@ class ApiService {
     deploymentId: string,
     targetVersion?: string
   ): Promise<Deployment> {
-    const { data } = await httpClient.post(
-      `/v1/tenants/${tenantId}/deployments/${deploymentId}/rollback`,
-      { target_version: targetVersion }
-    );
-    return data;
+    return deploymentsClient.rollback(tenantId, deploymentId, targetVersion);
   }
 
   async getDeploymentLogs(
@@ -377,11 +374,7 @@ class ApiService {
     afterSeq: number = 0,
     limit: number = 200
   ): Promise<DeploymentLogListResponse> {
-    const { data } = await httpClient.get(
-      `/v1/tenants/${tenantId}/deployments/${deploymentId}/logs`,
-      { params: { after_seq: afterSeq, limit } }
-    );
-    return data;
+    return deploymentsClient.getLogs(tenantId, deploymentId, afterSeq, limit);
   }
 
   // ── Promotions (CAB-1706) ──────────────────────────────────────────────────
@@ -440,10 +433,7 @@ class ApiService {
     tenantId: string,
     environment: string
   ): Promise<EnvironmentStatusResponse> {
-    const { data } = await httpClient.get(
-      `/v1/tenants/${tenantId}/deployments/environments/${environment}/status`
-    );
-    return data;
+    return deploymentsClient.getEnvironmentStatus(tenantId, environment);
   }
 
   // Git
@@ -467,54 +457,32 @@ class ApiService {
     status?: string,
     environment?: string
   ): Promise<{ traces: TraceSummary[]; total: number }> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const params: Record<string, any> = {};
-    if (limit) params.limit = limit;
-    if (tenantId) params.tenant_id = tenantId;
-    if (status) params.status = status;
-    if (environment) params.environment = environment;
-    const { data } = await httpClient.get('/v1/traces', { params });
-    return data;
+    return tracesClient.list(limit, tenantId, status, environment);
   }
 
   async getTrace(traceId: string): Promise<PipelineTrace> {
-    const { data } = await httpClient.get(`/v1/traces/${traceId}`);
-    return data;
+    return tracesClient.get(traceId);
   }
 
   async getTraceTimeline(traceId: string): Promise<TraceTimeline> {
-    const { data } = await httpClient.get(`/v1/traces/${traceId}/timeline`);
-    return data;
+    return tracesClient.getTimeline(traceId);
   }
 
   async getTraceStats(): Promise<TraceStats> {
-    const { data } = await httpClient.get('/v1/traces/stats');
-    return data;
+    return tracesClient.getStats();
   }
 
   async getLiveTraces(): Promise<{ traces: PipelineTrace[]; count: number }> {
-    const { data } = await httpClient.get('/v1/traces/live');
-    return data;
+    return tracesClient.listLive();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async getAiSessionStats(days?: number, worker?: string): Promise<any> {
-    const params: Record<string, string | number> = {};
-    if (days) params.days = days;
-    if (worker) params.worker = worker;
-    const { data } = await httpClient.get('/v1/traces/stats/ai-sessions', { params });
-    return data;
+    return tracesClient.getAiSessionStats(days, worker);
   }
 
   async exportAiSessionsCsv(days?: number, worker?: string): Promise<Blob> {
-    const params: Record<string, string | number> = {};
-    if (days) params.days = days;
-    if (worker) params.worker = worker;
-    const { data } = await httpClient.get('/v1/traces/export/ai-sessions', {
-      params,
-      responseType: 'blob',
-    });
-    return data;
+    return tracesClient.exportAiSessionsCsv(days, worker);
   }
 
   // Platform Status (CAB-654)
@@ -603,48 +571,41 @@ class ApiService {
     page_size?: number;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }): Promise<{ items: any[]; total: number; page: number; page_size: number }> {
-    const { data } = await httpClient.get('/v1/admin/gateways', { params });
-    return data;
+    return gatewaysClient.listInstances(params);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async getGatewayInstance(id: string): Promise<any> {
-    const { data } = await httpClient.get(`/v1/admin/gateways/${id}`);
-    return data;
+    return gatewaysClient.getInstance(id);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async getGatewayTools(id: string): Promise<any[]> {
-    const { data } = await httpClient.get(`/v1/admin/gateways/${id}/tools`);
-    return data;
+    return gatewaysClient.listTools(id);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async createGatewayInstance(payload: any): Promise<any> {
-    const { data } = await httpClient.post('/v1/admin/gateways', payload);
-    return data;
+    return gatewaysClient.createInstance(payload);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async updateGatewayInstance(id: string, payload: any): Promise<any> {
-    const { data } = await httpClient.put(`/v1/admin/gateways/${id}`, payload);
-    return data;
+    return gatewaysClient.updateInstance(id, payload);
   }
 
   async deleteGatewayInstance(id: string): Promise<void> {
-    await httpClient.delete(`/v1/admin/gateways/${id}`);
+    return gatewaysClient.removeInstance(id);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async restoreGatewayInstance(id: string): Promise<any> {
-    const { data } = await httpClient.post(`/v1/admin/gateways/${id}/restore`);
-    return data;
+    return gatewaysClient.restoreInstance(id);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async checkGatewayHealth(id: string): Promise<any> {
-    const { data } = await httpClient.post(`/v1/admin/gateways/${id}/health`);
-    return data;
+    return gatewaysClient.checkHealth(id);
   }
 
   async getGatewayModeStats(): Promise<{
@@ -657,15 +618,13 @@ class ApiService {
     }>;
     total_gateways: number;
   }> {
-    const { data } = await httpClient.get('/v1/admin/gateways/modes/stats');
-    return data;
+    return gatewaysClient.getModeStats();
   }
 
   // Gateway Deployments
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async getDeploymentStatusSummary(): Promise<any> {
-    const { data } = await httpClient.get('/v1/admin/deployments/status');
-    return data;
+    return gatewayDeploymentsClient.getStatusSummary();
   }
 
   async getGatewayDeployments(params?: {
@@ -677,14 +636,12 @@ class ApiService {
     page_size?: number;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }): Promise<{ items: any[]; total: number; page: number; page_size: number }> {
-    const { data } = await httpClient.get('/v1/admin/deployments', { params });
-    return data;
+    return gatewayDeploymentsClient.list(params);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async getGatewayDeployment(id: string): Promise<any> {
-    const { data } = await httpClient.get(`/v1/admin/deployments/${id}`);
-    return data;
+    return gatewayDeploymentsClient.get(id);
   }
 
   async deployApiToGateways(payload: {
@@ -692,18 +649,16 @@ class ApiService {
     gateway_instance_ids: string[];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }): Promise<any[]> {
-    const { data } = await httpClient.post('/v1/admin/deployments', payload);
-    return data;
+    return gatewayDeploymentsClient.deployApiToGateways(payload);
   }
 
   async undeployFromGateway(id: string): Promise<void> {
-    await httpClient.delete(`/v1/admin/deployments/${id}`);
+    return gatewayDeploymentsClient.undeploy(id);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async forceSyncDeployment(id: string): Promise<any> {
-    const { data } = await httpClient.post(`/v1/admin/deployments/${id}/sync`);
-    return data;
+    return gatewayDeploymentsClient.forceSync(id);
   }
 
   async testDeployment(id: string): Promise<{
@@ -714,15 +669,13 @@ class ApiService {
     gateway_url?: string;
     path?: string;
   }> {
-    const { data } = await httpClient.post(`/v1/admin/deployments/${id}/test`);
-    return data;
+    return gatewayDeploymentsClient.test(id);
   }
 
   async getCatalogEntries(): Promise<
     { id: string; api_name: string; tenant_id: string; version: string }[]
   > {
-    const { data } = await httpClient.get('/v1/admin/deployments/catalog-entries');
-    return data;
+    return gatewayDeploymentsClient.listCatalogEntries();
   }
 
   // API Deployment Orchestration (CAB-1888)
@@ -737,10 +690,7 @@ class ApiService {
       promotion_status: string;
     }[];
   }> {
-    const { data } = await httpClient.get(
-      `/v1/tenants/${tenantId}/apis/${apiId}/deployable-environments`
-    );
-    return data;
+    return deploymentsClient.getDeployableEnvironments(tenantId, apiId);
   }
 
   async deployApiToEnv(
@@ -748,8 +698,7 @@ class ApiService {
     apiId: string,
     payload: { environment: string; gateway_ids?: string[] }
   ): Promise<{ deployed: number; environment: string; deployment_ids: string[] }> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/apis/${apiId}/deploy`, payload);
-    return data;
+    return deploymentsClient.deployApiToEnv(tenantId, apiId, payload);
   }
 
   async getApiGatewayAssignments(
@@ -758,11 +707,7 @@ class ApiService {
     environment?: string
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<{ items: any[]; total: number }> {
-    const { data } = await httpClient.get(
-      `/v1/tenants/${tenantId}/apis/${apiId}/gateway-assignments`,
-      { params: environment ? { environment } : {} }
-    );
-    return data;
+    return deploymentsClient.getApiGatewayAssignments(tenantId, apiId, environment);
   }
 
   async createApiGatewayAssignment(
@@ -771,11 +716,7 @@ class ApiService {
     payload: { gateway_id: string; environment: string; auto_deploy: boolean }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any> {
-    const { data } = await httpClient.post(
-      `/v1/tenants/${tenantId}/apis/${apiId}/gateway-assignments`,
-      payload
-    );
-    return data;
+    return deploymentsClient.createApiGatewayAssignment(tenantId, apiId, payload);
   }
 
   async deleteApiGatewayAssignment(
@@ -783,9 +724,7 @@ class ApiService {
     apiId: string,
     assignmentId: string
   ): Promise<void> {
-    await httpClient.delete(
-      `/v1/tenants/${tenantId}/apis/${apiId}/gateway-assignments/${assignmentId}`
-    );
+    return deploymentsClient.deleteApiGatewayAssignment(tenantId, apiId, assignmentId);
   }
 
   // =========================================================================
@@ -794,28 +733,22 @@ class ApiService {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async getGatewayAggregatedMetrics(): Promise<any> {
-    const { data } = await httpClient.get('/v1/admin/gateways/metrics');
-    return data;
+    return gatewaysClient.getAggregatedMetrics();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async getGuardrailsEvents(limit = 20): Promise<any> {
-    const { data } = await httpClient.get(
-      `/v1/admin/gateways/metrics/guardrails/events?limit=${limit}`
-    );
-    return data;
+    return gatewaysClient.getGuardrailsEvents(limit);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async getGatewayHealthSummary(): Promise<any> {
-    const { data } = await httpClient.get('/v1/admin/gateways/health-summary');
-    return data;
+    return gatewaysClient.getHealthSummary();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async getGatewayInstanceMetrics(id: string): Promise<any> {
-    const { data } = await httpClient.get(`/v1/admin/gateways/${id}/metrics`);
-    return data;
+    return gatewaysClient.getInstanceMetrics(id);
   }
 
   // =========================================================================
@@ -824,34 +757,30 @@ class ApiService {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async getGatewayPolicies(params?: { tenant_id?: string; environment?: string }): Promise<any[]> {
-    const { data } = await httpClient.get('/v1/admin/policies', { params });
-    return data;
+    return gatewaysClient.listPolicies(params);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async createGatewayPolicy(payload: any): Promise<any> {
-    const { data } = await httpClient.post('/v1/admin/policies', payload);
-    return data;
+    return gatewaysClient.createPolicy(payload);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async updateGatewayPolicy(id: string, payload: any): Promise<any> {
-    const { data } = await httpClient.put(`/v1/admin/policies/${id}`, payload);
-    return data;
+    return gatewaysClient.updatePolicy(id, payload);
   }
 
   async deleteGatewayPolicy(id: string): Promise<void> {
-    await httpClient.delete(`/v1/admin/policies/${id}`);
+    return gatewaysClient.removePolicy(id);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async createPolicyBinding(payload: any): Promise<any> {
-    const { data } = await httpClient.post('/v1/admin/policies/bindings', payload);
-    return data;
+    return gatewaysClient.createPolicyBinding(payload);
   }
 
   async deletePolicyBinding(id: string): Promise<void> {
-    await httpClient.delete(`/v1/admin/policies/bindings/${id}`);
+    return gatewaysClient.removePolicyBinding(id);
   }
 
   // =========================================================================

--- a/control-plane-ui/src/services/api/deployments.ts
+++ b/control-plane-ui/src/services/api/deployments.ts
@@ -1,0 +1,133 @@
+import { httpClient } from '../http';
+import type {
+  Deployment,
+  DeploymentCreate,
+  DeploymentListResponse,
+  DeploymentLogListResponse,
+  EnvironmentStatusResponse,
+} from '../../types';
+
+export const deploymentsClient = {
+  // Lifecycle (CAB-1353)
+  async list(
+    tenantId: string,
+    params?: {
+      api_id?: string;
+      environment?: string;
+      status?: string;
+      page?: number;
+      page_size?: number;
+    }
+  ): Promise<DeploymentListResponse> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/deployments`, { params });
+    return data;
+  },
+
+  async get(tenantId: string, deploymentId: string): Promise<Deployment> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/deployments/${deploymentId}`);
+    return data;
+  },
+
+  async create(tenantId: string, request: DeploymentCreate): Promise<Deployment> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/deployments`, request);
+    return data;
+  },
+
+  async rollback(
+    tenantId: string,
+    deploymentId: string,
+    targetVersion?: string
+  ): Promise<Deployment> {
+    const { data } = await httpClient.post(
+      `/v1/tenants/${tenantId}/deployments/${deploymentId}/rollback`,
+      { target_version: targetVersion }
+    );
+    return data;
+  },
+
+  async getLogs(
+    tenantId: string,
+    deploymentId: string,
+    afterSeq: number = 0,
+    limit: number = 200
+  ): Promise<DeploymentLogListResponse> {
+    const { data } = await httpClient.get(
+      `/v1/tenants/${tenantId}/deployments/${deploymentId}/logs`,
+      { params: { after_seq: afterSeq, limit } }
+    );
+    return data;
+  },
+
+  // Environment status
+  async getEnvironmentStatus(
+    tenantId: string,
+    environment: string
+  ): Promise<EnvironmentStatusResponse> {
+    const { data } = await httpClient.get(
+      `/v1/tenants/${tenantId}/deployments/environments/${environment}/status`
+    );
+    return data;
+  },
+
+  // API Deployment Orchestration (CAB-1888)
+  async getDeployableEnvironments(
+    tenantId: string,
+    apiId: string
+  ): Promise<{
+    environments: {
+      environment: string;
+      deployable: boolean;
+      promotion_status: string;
+    }[];
+  }> {
+    const { data } = await httpClient.get(
+      `/v1/tenants/${tenantId}/apis/${apiId}/deployable-environments`
+    );
+    return data;
+  },
+
+  async deployApiToEnv(
+    tenantId: string,
+    apiId: string,
+    payload: { environment: string; gateway_ids?: string[] }
+  ): Promise<{ deployed: number; environment: string; deployment_ids: string[] }> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/apis/${apiId}/deploy`, payload);
+    return data;
+  },
+
+  async getApiGatewayAssignments(
+    tenantId: string,
+    apiId: string,
+    environment?: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Promise<{ items: any[]; total: number }> {
+    const { data } = await httpClient.get(
+      `/v1/tenants/${tenantId}/apis/${apiId}/gateway-assignments`,
+      { params: environment ? { environment } : {} }
+    );
+    return data;
+  },
+
+  async createApiGatewayAssignment(
+    tenantId: string,
+    apiId: string,
+    payload: { gateway_id: string; environment: string; auto_deploy: boolean }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Promise<any> {
+    const { data } = await httpClient.post(
+      `/v1/tenants/${tenantId}/apis/${apiId}/gateway-assignments`,
+      payload
+    );
+    return data;
+  },
+
+  async deleteApiGatewayAssignment(
+    tenantId: string,
+    apiId: string,
+    assignmentId: string
+  ): Promise<void> {
+    await httpClient.delete(
+      `/v1/tenants/${tenantId}/apis/${apiId}/gateway-assignments/${assignmentId}`
+    );
+  },
+};

--- a/control-plane-ui/src/services/api/gatewayDeployments.ts
+++ b/control-plane-ui/src/services/api/gatewayDeployments.ts
@@ -1,0 +1,70 @@
+import { httpClient } from '../http';
+
+// Admin-level gateway deployments — typed loosely (any) for parity with
+// the pre-UI-2 surface. Strict typing to be addressed with Schemas when
+// backend ships them.
+
+export const gatewayDeploymentsClient = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getStatusSummary(): Promise<any> {
+    const { data } = await httpClient.get('/v1/admin/deployments/status');
+    return data;
+  },
+
+  async list(params?: {
+    sync_status?: string;
+    gateway_instance_id?: string;
+    environment?: string;
+    gateway_type?: string;
+    page?: number;
+    page_size?: number;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }): Promise<{ items: any[]; total: number; page: number; page_size: number }> {
+    const { data } = await httpClient.get('/v1/admin/deployments', { params });
+    return data;
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async get(id: string): Promise<any> {
+    const { data } = await httpClient.get(`/v1/admin/deployments/${id}`);
+    return data;
+  },
+
+  async deployApiToGateways(payload: {
+    api_catalog_id: string;
+    gateway_instance_ids: string[];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }): Promise<any[]> {
+    const { data } = await httpClient.post('/v1/admin/deployments', payload);
+    return data;
+  },
+
+  async undeploy(id: string): Promise<void> {
+    await httpClient.delete(`/v1/admin/deployments/${id}`);
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async forceSync(id: string): Promise<any> {
+    const { data } = await httpClient.post(`/v1/admin/deployments/${id}/sync`);
+    return data;
+  },
+
+  async test(id: string): Promise<{
+    reachable: boolean;
+    status_code?: number;
+    latency_ms?: number;
+    error?: string;
+    gateway_url?: string;
+    path?: string;
+  }> {
+    const { data } = await httpClient.post(`/v1/admin/deployments/${id}/test`);
+    return data;
+  },
+
+  async listCatalogEntries(): Promise<
+    { id: string; api_name: string; tenant_id: string; version: string }[]
+  > {
+    const { data } = await httpClient.get('/v1/admin/deployments/catalog-entries');
+    return data;
+  },
+};

--- a/control-plane-ui/src/services/api/gateways.ts
+++ b/control-plane-ui/src/services/api/gateways.ts
@@ -1,0 +1,135 @@
+import { httpClient } from '../http';
+
+// Admin gateway instances (Control Plane Agnostique) + observability + policies.
+// Typage laissé à `any` quand l'API ne fournit pas encore de Schemas['X']
+// dédiés (UI-2 conserve la surface existante, pas de typage inventé).
+
+export const gatewaysClient = {
+  // Instances
+  async listInstances(params?: {
+    gateway_type?: string;
+    environment?: string;
+    tenant_id?: string;
+    include_deleted?: boolean;
+    page?: number;
+    page_size?: number;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }): Promise<{ items: any[]; total: number; page: number; page_size: number }> {
+    const { data } = await httpClient.get('/v1/admin/gateways', { params });
+    return data;
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getInstance(id: string): Promise<any> {
+    const { data } = await httpClient.get(`/v1/admin/gateways/${id}`);
+    return data;
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async listTools(id: string): Promise<any[]> {
+    const { data } = await httpClient.get(`/v1/admin/gateways/${id}/tools`);
+    return data;
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async createInstance(payload: any): Promise<any> {
+    const { data } = await httpClient.post('/v1/admin/gateways', payload);
+    return data;
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async updateInstance(id: string, payload: any): Promise<any> {
+    const { data } = await httpClient.put(`/v1/admin/gateways/${id}`, payload);
+    return data;
+  },
+
+  async removeInstance(id: string): Promise<void> {
+    await httpClient.delete(`/v1/admin/gateways/${id}`);
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async restoreInstance(id: string): Promise<any> {
+    const { data } = await httpClient.post(`/v1/admin/gateways/${id}/restore`);
+    return data;
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async checkHealth(id: string): Promise<any> {
+    const { data } = await httpClient.post(`/v1/admin/gateways/${id}/health`);
+    return data;
+  },
+
+  async getModeStats(): Promise<{
+    modes: Array<{
+      mode: string;
+      total: number;
+      online: number;
+      offline: number;
+      degraded: number;
+    }>;
+    total_gateways: number;
+  }> {
+    const { data } = await httpClient.get('/v1/admin/gateways/modes/stats');
+    return data;
+  },
+
+  // Observability
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getAggregatedMetrics(): Promise<any> {
+    const { data } = await httpClient.get('/v1/admin/gateways/metrics');
+    return data;
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getGuardrailsEvents(limit = 20): Promise<any> {
+    const { data } = await httpClient.get(
+      `/v1/admin/gateways/metrics/guardrails/events?limit=${limit}`
+    );
+    return data;
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getHealthSummary(): Promise<any> {
+    const { data } = await httpClient.get('/v1/admin/gateways/health-summary');
+    return data;
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getInstanceMetrics(id: string): Promise<any> {
+    const { data } = await httpClient.get(`/v1/admin/gateways/${id}/metrics`);
+    return data;
+  },
+
+  // Policies
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async listPolicies(params?: { tenant_id?: string; environment?: string }): Promise<any[]> {
+    const { data } = await httpClient.get('/v1/admin/policies', { params });
+    return data;
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async createPolicy(payload: any): Promise<any> {
+    const { data } = await httpClient.post('/v1/admin/policies', payload);
+    return data;
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async updatePolicy(id: string, payload: any): Promise<any> {
+    const { data } = await httpClient.put(`/v1/admin/policies/${id}`, payload);
+    return data;
+  },
+
+  async removePolicy(id: string): Promise<void> {
+    await httpClient.delete(`/v1/admin/policies/${id}`);
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async createPolicyBinding(payload: any): Promise<any> {
+    const { data } = await httpClient.post('/v1/admin/policies/bindings', payload);
+    return data;
+  },
+
+  async removePolicyBinding(id: string): Promise<void> {
+    await httpClient.delete(`/v1/admin/policies/bindings/${id}`);
+  },
+};

--- a/control-plane-ui/src/services/api/traces.ts
+++ b/control-plane-ui/src/services/api/traces.ts
@@ -1,0 +1,60 @@
+import { httpClient } from '../http';
+import type { PipelineTrace, TraceStats, TraceSummary, TraceTimeline } from '../../types';
+
+export const tracesClient = {
+  async list(
+    limit?: number,
+    tenantId?: string,
+    status?: string,
+    environment?: string
+  ): Promise<{ traces: TraceSummary[]; total: number }> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const params: Record<string, any> = {};
+    if (limit) params.limit = limit;
+    if (tenantId) params.tenant_id = tenantId;
+    if (status) params.status = status;
+    if (environment) params.environment = environment;
+    const { data } = await httpClient.get('/v1/traces', { params });
+    return data;
+  },
+
+  async get(traceId: string): Promise<PipelineTrace> {
+    const { data } = await httpClient.get(`/v1/traces/${traceId}`);
+    return data;
+  },
+
+  async getTimeline(traceId: string): Promise<TraceTimeline> {
+    const { data } = await httpClient.get(`/v1/traces/${traceId}/timeline`);
+    return data;
+  },
+
+  async getStats(): Promise<TraceStats> {
+    const { data } = await httpClient.get('/v1/traces/stats');
+    return data;
+  },
+
+  async listLive(): Promise<{ traces: PipelineTrace[]; count: number }> {
+    const { data } = await httpClient.get('/v1/traces/live');
+    return data;
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getAiSessionStats(days?: number, worker?: string): Promise<any> {
+    const params: Record<string, string | number> = {};
+    if (days) params.days = days;
+    if (worker) params.worker = worker;
+    const { data } = await httpClient.get('/v1/traces/stats/ai-sessions', { params });
+    return data;
+  },
+
+  async exportAiSessionsCsv(days?: number, worker?: string): Promise<Blob> {
+    const params: Record<string, string | number> = {};
+    if (days) params.days = days;
+    if (worker) params.worker = worker;
+    const { data } = await httpClient.get('/v1/traces/export/ai-sessions', {
+      params,
+      responseType: 'blob',
+    });
+    return data;
+  },
+};

--- a/control-plane-ui/src/test/services/api/ui2-s2d-clients.test.ts
+++ b/control-plane-ui/src/test/services/api/ui2-s2d-clients.test.ts
@@ -1,0 +1,422 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockHttpClient } = vi.hoisted(() => ({
+  mockHttpClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../../../services/http', () => ({
+  httpClient: mockHttpClient,
+}));
+
+import { deploymentsClient } from '../../../services/api/deployments';
+import { tracesClient } from '../../../services/api/traces';
+import { gatewaysClient } from '../../../services/api/gateways';
+import { gatewayDeploymentsClient } from '../../../services/api/gatewayDeployments';
+
+describe('UI-2 S2d domain clients', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('covers deploymentsClient request delegation', async () => {
+    const deploymentList = { items: [{ id: 'dep-1' }], total: 1 };
+    const deployment = { id: 'dep-1', status: 'running' };
+    const logs = { items: [{ seq: 1, message: 'ok' }] };
+    const envStatus = { environment: 'prod', status: 'healthy' };
+    const deployable = { environments: [{ environment: 'prod', deployable: true }] };
+    const deployResult = {
+      deployed: 1,
+      environment: 'prod',
+      deployment_ids: ['dep-1'],
+    };
+    const assignments = { items: [{ id: 'assign-1' }], total: 1 };
+    const assignment = { id: 'assign-1', gateway_id: 'gw-1' };
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: deploymentList })
+      .mockResolvedValueOnce({ data: deployment })
+      .mockResolvedValueOnce({ data: logs })
+      .mockResolvedValueOnce({ data: envStatus })
+      .mockResolvedValueOnce({ data: deployable })
+      .mockResolvedValueOnce({ data: assignments });
+    mockHttpClient.post
+      .mockResolvedValueOnce({ data: deployment })
+      .mockResolvedValueOnce({ data: deployment })
+      .mockResolvedValueOnce({ data: deployResult })
+      .mockResolvedValueOnce({ data: assignment });
+    mockHttpClient.delete.mockResolvedValueOnce({});
+
+    await expect(
+      deploymentsClient.list('tenant-1', {
+        api_id: 'api-1',
+        environment: 'prod',
+        status: 'running',
+        page: 2,
+        page_size: 20,
+      })
+    ).resolves.toBe(deploymentList);
+    await expect(deploymentsClient.get('tenant-1', 'dep-1')).resolves.toBe(deployment);
+    await expect(
+      deploymentsClient.create('tenant-1', {
+        api_id: 'api-1',
+        environment: 'prod',
+      } as never)
+    ).resolves.toBe(deployment);
+    await expect(
+      deploymentsClient.rollback('tenant-1', 'dep-1', '1.2.3')
+    ).resolves.toBe(deployment);
+    await expect(deploymentsClient.getLogs('tenant-1', 'dep-1', 10, 50)).resolves.toBe(logs);
+    await expect(
+      deploymentsClient.getEnvironmentStatus('tenant-1', 'prod')
+    ).resolves.toBe(envStatus);
+    await expect(
+      deploymentsClient.getDeployableEnvironments('tenant-1', 'api-1')
+    ).resolves.toBe(deployable);
+    await expect(
+      deploymentsClient.deployApiToEnv('tenant-1', 'api-1', {
+        environment: 'prod',
+        gateway_ids: ['gw-1'],
+      })
+    ).resolves.toBe(deployResult);
+    await expect(
+      deploymentsClient.getApiGatewayAssignments('tenant-1', 'api-1', 'prod')
+    ).resolves.toBe(assignments);
+    await expect(
+      deploymentsClient.createApiGatewayAssignment('tenant-1', 'api-1', {
+        gateway_id: 'gw-1',
+        environment: 'prod',
+        auto_deploy: true,
+      })
+    ).resolves.toBe(assignment);
+    await expect(
+      deploymentsClient.deleteApiGatewayAssignment('tenant-1', 'api-1', 'assign-1')
+    ).resolves.toBeUndefined();
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/deployments', {
+      params: {
+        api_id: 'api-1',
+        environment: 'prod',
+        status: 'running',
+        page: 2,
+        page_size: 20,
+      },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/deployments/dep-1'
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/deployments', {
+      api_id: 'api-1',
+      environment: 'prod',
+    });
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/deployments/dep-1/rollback',
+      {
+        target_version: '1.2.3',
+      }
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      3,
+      '/v1/tenants/tenant-1/deployments/dep-1/logs',
+      {
+        params: { after_seq: 10, limit: 50 },
+      }
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      4,
+      '/v1/tenants/tenant-1/deployments/environments/prod/status'
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      5,
+      '/v1/tenants/tenant-1/apis/api-1/deployable-environments'
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      3,
+      '/v1/tenants/tenant-1/apis/api-1/deploy',
+      {
+        environment: 'prod',
+        gateway_ids: ['gw-1'],
+      }
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      6,
+      '/v1/tenants/tenant-1/apis/api-1/gateway-assignments',
+      {
+        params: { environment: 'prod' },
+      }
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      4,
+      '/v1/tenants/tenant-1/apis/api-1/gateway-assignments',
+      {
+        gateway_id: 'gw-1',
+        environment: 'prod',
+        auto_deploy: true,
+      }
+    );
+    expect(mockHttpClient.delete).toHaveBeenCalledWith(
+      '/v1/tenants/tenant-1/apis/api-1/gateway-assignments/assign-1'
+    );
+  });
+
+  it('covers tracesClient request delegation', async () => {
+    const traceList = { traces: [{ id: 'trace-1' }], total: 1 };
+    const trace = { id: 'trace-1' };
+    const timeline = { events: [{ id: 'evt-1' }] };
+    const stats = { total: 10 };
+    const live = { traces: [{ id: 'trace-live' }], count: 1 };
+    const aiStats = { total_sessions: 5 };
+    const csvBlob = new Blob(['trace,data'], { type: 'text/csv' });
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: traceList })
+      .mockResolvedValueOnce({ data: trace })
+      .mockResolvedValueOnce({ data: timeline })
+      .mockResolvedValueOnce({ data: stats })
+      .mockResolvedValueOnce({ data: live })
+      .mockResolvedValueOnce({ data: aiStats })
+      .mockResolvedValueOnce({ data: csvBlob });
+
+    await expect(
+      tracesClient.list(25, 'tenant-1', 'failed', 'prod')
+    ).resolves.toBe(traceList);
+    await expect(tracesClient.get('trace-1')).resolves.toBe(trace);
+    await expect(tracesClient.getTimeline('trace-1')).resolves.toBe(timeline);
+    await expect(tracesClient.getStats()).resolves.toBe(stats);
+    await expect(tracesClient.listLive()).resolves.toBe(live);
+    await expect(tracesClient.getAiSessionStats(7, 'worker-a')).resolves.toBe(aiStats);
+    await expect(tracesClient.exportAiSessionsCsv(7, 'worker-a')).resolves.toBe(csvBlob);
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/traces', {
+      params: {
+        limit: 25,
+        tenant_id: 'tenant-1',
+        status: 'failed',
+        environment: 'prod',
+      },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/traces/trace-1');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(3, '/v1/traces/trace-1/timeline');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(4, '/v1/traces/stats');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(5, '/v1/traces/live');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(6, '/v1/traces/stats/ai-sessions', {
+      params: { days: 7, worker: 'worker-a' },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(7, '/v1/traces/export/ai-sessions', {
+      params: { days: 7, worker: 'worker-a' },
+      responseType: 'blob',
+    });
+  });
+
+  it('covers gatewaysClient request delegation', async () => {
+    const gatewayList = { items: [{ id: 'gw-1' }], total: 1, page: 1, page_size: 20 };
+    const gateway = { id: 'gw-1', mode: 'edge-mcp' };
+    const tools = [{ id: 'tool-1' }];
+    const modeStats = { modes: [{ mode: 'edge-mcp', total: 1 }], total_gateways: 1 };
+    const metrics = { requests_total: 42 };
+    const guardrails = { items: [{ id: 'evt-1' }] };
+    const healthSummary = { healthy: 1 };
+    const policies = [{ id: 'policy-1' }];
+    const policy = { id: 'policy-1' };
+    const binding = { id: 'binding-1' };
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: gatewayList })
+      .mockResolvedValueOnce({ data: gateway })
+      .mockResolvedValueOnce({ data: tools })
+      .mockResolvedValueOnce({ data: modeStats })
+      .mockResolvedValueOnce({ data: metrics })
+      .mockResolvedValueOnce({ data: guardrails })
+      .mockResolvedValueOnce({ data: healthSummary })
+      .mockResolvedValueOnce({ data: metrics })
+      .mockResolvedValueOnce({ data: policies });
+    mockHttpClient.post
+      .mockResolvedValueOnce({ data: gateway })
+      .mockResolvedValueOnce({ data: gateway })
+      .mockResolvedValueOnce({ data: gateway })
+      .mockResolvedValueOnce({ data: policy })
+      .mockResolvedValueOnce({ data: binding });
+    mockHttpClient.put
+      .mockResolvedValueOnce({ data: gateway })
+      .mockResolvedValueOnce({ data: policy });
+    mockHttpClient.delete.mockResolvedValueOnce({}).mockResolvedValueOnce({}).mockResolvedValueOnce({});
+
+    await expect(
+      gatewaysClient.listInstances({
+        gateway_type: 'mcp',
+        environment: 'prod',
+        tenant_id: 'tenant-1',
+        include_deleted: false,
+        page: 1,
+        page_size: 20,
+      })
+    ).resolves.toBe(gatewayList);
+    await expect(gatewaysClient.getInstance('gw-1')).resolves.toBe(gateway);
+    await expect(gatewaysClient.listTools('gw-1')).resolves.toBe(tools);
+    await expect(
+      gatewaysClient.createInstance({
+        name: 'Gateway 1',
+      })
+    ).resolves.toBe(gateway);
+    await expect(
+      gatewaysClient.updateInstance('gw-1', {
+        name: 'Gateway 1B',
+      })
+    ).resolves.toBe(gateway);
+    await expect(gatewaysClient.removeInstance('gw-1')).resolves.toBeUndefined();
+    await expect(gatewaysClient.restoreInstance('gw-1')).resolves.toBe(gateway);
+    await expect(gatewaysClient.checkHealth('gw-1')).resolves.toBe(gateway);
+    await expect(gatewaysClient.getModeStats()).resolves.toBe(modeStats);
+    await expect(gatewaysClient.getAggregatedMetrics()).resolves.toBe(metrics);
+    await expect(gatewaysClient.getGuardrailsEvents(15)).resolves.toBe(guardrails);
+    await expect(gatewaysClient.getHealthSummary()).resolves.toBe(healthSummary);
+    await expect(gatewaysClient.getInstanceMetrics('gw-1')).resolves.toBe(metrics);
+    await expect(
+      gatewaysClient.listPolicies({
+        tenant_id: 'tenant-1',
+        environment: 'prod',
+      })
+    ).resolves.toBe(policies);
+    await expect(
+      gatewaysClient.createPolicy({
+        name: 'Policy A',
+      })
+    ).resolves.toBe(policy);
+    await expect(
+      gatewaysClient.updatePolicy('policy-1', {
+        name: 'Policy B',
+      })
+    ).resolves.toBe(policy);
+    await expect(gatewaysClient.removePolicy('policy-1')).resolves.toBeUndefined();
+    await expect(
+      gatewaysClient.createPolicyBinding({
+        policy_id: 'policy-1',
+        gateway_id: 'gw-1',
+      })
+    ).resolves.toBe(binding);
+    await expect(gatewaysClient.removePolicyBinding('binding-1')).resolves.toBeUndefined();
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/admin/gateways', {
+      params: {
+        gateway_type: 'mcp',
+        environment: 'prod',
+        tenant_id: 'tenant-1',
+        include_deleted: false,
+        page: 1,
+        page_size: 20,
+      },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/admin/gateways/gw-1');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(3, '/v1/admin/gateways/gw-1/tools');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(1, '/v1/admin/gateways', {
+      name: 'Gateway 1',
+    });
+    expect(mockHttpClient.put).toHaveBeenNthCalledWith(1, '/v1/admin/gateways/gw-1', {
+      name: 'Gateway 1B',
+    });
+    expect(mockHttpClient.delete).toHaveBeenNthCalledWith(1, '/v1/admin/gateways/gw-1');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(2, '/v1/admin/gateways/gw-1/restore');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(3, '/v1/admin/gateways/gw-1/health');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(4, '/v1/admin/gateways/modes/stats');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(5, '/v1/admin/gateways/metrics');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      6,
+      '/v1/admin/gateways/metrics/guardrails/events?limit=15'
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(7, '/v1/admin/gateways/health-summary');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(8, '/v1/admin/gateways/gw-1/metrics');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(9, '/v1/admin/policies', {
+      params: { tenant_id: 'tenant-1', environment: 'prod' },
+    });
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(4, '/v1/admin/policies', {
+      name: 'Policy A',
+    });
+    expect(mockHttpClient.put).toHaveBeenNthCalledWith(2, '/v1/admin/policies/policy-1', {
+      name: 'Policy B',
+    });
+    expect(mockHttpClient.delete).toHaveBeenNthCalledWith(2, '/v1/admin/policies/policy-1');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(5, '/v1/admin/policies/bindings', {
+      policy_id: 'policy-1',
+      gateway_id: 'gw-1',
+    });
+    expect(mockHttpClient.delete).toHaveBeenNthCalledWith(
+      3,
+      '/v1/admin/policies/bindings/binding-1'
+    );
+  });
+
+  it('covers gatewayDeploymentsClient request delegation', async () => {
+    const statusSummary = { synced: 1 };
+    const deploymentList = { items: [{ id: 'dep-1' }], total: 1, page: 1, page_size: 20 };
+    const deployment = { id: 'dep-1', sync_status: 'ok' };
+    const created = [{ id: 'dep-1' }];
+    const syncResult = { synced: true };
+    const testResult = { reachable: true, status_code: 200 };
+    const catalogEntries = [{ id: 'cat-1', api_name: 'Payments', tenant_id: 'tenant-1', version: '1.0.0' }];
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: statusSummary })
+      .mockResolvedValueOnce({ data: deploymentList })
+      .mockResolvedValueOnce({ data: deployment })
+      .mockResolvedValueOnce({ data: catalogEntries });
+    mockHttpClient.post
+      .mockResolvedValueOnce({ data: created })
+      .mockResolvedValueOnce({ data: syncResult })
+      .mockResolvedValueOnce({ data: testResult });
+    mockHttpClient.delete.mockResolvedValueOnce({});
+
+    await expect(gatewayDeploymentsClient.getStatusSummary()).resolves.toBe(statusSummary);
+    await expect(
+      gatewayDeploymentsClient.list({
+        sync_status: 'ok',
+        gateway_instance_id: 'gw-1',
+        environment: 'prod',
+        gateway_type: 'mcp',
+        page: 2,
+        page_size: 50,
+      })
+    ).resolves.toBe(deploymentList);
+    await expect(gatewayDeploymentsClient.get('dep-1')).resolves.toBe(deployment);
+    await expect(
+      gatewayDeploymentsClient.deployApiToGateways({
+        api_catalog_id: 'cat-1',
+        gateway_instance_ids: ['gw-1'],
+      })
+    ).resolves.toBe(created);
+    await expect(gatewayDeploymentsClient.undeploy('dep-1')).resolves.toBeUndefined();
+    await expect(gatewayDeploymentsClient.forceSync('dep-1')).resolves.toBe(syncResult);
+    await expect(gatewayDeploymentsClient.test('dep-1')).resolves.toBe(testResult);
+    await expect(gatewayDeploymentsClient.listCatalogEntries()).resolves.toBe(catalogEntries);
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/admin/deployments/status');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/admin/deployments', {
+      params: {
+        sync_status: 'ok',
+        gateway_instance_id: 'gw-1',
+        environment: 'prod',
+        gateway_type: 'mcp',
+        page: 2,
+        page_size: 50,
+      },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(3, '/v1/admin/deployments/dep-1');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(1, '/v1/admin/deployments', {
+      api_catalog_id: 'cat-1',
+      gateway_instance_ids: ['gw-1'],
+    });
+    expect(mockHttpClient.delete).toHaveBeenCalledWith('/v1/admin/deployments/dep-1');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(2, '/v1/admin/deployments/dep-1/sync');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(3, '/v1/admin/deployments/dep-1/test');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      4,
+      '/v1/admin/deployments/catalog-entries'
+    );
+  });
+});

--- a/control-plane-ui/src/test/services/api/ui2-s2d-clients.test.ts
+++ b/control-plane-ui/src/test/services/api/ui2-s2d-clients.test.ts
@@ -68,16 +68,16 @@ describe('UI-2 S2d domain clients', () => {
         environment: 'prod',
       } as never)
     ).resolves.toBe(deployment);
-    await expect(
-      deploymentsClient.rollback('tenant-1', 'dep-1', '1.2.3')
-    ).resolves.toBe(deployment);
+    await expect(deploymentsClient.rollback('tenant-1', 'dep-1', '1.2.3')).resolves.toBe(
+      deployment
+    );
     await expect(deploymentsClient.getLogs('tenant-1', 'dep-1', 10, 50)).resolves.toBe(logs);
-    await expect(
-      deploymentsClient.getEnvironmentStatus('tenant-1', 'prod')
-    ).resolves.toBe(envStatus);
-    await expect(
-      deploymentsClient.getDeployableEnvironments('tenant-1', 'api-1')
-    ).resolves.toBe(deployable);
+    await expect(deploymentsClient.getEnvironmentStatus('tenant-1', 'prod')).resolves.toBe(
+      envStatus
+    );
+    await expect(deploymentsClient.getDeployableEnvironments('tenant-1', 'api-1')).resolves.toBe(
+      deployable
+    );
     await expect(
       deploymentsClient.deployApiToEnv('tenant-1', 'api-1', {
         environment: 'prod',
@@ -107,10 +107,7 @@ describe('UI-2 S2d domain clients', () => {
         page_size: 20,
       },
     });
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
-      2,
-      '/v1/tenants/tenant-1/deployments/dep-1'
-    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/tenants/tenant-1/deployments/dep-1');
     expect(mockHttpClient.post).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/deployments', {
       api_id: 'api-1',
       environment: 'prod',
@@ -184,9 +181,7 @@ describe('UI-2 S2d domain clients', () => {
       .mockResolvedValueOnce({ data: aiStats })
       .mockResolvedValueOnce({ data: csvBlob });
 
-    await expect(
-      tracesClient.list(25, 'tenant-1', 'failed', 'prod')
-    ).resolves.toBe(traceList);
+    await expect(tracesClient.list(25, 'tenant-1', 'failed', 'prod')).resolves.toBe(traceList);
     await expect(tracesClient.get('trace-1')).resolves.toBe(trace);
     await expect(tracesClient.getTimeline('trace-1')).resolves.toBe(timeline);
     await expect(tracesClient.getStats()).resolves.toBe(stats);
@@ -246,7 +241,10 @@ describe('UI-2 S2d domain clients', () => {
     mockHttpClient.put
       .mockResolvedValueOnce({ data: gateway })
       .mockResolvedValueOnce({ data: policy });
-    mockHttpClient.delete.mockResolvedValueOnce({}).mockResolvedValueOnce({}).mockResolvedValueOnce({});
+    mockHttpClient.delete
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
 
     await expect(
       gatewaysClient.listInstances({
@@ -359,7 +357,9 @@ describe('UI-2 S2d domain clients', () => {
     const created = [{ id: 'dep-1' }];
     const syncResult = { synced: true };
     const testResult = { reachable: true, status_code: 200 };
-    const catalogEntries = [{ id: 'cat-1', api_name: 'Payments', tenant_id: 'tenant-1', version: '1.0.0' }];
+    const catalogEntries = [
+      { id: 'cat-1', api_name: 'Payments', tenant_id: 'tenant-1', version: '1.0.0' },
+    ];
 
     mockHttpClient.get
       .mockResolvedValueOnce({ data: statusSummary })
@@ -414,9 +414,6 @@ describe('UI-2 S2d domain clients', () => {
     expect(mockHttpClient.delete).toHaveBeenCalledWith('/v1/admin/deployments/dep-1');
     expect(mockHttpClient.post).toHaveBeenNthCalledWith(2, '/v1/admin/deployments/dep-1/sync');
     expect(mockHttpClient.post).toHaveBeenNthCalledWith(3, '/v1/admin/deployments/dep-1/test');
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
-      4,
-      '/v1/admin/deployments/catalog-entries'
-    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(4, '/v1/admin/deployments/catalog-entries');
   });
 });


### PR DESCRIPTION
## Summary

Part 5/8 of UI-2 axios split. Extracts 4 infra-facing clients (deployments, traces, gateways, gatewayDeployments) into `services/<domain>/`.

**Stack base**: S2c.

## Size

+447/-120 across 5 files. Above 300 cap — mechanical extraction, no logic change.

## Test plan

- [x] `npm run typecheck` green
- [x] `npm run lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)