### PR TITLE
fix(cp-api): close CP-1 P0 batch on git provider rewrite

### DIFF
--- a/control-plane-api/BUG-REPORT-CP-1.md
+++ b/control-plane-api/BUG-REPORT-CP-1.md
@@ -1,0 +1,450 @@
+# BUG-REPORT-CP-1
+
+> **Document status**: audit artifact produced post-rewrite of CP-1
+> (GitProvider abstraction, CAB-1889). **Revision 2** (2026-04-23 pm) —
+> incorporates editorial feedback on provider-library defaults (PyGithub
+> throttle/retry/timeout par défaut, python-gitlab `obey_rate_limit` +
+> `max_retries=10` par défaut). Lifetime: reviewable until the P0/P1/P2
+> batches ship, then archive in `stoa-docs/audits/2026-04-23-cp-1/`.
+> Owner: @PotoMitan.
+
+> **P0 batch status (2026-04-23)** — all six P0 findings fixed on
+> branch `fix/cp-1-p0-batch`:
+>
+> | Bug | Commit | Fix |
+> |---|---|---|
+> | C.1 | `96bee87f9` | services/git_executor.py + GitLab/GitHub migration |
+> | C.2 | `b957768d6` | GIT_ASKPASS helper + logging filter |
+> | C.4 | `96bee87f9` | GITLAB_SEMAPHORE now uniform via run_sync |
+> | C.5 | `96bee87f9` | GitHub semaphores read=10 / contents-write=1 / meta=5 |
+> | C.6 | `96bee87f9` | write_file create-first + GitLab last_commit_id |
+> | C.7 | `672267d63` | gitlab_webhook: verify token before DB write |
+>
+> Plus `b0ab0620b` (connect closure hardening) and `eb5984259` (lint
+> cleanup). Regression guards: 29 new tests across
+> `test_regression_cp1_sync_in_async.py`,
+> `test_regression_cp1_token_leak.py`,
+> `test_regression_cp1_webhook_auth_first.py`.
+
+**Module**: CP-1 — GitProvider abstraction in `control-plane-api`
+**Path**: `control-plane-api/src/services/git_provider.py`, `git_service.py`, `github_service.py`, `src/routers/git.py`, `src/routers/webhooks.py`, `src/services/iam_sync_service.py`, `src/services/deployment_orchestration_service.py`, `src/workers/git_sync_worker.py`
+**Scope**: ~3 200 LOC across 8 files
+**Method**: categorised walkthrough A–G (concurrency / error-handling / contract drift / business logic / perf / observability / security), cross-checking the rewrite artefact `REWRITE-BUGS.md` (6 known bugs, 1 closed, 5 pending)
+**Date**: 2026-04-23 (Rev 2)
+**Prior art**: 6 bugs dans `REWRITE-BUGS.md`. Cet audit expand BUG-03 et surface 15 bugs net additionnels après consolidation.
+
+---
+
+## Executive summary
+
+**21 findings** (après dedup : M.1 retiré, M.3 fusionné dans C.5, M.7 fusionné dans C.6, H.9 absorbé dans C.1/C.5) :
+
+- **6 Critical (P0)** — concurrence architecturale + sécurité
+- **9 High (P1)** — error-handling + contract drift + observabilité + hardening
+- **4 Medium (P2)** — robustesse + perf
+- **2 Low** — hygiène
+
+**Top 3 risques confirmés** :
+
+1. **Les deux clients providers sont synchrones sous `async def`** (C.1, revu). PyGithub ET python-gitlab reposent sur `requests.Session`. Ils exposent des méthodes `def` ordinaires appelées depuis des `async def` handlers FastAPI sans `asyncio.to_thread()` — la boucle asyncio bloque pour toute la durée du round-trip HTTP provider. Les throttles/retries par défaut (PyGithub 2.1+ : 0.25s entre reads, 1s entre writes ; python-gitlab : `obey_rate_limit=True`, `max_retries=10`) s'exécutent DANS ce chemin synchrone, amplifiant le blocage.
+
+2. **Token leak via `git clone`** (C.2). Le secret est passé dans **l'argv du process `git`** (URL HTTPS authentifiée). C'est ça le bug confirmé — l'argv d'un process est exposé à `ps`, aux logs process et à tout caller qui wrap l'exception. La fuite additionnelle par `stderr` est plausible mais non garantie.
+
+3. **Webhook DoS amplification** (C.7). Le trace DB est inséré AVANT la vérification du token/signature. Un flood non-authentifié génère 1 insert + 2 updates par requête.
+
+---
+
+## Critical (6)
+
+### C.1 — Les deux clients providers bloquent la boucle asyncio : sync-in-async — **FIXED (96bee87f9)**
+
+**Files**: `control-plane-api/src/services/github_service.py` (toutes méthodes sauf `clone_repo`), `control-plane-api/src/services/git_service.py` (toutes méthodes sauf `clone_repo`)
+
+**Nature** :
+- `GitHubService` déclare `async def` partout et délègue à PyGithub. PyGithub expose des méthodes `def` synchrones (`repo.get_contents()`, `repo.create_file()`, `repo.get_commits()`, `repo.create_git_tree()`, etc.). Aucun `asyncio.to_thread()`.
+- `GitLabService` même pattern avec `python-gitlab` : `self._project.repository_tree(...)`, `self._gl.projects.get(...)`, `self._project.files.create(...)`. `python-gitlab.Gitlab.http_request` utilise `requests.Session` (sync).
+
+**Ce qui n'est PAS le bug** : PyGithub ≥ 2.1.0 a un throttle par défaut (`0.25 s` entre requests, `1.0 s` entre writes) et un retry par défaut ; python-gitlab a `obey_rate_limit=True` et `max_retries=10` par défaut. Ces protections existent — le rapport initial les sous-estimait.
+
+**Ce qui EST le bug** : toutes ces protections s'exécutent dans un chemin `def` synchrone. Quand un handler FastAPI `async def get_tree` fait `await git.list_tree(...)`, le `await` revient immédiatement sur l'awaitable, mais à l'intérieur du `async def list_tree`, l'appel `repo.get_contents(...)` est synchrone : il bloque le thread de boucle asyncio pour la durée du round-trip HTTP + throttle. Toutes les autres requêtes FastAPI attendent.
+
+**Reproduction** : 20 GET `/v1/tenants/*/git/files/*` concurrents → serialisation via event loop → latence × 20.
+
+**Impact** : architectural — touche toute l'application, pas seulement les routes git (y compris health checks, keycloak sync, etc., qui partagent la même boucle).
+
+**Fix direction** : `asyncio.to_thread(func, *args)` wrapper autour de chaque appel provider SDK. Ou migrer vers un client async-native (`ghapi`, `httpx` + REST GitHub/GitLab raw) — rewrite plus lourd mais résout proprement.
+
+---
+
+### C.2 — Token GitLab/GitHub exposé dans l'argv de `git clone` + stderr — **FIXED (b957768d6)**
+
+**Files**: `src/services/git_service.py:148-164`, `src/services/github_service.py:136-152`
+
+```python
+# git_service.py:151
+authed_url = repo_url.replace("https://", f"https://oauth2:{token}@")
+proc = await asyncio.create_subprocess_exec("git", "clone", ..., authed_url, ...)
+_, stderr = await proc.communicate()
+if proc.returncode != 0:
+    raise RuntimeError(f"git clone failed: {stderr.decode().strip()}")
+```
+
+**Confirmé** : le token est dans **l'argv du process** `git clone`. `ps aux` affiche l'argv pour tout user ayant accès au pod/hôte, les logs d'audit process capturent l'argv, et tout wrapper applicatif qui formatte `proc.args` le propage.
+
+**Plausible (non garanti)** : git CLI / libcurl n'affiche normalement PAS l'URL authenticated dans stderr sur failure standard. Mais avec `GIT_TRACE=1` / `GIT_CURL_VERBOSE=1` activés (y compris par erreur en prod), l'URL remonte dans stderr — et stderr remonte dans l'exception `RuntimeError`, qui peut atterrir dans les logs centralisés ou la réponse HTTP (cf. H.3 pour le leak via HTTPException).
+
+**Impact** : divulgation de PAT GitLab/GitHub avec droits écriture catalog. Incident de sécurité à déclarer DORA-grade.
+
+**Fix direction** : ne jamais passer le token dans l'argv. Alternatives :
+- `GIT_ASKPASS` pointant vers un helper qui lit le secret depuis un fd temporaire
+- Utiliser `git config credential.helper` au sein du tempdir
+- Commande `git -c http.extraHeader="Authorization: bearer $TOKEN" clone <https_url>` (sans token dans l'URL, header privé à ce process)
+
+---
+
+### C.3 — ~~Path traversal~~ (déplacé en H.10 — security hardening, non exploitable aujourd'hui)
+
+*Voir H.10. Downgrade justifié : GitLab Repository Files API rejette `/../` côté serveur et GitHub Git tree APIs traitent les paths comme littéraux. Le bug est réel comme défense-en-profondeur mais non-P0.*
+
+---
+
+### C.4 — `_fetch_with_protection` semaphore non appliqué uniformément — **FIXED (96bee87f9)**
+
+**File**: `src/services/git_service.py:26-63`
+
+**Nature** : `_fetch_with_protection` wrappe 3 protections applicatives :
+1. `GITLAB_SEMAPHORE = asyncio.Semaphore(10)` — cap la concurrence applicative.
+2. `asyncio.timeout(5.0)` — timeout par-appel.
+3. Retry custom sur 429 avec backoff.
+
+Le wrapper est appelé à **seulement 2 sites** : `list_apis_parallel` (ligne 514) et `get_all_openapi_specs_parallel` (ligne 529). Les 23+ autres méthodes de `GitLabService` l'ignorent.
+
+**Correction du rapport initial** : le retry 429 et le backoff existent ALREADY au niveau `python-gitlab.Gitlab` (`obey_rate_limit=True`, `max_retries=10` par défaut). Donc "no 429 retry at all" est faux. Ce qui reste vrai :
+- **Aucun cap applicatif de concurrence** : sans le semaphore, 50 requêtes concurrentes partent en 50 round-trips parallèles vers GitLab — c'est la fonction du semaphore 10.
+- **Timeout applicatif non uniforme** : seul le `timeout` passé à `_fetch_with_protection` est appliqué. `python-gitlab` a son timeout par défaut (configurable au constructor) — pas exposé dans le code, donc défaut silencieux.
+
+**Reproduction** : 50 requêtes concurrentes `GET /v1/tenants/*/git/files/*` sur GitLab → 50 calls parallèles (pas les 10 attendus) → risque de secondary rate limit GitLab.
+
+**Impact** : le protocole CAB-688 obligation #1 (cap concurrence 10) n'est respecté qu'à 2 endroits sur 25+. Les retries 429 eux sont bien assurés par `python-gitlab` côté client ; le semaphore applicatif était là en défense supplémentaire mais ne protège quasi rien.
+
+**Fix direction** : appliquer `_fetch_with_protection` (ou un décorateur équivalent) à chaque méthode publique de `GitLabService`. Alternative plus clean : wrapper le client `gitlab.Gitlab` à l'init avec un hook pre/post-request qui acquiert le semaphore.
+
+---
+
+### C.5 — Aucun cap applicatif de concurrence sur GitHub + sync-in-async amplifie — **FIXED (96bee87f9)**
+
+**File**: `src/services/github_service.py` (entier)
+
+**Nature** : zéro équivalent de `GITHUB_SEMAPHORE`. Les méthodes "parallèles" (`list_apis_parallel:333`, `list_mcp_servers:439`) font `asyncio.gather(*[...])` sans borne.
+
+**Correction du rapport initial** : PyGithub ≥ 2.1.0 a un throttle par défaut (0.25s reads / 1s writes), un timeout par défaut (15 s), un retry par défaut. Donc "no protection at all" est faux. Ce qui reste vrai :
+- **Aucun cap applicatif** : pour un tenant avec 500 APIs, `list_apis_parallel` spawn 500 tasks. PyGithub les sérialise de facto via son throttle — mais le buffer task + l'event loop pollué par C.1 rendent la chose pire que séquentiel pur.
+- **Sync-in-async (C.1)** amplifie le problème : les 500 tasks sont crées en bulk, toutes blockantes, la boucle asyncio fait du ping-pong entre elles sans avancer réellement.
+
+**M.3 absorbé ici** : `list_apis_parallel` + `list_mcp_servers` unbounded gather → symptôme du même bug.
+
+**Reproduction** : tenant avec 500 APIs → `/v1/tenants/X/apis` avec GitHub backend → latence observable 50×-100× plus haute qu'attendu pour le "parallel" fetcher.
+
+**Fix direction** : `GITHUB_SEMAPHORE = asyncio.Semaphore(10)` (reads) + `asyncio.Semaphore(5)` (writes), appliqué en wrapper sur chaque méthode publique. Combinable avec l'offload `asyncio.to_thread` de C.1 — le semaphore limite alors réellement la concurrence, pas juste la task count.
+
+---
+
+### C.6 — TOCTOU sur `write_file` + création/update/delete non-idempotents (both providers) — **FIXED (96bee87f9)**
+
+**Files**: `src/services/git_service.py:1012-1031`, `src/services/github_service.py:947-955` + `github_service.py:672-673` (M.7 absorbé)
+
+**Renforcement vs rapport initial** : GitHub documente explicitement dans la doc "Contents" que les endpoints create/update/delete file doivent être utilisés **sériellement** sur un même path car les requêtes parallèles **provoquent des conflits**. Le pré-check `_file_exists()` suivi de `create_file` ou `update_file` viole cette recommandation ET introduit une fenêtre TOCTOU en amont.
+
+**Écho côté GitLab** : GitLab Repository Files API expose `last_commit_id` précisément pour permettre de la concurrence optimiste sur update/delete — jamais utilisé par le code actuel.
+
+**Reproduction** : deux POST concurrents `/v1/tenants/X/git/files/foo.yaml` :
+- Deux `_file_exists == False` → deux `create_file` → le 2e raise `ValueError("File already exists")` → remonté en 500 via H.3.
+- Deux `_file_exists == True` → deux `update_file` → commits en course, GitHub peut reject "sha mismatch", GitLab peut accepter en silencieux avec perte du premier write.
+
+**M.7 absorbé** : `create_api` GitHub (`github_service.py:672-673`) a la même structure `if _file_exists → raise; else → create`. Même TOCTOU.
+
+**Impact** : silent data loss dans le catalog GitOps sous concurrence. Pour BDF qui audite le catalog pour DORA, fenêtre de désync non-traçable.
+
+**Fix direction** :
+- GitHub : rely sur 422 du `create_file` pour détection "already exists"; pour update, passer la `sha` en argument du router et vérifier matching.
+- GitLab : utiliser `last_commit_id` dans `file.save()` pour optimistic concurrency; sur 409, renvoyer l'erreur au caller qui retry avec la version fraîche.
+
+---
+
+### C.7 — Webhook trace DB insert AVANT vérification token — DoS amplification — **FIXED (672267d63)**
+
+**File**: `src/routers/webhooks.py:143 (GitLab), 279 (GitHub)`
+
+**Nature** : l'insertion `service.create(trace, ...)` précède la validation `verify_gitlab_token` / `verify_github_signature`. Un attaquant non-auth flood l'endpoint → 1 insert + 1-2 updates par request sans coût d'authentification.
+
+**Reproduction** : `for i in {1..10000}; do curl -X POST $CP/webhooks/gitlab -d '{"fake":true}'; done` → 10k inserts `traces` + 20k updates.
+
+**Impact** : pression DB soutenue. Combiné avec C.1 (event loop bloqué durant chaque DB write sync-in-async), cascade vers les routes légitimes. Les headers nécessaires à une vérification précoce (`X-Gitlab-Token`, `X-Hub-Signature-256`) sont lus AVANT la signature mais utilisés APRÈS l'insert.
+
+**Fix direction** : reordering. Le flow correct :
+1. Lire `x_gitlab_token` / `x_hub_signature_256`
+2. `verify_*` → si false, `raise HTTPException(401)` sans DB write
+3. SEULEMENT alors `service.create(trace, ...)` et la suite
+
+Coût : ~10 LOC de réorganisation par handler.
+
+---
+
+## High (9)
+
+### H.1 — Webhook replay : aucune déduplication par `X-GitHub-Delivery` / `X-Gitlab-Webhook-UUID`
+
+**File**: `src/routers/webhooks.py` (entier)
+
+**Nature** : GitHub recommande explicitement d'utiliser `X-GitHub-Delivery` pour dédupliquer, avec nuance : une "redelivery" manuelle réutilise le même delivery ID mais une livraison automatique après timeout en génère un nouveau. GitLab expose `X-Gitlab-Webhook-UUID`, `X-Gitlab-Event-UUID`, et `Idempotency-Key`.
+
+Aucun de ces headers n'est lu par le code actuel. Un webhook rejoué = deuxième exécution du pipeline.
+
+**Impact** : 2× publish Kafka, 2× trace, 2× sync catalog. Pour events mutants (api-create), second échoue avec "already exists" → compté comme erreur (ou comme success faussement positif via H.8).
+
+**Fix direction** : cache LRU in-memory ou Redis (10k entries × 24h TTL) sur delivery_id.
+
+---
+
+### H.2 — `contextlib.suppress(Exception)` swallow dans deployment_orchestration
+
+**File**: `src/services/deployment_orchestration_service.py:116-124`
+
+Rate limits, timeouts, parse YAML, auth failures — tous avalés silencieusement. `_upsert_api` reçoit `None` commit_sha et continue sans distinguer "pas de spec" de "impossible de fetch".
+
+**Fix** : `except FileNotFoundError: None ; except (RateLimitError, TimeoutError) as e: raise` — distinguer récupérable vs attendu.
+
+---
+
+### H.3 — Router leak `str(e)` dans HTTPException detail
+
+**File**: `src/routers/git.py:184, 209-210, 254-255, 273-274, 310-311`
+
+```python
+except Exception as e:
+    raise HTTPException(status_code=500, detail=f"Failed to save file: {e}")
+```
+
+`str(e)` sur exceptions PyGithub / python-gitlab contient URL API, headers, request IDs, parfois fragments de path internes. Amplifié par C.2 si le token est dans une URL partiellement masquée.
+
+**Fix** : `detail="Internal error"` + log full error serveur + request_id dans response pour corrélation.
+
+---
+
+### H.4 — `delete_file` convertit TOUTES exceptions en 404
+
+**File**: `src/routers/git.py:205-212`
+
+Timeout, 500 provider, 401 → tous deviennent 404. Cache les pannes sous un résultat "normal".
+
+**Fix** : `except FileNotFoundError: 404`, `except Exception: 500`.
+
+---
+
+### H.5 — `list_*` endpoints silencieusement `[]` sur toute erreur
+
+**File**: `src/routers/git.py:123-125, 160-161, 229-231, 290-292`
+
+4× pattern `except Exception: return []`. Auth errors, rate limits, 500s → tous deviennent liste vide. UI affiche "aucun commit/MR/branche" au lieu de signaler panne.
+
+**Fix** : 502 Bad Gateway avec raison pour routes user-facing.
+
+---
+
+### H.6 — `list_tree` contract drift : fichier vs dossier entre providers
+
+**Files**: `src/services/git_service.py:996-1003`, `src/services/github_service.py:905-922`
+
+**Reformulation** : l'audit initial prétendait que GitLab renvoie `[]` sur `path=<fichier>`. Plus prudent : c'est un **contract drift inter-provider** sur l'abstraction CP-1.
+
+- GitHub documente que "Get repository content" retourne **un objet unique** pour un fichier et **un tableau** pour un dossier. Le code ligne 914 wrappe l'objet unique en `[contents]` → propage comme `TreeEntry(type="blob", ...)` au caller.
+- GitLab `repository_tree` est un endpoint de **listing de tree** exclusivement. Sur un path qui pointe un fichier, comportement mal documenté (vide ou 404 selon version).
+
+La divergence existe et doit être normalisée dans l'abstraction, indépendamment du comportement exact de GitLab.
+
+**Fix direction** : dans `github_service.list_tree`, si `contents` n'est pas une list → retourner `[]` (le contrat ABC dit "list children" et un fichier n'a pas de children).
+
+---
+
+### H.7 — Kafka `enable_auto_commit=True` → perte d'events au crash worker
+
+**File**: `src/workers/git_sync_worker.py:150`
+
+aiokafka/kafka-python documente explicitement que `enable_auto_commit=True` peut mener à perte de données au crash. Recommandation standard : `enable_auto_commit=False` + commit manuel APRÈS succès async.
+
+**Impact** : API créé via Kafka event, worker crashe post-auto-commit pré-write GitHub → catalog divergent sans alerte.
+
+**Fix** : `enable_auto_commit=False`, `self._consumer.commit()` après `_handle_event` OK.
+
+---
+
+### H.8 — `ValueError` classifié success dans retry loop
+
+**File**: `src/workers/git_sync_worker.py:242-246`
+
+`except ValueError: status="success"` — mais ValueError est une large catégorie. `batch_commit("unknown action")` raise ValueError (ligne 528) et compte comme success. Métriques biaisées.
+
+**Fix** : discriminer `"already exists" in str(e)` ou `"not found" in str(e)` pour success ; reste = error.
+
+---
+
+### H.10 — Path sanitization manquante dans `_tenant_path` (hardening, security-adjacent)
+
+**File**: `src/routers/git.py:98-101`
+
+*Déplacé depuis C.3 (rapport v1) — non P0 car non exploitable aujourd'hui.*
+
+```python
+def _tenant_path(tenant_id: str, path: str = "") -> str:
+    base = f"tenants/{tenant_id}"
+    return f"{base}/{path}" if path else base
+```
+
+`file_path` capturé via `{file_path:path}` FastAPI accepte `..`, `\x00`, backslashes, paths absolus. Aucune sanitisation.
+
+**Non exploitable aujourd'hui** : GitLab Repository Files API documente `/../` comme rejeté côté serveur ; GitHub Git tree APIs traitent les paths comme littéraux (pas de normalisation).
+
+**Pourquoi le garder en P1** :
+- Tout refactor introduisant `os.path.normpath()` ou `Path().resolve()` ouvre le trou.
+- Défense en profondeur (DORA expectations BDF).
+- Coût du fix dérisoire (5 LOC + 3 tests).
+
+**Fix** : `if ".." in path.split("/") or "\x00" in path or path.startswith("/"): raise HTTPException(400)`.
+
+---
+
+## Medium (4)
+
+### M.2 — `merge_merge_request` GitHub : pas d'idempotence + double fetch
+
+**File**: `src/services/github_service.py:1013-1017`
+
+Si PR already merged / closed, `pr.merge()` raise. Aucun pre-check. Double `get_pull` (avant + après même iid).
+
+**Fix** : check `pr.merged` / `pr.state` avant merge, retourner ref existant si déjà merged.
+
+---
+
+### M.4 — `ref="main"` hardcodé dans dizaines d'endroits
+
+**Files**: `git_service.py`, `github_service.py` — multiples
+
+Pas de `settings.git.default_branch`. Repo avec `master` ou branche custom silent-fail.
+
+**Fix** : expose default_branch dans settings.
+
+---
+
+### M.5 — `connect()` GitLab sans retry au startup
+
+**File**: `src/services/git_service.py:103-116`
+
+Si GitLab lent/500 au boot CP-API, `connect()` échoue → service démarre en état not-connected → routes 503.
+
+**Fix** : retry exponentiel au connect (3 tentatives, backoff 1/2/4s).
+
+---
+
+### M.6 — `list_all_mcp_servers` GitHub : séquentiel par tenant (N+1)
+
+**File**: `src/services/github_service.py:442-447`
+
+100 tenants × 1 appel list_mcp_servers = 100 calls séquentiels. Avec C.1 (sync PyGithub), ~50s cumulées.
+
+**Fix** : `asyncio.gather` avec semaphore.
+
+---
+
+*Supprimés par rapport à v1 du rapport :*
+
+- ~~M.1 batch_commit delete mode/sha~~ — **REMOVED**. GitHub Git Data API documente `sha: null` comme signal de delete, et PyGithub `InputGitTreeElement(sha=None)` supporte ce cas. Le commentaire de code est trompeur (mode "000000" mentionné alors que "100644" est utilisé) mais le comportement est correct per la doc.
+- ~~M.3 list_apis_parallel unbounded~~ — **fusionné dans C.5**.
+- ~~M.7 create_api TOCTOU~~ — **fusionné dans C.6**.
+
+---
+
+## Low (2)
+
+### L.1 — Pagination : split par provider
+
+**PyGithub side** : `repo.get_branches()` / `repo.get_pulls()` / `repo.get_commits()` retournent des `PaginatedList`. L'itération est **transparente** — le code qui fait `for b in repo.get_branches()` récupère bien toutes les pages, pas la première seulement. Donc PyGithub n'a PAS le bug de troncation à 30.
+
+**python-gitlab side** : `project.branches.list()` / `project.mergerequests.list()` sans paramètre retourne la **première page seulement** (par défaut 20 items) sauf si `get_all=True` ou `iterator=True` est passé. Le code actuel :
+- `list_branches:1042` — `self._project.branches.list()` → **tronqué à 20**
+- `list_merge_requests:1081` — `self._project.mergerequests.list(state=state)` → **tronqué à 20**
+- `list_commits:697` — `self._project.commits.list(path=path, per_page=limit)` → limite explicite mais pas de all=True
+
+**Impact GitLab** : catalog repo avec >20 branches ou >20 MRs open → liste tronquée silencieusement.
+
+**Fix** : passer `get_all=True` (ou `iterator=True` + boucle) sur chaque `list()` GitLab qui attend une énumération complète.
+
+---
+
+### L.2 — Webhook handler fuit `str(e)` dans HTTPException 500
+
+**File**: `src/routers/webhooks.py:235`
+
+Même pattern que H.3, côté endpoint webhook. Attacker qui trigger exception interne récolte debug info.
+
+**Fix** : `detail="Internal error"` + log interne.
+
+---
+
+## Scope hors bugs — notes de design
+
+- **BUG-01, BUG-02 fixés silencieusement** (iam_sync, deployment_orchestration) mais REWRITE-BUGS.md les liste encore ouverts. Divergence doc/code à clarifier.
+- **`MergeRequestRef.iid`** : mapping GitLab iid vs GitHub pr.number correct, contract consistent.
+- **`read_file` vs `get_file_content` semantics** : divergence intentionnelle documentée ; piège latent pour refactors.
+- **`clone_repo` crée `tempfile.mkdtemp` jamais nettoyé** : fuite `/tmp/stoa-{gl,gh}-*` sur error ET success. Pollution disque, pas exploitable.
+- **M.1 removed** : voir section Medium. GitHub API documente `sha: null = delete`, PyGithub supporte — le code est probablement correct même si le commentaire est trompeur.
+
+---
+
+## Priorité de fix (recommandation)
+
+**P0 — avant démo juin** :
+- **C.2** (token leak dans argv `git clone`) — security incident grade
+- **C.4** (semaphore non uniforme) — fiabilité sous charge
+- **C.5** (no GitHub cap + sync-in-async amplifié) — perf + reliability
+- **C.6** (TOCTOU write) — silent data loss
+- **C.7** (webhook DoS amplification) — surface exposée
+
+**P0 conditionnel (si GitHub provider activé) OU P0 tout court vu que GitLab a le même problème** :
+- **C.1** (sync-in-async both providers) — architectural
+
+**P1 — stabilité démo** :
+- H.1 (webhook replay), H.6 (list_tree drift), H.7 (Kafka at-most-once), H.10 (path sanitization hardening)
+- H.3/H.4/H.5 (error handling router + info disclosure) — groupable
+
+**P2 — hygiène** :
+- M.2, M.4, M.5, M.6, L.1 (pagination GitLab), L.2
+
+---
+
+## Références aux suspects du brief
+
+| Suspect | Status | Bug |
+|---|---|---|
+| R5 semaphore bypass (`_gl.projects.get` writes) | **Confirmé + reformulé** | C.4 (uniformité applicative, pas "no retry") |
+| `MergeRequestRef.iid` GitLab iid vs GitHub pr.number | **Correct** | Pas de bug — mapping consistent |
+| `list_tree()` GitLab `[]` vs GitHub `[]` | **Contract drift** | H.6 — GitHub renvoie le fichier comme blob si path=file |
+| `read_file()` None vs `get_file_content()` raise | **OK intentionnel** | Piège latent documenté |
+| Bugs fonctionnels au-delà du leak `_project` (R4 hors-scope) | **Partiel** | iam_sync + deployment_orchestration fixés silencieusement ; nouveaux bugs (H.2) |
+
+---
+
+## Changelog Rev 2 (2026-04-23 pm)
+
+**Corrections après feedback éditorial** :
+
+- **C.1** : étendu à GitLab (python-gitlab aussi sync via requests.Session, vérifié par inspection du code client).
+- **C.4** : reformulé. Les retries 429 existent au niveau `python-gitlab` (`obey_rate_limit=True`, `max_retries=10` par défaut). Le bug restant = non-uniformité applicative du semaphore + timeout, pas absence de retry.
+- **C.5** : reformulé. PyGithub ≥ 2.1 a throttle/retry/timeout par défaut. Le bug restant = no cap applicatif + sync-in-async amplification. M.3 absorbé ici.
+- **C.3 → H.10** : downgrade vers P1 hardening. Non exploitable aujourd'hui (Git APIs traitent les paths littéralement).
+- **C.6 renforcé** : référence à GitHub doc "serial usage required", M.7 absorbé.
+- **H.9 retiré** : fusionné dans C.1/C.5 (la couverture timeout était déjà présente dans ces sections).
+- **M.1 retiré** : GitHub API + PyGithub supportent `sha=None` comme delete signal.
+- **M.3, M.7 retirés** : fusionnés respectivement dans C.5 et C.6.
+- **L.1 splitté par provider** : PyGithub PaginatedList transparent, seul python-gitlab `list()` tronque par défaut.
+
+**Compte final** : 21 findings solides (vs 25 prétendus en v1). 6 P0 consolidés + 9 P1 + 4 M + 2 L.

--- a/control-plane-api/src/core/secret_redactor.py
+++ b/control-plane-api/src/core/secret_redactor.py
@@ -1,0 +1,73 @@
+"""Logging filter that redacts provider tokens (CP-1 C.2 defense-in-depth).
+
+Defense-in-depth against accidental token leakage into logs. The primary
+fix for C.2 keeps tokens out of subprocess argv (see
+``services.git_credentials``); this filter catches the residual risk
+where a token reaches a log handler via a path we did not anticipate
+(exception ``__repr__``, third-party library logs, etc.).
+
+Patterns are anchored on the documented provider PAT prefixes to avoid
+redacting arbitrary strings that merely look tokenish:
+
+- ``ghp_``  : GitHub classic personal access token (36 alnum)
+- ``gho_``  : GitHub OAuth access token (36 alnum)
+- ``ghu_``  : GitHub user-to-server token
+- ``ghs_``  : GitHub server-to-server token
+- ``ghr_``  : GitHub refresh token
+- ``github_pat_`` : GitHub fine-grained PAT (82 chars incl. underscores)
+- ``glpat-`` : GitLab personal access token (20+ alnum/underscore/dash)
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+_REDACTED = "***REDACTED***"
+
+# Each pattern is the provider's documented prefix followed by its
+# character class. Ordering matters only insofar as the generic GitHub
+# two-letter prefixes would also match ``github_pat_`` — we anchor the
+# prefixes explicitly so they don't collide.
+_PATTERNS = [
+    re.compile(r"github_pat_[A-Za-z0-9_]{60,}"),
+    re.compile(r"gh[opusr]_[A-Za-z0-9]{30,}"),
+    re.compile(r"glpat-[A-Za-z0-9_-]{20,}"),
+]
+
+
+def redact_secrets(text: str) -> str:
+    """Return ``text`` with every known PAT pattern replaced."""
+    if not text:
+        return text
+    for pattern in _PATTERNS:
+        text = pattern.sub(_REDACTED, text)
+    return text
+
+
+class SecretRedactor(logging.Filter):
+    """Global logging filter that redacts provider PATs in log records.
+
+    Install once at application startup:
+
+        >>> logging.getLogger().addFilter(SecretRedactor())
+
+    Applies to both ``record.msg`` (before formatting) and the formatted
+    ``record.args`` values when msg is a format string.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.msg, str):
+            record.msg = redact_secrets(record.msg)
+        # Also scrub args — commonly used as printf-style format values.
+        if record.args:
+            if isinstance(record.args, dict):
+                record.args = {
+                    k: redact_secrets(v) if isinstance(v, str) else v
+                    for k, v in record.args.items()
+                }
+            elif isinstance(record.args, tuple):
+                record.args = tuple(
+                    redact_secrets(v) if isinstance(v, str) else v for v in record.args
+                )
+        return True

--- a/control-plane-api/src/main.py
+++ b/control-plane-api/src/main.py
@@ -4,6 +4,7 @@ FastAPI backend with RBAC, GitOps, and Kafka integration
 """
 
 import asyncio
+import logging as _stdlib_logging
 import os
 from contextlib import asynccontextmanager, suppress
 
@@ -19,6 +20,7 @@ from starlette.responses import Response
 from .config import settings
 from .consumers.deployment_consumer import deployment_consumer
 from .consumers.promotion_deploy_consumer import promotion_deploy_consumer
+from .core.secret_redactor import SecretRedactor
 from .features.error_snapshots import (
     add_error_snapshot_middleware,
     connect_error_snapshots,
@@ -151,6 +153,12 @@ def custom_generate_unique_id(route):
 
 # Configure structured logging (CAB-281)
 configure_logging()
+
+# CP-1 C.2 defense-in-depth: redact provider PATs from log records.
+# Installed at the root logger so every handler (stdout, files, Sentry,
+# OTLP) sees the redacted form regardless of where a token might leak in.
+_stdlib_logging.getLogger().addFilter(SecretRedactor())
+
 logger = get_logger(__name__)
 
 # Flag to control worker startup (can be disabled for dev/testing)

--- a/control-plane-api/src/routers/webhooks.py
+++ b/control-plane-api/src/routers/webhooks.py
@@ -102,7 +102,19 @@ async def gitlab_webhook(
 
     Captures the git author (who pushed) from the GitLab payload and stores
     traces in PostgreSQL for persistent monitoring.
+
+    CP-1 C.7: token verification happens BEFORE any DB write. Rejected
+    requests produce zero trace rows, eliminating the DoS amplification
+    vector where an unauthenticated flood would burn 1 INSERT + 2 UPDATEs
+    per request on the traces table.
     """
+    # CP-1 C.7 Step 1 — authenticate BEFORE any DB I/O.
+    webhook_secret = settings.git.gitlab.webhook_secret.get_secret_value()
+    if not verify_gitlab_token(x_gitlab_token, webhook_secret):
+        # No trace row is written for unauthenticated requests.
+        raise HTTPException(status_code=401, detail="Invalid webhook token")
+
+    # CP-1 C.7 Step 2 — only now do we parse and persist.
     service = TraceService(db)
     event_type = x_gitlab_event or "Unknown"
     body = await request.json()
@@ -139,7 +151,7 @@ async def gitlab_webhook(
         git_author = body.get("user_name") or body.get("user_username", "unknown")
         git_author_email = body.get("user_email")
 
-    # Create trace in PostgreSQL with full git info
+    # Create trace in PostgreSQL with full git info (auth already verified above).
     trace = await service.create(
         trigger_type=f"gitlab-{event_type.lower().replace(' hook', '').replace(' ', '-')}",
         trigger_source="gitlab",
@@ -153,7 +165,7 @@ async def gitlab_webhook(
     )
 
     try:
-        # Step 1: Webhook Reception
+        # Step 1: Webhook Reception (auth already verified, recorded here for observability)
         await service.add_step(
             trace,
             name="webhook_received",
@@ -168,18 +180,7 @@ async def gitlab_webhook(
             },
         )
 
-        # Step 2: Token Verification (CAB-DDoS: always enforce)
-        webhook_secret = settings.git.gitlab.webhook_secret.get_secret_value()
-        if not verify_gitlab_token(x_gitlab_token, webhook_secret):
-            await service.add_step(
-                trace,
-                name="token_verification",
-                status="failed",
-                error="Invalid or missing webhook token",
-            )
-            await service.complete(trace, TraceStatusDB.FAILED, "Authentication failed: Invalid webhook token")
-            raise HTTPException(status_code=401, detail="Invalid webhook token")
-
+        # Step 2: Token verification trace (the check happened pre-trace).
         await service.add_step(
             trace,
             name="token_verification",

--- a/control-plane-api/src/services/git_credentials.py
+++ b/control-plane-api/src/services/git_credentials.py
@@ -1,0 +1,120 @@
+"""Git credential helper for provider PATs (CP-1 C.2).
+
+The previous ``clone_repo`` implementation injected the PAT into the
+``git clone`` argv (``https://oauth2:<TOKEN>@host/repo``). Argv is
+readable via ``ps`` / ``/proc/PID/cmdline`` by any local user and is
+captured by container log scrapers — a DORA-grade disclosure.
+
+This module routes credentials through GIT_ASKPASS instead:
+
+- A per-call helper script is created in a private tempdir.
+- The script dispatches on the prompt git emits (``Username for ...``
+  vs ``Password for ...``) and prints the right value read from env vars.
+- The token stays in the subprocess environment only, never in argv.
+
+Reading env vars is restricted to the process owner on Linux
+(``/proc/PID/environ`` uid-protected), a distinct threat boundary from
+``/proc/PID/cmdline`` which is world-readable.
+
+Supporting env forced on the child:
+- GIT_ASKPASS=<helper>
+- GIT_TERMINAL_PROMPT=0  — block interactive fallback if ASKPASS fails.
+- GIT_TRACE=0, GIT_CURL_VERBOSE=0, GIT_TRACE_CURL=0,
+  GIT_TRACE_PACKET=0, GIT_TRACE_SETUP=0 — prevent stderr dumps that
+  would echo the bearer URL on failure paths.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import stat
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_HELPER_SCRIPT = """#!/bin/sh
+# STOA git credential helper — GIT_ASKPASS target.
+# $1 is the prompt git sends, e.g. "Username for 'https://...'" or "Password for ...".
+case "$1" in
+  Username*) printf '%s' "$STOA_GIT_USERNAME" ;;
+  Password*) printf '%s' "$STOA_GIT_PASSWORD" ;;
+  *)         printf '%s' "$STOA_GIT_PASSWORD" ;;
+esac
+"""
+
+# Variables forced on the child process to prevent token leakage through
+# git trace output. Keys only — values are always "0".
+_TRACE_KILL_VARS = (
+    "GIT_TRACE",
+    "GIT_CURL_VERBOSE",
+    "GIT_TRACE_CURL",
+    "GIT_TRACE_PACKET",
+    "GIT_TRACE_SETUP",
+)
+
+
+@contextlib.contextmanager
+def askpass_env(username: str, password: str) -> Iterator[dict[str, str]]:
+    """Yield an ``env`` dict for subprocess git invocations.
+
+    The helper script is created in a private tempdir, chmod 0500, and
+    deleted on context exit (success or failure). The yielded dict is
+    designed to be passed as ``env=`` to ``asyncio.create_subprocess_exec``
+    or ``subprocess.run``.
+
+    Args:
+        username: Git username (provider-specific — e.g. ``"oauth2"`` for
+            GitLab, ``"x-access-token"`` for GitHub).
+        password: The PAT / OAuth token. Passed to the child via
+            ``STOA_GIT_PASSWORD`` env entry, never argv.
+
+    Yields:
+        A dict suitable for subprocess ``env=`` that contains PATH, HOME,
+        the ASKPASS helper pointer, the credentials, and the trace-killing
+        overrides.
+    """
+    tmpdir = Path(tempfile.mkdtemp(prefix="stoa-askpass-"))
+    helper_path = tmpdir / "askpass.sh"
+    try:
+        helper_path.write_text(_HELPER_SCRIPT, encoding="utf-8")
+        # Owner-only read+execute; no group/other bits, no write.
+        os.chmod(helper_path, stat.S_IRUSR | stat.S_IXUSR)
+
+        env: dict[str, str] = {
+            # Preserve PATH and HOME so git can find itself and config.
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            "HOME": os.environ.get("HOME", str(tmpdir)),
+            "GIT_ASKPASS": str(helper_path),
+            "GIT_TERMINAL_PROMPT": "0",
+            "STOA_GIT_USERNAME": username,
+            "STOA_GIT_PASSWORD": password,
+        }
+        for key in _TRACE_KILL_VARS:
+            env[key] = "0"
+
+        yield env
+    finally:
+        # Always clean up the helper, even if the subprocess raised.
+        try:
+            if helper_path.exists():
+                helper_path.unlink()
+        except OSError as exc:  # best-effort; log and continue
+            logger.warning("askpass helper cleanup failed for %s: %s", helper_path, exc)
+        with contextlib.suppress(OSError):
+            tmpdir.rmdir()
+
+
+def redact_token(message: str, token: str) -> str:
+    """Replace every occurrence of ``token`` in ``message`` with a placeholder.
+
+    Used on subprocess stderr before surfacing it in exceptions so a
+    misconfigured trace env (set outside our control) cannot leak the
+    PAT into ``RuntimeError`` messages that land in logs.
+    """
+    if not token:
+        return message
+    return message.replace(token, "***REDACTED***")

--- a/control-plane-api/src/services/git_executor.py
+++ b/control-plane-api/src/services/git_executor.py
@@ -1,0 +1,98 @@
+"""Bounded sync-in-async executor for provider SDKs (CP-1 C.1/C.4/C.5).
+
+PyGithub and python-gitlab are synchronous clients. Calling them directly
+from ``async def`` handlers blocks the asyncio event loop for the full
+HTTP round-trip plus any library-side throttle/retry. Every synchronous
+SDK call MUST be routed through :func:`run_sync` so the loop stays
+responsive under load.
+
+Responsibilities:
+  - Offload to the default thread executor via ``asyncio.to_thread``.
+  - Cap applicative concurrency via per-purpose semaphores.
+  - Enforce a per-call timeout.
+
+Explicitly NOT responsible:
+  - Retry policy. PyGithub (``seconds_between_requests`` / ``retry``) and
+    python-gitlab (``obey_rate_limit`` / ``max_retries``) already ship
+    retry semantics for 429 / transient failures. Stacking a second opaque
+    layer here would fight those defaults.
+
+Implementation rule for callers (do not violate):
+  The entire SDK interaction — including iteration over ``PaginatedList``
+  objects and ``.decoded_content`` access on lazy ``ContentFile`` — MUST
+  happen inside the closure passed to :func:`run_sync`. Returning a lazy
+  object and iterating it after ``await`` re-introduces C.1.
+"""
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import TypeVar
+
+logger = logging.getLogger(__name__)
+
+# ── GitLab ──────────────────────────────────────────────────────────
+# CAB-688 obligation #1: cap applicative concurrency at 10.
+# Now applied uniformly across every GitLab SDK call via ``run_sync``.
+GITLAB_SEMAPHORE = asyncio.Semaphore(10)
+
+# ── GitHub ──────────────────────────────────────────────────────────
+# Read-side cap. 10 matches the GitLab setting.
+GITHUB_READ_SEMAPHORE = asyncio.Semaphore(10)
+
+# GitHub REST "Repository contents" endpoints (create/update/delete file)
+# MUST be serialised — parallel requests against the Contents API are
+# documented as causing conflicts. Applies to create_file, update_file,
+# delete_file, and any high-level path (write_file, create_api, ...)
+# that reaches those endpoints. Also used for the Git-Data tree path in
+# batch_commit to keep a single write lane.
+GITHUB_CONTENTS_WRITE_SEMAPHORE = asyncio.Semaphore(1)
+
+# Non-Contents writes (pull requests, branches, webhooks) tolerate
+# moderate concurrency.
+GITHUB_META_WRITE_SEMAPHORE = asyncio.Semaphore(5)
+
+# ── Timeouts ────────────────────────────────────────────────────────
+DEFAULT_TIMEOUT_S = 30.0
+BATCH_TIMEOUT_S = 60.0
+
+T = TypeVar("T")
+
+
+async def run_sync(
+    fn: Callable[..., T],
+    /,
+    *args: object,
+    semaphore: asyncio.Semaphore,
+    timeout: float = DEFAULT_TIMEOUT_S,
+    op_name: str = "git_sync_call",
+    **kwargs: object,
+) -> T:
+    """Offload a sync SDK call under semaphore + timeout.
+
+    Args:
+        fn: The synchronous function to run. Must fully materialise any
+            lazy SDK objects before returning (see module docstring).
+        *args, **kwargs: Forwarded to ``fn``.
+        semaphore: The applicative concurrency cap appropriate for this
+            call (one of the module-level semaphores).
+        timeout: Per-call timeout in seconds.
+        op_name: Short label for logs on timeout.
+
+    Raises:
+        TimeoutError: If the call exceeds ``timeout`` seconds. Note that
+            the underlying thread keeps running to completion — this is
+            an asyncio-level cancellation, not a thread-level kill.
+        Exception: Any exception raised by ``fn``.
+    """
+    async with semaphore:
+        try:
+            async with asyncio.timeout(timeout):
+                return await asyncio.to_thread(fn, *args, **kwargs)
+        except TimeoutError:
+            logger.warning(
+                "git_sync_call timeout: op=%s timeout=%.1fs",
+                op_name,
+                timeout,
+            )
+            raise

--- a/control-plane-api/src/services/git_service.py
+++ b/control-plane-api/src/services/git_service.py
@@ -133,14 +133,19 @@ class GitLabService(GitProvider):
         try:
             gl_cfg = settings.git.gitlab
 
-            def _connect() -> tuple[gitlab.Gitlab, Project]:
+            def _connect() -> tuple[gitlab.Gitlab, Project, str]:
                 client = gitlab.Gitlab(gl_cfg.url, private_token=gl_cfg.token.get_secret_value())
                 client.auth()
                 project = client.projects.get(gl_cfg.project_id)
-                return client, project
+                # Materialise the scalar inside the closure so the log
+                # line below does not trigger any lazy attribute access
+                # on the event loop.
+                return client, project, project.name
 
-            self._gl, self._project = await _gl_run(_connect, "gitlab.connect", timeout=15.0)
-            logger.info("Connected to GitLab project: %s", self._project.name)
+            self._gl, self._project, project_name = await _gl_run(
+                _connect, "gitlab.connect", timeout=15.0
+            )
+            logger.info("Connected to GitLab project: %s", project_name)
         except Exception as e:
             logger.error("Failed to connect to GitLab: %s", e)
             raise

--- a/control-plane-api/src/services/git_service.py
+++ b/control-plane-api/src/services/git_service.py
@@ -29,6 +29,7 @@ import yaml
 from gitlab.v4.objects import Project
 
 from ..config import settings
+from .git_credentials import askpass_env, redact_token
 from .git_executor import (
     BATCH_TIMEOUT_S,
     DEFAULT_TIMEOUT_S,
@@ -181,24 +182,27 @@ class GitLabService(GitProvider):
     async def clone_repo(self, repo_url: str) -> Path:
         """Clone a GitLab repository to a temporary directory.
 
-        NOTE: token-in-URL here is the C.2 leak — patched by the
-        subsequent commit (GIT_ASKPASS helper).
+        CP-1 C.2: the token never appears in argv. It is passed to git
+        through GIT_ASKPASS + env vars instead. ``repo_url`` must be a
+        plain HTTPS URL (no user/token prefix).
         """
         tmp_dir = Path(tempfile.mkdtemp(prefix="stoa-gl-"))
         token = settings.git.gitlab.token.get_secret_value()
-        authed_url = repo_url.replace("https://", f"https://oauth2:{token}@")
-        proc = await asyncio.create_subprocess_exec(
-            "git",
-            "clone",
-            "--depth=1",
-            authed_url,
-            str(tmp_dir / "repo"),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, stderr = await proc.communicate()
+        with askpass_env(username="oauth2", password=token) as env:
+            proc = await asyncio.create_subprocess_exec(
+                "git",
+                "clone",
+                "--depth=1",
+                repo_url,
+                str(tmp_dir / "repo"),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+            _, stderr = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(f"git clone failed: {stderr.decode().strip()}")
+            safe_stderr = redact_token(stderr.decode().strip(), token)
+            raise RuntimeError(f"git clone failed: {safe_stderr}")
         return tmp_dir / "repo"
 
     async def get_file_content(self, project_id: str, file_path: str, ref: str = "main") -> str:

--- a/control-plane-api/src/services/git_service.py
+++ b/control-plane-api/src/services/git_service.py
@@ -22,7 +22,7 @@ import re
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypeVar
 
 import gitlab
 import yaml
@@ -116,7 +116,14 @@ def _normalize_api_data(raw_data: dict) -> dict:
     return raw_data
 
 
-async def _gl_run(fn: Callable[..., Any], op_name: str, timeout: float = DEFAULT_TIMEOUT_S) -> Any:
+_GLT = TypeVar("_GLT")
+
+
+async def _gl_run(
+    fn: Callable[[], _GLT],
+    op_name: str,
+    timeout: float = DEFAULT_TIMEOUT_S,
+) -> _GLT:
     """Run a sync python-gitlab closure under the uniform GitLab semaphore."""
     return await run_sync(fn, semaphore=GITLAB_SEMAPHORE, timeout=timeout, op_name=op_name)
 

--- a/control-plane-api/src/services/git_service.py
+++ b/control-plane-api/src/services/git_service.py
@@ -1,4 +1,20 @@
-"""GitLab service for GitOps operations"""
+"""GitLab service for GitOps operations.
+
+CP-1 (C.1/C.4/C.5): every synchronous python-gitlab call is routed
+through :func:`.git_executor.run_sync` so the asyncio loop stays
+non-blocking and the applicative concurrency cap (``GITLAB_SEMAPHORE``)
+is enforced uniformly across all methods (not only the two callers that
+historically used ``_fetch_with_protection``).
+
+CP-1 (C.6): write paths drop the ``_file_exists`` pre-check. ``write_file``
+calls ``create_file`` first and falls through to ``update_file`` on the
+"already exists" error. GitLab's optimistic-concurrency ``last_commit_id``
+is threaded through ``update_file`` / ``delete_file`` / ``batch_commit``
+when in scope. Note that this closes the TOCTOU *existence-check* window;
+it does not provide full compare-and-swap against concurrent writers to
+the same file — full CAS would require the caller to round-trip a
+version token.
+"""
 
 import asyncio
 import logging
@@ -13,25 +29,28 @@ import yaml
 from gitlab.v4.objects import Project
 
 from ..config import settings
+from .git_executor import (
+    BATCH_TIMEOUT_S,
+    DEFAULT_TIMEOUT_S,
+    GITLAB_SEMAPHORE,
+    run_sync,
+)
 from .git_provider import BranchRef, CommitRef, GitProvider, MergeRequestRef, TreeEntry
 
 logger = logging.getLogger(__name__)
 
 # ============================================================
-# CAB-688: Protection for parallel GitLab calls
-# Obligation #1: Semaphore(10) max concurrent
-# Obligation #2: Retry exponential backoff on 429
-# Obligation #3: Timeout 5s per call
+# CAB-688 legacy retry wrapper — kept as a thin composition over
+# ``run_sync`` because the site-specific 429 backoff is more
+# aggressive than python-gitlab's default ``max_retries`` for the
+# two "parallel fetch" callers that historically used it.
 # ============================================================
-GITLAB_SEMAPHORE = asyncio.Semaphore(10)
 GITLAB_TIMEOUT = 5.0
 GITLAB_MAX_RETRIES = 3
 
 
 class GitLabRateLimitError(Exception):
-    """GitLab 429 rate limit exceeded"""
-
-    pass
+    """GitLab 429 rate limit exceeded."""
 
 
 async def _fetch_with_protection(
@@ -40,35 +59,39 @@ async def _fetch_with_protection(
     timeout: float = GITLAB_TIMEOUT,
     max_retries: int = GITLAB_MAX_RETRIES,
 ) -> Any:
-    """Execute GitLab call with semaphore, timeout, and retry on 429."""
-    async with GITLAB_SEMAPHORE:
-        last_error = None
-        for attempt in range(max_retries):
-            try:
-                async with asyncio.timeout(timeout):
-                    return await coro_factory()
-            except TimeoutError:
-                logger.warning(f"GitLab call '{name}' timed out (attempt {attempt + 1}/{max_retries})")
-                last_error = TimeoutError(f"{name} timed out")
-            except Exception as e:
-                if "429" in str(e) or "rate limit" in str(e).lower():
-                    wait_time = 2**attempt
-                    logger.warning(f"GitLab rate limit hit for '{name}', waiting {wait_time}s (attempt {attempt + 1})")
-                    await asyncio.sleep(wait_time)
-                    last_error = GitLabRateLimitError(str(e))
-                else:
-                    logger.error(f"GitLab call '{name}' failed: {e}")
-                    last_error = e
-                    break
-        raise last_error or Exception(f"Failed after {max_retries} attempts: {name}")
+    """Execute a coroutine with bounded retry on 429 / timeout.
+
+    ``coro_factory`` must return an awaitable (typically a GitLabService
+    method call). The method itself is expected to go through ``run_sync``
+    internally, so the applicative semaphore and offload are already
+    applied; this wrapper only adds per-site retry on 429 and timeout.
+    """
+    last_error: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            async with asyncio.timeout(timeout):
+                return await coro_factory()
+        except TimeoutError:
+            logger.warning("GitLab call '%s' timed out (attempt %d/%d)", name, attempt + 1, max_retries)
+            last_error = TimeoutError(f"{name} timed out")
+        except Exception as e:
+            if "429" in str(e) or "rate limit" in str(e).lower():
+                wait_time = 2**attempt
+                logger.warning("GitLab rate limit hit for '%s', waiting %ds (attempt %d)", name, wait_time, attempt + 1)
+                await asyncio.sleep(wait_time)
+                last_error = GitLabRateLimitError(str(e))
+            else:
+                logger.error("GitLab call '%s' failed: %s", name, e)
+                last_error = e
+                break
+    raise last_error or Exception(f"Failed after {max_retries} attempts: {name}")
 
 
 def _normalize_api_data(raw_data: dict) -> dict:
-    """
-    Normalize API data from GitLab YAML to standard format.
+    """Normalize API data from GitLab YAML to standard format.
+
     Supports both simple format and Kubernetes-style format (apiVersion/kind/spec).
     """
-    # If it's Kubernetes-style format
     if "apiVersion" in raw_data and "kind" in raw_data:
         metadata = raw_data.get("metadata", {})
         spec = raw_data.get("spec", {})
@@ -89,8 +112,12 @@ def _normalize_api_data(raw_data: dict) -> dict:
             },
         }
 
-    # Simple format - return as-is
     return raw_data
+
+
+async def _gl_run(fn: Callable[..., Any], op_name: str, timeout: float = DEFAULT_TIMEOUT_S) -> Any:
+    """Run a sync python-gitlab closure under the uniform GitLab semaphore."""
+    return await run_sync(fn, semaphore=GITLAB_SEMAPHORE, timeout=timeout, op_name=op_name)
 
 
 class GitLabService(GitProvider):
@@ -101,53 +128,64 @@ class GitLabService(GitProvider):
         self._project: Project | None = None
 
     async def connect(self) -> None:
-        """Initialize GitLab connection"""
+        """Initialize GitLab connection."""
         try:
             gl_cfg = settings.git.gitlab
-            self._gl = gitlab.Gitlab(gl_cfg.url, private_token=gl_cfg.token.get_secret_value())
-            self._gl.auth()
 
-            # Get the main APIM project
-            self._project = self._gl.projects.get(gl_cfg.project_id)
+            def _connect() -> tuple[gitlab.Gitlab, Project]:
+                client = gitlab.Gitlab(gl_cfg.url, private_token=gl_cfg.token.get_secret_value())
+                client.auth()
+                project = client.projects.get(gl_cfg.project_id)
+                return client, project
 
-            logger.info(f"Connected to GitLab project: {self._project.name}")
+            self._gl, self._project = await _gl_run(_connect, "gitlab.connect", timeout=15.0)
+            logger.info("Connected to GitLab project: %s", self._project.name)
         except Exception as e:
-            logger.error(f"Failed to connect to GitLab: {e}")
+            logger.error("Failed to connect to GitLab: %s", e)
             raise
 
     async def disconnect(self) -> None:
-        """Close GitLab connection"""
+        """Close GitLab connection."""
         self._gl = None
         self._project = None
 
     async def get_head_commit_sha(self, ref: str = "main") -> str | None:
         """Return the current HEAD commit SHA from GitLab."""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        commits = self._project.commits.list(ref_name=ref, per_page=1)
-        if not commits:
-            return None
-        return commits[0].id
+        project = self._require_project()
+
+        def _head() -> str | None:
+            commits = project.commits.list(ref_name=ref, per_page=1)
+            if not commits:
+                return None
+            return commits[0].id
+
+        return await _gl_run(_head, "gitlab.get_head_commit_sha")
 
     async def list_tenants(self) -> list[str]:
         """List tenant IDs from the catalog repository."""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        try:
-            tree = self._project.repository_tree(path="tenants", ref="main")
+        project = self._require_project()
+
+        def _list() -> list[str]:
+            try:
+                tree = project.repository_tree(path="tenants", ref="main")
+            except gitlab.exceptions.GitlabGetError:
+                return []
             return [item["name"] for item in tree if item["type"] == "tree"]
-        except gitlab.exceptions.GitlabGetError:
-            return []
+
+        return await _gl_run(_list, "gitlab.list_tenants")
 
     # ============================================================
     # GitProvider ABC implementations
     # ============================================================
 
     async def clone_repo(self, repo_url: str) -> Path:
-        """Clone a GitLab repository to a temporary directory."""
+        """Clone a GitLab repository to a temporary directory.
+
+        NOTE: token-in-URL here is the C.2 leak — patched by the
+        subsequent commit (GIT_ASKPASS helper).
+        """
         tmp_dir = Path(tempfile.mkdtemp(prefix="stoa-gl-"))
         token = settings.git.gitlab.token.get_secret_value()
-        # Inject token into HTTPS URL for auth
         authed_url = repo_url.replace("https://", f"https://oauth2:{token}@")
         proc = await asyncio.create_subprocess_exec(
             "git",
@@ -165,22 +203,28 @@ class GitLabService(GitProvider):
 
     async def get_file_content(self, project_id: str, file_path: str, ref: str = "main") -> str:
         """Retrieve raw file content from GitLab."""
-        if not self._gl:
-            raise RuntimeError("GitLab not connected")
-        project = self._gl.projects.get(project_id)
-        try:
-            f = project.files.get(file_path, ref=ref)
-            return f.decode().decode("utf-8")
-        except gitlab.exceptions.GitlabGetError as exc:
-            raise FileNotFoundError(f"{file_path} not found in project {project_id}") from exc
+        gl = self._require_gl()
+
+        def _get() -> str:
+            project = gl.projects.get(project_id)
+            try:
+                f = project.files.get(file_path, ref=ref)
+                return f.decode().decode("utf-8")
+            except gitlab.exceptions.GitlabGetError as exc:
+                raise FileNotFoundError(f"{file_path} not found in project {project_id}") from exc
+
+        return await _gl_run(_get, "gitlab.get_file_content")
 
     async def list_files(self, project_id: str, path: str = "", ref: str = "main") -> list[str]:
         """List files in a GitLab repository directory."""
-        if not self._gl:
-            raise RuntimeError("GitLab not connected")
-        project = self._gl.projects.get(project_id)
-        items = project.repository_tree(path=path, ref=ref, per_page=100, all=True)
-        return [item["path"] for item in items]
+        gl = self._require_gl()
+
+        def _list() -> list[str]:
+            project = gl.projects.get(project_id)
+            items = project.repository_tree(path=path, ref=ref, per_page=100, all=True)
+            return [item["path"] for item in items]
+
+        return await _gl_run(_list, "gitlab.list_files")
 
     async def create_webhook(
         self,
@@ -190,76 +234,79 @@ class GitLabService(GitProvider):
         events: list[str],
     ) -> dict[str, Any]:
         """Register a webhook on a GitLab project."""
-        if not self._gl:
-            raise RuntimeError("GitLab not connected")
-        project = self._gl.projects.get(project_id)
-        # Map generic event names to GitLab hook booleans
-        hook_data: dict[str, Any] = {"url": url, "token": secret}
-        event_map = {
-            "push": "push_events",
-            "merge_request": "merge_requests_events",
-            "tag": "tag_push_events",
-            "issues": "issues_events",
-        }
-        for event in events:
-            gl_key = event_map.get(event, f"{event}_events")
-            hook_data[gl_key] = True
-        hook = project.hooks.create(hook_data)
-        return {"id": str(hook.id), "url": hook.url}
+        gl = self._require_gl()
+
+        def _create() -> dict[str, Any]:
+            project = gl.projects.get(project_id)
+            hook_data: dict[str, Any] = {"url": url, "token": secret}
+            event_map = {
+                "push": "push_events",
+                "merge_request": "merge_requests_events",
+                "tag": "tag_push_events",
+                "issues": "issues_events",
+            }
+            for event in events:
+                gl_key = event_map.get(event, f"{event}_events")
+                hook_data[gl_key] = True
+            hook = project.hooks.create(hook_data)
+            return {"id": str(hook.id), "url": hook.url}
+
+        return await _gl_run(_create, "gitlab.create_webhook")
 
     async def delete_webhook(self, project_id: str, hook_id: str) -> bool:
         """Remove a webhook from a GitLab project."""
-        if not self._gl:
-            raise RuntimeError("GitLab not connected")
-        project = self._gl.projects.get(project_id)
-        try:
-            hook = project.hooks.get(int(hook_id))
-            hook.delete()
-            return True
-        except gitlab.exceptions.GitlabGetError:
-            return False
+        gl = self._require_gl()
+
+        def _delete() -> bool:
+            project = gl.projects.get(project_id)
+            try:
+                hook = project.hooks.get(int(hook_id))
+                hook.delete()
+                return True
+            except gitlab.exceptions.GitlabGetError:
+                return False
+
+        return await _gl_run(_delete, "gitlab.delete_webhook")
 
     async def get_repo_info(self, project_id: str) -> dict[str, Any]:
         """Retrieve GitLab project metadata."""
-        if not self._gl:
-            raise RuntimeError("GitLab not connected")
-        project = self._gl.projects.get(project_id)
-        return {
-            "name": project.name,
-            "default_branch": project.default_branch,
-            "url": project.web_url,
-            "visibility": project.visibility,
-        }
+        gl = self._require_gl()
+
+        def _info() -> dict[str, Any]:
+            project = gl.projects.get(project_id)
+            return {
+                "name": project.name,
+                "default_branch": project.default_branch,
+                "url": project.web_url,
+                "visibility": project.visibility,
+            }
+
+        return await _gl_run(_info, "gitlab.get_repo_info")
 
     # ============================================================
     # Legacy methods (used by existing callers)
     # ============================================================
 
     def _get_tenant_path(self, tenant_id: str) -> str:
-        """Get the base path for a tenant in the repo"""
         return f"tenants/{tenant_id}"
 
     def _get_api_path(self, tenant_id: str, api_name: str) -> str:
-        """Get the path for an API definition"""
         return f"{self._get_tenant_path(tenant_id)}/apis/{api_name}"
 
-    # Tenant operations
-    async def create_tenant_structure(self, tenant_id: str, tenant_data: dict) -> bool:
-        """
-        Create initial tenant directory structure in GitLab.
-
-        Structure:
-        tenants/{tenant_id}/
-        ├── tenant.yaml
-        ├── apis/
-        └── applications/
-        """
+    def _require_project(self) -> Project:
         if not self._project:
             raise RuntimeError("GitLab not connected")
+        return self._project
 
-        try:
-            # Create tenant.yaml
-            tenant_yaml = f"""# Tenant Configuration
+    def _require_gl(self) -> gitlab.Gitlab:
+        if not self._gl:
+            raise RuntimeError("GitLab not connected")
+        return self._gl
+
+    async def create_tenant_structure(self, tenant_id: str, tenant_data: dict) -> bool:
+        """Create initial tenant directory structure in GitLab."""
+        project = self._require_project()
+        tenant_yaml = f"""# Tenant Configuration
 id: {tenant_id}
 name: {tenant_data.get('name', tenant_id)}
 display_name: {tenant_data.get('display_name', tenant_id)}
@@ -272,28 +319,15 @@ settings:
     - dev
     - staging
 """
-            # Use commits API for atomic operation (single commit with all files)
-            # This prevents race conditions when creating multiple files
-            tenant_path = self._get_tenant_path(tenant_id)
-            actions = [
-                {
-                    "action": "create",
-                    "file_path": f"{tenant_path}/tenant.yaml",
-                    "content": tenant_yaml,
-                },
-                {
-                    "action": "create",
-                    "file_path": f"{tenant_path}/apis/.gitkeep",
-                    "content": "",
-                },
-                {
-                    "action": "create",
-                    "file_path": f"{tenant_path}/applications/.gitkeep",
-                    "content": "",
-                },
-            ]
+        tenant_path = self._get_tenant_path(tenant_id)
+        actions = [
+            {"action": "create", "file_path": f"{tenant_path}/tenant.yaml", "content": tenant_yaml},
+            {"action": "create", "file_path": f"{tenant_path}/apis/.gitkeep", "content": ""},
+            {"action": "create", "file_path": f"{tenant_path}/applications/.gitkeep", "content": ""},
+        ]
 
-            self._project.commits.create(
+        def _commit() -> None:
+            project.commits.create(
                 {
                     "branch": "main",
                     "commit_message": f"Create tenant {tenant_id}",
@@ -301,197 +335,194 @@ settings:
                 }
             )
 
-            logger.info(f"Created tenant structure for {tenant_id}")
+        try:
+            await _gl_run(_commit, "gitlab.create_tenant_structure", timeout=BATCH_TIMEOUT_S)
+            logger.info("Created tenant structure for %s", tenant_id)
             return True
-
         except Exception as e:
-            logger.error(f"Failed to create tenant structure: {e}")
+            logger.error("Failed to create tenant structure: %s", e)
             raise
 
     async def get_tenant(self, tenant_id: str) -> dict | None:
-        """Get tenant configuration from GitLab"""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
+        """Get tenant configuration from GitLab."""
+        project = self._require_project()
+        path = f"{self._get_tenant_path(tenant_id)}/tenant.yaml"
 
-        try:
-            file = self._project.files.get(f"{self._get_tenant_path(tenant_id)}/tenant.yaml", ref="main")
-            return yaml.safe_load(file.decode())
-        except gitlab.exceptions.GitlabGetError:
-            return None
+        def _get() -> dict | None:
+            try:
+                file = project.files.get(path, ref="main")
+                return yaml.safe_load(file.decode())
+            except gitlab.exceptions.GitlabGetError:
+                return None
+
+        return await _gl_run(_get, "gitlab.get_tenant")
 
     async def _ensure_tenant_exists(self, tenant_id: str) -> bool:
-        """Check if tenant exists, create structure if not"""
-        try:
-            self._project.files.get(f"{self._get_tenant_path(tenant_id)}/tenant.yaml", ref="main")
+        """Check if tenant exists, create structure if not."""
+        project = self._require_project()
+        path = f"{self._get_tenant_path(tenant_id)}/tenant.yaml"
+
+        def _exists() -> bool:
+            try:
+                project.files.get(path, ref="main")
+                return True
+            except gitlab.exceptions.GitlabGetError:
+                return False
+
+        if await _gl_run(_exists, "gitlab._ensure_tenant_exists"):
             return True
-        except gitlab.exceptions.GitlabGetError:
-            # Tenant doesn't exist, create minimal structure
-            logger.info(f"Tenant {tenant_id} doesn't exist, creating structure...")
-            await self.create_tenant_structure(
-                tenant_id,
-                {
-                    "name": tenant_id,
-                    "display_name": tenant_id,
-                },
-            )
-            return True
+        logger.info("Tenant %s doesn't exist, creating structure...", tenant_id)
+        await self.create_tenant_structure(
+            tenant_id,
+            {"name": tenant_id, "display_name": tenant_id},
+        )
+        return True
 
     async def _api_exists(self, tenant_id: str, api_name: str) -> bool:
-        """Check if API already exists"""
-        try:
-            self._project.files.get(f"{self._get_api_path(tenant_id, api_name)}/api.yaml", ref="main")
-            return True
-        except gitlab.exceptions.GitlabGetError:
-            return False
+        """Check if API already exists."""
+        project = self._require_project()
+        path = f"{self._get_api_path(tenant_id, api_name)}/api.yaml"
 
-    # API operations
+        def _check() -> bool:
+            try:
+                project.files.get(path, ref="main")
+                return True
+            except gitlab.exceptions.GitlabGetError:
+                return False
+
+        return await _gl_run(_check, "gitlab._api_exists")
+
     async def create_api(self, tenant_id: str, api_data: dict) -> str:
-        """
-        Create API definition in GitLab.
+        """Create API definition in GitLab.
 
-        Creates:
-        tenants/{tenant_id}/apis/{api_name}/
-        ├── api.yaml          # API metadata
-        ├── openapi.yaml      # OpenAPI specification
-        └── policies/         # Gateway policies
+        C.6: this retains its pre-check because the failure mode is
+        ``ValueError`` — the pre-check exists to return a specific error
+        shape to callers, not to race-guard a write. The TOCTOU fix for
+        writes lives in :meth:`write_file`.
         """
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-
+        project = self._require_project()
         api_name = api_data["name"]
         api_path = self._get_api_path(tenant_id, api_name)
 
-        # Ensure tenant exists
         await self._ensure_tenant_exists(tenant_id)
 
-        # Check if API already exists
         if await self._api_exists(tenant_id, api_name):
             raise ValueError(f"API '{api_name}' already exists for tenant '{tenant_id}'")
 
-        try:
-            # Create api.yaml with proper YAML escaping for description
-            api_content = {
-                "id": api_data.get("id", api_name),
-                "name": api_name,
-                "display_name": api_data.get("display_name", api_name),
-                "version": api_data.get("version", "1.0.0"),
-                "description": api_data.get("description", ""),
-                "backend_url": api_data.get("backend_url", ""),
-                "tags": api_data.get("tags", []),
-                "status": "draft",
-                "deployments": {
-                    "dev": False,
-                    "staging": False,
-                },
-            }
+        api_content = {
+            "id": api_data.get("id", api_name),
+            "name": api_name,
+            "display_name": api_data.get("display_name", api_name),
+            "version": api_data.get("version", "1.0.0"),
+            "description": api_data.get("description", ""),
+            "backend_url": api_data.get("backend_url", ""),
+            "tags": api_data.get("tags", []),
+            "status": "draft",
+            "deployments": {"dev": False, "staging": False},
+        }
 
-            api_yaml = yaml.dump(api_content, default_flow_style=False, allow_unicode=True)
+        api_yaml = yaml.dump(api_content, default_flow_style=False, allow_unicode=True)
 
-            # Use commits API to create all files in a single atomic commit
-            # This prevents race conditions when creating multiple files
-            actions = [
+        actions: list[dict[str, Any]] = [
+            {"action": "create", "file_path": f"{api_path}/api.yaml", "content": api_yaml},
+            {"action": "create", "file_path": f"{api_path}/policies/.gitkeep", "content": ""},
+        ]
+
+        if api_data.get("openapi_spec"):
+            actions.append(
                 {
                     "action": "create",
-                    "file_path": f"{api_path}/api.yaml",
-                    "content": api_yaml,
-                },
-                {
-                    "action": "create",
-                    "file_path": f"{api_path}/policies/.gitkeep",
-                    "content": "",
-                },
-            ]
-
-            # Add OpenAPI spec if provided
-            if api_data.get("openapi_spec"):
-                actions.append(
-                    {
-                        "action": "create",
-                        "file_path": f"{api_path}/openapi.yaml",
-                        "content": api_data["openapi_spec"],
-                    }
-                )
-
-            # Single atomic commit with all files
-            self._project.commits.create(
-                {
-                    "branch": "main",
-                    "commit_message": f"Create API {api_name} for tenant {tenant_id}",
-                    "actions": actions,
+                    "file_path": f"{api_path}/openapi.yaml",
+                    "content": api_data["openapi_spec"],
                 }
             )
 
-            logger.info(f"Created API {api_name} for tenant {tenant_id}")
-            return api_data.get("id", api_name)
+        def _commit() -> None:
+            try:
+                project.commits.create(
+                    {
+                        "branch": "main",
+                        "commit_message": f"Create API {api_name} for tenant {tenant_id}",
+                        "actions": actions,
+                    }
+                )
+            except gitlab.exceptions.GitlabCreateError as e:
+                if "already exists" in str(e).lower():
+                    raise ValueError(f"API '{api_name}' already exists for tenant '{tenant_id}'") from e
+                raise
 
-        except gitlab.exceptions.GitlabCreateError as e:
-            if "already exists" in str(e).lower():
-                raise ValueError(f"API '{api_name}' already exists for tenant '{tenant_id}'")
-            logger.error(f"Failed to create API: {e}")
+        try:
+            await _gl_run(_commit, "gitlab.create_api", timeout=BATCH_TIMEOUT_S)
+            logger.info("Created API %s for tenant %s", api_name, tenant_id)
+            return api_data.get("id", api_name)
+        except ValueError:
             raise
         except Exception as e:
-            logger.error(f"Failed to create API: {e}")
+            logger.error("Failed to create API: %s", e)
             raise
 
     async def get_api(self, tenant_id: str, api_name: str) -> dict | None:
-        """Get API configuration from GitLab"""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
+        """Get API configuration from GitLab."""
+        project = self._require_project()
+        path = f"{self._get_api_path(tenant_id, api_name)}/api.yaml"
 
-        try:
-            file = self._project.files.get(f"{self._get_api_path(tenant_id, api_name)}/api.yaml", ref="main")
-            raw_data = yaml.safe_load(file.decode())
-            return _normalize_api_data(raw_data)
-        except gitlab.exceptions.GitlabGetError:
-            return None
-        except yaml.YAMLError as e:
-            logger.error(f"Failed to parse API YAML for {api_name}: {e}")
-            return None
+        def _get() -> dict | None:
+            try:
+                file = project.files.get(path, ref="main")
+                raw_data = yaml.safe_load(file.decode())
+                return _normalize_api_data(raw_data)
+            except gitlab.exceptions.GitlabGetError:
+                return None
+            except yaml.YAMLError as e:
+                logger.error("Failed to parse API YAML for %s: %s", api_name, e)
+                return None
+
+        return await _gl_run(_get, "gitlab.get_api")
 
     async def get_api_openapi_spec(self, tenant_id: str, api_name: str) -> dict | None:
-        """Get OpenAPI specification for an API from GitLab"""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
+        """Get OpenAPI specification for an API from GitLab."""
+        project = self._require_project()
+        base = self._get_api_path(tenant_id, api_name)
 
-        try:
-            # Try openapi.yaml first, then openapi.json
-            for filename in ["openapi.yaml", "openapi.yml", "openapi.json"]:
-                try:
-                    file = self._project.files.get(f"{self._get_api_path(tenant_id, api_name)}/{filename}", ref="main")
-                    content = file.decode()
-                    if filename.endswith(".json"):
-                        import json
+        def _fetch() -> dict | None:
+            try:
+                for filename in ("openapi.yaml", "openapi.yml", "openapi.json"):
+                    try:
+                        file = project.files.get(f"{base}/{filename}", ref="main")
+                        content = file.decode()
+                        if filename.endswith(".json"):
+                            import json
 
-                        return json.loads(content)
-                    else:
+                            return json.loads(content)
                         return yaml.safe_load(content)
-                except gitlab.exceptions.GitlabGetError:
-                    continue
+                    except gitlab.exceptions.GitlabGetError:
+                        continue
+                return None
+            except Exception as e:
+                logger.error("Failed to get OpenAPI spec for %s: %s", api_name, e)
+                return None
 
-            return None
-        except Exception as e:
-            logger.error(f"Failed to get OpenAPI spec for {api_name}: {e}")
-            return None
+        return await _gl_run(_fetch, "gitlab.get_api_openapi_spec")
 
     async def list_apis(self, tenant_id: str) -> list[dict]:
-        """List all APIs for a tenant"""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
+        """List all APIs for a tenant."""
+        project = self._require_project()
+        base = f"{self._get_tenant_path(tenant_id)}/apis"
 
-        try:
-            tree = self._project.repository_tree(path=f"{self._get_tenant_path(tenant_id)}/apis", ref="main")
+        def _list_dirs() -> list[str]:
+            try:
+                tree = project.repository_tree(path=base, ref="main")
+            except gitlab.exceptions.GitlabGetError:
+                return []
+            return [item["name"] for item in tree if item["type"] == "tree" and item["name"] != ".gitkeep"]
 
-            apis = []
-            for item in tree:
-                if item["type"] == "tree" and item["name"] != ".gitkeep":
-                    api = await self.get_api(tenant_id, item["name"])
-                    if api:
-                        apis.append(api)
-
-            return apis
-
-        except gitlab.exceptions.GitlabGetError:
-            return []
+        api_dirs = await _gl_run(_list_dirs, "gitlab.list_apis.dirs")
+        apis: list[dict] = []
+        for api_name in api_dirs:
+            api = await self.get_api(tenant_id, api_name)
+            if api:
+                apis.append(api)
+        return apis
 
     # ============================================================
     # CAB-688: Parallel fetch methods
@@ -499,23 +530,26 @@ settings:
 
     async def list_apis_parallel(self, tenant_id: str) -> list[dict]:
         """List APIs for a tenant with parallel fetching (CAB-688)."""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
+        project = self._require_project()
+        base = f"{self._get_tenant_path(tenant_id)}/apis"
 
-        try:
-            tree = self._project.repository_tree(path=f"{self._get_tenant_path(tenant_id)}/apis", ref="main")
-        except gitlab.exceptions.GitlabGetError:
-            return []
+        def _list_dirs() -> list[str]:
+            try:
+                tree = project.repository_tree(path=base, ref="main")
+            except gitlab.exceptions.GitlabGetError:
+                return []
+            return [item["name"] for item in tree if item["type"] == "tree" and item["name"] != ".gitkeep"]
 
-        api_dirs = [item["name"] for item in tree if item["type"] == "tree" and item["name"] != ".gitkeep"]
+        api_dirs = await _gl_run(_list_dirs, "gitlab.list_apis_parallel.dirs")
 
         async def fetch_api(api_id: str) -> dict | None:
             try:
                 return await _fetch_with_protection(
-                    lambda aid=api_id: self.get_api(tenant_id, aid), f"api:{tenant_id}/{api_id}"
+                    lambda aid=api_id: self.get_api(tenant_id, aid),
+                    f"api:{tenant_id}/{api_id}",
                 )
             except Exception as e:
-                logger.warning(f"Failed to fetch API {tenant_id}/{api_id}: {e}")
+                logger.warning("Failed to fetch API %s/%s: %s", tenant_id, api_id, e)
                 return None
 
         results = await asyncio.gather(*[fetch_api(aid) for aid in api_dirs])
@@ -527,11 +561,12 @@ settings:
         async def fetch_spec(api_id: str) -> tuple[str, dict | None]:
             try:
                 spec = await _fetch_with_protection(
-                    lambda aid=api_id: self.get_api_openapi_spec(tenant_id, aid), f"openapi:{tenant_id}/{api_id}"
+                    lambda aid=api_id: self.get_api_openapi_spec(tenant_id, aid),
+                    f"openapi:{tenant_id}/{api_id}",
                 )
                 return (api_id, spec)
             except Exception as e:
-                logger.warning(f"Failed to fetch OpenAPI spec {tenant_id}/{api_id}: {e}")
+                logger.warning("Failed to fetch OpenAPI spec %s/%s: %s", tenant_id, api_id, e)
                 return (api_id, None)
 
         results = await asyncio.gather(*[fetch_spec(aid) for aid in api_ids])
@@ -539,9 +574,12 @@ settings:
 
     async def get_full_tree_recursive(self, path: str = "tenants") -> list[dict]:
         """Get full repository tree in ONE call (CAB-688 obligation #5)."""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        return self._project.repository_tree(path=path, ref="main", recursive=True, per_page=1000, all=True)
+        project = self._require_project()
+
+        def _tree() -> list[dict]:
+            return list(project.repository_tree(path=path, ref="main", recursive=True, per_page=1000, all=True))
+
+        return await _gl_run(_tree, "gitlab.get_full_tree_recursive", timeout=BATCH_TIMEOUT_S)
 
     def parse_tree_to_tenant_apis(self, tree: list[dict]) -> dict[str, list[str]]:
         """Parse recursive tree into {tenant_id: [api_ids]} structure."""
@@ -553,54 +591,55 @@ settings:
                 match = pattern.match(item["path"])
                 if match:
                     tenant_id, api_id = match.groups()
-                    if tenant_id not in tenant_apis:
-                        tenant_apis[tenant_id] = []
-                    tenant_apis[tenant_id].append(api_id)
+                    tenant_apis.setdefault(tenant_id, []).append(api_id)
 
         return tenant_apis
 
     async def update_api(self, tenant_id: str, api_name: str, api_data: dict) -> bool:
-        """Update API configuration in GitLab"""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
+        """Update API configuration in GitLab.
 
-        try:
-            file = self._project.files.get(f"{self._get_api_path(tenant_id, api_name)}/api.yaml", ref="main")
+        Uses ``last_commit_id`` for optimistic concurrency (GitLab server
+        rejects the save with 400 if another writer moved the pointer).
+        """
+        project = self._require_project()
+        path = f"{self._get_api_path(tenant_id, api_name)}/api.yaml"
+
+        def _update() -> None:
+            file = project.files.get(path, ref="main")
             current = yaml.safe_load(file.decode())
             current.update(api_data)
-
             file.content = yaml.dump(current, default_flow_style=False, allow_unicode=True)
-            file.save(branch="main", commit_message=f"Update API {api_name}")
+            save_kwargs: dict[str, Any] = {
+                "branch": "main",
+                "commit_message": f"Update API {api_name}",
+            }
+            last_commit_id = getattr(file, "last_commit_id", None)
+            if isinstance(last_commit_id, str) and last_commit_id:
+                save_kwargs["last_commit_id"] = last_commit_id
+            file.save(**save_kwargs)
 
-            logger.info(f"Updated API {api_name} for tenant {tenant_id}")
+        try:
+            await _gl_run(_update, "gitlab.update_api")
+            logger.info("Updated API %s for tenant %s", api_name, tenant_id)
             return True
-
         except Exception as e:
-            logger.error(f"Failed to update API: {e}")
+            logger.error("Failed to update API: %s", e)
             raise
 
     async def delete_api(self, tenant_id: str, api_name: str) -> bool:
-        """Delete API from GitLab"""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
+        """Delete API from GitLab."""
+        project = self._require_project()
+        api_path = self._get_api_path(tenant_id, api_name)
 
-        try:
-            # Delete entire API directory in a single atomic commit
-            api_path = self._get_api_path(tenant_id, api_name)
-            tree = self._project.repository_tree(path=api_path, ref="main", recursive=True)
-
-            actions = []
-            for item in tree:
-                if item["type"] == "blob":
-                    actions.append(
-                        {
-                            "action": "delete",
-                            "file_path": item["path"],
-                        }
-                    )
-
+        def _delete() -> None:
+            tree = project.repository_tree(path=api_path, ref="main", recursive=True)
+            actions = [
+                {"action": "delete", "file_path": item["path"]}
+                for item in tree
+                if item["type"] == "blob"
+            ]
             if actions:
-                self._project.commits.create(
+                project.commits.create(
                     {
                         "branch": "main",
                         "commit_message": f"Delete API {api_name}",
@@ -608,11 +647,12 @@ settings:
                     }
                 )
 
-            logger.info(f"Deleted API {api_name} for tenant {tenant_id}")
+        try:
+            await _gl_run(_delete, "gitlab.delete_api", timeout=BATCH_TIMEOUT_S)
+            logger.info("Deleted API %s for tenant %s", api_name, tenant_id)
             return True
-
         except Exception as e:
-            logger.error(f"Failed to delete API: {e}")
+            logger.error("Failed to delete API: %s", e)
             raise
 
     # ============================================================
@@ -623,45 +663,76 @@ settings:
         self, project_id: str, file_path: str, content: str, commit_message: str, branch: str = "main"
     ) -> dict[str, Any]:
         """Create a new file in GitLab."""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        project = self._gl.projects.get(project_id) if project_id else self._project
-        try:
-            project.files.create(
-                {"file_path": file_path, "branch": branch, "content": content, "commit_message": commit_message}
-            )
-            return {"sha": "", "url": ""}
-        except gitlab.exceptions.GitlabCreateError as e:
-            if "already exists" in str(e).lower():
-                raise ValueError(f"File already exists: {file_path}") from e
-            raise
+        gl = self._require_gl()
+        fallback = self._project
+
+        def _create() -> dict[str, Any]:
+            project = gl.projects.get(project_id) if project_id else fallback
+            if project is None:
+                raise RuntimeError("GitLab not connected")
+            try:
+                project.files.create(
+                    {
+                        "file_path": file_path,
+                        "branch": branch,
+                        "content": content,
+                        "commit_message": commit_message,
+                    }
+                )
+                return {"sha": "", "url": ""}
+            except gitlab.exceptions.GitlabCreateError as e:
+                if "already exists" in str(e).lower():
+                    raise ValueError(f"File already exists: {file_path}") from e
+                raise
+
+        return await _gl_run(_create, "gitlab.create_file")
 
     async def update_file(
         self, project_id: str, file_path: str, content: str, commit_message: str, branch: str = "main"
     ) -> dict[str, Any]:
-        """Update an existing file in GitLab."""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        project = self._gl.projects.get(project_id) if project_id else self._project
-        try:
-            f = project.files.get(file_path, ref=branch)
-            f.content = content
-            f.save(branch=branch, commit_message=commit_message)
-            return {"sha": "", "url": ""}
-        except gitlab.exceptions.GitlabGetError as e:
-            raise FileNotFoundError(f"{file_path} not found") from e
+        """Update an existing file in GitLab (uses last_commit_id)."""
+        gl = self._require_gl()
+        fallback = self._project
+
+        def _update() -> dict[str, Any]:
+            project = gl.projects.get(project_id) if project_id else fallback
+            if project is None:
+                raise RuntimeError("GitLab not connected")
+            try:
+                f = project.files.get(file_path, ref=branch)
+                f.content = content
+                save_kwargs: dict[str, Any] = {"branch": branch, "commit_message": commit_message}
+                last_commit_id = getattr(f, "last_commit_id", None)
+                if isinstance(last_commit_id, str) and last_commit_id:
+                    save_kwargs["last_commit_id"] = last_commit_id
+                f.save(**save_kwargs)
+                return {"sha": "", "url": ""}
+            except gitlab.exceptions.GitlabGetError as e:
+                raise FileNotFoundError(f"{file_path} not found") from e
+
+        return await _gl_run(_update, "gitlab.update_file")
 
     async def delete_file(self, project_id: str, file_path: str, commit_message: str, branch: str = "main") -> bool:
-        """Delete a file from GitLab."""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        project = self._gl.projects.get(project_id) if project_id else self._project
-        try:
-            f = project.files.get(file_path, ref=branch)
-            f.delete(branch=branch, commit_message=commit_message)
-            return True
-        except gitlab.exceptions.GitlabGetError as e:
-            raise FileNotFoundError(f"{file_path} not found") from e
+        """Delete a file from GitLab (uses last_commit_id)."""
+        gl = self._require_gl()
+        fallback = self._project
+
+        def _delete() -> bool:
+            project = gl.projects.get(project_id) if project_id else fallback
+            if project is None:
+                raise RuntimeError("GitLab not connected")
+            try:
+                f = project.files.get(file_path, ref=branch)
+                delete_kwargs: dict[str, Any] = {"branch": branch, "commit_message": commit_message}
+                last_commit_id = getattr(f, "last_commit_id", None)
+                if isinstance(last_commit_id, str) and last_commit_id:
+                    delete_kwargs["last_commit_id"] = last_commit_id
+                f.delete(**delete_kwargs)
+                return True
+            except gitlab.exceptions.GitlabGetError as e:
+                raise FileNotFoundError(f"{file_path} not found") from e
+
+        return await _gl_run(_delete, "gitlab.delete_file")
 
     async def batch_commit(
         self,
@@ -671,66 +742,67 @@ settings:
         branch: str = "main",
     ) -> dict[str, Any]:
         """Atomic multi-file commit via GitLab commits API."""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        project = self._gl.projects.get(project_id) if project_id else self._project
-        project.commits.create({"branch": branch, "commit_message": commit_message, "actions": actions})
-        return {"sha": "", "url": ""}
+        gl = self._require_gl()
+        fallback = self._project
+
+        def _commit() -> dict[str, Any]:
+            project = gl.projects.get(project_id) if project_id else fallback
+            if project is None:
+                raise RuntimeError("GitLab not connected")
+            project.commits.create({"branch": branch, "commit_message": commit_message, "actions": actions})
+            return {"sha": "", "url": ""}
+
+        return await _gl_run(_commit, "gitlab.batch_commit", timeout=BATCH_TIMEOUT_S)
 
     # Git operations
     async def get_file(self, path: str, ref: str = "main") -> str | None:
-        """Get file content from GitLab"""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
+        """Get file content from GitLab."""
+        project = self._require_project()
 
-        try:
-            file = self._project.files.get(path, ref=ref)
-            return file.decode().decode("utf-8")
-        except gitlab.exceptions.GitlabGetError:
-            return None
+        def _get() -> str | None:
+            try:
+                file = project.files.get(path, ref=ref)
+                return file.decode().decode("utf-8")
+            except gitlab.exceptions.GitlabGetError:
+                return None
+
+        return await _gl_run(_get, "gitlab.get_file")
 
     async def list_commits(self, path: str | None = None, limit: int = 20) -> list[dict]:
-        """List commits for a path"""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
+        """List commits for a path."""
+        project = self._require_project()
 
-        commits = self._project.commits.list(path=path, per_page=limit)
-        return [
-            {
-                "sha": c.id,
-                "message": c.message,
-                "author": c.author_name,
-                "date": c.created_at,
-            }
-            for c in commits
-        ]
+        def _list() -> list[dict]:
+            commits = project.commits.list(path=path, per_page=limit)
+            return [
+                {
+                    "sha": c.id,
+                    "message": c.message,
+                    "author": c.author_name,
+                    "date": c.created_at,
+                }
+                for c in commits
+            ]
+
+        return await _gl_run(_list, "gitlab.list_commits")
 
     # ===========================================
     # MCP Server GitOps Operations
     # ===========================================
 
     def _get_mcp_server_path(self, tenant_id: str, server_name: str) -> str:
-        """Get the path for an MCP server definition.
-
-        Platform servers: platform/mcp-servers/{server_name}
-        Tenant servers: tenants/{tenant_id}/mcp-servers/{server_name}
-        """
+        """Get the path for an MCP server definition."""
         if tenant_id == "_platform":
             return f"platform/mcp-servers/{server_name}"
         return f"{self._get_tenant_path(tenant_id)}/mcp-servers/{server_name}"
 
     def _normalize_mcp_server_data(self, raw_data: dict, git_path: str) -> dict:
-        """
-        Normalize MCP server data from GitLab YAML to standard format.
-        Supports Kubernetes-style format (apiVersion/kind/spec).
-        """
         metadata = raw_data.get("metadata", {})
         spec = raw_data.get("spec", {})
         visibility = spec.get("visibility", {})
         subscription = spec.get("subscription", {})
         backend = spec.get("backend", {})
 
-        # Normalize tools
         tools = []
         for tool in spec.get("tools", []):
             tools.append(
@@ -779,120 +851,110 @@ settings:
 
     async def get_mcp_server(self, tenant_id: str, server_name: str) -> dict | None:
         """Get MCP server configuration from GitLab."""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-
+        project = self._require_project()
         server_path = self._get_mcp_server_path(tenant_id, server_name)
 
-        try:
-            file = self._project.files.get(f"{server_path}/server.yaml", ref="main")
-            raw_data = yaml.safe_load(file.decode())
-            return self._normalize_mcp_server_data(raw_data, server_path)
-        except gitlab.exceptions.GitlabGetError:
-            return None
-        except yaml.YAMLError as e:
-            logger.error(f"Failed to parse MCP server YAML for {server_name}: {e}")
-            return None
+        def _get() -> dict | None:
+            try:
+                file = project.files.get(f"{server_path}/server.yaml", ref="main")
+                raw_data = yaml.safe_load(file.decode())
+                return self._normalize_mcp_server_data(raw_data, server_path)
+            except gitlab.exceptions.GitlabGetError:
+                return None
+            except yaml.YAMLError as e:
+                logger.error("Failed to parse MCP server YAML for %s: %s", server_name, e)
+                return None
+
+        return await _gl_run(_get, "gitlab.get_mcp_server")
 
     async def list_mcp_servers(self, tenant_id: str = "_platform") -> list[dict]:
         """List all MCP servers for a tenant or platform."""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
+        project = self._require_project()
+        base_path = (
+            "platform/mcp-servers"
+            if tenant_id == "_platform"
+            else f"{self._get_tenant_path(tenant_id)}/mcp-servers"
+        )
 
-        # Determine base path
-        if tenant_id == "_platform":
-            base_path = "platform/mcp-servers"
-        else:
-            base_path = f"{self._get_tenant_path(tenant_id)}/mcp-servers"
+        def _list_names() -> list[str]:
+            try:
+                tree = project.repository_tree(path=base_path, ref="main")
+            except gitlab.exceptions.GitlabGetError:
+                return []
+            return [item["name"] for item in tree if item["type"] == "tree" and item["name"] != ".gitkeep"]
 
-        try:
-            tree = self._project.repository_tree(path=base_path, ref="main")
-
-            servers = []
-            for item in tree:
-                if item["type"] == "tree" and item["name"] != ".gitkeep":
-                    server = await self.get_mcp_server(tenant_id, item["name"])
-                    if server:
-                        servers.append(server)
-
-            return servers
-
-        except gitlab.exceptions.GitlabGetError:
-            return []
+        names = await _gl_run(_list_names, "gitlab.list_mcp_servers.names")
+        servers: list[dict] = []
+        for name in names:
+            server = await self.get_mcp_server(tenant_id, name)
+            if server:
+                servers.append(server)
+        return servers
 
     async def list_all_mcp_servers(self) -> list[dict]:
         """List all MCP servers across platform and all tenants."""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
+        project = self._require_project()
+        all_servers: list[dict] = []
 
-        all_servers = []
-
-        # Get platform servers
         platform_servers = await self.list_mcp_servers("_platform")
         all_servers.extend(platform_servers)
 
-        # Get tenant servers
-        try:
-            tenants_tree = self._project.repository_tree(path="tenants", ref="main")
-            for tenant_item in tenants_tree:
-                if tenant_item["type"] == "tree":
-                    tenant_id = tenant_item["name"]
-                    tenant_servers = await self.list_mcp_servers(tenant_id)
-                    all_servers.extend(tenant_servers)
-        except gitlab.exceptions.GitlabGetError:
-            pass  # No tenants directory
+        def _list_tenant_ids() -> list[str]:
+            try:
+                tenants_tree = project.repository_tree(path="tenants", ref="main")
+            except gitlab.exceptions.GitlabGetError:
+                return []
+            return [item["name"] for item in tenants_tree if item["type"] == "tree"]
 
+        tenant_ids = await _gl_run(_list_tenant_ids, "gitlab.list_all_mcp_servers.tenants")
+        for tenant_id in tenant_ids:
+            tenant_servers = await self.list_mcp_servers(tenant_id)
+            all_servers.extend(tenant_servers)
         return all_servers
 
     async def create_mcp_server(self, tenant_id: str, server_data: dict) -> str:
         """Create MCP server definition in GitLab."""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-
+        project = self._require_project()
         server_name = server_data["name"]
         server_path = self._get_mcp_server_path(tenant_id, server_name)
 
-        # Check if server already exists
         existing = await self.get_mcp_server(tenant_id, server_name)
         if existing:
             raise ValueError(f"MCP server '{server_name}' already exists")
 
-        try:
-            # Build YAML content in Kubernetes-style format
-            server_yaml = yaml.dump(
-                {
-                    "apiVersion": "gostoa.dev/v1",
-                    "kind": "MCPServer",
-                    "metadata": {
-                        "name": server_name,
-                        "tenant": tenant_id,
-                        "version": server_data.get("version", "1.0.0"),
-                        "labels": {
-                            "managed-by": "gitops",
-                        },
-                    },
-                    "spec": {
-                        "displayName": server_data.get("display_name", server_name),
-                        "description": server_data.get("description", ""),
-                        "icon": server_data.get("icon", ""),
-                        "category": server_data.get("category", "public"),
-                        "status": server_data.get("status", "active"),
-                        "documentationUrl": server_data.get("documentation_url", ""),
-                        "visibility": server_data.get("visibility", {"public": True}),
-                        "subscription": {
-                            "requiresApproval": server_data.get("requires_approval", False),
-                            "autoApproveRoles": server_data.get("auto_approve_roles", []),
-                            "defaultPlan": server_data.get("default_plan", "free"),
-                        },
-                        "tools": server_data.get("tools", []),
-                        "backend": server_data.get("backend", {}),
-                    },
+        server_yaml = yaml.dump(
+            {
+                "apiVersion": "gostoa.dev/v1",
+                "kind": "MCPServer",
+                "metadata": {
+                    "name": server_name,
+                    "tenant": tenant_id,
+                    "version": server_data.get("version", "1.0.0"),
+                    "labels": {"managed-by": "gitops"},
                 },
-                default_flow_style=False,
-                allow_unicode=True,
-            )
+                "spec": {
+                    "displayName": server_data.get("display_name", server_name),
+                    "description": server_data.get("description", ""),
+                    "icon": server_data.get("icon", ""),
+                    "category": server_data.get("category", "public"),
+                    "status": server_data.get("status", "active"),
+                    "documentationUrl": server_data.get("documentation_url", ""),
+                    "visibility": server_data.get("visibility", {"public": True}),
+                    "subscription": {
+                        "requiresApproval": server_data.get("requires_approval", False),
+                        "autoApproveRoles": server_data.get("auto_approve_roles", []),
+                        "defaultPlan": server_data.get("default_plan", "free"),
+                    },
+                    "tools": server_data.get("tools", []),
+                    "backend": server_data.get("backend", {}),
+                },
+            },
+            default_flow_style=False,
+            allow_unicode=True,
+        )
 
-            self._project.commits.create(
+        def _commit() -> None:
+            project.commits.create(
                 {
                     "branch": "main",
                     "commit_message": f"Create MCP server {server_name}",
@@ -906,32 +968,30 @@ settings:
                 }
             )
 
-            logger.info(f"Created MCP server {server_name}")
+        try:
+            await _gl_run(_commit, "gitlab.create_mcp_server", timeout=BATCH_TIMEOUT_S)
+            logger.info("Created MCP server %s", server_name)
             return server_name
-
         except Exception as e:
-            logger.error(f"Failed to create MCP server: {e}")
+            logger.error("Failed to create MCP server: %s", e)
             raise
 
     async def update_mcp_server(self, tenant_id: str, server_name: str, server_data: dict) -> bool:
         """Update MCP server configuration in GitLab."""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-
+        project = self._require_project()
         server_path = self._get_mcp_server_path(tenant_id, server_name)
 
-        try:
-            file = self._project.files.get(f"{server_path}/server.yaml", ref="main")
+        def _update() -> None:
+            file = project.files.get(f"{server_path}/server.yaml", ref="main")
             current = yaml.safe_load(file.decode())
 
-            # Update spec fields
             if "spec" not in current:
                 current["spec"] = {}
 
             for key, value in server_data.items():
-                if key in ["display_name"]:
+                if key == "display_name":
                     current["spec"]["displayName"] = value
-                elif key in ["description", "icon", "category", "status"]:
+                elif key in ("description", "icon", "category", "status"):
                     current["spec"][key] = value
                 elif key == "documentation_url":
                     current["spec"]["documentationUrl"] = value
@@ -943,37 +1003,37 @@ settings:
                     current["spec"]["backend"] = value
 
             file.content = yaml.dump(current, default_flow_style=False, allow_unicode=True)
-            file.save(branch="main", commit_message=f"Update MCP server {server_name}")
+            save_kwargs: dict[str, Any] = {
+                "branch": "main",
+                "commit_message": f"Update MCP server {server_name}",
+            }
+            last_commit_id = getattr(file, "last_commit_id", None)
+            if isinstance(last_commit_id, str) and last_commit_id:
+                save_kwargs["last_commit_id"] = last_commit_id
+            file.save(**save_kwargs)
 
-            logger.info(f"Updated MCP server {server_name}")
+        try:
+            await _gl_run(_update, "gitlab.update_mcp_server")
+            logger.info("Updated MCP server %s", server_name)
             return True
-
         except Exception as e:
-            logger.error(f"Failed to update MCP server: {e}")
+            logger.error("Failed to update MCP server: %s", e)
             raise
 
     async def delete_mcp_server(self, tenant_id: str, server_name: str) -> bool:
         """Delete MCP server from GitLab."""
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-
+        project = self._require_project()
         server_path = self._get_mcp_server_path(tenant_id, server_name)
 
-        try:
-            tree = self._project.repository_tree(path=server_path, ref="main", recursive=True)
-
-            actions = []
-            for item in tree:
-                if item["type"] == "blob":
-                    actions.append(
-                        {
-                            "action": "delete",
-                            "file_path": item["path"],
-                        }
-                    )
-
+        def _delete() -> None:
+            tree = project.repository_tree(path=server_path, ref="main", recursive=True)
+            actions = [
+                {"action": "delete", "file_path": item["path"]}
+                for item in tree
+                if item["type"] == "blob"
+            ]
             if actions:
-                self._project.commits.create(
+                project.commits.create(
                     {
                         "branch": "main",
                         "commit_message": f"Delete MCP server {server_name}",
@@ -981,26 +1041,29 @@ settings:
                     }
                 )
 
-            logger.info(f"Deleted MCP server {server_name}")
+        try:
+            await _gl_run(_delete, "gitlab.delete_mcp_server", timeout=BATCH_TIMEOUT_S)
+            logger.info("Deleted MCP server %s", server_name)
             return True
-
         except Exception as e:
-            logger.error(f"Failed to delete MCP server: {e}")
+            logger.error("Failed to delete MCP server: %s", e)
             raise
 
     # ============================================================
     # CAB-1889 CP-1: provider-agnostic surface (GitProvider ABC).
-    # Operates on the connected catalog project (self._project).
     # ============================================================
 
     async def list_tree(self, path: str, ref: str = "main") -> list[TreeEntry]:
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        try:
-            tree = self._project.repository_tree(path=path, ref=ref)
-        except gitlab.exceptions.GitlabGetError:
-            return []
-        return [TreeEntry(name=item["name"], type=item["type"], path=item["path"]) for item in tree]
+        project = self._require_project()
+
+        def _list() -> list[TreeEntry]:
+            try:
+                tree = project.repository_tree(path=path, ref=ref)
+            except gitlab.exceptions.GitlabGetError:
+                return []
+            return [TreeEntry(name=item["name"], type=item["type"], path=item["path"]) for item in tree]
+
+        return await _gl_run(_list, "gitlab.list_tree")
 
     async def read_file(self, path: str, ref: str = "main") -> str | None:
         return await self.get_file(path, ref=ref)
@@ -1012,52 +1075,60 @@ settings:
     async def write_file(
         self, path: str, content: str, commit_message: str, branch: str = "main"
     ) -> Literal["created", "updated"]:
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        existing = await self.get_file(path, ref=branch)
-        if existing is not None:
-            file_obj = self._project.files.get(path, ref=branch)
-            file_obj.content = content
-            file_obj.save(branch=branch, commit_message=commit_message)
+        """CP-1 C.6: create-first, fall through to update on 'already exists'.
+
+        This closes the TOCTOU window from the prior _file_exists pre-check.
+        It does not provide full compare-and-swap — two concurrent writers
+        both hitting the 'already exists' branch can still lose one another's
+        content. update_file passes ``last_commit_id`` for GitLab-side
+        optimistic concurrency on that second step.
+        """
+        project_id = ""
+        _ = self._require_project()
+        try:
+            await self.create_file(project_id, path, content, commit_message, branch=branch)
+            return "created"
+        except ValueError:
+            await self.update_file(project_id, path, content, commit_message, branch=branch)
             return "updated"
-        self._project.files.create(
-            {
-                "file_path": path,
-                "branch": branch,
-                "content": content,
-                "commit_message": commit_message,
-            }
-        )
-        return "created"
 
     async def remove_file(self, path: str, commit_message: str, branch: str = "main") -> bool:
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        self._project.files.delete(file_path=path, commit_message=commit_message, branch=branch)
-        return True
+        project = self._require_project()
+
+        def _delete() -> bool:
+            project.files.delete(file_path=path, commit_message=commit_message, branch=branch)
+            return True
+
+        return await _gl_run(_delete, "gitlab.remove_file")
 
     async def list_branches(self) -> list[BranchRef]:
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        branches = self._project.branches.list()
-        return [
-            BranchRef(
+        project = self._require_project()
+
+        def _list() -> list[BranchRef]:
+            branches = project.branches.list()
+            return [
+                BranchRef(
+                    name=b.name,
+                    commit_sha=b.commit["id"] if isinstance(b.commit, dict) else str(b.commit),
+                    protected=getattr(b, "protected", False),
+                )
+                for b in branches
+            ]
+
+        return await _gl_run(_list, "gitlab.list_branches")
+
+    async def create_branch(self, name: str, ref: str = "main") -> BranchRef:
+        project = self._require_project()
+
+        def _create() -> BranchRef:
+            b = project.branches.create({"branch": name, "ref": ref})
+            return BranchRef(
                 name=b.name,
                 commit_sha=b.commit["id"] if isinstance(b.commit, dict) else str(b.commit),
                 protected=getattr(b, "protected", False),
             )
-            for b in branches
-        ]
 
-    async def create_branch(self, name: str, ref: str = "main") -> BranchRef:
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        b = self._project.branches.create({"branch": name, "ref": ref})
-        return BranchRef(
-            name=b.name,
-            commit_sha=b.commit["id"] if isinstance(b.commit, dict) else str(b.commit),
-            protected=getattr(b, "protected", False),
-        )
+        return await _gl_run(_create, "gitlab.create_branch")
 
     @staticmethod
     def _mr_to_ref(mr: Any) -> MergeRequestRef:
@@ -1076,10 +1147,13 @@ settings:
         )
 
     async def list_merge_requests(self, state: str = "opened") -> list[MergeRequestRef]:
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        mrs = self._project.mergerequests.list(state=state)
-        return [self._mr_to_ref(mr) for mr in mrs]
+        project = self._require_project()
+
+        def _list() -> list[MergeRequestRef]:
+            mrs = project.mergerequests.list(state=state)
+            return [self._mr_to_ref(mr) for mr in mrs]
+
+        return await _gl_run(_list, "gitlab.list_merge_requests")
 
     async def create_merge_request(
         self,
@@ -1088,24 +1162,30 @@ settings:
         source_branch: str,
         target_branch: str = "main",
     ) -> MergeRequestRef:
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        mr = self._project.mergerequests.create(
-            {
-                "title": title,
-                "description": description,
-                "source_branch": source_branch,
-                "target_branch": target_branch,
-            }
-        )
-        return self._mr_to_ref(mr)
+        project = self._require_project()
+
+        def _create() -> MergeRequestRef:
+            mr = project.mergerequests.create(
+                {
+                    "title": title,
+                    "description": description,
+                    "source_branch": source_branch,
+                    "target_branch": target_branch,
+                }
+            )
+            return self._mr_to_ref(mr)
+
+        return await _gl_run(_create, "gitlab.create_merge_request")
 
     async def merge_merge_request(self, iid: int) -> MergeRequestRef:
-        if not self._project:
-            raise RuntimeError("GitLab not connected")
-        mr = self._project.mergerequests.get(iid)
-        mr.merge()
-        return self._mr_to_ref(mr)
+        project = self._require_project()
+
+        def _merge() -> MergeRequestRef:
+            mr = project.mergerequests.get(iid)
+            mr.merge()
+            return self._mr_to_ref(mr)
+
+        return await _gl_run(_merge, "gitlab.merge_merge_request")
 
 
 # Global instance

--- a/control-plane-api/src/services/github_service.py
+++ b/control-plane-api/src/services/github_service.py
@@ -26,7 +26,7 @@ import re
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypeVar
 
 import yaml
 from github import Auth, Github, GithubException, InputGitTreeElement
@@ -45,22 +45,34 @@ from .git_provider import BranchRef, CommitRef, GitProvider, MergeRequestRef, Tr
 
 logger = logging.getLogger(__name__)
 
+_GHT = TypeVar("_GHT")
 
-async def _gh_read(fn: Callable[..., Any], op_name: str, timeout: float = DEFAULT_TIMEOUT_S) -> Any:
+
+async def _gh_read(
+    fn: Callable[[], _GHT],
+    op_name: str,
+    timeout: float = DEFAULT_TIMEOUT_S,
+) -> _GHT:
     """Run a sync PyGithub read closure under the read semaphore."""
     return await run_sync(fn, semaphore=GITHUB_READ_SEMAPHORE, timeout=timeout, op_name=op_name)
 
 
 async def _gh_contents_write(
-    fn: Callable[..., Any], op_name: str, timeout: float = DEFAULT_TIMEOUT_S
-) -> Any:
+    fn: Callable[[], _GHT],
+    op_name: str,
+    timeout: float = DEFAULT_TIMEOUT_S,
+) -> _GHT:
     """Run a sync PyGithub Contents-API write under the serial (1) semaphore."""
     return await run_sync(
         fn, semaphore=GITHUB_CONTENTS_WRITE_SEMAPHORE, timeout=timeout, op_name=op_name
     )
 
 
-async def _gh_meta_write(fn: Callable[..., Any], op_name: str, timeout: float = DEFAULT_TIMEOUT_S) -> Any:
+async def _gh_meta_write(
+    fn: Callable[[], _GHT],
+    op_name: str,
+    timeout: float = DEFAULT_TIMEOUT_S,
+) -> _GHT:
     """Run a sync PyGithub non-Contents write under the meta-write semaphore (5)."""
     return await run_sync(
         fn, semaphore=GITHUB_META_WRITE_SEMAPHORE, timeout=timeout, op_name=op_name

--- a/control-plane-api/src/services/github_service.py
+++ b/control-plane-api/src/services/github_service.py
@@ -1,7 +1,22 @@
 """GitHub implementation of GitProvider (CAB-1890 Wave 2, CAB-2011 write methods).
 
-Uses PyGithub for API operations and subprocess git for clone.
-project_id format: "org/repo" (e.g. "stoa-platform/stoa-catalog").
+CP-1 (C.1/C.5): PyGithub is synchronous; every SDK call is routed through
+:func:`.git_executor.run_sync` so the asyncio loop stays non-blocking.
+Read calls acquire ``GITHUB_READ_SEMAPHORE`` (cap 10). Write calls on the
+Repository Contents endpoints acquire ``GITHUB_CONTENTS_WRITE_SEMAPHORE``
+(cap 1 — serial, per GitHub docs "Running this endpoint with parallel
+requests is bound to cause errors"). Non-Contents writes (pull requests,
+branches, webhooks) acquire ``GITHUB_META_WRITE_SEMAPHORE`` (cap 5).
+
+CP-1 (C.6): ``write_file`` drops the ``_file_exists`` pre-check. It calls
+``create_file`` first and falls through to ``update_file`` on the 422
+"already exists" error.
+
+Implementation rule (see git_executor.py): the ENTIRE SDK interaction —
+including iteration over PyGithub ``PaginatedList`` objects and
+``.decoded_content`` access on lazy ``ContentFile`` — must happen inside
+the closure passed to ``run_sync``. Returning a lazy object and iterating
+it after ``await`` would re-introduce the blocking sync-in-async pattern.
 """
 
 import asyncio
@@ -9,6 +24,7 @@ import json
 import logging
 import re
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal
 
@@ -16,9 +32,38 @@ import yaml
 from github import Auth, Github, GithubException, InputGitTreeElement
 
 from ..config import settings
+from .git_executor import (
+    BATCH_TIMEOUT_S,
+    DEFAULT_TIMEOUT_S,
+    GITHUB_CONTENTS_WRITE_SEMAPHORE,
+    GITHUB_META_WRITE_SEMAPHORE,
+    GITHUB_READ_SEMAPHORE,
+    run_sync,
+)
 from .git_provider import BranchRef, CommitRef, GitProvider, MergeRequestRef, TreeEntry
 
 logger = logging.getLogger(__name__)
+
+
+async def _gh_read(fn: Callable[..., Any], op_name: str, timeout: float = DEFAULT_TIMEOUT_S) -> Any:
+    """Run a sync PyGithub read closure under the read semaphore."""
+    return await run_sync(fn, semaphore=GITHUB_READ_SEMAPHORE, timeout=timeout, op_name=op_name)
+
+
+async def _gh_contents_write(
+    fn: Callable[..., Any], op_name: str, timeout: float = DEFAULT_TIMEOUT_S
+) -> Any:
+    """Run a sync PyGithub Contents-API write under the serial (1) semaphore."""
+    return await run_sync(
+        fn, semaphore=GITHUB_CONTENTS_WRITE_SEMAPHORE, timeout=timeout, op_name=op_name
+    )
+
+
+async def _gh_meta_write(fn: Callable[..., Any], op_name: str, timeout: float = DEFAULT_TIMEOUT_S) -> Any:
+    """Run a sync PyGithub non-Contents write under the meta-write semaphore (5)."""
+    return await run_sync(
+        fn, semaphore=GITHUB_META_WRITE_SEMAPHORE, timeout=timeout, op_name=op_name
+    )
 
 
 def _normalize_api_data(raw_data: dict) -> dict:
@@ -49,7 +94,6 @@ def _normalize_api_data(raw_data: dict) -> dict:
 
 
 def _normalize_mcp_server_data(raw_data: dict, git_path: str) -> dict:
-    """Normalize MCP server YAML to the existing catalog sync format."""
     metadata = raw_data.get("metadata", {})
     spec = raw_data.get("spec", {})
     visibility = spec.get("visibility", {})
@@ -113,9 +157,13 @@ class GitHubService(GitProvider):
         """Initialize GitHub connection using settings.git.github.token."""
         try:
             auth = Auth.Token(settings.git.github.token.get_secret_value())
-            self._gh = Github(auth=auth)
-            # Validate credentials by fetching authenticated user
-            user = self._gh.get_user().login
+
+            def _connect() -> tuple[Github, str]:
+                client = Github(auth=auth)
+                login = client.get_user().login
+                return client, login
+
+            self._gh, user = await _gh_read(_connect, "github.connect", timeout=15.0)
             logger.info("Connected to GitHub as %s", user)
         except Exception as e:
             logger.error("Failed to connect to GitHub: %s", e)
@@ -132,10 +180,13 @@ class GitHubService(GitProvider):
         return self._gh is not None
 
     async def clone_repo(self, repo_url: str) -> Path:
-        """Clone a GitHub repository to a temporary directory."""
+        """Clone a GitHub repository to a temporary directory.
+
+        NOTE: token-in-URL here is the C.2 leak — patched by the
+        subsequent commit (GIT_ASKPASS helper).
+        """
         tmp_dir = Path(tempfile.mkdtemp(prefix="stoa-gh-"))
         token = settings.git.github.token.get_secret_value()
-        # Inject token into HTTPS URL for auth
         authed_url = repo_url.replace("https://", f"https://x-access-token:{token}@")
         proc = await asyncio.create_subprocess_exec(
             "git",
@@ -151,41 +202,55 @@ class GitHubService(GitProvider):
             raise RuntimeError(f"git clone failed: {stderr.decode().strip()}")
         return tmp_dir / "repo"
 
-    def _get_repo(self, project_id: str) -> Any:
-        """Get a PyGithub Repository object.
-
-        Args:
-            project_id: "org/repo" format (e.g. "stoa-platform/stoa-catalog").
-        """
+    def _require_gh(self) -> Github:
         if not self._gh:
             raise RuntimeError("GitHub not connected")
-        return self._gh.get_repo(project_id)
+        return self._gh
+
+    def _get_repo(self, project_id: str) -> Any:
+        """Return a PyGithub Repository object.
+
+        Used by tests and legacy code; call-sites that need to run inside
+        ``run_sync`` must fetch the repo inside the closure to avoid
+        reintroducing C.1 via lazy object accesses.
+        """
+        return self._require_gh().get_repo(project_id)
 
     async def get_file_content(self, project_id: str, file_path: str, ref: str = "main") -> str:
         """Retrieve raw file content from GitHub."""
-        repo = self._get_repo(project_id)
-        try:
-            content_file = repo.get_contents(file_path, ref=ref)
-            if isinstance(content_file, list):
-                raise FileNotFoundError(f"{file_path} is a directory, not a file, in {project_id}")
-            return content_file.decoded_content.decode("utf-8")
-        except GithubException as exc:
-            if exc.status == 404:
-                raise FileNotFoundError(f"{file_path} not found in project {project_id}") from exc
-            raise
+        gh = self._require_gh()
+
+        def _get() -> str:
+            repo = gh.get_repo(project_id)
+            try:
+                content_file = repo.get_contents(file_path, ref=ref)
+                if isinstance(content_file, list):
+                    raise FileNotFoundError(f"{file_path} is a directory, not a file, in {project_id}")
+                return content_file.decoded_content.decode("utf-8")
+            except GithubException as exc:
+                if exc.status == 404:
+                    raise FileNotFoundError(f"{file_path} not found in project {project_id}") from exc
+                raise
+
+        return await _gh_read(_get, "github.get_file_content")
 
     async def list_files(self, project_id: str, path: str = "", ref: str = "main") -> list[str]:
         """List files in a GitHub repository directory."""
-        repo = self._get_repo(project_id)
-        try:
-            contents = repo.get_contents(path, ref=ref)
+        gh = self._require_gh()
+
+        def _list() -> list[str]:
+            repo = gh.get_repo(project_id)
+            try:
+                contents = repo.get_contents(path, ref=ref)
+            except GithubException as exc:
+                if exc.status == 404:
+                    return []
+                raise
             if not isinstance(contents, list):
                 contents = [contents]
             return [item.path for item in contents]
-        except GithubException as exc:
-            if exc.status == 404:
-                return []
-            raise
+
+        return await _gh_read(_list, "github.list_files")
 
     async def create_webhook(
         self,
@@ -194,56 +259,76 @@ class GitHubService(GitProvider):
         secret: str,
         events: list[str],
     ) -> dict[str, Any]:
-        """Register a webhook on a GitHub repository."""
-        repo = self._get_repo(project_id)
-        # Map generic event names to GitHub webhook events
-        event_map = {
-            "push": "push",
-            "merge_request": "pull_request",
-            "tag": "create",
-            "issues": "issues",
-        }
-        gh_events = [event_map.get(e, e) for e in events]
-        hook = repo.create_hook(
-            name="web",
-            config={"url": url, "secret": secret, "content_type": "json"},
-            events=gh_events,
-            active=True,
-        )
-        return {"id": str(hook.id), "url": hook.config["url"]}
+        """Register a webhook on a GitHub repository (non-Contents write)."""
+        gh = self._require_gh()
+
+        def _create() -> dict[str, Any]:
+            repo = gh.get_repo(project_id)
+            event_map = {
+                "push": "push",
+                "merge_request": "pull_request",
+                "tag": "create",
+                "issues": "issues",
+            }
+            gh_events = [event_map.get(e, e) for e in events]
+            hook = repo.create_hook(
+                name="web",
+                config={"url": url, "secret": secret, "content_type": "json"},
+                events=gh_events,
+                active=True,
+            )
+            return {"id": str(hook.id), "url": hook.config["url"]}
+
+        return await _gh_meta_write(_create, "github.create_webhook")
 
     async def delete_webhook(self, project_id: str, hook_id: str) -> bool:
-        """Remove a webhook from a GitHub repository."""
-        repo = self._get_repo(project_id)
-        try:
-            hook = repo.get_hook(int(hook_id))
-            hook.delete()
-            return True
-        except GithubException as exc:
-            if exc.status == 404:
-                return False
-            raise
+        """Remove a webhook from a GitHub repository (non-Contents write)."""
+        gh = self._require_gh()
+
+        def _delete() -> bool:
+            repo = gh.get_repo(project_id)
+            try:
+                hook = repo.get_hook(int(hook_id))
+                hook.delete()
+                return True
+            except GithubException as exc:
+                if exc.status == 404:
+                    return False
+                raise
+
+        return await _gh_meta_write(_delete, "github.delete_webhook")
 
     async def get_repo_info(self, project_id: str) -> dict[str, Any]:
         """Retrieve GitHub repository metadata."""
-        repo = self._get_repo(project_id)
-        return {
-            "name": repo.name,
-            "default_branch": repo.default_branch,
-            "url": repo.html_url,
-            "visibility": "private" if repo.private else "public",
-        }
+        gh = self._require_gh()
+
+        def _info() -> dict[str, Any]:
+            repo = gh.get_repo(project_id)
+            return {
+                "name": repo.name,
+                "default_branch": repo.default_branch,
+                "url": repo.html_url,
+                "visibility": "private" if repo.private else "public",
+            }
+
+        return await _gh_read(_info, "github.get_repo_info")
 
     async def get_head_commit_sha(self, ref: str = "main") -> str | None:
         """Return the HEAD commit SHA for the catalog branch."""
-        repo = self._get_repo(self._catalog_project_id())
-        try:
-            branch = repo.get_branch(ref)
-        except GithubException as exc:
-            if exc.status == 404:
-                return None
-            raise
-        return branch.commit.sha
+        gh = self._require_gh()
+        project_id = self._catalog_project_id()
+
+        def _head() -> str | None:
+            repo = gh.get_repo(project_id)
+            try:
+                branch = repo.get_branch(ref)
+            except GithubException as exc:
+                if exc.status == 404:
+                    return None
+                raise
+            return branch.commit.sha
+
+        return await _gh_read(_head, "github.get_head_commit_sha")
 
     async def get_tenant(self, tenant_id: str) -> dict | None:
         """Return tenant metadata from tenant.yaml if present."""
@@ -262,18 +347,22 @@ class GitHubService(GitProvider):
 
     async def list_tenants(self) -> list[str]:
         """List tenants from the catalog repository."""
-        repo = self._get_repo(self._catalog_project_id())
-        try:
-            contents = repo.get_contents("tenants", ref="main")
-        except GithubException as exc:
-            if exc.status == 404:
-                return []
-            raise
+        gh = self._require_gh()
+        project_id = self._catalog_project_id()
 
-        if not isinstance(contents, list):
-            contents = [contents]
+        def _list() -> list[str]:
+            repo = gh.get_repo(project_id)
+            try:
+                contents = repo.get_contents("tenants", ref="main")
+            except GithubException as exc:
+                if exc.status == 404:
+                    return []
+                raise
+            if not isinstance(contents, list):
+                contents = [contents]
+            return [item.name for item in contents if item.type == "dir"]
 
-        return [item.name for item in contents if item.type == "dir"]
+        return await _gh_read(_list, "github.list_tenants")
 
     async def get_api(self, tenant_id: str, api_name: str) -> dict | None:
         """Return normalized API metadata from api.yaml."""
@@ -294,43 +383,50 @@ class GitHubService(GitProvider):
 
     async def list_apis(self, tenant_id: str) -> list[dict]:
         """List APIs for a tenant from GitHub."""
-        repo = self._get_repo(self._catalog_project_id())
+        gh = self._require_gh()
+        project_id = self._catalog_project_id()
         base_path = f"{self._get_tenant_path(tenant_id)}/apis"
-        try:
-            contents = repo.get_contents(base_path, ref="main")
-        except GithubException as exc:
-            if exc.status == 404:
-                return []
-            raise
 
-        if not isinstance(contents, list):
-            contents = [contents]
+        def _list_names() -> list[str]:
+            repo = gh.get_repo(project_id)
+            try:
+                contents = repo.get_contents(base_path, ref="main")
+            except GithubException as exc:
+                if exc.status == 404:
+                    return []
+                raise
+            if not isinstance(contents, list):
+                contents = [contents]
+            return [item.name for item in contents if item.type == "dir" and item.name != ".gitkeep"]
 
+        names = await _gh_read(_list_names, "github.list_apis.names")
         apis: list[dict] = []
-        for item in contents:
-            if item.type != "dir" or item.name == ".gitkeep":
-                continue
-            api = await self.get_api(tenant_id, item.name)
+        for name in names:
+            api = await self.get_api(tenant_id, name)
             if api:
                 apis.append(api)
         return apis
 
     async def list_apis_parallel(self, tenant_id: str) -> list[dict]:
         """List tenant APIs with concurrent GitHub fetches."""
-        repo = self._get_repo(self._catalog_project_id())
+        gh = self._require_gh()
+        project_id = self._catalog_project_id()
         base_path = f"{self._get_tenant_path(tenant_id)}/apis"
-        try:
-            contents = repo.get_contents(base_path, ref="main")
-        except GithubException as exc:
-            if exc.status == 404:
-                return []
-            raise
 
-        if not isinstance(contents, list):
-            contents = [contents]
+        def _list_names() -> list[str]:
+            repo = gh.get_repo(project_id)
+            try:
+                contents = repo.get_contents(base_path, ref="main")
+            except GithubException as exc:
+                if exc.status == 404:
+                    return []
+                raise
+            if not isinstance(contents, list):
+                contents = [contents]
+            return [item.name for item in contents if item.type == "dir" and item.name != ".gitkeep"]
 
-        api_names = [item.name for item in contents if item.type == "dir" and item.name != ".gitkeep"]
-        results = await asyncio.gather(*[self.get_api(tenant_id, api_name) for api_name in api_names])
+        api_names = await _gh_read(_list_names, "github.list_apis_parallel.names")
+        results = await asyncio.gather(*[self.get_api(tenant_id, name) for name in api_names])
         return [api for api in results if api is not None]
 
     async def get_api_openapi_spec(self, tenant_id: str, api_name: str) -> dict | None:
@@ -349,7 +445,9 @@ class GitHubService(GitProvider):
                     return json.loads(content)
                 return yaml.safe_load(content)
             except (json.JSONDecodeError, yaml.YAMLError) as exc:
-                logger.error("Failed to parse OpenAPI spec for %s/%s (%s): %s", tenant_id, api_name, filename, exc)
+                logger.error(
+                    "Failed to parse OpenAPI spec for %s/%s (%s): %s", tenant_id, api_name, filename, exc
+                )
                 return None
 
         return None
@@ -365,24 +463,29 @@ class GitHubService(GitProvider):
 
     async def get_full_tree_recursive(self, path: str = "tenants") -> list[dict]:
         """Return the recursive Git tree in the GitLab-compatible shape."""
-        repo = self._get_repo(self._catalog_project_id())
-        branch = repo.get_branch("main")
-        tree = repo.get_git_tree(branch.commit.sha, recursive=True).tree
-        prefix = f"{path}/"
+        gh = self._require_gh()
+        project_id = self._catalog_project_id()
 
-        items: list[dict] = []
-        for item in tree:
-            if item.path != path and not item.path.startswith(prefix):
-                continue
-            items.append(
-                {
-                    "id": item.sha,
-                    "name": Path(item.path).name,
-                    "type": "tree" if item.type == "tree" else "blob",
-                    "path": item.path,
-                }
-            )
-        return items
+        def _tree() -> list[dict]:
+            repo = gh.get_repo(project_id)
+            branch = repo.get_branch("main")
+            tree = repo.get_git_tree(branch.commit.sha, recursive=True).tree
+            prefix = f"{path}/"
+            items: list[dict] = []
+            for item in tree:
+                if item.path != path and not item.path.startswith(prefix):
+                    continue
+                items.append(
+                    {
+                        "id": item.sha,
+                        "name": Path(item.path).name,
+                        "type": "tree" if item.type == "tree" else "blob",
+                        "path": item.path,
+                    }
+                )
+            return items
+
+        return await _gh_read(_tree, "github.get_full_tree_recursive", timeout=BATCH_TIMEOUT_S)
 
     def parse_tree_to_tenant_apis(self, tree: list[dict]) -> dict[str, list[str]]:
         """Parse a recursive tree into {tenant_id: [api_ids]}."""
@@ -419,24 +522,28 @@ class GitHubService(GitProvider):
 
     async def list_mcp_servers(self, tenant_id: str = "_platform") -> list[dict]:
         """List MCP servers for a tenant or platform scope."""
-        repo = self._get_repo(self._catalog_project_id())
-        if tenant_id == "_platform":
-            base_path = "platform/mcp-servers"
-        else:
-            base_path = f"{self._get_tenant_path(tenant_id)}/mcp-servers"
+        gh = self._require_gh()
+        project_id = self._catalog_project_id()
+        base_path = (
+            "platform/mcp-servers"
+            if tenant_id == "_platform"
+            else f"{self._get_tenant_path(tenant_id)}/mcp-servers"
+        )
 
-        try:
-            contents = repo.get_contents(base_path, ref="main")
-        except GithubException as exc:
-            if exc.status == 404:
-                return []
-            raise
+        def _list_names() -> list[str]:
+            repo = gh.get_repo(project_id)
+            try:
+                contents = repo.get_contents(base_path, ref="main")
+            except GithubException as exc:
+                if exc.status == 404:
+                    return []
+                raise
+            if not isinstance(contents, list):
+                contents = [contents]
+            return [item.name for item in contents if item.type == "dir" and item.name != ".gitkeep"]
 
-        if not isinstance(contents, list):
-            contents = [contents]
-
-        server_names = [item.name for item in contents if item.type == "dir" and item.name != ".gitkeep"]
-        results = await asyncio.gather(*[self.get_mcp_server(tenant_id, server_name) for server_name in server_names])
+        names = await _gh_read(_list_names, "github.list_mcp_servers.names")
+        results = await asyncio.gather(*[self.get_mcp_server(tenant_id, name) for name in names])
         return [server for server in results if server is not None]
 
     async def list_all_mcp_servers(self) -> list[dict]:
@@ -453,45 +560,60 @@ class GitHubService(GitProvider):
     async def create_file(
         self, project_id: str, file_path: str, content: str, commit_message: str, branch: str = "main"
     ) -> dict[str, Any]:
-        """Create a new file in a GitHub repository."""
-        repo = self._get_repo(project_id)
-        try:
-            result = repo.create_file(file_path, commit_message, content, branch=branch)
-            return {"sha": result["commit"].sha, "url": result["commit"].html_url}
-        except GithubException as exc:
-            if exc.status == 422 and "sha" in str(exc.data).lower():
-                raise ValueError(f"File already exists: {file_path}") from exc
-            raise
+        """Create a new file in a GitHub repository (Contents API — serial)."""
+        gh = self._require_gh()
+
+        def _create() -> dict[str, Any]:
+            repo = gh.get_repo(project_id)
+            try:
+                result = repo.create_file(file_path, commit_message, content, branch=branch)
+                return {"sha": result["commit"].sha, "url": result["commit"].html_url}
+            except GithubException as exc:
+                if exc.status == 422 and "sha" in str(exc.data).lower():
+                    raise ValueError(f"File already exists: {file_path}") from exc
+                raise
+
+        return await _gh_contents_write(_create, "github.create_file")
 
     async def update_file(
         self, project_id: str, file_path: str, content: str, commit_message: str, branch: str = "main"
     ) -> dict[str, Any]:
-        """Update an existing file in a GitHub repository."""
-        repo = self._get_repo(project_id)
-        try:
-            existing = repo.get_contents(file_path, ref=branch)
-            if isinstance(existing, list):
-                raise ValueError(f"{file_path} is a directory, not a file")
-            result = repo.update_file(file_path, commit_message, content, existing.sha, branch=branch)
-            return {"sha": result["commit"].sha, "url": result["commit"].html_url}
-        except GithubException as exc:
-            if exc.status == 404:
-                raise FileNotFoundError(f"{file_path} not found in {project_id}") from exc
-            raise
+        """Update an existing file in a GitHub repository (Contents API — serial)."""
+        gh = self._require_gh()
+
+        def _update() -> dict[str, Any]:
+            repo = gh.get_repo(project_id)
+            try:
+                existing = repo.get_contents(file_path, ref=branch)
+                if isinstance(existing, list):
+                    raise ValueError(f"{file_path} is a directory, not a file")
+                result = repo.update_file(file_path, commit_message, content, existing.sha, branch=branch)
+                return {"sha": result["commit"].sha, "url": result["commit"].html_url}
+            except GithubException as exc:
+                if exc.status == 404:
+                    raise FileNotFoundError(f"{file_path} not found in {project_id}") from exc
+                raise
+
+        return await _gh_contents_write(_update, "github.update_file")
 
     async def delete_file(self, project_id: str, file_path: str, commit_message: str, branch: str = "main") -> bool:
-        """Delete a file from a GitHub repository."""
-        repo = self._get_repo(project_id)
-        try:
-            existing = repo.get_contents(file_path, ref=branch)
-            if isinstance(existing, list):
-                raise ValueError(f"{file_path} is a directory, not a file")
-            repo.delete_file(file_path, commit_message, existing.sha, branch=branch)
-            return True
-        except GithubException as exc:
-            if exc.status == 404:
-                raise FileNotFoundError(f"{file_path} not found in {project_id}") from exc
-            raise
+        """Delete a file from a GitHub repository (Contents API — serial)."""
+        gh = self._require_gh()
+
+        def _delete() -> bool:
+            repo = gh.get_repo(project_id)
+            try:
+                existing = repo.get_contents(file_path, ref=branch)
+                if isinstance(existing, list):
+                    raise ValueError(f"{file_path} is a directory, not a file")
+                repo.delete_file(file_path, commit_message, existing.sha, branch=branch)
+                return True
+            except GithubException as exc:
+                if exc.status == 404:
+                    raise FileNotFoundError(f"{file_path} not found in {project_id}") from exc
+                raise
+
+        return await _gh_contents_write(_delete, "github.delete_file")
 
     async def batch_commit(
         self,
@@ -502,41 +624,42 @@ class GitHubService(GitProvider):
     ) -> dict[str, Any]:
         """Atomic multi-file commit via the Git Tree API.
 
-        Equivalent to GitLab's project.commits.create() with an actions array.
-        Creates a new tree with all changes and points the branch ref at it.
+        Uses the Git Data tree path (not strictly Contents), but held under
+        the Contents-write semaphore to keep a single write lane and
+        preserve the "no parallel mutations" invariant.
         """
-        repo = self._get_repo(project_id)
+        gh = self._require_gh()
 
-        # 1. Get current commit on branch
-        ref = repo.get_git_ref(f"heads/{branch}")
-        base_sha = ref.object.sha
-        base_tree = repo.get_git_tree(base_sha)
+        def _commit() -> dict[str, Any]:
+            repo = gh.get_repo(project_id)
+            ref = repo.get_git_ref(f"heads/{branch}")
+            base_sha = ref.object.sha
+            base_tree = repo.get_git_tree(base_sha)
 
-        # 2. Build tree elements from actions
-        tree_elements: list[InputGitTreeElement] = []
-        for action in actions:
-            act = action["action"]
-            path = action["file_path"]
+            tree_elements: list[InputGitTreeElement] = []
+            for action in actions:
+                act = action["action"]
+                path = action["file_path"]
+                if act in ("create", "update"):
+                    content_value = action.get("content", "")
+                    tree_elements.append(InputGitTreeElement(path, "100644", "blob", content=content_value))
+                elif act == "delete":
+                    tree_elements.append(InputGitTreeElement(path, "100644", "blob", sha=None))
+                else:
+                    raise ValueError(f"Unknown action: {act}. Must be create, update, or delete.")
 
-            if act in ("create", "update"):
-                content = action.get("content", "")
-                tree_elements.append(InputGitTreeElement(path, "100644", "blob", content=content))
-            elif act == "delete":
-                # SHA "null" + mode "000000" removes the entry from the tree
-                tree_elements.append(InputGitTreeElement(path, "100644", "blob", sha=None))
-            else:
-                raise ValueError(f"Unknown action: {act}. Must be create, update, or delete.")
+            if not tree_elements:
+                raise ValueError("No actions provided for batch commit")
 
-        if not tree_elements:
-            raise ValueError("No actions provided for batch commit")
+            new_tree = repo.create_git_tree(tree_elements, base_tree=base_tree)
+            new_commit = repo.create_git_commit(commit_message, new_tree, [repo.get_git_commit(base_sha)])
+            ref.edit(new_commit.sha)
+            logger.info(
+                "Batch commit %s on %s/%s (%d actions)", new_commit.sha[:8], project_id, branch, len(actions)
+            )
+            return {"sha": new_commit.sha, "url": new_commit.html_url}
 
-        # 3. Create new tree, commit, and update ref
-        new_tree = repo.create_git_tree(tree_elements, base_tree=base_tree)
-        new_commit = repo.create_git_commit(commit_message, new_tree, [repo.get_git_commit(base_sha)])
-        ref.edit(new_commit.sha)
-
-        logger.info("Batch commit %s on %s/%s (%d actions)", new_commit.sha[:8], project_id, branch, len(actions))
-        return {"sha": new_commit.sha, "url": new_commit.html_url}
+        return await _gh_contents_write(_commit, "github.batch_commit", timeout=BATCH_TIMEOUT_S)
 
     async def create_pull_request(
         self,
@@ -547,25 +670,26 @@ class GitHubService(GitProvider):
         actions: list[dict[str, str]],
         base: str = "main",
     ) -> dict[str, Any]:
-        """Create a branch with changes and open a pull request.
+        """Create a branch with changes and open a pull request."""
+        gh = self._require_gh()
 
-        1. Creates a new branch from base
-        2. Commits all actions to that branch via batch_commit
-        3. Opens a PR from branch → base
-        """
-        repo = self._get_repo(project_id)
+        def _create_branch() -> None:
+            repo = gh.get_repo(project_id)
+            base_ref = repo.get_git_ref(f"heads/{base}")
+            repo.create_git_ref(f"refs/heads/{branch}", base_ref.object.sha)
 
-        # Create branch from base HEAD
-        base_ref = repo.get_git_ref(f"heads/{base}")
-        repo.create_git_ref(f"refs/heads/{branch}", base_ref.object.sha)
+        await _gh_meta_write(_create_branch, "github.create_pr.branch")
 
-        # Commit changes to the new branch
+        # batch_commit acquires its own contents-write semaphore
         await self.batch_commit(project_id, actions, title, branch=branch)
 
-        # Open PR
-        pr = repo.create_pull(title=title, body=body, head=branch, base=base)
-        logger.info("Created PR #%d on %s: %s", pr.number, project_id, title)
-        return {"pr_number": pr.number, "url": pr.html_url}
+        def _open_pr() -> dict[str, Any]:
+            repo = gh.get_repo(project_id)
+            pr = repo.create_pull(title=title, body=body, head=branch, base=base)
+            logger.info("Created PR #%d on %s: %s", pr.number, project_id, title)
+            return {"pr_number": pr.number, "url": pr.html_url}
+
+        return await _gh_meta_write(_open_pr, "github.create_pr.open")
 
     # ============================================================
     # High-level catalog operations (CAB-2011)
@@ -590,7 +714,13 @@ class GitHubService(GitProvider):
         return f"tenants/{tenant_id}/mcp-servers/{server_name}"
 
     async def _file_exists(self, project_id: str, file_path: str, ref: str = "main") -> bool:
-        """Check if a file exists in the repository."""
+        """Check if a file exists in the repository.
+
+        NOTE (C.6): not used by :meth:`write_file` anymore. Retained for
+        :meth:`create_api` / :meth:`update_api` where the pre-check is
+        about producing a specific error shape to callers rather than
+        race-guarding a write.
+        """
         try:
             await self.get_file_content(project_id, file_path, ref=ref)
             return True
@@ -600,14 +730,7 @@ class GitHubService(GitProvider):
     # --- Tenant operations ---
 
     async def create_tenant_structure(self, tenant_id: str, tenant_data: dict) -> bool:
-        """Create initial tenant directory structure in GitHub.
-
-        Structure:
-        tenants/{tenant_id}/
-        ├── tenant.yaml
-        ├── apis/.gitkeep
-        └── applications/.gitkeep
-        """
+        """Create initial tenant directory structure in GitHub."""
         project_id = self._catalog_project_id()
         tenant_path = self._get_tenant_path(tenant_id)
 
@@ -656,12 +779,9 @@ class GitHubService(GitProvider):
     async def create_api(self, tenant_id: str, api_data: dict) -> str:
         """Create API definition in GitHub.
 
-        Creates:
-        tenants/{tenant_id}/apis/{api_name}/
-        ├── api.yaml
-        ├── openapi.yaml (if provided)
-        ├── overrides/{env}.yaml (if provided, CAB-2015)
-        └── policies/.gitkeep
+        The pre-existence check produces a specific ``ValueError`` shape
+        for callers; the actual race-guard is handled at the batch_commit
+        layer via the serial Contents-write semaphore.
         """
         project_id = self._catalog_project_id()
         api_name = api_data["name"]
@@ -686,7 +806,7 @@ class GitHubService(GitProvider):
 
         api_yaml = yaml.dump(api_content, default_flow_style=False, allow_unicode=True)
 
-        actions = [
+        actions: list[dict[str, Any]] = [
             {"action": "create", "file_path": f"{api_path}/api.yaml", "content": api_yaml},
             {"action": "create", "file_path": f"{api_path}/policies/.gitkeep", "content": ""},
         ]
@@ -696,7 +816,6 @@ class GitHubService(GitProvider):
                 {"action": "create", "file_path": f"{api_path}/openapi.yaml", "content": api_data["openapi_spec"]}
             )
 
-        # CAB-2015: write per-environment overrides if provided
         overrides: dict[str, dict] = api_data.get("overrides", {})
         for env_name, env_config in overrides.items():
             override_yaml = yaml.dump(env_config, default_flow_style=False, allow_unicode=True)
@@ -724,16 +843,16 @@ class GitHubService(GitProvider):
         except FileNotFoundError:
             raise FileNotFoundError(f"API '{api_name}' not found for tenant '{tenant_id}'")
 
-        # Separate overrides from base api_data
         overrides: dict[str, dict] = api_data.pop("overrides", {})
 
         current = yaml.safe_load(current_content)
         current.update(api_data)
         updated_yaml = yaml.dump(current, default_flow_style=False, allow_unicode=True)
 
-        # CAB-2015: batch base + override updates in one commit
         if overrides:
-            actions = [{"action": "update", "file_path": file_path, "content": updated_yaml}]
+            actions: list[dict[str, Any]] = [
+                {"action": "update", "file_path": file_path, "content": updated_yaml}
+            ]
             for env_name, env_config in overrides.items():
                 override_path = f"{api_path}/overrides/{env_name}.yaml"
                 override_yaml = yaml.dump(env_config, default_flow_style=False, allow_unicode=True)
@@ -750,26 +869,29 @@ class GitHubService(GitProvider):
         """Delete API directory from GitHub."""
         project_id = self._catalog_project_id()
         api_path = self._get_api_path(tenant_id, api_name)
+        gh = self._require_gh()
 
-        # List all files in the API directory via recursive tree
-        repo = self._get_repo(project_id)
-        try:
-            contents = repo.get_contents(api_path, ref="main")
-        except GithubException as exc:
-            if exc.status == 404:
-                raise FileNotFoundError(f"API '{api_name}' not found for tenant '{tenant_id}'") from exc
-            raise
+        def _collect_files() -> list[str]:
+            repo = gh.get_repo(project_id)
+            try:
+                contents = repo.get_contents(api_path, ref="main")
+            except GithubException as exc:
+                if exc.status == 404:
+                    raise FileNotFoundError(f"API '{api_name}' not found for tenant '{tenant_id}'") from exc
+                raise
 
-        # Flatten directory contents recursively
-        files_to_delete: list[str] = []
-        stack = contents if isinstance(contents, list) else [contents]
-        while stack:
-            item = stack.pop()
-            if item.type == "dir":
-                sub_contents = repo.get_contents(item.path, ref="main")
-                stack.extend(sub_contents if isinstance(sub_contents, list) else [sub_contents])
-            else:
-                files_to_delete.append(item.path)
+            files_to_delete: list[str] = []
+            stack = contents if isinstance(contents, list) else [contents]
+            while stack:
+                item = stack.pop()
+                if item.type == "dir":
+                    sub_contents = repo.get_contents(item.path, ref="main")
+                    stack.extend(sub_contents if isinstance(sub_contents, list) else [sub_contents])
+                else:
+                    files_to_delete.append(item.path)
+            return files_to_delete
+
+        files_to_delete = await _gh_read(_collect_files, "github.delete_api.collect", timeout=BATCH_TIMEOUT_S)
 
         if not files_to_delete:
             return True
@@ -869,24 +991,31 @@ class GitHubService(GitProvider):
         """Delete MCP server from GitHub."""
         project_id = self._catalog_project_id()
         server_path = self._get_mcp_server_path(tenant_id, server_name)
+        gh = self._require_gh()
 
-        repo = self._get_repo(project_id)
-        try:
-            contents = repo.get_contents(server_path, ref="main")
-        except GithubException as exc:
-            if exc.status == 404:
-                raise FileNotFoundError(f"MCP server '{server_name}' not found") from exc
-            raise
+        def _collect_files() -> list[str]:
+            repo = gh.get_repo(project_id)
+            try:
+                contents = repo.get_contents(server_path, ref="main")
+            except GithubException as exc:
+                if exc.status == 404:
+                    raise FileNotFoundError(f"MCP server '{server_name}' not found") from exc
+                raise
 
-        files_to_delete: list[str] = []
-        stack = contents if isinstance(contents, list) else [contents]
-        while stack:
-            item = stack.pop()
-            if item.type == "dir":
-                sub_contents = repo.get_contents(item.path, ref="main")
-                stack.extend(sub_contents if isinstance(sub_contents, list) else [sub_contents])
-            else:
-                files_to_delete.append(item.path)
+            files_to_delete: list[str] = []
+            stack = contents if isinstance(contents, list) else [contents]
+            while stack:
+                item = stack.pop()
+                if item.type == "dir":
+                    sub_contents = repo.get_contents(item.path, ref="main")
+                    stack.extend(sub_contents if isinstance(sub_contents, list) else [sub_contents])
+                else:
+                    files_to_delete.append(item.path)
+            return files_to_delete
+
+        files_to_delete = await _gh_read(
+            _collect_files, "github.delete_mcp_server.collect", timeout=BATCH_TIMEOUT_S
+        )
 
         if not files_to_delete:
             return True
@@ -899,27 +1028,32 @@ class GitHubService(GitProvider):
 
     # ============================================================
     # CAB-1889 CP-1: provider-agnostic surface (GitProvider ABC).
-    # Operates on the catalog repo resolved via _catalog_project_id().
     # ============================================================
 
     async def list_tree(self, path: str, ref: str = "main") -> list[TreeEntry]:
-        repo = self._get_repo(self._catalog_project_id())
-        try:
-            contents = repo.get_contents(path, ref=ref)
-        except GithubException as exc:
-            if exc.status == 404:
-                return []
-            raise
-        if not isinstance(contents, list):
-            contents = [contents]
-        return [
-            TreeEntry(
-                name=item.name,
-                type="tree" if item.type == "dir" else "blob",
-                path=item.path,
-            )
-            for item in contents
-        ]
+        gh = self._require_gh()
+        project_id = self._catalog_project_id()
+
+        def _list() -> list[TreeEntry]:
+            repo = gh.get_repo(project_id)
+            try:
+                contents = repo.get_contents(path, ref=ref)
+            except GithubException as exc:
+                if exc.status == 404:
+                    return []
+                raise
+            if not isinstance(contents, list):
+                contents = [contents]
+            return [
+                TreeEntry(
+                    name=item.name,
+                    type="tree" if item.type == "dir" else "blob",
+                    path=item.path,
+                )
+                for item in contents
+            ]
+
+        return await _gh_read(_list, "github.list_tree")
 
     async def read_file(self, path: str, ref: str = "main") -> str | None:
         try:
@@ -928,50 +1062,84 @@ class GitHubService(GitProvider):
             return None
 
     async def list_path_commits(self, path: str | None, limit: int = 20) -> list[CommitRef]:
-        repo = self._get_repo(self._catalog_project_id())
-        kwargs: dict[str, Any] = {}
-        if path:
-            kwargs["path"] = path
-        commits = repo.get_commits(**kwargs)[:limit]
-        refs: list[CommitRef] = []
-        for c in commits:
-            author = ""
-            if c.author and getattr(c.author, "login", None):
-                author = c.author.login
-            elif c.commit and c.commit.author and c.commit.author.name:
-                author = c.commit.author.name
-            date = c.commit.author.date.isoformat() if c.commit and c.commit.author and c.commit.author.date else ""
-            refs.append(CommitRef(sha=c.sha, message=c.commit.message if c.commit else "", author=author, date=date))
-        return refs
+        gh = self._require_gh()
+        project_id = self._catalog_project_id()
+
+        def _list() -> list[CommitRef]:
+            repo = gh.get_repo(project_id)
+            kwargs: dict[str, Any] = {}
+            if path:
+                kwargs["path"] = path
+            # PaginatedList slice + iteration happens inside the thread.
+            commits = list(repo.get_commits(**kwargs)[:limit])
+            refs: list[CommitRef] = []
+            for c in commits:
+                author = ""
+                if c.author and getattr(c.author, "login", None):
+                    author = c.author.login
+                elif c.commit and c.commit.author and c.commit.author.name:
+                    author = c.commit.author.name
+                date = (
+                    c.commit.author.date.isoformat()
+                    if c.commit and c.commit.author and c.commit.author.date
+                    else ""
+                )
+                refs.append(
+                    CommitRef(sha=c.sha, message=c.commit.message if c.commit else "", author=author, date=date)
+                )
+            return refs
+
+        return await _gh_read(_list, "github.list_path_commits")
 
     async def write_file(
         self, path: str, content: str, commit_message: str, branch: str = "main"
     ) -> Literal["created", "updated"]:
+        """CP-1 C.6: create-first, fall through to update on 'already exists'.
+
+        Closes the TOCTOU window created by the old _file_exists pre-check.
+        Does not provide full compare-and-swap — PyGithub's update_file
+        already requires the blob sha (fetched inline in update_file), so
+        the second leg is optimistic-concurrent per file.
+        """
         project_id = self._catalog_project_id()
-        if await self._file_exists(project_id, path, ref=branch):
+        try:
+            await self.create_file(project_id, path, content, commit_message, branch=branch)
+            return "created"
+        except ValueError:
             await self.update_file(project_id, path, content, commit_message, branch=branch)
             return "updated"
-        await self.create_file(project_id, path, content, commit_message, branch=branch)
-        return "created"
 
     async def remove_file(self, path: str, commit_message: str, branch: str = "main") -> bool:
         return await self.delete_file(self._catalog_project_id(), path, commit_message, branch=branch)
 
     async def list_branches(self) -> list[BranchRef]:
-        repo = self._get_repo(self._catalog_project_id())
-        return [
-            BranchRef(name=b.name, commit_sha=b.commit.sha, protected=getattr(b, "protected", False))
-            for b in repo.get_branches()
-        ]
+        gh = self._require_gh()
+        project_id = self._catalog_project_id()
+
+        def _list() -> list[BranchRef]:
+            repo = gh.get_repo(project_id)
+            # PyGithub PaginatedList — materialise inside the thread.
+            return [
+                BranchRef(name=b.name, commit_sha=b.commit.sha, protected=getattr(b, "protected", False))
+                for b in repo.get_branches()
+            ]
+
+        return await _gh_read(_list, "github.list_branches")
 
     async def create_branch(self, name: str, ref: str = "main") -> BranchRef:
-        repo = self._get_repo(self._catalog_project_id())
-        base_ref = repo.get_git_ref(f"heads/{ref}")
-        repo.create_git_ref(f"refs/heads/{name}", base_ref.object.sha)
-        branch = repo.get_branch(name)
-        return BranchRef(
-            name=branch.name, commit_sha=branch.commit.sha, protected=getattr(branch, "protected", False)
-        )
+        gh = self._require_gh()
+        project_id = self._catalog_project_id()
+
+        def _create() -> BranchRef:
+            repo = gh.get_repo(project_id)
+            base_ref = repo.get_git_ref(f"heads/{ref}")
+            repo.create_git_ref(f"refs/heads/{name}", base_ref.object.sha)
+            branch = repo.get_branch(name)
+            return BranchRef(
+                name=branch.name, commit_sha=branch.commit.sha, protected=getattr(branch, "protected", False)
+            )
+
+        return await _gh_meta_write(_create, "github.create_branch")
 
     @staticmethod
     def _pr_to_ref(pr: Any) -> MergeRequestRef:
@@ -995,9 +1163,16 @@ class GitHubService(GitProvider):
         return {"opened": "open", "closed": "closed", "merged": "closed", "all": "all"}.get(state, state)
 
     async def list_merge_requests(self, state: str = "opened") -> list[MergeRequestRef]:
-        repo = self._get_repo(self._catalog_project_id())
+        gh = self._require_gh()
+        project_id = self._catalog_project_id()
         gh_state = self._map_mr_state_to_github(state)
-        return [self._pr_to_ref(pr) for pr in repo.get_pulls(state=gh_state)]
+
+        def _list() -> list[MergeRequestRef]:
+            repo = gh.get_repo(project_id)
+            # PaginatedList iteration materialised inside the thread.
+            return [self._pr_to_ref(pr) for pr in repo.get_pulls(state=gh_state)]
+
+        return await _gh_read(_list, "github.list_merge_requests")
 
     async def create_merge_request(
         self,
@@ -1006,12 +1181,24 @@ class GitHubService(GitProvider):
         source_branch: str,
         target_branch: str = "main",
     ) -> MergeRequestRef:
-        repo = self._get_repo(self._catalog_project_id())
-        pr = repo.create_pull(title=title, body=description, head=source_branch, base=target_branch)
-        return self._pr_to_ref(pr)
+        gh = self._require_gh()
+        project_id = self._catalog_project_id()
+
+        def _create() -> MergeRequestRef:
+            repo = gh.get_repo(project_id)
+            pr = repo.create_pull(title=title, body=description, head=source_branch, base=target_branch)
+            return self._pr_to_ref(pr)
+
+        return await _gh_meta_write(_create, "github.create_merge_request")
 
     async def merge_merge_request(self, iid: int) -> MergeRequestRef:
-        repo = self._get_repo(self._catalog_project_id())
-        pr = repo.get_pull(iid)
-        pr.merge()
-        return self._pr_to_ref(repo.get_pull(iid))
+        gh = self._require_gh()
+        project_id = self._catalog_project_id()
+
+        def _merge() -> MergeRequestRef:
+            repo = gh.get_repo(project_id)
+            pr = repo.get_pull(iid)
+            pr.merge()
+            return self._pr_to_ref(repo.get_pull(iid))
+
+        return await _gh_meta_write(_merge, "github.merge_merge_request")

--- a/control-plane-api/src/services/github_service.py
+++ b/control-plane-api/src/services/github_service.py
@@ -32,6 +32,7 @@ import yaml
 from github import Auth, Github, GithubException, InputGitTreeElement
 
 from ..config import settings
+from .git_credentials import askpass_env, redact_token
 from .git_executor import (
     BATCH_TIMEOUT_S,
     DEFAULT_TIMEOUT_S,
@@ -182,24 +183,27 @@ class GitHubService(GitProvider):
     async def clone_repo(self, repo_url: str) -> Path:
         """Clone a GitHub repository to a temporary directory.
 
-        NOTE: token-in-URL here is the C.2 leak — patched by the
-        subsequent commit (GIT_ASKPASS helper).
+        CP-1 C.2: the token never appears in argv. It is passed to git
+        through GIT_ASKPASS + env vars instead. ``repo_url`` must be a
+        plain HTTPS URL (no user/token prefix).
         """
         tmp_dir = Path(tempfile.mkdtemp(prefix="stoa-gh-"))
         token = settings.git.github.token.get_secret_value()
-        authed_url = repo_url.replace("https://", f"https://x-access-token:{token}@")
-        proc = await asyncio.create_subprocess_exec(
-            "git",
-            "clone",
-            "--depth=1",
-            authed_url,
-            str(tmp_dir / "repo"),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, stderr = await proc.communicate()
+        with askpass_env(username="x-access-token", password=token) as env:
+            proc = await asyncio.create_subprocess_exec(
+                "git",
+                "clone",
+                "--depth=1",
+                repo_url,
+                str(tmp_dir / "repo"),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+            _, stderr = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(f"git clone failed: {stderr.decode().strip()}")
+            safe_stderr = redact_token(stderr.decode().strip(), token)
+            raise RuntimeError(f"git clone failed: {safe_stderr}")
         return tmp_dir / "repo"
 
     def _require_gh(self) -> Github:

--- a/control-plane-api/tests/test_catalog_sync.py
+++ b/control-plane-api/tests/test_catalog_sync.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/control-plane-api/tests/test_catalog_sync.py
+++ b/control-plane-api/tests/test_catalog_sync.py
@@ -2,15 +2,13 @@
 import asyncio
 import logging
 import time
+from unittest.mock import MagicMock, patch
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.services.git_service import (
     GitLabService,
     _fetch_with_protection,
-    GitLabRateLimitError,
-    GITLAB_SEMAPHORE,
 )
 
 
@@ -73,27 +71,47 @@ async def test_fetch_with_protection_no_retry_on_other_errors():
 
 @pytest.mark.asyncio
 async def test_semaphore_limits_concurrency():
-    """Verify semaphore limits to 10 concurrent calls"""
-    concurrent = 0
-    max_concurrent = 0
-    sem = asyncio.Semaphore(10)
+    """Verify GITLAB_SEMAPHORE caps applicative concurrency at 10.
 
-    async def tracked_call():
-        nonlocal concurrent, max_concurrent
-        concurrent += 1
-        max_concurrent = max(max_concurrent, concurrent)
-        await asyncio.sleep(0.02)
-        concurrent -= 1
+    CP-1 (C.4): the semaphore was moved from _fetch_with_protection to
+    git_executor.run_sync so it applies UNIFORMLY across every GitLab
+    method, not only the two "parallel" fetchers. The invariant tested
+    here is the one that matters: run_sync, invoked 30x concurrently,
+    never lets more than 10 closures run in parallel.
+    """
+    import threading
+
+    from src.services import git_executor
+
+    concurrent = {"current": 0, "peak": 0}
+    lock = threading.Lock()
+
+    def tracked_sync_call():
+        with lock:
+            concurrent["current"] += 1
+            concurrent["peak"] = max(concurrent["peak"], concurrent["current"])
+        time.sleep(0.02)
+        with lock:
+            concurrent["current"] -= 1
         return "ok"
 
-    with patch("src.services.git_service.GITLAB_SEMAPHORE", sem):
-        tasks = [
-            _fetch_with_protection(tracked_call, f"call-{i}", max_retries=1)
-            for i in range(30)
-        ]
-        await asyncio.gather(*tasks)
+    # Use a fresh semaphore bound to the current loop — the module-level
+    # GITLAB_SEMAPHORE may have been acquired by an earlier test's loop.
+    fresh_sem = asyncio.Semaphore(10)
 
-    assert max_concurrent <= 10, f"Semaphore violated: {max_concurrent} concurrent"
+    tasks = [
+        git_executor.run_sync(
+            tracked_sync_call,
+            semaphore=fresh_sem,
+            op_name=f"call-{i}",
+        )
+        for i in range(30)
+    ]
+    await asyncio.gather(*tasks)
+
+    assert concurrent["peak"] <= 10, (
+        f"Semaphore violated: {concurrent['peak']} concurrent"
+    )
 
 
 @pytest.mark.asyncio

--- a/control-plane-api/tests/test_github_service.py
+++ b/control-plane-api/tests/test_github_service.py
@@ -80,20 +80,27 @@ class TestDisconnect:
 class TestCloneRepo:
     @pytest.mark.asyncio
     async def test_clone_repo_success(self, service):
+        """CP-1 C.2: token must NOT be in argv (GIT_ASKPASS handles auth)."""
         mock_proc = AsyncMock()
         mock_proc.returncode = 0
         mock_proc.communicate.return_value = (b"", b"")
 
+        repo_url = "https://github.com/stoa-platform/stoa-catalog.git"
         with patch("src.services.github_service.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            result = await service.clone_repo("https://github.com/stoa-platform/stoa-catalog.git")
+            result = await service.clone_repo(repo_url)
 
             assert isinstance(result, Path)
             args = mock_exec.call_args[0]
+            env = mock_exec.call_args[1].get("env", {})
             assert args[0] == "git"
             assert args[1] == "clone"
             assert "--depth=1" in args
-            # Token injected into URL
-            assert "x-access-token:" in args[3]
+            # URL is passed verbatim — no token injection.
+            assert repo_url in args
+            # Token travels via env, not argv.
+            assert "x-access-token:" not in " ".join(str(a) for a in args)
+            assert env.get("GIT_ASKPASS")
+            assert env.get("STOA_GIT_USERNAME") == "x-access-token"
 
     @pytest.mark.asyncio
     async def test_clone_repo_failure_raises(self, service):

--- a/control-plane-api/tests/test_regression_cp1_sync_in_async.py
+++ b/control-plane-api/tests/test_regression_cp1_sync_in_async.py
@@ -1,0 +1,383 @@
+"""Regression guards for CP-1 C.1/C.4/C.5/C.6.
+
+Closes:
+- C.1 (sync-in-async blocks event loop)
+- C.4 (GitLab semaphore not applied uniformly)
+- C.5 (GitHub has no applicative concurrency cap)
+- C.6 (write_file TOCTOU via _file_exists pre-check)
+
+These tests pin the invariants enforced by services/git_executor.py and
+the migration of GitLabService / GitHubService to route every sync SDK
+call through ``run_sync``.
+
+regression for CP-1 C.1
+regression for CP-1 C.4
+regression for CP-1 C.5
+regression for CP-1 C.6
+"""
+
+import asyncio
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.services import git_executor
+from src.services.git_service import GitLabService
+from src.services.github_service import GitHubService
+
+
+def _make_gitlab_service() -> GitLabService:
+    """Build a minimally-wired GitLabService whose _project/_gl are mocks."""
+    svc = GitLabService()
+    svc._gl = MagicMock()
+    svc._project = MagicMock()
+    return svc
+
+
+def _make_github_service() -> GitHubService:
+    """Build a minimally-wired GitHubService whose _gh is a mock."""
+    svc = GitHubService()
+    svc._gh = MagicMock()
+    return svc
+
+
+# ──────────────────────────────────────────────────────────────────
+# C.1 — event loop stays responsive under concurrent sync SDK calls
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_regression_cp1_read_does_not_starve_event_loop():
+    """Heartbeat stays alive while 10 sync reads run in parallel.
+
+    Without run_sync's offload, 10 x 200ms blocking reads monopolise the
+    loop for 2s and the heartbeat cannot tick. With offload, all 10 go
+    to threads and the heartbeat ticks freely.
+    """
+    svc = _make_github_service()
+
+    def _blocking_get_contents(path, ref):
+        time.sleep(0.2)
+        fake = MagicMock()
+        fake.decoded_content = b"hello"
+        return fake
+
+    repo = MagicMock()
+    repo.get_contents.side_effect = _blocking_get_contents
+    svc._gh.get_repo.return_value = repo
+
+    heartbeat = {"ticks": 0}
+    stop = False
+
+    async def _beat():
+        while not stop:
+            heartbeat["ticks"] += 1
+            await asyncio.sleep(0.01)
+
+    beat_task = asyncio.create_task(_beat())
+
+    start = time.monotonic()
+    await asyncio.gather(*[svc.get_file_content("org/repo", f"f{i}") for i in range(10)])
+    elapsed = time.monotonic() - start
+
+    stop = True
+    await asyncio.sleep(0)
+    beat_task.cancel()
+
+    # With 10-way parallel offload, wall clock should be far below serial 2s.
+    # Loose upper bound to avoid CI flakes on thread-pool lazy-init.
+    assert elapsed < 1.5, f"wall clock {elapsed:.2f}s suggests serial execution"
+    # Heartbeat should have ticked many times during the window.
+    # At 10ms cadence over ~200ms we expect at least 10 ticks in practice.
+    assert heartbeat["ticks"] >= 10, f"heartbeat only ticked {heartbeat['ticks']} times"
+
+
+# ──────────────────────────────────────────────────────────────────
+# C.5 / C.6 — GitHub Contents write semaphore serialises (cap=1)
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_regression_cp1_contents_write_semaphore_serialises():
+    """5 concurrent create_file calls must run strictly one at a time."""
+    svc = _make_github_service()
+
+    concurrent = {"current": 0, "peak": 0}
+    lock = threading.Lock()
+
+    def _create_file(*args, **kwargs):
+        with lock:
+            concurrent["current"] += 1
+            concurrent["peak"] = max(concurrent["peak"], concurrent["current"])
+        time.sleep(0.05)
+        with lock:
+            concurrent["current"] -= 1
+        return {"commit": MagicMock(sha="abc", html_url="http://x")}
+
+    repo = MagicMock()
+    repo.create_file.side_effect = _create_file
+    svc._gh.get_repo.return_value = repo
+
+    await asyncio.gather(
+        *[svc.create_file("org/repo", f"f{i}.txt", "hello", "msg") for i in range(5)]
+    )
+
+    assert concurrent["peak"] == 1, (
+        f"Contents writes must serialise — observed peak concurrency {concurrent['peak']}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────
+# C.5 — GitHub meta-write semaphore caps at 5
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_regression_cp1_meta_write_semaphore_caps_at_5():
+    """10 concurrent create_webhook calls must peak at <= 5 in parallel."""
+    svc = _make_github_service()
+
+    concurrent = {"current": 0, "peak": 0}
+    lock = threading.Lock()
+
+    def _create_hook(*args, **kwargs):
+        with lock:
+            concurrent["current"] += 1
+            concurrent["peak"] = max(concurrent["peak"], concurrent["current"])
+        time.sleep(0.05)
+        with lock:
+            concurrent["current"] -= 1
+        hook = MagicMock()
+        hook.id = 1
+        hook.config = {"url": "http://x"}
+        return hook
+
+    repo = MagicMock()
+    repo.create_hook.side_effect = _create_hook
+    svc._gh.get_repo.return_value = repo
+
+    await asyncio.gather(
+        *[svc.create_webhook("org/repo", f"http://h{i}", "secret", ["push"]) for i in range(10)]
+    )
+
+    assert concurrent["peak"] <= 5, (
+        f"Meta-write concurrency must be capped at 5 — observed peak {concurrent['peak']}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────
+# C.1 — per-call timeout enforced via run_sync
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_regression_cp1_timeout_enforced():
+    """run_sync must raise TimeoutError when the sync call exceeds timeout.
+
+    We exercise the helper directly because the per-call timeout is a
+    structural guarantee of run_sync — every service method routes its
+    sync SDK call through this helper, so the enforcement proven here
+    covers every migrated call site.
+    """
+
+    def _hang():
+        time.sleep(5.0)
+        return "never"
+
+    start = time.monotonic()
+    with pytest.raises(TimeoutError):
+        await git_executor.run_sync(
+            _hang,
+            semaphore=git_executor.GITHUB_READ_SEMAPHORE,
+            timeout=0.2,
+            op_name="test.timeout",
+        )
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0, f"timeout should fire around 0.2s, took {elapsed:.2f}s"
+
+
+# ──────────────────────────────────────────────────────────────────
+# C.6 — write_file has NO _file_exists pre-check (no TOCTOU window)
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_regression_cp1_write_file_no_toctou_github():
+    """write_file on GitHub must call create_file first, never _file_exists.
+
+    The pre-existing code did:
+        if await self._file_exists(...): update_file(...)
+        else: create_file(...)
+    which opens a TOCTOU window. The fix pattern is:
+        try: create_file(...)
+        except ValueError: update_file(...)
+    """
+    svc = _make_github_service()
+
+    # _file_exists must NOT be called by write_file. create_file raises
+    # "already exists"; update_file should be the fallback path.
+    with (
+        patch.object(svc, "_file_exists", new=MagicMock(side_effect=AssertionError("must not be called"))),
+        patch.object(svc, "create_file", side_effect=ValueError("File already exists: foo")) as mocked_create,
+        patch.object(svc, "update_file", return_value={"sha": "1", "url": "u"}) as mocked_update,
+    ):
+        result = await svc.write_file("foo.txt", "content", "msg")
+
+    assert result == "updated"
+    mocked_create.assert_called_once()
+    mocked_update.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_regression_cp1_write_file_no_toctou_gitlab():
+    """Same invariant for GitLab's write_file."""
+    svc = _make_gitlab_service()
+
+    # GitLab write_file's prior implementation used get_file → exists check → save or create.
+    # New pattern delegates to create_file → falls through to update_file on ValueError.
+    with (
+        patch.object(svc, "create_file", side_effect=ValueError("File already exists: foo")) as mocked_create,
+        patch.object(svc, "update_file", return_value={"sha": "1", "url": "u"}) as mocked_update,
+    ):
+        result = await svc.write_file("foo.txt", "content", "msg")
+
+    assert result == "updated"
+    mocked_create.assert_called_once()
+    mocked_update.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_regression_cp1_write_file_first_write_returns_created():
+    """write_file returns 'created' on the happy path where the file is new."""
+    svc = _make_github_service()
+    with (
+        patch.object(svc, "create_file", return_value={"sha": "1", "url": "u"}) as mocked_create,
+        patch.object(svc, "update_file") as mocked_update,
+    ):
+        result = await svc.write_file("new.txt", "content", "msg")
+
+    assert result == "created"
+    mocked_create.assert_called_once()
+    mocked_update.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────────
+# C.4 — GITLAB_SEMAPHORE applied uniformly across methods
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_regression_cp1_gitlab_semaphore_uniform():
+    """3 different read methods must all acquire the single GITLAB_SEMAPHORE.
+
+    Inflates concurrency: with cap 10 and 20 requests spanning 3 method types,
+    observed peak must stay <= 10.
+    """
+    svc = _make_gitlab_service()
+
+    concurrent = {"current": 0, "peak": 0}
+    lock = threading.Lock()
+
+    def _slow_op(*args, **kwargs):
+        with lock:
+            concurrent["current"] += 1
+            concurrent["peak"] = max(concurrent["peak"], concurrent["current"])
+        time.sleep(0.03)
+        with lock:
+            concurrent["current"] -= 1
+        return MagicMock()
+
+    # Make every sync SDK surface path increment the counter.
+    def _slow_list(*_a: object, **_kw: object) -> list:
+        _slow_op()
+        return []
+
+    def _slow_get(*_a: object, **_kw: object) -> MagicMock:
+        return _slow_op()
+
+    svc._project.repository_tree.side_effect = _slow_list
+    svc._project.files.get.side_effect = _slow_get
+    svc._project.commits.list.side_effect = _slow_list
+    svc._gl.projects.get.return_value = svc._project
+
+    # Fire across 3 methods.
+    coros = []
+    for _ in range(7):
+        coros.append(svc.list_tenants())
+    for _ in range(7):
+        coros.append(svc.list_commits(path="x"))
+    for _ in range(6):
+        coros.append(svc.list_tree("x"))
+
+    await asyncio.gather(*coros, return_exceptions=True)
+
+    assert concurrent["peak"] <= 10, (
+        f"GitLab applicative cap violated — observed peak {concurrent['peak']}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────
+# Implementation-rule regression — PaginatedList materialised in thread
+# ──────────────────────────────────────────────────────────────────
+
+
+class _FakePaginatedList:
+    """Simulates PyGithub PaginatedList with synchronous per-fetch sleeps."""
+
+    def __init__(self, items, fetch_delay=0.05):
+        self._items = items
+        self._fetch_delay = fetch_delay
+
+    def __iter__(self):
+        for item in self._items:
+            time.sleep(self._fetch_delay)
+            yield item
+
+
+@pytest.mark.asyncio
+async def test_regression_cp1_paginated_list_materialised_in_thread():
+    """Iterating a PaginatedList must happen inside run_sync, not after await.
+
+    If iteration leaked to the event loop, the heartbeat would freeze while
+    list_branches runs.
+    """
+    svc = _make_github_service()
+
+    def _make_branch(name):
+        b = MagicMock()
+        b.name = name
+        b.commit.sha = f"sha-{name}"
+        b.protected = False
+        return b
+
+    repo = MagicMock()
+    # get_branches returns a PaginatedList-like; each iteration step sleeps.
+    repo.get_branches.return_value = _FakePaginatedList(
+        [_make_branch(f"b{i}") for i in range(5)], fetch_delay=0.04
+    )
+    svc._gh.get_repo.return_value = repo
+
+    heartbeat = {"ticks": 0}
+    stop = False
+
+    async def _beat():
+        while not stop:
+            heartbeat["ticks"] += 1
+            await asyncio.sleep(0.01)
+
+    beat_task = asyncio.create_task(_beat())
+    result = await svc.list_branches()
+    stop = True
+    await asyncio.sleep(0)
+    beat_task.cancel()
+
+    assert len(result) == 5
+    # Iteration window is ~5 * 40ms = 200ms; at 10ms beat cadence we expect
+    # at least 8 ticks if iteration happened in a thread.
+    assert heartbeat["ticks"] >= 8, (
+        f"heartbeat froze during iteration — only {heartbeat['ticks']} ticks "
+        "(suggests PaginatedList iteration leaked onto the event loop)"
+    )

--- a/control-plane-api/tests/test_regression_cp1_token_leak.py
+++ b/control-plane-api/tests/test_regression_cp1_token_leak.py
@@ -1,0 +1,364 @@
+"""Regression guards for CP-1 C.2 (token leak in subprocess argv).
+
+Previously, ``clone_repo`` injected the provider PAT into the HTTPS URL
+passed to ``git clone``, making it visible via ``ps`` / ``/proc/PID/cmdline``
+and capturing in container log scrapers. The fix routes credentials via
+GIT_ASKPASS + environment vars; argv carries only the plain HTTPS URL.
+
+These tests pin four invariants:
+  1. Subprocess argv never contains the token.
+  2. Subprocess env forces all git trace variables to "0" and disables
+     interactive prompting.
+  3. The ASKPASS helper is cleaned up on both success and failure.
+  4. Exception messages raised from failed clones never echo the raw token.
+
+Plus the defense-in-depth logging filter:
+  5. Standard provider PAT formats are redacted in log records.
+  6. Benign strings that merely contain a prefix are left alone.
+
+regression for CP-1 C.2
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from src.config import GitHubConfig, GitLabConfig, GitProviderConfig
+from src.core.secret_redactor import SecretRedactor, redact_secrets
+from src.services.git_credentials import askpass_env, redact_token
+from src.services.git_service import GitLabService
+from src.services.github_service import GitHubService
+
+_GITLAB_TOKEN = "glpat-abcdefghijklmnopqrst1234"
+_GITHUB_TOKEN = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+
+def _make_process(returncode: int = 0, stderr: bytes = b"") -> AsyncMock:
+    """Build a mock for ``asyncio.create_subprocess_exec``'s return value."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(b"", stderr))
+    return proc
+
+
+def _patched_git_settings(provider: str, token: str) -> GitProviderConfig:
+    """Construct a settings object with an in-memory token."""
+    if provider == "gitlab":
+        return GitProviderConfig(
+            provider="gitlab",
+            gitlab=GitLabConfig(
+                url="https://gitlab.com",
+                token=SecretStr(token),
+                project_id="1",
+                webhook_secret=SecretStr("whsec"),
+            ),
+        )
+    return GitProviderConfig(
+        provider="github",
+        github=GitHubConfig(
+            token=SecretStr(token),
+            catalog_project_id="org/catalog",
+            webhook_secret=SecretStr("whsec"),
+        ),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────
+# 1. Subprocess argv must not contain the token
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clone_repo_gitlab_no_token_in_argv(tmp_path):
+    svc = GitLabService()
+    captured = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["args"] = args
+        captured["env"] = kwargs.get("env", {})
+        return _make_process(returncode=0)
+
+    settings_patch = _patched_git_settings("gitlab", _GITLAB_TOKEN)
+    with (
+        patch("src.services.git_service.settings") as mock_settings,
+        patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+        patch("tempfile.mkdtemp", return_value=str(tmp_path)),
+    ):
+        mock_settings.git = settings_patch
+        await svc.clone_repo("https://gitlab.com/foo/bar.git")
+
+    for arg in captured["args"]:
+        assert _GITLAB_TOKEN not in str(arg), (
+            f"token leaked to argv via {arg!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_clone_repo_github_no_token_in_argv(tmp_path):
+    svc = GitHubService()
+    captured = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["args"] = args
+        captured["env"] = kwargs.get("env", {})
+        return _make_process(returncode=0)
+
+    settings_patch = _patched_git_settings("github", _GITHUB_TOKEN)
+    with (
+        patch("src.services.github_service.settings") as mock_settings,
+        patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+        patch("tempfile.mkdtemp", return_value=str(tmp_path)),
+    ):
+        mock_settings.git = settings_patch
+        await svc.clone_repo("https://github.com/foo/bar.git")
+
+    for arg in captured["args"]:
+        assert _GITHUB_TOKEN not in str(arg), (
+            f"token leaked to argv via {arg!r}"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────
+# 2. Subprocess env forces trace vars and terminal-prompt to "0"
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clone_repo_sets_trace_env_zero(tmp_path):
+    svc = GitLabService()
+    captured = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["env"] = kwargs.get("env", {})
+        return _make_process(returncode=0)
+
+    settings_patch = _patched_git_settings("gitlab", _GITLAB_TOKEN)
+    with (
+        patch("src.services.git_service.settings") as mock_settings,
+        patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+        patch("tempfile.mkdtemp", return_value=str(tmp_path)),
+    ):
+        mock_settings.git = settings_patch
+        await svc.clone_repo("https://gitlab.com/foo/bar.git")
+
+    env = captured["env"]
+    assert env["GIT_TRACE"] == "0"
+    assert env["GIT_CURL_VERBOSE"] == "0"
+    assert env["GIT_TRACE_CURL"] == "0"
+    assert env["GIT_TRACE_PACKET"] == "0"
+    assert env["GIT_TRACE_SETUP"] == "0"
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    # ASKPASS helper path is present; token is NOT in the env key set
+    # (only in STOA_GIT_PASSWORD value, which is intended).
+    assert "GIT_ASKPASS" in env
+    assert env["STOA_GIT_USERNAME"] == "oauth2"
+    assert env["STOA_GIT_PASSWORD"] == _GITLAB_TOKEN
+
+
+# ──────────────────────────────────────────────────────────────────
+# 3. ASKPASS helper cleanup on both success and failure
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clone_repo_askpass_helper_cleanup_on_success(tmp_path):
+    svc = GitLabService()
+    captured = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["helper_path"] = kwargs["env"]["GIT_ASKPASS"]
+        # Helper must exist DURING the subprocess call.
+        assert Path(captured["helper_path"]).exists()
+        return _make_process(returncode=0)
+
+    settings_patch = _patched_git_settings("gitlab", _GITLAB_TOKEN)
+    with (
+        patch("src.services.git_service.settings") as mock_settings,
+        patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+        patch("tempfile.mkdtemp", return_value=str(tmp_path)),
+    ):
+        mock_settings.git = settings_patch
+        await svc.clone_repo("https://gitlab.com/foo/bar.git")
+
+    assert not Path(captured["helper_path"]).exists(), (
+        "helper must be deleted after successful clone"
+    )
+
+
+@pytest.mark.asyncio
+async def test_clone_repo_askpass_helper_cleanup_on_failure(tmp_path):
+    svc = GitLabService()
+    captured = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["helper_path"] = kwargs["env"]["GIT_ASKPASS"]
+        return _make_process(returncode=128, stderr=b"fatal: authentication failed")
+
+    settings_patch = _patched_git_settings("gitlab", _GITLAB_TOKEN)
+    with (
+        patch("src.services.git_service.settings") as mock_settings,
+        patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+        patch("tempfile.mkdtemp", return_value=str(tmp_path)),
+    ):
+        mock_settings.git = settings_patch
+        with pytest.raises(RuntimeError):
+            await svc.clone_repo("https://gitlab.com/foo/bar.git")
+
+    assert not Path(captured["helper_path"]).exists(), (
+        "helper must be deleted even when clone fails"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────
+# 4. Failed-clone exceptions never echo the raw token
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clone_repo_failure_exception_does_not_leak_token(tmp_path):
+    """If stderr echoes the authenticated URL (misconfig, trace override,
+    etc.), the exception message must redact the token before raising.
+    """
+    svc = GitLabService()
+    leaky_stderr = (
+        f"fatal: unable to access 'https://oauth2:{_GITLAB_TOKEN}@gitlab.com/foo/bar.git'"
+    ).encode()
+
+    async def fake_exec(*args, **kwargs):
+        return _make_process(returncode=128, stderr=leaky_stderr)
+
+    settings_patch = _patched_git_settings("gitlab", _GITLAB_TOKEN)
+    with (
+        patch("src.services.git_service.settings") as mock_settings,
+        patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+        patch("tempfile.mkdtemp", return_value=str(tmp_path)),
+    ):
+        mock_settings.git = settings_patch
+        with pytest.raises(RuntimeError) as exc:
+            await svc.clone_repo("https://gitlab.com/foo/bar.git")
+
+    assert _GITLAB_TOKEN not in str(exc.value), (
+        f"token leaked in exception: {exc.value}"
+    )
+    assert "***REDACTED***" in str(exc.value)
+
+
+# ──────────────────────────────────────────────────────────────────
+# ASKPASS helper dispatches username vs password correctly
+# ──────────────────────────────────────────────────────────────────
+
+
+def test_askpass_helper_replies_username_and_password_correctly(tmp_path):
+    """Run the helper as git would: once per prompt type, capture stdout.
+
+    Verifies the shell case statement dispatches Username / Password /
+    fallback correctly. ``askpass_env`` yields the env dict; we extract
+    the helper path and invoke it directly.
+    """
+    with askpass_env(username="x-access-token", password=_GITHUB_TOKEN) as env:
+        helper = env["GIT_ASKPASS"]
+        assert Path(helper).exists()
+        # Env must carry the username + password for the helper to read.
+        child_env = {**os.environ, **env}
+        u_prompt = subprocess.run(  # noqa: S603 — helper is our own trusted script
+            [helper, "Username for 'https://github.com':"],
+            env=child_env, capture_output=True, check=True,
+        )
+        p_prompt = subprocess.run(  # noqa: S603 — helper is our own trusted script
+            [helper, "Password for 'https://x-access-token@github.com':"],
+            env=child_env, capture_output=True, check=True,
+        )
+        fallback = subprocess.run(  # noqa: S603 — helper is our own trusted script
+            [helper, "Some other prompt:"],
+            env=child_env, capture_output=True, check=True,
+        )
+
+    assert u_prompt.stdout == b"x-access-token"
+    assert p_prompt.stdout == _GITHUB_TOKEN.encode()
+    # Conservative fallback returns the password.
+    assert fallback.stdout == _GITHUB_TOKEN.encode()
+
+
+# ──────────────────────────────────────────────────────────────────
+# Logging filter redaction
+# ──────────────────────────────────────────────────────────────────
+
+
+def test_logging_filter_redacts_gitlab_pat():
+    record = logging.LogRecord(
+        name="test", level=logging.INFO, pathname="", lineno=0,
+        msg="failure: glpat-abcdefghijklmnopqrst1234", args=(), exc_info=None,
+    )
+    SecretRedactor().filter(record)
+    assert "glpat-abcdefghijklmnopqrst1234" not in record.getMessage()
+    assert "***REDACTED***" in record.getMessage()
+
+
+def test_logging_filter_redacts_github_classic_pat():
+    record = logging.LogRecord(
+        name="test", level=logging.INFO, pathname="", lineno=0,
+        msg="failure: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", args=(), exc_info=None,
+    )
+    SecretRedactor().filter(record)
+    assert "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" not in record.getMessage()
+    assert "***REDACTED***" in record.getMessage()
+
+
+def test_logging_filter_redacts_github_finegrained_pat():
+    fine = "github_pat_11ABCD_" + "x" * 70
+    record = logging.LogRecord(
+        name="test", level=logging.INFO, pathname="", lineno=0,
+        msg=f"failure: {fine}", args=(), exc_info=None,
+    )
+    SecretRedactor().filter(record)
+    assert fine not in record.getMessage()
+    assert "***REDACTED***" in record.getMessage()
+
+
+def test_logging_filter_redacts_github_oauth_token():
+    record = logging.LogRecord(
+        name="test", level=logging.INFO, pathname="", lineno=0,
+        msg="failure: gho_abcdefghijklmnopqrstuvwxyz0123456789",
+        args=(), exc_info=None,
+    )
+    SecretRedactor().filter(record)
+    assert "gho_abcdefghijklmnopqrstuvwxyz0123456789" not in record.getMessage()
+
+
+def test_logging_filter_negative_non_token_string():
+    """Benign strings that vaguely resemble a token prefix stay intact."""
+    # These should NOT be redacted:
+    benign_cases = [
+        "not a ghp_",
+        "ghp_short",  # too short for the 30+ char tail
+        "glpat-short",  # too short for 20+ char tail
+        "regular log message without tokens",
+    ]
+    for msg in benign_cases:
+        assert redact_secrets(msg) == msg, (
+            f"Expected no redaction on {msg!r}, got {redact_secrets(msg)!r}"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────
+# redact_token helper (used in clone_repo exception paths)
+# ──────────────────────────────────────────────────────────────────
+
+
+def test_redact_token_replaces_occurrences():
+    text = f"auth failed for https://oauth2:{_GITLAB_TOKEN}@gitlab.com/x.git"
+    result = redact_token(text, _GITLAB_TOKEN)
+    assert _GITLAB_TOKEN not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_token_empty_token_is_noop():
+    text = "some message without token"
+    assert redact_token(text, "") == text

--- a/control-plane-api/tests/test_regression_cp1_webhook_auth_first.py
+++ b/control-plane-api/tests/test_regression_cp1_webhook_auth_first.py
@@ -1,0 +1,227 @@
+"""Regression guards for CP-1 C.7 (webhook DoS amplification).
+
+Previously the GitLab webhook handler created a trace row (1 INSERT +
+2 UPDATEs on the ``traces`` table) *before* verifying ``X-Gitlab-Token``.
+An unauthenticated flood therefore drove sustained DB pressure without
+paying the authentication cost first. Combined with C.1's event-loop
+blocking on every DB write, this cascaded into legitimate-traffic
+latency.
+
+Fix: reorder ``gitlab_webhook`` to authenticate BEFORE any DB I/O.
+
+The GitHub handler (``github_webhook``) already had the correct ordering
+since CAB-1890 — HMAC signature verified at request entry, trace row
+created afterwards. We pin that invariant here so a future refactor
+cannot silently introduce the same bug on the GitHub side.
+
+regression for CP-1 C.7
+"""
+
+from __future__ import annotations
+
+import hmac
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+_TEST_SECRET = "test-webhook-secret"
+
+
+def _minimal_push_payload() -> dict:
+    """Smallest GitLab push payload the handler accepts."""
+    return {
+        "object_kind": "push",
+        "event_name": "push",
+        "ref": "refs/heads/main",
+        "before": "0" * 40,
+        "after": "a" * 40,
+        "checkout_sha": "a" * 40,
+        "project_id": 42,
+        "project": {"path_with_namespace": "stoa/catalog"},
+        "user_name": "alice",
+        "user_username": "alice",
+        "commits": [],
+        "total_commits_count": 0,
+    }
+
+
+def _mock_trace_service_spy() -> tuple[MagicMock, MagicMock]:
+    """Spy-flavoured TraceService: real AsyncMock, verifiable call counts."""
+    mock_svc = MagicMock()
+    mock_trace = MagicMock()
+    mock_trace.id = "trace-001"
+    mock_trace.status = MagicMock(value="success")
+    mock_trace.total_duration_ms = 42
+    mock_svc.create = AsyncMock(return_value=mock_trace)
+    mock_svc.add_step = AsyncMock()
+    mock_svc.complete = AsyncMock()
+    return mock_svc, mock_trace
+
+
+# ──────────────────────────────────────────────────────────────────
+# GitLab: token verification MUST precede trace DB insert
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestGitLabWebhookAuthFirst:
+    def test_missing_token_rejects_without_db_write(self, app_with_cpi_admin, mock_db_session):
+        """POST /webhooks/gitlab without X-Gitlab-Token → 401, zero trace insert."""
+        mock_svc, _ = _mock_trace_service_spy()
+
+        with (
+            patch("src.routers.webhooks.TraceService", return_value=mock_svc),
+            patch("src.routers.webhooks.settings") as mock_settings,
+        ):
+            mock_settings.git.gitlab.webhook_secret = SecretStr(_TEST_SECRET)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(
+                    "/webhooks/gitlab",
+                    json=_minimal_push_payload(),
+                    headers={"X-Gitlab-Event": "Push Hook"},
+                    # deliberately no X-Gitlab-Token
+                )
+
+        assert response.status_code == 401
+        mock_svc.create.assert_not_called()
+        mock_svc.add_step.assert_not_called()
+        mock_svc.complete.assert_not_called()
+
+    def test_wrong_token_rejects_without_db_write(self, app_with_cpi_admin, mock_db_session):
+        """POST /webhooks/gitlab with an invalid token → 401, zero trace insert."""
+        mock_svc, _ = _mock_trace_service_spy()
+
+        with (
+            patch("src.routers.webhooks.TraceService", return_value=mock_svc),
+            patch("src.routers.webhooks.settings") as mock_settings,
+        ):
+            mock_settings.git.gitlab.webhook_secret = SecretStr(_TEST_SECRET)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(
+                    "/webhooks/gitlab",
+                    json=_minimal_push_payload(),
+                    headers={
+                        "X-Gitlab-Event": "Push Hook",
+                        "X-Gitlab-Token": "not-the-right-secret",
+                    },
+                )
+
+        assert response.status_code == 401
+        mock_svc.create.assert_not_called()
+        mock_svc.add_step.assert_not_called()
+        mock_svc.complete.assert_not_called()
+
+    def test_missing_server_side_secret_rejects_without_db_write(
+        self, app_with_cpi_admin, mock_db_session
+    ):
+        """If GITLAB_WEBHOOK_SECRET is unset, every request is rejected — still no DB write."""
+        mock_svc, _ = _mock_trace_service_spy()
+
+        with (
+            patch("src.routers.webhooks.TraceService", return_value=mock_svc),
+            patch("src.routers.webhooks.settings") as mock_settings,
+        ):
+            mock_settings.git.gitlab.webhook_secret = SecretStr("")
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(
+                    "/webhooks/gitlab",
+                    json=_minimal_push_payload(),
+                    headers={
+                        "X-Gitlab-Event": "Push Hook",
+                        "X-Gitlab-Token": _TEST_SECRET,
+                    },
+                )
+
+        assert response.status_code == 401
+        mock_svc.create.assert_not_called()
+
+    def test_valid_token_still_persists_trace(self, app_with_cpi_admin, mock_db_session):
+        """Happy path: valid token → trace row created, pipeline runs."""
+        mock_svc, _ = _mock_trace_service_spy()
+
+        with (
+            patch("src.routers.webhooks.TraceService", return_value=mock_svc),
+            patch("src.routers.webhooks.settings") as mock_settings,
+            patch("src.routers.webhooks.kafka_service") as mock_kafka,
+        ):
+            mock_settings.git.gitlab.webhook_secret = SecretStr(_TEST_SECRET)
+            mock_kafka.publish = AsyncMock(return_value="evt-1")
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(
+                    "/webhooks/gitlab",
+                    json=_minimal_push_payload(),
+                    headers={
+                        "X-Gitlab-Event": "Push Hook",
+                        "X-Gitlab-Token": _TEST_SECRET,
+                    },
+                )
+
+        assert response.status_code == 200
+        mock_svc.create.assert_called_once()
+
+
+# ──────────────────────────────────────────────────────────────────
+# GitHub: HMAC verification MUST precede trace DB insert (pin invariant)
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestGitHubWebhookInvariantPinned:
+    """GitHub's webhook already authenticates before persisting the trace
+    (CAB-1890 design). These tests pin that invariant so a future
+    refactor cannot silently regress the ordering and re-introduce C.7
+    on the GitHub side.
+    """
+
+    def _sign(self, body: bytes, secret: str) -> str:
+        return "sha256=" + hmac.new(secret.encode(), body, "sha256").hexdigest()
+
+    def test_missing_signature_rejects_without_db_write(
+        self, app_with_cpi_admin, mock_db_session
+    ):
+        mock_svc, _ = _mock_trace_service_spy()
+
+        with (
+            patch("src.routers.webhooks.TraceService", return_value=mock_svc),
+            patch("src.routers.webhooks.settings") as mock_settings,
+        ):
+            mock_settings.git.github.webhook_secret = SecretStr(_TEST_SECRET)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(
+                    "/webhooks/github",
+                    json={"ref": "refs/heads/main", "repository": {"full_name": "o/r"}},
+                    headers={"X-GitHub-Event": "push"},
+                    # deliberately no X-Hub-Signature-256
+                )
+
+        assert response.status_code == 401
+        mock_svc.create.assert_not_called()
+        mock_svc.add_step.assert_not_called()
+
+    def test_invalid_signature_rejects_without_db_write(
+        self, app_with_cpi_admin, mock_db_session
+    ):
+        mock_svc, _ = _mock_trace_service_spy()
+
+        with (
+            patch("src.routers.webhooks.TraceService", return_value=mock_svc),
+            patch("src.routers.webhooks.settings") as mock_settings,
+        ):
+            mock_settings.git.github.webhook_secret = SecretStr(_TEST_SECRET)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post(
+                    "/webhooks/github",
+                    json={"ref": "refs/heads/main", "repository": {"full_name": "o/r"}},
+                    headers={
+                        "X-GitHub-Event": "push",
+                        "X-Hub-Signature-256": "sha256=" + "0" * 64,
+                    },
+                )
+
+        assert response.status_code == 401
+        mock_svc.create.assert_not_called()


### PR DESCRIPTION
## Summary
- fix the CP-1 P0 findings on the Git provider rewrite stack: sync SDK calls on the event loop, missing applicative concurrency caps, contents write TOCTOU, token exposure in `git clone`, and GitLab webhook auth ordering
- add bounded `run_sync()` helpers plus provider-specific semaphores for GitLab and GitHub SDK calls
- move clone credentials out of argv via `GIT_ASKPASS` and update `BUG-REPORT-CP-1.md` with the shipped P0 fix table

## Scope
- base branch: `main`
- stacked follow-up branch: `fix/cp-1-p1-batch`
- commits: 6

## Validation rerun in worktree
- `ruff check src/`
- `pytest tests/test_regression_cp1_sync_in_async.py tests/test_regression_cp1_token_leak.py tests/test_regression_cp1_webhook_auth_first.py tests/test_catalog_sync.py tests/test_github_service.py -q`
  - 84 passed

## Notes
- package-level `mypy` is still noisy on the existing repo baseline when imports are followed, so it was not used as a publish gate for this handoff
- `BUG-REPORT-CP-1.md` now marks C.1, C.2, C.4, C.5, C.6 and C.7 as fixed with commit SHAs
