### PR TITLE
fix(gateway): GW-1 P1 — contract consistency (bind-first upsert / unbind-first delete)

### DIFF
--- a/stoa-gateway/src/handlers/admin/contracts.rs
+++ b/stoa-gateway/src/handlers/admin/contracts.rs
@@ -1,23 +1,111 @@
 //! UAC contract CRUD admin endpoints (CAB-1299).
+//!
+//! GW-1 P1-1 / P1-2 / P2-2: contract mutations are transactional
+//! across three stores (contract registry, REST route registry, MCP
+//! tool registry). The previous implementation persisted the contract
+//! *before* the binders ran, so a binder failure left the registry
+//! claiming routes/tools that did not exist. This module now enforces:
+//!
+//! - **upsert**: *bind-first*. Only commit to `contract_registry` once
+//!   both REST and MCP binds have succeeded. On failure, best-effort
+//!   unbind of the partial artefacts is attempted and the handler
+//!   returns `500`.
+//! - **delete**: *unbind-first*. Only remove from `contract_registry`
+//!   once both unbinds have succeeded. On failure, the contract stays
+//!   in the registry and the handler returns `500`.
+//! - **counts**: `routes_generated` / `tools_generated` come from the
+//!   real `BindingOutput` length, never from `contract.endpoints.len()`.
+//!
+//! The `ContractBinders` trait is a local abstraction used to inject
+//! test doubles; the production path wraps `RestBinder` + `McpBinder`
+//! via `RealBinders`.
 
+use std::sync::Arc;
+
+use async_trait::async_trait;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
-    response::IntoResponse,
+    response::{IntoResponse, Response},
     Json,
 };
 use tracing::warn;
 
 use crate::state::AppState;
-use crate::uac::binders::{mcp::McpBinder, rest::RestBinder, ProtocolBinder};
+use crate::uac::binders::{mcp::McpBinder, rest::RestBinder, BindingOutput, ProtocolBinder};
+use crate::uac::registry::ContractRegistry;
 use crate::uac::UacContractSpec;
 
-/// POST /admin/contracts — register or update a UAC contract
+/// Local abstraction over the REST + MCP binders so the handler logic
+/// can be tested with injected failures.
+#[async_trait]
+pub(crate) trait ContractBinders: Send + Sync {
+    async fn bind_rest(&self, contract: &UacContractSpec) -> Result<usize, String>;
+    async fn bind_mcp(&self, contract: &UacContractSpec) -> Result<usize, String>;
+    async fn unbind_rest(&self, key: &str) -> Result<usize, String>;
+    async fn unbind_mcp(&self, key: &str) -> Result<usize, String>;
+}
+
+/// Production impl backed by the real binders.
+pub(crate) struct RealBinders {
+    rest: RestBinder,
+    mcp: McpBinder,
+}
+
+impl RealBinders {
+    pub(crate) fn from_state(state: &AppState) -> Self {
+        Self {
+            rest: RestBinder::new(state.route_registry.clone()),
+            mcp: McpBinder::new(state.tool_registry.clone()),
+        }
+    }
+}
+
+#[async_trait]
+impl ContractBinders for RealBinders {
+    async fn bind_rest(&self, contract: &UacContractSpec) -> Result<usize, String> {
+        match self.rest.bind(contract).await? {
+            BindingOutput::Routes(r) => Ok(r.len()),
+            BindingOutput::Tools(_) => Err("REST binder returned Tools output".into()),
+        }
+    }
+    async fn bind_mcp(&self, contract: &UacContractSpec) -> Result<usize, String> {
+        match self.mcp.bind(contract).await? {
+            BindingOutput::Tools(t) => Ok(t.len()),
+            BindingOutput::Routes(_) => Err("MCP binder returned Routes output".into()),
+        }
+    }
+    async fn unbind_rest(&self, key: &str) -> Result<usize, String> {
+        self.rest.unbind(key).await
+    }
+    async fn unbind_mcp(&self, key: &str) -> Result<usize, String> {
+        self.mcp.unbind(key).await
+    }
+}
+
+/// POST /admin/contracts — register or update a UAC contract.
 pub async fn upsert_contract(
     State(state): State<AppState>,
-    Json(mut contract): Json<UacContractSpec>,
-) -> impl IntoResponse {
-    // Normalize endpoint shorthand: merge `method` into `methods` if provided
+    Json(contract): Json<UacContractSpec>,
+) -> Response {
+    let binders = RealBinders::from_state(&state);
+    perform_upsert(
+        state.contract_registry.clone(),
+        &binders,
+        state.config.llm_enabled,
+        contract,
+    )
+    .await
+}
+
+/// Transactional upsert — extracted so tests can inject `ContractBinders`.
+pub(crate) async fn perform_upsert(
+    registry: Arc<ContractRegistry>,
+    binders: &dyn ContractBinders,
+    llm_enabled: bool,
+    mut contract: UacContractSpec,
+) -> Response {
+    // Normalize endpoint shorthand: merge `method` into `methods` if provided.
     for ep in &mut contract.endpoints {
         if let Some(method) = ep.method.take() {
             if ep.methods.is_empty() {
@@ -26,7 +114,7 @@ pub async fn upsert_contract(
         }
     }
 
-    // Validate the contract
+    // Validate the contract.
     let errors = contract.validate();
     if !errors.is_empty() {
         return (
@@ -36,12 +124,11 @@ pub async fn upsert_contract(
             .into_response();
     }
 
-    // Ensure required_policies are up to date with classification
     contract.refresh_policies();
 
-    // Expand LLM capabilities into synthetic endpoints (CAB-709)
+    // Expand LLM capabilities into synthetic endpoints (CAB-709).
     let llm_capabilities = if let Some(ref llm_config) = contract.llm_config {
-        if state.config.llm_enabled {
+        if llm_enabled {
             let synthetic = llm_config.expand_endpoints();
             let count = synthetic.len();
             contract.endpoints.extend(synthetic);
@@ -58,28 +145,31 @@ pub async fn upsert_contract(
         .key
         .clone()
         .unwrap_or_else(|| format!("{}:{}", contract.tenant_id, contract.name));
-    let existed = state.contract_registry.upsert(contract.clone()).is_some();
 
-    // Auto-generate REST routes from contract (CAB-1299 PR3)
-    let rest_binder = RestBinder::new(state.route_registry.clone());
-    let routes_count = match rest_binder.bind(&contract).await {
-        Ok(_) => contract.endpoints.len(),
+    // ── bind-first ────────────────────────────────────────────
+    let routes_count = match binders.bind_rest(&contract).await {
+        Ok(n) => n,
         Err(e) => {
-            warn!(error = %e, contract = %key, "REST binder failed");
-            0
+            warn!(error = %e, contract = %key, "REST bind failed; contract NOT persisted");
+            // No partial state to clean: bind_rest failed before registering any route.
+            return binder_failure_response(&key, "REST", &e);
         }
     };
 
-    // Auto-generate MCP tools from contract (CAB-1299 PR4)
-    let mcp_binder = McpBinder::new(state.tool_registry.clone());
-    let tools_count = match mcp_binder.bind(&contract).await {
-        Ok(_) => contract.endpoints.len(),
+    let tools_count = match binders.bind_mcp(&contract).await {
+        Ok(n) => n,
         Err(e) => {
-            warn!(error = %e, contract = %key, "MCP binder failed");
-            0
+            warn!(error = %e, contract = %key, "MCP bind failed; rolling back REST routes");
+            // Best-effort rollback of the REST routes we just registered.
+            if let Err(rb) = binders.unbind_rest(&key).await {
+                warn!(error = %rb, contract = %key, "REST rollback unbind also failed");
+            }
+            return binder_failure_response(&key, "MCP", &e);
         }
     };
 
+    // ── commit ────────────────────────────────────────────────
+    let existed = registry.upsert(contract).is_some();
     let status = if existed {
         StatusCode::OK
     } else {
@@ -98,12 +188,12 @@ pub async fn upsert_contract(
         .into_response()
 }
 
-/// GET /admin/contracts — list all UAC contracts
+/// GET /admin/contracts — list all UAC contracts.
 pub async fn list_contracts(State(state): State<AppState>) -> Json<Vec<UacContractSpec>> {
     Json(state.contract_registry.list())
 }
 
-/// GET /admin/contracts/:key — get a single UAC contract by key (tenant_id:name)
+/// GET /admin/contracts/:key — get a single UAC contract by key.
 pub async fn get_contract(
     State(state): State<AppState>,
     Path(key): Path<String>,
@@ -114,35 +204,70 @@ pub async fn get_contract(
     }
 }
 
-/// DELETE /admin/contracts/:key — remove a UAC contract by key (tenant_id:name)
+/// DELETE /admin/contracts/:key — remove a UAC contract.
 ///
-/// Cascade-deletes all REST routes generated from this contract.
-pub async fn delete_contract(
-    State(state): State<AppState>,
-    Path(key): Path<String>,
-) -> impl IntoResponse {
-    match state.contract_registry.remove(&key) {
-        Some(_) => {
-            // Cascade-delete generated routes (CAB-1299 PR3)
-            let rest_binder = RestBinder::new(state.route_registry.clone());
-            let routes_removed = rest_binder.unbind(&key).await.unwrap_or(0);
+/// Cascade-unbinds REST routes and MCP tools **before** removing the
+/// contract from the registry. If either unbind fails, the registry is
+/// left untouched and the caller receives a `500` — prevents orphaned
+/// routes/tools persisting after the contract disappears.
+pub async fn delete_contract(State(state): State<AppState>, Path(key): Path<String>) -> Response {
+    let binders = RealBinders::from_state(&state);
+    perform_delete(state.contract_registry.clone(), &binders, key).await
+}
 
-            // Cascade-delete generated MCP tools (CAB-1299 PR4)
-            let mcp_binder = McpBinder::new(state.tool_registry.clone());
-            let tools_removed = mcp_binder.unbind(&key).await.unwrap_or(0);
-
-            (
-                StatusCode::OK,
-                Json(serde_json::json!({
-                    "status": "deleted",
-                    "routes_removed": routes_removed,
-                    "tools_removed": tools_removed,
-                })),
-            )
-                .into_response()
-        }
-        None => (StatusCode::NOT_FOUND, "Contract not found").into_response(),
+/// Transactional delete — extracted for testing.
+pub(crate) async fn perform_delete(
+    registry: Arc<ContractRegistry>,
+    binders: &dyn ContractBinders,
+    key: String,
+) -> Response {
+    if registry.get(&key).is_none() {
+        return (StatusCode::NOT_FOUND, "Contract not found").into_response();
     }
+
+    // ── unbind-first ──────────────────────────────────────────
+    let routes_removed = match binders.unbind_rest(&key).await {
+        Ok(n) => n,
+        Err(e) => {
+            warn!(error = %e, contract = %key, "REST unbind failed; contract NOT removed");
+            return binder_failure_response(&key, "REST", &e);
+        }
+    };
+
+    let tools_removed = match binders.unbind_mcp(&key).await {
+        Ok(n) => n,
+        Err(e) => {
+            warn!(error = %e, contract = %key, "MCP unbind failed; contract NOT removed");
+            // REST routes are already gone; best we can do is surface the error.
+            return binder_failure_response(&key, "MCP", &e);
+        }
+    };
+
+    // ── commit ────────────────────────────────────────────────
+    registry.remove(&key);
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "status": "deleted",
+            "routes_removed": routes_removed,
+            "tools_removed": tools_removed,
+        })),
+    )
+        .into_response()
+}
+
+fn binder_failure_response(key: &str, which: &str, _err: &str) -> Response {
+    // Client message is deliberately generic; full error is already in
+    // `tracing::warn!` server-side (see callers).
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({
+            "status": "error",
+            "message": format!("{} binder failed", which),
+            "key": key,
+        })),
+    )
+        .into_response()
 }
 
 #[cfg(test)]

--- a/stoa-gateway/src/handlers/admin/contracts.rs
+++ b/stoa-gateway/src/handlers/admin/contracts.rs
@@ -146,12 +146,30 @@ pub(crate) async fn perform_upsert(
         .clone()
         .unwrap_or_else(|| format!("{}:{}", contract.tenant_id, contract.name));
 
+    // Snapshot the previous contract (if this is an update) so any binder
+    // failure after bind_rest has started mutating the route/tool registries
+    // can be rolled back to the old state. `bind_rest` and `bind_mcp` both
+    // remove existing artefacts for the contract_key *before* installing
+    // new ones — without this snapshot, a post-remove failure would leave
+    // partial/empty bindings for a contract that still lives in the
+    // registry (GW-1 P1-1 update-case extension).
+    let previous = registry.get(&key);
+
     // ── bind-first ────────────────────────────────────────────
     let routes_count = match binders.bind_rest(&contract).await {
         Ok(n) => n,
         Err(e) => {
             warn!(error = %e, contract = %key, "REST bind failed; contract NOT persisted");
-            // No partial state to clean: bind_rest failed before registering any route.
+            // Restore the previous contract's bindings if this was an update.
+            // On a create, there's nothing to restore — the REST registry
+            // is still whatever state bind_rest left it in (today: no
+            // mutation before the Err return; defensively: restore_to_nothing
+            // via best-effort unbind).
+            if let Some(ref old) = previous {
+                restore_previous_bindings(binders, old, &key).await;
+            } else if let Err(rb) = binders.unbind_rest(&key).await {
+                warn!(error = %rb, contract = %key, "REST bind cleanup after failure also failed");
+            }
             return binder_failure_response(&key, "REST", &e);
         }
     };
@@ -159,10 +177,17 @@ pub(crate) async fn perform_upsert(
     let tools_count = match binders.bind_mcp(&contract).await {
         Ok(n) => n,
         Err(e) => {
-            warn!(error = %e, contract = %key, "MCP bind failed; rolling back REST routes");
-            // Best-effort rollback of the REST routes we just registered.
-            if let Err(rb) = binders.unbind_rest(&key).await {
-                warn!(error = %rb, contract = %key, "REST rollback unbind also failed");
+            warn!(error = %e, contract = %key, "MCP bind failed; rolling back bindings");
+            if let Some(ref old) = previous {
+                // Update case: restore the previous contract's REST + MCP
+                // bindings so the registry stays consistent with the artefact
+                // stores. Best-effort — failures are logged, response is 500.
+                restore_previous_bindings(binders, old, &key).await;
+            } else {
+                // Create case: unbind the REST routes we just registered.
+                if let Err(rb) = binders.unbind_rest(&key).await {
+                    warn!(error = %rb, contract = %key, "REST rollback unbind also failed");
+                }
             }
             return binder_failure_response(&key, "MCP", &e);
         }
@@ -221,9 +246,13 @@ pub(crate) async fn perform_delete(
     binders: &dyn ContractBinders,
     key: String,
 ) -> Response {
-    if registry.get(&key).is_none() {
-        return (StatusCode::NOT_FOUND, "Contract not found").into_response();
-    }
+    // Snapshot the contract up-front: if `unbind_mcp` fails after
+    // `unbind_rest` succeeded, we need the contract spec in hand to
+    // restore REST bindings (GW-1 P1-2 partial-state extension).
+    let old_contract = match registry.get(&key) {
+        Some(c) => c,
+        None => return (StatusCode::NOT_FOUND, "Contract not found").into_response(),
+    };
 
     // ── unbind-first ──────────────────────────────────────────
     let routes_removed = match binders.unbind_rest(&key).await {
@@ -237,8 +266,18 @@ pub(crate) async fn perform_delete(
     let tools_removed = match binders.unbind_mcp(&key).await {
         Ok(n) => n,
         Err(e) => {
-            warn!(error = %e, contract = %key, "MCP unbind failed; contract NOT removed");
-            // REST routes are already gone; best we can do is surface the error.
+            warn!(
+                error = %e,
+                contract = %key,
+                "MCP unbind failed; restoring REST routes and leaving contract in registry"
+            );
+            // Best-effort restore of the REST routes we just removed so
+            // the registry+REST view stays consistent. MCP state is
+            // indeterminate (the unbind failure means we can't predict
+            // what's there) — the caller sees 500 and can retry.
+            if let Err(rb) = binders.bind_rest(&old_contract).await {
+                warn!(error = %rb, contract = %key, "REST rollback bind(old) also failed");
+            }
             return binder_failure_response(&key, "MCP", &e);
         }
     };
@@ -254,6 +293,25 @@ pub(crate) async fn perform_delete(
         })),
     )
         .into_response()
+}
+
+/// Best-effort rollback that reinstalls the previous contract's REST
+/// routes and MCP tools. Used when an upsert's binder step fails on a
+/// contract that already existed. Each sub-step is independent and
+/// failures are only logged — the caller still returns 500 to the
+/// client, so partial restore is surfaced via server-side traces
+/// rather than a divergent response shape.
+async fn restore_previous_bindings(
+    binders: &dyn ContractBinders,
+    old: &UacContractSpec,
+    key: &str,
+) {
+    if let Err(e) = binders.bind_rest(old).await {
+        warn!(error = %e, contract = %key, "REST rollback bind(old) failed");
+    }
+    if let Err(e) = binders.bind_mcp(old).await {
+        warn!(error = %e, contract = %key, "MCP rollback bind(old) failed");
+    }
 }
 
 fn binder_failure_response(key: &str, which: &str, _err: &str) -> Response {

--- a/stoa-gateway/src/handlers/admin/contracts/tests.rs
+++ b/stoa-gateway/src/handlers/admin/contracts/tests.rs
@@ -559,7 +559,7 @@ mod transactional {
 
     // ── P1-1: upsert_contract_rest_bind_failure_does_not_persist_contract ─
     #[tokio::test]
-    async fn test_upsert_rest_bind_failure_does_not_persist() {
+    async fn regression_upsert_rest_bind_failure_does_not_persist() {
         let registry = Arc::new(ContractRegistry::new());
         let binders = MockBinders {
             rest_bind: Err("forced rest failure".into()),
@@ -773,7 +773,7 @@ mod transactional {
     //       so the rollback's bind_rest call also logs a warn — but the
     //       test's job is to verify the *attempt*, not the binder's health.
     #[tokio::test]
-    async fn test_upsert_existing_contract_rest_bind_failure_restores_previous_bindings() {
+    async fn regression_upsert_existing_contract_rest_bind_failure_restores_previous_bindings() {
         let registry = Arc::new(ContractRegistry::new());
         // Seed with the "old" version of the contract.
         let mut old = valid_contract("orders", "acme");
@@ -866,7 +866,7 @@ mod transactional {
     // indeterminate by construction, so we document it explicitly rather
     // than reporting false success.
     #[tokio::test]
-    async fn test_delete_contract_mcp_unbind_failure_restores_rest_bindings_or_reports_partial_state(
+    async fn regression_delete_contract_mcp_unbind_failure_restores_rest_bindings_or_reports_partial_state(
     ) {
         let registry = Arc::new(ContractRegistry::new());
         registry.upsert(valid_contract("orders", "acme"));

--- a/stoa-gateway/src/handlers/admin/contracts/tests.rs
+++ b/stoa-gateway/src/handlers/admin/contracts/tests.rs
@@ -684,6 +684,11 @@ mod transactional {
     }
 
     // ── P1-2: delete_contract_mcp_unbind_failure_does_not_delete ────────
+    //
+    // Asserts the core invariant (registry still holds the contract) and
+    // that the handler doesn't silently declare success. The specific
+    // rollback sequence is covered in more detail by
+    // `test_delete_contract_mcp_unbind_failure_restores_rest_bindings_or_reports_partial_state`.
     #[tokio::test]
     async fn test_delete_mcp_unbind_failure_does_not_remove_contract() {
         let registry = Arc::new(ContractRegistry::new());
@@ -709,8 +714,10 @@ mod transactional {
         assert_eq!(registry.count(), 1);
         assert!(registry.get("acme:orders").is_some());
 
+        // Both unbinds attempted in the right order; rollback path is
+        // asserted in detail by the dedicated restore-rollback test.
         let calls = binders.call_log();
-        assert_eq!(calls, vec!["unbind_rest", "unbind_mcp"]);
+        assert_eq!(&calls[..2], &["unbind_rest", "unbind_mcp"]);
     }
 
     // ── Happy delete through the transactional path ─────────────────────
@@ -747,5 +754,151 @@ mod transactional {
 
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
         assert!(binders.call_log().is_empty());
+    }
+
+    // =========================================================================
+    // GW-1 P1-1 / P1-2 update-case rollback (post-review patch on #2502)
+    //
+    // The CREATE-case tests above establish that new contracts aren't persisted
+    // if the binders fail. These UPDATE-case tests establish the stronger
+    // invariant that a binder failure on an *existing* contract restores the
+    // previous bindings, so registry + REST + MCP stay consistent.
+    // =========================================================================
+
+    // ── upsert_existing_contract_rest_failure_restores_previous_bindings ──
+    //
+    // Setup: pre-seeded registry with an "old" contract.
+    // Flow: bind_rest(new) fails → handler calls bind_rest(old) + bind_mcp(old)
+    //       as rollback. The mock returns Err for bind_rest on *every* call,
+    //       so the rollback's bind_rest call also logs a warn — but the
+    //       test's job is to verify the *attempt*, not the binder's health.
+    #[tokio::test]
+    async fn test_upsert_existing_contract_rest_bind_failure_restores_previous_bindings() {
+        let registry = Arc::new(ContractRegistry::new());
+        // Seed with the "old" version of the contract.
+        let mut old = valid_contract("orders", "acme");
+        old.version = "1.0.0".into();
+        registry.upsert(old);
+
+        let binders = MockBinders {
+            rest_bind: Err("forced rest failure".into()),
+            mcp_bind: Ok(5),
+            rest_unbind: Ok(0),
+            mcp_unbind: Ok(0),
+            calls: Arc::new(Mutex::new(vec![])),
+        };
+
+        // Attempt to upsert a "new" version.
+        let mut new = valid_contract("orders", "acme");
+        new.version = "2.0.0".into();
+        let resp = perform_upsert(registry.clone(), &binders, false, new)
+            .await
+            .into_response();
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        // Invariant: the OLD contract is still the one in the registry —
+        // the new upsert did not commit, and the rollback was attempted.
+        assert_eq!(registry.count(), 1);
+        let persisted = registry.get("acme:orders").expect("old contract kept");
+        assert_eq!(persisted.version, "1.0.0");
+
+        // Call log: bind_rest (new, fails) → bind_rest (old, rollback) →
+        //           bind_mcp (old, rollback). No bind_mcp on new.
+        assert_eq!(
+            binders.call_log(),
+            vec!["bind_rest", "bind_rest", "bind_mcp"]
+        );
+    }
+
+    // ── upsert_existing_contract_mcp_failure_restores_previous_bindings ──
+    //
+    // Flow: bind_rest(new) OK → bind_mcp(new) fails → handler tries
+    //       bind_rest(old) + bind_mcp(old) as rollback rather than just
+    //       unbind_rest (which would leave the contract_registry's "old"
+    //       row with no REST/MCP artefacts).
+    #[tokio::test]
+    async fn test_upsert_existing_contract_mcp_bind_failure_restores_previous_bindings() {
+        let registry = Arc::new(ContractRegistry::new());
+        let mut old = valid_contract("orders", "acme");
+        old.version = "1.0.0".into();
+        registry.upsert(old);
+
+        let binders = MockBinders {
+            rest_bind: Ok(7),
+            mcp_bind: Err("forced mcp failure".into()),
+            rest_unbind: Ok(0),
+            mcp_unbind: Ok(0),
+            calls: Arc::new(Mutex::new(vec![])),
+        };
+
+        let mut new = valid_contract("orders", "acme");
+        new.version = "2.0.0".into();
+        let resp = perform_upsert(registry.clone(), &binders, false, new)
+            .await
+            .into_response();
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        // Old contract still in registry, unchanged.
+        let persisted = registry.get("acme:orders").expect("old contract kept");
+        assert_eq!(persisted.version, "1.0.0");
+
+        // Call log: new path attempted (bind_rest OK, bind_mcp fails),
+        // then rollback restores (bind_rest old, bind_mcp old).
+        // Crucially: NO unbind_rest — on an update we restore rather than
+        // wipe, because wiping would leave the old contract with no artefacts.
+        let calls = binders.call_log();
+        assert_eq!(
+            calls,
+            vec!["bind_rest", "bind_mcp", "bind_rest", "bind_mcp"],
+            "expected restore sequence, got {:?}",
+            calls
+        );
+        assert!(!calls.contains(&"unbind_rest"));
+    }
+
+    // ── delete_contract_mcp_unbind_failure_restores_rest_bindings_or_reports_partial_state ──
+    //
+    // Flow: unbind_rest(key) OK (REST routes gone) → unbind_mcp(key) fails.
+    // Handler attempts bind_rest(old_contract) to restore REST routes, then
+    // returns 500 and leaves the contract in the registry. MCP state is
+    // indeterminate by construction, so we document it explicitly rather
+    // than reporting false success.
+    #[tokio::test]
+    async fn test_delete_contract_mcp_unbind_failure_restores_rest_bindings_or_reports_partial_state(
+    ) {
+        let registry = Arc::new(ContractRegistry::new());
+        registry.upsert(valid_contract("orders", "acme"));
+
+        let binders = MockBinders {
+            rest_bind: Ok(1),
+            mcp_bind: Ok(0),
+            rest_unbind: Ok(1),
+            mcp_unbind: Err("forced mcp unbind failure".into()),
+            calls: Arc::new(Mutex::new(vec![])),
+        };
+
+        let resp = perform_delete(registry.clone(), &binders, "acme:orders".into())
+            .await
+            .into_response();
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let json = read_body_json(resp).await;
+        assert!(json["message"].as_str().unwrap().contains("MCP"));
+
+        // Invariant: contract stays in registry (we could not fully delete).
+        assert_eq!(registry.count(), 1);
+        assert!(registry.get("acme:orders").is_some());
+
+        // Call log: unbind_rest (OK) → unbind_mcp (fails) → bind_rest(old)
+        // as best-effort REST restore.
+        let calls = binders.call_log();
+        assert_eq!(
+            calls,
+            vec!["unbind_rest", "unbind_mcp", "bind_rest"],
+            "expected REST restore after MCP unbind failure, got {:?}",
+            calls
+        );
     }
 }

--- a/stoa-gateway/src/handlers/admin/contracts/tests.rs
+++ b/stoa-gateway/src/handlers/admin/contracts/tests.rs
@@ -464,3 +464,288 @@ async fn test_mcp_tools_visible_via_list() {
     assert_eq!(tools[0].name, "uac:acme:payment-api:payment-api-0");
     assert_eq!(tools[0].tenant_id.as_deref(), Some("acme"));
 }
+
+// =============================================================================
+// GW-1 P1-1 / P1-2 / P2-2: transactional invariants
+// =============================================================================
+//
+// These tests exercise `perform_upsert` / `perform_delete` with mock
+// binders so we can inject failures — the concrete `RestBinder` /
+// `McpBinder` cannot currently fail, but the trait signature allows it
+// and the transactional path must be correct *by construction*.
+
+mod transactional {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    use crate::handlers::admin::contracts::{perform_delete, perform_upsert, ContractBinders};
+    use crate::uac::registry::ContractRegistry;
+    use crate::uac::schema::{ContractStatus, UacContractSpec, UacEndpoint};
+
+    /// Mock binder with per-method outcomes; remembers calls for assertions.
+    struct MockBinders {
+        rest_bind: Result<usize, String>,
+        mcp_bind: Result<usize, String>,
+        rest_unbind: Result<usize, String>,
+        mcp_unbind: Result<usize, String>,
+        calls: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    use std::sync::Mutex;
+
+    impl MockBinders {
+        fn happy(rest_n: usize, mcp_n: usize) -> Self {
+            Self {
+                rest_bind: Ok(rest_n),
+                mcp_bind: Ok(mcp_n),
+                rest_unbind: Ok(rest_n),
+                mcp_unbind: Ok(mcp_n),
+                calls: Arc::new(Mutex::new(vec![])),
+            }
+        }
+        fn record(&self, what: &'static str) {
+            self.calls.lock().unwrap().push(what);
+        }
+        fn call_log(&self) -> Vec<&'static str> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl ContractBinders for MockBinders {
+        async fn bind_rest(&self, _: &UacContractSpec) -> Result<usize, String> {
+            self.record("bind_rest");
+            self.rest_bind.clone()
+        }
+        async fn bind_mcp(&self, _: &UacContractSpec) -> Result<usize, String> {
+            self.record("bind_mcp");
+            self.mcp_bind.clone()
+        }
+        async fn unbind_rest(&self, _: &str) -> Result<usize, String> {
+            self.record("unbind_rest");
+            self.rest_unbind.clone()
+        }
+        async fn unbind_mcp(&self, _: &str) -> Result<usize, String> {
+            self.record("unbind_mcp");
+            self.mcp_unbind.clone()
+        }
+    }
+
+    fn valid_contract(name: &str, tenant: &str) -> UacContractSpec {
+        let mut spec = UacContractSpec::new(name, tenant);
+        spec.status = ContractStatus::Published;
+        spec.endpoints = vec![UacEndpoint {
+            path: "/tx".to_string(),
+            methods: vec!["GET".to_string()],
+            backend_url: "https://backend.test".to_string(),
+            method: None,
+            description: None,
+            operation_id: Some("tx".to_string()),
+            input_schema: None,
+            output_schema: None,
+        }];
+        spec
+    }
+
+    async fn read_body_json(resp: axum::response::Response) -> serde_json::Value {
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    // ── P1-1: upsert_contract_rest_bind_failure_does_not_persist_contract ─
+    #[tokio::test]
+    async fn test_upsert_rest_bind_failure_does_not_persist() {
+        let registry = Arc::new(ContractRegistry::new());
+        let binders = MockBinders {
+            rest_bind: Err("forced rest failure".into()),
+            mcp_bind: Ok(99), // unreachable — bind-first aborts earlier
+            rest_unbind: Ok(0),
+            mcp_unbind: Ok(0),
+            calls: Arc::new(Mutex::new(vec![])),
+        };
+
+        let resp = perform_upsert(
+            registry.clone(),
+            &binders,
+            /* llm_enabled */ false,
+            valid_contract("orders", "acme"),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let json = read_body_json(resp).await;
+        assert_eq!(json["status"], "error");
+        assert!(json["message"].as_str().unwrap().contains("REST"));
+
+        // Invariant: contract NOT persisted.
+        assert_eq!(registry.count(), 0);
+        assert!(registry.get("acme:orders").is_none());
+
+        // mcp_bind must not have been called: bind-first aborts on REST failure.
+        let calls = binders.call_log();
+        assert!(!calls.contains(&"bind_mcp"), "calls = {:?}", calls);
+    }
+
+    // ── P1-1: upsert_contract_mcp_bind_failure_does_not_persist_contract ──
+    #[tokio::test]
+    async fn test_upsert_mcp_bind_failure_does_not_persist_and_rolls_back_rest() {
+        let registry = Arc::new(ContractRegistry::new());
+        let binders = MockBinders {
+            rest_bind: Ok(1),
+            mcp_bind: Err("forced mcp failure".into()),
+            rest_unbind: Ok(1),
+            mcp_unbind: Ok(0),
+            calls: Arc::new(Mutex::new(vec![])),
+        };
+
+        let resp = perform_upsert(
+            registry.clone(),
+            &binders,
+            false,
+            valid_contract("orders", "acme"),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let json = read_body_json(resp).await;
+        assert!(json["message"].as_str().unwrap().contains("MCP"));
+
+        // Invariant: contract NOT persisted.
+        assert_eq!(registry.count(), 0);
+
+        // REST rollback must have been attempted.
+        let calls = binders.call_log();
+        assert_eq!(calls, vec!["bind_rest", "bind_mcp", "unbind_rest"]);
+    }
+
+    // ── P2-2: response counts come from BindingOutput lengths ───────────
+    #[tokio::test]
+    async fn test_upsert_uses_binding_output_lengths_not_endpoint_count() {
+        let registry = Arc::new(ContractRegistry::new());
+        // Contract has 1 endpoint, but mocks claim 7 REST routes and 3 tools —
+        // the response must echo the binder counts, not the endpoint count.
+        let binders = MockBinders::happy(7, 3);
+
+        let resp = perform_upsert(
+            registry.clone(),
+            &binders,
+            false,
+            valid_contract("orders", "acme"),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let json = read_body_json(resp).await;
+        assert_eq!(json["routes_generated"], 7);
+        assert_eq!(json["tools_generated"], 3);
+
+        // Happy path: contract IS persisted, and only after both binds.
+        assert_eq!(registry.count(), 1);
+        assert_eq!(binders.call_log(), vec!["bind_rest", "bind_mcp"]);
+    }
+
+    // ── P1-2: delete_contract_rest_unbind_failure_does_not_delete ───────
+    #[tokio::test]
+    async fn test_delete_rest_unbind_failure_does_not_remove_contract() {
+        let registry = Arc::new(ContractRegistry::new());
+        registry.upsert(valid_contract("orders", "acme"));
+
+        let binders = MockBinders {
+            rest_bind: Ok(0),
+            mcp_bind: Ok(0),
+            rest_unbind: Err("forced rest unbind failure".into()),
+            mcp_unbind: Ok(0),
+            calls: Arc::new(Mutex::new(vec![])),
+        };
+
+        let resp = perform_delete(registry.clone(), &binders, "acme:orders".into())
+            .await
+            .into_response();
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let json = read_body_json(resp).await;
+        assert!(json["message"].as_str().unwrap().contains("REST"));
+
+        // Invariant: contract NOT removed.
+        assert_eq!(registry.count(), 1);
+        assert!(registry.get("acme:orders").is_some());
+
+        // mcp_unbind must not have been called: unbind-first aborts on REST.
+        let calls = binders.call_log();
+        assert!(!calls.contains(&"unbind_mcp"));
+    }
+
+    // ── P1-2: delete_contract_mcp_unbind_failure_does_not_delete ────────
+    #[tokio::test]
+    async fn test_delete_mcp_unbind_failure_does_not_remove_contract() {
+        let registry = Arc::new(ContractRegistry::new());
+        registry.upsert(valid_contract("orders", "acme"));
+
+        let binders = MockBinders {
+            rest_bind: Ok(0),
+            mcp_bind: Ok(0),
+            rest_unbind: Ok(1),
+            mcp_unbind: Err("forced mcp unbind failure".into()),
+            calls: Arc::new(Mutex::new(vec![])),
+        };
+
+        let resp = perform_delete(registry.clone(), &binders, "acme:orders".into())
+            .await
+            .into_response();
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let json = read_body_json(resp).await;
+        assert!(json["message"].as_str().unwrap().contains("MCP"));
+
+        // Invariant: contract NOT removed (even though REST routes already gone).
+        assert_eq!(registry.count(), 1);
+        assert!(registry.get("acme:orders").is_some());
+
+        let calls = binders.call_log();
+        assert_eq!(calls, vec!["unbind_rest", "unbind_mcp"]);
+    }
+
+    // ── Happy delete through the transactional path ─────────────────────
+    #[tokio::test]
+    async fn test_delete_happy_path_reports_binding_counts() {
+        let registry = Arc::new(ContractRegistry::new());
+        registry.upsert(valid_contract("orders", "acme"));
+
+        let binders = MockBinders::happy(5, 2);
+        let resp = perform_delete(registry.clone(), &binders, "acme:orders".into())
+            .await
+            .into_response();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = read_body_json(resp).await;
+        assert_eq!(json["status"], "deleted");
+        assert_eq!(json["routes_removed"], 5);
+        assert_eq!(json["tools_removed"], 2);
+        assert_eq!(registry.count(), 0);
+
+        // Order must be unbind-first: both unbinds happened before remove.
+        assert_eq!(binders.call_log(), vec!["unbind_rest", "unbind_mcp"]);
+    }
+
+    // ── Unknown contract deletes still short-circuit to 404 ─────────────
+    #[tokio::test]
+    async fn test_delete_unknown_contract_returns_404_without_calling_binders() {
+        let registry = Arc::new(ContractRegistry::new());
+        let binders = MockBinders::happy(0, 0);
+
+        let resp = perform_delete(registry.clone(), &binders, "ghost:none".into())
+            .await
+            .into_response();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert!(binders.call_log().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes **P1-1, P1-2, P2-2** from `BUG-REPORT-GW-1` Rev 2.

Contract mutations on `/admin/contracts` now hold a single invariant: the registry never claims artefacts the binders didn't produce, and never outlives artefacts the binders didn't remove.

| Finding | Severity | Fix |
|---|---|---|
| P1-1 | P1 | `upsert_contract` is **bind-first**. Contract is persisted only after both REST + MCP binds return `Ok`. Binder failure returns `500`; MCP failure triggers a best-effort `unbind_rest` rollback. |
| P1-2 | P1 | `delete_contract` is **unbind-first**. Contract is removed only after both unbinds return `Ok`. Unbind failure returns `500` and leaves the contract in the registry. |
| P2-2 | P2 | `routes_generated` / `tools_generated` come from the binder return values, not `contract.endpoints.len()`. |

## Design — local `ContractBinders` trait

The concrete `RestBinder` / `McpBinder` return `Ok(...)` unconditionally today, so the trait signature allowed failures that never happened. The handler used to instantiate them inline, making failure-path testing impossible.

Introduced a module-local `ContractBinders` trait (`async_trait`) with 4 operations. Production wires `RealBinders { RestBinder, McpBinder }`; tests inject `MockBinders` with configurable outcomes and a call-log. Handlers delegate to extracted `perform_upsert` / `perform_delete` helpers — this is the seam the regression suite exercises.

## Client response changes

- `500 Internal Server Error` on binder failure, body `{ "status": "error", "message": "<REST|MCP> binder failed", "key": ... }`.
- Full error kept in `tracing::warn!` server-side (no leak of internals in the client payload, same hygiene as P1-0).
- `200/201` + counts on success — unchanged shape, `routes_generated` / `tools_generated` now authoritative.

## What stays out of this PR

- Contract-level audit log (P1-4) — dedicated PR, tactical `tracing` middleware.
- Admin input validation on other upserts (P1-6) — next in the P1 sequence per reviewer plan.
- Skills health memory growth (P1-5) — next after input validation.
- Admin rate-limit differentiation (read vs write, trusted-proxy headers) — follow-up to the P1-3-lite shipped in #2501.

## Test plan

- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo test`: 2187 unit + 53 + 52 + 15 + 38 integration tests green (0 failed).
- [x] 7 new `transactional::*` tests under `handlers::admin::contracts::tests`:
  - `test_upsert_rest_bind_failure_does_not_persist` (P1-1)
  - `test_upsert_mcp_bind_failure_does_not_persist_and_rolls_back_rest` (P1-1)
  - `test_upsert_uses_binding_output_lengths_not_endpoint_count` (P2-2)
  - `test_delete_rest_unbind_failure_does_not_remove_contract` (P1-2)
  - `test_delete_mcp_unbind_failure_does_not_remove_contract` (P1-2)
  - `test_delete_happy_path_reports_binding_counts`
  - `test_delete_unknown_contract_returns_404_without_calling_binders`
- [x] All 16 pre-existing contract tests still green (no regression on happy path through the real binders).

## Refs

- `stoa-gateway/BUG-REPORT-GW-1.md` § P1-1, P1-2, P2-2.
- Sibling PR #2501 (GW-1 P0 batch) — independent; this PR branches off `main`, no merge ordering required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)