### PR TITLE
fix(cp-1): close 5 P2 cleanup findings (CP-1 CLOSED)

### DIFF
--- a/control-plane-api/BUG-REPORT-CP-1.md
+++ b/control-plane-api/BUG-REPORT-CP-1.md
@@ -1,5 +1,28 @@
 # BUG-REPORT-CP-1
 
+> **CP-1 CLOSED (2026-04-23 pm)** — 21 findings / 21 fixed (6 P0 + 9 P1 +
+> 5 P2 + L.2 already-closed in P1). Final commit: `fix/cp-1-p2-batch`.
+> All three regression-guard invariants hold:
+>
+> - `grep -rn "self\._project\." src/ --include="*.py"` → 0 (CP-1 P0 C.1)
+> - `grep -rn "contextlib.suppress(Exception)"` inside `_sync_api_from_git`
+>   → 0 (CP-1 P1 H.2; the one remaining match is an unrelated
+>   `adapter.disconnect()` cleanup in `deploy_api_to_env`)
+> - `grep -rn 'ref="main"\|branch="main"'` across provider services and
+>   ancillary catalog callers → 0 (CP-1 P2 M.4)
+>
+> Regression tests: 88 across 9 files
+> (`test_regression_cp1_sync_in_async.py`,
+> `test_regression_cp1_token_leak.py`,
+> `test_regression_cp1_webhook_auth_first.py`,
+> `test_regression_cp1_p1_service_contracts.py`,
+> `test_regression_cp1_p1_router_errors.py`,
+> `test_regression_cp1_p1_webhook_dedup.py`,
+> `test_regression_cp1_p1_worker_reliability.py`, plus 5 P2 files listed
+> below).
+>
+> Archive path: `stoa-docs/audits/2026-04-23-cp-1/` (post-merge).
+
 > **Document status**: audit artifact produced post-rewrite of CP-1
 > (GitProvider abstraction, CAB-1889). **Revision 2** (2026-04-23 pm) —
 > incorporates editorial feedback on provider-library defaults (PyGithub
@@ -49,6 +72,30 @@
 >
 > **P1-adjacent bonus**: L.2 (webhook 500 leaks str(e)) closed
 > alongside H.1 in `52ba19012` — same class of bug as H.3.
+
+> **P2 batch status (2026-04-23 pm)** — all 5 P2 findings fixed on branch
+> `fix/cp-1-p2-batch` (1 atomic commit):
+>
+> | Bug | Fix |
+> |---|---|
+> | M.2 | `merge_merge_request` short-circuits on `pr.merged` / `mr.state=="merged"` only; closed-unmerged still raises. No double-fetch on idempotent path (GitHub), reuse mutated MR on GitLab. |
+> | M.4 | New `settings.git.default_branch` (env `GIT_DEFAULT_BRANCH`, default `"main"`). Provider method signatures switched to `ref: str \| None = None` / `branch: str \| None = None` with resolution at the method boundary. 50+ internal `"main"` literals swept. Ancillary callers (`iam_sync`, `deployment_orchestration`, `routers/traces`) drop explicit refs. |
+> | M.5 | `connect()` retries transient failures (network, `TimeoutError`, 5xx, 429) with **3 attempts / 2 sleeps (1s → 2s)**, 15s per-attempt timeout. Fails fast on 401/403 and other non-transient errors. Helpers `_is_transient_gitlab_error` / `_is_transient_github_error` at module scope. |
+> | M.6 | `list_all_mcp_servers` fans out per-tenant listings via `asyncio.gather` on both providers; platform-scope fetch runs concurrently with the tenant enumeration. Provider semaphores (`GITLAB_SEMAPHORE` / `GITHUB_READ_SEMAPHORE`) keep the overall concurrency bounded. |
+> | L.1 | GitLab `list_branches` and `list_merge_requests` pass `get_all=True`; `list_commits` uses `iterator=True` + `per_page=min(limit,100)` + `itertools.islice(..., limit)` so the `limit` contract survives while full pagination is restored. |
+>
+> Regression guards: 10 new tests across
+> `test_regression_cp1_p2_merge_idempotent.py` (2),
+> `test_regression_cp1_p2_default_branch.py` (2),
+> `test_regression_cp1_p2_connect_retry.py` (2),
+> `test_regression_cp1_p2_list_all_mcp_gathered.py` (2),
+> `test_regression_cp1_p2_gitlab_pagination.py` (2).
+>
+> Also updated `test_regression_cab_1889_external_git_leaks.py`,
+> `test_git_service.py::TestListCommits`,
+> `test_deployment_orchestration_service.py::TestRegressionCab1889`,
+> `test_iam_sync_service.py::TestRegressionCab1889` to assert the new
+> "caller drops explicit ref" contract.
 
 **Module**: CP-1 — GitProvider abstraction in `control-plane-api`
 **Path**: `control-plane-api/src/services/git_provider.py`, `git_service.py`, `github_service.py`, `src/routers/git.py`, `src/routers/webhooks.py`, `src/services/iam_sync_service.py`, `src/services/deployment_orchestration_service.py`, `src/workers/git_sync_worker.py`

--- a/control-plane-api/BUG-REPORT-CP-1.md
+++ b/control-plane-api/BUG-REPORT-CP-1.md
@@ -1,7 +1,9 @@
 # BUG-REPORT-CP-1
 
 > **CP-1 CLOSED (2026-04-23 pm)** — 21 findings / 21 fixed (6 P0 + 9 P1 +
-> 5 P2 + L.2 already-closed in P1). Final commit: `fix/cp-1-p2-batch`.
+> 5 P2 + L.2 already-closed in P1). P0 landed as PR #2496
+> (squash `4ed80850b`), P1 as PR #2499 (squash `b58bdca40`), P2 on
+> `fix/cp-1-p2-batch` rebased on top of origin/main.
 > All three regression-guard invariants hold:
 >
 > - `grep -rn "self\._project\." src/ --include="*.py"` → 0 (CP-1 P0 C.1)

--- a/control-plane-api/FIX-PLAN-CP1-P2.md
+++ b/control-plane-api/FIX-PLAN-CP1-P2.md
@@ -1,0 +1,206 @@
+# FIX-PLAN-CP1-P2
+
+> Phase 1 plan for the CP-1 P2 batch (5 findings: M.2, M.4, M.5, M.6, L.1).
+> Based on `control-plane-api/BUG-REPORT-CP-1.md` Rev 2.
+> Branch: `fix/cp-1-p2-batch` (cut from `fix/cp-1-p1-batch` — rebase on `main` once P0+P1 land).
+>
+> **Status: APPROVED WITH CORRECTIONS (2026-04-23 pm)** — user arbitration applied
+> directly in the fiches below. The material changes vs the initial draft are:
+>
+> 1. **M.2** — short-circuit is narrow: only when the PR/MR is *already merged*
+>    (`pr.merged is True` / `mr.state == "merged"`). "Closed but unmerged" still
+>    raises.
+> 2. **M.4** — resolve the default branch **at the provider-method boundary**, not
+>    only inside closures. Method signatures switch to `ref: str | None = None`
+>    (and `branch: str | None = None`) with `settings.git.default_branch`
+>    resolution inside each method. Otherwise callers that omit `ref` keep
+>    silently targeting `"main"`.
+> 3. **M.5** — retry only transient failures (network errors, `TimeoutError`,
+>    429, 5xx). Fail fast on 401/403 and bad-repo-config. Backoff math fixed:
+>    **3 attempts = 2 sleeps = 1s → 2s** (per-attempt timeout 15s, worst-case
+>    ~48s).
+> 4. **L.1** — option **A** for `list_commits`: `iterator=True` + `per_page=min(limit,100)`
+>    + `itertools.islice(..., limit)`. Preserves the `limit` contract.
+> 5. Commit-message/test-count doc inconsistency fixed: **10 regression tests**,
+>    not 8.
+>
+> Everything else from the initial draft stands as-is (M.6 gather, ancillary
+> sweep, no `per_page` tuning, no theatrical pre-fix tests).
+
+---
+
+## Anti-redundance sweep vs P0/P1
+
+Confirmed **none of the 5 P2 findings were incidentally closed** by the P0 (`fix/cp-1-p0-batch`) or P1 (`fix/cp-1-p1-batch`) commits:
+
+| Bug | Checked at | Still open? | Proof |
+|---|---|---|---|
+| M.2 | `github_service.py:1215-1225`, `git_service.py:1196-1204` | Yes | Both `merge_merge_request` closures go straight to `pr.merge()` / `mr.merge()` with no pre-check; GitHub still double-fetches via two `get_pull(iid)` around the merge call. |
+| M.4 | 50 call-sites in `git_service.py` + `github_service.py`, plus 3 in `iam_sync_service.py`, `deployment_orchestration_service.py`, `routers/traces.py` | Yes | `grep -n 'ref="main"\|branch="main"'` returns 50 matches in provider services post-P1. No `settings.git.default_branch` exists. |
+| M.5 | `git_service.py:138-158` (GitLab), `github_service.py:169-183` (GitHub) | Yes | Both `connect()` wrap their closure in `_gl_run` / `_gh_read` (15s timeout) but there is no retry loop. A single transient 500 at boot still yields "not connected" + 503 from every route. |
+| M.6 | `github_service.py:565-570`, `git_service.py:910-929` | Yes | Sequential `for tenant_id in ...: servers.extend(await self.list_mcp_servers(tenant_id))` in both providers. No `asyncio.gather`. |
+| L.1 | `git_service.py:792, 1124, 1169` | Yes | `project.branches.list()`, `project.mergerequests.list(state=state)`, `project.commits.list(path=path, per_page=limit)` all missing `get_all=True` / `iterator=True`. python-gitlab silently truncates to 20 for the first two; `list_commits` caps at `limit` but never paginates beyond. |
+
+No bug is obsolete / already-fixed.
+
+`L.2` was closed in `52ba19012` (P1) as explicitly documented in the bug report header. Not re-opening.
+
+---
+
+## Bug fiches
+
+### M.2 — `merge_merge_request` not idempotent + double fetch
+
+- **Résumé** : GitHub `merge_merge_request(iid)` calls `repo.get_pull(iid)` twice (once before `pr.merge()`, once after) and raises `GithubException` when the PR is already merged. GitLab mirrors the pattern: `mergerequests.get(iid)` → `mr.merge()` with no guard. Replaying a merge webhook after a manual merge surfaces as a 500 via `H.3` mapping.
+- **Fichier:ligne** : `control-plane-api/src/services/github_service.py:1215-1225`, `control-plane-api/src/services/git_service.py:1196-1204`
+- **Approche de fix (corrected)** :
+  - GitHub : fetch `pr = repo.get_pull(iid)` once. Short-circuit **only** when `pr.merged is True` → return `_pr_to_ref(pr)` without calling `pr.merge()`. "Closed but unmerged" (`state=="closed"` and `merged is False`) does **not** short-circuit — it falls through to `pr.merge()` which will raise the correct provider error. After `pr.merge()` returns, re-fetch via `repo.get_pull(iid)` once to get the fresh state for the returned ref (PyGithub's `PullRequest.merge()` returns a `PullRequestMergeStatus`, it does not mutate `pr` in place — verified empirically against stubs; documenting the constraint in an inline comment).
+  - GitLab : fetch `mr = project.mergerequests.get(iid)` once. Short-circuit **only** when `mr.state == "merged"` → return `_mr_to_ref(mr)`. Otherwise call `mr.merge()` — python-gitlab's `ProjectMergeRequest.merge()` does update the instance's attributes (documented), so the same `mr` is used for the returned ref without a second fetch.
+- **Régression guard proposé** (2 tests) :
+  - `test_regression_cp1_p2_merge_idempotent.py::test_github_merge_request_short_circuits_when_already_merged`
+    - Stub PR with `merged=True` → assert `pr.merge()` **not called**, ref reflects merged state.
+    - Secondary assertion in the **same** test: stub PR with `state="closed"` + `merged=False` → assert `pr.merge()` **is** called (raising the provider error). Proves the short-circuit is narrow.
+  - `test_regression_cp1_p2_merge_idempotent.py::test_gitlab_merge_request_short_circuits_when_already_merged`
+    - Mirror on GitLab: `state="merged"` → no `mr.merge()` call; `state="closed"` → `mr.merge()` is called.
+
+---
+
+### M.4 — Hardcoded `ref="main"` / `branch="main"` in provider closures
+
+- **Résumé** : 50 closures in `git_service.py` + `github_service.py` pin `ref="main"` / `branch="main"` inline. Any tenant whose catalog uses `master` or a custom default branch silent-fails. The active `GitProviderConfig` has no `default_branch` field.
+- **Fichier:ligne** :
+  - `git_service.py` — 17 internal `ref="main"` literals (lines 183, 369, 383, 404, 487, 507, 530, 554, 596, 624, 651, 875, 897, 920, 1001, 1045) plus `branch="main"` defaults on `create_file/update_file/delete_file/batch_commit/remove_file/create_branch`.
+  - `github_service.py` — 8 internal `ref="main"` literals (lines 372, 409, 435, 552, 893, 904, 1015, 1026) plus identical `branch="main"` defaults on write methods.
+  - Ancillary callers (out of P2 scope but trivial): `iam_sync_service.py:210`, `deployment_orchestration_service.py:132`, `routers/traces.py:512` — will be swept too since the cost is zero.
+- **Approche de fix (corrected — resolve at the provider-method boundary)** :
+  1. Add `default_branch: str = "main"` to `GitProviderConfig` (single field — catalog repo is shared across providers). Hydrate from new env var `GIT_DEFAULT_BRANCH` (backed by `Settings.GIT_DEFAULT_BRANCH: str = "main"`); `"main"` stays as the default so omitted config = no behaviour change.
+  2. **ABC update** (`git_provider.py`) : every method that currently has `ref: str = "main"` or `branch: str = "main"` (or `target_branch: str = "main"`) switches to `ref: str | None = None` / `branch: str | None = None`. 15 signatures affected: `get_file_content`, `list_files`, `create_file`, `update_file`, `delete_file`, `batch_commit`, `get_head_commit_sha`, `list_tree`, `read_file`, `write_file`, `remove_file`, `create_branch`, `create_merge_request`, and (indirectly) any override on the two impls. Docstrings updated: `ref` default now says "catalog default branch (from `settings.git.default_branch`)".
+  3. **Impl resolution** : inside each provider method, the first statement resolves the local `effective_ref = ref if ref is not None else settings.git.default_branch` (mirror for `branch`). Closures read from the local — settings never touched from inside `run_sync` / `_gl_run` / `_gh_read`, preserving the C.1 invariant.
+  4. **Internal hardcoded `"main"`** (list_tenants tree walks, tenant-scope helpers — 17 in GitLab, 8 in GitHub) : replace with the same `effective_ref` local. For methods that are not on the ABC and don't take a `ref` param today (e.g. `list_tenants`, `list_mcp_servers`, `create_mcp_server`), resolve `effective_ref = settings.git.default_branch` locally rather than extending the signature. Keeps the diff narrow and matches how the public API carries the override for callers that want one.
+  5. **Ancillary call-sites** : `iam_sync_service.py:210`, `deployment_orchestration_service.py:132`, `routers/traces.py:512` — drop the explicit `ref="main"` / `git_branch="main"` argument so the new default kicks in. (For `routers/traces.py:512` this is a response-payload field; replace the literal with `settings.git.default_branch`.)
+  6. **Callers with explicit `ref=...`** (iam_sync `list_tree`, deployment_orchestration `get_head_commit_sha`, tests) : unchanged — they already pass their own value.
+- **Régression guard proposé** :
+  - `test_regression_cp1_p2_default_branch.py::test_gitlab_list_tenants_uses_configured_default_branch`
+  - `test_regression_cp1_p2_default_branch.py::test_github_list_apis_uses_configured_default_branch`
+  - Scenario: monkeypatch `settings.git.default_branch = "develop"` → stub `repository_tree` / `get_contents` → invoke the service → assert the stub was called with `ref="develop"`, never `"main"`.
+
+---
+
+### M.5 — `connect()` has no retry at startup (both providers)
+
+- **Résumé** : `GitLabService.connect()` and `GitHubService.connect()` each run their network round-trip inside `_gl_run` / `_gh_read` with a 15s timeout — but **no retry**. A single transient blip during CP-API boot (GitLab 502, GitHub rate-limit on `get_user`) leaves the service `not connected` and every route returns 503 until the pod is restarted.
+- **Fichier:ligne** : `control-plane-api/src/services/git_service.py:138-158`, `control-plane-api/src/services/github_service.py:169-183`
+- **Approche de fix (corrected — transient-only, 1s→2s)** :
+  - 3 attempts total → **2 sleeps** → `1s → 2s` backoff. Per-attempt timeout stays at 15s (the value already in `_gl_run` / `_gh_read`). Worst-case startup delay: `3 × 15s + 1s + 2s = 48s` — intentional, documented in the log line.
+  - Transient classification:
+    - **Retry**: `asyncio.TimeoutError` / `TimeoutError`, `requests.exceptions.ConnectionError`, `requests.exceptions.Timeout`, GitLab `GitlabHttpError` with `response_code` in {429} ∪ 5xx, GitHub `GithubException` with `status` in {429} ∪ 5xx.
+    - **Fail fast** (re-raise immediately, no sleep): GitLab `GitlabAuthenticationError` (401/403); GitHub `BadCredentialsException`, or `GithubException` with `status` in {401, 403, 404}; any other exception class (unknown errors shouldn't be retried blindly).
+  - Implementation detail: the classification lives in a small module-level helper (`_is_transient_gitlab_error` / `_is_transient_github_error`) so tests can monkey-patch it easily and so the discrimination is auditable without scanning the retry loop. The loop re-raises the last transient error after 3 attempts.
+- **Régression guard proposé** :
+  - `test_regression_cp1_p2_connect_retry.py::test_gitlab_connect_retries_on_transient_and_succeeds`
+    - Scenario: stub closure to raise `requests.exceptions.ConnectionError` twice then succeed on the third call → assert `connect()` returns ok + exactly 3 attempts observed + `asyncio.sleep` called with `1` then `2` (in that order).
+    - Secondary assertion in the **same** test: stub closure to raise `GitlabAuthenticationError(401)` → assert **no retry** (fail fast, 1 attempt, 0 sleeps).
+  - `test_regression_cp1_p2_connect_retry.py::test_github_connect_retries_on_transient_and_succeeds`
+    - Mirror on GitHub: `requests.exceptions.ConnectionError` × 2 then ok → 3 attempts, sleeps 1s/2s. Secondary: `BadCredentialsException` → no retry.
+  - Sleep mocked via `monkeypatch.setattr("asyncio.sleep", AsyncMock())` to keep tests <100ms and to assert the backoff values directly.
+
+---
+
+### M.6 — `list_all_mcp_servers` sequential N+1 across tenants
+
+- **Résumé** : GitHub `list_all_mcp_servers` and GitLab `list_all_mcp_servers` both iterate tenants with an `await self.list_mcp_servers(tenant_id)` inside a `for` loop. With 100 tenants × 1 round-trip each = 100 serial round-trips. Combined with C.1, observable latency is in the tens of seconds.
+- **Fichier:ligne** : `control-plane-api/src/services/github_service.py:565-570`, `control-plane-api/src/services/git_service.py:910-929`
+- **Approche de fix** : replace the `for` loop with `asyncio.gather(*[self.list_mcp_servers(tid) for tid in tenant_ids])`. Bounded concurrency is already enforced at the provider level via `GITHUB_SEMAPHORE` / `GITLAB_SEMAPHORE` inside every `_gh_read` / `_gl_run` call, so a second semaphore layer here is unnecessary. Flatten results via `list(itertools.chain.from_iterable(...))` (or nested `extend` in a loop — keep whichever reads more natural; the semantic is "merge the N per-tenant lists").
+- **Régression guard proposé** :
+  - `test_regression_cp1_p2_list_all_mcp_gathered.py::test_github_list_all_mcp_servers_fans_out_in_parallel`
+  - `test_regression_cp1_p2_list_all_mcp_gathered.py::test_gitlab_list_all_mcp_servers_fans_out_in_parallel`
+  - Scenario: stub `list_mcp_servers` with a wrapper that records invocation-order timestamps + sleeps 50ms. Call `list_all_mcp_servers` with 5 tenants → assert the wrap-around wall time < `2 × 50ms` (proves concurrency) and all 5 tenants were queried. Not a micro-benchmark — compared against a generous ceiling.
+
+---
+
+### L.1 — GitLab pagination silently truncates `branches.list` / `mergerequests.list`
+
+- **Résumé** : python-gitlab's `list()` methods return page 1 (≤20 items) by default. `list_branches` and `list_merge_requests` both hit this. `list_commits` passes `per_page=limit` which bounds the first page to `limit`, but still never fetches beyond it. PyGithub pagination is transparent — this bug is GitLab-only per the Rev 2 report. Regression guards stay scoped to GitLab.
+- **Fichier:ligne** :
+  - `git_service.py:1124` — `project.branches.list()`
+  - `git_service.py:1169` — `project.mergerequests.list(state=state)`
+  - `git_service.py:792` — `project.commits.list(path=path, per_page=limit)` (borderline — see arbitration)
+- **Approche de fix (corrected — option A for `list_commits`)** :
+  - `list_branches` : `project.branches.list(get_all=True)`.
+  - `list_merge_requests` : `project.mergerequests.list(state=state, get_all=True)`.
+  - `list_commits` : `project.commits.list(path=path, per_page=min(limit, 100), iterator=True)` wrapped in `itertools.islice(..., limit)`. Preserves the existing `limit` contract while eliminating the silent truncation for `limit > 20`.
+- **Régression guard proposé** :
+  - `test_regression_cp1_p2_gitlab_pagination.py::test_list_branches_uses_get_all_true`
+  - `test_regression_cp1_p2_gitlab_pagination.py::test_list_merge_requests_and_commits_paginate_fully`
+    - One test covers `list_merge_requests` (assert `get_all=True` passed, 35 items returned) **and** `list_commits` in the same assertion block (assert `iterator=True` passed + `per_page=min(limit,100)` + the returned list honours `limit` via `islice`). Keeps the file to 2 tests per the one-per-bug rule while covering all three fixed methods.
+
+---
+
+## Commit plan
+
+**Single squashed commit on `fix/cp-1-p2-batch`** — all five fixes are defensive hardening / observability / reliability, each narrow in scope. Grouping keeps the git log clean (one P2 entry to match the one-per-batch pattern set by P0/P1) and lets reviewers read the five fiches side-by-side.
+
+Proposed commit message:
+
+```
+fix(cp-api/git): close P2 cleanup batch (5 findings)
+
+Defensive hardening and reliability for the CP-1 GitProvider abstraction:
+- M.2: merge_merge_request idempotent + single-fetch on both providers
+- M.4: replace hardcoded ref="main" with settings.git.default_branch (new config)
+- M.5: connect() retries with exponential backoff (1s/2s/4s, 3 attempts)
+- M.6: list_all_mcp_servers fans out via asyncio.gather (both providers)
+- L.1: GitLab list_branches / list_merge_requests / list_commits paginate fully
+
+Regression guards: 10 new tests across
+  test_regression_cp1_p2_merge_idempotent.py          (2)
+  test_regression_cp1_p2_default_branch.py            (2)
+  test_regression_cp1_p2_connect_retry.py             (2)
+  test_regression_cp1_p2_list_all_mcp_gathered.py     (2)
+  test_regression_cp1_p2_gitlab_pagination.py         (2)
+
+Closes: M.2, M.4, M.5, M.6, L.1 (BUG-REPORT-CP-1.md)
+```
+
+If arbitration #2 retains the three ancillary `ref="main"` call-sites (iam_sync / deployment_orchestration / traces) in scope, they fold into the same commit (scope note already covers them).
+
+No case justifies a second commit: none of the five forces a structural refactor. M.4 is the biggest footprint (config addition + ~25 closure-local assignments) but remains a mechanical one-pass sweep.
+
+---
+
+## Arbitration points
+
+1. **Scope of M.4 sweep** — Recommend limiting to provider services (`git_service.py`, `github_service.py`) plus the three ancillary call-sites I noted (`iam_sync_service.py:210`, `deployment_orchestration_service.py:132`, `routers/traces.py:512`). **Alternative** : leave the ancillary three as-is and open a follow-up. I recommend the full sweep because the 3 extra lines are a 1-line mechanical change each, and leaving them is a foot-gun for any future refactor that drops the `ref="main"` public default.
+
+2. **Breaking public-method defaults** — Do we also want `def get_file_content(..., ref: str | None = None)` that resolves to `settings.git.default_branch` when unset? I argue **no for this batch** — it's a public contract change with blast-radius beyond CP-1 (webMethods adapter, iam_sync, deployment_orchestration all call these with explicit `ref` today). P2 fixes the internal closures; a broader API harmonisation belongs in CP-1 follow-up or a new ticket.
+
+3. **`list_commits` fix shape for L.1** — Two options:
+   - **A** (recommended) : `per_page=min(limit, 100), iterator=True` + `islice(..., limit)` — preserves the `limit` semantics, eliminates truncation for `limit > 20`, no surprise for callers.
+   - **B** (simpler) : only touch `list_branches` + `list_merge_requests`, leave `list_commits` alone. Justification: `list_commits` already honours `limit=20`, which is "bounded on purpose" for UX use-cases. The Rev 2 bug report itself flags it as "borderline". I'd accept B if you prefer to keep the diff minimal.
+
+4. **L.1 regression test depth** — Bug report calls out "catalog repo with >20 branches or >20 MRs" as the failure case. The 2 tests I proposed stub 35 items; do you want a 3rd test explicitly demonstrating pre-fix behaviour (truncation to 20) as a recorded regression? I argue the monkeypatch on `list(get_all=True)` is already the assertion that matters — a "fail before fix" test over a stub is theatre here.
+
+5. **L.1 follow-up for `per_page` overrides** — Should we standardise `per_page=100` on `branches.list` / `mergerequests.list` to reduce round-trips? Recommend **no** for this batch — python-gitlab defaults are fine; adding `per_page=100` is a perf tweak that doesn't belong in a cleanup batch.
+
+---
+
+## Risques identifiés
+
+- **M.5 retry loop vs test startup** : if the `asyncio.sleep` is not mocked in fixtures that exercise `GitLabService().connect()` as a real side-effect (rare — most tests stub `connect` directly), test runtime could slow. Mitigation : the retry helper only sleeps on failure; passing tests never sleep. All new tests mock `asyncio.sleep`.
+- **M.4 hydration ordering** : the new `GIT_DEFAULT_BRANCH` env var must be hydrated inside `_hydrate_and_validate_git` model-validator (same as `GITHUB_TOKEN` etc.) so it survives the validator reassignment of `self.git`. Otherwise the default silently stays `"main"` because the `GitProviderConfig(...)` constructor replaces the whole object.
+- **M.6 parallelism and rate limits** : 100 parallel `list_mcp_servers` calls are all within `_gh_read` / `_gl_run` which serialise through the provider semaphore (10 slots). End-to-end concurrency stays capped, so no new rate-limit exposure. Just wanted to surface the reasoning.
+- **L.1 fetch cost on large repos** : `get_all=True` on a GitLab project with thousands of branches / MRs will now fetch the full set. This is the **desired** behaviour (the bug was silent truncation) but callers of `list_branches` / `list_merge_requests` should expect larger payloads. The two production callers (`routers/git.py`) already paginate / filter client-side, so no UI regression expected.
+- **None of the five fixes touch the sync-in-async invariant**. P0 closed the architectural split (`run_sync`), P1 closed the contract drift. P2 stays inside the closures.
+
+---
+
+## Global state after Phase 2 (preview)
+
+`pytest tests/` → expect +10 tests net, 6490 total (baseline: 6480 after P0+P1).
+`ruff check src/` → zero issue.
+`mypy src/services/git*.py src/routers/git.py` → no regression (new field is typed, new helpers are typed).
+CP-1 invariants hold:
+- `grep -rn "self._project\." src/ --include="*.py" | grep -v "_test"` → 0
+- `grep -rn "contextlib.suppress(Exception)" src/services/deployment_orchestration_service.py` → 0
+
+If this batch merges as-is, **CP-1 is CLOSED** (21/21 findings : 6 P0 + 9 P1 + 5 P2 + already-closed L.2). Phase 3 will add a "CP-1 CLOSED" banner to the top of `BUG-REPORT-CP-1.md` with the commit roll-up.

--- a/control-plane-api/src/config.py
+++ b/control-plane-api/src/config.py
@@ -71,6 +71,11 @@ class GitProviderConfig(BaseModel):
     provider: Literal["github", "gitlab"] = "github"
     github: GitHubConfig = Field(default_factory=GitHubConfig)
     gitlab: GitLabConfig = Field(default_factory=GitLabConfig)
+    # CP-1 P2 (M.4): catalog repo default branch. Provider-agnostic because
+    # the catalog is a single repo regardless of provider. Hydrated from
+    # ``GIT_DEFAULT_BRANCH`` env var; keep ``"main"`` as the default so
+    # omitted config is a no-op.
+    default_branch: str = "main"
 
     @property
     def active_catalog_project_id(self) -> str:
@@ -142,6 +147,8 @@ class Settings(BaseSettings):
     GITLAB_TOKEN: str = Field(default="", exclude=True)
     GITLAB_PROJECT_ID: str = Field(default="", exclude=True)
     GITLAB_WEBHOOK_SECRET: str = Field(default="", exclude=True)
+    # CP-1 P2 (M.4): catalog repo default branch, provider-agnostic.
+    GIT_DEFAULT_BRANCH: str = Field(default="main", exclude=True)
 
     # ── Git Provider — single source of truth for consumers ──────────────
     git: GitProviderConfig = Field(default_factory=GitProviderConfig)
@@ -477,6 +484,7 @@ class Settings(BaseSettings):
                 project_id=self.GITLAB_PROJECT_ID,
                 webhook_secret=SecretStr(self.GITLAB_WEBHOOK_SECRET),
             ),
+            default_branch=self.GIT_DEFAULT_BRANCH or "main",
         )
 
         # Step 2 — validation (gated; flipped in C.3).

--- a/control-plane-api/src/routers/traces.py
+++ b/control-plane-api/src/routers/traces.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth.dependencies import User
 from ..auth.rbac import require_role
+from ..config import settings
 from ..database import get_db
 from ..models.traces_db import TraceStatusDB
 from ..services.trace_service import TraceService
@@ -509,7 +510,7 @@ async def create_demo_trace(
                 "fix: handle edge case in payment processing",
             ]
         ),
-        git_branch="main",
+        git_branch=settings.git.default_branch,
         git_author=random.choice(["alice", "bob", "charlie", "diana", "eve"]),
         git_author_email="dev@gostoa.dev",
         git_project=random.choice(

--- a/control-plane-api/src/services/deployment_orchestration_service.py
+++ b/control-plane-api/src/services/deployment_orchestration_service.py
@@ -129,7 +129,9 @@ class DeploymentOrchestrationService:
             commit_sha: str | None = None
             try:
                 # regression for CAB-1889: use provider-agnostic ABC, not _project
-                commit_sha = await git_service.get_head_commit_sha(ref="main")
+                # CP-1 P2 (M.4): drop explicit ref so it resolves to
+                # settings.git.default_branch.
+                commit_sha = await git_service.get_head_commit_sha()
             except FileNotFoundError:
                 logger.debug("No head commit available for API '%s/%s' sync", tenant_id, api_id)
 

--- a/control-plane-api/src/services/git_provider.py
+++ b/control-plane-api/src/services/git_provider.py
@@ -88,13 +88,14 @@ class GitProvider(ABC):
         """
 
     @abstractmethod
-    async def get_file_content(self, project_id: str, file_path: str, ref: str = "main") -> str:
+    async def get_file_content(self, project_id: str, file_path: str, ref: str | None = None) -> str:
         """Retrieve raw file content from a repository.
 
         Args:
             project_id: Provider-specific project identifier.
             file_path: Path to the file within the repository.
-            ref: Branch, tag, or commit SHA. Defaults to "main".
+            ref: Branch, tag, or commit SHA. ``None`` resolves to
+                ``settings.git.default_branch`` (CP-1 P2 M.4).
 
         Returns:
             Raw file content as string.
@@ -104,13 +105,14 @@ class GitProvider(ABC):
         """
 
     @abstractmethod
-    async def list_files(self, project_id: str, path: str = "", ref: str = "main") -> list[str]:
+    async def list_files(self, project_id: str, path: str = "", ref: str | None = None) -> list[str]:
         """List files in a repository directory.
 
         Args:
             project_id: Provider-specific project identifier.
             path: Directory path within the repository. Empty for root.
-            ref: Branch, tag, or commit SHA. Defaults to "main".
+            ref: Branch, tag, or commit SHA. ``None`` resolves to
+                ``settings.git.default_branch`` (CP-1 P2 M.4).
 
         Returns:
             List of file paths relative to the repository root.
@@ -165,7 +167,12 @@ class GitProvider(ABC):
 
     @abstractmethod
     async def create_file(
-        self, project_id: str, file_path: str, content: str, commit_message: str, branch: str = "main"
+        self,
+        project_id: str,
+        file_path: str,
+        content: str,
+        commit_message: str,
+        branch: str | None = None,
     ) -> dict[str, Any]:
         """Create a new file in the repository.
 
@@ -174,7 +181,8 @@ class GitProvider(ABC):
             file_path: Path for the new file.
             content: File content.
             commit_message: Git commit message.
-            branch: Target branch. Defaults to "main".
+            branch: Target branch. ``None`` resolves to
+                ``settings.git.default_branch`` (CP-1 P2 M.4).
 
         Returns:
             Commit metadata (sha, url).
@@ -185,7 +193,12 @@ class GitProvider(ABC):
 
     @abstractmethod
     async def update_file(
-        self, project_id: str, file_path: str, content: str, commit_message: str, branch: str = "main"
+        self,
+        project_id: str,
+        file_path: str,
+        content: str,
+        commit_message: str,
+        branch: str | None = None,
     ) -> dict[str, Any]:
         """Update an existing file in the repository.
 
@@ -194,7 +207,8 @@ class GitProvider(ABC):
             file_path: Path to the existing file.
             content: New file content.
             commit_message: Git commit message.
-            branch: Target branch. Defaults to "main".
+            branch: Target branch. ``None`` resolves to
+                ``settings.git.default_branch`` (CP-1 P2 M.4).
 
         Returns:
             Commit metadata (sha, url).
@@ -204,14 +218,21 @@ class GitProvider(ABC):
         """
 
     @abstractmethod
-    async def delete_file(self, project_id: str, file_path: str, commit_message: str, branch: str = "main") -> bool:
+    async def delete_file(
+        self,
+        project_id: str,
+        file_path: str,
+        commit_message: str,
+        branch: str | None = None,
+    ) -> bool:
         """Delete a file from the repository.
 
         Args:
             project_id: Provider-specific project identifier.
             file_path: Path to the file to delete.
             commit_message: Git commit message.
-            branch: Target branch. Defaults to "main".
+            branch: Target branch. ``None`` resolves to
+                ``settings.git.default_branch`` (CP-1 P2 M.4).
 
         Returns:
             True if deleted.
@@ -241,8 +262,11 @@ class GitProvider(ABC):
         """Return True when the provider client is initialized."""
         return bool(getattr(self, "_project", None) or getattr(self, "_gh", None))
 
-    async def get_head_commit_sha(self, ref: str = "main") -> str | None:
-        """Return the current HEAD commit SHA for the provider's catalog repo."""
+    async def get_head_commit_sha(self, ref: str | None = None) -> str | None:
+        """Return the current HEAD commit SHA for the provider's catalog repo.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
         raise NotImplementedError("get_head_commit_sha() must be implemented by the provider")
 
     async def get_tenant(self, tenant_id: str) -> dict | None:
@@ -292,7 +316,7 @@ class GitProvider(ABC):
         project_id: str,
         actions: list[dict[str, str]],
         commit_message: str,
-        branch: str = "main",
+        branch: str | None = None,
     ) -> dict[str, Any]:
         """Create an atomic commit with multiple file operations.
 
@@ -303,7 +327,8 @@ class GitProvider(ABC):
                 - file_path: Path within the repository
                 - content: File content (required for create/update)
             commit_message: Git commit message.
-            branch: Target branch. Defaults to "main".
+            branch: Target branch. ``None`` resolves to
+                ``settings.git.default_branch`` (CP-1 P2 M.4).
 
         Returns:
             Commit metadata (sha, url).
@@ -315,17 +340,19 @@ class GitProvider(ABC):
     # router never needs to know about project_id / org-repo.
     # ============================================================
 
-    async def list_tree(self, path: str, ref: str = "main") -> list[TreeEntry]:
+    async def list_tree(self, path: str, ref: str | None = None) -> list[TreeEntry]:
         """List immediate children of ``path`` in the catalog repo.
 
         Returns an empty list when the path is absent. Never raises on 404.
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
         """
         raise NotImplementedError("list_tree() must be implemented by the provider")
 
-    async def read_file(self, path: str, ref: str = "main") -> str | None:
+    async def read_file(self, path: str, ref: str | None = None) -> str | None:
         """Return file content from the catalog repo, or ``None`` if missing.
 
         Unlike :meth:`get_file_content`, this method never raises FileNotFoundError.
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
         """
         raise NotImplementedError("read_file() must be implemented by the provider")
 
@@ -334,24 +361,31 @@ class GitProvider(ABC):
         raise NotImplementedError("list_path_commits() must be implemented by the provider")
 
     async def write_file(
-        self, path: str, content: str, commit_message: str, branch: str = "main"
+        self, path: str, content: str, commit_message: str, branch: str | None = None
     ) -> Literal["created", "updated"]:
         """Create-or-update a file on the catalog repo.
 
         Returns ``"created"`` if the file did not exist before, ``"updated"`` otherwise.
+        ``branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
         """
         raise NotImplementedError("write_file() must be implemented by the provider")
 
-    async def remove_file(self, path: str, commit_message: str, branch: str = "main") -> bool:
-        """Delete a file from the catalog repo. Raises FileNotFoundError if missing."""
+    async def remove_file(self, path: str, commit_message: str, branch: str | None = None) -> bool:
+        """Delete a file from the catalog repo. Raises FileNotFoundError if missing.
+
+        ``branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
         raise NotImplementedError("remove_file() must be implemented by the provider")
 
     async def list_branches(self) -> list[BranchRef]:
         """List branches on the catalog repo."""
         raise NotImplementedError("list_branches() must be implemented by the provider")
 
-    async def create_branch(self, name: str, ref: str = "main") -> BranchRef:
-        """Create a branch named ``name`` pointing at ``ref`` on the catalog repo."""
+    async def create_branch(self, name: str, ref: str | None = None) -> BranchRef:
+        """Create a branch named ``name`` pointing at ``ref`` on the catalog repo.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
         raise NotImplementedError("create_branch() must be implemented by the provider")
 
     async def list_merge_requests(self, state: str = "opened") -> list[MergeRequestRef]:
@@ -363,9 +397,12 @@ class GitProvider(ABC):
         title: str,
         description: str,
         source_branch: str,
-        target_branch: str = "main",
+        target_branch: str | None = None,
     ) -> MergeRequestRef:
-        """Open a merge request / pull request on the catalog repo."""
+        """Open a merge request / pull request on the catalog repo.
+
+        ``target_branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
         raise NotImplementedError("create_merge_request() must be implemented by the provider")
 
     async def merge_merge_request(self, iid: int) -> MergeRequestRef:

--- a/control-plane-api/src/services/git_service.py
+++ b/control-plane-api/src/services/git_service.py
@@ -17,6 +17,7 @@ version token.
 """
 
 import asyncio
+import itertools
 import logging
 import re
 import tempfile
@@ -25,6 +26,7 @@ from pathlib import Path
 from typing import Any, Literal, TypeVar
 
 import gitlab
+import requests.exceptions  # type: ignore[import-untyped]
 import yaml
 from gitlab.v4.objects import Project
 
@@ -128,6 +130,31 @@ async def _gl_run(
     return await run_sync(fn, semaphore=GITLAB_SEMAPHORE, timeout=timeout, op_name=op_name)
 
 
+# CP-1 P2 (M.5): transient error classifier for connect() retries. Kept
+# at module scope so tests can monkey-patch it and so the policy is
+# auditable without walking the retry loop.
+_GITLAB_RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+
+def _is_transient_gitlab_error(exc: BaseException) -> bool:
+    """Return True when ``exc`` is worth retrying at connect-time.
+
+    Retry: network errors, asyncio/stdlib TimeoutError, GitLab HTTP
+    errors with status in {429} or 5xx. Fail fast on auth errors (401/403)
+    and any other exception class.
+    """
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):
+        return True
+    if isinstance(exc, (requests.exceptions.ConnectionError, requests.exceptions.Timeout)):
+        return True
+    if isinstance(exc, gitlab.exceptions.GitlabAuthenticationError):
+        return False
+    if isinstance(exc, gitlab.exceptions.GitlabHttpError):
+        status = getattr(exc, "response_code", None)
+        return status in _GITLAB_RETRYABLE_STATUSES
+    return False
+
+
 class GitLabService(GitProvider):
     """GitLab implementation of GitProvider — GitOps source of truth."""
 
@@ -136,38 +163,67 @@ class GitLabService(GitProvider):
         self._project: Project | None = None
 
     async def connect(self) -> None:
-        """Initialize GitLab connection."""
-        try:
-            gl_cfg = settings.git.gitlab
+        """Initialize GitLab connection with transient-error retry (CP-1 P2 M.5).
 
-            def _connect() -> tuple[gitlab.Gitlab, Project, str]:
-                client = gitlab.Gitlab(gl_cfg.url, private_token=gl_cfg.token.get_secret_value())
-                client.auth()
-                project = client.projects.get(gl_cfg.project_id)
-                # Materialise the scalar inside the closure so the log
-                # line below does not trigger any lazy attribute access
-                # on the event loop.
-                return client, project, project.name
+        3 attempts, 1s then 2s backoff between retries, 15s per-attempt
+        timeout. Fails fast on auth errors — retrying a 401 doesn't help.
+        """
+        gl_cfg = settings.git.gitlab
 
-            self._gl, self._project, project_name = await _gl_run(
-                _connect, "gitlab.connect", timeout=15.0
-            )
-            logger.info("Connected to GitLab project: %s", project_name)
-        except Exception as e:
-            logger.error("Failed to connect to GitLab: %s", e)
-            raise
+        def _connect() -> tuple[gitlab.Gitlab, Project, str]:
+            client = gitlab.Gitlab(gl_cfg.url, private_token=gl_cfg.token.get_secret_value())
+            client.auth()
+            project = client.projects.get(gl_cfg.project_id)
+            # Materialise the scalar inside the closure so the log
+            # line below does not trigger any lazy attribute access
+            # on the event loop.
+            return client, project, project.name
+
+        max_attempts = 3
+        backoffs = [1, 2]  # 3 attempts = 2 sleeps
+        last_error: BaseException | None = None
+        for attempt in range(max_attempts):
+            try:
+                self._gl, self._project, project_name = await _gl_run(
+                    _connect, "gitlab.connect", timeout=15.0
+                )
+                logger.info("Connected to GitLab project: %s", project_name)
+                return
+            except Exception as exc:
+                last_error = exc
+                if not _is_transient_gitlab_error(exc):
+                    logger.error("Failed to connect to GitLab (non-transient): %s", exc)
+                    raise
+                if attempt + 1 < max_attempts:
+                    delay = backoffs[attempt]
+                    logger.warning(
+                        "GitLab connect attempt %d/%d failed (transient): %s. Retrying in %ds.",
+                        attempt + 1, max_attempts, exc, delay,
+                    )
+                    await asyncio.sleep(delay)
+                else:
+                    logger.error(
+                        "Failed to connect to GitLab after %d attempts: %s",
+                        max_attempts, exc,
+                    )
+        assert last_error is not None  # max_attempts >= 1, loop always assigns last_error on failure
+        raise last_error
 
     async def disconnect(self) -> None:
         """Close GitLab connection."""
         self._gl = None
         self._project = None
 
-    async def get_head_commit_sha(self, ref: str = "main") -> str | None:
-        """Return the current HEAD commit SHA from GitLab."""
+    async def get_head_commit_sha(self, ref: str | None = None) -> str | None:
+        """Return the current HEAD commit SHA from GitLab.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_ref = ref if ref is not None else settings.git.default_branch
         project = self._require_project()
 
         def _head() -> str | None:
-            commits = project.commits.list(ref_name=ref, per_page=1)
+            commits = project.commits.list(ref_name=effective_ref, per_page=1)
             if not commits:
                 return None
             return commits[0].id
@@ -176,11 +232,12 @@ class GitLabService(GitProvider):
 
     async def list_tenants(self) -> list[str]:
         """List tenant IDs from the catalog repository."""
+        default_ref = settings.git.default_branch
         project = self._require_project()
 
         def _list() -> list[str]:
             try:
-                tree = project.repository_tree(path="tenants", ref="main")
+                tree = project.repository_tree(path="tenants", ref=default_ref)
             except gitlab.exceptions.GitlabGetError:
                 return []
             return [item["name"] for item in tree if item["type"] == "tree"]
@@ -217,27 +274,35 @@ class GitLabService(GitProvider):
             raise RuntimeError(f"git clone failed: {safe_stderr}")
         return tmp_dir / "repo"
 
-    async def get_file_content(self, project_id: str, file_path: str, ref: str = "main") -> str:
-        """Retrieve raw file content from GitLab."""
+    async def get_file_content(self, project_id: str, file_path: str, ref: str | None = None) -> str:
+        """Retrieve raw file content from GitLab.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_ref = ref if ref is not None else settings.git.default_branch
         gl = self._require_gl()
 
         def _get() -> str:
             project = gl.projects.get(project_id)
             try:
-                f = project.files.get(file_path, ref=ref)
+                f = project.files.get(file_path, ref=effective_ref)
                 return f.decode().decode("utf-8")
             except gitlab.exceptions.GitlabGetError as exc:
                 raise FileNotFoundError(f"{file_path} not found in project {project_id}") from exc
 
         return await _gl_run(_get, "gitlab.get_file_content")
 
-    async def list_files(self, project_id: str, path: str = "", ref: str = "main") -> list[str]:
-        """List files in a GitLab repository directory."""
+    async def list_files(self, project_id: str, path: str = "", ref: str | None = None) -> list[str]:
+        """List files in a GitLab repository directory.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_ref = ref if ref is not None else settings.git.default_branch
         gl = self._require_gl()
 
         def _list() -> list[str]:
             project = gl.projects.get(project_id)
-            items = project.repository_tree(path=path, ref=ref, per_page=100, all=True)
+            items = project.repository_tree(path=path, ref=effective_ref, per_page=100, all=True)
             return [item["path"] for item in items]
 
         return await _gl_run(_list, "gitlab.list_files")
@@ -342,10 +407,12 @@ settings:
             {"action": "create", "file_path": f"{tenant_path}/applications/.gitkeep", "content": ""},
         ]
 
+        default_branch = settings.git.default_branch
+
         def _commit() -> None:
             project.commits.create(
                 {
-                    "branch": "main",
+                    "branch": default_branch,
                     "commit_message": f"Create tenant {tenant_id}",
                     "actions": actions,
                 }
@@ -361,12 +428,13 @@ settings:
 
     async def get_tenant(self, tenant_id: str) -> dict | None:
         """Get tenant configuration from GitLab."""
+        default_ref = settings.git.default_branch
         project = self._require_project()
         path = f"{self._get_tenant_path(tenant_id)}/tenant.yaml"
 
         def _get() -> dict | None:
             try:
-                file = project.files.get(path, ref="main")
+                file = project.files.get(path, ref=default_ref)
                 return yaml.safe_load(file.decode())
             except gitlab.exceptions.GitlabGetError:
                 return None
@@ -375,12 +443,13 @@ settings:
 
     async def _ensure_tenant_exists(self, tenant_id: str) -> bool:
         """Check if tenant exists, create structure if not."""
+        default_ref = settings.git.default_branch
         project = self._require_project()
         path = f"{self._get_tenant_path(tenant_id)}/tenant.yaml"
 
         def _exists() -> bool:
             try:
-                project.files.get(path, ref="main")
+                project.files.get(path, ref=default_ref)
                 return True
             except gitlab.exceptions.GitlabGetError:
                 return False
@@ -396,12 +465,13 @@ settings:
 
     async def _api_exists(self, tenant_id: str, api_name: str) -> bool:
         """Check if API already exists."""
+        default_ref = settings.git.default_branch
         project = self._require_project()
         path = f"{self._get_api_path(tenant_id, api_name)}/api.yaml"
 
         def _check() -> bool:
             try:
-                project.files.get(path, ref="main")
+                project.files.get(path, ref=default_ref)
                 return True
             except gitlab.exceptions.GitlabGetError:
                 return False
@@ -453,11 +523,13 @@ settings:
                 }
             )
 
+        default_branch = settings.git.default_branch
+
         def _commit() -> None:
             try:
                 project.commits.create(
                     {
-                        "branch": "main",
+                        "branch": default_branch,
                         "commit_message": f"Create API {api_name} for tenant {tenant_id}",
                         "actions": actions,
                     }
@@ -479,12 +551,13 @@ settings:
 
     async def get_api(self, tenant_id: str, api_name: str) -> dict | None:
         """Get API configuration from GitLab."""
+        default_ref = settings.git.default_branch
         project = self._require_project()
         path = f"{self._get_api_path(tenant_id, api_name)}/api.yaml"
 
         def _get() -> dict | None:
             try:
-                file = project.files.get(path, ref="main")
+                file = project.files.get(path, ref=default_ref)
                 raw_data = yaml.safe_load(file.decode())
                 return _normalize_api_data(raw_data)
             except gitlab.exceptions.GitlabGetError:
@@ -497,6 +570,7 @@ settings:
 
     async def get_api_openapi_spec(self, tenant_id: str, api_name: str) -> dict | None:
         """Get OpenAPI specification for an API from GitLab."""
+        default_ref = settings.git.default_branch
         project = self._require_project()
         base = self._get_api_path(tenant_id, api_name)
 
@@ -504,7 +578,7 @@ settings:
             try:
                 for filename in ("openapi.yaml", "openapi.yml", "openapi.json"):
                     try:
-                        file = project.files.get(f"{base}/{filename}", ref="main")
+                        file = project.files.get(f"{base}/{filename}", ref=default_ref)
                         content = file.decode()
                         if filename.endswith(".json"):
                             import json
@@ -522,12 +596,13 @@ settings:
 
     async def list_apis(self, tenant_id: str) -> list[dict]:
         """List all APIs for a tenant."""
+        default_ref = settings.git.default_branch
         project = self._require_project()
         base = f"{self._get_tenant_path(tenant_id)}/apis"
 
         def _list_dirs() -> list[str]:
             try:
-                tree = project.repository_tree(path=base, ref="main")
+                tree = project.repository_tree(path=base, ref=default_ref)
             except gitlab.exceptions.GitlabGetError:
                 return []
             return [item["name"] for item in tree if item["type"] == "tree" and item["name"] != ".gitkeep"]
@@ -546,12 +621,13 @@ settings:
 
     async def list_apis_parallel(self, tenant_id: str) -> list[dict]:
         """List APIs for a tenant with parallel fetching (CAB-688)."""
+        default_ref = settings.git.default_branch
         project = self._require_project()
         base = f"{self._get_tenant_path(tenant_id)}/apis"
 
         def _list_dirs() -> list[str]:
             try:
-                tree = project.repository_tree(path=base, ref="main")
+                tree = project.repository_tree(path=base, ref=default_ref)
             except gitlab.exceptions.GitlabGetError:
                 return []
             return [item["name"] for item in tree if item["type"] == "tree" and item["name"] != ".gitkeep"]
@@ -590,10 +666,11 @@ settings:
 
     async def get_full_tree_recursive(self, path: str = "tenants") -> list[dict]:
         """Get full repository tree in ONE call (CAB-688 obligation #5)."""
+        default_ref = settings.git.default_branch
         project = self._require_project()
 
         def _tree() -> list[dict]:
-            return list(project.repository_tree(path=path, ref="main", recursive=True, per_page=1000, all=True))
+            return list(project.repository_tree(path=path, ref=default_ref, recursive=True, per_page=1000, all=True))
 
         return await _gl_run(_tree, "gitlab.get_full_tree_recursive", timeout=BATCH_TIMEOUT_S)
 
@@ -617,16 +694,17 @@ settings:
         Uses ``last_commit_id`` for optimistic concurrency (GitLab server
         rejects the save with 400 if another writer moved the pointer).
         """
+        default_branch = settings.git.default_branch
         project = self._require_project()
         path = f"{self._get_api_path(tenant_id, api_name)}/api.yaml"
 
         def _update() -> None:
-            file = project.files.get(path, ref="main")
+            file = project.files.get(path, ref=default_branch)
             current = yaml.safe_load(file.decode())
             current.update(api_data)
             file.content = yaml.dump(current, default_flow_style=False, allow_unicode=True)
             save_kwargs: dict[str, Any] = {
-                "branch": "main",
+                "branch": default_branch,
                 "commit_message": f"Update API {api_name}",
             }
             last_commit_id = getattr(file, "last_commit_id", None)
@@ -644,11 +722,12 @@ settings:
 
     async def delete_api(self, tenant_id: str, api_name: str) -> bool:
         """Delete API from GitLab."""
+        default_branch = settings.git.default_branch
         project = self._require_project()
         api_path = self._get_api_path(tenant_id, api_name)
 
         def _delete() -> None:
-            tree = project.repository_tree(path=api_path, ref="main", recursive=True)
+            tree = project.repository_tree(path=api_path, ref=default_branch, recursive=True)
             actions = [
                 {"action": "delete", "file_path": item["path"]}
                 for item in tree
@@ -657,7 +736,7 @@ settings:
             if actions:
                 project.commits.create(
                     {
-                        "branch": "main",
+                        "branch": default_branch,
                         "commit_message": f"Delete API {api_name}",
                         "actions": actions,
                     }
@@ -676,9 +755,18 @@ settings:
     # ============================================================
 
     async def create_file(
-        self, project_id: str, file_path: str, content: str, commit_message: str, branch: str = "main"
+        self,
+        project_id: str,
+        file_path: str,
+        content: str,
+        commit_message: str,
+        branch: str | None = None,
     ) -> dict[str, Any]:
-        """Create a new file in GitLab."""
+        """Create a new file in GitLab.
+
+        ``branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_branch = branch if branch is not None else settings.git.default_branch
         gl = self._require_gl()
         fallback = self._project
 
@@ -690,7 +778,7 @@ settings:
                 project.files.create(
                     {
                         "file_path": file_path,
-                        "branch": branch,
+                        "branch": effective_branch,
                         "content": content,
                         "commit_message": commit_message,
                     }
@@ -704,9 +792,18 @@ settings:
         return await _gl_run(_create, "gitlab.create_file")
 
     async def update_file(
-        self, project_id: str, file_path: str, content: str, commit_message: str, branch: str = "main"
+        self,
+        project_id: str,
+        file_path: str,
+        content: str,
+        commit_message: str,
+        branch: str | None = None,
     ) -> dict[str, Any]:
-        """Update an existing file in GitLab (uses last_commit_id)."""
+        """Update an existing file in GitLab (uses last_commit_id).
+
+        ``branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_branch = branch if branch is not None else settings.git.default_branch
         gl = self._require_gl()
         fallback = self._project
 
@@ -715,9 +812,9 @@ settings:
             if project is None:
                 raise RuntimeError("GitLab not connected")
             try:
-                f = project.files.get(file_path, ref=branch)
+                f = project.files.get(file_path, ref=effective_branch)
                 f.content = content
-                save_kwargs: dict[str, Any] = {"branch": branch, "commit_message": commit_message}
+                save_kwargs: dict[str, Any] = {"branch": effective_branch, "commit_message": commit_message}
                 last_commit_id = getattr(f, "last_commit_id", None)
                 if isinstance(last_commit_id, str) and last_commit_id:
                     save_kwargs["last_commit_id"] = last_commit_id
@@ -728,8 +825,18 @@ settings:
 
         return await _gl_run(_update, "gitlab.update_file")
 
-    async def delete_file(self, project_id: str, file_path: str, commit_message: str, branch: str = "main") -> bool:
-        """Delete a file from GitLab (uses last_commit_id)."""
+    async def delete_file(
+        self,
+        project_id: str,
+        file_path: str,
+        commit_message: str,
+        branch: str | None = None,
+    ) -> bool:
+        """Delete a file from GitLab (uses last_commit_id).
+
+        ``branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_branch = branch if branch is not None else settings.git.default_branch
         gl = self._require_gl()
         fallback = self._project
 
@@ -738,8 +845,8 @@ settings:
             if project is None:
                 raise RuntimeError("GitLab not connected")
             try:
-                f = project.files.get(file_path, ref=branch)
-                delete_kwargs: dict[str, Any] = {"branch": branch, "commit_message": commit_message}
+                f = project.files.get(file_path, ref=effective_branch)
+                delete_kwargs: dict[str, Any] = {"branch": effective_branch, "commit_message": commit_message}
                 last_commit_id = getattr(f, "last_commit_id", None)
                 if isinstance(last_commit_id, str) and last_commit_id:
                     delete_kwargs["last_commit_id"] = last_commit_id
@@ -755,9 +862,13 @@ settings:
         project_id: str,
         actions: list[dict[str, str]],
         commit_message: str,
-        branch: str = "main",
+        branch: str | None = None,
     ) -> dict[str, Any]:
-        """Atomic multi-file commit via GitLab commits API."""
+        """Atomic multi-file commit via GitLab commits API.
+
+        ``branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_branch = branch if branch is not None else settings.git.default_branch
         gl = self._require_gl()
         fallback = self._project
 
@@ -765,19 +876,25 @@ settings:
             project = gl.projects.get(project_id) if project_id else fallback
             if project is None:
                 raise RuntimeError("GitLab not connected")
-            project.commits.create({"branch": branch, "commit_message": commit_message, "actions": actions})
+            project.commits.create(
+                {"branch": effective_branch, "commit_message": commit_message, "actions": actions}
+            )
             return {"sha": "", "url": ""}
 
         return await _gl_run(_commit, "gitlab.batch_commit", timeout=BATCH_TIMEOUT_S)
 
     # Git operations
-    async def get_file(self, path: str, ref: str = "main") -> str | None:
-        """Get file content from GitLab."""
+    async def get_file(self, path: str, ref: str | None = None) -> str | None:
+        """Get file content from GitLab.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_ref = ref if ref is not None else settings.git.default_branch
         project = self._require_project()
 
         def _get() -> str | None:
             try:
-                file = project.files.get(path, ref=ref)
+                file = project.files.get(path, ref=effective_ref)
                 return file.decode().decode("utf-8")
             except gitlab.exceptions.GitlabGetError:
                 return None
@@ -785,11 +902,17 @@ settings:
         return await _gl_run(_get, "gitlab.get_file")
 
     async def list_commits(self, path: str | None = None, limit: int = 20) -> list[dict]:
-        """List commits for a path."""
+        """List commits for a path.
+
+        CP-1 P2 (L.1): paginate via ``iterator=True`` so requests with
+        ``limit`` > 20 no longer silently truncate at the first page.
+        """
         project = self._require_project()
 
         def _list() -> list[dict]:
-            commits = project.commits.list(path=path, per_page=limit)
+            iterator = project.commits.list(
+                path=path, per_page=min(limit, 100), iterator=True
+            )
             return [
                 {
                     "sha": c.id,
@@ -797,7 +920,7 @@ settings:
                     "author": c.author_name,
                     "date": c.created_at,
                 }
-                for c in commits
+                for c in itertools.islice(iterator, limit)
             ]
 
         return await _gl_run(_list, "gitlab.list_commits")
@@ -867,12 +990,13 @@ settings:
 
     async def get_mcp_server(self, tenant_id: str, server_name: str) -> dict | None:
         """Get MCP server configuration from GitLab."""
+        default_ref = settings.git.default_branch
         project = self._require_project()
         server_path = self._get_mcp_server_path(tenant_id, server_name)
 
         def _get() -> dict | None:
             try:
-                file = project.files.get(f"{server_path}/server.yaml", ref="main")
+                file = project.files.get(f"{server_path}/server.yaml", ref=default_ref)
                 raw_data = yaml.safe_load(file.decode())
                 return self._normalize_mcp_server_data(raw_data, server_path)
             except gitlab.exceptions.GitlabGetError:
@@ -885,6 +1009,7 @@ settings:
 
     async def list_mcp_servers(self, tenant_id: str = "_platform") -> list[dict]:
         """List all MCP servers for a tenant or platform."""
+        default_ref = settings.git.default_branch
         project = self._require_project()
         base_path = (
             "platform/mcp-servers"
@@ -894,7 +1019,7 @@ settings:
 
         def _list_names() -> list[str]:
             try:
-                tree = project.repository_tree(path=base_path, ref="main")
+                tree = project.repository_tree(path=base_path, ref=default_ref)
             except gitlab.exceptions.GitlabGetError:
                 return []
             return [item["name"] for item in tree if item["type"] == "tree" and item["name"] != ".gitkeep"]
@@ -908,25 +1033,34 @@ settings:
         return servers
 
     async def list_all_mcp_servers(self) -> list[dict]:
-        """List all MCP servers across platform and all tenants."""
-        project = self._require_project()
-        all_servers: list[dict] = []
+        """List all MCP servers across platform and all tenants.
 
-        platform_servers = await self.list_mcp_servers("_platform")
-        all_servers.extend(platform_servers)
+        CP-1 P2 (M.6): fans out tenant listings via ``asyncio.gather`` so
+        100 tenants no longer serialise into 100 round-trips. The provider
+        semaphore ``GITLAB_SEMAPHORE`` inside ``_gl_run`` keeps the overall
+        concurrency bounded.
+        """
+        default_ref = settings.git.default_branch
+        project = self._require_project()
 
         def _list_tenant_ids() -> list[str]:
             try:
-                tenants_tree = project.repository_tree(path="tenants", ref="main")
+                tenants_tree = project.repository_tree(path="tenants", ref=default_ref)
             except gitlab.exceptions.GitlabGetError:
                 return []
             return [item["name"] for item in tenants_tree if item["type"] == "tree"]
 
+        # Fetch platform + tenant id list in parallel so the tenant
+        # enumeration doesn't wait for platform.
+        platform_servers_task = asyncio.create_task(self.list_mcp_servers("_platform"))
         tenant_ids = await _gl_run(_list_tenant_ids, "gitlab.list_all_mcp_servers.tenants")
-        for tenant_id in tenant_ids:
-            tenant_servers = await self.list_mcp_servers(tenant_id)
-            all_servers.extend(tenant_servers)
-        return all_servers
+
+        tenant_results = await asyncio.gather(
+            *[self.list_mcp_servers(tid) for tid in tenant_ids]
+        )
+        platform_servers = await platform_servers_task
+
+        return list(itertools.chain(platform_servers, *tenant_results))
 
     async def create_mcp_server(self, tenant_id: str, server_data: dict) -> str:
         """Create MCP server definition in GitLab."""
@@ -969,10 +1103,12 @@ settings:
             allow_unicode=True,
         )
 
+        default_branch = settings.git.default_branch
+
         def _commit() -> None:
             project.commits.create(
                 {
-                    "branch": "main",
+                    "branch": default_branch,
                     "commit_message": f"Create MCP server {server_name}",
                     "actions": [
                         {
@@ -994,11 +1130,12 @@ settings:
 
     async def update_mcp_server(self, tenant_id: str, server_name: str, server_data: dict) -> bool:
         """Update MCP server configuration in GitLab."""
+        default_branch = settings.git.default_branch
         project = self._require_project()
         server_path = self._get_mcp_server_path(tenant_id, server_name)
 
         def _update() -> None:
-            file = project.files.get(f"{server_path}/server.yaml", ref="main")
+            file = project.files.get(f"{server_path}/server.yaml", ref=default_branch)
             current = yaml.safe_load(file.decode())
 
             if "spec" not in current:
@@ -1020,7 +1157,7 @@ settings:
 
             file.content = yaml.dump(current, default_flow_style=False, allow_unicode=True)
             save_kwargs: dict[str, Any] = {
-                "branch": "main",
+                "branch": default_branch,
                 "commit_message": f"Update MCP server {server_name}",
             }
             last_commit_id = getattr(file, "last_commit_id", None)
@@ -1038,11 +1175,12 @@ settings:
 
     async def delete_mcp_server(self, tenant_id: str, server_name: str) -> bool:
         """Delete MCP server from GitLab."""
+        default_branch = settings.git.default_branch
         project = self._require_project()
         server_path = self._get_mcp_server_path(tenant_id, server_name)
 
         def _delete() -> None:
-            tree = project.repository_tree(path=server_path, ref="main", recursive=True)
+            tree = project.repository_tree(path=server_path, ref=default_branch, recursive=True)
             actions = [
                 {"action": "delete", "file_path": item["path"]}
                 for item in tree
@@ -1051,7 +1189,7 @@ settings:
             if actions:
                 project.commits.create(
                     {
-                        "branch": "main",
+                        "branch": default_branch,
                         "commit_message": f"Delete MCP server {server_name}",
                         "actions": actions,
                     }
@@ -1069,19 +1207,28 @@ settings:
     # CAB-1889 CP-1: provider-agnostic surface (GitProvider ABC).
     # ============================================================
 
-    async def list_tree(self, path: str, ref: str = "main") -> list[TreeEntry]:
+    async def list_tree(self, path: str, ref: str | None = None) -> list[TreeEntry]:
+        """List immediate children of ``path`` in the catalog repo.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_ref = ref if ref is not None else settings.git.default_branch
         project = self._require_project()
 
         def _list() -> list[TreeEntry]:
             try:
-                tree = project.repository_tree(path=path, ref=ref)
+                tree = project.repository_tree(path=path, ref=effective_ref)
             except gitlab.exceptions.GitlabGetError:
                 return []
             return [TreeEntry(name=item["name"], type=item["type"], path=item["path"]) for item in tree]
 
         return await _gl_run(_list, "gitlab.list_tree")
 
-    async def read_file(self, path: str, ref: str = "main") -> str | None:
+    async def read_file(self, path: str, ref: str | None = None) -> str | None:
+        """Return catalog file content or ``None`` if missing.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
         return await self.get_file(path, ref=ref)
 
     async def list_path_commits(self, path: str | None, limit: int = 20) -> list[CommitRef]:
@@ -1089,7 +1236,7 @@ settings:
         return [CommitRef(sha=c["sha"], message=c["message"], author=c["author"], date=c["date"]) for c in raw]
 
     async def write_file(
-        self, path: str, content: str, commit_message: str, branch: str = "main"
+        self, path: str, content: str, commit_message: str, branch: str | None = None
     ) -> Literal["created", "updated"]:
         """CP-1 C.6: create-first, fall through to update on 'already exists'.
 
@@ -1098,30 +1245,45 @@ settings:
         both hitting the 'already exists' branch can still lose one another's
         content. update_file passes ``last_commit_id`` for GitLab-side
         optimistic concurrency on that second step.
+
+        CP-1 P2 (M.4): ``branch=None`` resolves to ``settings.git.default_branch``.
         """
+        effective_branch = branch if branch is not None else settings.git.default_branch
         project_id = ""
         _ = self._require_project()
         try:
-            await self.create_file(project_id, path, content, commit_message, branch=branch)
+            await self.create_file(project_id, path, content, commit_message, branch=effective_branch)
             return "created"
         except ValueError:
-            await self.update_file(project_id, path, content, commit_message, branch=branch)
+            await self.update_file(project_id, path, content, commit_message, branch=effective_branch)
             return "updated"
 
-    async def remove_file(self, path: str, commit_message: str, branch: str = "main") -> bool:
+    async def remove_file(self, path: str, commit_message: str, branch: str | None = None) -> bool:
+        """Delete a file from the catalog repo.
+
+        ``branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_branch = branch if branch is not None else settings.git.default_branch
         project = self._require_project()
 
         def _delete() -> bool:
-            project.files.delete(file_path=path, commit_message=commit_message, branch=branch)
+            project.files.delete(
+                file_path=path, commit_message=commit_message, branch=effective_branch
+            )
             return True
 
         return await _gl_run(_delete, "gitlab.remove_file")
 
     async def list_branches(self) -> list[BranchRef]:
+        """List all branches on the catalog repo.
+
+        CP-1 P2 (L.1): ``get_all=True`` so catalogs with >20 branches no
+        longer silently truncate at the first page.
+        """
         project = self._require_project()
 
         def _list() -> list[BranchRef]:
-            branches = project.branches.list()
+            branches = project.branches.list(get_all=True)
             return [
                 BranchRef(
                     name=b.name,
@@ -1133,11 +1295,16 @@ settings:
 
         return await _gl_run(_list, "gitlab.list_branches")
 
-    async def create_branch(self, name: str, ref: str = "main") -> BranchRef:
+    async def create_branch(self, name: str, ref: str | None = None) -> BranchRef:
+        """Create a branch on the catalog repo.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_ref = ref if ref is not None else settings.git.default_branch
         project = self._require_project()
 
         def _create() -> BranchRef:
-            b = project.branches.create({"branch": name, "ref": ref})
+            b = project.branches.create({"branch": name, "ref": effective_ref})
             return BranchRef(
                 name=b.name,
                 commit_sha=b.commit["id"] if isinstance(b.commit, dict) else str(b.commit),
@@ -1163,10 +1330,15 @@ settings:
         )
 
     async def list_merge_requests(self, state: str = "opened") -> list[MergeRequestRef]:
+        """List merge requests on the catalog repo.
+
+        CP-1 P2 (L.1): ``get_all=True`` so catalogs with >20 open MRs no
+        longer silently truncate at the first page.
+        """
         project = self._require_project()
 
         def _list() -> list[MergeRequestRef]:
-            mrs = project.mergerequests.list(state=state)
+            mrs = project.mergerequests.list(state=state, get_all=True)
             return [self._mr_to_ref(mr) for mr in mrs]
 
         return await _gl_run(_list, "gitlab.list_merge_requests")
@@ -1176,8 +1348,15 @@ settings:
         title: str,
         description: str,
         source_branch: str,
-        target_branch: str = "main",
+        target_branch: str | None = None,
     ) -> MergeRequestRef:
+        """Open a merge request.
+
+        ``target_branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_target = (
+            target_branch if target_branch is not None else settings.git.default_branch
+        )
         project = self._require_project()
 
         def _create() -> MergeRequestRef:
@@ -1186,7 +1365,7 @@ settings:
                     "title": title,
                     "description": description,
                     "source_branch": source_branch,
-                    "target_branch": target_branch,
+                    "target_branch": effective_target,
                 }
             )
             return self._mr_to_ref(mr)
@@ -1194,10 +1373,19 @@ settings:
         return await _gl_run(_create, "gitlab.create_merge_request")
 
     async def merge_merge_request(self, iid: int) -> MergeRequestRef:
+        """Merge an MR by iid.
+
+        CP-1 P2 (M.2): idempotent when the MR is already merged. Short-circuits
+        **only** on ``state == "merged"``; closed-unmerged still falls through
+        to ``mr.merge()`` so the provider error surfaces correctly. python-gitlab
+        mutates the MR instance during ``merge()``, so no re-fetch is needed.
+        """
         project = self._require_project()
 
         def _merge() -> MergeRequestRef:
             mr = project.mergerequests.get(iid)
+            if mr.state == "merged":
+                return self._mr_to_ref(mr)
             mr.merge()
             return self._mr_to_ref(mr)
 

--- a/control-plane-api/src/services/github_service.py
+++ b/control-plane-api/src/services/github_service.py
@@ -20,6 +20,7 @@ it after ``await`` would re-introduce the blocking sync-in-async pattern.
 """
 
 import asyncio
+import itertools
 import json
 import logging
 import re
@@ -28,8 +29,9 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal, TypeVar
 
+import requests.exceptions  # type: ignore[import-untyped]
 import yaml
-from github import Auth, Github, GithubException, InputGitTreeElement
+from github import Auth, BadCredentialsException, Github, GithubException, InputGitTreeElement
 
 from ..config import settings
 from .git_credentials import askpass_env, redact_token
@@ -77,6 +79,35 @@ async def _gh_meta_write(
     return await run_sync(
         fn, semaphore=GITHUB_META_WRITE_SEMAPHORE, timeout=timeout, op_name=op_name
     )
+
+
+# CP-1 P2 (M.5): transient error classifier for connect() retries. Kept
+# at module scope so tests can monkey-patch it and so the retry policy
+# is auditable without walking the retry loop.
+_GITHUB_RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
+_GITHUB_NON_RETRYABLE_STATUSES = frozenset({401, 403, 404})
+
+
+def _is_transient_github_error(exc: BaseException) -> bool:
+    """Return True when ``exc`` is worth retrying at connect-time.
+
+    Retry: network errors, asyncio/stdlib TimeoutError, GitHub HTTP errors
+    with status in {429} or 5xx. Fail fast on ``BadCredentialsException``
+    and any ``GithubException`` with status 401/403/404, plus any other
+    exception class.
+    """
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):
+        return True
+    if isinstance(exc, (requests.exceptions.ConnectionError, requests.exceptions.Timeout)):
+        return True
+    if isinstance(exc, BadCredentialsException):
+        return False
+    if isinstance(exc, GithubException):
+        status = getattr(exc, "status", None)
+        if status in _GITHUB_NON_RETRYABLE_STATUSES:
+            return False
+        return status in _GITHUB_RETRYABLE_STATUSES
+    return False
 
 
 def _normalize_api_data(raw_data: dict) -> dict:
@@ -167,20 +198,46 @@ class GitHubService(GitProvider):
         self._gh: Github | None = None
 
     async def connect(self) -> None:
-        """Initialize GitHub connection using settings.git.github.token."""
-        try:
-            auth = Auth.Token(settings.git.github.token.get_secret_value())
+        """Initialize GitHub connection with transient-error retry (CP-1 P2 M.5).
 
-            def _connect() -> tuple[Github, str]:
-                client = Github(auth=auth)
-                login = client.get_user().login
-                return client, login
+        3 attempts, 1s then 2s backoff between retries, 15s per-attempt
+        timeout. Fails fast on credential/404 errors — retrying a 401
+        or a missing repo doesn't help.
+        """
+        auth = Auth.Token(settings.git.github.token.get_secret_value())
 
-            self._gh, user = await _gh_read(_connect, "github.connect", timeout=15.0)
-            logger.info("Connected to GitHub as %s", user)
-        except Exception as e:
-            logger.error("Failed to connect to GitHub: %s", e)
-            raise
+        def _connect() -> tuple[Github, str]:
+            client = Github(auth=auth)
+            login = client.get_user().login
+            return client, login
+
+        max_attempts = 3
+        backoffs = [1, 2]  # 3 attempts = 2 sleeps
+        last_error: BaseException | None = None
+        for attempt in range(max_attempts):
+            try:
+                self._gh, user = await _gh_read(_connect, "github.connect", timeout=15.0)
+                logger.info("Connected to GitHub as %s", user)
+                return
+            except Exception as exc:
+                last_error = exc
+                if not _is_transient_github_error(exc):
+                    logger.error("Failed to connect to GitHub (non-transient): %s", exc)
+                    raise
+                if attempt + 1 < max_attempts:
+                    delay = backoffs[attempt]
+                    logger.warning(
+                        "GitHub connect attempt %d/%d failed (transient): %s. Retrying in %ds.",
+                        attempt + 1, max_attempts, exc, delay,
+                    )
+                    await asyncio.sleep(delay)
+                else:
+                    logger.error(
+                        "Failed to connect to GitHub after %d attempts: %s",
+                        max_attempts, exc,
+                    )
+        assert last_error is not None  # loop always assigns on failure
+        raise last_error
 
     async def disconnect(self) -> None:
         """Close GitHub connection."""
@@ -232,14 +289,18 @@ class GitHubService(GitProvider):
         """
         return self._require_gh().get_repo(project_id)
 
-    async def get_file_content(self, project_id: str, file_path: str, ref: str = "main") -> str:
-        """Retrieve raw file content from GitHub."""
+    async def get_file_content(self, project_id: str, file_path: str, ref: str | None = None) -> str:
+        """Retrieve raw file content from GitHub.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_ref = ref if ref is not None else settings.git.default_branch
         gh = self._require_gh()
 
         def _get() -> str:
             repo = gh.get_repo(project_id)
             try:
-                content_file = repo.get_contents(file_path, ref=ref)
+                content_file = repo.get_contents(file_path, ref=effective_ref)
                 if isinstance(content_file, list):
                     raise FileNotFoundError(f"{file_path} is a directory, not a file, in {project_id}")
                 return content_file.decoded_content.decode("utf-8")
@@ -250,14 +311,18 @@ class GitHubService(GitProvider):
 
         return await _gh_read(_get, "github.get_file_content")
 
-    async def list_files(self, project_id: str, path: str = "", ref: str = "main") -> list[str]:
-        """List files in a GitHub repository directory."""
+    async def list_files(self, project_id: str, path: str = "", ref: str | None = None) -> list[str]:
+        """List files in a GitHub repository directory.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_ref = ref if ref is not None else settings.git.default_branch
         gh = self._require_gh()
 
         def _list() -> list[str]:
             repo = gh.get_repo(project_id)
             try:
-                contents = repo.get_contents(path, ref=ref)
+                contents = repo.get_contents(path, ref=effective_ref)
             except GithubException as exc:
                 if exc.status == 404:
                     return []
@@ -329,15 +394,19 @@ class GitHubService(GitProvider):
 
         return await _gh_read(_info, "github.get_repo_info")
 
-    async def get_head_commit_sha(self, ref: str = "main") -> str | None:
-        """Return the HEAD commit SHA for the catalog branch."""
+    async def get_head_commit_sha(self, ref: str | None = None) -> str | None:
+        """Return the HEAD commit SHA for the catalog branch.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_ref = ref if ref is not None else settings.git.default_branch
         gh = self._require_gh()
         project_id = self._catalog_project_id()
 
         def _head() -> str | None:
             repo = gh.get_repo(project_id)
             try:
-                branch = repo.get_branch(ref)
+                branch = repo.get_branch(effective_ref)
             except GithubException as exc:
                 if exc.status == 404:
                     return None
@@ -363,13 +432,14 @@ class GitHubService(GitProvider):
 
     async def list_tenants(self) -> list[str]:
         """List tenants from the catalog repository."""
+        default_ref = settings.git.default_branch
         gh = self._require_gh()
         project_id = self._catalog_project_id()
 
         def _list() -> list[str]:
             repo = gh.get_repo(project_id)
             try:
-                contents = repo.get_contents("tenants", ref="main")
+                contents = repo.get_contents("tenants", ref=default_ref)
             except GithubException as exc:
                 if exc.status == 404:
                     return []
@@ -399,6 +469,7 @@ class GitHubService(GitProvider):
 
     async def list_apis(self, tenant_id: str) -> list[dict]:
         """List APIs for a tenant from GitHub."""
+        default_ref = settings.git.default_branch
         gh = self._require_gh()
         project_id = self._catalog_project_id()
         base_path = f"{self._get_tenant_path(tenant_id)}/apis"
@@ -406,7 +477,7 @@ class GitHubService(GitProvider):
         def _list_names() -> list[str]:
             repo = gh.get_repo(project_id)
             try:
-                contents = repo.get_contents(base_path, ref="main")
+                contents = repo.get_contents(base_path, ref=default_ref)
             except GithubException as exc:
                 if exc.status == 404:
                     return []
@@ -425,6 +496,7 @@ class GitHubService(GitProvider):
 
     async def list_apis_parallel(self, tenant_id: str) -> list[dict]:
         """List tenant APIs with concurrent GitHub fetches."""
+        default_ref = settings.git.default_branch
         gh = self._require_gh()
         project_id = self._catalog_project_id()
         base_path = f"{self._get_tenant_path(tenant_id)}/apis"
@@ -432,7 +504,7 @@ class GitHubService(GitProvider):
         def _list_names() -> list[str]:
             repo = gh.get_repo(project_id)
             try:
-                contents = repo.get_contents(base_path, ref="main")
+                contents = repo.get_contents(base_path, ref=default_ref)
             except GithubException as exc:
                 if exc.status == 404:
                     return []
@@ -479,12 +551,13 @@ class GitHubService(GitProvider):
 
     async def get_full_tree_recursive(self, path: str = "tenants") -> list[dict]:
         """Return the recursive Git tree in the GitLab-compatible shape."""
+        default_ref = settings.git.default_branch
         gh = self._require_gh()
         project_id = self._catalog_project_id()
 
         def _tree() -> list[dict]:
             repo = gh.get_repo(project_id)
-            branch = repo.get_branch("main")
+            branch = repo.get_branch(default_ref)
             tree = repo.get_git_tree(branch.commit.sha, recursive=True).tree
             prefix = f"{path}/"
             items: list[dict] = []
@@ -546,10 +619,12 @@ class GitHubService(GitProvider):
             else f"{self._get_tenant_path(tenant_id)}/mcp-servers"
         )
 
+        default_ref = settings.git.default_branch
+
         def _list_names() -> list[str]:
             repo = gh.get_repo(project_id)
             try:
-                contents = repo.get_contents(base_path, ref="main")
+                contents = repo.get_contents(base_path, ref=default_ref)
             except GithubException as exc:
                 if exc.status == 404:
                     return []
@@ -563,26 +638,44 @@ class GitHubService(GitProvider):
         return [server for server in results if server is not None]
 
     async def list_all_mcp_servers(self) -> list[dict]:
-        """List all MCP servers across platform and tenant scopes."""
-        servers = await self.list_mcp_servers("_platform")
-        for tenant_id in await self.list_tenants():
-            servers.extend(await self.list_mcp_servers(tenant_id))
-        return servers
+        """List all MCP servers across platform and tenant scopes.
+
+        CP-1 P2 (M.6): fans out tenant listings via ``asyncio.gather`` so
+        100 tenants no longer serialise into 100 round-trips. The provider
+        semaphore ``GITHUB_READ_SEMAPHORE`` inside ``_gh_read`` keeps the
+        overall concurrency bounded.
+        """
+        platform_servers_task = asyncio.create_task(self.list_mcp_servers("_platform"))
+        tenant_ids = await self.list_tenants()
+        tenant_results = await asyncio.gather(
+            *[self.list_mcp_servers(tid) for tid in tenant_ids]
+        )
+        platform_servers = await platform_servers_task
+        return list(itertools.chain(platform_servers, *tenant_results))
 
     # ============================================================
     # Write operations (CAB-2011: GitOps source of truth)
     # ============================================================
 
     async def create_file(
-        self, project_id: str, file_path: str, content: str, commit_message: str, branch: str = "main"
+        self,
+        project_id: str,
+        file_path: str,
+        content: str,
+        commit_message: str,
+        branch: str | None = None,
     ) -> dict[str, Any]:
-        """Create a new file in a GitHub repository (Contents API — serial)."""
+        """Create a new file in a GitHub repository (Contents API — serial).
+
+        ``branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_branch = branch if branch is not None else settings.git.default_branch
         gh = self._require_gh()
 
         def _create() -> dict[str, Any]:
             repo = gh.get_repo(project_id)
             try:
-                result = repo.create_file(file_path, commit_message, content, branch=branch)
+                result = repo.create_file(file_path, commit_message, content, branch=effective_branch)
                 return {"sha": result["commit"].sha, "url": result["commit"].html_url}
             except GithubException as exc:
                 if exc.status == 422 and "sha" in str(exc.data).lower():
@@ -592,18 +685,29 @@ class GitHubService(GitProvider):
         return await _gh_contents_write(_create, "github.create_file")
 
     async def update_file(
-        self, project_id: str, file_path: str, content: str, commit_message: str, branch: str = "main"
+        self,
+        project_id: str,
+        file_path: str,
+        content: str,
+        commit_message: str,
+        branch: str | None = None,
     ) -> dict[str, Any]:
-        """Update an existing file in a GitHub repository (Contents API — serial)."""
+        """Update an existing file in a GitHub repository (Contents API — serial).
+
+        ``branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_branch = branch if branch is not None else settings.git.default_branch
         gh = self._require_gh()
 
         def _update() -> dict[str, Any]:
             repo = gh.get_repo(project_id)
             try:
-                existing = repo.get_contents(file_path, ref=branch)
+                existing = repo.get_contents(file_path, ref=effective_branch)
                 if isinstance(existing, list):
                     raise ValueError(f"{file_path} is a directory, not a file")
-                result = repo.update_file(file_path, commit_message, content, existing.sha, branch=branch)
+                result = repo.update_file(
+                    file_path, commit_message, content, existing.sha, branch=effective_branch
+                )
                 return {"sha": result["commit"].sha, "url": result["commit"].html_url}
             except GithubException as exc:
                 if exc.status == 404:
@@ -612,17 +716,27 @@ class GitHubService(GitProvider):
 
         return await _gh_contents_write(_update, "github.update_file")
 
-    async def delete_file(self, project_id: str, file_path: str, commit_message: str, branch: str = "main") -> bool:
-        """Delete a file from a GitHub repository (Contents API — serial)."""
+    async def delete_file(
+        self,
+        project_id: str,
+        file_path: str,
+        commit_message: str,
+        branch: str | None = None,
+    ) -> bool:
+        """Delete a file from a GitHub repository (Contents API — serial).
+
+        ``branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_branch = branch if branch is not None else settings.git.default_branch
         gh = self._require_gh()
 
         def _delete() -> bool:
             repo = gh.get_repo(project_id)
             try:
-                existing = repo.get_contents(file_path, ref=branch)
+                existing = repo.get_contents(file_path, ref=effective_branch)
                 if isinstance(existing, list):
                     raise ValueError(f"{file_path} is a directory, not a file")
-                repo.delete_file(file_path, commit_message, existing.sha, branch=branch)
+                repo.delete_file(file_path, commit_message, existing.sha, branch=effective_branch)
                 return True
             except GithubException as exc:
                 if exc.status == 404:
@@ -636,19 +750,22 @@ class GitHubService(GitProvider):
         project_id: str,
         actions: list[dict[str, str]],
         commit_message: str,
-        branch: str = "main",
+        branch: str | None = None,
     ) -> dict[str, Any]:
         """Atomic multi-file commit via the Git Tree API.
 
         Uses the Git Data tree path (not strictly Contents), but held under
         the Contents-write semaphore to keep a single write lane and
         preserve the "no parallel mutations" invariant.
+
+        ``branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
         """
+        effective_branch = branch if branch is not None else settings.git.default_branch
         gh = self._require_gh()
 
         def _commit() -> dict[str, Any]:
             repo = gh.get_repo(project_id)
-            ref = repo.get_git_ref(f"heads/{branch}")
+            ref = repo.get_git_ref(f"heads/{effective_branch}")
             base_sha = ref.object.sha
             base_tree = repo.get_git_tree(base_sha)
 
@@ -671,7 +788,8 @@ class GitHubService(GitProvider):
             new_commit = repo.create_git_commit(commit_message, new_tree, [repo.get_git_commit(base_sha)])
             ref.edit(new_commit.sha)
             logger.info(
-                "Batch commit %s on %s/%s (%d actions)", new_commit.sha[:8], project_id, branch, len(actions)
+                "Batch commit %s on %s/%s (%d actions)",
+                new_commit.sha[:8], project_id, effective_branch, len(actions),
             )
             return {"sha": new_commit.sha, "url": new_commit.html_url}
 
@@ -684,14 +802,18 @@ class GitHubService(GitProvider):
         title: str,
         body: str,
         actions: list[dict[str, str]],
-        base: str = "main",
+        base: str | None = None,
     ) -> dict[str, Any]:
-        """Create a branch with changes and open a pull request."""
+        """Create a branch with changes and open a pull request.
+
+        ``base=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_base = base if base is not None else settings.git.default_branch
         gh = self._require_gh()
 
         def _create_branch() -> None:
             repo = gh.get_repo(project_id)
-            base_ref = repo.get_git_ref(f"heads/{base}")
+            base_ref = repo.get_git_ref(f"heads/{effective_base}")
             repo.create_git_ref(f"refs/heads/{branch}", base_ref.object.sha)
 
         await _gh_meta_write(_create_branch, "github.create_pr.branch")
@@ -701,7 +823,7 @@ class GitHubService(GitProvider):
 
         def _open_pr() -> dict[str, Any]:
             repo = gh.get_repo(project_id)
-            pr = repo.create_pull(title=title, body=body, head=branch, base=base)
+            pr = repo.create_pull(title=title, body=body, head=branch, base=effective_base)
             logger.info("Created PR #%d on %s: %s", pr.number, project_id, title)
             return {"pr_number": pr.number, "url": pr.html_url}
 
@@ -729,13 +851,15 @@ class GitHubService(GitProvider):
             return f"platform/mcp-servers/{server_name}"
         return f"tenants/{tenant_id}/mcp-servers/{server_name}"
 
-    async def _file_exists(self, project_id: str, file_path: str, ref: str = "main") -> bool:
+    async def _file_exists(self, project_id: str, file_path: str, ref: str | None = None) -> bool:
         """Check if a file exists in the repository.
 
         NOTE (C.6): not used by :meth:`write_file` anymore. Retained for
         :meth:`create_api` / :meth:`update_api` where the pre-check is
         about producing a specific error shape to callers rather than
         race-guarding a write.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
         """
         try:
             await self.get_file_content(project_id, file_path, ref=ref)
@@ -883,6 +1007,7 @@ class GitHubService(GitProvider):
 
     async def delete_api(self, tenant_id: str, api_name: str) -> bool:
         """Delete API directory from GitHub."""
+        default_ref = settings.git.default_branch
         project_id = self._catalog_project_id()
         api_path = self._get_api_path(tenant_id, api_name)
         gh = self._require_gh()
@@ -890,7 +1015,7 @@ class GitHubService(GitProvider):
         def _collect_files() -> list[str]:
             repo = gh.get_repo(project_id)
             try:
-                contents = repo.get_contents(api_path, ref="main")
+                contents = repo.get_contents(api_path, ref=default_ref)
             except GithubException as exc:
                 if exc.status == 404:
                     raise FileNotFoundError(f"API '{api_name}' not found for tenant '{tenant_id}'") from exc
@@ -901,7 +1026,7 @@ class GitHubService(GitProvider):
             while stack:
                 item = stack.pop()
                 if item.type == "dir":
-                    sub_contents = repo.get_contents(item.path, ref="main")
+                    sub_contents = repo.get_contents(item.path, ref=default_ref)
                     stack.extend(sub_contents if isinstance(sub_contents, list) else [sub_contents])
                 else:
                     files_to_delete.append(item.path)
@@ -1005,6 +1130,7 @@ class GitHubService(GitProvider):
 
     async def delete_mcp_server(self, tenant_id: str, server_name: str) -> bool:
         """Delete MCP server from GitHub."""
+        default_ref = settings.git.default_branch
         project_id = self._catalog_project_id()
         server_path = self._get_mcp_server_path(tenant_id, server_name)
         gh = self._require_gh()
@@ -1012,7 +1138,7 @@ class GitHubService(GitProvider):
         def _collect_files() -> list[str]:
             repo = gh.get_repo(project_id)
             try:
-                contents = repo.get_contents(server_path, ref="main")
+                contents = repo.get_contents(server_path, ref=default_ref)
             except GithubException as exc:
                 if exc.status == 404:
                     raise FileNotFoundError(f"MCP server '{server_name}' not found") from exc
@@ -1023,7 +1149,7 @@ class GitHubService(GitProvider):
             while stack:
                 item = stack.pop()
                 if item.type == "dir":
-                    sub_contents = repo.get_contents(item.path, ref="main")
+                    sub_contents = repo.get_contents(item.path, ref=default_ref)
                     stack.extend(sub_contents if isinstance(sub_contents, list) else [sub_contents])
                 else:
                     files_to_delete.append(item.path)
@@ -1046,14 +1172,19 @@ class GitHubService(GitProvider):
     # CAB-1889 CP-1: provider-agnostic surface (GitProvider ABC).
     # ============================================================
 
-    async def list_tree(self, path: str, ref: str = "main") -> list[TreeEntry]:
+    async def list_tree(self, path: str, ref: str | None = None) -> list[TreeEntry]:
+        """List catalog tree children.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_ref = ref if ref is not None else settings.git.default_branch
         gh = self._require_gh()
         project_id = self._catalog_project_id()
 
         def _list() -> list[TreeEntry]:
             repo = gh.get_repo(project_id)
             try:
-                contents = repo.get_contents(path, ref=ref)
+                contents = repo.get_contents(path, ref=effective_ref)
             except GithubException as exc:
                 if exc.status == 404:
                     return []
@@ -1076,7 +1207,11 @@ class GitHubService(GitProvider):
 
         return await _gh_read(_list, "github.list_tree")
 
-    async def read_file(self, path: str, ref: str = "main") -> str | None:
+    async def read_file(self, path: str, ref: str | None = None) -> str | None:
+        """Return catalog file content or ``None`` if missing.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
         try:
             return await self.get_file_content(self._catalog_project_id(), path, ref=ref)
         except FileNotFoundError:
@@ -1113,7 +1248,7 @@ class GitHubService(GitProvider):
         return await _gh_read(_list, "github.list_path_commits")
 
     async def write_file(
-        self, path: str, content: str, commit_message: str, branch: str = "main"
+        self, path: str, content: str, commit_message: str, branch: str | None = None
     ) -> Literal["created", "updated"]:
         """CP-1 C.6: create-first, fall through to update on 'already exists'.
 
@@ -1121,19 +1256,32 @@ class GitHubService(GitProvider):
         Does not provide full compare-and-swap — PyGithub's update_file
         already requires the blob sha (fetched inline in update_file), so
         the second leg is optimistic-concurrent per file.
+
+        CP-1 P2 (M.4): ``branch=None`` resolves to ``settings.git.default_branch``.
         """
+        effective_branch = branch if branch is not None else settings.git.default_branch
         project_id = self._catalog_project_id()
         try:
-            await self.create_file(project_id, path, content, commit_message, branch=branch)
+            await self.create_file(project_id, path, content, commit_message, branch=effective_branch)
             return "created"
         except ValueError:
-            await self.update_file(project_id, path, content, commit_message, branch=branch)
+            await self.update_file(project_id, path, content, commit_message, branch=effective_branch)
             return "updated"
 
-    async def remove_file(self, path: str, commit_message: str, branch: str = "main") -> bool:
+    async def remove_file(self, path: str, commit_message: str, branch: str | None = None) -> bool:
+        """Delete a file from the catalog repo.
+
+        ``branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
         return await self.delete_file(self._catalog_project_id(), path, commit_message, branch=branch)
 
     async def list_branches(self) -> list[BranchRef]:
+        """List catalog branches.
+
+        PyGithub's ``PaginatedList`` iterates transparently across pages,
+        so there's no silent truncation to guard against (unlike GitLab's
+        L.1 bug on ``project.branches.list()``). Included here for symmetry.
+        """
         gh = self._require_gh()
         project_id = self._catalog_project_id()
 
@@ -1147,13 +1295,18 @@ class GitHubService(GitProvider):
 
         return await _gh_read(_list, "github.list_branches")
 
-    async def create_branch(self, name: str, ref: str = "main") -> BranchRef:
+    async def create_branch(self, name: str, ref: str | None = None) -> BranchRef:
+        """Create a branch on the catalog repo.
+
+        ``ref=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_ref = ref if ref is not None else settings.git.default_branch
         gh = self._require_gh()
         project_id = self._catalog_project_id()
 
         def _create() -> BranchRef:
             repo = gh.get_repo(project_id)
-            base_ref = repo.get_git_ref(f"heads/{ref}")
+            base_ref = repo.get_git_ref(f"heads/{effective_ref}")
             repo.create_git_ref(f"refs/heads/{name}", base_ref.object.sha)
             branch = repo.get_branch(name)
             return BranchRef(
@@ -1200,25 +1353,45 @@ class GitHubService(GitProvider):
         title: str,
         description: str,
         source_branch: str,
-        target_branch: str = "main",
+        target_branch: str | None = None,
     ) -> MergeRequestRef:
+        """Open a pull request.
+
+        ``target_branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
+        """
+        effective_target = (
+            target_branch if target_branch is not None else settings.git.default_branch
+        )
         gh = self._require_gh()
         project_id = self._catalog_project_id()
 
         def _create() -> MergeRequestRef:
             repo = gh.get_repo(project_id)
-            pr = repo.create_pull(title=title, body=description, head=source_branch, base=target_branch)
+            pr = repo.create_pull(
+                title=title, body=description, head=source_branch, base=effective_target
+            )
             return self._pr_to_ref(pr)
 
         return await _gh_meta_write(_create, "github.create_merge_request")
 
     async def merge_merge_request(self, iid: int) -> MergeRequestRef:
+        """Merge a pull request by number.
+
+        CP-1 P2 (M.2): idempotent when the PR is already merged. Short-circuits
+        **only** on ``pr.merged is True``; closed-unmerged still falls through
+        to ``pr.merge()`` so the provider error surfaces correctly. PyGithub's
+        ``PullRequest.merge()`` does not mutate the instance in place — it
+        returns a ``PullRequestMergeStatus`` — so a single re-fetch is needed
+        after a successful merge to reflect the new state.
+        """
         gh = self._require_gh()
         project_id = self._catalog_project_id()
 
         def _merge() -> MergeRequestRef:
             repo = gh.get_repo(project_id)
             pr = repo.get_pull(iid)
+            if pr.merged:
+                return self._pr_to_ref(pr)
             pr.merge()
             return self._pr_to_ref(repo.get_pull(iid))
 

--- a/control-plane-api/src/services/iam_sync_service.py
+++ b/control-plane-api/src/services/iam_sync_service.py
@@ -207,7 +207,9 @@ class IAMSyncService:
                 result["errors"] = ["Git provider not connected"]
                 return result
 
-            tree = await git_service.list_tree("tenants", ref="main")
+            # CP-1 P2 (M.4): drop explicit ref so list_tree resolves
+            # to settings.git.default_branch.
+            tree = await git_service.list_tree("tenants")
 
             for item in tree:
                 if item.type == "tree":

--- a/control-plane-api/tests/test_deployment_orchestration_service.py
+++ b/control-plane-api/tests/test_deployment_orchestration_service.py
@@ -374,7 +374,9 @@ class TestRegressionCab1889:
             await svc._sync_api_from_git("acme", "payments")
 
             mock_git.is_connected.assert_called()
-            mock_git.get_head_commit_sha.assert_awaited_once_with(ref="main")
+            # CP-1 P2 M.4: caller drops explicit ref so the provider resolves
+            # it from ``settings.git.default_branch``.
+            mock_git.get_head_commit_sha.assert_awaited_once_with()
             # _project must never be touched — if it is, this attribute access would work on MagicMock
             # so we assert that only the interface methods were called.
             assert not any(

--- a/control-plane-api/tests/test_git_service.py
+++ b/control-plane-api/tests/test_git_service.py
@@ -980,10 +980,18 @@ class TestListCommits:
         assert result[0]["author"] == "Alice"
 
     async def test_default_limit_is_twenty(self):
+        """CP-1 P2 L.1: list_commits now uses iterator=True + islice.
+
+        The call must pass ``iterator=True`` and ``per_page=min(limit,100)=20``
+        so paginated truncation is fixed, while ``islice`` caps the returned
+        list at the caller's ``limit``.
+        """
         svc = _connected_service()
-        svc._project.commits.list.return_value = []
+        svc._project.commits.list.side_effect = lambda **_: iter([])
         await svc.list_commits()
-        svc._project.commits.list.assert_called_once_with(path=None, per_page=20)
+        svc._project.commits.list.assert_called_once_with(
+            path=None, per_page=20, iterator=True
+        )
 
 
 # ─────────────────────────────────────────────

--- a/control-plane-api/tests/test_iam_sync_service.py
+++ b/control-plane-api/tests/test_iam_sync_service.py
@@ -644,7 +644,9 @@ class TestRegressionCab1889:
             mock_git.list_tree = AsyncMock(return_value=[])
             await svc.sync_all_tenants()
             mock_git.is_connected.assert_called()
-            mock_git.list_tree.assert_awaited_once_with("tenants", ref="main")
+            # CP-1 P2 M.4: caller drops explicit ref so the provider resolves
+            # it from ``settings.git.default_branch``.
+            mock_git.list_tree.assert_awaited_once_with("tenants")
 
 
 class TestHandleTenantEventUserRemovedNoEmail:

--- a/control-plane-api/tests/test_regression_cab_1889_external_git_leaks.py
+++ b/control-plane-api/tests/test_regression_cab_1889_external_git_leaks.py
@@ -23,7 +23,10 @@ async def test_regression_cab_1889_iam_sync_uses_provider_tree_listing():
         await svc.sync_all_tenants()
 
     mock_git.is_connected.assert_called_once_with()
-    mock_git.list_tree.assert_awaited_once_with("tenants", ref="main")
+    # CP-1 P2 M.4: the caller drops the explicit ref so list_tree resolves
+    # to settings.git.default_branch inside the provider. The important
+    # invariant is that the ABC is used (no _project leakage).
+    mock_git.list_tree.assert_awaited_once_with("tenants")
     svc.sync_tenant.assert_awaited_once_with("acme")
     assert not any("_project" in str(call) for call in mock_git.mock_calls), (
         f"_project leaked into calls: {mock_git.mock_calls}"
@@ -54,7 +57,10 @@ async def test_regression_cab_1889_deployment_sync_uses_provider_head_lookup():
         await svc._sync_api_from_git("acme", "payments")
 
     mock_git.is_connected.assert_called_once_with()
-    mock_git.get_head_commit_sha.assert_awaited_once_with(ref="main")
+    # CP-1 P2 M.4: the caller drops the explicit ref so get_head_commit_sha
+    # resolves to settings.git.default_branch inside the provider. The
+    # important invariant is that the ABC is used (no _project leakage).
+    mock_git.get_head_commit_sha.assert_awaited_once_with()
     assert not any("_project" in str(call) for call in mock_git.mock_calls), (
         f"_project leaked into calls: {mock_git.mock_calls}"
     )

--- a/control-plane-api/tests/test_regression_cp1_p2_connect_retry.py
+++ b/control-plane-api/tests/test_regression_cp1_p2_connect_retry.py
@@ -1,0 +1,159 @@
+"""Regression guard for CP-1 P2 M.5 — connect() retries transient errors.
+
+Closes M.5 (BUG-REPORT-CP-1.md): ``connect()`` on both providers retries
+transient failures (network errors, TimeoutError, 5xx, 429) with
+1s → 2s exponential backoff over 3 attempts. Authentication errors
+(401/403) fail fast — retrying them is pointless and costly.
+
+regression for CP-1 M.5
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import gitlab.exceptions
+import pytest
+import requests.exceptions
+from github import BadCredentialsException, GithubException
+
+import sys
+
+from src.services.git_service import GitLabService
+from src.services.github_service import GitHubService
+
+# `src.services.git_service` is shadowed in the package namespace by the
+# `git_service` GitLabService instance re-exported from __init__.py — go
+# through sys.modules to reach the actual module for monkeypatching.
+git_service_mod = sys.modules["src.services.git_service"]
+github_service_mod = sys.modules["src.services.github_service"]
+
+
+@pytest.mark.asyncio
+async def test_gitlab_connect_retries_on_transient_and_succeeds(monkeypatch):
+    """GitLab connect: 2 ConnectionError then success → 3 attempts,
+    sleeps 1s then 2s. Auth error → no retry.
+
+    regression for CP-1 M.5
+    """
+    svc = GitLabService()
+
+    # Part 1: transient path.
+    successful_tuple = (MagicMock(), MagicMock(name="project"), "catalog-repo")
+
+    call_count = {"n": 0}
+
+    async def fake_gl_run(fn, op_name, timeout=15.0):  # type: ignore[no-untyped-def]
+        call_count["n"] += 1
+        if call_count["n"] < 3:
+            raise requests.exceptions.ConnectionError("network down")
+        return successful_tuple
+
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(git_service_mod, "_gl_run", fake_gl_run)
+    monkeypatch.setattr(git_service_mod.asyncio, "sleep", sleep_mock)
+    # settings.git.gitlab must have a token; the closure is never actually
+    # executed because _gl_run is patched, but the method reads gl_cfg first.
+    monkeypatch.setattr(
+        git_service_mod.settings.git.gitlab.token,
+        "get_secret_value",
+        lambda: "fake-token",
+    )
+
+    await svc.connect()
+
+    assert call_count["n"] == 3, "must retry exactly until success (3 attempts)"
+    assert sleep_mock.call_args_list == [((1,),), ((2,),)], (
+        f"expected sleeps of 1s then 2s, got {sleep_mock.call_args_list}"
+    )
+    assert svc._gl is successful_tuple[0]
+
+    # Part 2: auth error fails fast. Reset state.
+    svc2 = GitLabService()
+    auth_call_count = {"n": 0}
+
+    async def fake_gl_run_auth(fn, op_name, timeout=15.0):  # type: ignore[no-untyped-def]
+        auth_call_count["n"] += 1
+        raise gitlab.exceptions.GitlabAuthenticationError("bad token", response_code=401)
+
+    sleep_mock_auth = AsyncMock()
+    monkeypatch.setattr(git_service_mod, "_gl_run", fake_gl_run_auth)
+    monkeypatch.setattr(git_service_mod.asyncio, "sleep", sleep_mock_auth)
+
+    with pytest.raises(gitlab.exceptions.GitlabAuthenticationError):
+        await svc2.connect()
+
+    assert auth_call_count["n"] == 1, "must fail fast on auth error (no retry)"
+    assert sleep_mock_auth.call_count == 0, "must NOT sleep on auth error"
+
+
+@pytest.mark.asyncio
+async def test_github_connect_retries_on_transient_and_succeeds(monkeypatch):
+    """GitHub connect: 2 ConnectionError then success → 3 attempts,
+    sleeps 1s then 2s. Bad credentials → no retry.
+
+    regression for CP-1 M.5
+    """
+    svc = GitHubService()
+    successful_tuple = (MagicMock(), "octocat")
+
+    call_count = {"n": 0}
+
+    async def fake_gh_read(fn, op_name, timeout=15.0):  # type: ignore[no-untyped-def]
+        call_count["n"] += 1
+        if call_count["n"] < 3:
+            raise requests.exceptions.ConnectionError("network down")
+        return successful_tuple
+
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(github_service_mod, "_gh_read", fake_gh_read)
+    monkeypatch.setattr(github_service_mod.asyncio, "sleep", sleep_mock)
+    monkeypatch.setattr(
+        github_service_mod.settings.git.github.token,
+        "get_secret_value",
+        lambda: "fake-gh-token",
+    )
+
+    await svc.connect()
+
+    assert call_count["n"] == 3, "must retry exactly until success (3 attempts)"
+    assert sleep_mock.call_args_list == [((1,),), ((2,),)], (
+        f"expected sleeps of 1s then 2s, got {sleep_mock.call_args_list}"
+    )
+    assert svc._gh is successful_tuple[0]
+
+    # Part 2: bad credentials fails fast.
+    svc2 = GitHubService()
+    auth_call_count = {"n": 0}
+
+    async def fake_gh_read_auth(fn, op_name, timeout=15.0):  # type: ignore[no-untyped-def]
+        auth_call_count["n"] += 1
+        raise BadCredentialsException(401, {"message": "Bad credentials"}, {})
+
+    sleep_mock_auth = AsyncMock()
+    monkeypatch.setattr(github_service_mod, "_gh_read", fake_gh_read_auth)
+    monkeypatch.setattr(github_service_mod.asyncio, "sleep", sleep_mock_auth)
+
+    with pytest.raises(BadCredentialsException):
+        await svc2.connect()
+
+    assert auth_call_count["n"] == 1, "must fail fast on credential error (no retry)"
+    assert sleep_mock_auth.call_count == 0, "must NOT sleep on credential error"
+
+    # Sanity: 5xx is retried (uses same classifier).
+    call_count_5xx = {"n": 0}
+
+    async def fake_gh_read_5xx(fn, op_name, timeout=15.0):  # type: ignore[no-untyped-def]
+        call_count_5xx["n"] += 1
+        if call_count_5xx["n"] == 1:
+            raise GithubException(503, {"message": "Service unavailable"}, {})
+        return successful_tuple
+
+    sleep_mock_5xx = AsyncMock()
+    svc3 = GitHubService()
+    monkeypatch.setattr(github_service_mod, "_gh_read", fake_gh_read_5xx)
+    monkeypatch.setattr(github_service_mod.asyncio, "sleep", sleep_mock_5xx)
+
+    await svc3.connect()
+    assert call_count_5xx["n"] == 2, "5xx is transient; must retry once"
+    assert sleep_mock_5xx.call_args_list == [((1,),)]

--- a/control-plane-api/tests/test_regression_cp1_p2_default_branch.py
+++ b/control-plane-api/tests/test_regression_cp1_p2_default_branch.py
@@ -1,0 +1,71 @@
+"""Regression guard for CP-1 P2 M.4 — default branch resolved at boundary.
+
+Closes M.4 (BUG-REPORT-CP-1.md): provider methods that used to hardcode
+``ref="main"`` / ``branch="main"`` now resolve ``None`` to
+``settings.git.default_branch`` at the method boundary. Callers that
+omit ``ref`` must hit the configured default, not the hardcoded ``"main"``.
+
+regression for CP-1 M.4
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.config import settings
+from src.services.git_service import GitLabService
+from src.services.github_service import GitHubService
+
+
+@pytest.mark.asyncio
+async def test_gitlab_list_tenants_uses_configured_default_branch(monkeypatch):
+    """GitLab list_tenants must call ``repository_tree(..., ref=default_branch)``
+    with the configured default, not hardcoded ``"main"``.
+
+    regression for CP-1 M.4
+    """
+    monkeypatch.setattr(settings.git, "default_branch", "develop")
+
+    svc = GitLabService()
+    project = MagicMock()
+    project.repository_tree.return_value = [
+        {"name": "acme", "type": "tree"},
+        {"name": "globex", "type": "tree"},
+    ]
+    svc._project = project
+    svc._gl = MagicMock()
+
+    tenants = await svc.list_tenants()
+
+    assert tenants == ["acme", "globex"]
+    project.repository_tree.assert_called_once_with(path="tenants", ref="develop")
+    # No call should have used the old hardcoded literal.
+    for _, kwargs in project.repository_tree.call_args_list:
+        assert kwargs.get("ref") != "main", "old hardcoded ref=main leaked through"
+
+
+@pytest.mark.asyncio
+async def test_github_list_apis_uses_configured_default_branch(monkeypatch):
+    """GitHub list_apis must call ``get_contents(base_path, ref=default_branch)``
+    with the configured default, not hardcoded ``"main"``.
+
+    regression for CP-1 M.4
+    """
+    monkeypatch.setattr(settings.git, "default_branch", "trunk")
+
+    svc = GitHubService()
+    gh = MagicMock()
+    svc._gh = gh
+
+    repo = MagicMock()
+    repo.get_contents.return_value = []  # empty tenant/apis directory
+    gh.get_repo.return_value = repo
+
+    apis = await svc.list_apis("acme")
+
+    assert apis == []
+    repo.get_contents.assert_called_once()
+    _, kwargs = repo.get_contents.call_args
+    assert kwargs.get("ref") == "trunk", f"expected ref=trunk, got {kwargs.get('ref')}"

--- a/control-plane-api/tests/test_regression_cp1_p2_gitlab_pagination.py
+++ b/control-plane-api/tests/test_regression_cp1_p2_gitlab_pagination.py
@@ -1,0 +1,134 @@
+"""Regression guard for CP-1 P2 L.1 — GitLab pagination stops truncating.
+
+Closes L.1 (BUG-REPORT-CP-1.md): ``project.branches.list()`` and
+``project.mergerequests.list(state=...)`` in python-gitlab default to
+page 1 only (≤20 items). ``project.commits.list(path=..., per_page=N)``
+caps at N for the first page and never fetches beyond. All three must
+now paginate fully. PyGithub's PaginatedList iterates transparently,
+so only GitLab is affected.
+
+regression for CP-1 L.1
+"""
+
+from __future__ import annotations
+
+import itertools
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.services.git_service import GitLabService
+
+
+def _make_fake_branch(i: int):
+    b = MagicMock()
+    b.name = f"branch-{i}"
+    b.commit = {"id": f"sha{i:03d}"}
+    b.protected = False
+    return b
+
+
+def _make_fake_mr(i: int):
+    mr = MagicMock()
+    mr.id = 1000 + i
+    mr.iid = i
+    mr.title = f"MR {i}"
+    mr.description = ""
+    mr.state = "opened"
+    mr.source_branch = f"feature/{i}"
+    mr.target_branch = "main"
+    mr.web_url = f"https://gl/mr/{i}"
+    mr.created_at = "2026-04-23T00:00:00Z"
+    mr.author = {"name": "tester"}
+    return mr
+
+
+def _make_fake_commit(i: int):
+    c = MagicMock()
+    c.id = f"commit{i:03d}"
+    c.message = f"commit {i}"
+    c.author_name = "tester"
+    c.created_at = "2026-04-23T00:00:00Z"
+    return c
+
+
+@pytest.mark.asyncio
+async def test_list_branches_uses_get_all_true(monkeypatch):
+    """GitLab list_branches must pass ``get_all=True`` so catalogs with
+    >20 branches no longer silently truncate.
+
+    regression for CP-1 L.1
+    """
+    svc = GitLabService()
+    project = MagicMock()
+    svc._project = project
+    svc._gl = MagicMock()
+
+    # Stub 35 branches — would be truncated to 20 under the old default.
+    fake_branches = [_make_fake_branch(i) for i in range(35)]
+    project.branches.list.return_value = fake_branches
+
+    branches = await svc.list_branches()
+
+    # get_all=True must be passed — NOT "page" / "per_page" / defaults only.
+    project.branches.list.assert_called_once_with(get_all=True)
+    # No silent truncation: we got all 35, not 20.
+    assert len(branches) == 35, f"expected 35 branches, got {len(branches)}"
+    assert branches[20].name == "branch-20", "item past page-1 boundary must be present"
+
+
+@pytest.mark.asyncio
+async def test_list_merge_requests_and_commits_paginate_fully(monkeypatch):
+    """GitLab list_merge_requests must pass get_all=True; list_commits must
+    use iterator=True + per_page=min(limit,100) and honour the ``limit``
+    contract via itertools.islice.
+
+    regression for CP-1 L.1
+    """
+    svc = GitLabService()
+    project = MagicMock()
+    svc._project = project
+    svc._gl = MagicMock()
+
+    # --- list_merge_requests: 35 items, get_all=True expected. ---
+    fake_mrs = [_make_fake_mr(i) for i in range(35)]
+    project.mergerequests.list.return_value = fake_mrs
+
+    mrs = await svc.list_merge_requests(state="opened")
+
+    project.mergerequests.list.assert_called_once_with(state="opened", get_all=True)
+    assert len(mrs) == 35, f"expected 35 MRs, got {len(mrs)}"
+
+    # --- list_commits: stub returns an iterator of 150 commits; call with
+    # limit=50 → iterator=True, per_page=min(50,100)=50, islice caps at 50. ---
+    def commit_iterator(**_kwargs):
+        # Return an unbounded iterator of fake commits — the stub asserts
+        # that production code does not materialise the full paginated
+        # list in memory.
+        return iter(_make_fake_commit(i) for i in range(10_000))
+
+    project.commits.list.side_effect = commit_iterator
+
+    commits = await svc.list_commits(path="docs/api.md", limit=50)
+
+    # Only one call, and the kwargs are tight.
+    assert project.commits.list.call_count == 1
+    _, kwargs = project.commits.list.call_args
+    assert kwargs.get("iterator") is True, "list_commits must pass iterator=True"
+    assert kwargs.get("per_page") == 50, f"per_page should be min(50,100)=50, got {kwargs.get('per_page')}"
+    assert kwargs.get("path") == "docs/api.md"
+    # islice honours limit: exactly 50 commits returned.
+    assert len(commits) == 50, f"expected limit=50 commits, got {len(commits)}"
+    assert commits[0]["sha"] == "commit000"
+    assert commits[49]["sha"] == "commit049"
+
+    # And per_page caps at 100 when limit > 100.
+    project.commits.list.reset_mock()
+    project.commits.list.side_effect = commit_iterator
+    big = await svc.list_commits(limit=250)
+    _, big_kwargs = project.commits.list.call_args
+    assert big_kwargs.get("per_page") == 100, "per_page must cap at 100 even when limit > 100"
+    assert len(big) == 250, "islice still honours the caller's limit"
+    # itertools.islice sanity — proves we don't leak into the 10_000-item tail.
+    assert isinstance(big, list)
+    _ = itertools  # silence unused-import lint on reruns

--- a/control-plane-api/tests/test_regression_cp1_p2_list_all_mcp_gathered.py
+++ b/control-plane-api/tests/test_regression_cp1_p2_list_all_mcp_gathered.py
@@ -1,0 +1,101 @@
+"""Regression guard for CP-1 P2 M.6 — list_all_mcp_servers fans out.
+
+Closes M.6 (BUG-REPORT-CP-1.md): ``list_all_mcp_servers`` on both providers
+must fetch per-tenant MCP server lists via ``asyncio.gather`` rather than
+a serial ``for`` loop. With N tenants and per-call latency L, the total
+wall time must be closer to L than N*L.
+
+regression for CP-1 M.6
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.services.git_service import GitLabService
+from src.services.github_service import GitHubService
+
+
+@pytest.mark.asyncio
+async def test_github_list_all_mcp_servers_fans_out_in_parallel(monkeypatch):
+    """GitHub list_all_mcp_servers must run per-tenant list_mcp_servers
+    concurrently via asyncio.gather, not sequentially.
+
+    regression for CP-1 M.6
+    """
+    svc = GitHubService()
+
+    per_call_latency = 0.05  # 50 ms
+    tenants = ["t1", "t2", "t3", "t4", "t5"]
+
+    async def fake_list_tenants() -> list[str]:
+        return tenants
+
+    call_log: list[str] = []
+
+    async def fake_list_mcp_servers(tenant_id: str) -> list[dict]:
+        call_log.append(tenant_id)
+        await asyncio.sleep(per_call_latency)
+        return [{"name": f"{tenant_id}-srv", "tenant_id": tenant_id}]
+
+    monkeypatch.setattr(svc, "list_tenants", fake_list_tenants)
+    monkeypatch.setattr(svc, "list_mcp_servers", fake_list_mcp_servers)
+
+    start = time.perf_counter()
+    servers = await svc.list_all_mcp_servers()
+    elapsed = time.perf_counter() - start
+
+    # Platform scope + 5 tenants = 6 calls → serial would be ≥ 300 ms.
+    # Concurrent upper bound: ≈ per_call_latency (one batch), so assert < 2× latency.
+    assert elapsed < 2 * per_call_latency, (
+        f"expected parallel fan-out (<{2 * per_call_latency}s), got {elapsed:.3f}s"
+    )
+    # All 5 tenants plus "_platform" visited.
+    assert set(call_log) == set(tenants) | {"_platform"}
+    # 6 servers total (1 per scope).
+    assert len(servers) == 6
+
+
+@pytest.mark.asyncio
+async def test_gitlab_list_all_mcp_servers_fans_out_in_parallel(monkeypatch):
+    """GitLab list_all_mcp_servers must run per-tenant list_mcp_servers
+    concurrently via asyncio.gather, not sequentially.
+
+    regression for CP-1 M.6
+    """
+    from unittest.mock import MagicMock
+
+    svc = GitLabService()
+    # Minimal stub: _require_project + _gl_run for tenant enumeration.
+    project = MagicMock()
+    project.repository_tree.return_value = [
+        {"name": f"t{i}", "type": "tree"} for i in range(1, 6)
+    ]
+    svc._project = project
+    svc._gl = MagicMock()
+
+    per_call_latency = 0.05
+
+    call_log: list[str] = []
+
+    async def fake_list_mcp_servers(tenant_id: str = "_platform") -> list[dict]:
+        call_log.append(tenant_id)
+        await asyncio.sleep(per_call_latency)
+        return [{"name": f"{tenant_id}-srv", "tenant_id": tenant_id}]
+
+    monkeypatch.setattr(svc, "list_mcp_servers", fake_list_mcp_servers)
+
+    start = time.perf_counter()
+    servers = await svc.list_all_mcp_servers()
+    elapsed = time.perf_counter() - start
+
+    # Platform + 5 tenants = 6 awaits → serial ≥ 300 ms; parallel ≈ 50 ms.
+    assert elapsed < 2 * per_call_latency, (
+        f"expected parallel fan-out (<{2 * per_call_latency}s), got {elapsed:.3f}s"
+    )
+    assert set(call_log) == {f"t{i}" for i in range(1, 6)} | {"_platform"}
+    assert len(servers) == 6

--- a/control-plane-api/tests/test_regression_cp1_p2_merge_idempotent.py
+++ b/control-plane-api/tests/test_regression_cp1_p2_merge_idempotent.py
@@ -1,0 +1,118 @@
+"""Regression guard for CP-1 P2 M.2 — idempotent merge_merge_request.
+
+Closes M.2 (BUG-REPORT-CP-1.md): ``merge_merge_request`` on both providers
+must short-circuit when the target PR/MR is **already merged**, but must
+NOT short-circuit on "closed but unmerged" — those still fall through to
+``pr.merge()`` / ``mr.merge()`` and surface the provider error.
+
+regression for CP-1 M.2
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.services.git_service import GitLabService
+from src.services.github_service import GitHubService
+
+
+@pytest.mark.asyncio
+async def test_github_merge_request_short_circuits_when_already_merged(monkeypatch):
+    """GitHub: ``pr.merged is True`` → no pr.merge() call; closed-unmerged
+    still calls pr.merge() and raises.
+
+    regression for CP-1 M.2
+    """
+    svc = GitHubService()
+    gh = MagicMock()
+    svc._gh = gh
+
+    # Case 1 — PR already merged. Expect NO pr.merge() call, ref returned
+    # reflects the already-merged state.
+    merged_pr = MagicMock()
+    merged_pr.merged = True
+    merged_pr.id = 42
+    merged_pr.number = 7
+    merged_pr.title = "already merged PR"
+    merged_pr.body = "payload"
+    merged_pr.state = "closed"
+    merged_pr.head = MagicMock(ref="feature/x")
+    merged_pr.base = MagicMock(ref="main")
+    merged_pr.html_url = "https://gh/pr/7"
+    merged_pr.created_at = None
+    merged_pr.user = MagicMock(login="alice")
+
+    repo = MagicMock()
+    repo.get_pull.return_value = merged_pr
+    gh.get_repo.return_value = repo
+
+    ref = await svc.merge_merge_request(7)
+
+    assert ref.iid == 7
+    assert ref.state == "closed"
+    assert merged_pr.merge.call_count == 0, "pr.merge() must not run when already merged"
+    # Single get_pull call: we did NOT re-fetch because we short-circuited.
+    assert repo.get_pull.call_count == 1
+
+    # Case 2 — PR closed but NOT merged. Must fall through to pr.merge()
+    # and propagate its error. Proves the short-circuit is narrow.
+    closed_unmerged = MagicMock()
+    closed_unmerged.merged = False
+    closed_unmerged.merge.side_effect = RuntimeError("provider rejects merge of closed PR")
+
+    repo2 = MagicMock()
+    repo2.get_pull.return_value = closed_unmerged
+    gh.get_repo.return_value = repo2
+
+    with pytest.raises(RuntimeError, match="provider rejects merge of closed PR"):
+        await svc.merge_merge_request(7)
+
+    assert closed_unmerged.merge.call_count == 1, "closed-unmerged must still call pr.merge()"
+
+
+@pytest.mark.asyncio
+async def test_gitlab_merge_request_short_circuits_when_already_merged(monkeypatch):
+    """GitLab: ``mr.state == "merged"`` → no mr.merge() call; closed-unmerged
+    still calls mr.merge() and raises.
+
+    regression for CP-1 M.2
+    """
+    svc = GitLabService()
+    project = MagicMock()
+    svc._project = project
+    svc._gl = MagicMock()
+
+    # Case 1 — MR already merged.
+    merged_mr = MagicMock()
+    merged_mr.state = "merged"
+    merged_mr.id = 100
+    merged_mr.iid = 13
+    merged_mr.title = "done MR"
+    merged_mr.description = "payload"
+    merged_mr.source_branch = "feature/y"
+    merged_mr.target_branch = "main"
+    merged_mr.web_url = "https://gl/mr/13"
+    merged_mr.created_at = "2026-04-20T10:00:00Z"
+    merged_mr.author = {"name": "bob"}
+
+    project.mergerequests.get.return_value = merged_mr
+
+    ref = await svc.merge_merge_request(13)
+
+    assert ref.iid == 13
+    assert ref.state == "merged"
+    assert merged_mr.merge.call_count == 0, "mr.merge() must not run when already merged"
+
+    # Case 2 — MR closed-unmerged. Must call mr.merge() and propagate.
+    closed_mr = MagicMock()
+    closed_mr.state = "closed"
+    closed_mr.merge.side_effect = RuntimeError("provider rejects merge of closed MR")
+
+    project.mergerequests.get.return_value = closed_mr
+
+    with pytest.raises(RuntimeError, match="provider rejects merge of closed MR"):
+        await svc.merge_merge_request(13)
+
+    assert closed_mr.merge.call_count == 1, "closed-unmerged must still call mr.merge()"


### PR DESCRIPTION
Closes 5 P2 findings from `control-plane-api/BUG-REPORT-CP-1.md`. Final batch in the CP-1 GitProvider cleanup — CP-1 fully closed at 21/21 findings once this merges.

**P0 and P1 already landed** — #2496 (P0, squash `4ed80850b`) and #2499 (P1, squash `b58bdca40`). This branch rebases the P2 work directly on top of `origin/main`; only P2-specific commits remain (2 commits, ~1.5 k additions over 18 files, most of it is new regression tests).

## Findings closed

- **M.2** — `merge_merge_request` short-circuits only on actually-merged state (`pr.merged is True` / `mr.state == "merged"`). Closed-but-unmerged still falls through to the provider error. Narrow short-circuit, not blanket "closed".
- **M.4** — default branch is now config-driven via new `GIT_DEFAULT_BRANCH` env var (`settings.git.default_branch`, defaults to `main` so no behaviour change on omission). ABC + provider impl signatures switched to `ref: str | None = None` / `branch: str | None = None` with resolution at the method boundary — the only way to fully close the bug (fixing only internal closures left callers that omit `ref` still targeting `"main"` silently). 50+ internal literals swept. Ancillary callers (`iam_sync`, `deployment_orchestration`, `routers/traces`) drop their explicit `ref="main"` too.
- **M.5** — `connect()` retries transient failures (network errors, `TimeoutError`, 5xx, 429) with 3 attempts / 2 sleeps (1s → 2s), 15s per-attempt timeout, worst-case ~48 s. Fails fast on 401/403 and other non-transient errors via `_is_transient_gitlab_error` / `_is_transient_github_error` helpers at module scope (auditable, easy to monkey-patch in tests).
- **M.6** — `list_all_mcp_servers` fans out per-tenant listings via `asyncio.gather` on both providers; platform-scope runs concurrently with the tenant enumeration. Provider semaphores (`GITLAB_SEMAPHORE` / `GITHUB_READ_SEMAPHORE`) inside `_gl_run` / `_gh_read` keep overall concurrency bounded.
- **L.1** — GitLab `list_branches` and `list_merge_requests` pass `get_all=True`; `list_commits` uses `iterator=True` + `per_page=min(limit, 100)` + `itertools.islice(..., limit)` so the `limit` contract survives while full pagination is restored. PyGithub's `PaginatedList` already iterates transparently (L.1 was GitLab-only).

## Regression guards

10 new tests across 5 files:

| File | Tests | What it pins |
|---|---|---|
| `test_regression_cp1_p2_merge_idempotent.py` | 2 | Short-circuit only on `merged=True`; closed-unmerged still raises on both providers |
| `test_regression_cp1_p2_default_branch.py` | 2 | `list_tenants` / `list_apis` call into provider SDKs with the configured default branch, not the old hardcoded `"main"` |
| `test_regression_cp1_p2_connect_retry.py` | 2 | `connect()` retries exactly 2 transient failures with sleeps `1s, 2s`; fails fast on auth errors |
| `test_regression_cp1_p2_list_all_mcp_gathered.py` | 2 | Wall-clock asserts parallel fan-out (5 tenants × 50 ms latency ≈ 50 ms end-to-end, not 300 ms) |
| `test_regression_cp1_p2_gitlab_pagination.py` | 2 | `get_all=True` / `iterator=True` kwargs asserted; 35-item stubs prove no silent truncation |

Also updates `test_regression_cab_1889_external_git_leaks.py`, `test_git_service.py`, `test_deployment_orchestration_service.py` and `test_iam_sync_service.py` to assert the new "caller drops explicit ref" contract.

## CP-1 invariants verified post-rebase

- `grep -rn "self\._project\." src/ --include="*.py"` → 0 (CP-1 P0 C.1)
- `grep -rn "contextlib.suppress(Exception)"` inside `_sync_api_from_git` → 0 (CP-1 P1 H.2; remaining match is unrelated `adapter.disconnect()` cleanup in `deploy_api_to_env`)
- `grep -rn 'ref="main"\|branch="main"'` across provider services and ancillary catalog callers → 0 (this PR)

## Test plan

- [x] `pytest tests/test_regression_cp1_p2_*.py --asyncio-mode=auto -v` → 10/10 green
- [x] `pytest tests/test_regression_cp1_*.py tests/test_regression_cab_1889_*.py tests/test_git_service.py tests/test_github_service.py tests/test_github_service_catalog_parity.py tests/test_iam_sync_service.py tests/test_deployment_orchestration_service.py --asyncio-mode=auto` → 367/367 green
- [x] `ruff check src/` → 0 issues
- [x] `mypy src/services/git*.py src/routers/git.py` → 67 errors (same as baseline — no regression)
- [x] Gitleaks preflight on `git diff origin/main..HEAD` → 0 findings
- [ ] CI green on the PR

## Plan & audit artefacts

Kept in the branch for archival + traceability:
- `control-plane-api/FIX-PLAN-CP1-P2.md` — Phase 1 plan with approved-with-corrections header (M.2 narrow short-circuit, M.4 method-boundary resolution, M.5 transient-only + correct 1s→2s backoff math, L.1 option A for `list_commits`, 10-test count).
- `control-plane-api/BUG-REPORT-CP-1.md` — updated with the `CP-1 CLOSED` banner + P2 batch section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)