### PR TITLE
chore(ui): ban axios imports outside services/http (UI-2 bonus)

### DIFF
--- a/control-plane-ui/.eslintrc.cjs
+++ b/control-plane-ui/.eslintrc.cjs
@@ -24,5 +24,25 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 'off',
       },
     },
+    {
+      // UI-2: axios must stay confined to services/http/. Everyone else goes
+      // through services/api/<domain>.ts or services/api (legacy façade).
+      files: ['src/**/*.ts', 'src/**/*.tsx'],
+      excludedFiles: ['src/services/http/**'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: 'axios',
+                message:
+                  'Import httpClient from services/http (or a domain client from services/api/<domain>). Direct axios use is confined to services/http/.',
+              },
+            ],
+          },
+        ],
+      },
+    },
   ],
 }


### PR DESCRIPTION
## Summary

Part 8/8 of UI-2 axios split. Adds ESLint rule banning raw `axios` imports outside `services/http/`. Enforces the extraction done in S1-S4: all HTTP calls must go through the shared http core.

**Stack base**: S4.

## Size

+20/-0 across 1 file ✅.

## Test plan

- [x] `npm run lint` green with new rule active
- [x] No existing violations (would have broken S1-S3 review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)