### PR TITLE
refactor(ui): extract platform/chat/llm/monitoring + relocate 27 types (UI-2 S3)

### DIFF
--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -81,6 +81,81 @@ import { deploymentsClient } from './api/deployments';
 import { tracesClient } from './api/traces';
 import { gatewaysClient } from './api/gateways';
 import { gatewayDeploymentsClient } from './api/gatewayDeployments';
+import { platformClient } from './api/platform';
+import { chatClient } from './api/chat';
+import { llmClient } from './api/llm';
+import { monitoringClient } from './api/monitoring';
+
+// Imports internes des types co-localisés (nécessaires pour les signatures de
+// la classe ApiService ci-dessous). Ré-exports publics : voir en bas de fichier.
+import type {
+  OperationsMetrics,
+  BusinessMetrics,
+  TopAPI,
+  ComponentStatus,
+  PlatformEvent,
+  PlatformStatusResponse,
+  ApplicationDiffResponse,
+} from './api/platform';
+import type {
+  TenantChatSettings,
+  ChatUsageBySource,
+  TokenBudgetStatus,
+  TokenUsageStats,
+  ChatConversationMetrics,
+  ChatModelDistribution,
+} from './api/chat';
+import type {
+  LlmUsageResponse,
+  LlmTimeseriesResponse,
+  LlmProviderBreakdownResponse,
+  LlmBudgetResponse,
+} from './api/llm';
+import type {
+  MonitoringTransaction,
+  MonitoringTransactionDetail,
+  MonitoringStats,
+} from './api/monitoring';
+
+// ── Type re-exports (historiquement inline en bas de api.ts) ─────────────────
+// Ces types sont désormais co-localisés avec leur client de domaine.
+// On ré-exporte par sous-chemin explicite (pas de api/index.ts — collision
+// de résolution avec le fichier api.ts, cf. REWRITE-PLAN § C).
+export type {
+  OperationsMetrics,
+  BusinessMetrics,
+  TopAPI,
+  ComponentStatus,
+  GitOpsStatus,
+  PlatformEvent,
+  ExternalLinks,
+  PlatformStatusResponse,
+  ApplicationDiffResource,
+  ApplicationDiffResponse,
+} from './api/platform';
+export type {
+  TenantChatSettings,
+  ChatSourceEntry,
+  ChatUsageBySource,
+  TokenBudgetStatus,
+  TokenUsageStats,
+  ChatConversationMetrics,
+  ModelDistributionEntry,
+  ChatModelDistribution,
+} from './api/chat';
+export type {
+  LlmUsageResponse,
+  LlmTimeseriesPoint,
+  LlmTimeseriesResponse,
+  LlmProviderCostEntry,
+  LlmProviderBreakdownResponse,
+  LlmBudgetResponse,
+} from './api/llm';
+export type {
+  MonitoringTransaction,
+  MonitoringTransactionDetail,
+  MonitoringStats,
+} from './api/monitoring';
 
 // =============================================================================
 // Façade ApiService — agrège le core transport (services/http) et les méthodes
@@ -487,37 +562,27 @@ class ApiService {
 
   // Platform Status (CAB-654)
   async getPlatformStatus(): Promise<PlatformStatusResponse> {
-    const { data } = await httpClient.get('/v1/platform/status');
-    return data;
+    return platformClient.getStatus();
   }
 
   async getPlatformComponents(): Promise<ComponentStatus[]> {
-    const { data } = await httpClient.get('/v1/platform/components');
-    return data;
+    return platformClient.listComponents();
   }
 
   async getComponentStatus(name: string): Promise<ComponentStatus> {
-    const { data } = await httpClient.get(`/v1/platform/components/${name}`);
-    return data;
+    return platformClient.getComponent(name);
   }
 
   async syncPlatformComponent(name: string): Promise<{ message: string; operation: string }> {
-    const { data } = await httpClient.post(`/v1/platform/components/${name}/sync`);
-    return data;
+    return platformClient.syncComponent(name);
   }
 
   async getComponentDiff(name: string): Promise<ApplicationDiffResponse> {
-    const { data } = await httpClient.get(`/v1/platform/components/${name}/diff`);
-    return data;
+    return platformClient.getComponentDiff(name);
   }
 
   async getPlatformEvents(component?: string, limit?: number): Promise<PlatformEvent[]> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const params: Record<string, any> = {};
-    if (component) params.component = component;
-    if (limit) params.limit = limit;
-    const { data } = await httpClient.get('/v1/platform/events', { params });
-    return data;
+    return platformClient.listEvents(component, limit);
   }
 
   // Admin Prospects (CAB-911)
@@ -788,8 +853,7 @@ class ApiService {
   // =========================================================================
 
   async getOperationsMetrics(): Promise<OperationsMetrics> {
-    const { data } = await httpClient.get('/v1/operations/metrics');
-    return data;
+    return platformClient.getOperationsMetrics();
   }
 
   // =========================================================================
@@ -797,13 +861,11 @@ class ApiService {
   // =========================================================================
 
   async getBusinessMetrics(): Promise<BusinessMetrics> {
-    const { data } = await httpClient.get('/v1/business/metrics');
-    return data;
+    return platformClient.getBusinessMetrics();
   }
 
   async getTopAPIs(limit = 10): Promise<TopAPI[]> {
-    const { data } = await httpClient.get(`/v1/business/top-apis?limit=${limit}`);
-    return data;
+    return platformClient.getTopAPIs(limit);
   }
 
   // Workflow Engine methods (CAB-593)
@@ -885,29 +947,23 @@ class ApiService {
 
   // Chat Settings (CAB-1852)
   async getChatSettings(tenantId: string): Promise<TenantChatSettings> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/chat/settings`);
-    return data;
+    return chatClient.getSettings(tenantId);
   }
 
   async updateChatSettings(
     tenantId: string,
     settings: Partial<TenantChatSettings>
   ): Promise<TenantChatSettings> {
-    const { data } = await httpClient.put(`/v1/tenants/${tenantId}/chat/settings`, settings);
-    return data;
+    return chatClient.updateSettings(tenantId, settings);
   }
 
   // Chat Token Metering (CAB-288)
   async getChatBudgetStatus(tenantId: string): Promise<TokenBudgetStatus> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/chat/usage/budget`);
-    return data;
+    return chatClient.getBudgetStatus(tenantId);
   }
 
   async getChatUsageStats(tenantId: string, days = 30): Promise<TokenUsageStats> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/chat/usage/metering`, {
-      params: { days },
-    });
-    return data;
+    return chatClient.getUsageStats(tenantId, days);
   }
 
   // Chat Usage by source — per-app breakdown (CAB-1868)
@@ -915,32 +971,24 @@ class ApiService {
     tenantId: string,
     params: { group_by?: string; days?: number } = {}
   ): Promise<ChatUsageBySource> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/chat/usage/tenant`, {
-      params: { group_by: 'source', ...params },
-    });
-    return data;
+    return chatClient.getUsageBySource(tenantId, params);
   }
 
   // Chat conversation metrics — tenant-level aggregates (CAB-1868)
   async getChatConversationMetrics(tenantId: string): Promise<ChatConversationMetrics> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/chat/usage/tenant`);
-    return data;
+    return chatClient.getConversationMetrics(tenantId);
   }
 
   // Chat model distribution — conversations per model (CAB-1868)
   async getChatModelDistribution(tenantId: string): Promise<ChatModelDistribution> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/chat/usage/models`);
-    return data;
+    return chatClient.getModelDistribution(tenantId);
   }
 
   async createChatConversation(
     tenantId: string,
     title = 'New conversation'
   ): Promise<{ id: string }> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/chat/conversations`, {
-      title,
-    });
-    return data;
+    return chatClient.createConversation(tenantId, title);
   }
 
   // =========================================================================
@@ -985,43 +1033,32 @@ class ApiService {
     tenantId: string,
     period: 'hour' | 'day' | 'week' | 'month' = 'month'
   ): Promise<LlmUsageResponse> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/llm/usage`, {
-      params: { period },
-    });
-    return data;
+    return llmClient.getUsage(tenantId, period);
   }
 
   async getLlmTimeseries(
     tenantId: string,
     period: 'hour' | 'day' | 'week' | 'month' = 'week'
   ): Promise<LlmTimeseriesResponse> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/llm/usage/timeseries`, {
-      params: { period },
-    });
-    return data;
+    return llmClient.getTimeseries(tenantId, period);
   }
 
   async getLlmProviderBreakdown(
     tenantId: string,
     period: 'hour' | 'day' | 'week' | 'month' = 'month'
   ): Promise<LlmProviderBreakdownResponse> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/llm/usage/providers`, {
-      params: { period },
-    });
-    return data;
+    return llmClient.getProviderBreakdown(tenantId, period);
   }
 
   async getLlmBudget(tenantId: string): Promise<LlmBudgetResponse> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/llm/budget`);
-    return data;
+    return llmClient.getBudget(tenantId);
   }
 
   async updateLlmBudget(
     tenantId: string,
     update: { monthly_limit_usd?: number; alert_threshold_pct?: number }
   ): Promise<LlmBudgetResponse> {
-    const { data } = await httpClient.put(`/v1/tenants/${tenantId}/llm/budget`, update);
-    return data;
+    return llmClient.updateBudget(tenantId, update);
   }
 
   // ============== Subscription Management (CAB-1635) ==============
@@ -1189,272 +1226,23 @@ class ApiService {
     statusCode?: number,
     route?: string
   ): Promise<{ transactions: MonitoringTransaction[] }> {
-    const params: Record<string, string | number> = { limit };
-    if (status) params.status = status;
-    if (timeRange) params.time_range = timeRange;
-    if (serviceType) params.service_type = serviceType;
-    if (statusCode) params.status_code = statusCode;
-    if (route) params.route = route;
-    const { data } = await httpClient.get('/v1/monitoring/transactions', { params });
-    return data;
+    return monitoringClient.listTransactions(
+      limit,
+      status,
+      timeRange,
+      serviceType,
+      statusCode,
+      route
+    );
   }
 
   async getTransactionDetail(transactionId: string): Promise<MonitoringTransactionDetail> {
-    const { data } = await httpClient.get(`/v1/monitoring/transactions/${transactionId}`);
-    return data;
+    return monitoringClient.getTransactionDetail(transactionId);
   }
 
   async getTransactionStats(timeRange?: string): Promise<MonitoringStats> {
-    const params: Record<string, string> = {};
-    if (timeRange) params.time_range = timeRange;
-    const { data } = await httpClient.get('/v1/monitoring/transactions/stats', { params });
-    return data;
+    return monitoringClient.getTransactionStats(timeRange);
   }
-}
-
-// Operations metrics types (CAB-Observability)
-export interface OperationsMetrics {
-  error_rate: number;
-  p95_latency_ms: number;
-  requests_per_minute: number;
-  active_alerts: number;
-  uptime: number;
-}
-
-// Business metrics types (CAB-Observability)
-export interface BusinessMetrics {
-  active_tenants: number;
-  new_tenants_30d: number;
-  tenant_growth: number;
-  apdex_score: number;
-  total_tokens: number;
-  total_calls: number;
-}
-
-export interface TopAPI {
-  tool_name: string;
-  display_name: string;
-  calls: number;
-}
-
-// Chat Settings types (CAB-1852)
-export interface TenantChatSettings {
-  chat_console_enabled: boolean;
-  chat_portal_enabled: boolean;
-  chat_daily_budget: number;
-}
-
-// Chat Usage by source — per-app breakdown (CAB-1868)
-export interface ChatSourceEntry {
-  source: string;
-  tokens: number;
-  requests: number;
-}
-
-export interface ChatUsageBySource {
-  sources: ChatSourceEntry[];
-  total_tokens: number;
-  total_requests: number;
-  period_days: number;
-}
-
-// Chat Token Metering types (CAB-288)
-export interface TokenBudgetStatus {
-  user_tokens_today: number;
-  tenant_tokens_today: number;
-  daily_budget: number;
-  remaining: number;
-  budget_exceeded: boolean;
-  usage_percent: number;
-}
-
-export interface TokenUsageStats {
-  tenant_id: string;
-  period_days: number;
-  total_tokens: number;
-  total_input_tokens: number;
-  total_output_tokens: number;
-  total_requests: number;
-  today_tokens: number;
-  top_users: { user_id: string; tokens: number }[];
-  daily_breakdown: { date: string; tokens: number }[];
-}
-
-// Chat conversation metrics (CAB-1868)
-export interface ChatConversationMetrics {
-  tenant_id: string;
-  total_conversations: number;
-  total_messages: number;
-  total_tokens: number;
-  unique_users: number;
-}
-
-export interface ModelDistributionEntry {
-  model: string;
-  conversations: number;
-}
-
-export interface ChatModelDistribution {
-  models: ModelDistributionEntry[];
-  total_conversations: number;
-}
-
-// Platform Status types (CAB-654)
-export interface ComponentStatus {
-  name: string;
-  display_name: string;
-  sync_status: string;
-  health_status: string;
-  revision: string;
-  last_sync: string | null;
-  message: string | null;
-}
-
-export interface GitOpsStatus {
-  status: string;
-  components: ComponentStatus[];
-  checked_at: string;
-}
-
-export interface PlatformEvent {
-  id: number | null;
-  component: string;
-  event_type: string;
-  status: string;
-  revision: string;
-  message: string | null;
-  timestamp: string;
-  actor: string | null;
-}
-
-export interface ExternalLinks {
-  argocd: string;
-  grafana: string;
-  prometheus: string;
-  logs: string;
-}
-
-export interface PlatformStatusResponse {
-  gitops: GitOpsStatus;
-  events: PlatformEvent[];
-  external_links: ExternalLinks;
-  timestamp: string;
-}
-
-export interface ApplicationDiffResource {
-  name: string;
-  namespace: string | null;
-  kind: string;
-  group: string | null;
-  status: string;
-  health: string | null;
-  diff: string | null;
-}
-
-export interface ApplicationDiffResponse {
-  application: string;
-  total_resources: number;
-  diff_count: number;
-  resources: ApplicationDiffResource[];
-}
-
-// LLM Usage & Cost types (CAB-1487)
-export interface LlmUsageResponse {
-  total_cost_usd: number;
-  input_tokens: number;
-  output_tokens: number;
-  avg_cost_per_request: number;
-  cache_read_cost_usd: number;
-  cache_write_cost_usd: number;
-  period: string;
-}
-
-export interface LlmTimeseriesPoint {
-  timestamp: string;
-  value: number;
-}
-
-export interface LlmTimeseriesResponse {
-  points: LlmTimeseriesPoint[];
-  period: string;
-  step: string;
-}
-
-export interface LlmProviderCostEntry {
-  provider: string;
-  model: string;
-  cost_usd: number;
-}
-
-export interface LlmProviderBreakdownResponse {
-  providers: LlmProviderCostEntry[];
-  period: string;
-}
-
-export interface LlmBudgetResponse {
-  id: string;
-  tenant_id: string;
-  monthly_limit_usd: number;
-  current_spend_usd: number;
-  remaining_usd: number;
-  usage_pct: number;
-  alert_threshold_pct: number;
-  is_over_budget: boolean;
-}
-
-// ─── Monitoring / Call Flow ───
-
-export interface MonitoringTransaction {
-  id: string;
-  trace_id: string;
-  api_name: string;
-  method: string;
-  path: string;
-  status_code: number;
-  status: string;
-  status_text: string;
-  error_source: string | null;
-  started_at: string;
-  total_duration_ms: number;
-  spans_count: number;
-  deployment_mode?: string;
-  spans?: Array<{
-    name: string;
-    service: string;
-    start_offset_ms: number;
-    duration_ms: number;
-    status: string;
-  }>;
-}
-
-export interface MonitoringTransactionDetail extends MonitoringTransaction {
-  tenant_id: string | null;
-  client_ip: string | null;
-  user_id: string | null;
-  spans: Array<{
-    name: string;
-    service: string;
-    start_offset_ms: number;
-    duration_ms: number;
-    status: string;
-    metadata: Record<string, unknown>;
-  }>;
-  request_headers: Record<string, string> | null;
-  response_headers: Record<string, string> | null;
-  error_message: string | null;
-  demo_mode: boolean;
-}
-
-export interface MonitoringStats {
-  total_requests: number;
-  success_count: number;
-  error_count: number;
-  timeout_count: number;
-  avg_latency_ms: number;
-  p95_latency_ms: number;
-  requests_per_minute: number;
-  by_api: Record<string, number>;
-  by_status_code: Record<string, number>;
 }
 
 export const apiService = new ApiService();

--- a/control-plane-ui/src/services/api/chat.ts
+++ b/control-plane-ui/src/services/api/chat.ts
@@ -1,0 +1,121 @@
+import { httpClient } from '../http';
+
+// ── Chat Settings (CAB-1852) ─────────────────────────────────────────────────
+
+export interface TenantChatSettings {
+  chat_console_enabled: boolean;
+  chat_portal_enabled: boolean;
+  chat_daily_budget: number;
+}
+
+// ── Chat usage by source — per-app breakdown (CAB-1868) ─────────────────────
+
+export interface ChatSourceEntry {
+  source: string;
+  tokens: number;
+  requests: number;
+}
+
+export interface ChatUsageBySource {
+  sources: ChatSourceEntry[];
+  total_tokens: number;
+  total_requests: number;
+  period_days: number;
+}
+
+// ── Chat token metering (CAB-288) ───────────────────────────────────────────
+
+export interface TokenBudgetStatus {
+  user_tokens_today: number;
+  tenant_tokens_today: number;
+  daily_budget: number;
+  remaining: number;
+  budget_exceeded: boolean;
+  usage_percent: number;
+}
+
+export interface TokenUsageStats {
+  tenant_id: string;
+  period_days: number;
+  total_tokens: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_requests: number;
+  today_tokens: number;
+  top_users: { user_id: string; tokens: number }[];
+  daily_breakdown: { date: string; tokens: number }[];
+}
+
+// ── Chat conversation metrics (CAB-1868) ────────────────────────────────────
+
+export interface ChatConversationMetrics {
+  tenant_id: string;
+  total_conversations: number;
+  total_messages: number;
+  total_tokens: number;
+  unique_users: number;
+}
+
+export interface ModelDistributionEntry {
+  model: string;
+  conversations: number;
+}
+
+export interface ChatModelDistribution {
+  models: ModelDistributionEntry[];
+  total_conversations: number;
+}
+
+export const chatClient = {
+  async getSettings(tenantId: string): Promise<TenantChatSettings> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/chat/settings`);
+    return data;
+  },
+
+  async updateSettings(
+    tenantId: string,
+    settings: Partial<TenantChatSettings>
+  ): Promise<TenantChatSettings> {
+    const { data } = await httpClient.put(`/v1/tenants/${tenantId}/chat/settings`, settings);
+    return data;
+  },
+
+  async getBudgetStatus(tenantId: string): Promise<TokenBudgetStatus> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/chat/usage/budget`);
+    return data;
+  },
+
+  async getUsageStats(tenantId: string, days = 30): Promise<TokenUsageStats> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/chat/usage/metering`, {
+      params: { days },
+    });
+    return data;
+  },
+
+  async getUsageBySource(
+    tenantId: string,
+    params: { group_by?: string; days?: number } = {}
+  ): Promise<ChatUsageBySource> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/chat/usage/tenant`, {
+      params: { group_by: 'source', ...params },
+    });
+    return data;
+  },
+
+  async getConversationMetrics(tenantId: string): Promise<ChatConversationMetrics> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/chat/usage/tenant`);
+    return data;
+  },
+
+  async getModelDistribution(tenantId: string): Promise<ChatModelDistribution> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/chat/usage/models`);
+    return data;
+  },
+
+  async createConversation(tenantId: string, title = 'New conversation'): Promise<{ id: string }> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/chat/conversations`, {
+      title,
+    });
+    return data;
+  },
+};

--- a/control-plane-ui/src/services/api/llm.ts
+++ b/control-plane-ui/src/services/api/llm.ts
@@ -1,0 +1,90 @@
+import { httpClient } from '../http';
+
+// ── LLM usage & cost (CAB-1487) ──────────────────────────────────────────────
+
+export interface LlmUsageResponse {
+  total_cost_usd: number;
+  input_tokens: number;
+  output_tokens: number;
+  avg_cost_per_request: number;
+  cache_read_cost_usd: number;
+  cache_write_cost_usd: number;
+  period: string;
+}
+
+export interface LlmTimeseriesPoint {
+  timestamp: string;
+  value: number;
+}
+
+export interface LlmTimeseriesResponse {
+  points: LlmTimeseriesPoint[];
+  period: string;
+  step: string;
+}
+
+export interface LlmProviderCostEntry {
+  provider: string;
+  model: string;
+  cost_usd: number;
+}
+
+export interface LlmProviderBreakdownResponse {
+  providers: LlmProviderCostEntry[];
+  period: string;
+}
+
+export interface LlmBudgetResponse {
+  id: string;
+  tenant_id: string;
+  monthly_limit_usd: number;
+  current_spend_usd: number;
+  remaining_usd: number;
+  usage_pct: number;
+  alert_threshold_pct: number;
+  is_over_budget: boolean;
+}
+
+type LlmPeriod = 'hour' | 'day' | 'week' | 'month';
+
+export const llmClient = {
+  async getUsage(tenantId: string, period: LlmPeriod = 'month'): Promise<LlmUsageResponse> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/llm/usage`, {
+      params: { period },
+    });
+    return data;
+  },
+
+  async getTimeseries(
+    tenantId: string,
+    period: LlmPeriod = 'week'
+  ): Promise<LlmTimeseriesResponse> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/llm/usage/timeseries`, {
+      params: { period },
+    });
+    return data;
+  },
+
+  async getProviderBreakdown(
+    tenantId: string,
+    period: LlmPeriod = 'month'
+  ): Promise<LlmProviderBreakdownResponse> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/llm/usage/providers`, {
+      params: { period },
+    });
+    return data;
+  },
+
+  async getBudget(tenantId: string): Promise<LlmBudgetResponse> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/llm/budget`);
+    return data;
+  },
+
+  async updateBudget(
+    tenantId: string,
+    update: { monthly_limit_usd?: number; alert_threshold_pct?: number }
+  ): Promise<LlmBudgetResponse> {
+    const { data } = await httpClient.put(`/v1/tenants/${tenantId}/llm/budget`, update);
+    return data;
+  },
+};

--- a/control-plane-ui/src/services/api/monitoring.ts
+++ b/control-plane-ui/src/services/api/monitoring.ts
@@ -1,0 +1,88 @@
+import { httpClient } from '../http';
+
+// ── Monitoring / Call flow (CAB-1869) ────────────────────────────────────────
+
+export interface MonitoringTransaction {
+  id: string;
+  trace_id: string;
+  api_name: string;
+  method: string;
+  path: string;
+  status_code: number;
+  status: string;
+  status_text: string;
+  error_source: string | null;
+  started_at: string;
+  total_duration_ms: number;
+  spans_count: number;
+  deployment_mode?: string;
+  spans?: Array<{
+    name: string;
+    service: string;
+    start_offset_ms: number;
+    duration_ms: number;
+    status: string;
+  }>;
+}
+
+export interface MonitoringTransactionDetail extends MonitoringTransaction {
+  tenant_id: string | null;
+  client_ip: string | null;
+  user_id: string | null;
+  spans: Array<{
+    name: string;
+    service: string;
+    start_offset_ms: number;
+    duration_ms: number;
+    status: string;
+    metadata: Record<string, unknown>;
+  }>;
+  request_headers: Record<string, string> | null;
+  response_headers: Record<string, string> | null;
+  error_message: string | null;
+  demo_mode: boolean;
+}
+
+export interface MonitoringStats {
+  total_requests: number;
+  success_count: number;
+  error_count: number;
+  timeout_count: number;
+  avg_latency_ms: number;
+  p95_latency_ms: number;
+  requests_per_minute: number;
+  by_api: Record<string, number>;
+  by_status_code: Record<string, number>;
+}
+
+export const monitoringClient = {
+  async listTransactions(
+    limit = 20,
+    status?: string,
+    timeRange?: string,
+    serviceType?: string,
+    statusCode?: number,
+    route?: string
+  ): Promise<{ transactions: MonitoringTransaction[] }> {
+    const params: Record<string, string | number> = { limit };
+    if (status) params.status = status;
+    if (timeRange) params.time_range = timeRange;
+    if (serviceType) params.service_type = serviceType;
+    if (statusCode) params.status_code = statusCode;
+    if (route) params.route = route;
+    const { data } = await httpClient.get('/v1/monitoring/transactions', { params });
+    return data;
+  },
+
+  async getTransactionDetail(transactionId: string): Promise<MonitoringTransactionDetail> {
+    const { data } = await httpClient.get(`/v1/monitoring/transactions/${transactionId}`);
+    return data;
+  },
+
+  async getTransactionStats(timeRange?: string): Promise<MonitoringStats> {
+    const params: Record<string, string> = {};
+    if (timeRange) params.time_range = timeRange;
+    const { data } = await httpClient.get('/v1/monitoring/transactions/stats', { params });
+    return data;
+  },
+};

--- a/control-plane-ui/src/services/api/platform.ts
+++ b/control-plane-ui/src/services/api/platform.ts
@@ -1,0 +1,142 @@
+import { httpClient } from '../http';
+
+// ── Platform Status (CAB-654) ────────────────────────────────────────────────
+
+export interface ComponentStatus {
+  name: string;
+  display_name: string;
+  sync_status: string;
+  health_status: string;
+  revision: string;
+  last_sync: string | null;
+  message: string | null;
+}
+
+export interface GitOpsStatus {
+  status: string;
+  components: ComponentStatus[];
+  checked_at: string;
+}
+
+export interface PlatformEvent {
+  id: number | null;
+  component: string;
+  event_type: string;
+  status: string;
+  revision: string;
+  message: string | null;
+  timestamp: string;
+  actor: string | null;
+}
+
+export interface ExternalLinks {
+  argocd: string;
+  grafana: string;
+  prometheus: string;
+  logs: string;
+}
+
+export interface PlatformStatusResponse {
+  gitops: GitOpsStatus;
+  events: PlatformEvent[];
+  external_links: ExternalLinks;
+  timestamp: string;
+}
+
+export interface ApplicationDiffResource {
+  name: string;
+  namespace: string | null;
+  kind: string;
+  group: string | null;
+  status: string;
+  health: string | null;
+  diff: string | null;
+}
+
+export interface ApplicationDiffResponse {
+  application: string;
+  total_resources: number;
+  diff_count: number;
+  resources: ApplicationDiffResource[];
+}
+
+// ── Operations metrics (CAB-Observability) ──────────────────────────────────
+
+export interface OperationsMetrics {
+  error_rate: number;
+  p95_latency_ms: number;
+  requests_per_minute: number;
+  active_alerts: number;
+  uptime: number;
+}
+
+// ── Business analytics (CAB-Observability) ──────────────────────────────────
+
+export interface BusinessMetrics {
+  active_tenants: number;
+  new_tenants_30d: number;
+  tenant_growth: number;
+  apdex_score: number;
+  total_tokens: number;
+  total_calls: number;
+}
+
+export interface TopAPI {
+  tool_name: string;
+  display_name: string;
+  calls: number;
+}
+
+export const platformClient = {
+  // Status
+  async getStatus(): Promise<PlatformStatusResponse> {
+    const { data } = await httpClient.get('/v1/platform/status');
+    return data;
+  },
+
+  async listComponents(): Promise<ComponentStatus[]> {
+    const { data } = await httpClient.get('/v1/platform/components');
+    return data;
+  },
+
+  async getComponent(name: string): Promise<ComponentStatus> {
+    const { data } = await httpClient.get(`/v1/platform/components/${name}`);
+    return data;
+  },
+
+  async syncComponent(name: string): Promise<{ message: string; operation: string }> {
+    const { data } = await httpClient.post(`/v1/platform/components/${name}/sync`);
+    return data;
+  },
+
+  async getComponentDiff(name: string): Promise<ApplicationDiffResponse> {
+    const { data } = await httpClient.get(`/v1/platform/components/${name}/diff`);
+    return data;
+  },
+
+  async listEvents(component?: string, limit?: number): Promise<PlatformEvent[]> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const params: Record<string, any> = {};
+    if (component) params.component = component;
+    if (limit) params.limit = limit;
+    const { data } = await httpClient.get('/v1/platform/events', { params });
+    return data;
+  },
+
+  // Operations
+  async getOperationsMetrics(): Promise<OperationsMetrics> {
+    const { data } = await httpClient.get('/v1/operations/metrics');
+    return data;
+  },
+
+  // Business
+  async getBusinessMetrics(): Promise<BusinessMetrics> {
+    const { data } = await httpClient.get('/v1/business/metrics');
+    return data;
+  },
+
+  async getTopAPIs(limit = 10): Promise<TopAPI[]> {
+    const { data } = await httpClient.get(`/v1/business/top-apis?limit=${limit}`);
+    return data;
+  },
+};

--- a/control-plane-ui/src/test/services/api/ui2-s3-clients.test.ts
+++ b/control-plane-ui/src/test/services/api/ui2-s3-clients.test.ts
@@ -142,10 +142,7 @@ describe('UI-2 S3 domain clients', () => {
     expect(mockHttpClient.put).toHaveBeenCalledWith('/v1/tenants/tenant-1/chat/settings', {
       chat_portal_enabled: true,
     });
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
-      2,
-      '/v1/tenants/tenant-1/chat/usage/budget'
-    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/tenants/tenant-1/chat/usage/budget');
     expect(mockHttpClient.get).toHaveBeenNthCalledWith(
       3,
       '/v1/tenants/tenant-1/chat/usage/metering',
@@ -160,20 +157,11 @@ describe('UI-2 S3 domain clients', () => {
         params: { group_by: 'source', days: 7 },
       }
     );
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
-      5,
-      '/v1/tenants/tenant-1/chat/usage/tenant'
-    );
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
-      6,
-      '/v1/tenants/tenant-1/chat/usage/models'
-    );
-    expect(mockHttpClient.post).toHaveBeenCalledWith(
-      '/v1/tenants/tenant-1/chat/conversations',
-      {
-        title: 'Runbook',
-      }
-    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(5, '/v1/tenants/tenant-1/chat/usage/tenant');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(6, '/v1/tenants/tenant-1/chat/usage/models');
+    expect(mockHttpClient.post).toHaveBeenCalledWith('/v1/tenants/tenant-1/chat/conversations', {
+      title: 'Runbook',
+    });
   });
 
   it('covers llmClient request delegation', async () => {
@@ -271,7 +259,9 @@ describe('UI-2 S3 domain clients', () => {
     await expect(
       monitoringClient.listTransactions(30, 'error', '24h', 'gateway', 500, '/payments')
     ).resolves.toBe(transactions);
-    await expect(monitoringClient.getTransactionDetail('txn-1')).resolves.toBe(transaction as never);
+    await expect(monitoringClient.getTransactionDetail('txn-1')).resolves.toBe(
+      transaction as never
+    );
     await expect(monitoringClient.getTransactionStats('24h')).resolves.toBe(stats);
 
     expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/monitoring/transactions', {
@@ -284,16 +274,9 @@ describe('UI-2 S3 domain clients', () => {
         route: '/payments',
       },
     });
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
-      2,
-      '/v1/monitoring/transactions/txn-1'
-    );
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
-      3,
-      '/v1/monitoring/transactions/stats',
-      {
-        params: { time_range: '24h' },
-      }
-    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/monitoring/transactions/txn-1');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(3, '/v1/monitoring/transactions/stats', {
+      params: { time_range: '24h' },
+    });
   });
 });

--- a/control-plane-ui/src/test/services/api/ui2-s3-clients.test.ts
+++ b/control-plane-ui/src/test/services/api/ui2-s3-clients.test.ts
@@ -1,0 +1,299 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockHttpClient } = vi.hoisted(() => ({
+  mockHttpClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../../../services/http', () => ({
+  httpClient: mockHttpClient,
+}));
+
+import { platformClient } from '../../../services/api/platform';
+import { chatClient } from '../../../services/api/chat';
+import { llmClient } from '../../../services/api/llm';
+import { monitoringClient } from '../../../services/api/monitoring';
+
+describe('UI-2 S3 domain clients', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('covers platformClient request delegation', async () => {
+    const status = { timestamp: '2026-04-22T00:00:00Z' };
+    const components = [{ name: 'api' }];
+    const component = { name: 'api', health_status: 'healthy' };
+    const sync = { message: 'started', operation: 'sync' };
+    const diff = { application: 'api', total_resources: 1, diff_count: 0, resources: [] };
+    const events = [{ id: 1, component: 'api' }];
+    const operations = { error_rate: 0.1 };
+    const business = { active_tenants: 2 };
+    const topApis = [{ tool_name: 'payments', display_name: 'Payments', calls: 42 }];
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: status })
+      .mockResolvedValueOnce({ data: components })
+      .mockResolvedValueOnce({ data: component })
+      .mockResolvedValueOnce({ data: diff })
+      .mockResolvedValueOnce({ data: events })
+      .mockResolvedValueOnce({ data: operations })
+      .mockResolvedValueOnce({ data: business })
+      .mockResolvedValueOnce({ data: topApis });
+    mockHttpClient.post.mockResolvedValueOnce({ data: sync });
+
+    await expect(platformClient.getStatus()).resolves.toBe(status as never);
+    await expect(platformClient.listComponents()).resolves.toBe(components as never);
+    await expect(platformClient.getComponent('api')).resolves.toBe(component as never);
+    await expect(platformClient.syncComponent('api')).resolves.toBe(sync);
+    await expect(platformClient.getComponentDiff('api')).resolves.toBe(diff as never);
+    await expect(platformClient.listEvents('api', 15)).resolves.toBe(events as never);
+    await expect(platformClient.getOperationsMetrics()).resolves.toBe(operations as never);
+    await expect(platformClient.getBusinessMetrics()).resolves.toBe(business as never);
+    await expect(platformClient.getTopAPIs(5)).resolves.toBe(topApis as never);
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/platform/status');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/platform/components');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(3, '/v1/platform/components/api');
+    expect(mockHttpClient.post).toHaveBeenCalledWith('/v1/platform/components/api/sync');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(4, '/v1/platform/components/api/diff');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(5, '/v1/platform/events', {
+      params: { component: 'api', limit: 15 },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(6, '/v1/operations/metrics');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(7, '/v1/business/metrics');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(8, '/v1/business/top-apis?limit=5');
+  });
+
+  it('covers chatClient request delegation', async () => {
+    const settings = {
+      chat_console_enabled: true,
+      chat_portal_enabled: false,
+      chat_daily_budget: 1000,
+    };
+    const budget = {
+      user_tokens_today: 10,
+      tenant_tokens_today: 100,
+      daily_budget: 1000,
+      remaining: 900,
+      budget_exceeded: false,
+      usage_percent: 10,
+    };
+    const usage = {
+      tenant_id: 'tenant-1',
+      period_days: 7,
+      total_tokens: 1000,
+      total_input_tokens: 600,
+      total_output_tokens: 400,
+      total_requests: 10,
+      today_tokens: 100,
+      top_users: [],
+      daily_breakdown: [],
+    };
+    const bySource = {
+      sources: [{ source: 'console', tokens: 100, requests: 2 }],
+      total_tokens: 100,
+      total_requests: 2,
+      period_days: 7,
+    };
+    const conversationMetrics = {
+      tenant_id: 'tenant-1',
+      total_conversations: 5,
+      total_messages: 20,
+      total_tokens: 1000,
+      unique_users: 3,
+    };
+    const models = {
+      models: [{ model: 'gpt-5.4', conversations: 5 }],
+      total_conversations: 5,
+    };
+    const conversation = { id: 'conv-1' };
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: settings })
+      .mockResolvedValueOnce({ data: budget })
+      .mockResolvedValueOnce({ data: usage })
+      .mockResolvedValueOnce({ data: bySource })
+      .mockResolvedValueOnce({ data: conversationMetrics })
+      .mockResolvedValueOnce({ data: models });
+    mockHttpClient.put.mockResolvedValueOnce({ data: settings });
+    mockHttpClient.post.mockResolvedValueOnce({ data: conversation });
+
+    await expect(chatClient.getSettings('tenant-1')).resolves.toBe(settings);
+    await expect(
+      chatClient.updateSettings('tenant-1', {
+        chat_portal_enabled: true,
+      })
+    ).resolves.toBe(settings);
+    await expect(chatClient.getBudgetStatus('tenant-1')).resolves.toBe(budget);
+    await expect(chatClient.getUsageStats('tenant-1', 7)).resolves.toBe(usage);
+    await expect(
+      chatClient.getUsageBySource('tenant-1', { days: 7, group_by: 'source' })
+    ).resolves.toBe(bySource);
+    await expect(chatClient.getConversationMetrics('tenant-1')).resolves.toBe(conversationMetrics);
+    await expect(chatClient.getModelDistribution('tenant-1')).resolves.toBe(models);
+    await expect(chatClient.createConversation('tenant-1', 'Runbook')).resolves.toBe(conversation);
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/chat/settings');
+    expect(mockHttpClient.put).toHaveBeenCalledWith('/v1/tenants/tenant-1/chat/settings', {
+      chat_portal_enabled: true,
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/chat/usage/budget'
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      3,
+      '/v1/tenants/tenant-1/chat/usage/metering',
+      {
+        params: { days: 7 },
+      }
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      4,
+      '/v1/tenants/tenant-1/chat/usage/tenant',
+      {
+        params: { group_by: 'source', days: 7 },
+      }
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      5,
+      '/v1/tenants/tenant-1/chat/usage/tenant'
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      6,
+      '/v1/tenants/tenant-1/chat/usage/models'
+    );
+    expect(mockHttpClient.post).toHaveBeenCalledWith(
+      '/v1/tenants/tenant-1/chat/conversations',
+      {
+        title: 'Runbook',
+      }
+    );
+  });
+
+  it('covers llmClient request delegation', async () => {
+    const usage = {
+      total_cost_usd: 10,
+      input_tokens: 1000,
+      output_tokens: 500,
+      avg_cost_per_request: 1,
+      cache_read_cost_usd: 0,
+      cache_write_cost_usd: 0,
+      period: 'month',
+    };
+    const timeseries = {
+      points: [{ timestamp: '2026-04-22T00:00:00Z', value: 12 }],
+      period: 'week',
+      step: 'day',
+    };
+    const providers = {
+      providers: [{ provider: 'openai', model: 'gpt-5.4', cost_usd: 10 }],
+      period: 'month',
+    };
+    const budget = {
+      id: 'budget-1',
+      tenant_id: 'tenant-1',
+      monthly_limit_usd: 100,
+      current_spend_usd: 20,
+      remaining_usd: 80,
+      usage_pct: 20,
+      alert_threshold_pct: 80,
+      is_over_budget: false,
+    };
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: usage })
+      .mockResolvedValueOnce({ data: timeseries })
+      .mockResolvedValueOnce({ data: providers })
+      .mockResolvedValueOnce({ data: budget });
+    mockHttpClient.put.mockResolvedValueOnce({ data: budget });
+
+    await expect(llmClient.getUsage('tenant-1', 'month')).resolves.toBe(usage);
+    await expect(llmClient.getTimeseries('tenant-1', 'week')).resolves.toBe(timeseries);
+    await expect(llmClient.getProviderBreakdown('tenant-1', 'month')).resolves.toBe(providers);
+    await expect(llmClient.getBudget('tenant-1')).resolves.toBe(budget);
+    await expect(
+      llmClient.updateBudget('tenant-1', {
+        monthly_limit_usd: 120,
+        alert_threshold_pct: 85,
+      })
+    ).resolves.toBe(budget);
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/llm/usage', {
+      params: { period: 'month' },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/llm/usage/timeseries',
+      {
+        params: { period: 'week' },
+      }
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      3,
+      '/v1/tenants/tenant-1/llm/usage/providers',
+      {
+        params: { period: 'month' },
+      }
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(4, '/v1/tenants/tenant-1/llm/budget');
+    expect(mockHttpClient.put).toHaveBeenCalledWith('/v1/tenants/tenant-1/llm/budget', {
+      monthly_limit_usd: 120,
+      alert_threshold_pct: 85,
+    });
+  });
+
+  it('covers monitoringClient request delegation', async () => {
+    const transactions = { transactions: [{ id: 'txn-1' }] };
+    const transaction = { id: 'txn-1', trace_id: 'trace-1', spans: [] };
+    const stats = {
+      total_requests: 10,
+      success_count: 9,
+      error_count: 1,
+      timeout_count: 0,
+      avg_latency_ms: 100,
+      p95_latency_ms: 180,
+      requests_per_minute: 2,
+      by_api: { payments: 10 },
+      by_status_code: { '200': 9, '500': 1 },
+    };
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: transactions })
+      .mockResolvedValueOnce({ data: transaction })
+      .mockResolvedValueOnce({ data: stats });
+
+    await expect(
+      monitoringClient.listTransactions(30, 'error', '24h', 'gateway', 500, '/payments')
+    ).resolves.toBe(transactions);
+    await expect(monitoringClient.getTransactionDetail('txn-1')).resolves.toBe(transaction as never);
+    await expect(monitoringClient.getTransactionStats('24h')).resolves.toBe(stats);
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/monitoring/transactions', {
+      params: {
+        limit: 30,
+        status: 'error',
+        time_range: '24h',
+        service_type: 'gateway',
+        status_code: 500,
+        route: '/payments',
+      },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      2,
+      '/v1/monitoring/transactions/txn-1'
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      3,
+      '/v1/monitoring/transactions/stats',
+      {
+        params: { time_range: '24h' },
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Part 6/8 of UI-2 axios split. Extracts platform/chat/llm/monitoring clients and relocates 27 shared types from `services/api.ts` to domain-local type files.

**Stack base**: S2d.

## Size

+548/-319 across 5 files. Above 300 cap — type relocations account for most of the volume (pure moves + imports rewire).

## Test plan

- [x] `npm run typecheck` green
- [x] `npm run lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)