### PR TITLE
fix(stoa-go): GO-1 P2 — defensive hardening + cleanup (7 bugs)

### DIFF
--- a/stoa-go/internal/connect/adapters/gravitee.go
+++ b/stoa-go/internal/connect/adapters/gravitee.go
@@ -25,6 +25,11 @@ func NewGraviteeAdapter(cfg AdapterConfig) *GraviteeAdapter {
 }
 
 // Detect checks if the admin URL hosts a Gravitee Management API.
+//
+// GO-1 M.3: network errors are now propagated instead of silently
+// returning (false, nil). See webmethods_adapter.go Detect for the
+// rationale — autoDetect already logs err and continues to the next
+// gateway candidate.
 func (g *GraviteeAdapter) Detect(ctx context.Context, adminURL string) (bool, error) {
 	url := adminURL + "/management/v2/organizations/DEFAULT"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -35,7 +40,7 @@ func (g *GraviteeAdapter) Detect(ctx context.Context, adminURL string) (bool, er
 
 	resp, err := g.client.Do(req)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/stoa-go/internal/connect/adapters/kong.go
+++ b/stoa-go/internal/connect/adapters/kong.go
@@ -27,6 +27,10 @@ func NewKongAdapter(cfg AdapterConfig) *KongAdapter {
 
 // Detect checks if the admin URL hosts a Kong gateway.
 // Kong's root endpoint returns {"tagline":"Welcome to kong"}.
+//
+// GO-1 M.3: network errors are now propagated instead of silently
+// returning (false, nil). See webmethods_adapter.go Detect for the
+// rationale — autoDetect treats err as "skip to next gateway" already.
 func (k *KongAdapter) Detect(ctx context.Context, adminURL string) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, adminURL+"/", nil)
 	if err != nil {
@@ -36,7 +40,7 @@ func (k *KongAdapter) Detect(ctx context.Context, adminURL string) (bool, error)
 
 	resp, err := k.client.Do(req)
 	if err != nil {
-		return false, nil // Not reachable = not Kong
+		return false, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/stoa-go/internal/connect/adapters/kong_test.go
+++ b/stoa-go/internal/connect/adapters/kong_test.go
@@ -49,11 +49,17 @@ func TestKongDetectNotKong(t *testing.T) {
 	}
 }
 
+// TestKongDetectUnreachable — GO-1 M.3 behaviour flip: Detect now propagates
+// network errors (pre-M.3 it silently returned `(false, nil)` on unreachable
+// hosts, which was indistinguishable from "host up but not Kong"). The
+// autoDetect caller in connect/discovery.go already handles the error by
+// logging and trying the next gateway, so the contract for auto-detection
+// is unchanged — only the observability improved.
 func TestKongDetectUnreachable(t *testing.T) {
 	adapter := NewKongAdapter(AdapterConfig{})
 	ok, err := adapter.Detect(context.Background(), "http://127.0.0.1:1")
-	if err != nil {
-		t.Fatalf("detect should not error on unreachable, got: %v", err)
+	if err == nil {
+		t.Fatal("expected network error to be propagated after GO-1 M.3")
 	}
 	if ok {
 		t.Error("expected false for unreachable host")

--- a/stoa-go/internal/connect/adapters/webmethods_adapter.go
+++ b/stoa-go/internal/connect/adapters/webmethods_adapter.go
@@ -31,6 +31,13 @@ func NewWebMethodsAdapter(cfg AdapterConfig) *WebMethodsAdapter {
 }
 
 // Detect checks if the admin URL hosts a webMethods API Gateway.
+//
+// GO-1 M.3: network errors are now propagated to the caller instead of
+// silently returning (false, nil). autoDetect (internal/connect/discovery.go)
+// already logs and skips to the next adapter when err is non-nil, so the
+// auto-detection contract stays "try next gateway on unreachable" — but
+// now the error is visible in logs instead of indistinguishable from
+// "reachable but not webMethods".
 func (w *WebMethodsAdapter) Detect(ctx context.Context, adminURL string) (bool, error) {
 	url := adminURL + "/rest/apigateway/health"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -41,7 +48,7 @@ func (w *WebMethodsAdapter) Detect(ctx context.Context, adminURL string) (bool, 
 
 	resp, err := w.client.Do(req)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/stoa-go/internal/connect/adapters/webmethods_p2_cleanup_test.go
+++ b/stoa-go/internal/connect/adapters/webmethods_p2_cleanup_test.go
@@ -1,0 +1,199 @@
+// regression for CAB-1944 (GO-1 audit P2 cleanup, BUG-REPORT-GO-1.md):
+// defensive hardening and hygiene across webMethods adapter + cross-adapter
+// Detect error propagation. Covers H.3, H.5, M.2, M.3, M.4, L.1, L.2.
+package adapters
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// H.5 — json.Valid check after transforms (fail-closed on corruption)
+// ---------------------------------------------------------------------------
+
+// TestValidateSpecAfterTransform_InvalidJSON — if a transform's Marshal
+// somehow produces invalid JSON (unreachable in practice with
+// map[string]interface{}, but defended against), safeMarshal must return
+// the original spec unchanged. This guards against future refactors that
+// swap the data model or add a custom MarshalJSON that could misbehave.
+func TestValidateSpecAfterTransform_InvalidJSON(t *testing.T) {
+	orig := []byte(`{"hello":"world"}`)
+	// Inject a custom type whose MarshalJSON returns invalid bytes.
+	bad := badJSON{}
+	out := safeMarshal(orig, bad)
+	if string(out) != string(orig) {
+		t.Errorf("safeMarshal must fall back to original on invalid JSON, got %q", string(out))
+	}
+}
+
+type badJSON struct{}
+
+func (badJSON) MarshalJSON() ([]byte, error) { return []byte("not-json"), nil }
+
+// ---------------------------------------------------------------------------
+// M.2 — fixSecuritySchemeTypes uppercases `scheme` for http schemes
+// ---------------------------------------------------------------------------
+
+// TestFixSecuritySchemeTypes_HTTPScheme — pre-M.2 only `type` and `in` were
+// uppercased. For `{"type":"http","scheme":"bearer"}` the output was
+// `{"type":"HTTP","scheme":"bearer"}` and webMethods partially rejected.
+// Now the `scheme` field also transitions to uppercase.
+func TestFixSecuritySchemeTypes_HTTPScheme(t *testing.T) {
+	in := []byte(`{"components":{"securitySchemes":{"bearerAuth":{"type":"http","scheme":"bearer"}}}}`)
+	out := fixSecuritySchemeTypes(in)
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	bearer := m["components"].(map[string]interface{})["securitySchemes"].(map[string]interface{})["bearerAuth"].(map[string]interface{})
+	if bearer["type"] != "HTTP" {
+		t.Errorf("type: got %v, want HTTP", bearer["type"])
+	}
+	if bearer["scheme"] != "BEARER" {
+		t.Errorf("scheme: got %v, want BEARER (M.2 fix)", bearer["scheme"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// M.3 — Detect propagates network errors (3 adapters)
+// ---------------------------------------------------------------------------
+
+// TestDetect_NetworkErrorPropagated_WebMethods — wM Detect returns the
+// underlying HTTP error instead of masking it as (false, nil).
+func TestDetect_NetworkErrorPropagated_WebMethods(t *testing.T) {
+	adapter := NewWebMethodsAdapter(AdapterConfig{})
+	ok, err := adapter.Detect(context.Background(), "http://127.0.0.1:1")
+	if err == nil {
+		t.Fatal("expected network error")
+	}
+	if ok {
+		t.Error("expected false on unreachable host")
+	}
+}
+
+// TestDetect_NetworkErrorPropagated_Gravitee — Gravitee Detect mirrors the
+// wM fix. Kong is covered in kong_test.go TestKongDetectUnreachable.
+func TestDetect_NetworkErrorPropagated_Gravitee(t *testing.T) {
+	adapter := NewGraviteeAdapter(AdapterConfig{})
+	ok, err := adapter.Detect(context.Background(), "http://127.0.0.1:1")
+	if err == nil {
+		t.Fatal("expected network error")
+	}
+	if ok {
+		t.Error("expected false on unreachable host")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// M.4 — parseEpochMillis rejects partial parses
+// ---------------------------------------------------------------------------
+
+// TestParseEpochMillis_RejectsPartial — pre-M.4 fmt.Sscanf accepted "123abc"
+// as 123 with nil error, which silently truncated corrupted timestamps.
+// strconv.ParseInt rejects any non-decimal suffix.
+func TestParseEpochMillis_RejectsPartial(t *testing.T) {
+	if _, err := parseEpochMillis("123abc"); err == nil {
+		t.Error("expected error on partial parse, got nil (M.4 not applied?)")
+	}
+	if got, err := parseEpochMillis("1700000000000"); err != nil || got != 1700000000000 {
+		t.Errorf("clean parse: got (%d, %v), want (1700000000000, nil)", got, err)
+	}
+	if _, err := parseEpochMillis(""); err == nil {
+		t.Error("expected error on empty input")
+	}
+	if _, err := parseEpochMillis("abc"); err == nil {
+		t.Error("expected error on non-numeric input")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// L.1 — sanitizeWMName collision warn log
+// ---------------------------------------------------------------------------
+
+// TestSyncRoutes_SanitizeCollisionLogged — two route names that collapse
+// to the same wM apiName after sanitizeWMName produce a warn log line.
+// The sync itself is not blocked — the L.1 scope is "make observable", not
+// "harden with errors".
+func TestSyncRoutes_SanitizeCollisionLogged(t *testing.T) {
+	// Capture log output.
+	var buf strings.Builder
+	origOutput := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(origOutput)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/rest/apigateway/apis" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"apiResponse": []interface{}{}})
+		case r.URL.Path == "/rest/apigateway/apis" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": "ok"})
+		case r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": "ok", "apiName": "stoa-foo-bar", "isActive": true})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	adapter := NewWebMethodsAdapter(AdapterConfig{})
+	// Both names sanitize to "stoa-foo-bar".
+	_, _ = adapter.SyncRoutes(context.Background(), server.URL, []Route{
+		{Name: "foo/bar", Activated: true},
+		{Name: "foo bar", Activated: true},
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, "collision") {
+		t.Errorf("expected collision warn log, got: %s", out)
+	}
+	if !strings.Contains(out, "stoa-foo-bar") {
+		t.Errorf("expected collision log to mention collapsed name, got: %s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// L.2 — openAPI31 detection via JSON parse, not regex
+// ---------------------------------------------------------------------------
+
+// TestDowngradeOpenAPI31_ViaJSONParse_NoFalseMatch — a spec whose root
+// `openapi` field is 3.0 but whose description contains a literal string
+// like `"openapi": "3.1.0"` (in a metadata example) must NOT be downgraded.
+// The pre-L.2 regex matched anywhere in the byte stream.
+func TestDowngradeOpenAPI31_ViaJSONParse_NoFalseMatch(t *testing.T) {
+	// description contains the 3.1.0 pattern as a literal substring.
+	in := []byte(`{"openapi":"3.0.0","info":{"title":"t","version":"1","description":"References the openapi 3.1.0 spec for X"}}`)
+	out := downgradeOpenAPI31(in)
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m["openapi"] != "3.0.0" {
+		t.Errorf("openapi: got %v, want 3.0.0 (L.2 false-match bug)", m["openapi"])
+	}
+}
+
+// TestDowngradeOpenAPI31_ViaJSONParse_ActualMatch — baseline: a real 3.1.x
+// top-level version IS downgraded.
+func TestDowngradeOpenAPI31_ViaJSONParse_ActualMatch(t *testing.T) {
+	in := []byte(`{"openapi":"3.1.0","info":{"title":"t","version":"1"}}`)
+	out := downgradeOpenAPI31(in)
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m["openapi"] != "3.0.3" {
+		t.Errorf("openapi: got %v, want 3.0.3", m["openapi"])
+	}
+}
+

--- a/stoa-go/internal/connect/adapters/webmethods_spec.go
+++ b/stoa-go/internal/connect/adapters/webmethods_spec.go
@@ -7,9 +7,6 @@ import (
 	"strings"
 )
 
-// openAPI31Re matches OpenAPI 3.1.x version strings.
-var openAPI31Re = regexp.MustCompile(`"openapi"\s*:\s*"3\.1\.\d+"`)
-
 // wmNameRe captures characters that webMethods rejects in apiName.
 // webMethods only accepts alphanumeric, hyphens, underscores, and dots.
 var wmNameRe = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
@@ -19,13 +16,40 @@ func sanitizeWMName(name string) string {
 	return wmNameRe.ReplaceAllString(name, "-")
 }
 
+// safeMarshal re-encodes parsed JSON and returns the bytes only when they
+// round-trip to valid JSON. Any failure (marshal error, invalid bytes) falls
+// back to the original spec. Closes GO-1 H.5 — previously each transform
+// silently returned its own Marshal output even if malformed, leaving a
+// potentially corrupt payload to be sent to webMethods as-is.
+func safeMarshal(orig []byte, parsed interface{}) []byte {
+	fixed, err := json.Marshal(parsed)
+	if err != nil {
+		return orig
+	}
+	if !json.Valid(fixed) {
+		return orig
+	}
+	return fixed
+}
+
 // downgradeOpenAPI31 rewrites an OpenAPI 3.1.x spec to 3.0.3.
 // webMethods only accepts OpenAPI 3.0.x.
+//
+// Closes GO-1 L.2 — the previous implementation used a regexp scan on the
+// raw bytes, which could false-match any string value that happened to
+// contain `"openapi": "3.1.x"` (example metadata, docs strings). Now the
+// version is read from the decoded `openapi` top-level field only.
 func downgradeOpenAPI31(spec []byte) []byte {
-	if !openAPI31Re.Match(spec) {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(spec, &parsed); err != nil {
 		return spec
 	}
-	return openAPI31Re.ReplaceAll(spec, []byte(`"openapi": "3.0.3"`))
+	v, ok := parsed["openapi"].(string)
+	if !ok || !strings.HasPrefix(v, "3.1.") {
+		return spec
+	}
+	parsed["openapi"] = "3.0.3"
+	return safeMarshal(spec, parsed)
 }
 
 // wrapExternalDocs recursively walks any JSON value and wraps every
@@ -86,16 +110,17 @@ func fixExternalDocs(spec []byte) []byte {
 	if !wrapExternalDocs(parsed) {
 		return spec
 	}
-	fixed, err := json.Marshal(parsed)
-	if err != nil {
-		return spec
-	}
-	return fixed
+	return safeMarshal(spec, parsed)
 }
 
 // fixSecuritySchemeTypes uppercases securityScheme enum values.
-// webMethods expects OAUTH2/HTTP/APIKEY/OPENIDCONNECT and HEADER/QUERY/COOKIE,
-// but OpenAPI specs use lowercase: oauth2, http, apiKey, header, query.
+// webMethods expects OAUTH2/HTTP/APIKEY/OPENIDCONNECT, HEADER/QUERY/COOKIE,
+// and BASIC/BEARER/DIGEST for http schemes — OpenAPI specs use lowercase
+// (oauth2, http, apiKey, header, query, bearer, basic).
+//
+// GO-1 M.2: the `scheme` field (for type=http) is now uppercased too. Without
+// it, `{"type":"http","scheme":"bearer"}` became `{"type":"HTTP","scheme":"bearer"}`
+// which webMethods partially rejects.
 func fixSecuritySchemeTypes(spec []byte) []byte {
 	var parsed map[string]interface{}
 	if err := json.Unmarshal(spec, &parsed); err != nil {
@@ -117,7 +142,8 @@ func fixSecuritySchemeTypes(spec []byte) []byte {
 		if !ok {
 			continue
 		}
-		for _, field := range []string{"type", "in"} {
+		// "scheme" added in GO-1 M.2 (http bearerFormat / basic).
+		for _, field := range []string{"type", "in", "scheme"} {
 			if val, ok := scheme[field].(string); ok {
 				upper := strings.ToUpper(val)
 				if upper != val {
@@ -132,21 +158,27 @@ func fixSecuritySchemeTypes(spec []byte) []byte {
 	if !modified {
 		return spec
 	}
-
-	fixed, err := json.Marshal(parsed)
-	if err != nil {
-		return spec
-	}
-	return fixed
+	return safeMarshal(spec, parsed)
 }
 
-// stripSwagger2ResponseRefs removes $ref from response schemas in Swagger 2.0 specs.
-// webMethods 10.15 RefProperty parser crashes on $ref inside response schema objects
-// (e.g. {"schema":{"$ref":"#/definitions/Pet"}}). We strip the schema entirely since
-// webMethods doesn't use response schemas for routing — it only needs paths + methods.
-func stripSwagger2ResponseRefs(spec []byte) []byte {
-	if !bytes.Contains(spec, []byte(`"swagger"`)) {
-		return spec // Not Swagger 2.0
+// stripResponseSchemas removes schema bodies from response objects in both
+// Swagger 2.0 and OpenAPI 3.x specs. webMethods 10.15 RefProperty parser
+// crashes on $ref inside response schema objects (and on other complex
+// schema constructs). Response schemas aren't needed for gateway routing,
+// so we delete them wholesale.
+//
+// Covered sites:
+//   - Swagger 2.0: paths[*].<method>.responses.<code>.schema
+//   - OpenAPI 3.x: paths[*].<method>.responses.<code>.content.<mime>.schema
+//
+// Closes GO-1 H.3 — the pre-fix function (stripSwagger2ResponseRefs) only
+// covered the 2.0 shape, so a 3.x spec with $ref in response content still
+// crashed webMethods with the same pattern. Renamed to reflect the wider
+// scope.
+func stripResponseSchemas(spec []byte) []byte {
+	// Cheap gate: skip if neither openapi nor swagger marker is present.
+	if !bytes.Contains(spec, []byte(`"openapi"`)) && !bytes.Contains(spec, []byte(`"swagger"`)) {
+		return spec
 	}
 
 	var parsed map[string]interface{}
@@ -179,15 +211,26 @@ func stripSwagger2ResponseRefs(spec []byte) []byte {
 				if !ok {
 					continue
 				}
-				// Strip ALL response schemas — webMethods RefProperty parser
-				// crashes on $ref, additionalProperties, and other complex
-				// schema constructs during PUT. Response schemas aren't needed
-				// for gateway routing.
+				// Swagger 2.0 shape.
 				if _, hasSchema := r["schema"]; hasSchema {
 					delete(r, "schema")
-					responses[code] = r
 					modified = true
 				}
+				// OpenAPI 3.x shape.
+				if content, ok := r["content"].(map[string]interface{}); ok {
+					for mime, mediaType := range content {
+						mt, ok := mediaType.(map[string]interface{})
+						if !ok {
+							continue
+						}
+						if _, hasSchema := mt["schema"]; hasSchema {
+							delete(mt, "schema")
+							content[mime] = mt
+							modified = true
+						}
+					}
+				}
+				responses[code] = r
 			}
 		}
 	}
@@ -195,10 +238,5 @@ func stripSwagger2ResponseRefs(spec []byte) []byte {
 	if !modified {
 		return spec
 	}
-
-	fixed, err := json.Marshal(parsed)
-	if err != nil {
-		return spec
-	}
-	return fixed
+	return safeMarshal(spec, parsed)
 }

--- a/stoa-go/internal/connect/adapters/webmethods_spec_test.go
+++ b/stoa-go/internal/connect/adapters/webmethods_spec_test.go
@@ -2,35 +2,39 @@ package adapters
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 )
 
 func TestWebMethodsOpenAPI31Downgrade(t *testing.T) {
-	spec31 := []byte(`{"openapi": "3.1.0", "info": {"title": "Test"}}`)
-	result := downgradeOpenAPI31(spec31)
-	expected := `{"openapi": "3.0.3", "info": {"title": "Test"}}`
-	if string(result) != expected {
-		t.Errorf("expected %s, got %s", expected, string(result))
+	// GO-1 L.2: downgradeOpenAPI31 now parses JSON instead of regex-matching,
+	// so the output key ordering and whitespace may differ from the input.
+	// Assert on the parsed value of the `openapi` field only.
+	check := func(t *testing.T, in []byte, wantVersion string) {
+		t.Helper()
+		out := downgradeOpenAPI31(in)
+		var m map[string]interface{}
+		if err := json.Unmarshal(out, &m); err != nil {
+			t.Fatalf("parse: %v; out=%s", err, string(out))
+		}
+		if got := m["openapi"]; got != wantVersion {
+			t.Errorf("openapi: got %v, want %q", got, wantVersion)
+		}
 	}
 
-	spec311 := []byte(`{"openapi": "3.1.1", "info": {"title": "Test"}}`)
-	result311 := downgradeOpenAPI31(spec311)
-	if !strings.Contains(string(result311), `"3.0.3"`) {
-		t.Errorf("expected 3.0.3, got %s", string(result311))
-	}
-
-	spec30 := []byte(`{"openapi": "3.0.2", "info": {"title": "Test"}}`)
-	result30 := downgradeOpenAPI31(spec30)
-	if string(result30) != string(spec30) {
-		t.Errorf("expected 3.0.2 unchanged, got %s", string(result30))
-	}
+	check(t, []byte(`{"openapi": "3.1.0", "info": {"title": "Test"}}`), "3.0.3")
+	check(t, []byte(`{"openapi": "3.1.1", "info": {"title": "Test"}}`), "3.0.3")
+	check(t, []byte(`{"openapi": "3.0.2", "info": {"title": "Test"}}`), "3.0.2")
+	check(t, []byte(`{"openapi": "2.0", "info": {"title": "Test"}}`), "2.0")
 }
 
-// TestRegressionStripSwagger2ResponseRefs — CAB-1944: webMethods RefProperty crash on $ref in response schemas.
-func TestRegressionStripSwagger2ResponseRefs(t *testing.T) {
+// TestRegressionStripResponseSchemasSwagger2 — CAB-1944 regression guard:
+// webMethods RefProperty parser crashes on $ref in Swagger 2.0 response
+// schemas. Renamed from TestRegressionStripSwagger2ResponseRefs in GO-1
+// H.3 (BUG-REPORT-GO-1.md) to reflect the broader scope now that the
+// function also handles OpenAPI 3.x responses.
+func TestRegressionStripResponseSchemasSwagger2(t *testing.T) {
 	spec := []byte(`{"swagger":"2.0","paths":{"/pet/findByStatus":{"get":{"responses":{"200":{"description":"ok","schema":{"type":"array","items":{"$ref":"#/definitions/Pet"}}}}}}}}`)
-	result := stripSwagger2ResponseRefs(spec)
+	result := stripResponseSchemas(spec)
 
 	var parsed map[string]interface{}
 	if err := json.Unmarshal(result, &parsed); err != nil {
@@ -41,15 +45,33 @@ func TestRegressionStripSwagger2ResponseRefs(t *testing.T) {
 	get := paths["/pet/findByStatus"].(map[string]interface{})["get"].(map[string]interface{})
 	resp200 := get["responses"].(map[string]interface{})["200"].(map[string]interface{})
 	if _, hasSchema := resp200["schema"]; hasSchema {
-		t.Error("schema with $ref should have been stripped")
+		t.Error("Swagger 2.0 response schema should have been stripped")
 	}
 }
 
-func TestRegressionStripSwagger2ResponseRefsNoOpOpenAPI3(t *testing.T) {
-	// No-op for OpenAPI 3.x specs
+// TestRegressionStripResponseSchemasOpenAPI3 — CAB-1944 / GO-1 H.3: the
+// function now strips OpenAPI 3.x content schemas too. Pre-H.3 this was
+// asserted as a no-op (function covered only Swagger 2.0), but webMethods
+// 10.15 RefProperty crashes on $ref in 3.x response content schemas the
+// same way.
+func TestRegressionStripResponseSchemasOpenAPI3(t *testing.T) {
 	spec := []byte(`{"openapi":"3.0.0","paths":{"/pet":{"get":{"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/Pet"}}}}}}}}}`)
-	result := stripSwagger2ResponseRefs(spec)
-	if string(result) != string(spec) {
-		t.Error("should not modify OpenAPI 3.x specs")
+	result := stripResponseSchemas(spec)
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	paths := parsed["paths"].(map[string]interface{})
+	get := paths["/pet"].(map[string]interface{})["get"].(map[string]interface{})
+	resp200 := get["responses"].(map[string]interface{})["200"].(map[string]interface{})
+	content, ok := resp200["content"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("content missing: %v", resp200)
+	}
+	mt := content["application/json"].(map[string]interface{})
+	if _, hasSchema := mt["schema"]; hasSchema {
+		t.Error("OpenAPI 3.x response content schema should have been stripped")
 	}
 }

--- a/stoa-go/internal/connect/adapters/webmethods_sync.go
+++ b/stoa-go/internal/connect/adapters/webmethods_sync.go
@@ -142,8 +142,22 @@ func (w *WebMethodsAdapter) SyncRoutes(ctx context.Context, adminURL string, rou
 
 	var syncErrors []string
 
+	// L.1 (GO-1): sanitizeWMName can collapse two distinct route names
+	// (e.g. "foo/bar" and "foo bar") to the same webMethods apiName.
+	// Silent collision means the second route's PUT overwrites the first's
+	// definition on the gateway with no error surface. Log a warning when
+	// a collision is detected so operators can investigate. Non-blocking:
+	// the existing overwrite semantics are preserved (scope of P2 cleanup
+	// is "make observable", not "harden with new errors").
+	nameCollisions := make(map[string]string)
+
 	for _, route := range routes {
 		wmName := sanitizeWMName("stoa-" + route.Name)
+		if prev, collision := nameCollisions[wmName]; collision && prev != route.Name {
+			log.Printf("warn: webmethods sanitizeWMName collision — routes %q and %q both map to %q; later PUT will overwrite earlier",
+				prev, route.Name, wmName)
+		}
+		nameCollisions[wmName] = route.Name
 
 		// Deactivated route: deactivate on gateway if it exists.
 		// C.5: deactivate failure is tracked, not returned — the batch continues.
@@ -173,7 +187,7 @@ func (w *WebMethodsAdapter) SyncRoutes(ctx context.Context, adminURL string, rou
 			spec = downgradeOpenAPI31(spec)
 			spec = fixExternalDocs(spec)
 			spec = fixSecuritySchemeTypes(spec)
-			spec = stripSwagger2ResponseRefs(spec)
+			spec = stripResponseSchemas(spec)
 		}
 
 		apiPayload := buildSyncPayload(route, wmName, spec)

--- a/stoa-go/internal/connect/adapters/webmethods_telemetry.go
+++ b/stoa-go/internal/connect/adapters/webmethods_telemetry.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -40,10 +41,13 @@ func NormalizeEvent(raw wmTransactionalEvent) TelemetryEvent {
 }
 
 // parseEpochMillis parses a string epoch timestamp in milliseconds.
+//
+// GO-1 M.4: switched from fmt.Sscanf (which accepts partial parses — e.g.
+// "123abc" returned 123, nil) to strconv.ParseInt, which rejects any
+// non-decimal suffix. Prevents silently truncated timestamps from ending
+// up horodated at epoch 0 in downstream dashboards.
 func parseEpochMillis(s string) (int64, error) {
-	var ms int64
-	_, err := fmt.Sscanf(s, "%d", &ms)
-	return ms, err
+	return strconv.ParseInt(s, 10, 64)
 }
 
 // SubscribeTelemetry creates a push subscription on webMethods to receive transactional events.


### PR DESCRIPTION
## Summary

Closes **H.3, H.5, M.2, M.3, M.4, L.1, L.2** from `BUG-REPORT-GO-1.md` in a single atomic commit. All independent cleanup with no cross-dependencies; bundling them keeps the review self-contained.

**Final batch of the GO-1 series.** After merge, the audit is closed with 14 bugs shipped (6 Critical in P0, 3 High in P1, 7 mixed H/M/L here) and 1 Medium deliberately deferred (M.1 round-trip key ordering — requires a walk refactor, not a bug fix).

## What's in this PR

- **H.5** `safeMarshal` helper validates every transform's output via `json.Valid` — fail-closed fallback to the original spec if a transform ever produces corrupt bytes.
- **H.3** `stripSwagger2ResponseRefs` → `stripResponseSchemas`. Covers both Swagger 2.0 (`response.schema`) and OpenAPI 3.x (`response.content.<mime>.schema`). Same RefProperty-crash pattern afflicts 3.x specs, previously untreated.
- **M.2** `fixSecuritySchemeTypes` now uppercases the `scheme` field for HTTP schemes (`bearer` → `BEARER`).
- **M.3** `Detect()` propagates network errors in all three adapters (wM, **Kong, Gravitee** — same bug pattern, fixed uniformly). `autoDetect` caller already handled errors correctly, so auto-detection contract is unchanged — only observability improved.
- **M.4** `parseEpochMillis` uses `strconv.ParseInt` instead of `fmt.Sscanf` (rejects partial parses like `"123abc"`).
- **L.1** `sanitizeWMName` collisions are now logged as warnings (non-blocking, existing overwrite semantics preserved).
- **L.2** `downgradeOpenAPI31` reads the parsed `openapi` field instead of regex-matching raw bytes (no false positives on description strings).

## Cross-adapter impact (verified)

The Phase 1 pre-commit check confirmed `Detect` had the identical `return false, nil` swallow-on-error pattern in Kong (`kong.go:37`) and Gravitee (`gravitee.go:37`) on top of webMethods. `autoDetect` (`discovery.go:80-88`) already does `if err != nil { log.Printf(...); continue }` — so propagating the error from all three adapters is a pure uplift with zero behavioural regression at the caller.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./... -race -count=1` — green (23 packages, no FAIL)
- [x] `go build ./cmd/stoa-connect ./cmd/stoactl` — clean
- [x] 11 new regression guards pass under `-race` (8 new in `webmethods_p2_cleanup_test.go` + 2 updated in `webmethods_spec_test.go` for the H.3 rename + 1 updated in `kong_test.go` for M.3 semantic flip)
- [ ] CI full sweep on GitHub Actions

## Risk

- **Interface-level behaviour change on `Detect`**: existing tests updated to reflect new contract. `TestKongDetectUnreachable` now asserts error is returned (was "nil on unreachable"). No external (cross-repo) caller depends on the silent behaviour; `autoDetect` is the only consumer.
- **H.3 rename** `stripSwagger2ResponseRefs` → `stripResponseSchemas`: one caller in `webmethods_sync.go`, updated. No external consumer.
- **L.1 collision warn**: pure log addition, no behaviour change. If `sanitizeWMName` collisions were already happening in prod unnoticed, they'll now surface — that's the point.
- **M.4 `strconv.ParseInt`**: a small tightening — rejects malformed timestamps that previously truncated to valid-looking ints. Downstream (telemetry pipeline) already has error handling, so failures now surface explicitly.

## End-of-GO-1 recap

After this merges, the GO-1 audit is fully closed:

| Batch | PR | Bugs | Status |
|---|---|---|---|
| P0 | #2492 | C.1-C.6 (6 Critical) | Merged `afaef4bf9` |
| P1 | #2494 | H.1, H.2, H.4 (3 High) | Merged `d9f90895b` |
| P2 | this | H.3, H.5, M.2-M.4, L.1-L.2 (7) | ← |
| M.1 | deferred | round-trip refactor | Out of bug-fix scope |

Plus **CAB-2161** for wM 10.15 staging validation on the H.4 mapping hypothesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)