### PR TITLE
refactor(ui): extract git/session/admin/toolPermissions/workflows clients (UI-2 S2a)

### DIFF
--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -63,6 +63,11 @@ import {
   createEventSource as createEventSourceCore,
   type TokenRefresher,
 } from './http';
+import { gitClient } from './api/git';
+import { sessionClient } from './api/session';
+import { adminClient } from './api/admin';
+import { toolPermissionsClient } from './api/toolPermissions';
+import { workflowsClient } from './api/workflows';
 
 // =============================================================================
 // Façade ApiService — agrège le core transport (services/http) et les méthodes
@@ -123,8 +128,7 @@ class ApiService {
     role_display_names?: Record<string, string>;
     tenant_id?: string;
   }> {
-    const { data } = await httpClient.get('/v1/me');
-    return data;
+    return sessionClient.getMe();
   }
 
   // Tenants
@@ -154,8 +158,7 @@ class ApiService {
 
   // Environments (ADR-040)
   async getEnvironments(): Promise<EnvironmentConfig[]> {
-    const { data } = await httpClient.get('/v1/environments');
-    return data.environments;
+    return sessionClient.listEnvironments();
   }
 
   // APIs
@@ -502,14 +505,11 @@ class ApiService {
 
   // Git
   async getCommits(tenantId: string, path?: string): Promise<CommitInfo[]> {
-    const params = path ? { path } : {};
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/git/commits`, { params });
-    return data;
+    return gitClient.listCommits(tenantId, path);
   }
 
   async getMergeRequests(tenantId: string): Promise<MergeRequest[]> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/git/merge-requests`);
-    return data;
+    return gitClient.listMergeRequests(tenantId);
   }
 
   // SSE Events — délègue au helper du core transport
@@ -618,21 +618,18 @@ class ApiService {
     page?: number;
     limit?: number;
   }): Promise<ProspectListResponse> {
-    const { data } = await httpClient.get('/v1/admin/prospects', { params });
-    return data;
+    return adminClient.listProspects(params);
   }
 
   async getProspectsMetrics(params?: {
     date_from?: string;
     date_to?: string;
   }): Promise<ProspectsMetricsResponse> {
-    const { data } = await httpClient.get('/v1/admin/prospects/metrics', { params });
-    return data;
+    return adminClient.getProspectsMetrics(params);
   }
 
   async getProspect(inviteId: string): Promise<ProspectDetail> {
-    const { data } = await httpClient.get(`/v1/admin/prospects/${inviteId}`);
-    return data;
+    return adminClient.getProspect(inviteId);
   }
 
   async exportProspectsCSV(params?: {
@@ -641,11 +638,7 @@ class ApiService {
     date_from?: string;
     date_to?: string;
   }): Promise<Blob> {
-    const { data } = await httpClient.get('/v1/admin/prospects/export', {
-      params,
-      responseType: 'blob',
-    });
-    return data;
+    return adminClient.exportProspectsCSV(params);
   }
 
   // Admin Access Requests (CAB-1468)
@@ -654,8 +647,7 @@ class ApiService {
     page?: number;
     limit?: number;
   }): Promise<AccessRequestListResponse> {
-    const { data } = await httpClient.get('/v1/admin/access-requests', { params });
-    return data;
+    return adminClient.listAccessRequests(params);
   }
 
   // Gateway Instances (Control Plane Agnostique)
@@ -944,16 +936,14 @@ class ApiService {
 
   // Workflow Engine methods (CAB-593)
   async listWorkflowTemplates(tenantId: string): Promise<WorkflowTemplateListResponse> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/workflows/templates`);
-    return data;
+    return workflowsClient.listTemplates(tenantId);
   }
 
   async createWorkflowTemplate(
     tenantId: string,
     payload: WorkflowTemplateCreate
   ): Promise<WorkflowTemplate> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/workflows/templates`, payload);
-    return data;
+    return workflowsClient.createTemplate(tenantId, payload);
   }
 
   async updateWorkflowTemplate(
@@ -961,33 +951,25 @@ class ApiService {
     templateId: string,
     payload: WorkflowTemplateUpdate
   ): Promise<WorkflowTemplate> {
-    const { data } = await httpClient.put(
-      `/v1/tenants/${tenantId}/workflows/templates/${templateId}`,
-      payload
-    );
-    return data;
+    return workflowsClient.updateTemplate(tenantId, templateId, payload);
   }
 
   async deleteWorkflowTemplate(tenantId: string, templateId: string): Promise<void> {
-    await httpClient.delete(`/v1/tenants/${tenantId}/workflows/templates/${templateId}`);
+    return workflowsClient.deleteTemplate(tenantId, templateId);
   }
 
   async listWorkflowInstances(
     tenantId: string,
     params?: { status?: string; skip?: number; limit?: number }
   ): Promise<WorkflowListResponse> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/workflows/instances`, {
-      params,
-    });
-    return data;
+    return workflowsClient.listInstances(tenantId, params);
   }
 
   async startWorkflow(
     tenantId: string,
     payload: { template_id: string; subject_id: string; subject_email: string }
   ): Promise<WorkflowInstance> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/workflows/instances`, payload);
-    return data;
+    return workflowsClient.start(tenantId, payload);
   }
 
   async approveWorkflowStep(
@@ -995,11 +977,7 @@ class ApiService {
     instanceId: string,
     payload: { comment?: string }
   ): Promise<WorkflowInstance> {
-    const { data } = await httpClient.post(
-      `/v1/tenants/${tenantId}/workflows/instances/${instanceId}/approve`,
-      payload
-    );
-    return data;
+    return workflowsClient.approveStep(tenantId, instanceId, payload);
   }
 
   async rejectWorkflowStep(
@@ -1007,16 +985,11 @@ class ApiService {
     instanceId: string,
     payload: { comment?: string }
   ): Promise<WorkflowInstance> {
-    const { data } = await httpClient.post(
-      `/v1/tenants/${tenantId}/workflows/instances/${instanceId}/reject`,
-      payload
-    );
-    return data;
+    return workflowsClient.rejectStep(tenantId, instanceId, payload);
   }
 
   async seedWorkflowTemplates(tenantId: string): Promise<{ message: string }> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/workflows/templates/seed`);
-    return data;
+    return workflowsClient.seedTemplates(tenantId);
   }
 
   // Tool Permissions (CAB-1982)
@@ -1024,22 +997,18 @@ class ApiService {
     tenantId: string,
     params?: { mcp_server_id?: string; page?: number; page_size?: number }
   ): Promise<TenantToolPermissionListResponse> {
-    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/tool-permissions`, {
-      params: { ...params, page_size: params?.page_size ?? 100 },
-    });
-    return data;
+    return toolPermissionsClient.list(tenantId, params);
   }
 
   async upsertToolPermission(
     tenantId: string,
     body: Schemas['TenantToolPermissionCreate']
   ): Promise<TenantToolPermission> {
-    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/tool-permissions`, body);
-    return data;
+    return toolPermissionsClient.upsert(tenantId, body);
   }
 
   async deleteToolPermission(tenantId: string, permissionId: string): Promise<void> {
-    await httpClient.delete(`/v1/tenants/${tenantId}/tool-permissions/${permissionId}`);
+    return toolPermissionsClient.remove(tenantId, permissionId);
   }
 
   // Chat Settings (CAB-1852)
@@ -1113,8 +1082,7 @@ class ApiService {
     page?: number;
     limit?: number;
   }): Promise<AdminUserListResponse> {
-    const { data } = await httpClient.get('/v1/admin/users', { params });
-    return data;
+    return adminClient.listUsers(params);
   }
 
   // =========================================================================
@@ -1122,13 +1090,11 @@ class ApiService {
   // =========================================================================
 
   async getPlatformSettings(params?: { category?: string }): Promise<PlatformSettingsResponse> {
-    const { data } = await httpClient.get('/v1/admin/settings', { params });
-    return data;
+    return adminClient.listSettings(params);
   }
 
   async updatePlatformSetting(key: string, value: string): Promise<PlatformSetting> {
-    const { data } = await httpClient.put(`/v1/admin/settings/${key}`, { value });
-    return data;
+    return adminClient.updateSetting(key, value);
   }
 
   // =========================================================================
@@ -1136,8 +1102,7 @@ class ApiService {
   // =========================================================================
 
   async getAdminRoles(): Promise<RoleListResponse> {
-    const { data } = await httpClient.get('/v1/admin/roles');
-    return data;
+    return adminClient.listRoles();
   }
 
   // =========================================================================

--- a/control-plane-ui/src/services/api/admin.ts
+++ b/control-plane-ui/src/services/api/admin.ts
@@ -1,0 +1,91 @@
+import { httpClient } from '../http';
+import type {
+  AdminUserListResponse,
+  AccessRequestListResponse,
+  PlatformSettingsResponse,
+  PlatformSetting,
+  RoleListResponse,
+  ProspectListResponse,
+  ProspectsMetricsResponse,
+  ProspectDetail,
+} from '../../types';
+
+export const adminClient = {
+  // Users (CAB-1454)
+  async listUsers(params: {
+    role?: string;
+    status?: string;
+    search?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<AdminUserListResponse> {
+    const { data } = await httpClient.get('/v1/admin/users', { params });
+    return data;
+  },
+
+  // Platform Settings (CAB-1454)
+  async listSettings(params?: { category?: string }): Promise<PlatformSettingsResponse> {
+    const { data } = await httpClient.get('/v1/admin/settings', { params });
+    return data;
+  },
+
+  async updateSetting(key: string, value: string): Promise<PlatformSetting> {
+    const { data } = await httpClient.put(`/v1/admin/settings/${key}`, { value });
+    return data;
+  },
+
+  // RBAC Roles (CAB-1454)
+  async listRoles(): Promise<RoleListResponse> {
+    const { data } = await httpClient.get('/v1/admin/roles');
+    return data;
+  },
+
+  // Access Requests (CAB-1468)
+  async listAccessRequests(params: {
+    status?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<AccessRequestListResponse> {
+    const { data } = await httpClient.get('/v1/admin/access-requests', { params });
+    return data;
+  },
+
+  // Prospects (CAB-911)
+  async listProspects(params: {
+    company?: string;
+    status?: string;
+    date_from?: string;
+    date_to?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<ProspectListResponse> {
+    const { data } = await httpClient.get('/v1/admin/prospects', { params });
+    return data;
+  },
+
+  async getProspectsMetrics(params?: {
+    date_from?: string;
+    date_to?: string;
+  }): Promise<ProspectsMetricsResponse> {
+    const { data } = await httpClient.get('/v1/admin/prospects/metrics', { params });
+    return data;
+  },
+
+  async getProspect(inviteId: string): Promise<ProspectDetail> {
+    const { data } = await httpClient.get(`/v1/admin/prospects/${inviteId}`);
+    return data;
+  },
+
+  async exportProspectsCSV(params?: {
+    company?: string;
+    status?: string;
+    date_from?: string;
+    date_to?: string;
+  }): Promise<Blob> {
+    const { data } = await httpClient.get('/v1/admin/prospects/export', {
+      params,
+      responseType: 'blob',
+    });
+    return data;
+  },
+};

--- a/control-plane-ui/src/services/api/git.ts
+++ b/control-plane-ui/src/services/api/git.ts
@@ -1,0 +1,15 @@
+import { httpClient } from '../http';
+import type { CommitInfo, MergeRequest } from '../../types';
+
+export const gitClient = {
+  async listCommits(tenantId: string, path?: string): Promise<CommitInfo[]> {
+    const params = path ? { path } : {};
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/git/commits`, { params });
+    return data;
+  },
+
+  async listMergeRequests(tenantId: string): Promise<MergeRequest[]> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/git/merge-requests`);
+    return data;
+  },
+};

--- a/control-plane-ui/src/services/api/session.ts
+++ b/control-plane-ui/src/services/api/session.ts
@@ -1,0 +1,21 @@
+import { httpClient } from '../http';
+import type { EnvironmentConfig } from '../../types';
+
+export interface MeResponse {
+  roles: string[];
+  permissions: string[];
+  role_display_names?: Record<string, string>;
+  tenant_id?: string;
+}
+
+export const sessionClient = {
+  async getMe(): Promise<MeResponse> {
+    const { data } = await httpClient.get<MeResponse>('/v1/me');
+    return data;
+  },
+
+  async listEnvironments(): Promise<EnvironmentConfig[]> {
+    const { data } = await httpClient.get('/v1/environments');
+    return data.environments;
+  },
+};

--- a/control-plane-ui/src/services/api/toolPermissions.ts
+++ b/control-plane-ui/src/services/api/toolPermissions.ts
@@ -1,0 +1,27 @@
+import { httpClient } from '../http';
+import type { Schemas } from '@stoa/shared/api-types';
+import type { TenantToolPermission, TenantToolPermissionListResponse } from '../../types';
+
+export const toolPermissionsClient = {
+  async list(
+    tenantId: string,
+    params?: { mcp_server_id?: string; page?: number; page_size?: number }
+  ): Promise<TenantToolPermissionListResponse> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/tool-permissions`, {
+      params: { ...params, page_size: params?.page_size ?? 100 },
+    });
+    return data;
+  },
+
+  async upsert(
+    tenantId: string,
+    body: Schemas['TenantToolPermissionCreate']
+  ): Promise<TenantToolPermission> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/tool-permissions`, body);
+    return data;
+  },
+
+  async remove(tenantId: string, permissionId: string): Promise<void> {
+    await httpClient.delete(`/v1/tenants/${tenantId}/tool-permissions/${permissionId}`);
+  },
+};

--- a/control-plane-ui/src/services/api/workflows.ts
+++ b/control-plane-ui/src/services/api/workflows.ts
@@ -1,0 +1,87 @@
+import { httpClient } from '../http';
+import type {
+  WorkflowInstance,
+  WorkflowListResponse,
+  WorkflowTemplate,
+  WorkflowTemplateCreate,
+  WorkflowTemplateListResponse,
+  WorkflowTemplateUpdate,
+} from '../../types';
+
+export const workflowsClient = {
+  async listTemplates(tenantId: string): Promise<WorkflowTemplateListResponse> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/workflows/templates`);
+    return data;
+  },
+
+  async createTemplate(
+    tenantId: string,
+    payload: WorkflowTemplateCreate
+  ): Promise<WorkflowTemplate> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/workflows/templates`, payload);
+    return data;
+  },
+
+  async updateTemplate(
+    tenantId: string,
+    templateId: string,
+    payload: WorkflowTemplateUpdate
+  ): Promise<WorkflowTemplate> {
+    const { data } = await httpClient.put(
+      `/v1/tenants/${tenantId}/workflows/templates/${templateId}`,
+      payload
+    );
+    return data;
+  },
+
+  async deleteTemplate(tenantId: string, templateId: string): Promise<void> {
+    await httpClient.delete(`/v1/tenants/${tenantId}/workflows/templates/${templateId}`);
+  },
+
+  async listInstances(
+    tenantId: string,
+    params?: { status?: string; skip?: number; limit?: number }
+  ): Promise<WorkflowListResponse> {
+    const { data } = await httpClient.get(`/v1/tenants/${tenantId}/workflows/instances`, {
+      params,
+    });
+    return data;
+  },
+
+  async start(
+    tenantId: string,
+    payload: { template_id: string; subject_id: string; subject_email: string }
+  ): Promise<WorkflowInstance> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/workflows/instances`, payload);
+    return data;
+  },
+
+  async approveStep(
+    tenantId: string,
+    instanceId: string,
+    payload: { comment?: string }
+  ): Promise<WorkflowInstance> {
+    const { data } = await httpClient.post(
+      `/v1/tenants/${tenantId}/workflows/instances/${instanceId}/approve`,
+      payload
+    );
+    return data;
+  },
+
+  async rejectStep(
+    tenantId: string,
+    instanceId: string,
+    payload: { comment?: string }
+  ): Promise<WorkflowInstance> {
+    const { data } = await httpClient.post(
+      `/v1/tenants/${tenantId}/workflows/instances/${instanceId}/reject`,
+      payload
+    );
+    return data;
+  },
+
+  async seedTemplates(tenantId: string): Promise<{ message: string }> {
+    const { data } = await httpClient.post(`/v1/tenants/${tenantId}/workflows/templates/seed`);
+    return data;
+  },
+};

--- a/control-plane-ui/src/test/services/api/ui2-s2a-clients.test.ts
+++ b/control-plane-ui/src/test/services/api/ui2-s2a-clients.test.ts
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockHttpClient } = vi.hoisted(() => ({
+  mockHttpClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../../../services/http', () => ({
+  httpClient: mockHttpClient,
+}));
+
+import { adminClient } from '../../../services/api/admin';
+import { gitClient } from '../../../services/api/git';
+import { sessionClient } from '../../../services/api/session';
+import { toolPermissionsClient } from '../../../services/api/toolPermissions';
+import { workflowsClient } from '../../../services/api/workflows';
+
+describe('UI-2 S2a domain clients', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('covers adminClient request delegation', async () => {
+    const users = { items: [] };
+    const settings = { items: [] };
+    const setting = { key: 'theme', value: 'dark' };
+    const roles = { items: [] };
+    const accessRequests = { items: [] };
+    const prospects = { items: [] };
+    const metrics = { total: 1 };
+    const prospect = { invite_id: 'inv-1' };
+    const csvBlob = new Blob(['id,name']);
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: users })
+      .mockResolvedValueOnce({ data: settings })
+      .mockResolvedValueOnce({ data: roles })
+      .mockResolvedValueOnce({ data: accessRequests })
+      .mockResolvedValueOnce({ data: prospects })
+      .mockResolvedValueOnce({ data: metrics })
+      .mockResolvedValueOnce({ data: prospect })
+      .mockResolvedValueOnce({ data: csvBlob });
+    mockHttpClient.put.mockResolvedValueOnce({ data: setting });
+
+    await expect(
+      adminClient.listUsers({ role: 'tenant-admin', status: 'active', page: 2 })
+    ).resolves.toBe(users);
+    await expect(adminClient.listSettings({ category: 'security' })).resolves.toBe(settings);
+    await expect(adminClient.updateSetting('theme', 'dark')).resolves.toBe(setting);
+    await expect(adminClient.listRoles()).resolves.toBe(roles);
+    await expect(adminClient.listAccessRequests({ status: 'pending', page: 1 })).resolves.toBe(
+      accessRequests
+    );
+    await expect(
+      adminClient.listProspects({ company: 'STOA', status: 'new', limit: 10 })
+    ).resolves.toBe(prospects);
+    await expect(
+      adminClient.getProspectsMetrics({ date_from: '2026-04-01', date_to: '2026-04-22' })
+    ).resolves.toBe(metrics);
+    await expect(adminClient.getProspect('inv-1')).resolves.toBe(prospect);
+    await expect(adminClient.exportProspectsCSV({ company: 'STOA' })).resolves.toBe(csvBlob);
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/admin/users', {
+      params: { role: 'tenant-admin', status: 'active', page: 2 },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/admin/settings', {
+      params: { category: 'security' },
+    });
+    expect(mockHttpClient.put).toHaveBeenCalledWith('/v1/admin/settings/theme', {
+      value: 'dark',
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(3, '/v1/admin/roles');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(4, '/v1/admin/access-requests', {
+      params: { status: 'pending', page: 1 },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(5, '/v1/admin/prospects', {
+      params: { company: 'STOA', status: 'new', limit: 10 },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(6, '/v1/admin/prospects/metrics', {
+      params: { date_from: '2026-04-01', date_to: '2026-04-22' },
+    });
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(7, '/v1/admin/prospects/inv-1');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(8, '/v1/admin/prospects/export', {
+      params: { company: 'STOA' },
+      responseType: 'blob',
+    });
+  });
+
+  it('covers gitClient request delegation', async () => {
+    const commits = [{ id: 'c1' }];
+    const mergeRequests = [{ id: 'mr-1' }];
+
+    mockHttpClient.get.mockResolvedValueOnce({ data: commits }).mockResolvedValueOnce({
+      data: mergeRequests,
+    });
+
+    await expect(gitClient.listCommits('tenant-1', 'catalog/uac.yaml')).resolves.toBe(commits);
+    await expect(gitClient.listMergeRequests('tenant-1')).resolves.toBe(mergeRequests);
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      1,
+      '/v1/tenants/tenant-1/git/commits',
+      { params: { path: 'catalog/uac.yaml' } }
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/git/merge-requests'
+    );
+  });
+
+  it('covers sessionClient request delegation', async () => {
+    const me = { roles: ['cpi-admin'], permissions: ['stoa:admin'], tenant_id: 'tenant-1' };
+    const environments = [{ name: 'prod' }];
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: me })
+      .mockResolvedValueOnce({ data: { environments } });
+
+    await expect(sessionClient.getMe()).resolves.toBe(me);
+    await expect(sessionClient.listEnvironments()).resolves.toBe(environments);
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/me');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/environments');
+  });
+
+  it('covers toolPermissionsClient request delegation', async () => {
+    const permissionList = { items: [] };
+    const permission = { id: 'perm-1' };
+
+    mockHttpClient.get.mockResolvedValueOnce({ data: permissionList });
+    mockHttpClient.post.mockResolvedValueOnce({ data: permission });
+    mockHttpClient.delete.mockResolvedValueOnce({});
+
+    await expect(
+      toolPermissionsClient.list('tenant-1', { mcp_server_id: 'srv-1', page: 2 })
+    ).resolves.toBe(permissionList);
+    await expect(
+      toolPermissionsClient.upsert('tenant-1', {
+        mcp_server_id: 'srv-1',
+        tool_name: 'list_users',
+        allowed: true,
+      })
+    ).resolves.toBe(permission);
+    await expect(toolPermissionsClient.remove('tenant-1', 'perm-1')).resolves.toBeUndefined();
+
+    expect(mockHttpClient.get).toHaveBeenCalledWith('/v1/tenants/tenant-1/tool-permissions', {
+      params: { mcp_server_id: 'srv-1', page: 2, page_size: 100 },
+    });
+    expect(mockHttpClient.post).toHaveBeenCalledWith('/v1/tenants/tenant-1/tool-permissions', {
+      mcp_server_id: 'srv-1',
+      tool_name: 'list_users',
+      allowed: true,
+    });
+    expect(mockHttpClient.delete).toHaveBeenCalledWith(
+      '/v1/tenants/tenant-1/tool-permissions/perm-1'
+    );
+  });
+
+  it('covers workflowsClient request delegation', async () => {
+    const templateList = { items: [] };
+    const template = { id: 'tpl-1' };
+    const workflowList = { items: [] };
+    const workflowInstance = { id: 'wf-1' };
+    const seeded = { message: 'seeded' };
+
+    mockHttpClient.get
+      .mockResolvedValueOnce({ data: templateList })
+      .mockResolvedValueOnce({ data: workflowList });
+    mockHttpClient.post
+      .mockResolvedValueOnce({ data: template })
+      .mockResolvedValueOnce({ data: workflowInstance })
+      .mockResolvedValueOnce({ data: workflowInstance })
+      .mockResolvedValueOnce({ data: workflowInstance })
+      .mockResolvedValueOnce({ data: seeded });
+    mockHttpClient.put.mockResolvedValueOnce({ data: template });
+    mockHttpClient.delete.mockResolvedValueOnce({});
+
+    await expect(workflowsClient.listTemplates('tenant-1')).resolves.toBe(templateList);
+    await expect(
+      workflowsClient.createTemplate('tenant-1', {
+        name: 'Security Review',
+        description: 'Gate',
+        steps: [],
+      })
+    ).resolves.toBe(template);
+    await expect(
+      workflowsClient.updateTemplate('tenant-1', 'tpl-1', {
+        name: 'Security Review v2',
+      })
+    ).resolves.toBe(template);
+    await expect(workflowsClient.deleteTemplate('tenant-1', 'tpl-1')).resolves.toBeUndefined();
+    await expect(
+      workflowsClient.listInstances('tenant-1', { status: 'pending', limit: 20 })
+    ).resolves.toBe(workflowList);
+    await expect(
+      workflowsClient.start('tenant-1', {
+        template_id: 'tpl-1',
+        subject_id: 'user-1',
+        subject_email: 'user@example.com',
+      })
+    ).resolves.toBe(workflowInstance);
+    await expect(
+      workflowsClient.approveStep('tenant-1', 'wf-1', { comment: 'ok' })
+    ).resolves.toBe(workflowInstance);
+    await expect(
+      workflowsClient.rejectStep('tenant-1', 'wf-1', { comment: 'nope' })
+    ).resolves.toBe(workflowInstance);
+    await expect(workflowsClient.seedTemplates('tenant-1')).resolves.toBe(seeded);
+
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      1,
+      '/v1/tenants/tenant-1/workflows/templates'
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      1,
+      '/v1/tenants/tenant-1/workflows/templates',
+      {
+        name: 'Security Review',
+        description: 'Gate',
+        steps: [],
+      }
+    );
+    expect(mockHttpClient.put).toHaveBeenCalledWith(
+      '/v1/tenants/tenant-1/workflows/templates/tpl-1',
+      {
+        name: 'Security Review v2',
+      }
+    );
+    expect(mockHttpClient.delete).toHaveBeenCalledWith(
+      '/v1/tenants/tenant-1/workflows/templates/tpl-1'
+    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/workflows/instances',
+      {
+        params: { status: 'pending', limit: 20 },
+      }
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/workflows/instances',
+      {
+        template_id: 'tpl-1',
+        subject_id: 'user-1',
+        subject_email: 'user@example.com',
+      }
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      3,
+      '/v1/tenants/tenant-1/workflows/instances/wf-1/approve',
+      { comment: 'ok' }
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      4,
+      '/v1/tenants/tenant-1/workflows/instances/wf-1/reject',
+      { comment: 'nope' }
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      5,
+      '/v1/tenants/tenant-1/workflows/templates/seed'
+    );
+  });
+});

--- a/control-plane-ui/src/test/services/api/ui2-s2a-clients.test.ts
+++ b/control-plane-ui/src/test/services/api/ui2-s2a-clients.test.ts
@@ -101,11 +101,9 @@ describe('UI-2 S2a domain clients', () => {
     await expect(gitClient.listCommits('tenant-1', 'catalog/uac.yaml')).resolves.toBe(commits);
     await expect(gitClient.listMergeRequests('tenant-1')).resolves.toBe(mergeRequests);
 
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(
-      1,
-      '/v1/tenants/tenant-1/git/commits',
-      { params: { path: 'catalog/uac.yaml' } }
-    );
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(1, '/v1/tenants/tenant-1/git/commits', {
+      params: { path: 'catalog/uac.yaml' },
+    });
     expect(mockHttpClient.get).toHaveBeenNthCalledWith(
       2,
       '/v1/tenants/tenant-1/git/merge-requests'
@@ -203,12 +201,12 @@ describe('UI-2 S2a domain clients', () => {
         subject_email: 'user@example.com',
       })
     ).resolves.toBe(workflowInstance);
-    await expect(
-      workflowsClient.approveStep('tenant-1', 'wf-1', { comment: 'ok' })
-    ).resolves.toBe(workflowInstance);
-    await expect(
-      workflowsClient.rejectStep('tenant-1', 'wf-1', { comment: 'nope' })
-    ).resolves.toBe(workflowInstance);
+    await expect(workflowsClient.approveStep('tenant-1', 'wf-1', { comment: 'ok' })).resolves.toBe(
+      workflowInstance
+    );
+    await expect(workflowsClient.rejectStep('tenant-1', 'wf-1', { comment: 'nope' })).resolves.toBe(
+      workflowInstance
+    );
     await expect(workflowsClient.seedTemplates('tenant-1')).resolves.toBe(seeded);
 
     expect(mockHttpClient.get).toHaveBeenNthCalledWith(


### PR DESCRIPTION
## Summary

Part 2/8 of UI-2 axios split. Extracts 5 smaller domain clients (git, session, admin, toolPermissions, workflows) into `services/<domain>/` modules using the http core from S1.

Replaces #2482 (auto-closed when the base branch `ui-2-s1` was deleted by the S1 merge — gotcha `gh_pr_branch_disconnect_on_delete`). Same diff, base re-pointed to `main`.

## Size

+271/-65 across 6 files. Within 300 LOC cap.

## Test plan

- [x] `npm run typecheck` green
- [x] `npm run lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)