### PR TITLE
fix(stoa-go): GO-1 P1 — externalDocs walk + jwt/ipFilter mapping

### DIFF
--- a/stoa-go/internal/connect/adapters/webmethods_policy.go
+++ b/stoa-go/internal/connect/adapters/webmethods_policy.go
@@ -20,6 +20,19 @@ var wmPolicyTypeMapping = map[string]string{
 }
 
 // mapPolicyConfig converts STOA-format config to webMethods-specific parameters.
+//
+// The jwtPolicy and ipFilterPolicy cases were added to close GO-1 H.4
+// (BUG-REPORT-GO-1.md) — previously they fell through to the default
+// passthrough, sending STOA's raw config to webMethods which rejected with
+// 400 "invalid policy params" (direct impact on CAB-2079 Auth/RBAC for the
+// BDF demo).
+//
+// WM-10.15-HYPOTHESIS: the exact webMethods 10.15 parameter names below
+// (jwtIssuer / jwtAudience / jwksURL / requiredClaims for jwtPolicy;
+// ipFilterMode / ipList for ipFilterPolicy) are a best-effort mapping drawn
+// from webMethods doc patterns but not confirmed against a live 10.15
+// instance. MUST VALIDATE in staging before BDF demo — see ticket CAB-2161.
+// If field names differ, update the cases below and remove this comment.
 func mapPolicyConfig(wmType string, config map[string]interface{}) map[string]interface{} {
 	switch wmType {
 	case "corsPolicy":
@@ -41,9 +54,41 @@ func mapPolicyConfig(wmType string, config map[string]interface{}) map[string]in
 			"logRequestPayload":  getOrDefault(config, "logRequest", true),
 			"logResponsePayload": getOrDefault(config, "logResponse", true),
 		}
+	case "jwtPolicy":
+		// WM-10.15-HYPOTHESIS (CAB-2161) — validate in staging.
+		return map[string]interface{}{
+			"jwtIssuer":      getOrDefault(config, "issuer", ""),
+			"jwtAudience":    getOrDefault(config, "audience", ""),
+			"jwksURL":        getOrDefault(config, "jwks_url", ""),
+			"requiredClaims": getOrDefault(config, "required_claims", map[string]interface{}{}),
+		}
+	case "ipFilterPolicy":
+		// WM-10.15-HYPOTHESIS (CAB-2161) — validate in staging.
+		// mode uppercased to match the broader fixSecuritySchemeTypes
+		// convention (webMethods enum values are uppercase).
+		mode, _ := getOrDefault(config, "mode", "allow").(string)
+		return map[string]interface{}{
+			"ipFilterMode": upperASCII(mode),
+			"ipList":       getOrDefault(config, "ip_list", []interface{}{}),
+		}
 	default:
 		return config
 	}
+}
+
+// upperASCII uppercases an ASCII string without pulling in strings.ToUpper,
+// which would also touch non-ASCII code points. The enum values we care
+// about (allow/deny) are ASCII-only.
+func upperASCII(s string) string {
+	out := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out[i] = c
+	}
+	return string(out)
 }
 
 func getOrDefault(config map[string]interface{}, key string, defaultVal interface{}) interface{} {

--- a/stoa-go/internal/connect/adapters/webmethods_policy_jwt_ipfilter_test.go
+++ b/stoa-go/internal/connect/adapters/webmethods_policy_jwt_ipfilter_test.go
@@ -1,0 +1,217 @@
+// regression for CAB-1944 (GO-1 audit H.4, tracked in CAB-2161): jwtPolicy
+// and ipFilterPolicy STOA → webMethods parameter mapping. Pre-fix, both
+// types fell through to the default passthrough, sending raw STOA config
+// to webMethods which rejected with 400. Field names below are committed
+// under WM-10.15-HYPOTHESIS and must be validated in staging before the
+// BDF demo — ticket CAB-2161.
+package adapters
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestMapPolicyConfig_JwtPolicy — STOA-shaped jwt config is mapped to the
+// webMethods-expected field names (jwtIssuer, jwtAudience, jwksURL,
+// requiredClaims).
+func TestMapPolicyConfig_JwtPolicy(t *testing.T) {
+	result := mapPolicyConfig("jwtPolicy", map[string]interface{}{
+		"issuer":          "https://keycloak.gostoa.dev/realms/oasis",
+		"audience":        "stoa-portal",
+		"jwks_url":        "https://keycloak.gostoa.dev/realms/oasis/protocol/openid-connect/certs",
+		"required_claims": map[string]interface{}{"sub": "required"},
+	})
+
+	if result["jwtIssuer"] != "https://keycloak.gostoa.dev/realms/oasis" {
+		t.Errorf("jwtIssuer: got %v", result["jwtIssuer"])
+	}
+	if result["jwtAudience"] != "stoa-portal" {
+		t.Errorf("jwtAudience: got %v", result["jwtAudience"])
+	}
+	if result["jwksURL"] != "https://keycloak.gostoa.dev/realms/oasis/protocol/openid-connect/certs" {
+		t.Errorf("jwksURL: got %v", result["jwksURL"])
+	}
+	claims, ok := result["requiredClaims"].(map[string]interface{})
+	if !ok || claims["sub"] != "required" {
+		t.Errorf("requiredClaims: got %v", result["requiredClaims"])
+	}
+}
+
+// TestMapPolicyConfig_JwtPolicyDefaults — missing STOA fields fall back to
+// safe defaults (empty strings / empty map) rather than nil, so the
+// webMethods payload always has every field present.
+func TestMapPolicyConfig_JwtPolicyDefaults(t *testing.T) {
+	result := mapPolicyConfig("jwtPolicy", map[string]interface{}{})
+	for _, key := range []string{"jwtIssuer", "jwtAudience", "jwksURL"} {
+		if result[key] != "" {
+			t.Errorf("%s should default to empty string, got %v", key, result[key])
+		}
+	}
+	if _, ok := result["requiredClaims"].(map[string]interface{}); !ok {
+		t.Errorf("requiredClaims default should be map, got %T", result["requiredClaims"])
+	}
+}
+
+// TestMapPolicyConfig_IpFilterPolicy — mode is uppercased, ip_list is
+// renamed to ipList.
+func TestMapPolicyConfig_IpFilterPolicy(t *testing.T) {
+	result := mapPolicyConfig("ipFilterPolicy", map[string]interface{}{
+		"mode":    "allow",
+		"ip_list": []interface{}{"10.0.0.0/8", "192.168.1.1"},
+	})
+
+	if result["ipFilterMode"] != "ALLOW" {
+		t.Errorf("ipFilterMode: got %v, want ALLOW", result["ipFilterMode"])
+	}
+	list, ok := result["ipList"].([]interface{})
+	if !ok || len(list) != 2 {
+		t.Fatalf("ipList: got %v", result["ipList"])
+	}
+	if list[0] != "10.0.0.0/8" || list[1] != "192.168.1.1" {
+		t.Errorf("ipList contents: got %v", list)
+	}
+}
+
+// TestMapPolicyConfig_IpFilterPolicy_DenyMode — deny mode also uppercases.
+func TestMapPolicyConfig_IpFilterPolicy_DenyMode(t *testing.T) {
+	result := mapPolicyConfig("ipFilterPolicy", map[string]interface{}{
+		"mode":    "deny",
+		"ip_list": []interface{}{"1.2.3.4"},
+	})
+	if result["ipFilterMode"] != "DENY" {
+		t.Errorf("ipFilterMode: got %v, want DENY", result["ipFilterMode"])
+	}
+}
+
+// TestMapPolicyConfig_UnknownTypePassthrough — baseline: types that are
+// neither in the mapping nor in the switch fall through unchanged. Proves
+// the jwt/ipFilter cases didn't break the fallback contract used by
+// custom gateway-specific policies.
+func TestMapPolicyConfig_UnknownTypePassthrough(t *testing.T) {
+	in := map[string]interface{}{"custom": "value", "n": 42}
+	result := mapPolicyConfig("someCustomType", in)
+	if result["custom"] != "value" || result["n"] != 42 {
+		t.Errorf("passthrough broken: %v", result)
+	}
+}
+
+// TestApplyPolicy_JwtEndToEnd — full path: ApplyPolicy(type=jwt) resolves
+// the API, discovers no existing policy (POST path), and sends a payload
+// whose `type` is the mapped wM name and whose `parameters` are the mapped
+// field names. Proves the H.4 wiring reaches the HTTP layer as expected.
+func TestApplyPolicy_JwtEndToEnd(t *testing.T) {
+	var receivedPayload map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/rest/apigateway/apis" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"apiResponse": []map[string]interface{}{
+					{"id": "api-secured", "apiName": "Petstore", "apiVersion": "1.0", "isActive": true},
+				},
+			})
+		case r.URL.Path == "/rest/apigateway/apis/api-secured/policyActions" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"policyActions": []interface{}{}})
+		case r.URL.Path == "/rest/apigateway/policyActions" && r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &receivedPayload)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"policyAction": map[string]interface{}{"id": "pa-jwt-1"}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	adapter := NewWebMethodsAdapter(AdapterConfig{Username: "admin", Password: "manage"})
+	err := adapter.ApplyPolicy(context.Background(), server.URL, "Petstore", PolicyAction{
+		Type: "jwt",
+		Config: map[string]interface{}{
+			"issuer":   "https://kc/realms/oasis",
+			"audience": "stoa-portal",
+			"jwks_url": "https://kc/realms/oasis/certs",
+		},
+	})
+	if err != nil {
+		t.Fatalf("apply policy error: %v", err)
+	}
+
+	pa, ok := receivedPayload["policyAction"].(map[string]interface{})
+	if !ok {
+		t.Fatal("missing policyAction in payload")
+	}
+	if pa["type"] != "jwtPolicy" {
+		t.Errorf("expected type jwtPolicy, got %v", pa["type"])
+	}
+	params, ok := pa["parameters"].(map[string]interface{})
+	if !ok {
+		t.Fatal("missing parameters")
+	}
+	if params["jwtIssuer"] != "https://kc/realms/oasis" {
+		t.Errorf("jwtIssuer not mapped: %v", params["jwtIssuer"])
+	}
+	if params["jwtAudience"] != "stoa-portal" {
+		t.Errorf("jwtAudience not mapped: %v", params["jwtAudience"])
+	}
+	if params["jwksURL"] != "https://kc/realms/oasis/certs" {
+		t.Errorf("jwksURL not mapped: %v", params["jwksURL"])
+	}
+}
+
+// TestApplyPolicy_IpFilterEndToEnd — same end-to-end proof for ipFilter:
+// type is ipFilterPolicy, parameters are ipFilterMode + ipList.
+func TestApplyPolicy_IpFilterEndToEnd(t *testing.T) {
+	var receivedPayload map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/rest/apigateway/apis" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"apiResponse": []map[string]interface{}{
+					{"id": "api-iplock", "apiName": "Internal", "apiVersion": "1.0", "isActive": true},
+				},
+			})
+		case r.URL.Path == "/rest/apigateway/apis/api-iplock/policyActions" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"policyActions": []interface{}{}})
+		case r.URL.Path == "/rest/apigateway/policyActions" && r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &receivedPayload)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"policyAction": map[string]interface{}{"id": "pa-ipf-1"}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	adapter := NewWebMethodsAdapter(AdapterConfig{})
+	err := adapter.ApplyPolicy(context.Background(), server.URL, "Internal", PolicyAction{
+		Type: "ip_filter",
+		Config: map[string]interface{}{
+			"mode":    "allow",
+			"ip_list": []interface{}{"10.0.0.0/8"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("apply policy error: %v", err)
+	}
+
+	pa := receivedPayload["policyAction"].(map[string]interface{})
+	if pa["type"] != "ipFilterPolicy" {
+		t.Errorf("expected type ipFilterPolicy, got %v", pa["type"])
+	}
+	params := pa["parameters"].(map[string]interface{})
+	if params["ipFilterMode"] != "ALLOW" {
+		t.Errorf("ipFilterMode: got %v", params["ipFilterMode"])
+	}
+	list, ok := params["ipList"].([]interface{})
+	if !ok || len(list) != 1 || list[0] != "10.0.0.0/8" {
+		t.Errorf("ipList: got %v", params["ipList"])
+	}
+}

--- a/stoa-go/internal/connect/adapters/webmethods_spec.go
+++ b/stoa-go/internal/connect/adapters/webmethods_spec.go
@@ -28,36 +28,69 @@ func downgradeOpenAPI31(spec []byte) []byte {
 	return openAPI31Re.ReplaceAll(spec, []byte(`"openapi": "3.0.3"`))
 }
 
-// fixExternalDocs wraps externalDocs object into an array if needed.
-// webMethods expects externalDocs as an array, but OpenAPI/Swagger specs
-// define it as a single object. This causes deserialization errors on PUT.
+// wrapExternalDocs recursively walks any JSON value and wraps every
+// externalDocs single-object occurrence into a single-element array.
+// Returns true if any wrap was performed.
+//
+// The recursion enters each map value and each array item, so nested
+// occurrences at arbitrary depth (tags[], paths[].<operation>,
+// components.schemas.<name>, Schema.properties.<field>, Schema.items,
+// Schema.{allOf|oneOf|anyOf}[*], even inside vendor extensions) are all
+// reached in one pass. Values that are already arrays, primitives, or null
+// are left untouched.
+func wrapExternalDocs(v interface{}) bool {
+	modified := false
+	switch val := v.(type) {
+	case map[string]interface{}:
+		if ed, ok := val["externalDocs"]; ok {
+			if obj, isObj := ed.(map[string]interface{}); isObj {
+				val["externalDocs"] = []interface{}{obj}
+				modified = true
+			}
+		}
+		for _, child := range val {
+			if wrapExternalDocs(child) {
+				modified = true
+			}
+		}
+	case []interface{}:
+		for _, item := range val {
+			if wrapExternalDocs(item) {
+				modified = true
+			}
+		}
+	}
+	return modified
+}
+
+// fixExternalDocs walks the full OpenAPI document and wraps every
+// externalDocs single-object occurrence into a single-element array.
+// webMethods expects externalDocs as an array at every level (root, tags[*],
+// paths[*].<operation>, components.schemas.<name>, nested Schemas via
+// allOf/oneOf/anyOf/items/properties.*/additionalProperties). OpenAPI and
+// Swagger specs default to a single object, which webMethods rejects with a
+// deserialization error on PUT.
+//
+// Closes GO-1 H.2 (BUG-REPORT-GO-1.md) — the previous implementation only
+// handled the root-level occurrence, letting FastAPI / Swaggerhub specs that
+// put externalDocs in tags[] or operations bubble up 500s on PUT.
+//
+// Malformed input (invalid JSON) is returned unchanged — defensive fallback.
+// If the walk produced no modification, the original bytes are returned to
+// preserve key ordering.
 func fixExternalDocs(spec []byte) []byte {
-	var parsed map[string]interface{}
+	var parsed interface{}
 	if err := json.Unmarshal(spec, &parsed); err != nil {
 		return spec
 	}
-
-	ed, ok := parsed["externalDocs"]
-	if !ok {
+	if !wrapExternalDocs(parsed) {
 		return spec
 	}
-
-	// If it's already an array, no fix needed
-	if _, isArray := ed.([]interface{}); isArray {
+	fixed, err := json.Marshal(parsed)
+	if err != nil {
 		return spec
 	}
-
-	// If it's an object, wrap in array
-	if obj, isObj := ed.(map[string]interface{}); isObj {
-		parsed["externalDocs"] = []interface{}{obj}
-		fixed, err := json.Marshal(parsed)
-		if err != nil {
-			return spec
-		}
-		return fixed
-	}
-
-	return spec
+	return fixed
 }
 
 // fixSecuritySchemeTypes uppercases securityScheme enum values.

--- a/stoa-go/internal/connect/adapters/webmethods_spec_external_docs_test.go
+++ b/stoa-go/internal/connect/adapters/webmethods_spec_external_docs_test.go
@@ -1,0 +1,182 @@
+// regression for CAB-1944 (GO-1 audit H.2 + H.1): fixExternalDocs must walk
+// the full OpenAPI tree (tags, operations, components.schemas and nested
+// schemas), not just the root. Also covers removal of the dead-code call
+// in webmethods_sync.go — the wrapper payload never carried externalDocs
+// at top level, so the previous post-marshal application was a no-op.
+package adapters
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// unmarshalTo is a tiny helper: decode bytes to map[string]interface{} or
+// fail the test. Keeps assertions terse below.
+func unmarshalTo(t *testing.T, data []byte) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v; payload=%s", err, string(data))
+	}
+	return m
+}
+
+// isArrayOfOneObject returns true if v is a []interface{} containing exactly
+// one map[string]interface{}.
+func isArrayOfOneObject(v interface{}) bool {
+	arr, ok := v.([]interface{})
+	if !ok || len(arr) != 1 {
+		return false
+	}
+	_, ok = arr[0].(map[string]interface{})
+	return ok
+}
+
+// ---------------------------------------------------------------------------
+// TestWebMethodsFixExternalDocs_TopLevel — baseline, preserves pre-GO-1
+// behaviour for specs whose only externalDocs lives at the root.
+// ---------------------------------------------------------------------------
+func TestWebMethodsFixExternalDocs_TopLevel(t *testing.T) {
+	in := []byte(`{"openapi":"3.0.3","info":{"title":"t","version":"1"},"externalDocs":{"url":"https://a","description":"A"}}`)
+	out := fixExternalDocs(in)
+	m := unmarshalTo(t, out)
+	if !isArrayOfOneObject(m["externalDocs"]) {
+		t.Errorf("root externalDocs not wrapped: %v", m["externalDocs"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestWebMethodsFixExternalDocs_InTags — per-tag externalDocs must wrap;
+// tags that don't have externalDocs must be untouched.
+// ---------------------------------------------------------------------------
+func TestWebMethodsFixExternalDocs_InTags(t *testing.T) {
+	in := []byte(`{"openapi":"3.0.3","info":{"title":"t","version":"1"},"tags":[{"name":"pets","externalDocs":{"url":"https://pets"}},{"name":"users"}],"paths":{}}`)
+	out := fixExternalDocs(in)
+	m := unmarshalTo(t, out)
+
+	tags, ok := m["tags"].([]interface{})
+	if !ok || len(tags) != 2 {
+		t.Fatalf("expected 2 tags, got %v", m["tags"])
+	}
+	tag0 := tags[0].(map[string]interface{})
+	if !isArrayOfOneObject(tag0["externalDocs"]) {
+		t.Errorf("tag[0].externalDocs not wrapped: %v", tag0["externalDocs"])
+	}
+	tag1 := tags[1].(map[string]interface{})
+	if _, has := tag1["externalDocs"]; has {
+		t.Errorf("tag[1] should have no externalDocs, got %v", tag1)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestWebMethodsFixExternalDocs_InOperations — Operation Object externalDocs
+// (paths[*].<method>.externalDocs) must wrap.
+// ---------------------------------------------------------------------------
+func TestWebMethodsFixExternalDocs_InOperations(t *testing.T) {
+	in := []byte(`{"openapi":"3.0.3","info":{"title":"t","version":"1"},"paths":{"/p":{"get":{"operationId":"g","externalDocs":{"url":"https://op"},"responses":{}}}}}`)
+	out := fixExternalDocs(in)
+	m := unmarshalTo(t, out)
+
+	op := m["paths"].(map[string]interface{})["/p"].(map[string]interface{})["get"].(map[string]interface{})
+	if !isArrayOfOneObject(op["externalDocs"]) {
+		t.Errorf("operation externalDocs not wrapped: %v", op["externalDocs"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestWebMethodsFixExternalDocs_InComponents — nested Schema externalDocs
+// (components.schemas.Pet.externalDocs and deep-nested
+// components.schemas.Pet.properties.owner.externalDocs) must both wrap.
+// ---------------------------------------------------------------------------
+func TestWebMethodsFixExternalDocs_InComponents(t *testing.T) {
+	in := []byte(`{"openapi":"3.0.3","info":{"title":"t","version":"1"},"paths":{},"components":{"schemas":{"Pet":{"type":"object","externalDocs":{"url":"https://pet-doc"},"properties":{"owner":{"type":"object","externalDocs":{"url":"https://owner-doc"}}}}}}}`)
+	out := fixExternalDocs(in)
+	m := unmarshalTo(t, out)
+
+	pet := m["components"].(map[string]interface{})["schemas"].(map[string]interface{})["Pet"].(map[string]interface{})
+	if !isArrayOfOneObject(pet["externalDocs"]) {
+		t.Errorf("Pet.externalDocs not wrapped: %v", pet["externalDocs"])
+	}
+	owner := pet["properties"].(map[string]interface{})["owner"].(map[string]interface{})
+	if !isArrayOfOneObject(owner["externalDocs"]) {
+		t.Errorf("Pet.properties.owner.externalDocs not wrapped: %v", owner["externalDocs"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestWebMethodsFixExternalDocs_DeepNesting — combination: root + tags +
+// operation + components.schemas. A single call wraps all sites.
+// ---------------------------------------------------------------------------
+func TestWebMethodsFixExternalDocs_DeepNesting(t *testing.T) {
+	in := []byte(`{
+		"openapi":"3.0.3",
+		"info":{"title":"t","version":"1"},
+		"externalDocs":{"url":"https://root"},
+		"tags":[{"name":"pets","externalDocs":{"url":"https://pets"}}],
+		"paths":{"/p":{"get":{"externalDocs":{"url":"https://op"},"responses":{}}}},
+		"components":{"schemas":{"Pet":{"type":"object","externalDocs":{"url":"https://pet-doc"}}}}
+	}`)
+	out := fixExternalDocs(in)
+	m := unmarshalTo(t, out)
+
+	if !isArrayOfOneObject(m["externalDocs"]) {
+		t.Errorf("root externalDocs not wrapped: %v", m["externalDocs"])
+	}
+	tag0 := m["tags"].([]interface{})[0].(map[string]interface{})
+	if !isArrayOfOneObject(tag0["externalDocs"]) {
+		t.Errorf("tag[0].externalDocs not wrapped: %v", tag0["externalDocs"])
+	}
+	op := m["paths"].(map[string]interface{})["/p"].(map[string]interface{})["get"].(map[string]interface{})
+	if !isArrayOfOneObject(op["externalDocs"]) {
+		t.Errorf("operation externalDocs not wrapped: %v", op["externalDocs"])
+	}
+	pet := m["components"].(map[string]interface{})["schemas"].(map[string]interface{})["Pet"].(map[string]interface{})
+	if !isArrayOfOneObject(pet["externalDocs"]) {
+		t.Errorf("Pet.externalDocs not wrapped: %v", pet["externalDocs"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestWebMethodsFixExternalDocs_NoExternalDocs — spec without any
+// externalDocs is returned byte-for-byte unchanged (no Unmarshal-Marshal
+// round-trip cost, no key-order reshuffle).
+// ---------------------------------------------------------------------------
+func TestWebMethodsFixExternalDocs_NoExternalDocs(t *testing.T) {
+	in := []byte(`{"openapi":"3.0.3","info":{"title":"t","version":"1"},"paths":{"/p":{"get":{"responses":{}}}}}`)
+	out := fixExternalDocs(in)
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("expected identical bytes when no externalDocs present\nin : %s\nout: %s", string(in), string(out))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestWebMethodsFixExternalDocs_AlreadyArray — an externalDocs that is
+// already a single-element array must NOT be double-wrapped.
+// ---------------------------------------------------------------------------
+func TestWebMethodsFixExternalDocs_AlreadyArray(t *testing.T) {
+	in := []byte(`{"openapi":"3.0.3","info":{"title":"t","version":"1"},"externalDocs":[{"url":"https://already"}]}`)
+	out := fixExternalDocs(in)
+	m := unmarshalTo(t, out)
+
+	arr, ok := m["externalDocs"].([]interface{})
+	if !ok || len(arr) != 1 {
+		t.Fatalf("expected 1-element array, got %v", m["externalDocs"])
+	}
+	// The element is the original object, not another array.
+	if _, isArr := arr[0].([]interface{}); isArr {
+		t.Errorf("double-wrap detected: externalDocs[0] is an array, want object")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestWebMethodsFixExternalDocs_InvalidJSON — malformed input is returned
+// byte-for-byte unchanged (defensive fallback, identical to pre-GO-1 intent).
+// ---------------------------------------------------------------------------
+func TestWebMethodsFixExternalDocs_InvalidJSON(t *testing.T) {
+	in := []byte(`{"openapi":"3.0.3"`) // truncated
+	out := fixExternalDocs(in)
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("expected identical bytes on parse error\nin : %s\nout: %s", string(in), string(out))
+	}
+}

--- a/stoa-go/internal/connect/adapters/webmethods_sync.go
+++ b/stoa-go/internal/connect/adapters/webmethods_sync.go
@@ -186,7 +186,12 @@ func (w *WebMethodsAdapter) SyncRoutes(ctx context.Context, adminURL string, rou
 			)
 			continue
 		}
-		data = fixExternalDocs(data)
+		// H.1 (GO-1): fixExternalDocs was previously applied here to `data`
+		// too, but this call was dead code — the wrapper payload has no
+		// top-level externalDocs (the spec is nested inside apiDefinition
+		// as json.RawMessage, so the Unmarshal-to-map walk never entered
+		// it). The walk at line 170 on the raw spec is the sole effective
+		// site.
 
 		// Initial method + URL selection.
 		var method, apiURL string


### PR DESCRIPTION
## Summary

Closes **H.1, H.2, H.4** from `BUG-REPORT-GO-1.md`. Two commits, independently reviewable:

- **Commit 1** (`29e3938dc`) — **H.2 externalDocs recursive walk + H.1 dead code removal**. `fixExternalDocs` now wraps every `externalDocs` single-object occurrence at any depth (tags, operations, components.schemas, nested schemas) in one map-based recursive pass. Previously only the root was handled, so FastAPI / Swaggerhub specs with `externalDocs` in `tags[]` or `paths[].<op>` crashed webMethods with 500 on PUT. Also drops the dead post-marshal call in `webmethods_sync.go` (no-op — the wrapper payload has no top-level `externalDocs` since the spec is nested inside `apiDefinition` as `json.RawMessage`).

- **Commit 2** (`81845854f`) — **H.4 jwtPolicy + ipFilterPolicy mapping**. `mapPolicyConfig` now translates STOA's `jwt` and `ip_filter` policy types to the webMethods 10.15 parameter schema (`jwtIssuer` / `jwtAudience` / `jwksURL` / `requiredClaims`, and `ipFilterMode` / `ipList`). Pre-fix these types fell through to raw passthrough and wM rejected with 400 — direct blocker for CAB-2079 (Auth/RBAC BDF demo). Committed under `WM-10.15-HYPOTHESIS` marker tracked in **CAB-2161** for staging validation.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./... -race -count=1` — green (23 packages, no FAIL)
- [x] `go build ./cmd/stoa-connect ./cmd/stoactl` — clean
- [x] 15 new regression guards pass under `-race` (8 for externalDocs walk, 7 for jwt/ipFilter mapping)
- [ ] CI full sweep on GitHub Actions
- [ ] Staging validation against wM 10.15 — owned by CAB-2161, non-blocking for this PR

## Risk

- **H.4 field names are a hypothesis** until CAB-2161 validates. Post-fix behaviour is **strictly better** than pre-fix (silent 400 → documented attempt), so worst case = same failure surface. Marker is embedded in `webmethods_policy.go` so the next contributor sees the caveat.
- **H.2 walk is pragmatic**: matches every `externalDocs: {...}` key recursively, including inside vendor extensions (`x-*.externalDocs`). Semantically bénin for webMethods (it doesn't interpret `x-*`), and makes the transform more general than OpenAPI standard. Documented in the godoc.
- **No ABI / interface changes**. No call-site updates needed beyond `webmethods_sync.go:189` (the dead line removal).

## P2 follow-up

`fix/go-1-p2-batch` will branch from `main` after this merges and ship H.3 + H.5 + M.2 + M.3 + M.4 + L.1 + L.2 in a single commit. Plan: `stoa-go/FIX-PLAN-GO1-P1-P2.md` (shipped in the P0 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)