### PR TITLE
refactor(stoa-go): split stoa-connect internal/connect orchestration

### DIFF
--- a/stoa-go/REWRITE-BUGS.md
+++ b/stoa-go/REWRITE-BUGS.md
@@ -1,0 +1,145 @@
+# REWRITE-BUGS — GO-2
+
+Bugs découverts pendant la Phase 1 d'inventaire du refactor `internal/connect/`.
+État au 2026-04-22.
+
+Colonne `Fix` :
+- `S<n>` = corrigé in-flight dans l'étape correspondante de GO-2.
+- `follow-up` = documenté ici, à traiter dans un ticket séparé après GO-2.
+
+---
+
+## Race conditions
+
+### F.1 — Race sur `Agent.gatewayID` (fix in-flight S1)
+
+**Symptôme potentiel** : goroutine heartbeat écrit `a.gatewayID = ""` puis `a.gatewayID = newID` (via `Register`) pendant que 5 autres goroutines lisent `a.gatewayID` pour construire des URLs (`heartbeat`, `discovery`, `fetch-config`, `fetch-routes`, `sync-ack`, `route-sync-ack`, `SSE events`).
+
+**État actuel** : pas détecté par `go test -race` parce que les tests ne lancent pas les goroutines `Start*` simultanément avec un déclenchement de re-register. **Latent, réel en prod si un événement déclenche 3× 404 pendant que d'autres boucles tournent.**
+
+**Preuve** : aucun `sync.Mutex` dans `internal/connect/*.go` (hors adapters). `grep -rn "sync.Mutex\|sync.RWMutex" internal/connect/*.go` → vide.
+
+**Fix S1** : migrer `gatewayID` dans `agentState` derrière `sync.RWMutex`. Accesseurs `GatewayID() string`, `SetGatewayID(id string)`, `ClearGatewayID()`. Tous les callers passent par ces accesseurs.
+
+**Régression guard** : `TestAgentStateRace` avec N goroutines lisant `GatewayID` + 1 goroutine alternant `Clear`/`Set`, sous `-race`.
+
+---
+
+### F.2 — Race sur `Agent.lastDiscoveredAPIs` (fix in-flight S1)
+
+**Symptôme potentiel** : discovery goroutine `runDiscovery` fait `a.lastDiscoveredAPIs = payloads` (assignation de slice), pendant que :
+- heartbeat goroutine lit via `a.computeRoutesCount()` (range sur le slice)
+- `/health` handler lit via `a.DiscoveredAPIsCount()`
+
+Slice header (ptr+len+cap) non-atomique. Lecture concurrente sans sync = data race.
+
+**Fix S1** :
+- `SetDiscoveredAPIs(in []DiscoveredAPIPayload)` copie l'input dans un nouveau slice interne.
+- `DiscoveredAPIs() []DiscoveredAPIPayload` retourne une copie.
+- `ComputeRoutesCount()` et `DiscoveredAPIsCount()` lisent sous `RLock` (pas de leak de référence).
+
+**Régression guard** : intégré dans `TestAgentStateRace` (goroutine `SetDiscoveredAPIs` en parallèle de `ComputeRoutesCount`).
+
+---
+
+### F.3 — Goroutine SSE peut rester bloquée dans catch-up (follow-up)
+
+**Lieu** : `sse.go:75-107` — `StartDeploymentStream` appelle `RunRouteSync(ctx, ...)` AVANT chaque reconnect. Si `ctx` est cancellé pendant ce `RunRouteSync`, on sort de cette fonction (ses appels HTTP respectent le ctx) mais la boucle externe ne revalide `ctx.Done()` qu'après.
+
+**Impact** : fragile mais correctness OK (le ctx se propage aux HTTP calls). La boucle sort quand même proprement.
+
+**Traitement** : improvement naturel en S9 (`loop_sse.go` recoiffé), sans plus.
+
+---
+
+## SSE transport
+
+### F.6 — `bufio.Scanner` buffer 64KB (fix in-flight S5)
+
+**Lieu** : `sse.go:146` — `scanner := bufio.NewScanner(resp.Body)`.
+
+**Symptôme** : un event SSE avec `desired_state` volumineux (OpenAPI spec inlinée > 64KB) dépasse le buffer scanner défaut (`bufio.MaxScanTokenSize` = 64KB). Comportement :
+1. Scanner retourne `false` silencieusement.
+2. Boucle sort.
+3. `scanner.Err()` serait `bufio.ErrTooLong` **mais n'est jamais lu** par le code actuel.
+4. La fonction retourne `fmt.Errorf("SSE stream ended")` — l'erreur réelle est perdue.
+5. Outer loop reconnecte, même event arrive à nouveau, même truncation. Boucle infinie de reconnect.
+
+**Preuve** : `grep -n "scanner.Err()" internal/connect/sse.go` → ligne 172, mais la condition est seulement évaluée si la boucle `for scanner.Scan()` se termine "proprement" — or `ErrTooLong` met aussi fin à la boucle, donc en théorie `scanner.Err()` attrape bien l'erreur. À vérifier côté comportement observé.
+
+**Fix S5** :
+```go
+scanner := bufio.NewScanner(resp.Body)
+scanner.Buffer(make([]byte, 0, 64<<10), 1<<20) // 1 MB max
+```
+Et `sseStream.Run(ctx, sink) error` retourne `scanner.Err()` explicite (ne reformule pas en "stream ended").
+
+**Régression guard** : test avec `data:` > 64KB → `sink` reçoit le message entier sans truncation.
+
+---
+
+### F.5 — SSE catch-up RouteSync à chaque reconnect = re-push complet (follow-up)
+
+**Lieu** : `sse.go:87` — `a.RunRouteSync(ctx, adapter, adminURL)` est appelé avant CHAQUE tentative de connect, y compris après un disconnect transitoire.
+
+**Impact** : sur un réseau flappy, chaque reconnexion re-pousse TOUTES les routes CP vers le gateway local. Correctness OK (adapter.SyncRoutes idempotent), mais perf : ~100 routes × 1 appel HTTP chacun côté gateway à chaque flap.
+
+**Traitement** : follow-up. Option 1 : ne catch-up qu'après un gap > N secondes. Option 2 : utiliser un `Last-Event-ID` côté SSE (protocol change, lourd).
+
+---
+
+### F.7 — Double-ack possible après reconnect SSE (follow-up côté CP)
+
+**Lieu** : après reconnect SSE, le CP peut re-streamer un event déjà traité. L'agent l'applique à nouveau (idempotent côté adapter) + re-ack.
+
+**Impact** : CP doit dedupe sur `deployment_id` — à vérifier côté `control-plane-api`.
+
+**Traitement** : follow-up côté CP. L'agent reste at-least-once, c'est la sémantique attendue.
+
+---
+
+## Type safety
+
+### F.10 — `ReportDiscovery(ctx, apis interface{})` (fix in-flight S4)
+
+**Lieu** : `connect.go:360-429`.
+
+**Symptôme** : la signature prend `interface{}` et fait marshal/unmarshal pour convertir `adapters.DiscoveredAPI` → `DiscoveredAPIPayload`. Code smell : type safety perdue au compile-time.
+
+**Fix S4** : signature typée `ReportDiscovery(ctx context.Context, apis []DiscoveredAPIPayload) error`. La conversion depuis `adapters.DiscoveredAPI` reste dans `runDiscovery` (discovery.go:146-157) où elle est déjà faite, juste sans le re-marshal gymnastic.
+
+---
+
+### F.11 — `failedRoutesProvider` type-assertion implicite (documenté, reste local)
+
+**Lieu** : `routes.go:133-139` — interface anonyme découverte via cast runtime sur `adapter.(failedRoutesProvider)`.
+
+**Impact** : couplage faible, pas de compile-time check. Seul le `webMethods` adapter l'implémente ; pour kong/gravitee, `failedMap` reste vide et on tombe sur le fallback "global error".
+
+**Traitement** : helper privé `failedRoutesFromAdapter(adapter) map[string]string` dans `sync_route.go` (S7). Pas d'export depuis `adapters/` (hors scope GO-1/GO-2). Dette assumée.
+
+---
+
+## Champs wire morts / obsolètes (follow-up)
+
+### F.8 — `HeartbeatPayload.PoliciesCount` jamais populé
+
+**Lieu** : `connect.go:100` — déclaré `PoliciesCount int \`json:"policies_count"\``, toujours envoyé à 0 car jamais assigné dans `Heartbeat`.
+
+**Traitement** : soit brancher (compter les policies synced via `state`), soit supprimer du wire. Vérifier consommation côté CP avant suppression. Follow-up.
+
+---
+
+### F.9 — `GatewayConfigResponse.PendingDeployments []interface{}` jamais lu
+
+**Lieu** : `sync.go:30` — déclaré, jamais itéré. Légacy d'une spec précédente.
+
+**Traitement** : grep côté `control-plane-api` pour voir si le champ est encore émis ; si non, supprimer la déclaration en suivi. Follow-up.
+
+---
+
+## Non-bugs relevés mais conscients
+
+- **`a.client.Timeout = 15s`** global vs SSE override via nouveau `http.Client{Transport: a.client.Transport}` (ligne 129) : OK, le otelhttp transport est partagé correctement. Juste une alloc par reconnect, négligeable.
+- **Seuil `reRegisterThreshold = 3`** avant re-register : sémantique conservée (ADR-057), extrait en const.
+- **Ack timing at-least-once** : documenté, conservé.

--- a/stoa-go/REWRITE-BUGS.md
+++ b/stoa-go/REWRITE-BUGS.md
@@ -176,6 +176,36 @@ Caller side (`sse.go:StartDeploymentStream`) logue maintenant `"sse-stream: term
 
 ---
 
+## Asymétries policy sync consolidées en S8
+
+### C.1 — `OIDCAdapter` interface asymétrique apply vs remove (documented, out of GO-2 scope)
+
+**Lieu** : `internal/connect/adapters/adapter.go:128-132` — `OIDCAdapter` interface.
+
+**Constat** :
+- **Apply side** : 3 méthodes typées (`UpsertAuthServer`, `UpsertStrategy`, `UpsertScope`) + fallback générique `ApplyPolicy` via `GatewayAdapter`.
+- **Remove side** : 1 seule méthode typée (`DeleteAuthServer`). `DeleteStrategy` et `DeleteScope` **n'existent pas sur l'interface**.
+
+**Conséquence runtime** : quand le CP émet une `PendingPolicy{PolicyType: "oidc_strategy", Enabled: false}` (i.e. "désactive cette stratégie"), le `policySyncer.remove` tombe sur le fallback `adapter.RemovePolicy(ctx, adminURL, name, "oidc_strategy")`. C'est à l'implémentation concrète (webmethods / kong / gravitee) de reconnaître ce hint string et de faire la bonne chose — ou de no-op silencieusement.
+
+**Bug latent potentiel** : si webmethods.RemovePolicy ne gère pas le type `oidc_strategy`, on a un leak — la strategy reste configurée côté gateway alors que le CP pense l'avoir supprimée. Pas vérifié dans cette passe (hors scope).
+
+**Pourquoi pas fixé en GO-2** : ajouter `DeleteStrategy` / `DeleteScope` touche l'interface dans `adapters/`, qui est le territoire de GO-1 (rewrite adapters terminé). GO-2 se limite à `internal/connect/` hors adapters. Un ticket GO-3 ou un fix ciblé côté webmethods est le bon chemin.
+
+**Preuve de comportement préservé** :
+- `TestPolicySyncerRemovesOIDCStrategyViaGenericFallback` vérifie que le disabled `oidc_strategy` passe bien par `RemovePolicy("oidc_strategy")` (pas un crash, pas un chemin typé).
+- `TestPolicySyncerRemovesOIDCAuthServer` vérifie que seul `oidc_auth_server` prend le chemin typé `DeleteAuthServer`.
+
+### C.2 — `AliasAdapter` non utilisé dans RunSync (documented, follow-up)
+
+**Lieu** : `internal/connect/adapters/adapter.go:136-139` — `AliasAdapter{UpsertAlias, DeleteAlias}` existe mais aucune référence dans `internal/connect/*.go` hors tests.
+
+**Conséquence** : si le CP émet un `PolicyType: "alias"` (ou similaire), il tombe dans le fallback générique `adapter.ApplyPolicy` — l'interface `AliasAdapter` reste dead code.
+
+**Traitement** : à brancher dans un ticket séparé si le CP doit émettre des policies d'alias côté connect. Pour l'instant : dead code côté connect, utilisé ailleurs (peut-être par stoa-gateway ou stoa-connect côté webmethods adapter interne).
+
+---
+
 ## Non-bugs relevés mais conscients
 
 - **`a.client.Timeout = 15s`** global vs SSE override via nouveau `http.Client{Transport: a.client.Transport}` (ligne 129) : OK, le otelhttp transport est partagé correctement. Juste une alloc par reconnect, négligeable.

--- a/stoa-go/REWRITE-BUGS.md
+++ b/stoa-go/REWRITE-BUGS.md
@@ -54,27 +54,37 @@ Slice header (ptr+len+cap) non-atomique. Lecture concurrente sans sync = data ra
 
 ## SSE transport
 
-### F.6 — `bufio.Scanner` buffer 64KB (fix in-flight S5)
+### F.6 — `bufio.Scanner` buffer 64KB (FIXED in S5, commit pending)
 
-**Lieu** : `sse.go:146` — `scanner := bufio.NewScanner(resp.Body)`.
+**Lieu original** : `sse.go:146` (pre-S5) — `scanner := bufio.NewScanner(resp.Body)` sans `scanner.Buffer(...)`.
 
-**Symptôme** : un event SSE avec `desired_state` volumineux (OpenAPI spec inlinée > 64KB) dépasse le buffer scanner défaut (`bufio.MaxScanTokenSize` = 64KB). Comportement :
-1. Scanner retourne `false` silencieusement.
-2. Boucle sort.
-3. `scanner.Err()` serait `bufio.ErrTooLong` **mais n'est jamais lu** par le code actuel.
-4. La fonction retourne `fmt.Errorf("SSE stream ended")` — l'erreur réelle est perdue.
-5. Outer loop reconnecte, même event arrive à nouveau, même truncation. Boucle infinie de reconnect.
+**Symptôme** : un event SSE avec `desired_state` volumineux (OpenAPI spec inlinée > 64KB) dépasse le buffer scanner défaut (`bufio.MaxScanTokenSize` = 64KB). Comportement observé en théorie :
+1. Scanner retourne `false` avec `scanner.Err() == bufio.ErrTooLong`.
+2. La boucle sort.
+3. `scanner.Err()` ÉTAIT lu (ligne 172 pré-S5) mais l'erreur retournée était ensuite écrasée par le sentinel `fmt.Errorf("SSE stream ended")` — donc le reconnect loop ne voyait jamais la cause réelle dans ses logs.
+4. Worst case : reconnect infini avec même event qui retruncate silencieusement.
 
-**Preuve** : `grep -n "scanner.Err()" internal/connect/sse.go` → ligne 172, mais la condition est seulement évaluée si la boucle `for scanner.Scan()` se termine "proprement" — or `ErrTooLong` met aussi fin à la boucle, donc en théorie `scanner.Err()` attrape bien l'erreur. À vérifier côté comportement observé.
+**Impact en prod** : latent. Jamais observé (les OpenAPI specs actuels passent sous 64KB). Devient un bug visible si un client pousse un spec volumineux (démo BDF type : spec webMethods complet avec ~200 paths).
 
-**Fix S5** :
+**Fix appliqué (S5)** :
 ```go
+// transport_sse.go
 scanner := bufio.NewScanner(resp.Body)
-scanner.Buffer(make([]byte, 0, 64<<10), 1<<20) // 1 MB max
+scanner.Buffer(make([]byte, 0, sseScannerInitialBuf), sseScannerMaxBuf) // 64KB init, 1MB max
+// ...
+if err := scanner.Err(); err != nil {
+    return spanFail(span, fmt.Errorf("SSE read: %w", err), "scanner error")
+}
+return io.EOF // clean end — distinguishable from scanner failure via errors.Is
 ```
-Et `sseStream.Run(ctx, sink) error` retourne `scanner.Err()` explicite (ne reformule pas en "stream ended").
 
-**Régression guard** : test avec `data:` > 64KB → `sink` reçoit le message entier sans truncation.
+**Régression guard** (`transport_sse_test.go`) :
+1. `TestSSEStreamAcceptsLargeEvent` — 500 KB event, sink doit recevoir le payload complet sans truncation.
+2. `TestSSEStreamReportsScannerErrorOnOversizedEvent` — 2 MB event (> 1 MB cap), `errors.Is(err, bufio.ErrTooLong)` doit être true.
+3. `TestSSEStreamPropagatesHTTPStatus` — non-200 surfaces proprement.
+4. `TestSSEStreamSinkErrorAborts` — sink error interrompt le stream et remonte.
+
+Caller side (`sse.go:StartDeploymentStream`) logue maintenant `"sse-stream: terminal error: <cause>"` avant backoff, plutôt que le générique `"connection lost"`. En production : les logs isolent immédiatement `ErrTooLong` d'une déconnexion réseau.
 
 ---
 

--- a/stoa-go/REWRITE-BUGS.md
+++ b/stoa-go/REWRITE-BUGS.md
@@ -148,6 +148,34 @@ Caller side (`sse.go:StartDeploymentStream`) logue maintenant `"sse-stream: term
 
 ---
 
+## Divergences polling ↔ SSE fusionnées en S7
+
+### B.1 — Generation field silencieusement droppé sur chemin SSE (FIXED in S7)
+
+**Lieu pré-S7** : `sse.go:handleSyncDeployment` — construisait un `SyncedRouteResult` sans `Generation`. `routes.go:RunRouteSync` le posait correctement via `Generation: r.Generation`.
+
+**Impact** : CAB-1950 introduit un mécanisme de génération-based reconciliation côté CP. Quand un deployment arrive via SSE, l'agent applique la route mais l'ack revient sans generation → le CP ne peut pas vérifier quelle version est déployée. Divergence possible silencieuse entre état CP (base de données) et état gateway local. Jamais flaggé par les tests existants (aucun n'assertait sur `result.Generation` côté SSE).
+
+**Fix S7** : le `routeSyncer` unifié remplit toujours `Generation: r.Generation` quel que soit le chemin d'entrée (polling ou SSE). Regression guard : `TestRouteSyncerAppliedBatch` vérifie explicitement que `Generation` est propagé avec les valeurs exactes.
+
+---
+
+### B.2 — `failedRoutesProvider` type-assert sur polling uniquement (consolidated, no behavior change)
+
+**Divergence** : seul `routes.go:RunRouteSync` faisait le type-assert sur l'interface anonyme `failedRoutesProvider`. Le chemin SSE ignorait ce provider — mais comme SSE traite 1 route à la fois, un `syncErr != nil` mappe forcément vers cette unique route. Résultat fonctionnellement identique.
+
+**Fix S7** : le `routeSyncer` fait le type-assert inconditionnellement. Pour 1 route, `failedMap[dep-id]` détermine le status ; pour N routes, pareil ; pour un adapter sans l'interface, fallback sur le global error. Un seul chemin de résolution per-route, testable en isolation (`TestRouteSyncerPerRouteFailure`).
+
+---
+
+### B.3 — Route sans `deployment_id` silencieusement droppée (visibilité améliorée en S7)
+
+**Lieu pré-S7** : `routes.go:RunRouteSync` faisait `if r.DeploymentID == "" { continue }` sans log. Une route arrivant sans deployment_id = symptôme d'un contract drift CP↔agent (CP est censé toujours tagger), mais était invisible aux ops.
+
+**Fix S7** : le skip reste (on ne peut toujours pas ack sans deployment_id), mais `routeSyncer` logue `"route-sync: skipping route %q — missing deployment_id (CP contract drift?)"`. Regression guard : `TestRouteSyncerSkipsMissingDeploymentID`.
+
+---
+
 ## Non-bugs relevés mais conscients
 
 - **`a.client.Timeout = 15s`** global vs SSE override via nouveau `http.Client{Transport: a.client.Transport}` (ligne 129) : OK, le otelhttp transport est partagé correctement. Juste une alloc par reconnect, négligeable.

--- a/stoa-go/REWRITE-PLAN.md
+++ b/stoa-go/REWRITE-PLAN.md
@@ -1,0 +1,308 @@
+# REWRITE-PLAN — GO-2 : durcir `internal/connect/`
+
+**Status** : VALIDATED 2026-04-22 (avec amendements). Prêt pour Phase 2.
+
+**Scope** : `internal/connect/*.go` (hors `adapters/`, hors `telemetry/`)
+**LOC actuels (prod)** : 2 127 LOC sur 8 fichiers + `cmd/stoa-connect/main.go` (177 LOC)
+**Tests existants** : 69 tests sur 8 fichiers `*_test.go` (1 858 LOC) — `go test -race ./internal/connect/...` : **green baseline**
+
+---
+
+## A. Cartographie du flux actuel
+
+### Processus top-level (`cmd/stoa-connect/main.go`)
+
+```
+main() ──► Agent.New(cfg)
+        ├─► Register(ctx, port)          ... 1 call HTTP
+        ├─► StartHeartbeat(ctx)           ... goroutine #1
+        ├─► StartDiscovery(ctx, dcfg)     ... goroutine #2 (spawns adapter)
+        ├─► StartSync(ctx, adapter)       ... goroutine #3 — policy sync
+        ├─► if SSE enabled:
+        │     StartDeploymentStream(..)   ... goroutine #4a — SSE route sync
+        │   else:
+        │     StartRouteSync(..)          ... goroutine #4b — polling route sync
+        ├─► StartCredentialSync(..)       ... goroutine #5 (vault → adapter)
+        └─► HTTP srv (health, metrics, /webhook/events)   ... goroutine #6
+```
+
+6 goroutines de fond lancées par `Agent.Start*`. Toutes ont un `select { case <-ctx.Done(): return }`. Cancel unifié via `ctx, cancel := context.WithCancel(background)` dans `main()`.
+
+### Flux d'un event SSE (chemin chaud)
+
+```
+[CP API] POST /v1/internal/gateways/{id}/events (SSE)
+  ▼
+sse.go:StartDeploymentStream (goroutine)
+  │  outer reconnect loop + expo backoff (2→60s)
+  │  AVANT chaque connect: RunRouteSync(ctx, adapter, adminURL)  ◄── catch-up
+  ▼
+sse.go:streamEvents
+  │  http.Client sans timeout, bufio.Scanner (64KB default), parse "event:" / "data:"
+  ▼
+sse.go:handleSSEEvent  (switch eventType)
+  ├─ "heartbeat" → no-op
+  └─ "sync-deployment" → handleSyncDeployment
+        │  builds SyncStep trace : agent_received, adapter_connected, api_synced
+        │  decode DeploymentEvent + desired_state → adapters.Route
+        ▼
+adapter.SyncRoutes(ctx, adminURL, []Route{route})
+        ▼
+reportDeploymentResultWithSteps → ReportRouteSyncAck (POST /route-sync-ack)
+```
+
+### Flux polling route sync (fallback SSE off)
+
+```
+routes.go:RunRouteSync (tick 30s)
+  ├─► FetchRoutes (GET /v1/internal/gateways/routes?gateway_name=X)
+  ├─► adapter.SyncRoutes(ctx, adminURL, routes)
+  ├─► type-assert adapter.(failedRoutesProvider) → per-route status
+  ├─► for each route with DeploymentID: build SyncedRouteResult
+  └─► ReportRouteSyncAck (POST /route-sync-ack)
+```
+
+### Flux policy sync
+
+```
+sync.go:RunSync (tick 60s)
+  ├─► FetchConfig (GET /v1/internal/gateways/{id}/config)
+  ├─► for each PendingPolicy:
+  │     switch (policy.PolicyType, adapter.(OIDCAdapter)):
+  │       ├─ oidc_auth_server → oidcAdapter.UpsertAuthServer / DeleteAuthServer
+  │       ├─ oidc_strategy    → oidcAdapter.UpsertStrategy
+  │       ├─ oidc_scope       → oidcAdapter.UpsertScope
+  │       └─ default          → adapter.ApplyPolicy / RemovePolicy
+  ├─► update Prom metrics (applied, failed, status)
+  └─► ReportSyncAck (POST /sync-ack)
+```
+
+### Flux heartbeat + re-register
+
+```
+connect.go:StartHeartbeat (tick 30s)
+  ├─► Heartbeat (POST /heartbeat with uptime, routes_count, discovered_apis)
+  │   → 404 = ErrGatewayNotFound
+  └─► si 3× 404 consécutifs:
+        ├─► a.gatewayID = ""               ◄── WRITE non-mutexed
+        └─► Register(ctx, a.healthPort)    ◄── reset gatewayID
+```
+
+---
+
+## B. Responsabilités identifiées
+
+Chevauchements ciblés — six couches à démêler :
+
+| Couche | Rôle | Aujourd'hui dispersé dans |
+|--------|------|---------------------------|
+| **Transport CP** | HTTP client, URL building, headers, JSON roundtrip, tracer spans | `connect.go` (Register/Heartbeat/ReportDiscovery), `sync.go` (FetchConfig/ReportSyncAck/ReportRouteSyncAck), `routes.go` (FetchRoutes) |
+| **Transport SSE** | Connexion SSE, reconnect, scanner, wire parsing | `sse.go:streamEvents` (mélangé avec dispatch) |
+| **Event dispatch** | Parsing SSE event type → route vers handler métier | `sse.go:handleSSEEvent` + `handleSyncDeployment` (dispatch + business logic collés) |
+| **Sync orchestration** | Orchestration `adapter.Sync*` + build `[]SyncStep` + ack | `sync.go:RunSync` (policies), `routes.go:RunRouteSync` (routes polling), `sse.go:handleSyncDeployment` (routes SSE) — **3 chemins parallèles pour les mêmes primitives** |
+| **State** | `gatewayID`, `lastDiscoveredAPIs` (mutable, multi-goroutines) — `healthPort` et `cfg` restent immuables | `Agent` struct (connect.go) sans mutex ; failed routes dans adapter via type-assert hack |
+| **Retry** | Backoff SSE (concept distinct du seuil heartbeat) | SSE reconnect inline (`sse.go:75-107`) |
+
+### Fonctions > 50 LOC concentrant plusieurs responsabilités
+
+| Fonction | LOC | Responsabilités mélangées |
+|----------|-----|---------------------------|
+| `sync.go:RunSync` | 115 | fetch + big switch OIDC × 4 × (enabled/disabled) + métriques + ack |
+| `routes.go:RunRouteSync` | 94 | fetch + sync + build steps + type-assert failedRoutes + ack |
+| `connect.go:ReportDiscovery` | 69 | marshal hack (`interface{}` → remarshal) + HTTP + span + decode |
+| `connect.go:Heartbeat` | 67 | build payload + HTTP + 404 handling + metrics |
+| `sse.go:streamEvents` | 66 | connect + headers + scanner loop + line parsing + event emission |
+| `connect.go:Register` | 67 | build payload + HTTP + decode + log + state mutation |
+| `sse.go:handleSyncDeployment` | 54 | decode + build steps + sync + ack |
+| `connect.go:StartHeartbeat` | 36 | loop + re-register threshold logic |
+
+---
+
+## C. Découpage fichier cible — FICHIERS PLATS, MÊME PACKAGE `connect`
+
+Raison du flat : en Go, chaque sous-répertoire est un package distinct. Éclater en `sync/`, `loops/`, `dispatcher/` forcerait à sur-exporter les DTOs, introduire des interfaces partout pour briser les cycles, et `sync` conflit avec le package stdlib. Même package = accès direct aux types non-exportés, moins de churn d'imports. Boundaries enforced par convention de nom de fichier.
+
+```
+internal/connect/
+├── agent.go               (~120)  Agent struct, New, SetTracer, Start*  (top-level composition)
+├── config.go              (~180)  Toutes les *Config + *ConfigFromEnv
+├── types.go               (~120)  DTOs wire : Registration*, Heartbeat*, Discovery*, PendingPolicy,
+│                                   SyncAckPayload, SyncedPolicyResult, SyncedRouteResult, DeploymentEvent
+├── state.go               (~100)  agentState{sync.RWMutex, gatewayID, lastDiscoveredAPIs}
+│                                   GatewayID() / SetGatewayID() / ClearGatewayID()
+│                                   SetDiscoveredAPIs(in) → copy    /   DiscoveredAPIs() → copy
+│                                   ComputeRoutesCount(), DiscoveredAPIsCount()
+│                                   /!\ healthPort et cfg restent immuables SUR Agent, hors lock.
+├── steps.go               (~40)   SyncStep + newSyncStep + helpers
+├── errors.go               (~30)   ErrGatewayNotFound + ErrNotRegistered (sentinels)
+├── retry.go                (~80)   retry.Policy{Initial, Max, Multiplier} + Policy.Backoff(attempt)
+│                                   USAGE : SSE reconnect UNIQUEMENT.
+│                                   Le seuil heartbeat reRegisterThreshold=3 RESTE const séparée.
+│
+├── transport_cp.go        (~280)  cpClient : Register, Heartbeat, ReportDiscovery (typé),
+│                                   FetchConfig, FetchRoutes, ReportSyncAck, ReportRouteSyncAck
+│                                   1 constructor, 1 http.Client partagé, 1 startSpan helper
+├── transport_sse.go       (~180)  sseStream.Run(ctx, sink func(rawEvent) error) error
+│                                   Retourne l'erreur terminale du scanner (scanner.Err() inclus).
+│                                   scanner.Buffer(initial=64KB, max=1MB) — fix bufio.ErrTooLong.
+│                                   Pure transport : aucune dep à adapter/sync.
+│
+├── dispatcher.go          (~100)  dispatcher.Register(type, handler) + Dispatch(ctx, rawEvent)
+│                                   Fermé au single-handler-par-type pattern.
+│
+├── sync_route.go          (~180)  routeSyncer.SyncRoutes(ctx, []Route) ([]SyncedRouteResult, error)
+│                                   UNIQUE chemin partagé par polling + SSE.
+│                                   Hébergé ici : le helper privé failedRoutesFromAdapter() qui
+│                                   encapsule le type-assert (pas d'export depuis adapters/).
+├── sync_policy.go         (~220)  policySyncer.SyncPolicies(ctx, []PendingPolicy) → []SyncedPolicyResult
+│                                   Switch OIDC → méthodes privées : applyAuthServer, applyStrategy,
+│                                   applyScope, applyGeneric, removeGeneric.
+│
+├── loop_heartbeat.go      (~80)   runHeartbeat(ctx, Agent) — inclut seuil 3 inchangé
+├── loop_sse.go            (~80)   runSSEStream(ctx, ...) — reconnect via retry.Policy + catch-up + dispatch
+├── loop_discovery.go      (~60)   runDiscovery(ctx, ...)
+├── loop_credentials.go    (~60)   runCredentialSync(ctx, ...)
+│   (NB : StartSync tick 60s policy reste inline dans agent.go — trivial — OU ajouté en loop_sync.go)
+│
+├── metrics.go             (~90)   INCHANGÉ
+└── vault.go               (~180)  INCHANGÉ
+```
+
+22 fichiers prod (vs 8), tous ≤ 300 LOC. Un seul package, zéro changement d'import pour les callers (`cmd/stoa-connect/main.go` continue d'`import "internal/connect"`).
+
+---
+
+## D. Retry / ack policy
+
+### Dispersion actuelle
+
+| Endroit | Politique | Valeurs hardcodées |
+|---------|-----------|--------------------|
+| `sse.go:75-107` | expo backoff × 2 cap 60s | 2s, 60s, multiplier 2 |
+| `connect.go:317-348` | seuil 3× 404 avant re-register | `reRegisterThreshold = 3` |
+| `credentials.go:46-51` | TTL < 300s → renew, fail → re-login | 300 |
+| `sync.go`/`routes.go` (ack) | fire-and-forget, log warning | — |
+| `http.Client.Timeout` | 15s global | SSE override : `client.Timeout = 0` |
+
+### Proposition (amendée)
+
+**1. `retry.Policy`** — backoff SSE **uniquement** :
+```go
+type Policy struct {
+    Initial    time.Duration
+    Max        time.Duration
+    Multiplier float64
+}
+func (p Policy) Backoff(attempt int) time.Duration { /* expo capped */ }
+```
+Utilisé seulement dans `loop_sse.go`. Configurable via `SSEConfig` (déjà le cas aujourd'hui).
+
+**2. Seuil heartbeat re-register** : **inchangé** à 3. Juste extrait en const :
+```go
+// connect.go ou loop_heartbeat.go
+const reRegisterThreshold = 3
+```
+Ne PAS mélanger avec `retry.Policy` — sémantique différente (compteur stateful vs backoff timing).
+
+**3. Vault renew** : hors scope GO-2, reste dans `credentials.go`/`vault.go`.
+
+**4. Ack timing — sémantique at-least-once** (inchangée, documentée) :
+- Ack APRÈS apply. Si sync fail → ack status="failed". Si ack fail → fire-and-forget (le prochain tick re-synchronisera).
+- Pas de retry sur l'ack côté agent.
+- Double-ack possible après SSE reconnect : CP doit dedupe sur `deployment_id`.
+
+**5. SSE transport remonte l'erreur terminale** :
+```go
+// transport_sse.go
+func (s *sseStream) Run(ctx context.Context, sink func(rawEvent) error) error
+```
+- Return `scanner.Err()` si non-nil (inclut `bufio.ErrTooLong`).
+- Return `io.EOF`-style pour fermeture propre côté serveur.
+- La boucle `runSSEStream` log l'erreur concrète AVANT le backoff, pas juste "connection lost".
+
+---
+
+## E. Plan d'exécution — bottom-up
+
+Chaque étape : commit séparé, tests verts avec `-race` avant commit, pas de régression LOC/coverage.
+
+| # | Étape | Fichiers touchés | Critère vert | Commit |
+|---|-------|------------------|--------------|--------|
+| **S1** | `state.go` + mutex + copy-on-write | créer `state.go`, migrer `Agent.gatewayID` + `lastDiscoveredAPIs` derrière RWMutex. `SetDiscoveredAPIs` copie l'entrée. `DiscoveredAPIs()` retourne une copie. `ComputeRoutesCount`/`DiscoveredAPIsCount` lisent sous RLock. `healthPort` et `cfg` **restent sur Agent, hors lock** (immuables après `New`). | Tests existants verts. **Nouveau** `TestAgentStateRace` : N goroutines `Heartbeat()` + 1 goroutine `ClearGatewayID` + 1 goroutine `SetDiscoveredAPIs` sous `-race`. | `refactor(connect): extract agentState with RWMutex (GO-2 S1)` |
+| **S2** | `retry.go` pour SSE backoff seul | créer `retry.go` avec `Policy{}` + `Backoff(attempt)`. Migrer `StartDeploymentStream` pour l'utiliser. Seuil heartbeat **non-touché** à cette étape. | `sse_test` inchangé (comportement identique, reconnect test adapté éventuellement). Table test `TestRetryPolicyBackoff`. | `refactor(connect): extract retry.Policy for SSE backoff (GO-2 S2)` |
+| **S3** | `types.go` + `steps.go` + `errors.go` | déplacer DTOs wire + `newSyncStep` + `ErrGatewayNotFound` + nouveau `ErrNotRegistered`. Remplacer tous les `fmt.Errorf("not registered")` par le sentinel. | Tests verts (déplacement pur). | `refactor(connect): extract wire DTOs + sentinel errors (GO-2 S3)` |
+| **S4** | `transport_cp.go` | créer `cpClient{client, tracer, baseURL, apiKey}` avec 7 méthodes HTTP (~30 LOC chacune). **Fix in-flight** : `ReportDiscovery` prend `[]DiscoveredAPIPayload` typé (la conversion depuis `adapters.DiscoveredAPI` reste dans `runDiscovery`). Agent délègue : `a.cp.Register(ctx, ...)`. | Tests HTTP existants adaptés aux signatures typées. | `refactor(connect): extract cpClient HTTP transport (GO-2 S4)` |
+| **S5** | `transport_sse.go` avec erreur terminale + buffer fix | créer `sseStream.Run(ctx, sink) error`. Retourner `scanner.Err()`. `scanner.Buffer(make([]byte, 0, 64<<10), 1<<20)`. Aucun appel à adapter/sync dans ce fichier. | `TestStreamEventsParsesSyncDeployment` etc. adaptés à consommer depuis `sink`. Nouveau test : message > 64KB → pas d'ErrTooLong silencieux (le sink reçoit le gros message OU Run retourne l'erreur propre). | `refactor(connect): extract sseStream with error propagation + buffer fix (GO-2 S5)` |
+| **S6** | `dispatcher.go` | petit module Dispatcher. `loop_sse.go` (step S9) l'utilisera : SSE → rawEvent → dispatcher.Dispatch. | Nouveau `dispatcher_test.go` (3-4 tests). | `refactor(connect): extract event dispatcher (GO-2 S6)` |
+| **S7** | `sync_route.go` unifié | `routeSyncer.SyncRoutes(ctx, []Route) []SyncedRouteResult`. **Point clé** : la duplication `routes.RunRouteSync` ↔ `sse.handleSyncDeployment` converge ici. Le helper privé `failedRoutesFromAdapter()` encapsule le type-assert. | `TestRunRouteSync*` + `TestSSESyncDeployment*` passent via le nouveau syncer. | `refactor(connect): unify route sync path (GO-2 S7)` |
+| **S8** | `sync_policy.go` | `policySyncer.SyncPolicies(ctx, []PendingPolicy)`. Switch OIDC → `applyAuthServer` / `applyStrategy` / `applyScope` / `applyGeneric` / `removeGeneric`. | `TestRunSync*` verts. | `refactor(connect): split policy sync by type (GO-2 S8)` |
+| **S9** | `loop_*.go` | extraire les boucles hors de l'Agent. `runHeartbeat(ctx, Agent)` garde `const reRegisterThreshold = 3`. `runSSEStream(ctx, ...)` utilise `retry.Policy` + dispatcher + transport_sse. `runDiscovery` / `runCredentialSync` idem. | Tests `TestStartXxxSkipsNoURL` + `TestStartHeartbeat*` verts. | `refactor(connect): extract orchestration loops (GO-2 S9)` |
+| **S10** | Cleanup + cmd | supprimer code mort (anciennes méthodes Agent devenues redondantes), adapter `cmd/stoa-connect/main.go` si signature change. `golangci-lint run` vert. | Build + `go test ./... -race` + `golangci-lint run` verts. `find internal/connect -maxdepth 1 -name '*.go' -not -name '*_test.go' \| xargs wc -l \| sort -rn` → max ≤ 300. | `refactor(connect): finalize GO-2 split + cleanup` |
+
+**Validation entre chaque étape** :
+```bash
+go vet ./... && \
+go test ./internal/connect/... -race -count=1 && \
+go build ./cmd/stoa-connect && \
+find internal/connect -maxdepth 1 -name '*.go' -not -name '*_test.go' | xargs wc -l | sort -rn | head
+```
+
+**Test manuel en fin de parcours (S10)** : `STOA_CONTROL_PLANE_URL=http://localhost:8000 STOA_GATEWAY_API_KEY=xxx stoa-connect` + simuler déconnexion réseau → reconnexion propre + pas de double apply côté gateway local.
+
+---
+
+## F. Risques identifiés
+
+### Concurrence — fixés in-flight pendant GO-2
+
+| # | Bug | Impact | Fix étape |
+|---|-----|--------|-----------|
+| F.1 | RACE `Agent.gatewayID` — heartbeat loop écrit `""` pendant re-register, 5 autres goroutines lisent. `-race` ne flag pas aujourd'hui (tests pas concurrents) mais réel en prod. | latent | **S1** |
+| F.2 | RACE `Agent.lastDiscoveredAPIs` — discovery loop écrit slice, `/health` handler + heartbeat `computeRoutesCount` lisent. | latent | **S1** (copy-on-write) |
+| F.6 | `bufio.Scanner` buffer défaut 64KB — un event SSE avec `desired_state` volumineux → `bufio.ErrTooLong`, goroutine SSE sort silencieusement (Scanner.Err() non lu aujourd'hui). | latent | **S5** (`scanner.Buffer` + propagation d'erreur) |
+| F.10 | `ReportDiscovery(apis interface{})` — marshal/unmarshal hack pour conversion type. | code smell | **S4** (signature typée `[]DiscoveredAPIPayload`) |
+
+### Concurrence — documentés, NOT fixed in-flight
+
+| # | Bug | Raison |
+|---|-----|--------|
+| F.3 | Goroutine SSE : si ctx cancellé pendant le `RunRouteSync` catch-up, on reste dans ce call. | Fragile mais correctness OK ; l'amélioration naturelle vient avec S9 (loop propre). |
+| F.4 | Discovery 1st batch perdu si `gatewayID == ""` au moment du call. | Récupéré au tick suivant (60s), impact faible. |
+| F.5 | SSE catch-up RouteSync à chaque reconnect = re-push complet au gateway local. | Perf, pas correctness. Hors scope ; ticket follow-up si la démo montre un problème. |
+| F.7 | Double-ack possible après reconnect SSE. | CP doit dedupe sur `deployment_id` (à vérifier côté CP-API). Hors scope agent. |
+
+### Champs morts / obsolètes
+
+| # | Champ | Traitement |
+|---|-------|------------|
+| F.8 | `HeartbeatPayload.PoliciesCount` déclaré, jamais populé. | Documenté dans `REWRITE-BUGS.md`, laissé en place (wire stability). Fix follow-up. |
+| F.9 | `GatewayConfigResponse.PendingDeployments []interface{}` déclaré, jamais lu. | Idem. Vérifier côté CP si encore émis. |
+
+### Type safety
+
+| # | Item | Traitement |
+|---|------|------------|
+| F.11 | `failedRoutesProvider` type-assertion implicite. | **Helper local privé** dans `sync_route.go`, pas d'export depuis `adapters/` (hors scope GO-1/GO-2). Dette documentée. |
+
+### Ce qu'on ne touche PAS
+
+- Protocole wire CP ↔ agent (ADR-057 + ADR-059). Zéro changement : event types SSE, structure payloads, headers, endpoints.
+- Interfaces `adapters.GatewayAdapter / OIDCAdapter / AliasAdapter` (GO-1 territory).
+- `cmd/stoa-connect/main.go` sauf adaptations forcées par signature Agent.
+- `telemetry/` et `pkg/config/`.
+
+---
+
+## Décisions validées (2026-04-22)
+
+1. **Fichiers plats, même package** `connect` — pas de sous-packages.
+2. **Seuil `reRegisterThreshold = 3`** conservé inchangé, juste extrait en const.
+3. **SSE transport** expose l'erreur terminale via `Run(ctx, sink) error`.
+4. **`state.go`** mute `gatewayID` + `lastDiscoveredAPIs` avec RWMutex + COW sur slice. `healthPort` et `cfg` restent immuables sur Agent.
+5. **Fix in-flight** : F.1 (race gatewayID, S1), F.2 (race slice, S1), F.6 (Scanner buffer, S5), F.10 (`ReportDiscovery` typé, S4).
+6. **`failedRoutesProvider`** reste un helper local dans `sync_route.go`, pas d'export `adapters/`.
+7. **Nouvelle branche** `refactor/go-2-connect-split` depuis `main`.
+
+---
+
+**GO Phase 2.**

--- a/stoa-go/TEST-PLAN.md
+++ b/stoa-go/TEST-PLAN.md
@@ -1,0 +1,219 @@
+# TEST-PLAN — GO-2 pre-merge validation
+
+Status: automated checks green (104 tests `-race`, `go vet`, `golangci-lint`,
+2 mock-CP smoke tests). This file documents the MANUAL end-to-end checks
+that the user runs against a real CP-API before merging `refactor/go-2-connect-split`.
+
+All runnable from `stoa-go/` after `make build-connect`.
+
+---
+
+## What's already automated
+
+Run these any time — all green as of commit `e78e89d45`:
+
+```bash
+cd stoa-go/
+go vet ./...
+go test ./internal/connect/... -race -count=1        # 104 tests
+$HOME/go/bin/golangci-lint run ./...
+go build ./cmd/...
+```
+
+Mock-CP integration smokes reproduced below for reference. These mock the
+CP-API with a 60-line Python server and exercise the hot paths end-to-end
+against the real `stoa-connect` binary (not Go httptest).
+
+### Smoke 1 — Register + Heartbeat + clean shutdown (GO-2 S1 + S4 + S9)
+
+```bash
+cat > /tmp/mock_cp.py << 'EOF'
+import http.server, json, threading, time
+events = {"register": 0, "heartbeat": 0}
+class H(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *a, **kw): pass
+    def do_POST(self):
+        _ = self.rfile.read(int(self.headers.get("Content-Length", 0)) or 0)
+        if self.path.endswith("/register"):
+            events["register"] += 1
+            self.send_response(200); self.send_header("Content-Type","application/json"); self.end_headers()
+            self.wfile.write(json.dumps({"id":"gw-mock-42","name":"mock","environment":"dev","status":"active"}).encode())
+        elif self.path.endswith("/heartbeat"):
+            events["heartbeat"] += 1
+            self.send_response(204); self.end_headers()
+        else: self.send_response(404); self.end_headers()
+srv = http.server.HTTPServer(("127.0.0.1", 9999), H)
+threading.Thread(target=srv.serve_forever, daemon=True).start()
+time.sleep(8); srv.shutdown()
+print(json.dumps(events))
+EOF
+python3 /tmp/mock_cp.py &
+sleep 0.5
+STOA_CONTROL_PLANE_URL=http://127.0.0.1:9999 \
+STOA_GATEWAY_API_KEY=test-key \
+STOA_INSTANCE_NAME=smoke-agent \
+STOA_HEARTBEAT_INTERVAL=500ms \
+STOA_CONNECT_PORT=8091 \
+timeout 6 ./bin/stoa-connect
+wait
+```
+
+Expected: 1 register, ~10 heartbeats, `"heartbeat stopped"` on SIGTERM.
+
+### Smoke 2 — 404 → re-register threshold (ADR-057, reRegisterThreshold=3)
+
+Same harness, but the mock returns 404 on every heartbeat. Expected:
+`heartbeat 404 (1/3)`, `(2/3)`, `(3/3)` → `"gateway purged from CP,
+re-registering..."` → `"re-registered with CP: id=gw-rev-2"` → loop.
+
+Validated 2026-04-22: 6 re-registrations in 5s with interval=300ms, each
+preceded by exactly 3× 404. State flips correctly (new gateway_id is
+read back after ClearGatewayID + Register).
+
+---
+
+## Manual end-to-end checks before merge
+
+These require a real CP-API reachable. Recommended path: a local Tilt
+stack (`cd ~/hlfh-repos/stoa && tilt up`) with the CP-API pod up and
+reachable at `https://api.gostoa.local` (or whatever Tilt binds).
+
+The agent config should target that CP and a real third-party gateway
+admin (kong/gravitee/webmethods) or the webmethods pod in the Tilt stack
+if you have one running.
+
+### Check E1 — Happy path (register + heartbeat for 60s)
+
+```bash
+export STOA_CONTROL_PLANE_URL=https://api.gostoa.local
+export STOA_GATEWAY_API_KEY=<from vault or Tilt secret>
+export STOA_INSTANCE_NAME=go2-test-$(date +%s)
+export STOA_ENVIRONMENT=development
+export STOA_GATEWAY_ADMIN_URL=http://localhost:8001  # kong admin e.g.
+./bin/stoa-connect
+```
+
+Watch for:
+- [ ] `registered with CP: id=<uuid>` within 1s
+- [ ] `discovery started: type=<kong|gravitee|webmethods>`
+- [ ] `starting policy sync loop (interval=60s)`
+- [ ] `starting route sync loop (interval=30s)` (if SSE disabled)
+- [ ] Heartbeat every 30s
+- [ ] `GET /health` on :8090 returns `{"status":"ok", ...}` with correct gateway_id
+- [ ] `GET /metrics` on :8090 exposes `stoa_connect_*` counters
+
+Ctrl+C → expect:
+- [ ] `shutting down...`
+- [ ] `heartbeat stopped`, `discovery stopped`, `sync stopped`, `route-sync stopped`
+- [ ] Process exits within 5s (no stuck goroutines)
+
+### Check E2 — SSE deployment stream (ADR-059) — CRITICAL for B.1 fix
+
+Requires the CP-API SSE endpoint active and a deployment event to trigger.
+
+```bash
+export STOA_SSE_ENABLED=true
+./bin/stoa-connect
+# In another terminal, trigger a deployment via CP admin UI or CLI
+stoactl uac deploy <api> <gateway>
+```
+
+Watch for:
+- [ ] `starting SSE deployment stream (initial=2s max=60s)`
+- [ ] `sse-stream: connected to https://api.gostoa.local/v1/internal/gateways/<id>/events`
+- [ ] On deployment: `sse-stream: received deployment <dep-id> (status=pending)`
+- [ ] `sse-stream: sync deployment <dep-id> applied`
+- [ ] **In CP-API database or admin UI**: the ack carries `generation` != 0
+      (B.1 regression — see REWRITE-BUGS.md)
+
+### Check E3 — SSE reconnect on network drop (B.6 fix + retry policy)
+
+With SSE stream active from E2:
+
+```bash
+# Terminal 2: suspend CP-API pod (drops the SSE connection mid-stream)
+kubectl scale deployment control-plane-api -n stoa --replicas=0
+sleep 10
+kubectl scale deployment control-plane-api -n stoa --replicas=1
+```
+
+Watch for:
+- [ ] `sse-stream: terminal error: <concrete cause> (reconnecting in 2s, attempt 1)`
+- [ ] Backoff progression: `attempt 1 → 2s`, `attempt 2 → 4s`, `attempt 3 → 8s`…
+- [ ] After CP restart: reconnect succeeds, attempt counter resets
+- [ ] No duplicate sync of routes already applied (idempotency)
+
+### Check E4 — Oversized SSE event (F.6 regression guard)
+
+Trigger a deployment whose `desired_state` exceeds 64 KB (a realistic
+webMethods OpenAPI spec with ~50 paths). Pre-S5, this would silently
+truncate; now the scanner buffer is 1 MB.
+
+- [ ] Large event flows through to `adapter.SyncRoutes` without
+      `bufio.ErrTooLong` in the logs.
+- [ ] If you want to force the failure path: craft a >2 MB event on the
+      CP side — expect `sse-stream: terminal error: SSE read: bufio.Scanner: token too long`.
+
+### Check E5 — Vault credential sync
+
+Requires Vault reachable with a pre-populated `stoa/data/consumers/<tenant_id>`.
+
+```bash
+export VAULT_ADDR=https://hcvault.gostoa.dev
+export VAULT_ROLE_ID=<role>
+export VAULT_SECRET_ID=<secret>
+export STOA_TENANT_ID=<tenant>
+./bin/stoa-connect
+```
+
+Watch for:
+- [ ] `vault: authenticated via AppRole (lease=<seconds>s)`
+- [ ] `starting credential sync loop (interval=60s, tenant=<tenant>)`
+- [ ] `credential-sync: injected N credentials` on first cycle
+- [ ] Gateway (kong/gravitee) actually has the consumer credentials after cycle
+- [ ] TTL approach: if you set Vault token TTL < 5min, expect
+      `vault: token renewal warning` or `vault: re-authenticating via AppRole`
+
+### Check E6 — goroutine leak audit (SIGTERM response time)
+
+From any running E1..E5 scenario:
+
+```bash
+# Send SIGTERM and time the shutdown
+time kill -TERM $(pgrep -f stoa-connect)
+```
+
+- [ ] Process exits in < 5s consistently (Ctrl+C shuts down all 6 loops cleanly)
+- [ ] No `goroutine NN [running]` stuck traces visible in the last output
+- [ ] If you want to verify programmatically:
+      `GOTRACEBACK=all kill -ABRT $(pgrep -f stoa-connect)` then grep the
+      core dump for `chan receive` or `IO wait` goroutines that outlive ctx.
+
+---
+
+## Out-of-scope items documented elsewhere
+
+The following are KNOWN latent issues documented but NOT fixed in GO-2:
+
+- F.3 / F.4 / F.5 / F.7 / F.8 / F.9 — see `REWRITE-BUGS.md`
+- C.1 — `OIDCAdapter` asymmetric delete surface (would need GO-1-bis)
+- C.2 — `AliasAdapter` dead code on agent side
+
+None block merging GO-2; all are listed as follow-up tickets.
+
+---
+
+## Sign-off checklist before merge
+
+- [ ] `go vet ./...` clean
+- [ ] `go test ./internal/connect/... -race -count=1` → 104 tests green
+- [ ] `$HOME/go/bin/golangci-lint run ./...` clean
+- [ ] Smoke 1 (register + heartbeat) passes locally
+- [ ] Smoke 2 (404 → re-register) passes locally
+- [ ] E1 (happy path) validated against real Tilt stack
+- [ ] E2 (SSE deployment + generation in ack) validated
+- [ ] E3 (SSE reconnect) validated OR acknowledged as covered by unit tests
+- [ ] E6 (SIGTERM < 5s) validated
+- [ ] E4 (oversized event) — optional, covered by unit test
+      `TestSSEStreamAcceptsLargeEvent` already
+- [ ] E5 (Vault) — optional, credentials.go path not touched by GO-2

--- a/stoa-go/internal/connect/connect.go
+++ b/stoa-go/internal/connect/connect.go
@@ -74,51 +74,6 @@ func ConfigFromEnv(version string) Config {
 	return cfg
 }
 
-// RegistrationPayload is the payload sent to POST /v1/internal/gateways/register.
-type RegistrationPayload struct {
-	Hostname         string   `json:"hostname"`
-	Mode             string   `json:"mode"`
-	Version          string   `json:"version"`
-	Environment      string   `json:"environment"`
-	Capabilities     []string `json:"capabilities"`
-	AdminURL         string   `json:"admin_url"`
-	TargetGatewayURL string   `json:"target_gateway_url,omitempty"`
-	PublicURL        string   `json:"public_url,omitempty"`
-	UIURL            string   `json:"ui_url,omitempty"`
-}
-
-// RegistrationResponse is the response from the register endpoint.
-type RegistrationResponse struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Environment string `json:"environment"`
-	Status      string `json:"status"`
-}
-
-// HeartbeatPayload is the payload sent to POST /v1/internal/gateways/{id}/heartbeat.
-type HeartbeatPayload struct {
-	UptimeSeconds  int `json:"uptime_seconds"`
-	RoutesCount    int `json:"routes_count"`
-	PoliciesCount  int `json:"policies_count"`
-	DiscoveredAPIs int `json:"discovered_apis"`
-}
-
-// DiscoveryPayload is the payload sent to POST /v1/internal/gateways/{id}/discovery.
-type DiscoveryPayload struct {
-	APIs []DiscoveredAPIPayload `json:"apis"`
-}
-
-// DiscoveredAPIPayload represents a single discovered API for the CP.
-type DiscoveredAPIPayload struct {
-	Name       string   `json:"name"`
-	Version    string   `json:"version,omitempty"`
-	BackendURL string   `json:"backend_url,omitempty"`
-	Paths      []string `json:"paths,omitempty"`
-	Methods    []string `json:"methods,omitempty"`
-	Policies   []string `json:"policies,omitempty"`
-	IsActive   bool     `json:"is_active"`
-}
-
 // Agent is the STOA Connect runtime agent.
 //
 // Mutable runtime state (gatewayID, discovered APIs) lives under Agent.state
@@ -244,15 +199,11 @@ func (a *Agent) GatewayID() string {
 	return a.state.GatewayID()
 }
 
-// ErrGatewayNotFound is returned when the CP responds 404 to a heartbeat,
-// indicating the gateway instance was purged and needs re-registration.
-var ErrGatewayNotFound = fmt.Errorf("gateway not found on Control Plane (purged)")
-
 // Heartbeat sends a single heartbeat to the Control Plane.
 func (a *Agent) Heartbeat(ctx context.Context) error {
 	gatewayID := a.state.GatewayID()
 	if gatewayID == "" {
-		return fmt.Errorf("not registered")
+		return ErrNotRegistered
 	}
 
 	ctx, span := a.startSpan(ctx, "stoa-connect.heartbeat",
@@ -375,7 +326,7 @@ func (a *Agent) IsConfigured() bool {
 func (a *Agent) ReportDiscovery(ctx context.Context, apis []DiscoveredAPIPayload) error {
 	gatewayID := a.state.GatewayID()
 	if gatewayID == "" {
-		return fmt.Errorf("not registered")
+		return ErrNotRegistered
 	}
 
 	ctx, span := a.startSpan(ctx, "stoa-connect.discovery",

--- a/stoa-go/internal/connect/connect.go
+++ b/stoa-go/internal/connect/connect.go
@@ -83,7 +83,8 @@ func ConfigFromEnv(version string) Config {
 type Agent struct {
 	cfg        Config
 	cp         *cpClient         // CP HTTP client; 7 endpoints delegated here
-	transport  http.RoundTripper // otelhttp-wrapped; shared with SSE stream
+	sse        *sseStream        // CP SSE transport; reconnect loop + dispatch live on Agent (for now)
+	transport  http.RoundTripper // otelhttp-wrapped; shared between cp and sse
 	tracer     trace.Tracer      // used for business spans that live on the Agent (RunSync etc.)
 	state      *agentState
 	healthPort string // set in the first Register; read from the heartbeat loop on re-register
@@ -92,12 +93,14 @@ type Agent struct {
 
 // New creates a new STOA Connect agent.
 // The HTTP transport is wrapped with otelhttp for automatic W3C traceparent
-// propagation and is shared between the CP client and the SSE stream.
+// propagation and is shared between the CP client (15s timeout) and the SSE
+// stream (no timeout).
 func New(cfg Config) *Agent {
 	transport := otelhttp.NewTransport(http.DefaultTransport)
 	return &Agent{
 		cfg:       cfg,
 		cp:        newCPClient(cfg.ControlPlaneURL, cfg.GatewayAPIKey, transport),
+		sse:       newSSEStream(cfg.ControlPlaneURL, cfg.GatewayAPIKey, transport),
 		transport: transport,
 		state:     newAgentState(),
 		startTime: time.Now(),
@@ -105,10 +108,12 @@ func New(cfg Config) *Agent {
 }
 
 // SetTracer sets the OpenTelemetry tracer for the agent. Propagates to the
-// CP client so every stoa-connect.<action> span uses the same tracer.
+// CP client and SSE stream so every stoa-connect.<action> span uses the
+// same tracer.
 func (a *Agent) SetTracer(t trace.Tracer) {
 	a.tracer = t
 	a.cp.SetTracer(t)
+	a.sse.SetTracer(t)
 }
 
 // startSpan creates a new span on the Agent's tracer if one is configured.

--- a/stoa-go/internal/connect/connect.go
+++ b/stoa-go/internal/connect/connect.go
@@ -8,7 +8,6 @@ package connect
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -194,40 +193,7 @@ const reRegisterThreshold = 3
 // it re-registers automatically after reRegisterThreshold consecutive 404s.
 // Stops when ctx is cancelled.
 func (a *Agent) StartHeartbeat(ctx context.Context) {
-	ticker := time.NewTicker(a.cfg.HeartbeatInterval)
-	go func() {
-		defer ticker.Stop()
-		consecutiveNotFound := 0
-		for {
-			select {
-			case <-ctx.Done():
-				log.Println("heartbeat stopped")
-				return
-			case <-ticker.C:
-				if err := a.Heartbeat(ctx); err != nil {
-					if errors.Is(err, ErrGatewayNotFound) {
-						consecutiveNotFound++
-						log.Printf("heartbeat 404 (%d/%d) — gateway not found on CP",
-							consecutiveNotFound, reRegisterThreshold)
-						if consecutiveNotFound >= reRegisterThreshold {
-							log.Println("gateway purged from CP, re-registering...")
-							a.state.ClearGatewayID()
-							if regErr := a.Register(ctx, a.healthPort); regErr != nil {
-								log.Printf("re-registration failed: %v", regErr)
-							} else {
-								log.Printf("re-registered with CP: id=%s", a.state.GatewayID())
-								consecutiveNotFound = 0
-							}
-						}
-					} else {
-						log.Printf("heartbeat error: %v", err)
-					}
-				} else {
-					consecutiveNotFound = 0
-				}
-			}
-		}
-	}()
+	go runHeartbeat(ctx, a)
 }
 
 // IsConfigured returns true if the agent has enough config to register.

--- a/stoa-go/internal/connect/connect.go
+++ b/stoa-go/internal/connect/connect.go
@@ -120,14 +120,22 @@ type DiscoveredAPIPayload struct {
 }
 
 // Agent is the STOA Connect runtime agent.
+//
+// Mutable runtime state (gatewayID, discovered APIs) lives under Agent.state
+// behind a RWMutex — safe for concurrent access from the heartbeat, discovery,
+// sync, SSE and /health goroutines.
+//
+// Fields set once before any loop goroutine starts (cfg, client, startTime,
+// healthPort — written in the first Register call from main goroutine) are kept
+// on Agent without locking; happens-before is guaranteed by the `go` statement
+// that later launches the loops.
 type Agent struct {
-	cfg                Config
-	client             *http.Client
-	tracer             trace.Tracer
-	gatewayID          string
-	healthPort         string // stored after Register for re-registration
-	startTime          time.Time
-	lastDiscoveredAPIs []DiscoveredAPIPayload
+	cfg        Config
+	client     *http.Client
+	tracer     trace.Tracer
+	state      *agentState
+	healthPort string // set in the first Register; read from the heartbeat loop on re-register
+	startTime  time.Time
 }
 
 // New creates a new STOA Connect agent.
@@ -139,6 +147,7 @@ func New(cfg Config) *Agent {
 			Timeout:   15 * time.Second,
 			Transport: otelhttp.NewTransport(http.DefaultTransport),
 		},
+		state:     newAgentState(),
 		startTime: time.Now(),
 	}
 }
@@ -222,7 +231,7 @@ func (a *Agent) Register(ctx context.Context, healthPort string) error {
 		return fmt.Errorf("decode registration response: %w", err)
 	}
 
-	a.gatewayID = result.ID
+	a.state.SetGatewayID(result.ID)
 	a.healthPort = healthPort
 	span.SetAttributes(attribute.String("stoa.gateway_id", result.ID))
 	span.SetStatus(codes.Ok, "registered")
@@ -232,7 +241,7 @@ func (a *Agent) Register(ctx context.Context, healthPort string) error {
 
 // GatewayID returns the assigned gateway ID after registration.
 func (a *Agent) GatewayID() string {
-	return a.gatewayID
+	return a.state.GatewayID()
 }
 
 // ErrGatewayNotFound is returned when the CP responds 404 to a heartbeat,
@@ -241,19 +250,20 @@ var ErrGatewayNotFound = fmt.Errorf("gateway not found on Control Plane (purged)
 
 // Heartbeat sends a single heartbeat to the Control Plane.
 func (a *Agent) Heartbeat(ctx context.Context) error {
-	if a.gatewayID == "" {
+	gatewayID := a.state.GatewayID()
+	if gatewayID == "" {
 		return fmt.Errorf("not registered")
 	}
 
 	ctx, span := a.startSpan(ctx, "stoa-connect.heartbeat",
-		attribute.String("stoa.gateway_id", a.gatewayID),
+		attribute.String("stoa.gateway_id", gatewayID),
 	)
 	defer span.End()
 
 	payload := HeartbeatPayload{
 		UptimeSeconds:  int(time.Since(a.startTime).Seconds()),
-		RoutesCount:    a.computeRoutesCount(),
-		DiscoveredAPIs: len(a.lastDiscoveredAPIs),
+		RoutesCount:    a.state.ComputeRoutesCount(),
+		DiscoveredAPIs: a.state.DiscoveredAPIsCount(),
 	}
 
 	span.SetAttributes(
@@ -269,7 +279,7 @@ func (a *Agent) Heartbeat(ctx context.Context) error {
 		return fmt.Errorf("marshal heartbeat: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/v1/internal/gateways/%s/heartbeat", a.cfg.ControlPlaneURL, a.gatewayID)
+	url := fmt.Sprintf("%s/v1/internal/gateways/%s/heartbeat", a.cfg.ControlPlaneURL, gatewayID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {
 		span.RecordError(err)
@@ -309,12 +319,17 @@ func (a *Agent) Heartbeat(ctx context.Context) error {
 	return nil
 }
 
+// reRegisterThreshold is the number of consecutive 404 heartbeats before the
+// agent auto-re-registers with the Control Plane. Chosen conservatively to avoid
+// thrashing on transient CP outages; do not tune without validating CP-side
+// expectations (ADR-057).
+const reRegisterThreshold = 3
+
 // StartHeartbeat starts a background goroutine that sends heartbeats
 // at the configured interval. If the CP responds 404 (gateway purged),
-// it re-registers automatically after 3 consecutive 404s.
+// it re-registers automatically after reRegisterThreshold consecutive 404s.
 // Stops when ctx is cancelled.
 func (a *Agent) StartHeartbeat(ctx context.Context) {
-	const reRegisterThreshold = 3
 	ticker := time.NewTicker(a.cfg.HeartbeatInterval)
 	go func() {
 		defer ticker.Stop()
@@ -332,11 +347,11 @@ func (a *Agent) StartHeartbeat(ctx context.Context) {
 							consecutiveNotFound, reRegisterThreshold)
 						if consecutiveNotFound >= reRegisterThreshold {
 							log.Println("gateway purged from CP, re-registering...")
-							a.gatewayID = ""
+							a.state.ClearGatewayID()
 							if regErr := a.Register(ctx, a.healthPort); regErr != nil {
 								log.Printf("re-registration failed: %v", regErr)
 							} else {
-								log.Printf("re-registered with CP: id=%s", a.gatewayID)
+								log.Printf("re-registered with CP: id=%s", a.state.GatewayID())
 								consecutiveNotFound = 0
 							}
 						}
@@ -357,35 +372,18 @@ func (a *Agent) IsConfigured() bool {
 }
 
 // ReportDiscovery sends discovered APIs to the Control Plane.
-func (a *Agent) ReportDiscovery(ctx context.Context, apis interface{}) error {
-	if a.gatewayID == "" {
+func (a *Agent) ReportDiscovery(ctx context.Context, apis []DiscoveredAPIPayload) error {
+	gatewayID := a.state.GatewayID()
+	if gatewayID == "" {
 		return fmt.Errorf("not registered")
 	}
 
 	ctx, span := a.startSpan(ctx, "stoa-connect.discovery",
-		attribute.String("stoa.gateway_id", a.gatewayID),
+		attribute.String("stoa.gateway_id", gatewayID),
 	)
 	defer span.End()
 
-	payload := DiscoveryPayload{}
-	// Convert adapters.DiscoveredAPI to DiscoveredAPIPayload
-	switch v := apis.(type) {
-	case []DiscoveredAPIPayload:
-		payload.APIs = v
-	default:
-		// Marshal and re-unmarshal for type conversion
-		data, err := json.Marshal(apis)
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "marshal failed")
-			return fmt.Errorf("marshal discovery apis: %w", err)
-		}
-		if err := json.Unmarshal(data, &payload.APIs); err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "convert failed")
-			return fmt.Errorf("convert discovery apis: %w", err)
-		}
-	}
+	payload := DiscoveryPayload{APIs: apis}
 
 	span.SetAttributes(attribute.Int("stoa.discovered_apis", len(payload.APIs)))
 
@@ -396,7 +394,7 @@ func (a *Agent) ReportDiscovery(ctx context.Context, apis interface{}) error {
 		return fmt.Errorf("marshal discovery payload: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/v1/internal/gateways/%s/discovery", a.cfg.ControlPlaneURL, a.gatewayID)
+	url := fmt.Sprintf("%s/v1/internal/gateways/%s/discovery", a.cfg.ControlPlaneURL, gatewayID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {
 		span.RecordError(err)
@@ -428,24 +426,7 @@ func (a *Agent) ReportDiscovery(ctx context.Context, apis interface{}) error {
 	return nil
 }
 
-// computeRoutesCount computes the total number of routes from discovered APIs.
-// Each path on an active API counts as one route (CAB-1916).
-func (a *Agent) computeRoutesCount() int {
-	count := 0
-	for _, api := range a.lastDiscoveredAPIs {
-		if api.IsActive {
-			paths := len(api.Paths)
-			if paths == 0 {
-				// API with no explicit paths still counts as 1 route
-				paths = 1
-			}
-			count += paths
-		}
-	}
-	return count
-}
-
 // DiscoveredAPIsCount returns the count of last discovered APIs.
 func (a *Agent) DiscoveredAPIsCount() int {
-	return len(a.lastDiscoveredAPIs)
+	return a.state.DiscoveredAPIsCount()
 }

--- a/stoa-go/internal/connect/connect.go
+++ b/stoa-go/internal/connect/connect.go
@@ -7,12 +7,9 @@
 package connect
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
@@ -20,7 +17,6 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -80,39 +76,44 @@ func ConfigFromEnv(version string) Config {
 // behind a RWMutex — safe for concurrent access from the heartbeat, discovery,
 // sync, SSE and /health goroutines.
 //
-// Fields set once before any loop goroutine starts (cfg, client, startTime,
-// healthPort — written in the first Register call from main goroutine) are kept
-// on Agent without locking; happens-before is guaranteed by the `go` statement
-// that later launches the loops.
+// Fields set once before any loop goroutine starts (cfg, cp, transport, tracer,
+// startTime; healthPort — written in the first Register call from main
+// goroutine) are kept on Agent without locking; happens-before is guaranteed
+// by the `go` statement that later launches the loops.
 type Agent struct {
 	cfg        Config
-	client     *http.Client
-	tracer     trace.Tracer
+	cp         *cpClient         // CP HTTP client; 7 endpoints delegated here
+	transport  http.RoundTripper // otelhttp-wrapped; shared with SSE stream
+	tracer     trace.Tracer      // used for business spans that live on the Agent (RunSync etc.)
 	state      *agentState
 	healthPort string // set in the first Register; read from the heartbeat loop on re-register
 	startTime  time.Time
 }
 
 // New creates a new STOA Connect agent.
-// The HTTP client is wrapped with otelhttp for automatic W3C traceparent propagation.
+// The HTTP transport is wrapped with otelhttp for automatic W3C traceparent
+// propagation and is shared between the CP client and the SSE stream.
 func New(cfg Config) *Agent {
+	transport := otelhttp.NewTransport(http.DefaultTransport)
 	return &Agent{
-		cfg: cfg,
-		client: &http.Client{
-			Timeout:   15 * time.Second,
-			Transport: otelhttp.NewTransport(http.DefaultTransport),
-		},
+		cfg:       cfg,
+		cp:        newCPClient(cfg.ControlPlaneURL, cfg.GatewayAPIKey, transport),
+		transport: transport,
 		state:     newAgentState(),
 		startTime: time.Now(),
 	}
 }
 
-// SetTracer sets the OpenTelemetry tracer for the agent.
+// SetTracer sets the OpenTelemetry tracer for the agent. Propagates to the
+// CP client so every stoa-connect.<action> span uses the same tracer.
 func (a *Agent) SetTracer(t trace.Tracer) {
 	a.tracer = t
+	a.cp.SetTracer(t)
 }
 
-// startSpan creates a new span if a tracer is configured.
+// startSpan creates a new span on the Agent's tracer if one is configured.
+// Used for orchestration-level spans (RunSync, RunRouteSync, SSE handlers);
+// transport-level spans live on the cpClient.
 func (a *Agent) startSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
 	if a.tracer == nil {
 		return ctx, trace.SpanFromContext(ctx)
@@ -123,15 +124,10 @@ func (a *Agent) startSpan(ctx context.Context, name string, attrs ...attribute.K
 	)
 }
 
-// Register registers this agent with the Control Plane.
-// Returns the assigned gateway ID.
+// Register registers this agent with the Control Plane and records the
+// assigned gateway ID plus the local healthPort on success (for later
+// re-registration).
 func (a *Agent) Register(ctx context.Context, healthPort string) error {
-	ctx, span := a.startSpan(ctx, "stoa-connect.register",
-		attribute.String("stoa.instance_name", a.cfg.InstanceName),
-		attribute.String("stoa.environment", a.cfg.Environment),
-	)
-	defer span.End()
-
 	payload := RegistrationPayload{
 		Hostname:         a.cfg.InstanceName,
 		Mode:             "connect",
@@ -144,52 +140,13 @@ func (a *Agent) Register(ctx context.Context, healthPort string) error {
 		UIURL:            a.cfg.UIURL,
 	}
 
-	data, err := json.Marshal(payload)
+	result, err := a.cp.Register(ctx, payload)
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "marshal failed")
-		return fmt.Errorf("marshal registration: %w", err)
-	}
-
-	url := fmt.Sprintf("%s/v1/internal/gateways/register", a.cfg.ControlPlaneURL)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "create request failed")
-		return fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Gateway-Key", a.cfg.GatewayAPIKey)
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "request failed")
-		return fmt.Errorf("register request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, _ := io.ReadAll(resp.Body)
-	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
-
-	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		err := fmt.Errorf("register failed (%d): %s", resp.StatusCode, string(body))
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "registration rejected")
 		return err
-	}
-
-	var result RegistrationResponse
-	if err := json.Unmarshal(body, &result); err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "decode failed")
-		return fmt.Errorf("decode registration response: %w", err)
 	}
 
 	a.state.SetGatewayID(result.ID)
 	a.healthPort = healthPort
-	span.SetAttributes(attribute.String("stoa.gateway_id", result.ID))
-	span.SetStatus(codes.Ok, "registered")
 	log.Printf("registered with CP: id=%s name=%s", result.ID, result.Name)
 	return nil
 }
@@ -200,16 +157,13 @@ func (a *Agent) GatewayID() string {
 }
 
 // Heartbeat sends a single heartbeat to the Control Plane.
+// Returns ErrNotRegistered if called before Register, ErrGatewayNotFound if
+// the CP responds 404 (gateway purged).
 func (a *Agent) Heartbeat(ctx context.Context) error {
 	gatewayID := a.state.GatewayID()
 	if gatewayID == "" {
 		return ErrNotRegistered
 	}
-
-	ctx, span := a.startSpan(ctx, "stoa-connect.heartbeat",
-		attribute.String("stoa.gateway_id", gatewayID),
-	)
-	defer span.End()
 
 	payload := HeartbeatPayload{
 		UptimeSeconds:  int(time.Since(a.startTime).Seconds()),
@@ -217,55 +171,9 @@ func (a *Agent) Heartbeat(ctx context.Context) error {
 		DiscoveredAPIs: a.state.DiscoveredAPIsCount(),
 	}
 
-	span.SetAttributes(
-		attribute.Int("stoa.uptime_seconds", payload.UptimeSeconds),
-		attribute.Int("stoa.routes_count", payload.RoutesCount),
-		attribute.Int("stoa.discovered_apis", payload.DiscoveredAPIs),
-	)
-
-	data, err := json.Marshal(payload)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "marshal failed")
-		return fmt.Errorf("marshal heartbeat: %w", err)
-	}
-
-	url := fmt.Sprintf("%s/v1/internal/gateways/%s/heartbeat", a.cfg.ControlPlaneURL, gatewayID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "create request failed")
-		return fmt.Errorf("create heartbeat request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Gateway-Key", a.cfg.GatewayAPIKey)
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "request failed")
-		return fmt.Errorf("heartbeat request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
-
-	if resp.StatusCode == http.StatusNotFound {
-		err := ErrGatewayNotFound
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "gateway purged from CP")
+	if err := a.cp.Heartbeat(ctx, gatewayID, payload); err != nil {
 		return err
 	}
-
-	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		err := fmt.Errorf("heartbeat failed (%d): %s", resp.StatusCode, string(body))
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "heartbeat rejected")
-		return err
-	}
-
-	span.SetStatus(codes.Ok, "heartbeat sent")
 	HeartbeatsSent.Inc()
 	return nil
 }
@@ -328,53 +236,7 @@ func (a *Agent) ReportDiscovery(ctx context.Context, apis []DiscoveredAPIPayload
 	if gatewayID == "" {
 		return ErrNotRegistered
 	}
-
-	ctx, span := a.startSpan(ctx, "stoa-connect.discovery",
-		attribute.String("stoa.gateway_id", gatewayID),
-	)
-	defer span.End()
-
-	payload := DiscoveryPayload{APIs: apis}
-
-	span.SetAttributes(attribute.Int("stoa.discovered_apis", len(payload.APIs)))
-
-	data, err := json.Marshal(payload)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "marshal failed")
-		return fmt.Errorf("marshal discovery payload: %w", err)
-	}
-
-	url := fmt.Sprintf("%s/v1/internal/gateways/%s/discovery", a.cfg.ControlPlaneURL, gatewayID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "create request failed")
-		return fmt.Errorf("create discovery request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Gateway-Key", a.cfg.GatewayAPIKey)
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "request failed")
-		return fmt.Errorf("discovery report request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		body, _ := io.ReadAll(resp.Body)
-		err := fmt.Errorf("discovery report failed (%d): %s", resp.StatusCode, string(body))
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "discovery rejected")
-		return err
-	}
-
-	span.SetStatus(codes.Ok, "discovery reported")
-	return nil
+	return a.cp.ReportDiscovery(ctx, gatewayID, DiscoveryPayload{APIs: apis})
 }
 
 // DiscoveredAPIsCount returns the count of last discovered APIs.

--- a/stoa-go/internal/connect/connect_test.go
+++ b/stoa-go/internal/connect/connect_test.go
@@ -170,7 +170,7 @@ func TestHeartbeatSuccess(t *testing.T) {
 		ControlPlaneURL: server.URL,
 		GatewayAPIKey:   "hb-key",
 	})
-	agent.gatewayID = "gw-123"
+	agent.state.SetGatewayID("gw-123")
 
 	err := agent.Heartbeat(context.Background())
 	if err != nil {
@@ -196,39 +196,39 @@ func TestHeartbeatNotRegistered(t *testing.T) {
 
 func TestComputeRoutesCountEmpty(t *testing.T) {
 	a := New(Config{ControlPlaneURL: "http://cp", GatewayAPIKey: "key"})
-	if got := a.computeRoutesCount(); got != 0 {
+	if got := a.state.ComputeRoutesCount(); got != 0 {
 		t.Errorf("computeRoutesCount() = %d, want 0", got)
 	}
 }
 
 func TestComputeRoutesCountWithPaths(t *testing.T) {
 	a := New(Config{ControlPlaneURL: "http://cp", GatewayAPIKey: "key"})
-	a.lastDiscoveredAPIs = []DiscoveredAPIPayload{
+	a.state.SetDiscoveredAPIs([]DiscoveredAPIPayload{
 		{Name: "petstore", Paths: []string{"/pets", "/pets/{id}"}, IsActive: true},
 		{Name: "payments", Paths: []string{"/charge"}, IsActive: true},
-	}
-	if got := a.computeRoutesCount(); got != 3 {
+	})
+	if got := a.state.ComputeRoutesCount(); got != 3 {
 		t.Errorf("computeRoutesCount() = %d, want 3", got)
 	}
 }
 
 func TestComputeRoutesCountSkipsInactive(t *testing.T) {
 	a := New(Config{ControlPlaneURL: "http://cp", GatewayAPIKey: "key"})
-	a.lastDiscoveredAPIs = []DiscoveredAPIPayload{
+	a.state.SetDiscoveredAPIs([]DiscoveredAPIPayload{
 		{Name: "active", Paths: []string{"/ok"}, IsActive: true},
 		{Name: "inactive", Paths: []string{"/skip1", "/skip2"}, IsActive: false},
-	}
-	if got := a.computeRoutesCount(); got != 1 {
+	})
+	if got := a.state.ComputeRoutesCount(); got != 1 {
 		t.Errorf("computeRoutesCount() = %d, want 1", got)
 	}
 }
 
 func TestComputeRoutesCountNoPaths(t *testing.T) {
 	a := New(Config{ControlPlaneURL: "http://cp", GatewayAPIKey: "key"})
-	a.lastDiscoveredAPIs = []DiscoveredAPIPayload{
+	a.state.SetDiscoveredAPIs([]DiscoveredAPIPayload{
 		{Name: "minimal", IsActive: true},
-	}
-	if got := a.computeRoutesCount(); got != 1 {
+	})
+	if got := a.state.ComputeRoutesCount(); got != 1 {
 		t.Errorf("computeRoutesCount() = %d, want 1 (API with no paths counts as 1)", got)
 	}
 }
@@ -248,10 +248,10 @@ func TestHeartbeatSendsRoutesCount(t *testing.T) {
 		ControlPlaneURL: server.URL,
 		GatewayAPIKey:   "key",
 	})
-	agent.gatewayID = "gw-123"
-	agent.lastDiscoveredAPIs = []DiscoveredAPIPayload{
+	agent.state.SetGatewayID("gw-123")
+	agent.state.SetDiscoveredAPIs([]DiscoveredAPIPayload{
 		{Name: "petstore", Paths: []string{"/pets", "/pets/{id}"}, IsActive: true},
-	}
+	})
 
 	err := agent.Heartbeat(context.Background())
 	if err != nil {
@@ -278,7 +278,7 @@ func TestStartHeartbeatStopsOnCancel(t *testing.T) {
 		GatewayAPIKey:     "key",
 		HeartbeatInterval: 50 * time.Millisecond,
 	})
-	agent.gatewayID = "gw-test"
+	agent.state.SetGatewayID("gw-test")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	agent.StartHeartbeat(ctx)
@@ -306,7 +306,7 @@ func TestHeartbeat404ReturnsNotFound(t *testing.T) {
 		GatewayAPIKey:   "key",
 		InstanceName:    "test-agent",
 	})
-	agent.gatewayID = "purged-id"
+	agent.state.SetGatewayID("purged-id")
 
 	err := agent.Heartbeat(context.Background())
 	if err == nil {
@@ -344,7 +344,7 @@ func TestStartHeartbeat404ReRegisters(t *testing.T) {
 		InstanceName:      "test-agent",
 		HeartbeatInterval: 20 * time.Millisecond,
 	})
-	agent.gatewayID = "old-purged-id"
+	agent.state.SetGatewayID("old-purged-id")
 	agent.healthPort = "8090"
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -358,7 +358,7 @@ func TestStartHeartbeat404ReRegisters(t *testing.T) {
 	if registerCount.Load() < 1 {
 		t.Errorf("expected at least 1 re-registration, got %d", registerCount.Load())
 	}
-	if agent.gatewayID != "new-id" {
-		t.Errorf("expected gatewayID=new-id after re-registration, got %s", agent.gatewayID)
+	if got := agent.state.GatewayID(); got != "new-id" {
+		t.Errorf("expected gatewayID=new-id after re-registration, got %s", got)
 	}
 }

--- a/stoa-go/internal/connect/credentials.go
+++ b/stoa-go/internal/connect/credentials.go
@@ -81,7 +81,8 @@ func (a *Agent) RunCredentialSync(ctx context.Context, vc *VaultClient, adapter 
 }
 
 // StartCredentialSync starts a background goroutine that syncs credentials
-// from Vault to the local gateway at the configured interval.
+// from Vault to the local gateway at the configured interval. See
+// runCredentialSyncLoop in loop_credentials.go for the loop body.
 func (a *Agent) StartCredentialSync(ctx context.Context, vc *VaultClient, adapter adapters.GatewayAdapter, adminURL string, cfg CredentialSyncConfig) {
 	if adminURL == "" {
 		log.Println("credential-sync skipped: no gateway admin URL configured")
@@ -91,27 +92,10 @@ func (a *Agent) StartCredentialSync(ctx context.Context, vc *VaultClient, adapte
 		log.Println("credential-sync skipped: STOA_TENANT_ID not set")
 		return
 	}
-
 	interval := cfg.Interval
 	if interval == 0 {
 		interval = 60 * time.Second
 	}
-
 	log.Printf("starting credential sync loop (interval=%s, tenant=%s)", interval, cfg.TenantID)
-
-	ticker := time.NewTicker(interval)
-	go func() {
-		defer ticker.Stop()
-		// Run immediately on start
-		a.RunCredentialSync(ctx, vc, adapter, adminURL, cfg.TenantID)
-		for {
-			select {
-			case <-ctx.Done():
-				log.Println("credential-sync stopped")
-				return
-			case <-ticker.C:
-				a.RunCredentialSync(ctx, vc, adapter, adminURL, cfg.TenantID)
-			}
-		}
-	}()
+	go runCredentialSyncLoop(ctx, a, vc, adapter, adminURL, cfg.TenantID, interval)
 }

--- a/stoa-go/internal/connect/discovery.go
+++ b/stoa-go/internal/connect/discovery.go
@@ -155,10 +155,10 @@ func (a *Agent) runDiscovery(ctx context.Context, adapter adapters.GatewayAdapte
 			IsActive:   api.IsActive,
 		}
 	}
-	a.lastDiscoveredAPIs = payloads
+	a.state.SetDiscoveredAPIs(payloads)
 
 	// Report to CP if registered
-	if a.gatewayID != "" {
+	if a.state.GatewayID() != "" {
 		if err := a.ReportDiscovery(ctx, payloads); err != nil {
 			log.Printf("discovery report error: %v", err)
 		}

--- a/stoa-go/internal/connect/discovery.go
+++ b/stoa-go/internal/connect/discovery.go
@@ -92,37 +92,20 @@ func autoDetect(ctx context.Context, adminURL string, acfg adapters.AdapterConfi
 }
 
 // StartDiscovery starts a background goroutine that periodically discovers
-// APIs from the local gateway and reports them to the Control Plane.
+// APIs from the local gateway and reports them to the Control Plane. See
+// runDiscoveryLoop in loop_discovery.go for the loop body.
 func (a *Agent) StartDiscovery(ctx context.Context, dcfg DiscoveryConfig) {
 	if dcfg.GatewayAdminURL == "" {
 		log.Println("discovery skipped: STOA_GATEWAY_ADMIN_URL not set")
 		return
 	}
-
 	adapter, gwType, err := ResolveAdapter(ctx, dcfg)
 	if err != nil {
 		log.Printf("discovery setup failed: %v", err)
 		return
 	}
-
 	log.Printf("discovery started: type=%s url=%s interval=%s", gwType, dcfg.GatewayAdminURL, dcfg.Interval)
-
-	// Run immediately, then on interval
-	go func() {
-		a.runDiscovery(ctx, adapter, dcfg.GatewayAdminURL)
-
-		ticker := time.NewTicker(dcfg.Interval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				log.Println("discovery stopped")
-				return
-			case <-ticker.C:
-				a.runDiscovery(ctx, adapter, dcfg.GatewayAdminURL)
-			}
-		}
-	}()
+	go runDiscoveryLoop(ctx, a, adapter, dcfg.GatewayAdminURL, dcfg.Interval)
 }
 
 // runDiscovery performs a single discovery cycle.

--- a/stoa-go/internal/connect/discovery_test.go
+++ b/stoa-go/internal/connect/discovery_test.go
@@ -170,7 +170,7 @@ func TestRunDiscoveryReportsToCP(t *testing.T) {
 		ControlPlaneURL: cpServer.URL,
 		GatewayAPIKey:   "key",
 	})
-	agent.gatewayID = "gw-test"
+	agent.state.SetGatewayID("gw-test")
 
 	// Create a mock adapter that returns test data
 	gwServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/stoa-go/internal/connect/dispatcher.go
+++ b/stoa-go/internal/connect/dispatcher.go
@@ -1,0 +1,52 @@
+package connect
+
+import (
+	"context"
+	"log"
+)
+
+// eventHandler processes one rawEvent's payload. Handlers run inline on the
+// SSE scanner goroutine — they MUST NOT block indefinitely. Long-running
+// side effects (adapter syncs) are fine, but should respect ctx cancellation.
+type eventHandler func(ctx context.Context, data []byte)
+
+// eventDispatcher routes SSE rawEvents to registered handlers by event type.
+//
+// Each event is handled independently — the SSE protocol here has no
+// ordering contract between event types (a "heartbeat" and a
+// "sync-deployment" arriving back-to-back are logically concurrent; the
+// scanner just delivers them in wire order). If we ever introduce a pair
+// with an ordering dependency (e.g. "config-updated" gating "route-sync"),
+// this is the place to make it explicit — either via a queue, a blocking
+// ordering handler, or by moving one of the events out of the SSE channel.
+//
+// Unknown event types are logged and dropped (never fatal) so the CP can
+// roll out new event types without breaking older agents.
+//
+// NOT safe for concurrent Register; intended to be populated once at
+// goroutine spawn time. Dispatch is safe to call concurrently with reads
+// once registration is complete (handlers map is read-only post-setup).
+type eventDispatcher struct {
+	handlers map[string]eventHandler
+}
+
+func newEventDispatcher() *eventDispatcher {
+	return &eventDispatcher{handlers: make(map[string]eventHandler)}
+}
+
+// Register installs a handler for the given SSE event type. Silently
+// overwrites any prior handler for the same type — callers are assumed to
+// own their type exclusively.
+func (d *eventDispatcher) Register(eventType string, h eventHandler) {
+	d.handlers[eventType] = h
+}
+
+// Dispatch routes ev to the handler registered for ev.Type. Unknown types
+// are logged at info level and dropped.
+func (d *eventDispatcher) Dispatch(ctx context.Context, ev rawEvent) {
+	if h, ok := d.handlers[ev.Type]; ok {
+		h(ctx, ev.Data)
+		return
+	}
+	log.Printf("sse-stream: unknown event type %q", ev.Type)
+}

--- a/stoa-go/internal/connect/dispatcher_test.go
+++ b/stoa-go/internal/connect/dispatcher_test.go
@@ -1,0 +1,70 @@
+package connect
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+)
+
+func TestDispatcherCallsRegisteredHandler(t *testing.T) {
+	d := newEventDispatcher()
+	var called atomic.Int32
+	var receivedData atomic.Pointer[[]byte]
+
+	d.Register("sync-deployment", func(ctx context.Context, data []byte) {
+		called.Add(1)
+		cp := make([]byte, len(data))
+		copy(cp, data)
+		receivedData.Store(&cp)
+	})
+
+	d.Dispatch(context.Background(), rawEvent{Type: "sync-deployment", Data: []byte("hello")})
+
+	if got := called.Load(); got != 1 {
+		t.Errorf("expected handler called once, got %d", got)
+	}
+	if got := receivedData.Load(); got == nil || string(*got) != "hello" {
+		t.Errorf("expected data 'hello', got %v", got)
+	}
+}
+
+func TestDispatcherUnknownEventTypeDropped(t *testing.T) {
+	d := newEventDispatcher()
+	var called atomic.Int32
+	d.Register("sync-deployment", func(ctx context.Context, data []byte) {
+		called.Add(1)
+	})
+
+	// "heartbeat" is NOT registered — should be logged + dropped, no panic.
+	d.Dispatch(context.Background(), rawEvent{Type: "heartbeat", Data: []byte("{}")})
+
+	if got := called.Load(); got != 0 {
+		t.Errorf("expected registered handler not called, got %d calls", got)
+	}
+}
+
+func TestDispatcherNoOpHandler(t *testing.T) {
+	// A registered no-op handler must silence the "unknown event" log by
+	// matching the type — this is how we handle SSE heartbeats without
+	// the log line polluting output on every keepalive.
+	d := newEventDispatcher()
+	d.Register("heartbeat", func(ctx context.Context, data []byte) {})
+	// Should not panic, should not log "unknown event type".
+	d.Dispatch(context.Background(), rawEvent{Type: "heartbeat", Data: nil})
+}
+
+func TestDispatcherLastRegisterWins(t *testing.T) {
+	d := newEventDispatcher()
+	var first, second atomic.Int32
+	d.Register("x", func(ctx context.Context, data []byte) { first.Add(1) })
+	d.Register("x", func(ctx context.Context, data []byte) { second.Add(1) })
+
+	d.Dispatch(context.Background(), rawEvent{Type: "x", Data: nil})
+
+	if first.Load() != 0 {
+		t.Errorf("first handler called %d times, expected 0 (overwritten)", first.Load())
+	}
+	if second.Load() != 1 {
+		t.Errorf("second handler called %d times, expected 1", second.Load())
+	}
+}

--- a/stoa-go/internal/connect/errors.go
+++ b/stoa-go/internal/connect/errors.go
@@ -1,0 +1,13 @@
+package connect
+
+import "errors"
+
+// ErrGatewayNotFound is returned by Heartbeat when the CP responds 404,
+// indicating the gateway instance was purged on the CP side and needs
+// re-registration. Consumers compare via errors.Is(err, ErrGatewayNotFound).
+var ErrGatewayNotFound = errors.New("gateway not found on Control Plane (purged)")
+
+// ErrNotRegistered is returned by any CP-bound call attempted before the
+// agent has completed Register() (or after ClearGatewayID on re-register).
+// Consumers compare via errors.Is(err, ErrNotRegistered).
+var ErrNotRegistered = errors.New("stoa-connect: agent not registered with Control Plane")

--- a/stoa-go/internal/connect/loop_credentials.go
+++ b/stoa-go/internal/connect/loop_credentials.go
@@ -1,0 +1,27 @@
+package connect
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/stoa-platform/stoa-go/internal/connect/adapters"
+)
+
+// runCredentialSyncLoop drives the credential-sync ticker loop. Runs
+// a.RunCredentialSync immediately then on each interval tick. Vault token
+// renewal is handled inside RunCredentialSync itself (see credentials.go).
+func runCredentialSyncLoop(ctx context.Context, a *Agent, vc *VaultClient, adapter adapters.GatewayAdapter, adminURL, tenantID string, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	a.RunCredentialSync(ctx, vc, adapter, adminURL, tenantID)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("credential-sync stopped")
+			return
+		case <-ticker.C:
+			a.RunCredentialSync(ctx, vc, adapter, adminURL, tenantID)
+		}
+	}
+}

--- a/stoa-go/internal/connect/loop_discovery.go
+++ b/stoa-go/internal/connect/loop_discovery.go
@@ -1,0 +1,26 @@
+package connect
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/stoa-platform/stoa-go/internal/connect/adapters"
+)
+
+// runDiscoveryLoop drives the gateway-discovery ticker loop. Runs
+// a.runDiscovery immediately then on each interval tick.
+func runDiscoveryLoop(ctx context.Context, a *Agent, adapter adapters.GatewayAdapter, adminURL string, interval time.Duration) {
+	a.runDiscovery(ctx, adapter, adminURL)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("discovery stopped")
+			return
+		case <-ticker.C:
+			a.runDiscovery(ctx, adapter, adminURL)
+		}
+	}
+}

--- a/stoa-go/internal/connect/loop_heartbeat.go
+++ b/stoa-go/internal/connect/loop_heartbeat.go
@@ -1,0 +1,51 @@
+package connect
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+)
+
+// runHeartbeat is the heartbeat ticker loop. Sends a.Heartbeat on each tick
+// and auto-re-registers after reRegisterThreshold consecutive 404 responses
+// from the CP (see ADR-057). Exits cleanly on ctx cancellation.
+//
+// Threshold value preserved verbatim from pre-GO-2 behavior — changing it
+// would alter the CP↔agent re-registration sliding window.
+func runHeartbeat(ctx context.Context, a *Agent) {
+	ticker := time.NewTicker(a.cfg.HeartbeatInterval)
+	defer ticker.Stop()
+	consecutiveNotFound := 0
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("heartbeat stopped")
+			return
+		case <-ticker.C:
+			err := a.Heartbeat(ctx)
+			if err == nil {
+				consecutiveNotFound = 0
+				continue
+			}
+			if !errors.Is(err, ErrGatewayNotFound) {
+				log.Printf("heartbeat error: %v", err)
+				continue
+			}
+			consecutiveNotFound++
+			log.Printf("heartbeat 404 (%d/%d) — gateway not found on CP",
+				consecutiveNotFound, reRegisterThreshold)
+			if consecutiveNotFound < reRegisterThreshold {
+				continue
+			}
+			log.Println("gateway purged from CP, re-registering...")
+			a.state.ClearGatewayID()
+			if regErr := a.Register(ctx, a.healthPort); regErr != nil {
+				log.Printf("re-registration failed: %v", regErr)
+			} else {
+				log.Printf("re-registered with CP: id=%s", a.state.GatewayID())
+				consecutiveNotFound = 0
+			}
+		}
+	}
+}

--- a/stoa-go/internal/connect/loop_sse.go
+++ b/stoa-go/internal/connect/loop_sse.go
@@ -1,0 +1,46 @@
+package connect
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/stoa-platform/stoa-go/internal/connect/adapters"
+)
+
+// runSSEStream drives the SSE deployment-stream reconnect loop. Before
+// each connect attempt it runs a route-sync catch-up to reconcile any
+// deployment missed during a disconnection. On terminal error from
+// sseStream, it waits according to the backoff policy and reconnects.
+//
+// Exits cleanly on ctx cancellation.
+func runSSEStream(ctx context.Context, a *Agent, adapter adapters.GatewayAdapter, adminURL string, policy backoffPolicy) {
+	attempt := 0
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("sse-stream stopped")
+			return
+		default:
+		}
+
+		// Catch up on any missed deployments before streaming.
+		a.RunRouteSync(ctx, adapter, adminURL)
+
+		err := a.streamEvents(ctx, adapter, adminURL)
+		if err == nil || ctx.Err() != nil {
+			// Clean disconnect or context cancelled — reset attempt and loop.
+			attempt = 0
+			continue
+		}
+
+		attempt++
+		wait := policy.backoff(attempt)
+		log.Printf("sse-stream: terminal error: %v (reconnecting in %s, attempt %d)", err, wait, attempt)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(wait):
+		}
+	}
+}

--- a/stoa-go/internal/connect/loop_sync.go
+++ b/stoa-go/internal/connect/loop_sync.go
@@ -1,0 +1,43 @@
+package connect
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/stoa-platform/stoa-go/internal/connect/adapters"
+)
+
+// runPolicySync drives the policy-sync ticker loop. Runs RunSync immediately
+// then on each interval tick until ctx is cancelled.
+func runPolicySync(ctx context.Context, a *Agent, adapter adapters.GatewayAdapter, adminURL string, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	a.RunSync(ctx, adapter, adminURL)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("sync stopped")
+			return
+		case <-ticker.C:
+			a.RunSync(ctx, adapter, adminURL)
+		}
+	}
+}
+
+// runRouteSyncPolling drives the route-sync polling ticker loop (fallback
+// when SSE is disabled). Runs RunRouteSync immediately then on each tick.
+func runRouteSyncPolling(ctx context.Context, a *Agent, adapter adapters.GatewayAdapter, adminURL string, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	a.RunRouteSync(ctx, adapter, adminURL)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("route-sync stopped")
+			return
+		case <-ticker.C:
+			a.RunRouteSync(ctx, adapter, adminURL)
+		}
+	}
+}

--- a/stoa-go/internal/connect/retry.go
+++ b/stoa-go/internal/connect/retry.go
@@ -1,0 +1,46 @@
+package connect
+
+import "time"
+
+// backoffPolicy describes an exponential backoff schedule used by the SSE
+// reconnect loop. Currently the single user, but kept as a named type so the
+// policy (initial, cap, multiplier) can be surfaced in logs and tuned via
+// configuration rather than buried as magic constants.
+//
+// Scope is deliberately SSE-only. The heartbeat 404 re-register threshold is
+// a different concept (a stateful counter) and lives as its own const in
+// connect.go — do not fold it in here without considering the protocol
+// semantics described in ADR-057.
+type backoffPolicy struct {
+	Initial    time.Duration // delay before the 1st retry
+	Max        time.Duration // cap on any single delay
+	Multiplier float64       // growth factor per attempt (typically 2.0)
+}
+
+// backoff returns the delay to wait before the `attempt`-th retry (1-indexed).
+// attempt=1 returns Initial. Each subsequent attempt multiplies by Multiplier,
+// capped at Max. attempt<=0 returns 0.
+func (p backoffPolicy) backoff(attempt int) time.Duration {
+	if attempt <= 0 {
+		return 0
+	}
+	if p.Multiplier <= 0 {
+		// Guard against misconfiguration; treat as flat Initial.
+		return clampDuration(p.Initial, p.Max)
+	}
+	d := float64(p.Initial)
+	for i := 1; i < attempt; i++ {
+		d *= p.Multiplier
+		if p.Max > 0 && d >= float64(p.Max) {
+			return p.Max
+		}
+	}
+	return clampDuration(time.Duration(d), p.Max)
+}
+
+func clampDuration(d, max time.Duration) time.Duration {
+	if max > 0 && d > max {
+		return max
+	}
+	return d
+}

--- a/stoa-go/internal/connect/retry_test.go
+++ b/stoa-go/internal/connect/retry_test.go
@@ -1,0 +1,61 @@
+package connect
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBackoffPolicy(t *testing.T) {
+	p := backoffPolicy{
+		Initial:    2 * time.Second,
+		Max:        60 * time.Second,
+		Multiplier: 2.0,
+	}
+
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{0, 0},
+		{-1, 0},
+		{1, 2 * time.Second},
+		{2, 4 * time.Second},
+		{3, 8 * time.Second},
+		{4, 16 * time.Second},
+		{5, 32 * time.Second},
+		{6, 60 * time.Second},   // capped
+		{100, 60 * time.Second}, // still capped
+	}
+	for _, tc := range tests {
+		got := p.backoff(tc.attempt)
+		if got != tc.want {
+			t.Errorf("backoff(%d) = %s, want %s", tc.attempt, got, tc.want)
+		}
+	}
+}
+
+func TestBackoffPolicyNoMultiplierTreatedAsFlat(t *testing.T) {
+	p := backoffPolicy{
+		Initial:    2 * time.Second,
+		Max:        60 * time.Second,
+		Multiplier: 0, // misconfigured
+	}
+	if got := p.backoff(1); got != 2*time.Second {
+		t.Errorf("attempt=1 with zero Multiplier: got %s, want %s", got, 2*time.Second)
+	}
+	if got := p.backoff(5); got != 2*time.Second {
+		t.Errorf("attempt=5 with zero Multiplier: got %s, want %s (should stay flat)", got, 2*time.Second)
+	}
+}
+
+func TestBackoffPolicyNoMaxUnbounded(t *testing.T) {
+	p := backoffPolicy{
+		Initial:    1 * time.Second,
+		Max:        0, // unbounded
+		Multiplier: 2.0,
+	}
+	// attempt=4 → 1 * 2 * 2 * 2 = 8s, no cap
+	if got := p.backoff(4); got != 8*time.Second {
+		t.Errorf("attempt=4 unbounded: got %s, want 8s", got)
+	}
+}

--- a/stoa-go/internal/connect/routes.go
+++ b/stoa-go/internal/connect/routes.go
@@ -37,15 +37,15 @@ func (a *Agent) FetchRoutes(ctx context.Context) ([]adapters.Route, error) {
 	return a.cp.FetchRoutes(ctx, a.cfg.InstanceName)
 }
 
-// RunRouteSync performs a single route sync cycle: fetch CP routes → push to local gateway.
+// RunRouteSync performs a single route sync cycle: fetch CP routes → push
+// to local gateway via the unified routeSyncer → ack per-route results.
+// Shares the route-sync code path with the SSE deployment stream
+// (handleSyncDeployment) — see sync_route.go.
 func (a *Agent) RunRouteSync(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string) {
 	ctx, span := a.startSpan(ctx, "stoa-connect.routes.sync",
 		attribute.String("stoa.gateway_id", a.state.GatewayID()),
 	)
 	defer span.End()
-
-	// Step: agent_received — sync cycle started
-	agentStep := newSyncStep("agent_received", "success", "")
 
 	routes, err := a.FetchRoutes(ctx)
 	if err != nil {
@@ -61,59 +61,12 @@ func (a *Agent) RunRouteSync(ctx context.Context, adapter adapters.GatewayAdapte
 		return
 	}
 
-	// Step: adapter_connected — gateway adapter ready
-	adapterStep := newSyncStep("adapter_connected", "success", "")
-
 	span.SetAttributes(attribute.Int("stoa.routes_count", len(routes)))
 	log.Printf("route-sync: %d routes to push", len(routes))
 
-	syncErr := adapter.SyncRoutes(ctx, adminURL, routes)
+	syncer := newRouteSyncer(adapter)
+	results, syncErr := syncer.Sync(ctx, adminURL, routes)
 
-	// Step: api_synced
-	var apiStep SyncStep
-	if syncErr != nil {
-		apiStep = newSyncStep("api_synced", "failed", syncErr.Error())
-	} else {
-		apiStep = newSyncStep("api_synced", "success", "")
-	}
-
-	steps := []SyncStep{agentStep, adapterStep, apiStep}
-
-	// Build ack results — per-route status from adapter FailedRoutes map
-	// This gives accurate results: routes that succeeded are "applied",
-	// only routes that actually failed are "failed".
-	type failedRoutesProvider interface {
-		GetFailedRoutes() map[string]string
-	}
-	failedMap := make(map[string]string)
-	if frp, ok := adapter.(failedRoutesProvider); ok {
-		failedMap = frp.GetFailedRoutes()
-	}
-
-	var results []SyncedRouteResult
-	for _, r := range routes {
-		if r.DeploymentID == "" {
-			continue // Skip routes without deployment tracking
-		}
-		result := SyncedRouteResult{
-			DeploymentID: r.DeploymentID,
-			Steps:        steps,
-			Generation:   r.Generation,
-		}
-		if routeErr, failed := failedMap[r.DeploymentID]; failed {
-			result.Status = "failed"
-			result.Error = routeErr
-		} else if syncErr != nil && len(failedMap) == 0 {
-			// Fallback: global error without per-route tracking (non-webmethods adapters)
-			result.Status = "failed"
-			result.Error = syncErr.Error()
-		} else {
-			result.Status = "applied"
-		}
-		results = append(results, result)
-	}
-
-	// Report route sync results to CP (fire-and-forget: log warning on failure)
 	if len(results) > 0 {
 		if ackErr := a.ReportRouteSyncAck(ctx, results); ackErr != nil {
 			log.Printf("route-sync: report ack error: %v", ackErr)

--- a/stoa-go/internal/connect/routes.go
+++ b/stoa-go/internal/connect/routes.go
@@ -2,11 +2,7 @@ package connect
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 	"log"
-	"net/http"
 	"os"
 	"time"
 
@@ -35,54 +31,10 @@ func RouteSyncConfigFromEnv() RouteSyncConfig {
 	return cfg
 }
 
-// FetchRoutes pulls the route table from the CP via GET /v1/internal/gateways/routes.
+// FetchRoutes pulls the route table from the CP, filtered by InstanceName
+// (empty = all). Thin delegator — HTTP logic lives in cpClient.FetchRoutes.
 func (a *Agent) FetchRoutes(ctx context.Context) ([]adapters.Route, error) {
-	ctx, span := a.startSpan(ctx, "stoa-connect.routes.fetch",
-		attribute.String("stoa.gateway_id", a.state.GatewayID()),
-	)
-	defer span.End()
-
-	url := fmt.Sprintf("%s/v1/internal/gateways/routes", a.cfg.ControlPlaneURL)
-	if a.cfg.InstanceName != "" {
-		url += "?gateway_name=" + a.cfg.InstanceName
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "create request failed")
-		return nil, fmt.Errorf("create routes request: %w", err)
-	}
-	req.Header.Set("X-Gateway-Key", a.cfg.GatewayAPIKey)
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "request failed")
-		return nil, fmt.Errorf("routes request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, _ := io.ReadAll(resp.Body)
-	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
-
-	if resp.StatusCode != http.StatusOK {
-		err := fmt.Errorf("routes request failed (%d): %s", resp.StatusCode, string(body))
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "fetch routes rejected")
-		return nil, err
-	}
-
-	var routes []adapters.Route
-	if err := json.Unmarshal(body, &routes); err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "decode failed")
-		return nil, fmt.Errorf("decode routes response: %w", err)
-	}
-
-	span.SetAttributes(attribute.Int("stoa.routes_count", len(routes)))
-	span.SetStatus(codes.Ok, "routes fetched")
-	return routes, nil
+	return a.cp.FetchRoutes(ctx, a.cfg.InstanceName)
 }
 
 // RunRouteSync performs a single route sync cycle: fetch CP routes → push to local gateway.

--- a/stoa-go/internal/connect/routes.go
+++ b/stoa-go/internal/connect/routes.go
@@ -38,7 +38,7 @@ func RouteSyncConfigFromEnv() RouteSyncConfig {
 // FetchRoutes pulls the route table from the CP via GET /v1/internal/gateways/routes.
 func (a *Agent) FetchRoutes(ctx context.Context) ([]adapters.Route, error) {
 	ctx, span := a.startSpan(ctx, "stoa-connect.routes.fetch",
-		attribute.String("stoa.gateway_id", a.gatewayID),
+		attribute.String("stoa.gateway_id", a.state.GatewayID()),
 	)
 	defer span.End()
 
@@ -88,7 +88,7 @@ func (a *Agent) FetchRoutes(ctx context.Context) ([]adapters.Route, error) {
 // RunRouteSync performs a single route sync cycle: fetch CP routes → push to local gateway.
 func (a *Agent) RunRouteSync(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string) {
 	ctx, span := a.startSpan(ctx, "stoa-connect.routes.sync",
-		attribute.String("stoa.gateway_id", a.gatewayID),
+		attribute.String("stoa.gateway_id", a.state.GatewayID()),
 	)
 	defer span.End()
 

--- a/stoa-go/internal/connect/routes.go
+++ b/stoa-go/internal/connect/routes.go
@@ -86,34 +86,18 @@ func (a *Agent) RunRouteSync(ctx context.Context, adapter adapters.GatewayAdapte
 	log.Printf("route-sync: pushed %d routes to gateway", len(routes))
 }
 
-// StartRouteSync starts a background goroutine that syncs CP routes
-// to the local gateway at the configured interval.
+// StartRouteSync starts a background goroutine that polls CP routes and
+// pushes them to the local gateway at the configured interval. Used as the
+// fallback when SSE is disabled — see runRouteSyncPolling in loop_sync.go.
 func (a *Agent) StartRouteSync(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string, cfg RouteSyncConfig) {
 	if adminURL == "" {
 		log.Println("route-sync skipped: no gateway admin URL configured")
 		return
 	}
-
 	interval := cfg.Interval
 	if interval == 0 {
 		interval = 30 * time.Second
 	}
-
 	log.Printf("starting route sync loop (interval=%s)", interval)
-
-	ticker := time.NewTicker(interval)
-	go func() {
-		defer ticker.Stop()
-		// Run immediately on start
-		a.RunRouteSync(ctx, adapter, adminURL)
-		for {
-			select {
-			case <-ctx.Done():
-				log.Println("route-sync stopped")
-				return
-			case <-ticker.C:
-				a.RunRouteSync(ctx, adapter, adminURL)
-			}
-		}
-	}()
+	go runRouteSyncPolling(ctx, a, adapter, adminURL, interval)
 }

--- a/stoa-go/internal/connect/routes_test.go
+++ b/stoa-go/internal/connect/routes_test.go
@@ -219,7 +219,7 @@ func TestRunRouteSyncSendsAckWithDeploymentIDs(t *testing.T) {
 		ControlPlaneURL: cpServer.URL,
 		GatewayAPIKey:   "key",
 	})
-	agent.gatewayID = "gw-test"
+	agent.state.SetGatewayID("gw-test")
 
 	adapter := &mockSyncAdapter{}
 	agent.RunRouteSync(context.Background(), adapter, "http://gateway:8001")
@@ -263,7 +263,7 @@ func TestRunRouteSyncAckReportsFailedStatus(t *testing.T) {
 		ControlPlaneURL: cpServer.URL,
 		GatewayAPIKey:   "key",
 	})
-	agent.gatewayID = "gw-test"
+	agent.state.SetGatewayID("gw-test")
 
 	adapter := &mockSyncAdapter{syncRoutesErr: fmt.Errorf("gateway unreachable")}
 	agent.RunRouteSync(context.Background(), adapter, "http://gateway:8001")
@@ -304,7 +304,7 @@ func TestRunRouteSyncNoAckWithoutDeploymentIDs(t *testing.T) {
 		ControlPlaneURL: cpServer.URL,
 		GatewayAPIKey:   "key",
 	})
-	agent.gatewayID = "gw-test"
+	agent.state.SetGatewayID("gw-test")
 
 	adapter := &mockSyncAdapter{}
 	agent.RunRouteSync(context.Background(), adapter, "http://gateway:8001")
@@ -339,7 +339,7 @@ func TestRunRouteSyncIncludesStepsInAck(t *testing.T) {
 		ControlPlaneURL: cpServer.URL,
 		GatewayAPIKey:   "key",
 	})
-	agent.gatewayID = "gw-test"
+	agent.state.SetGatewayID("gw-test")
 
 	adapter := &mockSyncAdapter{}
 	agent.RunRouteSync(context.Background(), adapter, "http://gateway:8001")
@@ -392,7 +392,7 @@ func TestRunRouteSyncStepsShowFailure(t *testing.T) {
 		ControlPlaneURL: cpServer.URL,
 		GatewayAPIKey:   "key",
 	})
-	agent.gatewayID = "gw-test"
+	agent.state.SetGatewayID("gw-test")
 
 	adapter := &mockSyncAdapter{syncRoutesErr: fmt.Errorf("gateway unreachable")}
 	agent.RunRouteSync(context.Background(), adapter, "http://gateway:8001")

--- a/stoa-go/internal/connect/sse.go
+++ b/stoa-go/internal/connect/sse.go
@@ -92,26 +92,35 @@ func (a *Agent) StartDeploymentStream(ctx context.Context, adapter adapters.Gate
 }
 
 // streamEvents connects to the SSE endpoint via a.sse and dispatches each
-// parsed rawEvent through handleSSEEvent. Returns the terminal cause surfaced
-// by sseStream.Run — scanner error, HTTP status, or io.EOF on clean close.
+// parsed rawEvent through a per-call dispatcher wired with the adapter +
+// adminURL closures. Returns the terminal cause surfaced by sseStream.Run.
+//
+// A fresh dispatcher is built per call (cheap — handlers are closure refs)
+// so reconnects pick up the latest adapter/adminURL if the caller ever
+// re-invokes with different values. In practice the args are stable across
+// the lifetime of StartDeploymentStream.
 func (a *Agent) streamEvents(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string) error {
+	dispatcher := a.newSSEDispatcher(adapter, adminURL)
 	gatewayID := a.state.GatewayID()
 	return a.sse.Run(ctx, gatewayID, func(evCtx context.Context, ev rawEvent) error {
-		a.handleSSEEvent(evCtx, adapter, adminURL, ev.Type, ev.Data)
+		dispatcher.Dispatch(evCtx, ev)
 		return nil
 	})
 }
 
-// handleSSEEvent processes a single SSE event.
-func (a *Agent) handleSSEEvent(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string, eventType string, data []byte) {
-	switch eventType {
-	case "sync-deployment":
+// newSSEDispatcher wires the SSE event table. sync-deployment applies the
+// route to the local gateway via handleSyncDeployment; heartbeat is an
+// explicit no-op so the unknown-event log line stays silent on every
+// keepalive. Unknown types are logged by the dispatcher itself.
+func (a *Agent) newSSEDispatcher(adapter adapters.GatewayAdapter, adminURL string) *eventDispatcher {
+	d := newEventDispatcher()
+	d.Register("sync-deployment", func(ctx context.Context, data []byte) {
 		a.handleSyncDeployment(ctx, adapter, adminURL, data)
-	case "heartbeat":
-		// Keepalive — ignore
-	default:
-		log.Printf("sse-stream: unknown event type %q", eventType)
-	}
+	})
+	d.Register("heartbeat", func(ctx context.Context, data []byte) {
+		// keepalive — deliberately empty
+	})
+	return d
 }
 
 // handleSyncDeployment processes a sync-deployment event by applying the route and acking.

--- a/stoa-go/internal/connect/sse.go
+++ b/stoa-go/internal/connect/sse.go
@@ -123,20 +123,19 @@ func (a *Agent) newSSEDispatcher(adapter adapters.GatewayAdapter, adminURL strin
 	return d
 }
 
-// handleSyncDeployment processes a sync-deployment event by applying the route and acking.
+// handleSyncDeployment processes a sync-deployment SSE event: decode the
+// event wrapper + desired_state, route the single-route batch through the
+// unified routeSyncer, and ack the result. Shares the route-sync code
+// path with the polling loop (RunRouteSync) — see sync_route.go.
 func (a *Agent) handleSyncDeployment(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string, data []byte) {
 	ctx, span := a.startSpan(ctx, "stoa-connect.sse.sync-deployment",
 		attribute.String("stoa.gateway_id", a.state.GatewayID()),
 	)
 	defer span.End()
 
-	var steps []SyncStep
-
-	// Step: agent_received — SSE event consumed
-	steps = append(steps, newSyncStep("agent_received", "success", ""))
-
 	var event DeploymentEvent
 	if err := json.Unmarshal(data, &event); err != nil {
+		// No deployment_id known — cannot ack. Surface + drop.
 		log.Printf("sse-stream: decode deployment event error: %v", err)
 		span.RecordError(err)
 		return
@@ -145,50 +144,50 @@ func (a *Agent) handleSyncDeployment(ctx context.Context, adapter adapters.Gatew
 	span.SetAttributes(attribute.String("stoa.deployment_id", event.DeploymentID))
 	log.Printf("sse-stream: received deployment %s (status=%s)", event.DeploymentID, event.SyncStatus)
 
-	// Step: adapter_connected — gateway adapter ready
-	steps = append(steps, newSyncStep("adapter_connected", "success", ""))
-
-	// Parse desired_state into a Route for the adapter
 	var route adapters.Route
 	if err := json.Unmarshal(event.DesiredState, &route); err != nil {
-		log.Printf("sse-stream: decode desired_state error: %v", err)
+		// Synthesize a failed ack with the same 3-step shape the polling
+		// path produces, so CP UI renders a consistent step trace. Note:
+		// Generation is unknown at this point (desired_state undecodable).
+		decodeDetail := fmt.Sprintf("decode desired_state: %v", err)
+		log.Printf("sse-stream: %s", decodeDetail)
 		span.RecordError(err)
-		steps = append(steps, newSyncStep("api_synced", "failed", fmt.Sprintf("decode desired_state: %v", err)))
-		a.reportDeploymentResultWithSteps(ctx, event.DeploymentID, "failed", fmt.Sprintf("decode desired_state: %v", err), steps)
+		span.SetStatus(codes.Error, "decode desired_state failed")
+		a.ackRouteResult(ctx, SyncedRouteResult{
+			DeploymentID: event.DeploymentID,
+			Status:       "failed",
+			Error:        decodeDetail,
+			Steps: []SyncStep{
+				newSyncStep("agent_received", "success", ""),
+				newSyncStep("adapter_connected", "success", ""),
+				newSyncStep("api_synced", "failed", decodeDetail),
+			},
+		})
 		return
 	}
 	route.DeploymentID = event.DeploymentID
 
-	// Apply to gateway — Step: api_synced
-	syncErr := adapter.SyncRoutes(ctx, adminURL, []adapters.Route{route})
+	syncer := newRouteSyncer(adapter)
+	results, syncErr := syncer.Sync(ctx, adminURL, []adapters.Route{route})
 
-	status := "applied"
-	errMsg := ""
 	if syncErr != nil {
-		status = "failed"
-		errMsg = syncErr.Error()
 		span.RecordError(syncErr)
 		span.SetStatus(codes.Error, "sync failed")
 		log.Printf("sse-stream: sync deployment %s failed: %v", event.DeploymentID, syncErr)
-		steps = append(steps, newSyncStep("api_synced", "failed", syncErr.Error()))
 	} else {
 		span.SetStatus(codes.Ok, "synced")
 		log.Printf("sse-stream: sync deployment %s applied", event.DeploymentID)
-		steps = append(steps, newSyncStep("api_synced", "success", ""))
 	}
 
-	a.reportDeploymentResultWithSteps(ctx, event.DeploymentID, status, errMsg, steps)
+	for _, result := range results {
+		a.ackRouteResult(ctx, result)
+	}
 }
 
-// reportDeploymentResultWithSteps sends a single deployment ack with step trace via route-sync-ack.
-func (a *Agent) reportDeploymentResultWithSteps(ctx context.Context, deploymentID, status, errMsg string, steps []SyncStep) {
-	result := SyncedRouteResult{
-		DeploymentID: deploymentID,
-		Status:       status,
-		Error:        errMsg,
-		Steps:        steps,
-	}
-	if ackErr := a.ReportRouteSyncAck(ctx, []SyncedRouteResult{result}); ackErr != nil {
-		log.Printf("sse-stream: ack error for %s: %v", deploymentID, ackErr)
+// ackRouteResult sends a single SyncedRouteResult via route-sync-ack,
+// logging on failure (fire-and-forget: the next sync cycle re-reconciles).
+func (a *Agent) ackRouteResult(ctx context.Context, result SyncedRouteResult) {
+	if err := a.ReportRouteSyncAck(ctx, []SyncedRouteResult{result}); err != nil {
+		log.Printf("sse-stream: ack error for %s: %v", result.DeploymentID, err)
 	}
 }

--- a/stoa-go/internal/connect/sse.go
+++ b/stoa-go/internal/connect/sse.go
@@ -70,10 +70,15 @@ func (a *Agent) StartDeploymentStream(ctx context.Context, adapter adapters.Gate
 		return
 	}
 
-	log.Printf("starting SSE deployment stream (reconnect=%s)", cfg.ReconnectInterval)
+	policy := backoffPolicy{
+		Initial:    cfg.ReconnectInterval,
+		Max:        cfg.MaxReconnectInterval,
+		Multiplier: 2.0,
+	}
+	log.Printf("starting SSE deployment stream (initial=%s max=%s)", policy.Initial, policy.Max)
 
 	go func() {
-		backoff := cfg.ReconnectInterval
+		attempt := 0
 
 		for {
 			select {
@@ -88,20 +93,17 @@ func (a *Agent) StartDeploymentStream(ctx context.Context, adapter adapters.Gate
 
 			err := a.streamEvents(ctx, adapter, adminURL)
 			if err != nil && ctx.Err() == nil {
-				log.Printf("sse-stream: connection lost: %v (reconnecting in %s)", err, backoff)
+				attempt++
+				wait := policy.backoff(attempt)
+				log.Printf("sse-stream: connection lost: %v (reconnecting in %s, attempt %d)", err, wait, attempt)
 				select {
 				case <-ctx.Done():
 					return
-				case <-time.After(backoff):
-				}
-				// Exponential backoff capped at max
-				backoff = backoff * 2
-				if backoff > cfg.MaxReconnectInterval {
-					backoff = cfg.MaxReconnectInterval
+				case <-time.After(wait):
 				}
 			} else {
-				// Reset backoff on clean disconnect
-				backoff = cfg.ReconnectInterval
+				// Reset attempt counter on clean disconnect
+				attempt = 0
 			}
 		}
 	}()

--- a/stoa-go/internal/connect/sse.go
+++ b/stoa-go/internal/connect/sse.go
@@ -61,7 +61,7 @@ type DeploymentEvent struct {
 // On each event, it syncs the route to the local gateway and reports back via route-sync-ack.
 // On disconnect, it catches up via FetchRoutes() then resumes SSE.
 func (a *Agent) StartDeploymentStream(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string, cfg SSEConfig) {
-	if a.gatewayID == "" {
+	if a.state.GatewayID() == "" {
 		log.Println("sse-stream skipped: not registered with CP")
 		return
 	}
@@ -109,12 +109,13 @@ func (a *Agent) StartDeploymentStream(ctx context.Context, adapter adapters.Gate
 
 // streamEvents connects to the SSE endpoint and processes events until the stream drops.
 func (a *Agent) streamEvents(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string) error {
+	gatewayID := a.state.GatewayID()
 	ctx, span := a.startSpan(ctx, "stoa-connect.sse.stream",
-		attribute.String("stoa.gateway_id", a.gatewayID),
+		attribute.String("stoa.gateway_id", gatewayID),
 	)
 	defer span.End()
 
-	url := fmt.Sprintf("%s/v1/internal/gateways/%s/events", a.cfg.ControlPlaneURL, a.gatewayID)
+	url := fmt.Sprintf("%s/v1/internal/gateways/%s/events", a.cfg.ControlPlaneURL, gatewayID)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -191,7 +192,7 @@ func (a *Agent) handleSSEEvent(ctx context.Context, adapter adapters.GatewayAdap
 // handleSyncDeployment processes a sync-deployment event by applying the route and acking.
 func (a *Agent) handleSyncDeployment(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string, data []byte) {
 	ctx, span := a.startSpan(ctx, "stoa-connect.sse.sync-deployment",
-		attribute.String("stoa.gateway_id", a.gatewayID),
+		attribute.String("stoa.gateway_id", a.state.GatewayID()),
 	)
 	defer span.End()
 

--- a/stoa-go/internal/connect/sse.go
+++ b/stoa-go/internal/connect/sse.go
@@ -1,14 +1,11 @@
 package connect
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -44,7 +41,7 @@ func SSEConfigFromEnv() SSEConfig {
 
 // StartDeploymentStream starts an SSE listener for real-time deployment events (ADR-059).
 // On each event, it syncs the route to the local gateway and reports back via route-sync-ack.
-// On disconnect, it catches up via FetchRoutes() then resumes SSE.
+// On disconnect, it catches up via RunRouteSync() then resumes SSE with exponential backoff.
 func (a *Agent) StartDeploymentStream(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string, cfg SSEConfig) {
 	if a.state.GatewayID() == "" {
 		log.Println("sse-stream skipped: not registered with CP")
@@ -80,7 +77,7 @@ func (a *Agent) StartDeploymentStream(ctx context.Context, adapter adapters.Gate
 			if err != nil && ctx.Err() == nil {
 				attempt++
 				wait := policy.backoff(attempt)
-				log.Printf("sse-stream: connection lost: %v (reconnecting in %s, attempt %d)", err, wait, attempt)
+				log.Printf("sse-stream: terminal error: %v (reconnecting in %s, attempt %d)", err, wait, attempt)
 				select {
 				case <-ctx.Done():
 					return
@@ -94,74 +91,15 @@ func (a *Agent) StartDeploymentStream(ctx context.Context, adapter adapters.Gate
 	}()
 }
 
-// streamEvents connects to the SSE endpoint and processes events until the stream drops.
+// streamEvents connects to the SSE endpoint via a.sse and dispatches each
+// parsed rawEvent through handleSSEEvent. Returns the terminal cause surfaced
+// by sseStream.Run — scanner error, HTTP status, or io.EOF on clean close.
 func (a *Agent) streamEvents(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string) error {
 	gatewayID := a.state.GatewayID()
-	ctx, span := a.startSpan(ctx, "stoa-connect.sse.stream",
-		attribute.String("stoa.gateway_id", gatewayID),
-	)
-	defer span.End()
-
-	url := fmt.Sprintf("%s/v1/internal/gateways/%s/events", a.cfg.ControlPlaneURL, gatewayID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		span.RecordError(err)
-		return fmt.Errorf("create SSE request: %w", err)
-	}
-	req.Header.Set("X-Gateway-Key", a.cfg.GatewayAPIKey)
-	req.Header.Set("Accept", "text/event-stream")
-	req.Header.Set("Cache-Control", "no-cache")
-
-	// Use a separate client without timeout for long-lived SSE connections
-	sseClient := &http.Client{Transport: a.transport}
-	resp, err := sseClient.Do(req)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "SSE connect failed")
-		return fmt.Errorf("SSE connect: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		span.SetStatus(codes.Error, "SSE rejected")
-		return fmt.Errorf("SSE endpoint returned %d", resp.StatusCode)
-	}
-
-	log.Printf("sse-stream: connected to %s", url)
-	span.SetStatus(codes.Ok, "connected")
-
-	scanner := bufio.NewScanner(resp.Body)
-	var eventType string
-	var dataLines []string
-
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		if line == "" {
-			// Empty line = end of event
-			if eventType != "" && len(dataLines) > 0 {
-				data := strings.Join(dataLines, "\n")
-				a.handleSSEEvent(ctx, adapter, adminURL, eventType, []byte(data))
-			}
-			eventType = ""
-			dataLines = nil
-			continue
-		}
-
-		if strings.HasPrefix(line, "event:") {
-			eventType = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
-		} else if strings.HasPrefix(line, "data:") {
-			dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
-		}
-		// Ignore "id:", "retry:", comments (":")
-	}
-
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("SSE read: %w", err)
-	}
-
-	return fmt.Errorf("SSE stream ended")
+	return a.sse.Run(ctx, gatewayID, func(evCtx context.Context, ev rawEvent) error {
+		a.handleSSEEvent(evCtx, adapter, adminURL, ev.Type, ev.Data)
+		return nil
+	})
 }
 
 // handleSSEEvent processes a single SSE event.

--- a/stoa-go/internal/connect/sse.go
+++ b/stoa-go/internal/connect/sse.go
@@ -114,7 +114,7 @@ func (a *Agent) streamEvents(ctx context.Context, adapter adapters.GatewayAdapte
 	req.Header.Set("Cache-Control", "no-cache")
 
 	// Use a separate client without timeout for long-lived SSE connections
-	sseClient := &http.Client{Transport: a.client.Transport}
+	sseClient := &http.Client{Transport: a.transport}
 	resp, err := sseClient.Do(req)
 	if err != nil {
 		span.RecordError(err)

--- a/stoa-go/internal/connect/sse.go
+++ b/stoa-go/internal/connect/sse.go
@@ -42,21 +42,6 @@ func SSEConfigFromEnv() SSEConfig {
 	return cfg
 }
 
-// SSEEvent represents a parsed Server-Sent Event.
-type SSEEvent struct {
-	Event string          `json:"event"`
-	Data  json.RawMessage `json:"data"`
-}
-
-// DeploymentEvent is the data payload for a sync-deployment SSE event.
-type DeploymentEvent struct {
-	DeploymentID      string          `json:"deployment_id"`
-	APICatalogID      string          `json:"api_catalog_id"`
-	GatewayInstanceID string          `json:"gateway_instance_id"`
-	SyncStatus        string          `json:"sync_status"`
-	DesiredState      json.RawMessage `json:"desired_state"`
-}
-
 // StartDeploymentStream starts an SSE listener for real-time deployment events (ADR-059).
 // On each event, it syncs the route to the local gateway and reports back via route-sync-ack.
 // On disconnect, it catches up via FetchRoutes() then resumes SSE.

--- a/stoa-go/internal/connect/sse.go
+++ b/stoa-go/internal/connect/sse.go
@@ -39,9 +39,11 @@ func SSEConfigFromEnv() SSEConfig {
 	return cfg
 }
 
-// StartDeploymentStream starts an SSE listener for real-time deployment events (ADR-059).
-// On each event, it syncs the route to the local gateway and reports back via route-sync-ack.
-// On disconnect, it catches up via RunRouteSync() then resumes SSE with exponential backoff.
+// StartDeploymentStream starts an SSE listener for real-time deployment
+// events (ADR-059). On each event, it syncs the route to the local gateway
+// and reports back via route-sync-ack. On disconnect, it catches up via
+// RunRouteSync() then resumes SSE with exponential backoff. See
+// runSSEStream in loop_sse.go for the loop body.
 func (a *Agent) StartDeploymentStream(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string, cfg SSEConfig) {
 	if a.state.GatewayID() == "" {
 		log.Println("sse-stream skipped: not registered with CP")
@@ -51,44 +53,13 @@ func (a *Agent) StartDeploymentStream(ctx context.Context, adapter adapters.Gate
 		log.Println("sse-stream skipped: no gateway admin URL configured")
 		return
 	}
-
 	policy := backoffPolicy{
 		Initial:    cfg.ReconnectInterval,
 		Max:        cfg.MaxReconnectInterval,
 		Multiplier: 2.0,
 	}
 	log.Printf("starting SSE deployment stream (initial=%s max=%s)", policy.Initial, policy.Max)
-
-	go func() {
-		attempt := 0
-
-		for {
-			select {
-			case <-ctx.Done():
-				log.Println("sse-stream stopped")
-				return
-			default:
-			}
-
-			// Catch up on any missed deployments before streaming
-			a.RunRouteSync(ctx, adapter, adminURL)
-
-			err := a.streamEvents(ctx, adapter, adminURL)
-			if err != nil && ctx.Err() == nil {
-				attempt++
-				wait := policy.backoff(attempt)
-				log.Printf("sse-stream: terminal error: %v (reconnecting in %s, attempt %d)", err, wait, attempt)
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(wait):
-				}
-			} else {
-				// Reset attempt counter on clean disconnect
-				attempt = 0
-			}
-		}
-	}()
+	go runSSEStream(ctx, a, adapter, adminURL, policy)
 }
 
 // streamEvents connects to the SSE endpoint via a.sse and dispatches each

--- a/stoa-go/internal/connect/sse_test.go
+++ b/stoa-go/internal/connect/sse_test.go
@@ -125,7 +125,7 @@ func TestStreamEventsParsesSyncDeployment(t *testing.T) {
 		GatewayAPIKey:   "test-key",
 		InstanceName:    "test-gw",
 	})
-	agent.gatewayID = "gw-789"
+	agent.state.SetGatewayID("gw-789")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -167,7 +167,7 @@ func TestStreamEventsIgnoresHeartbeat(t *testing.T) {
 		ControlPlaneURL: sseServer.URL,
 		GatewayAPIKey:   "test-key",
 	})
-	agent.gatewayID = "gw-1"
+	agent.state.SetGatewayID("gw-1")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -189,7 +189,7 @@ func TestStreamEventsRejectsUnauthorized(t *testing.T) {
 		ControlPlaneURL: sseServer.URL,
 		GatewayAPIKey:   "bad-key",
 	})
-	agent.gatewayID = "gw-1"
+	agent.state.SetGatewayID("gw-1")
 
 	ctx := context.Background()
 	err := agent.streamEvents(ctx, &mockSSEAdapter{}, "http://localhost:8080")
@@ -263,7 +263,7 @@ func TestSSESyncDeploymentIncludesSteps(t *testing.T) {
 		GatewayAPIKey:   "test-key",
 		InstanceName:    "test-gw",
 	})
-	agent.gatewayID = "gw-sse"
+	agent.state.SetGatewayID("gw-sse")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()

--- a/stoa-go/internal/connect/state.go
+++ b/stoa-go/internal/connect/state.go
@@ -1,0 +1,94 @@
+package connect
+
+import "sync"
+
+// agentState holds the agent's mutable runtime state, guarded by a single RWMutex.
+//
+// Only fields that are concurrently mutated from multiple goroutines live here.
+// Immutable-after-New fields (Agent.cfg, Agent.client, Agent.startTime, Agent.healthPort
+// — set once in the first Register before any loop goroutine starts) stay on Agent
+// without locking.
+type agentState struct {
+	mu             sync.RWMutex
+	gatewayID      string
+	discoveredAPIs []DiscoveredAPIPayload // owned copy; SetDiscoveredAPIs and DiscoveredAPIs
+	// clone the outer slice. Inner slices (Paths, Methods, Policies) are treated
+	// as read-only by all consumers — freshly built in runDiscovery, never mutated
+	// afterwards — so shallow clone is sufficient.
+}
+
+func newAgentState() *agentState {
+	return &agentState{}
+}
+
+// GatewayID returns the current assigned gateway ID, or empty string if unregistered.
+func (s *agentState) GatewayID() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.gatewayID
+}
+
+// SetGatewayID stores the given gateway ID.
+func (s *agentState) SetGatewayID(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.gatewayID = id
+}
+
+// ClearGatewayID resets the gateway ID to empty (used before re-registration).
+func (s *agentState) ClearGatewayID() {
+	s.SetGatewayID("")
+}
+
+// SetDiscoveredAPIs stores a defensive copy of in. Mutating in after this call
+// does not affect internal state.
+func (s *agentState) SetDiscoveredAPIs(in []DiscoveredAPIPayload) {
+	var copied []DiscoveredAPIPayload
+	if in != nil {
+		copied = make([]DiscoveredAPIPayload, len(in))
+		copy(copied, in)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.discoveredAPIs = copied
+}
+
+// DiscoveredAPIs returns a defensive copy of the currently cached discovered APIs.
+// The returned slice is safe for the caller to mutate.
+func (s *agentState) DiscoveredAPIs() []DiscoveredAPIPayload {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.discoveredAPIs == nil {
+		return nil
+	}
+	out := make([]DiscoveredAPIPayload, len(s.discoveredAPIs))
+	copy(out, s.discoveredAPIs)
+	return out
+}
+
+// DiscoveredAPIsCount returns the number of cached discovered APIs.
+func (s *agentState) DiscoveredAPIsCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.discoveredAPIs)
+}
+
+// ComputeRoutesCount returns the total number of routes across active discovered APIs.
+// Each path on an active API counts as one route (CAB-1916); an active API with no
+// declared paths counts as 1.
+func (s *agentState) ComputeRoutesCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	count := 0
+	for _, api := range s.discoveredAPIs {
+		if !api.IsActive {
+			continue
+		}
+		paths := len(api.Paths)
+		if paths == 0 {
+			paths = 1
+		}
+		count += paths
+	}
+	return count
+}

--- a/stoa-go/internal/connect/state_test.go
+++ b/stoa-go/internal/connect/state_test.go
@@ -1,0 +1,156 @@
+package connect
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAgentStateSetAndGetGatewayID(t *testing.T) {
+	s := newAgentState()
+	if got := s.GatewayID(); got != "" {
+		t.Fatalf("expected empty initial gatewayID, got %q", got)
+	}
+	s.SetGatewayID("gw-1")
+	if got := s.GatewayID(); got != "gw-1" {
+		t.Fatalf("expected gw-1, got %q", got)
+	}
+	s.ClearGatewayID()
+	if got := s.GatewayID(); got != "" {
+		t.Fatalf("expected empty after Clear, got %q", got)
+	}
+}
+
+func TestAgentStateDiscoveredAPIsCopyIn(t *testing.T) {
+	s := newAgentState()
+	in := []DiscoveredAPIPayload{
+		{Name: "a", IsActive: true, Paths: []string{"/a"}},
+		{Name: "b", IsActive: false},
+	}
+	s.SetDiscoveredAPIs(in)
+
+	// Mutating in after Set must NOT affect internal state.
+	in[0].Name = "mutated"
+	in[0].IsActive = false
+
+	got := s.DiscoveredAPIs()
+	if len(got) != 2 {
+		t.Fatalf("expected 2, got %d", len(got))
+	}
+	if got[0].Name != "a" {
+		t.Fatalf("copy-in broken: expected name=a, got %q", got[0].Name)
+	}
+	if !got[0].IsActive {
+		t.Fatalf("copy-in broken: expected IsActive=true, got false")
+	}
+}
+
+func TestAgentStateDiscoveredAPIsCopyOut(t *testing.T) {
+	s := newAgentState()
+	s.SetDiscoveredAPIs([]DiscoveredAPIPayload{
+		{Name: "a", IsActive: true},
+	})
+
+	// Mutating the returned slice must NOT affect internal state.
+	got := s.DiscoveredAPIs()
+	got[0].Name = "hacked"
+	got[0].IsActive = false
+
+	second := s.DiscoveredAPIs()
+	if second[0].Name != "a" {
+		t.Fatalf("copy-out broken: expected name=a, got %q", second[0].Name)
+	}
+	if !second[0].IsActive {
+		t.Fatalf("copy-out broken: expected IsActive=true, got false")
+	}
+}
+
+func TestAgentStateDiscoveredAPIsNil(t *testing.T) {
+	s := newAgentState()
+	s.SetDiscoveredAPIs(nil)
+	if got := s.DiscoveredAPIs(); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+	if got := s.DiscoveredAPIsCount(); got != 0 {
+		t.Fatalf("expected 0, got %d", got)
+	}
+}
+
+func TestAgentStateComputeRoutesCount(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []DiscoveredAPIPayload
+		want int
+	}{
+		{"empty", nil, 0},
+		{"single active with paths", []DiscoveredAPIPayload{
+			{IsActive: true, Paths: []string{"/a", "/b"}},
+		}, 2},
+		{"active without paths counts as 1", []DiscoveredAPIPayload{
+			{IsActive: true},
+		}, 1},
+		{"inactive skipped", []DiscoveredAPIPayload{
+			{IsActive: false, Paths: []string{"/skipped"}},
+			{IsActive: true, Paths: []string{"/kept"}},
+		}, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newAgentState()
+			s.SetDiscoveredAPIs(tc.in)
+			if got := s.ComputeRoutesCount(); got != tc.want {
+				t.Errorf("expected %d, got %d", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestAgentStateRace fires concurrent writers and readers against agentState
+// with -race on to detect any unprotected field access. The test itself
+// cannot fail under a correct implementation; the race detector is the judge.
+func TestAgentStateRace(t *testing.T) {
+	s := newAgentState()
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	// Writer: flips gatewayID and discoveredAPIs continuously.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var i int
+		for ctx.Err() == nil {
+			i++
+			s.SetGatewayID(fmt.Sprintf("gw-%d", i))
+			s.SetDiscoveredAPIs([]DiscoveredAPIPayload{
+				{Name: fmt.Sprintf("api-%d", i), IsActive: i%2 == 0, Paths: []string{"/p1", "/p2"}},
+			})
+			if i%5 == 0 {
+				s.ClearGatewayID()
+			}
+			runtime.Gosched()
+		}
+	}()
+
+	// Readers: mimic the goroutines that concurrently read in production
+	// (heartbeat, /health handler, sync loops, SSE URL building).
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ctx.Err() == nil {
+				_ = s.GatewayID()
+				_ = s.DiscoveredAPIsCount()
+				_ = s.ComputeRoutesCount()
+				_ = s.DiscoveredAPIs()
+				runtime.Gosched()
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/stoa-go/internal/connect/steps.go
+++ b/stoa-go/internal/connect/steps.go
@@ -1,0 +1,30 @@
+package connect
+
+import "time"
+
+// SyncStep records a single step in a sync pipeline for observability.
+// Steps are attached to a SyncedRouteResult and surfaced by the CP UI to
+// trace the deployment lifecycle (agent_received → adapter_connected →
+// api_synced → ...).
+type SyncStep struct {
+	Name        string `json:"name"`
+	Status      string `json:"status"` // "success", "failed", "skipped"
+	StartedAt   string `json:"started_at"`
+	CompletedAt string `json:"completed_at,omitempty"`
+	Detail      string `json:"detail,omitempty"`
+}
+
+// newSyncStep creates a completed SyncStep with StartedAt == CompletedAt set
+// to the current UTC time. Steps synthesized inline by the sync path are
+// considered atomic — instrumenting real start/end timestamps would require
+// restructuring the sync pipeline (follow-up).
+func newSyncStep(name, status, detail string) SyncStep {
+	now := time.Now().UTC().Format(time.RFC3339)
+	return SyncStep{
+		Name:        name,
+		Status:      status,
+		StartedAt:   now,
+		CompletedAt: now,
+		Detail:      detail,
+	}
+}

--- a/stoa-go/internal/connect/sync.go
+++ b/stoa-go/internal/connect/sync.go
@@ -106,33 +106,17 @@ func (a *Agent) RunSync(ctx context.Context, adapter adapters.GatewayAdapter, ad
 	span.SetStatus(codes.Ok, "sync cycle complete")
 }
 
-// StartSync starts a background goroutine that syncs policies at the configured interval.
+// StartSync starts a background goroutine that syncs policies at the
+// configured interval. See runPolicySync in loop_sync.go for the loop body.
 func (a *Agent) StartSync(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string, cfg SyncConfig) {
 	if adminURL == "" {
 		log.Println("sync skipped: no gateway admin URL configured")
 		return
 	}
-
 	interval := cfg.Interval
 	if interval == 0 {
 		interval = 60 * time.Second
 	}
-
 	log.Printf("starting policy sync loop (interval=%s)", interval)
-
-	ticker := time.NewTicker(interval)
-	go func() {
-		defer ticker.Stop()
-		// Run immediately on start
-		a.RunSync(ctx, adapter, adminURL)
-		for {
-			select {
-			case <-ctx.Done():
-				log.Println("sync stopped")
-				return
-			case <-ticker.C:
-				a.RunSync(ctx, adapter, adminURL)
-			}
-		}
-	}()
+	go runPolicySync(ctx, a, adapter, adminURL, interval)
 }

--- a/stoa-go/internal/connect/sync.go
+++ b/stoa-go/internal/connect/sync.go
@@ -1,13 +1,8 @@
 package connect
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 	"log"
-	"net/http"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -23,54 +18,13 @@ type SyncConfig struct {
 }
 
 // FetchConfig pulls the gateway config (policies, deployments) from the CP.
+// Thin delegator — HTTP logic lives in cpClient.FetchConfig.
 func (a *Agent) FetchConfig(ctx context.Context) (*GatewayConfigResponse, error) {
 	gatewayID := a.state.GatewayID()
 	if gatewayID == "" {
 		return nil, ErrNotRegistered
 	}
-
-	ctx, span := a.startSpan(ctx, "stoa-connect.sync.fetch-config",
-		attribute.String("stoa.gateway_id", gatewayID),
-	)
-	defer span.End()
-
-	url := fmt.Sprintf("%s/v1/internal/gateways/%s/config", a.cfg.ControlPlaneURL, gatewayID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "create request failed")
-		return nil, fmt.Errorf("create config request: %w", err)
-	}
-	req.Header.Set("X-Gateway-Key", a.cfg.GatewayAPIKey)
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "request failed")
-		return nil, fmt.Errorf("config request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, _ := io.ReadAll(resp.Body)
-	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
-
-	if resp.StatusCode != http.StatusOK {
-		err := fmt.Errorf("config request failed (%d): %s", resp.StatusCode, string(body))
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "fetch config rejected")
-		return nil, err
-	}
-
-	var config GatewayConfigResponse
-	if err := json.Unmarshal(body, &config); err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "decode failed")
-		return nil, fmt.Errorf("decode config response: %w", err)
-	}
-
-	span.SetAttributes(attribute.Int("stoa.pending_policies", len(config.PendingPolicies)))
-	span.SetStatus(codes.Ok, "config fetched")
-	return &config, nil
+	return a.cp.FetchConfig(ctx, gatewayID)
 }
 
 // ReportSyncAck sends policy sync results to the CP.
@@ -79,73 +33,10 @@ func (a *Agent) ReportSyncAck(ctx context.Context, results []SyncedPolicyResult)
 	if gatewayID == "" {
 		return ErrNotRegistered
 	}
-
-	ctx, span := a.startSpan(ctx, "stoa-connect.sync.ack",
-		attribute.String("stoa.gateway_id", gatewayID),
-		attribute.Int("stoa.synced_policies", len(results)),
-	)
-	defer span.End()
-
-	// Count results by status
-	var applied, removed, failed int
-	for _, r := range results {
-		switch r.Status {
-		case "applied":
-			applied++
-		case "removed":
-			removed++
-		case "failed":
-			failed++
-		}
-	}
-	span.SetAttributes(
-		attribute.Int("stoa.policies_applied", applied),
-		attribute.Int("stoa.policies_removed", removed),
-		attribute.Int("stoa.policies_failed", failed),
-	)
-
-	payload := SyncAckPayload{
+	return a.cp.ReportSyncAck(ctx, gatewayID, SyncAckPayload{
 		SyncedPolicies: results,
 		SyncTimestamp:  time.Now().UTC().Format(time.RFC3339),
-	}
-
-	data, err := json.Marshal(payload)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "marshal failed")
-		return fmt.Errorf("marshal sync-ack: %w", err)
-	}
-
-	url := fmt.Sprintf("%s/v1/internal/gateways/%s/sync-ack", a.cfg.ControlPlaneURL, gatewayID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "create request failed")
-		return fmt.Errorf("create sync-ack request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Gateway-Key", a.cfg.GatewayAPIKey)
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "request failed")
-		return fmt.Errorf("sync-ack request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		body, _ := io.ReadAll(resp.Body)
-		err := fmt.Errorf("sync-ack failed (%d): %s", resp.StatusCode, string(body))
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "sync-ack rejected")
-		return err
-	}
-
-	span.SetStatus(codes.Ok, "sync-ack sent")
-	return nil
+	})
 }
 
 // ReportRouteSyncAck sends route sync results to the CP.
@@ -154,55 +45,10 @@ func (a *Agent) ReportRouteSyncAck(ctx context.Context, results []SyncedRouteRes
 	if gatewayID == "" {
 		return ErrNotRegistered
 	}
-
-	ctx, span := a.startSpan(ctx, "stoa-connect.routes.ack",
-		attribute.String("stoa.gateway_id", gatewayID),
-		attribute.Int("stoa.synced_routes", len(results)),
-	)
-	defer span.End()
-
-	payload := RouteSyncAckPayload{
+	return a.cp.ReportRouteSyncAck(ctx, gatewayID, RouteSyncAckPayload{
 		SyncedRoutes:  results,
 		SyncTimestamp: time.Now().UTC().Format(time.RFC3339),
-	}
-
-	data, err := json.Marshal(payload)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "marshal failed")
-		return fmt.Errorf("marshal route-sync-ack: %w", err)
-	}
-
-	url := fmt.Sprintf("%s/v1/internal/gateways/%s/route-sync-ack", a.cfg.ControlPlaneURL, gatewayID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "create request failed")
-		return fmt.Errorf("create route-sync-ack request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Gateway-Key", a.cfg.GatewayAPIKey)
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "request failed")
-		return fmt.Errorf("route-sync-ack request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		body, _ := io.ReadAll(resp.Body)
-		err := fmt.Errorf("route-sync-ack failed (%d): %s", resp.StatusCode, string(body))
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "route-sync-ack rejected")
-		return err
-	}
-
-	span.SetStatus(codes.Ok, "route-sync-ack sent")
-	return nil
+	})
 }
 
 // RunSync performs a single policy sync cycle: fetch config → apply/remove → ack.

--- a/stoa-go/internal/connect/sync.go
+++ b/stoa-go/internal/connect/sync.go
@@ -24,12 +24,12 @@ type SyncConfig struct {
 
 // GatewayConfigResponse is the response from GET /v1/internal/gateways/{id}/config.
 type GatewayConfigResponse struct {
-	GatewayID          string           `json:"gateway_id"`
-	Name               string           `json:"name"`
-	Environment        string           `json:"environment"`
-	TenantID           string           `json:"tenant_id"`
-	PendingDeployments []interface{}    `json:"pending_deployments"`
-	PendingPolicies    []PendingPolicy  `json:"pending_policies"`
+	GatewayID          string          `json:"gateway_id"`
+	Name               string          `json:"name"`
+	Environment        string          `json:"environment"`
+	TenantID           string          `json:"tenant_id"`
+	PendingDeployments []interface{}   `json:"pending_deployments"`
+	PendingPolicies    []PendingPolicy `json:"pending_policies"`
 }
 
 // PendingPolicy represents a policy from the CP config endpoint.
@@ -66,16 +66,17 @@ type SyncStep struct {
 
 // FetchConfig pulls the gateway config (policies, deployments) from the CP.
 func (a *Agent) FetchConfig(ctx context.Context) (*GatewayConfigResponse, error) {
-	if a.gatewayID == "" {
+	gatewayID := a.state.GatewayID()
+	if gatewayID == "" {
 		return nil, fmt.Errorf("not registered")
 	}
 
 	ctx, span := a.startSpan(ctx, "stoa-connect.sync.fetch-config",
-		attribute.String("stoa.gateway_id", a.gatewayID),
+		attribute.String("stoa.gateway_id", gatewayID),
 	)
 	defer span.End()
 
-	url := fmt.Sprintf("%s/v1/internal/gateways/%s/config", a.cfg.ControlPlaneURL, a.gatewayID)
+	url := fmt.Sprintf("%s/v1/internal/gateways/%s/config", a.cfg.ControlPlaneURL, gatewayID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		span.RecordError(err)
@@ -116,12 +117,13 @@ func (a *Agent) FetchConfig(ctx context.Context) (*GatewayConfigResponse, error)
 
 // ReportSyncAck sends policy sync results to the CP.
 func (a *Agent) ReportSyncAck(ctx context.Context, results []SyncedPolicyResult) error {
-	if a.gatewayID == "" {
+	gatewayID := a.state.GatewayID()
+	if gatewayID == "" {
 		return fmt.Errorf("not registered")
 	}
 
 	ctx, span := a.startSpan(ctx, "stoa-connect.sync.ack",
-		attribute.String("stoa.gateway_id", a.gatewayID),
+		attribute.String("stoa.gateway_id", gatewayID),
 		attribute.Int("stoa.synced_policies", len(results)),
 	)
 	defer span.End()
@@ -156,7 +158,7 @@ func (a *Agent) ReportSyncAck(ctx context.Context, results []SyncedPolicyResult)
 		return fmt.Errorf("marshal sync-ack: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/v1/internal/gateways/%s/sync-ack", a.cfg.ControlPlaneURL, a.gatewayID)
+	url := fmt.Sprintf("%s/v1/internal/gateways/%s/sync-ack", a.cfg.ControlPlaneURL, gatewayID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {
 		span.RecordError(err)
@@ -205,12 +207,13 @@ type SyncedRouteResult struct {
 
 // ReportRouteSyncAck sends route sync results to the CP.
 func (a *Agent) ReportRouteSyncAck(ctx context.Context, results []SyncedRouteResult) error {
-	if a.gatewayID == "" {
+	gatewayID := a.state.GatewayID()
+	if gatewayID == "" {
 		return fmt.Errorf("not registered")
 	}
 
 	ctx, span := a.startSpan(ctx, "stoa-connect.routes.ack",
-		attribute.String("stoa.gateway_id", a.gatewayID),
+		attribute.String("stoa.gateway_id", gatewayID),
 		attribute.Int("stoa.synced_routes", len(results)),
 	)
 	defer span.End()
@@ -227,7 +230,7 @@ func (a *Agent) ReportRouteSyncAck(ctx context.Context, results []SyncedRouteRes
 		return fmt.Errorf("marshal route-sync-ack: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/v1/internal/gateways/%s/route-sync-ack", a.cfg.ControlPlaneURL, a.gatewayID)
+	url := fmt.Sprintf("%s/v1/internal/gateways/%s/route-sync-ack", a.cfg.ControlPlaneURL, gatewayID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {
 		span.RecordError(err)
@@ -262,7 +265,7 @@ func (a *Agent) ReportRouteSyncAck(ctx context.Context, results []SyncedRouteRes
 // RunSync performs a single policy sync cycle: fetch config → apply/remove → ack.
 func (a *Agent) RunSync(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string) {
 	ctx, span := a.startSpan(ctx, "stoa-connect.sync",
-		attribute.String("stoa.gateway_id", a.gatewayID),
+		attribute.String("stoa.gateway_id", a.state.GatewayID()),
 	)
 	defer span.End()
 

--- a/stoa-go/internal/connect/sync.go
+++ b/stoa-go/internal/connect/sync.go
@@ -22,53 +22,11 @@ type SyncConfig struct {
 	Interval time.Duration
 }
 
-// GatewayConfigResponse is the response from GET /v1/internal/gateways/{id}/config.
-type GatewayConfigResponse struct {
-	GatewayID          string          `json:"gateway_id"`
-	Name               string          `json:"name"`
-	Environment        string          `json:"environment"`
-	TenantID           string          `json:"tenant_id"`
-	PendingDeployments []interface{}   `json:"pending_deployments"`
-	PendingPolicies    []PendingPolicy `json:"pending_policies"`
-}
-
-// PendingPolicy represents a policy from the CP config endpoint.
-type PendingPolicy struct {
-	ID         string                 `json:"id"`
-	Name       string                 `json:"name"`
-	PolicyType string                 `json:"policy_type"`
-	Config     map[string]interface{} `json:"config"`
-	Priority   int                    `json:"priority"`
-	Enabled    bool                   `json:"enabled"`
-}
-
-// SyncAckPayload is sent to POST /v1/internal/gateways/{id}/sync-ack.
-type SyncAckPayload struct {
-	SyncedPolicies []SyncedPolicyResult `json:"synced_policies"`
-	SyncTimestamp  string               `json:"sync_timestamp"`
-}
-
-// SyncedPolicyResult reports the sync result for one policy.
-type SyncedPolicyResult struct {
-	PolicyID string `json:"policy_id"`
-	Status   string `json:"status"` // "applied", "removed", "failed"
-	Error    string `json:"error,omitempty"`
-}
-
-// SyncStep records a single step in a sync pipeline for observability.
-type SyncStep struct {
-	Name        string `json:"name"`
-	Status      string `json:"status"` // "success", "failed", "skipped"
-	StartedAt   string `json:"started_at"`
-	CompletedAt string `json:"completed_at,omitempty"`
-	Detail      string `json:"detail,omitempty"`
-}
-
 // FetchConfig pulls the gateway config (policies, deployments) from the CP.
 func (a *Agent) FetchConfig(ctx context.Context) (*GatewayConfigResponse, error) {
 	gatewayID := a.state.GatewayID()
 	if gatewayID == "" {
-		return nil, fmt.Errorf("not registered")
+		return nil, ErrNotRegistered
 	}
 
 	ctx, span := a.startSpan(ctx, "stoa-connect.sync.fetch-config",
@@ -119,7 +77,7 @@ func (a *Agent) FetchConfig(ctx context.Context) (*GatewayConfigResponse, error)
 func (a *Agent) ReportSyncAck(ctx context.Context, results []SyncedPolicyResult) error {
 	gatewayID := a.state.GatewayID()
 	if gatewayID == "" {
-		return fmt.Errorf("not registered")
+		return ErrNotRegistered
 	}
 
 	ctx, span := a.startSpan(ctx, "stoa-connect.sync.ack",
@@ -190,26 +148,11 @@ func (a *Agent) ReportSyncAck(ctx context.Context, results []SyncedPolicyResult)
 	return nil
 }
 
-// RouteSyncAckPayload is sent to POST /v1/internal/gateways/{id}/route-sync-ack.
-type RouteSyncAckPayload struct {
-	SyncedRoutes  []SyncedRouteResult `json:"synced_routes"`
-	SyncTimestamp string              `json:"sync_timestamp"`
-}
-
-// SyncedRouteResult reports the sync result for one route deployment.
-type SyncedRouteResult struct {
-	DeploymentID string     `json:"deployment_id"`
-	Status       string     `json:"status"` // "applied", "failed"
-	Error        string     `json:"error,omitempty"`
-	Steps        []SyncStep `json:"steps,omitempty"`
-	Generation   int        `json:"generation,omitempty"` // CAB-1950: generation that was synced
-}
-
 // ReportRouteSyncAck sends route sync results to the CP.
 func (a *Agent) ReportRouteSyncAck(ctx context.Context, results []SyncedRouteResult) error {
 	gatewayID := a.state.GatewayID()
 	if gatewayID == "" {
-		return fmt.Errorf("not registered")
+		return ErrNotRegistered
 	}
 
 	ctx, span := a.startSpan(ctx, "stoa-connect.routes.ack",
@@ -409,18 +352,6 @@ func (a *Agent) StartSync(ctx context.Context, adapter adapters.GatewayAdapter, 
 			}
 		}
 	}()
-}
-
-// newSyncStep creates a completed SyncStep with the current timestamp.
-func newSyncStep(name, status, detail string) SyncStep {
-	now := time.Now().UTC().Format(time.RFC3339)
-	return SyncStep{
-		Name:        name,
-		Status:      status,
-		StartedAt:   now,
-		CompletedAt: now,
-		Detail:      detail,
-	}
 }
 
 // getStringConfig safely extracts a string value from a config map.

--- a/stoa-go/internal/connect/sync.go
+++ b/stoa-go/internal/connect/sync.go
@@ -51,7 +51,9 @@ func (a *Agent) ReportRouteSyncAck(ctx context.Context, results []SyncedRouteRes
 	})
 }
 
-// RunSync performs a single policy sync cycle: fetch config → apply/remove → ack.
+// RunSync performs a single policy sync cycle: fetch config → dispatch via
+// policySyncer → update metrics → ack. Per-policy dispatch (OIDC vs
+// generic, apply vs remove) lives in sync_policy.go.
 func (a *Agent) RunSync(ctx context.Context, adapter adapters.GatewayAdapter, adminURL string) {
 	ctx, span := a.startSpan(ctx, "stoa-connect.sync",
 		attribute.String("stoa.gateway_id", a.state.GatewayID()),
@@ -75,73 +77,8 @@ func (a *Agent) RunSync(ctx context.Context, adapter adapters.GatewayAdapter, ad
 	span.SetAttributes(attribute.Int("stoa.pending_policies", len(config.PendingPolicies)))
 	log.Printf("sync: %d policies to reconcile", len(config.PendingPolicies))
 
-	var results []SyncedPolicyResult
-
-	// Check if adapter supports OIDC operations
-	oidcAdapter, hasOIDC := adapter.(adapters.OIDCAdapter)
-
-	for _, policy := range config.PendingPolicies {
-		result := SyncedPolicyResult{PolicyID: policy.ID}
-
-		if !policy.Enabled {
-			var syncErr error
-			if policy.PolicyType == "oidc_auth_server" && hasOIDC {
-				syncErr = oidcAdapter.DeleteAuthServer(ctx, adminURL, policy.Name)
-			} else {
-				syncErr = adapter.RemovePolicy(ctx, adminURL, policy.Name, policy.PolicyType)
-			}
-			if syncErr != nil {
-				result.Status = "failed"
-				result.Error = syncErr.Error()
-				log.Printf("sync: remove policy %s failed: %v", policy.Name, syncErr)
-			} else {
-				result.Status = "removed"
-				log.Printf("sync: removed policy %s (%s)", policy.Name, policy.PolicyType)
-			}
-		} else {
-			var syncErr error
-			switch {
-			case policy.PolicyType == "oidc_auth_server" && hasOIDC:
-				syncErr = oidcAdapter.UpsertAuthServer(ctx, adminURL, adapters.AuthServerSpec{
-					Name:         policy.Name,
-					DiscoveryURL: getStringConfig(policy.Config, "discovery_url"),
-					ClientID:     getStringConfig(policy.Config, "client_id"),
-					ClientSecret: getStringConfig(policy.Config, "client_secret"),
-					Scopes:       getStringSliceConfig(policy.Config, "scopes"),
-				})
-			case policy.PolicyType == "oidc_strategy" && hasOIDC:
-				syncErr = oidcAdapter.UpsertStrategy(ctx, adminURL, adapters.StrategySpec{
-					Name:            policy.Name,
-					AuthServerAlias: getStringConfig(policy.Config, "auth_server_alias"),
-					ClientID:        getStringConfig(policy.Config, "client_id"),
-					Audience:        getStringConfig(policy.Config, "audience"),
-				})
-			case policy.PolicyType == "oidc_scope" && hasOIDC:
-				syncErr = oidcAdapter.UpsertScope(ctx, adminURL, adapters.ScopeSpec{
-					ScopeName:       getStringConfig(policy.Config, "scope_name"),
-					Audience:        getStringConfig(policy.Config, "audience"),
-					AuthServerAlias: getStringConfig(policy.Config, "auth_server_alias"),
-					KeycloakScope:   getStringConfig(policy.Config, "keycloak_scope"),
-				})
-			default:
-				action := adapters.PolicyAction{
-					Type:   policy.PolicyType,
-					Config: policy.Config,
-				}
-				syncErr = adapter.ApplyPolicy(ctx, adminURL, policy.Name, action)
-			}
-			if syncErr != nil {
-				result.Status = "failed"
-				result.Error = syncErr.Error()
-				log.Printf("sync: apply policy %s failed: %v", policy.Name, syncErr)
-			} else {
-				result.Status = "applied"
-				log.Printf("sync: applied policy %s (%s)", policy.Name, policy.PolicyType)
-			}
-		}
-
-		results = append(results, result)
-	}
+	syncer := newPolicySyncer(adapter)
+	results := syncer.SyncPolicies(ctx, adminURL, config.PendingPolicies)
 
 	// Update Prometheus metrics
 	allOk := true
@@ -198,36 +135,4 @@ func (a *Agent) StartSync(ctx context.Context, adapter adapters.GatewayAdapter, 
 			}
 		}
 	}()
-}
-
-// getStringConfig safely extracts a string value from a config map.
-func getStringConfig(config map[string]interface{}, key string) string {
-	if v, ok := config[key]; ok {
-		if s, ok := v.(string); ok {
-			return s
-		}
-	}
-	return ""
-}
-
-// getStringSliceConfig safely extracts a string slice from a config map.
-func getStringSliceConfig(config map[string]interface{}, key string) []string {
-	v, ok := config[key]
-	if !ok {
-		return nil
-	}
-	switch val := v.(type) {
-	case []string:
-		return val
-	case []interface{}:
-		var result []string
-		for _, item := range val {
-			if s, ok := item.(string); ok {
-				result = append(result, s)
-			}
-		}
-		return result
-	default:
-		return nil
-	}
 }

--- a/stoa-go/internal/connect/sync_policy.go
+++ b/stoa-go/internal/connect/sync_policy.go
@@ -1,0 +1,167 @@
+package connect
+
+import (
+	"context"
+	"log"
+
+	"github.com/stoa-platform/stoa-go/internal/connect/adapters"
+)
+
+// policySyncer reconciles one config cycle worth of PendingPolicy entries
+// against the local gateway adapter. Dispatch splits along two axes:
+//
+//  1. enabled vs disabled (apply vs remove)
+//  2. policy type + adapter capability (OIDC-aware vs generic)
+//
+// Each dispatch branch is its own typed method (applyAuthServer,
+// applyStrategy, applyScope, removePolicy, ...), so adding or
+// regression-testing a single branch is a ~15-LOC operation.
+//
+// policySyncer is stateless beyond the one-time OIDCAdapter type-assert
+// cached at construction.
+type policySyncer struct {
+	adapter     adapters.GatewayAdapter
+	oidcAdapter adapters.OIDCAdapter // nil if adapter does not implement OIDCAdapter
+}
+
+func newPolicySyncer(adapter adapters.GatewayAdapter) *policySyncer {
+	oidc, _ := adapter.(adapters.OIDCAdapter)
+	return &policySyncer{adapter: adapter, oidcAdapter: oidc}
+}
+
+func (s *policySyncer) hasOIDC() bool { return s.oidcAdapter != nil }
+
+// SyncPolicies returns one SyncedPolicyResult per input policy. The caller
+// is responsible for updating Prometheus counters and sending the ack —
+// policySyncer is pure dispatch + per-policy logging.
+func (s *policySyncer) SyncPolicies(ctx context.Context, adminURL string, policies []PendingPolicy) []SyncedPolicyResult {
+	results := make([]SyncedPolicyResult, 0, len(policies))
+	for _, p := range policies {
+		results = append(results, s.syncOne(ctx, adminURL, p))
+	}
+	return results
+}
+
+func (s *policySyncer) syncOne(ctx context.Context, adminURL string, p PendingPolicy) SyncedPolicyResult {
+	result := SyncedPolicyResult{PolicyID: p.ID}
+
+	var err error
+	successStatus := "applied"
+	if !p.Enabled {
+		successStatus = "removed"
+		err = s.remove(ctx, adminURL, p)
+	} else {
+		err = s.apply(ctx, adminURL, p)
+	}
+
+	if err != nil {
+		result.Status = "failed"
+		result.Error = err.Error()
+		// Log reads naturally whether we attempted apply or remove.
+		verb := "apply"
+		if !p.Enabled {
+			verb = "remove"
+		}
+		log.Printf("sync: %s policy %s failed: %v", verb, p.Name, err)
+		return result
+	}
+
+	result.Status = successStatus
+	log.Printf("sync: %s policy %s (%s)", successStatus, p.Name, p.PolicyType)
+	return result
+}
+
+// apply routes an enabled PendingPolicy through the typed OIDC handlers
+// (if the adapter supports OIDC) or the generic ApplyPolicy entry.
+func (s *policySyncer) apply(ctx context.Context, adminURL string, p PendingPolicy) error {
+	switch {
+	case p.PolicyType == "oidc_auth_server" && s.hasOIDC():
+		return s.applyAuthServer(ctx, adminURL, p)
+	case p.PolicyType == "oidc_strategy" && s.hasOIDC():
+		return s.applyStrategy(ctx, adminURL, p)
+	case p.PolicyType == "oidc_scope" && s.hasOIDC():
+		return s.applyScope(ctx, adminURL, p)
+	default:
+		return s.adapter.ApplyPolicy(ctx, adminURL, p.Name, adapters.PolicyAction{
+			Type:   p.PolicyType,
+			Config: p.Config,
+		})
+	}
+}
+
+// remove routes a disabled PendingPolicy. Only oidc_auth_server has a
+// dedicated Delete on OIDCAdapter (DeleteStrategy / DeleteScope don't
+// exist on the interface — see REWRITE-BUGS.md C.1). All other types
+// fall through to the adapter's generic RemovePolicy, which is expected
+// to handle or no-op based on the policyType hint.
+func (s *policySyncer) remove(ctx context.Context, adminURL string, p PendingPolicy) error {
+	if p.PolicyType == "oidc_auth_server" && s.hasOIDC() {
+		return s.oidcAdapter.DeleteAuthServer(ctx, adminURL, p.Name)
+	}
+	return s.adapter.RemovePolicy(ctx, adminURL, p.Name, p.PolicyType)
+}
+
+// --- Typed apply handlers ---
+
+func (s *policySyncer) applyAuthServer(ctx context.Context, adminURL string, p PendingPolicy) error {
+	return s.oidcAdapter.UpsertAuthServer(ctx, adminURL, adapters.AuthServerSpec{
+		Name:         p.Name,
+		DiscoveryURL: getStringConfig(p.Config, "discovery_url"),
+		ClientID:     getStringConfig(p.Config, "client_id"),
+		ClientSecret: getStringConfig(p.Config, "client_secret"),
+		Scopes:       getStringSliceConfig(p.Config, "scopes"),
+	})
+}
+
+func (s *policySyncer) applyStrategy(ctx context.Context, adminURL string, p PendingPolicy) error {
+	return s.oidcAdapter.UpsertStrategy(ctx, adminURL, adapters.StrategySpec{
+		Name:            p.Name,
+		AuthServerAlias: getStringConfig(p.Config, "auth_server_alias"),
+		ClientID:        getStringConfig(p.Config, "client_id"),
+		Audience:        getStringConfig(p.Config, "audience"),
+	})
+}
+
+func (s *policySyncer) applyScope(ctx context.Context, adminURL string, p PendingPolicy) error {
+	return s.oidcAdapter.UpsertScope(ctx, adminURL, adapters.ScopeSpec{
+		ScopeName:       getStringConfig(p.Config, "scope_name"),
+		Audience:        getStringConfig(p.Config, "audience"),
+		AuthServerAlias: getStringConfig(p.Config, "auth_server_alias"),
+		KeycloakScope:   getStringConfig(p.Config, "keycloak_scope"),
+	})
+}
+
+// --- Config helpers (moved from sync.go; only used by policy dispatch) ---
+
+// getStringConfig safely extracts a string value from a config map.
+func getStringConfig(config map[string]interface{}, key string) string {
+	if v, ok := config[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// getStringSliceConfig safely extracts a string slice from a config map.
+// Accepts either []string (native) or []interface{} of strings (JSON-decoded).
+func getStringSliceConfig(config map[string]interface{}, key string) []string {
+	v, ok := config[key]
+	if !ok {
+		return nil
+	}
+	switch val := v.(type) {
+	case []string:
+		return val
+	case []interface{}:
+		var result []string
+		for _, item := range val {
+			if s, ok := item.(string); ok {
+				result = append(result, s)
+			}
+		}
+		return result
+	default:
+		return nil
+	}
+}

--- a/stoa-go/internal/connect/sync_policy_test.go
+++ b/stoa-go/internal/connect/sync_policy_test.go
@@ -1,0 +1,289 @@
+package connect
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stoa-platform/stoa-go/internal/connect/adapters"
+)
+
+// policyMock implements GatewayAdapter. It captures every apply/remove call
+// so tests can assert which dispatch branch was taken.
+type policyMock struct {
+	applied        []string // "apiName:policyType"
+	removed        []string // "apiName:policyType"
+	applyErr       error
+	removeErr      error
+	syncRoutesErr  error
+	injectCredsErr error
+}
+
+func (m *policyMock) Detect(ctx context.Context, adminURL string) (bool, error) {
+	return true, nil
+}
+func (m *policyMock) Discover(ctx context.Context, adminURL string) ([]adapters.DiscoveredAPI, error) {
+	return nil, nil
+}
+func (m *policyMock) ApplyPolicy(ctx context.Context, adminURL, apiName string, p adapters.PolicyAction) error {
+	m.applied = append(m.applied, apiName+":"+p.Type)
+	return m.applyErr
+}
+func (m *policyMock) RemovePolicy(ctx context.Context, adminURL, apiName, policyType string) error {
+	m.removed = append(m.removed, apiName+":"+policyType)
+	return m.removeErr
+}
+func (m *policyMock) SyncRoutes(ctx context.Context, adminURL string, routes []adapters.Route) error {
+	return m.syncRoutesErr
+}
+func (m *policyMock) InjectCredentials(ctx context.Context, adminURL string, creds []adapters.Credential) error {
+	return m.injectCredsErr
+}
+
+// policyMockOIDC wraps policyMock and additionally implements OIDCAdapter.
+// Each typed method records its arguments so tests can assert dispatch
+// went through the OIDC-specific path, not the generic fallback.
+type policyMockOIDC struct {
+	policyMock
+	authServerSpecs []adapters.AuthServerSpec
+	strategySpecs   []adapters.StrategySpec
+	scopeSpecs      []adapters.ScopeSpec
+	deletedServers  []string
+}
+
+func (m *policyMockOIDC) UpsertAuthServer(ctx context.Context, adminURL string, spec adapters.AuthServerSpec) error {
+	m.authServerSpecs = append(m.authServerSpecs, spec)
+	return nil
+}
+func (m *policyMockOIDC) UpsertStrategy(ctx context.Context, adminURL string, spec adapters.StrategySpec) error {
+	m.strategySpecs = append(m.strategySpecs, spec)
+	return nil
+}
+func (m *policyMockOIDC) UpsertScope(ctx context.Context, adminURL string, spec adapters.ScopeSpec) error {
+	m.scopeSpecs = append(m.scopeSpecs, spec)
+	return nil
+}
+func (m *policyMockOIDC) DeleteAuthServer(ctx context.Context, adminURL, name string) error {
+	m.deletedServers = append(m.deletedServers, name)
+	return nil
+}
+
+// --- Apply dispatch ---
+
+func TestPolicySyncerAppliesGeneric(t *testing.T) {
+	m := &policyMock{}
+	s := newPolicySyncer(m)
+	results := s.SyncPolicies(context.Background(), "http://gw", []PendingPolicy{
+		{ID: "p1", Name: "rate-limit", PolicyType: "rate_limit", Enabled: true, Config: map[string]interface{}{"rpm": 100}},
+	})
+	if len(results) != 1 || results[0].Status != "applied" {
+		t.Errorf("expected 1 applied result, got %+v", results)
+	}
+	if len(m.applied) != 1 || m.applied[0] != "rate-limit:rate_limit" {
+		t.Errorf("generic ApplyPolicy not called correctly: %v", m.applied)
+	}
+}
+
+func TestPolicySyncerAppliesOIDCAuthServer(t *testing.T) {
+	m := &policyMockOIDC{}
+	s := newPolicySyncer(m)
+	s.SyncPolicies(context.Background(), "http://gw", []PendingPolicy{{
+		ID:         "p1",
+		Name:       "primary-idp",
+		PolicyType: "oidc_auth_server",
+		Enabled:    true,
+		Config: map[string]interface{}{
+			"discovery_url": "https://kc.example/.well-known",
+			"client_id":     "cid",
+			"client_secret": "csec",
+			"scopes":        []interface{}{"openid", "profile"},
+		},
+	}})
+	if len(m.authServerSpecs) != 1 {
+		t.Fatalf("UpsertAuthServer not called, got %d calls", len(m.authServerSpecs))
+	}
+	spec := m.authServerSpecs[0]
+	if spec.Name != "primary-idp" || spec.DiscoveryURL != "https://kc.example/.well-known" {
+		t.Errorf("wrong spec: %+v", spec)
+	}
+	if len(spec.Scopes) != 2 || spec.Scopes[0] != "openid" {
+		t.Errorf("scopes not decoded from []interface{}: %v", spec.Scopes)
+	}
+	if len(m.applied) != 0 {
+		t.Errorf("generic ApplyPolicy should NOT be called on OIDC type, got %v", m.applied)
+	}
+}
+
+func TestPolicySyncerAppliesOIDCStrategy(t *testing.T) {
+	m := &policyMockOIDC{}
+	s := newPolicySyncer(m)
+	s.SyncPolicies(context.Background(), "http://gw", []PendingPolicy{{
+		ID:         "p1",
+		Name:       "strat-a",
+		PolicyType: "oidc_strategy",
+		Enabled:    true,
+		Config: map[string]interface{}{
+			"auth_server_alias": "primary-idp",
+			"client_id":         "strat-client",
+			"audience":          "api-x",
+		},
+	}})
+	if len(m.strategySpecs) != 1 || m.strategySpecs[0].AuthServerAlias != "primary-idp" {
+		t.Errorf("UpsertStrategy not called correctly: %+v", m.strategySpecs)
+	}
+}
+
+func TestPolicySyncerAppliesOIDCScope(t *testing.T) {
+	m := &policyMockOIDC{}
+	s := newPolicySyncer(m)
+	s.SyncPolicies(context.Background(), "http://gw", []PendingPolicy{{
+		ID:         "p1",
+		Name:       "scope-a",
+		PolicyType: "oidc_scope",
+		Enabled:    true,
+		Config: map[string]interface{}{
+			"scope_name":        "read:api",
+			"audience":          "api-x",
+			"auth_server_alias": "primary-idp",
+			"keycloak_scope":    "api-read",
+		},
+	}})
+	if len(m.scopeSpecs) != 1 || m.scopeSpecs[0].ScopeName != "read:api" {
+		t.Errorf("UpsertScope not called correctly: %+v", m.scopeSpecs)
+	}
+}
+
+// TestPolicySyncerOIDCFallsBackWithoutAdapter covers the case where the CP
+// emits an OIDC policy type but the local adapter does not implement
+// OIDCAdapter — the policy must fall through to generic ApplyPolicy rather
+// than crash with a nil dereference.
+func TestPolicySyncerOIDCFallsBackWithoutAdapter(t *testing.T) {
+	m := &policyMock{} // NOT OIDC
+	s := newPolicySyncer(m)
+	s.SyncPolicies(context.Background(), "http://gw", []PendingPolicy{{
+		ID:         "p1",
+		Name:       "strat-a",
+		PolicyType: "oidc_strategy",
+		Enabled:    true,
+		Config:     map[string]interface{}{},
+	}})
+	if len(m.applied) != 1 || m.applied[0] != "strat-a:oidc_strategy" {
+		t.Errorf("expected generic ApplyPolicy fallback, got %v", m.applied)
+	}
+}
+
+// --- Remove dispatch ---
+
+func TestPolicySyncerRemovesGeneric(t *testing.T) {
+	m := &policyMock{}
+	s := newPolicySyncer(m)
+	results := s.SyncPolicies(context.Background(), "http://gw", []PendingPolicy{
+		{ID: "p1", Name: "rate-limit", PolicyType: "rate_limit", Enabled: false},
+	})
+	if results[0].Status != "removed" {
+		t.Errorf("expected removed, got %q", results[0].Status)
+	}
+	if len(m.removed) != 1 || m.removed[0] != "rate-limit:rate_limit" {
+		t.Errorf("generic RemovePolicy not called: %v", m.removed)
+	}
+}
+
+func TestPolicySyncerRemovesOIDCAuthServer(t *testing.T) {
+	m := &policyMockOIDC{}
+	s := newPolicySyncer(m)
+	s.SyncPolicies(context.Background(), "http://gw", []PendingPolicy{
+		{ID: "p1", Name: "primary-idp", PolicyType: "oidc_auth_server", Enabled: false},
+	})
+	if len(m.deletedServers) != 1 || m.deletedServers[0] != "primary-idp" {
+		t.Errorf("DeleteAuthServer not called correctly: %v", m.deletedServers)
+	}
+	if len(m.removed) != 0 {
+		t.Errorf("generic RemovePolicy should NOT be called for oidc_auth_server, got %v", m.removed)
+	}
+}
+
+// TestPolicySyncerRemovesOIDCStrategyViaGenericFallback documents the
+// asymmetry in the OIDCAdapter interface (C.1 in REWRITE-BUGS.md):
+// DeleteStrategy/DeleteScope do not exist, so disabling an oidc_strategy
+// falls through to adapter.RemovePolicy with the type as a hint. Whether
+// the concrete adapter handles or no-ops is adapter-specific (GO-1 scope).
+func TestPolicySyncerRemovesOIDCStrategyViaGenericFallback(t *testing.T) {
+	m := &policyMockOIDC{}
+	s := newPolicySyncer(m)
+	s.SyncPolicies(context.Background(), "http://gw", []PendingPolicy{
+		{ID: "p1", Name: "strat-a", PolicyType: "oidc_strategy", Enabled: false},
+	})
+	// Went through generic RemovePolicy (not a typed OIDC method).
+	if len(m.removed) != 1 || m.removed[0] != "strat-a:oidc_strategy" {
+		t.Errorf("expected generic RemovePolicy fallback, got %v", m.removed)
+	}
+	if len(m.deletedServers) != 0 {
+		t.Errorf("DeleteAuthServer should NOT be called for oidc_strategy, got %v", m.deletedServers)
+	}
+}
+
+// --- Failure handling ---
+
+func TestPolicySyncerFailedApplyProducesFailedResult(t *testing.T) {
+	m := &policyMock{applyErr: errors.New("gateway 500")}
+	s := newPolicySyncer(m)
+	results := s.SyncPolicies(context.Background(), "http://gw", []PendingPolicy{
+		{ID: "p1", Name: "x", PolicyType: "generic", Enabled: true},
+	})
+	if results[0].Status != "failed" || results[0].Error != "gateway 500" {
+		t.Errorf("expected failed/gateway 500, got %+v", results[0])
+	}
+}
+
+func TestPolicySyncerFailedRemoveProducesFailedResult(t *testing.T) {
+	m := &policyMock{removeErr: errors.New("not found")}
+	s := newPolicySyncer(m)
+	results := s.SyncPolicies(context.Background(), "http://gw", []PendingPolicy{
+		{ID: "p1", Name: "x", PolicyType: "generic", Enabled: false},
+	})
+	if results[0].Status != "failed" || results[0].Error != "not found" {
+		t.Errorf("expected failed/not found, got %+v", results[0])
+	}
+}
+
+// --- Config helpers ---
+
+func TestGetStringConfigFallback(t *testing.T) {
+	m := map[string]interface{}{"key": "value", "wrong_type": 42}
+	if got := getStringConfig(m, "key"); got != "value" {
+		t.Errorf("got %q, want 'value'", got)
+	}
+	if got := getStringConfig(m, "missing"); got != "" {
+		t.Errorf("got %q, want ''", got)
+	}
+	if got := getStringConfig(m, "wrong_type"); got != "" {
+		t.Errorf("got %q, want '' for non-string", got)
+	}
+}
+
+func TestGetStringSliceConfigVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		in   interface{}
+		want []string
+	}{
+		{"native []string", []string{"a", "b"}, []string{"a", "b"}},
+		{"JSON []interface{}", []interface{}{"a", "b"}, []string{"a", "b"}},
+		{"mixed types skipped", []interface{}{"a", 42, "b"}, []string{"a", "b"}},
+		{"wrong outer type", "just-a-string", nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := map[string]interface{}{"scopes": tc.in}
+			got := getStringSliceConfig(m, "scopes")
+			if len(got) != len(tc.want) {
+				t.Fatalf("len mismatch: got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("[%d]: got %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/stoa-go/internal/connect/sync_route.go
+++ b/stoa-go/internal/connect/sync_route.go
@@ -1,0 +1,113 @@
+package connect
+
+import (
+	"context"
+	"log"
+
+	"github.com/stoa-platform/stoa-go/internal/connect/adapters"
+)
+
+// routeSyncer pushes a batch of routes to the local gateway adapter and
+// produces per-route SyncStep-annotated results ready for CP route-sync-ack.
+//
+// It is the SINGLE code path used by both:
+//   - RunRouteSync (polling, N routes per cycle)
+//   - handleSyncDeployment (SSE, 1 route per deployment event)
+//
+// Previously these two paths duplicated step construction, per-route status
+// resolution and result assembly — and had diverged. See REWRITE-BUGS.md
+// B.1..B.3 for the divergences consolidated here; most notably the
+// Generation field (CAB-1950) is now always propagated.
+//
+// routeSyncer is stateless; the caller decides whether to re-use the
+// instance per call or per agent. Cost-wise the difference is negligible.
+type routeSyncer struct {
+	adapter adapters.GatewayAdapter
+}
+
+func newRouteSyncer(adapter adapters.GatewayAdapter) *routeSyncer {
+	return &routeSyncer{adapter: adapter}
+}
+
+// Sync pushes routes to the adapter at adminURL and returns one
+// SyncedRouteResult per route that carries a DeploymentID. The second
+// return is the adapter's global error (if any) for callers that want to
+// log it alongside the per-route results.
+//
+// Behavior:
+//   - Empty routes → returns nil, nil (caller decides what to log).
+//   - Route without DeploymentID → logged as warning, skipped in results.
+//     Symptom of a CP↔agent contract drift (CP should always tag routes
+//     with deployment_id).
+//   - Steps attached to each result: agent_received, adapter_connected,
+//     api_synced (with the adapter's actual outcome + error detail).
+//   - Per-route status resolution priority:
+//     1. adapter-reported per-route failure (failedRoutesProvider) →
+//     status=failed with the adapter's own error string.
+//     2. adapter returned a global error AND no per-route map → all
+//     routes get status=failed with the global error (fallback for
+//     adapters like kong/gravitee that don't track per-route).
+//     3. otherwise → status=applied.
+func (s *routeSyncer) Sync(ctx context.Context, adminURL string, routes []adapters.Route) ([]SyncedRouteResult, error) {
+	if len(routes) == 0 {
+		return nil, nil
+	}
+
+	// Step trace: agent_received and adapter_connected are success by the
+	// time we call the adapter. api_synced reflects the adapter's actual
+	// outcome. All routes in a single call share the same step timeline.
+	agentStep := newSyncStep("agent_received", "success", "")
+	adapterStep := newSyncStep("adapter_connected", "success", "")
+
+	syncErr := s.adapter.SyncRoutes(ctx, adminURL, routes)
+
+	var apiStep SyncStep
+	if syncErr != nil {
+		apiStep = newSyncStep("api_synced", "failed", syncErr.Error())
+	} else {
+		apiStep = newSyncStep("api_synced", "success", "")
+	}
+	steps := []SyncStep{agentStep, adapterStep, apiStep}
+
+	failedMap := failedRoutesFromAdapter(s.adapter)
+
+	var results []SyncedRouteResult
+	for _, r := range routes {
+		if r.DeploymentID == "" {
+			log.Printf("route-sync: skipping route %q — missing deployment_id (CP contract drift?)", r.Name)
+			continue
+		}
+		result := SyncedRouteResult{
+			DeploymentID: r.DeploymentID,
+			Steps:        steps,
+			Generation:   r.Generation, // CAB-1950 — propagated on both paths (B.1 fix)
+		}
+		if routeErr, failed := failedMap[r.DeploymentID]; failed {
+			result.Status = "failed"
+			result.Error = routeErr
+		} else if syncErr != nil && len(failedMap) == 0 {
+			result.Status = "failed"
+			result.Error = syncErr.Error()
+		} else {
+			result.Status = "applied"
+		}
+		results = append(results, result)
+	}
+
+	return results, syncErr
+}
+
+// failedRoutesFromAdapter encapsulates the type-assertion against the
+// adapter-optional per-route error interface. Kept local to package connect
+// (not exported from adapters/) to contain GO-2 scope — only webmethods
+// implements it today. Documented debt; GO-3 may promote to a proper
+// interface on GatewayAdapter.
+func failedRoutesFromAdapter(adapter adapters.GatewayAdapter) map[string]string {
+	type failedRoutesProvider interface {
+		GetFailedRoutes() map[string]string
+	}
+	if frp, ok := adapter.(failedRoutesProvider); ok {
+		return frp.GetFailedRoutes()
+	}
+	return map[string]string{}
+}

--- a/stoa-go/internal/connect/sync_route_test.go
+++ b/stoa-go/internal/connect/sync_route_test.go
@@ -1,0 +1,178 @@
+package connect
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stoa-platform/stoa-go/internal/connect/adapters"
+)
+
+// routeSyncMock is a GatewayAdapter stub for routeSyncer tests. syncRoutesErr
+// is returned from SyncRoutes; if failedRoutes is non-nil, routeSyncMock
+// also implements the adapter-local failedRoutesProvider interface.
+type routeSyncMock struct {
+	capturedRoutes []adapters.Route
+	syncRoutesErr  error
+	failedRoutes   map[string]string // if nil, provider interface not satisfied
+}
+
+func (m *routeSyncMock) Detect(ctx context.Context, adminURL string) (bool, error) {
+	return true, nil
+}
+func (m *routeSyncMock) Discover(ctx context.Context, adminURL string) ([]adapters.DiscoveredAPI, error) {
+	return nil, nil
+}
+func (m *routeSyncMock) ApplyPolicy(ctx context.Context, adminURL, apiName string, policy adapters.PolicyAction) error {
+	return nil
+}
+func (m *routeSyncMock) RemovePolicy(ctx context.Context, adminURL, apiName, policyType string) error {
+	return nil
+}
+func (m *routeSyncMock) SyncRoutes(ctx context.Context, adminURL string, routes []adapters.Route) error {
+	m.capturedRoutes = append(m.capturedRoutes, routes...)
+	return m.syncRoutesErr
+}
+func (m *routeSyncMock) InjectCredentials(ctx context.Context, adminURL string, creds []adapters.Credential) error {
+	return nil
+}
+
+// routeSyncMockWithFailed wraps routeSyncMock and additionally implements
+// the failedRoutesProvider interface used by routeSyncer.
+type routeSyncMockWithFailed struct {
+	routeSyncMock
+}
+
+func (m *routeSyncMockWithFailed) GetFailedRoutes() map[string]string {
+	return m.failedRoutes
+}
+
+func TestRouteSyncerAppliedBatch(t *testing.T) {
+	m := &routeSyncMock{}
+	s := newRouteSyncer(m)
+
+	routes := []adapters.Route{
+		{DeploymentID: "dep-1", Name: "api-a", Generation: 3},
+		{DeploymentID: "dep-2", Name: "api-b", Generation: 7},
+	}
+	results, err := s.Sync(context.Background(), "http://gw", routes)
+	if err != nil {
+		t.Fatalf("unexpected syncErr: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	for i, r := range results {
+		if r.Status != "applied" {
+			t.Errorf("result %d: status=%q, want applied", i, r.Status)
+		}
+		if len(r.Steps) != 3 {
+			t.Errorf("result %d: expected 3 steps, got %d", i, len(r.Steps))
+		}
+	}
+	// B.1 regression: Generation must be propagated to the ack.
+	if results[0].Generation != 3 || results[1].Generation != 7 {
+		t.Errorf("Generation not propagated: got %d, %d; want 3, 7", results[0].Generation, results[1].Generation)
+	}
+}
+
+func TestRouteSyncerGlobalErrorFanOut(t *testing.T) {
+	// Adapter without failedRoutesProvider (e.g. kong/gravitee). Global
+	// sync error should fan out to all routes with status=failed.
+	sentinel := errors.New("gateway unreachable")
+	m := &routeSyncMock{syncRoutesErr: sentinel}
+	s := newRouteSyncer(m)
+
+	routes := []adapters.Route{
+		{DeploymentID: "dep-1", Name: "api-a"},
+		{DeploymentID: "dep-2", Name: "api-b"},
+	}
+	results, err := s.Sync(context.Background(), "http://gw", routes)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected syncErr to surface, got %v", err)
+	}
+	for i, r := range results {
+		if r.Status != "failed" {
+			t.Errorf("result %d: status=%q, want failed", i, r.Status)
+		}
+		if r.Error != sentinel.Error() {
+			t.Errorf("result %d: error=%q, want %q", i, r.Error, sentinel.Error())
+		}
+	}
+}
+
+func TestRouteSyncerPerRouteFailure(t *testing.T) {
+	// Adapter WITH failedRoutesProvider (webmethods-style). Only dep-2 fails.
+	m := &routeSyncMockWithFailed{
+		routeSyncMock: routeSyncMock{syncRoutesErr: errors.New("partial failure")},
+	}
+	m.failedRoutes = map[string]string{"dep-2": "route conflict"}
+	s := newRouteSyncer(m)
+
+	routes := []adapters.Route{
+		{DeploymentID: "dep-1", Name: "api-a"},
+		{DeploymentID: "dep-2", Name: "api-b"},
+	}
+	results, _ := s.Sync(context.Background(), "http://gw", routes)
+
+	if results[0].Status != "applied" {
+		t.Errorf("dep-1 should be applied, got %q", results[0].Status)
+	}
+	if results[1].Status != "failed" || results[1].Error != "route conflict" {
+		t.Errorf("dep-2 should be failed with 'route conflict', got status=%q err=%q", results[1].Status, results[1].Error)
+	}
+}
+
+func TestRouteSyncerSkipsMissingDeploymentID(t *testing.T) {
+	m := &routeSyncMock{}
+	s := newRouteSyncer(m)
+
+	// First route lacks deployment_id and must be dropped from results.
+	routes := []adapters.Route{
+		{DeploymentID: "", Name: "orphan"},
+		{DeploymentID: "dep-1", Name: "tracked"},
+	}
+	results, _ := s.Sync(context.Background(), "http://gw", routes)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (orphan dropped), got %d", len(results))
+	}
+	if results[0].DeploymentID != "dep-1" {
+		t.Errorf("wrong route kept: %q", results[0].DeploymentID)
+	}
+	// Adapter still receives all routes (only the ack side filters).
+	if len(m.capturedRoutes) != 2 {
+		t.Errorf("adapter should see all 2 routes, got %d", len(m.capturedRoutes))
+	}
+}
+
+func TestRouteSyncerEmpty(t *testing.T) {
+	m := &routeSyncMock{}
+	s := newRouteSyncer(m)
+	results, err := s.Sync(context.Background(), "http://gw", nil)
+	if err != nil || results != nil {
+		t.Errorf("expected (nil, nil), got (%v, %v)", results, err)
+	}
+	if len(m.capturedRoutes) != 0 {
+		t.Errorf("adapter should not be called on empty input, got %d routes", len(m.capturedRoutes))
+	}
+}
+
+func TestRouteSyncerStepsReflectOutcome(t *testing.T) {
+	// Success: api_synced=success with no detail
+	m := &routeSyncMock{}
+	s := newRouteSyncer(m)
+	routes := []adapters.Route{{DeploymentID: "dep-1"}}
+	results, _ := s.Sync(context.Background(), "http://gw", routes)
+	if got := results[0].Steps[2]; got.Name != "api_synced" || got.Status != "success" || got.Detail != "" {
+		t.Errorf("success steps[2]: %+v", got)
+	}
+
+	// Failure: api_synced=failed with error detail
+	mFail := &routeSyncMock{syncRoutesErr: errors.New("boom")}
+	sFail := newRouteSyncer(mFail)
+	resultsFail, _ := sFail.Sync(context.Background(), "http://gw", routes)
+	if got := resultsFail[0].Steps[2]; got.Name != "api_synced" || got.Status != "failed" || got.Detail != "boom" {
+		t.Errorf("failure steps[2]: %+v", got)
+	}
+}

--- a/stoa-go/internal/connect/sync_test.go
+++ b/stoa-go/internal/connect/sync_test.go
@@ -3,6 +3,7 @@ package connect
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -298,11 +299,8 @@ func TestReportRouteSyncAckNotRegistered(t *testing.T) {
 	err := agent.ReportRouteSyncAck(context.Background(), []SyncedRouteResult{
 		{DeploymentID: "dep-1", Status: "applied"},
 	})
-	if err == nil {
-		t.Fatal("expected error when not registered")
-	}
-	if err.Error() != "not registered" {
-		t.Errorf("expected 'not registered', got %s", err.Error())
+	if !errors.Is(err, ErrNotRegistered) {
+		t.Errorf("expected ErrNotRegistered, got %v", err)
 	}
 }
 

--- a/stoa-go/internal/connect/sync_test.go
+++ b/stoa-go/internal/connect/sync_test.go
@@ -39,7 +39,7 @@ func TestFetchConfig(t *testing.T) {
 		ControlPlaneURL: cpServer.URL,
 		GatewayAPIKey:   "key",
 	})
-	agent.gatewayID = "gw-test"
+	agent.state.SetGatewayID("gw-test")
 
 	config, err := agent.FetchConfig(context.Background())
 	if err != nil {
@@ -85,7 +85,7 @@ func TestReportSyncAck(t *testing.T) {
 		ControlPlaneURL: cpServer.URL,
 		GatewayAPIKey:   "key",
 	})
-	agent.gatewayID = "gw-test"
+	agent.state.SetGatewayID("gw-test")
 
 	results := []SyncedPolicyResult{
 		{PolicyID: "pol-1", Status: "applied"},
@@ -106,14 +106,14 @@ func TestReportSyncAck(t *testing.T) {
 
 // mockSyncAdapter implements GatewayAdapter for sync testing.
 type mockSyncAdapter struct {
-	appliedPolicies   []string
-	removedPolicies   []string
-	syncedRoutes      []adapters.Route
-	injectedCreds     []adapters.Credential
-	applyErr          error
-	removeErr         error
-	syncRoutesErr     error
-	injectCredsErr    error
+	appliedPolicies []string
+	removedPolicies []string
+	syncedRoutes    []adapters.Route
+	injectedCreds   []adapters.Credential
+	applyErr        error
+	removeErr       error
+	syncRoutesErr   error
+	injectCredsErr  error
 }
 
 func (m *mockSyncAdapter) Detect(ctx context.Context, adminURL string) (bool, error) {
@@ -173,7 +173,7 @@ func TestRunSyncAppliesEnabledPolicies(t *testing.T) {
 		ControlPlaneURL: cpServer.URL,
 		GatewayAPIKey:   "key",
 	})
-	agent.gatewayID = "gw-test"
+	agent.state.SetGatewayID("gw-test")
 
 	adapter := &mockSyncAdapter{}
 	agent.RunSync(context.Background(), adapter, cpServer.URL)
@@ -221,7 +221,7 @@ func TestRunSyncNoPolicies(t *testing.T) {
 		ControlPlaneURL: cpServer.URL,
 		GatewayAPIKey:   "key",
 	})
-	agent.gatewayID = "gw-test"
+	agent.state.SetGatewayID("gw-test")
 
 	adapter := &mockSyncAdapter{}
 	agent.RunSync(context.Background(), adapter, cpServer.URL)
@@ -264,7 +264,7 @@ func TestReportRouteSyncAck(t *testing.T) {
 		ControlPlaneURL: cpServer.URL,
 		GatewayAPIKey:   "key",
 	})
-	agent.gatewayID = "gw-test"
+	agent.state.SetGatewayID("gw-test")
 
 	results := []SyncedRouteResult{
 		{DeploymentID: "dep-1", Status: "applied"},
@@ -317,7 +317,7 @@ func TestReportRouteSyncAckServerError(t *testing.T) {
 		ControlPlaneURL: cpServer.URL,
 		GatewayAPIKey:   "key",
 	})
-	agent.gatewayID = "gw-test"
+	agent.state.SetGatewayID("gw-test")
 
 	err := agent.ReportRouteSyncAck(context.Background(), []SyncedRouteResult{
 		{DeploymentID: "dep-1", Status: "applied"},

--- a/stoa-go/internal/connect/transport_cp.go
+++ b/stoa-go/internal/connect/transport_cp.go
@@ -1,0 +1,303 @@
+package connect
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/stoa-platform/stoa-go/internal/connect/adapters"
+)
+
+// cpClient is the HTTP client for calls to the Control Plane.
+//
+// It owns a single http.Client (15s timeout) built on a shared otelhttp-wrapped
+// transport so W3C traceparent propagation is consistent. The baseURL + apiKey
+// are injected once at construction — the 7 methods below take the gatewayID
+// as an argument instead of reading it from state, so the client holds no
+// mutable runtime state.
+//
+// Each method emits one business-level span named "stoa-connect.<action>" on
+// top of the auto span emitted by otelhttp, so traces show both the HTTP
+// transport and the connect-specific semantics.
+type cpClient struct {
+	http    *http.Client
+	tracer  trace.Tracer // may be nil before SetTracer
+	baseURL string
+	apiKey  string
+}
+
+// newCPClient wires the shared transport into an http.Client with the standard
+// 15s timeout used for all CP requests. The transport is also used by the SSE
+// stream (no timeout) via Agent.transport — both share it for otelhttp
+// consistency.
+func newCPClient(baseURL, apiKey string, transport http.RoundTripper) *cpClient {
+	return &cpClient{
+		http: &http.Client{
+			Timeout:   15 * time.Second,
+			Transport: transport,
+		},
+		baseURL: baseURL,
+		apiKey:  apiKey,
+	}
+}
+
+// SetTracer installs the OpenTelemetry tracer used for business spans.
+// Intended to be called from the main goroutine before any loop starts.
+func (c *cpClient) SetTracer(t trace.Tracer) {
+	c.tracer = t
+}
+
+func (c *cpClient) startSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	if c.tracer == nil {
+		return ctx, trace.SpanFromContext(ctx)
+	}
+	return c.tracer.Start(ctx, name,
+		trace.WithAttributes(attrs...),
+		trace.WithSpanKind(trace.SpanKindClient),
+	)
+}
+
+// spanFail records err on span, sets Error status, and returns the err as-is
+// so callers can write `return spanFail(...)`. Single helper kills the 3-line
+// record+status+return pattern that would otherwise repeat ~20 times below.
+func spanFail(span trace.Span, err error, reason string) error {
+	span.RecordError(err)
+	span.SetStatus(codes.Error, reason)
+	return err
+}
+
+// sendJSON marshals body (if non-nil), sends the request, reads the full
+// response body, and returns status + body. Callers interpret status codes
+// (e.g. 404 on heartbeat is ErrGatewayNotFound, not a generic failure).
+func (c *cpClient) sendJSON(ctx context.Context, method, path string, body any) (int, []byte, error) {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return 0, nil, fmt.Errorf("marshal: %w", err)
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return 0, nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("X-Gateway-Key", c.apiKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("http: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, respBody, nil
+}
+
+// --- CP endpoints ---
+
+// Register POSTs the registration payload. Returns the CP-assigned gateway ID.
+func (c *cpClient) Register(ctx context.Context, payload RegistrationPayload) (RegistrationResponse, error) {
+	ctx, span := c.startSpan(ctx, "stoa-connect.register",
+		attribute.String("stoa.instance_name", payload.Hostname),
+		attribute.String("stoa.environment", payload.Environment),
+	)
+	defer span.End()
+
+	status, body, err := c.sendJSON(ctx, http.MethodPost, "/v1/internal/gateways/register", payload)
+	if err != nil {
+		return RegistrationResponse{}, spanFail(span, fmt.Errorf("register request: %w", err), "register request failed")
+	}
+	span.SetAttributes(attribute.Int("http.status_code", status))
+
+	if status != http.StatusCreated && status != http.StatusOK {
+		return RegistrationResponse{}, spanFail(span, fmt.Errorf("register failed (%d): %s", status, string(body)), "registration rejected")
+	}
+
+	var result RegistrationResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return RegistrationResponse{}, spanFail(span, fmt.Errorf("decode registration response: %w", err), "decode failed")
+	}
+
+	span.SetAttributes(attribute.String("stoa.gateway_id", result.ID))
+	span.SetStatus(codes.Ok, "registered")
+	return result, nil
+}
+
+// Heartbeat POSTs a heartbeat. Returns ErrGatewayNotFound on 404 (CP purged).
+func (c *cpClient) Heartbeat(ctx context.Context, gatewayID string, payload HeartbeatPayload) error {
+	ctx, span := c.startSpan(ctx, "stoa-connect.heartbeat",
+		attribute.String("stoa.gateway_id", gatewayID),
+		attribute.Int("stoa.uptime_seconds", payload.UptimeSeconds),
+		attribute.Int("stoa.routes_count", payload.RoutesCount),
+		attribute.Int("stoa.discovered_apis", payload.DiscoveredAPIs),
+	)
+	defer span.End()
+
+	status, body, err := c.sendJSON(ctx, http.MethodPost,
+		fmt.Sprintf("/v1/internal/gateways/%s/heartbeat", gatewayID), payload)
+	if err != nil {
+		return spanFail(span, fmt.Errorf("heartbeat request: %w", err), "heartbeat request failed")
+	}
+	span.SetAttributes(attribute.Int("http.status_code", status))
+
+	if status == http.StatusNotFound {
+		return spanFail(span, ErrGatewayNotFound, "gateway purged from CP")
+	}
+	if status != http.StatusNoContent && status != http.StatusOK {
+		return spanFail(span, fmt.Errorf("heartbeat failed (%d): %s", status, string(body)), "heartbeat rejected")
+	}
+
+	span.SetStatus(codes.Ok, "heartbeat sent")
+	return nil
+}
+
+// ReportDiscovery POSTs discovered APIs.
+func (c *cpClient) ReportDiscovery(ctx context.Context, gatewayID string, payload DiscoveryPayload) error {
+	ctx, span := c.startSpan(ctx, "stoa-connect.discovery",
+		attribute.String("stoa.gateway_id", gatewayID),
+		attribute.Int("stoa.discovered_apis", len(payload.APIs)),
+	)
+	defer span.End()
+
+	status, body, err := c.sendJSON(ctx, http.MethodPost,
+		fmt.Sprintf("/v1/internal/gateways/%s/discovery", gatewayID), payload)
+	if err != nil {
+		return spanFail(span, fmt.Errorf("discovery report request: %w", err), "discovery request failed")
+	}
+	span.SetAttributes(attribute.Int("http.status_code", status))
+
+	if status != http.StatusOK && status != http.StatusNoContent {
+		return spanFail(span, fmt.Errorf("discovery report failed (%d): %s", status, string(body)), "discovery rejected")
+	}
+
+	span.SetStatus(codes.Ok, "discovery reported")
+	return nil
+}
+
+// FetchConfig GETs the gateway config (policies, deployments).
+func (c *cpClient) FetchConfig(ctx context.Context, gatewayID string) (*GatewayConfigResponse, error) {
+	ctx, span := c.startSpan(ctx, "stoa-connect.sync.fetch-config",
+		attribute.String("stoa.gateway_id", gatewayID),
+	)
+	defer span.End()
+
+	status, body, err := c.sendJSON(ctx, http.MethodGet,
+		fmt.Sprintf("/v1/internal/gateways/%s/config", gatewayID), nil)
+	if err != nil {
+		return nil, spanFail(span, fmt.Errorf("config request: %w", err), "config request failed")
+	}
+	span.SetAttributes(attribute.Int("http.status_code", status))
+
+	if status != http.StatusOK {
+		return nil, spanFail(span, fmt.Errorf("config request failed (%d): %s", status, string(body)), "fetch config rejected")
+	}
+
+	var cfg GatewayConfigResponse
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		return nil, spanFail(span, fmt.Errorf("decode config response: %w", err), "decode failed")
+	}
+	span.SetAttributes(attribute.Int("stoa.pending_policies", len(cfg.PendingPolicies)))
+	span.SetStatus(codes.Ok, "config fetched")
+	return &cfg, nil
+}
+
+// FetchRoutes GETs the route table filtered by gatewayName (empty = all).
+// Unlike the other methods, this endpoint is filtered by gateway_name query
+// param rather than a path-scoped gatewayID — it's called before Register
+// in some startup paths.
+func (c *cpClient) FetchRoutes(ctx context.Context, gatewayName string) ([]adapters.Route, error) {
+	ctx, span := c.startSpan(ctx, "stoa-connect.routes.fetch",
+		attribute.String("stoa.gateway_name", gatewayName),
+	)
+	defer span.End()
+
+	path := "/v1/internal/gateways/routes"
+	if gatewayName != "" {
+		path += "?gateway_name=" + gatewayName
+	}
+	status, body, err := c.sendJSON(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, spanFail(span, fmt.Errorf("routes request: %w", err), "routes request failed")
+	}
+	span.SetAttributes(attribute.Int("http.status_code", status))
+
+	if status != http.StatusOK {
+		return nil, spanFail(span, fmt.Errorf("routes request failed (%d): %s", status, string(body)), "fetch routes rejected")
+	}
+
+	var routes []adapters.Route
+	if err := json.Unmarshal(body, &routes); err != nil {
+		return nil, spanFail(span, fmt.Errorf("decode routes response: %w", err), "decode failed")
+	}
+	span.SetAttributes(attribute.Int("stoa.routes_count", len(routes)))
+	span.SetStatus(codes.Ok, "routes fetched")
+	return routes, nil
+}
+
+// ReportSyncAck POSTs policy sync results.
+func (c *cpClient) ReportSyncAck(ctx context.Context, gatewayID string, payload SyncAckPayload) error {
+	var applied, removed, failed int
+	for _, r := range payload.SyncedPolicies {
+		switch r.Status {
+		case "applied":
+			applied++
+		case "removed":
+			removed++
+		case "failed":
+			failed++
+		}
+	}
+	ctx, span := c.startSpan(ctx, "stoa-connect.sync.ack",
+		attribute.String("stoa.gateway_id", gatewayID),
+		attribute.Int("stoa.synced_policies", len(payload.SyncedPolicies)),
+		attribute.Int("stoa.policies_applied", applied),
+		attribute.Int("stoa.policies_removed", removed),
+		attribute.Int("stoa.policies_failed", failed),
+	)
+	defer span.End()
+
+	status, body, err := c.sendJSON(ctx, http.MethodPost,
+		fmt.Sprintf("/v1/internal/gateways/%s/sync-ack", gatewayID), payload)
+	if err != nil {
+		return spanFail(span, fmt.Errorf("sync-ack request: %w", err), "sync-ack request failed")
+	}
+	span.SetAttributes(attribute.Int("http.status_code", status))
+
+	if status != http.StatusOK && status != http.StatusNoContent {
+		return spanFail(span, fmt.Errorf("sync-ack failed (%d): %s", status, string(body)), "sync-ack rejected")
+	}
+	span.SetStatus(codes.Ok, "sync-ack sent")
+	return nil
+}
+
+// ReportRouteSyncAck POSTs route sync results.
+func (c *cpClient) ReportRouteSyncAck(ctx context.Context, gatewayID string, payload RouteSyncAckPayload) error {
+	ctx, span := c.startSpan(ctx, "stoa-connect.routes.ack",
+		attribute.String("stoa.gateway_id", gatewayID),
+		attribute.Int("stoa.synced_routes", len(payload.SyncedRoutes)),
+	)
+	defer span.End()
+
+	status, body, err := c.sendJSON(ctx, http.MethodPost,
+		fmt.Sprintf("/v1/internal/gateways/%s/route-sync-ack", gatewayID), payload)
+	if err != nil {
+		return spanFail(span, fmt.Errorf("route-sync-ack request: %w", err), "route-sync-ack request failed")
+	}
+	span.SetAttributes(attribute.Int("http.status_code", status))
+
+	if status != http.StatusOK && status != http.StatusNoContent {
+		return spanFail(span, fmt.Errorf("route-sync-ack failed (%d): %s", status, string(body)), "route-sync-ack rejected")
+	}
+	span.SetStatus(codes.Ok, "route-sync-ack sent")
+	return nil
+}

--- a/stoa-go/internal/connect/transport_sse.go
+++ b/stoa-go/internal/connect/transport_sse.go
@@ -1,0 +1,162 @@
+package connect
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// rawEvent is an un-interpreted SSE event pulled off the wire.
+// Dispatch to business handlers (sync-deployment, heartbeat, ...) happens
+// in the caller — sseStream only parses the wire format.
+type rawEvent struct {
+	Type string
+	Data []byte
+}
+
+// Default scanner buffer caps used by sseStream. Exposed as package-level
+// constants so tests can reason about the max-message threshold.
+const (
+	// sseScannerInitialBuf is the initial token buffer size; matches the
+	// bufio default so small events are zero-realloc.
+	sseScannerInitialBuf = 64 << 10 // 64 KB
+	// sseScannerMaxBuf is the hard cap for a single SSE event payload.
+	// Chosen to accommodate large OpenAPI specs inlined in desired_state.
+	// Default bufio.MaxScanTokenSize (64 KB) was insufficient — see
+	// REWRITE-BUGS.md F.6.
+	sseScannerMaxBuf = 1 << 20 // 1 MB
+)
+
+// sseStream is the Control Plane SSE transport.
+//
+// Pure transport: it connects to /v1/internal/gateways/{id}/events, parses
+// the wire format, and pipes rawEvents into a caller-supplied sink until the
+// stream ends. No dependencies on adapters, sync, or Agent state — the outer
+// loop (StartDeploymentStream / loops.runSSEStream in S9) owns reconnect,
+// dispatch, and business logic.
+//
+// Unlike cpClient's http.Client which has a 15s timeout, the SSE client has
+// NO timeout — the stream stays open indefinitely under normal operation.
+// Both clients share the same otelhttp-wrapped RoundTripper for consistent
+// W3C traceparent propagation.
+type sseStream struct {
+	client  *http.Client
+	tracer  trace.Tracer // may be nil before SetTracer
+	baseURL string
+	apiKey  string
+}
+
+// newSSEStream wires the shared transport into a no-timeout http.Client for
+// the long-lived SSE connection.
+func newSSEStream(baseURL, apiKey string, transport http.RoundTripper) *sseStream {
+	return &sseStream{
+		client:  &http.Client{Transport: transport},
+		baseURL: baseURL,
+		apiKey:  apiKey,
+	}
+}
+
+// SetTracer installs the OpenTelemetry tracer used for the stream span.
+func (s *sseStream) SetTracer(t trace.Tracer) {
+	s.tracer = t
+}
+
+func (s *sseStream) startSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	if s.tracer == nil {
+		return ctx, trace.SpanFromContext(ctx)
+	}
+	return s.tracer.Start(ctx, name,
+		trace.WithAttributes(attrs...),
+		trace.WithSpanKind(trace.SpanKindClient),
+	)
+}
+
+// Run connects to the gateway's SSE events endpoint and invokes sink for
+// each rawEvent parsed off the wire. It returns the terminal cause: an HTTP
+// error, an unexpected status, a scanner error (including bufio.ErrTooLong
+// if a single event payload exceeds sseScannerMaxBuf), a sink error, or
+// io.EOF if the server closed the stream cleanly.
+//
+// The context passed to sink is derived from the stream span, so handler
+// spans nest correctly under "stoa-connect.sse.stream".
+//
+// Run is a blocking, single-connection call. Callers implement reconnect
+// outside (see runSSEStream in S9).
+func (s *sseStream) Run(ctx context.Context, gatewayID string, sink func(context.Context, rawEvent) error) error {
+	ctx, span := s.startSpan(ctx, "stoa-connect.sse.stream",
+		attribute.String("stoa.gateway_id", gatewayID),
+	)
+	defer span.End()
+
+	url := fmt.Sprintf("%s/v1/internal/gateways/%s/events", s.baseURL, gatewayID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return spanFail(span, fmt.Errorf("create SSE request: %w", err), "create request failed")
+	}
+	req.Header.Set("X-Gateway-Key", s.apiKey)
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return spanFail(span, fmt.Errorf("SSE connect: %w", err), "SSE connect failed")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return spanFail(span, fmt.Errorf("SSE endpoint returned %d", resp.StatusCode), "SSE rejected")
+	}
+	log.Printf("sse-stream: connected to %s", url)
+	span.SetStatus(codes.Ok, "connected")
+
+	scanner := bufio.NewScanner(resp.Body)
+	// Default token buffer is bufio.MaxScanTokenSize (64 KB). Events carrying
+	// large desired_state JSON (OpenAPI spec inlined) would hit bufio.ErrTooLong
+	// and the loop would exit silently without propagating the reason. We
+	// allocate the same 64 KB initial but raise max to 1 MB and rely on
+	// scanner.Err() below to surface ErrTooLong if ever hit.
+	scanner.Buffer(make([]byte, 0, sseScannerInitialBuf), sseScannerMaxBuf)
+
+	var eventType string
+	var dataLines []string
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if line == "" {
+			// Empty line terminates an event.
+			if eventType != "" && len(dataLines) > 0 {
+				data := strings.Join(dataLines, "\n")
+				if err := sink(ctx, rawEvent{Type: eventType, Data: []byte(data)}); err != nil {
+					return spanFail(span, fmt.Errorf("sink: %w", err), "sink returned error")
+				}
+			}
+			eventType = ""
+			dataLines = nil
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(line, "event:"):
+			eventType = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+		// Ignore "id:", "retry:", and comment lines starting with ":".
+	}
+
+	if err := scanner.Err(); err != nil {
+		return spanFail(span, fmt.Errorf("SSE read: %w", err), "scanner error")
+	}
+
+	// Scanner exited without error → server closed the stream cleanly.
+	// Caller treats io.EOF as a signal to reconnect via backoff policy.
+	return io.EOF
+}

--- a/stoa-go/internal/connect/transport_sse_test.go
+++ b/stoa-go/internal/connect/transport_sse_test.go
@@ -1,0 +1,140 @@
+package connect
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// sseTestServer builds an httptest.Server that emits a single sync-deployment
+// event with `data:` payload of the given size, then closes the stream.
+func sseTestServer(t *testing.T, dataSize int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		// Build a large data line. desired_state carries an inline JSON object
+		// approximated here by a string of `x` chars large enough to exceed
+		// bufio default 64KB.
+		payload := strings.Repeat("x", dataSize)
+		_, _ = fmt.Fprintf(w, "event: sync-deployment\ndata: %s\n\n", payload)
+		flusher.Flush()
+	}))
+}
+
+// TestSSEStreamAcceptsLargeEvent is the regression guard for REWRITE-BUGS.md F.6.
+// Default bufio.Scanner buffer (64 KB) would silently drop events whose `data:`
+// line exceeds that size; the fix raises max to sseScannerMaxBuf (1 MB) and
+// relies on scanner.Err() propagation to surface bufio.ErrTooLong if ever hit.
+func TestSSEStreamAcceptsLargeEvent(t *testing.T) {
+	// 500 KB — well past the old 64 KB limit, comfortably under the new 1 MB cap.
+	const size = 500 << 10
+	srv := sseTestServer(t, size)
+	defer srv.Close()
+
+	stream := newSSEStream(srv.URL, "test-key", http.DefaultTransport)
+	var receivedSize atomic.Int64
+	sink := func(ctx context.Context, ev rawEvent) error {
+		if ev.Type == "sync-deployment" {
+			receivedSize.Store(int64(len(ev.Data)))
+		}
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	err := stream.Run(ctx, "gw-big", sink)
+
+	// Stream ends when server closes connection — expect io.EOF, NOT ErrTooLong.
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("expected io.EOF, got %v", err)
+	}
+	if errors.Is(err, bufio.ErrTooLong) {
+		t.Errorf("scanner should not trigger ErrTooLong for %d-byte event", size)
+	}
+	if got := receivedSize.Load(); got != int64(size) {
+		t.Errorf("sink received %d bytes, expected %d (silent truncation? F.6 regression)", got, size)
+	}
+}
+
+// TestSSEStreamReportsScannerErrorOnOversizedEvent asserts that an event
+// payload exceeding sseScannerMaxBuf surfaces bufio.ErrTooLong visibly
+// rather than ending the stream silently.
+func TestSSEStreamReportsScannerErrorOnOversizedEvent(t *testing.T) {
+	// 2 MB — past the 1 MB cap.
+	const size = 2 << 20
+	srv := sseTestServer(t, size)
+	defer srv.Close()
+
+	stream := newSSEStream(srv.URL, "test-key", http.DefaultTransport)
+	sink := func(ctx context.Context, ev rawEvent) error {
+		t.Errorf("sink should not receive an oversized event, got %d bytes", len(ev.Data))
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	err := stream.Run(ctx, "gw-huge", sink)
+
+	if err == nil {
+		t.Fatal("expected non-nil error on oversized event")
+	}
+	if !errors.Is(err, bufio.ErrTooLong) {
+		t.Errorf("expected bufio.ErrTooLong wrapped in err chain, got %v", err)
+	}
+}
+
+// TestSSEStreamPropagatesHTTPStatus asserts a non-200 status from the SSE
+// endpoint surfaces as a concrete error (caller decides whether to retry).
+func TestSSEStreamPropagatesHTTPStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	stream := newSSEStream(srv.URL, "bad-key", http.DefaultTransport)
+	err := stream.Run(context.Background(), "gw-401", func(ctx context.Context, ev rawEvent) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected non-nil error on 401")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected error to mention status 401, got %v", err)
+	}
+}
+
+// TestSSEStreamSinkErrorAborts asserts a sink error stops the stream loop
+// and is surfaced to the caller.
+func TestSSEStreamSinkErrorAborts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		_, _ = fmt.Fprintf(w, "event: sync-deployment\ndata: {\"x\":1}\n\n")
+		flusher.Flush()
+		// Keep conn open so scanner waits — sink error should bail out.
+		time.Sleep(2 * time.Second)
+	}))
+	defer srv.Close()
+
+	sinkErr := errors.New("sink failure")
+	stream := newSSEStream(srv.URL, "key", http.DefaultTransport)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	err := stream.Run(ctx, "gw-sink-err", func(ctx context.Context, ev rawEvent) error {
+		return sinkErr
+	})
+	if !errors.Is(err, sinkErr) {
+		t.Errorf("expected sink error surfaced, got %v", err)
+	}
+}

--- a/stoa-go/internal/connect/types.go
+++ b/stoa-go/internal/connect/types.go
@@ -1,0 +1,132 @@
+package connect
+
+import "encoding/json"
+
+// Wire DTOs for the CP Registration Protocol (ADR-057) and SSE deployment
+// stream (ADR-059). Struct tags are the source of truth — do not rename a
+// `json:"..."` tag without coordinating the corresponding change on the CP
+// side (control-plane-api).
+
+// --- Registration (POST /v1/internal/gateways/register) ---
+
+// RegistrationPayload is the payload sent to the register endpoint.
+type RegistrationPayload struct {
+	Hostname         string   `json:"hostname"`
+	Mode             string   `json:"mode"`
+	Version          string   `json:"version"`
+	Environment      string   `json:"environment"`
+	Capabilities     []string `json:"capabilities"`
+	AdminURL         string   `json:"admin_url"`
+	TargetGatewayURL string   `json:"target_gateway_url,omitempty"`
+	PublicURL        string   `json:"public_url,omitempty"`
+	UIURL            string   `json:"ui_url,omitempty"`
+}
+
+// RegistrationResponse is the response returned by the register endpoint.
+type RegistrationResponse struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Environment string `json:"environment"`
+	Status      string `json:"status"`
+}
+
+// --- Heartbeat (POST /v1/internal/gateways/{id}/heartbeat) ---
+
+// HeartbeatPayload is the payload sent to the heartbeat endpoint.
+// PoliciesCount is currently always zero (see REWRITE-BUGS.md F.8).
+type HeartbeatPayload struct {
+	UptimeSeconds  int `json:"uptime_seconds"`
+	RoutesCount    int `json:"routes_count"`
+	PoliciesCount  int `json:"policies_count"`
+	DiscoveredAPIs int `json:"discovered_apis"`
+}
+
+// --- Discovery (POST /v1/internal/gateways/{id}/discovery) ---
+
+// DiscoveryPayload is the payload sent to the discovery endpoint.
+type DiscoveryPayload struct {
+	APIs []DiscoveredAPIPayload `json:"apis"`
+}
+
+// DiscoveredAPIPayload represents a single discovered API for the CP.
+type DiscoveredAPIPayload struct {
+	Name       string   `json:"name"`
+	Version    string   `json:"version,omitempty"`
+	BackendURL string   `json:"backend_url,omitempty"`
+	Paths      []string `json:"paths,omitempty"`
+	Methods    []string `json:"methods,omitempty"`
+	Policies   []string `json:"policies,omitempty"`
+	IsActive   bool     `json:"is_active"`
+}
+
+// --- Gateway config fetch (GET /v1/internal/gateways/{id}/config) ---
+
+// GatewayConfigResponse is the response from the config endpoint.
+// PendingDeployments is currently unused by the agent (see REWRITE-BUGS.md F.9).
+type GatewayConfigResponse struct {
+	GatewayID          string          `json:"gateway_id"`
+	Name               string          `json:"name"`
+	Environment        string          `json:"environment"`
+	TenantID           string          `json:"tenant_id"`
+	PendingDeployments []interface{}   `json:"pending_deployments"`
+	PendingPolicies    []PendingPolicy `json:"pending_policies"`
+}
+
+// PendingPolicy represents a policy returned by the CP config endpoint.
+type PendingPolicy struct {
+	ID         string                 `json:"id"`
+	Name       string                 `json:"name"`
+	PolicyType string                 `json:"policy_type"`
+	Config     map[string]interface{} `json:"config"`
+	Priority   int                    `json:"priority"`
+	Enabled    bool                   `json:"enabled"`
+}
+
+// --- Policy sync ack (POST /v1/internal/gateways/{id}/sync-ack) ---
+
+// SyncAckPayload is the payload sent to the policy sync-ack endpoint.
+type SyncAckPayload struct {
+	SyncedPolicies []SyncedPolicyResult `json:"synced_policies"`
+	SyncTimestamp  string               `json:"sync_timestamp"`
+}
+
+// SyncedPolicyResult reports the sync result for one policy.
+type SyncedPolicyResult struct {
+	PolicyID string `json:"policy_id"`
+	Status   string `json:"status"` // "applied", "removed", "failed"
+	Error    string `json:"error,omitempty"`
+}
+
+// --- Route sync ack (POST /v1/internal/gateways/{id}/route-sync-ack) ---
+
+// RouteSyncAckPayload is the payload sent to the route-sync-ack endpoint.
+type RouteSyncAckPayload struct {
+	SyncedRoutes  []SyncedRouteResult `json:"synced_routes"`
+	SyncTimestamp string              `json:"sync_timestamp"`
+}
+
+// SyncedRouteResult reports the sync result for one route deployment.
+type SyncedRouteResult struct {
+	DeploymentID string     `json:"deployment_id"`
+	Status       string     `json:"status"` // "applied", "failed"
+	Error        string     `json:"error,omitempty"`
+	Steps        []SyncStep `json:"steps,omitempty"`
+	Generation   int        `json:"generation,omitempty"` // CAB-1950: generation that was synced
+}
+
+// --- SSE deployment stream (GET /v1/internal/gateways/{id}/events) ---
+
+// SSEEvent is the on-the-wire form of a Server-Sent Event produced by the CP.
+type SSEEvent struct {
+	Event string          `json:"event"`
+	Data  json.RawMessage `json:"data"`
+}
+
+// DeploymentEvent is the data payload for a "sync-deployment" SSE event.
+type DeploymentEvent struct {
+	DeploymentID      string          `json:"deployment_id"`
+	APICatalogID      string          `json:"api_catalog_id"`
+	GatewayInstanceID string          `json:"gateway_instance_id"`
+	SyncStatus        string          `json:"sync_status"`
+	DesiredState      json.RawMessage `json:"desired_state"`
+}


### PR DESCRIPTION
## Summary

- split `stoa-go/internal/connect` into focused transport, state, dispatcher, sync, and loop files while keeping the caller-facing package intact
- unify the route-sync path used by polling and SSE, and document the latent bugs the GO-2 rewrite surfaced
- add targeted regression coverage for state races, SSE buffering, route sync generation propagation, and policy sync behavior

## Type of Change

- [x] Refactoring (no functional changes)
- [x] Tests (adding or updating tests)
- [x] Documentation update

## Breaking Changes

- [x] No breaking changes

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

## Validation

- `go vet ./...`
- `go build ./cmd/...`
- `go test -v -race -coverprofile=coverage.out ./...`
- Smoke 1: register + heartbeat + SIGTERM clean stop against a mock CP using the real `bin/stoa-connect`
- Smoke 2: 404 heartbeat loop re-registers after exactly 3 consecutive 404s, repeatedly, using the real `bin/stoa-connect`

## Remaining Manual Gates

- `stoa-go/TEST-PLAN.md` E1/E2/E3/E6 still need a real local Tilt or CP validation before merge sign-off
- `E5` stays optional per the plan because GO-2 did not touch the Vault sync path
