### PR TITLE
fix(cp-api): close CP-1 P1 hardening batch

### DIFF
--- a/control-plane-api/BUG-REPORT-CP-1.md
+++ b/control-plane-api/BUG-REPORT-CP-1.md
@@ -26,6 +26,30 @@
 > `test_regression_cp1_token_leak.py`,
 > `test_regression_cp1_webhook_auth_first.py`.
 
+> **P1 batch status (2026-04-23 pm)** — all nine P1 findings fixed on
+> branch `fix/cp-1-p1-batch` (4 atomic commits):
+>
+> | Bug | Commit | Fix |
+> |---|---|---|
+> | H.1 | `52ba19012` | webhook_dedup.py claim/process/done state machine, Idempotency-Key priority |
+> | H.2 | `4818b023a` | narrow `except FileNotFoundError` in `_sync_api_from_git`, keep provider-agnostic |
+> | H.3 | `71f646f33` | router `_map_provider_exception` → stable generic detail, no `str(e)` leak |
+> | H.4 | `71f646f33` | `delete_file` tri-state mapping: FileNotFoundError→404, TimeoutError→504, other→502 |
+> | H.5 | `71f646f33` | listing routes surface 502/504 instead of silent `[]` (get_tree keeps FNF→[]) |
+> | H.6 | `4818b023a` | `github_service.list_tree` returns `[]` on file path (no singleton blob) |
+> | H.7 | `65abd37e1` | Kafka `enable_auto_commit=False` + manual commit after handler success |
+> | H.8 | `65abd37e1` | discriminate ValueError by "already exists"/"not found" — unknown = error |
+> | H.10 | `71f646f33` | `_validate_file_path` rejects `..`, absolute, backslash, ASCII control chars |
+>
+> Regression guards: 49 new tests across
+> `test_regression_cp1_p1_service_contracts.py` (7),
+> `test_regression_cp1_p1_router_errors.py` (17),
+> `test_regression_cp1_p1_webhook_dedup.py` (18),
+> `test_regression_cp1_p1_worker_reliability.py` (7).
+>
+> **P1-adjacent bonus**: L.2 (webhook 500 leaks str(e)) closed
+> alongside H.1 in `52ba19012` — same class of bug as H.3.
+
 **Module**: CP-1 — GitProvider abstraction in `control-plane-api`
 **Path**: `control-plane-api/src/services/git_provider.py`, `git_service.py`, `github_service.py`, `src/routers/git.py`, `src/routers/webhooks.py`, `src/services/iam_sync_service.py`, `src/services/deployment_orchestration_service.py`, `src/workers/git_sync_worker.py`
 **Scope**: ~3 200 LOC across 8 files

--- a/control-plane-api/FIX-PLAN-CP1-P1.md
+++ b/control-plane-api/FIX-PLAN-CP1-P1.md
@@ -1,0 +1,474 @@
+# FIX-PLAN-CP1-P1
+
+> **Scope** : the 9 High-priority findings from `BUG-REPORT-CP-1.md` Rev 2.
+> **Branch** : `fix/cp-1-p1-batch` (cut from `fix/cp-1-p0-batch`; rebase on
+> `main` once the P0 batch is merged).
+> **Method** : Phase 1 plan (this doc) → STOP for human validation → Phase 2
+> atomic commits with per-bug regression guards → Phase 3 global validation.
+> **Owner** : @PotoMitan. Date : 2026-04-23.
+
+---
+
+## 1. Bug roster (9 findings)
+
+### H.1 — Webhook replay: no dedup on delivery headers
+
+- **File/line** : `src/routers/webhooks.py` (entier — GitLab handler L.93 onward, GitHub handler L.239 onward)
+- **Cause racine** : **Group B** (webhook surface hardening)
+- **Résumé** : aucun des deux handlers ne lit `X-GitHub-Delivery` ou
+  `X-Gitlab-Webhook-UUID` / `X-Gitlab-Event-UUID`. GitHub/GitLab rejouent sur
+  timeout → pipeline exécuté 2×: Kafka publish × 2, trace × 2, retry sur
+  `already exists` compté comme erreur (ou faux-positif via H.8).
+- **Approche** : cache TTL in-memory (stdlib, pas de Redis en P1) indexé
+  sur `(source, delivery_id)`, capacité 10 000 entrées, TTL 24h (fenêtre GitHub
+  redelivery standard). Au hit → 200 + `status="duplicate"` sans publish Kafka
+  ni trace DB.
+- **API publique** : réponse existante (`WebhookProcessedResponse`) conservée
+  ; un nouveau `status="duplicate"` s'ajoute. Le status code reste 200.
+- **Régression guards** : 3 tests
+  - `test_gitlab_webhook_dedup_on_repeated_uuid`
+  - `test_github_webhook_dedup_on_repeated_delivery_id`
+  - `test_missing_delivery_header_still_processes_but_logs_warning`
+
+### H.2 — `contextlib.suppress(Exception)` in `_sync_api_from_git`
+
+- **File/line** : `src/services/deployment_orchestration_service.py:115-124`
+- **Cause racine** : **Group D** (service-layer contract hardening)
+- **Résumé** : deux blocs `with contextlib.suppress(Exception):` avalent
+  timeout, rate-limit, YAML parse errors, auth failures. `_upsert_api` reçoit
+  `None` sans distinguer "pas de spec" de "provider injoignable".
+- **Approche** : remplacer par `except FileNotFoundError` (fichier absent =
+  None attendu) ; laisser `TimeoutError`, `GitlabGetError` quand c'est un 429 /
+  5xx, et `GithubException` avec `status != 404` remonter. Logger WARNING
+  pour le cas inattendu au lieu de tout swallow.
+- **API publique** : non (méthode privée `_sync_api_from_git`). Callers
+  actuels consomment déjà le `None` comme "pas trouvé" — on conserve ce
+  contrat pour le cas `FileNotFoundError`. Les vraies pannes remontent en
+  exception, cohérent avec le reste du service.
+- **Régression guards** : 3 tests
+  - `test_sync_api_suppresses_missing_openapi_spec`
+  - `test_sync_api_propagates_rate_limit_error`
+  - `test_sync_api_propagates_timeout_error`
+
+### H.3 — Router leaks `str(e)` in HTTPException `detail`
+
+- **File/line** : `src/routers/git.py:185, 209-210, 254-255, 273-274, 310-311`
+- **Cause racine** : **Group A** (router error mapping)
+- **Résumé** : `f"Failed to ...: {e}"` dans `detail` remonte PyGithub /
+  python-gitlab error strings : URL API, headers, request IDs, fragments de
+  stack. Post-C.2, le risque de fuite de token est fermé mais d'autres
+  éléments de diagnostic exposés restent.
+- **Approche** : message générique (`detail="Failed to <action>"`) ; log
+  serveur conserve l'exception complète avec `exc_info=True` et le
+  `request_id` est déjà bindé en contextvars par `logging_config.py` donc
+  inclus automatiquement dans chaque log. Le client récupère le `request_id`
+  côté réponse via le header `X-Request-ID` (middleware
+  `http_logging.py:111`).
+- **API publique** : le `detail` devient stable ("Failed to save file",
+  "Failed to merge", etc.). Les tests existants qui inspectent `detail` doivent
+  être revus — on regarde au Phase 2.
+- **Régression guards** : 2 tests (1 par pattern affecté)
+  - `test_router_generic_detail_on_write_file_failure`
+  - `test_router_generic_detail_on_merge_failure`
+
+### H.4 — `delete_file` router converts ALL exceptions into 404
+
+- **File/line** : `src/routers/git.py:205-212`
+- **Cause racine** : **Group A** (router error mapping)
+- **Résumé** : `except Exception: raise HTTPException(404)`. Timeout, 500
+  provider, 401 déguisés en 404 "File not found" → le frontend affiche "fichier
+  absent" sur une panne provider.
+- **Approche** : `except FileNotFoundError: 404`, `except TimeoutError: 504`,
+  `except Exception: 502` (Bad Gateway = dépendance amont HS). Même stratégie
+  que la PR P0 sur `write_file` (create-first qui distingue create vs update).
+- **API publique** : 404 cesse d'être le fourre-tout ; les clients qui
+  traitaient 404 comme "file missing" continuent de marcher ; nouveaux status
+  (502, 504) à communiquer côté UI — noter dans la PR description.
+- **Régression guards** : 3 tests
+  - `test_delete_missing_file_returns_404`
+  - `test_delete_timeout_returns_504`
+  - `test_delete_provider_5xx_returns_502`
+
+### H.5 — `list_*` routes silently return `[]` on any error
+
+- **File/line** : `src/routers/git.py:123-125, 160-161, 229-231, 290-292`
+- **Cause racine** : **Group A** (router error mapping)
+- **Résumé** : 4 routes (`list_commits`, `get_tree`, `list_merge_requests`,
+  `list_branches`) avalent tout et rendent `[]`. UI affiche "aucun commit /
+  branch / MR" au lieu de "provider injoignable".
+- **Approche** : identique à H.4 mais sur listings. `FileNotFoundError`
+  (path n'existe pas côté GitLab) reste `[]` — c'est une vraie "liste vide".
+  Timeout → 504. Autre exception → 502.
+- **Cas particulier `list_tree`** : il appelle déjà `list_tree` du service
+  qui normalise les 404 en `[]` (post-C.6 + H.6 à venir). Le try/except
+  router au-dessus devient un filet pour 5xx provider uniquement.
+- **API publique** : même remarque que H.4 — nouveaux codes à relier au
+  frontend.
+- **Régression guards** : 2 tests (pattern partagé avec H.4)
+  - `test_list_commits_provider_5xx_returns_502`
+  - `test_list_branches_timeout_returns_504`
+
+### H.6 — `list_tree` contract drift: file vs directory across providers
+
+- **File/line** : `src/services/github_service.py:1049-1072`,
+  `src/services/git_service.py:1072-1082`
+- **Cause racine** : **Group D** (service-layer contract hardening)
+- **Résumé** : sur un `path` qui pointe un fichier (pas un dossier), GitHub
+  renvoie un objet unique que le code wrap en `[contents]` et propage comme
+  `TreeEntry(type="blob")`. GitLab renvoie `[]` ou 404 selon version. Le
+  contrat ABC `list_tree` signifie "énumère les enfants" ; un fichier n'a pas
+  d'enfants.
+- **Approche** : dans `github_service.list_tree`, si `contents` n'est pas
+  une `list` → retourner `[]`. Normalise le contrat inter-provider, supprime
+  le piège côté caller.
+- **API publique** : le comportement passe de "un entry blob pour un path
+  fichier" à "`[]` pour un path fichier". Aucun caller dans cp-api ne dépend
+  du comportement actuel (vérifier au Phase 2 via `grep list_tree`). Si un
+  caller s'appuyait dessus, il devait déjà gérer les deux providers
+  divergents — donc cast légitime.
+- **Régression guards** : 2 tests
+  - `test_github_list_tree_returns_empty_on_file_path`
+  - `test_gitlab_list_tree_returns_empty_on_file_path`
+
+### H.7 — Kafka `enable_auto_commit=True` — at-most-once loss
+
+- **File/line** : `src/workers/git_sync_worker.py:150`
+- **Cause racine** : **Group C** (worker reliability)
+- **Résumé** : avec auto-commit, l'offset avance indépendamment du succès du
+  handler async dispatché via `asyncio.run_coroutine_threadsafe`. Un crash
+  entre auto-commit et exécution async → event perdu sans alerte → catalog
+  divergent.
+- **Approche** : `enable_auto_commit=False` + commit manuel **après**
+  completion du future dans `_dispatch_event`. `future.result(timeout=60)`
+  bloque le consumer thread jusqu'au succès du handler ; puis
+  `self._consumer.commit()`. En cas d'exception → log error + PAS de commit
+  → message re-livré au prochain poll (at-least-once, idempotence assurée par
+  H.8 et par le GitHub API side).
+- **Impact latence** : on sérialise par partition. Le topic `api-lifecycle`
+  a peu de trafic (< 100 events/s en démo). Acceptable. Alternative future =
+  committer async via callback + queue locale, hors scope P1.
+- **API publique** : non (worker interne). Noter changement dans le commit
+  message.
+- **Régression guards** : 2 tests
+  - `test_kafka_consumer_disables_auto_commit`
+  - `test_commit_only_after_handler_success`
+
+### H.8 — `ValueError` blanket-classified as success in retry loop
+
+- **File/line** : `src/workers/git_sync_worker.py:242-246`
+- **Cause racine** : **Group C** (worker reliability)
+- **Résumé** : `except ValueError: status="success"` traite toute ValueError
+  comme idempotent. Mais `batch_commit("unknown action")` raise ValueError —
+  un bug fonctionnel compte comme success dans les métriques.
+- **Approche** : discriminer par message :
+  ```python
+  except ValueError as e:
+      msg = str(e).lower()
+      if "already exists" in msg or "not found" in msg:
+          status = "success"  # idempotent
+          return
+      # unknown ValueError — log + treat as error
+      last_error = e
+      # fall through to retry path
+  ```
+- **API publique** : métrique `catalog_git_sync_total{status=...}` devient
+  plus précise ; alerting doit vérifier.
+- **Régression guards** : 2 tests
+  - `test_value_error_already_exists_counted_as_success`
+  - `test_value_error_unknown_message_counted_as_error`
+
+### H.10 — Path sanitization missing in `_tenant_path` (defensive hardening)
+
+- **File/line** : `src/routers/git.py:98-101`
+- **Cause racine** : **Group A** (router input validation)
+- **Résumé** : le path ramassé par `{file_path:path}` accepte `..`, `\x00`,
+  backslashes, paths absolus. Pas exploitable aujourd'hui (GitLab rejette
+  `/../` côté serveur ; GitHub traite littéralement). Mais tout refactor
+  introduisant `os.path.normpath` ouvre le trou.
+- **Approche** : centraliser la validation dans `_tenant_path` (et
+  nouveau helper `_validate_file_path`) :
+  ```python
+  if ".." in path.split("/") or "\x00" in path or path.startswith("/"):
+      raise HTTPException(status_code=400, detail="Invalid path")
+  ```
+  `\` backslash → rejet aussi (Windows-style reserved). Appliqué à
+  `get_file`, `create_or_update_file`, `delete_file`, `get_tree`.
+- **API publique** : paths déviants rejetés avec 400 (avant: 200 + effet
+  indéterminé). Documenter dans la PR — théoriquement aucun path valide
+  affecté.
+- **Régression guards** : 4 tests
+  - `test_path_traversal_rejected`
+  - `test_null_byte_rejected`
+  - `test_absolute_path_rejected`
+  - `test_normal_nested_path_accepted`
+
+---
+
+## 2. Cause racine — mapping final
+
+| Groupe | Bugs | Nature | Fichier principal |
+|---|---|---|---|
+| A — Router error mapping + input validation | H.3, H.4, H.5, H.10 | boundary defense | `src/routers/git.py` |
+| B — Webhook surface hardening | H.1 | idempotence replay | `src/routers/webhooks.py` |
+| C — Worker reliability | H.7, H.8 | at-least-once + metric precision | `src/workers/git_sync_worker.py` |
+| D — Service contract hardening | H.2, H.6 | expected vs unexpected errors, list_tree normalization | `src/services/deployment_orchestration_service.py`, `src/services/github_service.py` |
+
+---
+
+## 3. Commit plan (4 atomic commits)
+
+### Commit 1 — `fix(cp-api/git): tighten service contracts for list_tree + deploy_sync errors`
+
+- **Closes** : H.2, H.6 (Group D)
+- Ordre logique : commencé par la couche service car elle alimente les
+  signaux que la couche router (Commit 2) va relayer proprement.
+- **Diff** :
+  - `github_service.list_tree` : return `[]` quand `contents` n'est pas
+    une list.
+  - `deployment_orchestration_service._sync_api_from_git` : remplacer les
+    `contextlib.suppress(Exception)` par des `except FileNotFoundError`
+    + log WARNING sur autres exceptions avant de les propager.
+- **Régression tests** :
+  `tests/test_regression_cp1_p1_service_contracts.py` (5 tests)
+- **Risques** :
+  - Si un caller historique consommait la sémantique "file as blob" pour
+    un path fichier via `list_tree`, il cesse de le recevoir. Vérif
+    grep-scope au Phase 2.
+  - Les `with suppress` étaient peut-être là pour masquer un bug
+    upstream (ex: adapter gateway 500 sur connect). À surveiller en CI.
+
+### Commit 2 — `fix(cp-api/git): normalize router error mapping + sanitize tenant paths`
+
+- **Closes** : H.3, H.4, H.5, H.10 (Group A)
+- **Diff** :
+  - `_tenant_path` + nouveau `_validate_file_path(path)` : reject
+    `..`, `\x00`, `/abs`, `\`.
+  - Helper `_map_provider_exception(e) -> HTTPException` centralise
+    `FileNotFoundError → 404`, `TimeoutError → 504`, autre → 502 avec
+    detail générique.
+  - Remplacer chaque `detail=f"...: {e}"` par message stable
+    (`"Failed to save file"`, etc.). Log serveur garde `exc_info=True`
+    — `request_id` bindé via contextvars dans `logging_config.py:237`
+    → remonte automatiquement dans les logs structlog. Client
+    récupère `X-Request-ID` via header réponse (middleware existant).
+  - `delete_file` : `except FileNotFoundError: 404 ; except TimeoutError:
+    504 ; except Exception: 502`.
+  - `list_commits`, `get_tree`, `list_merge_requests`, `list_branches`
+    (routes listing) : même helper. `FileNotFoundError` → `[]`,
+    timeout → 504, provider error → 502.
+- **Arbitrage résolu** :
+  - Code HTTP sur panne upstream : **502 Bad Gateway** (norme REST :
+    dépendance HS). **504 Gateway Timeout** pour `TimeoutError`. Pas
+    500 (500 = bug cp-api).
+  - `request_id` exposition : via header `X-Request-ID` existant, pas
+    dans `detail` (redondant).
+- **Régression tests** :
+  `tests/test_regression_cp1_p1_router_errors.py` (11 tests consolidés
+  sur H.3/H.4/H.5/H.10)
+- **Risques** :
+  - Tests E2E existants peuvent asserter `detail` string → à adapter.
+  - Clients UI qui lisaient "File not found" sur toute erreur delete
+    verront 502/504 → owner UI à notifier via PR description. Pas de
+    breaking change client-side si l'UI se fie au status code.
+
+### Commit 3 — `fix(cp-api/webhooks): dedup webhook replays via delivery headers`
+
+- **Closes** : H.1 (Group B)
+- **Diff** :
+  - Nouveau `src/services/webhook_dedup.py` : cache TTL in-memory
+    indexé `(source, delivery_id)`. Capacité 10 000, TTL 24h. Thread-safe
+    via `asyncio.Lock`. Pure-stdlib.
+  - `gitlab_webhook` : lire `X-Gitlab-Webhook-UUID` (fallback
+    `X-Gitlab-Event-UUID`). Si absent → log warning (compat ancien
+    GitLab < 14.0) mais continuer. Si vu récemment → renvoyer
+    `{"status": "duplicate", "event": ..., "trace_id": "<cached>"}` 200.
+  - `github_webhook` : lire `X-GitHub-Delivery`. Même logique.
+  - Position dans le pipeline : **après** l'auth (C.7 invariant),
+    **avant** le trace DB insert → évite doublons en base.
+- **Arbitrage résolu** :
+  - **In-memory (stdlib) vs Redis** : in-memory OK en P1 car
+    CP-API tourne en single-replica aujourd'hui (ArgoCD values.yaml à
+    vérifier). Redis = P2/P3 quand HPA activé, noté dans commit body.
+  - **Missing delivery header** : warn + process (pas reject) — compat
+    ascendante, certains clients custom n'émettent pas ces headers.
+- **Régression tests** :
+  `tests/test_regression_cp1_p1_webhook_dedup.py` (3 tests)
+- **Risques** :
+  - Single-replica hypothesis : si 2 réplicas CP-API → dédup ne marche
+    pas entre instances. Documenter en commit + issue follow-up Redis
+    (backlog).
+  - Capacité 10k : à 100 webhooks/s × 24h = 8.6M entries. Cap = éviction
+    LRU ; rares faux négatifs sur redelivery > 24h OK (seuil GitHub).
+
+### Commit 4 — `fix(cp-api/workers): at-least-once Kafka commit + precise idempotency classification`
+
+- **Closes** : H.7, H.8 (Group C)
+- **Diff** :
+  - `_create_consumer` : `enable_auto_commit=False`.
+  - `_dispatch_event` : après `run_coroutine_threadsafe`, attendre
+    `future.result(timeout=60)`. Si succès → `self._consumer.commit()`.
+    Exception → log + PAS de commit (re-livraison au prochain poll).
+  - `_handle_event` : `except ValueError` n'est plus un passe-droit —
+    discriminer `"already exists"`/`"not found"` in message. Autres
+    ValueError → traiter comme erreur retriable.
+- **Arbitrage résolu** :
+  - **Sérialisation par partition** : acceptée — topic bas trafic en
+    démo. Optimisation commit-batch = P3, hors scope.
+  - **Timeout `future.result`** : 60s = 2× timeout HTTP provider
+    (`DEFAULT_TIMEOUT_S=30`). Si dépassé → log + commit (on avance, sinon
+    on bloque indéfiniment).
+  - Actually no — si `future.result(60)` timeout, NE PAS committer
+    (event non traité) et annuler le future. Documenter dans commit :
+    "timeout treated as failure, message re-delivered".
+- **Régression tests** :
+  `tests/test_regression_cp1_p1_worker_reliability.py` (4 tests)
+- **Risques** :
+  - Si le topic remplit beaucoup de redelivery (mauvais handler), le
+    consumer bloque par message. Monitoring prometheus `GIT_SYNC_RETRIES_TOTAL`
+    à aligner.
+  - Passage à manual commit : si le commit lui-même raise (broker
+    injoignable), le message sera retraité. OK car les handlers
+    catalog sont idempotents (create → "already exists" path).
+
+---
+
+## 4. Arbitrages transverses
+
+1. **Déjà fixé par P0 ?** Vérifié bug par bug :
+   - H.1/H.2/H.3/H.4/H.5/H.6/H.8/H.10 : **non couverts** par P0 (C.1→C.7 ne
+     touchent ni le router `git.py` ni `deployment_orchestration_service` ni
+     `list_tree` ni le worker). OK à commiter.
+   - H.7 (Kafka auto-commit) : P0 n'a pas touché `git_sync_worker.py`.
+     Confirmé.
+
+2. **Retry/timeout policy unifiée ?** **Non**. P0 a déjà introduit
+   `run_sync` + semaphores + timeout dans `git_executor.py`. Dupliquer un
+   RETRY_POLICY ici fight les SDK retries (PyGithub / python-gitlab). Les
+   fixes H restent localisés : H.4/H.5 consomment les exceptions qui
+   remontent du wrapper existant, H.7 durcit Kafka seul. Pas de nouvelle
+   abstraction.
+
+3. **Observabilité consolidée ?** Partiellement :
+   - H.3 → log `exc_info=True` + `request_id` via contextvars (déjà
+     en place dans middleware `http_logging.py`).
+   - H.5 → même strat.
+   - H.7/H.8 → métriques Prometheus existent déjà (`GIT_SYNC_TOTAL`,
+     `GIT_SYNC_RETRIES_TOTAL`) ; H.8 les rend plus précises.
+   - Pas de commit obs-only : c'est intégré dans chaque commit concerné.
+
+4. **H.10 fix maintenant ou backlog ?** **Fix maintenant**. Coût 5 LOC
+   + 4 tests. Défense en profondeur requise par attentes DORA BDF. Tout
+   refactor futur introduisant `os.path.normpath` ouvre la fenêtre — le
+   garde-fou doit être côté router, pas côté provider.
+
+5. **Dépendance inter-commit ?** Non — les 4 commits sont indépendants :
+   - Commit 1 (services) et Commit 2 (router) partagent la sémantique
+     `FileNotFoundError → 404` mais ne dépendent pas l'un de l'autre
+     (la normalisation existe déjà post-C.6).
+   - Commit 3 (webhooks) et Commit 4 (worker) sont isolés.
+   - Ordre de commit suggéré : 1 → 2 → 3 → 4 (services → router →
+     webhooks → worker) par cohérence de revue.
+
+---
+
+## 5. Risques globaux identifiés
+
+| Risque | Commit | Mitigation |
+|---|---|---|
+| Tests existants asserting `detail` string cassent | 2 | Recherche `assert.*detail.*Failed to.*:` pendant Phase 2, ajustement ciblé |
+| Dedup in-memory ne tient pas en multi-replica | 3 | Vérifier `replicas: 1` dans chart + backlog P2/P3 pour Redis |
+| Consumer block sur `future.result(60s)` en boucle si handler HS | 4 | Log `GIT_SYNC_TOTAL{status="error"}` + alerte Prometheus |
+| Normalisation list_tree casse un caller silencieux | 1 | `grep -rn "list_tree\(.*\)\." src/` avant commit pour recenser les callers |
+| 502/504 surprise le frontend | 2 | Note explicite dans PR description, tag `@frontend-owner` |
+
+---
+
+## 6. Validation Phase 3 (à exécuter après les 4 commits)
+
+1. `pytest tests/ --asyncio-mode=auto -x -v`
+2. `ruff check src/`
+3. `mypy src/services/git*.py src/routers/git.py src/routers/webhooks.py src/services/deployment_orchestration_service.py src/workers/git_sync_worker.py src/services/webhook_dedup.py`
+4. `grep -rn "self._project\." src/ --include="*.py" | grep -v "_test"` → toujours 0
+5. `grep -rn "contextlib.suppress(Exception)" src/services/ --include="*.py"` → toujours 0 sur deployment_orchestration
+6. Smoke manuel : 3 scénarios
+   - POST `/webhooks/gitlab` avec même `X-Gitlab-Webhook-UUID` 2× → 2e réponse `status="duplicate"`
+   - DELETE `/v1/tenants/X/git/files/doesnotexist.yaml` → 404 (inchangé)
+   - DELETE `/v1/tenants/X/git/files/valid.yaml` avec provider down → 502 (nouveau)
+7. Mettre à jour `BUG-REPORT-CP-1.md` : marquer H.1-H.8, H.10 avec commit SHA dans l'encadré "P1 batch status".
+
+---
+
+**Phase 1 complete. STOP for validation before implementing.**
+
+---
+
+## 7. Amendments post-review (2026-04-23, green-light)
+
+Human reviewer approved with 3 mandatory changes + 1 follow-up note.
+
+### 7.1 Commit 3 / H.1 — dedup key priority + claim lifecycle
+
+- **GitLab key priority** : `Idempotency-Key` **first** (stable across retries
+  per GitLab webhooks doc) ; fallback `X-Gitlab-Webhook-UUID` (per-webhook
+  unique). **Never** use `X-Gitlab-Event-UUID` as primary key — it is shared
+  across recursive webhooks, so deduping on it swallows legitimate events.
+- **GitHub key** : `X-GitHub-Delivery` stays the right one.
+- **Claim lifecycle** : not a simple "seen" flag. Three-state:
+  - `claim` (inserted when entering the pipeline, after auth, before any
+    side effect).
+  - `done` (set after the pipeline completes successfully).
+  - on exception → **release the claim** so the next retry is not
+    answered with `status="duplicate"` (which would lose the event).
+- **Contract** : a delivery with an existing `done` entry → 200 +
+  `status="duplicate"`, no side effect. A delivery with an in-flight `claim`
+  → 200 + `status="in-flight"` (GitHub re-delivers only after 10s timeout,
+  so this is a real collision between replicas or slow handlers). A delivery
+  with no entry → normal flow + `claim` set.
+- **Ordering** : still after auth (C.7 + GitHub doc on signature-before-
+  process). Implemented entirely in-memory for P1 — single-replica
+  assumption documented, Redis-backed version = P2/P3 follow-up issue.
+
+### 7.2 Commit 2 / H.5 — tighten `FileNotFoundError → []` scope
+
+- Keep `FileNotFoundError → []` **only** for `get_tree` (path doesn't exist
+  = empty listing, natural contract).
+- `list_commits` — `FileNotFoundError` on a path-scoped call can still mean
+  "no such path" → treat as `[]` when `path` is set ; otherwise 502.
+- `list_branches`, `list_merge_requests` — **no** natural "file missing"
+  notion. A missing repo = upstream misconfig, not empty list. Must return
+  502 (provider/config) or 504 (timeout) instead of silent `[]`.
+
+### 7.3 Commit 2 / H.10 — control chars, not just `\x00`
+
+- Reject: any segment == `..`, absolute path (`/...`), backslash, **any
+  ASCII control character** (range `\x00`–`\x1f` plus `\x7f`).
+- Implementation: single regex or `any(ord(c) < 0x20 or ord(c) == 0x7f for c
+  in path)` guard in `_validate_file_path`.
+
+### 7.4 Commit 1 / H.2 — keep deployment_orchestration provider-agnostic
+
+- `_sync_api_from_git` : catch **only** `FileNotFoundError`. Let
+  `TimeoutError`, `GitlabGetError`, `GithubException`, `GitLabRateLimitError`
+  propagate untouched. Do **not** import provider-specific exception
+  classes in this layer — that couples the orchestration service to the
+  PyGithub / python-gitlab implementations, defeating the CAB-1889
+  `GitProvider` abstraction.
+- Log message on the caught `FileNotFoundError` stays (expected path).
+- Comment in the except clause to document why we do NOT widen it.
+
+### 7.5 Commit 4 follow-up — rebalance / partition revoke note
+
+- Our worker uses `kafka-python` (sync, not `aiokafka`). Manual-commit +
+  rebalance corner case still applies: between `future.result()` success
+  and `consumer.commit()`, a rebalance can reassign the partition → the
+  next consumer re-reads the same offset → duplicate delivery. Current
+  handlers are idempotent by design (create → "already exists" path), so
+  this is acceptable for P1.
+- Follow-up (backlog, not P1) : add `on_partitions_revoked` hook that
+  commits pending offsets before yielding the partition. Documented in
+  the commit body so future investigators see the reasoning.
+
+### 7.6 Final commit ordering (unchanged)
+
+1. Commit 1 (services) → 2 (router) → 3 (webhook) → 4 (worker).
+

--- a/control-plane-api/src/routers/git.py
+++ b/control-plane-api/src/routers/git.py
@@ -9,6 +9,13 @@ from pydantic import BaseModel
 from ..auth import Permission, User, get_current_user, require_permission, require_tenant_access
 from ..services.git_provider import GitProvider, get_git_provider, git_provider_factory
 
+# CP-1 H.10: reject paths containing parent segments, absolute prefix,
+# backslash, or any ASCII control character (including NUL, TAB, etc).
+# Defensive hardening - current providers treat paths literally, but any
+# future refactor introducing os.path.normpath / Path().resolve would
+# open a traversal window. Applied centrally in _validate_file_path.
+_CONTROL_CHAR_RANGE = frozenset((*range(0x00, 0x20), 0x7F))
+
 
 class TreeItem(BaseModel):
     name: str
@@ -95,8 +102,35 @@ class BranchCreate(BaseModel):
     ref: str = "main"
 
 
+def _validate_file_path(path: str) -> None:
+    """CP-1 H.10: reject paths that could escape the tenant scope.
+
+    Rejects:
+      - any ``..`` segment (parent traversal)
+      - absolute path (``/...``)
+      - backslash (Windows-style separator; reserved)
+      - any ASCII control character (0x00-0x1f and 0x7f)
+
+    Raises:
+        HTTPException(400) on any violation.
+    """
+    if not path:
+        return
+    if path.startswith("/") or "\\" in path:
+        raise HTTPException(status_code=400, detail="Invalid path")
+    if ".." in path.split("/"):
+        raise HTTPException(status_code=400, detail="Invalid path")
+    if any(ord(c) in _CONTROL_CHAR_RANGE for c in path):
+        raise HTTPException(status_code=400, detail="Invalid path")
+
+
 def _tenant_path(tenant_id: str, path: str = "") -> str:
-    """Build scoped path under the tenant directory."""
+    """Build scoped path under the tenant directory.
+
+    CP-1 H.10: caller-supplied ``path`` is validated for traversal /
+    control-char injection before concatenation.
+    """
+    _validate_file_path(path)
     base = f"tenants/{tenant_id}"
     return f"{base}/{path}" if path else base
 
@@ -104,6 +138,27 @@ def _tenant_path(tenant_id: str, path: str = "") -> str:
 def _require_connected(git: GitProvider) -> None:
     if not git.is_connected():
         raise HTTPException(status_code=503, detail="Git provider not connected")
+
+
+def _map_provider_exception(exc: Exception, action: str) -> HTTPException:
+    """CP-1 H.3/H.4/H.5: map a raw provider exception to a sanitised HTTP error.
+
+    - ``FileNotFoundError`` → 404 "Not found"
+    - ``TimeoutError`` → 504 "Upstream timeout"
+    - anything else → 502 "Upstream provider error"
+
+    The original exception is never echoed into ``detail`` — ``str(exc)``
+    on PyGithub / python-gitlab errors contains API URLs, request IDs,
+    and can surface token fragments. The caller logs ``exc_info=True`` at
+    ERROR, and the request_id bound in contextvars by the http_logging
+    middleware is returned to the client via the ``X-Request-ID``
+    response header for server-side correlation.
+    """
+    if isinstance(exc, FileNotFoundError):
+        return HTTPException(status_code=404, detail="Not found")
+    if isinstance(exc, TimeoutError):
+        return HTTPException(status_code=504, detail=f"Upstream timeout while attempting to {action}")
+    return HTTPException(status_code=502, detail=f"Upstream provider error while attempting to {action}")
 
 
 @router.get("/commits", response_model=list[CommitInfo])
@@ -121,8 +176,11 @@ async def list_commits(
         commits = await git.list_path_commits(path=scoped_path, limit=limit)
         return [CommitInfo(**asdict(c)) for c in commits]
     except Exception as e:
-        logger.error(f"Failed to list commits for tenant {tenant_id}: {e}")
-        return []
+        # CP-1 H.5: do not silently swallow into []. Provider down must
+        # surface as 502/504 so the UI can distinguish "no commits" from
+        # "provider unreachable".
+        logger.error("Failed to list commits for tenant %s", tenant_id, exc_info=True)
+        raise _map_provider_exception(e, "list commits") from e
 
 
 @router.get("/files/{file_path:path}", response_model=FileContent)
@@ -136,7 +194,13 @@ async def get_file(
 ):
     """Get file content from git provider"""
     scoped_path = _tenant_path(tenant_id, file_path)
-    content = await git.read_file(scoped_path, ref=ref)
+    try:
+        content = await git.read_file(scoped_path, ref=ref)
+    except (FileNotFoundError, TimeoutError) as e:
+        raise _map_provider_exception(e, "read file") from e
+    except Exception as e:
+        logger.error("Failed to read file %s", scoped_path, exc_info=True)
+        raise _map_provider_exception(e, "read file") from e
     if content is None:
         raise HTTPException(status_code=404, detail="File not found")
     return FileContent(path=file_path, content=content)
@@ -157,8 +221,16 @@ async def get_tree(
     try:
         entries = await git.list_tree(scoped_path, ref=ref)
         return TreeListResponse(items=[TreeItem(**asdict(e)) for e in entries])
-    except Exception:
+    except FileNotFoundError:
+        # CP-1 H.5: path that does not exist in the tree is a legitimate
+        # "empty listing" (distinct from a provider failure). get_tree is
+        # the ONLY listing route that keeps this mapping — list_commits,
+        # list_branches and list_merge_requests surface provider errors
+        # as 502/504 instead of masking them.
         return TreeListResponse(items=[])
+    except Exception as e:
+        logger.error("Failed to list tree at %s", scoped_path, exc_info=True)
+        raise _map_provider_exception(e, "list tree") from e
 
 
 @router.post("/files/{file_path:path}", status_code=201, response_model=FileActionResponse)
@@ -181,8 +253,10 @@ async def create_or_update_file(
     try:
         action = await git.write_file(scoped_path, body.content, commit_message=msg, branch=branch)
     except Exception as e:
-        logger.error(f"Failed to create/update file {scoped_path}: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to save file: {e}")
+        # CP-1 H.3: generic detail — no str(e) leak. Full trace stays in
+        # server log via exc_info=True; clients correlate via X-Request-ID.
+        logger.error("Failed to create/update file %s", scoped_path, exc_info=True)
+        raise _map_provider_exception(e, "save file") from e
 
     return {"path": file_path, "action": action}
 
@@ -206,8 +280,11 @@ async def delete_file(
     try:
         await git.remove_file(scoped_path, commit_message=msg, branch=branch)
     except Exception as e:
-        logger.error(f"Failed to delete file {scoped_path}: {e}")
-        raise HTTPException(status_code=404, detail="File not found")
+        # CP-1 H.4: do NOT convert every error into 404. Missing file →
+        # 404 ; timeout → 504 ; other provider failure → 502. Prior
+        # blanket 404 masked outages as "file not found" in the UI.
+        logger.error("Failed to delete file %s", scoped_path, exc_info=True)
+        raise _map_provider_exception(e, "delete file") from e
 
     return {"message": "File deleted"}
 
@@ -227,8 +304,11 @@ async def list_merge_requests(
         mrs = await git.list_merge_requests(state=state)
         return [MergeRequestResponse(**asdict(mr)) for mr in mrs]
     except Exception as e:
-        logger.error(f"Failed to list merge requests: {e}")
-        return []
+        # CP-1 H.5: merge-request listing has no natural "file absent"
+        # semantics. A missing/unreachable repo must surface, not be
+        # silently flattened to [].
+        logger.error("Failed to list merge requests", exc_info=True)
+        raise _map_provider_exception(e, "list merge requests") from e
 
 
 @router.post("/merge-requests", response_model=MergeRequestResponse, status_code=201)
@@ -251,8 +331,8 @@ async def create_merge_request(
         )
         return MergeRequestResponse(**asdict(new_mr))
     except Exception as e:
-        logger.error(f"Failed to create merge request: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to create merge request: {e}")
+        logger.error("Failed to create merge request", exc_info=True)
+        raise _map_provider_exception(e, "create merge request") from e
 
 
 @router.post("/merge-requests/{mr_iid}/merge", response_model=MergeResultResponse)
@@ -270,8 +350,8 @@ async def merge_request(
         await git.merge_merge_request(mr_iid)
         return {"message": "Merge request merged", "iid": mr_iid}
     except Exception as e:
-        logger.error(f"Failed to merge MR !{mr_iid}: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to merge: {e}")
+        logger.error("Failed to merge MR !%s", mr_iid, exc_info=True)
+        raise _map_provider_exception(e, "merge merge request") from e
 
 
 # Branches
@@ -288,8 +368,11 @@ async def list_branches(
         branches = await git.list_branches()
         return [BranchInfo(**asdict(b)) for b in branches]
     except Exception as e:
-        logger.error(f"Failed to list branches: {e}")
-        return []
+        # CP-1 H.5: same rationale as list_merge_requests — branch
+        # listing has no natural "missing path" case. Provider failure
+        # must surface.
+        logger.error("Failed to list branches", exc_info=True)
+        raise _map_provider_exception(e, "list branches") from e
 
 
 @router.post("/branches", response_model=BranchInfo, status_code=201)
@@ -307,5 +390,5 @@ async def create_branch(
         branch = await git.create_branch(name=body.name, ref=body.ref)
         return BranchInfo(**asdict(branch))
     except Exception as e:
-        logger.error(f"Failed to create branch {body.name}: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to create branch: {e}")
+        logger.error("Failed to create branch %s", body.name, exc_info=True)
+        raise _map_provider_exception(e, "create branch") from e

--- a/control-plane-api/src/routers/webhooks.py
+++ b/control-plane-api/src/routers/webhooks.py
@@ -12,6 +12,12 @@ from ..database import get_db
 from ..models.traces_db import TraceStatusDB
 from ..services.kafka_service import Topics, kafka_service
 from ..services.trace_service import TraceService
+from ..services.webhook_dedup import (
+    DedupVerdict,
+    github_delivery_id,
+    gitlab_delivery_id,
+    webhook_dedup_cache,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +101,8 @@ async def gitlab_webhook(
     request: Request,
     x_gitlab_token: str | None = Header(None, alias="X-Gitlab-Token"),
     x_gitlab_event: str | None = Header(None, alias="X-Gitlab-Event"),
+    x_gitlab_webhook_uuid: str | None = Header(None, alias="X-Gitlab-Webhook-UUID"),
+    idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -107,6 +115,13 @@ async def gitlab_webhook(
     requests produce zero trace rows, eliminating the DoS amplification
     vector where an unauthenticated flood would burn 1 INSERT + 2 UPDATEs
     per request on the traces table.
+
+    CP-1 H.1: after auth, we claim a dedup slot keyed on Idempotency-Key
+    (preferred) or X-Gitlab-Webhook-UUID. X-Gitlab-Event-UUID is NEVER
+    used as primary key because it is shared across recursive webhooks —
+    deduping on it would drop legitimate events. The claim is released
+    on pipeline failure so the next redelivery retries cleanly instead
+    of being answered with "duplicate forever".
     """
     # CP-1 C.7 Step 1 — authenticate BEFORE any DB I/O.
     webhook_secret = settings.git.gitlab.webhook_secret.get_secret_value()
@@ -114,9 +129,34 @@ async def gitlab_webhook(
         # No trace row is written for unauthenticated requests.
         raise HTTPException(status_code=401, detail="Invalid webhook token")
 
-    # CP-1 C.7 Step 2 — only now do we parse and persist.
-    service = TraceService(db)
     event_type = x_gitlab_event or "Unknown"
+
+    # CP-1 H.1 Step 2 — dedup BEFORE DB insert / Kafka publish.
+    dedup_key = gitlab_delivery_id(idempotency_key, x_gitlab_webhook_uuid)
+    if dedup_key is None:
+        logger.warning(
+            "GitLab webhook missing Idempotency-Key and X-Gitlab-Webhook-UUID; "
+            "processing without dedup"
+        )
+    else:
+        verdict, cached = await webhook_dedup_cache.claim("gitlab", dedup_key)
+        if verdict is DedupVerdict.DUPLICATE:
+            return {
+                "status": "duplicate",
+                "event": event_type,
+                "trace_id": (cached or {}).get("trace_id", ""),
+                "duration_ms": (cached or {}).get("duration_ms"),
+                "author": (cached or {}).get("author"),
+            }
+        if verdict is DedupVerdict.IN_FLIGHT:
+            return {
+                "status": "in-flight",
+                "event": event_type,
+                "trace_id": "",
+            }
+
+    # CP-1 C.7 Step 3 — only now do we parse and persist.
+    service = TraceService(db)
     body = await request.json()
 
     # Extract Git info from payload
@@ -220,20 +260,32 @@ async def gitlab_webhook(
             f"Pipeline trace {trace.id}: {trace.status.value} in {trace.total_duration_ms}ms (author: {git_author})"
         )
 
-        return {
+        response = {
             "status": "processed",
             "event": event_type,
             "trace_id": trace.id,
             "duration_ms": trace.total_duration_ms,
             "author": git_author,
         }
+        # CP-1 H.1: promote claim → done so retries return 'duplicate'
+        # with the cached result instead of re-running the pipeline.
+        if dedup_key is not None:
+            await webhook_dedup_cache.mark_done("gitlab", dedup_key, response)
+        return response
 
     except HTTPException:
+        # CP-1 H.1: release claim so redelivery retries cleanly.
+        if dedup_key is not None:
+            await webhook_dedup_cache.release("gitlab", dedup_key)
         raise
     except Exception as e:
-        logger.error(f"Error processing GitLab webhook: {e}", exc_info=True)
+        logger.error("Error processing GitLab webhook", exc_info=True)
         await service.complete(trace, TraceStatusDB.FAILED, str(e))
-        raise HTTPException(status_code=500, detail=str(e))
+        # CP-1 H.1: release claim so redelivery retries cleanly.
+        # CP-1 H.3-adjacent: do not echo str(e) back to the sender.
+        if dedup_key is not None:
+            await webhook_dedup_cache.release("gitlab", dedup_key)
+        raise HTTPException(status_code=500, detail="Internal error processing webhook") from e
 
 
 @router.post("/github", response_model=WebhookProcessedResponse)
@@ -241,85 +293,140 @@ async def github_webhook(
     request: Request,
     x_hub_signature_256: str | None = Header(None, alias="X-Hub-Signature-256"),
     x_github_event: str | None = Header(None, alias="X-GitHub-Event"),
+    x_github_delivery: str | None = Header(None, alias="X-GitHub-Delivery"),
     db: AsyncSession = Depends(get_db),
 ):
-    """Handle GitHub webhooks for GitOps."""
-    service = TraceService(db)
+    """Handle GitHub webhooks for GitOps.
+
+    CP-1 H.1: after signature verification, claim a dedup slot keyed on
+    X-GitHub-Delivery. Claim is released on pipeline failure so the
+    next redelivery retries cleanly.
+    """
     event_type = x_github_event or "unknown"
     raw_body = await request.body()
-    body = await request.json()
 
-    # Verify HMAC-SHA256
+    # CP-1 C.7 invariant — verify HMAC BEFORE any DB I/O or dedup state.
     if not verify_github_signature(
         raw_body, x_hub_signature_256, settings.git.github.webhook_secret.get_secret_value()
     ):
         raise HTTPException(status_code=401, detail="Invalid signature")
 
-    # Extract git info
-    if event_type == "push":
-        git_project = body.get("repository", {}).get("full_name", "")
-        git_branch = body.get("ref", "").replace("refs/heads/", "")
-        head_commit = body.get("head_commit", {})
-        git_author = head_commit.get("author", {}).get("name", body.get("sender", {}).get("login", "unknown"))
-        git_commit_sha = head_commit.get("id")
-        git_commit_message = head_commit.get("message", "")[:200]
-    elif event_type == "pull_request":
-        pr = body.get("pull_request", {})
-        git_project = body.get("repository", {}).get("full_name", "")
-        git_branch = pr.get("head", {}).get("ref", "")
-        git_author = pr.get("user", {}).get("login", "unknown")
-        git_commit_sha = pr.get("merge_commit_sha")
-        git_commit_message = pr.get("title", "")[:200]
+    # CP-1 H.1 — dedup BEFORE DB insert / Kafka publish.
+    dedup_key = github_delivery_id(x_github_delivery)
+    if dedup_key is None:
+        logger.warning("GitHub webhook missing X-GitHub-Delivery; processing without dedup")
     else:
-        git_project = body.get("repository", {}).get("full_name", "")
-        git_branch = ""
-        git_author = body.get("sender", {}).get("login", "unknown")
-        git_commit_sha = None
-        git_commit_message = None
+        verdict, cached = await webhook_dedup_cache.claim("github", dedup_key)
+        if verdict is DedupVerdict.DUPLICATE:
+            return WebhookProcessedResponse(
+                status="duplicate",
+                event=event_type,
+                trace_id=(cached or {}).get("trace_id", ""),
+            )
+        if verdict is DedupVerdict.IN_FLIGHT:
+            return WebhookProcessedResponse(
+                status="in-flight",
+                event=event_type,
+                trace_id="",
+            )
 
-    trace = await service.create(
-        trigger_type=f"github-{event_type}",
-        trigger_source="github",
-        git_project=git_project,
-        git_branch=git_branch,
-        git_commit_sha=git_commit_sha,
-        git_commit_message=git_commit_message,
-        git_author=git_author,
-    )
+    service = TraceService(db)
+    body = await request.json()
 
-    await service.add_step(
-        trace,
-        name="webhook_received",
-        status="success",
-        duration_ms=5,
-        details={"event_type": event_type, "project": git_project, "action": body.get("action")},
-    )
+    try:
+        # Extract git info
+        if event_type == "push":
+            git_project = body.get("repository", {}).get("full_name", "")
+            git_branch = body.get("ref", "").replace("refs/heads/", "")
+            head_commit = body.get("head_commit", {})
+            git_author = head_commit.get("author", {}).get(
+                "name", body.get("sender", {}).get("login", "unknown")
+            )
+            git_commit_sha = head_commit.get("id")
+            git_commit_message = head_commit.get("message", "")[:200]
+        elif event_type == "pull_request":
+            pr = body.get("pull_request", {})
+            git_project = body.get("repository", {}).get("full_name", "")
+            git_branch = pr.get("head", {}).get("ref", "")
+            git_author = pr.get("user", {}).get("login", "unknown")
+            git_commit_sha = pr.get("merge_commit_sha")
+            git_commit_message = pr.get("title", "")[:200]
+        else:
+            git_project = body.get("repository", {}).get("full_name", "")
+            git_branch = ""
+            git_author = body.get("sender", {}).get("login", "unknown")
+            git_commit_sha = None
+            git_commit_message = None
 
-    # Dispatch to Kafka for async processing
-    if event_type == "push":
-        await kafka_service.publish(
-            topic=Topics.DEPLOY_REQUESTS,
-            event_type="sync-catalog",
-            tenant_id="all",
-            payload={"trace_id": str(trace.id), "source": "github", "project": git_project, "branch": git_branch},
-            user_id=git_author,
+        trace = await service.create(
+            trigger_type=f"github-{event_type}",
+            trigger_source="github",
+            git_project=git_project,
+            git_branch=git_branch,
+            git_commit_sha=git_commit_sha,
+            git_commit_message=git_commit_message,
+            git_author=git_author,
         )
-    elif event_type == "pull_request" and body.get("action") == "closed" and body.get("pull_request", {}).get("merged"):
-        await kafka_service.publish(
-            topic=Topics.DEPLOY_REQUESTS,
-            event_type="sync-gitops",
-            tenant_id="all",
-            payload={
-                "trace_id": str(trace.id),
-                "source": "github",
-                "project": git_project,
-                "pr_number": body["pull_request"]["number"],
-            },
-            user_id=git_author,
+
+        await service.add_step(
+            trace,
+            name="webhook_received",
+            status="success",
+            duration_ms=5,
+            details={"event_type": event_type, "project": git_project, "action": body.get("action")},
         )
 
-    await service.complete(trace, TraceStatusDB.SUCCESS, f"GitHub {event_type} processed")
-    return WebhookProcessedResponse(status="processed", event=event_type, trace_id=str(trace.id))
+        # Dispatch to Kafka for async processing
+        if event_type == "push":
+            await kafka_service.publish(
+                topic=Topics.DEPLOY_REQUESTS,
+                event_type="sync-catalog",
+                tenant_id="all",
+                payload={
+                    "trace_id": str(trace.id),
+                    "source": "github",
+                    "project": git_project,
+                    "branch": git_branch,
+                },
+                user_id=git_author,
+            )
+        elif (
+            event_type == "pull_request"
+            and body.get("action") == "closed"
+            and body.get("pull_request", {}).get("merged")
+        ):
+            await kafka_service.publish(
+                topic=Topics.DEPLOY_REQUESTS,
+                event_type="sync-gitops",
+                tenant_id="all",
+                payload={
+                    "trace_id": str(trace.id),
+                    "source": "github",
+                    "project": git_project,
+                    "pr_number": body["pull_request"]["number"],
+                },
+                user_id=git_author,
+            )
+
+        await service.complete(trace, TraceStatusDB.SUCCESS, f"GitHub {event_type} processed")
+        response = WebhookProcessedResponse(
+            status="processed", event=event_type, trace_id=str(trace.id)
+        )
+        # CP-1 H.1: promote claim → done; retries return 'duplicate'.
+        if dedup_key is not None:
+            await webhook_dedup_cache.mark_done(
+                "github", dedup_key, response.model_dump()
+            )
+        return response
+    except HTTPException:
+        if dedup_key is not None:
+            await webhook_dedup_cache.release("github", dedup_key)
+        raise
+    except Exception:
+        logger.error("Error processing GitHub webhook", exc_info=True)
+        if dedup_key is not None:
+            await webhook_dedup_cache.release("github", dedup_key)
+        raise HTTPException(status_code=500, detail="Internal error processing webhook") from None
 
 
 async def handle_push_event_traced_pg(payload: dict, trace, service: TraceService) -> dict:

--- a/control-plane-api/src/services/deployment_orchestration_service.py
+++ b/control-plane-api/src/services/deployment_orchestration_service.py
@@ -112,16 +112,26 @@ class DeploymentOrchestrationService:
 
             sync_svc = CatalogSyncService(self.db, git_service, enable_gateway_reconciliation=False)
 
-            import contextlib
-
+            # CP-1 H.2: catch only FileNotFoundError (missing spec / missing
+            # head commit are expected "None" outcomes). Any transient
+            # provider failure (TimeoutError, rate-limit, auth error, etc.)
+            # propagates to the outer except, which short-circuits the
+            # upsert — better to refuse syncing than to persist a corrupt
+            # catalog row with silently-None fields. Stays provider-agnostic
+            # on purpose: do NOT import PyGithub / python-gitlab exceptions
+            # in this layer (CAB-1889 GitProvider abstraction invariant).
             openapi_spec = None
-            with contextlib.suppress(Exception):
+            try:
                 openapi_spec = await git_service.get_api_openapi_spec(tenant_id, api_id)
+            except FileNotFoundError:
+                logger.debug("No OpenAPI spec for API '%s/%s' — syncing without spec", tenant_id, api_id)
 
             commit_sha: str | None = None
-            with contextlib.suppress(Exception):
+            try:
                 # regression for CAB-1889: use provider-agnostic ABC, not _project
                 commit_sha = await git_service.get_head_commit_sha(ref="main")
+            except FileNotFoundError:
+                logger.debug("No head commit available for API '%s/%s' sync", tenant_id, api_id)
 
             await sync_svc._upsert_api(tenant_id, api_id, api_data, openapi_spec, commit_sha)
             await self.db.commit()

--- a/control-plane-api/src/services/github_service.py
+++ b/control-plane-api/src/services/github_service.py
@@ -1058,8 +1058,13 @@ class GitHubService(GitProvider):
                 if exc.status == 404:
                     return []
                 raise
+            # CP-1 H.6: GitHub's "Get repository content" returns a single
+            # ContentFile for file paths and a list for directories. The
+            # GitProvider contract is "enumerate children" — a file has no
+            # children, so normalise to [] instead of propagating a singleton
+            # blob. Matches python-gitlab behaviour on file paths.
             if not isinstance(contents, list):
-                contents = [contents]
+                return []
             return [
                 TreeEntry(
                     name=item.name,

--- a/control-plane-api/src/services/webhook_dedup.py
+++ b/control-plane-api/src/services/webhook_dedup.py
@@ -1,0 +1,189 @@
+"""In-memory webhook dedup cache (CP-1 H.1).
+
+Both GitHub and GitLab re-deliver the same webhook on timeout, on manual
+redelivery, or on some transient failures. Without dedup the pipeline
+runs twice: Kafka publish x2, trace x2, and the "already exists" path is
+either counted as an error (H.8 pre-fix) or masked as success (H.8
+post-fix). Either way the downstream state drifts.
+
+This module implements a three-state claim/process/done state machine
+keyed on ``(source, delivery_id)``:
+
+- ``claim`` — inserted before any side effect (after auth). Signals
+  that this delivery is being processed RIGHT NOW by this replica. A
+  concurrent retry hitting the same key while still ``claim`` returns
+  ``in-flight``.
+- ``done`` — set after the pipeline completes successfully. A later
+  redelivery hitting the same key returns ``duplicate`` with zero
+  side effects.
+- on exception → the claim is explicitly **released**, leaving no entry
+  so the next retry enters the normal flow. This is the bit that
+  matters: a first attempt that passes auth but fails midway must not
+  turn the next retry into a spurious "duplicate forever".
+
+Important scope notes:
+
+- **Single-replica only.** The store is per-process. If CP-API scales
+  horizontally, two replicas may each process the same delivery. The
+  Helm chart currently pins ``replicas: 1`` ; a Redis / Postgres-backed
+  successor is tracked for P2/P3.
+- **Header priority — GitLab.** ``Idempotency-Key`` (stable across
+  retries, documented as the dedup primitive) first, with fallback to
+  ``X-Gitlab-Webhook-UUID`` (per-webhook unique id). ``X-Gitlab-Event-
+  UUID`` is **never** used as primary key: it is shared across
+  recursive webhooks so deduping on it drops legitimate events.
+- **Header priority — GitHub.** ``X-GitHub-Delivery`` is the canonical
+  id per GitHub docs.
+
+The cache is bounded: 10 000 entries, 24 h TTL. Under typical webhook
+volumes this covers GitHub's standard redelivery window. Entries past
+the TTL are lazily evicted on read ; on capacity overflow the oldest
+entry is dropped (FIFO) before the new one is added.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+
+
+class DedupVerdict(enum.Enum):
+    """Outcome of a claim attempt."""
+
+    NEW = "new"
+    """First time we see this delivery — caller must process it."""
+
+    DUPLICATE = "duplicate"
+    """Already processed successfully — caller must return cached result."""
+
+    IN_FLIGHT = "in-flight"
+    """Another request is currently processing this delivery."""
+
+
+@dataclass
+class DedupEntry:
+    state: str  # "claim" | "done"
+    inserted_at: float
+    result: dict | None = None  # populated on mark_done
+
+
+class WebhookDedupCache:
+    """TTL + capacity-bounded in-memory dedup keyed by (source, id)."""
+
+    def __init__(self, *, capacity: int = 10_000, ttl_seconds: float = 86_400.0) -> None:
+        self._capacity = capacity
+        self._ttl = ttl_seconds
+        self._entries: OrderedDict[tuple[str, str], DedupEntry] = OrderedDict()
+        self._lock = asyncio.Lock()
+
+    def _expired(self, entry: DedupEntry, now: float) -> bool:
+        return now - entry.inserted_at > self._ttl
+
+    async def claim(self, source: str, delivery_id: str) -> tuple[DedupVerdict, dict | None]:
+        """Attempt to claim a delivery slot for this process.
+
+        Returns:
+            (NEW, None) — no prior record, caller must process then call
+                mark_done or release.
+            (DUPLICATE, cached_result) — already processed successfully.
+            (IN_FLIGHT, None) — another caller is still processing.
+        """
+        key = (source, delivery_id)
+        now = time.monotonic()
+        async with self._lock:
+            entry = self._entries.get(key)
+            if entry is not None and not self._expired(entry, now):
+                if entry.state == "done":
+                    return DedupVerdict.DUPLICATE, entry.result
+                return DedupVerdict.IN_FLIGHT, None
+
+            # Evict lazily if expired or missing.
+            if entry is not None:
+                self._entries.pop(key, None)
+
+            # Enforce capacity BEFORE insert.
+            while len(self._entries) >= self._capacity:
+                self._entries.popitem(last=False)
+
+            self._entries[key] = DedupEntry(state="claim", inserted_at=now)
+            return DedupVerdict.NEW, None
+
+    async def mark_done(self, source: str, delivery_id: str, result: dict) -> None:
+        """Promote a claim to 'done' and cache the pipeline result."""
+        key = (source, delivery_id)
+        async with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                # Someone released before us — insert a fresh 'done' entry
+                # so a later retry still gets DUPLICATE instead of NEW.
+                self._entries[key] = DedupEntry(
+                    state="done", inserted_at=time.monotonic(), result=result
+                )
+                return
+            entry.state = "done"
+            entry.inserted_at = time.monotonic()
+            entry.result = result
+            self._entries.move_to_end(key)
+
+    async def release(self, source: str, delivery_id: str) -> None:
+        """Remove a claim on failure so the next retry is not 'duplicate'.
+
+        This is the critical piece of H.1: a first attempt that
+        authenticates successfully but fails mid-pipeline must NOT turn
+        the next redelivery into a spurious DUPLICATE (which would lose
+        the event).
+        """
+        key = (source, delivery_id)
+        async with self._lock:
+            self._entries.pop(key, None)
+
+    async def size(self) -> int:
+        async with self._lock:
+            return len(self._entries)
+
+    async def reset(self) -> None:
+        """Test-only helper."""
+        async with self._lock:
+            self._entries.clear()
+
+
+# Module-level singleton. Two replicas get two independent caches —
+# documented limitation, P2/P3 moves to Redis.
+webhook_dedup_cache = WebhookDedupCache()
+
+
+def gitlab_delivery_id(
+    idempotency_key: str | None, webhook_uuid: str | None
+) -> str | None:
+    """Compute the dedup key for a GitLab webhook.
+
+    Priority:
+      1. ``Idempotency-Key`` — documented as stable across retries.
+      2. ``X-Gitlab-Webhook-UUID`` — per-webhook unique id (fallback).
+
+    Never use ``X-Gitlab-Event-UUID`` here: it is shared across
+    recursive webhooks, so deduping on it swallows legitimate events.
+    """
+    key = (idempotency_key or "").strip()
+    if key:
+        return f"gitlab:idem:{key}"
+    key = (webhook_uuid or "").strip()
+    if key:
+        return f"gitlab:webhook:{key}"
+    return None
+
+
+def github_delivery_id(delivery_header: str | None) -> str | None:
+    """Compute the dedup key for a GitHub webhook.
+
+    Uses ``X-GitHub-Delivery`` which GitHub documents as the canonical
+    delivery identifier (stable across manual redelivery, new on
+    automatic redelivery post-timeout).
+    """
+    key = (delivery_header or "").strip()
+    if key:
+        return f"github:{key}"
+    return None

--- a/control-plane-api/src/workers/git_sync_worker.py
+++ b/control-plane-api/src/workers/git_sync_worker.py
@@ -51,6 +51,19 @@ GIT_SYNC_RETRIES_TOTAL = Counter(
 CONSUMER_GROUP = "git-sync-worker"
 DEFAULT_RETRY_DELAYS = [2, 4, 8]  # Exponential backoff: 2s, 4s, 8s
 
+# CP-1 H.7: upper bound on how long the consumer thread waits for the
+# async handler to complete before declaring failure. 60 s is 2x the
+# provider HTTP timeout (DEFAULT_TIMEOUT_S=30 in services/git_executor.py)
+# so a handler that waits on a normal timeout can still finish. Past 60 s
+# we treat it as failure and do NOT commit — Kafka will redeliver.
+HANDLER_RESULT_TIMEOUT_S = 60.0
+
+# CP-1 H.8: substrings that classify a ValueError as an expected
+# idempotent outcome (not an error). Anything else is treated as a real
+# failure so a functional bug (e.g. batch_commit("unknown action")) is
+# not silently counted as success in GIT_SYNC_TOTAL.
+_IDEMPOTENT_VALUE_ERROR_SUBSTRINGS = ("already exists", "not found")
+
 
 class GitSyncWorker:
     """Async Git sync worker — commits API CRUD changes to stoa-catalog.
@@ -141,13 +154,29 @@ class GitSyncWorker:
                 self._consumer.close()
 
     def _create_consumer(self) -> KafkaConsumer | None:
-        """Create Kafka consumer for API lifecycle events."""
+        """Create Kafka consumer for API lifecycle events.
+
+        CP-1 H.7: enable_auto_commit is now False. Offsets are committed
+        synchronously from _dispatch_event AFTER the async handler
+        completes successfully. Previously auto-commit could advance the
+        offset before the handler ran, losing the event if the worker
+        crashed in between.
+
+        Known follow-up (not in P1 scope): handle on_partitions_revoked
+        during rebalance. Between future.result() success and
+        consumer.commit(), a rebalance can reassign the partition and
+        cause the next consumer to re-read the offset — a duplicate
+        delivery. Current handlers are idempotent by design (create →
+        'already exists' path, treated as success via H.8 discriminator),
+        so this is acceptable for P1. Upgrade to a ConsumerRebalance
+        Listener when this worker scales past one replica.
+        """
         try:
             kafka_config: dict = {
                 "bootstrap_servers": settings.KAFKA_BOOTSTRAP_SERVERS.split(","),
                 "group_id": self.GROUP,
                 "auto_offset_reset": "latest",
-                "enable_auto_commit": True,
+                "enable_auto_commit": False,  # CP-1 H.7: manual commit after success
                 "value_deserializer": lambda m: json.loads(m.decode("utf-8")),
             }
 
@@ -168,24 +197,56 @@ class GitSyncWorker:
             return None
 
     def _dispatch_event(self, message) -> None:
-        """Dispatch Kafka message to async handler via event loop."""
+        """Dispatch Kafka message to async handler and commit on success.
+
+        CP-1 H.7: this method now blocks the consumer thread on the
+        handler future before committing the offset. Under the prior
+        fire-and-forget callback pattern combined with
+        enable_auto_commit=True the offset could advance before the
+        async handler ran, losing events on crash. Serialising per
+        message trades throughput for at-least-once durability, which
+        is the right tradeoff for a low-volume catalog-write worker.
+        """
+        if not self._loop or self._consumer is None:
+            return
         try:
-            if self._loop:
-                future = asyncio.run_coroutine_threadsafe(
-                    self._handle_event(message.value),
-                    self._loop,
+            future = asyncio.run_coroutine_threadsafe(
+                self._handle_event(message.value),
+                self._loop,
+            )
+            try:
+                future.result(timeout=HANDLER_RESULT_TIMEOUT_S)
+            except TimeoutError:
+                # Do NOT commit — Kafka will redeliver. We also cancel
+                # the still-running coroutine so the event loop is not
+                # poisoned by a growing backlog of stuck tasks.
+                future.cancel()
+                logger.error(
+                    "Git sync handler exceeded %.0fs; offset NOT committed, "
+                    "event will be redelivered",
+                    HANDLER_RESULT_TIMEOUT_S,
                 )
-                future.add_done_callback(self._event_callback)
+                return
+            except Exception as e:
+                logger.error("Git sync event handling failed: %s", e, exc_info=True)
+                return
+
+            # Handler succeeded — commit the offset so this message is
+            # not re-delivered.
+            try:
+                self._consumer.commit()
+            except Exception as e:
+                # Commit failure means the message will be redelivered.
+                # Handlers are idempotent (create → "already exists"
+                # path is classified as success by H.8 discriminator),
+                # so this is recoverable.
+                logger.error(
+                    "Git sync offset commit failed (message will be redelivered): %s",
+                    e,
+                    exc_info=True,
+                )
         except Exception as e:
             logger.error("Failed to dispatch git sync event: %s", e, exc_info=True)
-
-    @staticmethod
-    def _event_callback(future) -> None:
-        """Log exceptions from async event handling."""
-        try:
-            future.result()
-        except Exception as e:
-            logger.error("Git sync event handling failed: %s", e, exc_info=True)
 
     # ── Event handling ─────────────────────────────────────────────────
 
@@ -240,10 +301,33 @@ class GitSyncWorker:
                 return  # Success
 
             except ValueError as e:
-                # Idempotency: "already exists" or "not found" — not retriable
-                GIT_SYNC_TOTAL.labels(status="success", operation=operation).inc()
-                logger.info("Git sync %s skipped (idempotent): %s", event_type, e)
-                return
+                # CP-1 H.8: not every ValueError is an idempotent
+                # outcome. Discriminate by message: "already exists" /
+                # "not found" are real idempotency signals, anything
+                # else (e.g. batch_commit("unknown action") raising
+                # ValueError) is a genuine failure. The prior blanket
+                # success classification biased GIT_SYNC_TOTAL metrics
+                # and hid functional bugs.
+                msg = str(e).lower()
+                if any(s in msg for s in _IDEMPOTENT_VALUE_ERROR_SUBSTRINGS):
+                    GIT_SYNC_TOTAL.labels(status="success", operation=operation).inc()
+                    logger.info("Git sync %s skipped (idempotent): %s", event_type, e)
+                    return
+                # Fall through to the retry path: treat as real error.
+                last_error = e
+                if attempt < len(self._retry_delays):
+                    delay = self._retry_delays[attempt]
+                    GIT_SYNC_RETRIES_TOTAL.inc()
+                    logger.warning(
+                        "Git sync %s ValueError (unknown; attempt %d/%d), retrying in %ds: %s",
+                        event_type,
+                        attempt + 1,
+                        max_attempts,
+                        delay,
+                        e,
+                    )
+                    await asyncio.sleep(delay)
+                continue
 
             except Exception as e:
                 last_error = e

--- a/control-plane-api/tests/test_git_router.py
+++ b/control-plane-api/tests/test_git_router.py
@@ -157,12 +157,23 @@ def test_tree_success():
     assert len(resp.json()["items"]) == 2
 
 
-def test_tree_empty():
-    mock_git = _make_mock_git(list_tree=AsyncMock(side_effect=Exception("not found")))
+def test_tree_empty_on_missing_path():
+    # CP-1 H.5: get_tree is the ONLY listing route that keeps
+    # FileNotFoundError → []. Missing path in the tree = legitimate
+    # empty enumeration.
+    mock_git = _make_mock_git(list_tree=AsyncMock(side_effect=FileNotFoundError("no such path")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/tree")
     assert resp.status_code == 200
     assert resp.json()["items"] == []
+
+
+def test_tree_provider_failure_returns_502():
+    # CP-1 H.5: non-FileNotFoundError must surface as 502, not silent [].
+    mock_git = _make_mock_git(list_tree=AsyncMock(side_effect=Exception("gitlab down")))
+    client = TestClient(_build_test_app(mock_git=mock_git))
+    resp = client.get(f"{BASE}/tree")
+    assert resp.status_code == 502
 
 
 # ---- Merge Requests ----
@@ -333,78 +344,86 @@ def test_create_branch_503_when_disconnected():
 # ---- Exception / error fallback paths ----
 
 
-def test_list_commits_exception_returns_empty():
-    mock_git = _make_mock_git(list_path_commits=AsyncMock(side_effect=Exception("gitlab timeout")))
+def test_list_commits_exception_returns_502():
+    # CP-1 H.5: provider failure surfaces as 502, not silent [].
+    mock_git = _make_mock_git(list_path_commits=AsyncMock(side_effect=Exception("gitlab down")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/commits")
-    assert resp.status_code == 200
-    assert resp.json() == []
+    assert resp.status_code == 502
+    assert "Upstream provider error" in resp.json()["detail"]
 
 
-def test_create_file_exception_returns_500():
+def test_create_file_exception_returns_502():
+    # CP-1 H.3: generic detail, no str(e) leak. Status 502 (upstream error).
     mock_git = _make_mock_git(write_file=AsyncMock(side_effect=Exception("write failed")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/files/new.yaml", json={"content": "x"})
-    assert resp.status_code == 500
-    assert "Failed to save file" in resp.json()["detail"]
+    assert resp.status_code == 502
+    assert "write failed" not in resp.json()["detail"]
+    assert "save file" in resp.json()["detail"]
 
 
-def test_update_file_exception_returns_500():
+def test_update_file_exception_returns_502():
     mock_git = _make_mock_git(write_file=AsyncMock(side_effect=Exception("save failed")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/files/existing.yaml", json={"content": "new"})
-    assert resp.status_code == 500
+    assert resp.status_code == 502
 
 
-def test_delete_file_exception_returns_404():
-    mock_git = _make_mock_git(remove_file=AsyncMock(side_effect=Exception("not found")))
+def test_delete_file_not_found_returns_404():
+    # CP-1 H.4: FileNotFoundError → 404 (expected path).
+    mock_git = _make_mock_git(remove_file=AsyncMock(side_effect=FileNotFoundError("missing")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.delete(f"{BASE}/files/missing.yaml")
     assert resp.status_code == 404
-    assert "File not found" in resp.json()["detail"]
 
 
-def test_list_merge_requests_exception_returns_empty():
+def test_delete_file_exception_returns_502():
+    # CP-1 H.4: generic provider exception no longer masquerades as 404.
+    mock_git = _make_mock_git(remove_file=AsyncMock(side_effect=Exception("provider 500")))
+    client = TestClient(_build_test_app(mock_git=mock_git))
+    resp = client.delete(f"{BASE}/files/some.yaml")
+    assert resp.status_code == 502
+
+
+def test_list_merge_requests_exception_returns_502():
     mock_git = _make_mock_git(list_merge_requests=AsyncMock(side_effect=Exception("gitlab error")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/merge-requests")
-    assert resp.status_code == 200
-    assert resp.json() == []
+    assert resp.status_code == 502
 
 
-def test_create_merge_request_exception_returns_500():
+def test_create_merge_request_exception_returns_502():
     mock_git = _make_mock_git(create_merge_request=AsyncMock(side_effect=Exception("create failed")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(
         f"{BASE}/merge-requests",
         json={"title": "T", "description": "D", "source_branch": "feat/x", "target_branch": "main"},
     )
-    assert resp.status_code == 500
-    assert "Failed to create merge request" in resp.json()["detail"]
+    assert resp.status_code == 502
+    assert "create failed" not in resp.json()["detail"]
 
 
-def test_merge_merge_request_exception_returns_500():
+def test_merge_merge_request_exception_returns_502():
     mock_git = _make_mock_git(merge_merge_request=AsyncMock(side_effect=Exception("merge failed")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/merge-requests/1/merge")
-    assert resp.status_code == 500
-    assert "Failed to merge" in resp.json()["detail"]
+    assert resp.status_code == 502
 
 
-def test_list_branches_exception_returns_empty():
+def test_list_branches_exception_returns_502():
     mock_git = _make_mock_git(list_branches=AsyncMock(side_effect=Exception("gitlab error")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.get(f"{BASE}/branches")
-    assert resp.status_code == 200
-    assert resp.json() == []
+    assert resp.status_code == 502
 
 
-def test_create_branch_exception_returns_500():
+def test_create_branch_exception_returns_502():
     mock_git = _make_mock_git(create_branch=AsyncMock(side_effect=Exception("create failed")))
     client = TestClient(_build_test_app(mock_git=mock_git))
     resp = client.post(f"{BASE}/branches", json={"name": "feat/err", "ref": "main"})
-    assert resp.status_code == 500
-    assert "Failed to create branch" in resp.json()["detail"]
+    assert resp.status_code == 502
+    assert "create failed" not in resp.json()["detail"]
 
 
 # ---- Additional edge cases ----

--- a/control-plane-api/tests/test_regression_cp1_p1_router_errors.py
+++ b/control-plane-api/tests/test_regression_cp1_p1_router_errors.py
@@ -1,0 +1,245 @@
+"""Regression guards for CP-1 P1 — router error mapping + path validation.
+
+Closes:
+- H.3 (HTTPException detail leaking str(e) with provider internals)
+- H.4 (delete_file converted every exception into 404)
+- H.5 (listing routes silently returning [] on provider failure)
+- H.10 (missing path sanitization in _tenant_path)
+
+Invariants pinned:
+- FileNotFoundError is ONLY translated to an empty response on get_tree
+  (and a raw 404 on get_file / delete_file). list_commits, list_branches
+  and list_merge_requests surface provider failures as 502/504.
+- HTTPException.detail never echoes the raw str(exc). Server log still
+  carries exc_info=True; clients correlate via X-Request-ID response
+  header.
+- Path segments ``..``, backslash, absolute prefix, and any ASCII
+  control character (0x00-0x1f + 0x7f) are rejected with 400.
+
+regression for CP-1 H.3
+regression for CP-1 H.4
+regression for CP-1 H.5
+regression for CP-1 H.10
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_ADMIN_USER = MagicMock()
+_ADMIN_USER.id = "admin-1"
+_ADMIN_USER.email = "admin@gostoa.dev"
+_ADMIN_USER.tenant_id = "acme"
+_ADMIN_USER.roles = ["cpi-admin"]
+
+
+def _build_app(mock_git=None):
+    from src.auth.dependencies import get_current_user
+    from src.routers.git import router
+    from src.services.git_provider import get_git_provider
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: _ADMIN_USER
+    if mock_git is not None:
+        app.dependency_overrides[get_git_provider] = lambda: mock_git
+    return app
+
+
+def _mock_git(**attrs):
+    m = MagicMock()
+    m.is_connected = MagicMock(return_value=True)
+    for k, v in attrs.items():
+        setattr(m, k, v)
+    return m
+
+
+BASE = "/v1/tenants/acme/git"
+
+# Sentinels that should never leak into detail.
+_SECRET_SHAPED = "token=ghp_SENSITIVE_ABC123 at https://api.github.com/repos/stoa/catalog"
+
+
+# ──────────────────────────────────────────────────────────────────
+# H.3 — no str(e) leak in HTTPException.detail
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestNoExceptionLeakInDetail:
+    def test_write_file_generic_detail_no_leak(self):
+        """regression for CP-1 H.3"""
+        mock_git = _mock_git(write_file=AsyncMock(side_effect=Exception(_SECRET_SHAPED)))
+        client = TestClient(_build_app(mock_git))
+        resp = client.post(f"{BASE}/files/new.yaml", json={"content": "x"})
+        assert resp.status_code == 502
+        assert _SECRET_SHAPED not in resp.text
+        assert "ghp_SENSITIVE_ABC123" not in resp.text
+        assert "api.github.com" not in resp.text
+
+    def test_create_merge_request_generic_detail_no_leak(self):
+        """regression for CP-1 H.3"""
+        mock_git = _mock_git(create_merge_request=AsyncMock(side_effect=Exception(_SECRET_SHAPED)))
+        client = TestClient(_build_app(mock_git))
+        resp = client.post(
+            f"{BASE}/merge-requests",
+            json={
+                "title": "T",
+                "description": "D",
+                "source_branch": "feat/x",
+                "target_branch": "main",
+            },
+        )
+        assert resp.status_code == 502
+        assert _SECRET_SHAPED not in resp.text
+
+    def test_merge_request_generic_detail_no_leak(self):
+        """regression for CP-1 H.3"""
+        mock_git = _mock_git(merge_merge_request=AsyncMock(side_effect=Exception(_SECRET_SHAPED)))
+        client = TestClient(_build_app(mock_git))
+        resp = client.post(f"{BASE}/merge-requests/1/merge")
+        assert resp.status_code == 502
+        assert _SECRET_SHAPED not in resp.text
+
+    def test_create_branch_generic_detail_no_leak(self):
+        """regression for CP-1 H.3"""
+        mock_git = _mock_git(create_branch=AsyncMock(side_effect=Exception(_SECRET_SHAPED)))
+        client = TestClient(_build_app(mock_git))
+        resp = client.post(f"{BASE}/branches", json={"name": "feat/x", "ref": "main"})
+        assert resp.status_code == 502
+        assert _SECRET_SHAPED not in resp.text
+
+
+# ──────────────────────────────────────────────────────────────────
+# H.4 — delete_file error mapping
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestDeleteFileErrorMapping:
+    def test_missing_file_returns_404(self):
+        """regression for CP-1 H.4"""
+        mock_git = _mock_git(remove_file=AsyncMock(side_effect=FileNotFoundError("nope")))
+        client = TestClient(_build_app(mock_git))
+        resp = client.delete(f"{BASE}/files/nope.yaml")
+        assert resp.status_code == 404
+
+    def test_timeout_returns_504(self):
+        """regression for CP-1 H.4"""
+        mock_git = _mock_git(remove_file=AsyncMock(side_effect=TimeoutError("slow")))
+        client = TestClient(_build_app(mock_git))
+        resp = client.delete(f"{BASE}/files/valid.yaml")
+        assert resp.status_code == 504
+        assert "timeout" in resp.json()["detail"].lower()
+
+    def test_provider_5xx_returns_502(self):
+        """regression for CP-1 H.4"""
+        mock_git = _mock_git(remove_file=AsyncMock(side_effect=Exception("GitHub 500")))
+        client = TestClient(_build_app(mock_git))
+        resp = client.delete(f"{BASE}/files/valid.yaml")
+        assert resp.status_code == 502
+        assert "GitHub 500" not in resp.text
+
+
+# ──────────────────────────────────────────────────────────────────
+# H.5 — listing routes surface provider failures instead of silent []
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestListingsSurfaceProviderFailures:
+    def test_list_commits_provider_5xx_returns_502(self):
+        """regression for CP-1 H.5"""
+        mock_git = _mock_git(list_path_commits=AsyncMock(side_effect=Exception("provider down")))
+        client = TestClient(_build_app(mock_git))
+        resp = client.get(f"{BASE}/commits")
+        assert resp.status_code == 502
+
+    def test_list_branches_timeout_returns_504(self):
+        """regression for CP-1 H.5"""
+        mock_git = _mock_git(list_branches=AsyncMock(side_effect=TimeoutError("slow")))
+        client = TestClient(_build_app(mock_git))
+        resp = client.get(f"{BASE}/branches")
+        assert resp.status_code == 504
+
+    def test_list_merge_requests_provider_5xx_returns_502(self):
+        """regression for CP-1 H.5"""
+        mock_git = _mock_git(list_merge_requests=AsyncMock(side_effect=Exception("provider down")))
+        client = TestClient(_build_app(mock_git))
+        resp = client.get(f"{BASE}/merge-requests")
+        assert resp.status_code == 502
+
+    def test_get_tree_file_not_found_returns_empty(self):
+        """regression for CP-1 H.5 — get_tree is the ONLY listing that
+        preserves FileNotFoundError → []. Other listings must not do the
+        same or they reintroduce the false-empty bug."""
+        mock_git = _mock_git(list_tree=AsyncMock(side_effect=FileNotFoundError("missing path")))
+        client = TestClient(_build_app(mock_git))
+        resp = client.get(f"{BASE}/tree")
+        assert resp.status_code == 200
+        assert resp.json()["items"] == []
+
+    def test_get_tree_provider_failure_returns_502(self):
+        """regression for CP-1 H.5"""
+        mock_git = _mock_git(list_tree=AsyncMock(side_effect=Exception("provider down")))
+        client = TestClient(_build_app(mock_git))
+        resp = client.get(f"{BASE}/tree")
+        assert resp.status_code == 502
+
+
+# ──────────────────────────────────────────────────────────────────
+# H.10 — path sanitization
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestPathSanitization:
+    def test_parent_segment_rejected(self):
+        """regression for CP-1 H.10"""
+        mock_git = _mock_git(remove_file=AsyncMock())
+        client = TestClient(_build_app(mock_git))
+        resp = client.delete(f"{BASE}/files/..%2Fescape.yaml")
+        assert resp.status_code == 400
+        mock_git.remove_file.assert_not_awaited()
+
+    def test_null_byte_rejected(self):
+        """regression for CP-1 H.10"""
+        mock_git = _mock_git(write_file=AsyncMock())
+        client = TestClient(_build_app(mock_git))
+        # %00 is a NUL byte; starlette URL-decodes path params.
+        resp = client.post(f"{BASE}/files/evil%00.yaml", json={"content": "x"})
+        assert resp.status_code == 400
+        mock_git.write_file.assert_not_awaited()
+
+    def test_other_control_chars_rejected_unit(self):
+        """regression for CP-1 H.10 - validate_file_path unit check.
+
+        HTTP layer mangles raw control chars (e.g. %0A bounces to 404 via
+        starlette's routing quirks), so we exercise the validator itself
+        to prove every ASCII control char 0x00-0x1f plus 0x7f rejects.
+        """
+        import pytest as _pytest
+        from fastapi import HTTPException
+
+        from src.routers.git import _validate_file_path
+
+        for code in (*range(0x00, 0x20), 0x7F):
+            bad = f"foo{chr(code)}bar.yaml"
+            with _pytest.raises(HTTPException) as excinfo:
+                _validate_file_path(bad)
+            assert excinfo.value.status_code == 400, f"expected 400 for code {code:#04x}"
+
+    def test_backslash_rejected(self):
+        """regression for CP-1 H.10"""
+        mock_git = _mock_git(write_file=AsyncMock())
+        client = TestClient(_build_app(mock_git))
+        resp = client.post(f"{BASE}/files/foo%5Cbar.yaml", json={"content": "x"})
+        assert resp.status_code == 400
+        mock_git.write_file.assert_not_awaited()
+
+    def test_normal_nested_path_accepted(self):
+        """regression for CP-1 H.10 — valid nested paths still pass."""
+        mock_git = _mock_git(write_file=AsyncMock(return_value="created"))
+        client = TestClient(_build_app(mock_git))
+        resp = client.post(f"{BASE}/files/apis/foo/api.yaml", json={"content": "x"})
+        assert resp.status_code == 201
+        mock_git.write_file.assert_awaited_once()

--- a/control-plane-api/tests/test_regression_cp1_p1_service_contracts.py
+++ b/control-plane-api/tests/test_regression_cp1_p1_service_contracts.py
@@ -1,0 +1,290 @@
+"""Regression guards for CP-1 P1 — service-layer contract hardening.
+
+Closes:
+- H.2 (deployment_orchestration swallow real failures via suppress(Exception))
+- H.6 (list_tree returns file-as-blob singleton on GitHub, breaks ABC contract)
+
+These tests pin:
+- GitHubService.list_tree MUST return [] when the path points at a file,
+  matching the "enumerate children" contract implemented by GitLabService.
+- DeploymentOrchestrationService._sync_api_from_git catches ONLY
+  FileNotFoundError. Transient provider failures (TimeoutError, rate-limit,
+  auth) MUST propagate past the narrow except, ensuring _upsert_api is NOT
+  called with silently-None inputs derived from a real failure.
+
+regression for CP-1 H.2
+regression for CP-1 H.6
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.github_service import GitHubService
+
+# ──────────────────────────────────────────────────────────────────
+# H.6 — list_tree contract parity across providers
+# ──────────────────────────────────────────────────────────────────
+
+
+def _make_github_service() -> GitHubService:
+    svc = GitHubService()
+    svc._gh = MagicMock()
+    return svc
+
+
+class TestListTreeContractParity:
+    """GitHubService.list_tree must return [] for file paths (no children)."""
+
+    @pytest.mark.asyncio
+    async def test_github_list_tree_returns_empty_on_file_path(self):
+        """When repo.get_contents returns a single ContentFile, list_tree must
+        return [] — NOT a singleton [blob]. The abstract contract is
+        "enumerate children"; a file has none.
+
+        regression for CP-1 H.6
+        """
+        svc = _make_github_service()
+
+        # Single ContentFile (what GitHub returns for a file path).
+        single_file = MagicMock()
+        single_file.name = "api.yaml"
+        single_file.type = "file"
+        single_file.path = "tenants/acme/apis/foo/api.yaml"
+
+        repo = MagicMock()
+        # get_contents for a FILE path returns the object itself (not a list).
+        repo.get_contents.return_value = single_file
+        svc._gh.get_repo.return_value = repo
+
+        result = await svc.list_tree("tenants/acme/apis/foo/api.yaml")
+
+        assert result == [], (
+            f"GitHub list_tree on file path must return [] (no children), "
+            f"got {result}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_github_list_tree_returns_entries_for_directory(self):
+        """Happy path: directory still returns a proper enumeration.
+
+        regression for CP-1 H.6
+        """
+        svc = _make_github_service()
+
+        file_a = MagicMock()
+        file_a.name = "a.yaml"
+        file_a.type = "file"
+        file_a.path = "tenants/acme/a.yaml"
+
+        dir_b = MagicMock()
+        dir_b.name = "subdir"
+        dir_b.type = "dir"
+        dir_b.path = "tenants/acme/subdir"
+
+        repo = MagicMock()
+        repo.get_contents.return_value = [file_a, dir_b]
+        svc._gh.get_repo.return_value = repo
+
+        result = await svc.list_tree("tenants/acme")
+
+        assert len(result) == 2
+        assert {e.name for e in result} == {"a.yaml", "subdir"}
+        # Directory → "tree", file → "blob" (provider-agnostic TreeEntry type).
+        by_name = {e.name: e.type for e in result}
+        assert by_name["a.yaml"] == "blob"
+        assert by_name["subdir"] == "tree"
+
+    @pytest.mark.asyncio
+    async def test_github_list_tree_returns_empty_on_404(self):
+        """Path that does not exist → [] (pre-existing behaviour, pinned).
+
+        regression for CP-1 H.6
+        """
+        from github import GithubException
+
+        svc = _make_github_service()
+        repo = MagicMock()
+        repo.get_contents.side_effect = GithubException(status=404, data={}, headers={})
+        svc._gh.get_repo.return_value = repo
+
+        result = await svc.list_tree("tenants/nope")
+
+        assert result == []
+
+
+# ──────────────────────────────────────────────────────────────────
+# H.2 — deployment_orchestration suppress(Exception) → narrow catch
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestDeploymentOrchestrationNarrowCatch:
+    """_sync_api_from_git must only swallow FileNotFoundError (expected-None).
+
+    Any transient provider failure (TimeoutError, rate-limit, auth error)
+    MUST NOT be swallowed silently at the data-gathering step. The prior
+    behaviour called _upsert_api with openapi_spec=None / commit_sha=None
+    derived from a real failure, persisting a corrupt catalog row.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_openapi_spec_proceeds_with_none(self):
+        """FileNotFoundError on openapi spec → upsert still called with None.
+
+        regression for CP-1 H.2
+        """
+        from src.services.deployment_orchestration_service import (
+            DeploymentOrchestrationService,
+        )
+
+        mock_db = MagicMock()
+        mock_db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: MagicMock()))
+        mock_db.commit = AsyncMock()
+        svc = DeploymentOrchestrationService(mock_db)
+
+        mock_git = MagicMock()
+        mock_git.is_connected.return_value = True
+        mock_git.connect = AsyncMock()
+        mock_git.get_api = AsyncMock(return_value={"name": "foo"})
+        # FileNotFoundError = expected "no spec" outcome.
+        mock_git.get_api_openapi_spec = AsyncMock(side_effect=FileNotFoundError("no spec"))
+        mock_git.get_head_commit_sha = AsyncMock(return_value="abc123")
+
+        mock_sync = MagicMock()
+        mock_sync._upsert_api = AsyncMock()
+
+        with (
+            patch("src.services.git_service.git_service", mock_git),
+            patch(
+                "src.services.catalog_sync_service.CatalogSyncService",
+                return_value=mock_sync,
+            ),
+        ):
+            await svc._sync_api_from_git("acme", "foo")
+
+        # upsert MUST have been called with openapi_spec=None (expected).
+        mock_sync._upsert_api.assert_awaited_once()
+        call_args = mock_sync._upsert_api.await_args
+        # Positional args: tenant_id, api_id, api_data, openapi_spec, commit_sha
+        assert call_args.args[3] is None, "openapi_spec should be None on FileNotFoundError"
+
+    @pytest.mark.asyncio
+    async def test_timeout_on_openapi_short_circuits_upsert(self):
+        """TimeoutError on openapi fetch → _upsert_api is NOT called with a
+        silently-None spec. The transient failure reaches the outer except,
+        which logs + returns None, leaving the catalog untouched.
+
+        regression for CP-1 H.2
+        """
+        from src.services.deployment_orchestration_service import (
+            DeploymentOrchestrationService,
+        )
+
+        mock_db = MagicMock()
+        mock_db.execute = AsyncMock()
+        mock_db.commit = AsyncMock()
+        svc = DeploymentOrchestrationService(mock_db)
+
+        mock_git = MagicMock()
+        mock_git.is_connected.return_value = True
+        mock_git.connect = AsyncMock()
+        mock_git.get_api = AsyncMock(return_value={"name": "foo"})
+        # TimeoutError = transient provider failure, MUST propagate.
+        mock_git.get_api_openapi_spec = AsyncMock(side_effect=TimeoutError("upstream slow"))
+        mock_git.get_head_commit_sha = AsyncMock(return_value="abc123")
+
+        mock_sync = MagicMock()
+        mock_sync._upsert_api = AsyncMock()
+
+        with (
+            patch("src.services.git_service.git_service", mock_git),
+            patch(
+                "src.services.catalog_sync_service.CatalogSyncService",
+                return_value=mock_sync,
+            ),
+        ):
+            result = await svc._sync_api_from_git("acme", "foo")
+
+        # Outer `except Exception: return None` kicks in → caller sees None.
+        assert result is None
+        # BUT _upsert_api MUST NOT have been called — no corrupt row written.
+        mock_sync._upsert_api.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_timeout_on_head_commit_short_circuits_upsert(self):
+        """Same contract for the head commit fetch: transient failure
+        must not be silently swallowed into commit_sha=None.
+
+        regression for CP-1 H.2
+        """
+        from src.services.deployment_orchestration_service import (
+            DeploymentOrchestrationService,
+        )
+
+        mock_db = MagicMock()
+        mock_db.execute = AsyncMock()
+        mock_db.commit = AsyncMock()
+        svc = DeploymentOrchestrationService(mock_db)
+
+        mock_git = MagicMock()
+        mock_git.is_connected.return_value = True
+        mock_git.connect = AsyncMock()
+        mock_git.get_api = AsyncMock(return_value={"name": "foo"})
+        mock_git.get_api_openapi_spec = AsyncMock(return_value={"openapi": "3.0"})
+        mock_git.get_head_commit_sha = AsyncMock(side_effect=TimeoutError("upstream slow"))
+
+        mock_sync = MagicMock()
+        mock_sync._upsert_api = AsyncMock()
+
+        with (
+            patch("src.services.git_service.git_service", mock_git),
+            patch(
+                "src.services.catalog_sync_service.CatalogSyncService",
+                return_value=mock_sync,
+            ),
+        ):
+            result = await svc._sync_api_from_git("acme", "foo")
+
+        assert result is None
+        mock_sync._upsert_api.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_head_commit_proceeds_with_none(self):
+        """FileNotFoundError on head commit → upsert called with commit_sha=None.
+
+        regression for CP-1 H.2
+        """
+        from src.services.deployment_orchestration_service import (
+            DeploymentOrchestrationService,
+        )
+
+        mock_db = MagicMock()
+        mock_db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: MagicMock()))
+        mock_db.commit = AsyncMock()
+        svc = DeploymentOrchestrationService(mock_db)
+
+        mock_git = MagicMock()
+        mock_git.is_connected.return_value = True
+        mock_git.connect = AsyncMock()
+        mock_git.get_api = AsyncMock(return_value={"name": "foo"})
+        mock_git.get_api_openapi_spec = AsyncMock(return_value={"openapi": "3.0"})
+        mock_git.get_head_commit_sha = AsyncMock(side_effect=FileNotFoundError("no commit"))
+
+        mock_sync = MagicMock()
+        mock_sync._upsert_api = AsyncMock()
+
+        with (
+            patch("src.services.git_service.git_service", mock_git),
+            patch(
+                "src.services.catalog_sync_service.CatalogSyncService",
+                return_value=mock_sync,
+            ),
+        ):
+            await svc._sync_api_from_git("acme", "foo")
+
+        mock_sync._upsert_api.assert_awaited_once()
+        call_args = mock_sync._upsert_api.await_args
+        # commit_sha is the 5th positional arg
+        assert call_args.args[4] is None, "commit_sha should be None on FileNotFoundError"

--- a/control-plane-api/tests/test_regression_cp1_p1_webhook_dedup.py
+++ b/control-plane-api/tests/test_regression_cp1_p1_webhook_dedup.py
@@ -1,0 +1,413 @@
+"""Regression guards for CP-1 P1 H.1 — webhook replay dedup.
+
+GitHub and GitLab re-deliver the same webhook on timeout, on manual
+redelivery, or on transient failures. Prior to this fix the pipeline
+ran twice: Kafka publish x2, trace x2. The new state machine keyed on
+(source, delivery_id) ensures:
+
+1. First delivery passes auth and is marked with a ``claim`` state.
+2. On successful pipeline completion, the claim is promoted to ``done``
+   and a cached response is stored.
+3. A redelivery with the same id while ``done`` returns
+   ``status="duplicate"`` with zero side effects.
+4. A redelivery while another process is still on ``claim`` returns
+   ``status="in-flight"``.
+5. On pipeline failure the claim is **released**, so the next retry
+   does NOT get a spurious "duplicate forever" — the event cannot be
+   lost because a first attempt failed midway.
+
+Key contract pinned here:
+- GitLab dedup primary key is ``Idempotency-Key``. Fallback:
+  ``X-Gitlab-Webhook-UUID``. ``X-Gitlab-Event-UUID`` is NEVER the key
+  (shared across recursive webhooks — would drop legitimate events).
+- GitHub dedup key is ``X-GitHub-Delivery``.
+
+regression for CP-1 H.1
+"""
+
+from __future__ import annotations
+
+import hmac
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from src.services.webhook_dedup import (
+    DedupVerdict,
+    WebhookDedupCache,
+    github_delivery_id,
+    gitlab_delivery_id,
+    webhook_dedup_cache,
+)
+
+_TEST_SECRET = "test-webhook-secret"
+
+
+# ──────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+async def _clean_cache():
+    """Reset the module-level cache between tests."""
+    await webhook_dedup_cache.reset()
+    yield
+    await webhook_dedup_cache.reset()
+
+
+def _minimal_gitlab_push_payload() -> dict:
+    return {
+        "object_kind": "push",
+        "event_name": "push",
+        "ref": "refs/heads/main",
+        "before": "0" * 40,
+        "after": "a" * 40,
+        "checkout_sha": "a" * 40,
+        "project_id": 42,
+        "project": {"path_with_namespace": "stoa/catalog"},
+        "user_name": "alice",
+        "user_username": "alice",
+        "commits": [],
+        "total_commits_count": 0,
+    }
+
+
+def _mock_trace_service_spy() -> tuple[MagicMock, MagicMock]:
+    mock_svc = MagicMock()
+    mock_trace = MagicMock()
+    mock_trace.id = "trace-001"
+    mock_trace.status = MagicMock(value="success")
+    mock_trace.total_duration_ms = 42
+    mock_svc.create = AsyncMock(return_value=mock_trace)
+    mock_svc.add_step = AsyncMock()
+    mock_svc.complete = AsyncMock()
+    return mock_svc, mock_trace
+
+
+def _sign_github(body: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, "sha256").hexdigest()
+
+
+# ──────────────────────────────────────────────────────────────────
+# Unit-level — the dedup cache state machine
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestDedupCacheStateMachine:
+    @pytest.mark.asyncio
+    async def test_first_claim_is_new(self):
+        """regression for CP-1 H.1"""
+        cache = WebhookDedupCache()
+        verdict, cached = await cache.claim("github", "id-1")
+        assert verdict is DedupVerdict.NEW
+        assert cached is None
+
+    @pytest.mark.asyncio
+    async def test_second_claim_while_in_flight(self):
+        """regression for CP-1 H.1"""
+        cache = WebhookDedupCache()
+        await cache.claim("github", "id-1")
+        verdict, _ = await cache.claim("github", "id-1")
+        assert verdict is DedupVerdict.IN_FLIGHT
+
+    @pytest.mark.asyncio
+    async def test_claim_after_done_is_duplicate(self):
+        """regression for CP-1 H.1"""
+        cache = WebhookDedupCache()
+        await cache.claim("github", "id-1")
+        await cache.mark_done("github", "id-1", {"foo": "bar"})
+        verdict, cached = await cache.claim("github", "id-1")
+        assert verdict is DedupVerdict.DUPLICATE
+        assert cached == {"foo": "bar"}
+
+    @pytest.mark.asyncio
+    async def test_release_after_failure_allows_retry(self):
+        """The critical H.1 property: a failed first attempt must not
+        turn the retry into 'duplicate forever' and drop the event.
+
+        regression for CP-1 H.1
+        """
+        cache = WebhookDedupCache()
+        await cache.claim("github", "id-1")
+        await cache.release("github", "id-1")
+        verdict, _ = await cache.claim("github", "id-1")
+        assert verdict is DedupVerdict.NEW  # retry, not DUPLICATE
+
+    @pytest.mark.asyncio
+    async def test_sources_do_not_collide(self):
+        """github:id-1 and gitlab:id-1 are separate keys.
+
+        regression for CP-1 H.1
+        """
+        cache = WebhookDedupCache()
+        v1, _ = await cache.claim("github", "id-1")
+        v2, _ = await cache.claim("gitlab", "id-1")
+        assert v1 is DedupVerdict.NEW
+        assert v2 is DedupVerdict.NEW
+
+    @pytest.mark.asyncio
+    async def test_capacity_evicts_oldest(self):
+        """regression for CP-1 H.1"""
+        cache = WebhookDedupCache(capacity=2)
+        await cache.claim("github", "id-1")
+        await cache.claim("github", "id-2")
+        await cache.claim("github", "id-3")
+        assert await cache.size() == 2
+
+    @pytest.mark.asyncio
+    async def test_ttl_expires_entries(self):
+        """regression for CP-1 H.1"""
+        cache = WebhookDedupCache(ttl_seconds=0.05)
+        await cache.claim("github", "id-1")
+        await cache.mark_done("github", "id-1", {"r": 1})
+        # Advance time beyond TTL.
+        import asyncio
+
+        await asyncio.sleep(0.06)
+        verdict, _ = await cache.claim("github", "id-1")
+        assert verdict is DedupVerdict.NEW  # entry expired, retry is new
+
+
+# ──────────────────────────────────────────────────────────────────
+# Unit-level — dedup key priority (the "never Event-UUID" rule)
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestGitLabDedupKeyPriority:
+    def test_idempotency_key_wins_over_webhook_uuid(self):
+        """regression for CP-1 H.1"""
+        key = gitlab_delivery_id("idem-42", "webhook-7")
+        assert key == "gitlab:idem:idem-42"
+
+    def test_falls_back_to_webhook_uuid(self):
+        """regression for CP-1 H.1"""
+        key = gitlab_delivery_id(None, "webhook-7")
+        assert key == "gitlab:webhook:webhook-7"
+
+    def test_none_when_both_absent(self):
+        """regression for CP-1 H.1"""
+        assert gitlab_delivery_id(None, None) is None
+        assert gitlab_delivery_id("", "") is None
+
+    def test_idempotency_key_namespace_is_distinct(self):
+        """Idempotency-Key and Webhook-UUID use DIFFERENT namespaces so
+        a webhook with the same raw string under different header types
+        is not conflated.
+
+        regression for CP-1 H.1
+        """
+        k1 = gitlab_delivery_id("42", None)
+        k2 = gitlab_delivery_id(None, "42")
+        assert k1 != k2
+
+
+class TestGitHubDedupKey:
+    def test_delivery_header_becomes_key(self):
+        """regression for CP-1 H.1"""
+        assert github_delivery_id("abc-123") == "github:abc-123"
+
+    def test_none_when_header_missing(self):
+        """regression for CP-1 H.1"""
+        assert github_delivery_id(None) is None
+        assert github_delivery_id("") is None
+
+
+# ──────────────────────────────────────────────────────────────────
+# HTTP-level — GitLab webhook dedup
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestGitLabWebhookDedupHTTP:
+    def test_replayed_delivery_via_idempotency_key_is_duplicate(
+        self, app_with_cpi_admin, mock_db_session
+    ):
+        """Two POSTs with identical Idempotency-Key → first = processed,
+        second = duplicate (no second Kafka publish, no second trace).
+
+        regression for CP-1 H.1
+        """
+        mock_svc, _ = _mock_trace_service_spy()
+        with (
+            patch("src.routers.webhooks.TraceService", return_value=mock_svc),
+            patch("src.routers.webhooks.settings") as mock_settings,
+            patch("src.routers.webhooks.kafka_service") as mock_kafka,
+        ):
+            mock_settings.git.gitlab.webhook_secret = SecretStr(_TEST_SECRET)
+            mock_kafka.publish = AsyncMock(return_value="evt-1")
+
+            headers = {
+                "X-Gitlab-Event": "Push Hook",
+                "X-Gitlab-Token": _TEST_SECRET,
+                "Idempotency-Key": "idem-abc-123",
+            }
+            with TestClient(app_with_cpi_admin) as client:
+                r1 = client.post(
+                    "/webhooks/gitlab", json=_minimal_gitlab_push_payload(), headers=headers
+                )
+                r2 = client.post(
+                    "/webhooks/gitlab", json=_minimal_gitlab_push_payload(), headers=headers
+                )
+
+        assert r1.status_code == 200
+        assert r1.json()["status"] in {"processed", "ignored"}
+        assert r2.status_code == 200
+        assert r2.json()["status"] == "duplicate"
+        # Only ONE trace row created across both requests.
+        assert mock_svc.create.call_count == 1
+
+    def test_webhook_uuid_fallback_when_no_idempotency_key(
+        self, app_with_cpi_admin, mock_db_session
+    ):
+        """regression for CP-1 H.1"""
+        mock_svc, _ = _mock_trace_service_spy()
+        with (
+            patch("src.routers.webhooks.TraceService", return_value=mock_svc),
+            patch("src.routers.webhooks.settings") as mock_settings,
+            patch("src.routers.webhooks.kafka_service") as mock_kafka,
+        ):
+            mock_settings.git.gitlab.webhook_secret = SecretStr(_TEST_SECRET)
+            mock_kafka.publish = AsyncMock(return_value="evt-1")
+
+            headers = {
+                "X-Gitlab-Event": "Push Hook",
+                "X-Gitlab-Token": _TEST_SECRET,
+                "X-Gitlab-Webhook-UUID": "webhook-xyz-999",
+            }
+            with TestClient(app_with_cpi_admin) as client:
+                r1 = client.post(
+                    "/webhooks/gitlab", json=_minimal_gitlab_push_payload(), headers=headers
+                )
+                r2 = client.post(
+                    "/webhooks/gitlab", json=_minimal_gitlab_push_payload(), headers=headers
+                )
+
+        assert r1.status_code == 200
+        assert r2.json()["status"] == "duplicate"
+        assert mock_svc.create.call_count == 1
+
+    def test_missing_dedup_header_still_processes(
+        self, app_with_cpi_admin, mock_db_session
+    ):
+        """No Idempotency-Key AND no Webhook-UUID → process (with warning
+        log). Backward-compat for older GitLab deployments.
+
+        regression for CP-1 H.1
+        """
+        mock_svc, _ = _mock_trace_service_spy()
+        with (
+            patch("src.routers.webhooks.TraceService", return_value=mock_svc),
+            patch("src.routers.webhooks.settings") as mock_settings,
+            patch("src.routers.webhooks.kafka_service") as mock_kafka,
+        ):
+            mock_settings.git.gitlab.webhook_secret = SecretStr(_TEST_SECRET)
+            mock_kafka.publish = AsyncMock(return_value="evt-1")
+
+            headers = {
+                "X-Gitlab-Event": "Push Hook",
+                "X-Gitlab-Token": _TEST_SECRET,
+            }
+            with TestClient(app_with_cpi_admin) as client:
+                resp = client.post(
+                    "/webhooks/gitlab", json=_minimal_gitlab_push_payload(), headers=headers
+                )
+
+        assert resp.status_code == 200
+        # No dedup key means the trace is still created — and a second
+        # request would also create a trace (can't dedup without a key).
+        assert mock_svc.create.call_count == 1
+
+
+# ──────────────────────────────────────────────────────────────────
+# HTTP-level — GitHub webhook dedup
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestGitHubWebhookDedupHTTP:
+    def test_replayed_delivery_returns_duplicate(
+        self, app_with_cpi_admin, mock_db_session
+    ):
+        """regression for CP-1 H.1"""
+        mock_svc, _ = _mock_trace_service_spy()
+        payload = {
+            "ref": "refs/heads/main",
+            "repository": {"full_name": "stoa/catalog"},
+            "head_commit": {"id": "abc123", "message": "x", "author": {"name": "alice"}},
+            "sender": {"login": "alice"},
+        }
+        import json
+
+        body = json.dumps(payload).encode()
+        sig = _sign_github(body, _TEST_SECRET)
+
+        with (
+            patch("src.routers.webhooks.TraceService", return_value=mock_svc),
+            patch("src.routers.webhooks.settings") as mock_settings,
+            patch("src.routers.webhooks.kafka_service") as mock_kafka,
+        ):
+            mock_settings.git.github.webhook_secret = SecretStr(_TEST_SECRET)
+            mock_kafka.publish = AsyncMock(return_value="evt-1")
+
+            headers = {
+                "X-GitHub-Event": "push",
+                "X-Hub-Signature-256": sig,
+                "X-GitHub-Delivery": "delivery-abc-123",
+                "Content-Type": "application/json",
+            }
+            with TestClient(app_with_cpi_admin) as client:
+                r1 = client.post("/webhooks/github", content=body, headers=headers)
+                r2 = client.post("/webhooks/github", content=body, headers=headers)
+
+        assert r1.status_code == 200
+        assert r1.json()["status"] == "processed"
+        assert r2.status_code == 200
+        assert r2.json()["status"] == "duplicate"
+        assert mock_svc.create.call_count == 1
+
+    def test_claim_released_on_failure_allows_retry(
+        self, app_with_cpi_admin, mock_db_session
+    ):
+        """First attempt passes auth but fails mid-pipeline → claim
+        released → retry is NOT treated as duplicate.
+
+        regression for CP-1 H.1
+        """
+        mock_svc, _ = _mock_trace_service_spy()
+        # First call: service.complete raises. Second call: succeeds.
+        mock_svc.complete = AsyncMock(side_effect=[RuntimeError("kafka boom"), None])
+        payload = {
+            "ref": "refs/heads/main",
+            "repository": {"full_name": "stoa/catalog"},
+            "head_commit": {"id": "abc123", "message": "x", "author": {"name": "alice"}},
+            "sender": {"login": "alice"},
+        }
+        import json
+
+        body = json.dumps(payload).encode()
+        sig = _sign_github(body, _TEST_SECRET)
+
+        with (
+            patch("src.routers.webhooks.TraceService", return_value=mock_svc),
+            patch("src.routers.webhooks.settings") as mock_settings,
+            patch("src.routers.webhooks.kafka_service") as mock_kafka,
+        ):
+            mock_settings.git.github.webhook_secret = SecretStr(_TEST_SECRET)
+            mock_kafka.publish = AsyncMock(return_value="evt-1")
+
+            headers = {
+                "X-GitHub-Event": "push",
+                "X-Hub-Signature-256": sig,
+                "X-GitHub-Delivery": "delivery-ff-1",
+                "Content-Type": "application/json",
+            }
+            with TestClient(app_with_cpi_admin) as client:
+                r1 = client.post("/webhooks/github", content=body, headers=headers)
+                r2 = client.post("/webhooks/github", content=body, headers=headers)
+
+        assert r1.status_code == 500  # first failed
+        assert r1.json()["detail"] == "Internal error processing webhook"
+        # r2 must be NEW processing, not DUPLICATE — claim was released.
+        assert r2.status_code == 200
+        assert r2.json()["status"] == "processed"

--- a/control-plane-api/tests/test_regression_cp1_p1_worker_reliability.py
+++ b/control-plane-api/tests/test_regression_cp1_p1_worker_reliability.py
@@ -1,0 +1,236 @@
+"""Regression guards for CP-1 P1 — git sync worker reliability.
+
+Closes:
+- H.7 (Kafka enable_auto_commit=True → events lost on crash)
+- H.8 (blanket ValueError classified as success masks functional bugs)
+
+Invariants pinned:
+- Kafka consumer is created with enable_auto_commit=False.
+- Offset commit happens AFTER a successful _handle_event, synchronously
+  from _dispatch_event.
+- On handler failure or timeout, NO commit is issued — Kafka will
+  redeliver.
+- ValueError is classified as "idempotent success" ONLY if the message
+  contains "already exists" or "not found". Other ValueErrors flow
+  through the retry path like any real failure.
+
+regression for CP-1 H.7
+regression for CP-1 H.8
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ──────────────────────────────────────────────────────────────────
+# H.7 — Kafka consumer config + manual commit
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestKafkaManualCommit:
+    def test_consumer_disables_auto_commit(self):
+        """regression for CP-1 H.7"""
+        from src.workers.git_sync_worker import GitSyncWorker
+
+        worker = GitSyncWorker()
+        with patch("src.workers.git_sync_worker.KafkaConsumer") as mock_consumer_cls:
+            worker._create_consumer()
+            # The kafka config is the second argument (kwargs dict).
+            _, kwargs = mock_consumer_cls.call_args
+            assert kwargs["enable_auto_commit"] is False, (
+                "CP-1 H.7: enable_auto_commit MUST be False to avoid "
+                "losing events between auto-advance and handler run"
+            )
+
+    def test_commit_called_only_after_handler_success(self):
+        """Success path: future.result() returns → consumer.commit() is called.
+
+        regression for CP-1 H.7
+        """
+        from src.workers.git_sync_worker import GitSyncWorker
+
+        worker = GitSyncWorker()
+        mock_consumer = MagicMock()
+        worker._consumer = mock_consumer
+
+        # Spin a real asyncio loop in a thread so run_coroutine_threadsafe
+        # behaves like in production.
+        loop = asyncio.new_event_loop()
+        t = threading.Thread(target=loop.run_forever, daemon=True)
+        t.start()
+        worker._loop = loop
+
+        async def _ok_handler(_event):
+            return None
+
+        try:
+            with patch.object(worker, "_handle_event", _ok_handler):
+                message = MagicMock()
+                message.value = {"event_type": "api-created", "tenant_id": "acme", "payload": {}}
+                worker._dispatch_event(message)
+
+            # commit MUST have been called exactly once.
+            assert mock_consumer.commit.call_count == 1
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            t.join(timeout=1.0)
+            loop.close()
+
+    def test_commit_NOT_called_when_handler_raises(self):
+        """regression for CP-1 H.7"""
+        from src.workers.git_sync_worker import GitSyncWorker
+
+        worker = GitSyncWorker()
+        mock_consumer = MagicMock()
+        worker._consumer = mock_consumer
+
+        loop = asyncio.new_event_loop()
+        t = threading.Thread(target=loop.run_forever, daemon=True)
+        t.start()
+        worker._loop = loop
+
+        async def _bad_handler(_event):
+            raise RuntimeError("kaboom")
+
+        try:
+            with patch.object(worker, "_handle_event", _bad_handler):
+                message = MagicMock()
+                message.value = {"event_type": "api-created", "tenant_id": "acme", "payload": {}}
+                worker._dispatch_event(message)
+
+            mock_consumer.commit.assert_not_called()
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            t.join(timeout=1.0)
+            loop.close()
+
+    def test_commit_NOT_called_on_handler_timeout(self):
+        """regression for CP-1 H.7"""
+        from src.workers import git_sync_worker as mod
+        from src.workers.git_sync_worker import GitSyncWorker
+
+        worker = GitSyncWorker()
+        mock_consumer = MagicMock()
+        worker._consumer = mock_consumer
+
+        loop = asyncio.new_event_loop()
+        t = threading.Thread(target=loop.run_forever, daemon=True)
+        t.start()
+        worker._loop = loop
+
+        async def _slow_handler(_event):
+            await asyncio.sleep(10)
+
+        try:
+            with (
+                patch.object(worker, "_handle_event", _slow_handler),
+                patch.object(mod, "HANDLER_RESULT_TIMEOUT_S", 0.05),
+            ):
+                message = MagicMock()
+                message.value = {"event_type": "api-created", "tenant_id": "acme", "payload": {}}
+                worker._dispatch_event(message)
+
+            mock_consumer.commit.assert_not_called()
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            t.join(timeout=1.0)
+            loop.close()
+
+
+# ──────────────────────────────────────────────────────────────────
+# H.8 — ValueError discrimination
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestValueErrorDiscriminator:
+    @pytest.mark.asyncio
+    async def test_value_error_already_exists_is_success(self):
+        """regression for CP-1 H.8"""
+        from src.workers.git_sync_worker import GIT_SYNC_TOTAL, GitSyncWorker
+
+        worker = GitSyncWorker()
+        worker._github_service = AsyncMock()
+        worker._github_service.create_api = AsyncMock(
+            side_effect=ValueError("API 'foo' already exists for tenant 'acme'")
+        )
+
+        before = GIT_SYNC_TOTAL.labels(status="success", operation="created")._value.get()
+        await worker._handle_event(
+            {"event_type": "api-created", "tenant_id": "acme", "payload": {"name": "foo"}}
+        )
+        after = GIT_SYNC_TOTAL.labels(status="success", operation="created")._value.get()
+
+        assert after - before == 1, (
+            "ValueError with 'already exists' MUST increment success counter"
+        )
+
+    @pytest.mark.asyncio
+    async def test_value_error_not_found_is_success(self):
+        """regression for CP-1 H.8"""
+        from src.workers.git_sync_worker import GIT_SYNC_TOTAL, GitSyncWorker
+
+        worker = GitSyncWorker()
+        worker._github_service = AsyncMock()
+        worker._github_service.is_api_up_to_date = AsyncMock(return_value=False)
+        worker._github_service.update_api = AsyncMock(
+            side_effect=ValueError("API 'missing' not found for tenant 'acme'")
+        )
+
+        before = GIT_SYNC_TOTAL.labels(status="success", operation="updated")._value.get()
+        await worker._handle_event(
+            {
+                "event_type": "api-updated",
+                "tenant_id": "acme",
+                "payload": {"name": "missing"},
+            }
+        )
+        after = GIT_SYNC_TOTAL.labels(status="success", operation="updated")._value.get()
+
+        assert after - before == 1
+
+    @pytest.mark.asyncio
+    async def test_unknown_value_error_is_error_not_success(self):
+        """An unrelated ValueError (e.g. 'unknown action') must NOT be
+        classified as success — it is a real failure that the prior
+        blanket except swallowed into the success counter.
+
+        regression for CP-1 H.8
+        """
+        from src.workers.git_sync_worker import GIT_SYNC_TOTAL, GitSyncWorker
+
+        worker = GitSyncWorker()
+        worker._github_service = AsyncMock()
+        worker._github_service.create_api = AsyncMock(
+            side_effect=ValueError("unknown action: something_else")
+        )
+        # Kill the retry delays so the test runs fast.
+        worker._retry_delays = [0]
+
+        success_before = GIT_SYNC_TOTAL.labels(
+            status="success", operation="created"
+        )._value.get()
+        error_before = GIT_SYNC_TOTAL.labels(
+            status="error", operation="created"
+        )._value.get()
+
+        await worker._handle_event(
+            {"event_type": "api-created", "tenant_id": "acme", "payload": {"name": "x"}}
+        )
+
+        success_after = GIT_SYNC_TOTAL.labels(
+            status="success", operation="created"
+        )._value.get()
+        error_after = GIT_SYNC_TOTAL.labels(
+            status="error", operation="created"
+        )._value.get()
+
+        assert success_after == success_before, (
+            "Unknown ValueError must NOT increment success counter"
+        )
+        assert error_after - error_before == 1, (
+            "Unknown ValueError must increment error counter after retries"
+        )


### PR DESCRIPTION
## Summary
- fix the CP-1 P1 findings on top of P0: router error mapping, path sanitization, webhook replay dedup, service-contract hardening, and worker reliability
- add the in-memory webhook dedup claim/release state machine plus targeted router/worker regression guards
- update `BUG-REPORT-CP-1.md` with the shipped P1 fix table and archive `FIX-PLAN-CP1-P1.md`

## Scope
- base branch: `fix/cp-1-p0-batch`
- commits on top of P0: 5

## Validation rerun in worktree
- `ruff check src/`
- `pytest tests/test_git_router.py tests/test_regression_cp1_p1_router_errors.py tests/test_regression_cp1_p1_service_contracts.py tests/test_regression_cp1_p1_webhook_dedup.py tests/test_regression_cp1_p1_worker_reliability.py tests/test_regression_cp1_webhook_auth_first.py -q`
  - 102 passed

## Notes
- package-level `mypy` remains too noisy on the repo baseline to be a useful publish gate here
- `BUG-REPORT-CP-1.md` now marks H.1 through H.8 plus H.10 as fixed with commit SHAs
- this PR is intentionally stacked on top of P0 and should retarget to `main` once `fix/cp-1-p0-batch` is merged
