### PR TITLE
fix(gateway): GW-1 P2 batch — 8 admin cleanup items (GW-1 CLOSED)

### DIFF
--- a/stoa-gateway/BUG-REPORT-GW-1.md
+++ b/stoa-gateway/BUG-REPORT-GW-1.md
@@ -1,5 +1,13 @@
 # BUG-REPORT-GW-1 — `stoa-gateway/src/handlers/admin/`
 
+> **GW-1 CLOSED 2026-04-24** — 20/20 bugs shipped across 4 batches.
+> - **P0** (#2501) : P0-1 constant-time auth + P0-2 route orphan + P1-0 reload leak + P1-3 admin rate-limit
+> - **P1 contracts** (#2502) : P1-1 bind-first upsert + P1-2 unbind error propagation + P2-2 BindingOutput length
+> - **P1 input validation** (#2504) : P1-6 required-fields across 5 upsert endpoints + P1-9 OAuth2 URL parsing
+> - **P1 admin audit log** (#2506) : P1-4 tactical audit middleware (request_id, action, resource, outcome)
+> - **P1 skills health safety** (#2508) : P1-5 `stats_opt` read-only + 404 on unknown skill
+> - **P2 batch** (branch `fix/gw-1-p2-batch`, commits `4a29c7990..48a4e4a68`) : P1-7 + P2-1/2-3/2-4/2-5/2-6/2-7/2-8 + P2-test-1
+>
 > **Rev 2 (post-review)** — reclassifications appliquées après review :
 > P0-3 reclassé P1 (sécurité/hardening), P1-7 marqué "à vérifier / probablement non-bug" (matchit literal>param + MethodRouter 405), P1-8 reclassé P2 test-infra, P1-10 reclassé P2 (observabilité DORA-adjacent).
 > Exploitability de P0-1 atténuée (sans mesure réelle d'infra, "~1h" était trop précis). P2-2 rattaché au batch contracts avec P1-1/P1-2.
@@ -39,6 +47,7 @@
 ## Critical (P0)
 
 ### P0-1 — Timing attack sur `admin_auth`
+- **STATUS** : **FIXED** — PR #2501 (constant-time compare via `subtle::ConstantTimeEq`).
 - **Fichier** : `src/handlers/admin/auth.rs:43`
 - **Code** :
   ```rust
@@ -61,6 +70,7 @@
 - **Tests à ajouter** : test de régression unit `test_admin_auth_wrong_length` + `test_admin_auth_same_length_wrong_byte`.
 
 ### P0-2 — Endpoint orphelin `/admin/api-proxy/backends` sans auth
+- **STATUS** : **FIXED** — PR #2501 (route moved inside `admin_router`).
 - **Fichier** : `src/lib.rs:374` (+ `src/proxy/api_proxy_handler.rs:451-489`)
 - **Code** :
   ```rust
@@ -86,6 +96,7 @@
 ## High (P1)
 
 ### P1-0 — Fuite d'informations internes dans les erreurs de `/admin/routes/reload` *(ex-P0-3, reclassé P1 post-review)*
+- **STATUS** : **FIXED** — PR #2501 (sanitized client messages + 502/503/500 mapping + request_id log correlation).
 - **Fichier** : `src/handlers/admin/reload.rs:33-39, 53-79`
 - **Code** :
   ```rust
@@ -110,6 +121,7 @@
   3. Mapping ciblé pour les erreurs connues-utiles : `404` si CP a répondu 404, `502` si CP down, `503` si `STOA_CONTROL_PLANE_URL` absent.
 
 ### P1-1 — État transactionnel cassé sur `upsert_contract`
+- **STATUS** : **FIXED** — PR #2502 (bind-first upsert + partial-state rollback).
 - **Fichier** : `src/handlers/admin/contracts.rs:57-99`
 - **Séquence** :
   1. `contract_registry.upsert(contract.clone())` → commit en mémoire (ligne 61).
@@ -121,6 +133,7 @@
 - **Fix direction** : séquence bind-first → puis upsert, ou deux-phase commit (bind dans une struct temporaire → swap atomique) ; **a minima** retourner `207 Multi-Status` / `500` avec `binders_failed: [...]` dans le body quand une des opérations bind échoue.
 
 ### P1-2 — Erreur d'unbind silencieusement écrasée sur `delete_contract`
+- **STATUS** : **FIXED** — PR #2502 (unbind-first delete + error propagation, no more `unwrap_or(0)`).
 - **Fichier** : `src/handlers/admin/contracts.rs:128, 132`
 - **Code** :
   ```rust
@@ -132,18 +145,21 @@
 - **Fix direction** : propager l'erreur — `unbind().await.map_err(...)?` ou `match` explicite avec `500` + log.
 
 ### P1-3 — Pas de rate-limit sur le routeur admin → amplifie P0-1
+- **STATUS** : **FIXED** — PR #2501 (admin_rate_limit middleware, keyed `admin:<peer_ip>`, fail-open without ConnectInfo).
 - **Fichier** : `src/lib.rs:93-264` (admin_router + nest)
 - **Problème** : le routeur admin applique `admin_auth` mais aucune couche de rate-limit/back-off. Combiné au timing-attack (P0-1), un attaquant peut déclencher des millions de comparaisons de token sans être ralenti. `state.rate_limiter` existe (`src/state.rs:59`) mais n'est pas branché ici.
 - **Sévérité P1** : propre (rate-limit absent = bug d'ops même sans timing-attack).
 - **Fix direction** : ajouter une layer `tower_governor` ou impl maison à 60 req/min/IP avant `admin_auth`. Distinguer les endpoints read-only (tolérance large) des endpoints mutatifs (quelques req/min). **Candidat à inclure dans le batch P0** si la layer est simple (~40 LOC) — renforce directement P0-1.
 
 ### P1-4 — Pas d'audit log pour les actions admin mutantes
+- **STATUS** : **FIXED** — PR #2506 (tactical `admin_audit_log` middleware in `handlers/admin/audit.rs`, structured `audit=true` tracing events per request with request_id, method, path, status, actor, action, resource, outcome, duration_ms; applied as outermost layer).
 - **Fichiers concernés** : `apis.rs` (upsert/delete), `policies.rs` (upsert/delete), `contracts.rs` (upsert/delete), `credentials.rs` (4 endpoints mutants), `skills.rs` (upsert/update/delete/sync/reset/health_reset), `reload.rs`, `federation.rs` (cache_invalidate), `quotas.rs` (reset), `circuit_breaker.rs` (reset).
 - **Problème** : aucune de ces routes n'émet un événement d'audit structuré (actor, action, resource_key, outcome, timestamp). Les seuls signaux sont des `tracing::warn!` sur rejection (apis.rs:41, 49, 61). Insuffisant pour DORA (exige "auditabilité complète des opérations admin"), ISO 27001 A.12.4.1.
 - **Sévérité P1** : bloquant pour certification bancaire (cf. démo juin multi-client).
 - **Fix direction** : trait `AdminAuditSink` → topic Kafka dédié / log structuré filtré par appender. Wrapper middleware sur `admin_router` qui capture méthode, path, status, actor, durée. Alternative tactique : crate `tracing` avec champ `audit=true` filtré par un layer dédié. **PR la plus grosse du lot** (~200 LOC + design) — isoler.
 
 ### P1-5 — `skills_health` fait croître la mémoire sans borne + fake-positive
+- **STATUS** : **FIXED** — PR #2508 (`stats_opt` read-only + 404 on unknown skill via `skill_resolver.get()` pre-check + `skills_health_reset` symmetric 404).
 - **Fichier** : `src/handlers/admin/skills.rs:255-259` ; délégué à `src/skills/health.rs:90-114`
 - **Code** :
   ```rust
@@ -160,6 +176,7 @@
 - **Fix direction** : dans `skills.rs:255`, vérifier d'abord `state.skill_resolver.get(&id).is_none()` → `404`. Puis `stats` ne doit lire que via une route `get` pure (pas `get_or_create`). Séparer un chemin `get_or_create_for_record()` (usage interne quand on **enregistre** un call) d'un chemin `peek()` read-only pour l'endpoint admin.
 
 ### P1-6 — Validation manquante sur 5 endpoints upsert
+- **STATUS** : **FIXED** — PR #2504 (shared `validation::require_non_empty` + batched BAD_REQUEST error body across apis/policies/credentials/skills/contracts upserts).
 - **`policies.rs:13-25`** — `PolicyEntry.id`, `name`, `policy_type`, `config`, `api_id` tous acceptés vides. Policy avec id="" stockée sous clé `""`, collision avec autres policy sans id.
 - **`credentials.rs:68-69`** (upsert_backend_credential) — `route_id`, `header_name`, `header_value` non vérifiés vides. Clé `""` en store crée conflits ; credential à valeur vide = injection de `Authorization: Bearer ` vide en aval.
 - **`credentials.rs:109-126`** (upsert_consumer_credential) — zéro validation : pas de check SSRF même si OAuth2, pas de check presence champs.
@@ -169,6 +186,7 @@
 - **Fix direction** : un helper `validate_admin_input!(route.id, route.tenant_id, ...)` qui renvoie `400 BAD_REQUEST` listant les champs en défaut. Les `validate()` ad-hoc existants (ex : `UacContractSpec::validate` couvre déjà bien, `src/uac/schema.rs:169-185`) peuvent servir de modèle.
 
 ### P1-7 — ~~Conflit de matching `/skills/status` vs `/skills/:id`~~ **À vérifier / probablement non-bug**
+- **STATUS** : **CLOSED as non-bug** — branch `fix/gw-1-p2-batch` commit `4a29c7990` (regression test `regression_delete_skills_status_returns_405_not_delete_by_id` in `src/handlers/admin/router.rs` verifies matchit's literal > param priority + Axum's default `MethodRouter` 405 response with `Allow` header).
 - **Fichier** : `src/lib.rs:162-181`
 - **Statut post-review** : le finding initial supposait un fallthrough méthode sur `MethodRouter` Axum. Revue faite :
   - `matchit` donne priorité aux segments statiques sur les segments dynamiques → `/skills/status` match le literal avant `/skills/:id`.
@@ -188,6 +206,7 @@
 - *(Section déplacée vers Medium / P2 — voir P2-test-1)*
 
 ### P1-9 — HTTPS check case-sensitive + pas de normalisation URL sur OAuth2 token_url
+- **STATUS** : **FIXED** — PR #2504 (`url::Url::parse` + lowercase scheme check + CRLF injection test).
 - **Fichier** : `src/handlers/admin/credentials.rs:44`
 - **Code** : `if !oauth2.token_url.starts_with("https://") { return 400; }`
 - **Problème** : `HTTPS://...` est rejeté (faux positif sur URL valide), `https://foo\nHost: evil` accepté (pas de parsing URL propre). La chaîne brute est passée plus tard à `is_blocked_url` (ligne 54) qui fait sans doute un parse ; mais la validation initiale est naïve.
@@ -199,47 +218,56 @@
 ## Medium (P2)
 
 ### P2-1 — `health.rs` toujours `"ok"` — endpoint admin_health sans liveness/readiness
+- **STATUS** : **FIXED** — `fix/gw-1-p2-batch` commit `0233e0598` (added `contracts_count`, `skills_count`, `uptime_seconds` + module doc-comment clarifying this is NOT a liveness probe; `/ready` and `/health/ready` remain the K8s probes).
 - **Fichier** : `src/handlers/admin/health.rs:17-25`
 - **Problème** : `/admin/health` renvoie toujours `status: "ok"`, même si route_registry / policy_registry sont vides mais fonctionnels. Pas de signal de readiness (ex : CP atteignable, KC atteignable). Utilisé comme endpoint admin, pas comme liveness probe K8s — MAIS confusion possible si un opérateur s'y réfère.
 - **Fix direction** : ajouter un mode `?readiness=true` qui vérifie CP reachability + KC JWKS cache âge ; ou laisser `/admin/health` purement statique (version + compteurs) et déléguer liveness/readiness à `/ready` + `/health/ready` déjà présents (`src/lib.rs:260-263`) — documenter dans le doc-comment de `admin_health`.
 
 ### P2-2 — `routes_count` / `tools_count` couplés à `contract.endpoints.len()` *(rattaché au batch P1-1/P1-2)*
+- **STATUS** : **FIXED** — PR #2502 (uses `BindingOutput` actual lengths).
 - **Fichier** : `src/handlers/admin/contracts.rs:66, 76`
 - **Problème** : on fait confiance à la taille de `contract.endpoints` comme proxy de "nombre de routes/tools générés". Aujourd'hui `RestBinder::generate_routes` est 1-pour-1 (cf. `src/uac/binders/rest.rs:26-68`) mais c'est un couplage implicite. Un futur skip/filtre rendra la métrique fausse sans casser de test.
 - **Fix direction** : `rest_binder.bind(...)` renvoie déjà `BindingOutput::Routes(Vec<_>)` ; utiliser `.len()` sur le retour. Idem côté MCP. **À inclure dans la PR "Contract consistency"** avec P1-1 et P1-2.
 
 ### P2-3 — `skills_delete` legacy (?key=) coexiste avec `skills_delete_by_id` (:id)
+- **STATUS** : **FIXED** — `fix/gw-1-p2-batch` commit `0ac0e1671` (RFC 9745 `Deprecation: @1776988800` + RFC 8594 `Sunset: Sat, 24 Oct 2026 23:59:59 GMT` + RFC 8288 `Link` successor-version + `warn!` tracing; `#[deprecated]` intentionally avoided to stay compatible with `-D warnings`).
 - **Fichier** : `src/handlers/admin/skills.rs:186-195, 243-252`
 - **Problème** : deux endpoints DELETE fonctionnellement redondants. Tech-debt, risque de drift comportemental (audit/observabilité inégale).
 - **Fix direction** : documenter le legacy comme deprecated + header `Deprecation:` ; planifier suppression CAB.
 
 ### P2-4 — `skills_upsert` retourne toujours `200 OK` jamais `201 CREATED`
+- **STATUS** : **FIXED** — `fix/gw-1-p2-batch` commit `0ac0e1671` (probe `skill_resolver.get(&key).is_some()` before upsert to choose 201/200; aligned with apis/policies/credentials/contracts convention).
 - **Fichier** : `src/handlers/admin/skills.rs:113-117`
 - **Problème** : tous les autres upsert admin (`apis.rs`, `policies.rs`, `credentials.rs`, `contracts.rs`) respectent la convention `OK (update) / CREATED (new)`. Skills casse le contrat.
 - **Fix direction** : `let existed = state.skill_resolver.upsert(skill).is_some();` si l'API le permet, sinon probe préalable. Aligner sur le reste.
 
 ### P2-5 — `federation_cache_invalidate` renvoie 200 aveuglément
+- **STATUS** : **FIXED** — `fix/gw-1-p2-batch` commit `0ac0e1671` (new `FederationCache::contains` wraps moka's `contains_key`; response body carries `{ invalidated: bool, sub_account_id }`).
 - **Fichier** : `src/handlers/admin/federation.rs:41-53`
 - **Problème** : aucune indication si la clé existait. Admin ne peut pas distinguer "cache invalidé" vs "sub_account_id typé n'avait rien en cache" vs "typo dans l'ID".
 - **Fix direction** : retourner `{ "invalidated": true|false, "entries_removed": N }` selon l'API du cache.
 
 ### P2-6 — `circuit_breaker_reset` ne remonte pas l'état précédent
+- **STATUS** : **FIXED** — `fix/gw-1-p2-batch` commit `0ac0e1671` (new atomic `CircuitBreaker::reset_with_previous` + `CircuitBreakerRegistry::reset_with_previous`; both legacy CP and per-upstream endpoints now return `{ previous_state, new_state }`).
 - **Fichier** : `src/handlers/admin/circuit_breaker.rs:44-51`
 - **Problème** : retourne 200 OK même si le CB était déjà `closed`. Admin ne peut pas voir si l'action a eu un effet.
 - **Fix direction** : réponse `{ "previous_state": "...", "new_state": "closed" }`.
 
 ### P2-7 — `prometheus::gather()` plein-scan à chaque `/admin/llm/costs`
+- **STATUS** : **FIXED** — `fix/gw-1-p2-batch` commit `48a4e4a68` (replaced global `prometheus::gather()` with `LLM_COST_TOTAL.collect()` via `prometheus::core::Collector`; reader-side only, no change to counter registration or increments).
 - **Fichier** : `src/handlers/admin/llm.rs:124`
 - **Problème** : `prometheus::gather()` itère toutes les MetricFamilies du registry global (peut être centaines de milliers de lignes dans une instance prod chargée). Endpoint admin, appelé rarement, donc pas un P0/P1 — mais inutile ; on peut exposer un `CounterVec` dédié et le lire directement.
 - **Fix direction** : stocker une référence aux counters `gateway_llm_cost_total_*` dans `state.cost_calculator` et les lire ciblément.
 
 ### P2-8 — `upsert_api` émet des steps de progression fictifs *(ex-P1-10, reclassé P2)*
+- **STATUS** : **FIXED** — `fix/gw-1-p2-batch` commit `0233e0598` (removed fake `ApplyingPolicies` and `Activating` step pairs; honest sequence is now `Validating` → `ApplyingRoutes` → `Done`; enum variants preserved for real consumers).
 - **Fichier** : `src/handlers/admin/apis.rs:108-147`
 - **Problème** : les steps `ApplyingPolicies` et `Activating` sont émis `step_started`/`step_completed` sans exécuter de travail (`// no-op for direct route upsert`, ligne 108). La route est en fait activée en un seul appel `route_registry.upsert` ligne 95. Les événements télémétriques sont donc mensongers : un consommateur de `state.deploy_progress` (ex : portal UI) affiche une chronologie synthétique qui ne reflète pas la réalité.
 - **Sévérité P2 (DORA-adjacent)** : observabilité mensongère. Pour un audit DORA post-incident, un opérateur regardant la timeline peut mal attribuer la cause racine. Downgradé sous P1-4 (audit log) qui est le vrai mécanisme d'auditabilité.
 - **Fix direction** : soit émettre ces steps pour de vraies phases (brancher une vraie logique "apply policies" une fois que `upsert_api` les gère), soit les supprimer et laisser `Validating` → `ApplyingRoutes` → `Done` (3 steps honnêtes).
 
 ### P2-test-1 — Drift `build_full_admin_router` *(ex-P1-8, reclassé test-infra)*
+- **STATUS** : **FIXED** — `fix/gw-1-p2-batch` commit `4a29c7990` (factory `admin::build_admin_router` in new `src/handlers/admin/router.rs` is the single source of truth; `lib.rs` calls it with `.nest("/admin", ...)` and `test_helpers::build_full_admin_router` delegates to the same factory — zero drift possible by construction).
 - **Fichier** : `src/handlers/admin/test_helpers.rs:48-112` vs prod `src/lib.rs:93-263`
 - **Problème** : le helper `build_full_admin_router` utilisé par les tests n'inclut **pas** les endpoints suivants (présents en prod) : `skills_*` (11 routes), `reload_routes`, `llm_*` (3), `diagnostic_*` (3), `snapshot_*` (3), `ebpf_*`, `a2a/agents/*`, `hegemon/*`. Conséquence : aucune des rewrite-GW1 tests ne couvre ces handlers à travers le middleware `admin_auth`. Pire : la couverture varie en fonction du test harness — drift silencieux possible.
 - **Sévérité P2 test-infra** : dette structurelle. Pas de bug runtime directement exploitable, mais sous-estime la couverture réelle et rate des régressions d'auth middleware sur ~25 routes prod.

--- a/stoa-gateway/src/federation/cache.rs
+++ b/stoa-gateway/src/federation/cache.rs
@@ -105,6 +105,15 @@ impl FederationCache {
         }
     }
 
+    /// Return whether `sub_account_id` is currently cached (GW-1 P2-5).
+    /// Synchronous O(1) probe used by the admin invalidation handler so
+    /// the response body can tell the caller whether an entry was
+    /// actually purged. moka may expose an entry that is about to
+    /// expire; accepting that tiny window keeps the admin call cheap.
+    pub fn contains(&self, sub_account_id: &str) -> bool {
+        self.cache.contains_key(sub_account_id)
+    }
+
     /// Manually invalidate a sub-account's cached allow-list.
     pub async fn invalidate(&self, sub_account_id: &str) {
         self.cache.invalidate(sub_account_id).await;

--- a/stoa-gateway/src/handlers/admin.rs
+++ b/stoa-gateway/src/handlers/admin.rs
@@ -34,6 +34,7 @@ mod mtls;
 mod policies;
 mod quotas;
 mod reload;
+mod router;
 mod sessions;
 mod skills;
 mod tracing;
@@ -70,6 +71,7 @@ pub use mtls::{mtls_config, mtls_stats};
 pub use policies::{delete_policy, list_policies, upsert_policy};
 pub use quotas::{get_consumer_quota, list_quotas, reset_consumer_quota};
 pub use reload::{reload_routes_from_cp, routes_reload};
+pub(crate) use router::build_admin_router;
 pub use sessions::{session_stats, SessionStatsResponse};
 pub use skills::{
     skills_delete, skills_delete_by_id, skills_get_by_id, skills_health, skills_health_all,

--- a/stoa-gateway/src/handlers/admin/apis.rs
+++ b/stoa-gateway/src/handlers/admin/apis.rs
@@ -103,39 +103,18 @@ pub async fn upsert_api(
         tid,
     );
 
-    // Step 3: Applying policies (no-op for direct route upsert, but signals step)
-    emitter.step_started(
-        deployment_id,
-        DeployStep::ApplyingPolicies,
-        "Checking associated policies",
-        aid,
-        tid,
-    );
-    emitter.step_completed(
-        deployment_id,
-        DeployStep::ApplyingPolicies,
-        "Policy check complete",
-        aid,
-        tid,
-    );
+    // GW-1 P2-8: `upsert_api` does NOT apply policies and does NOT have
+    // a separate activation phase — `route_registry.upsert` above both
+    // persists and activates the route in one call. Emitting fake
+    // `ApplyingPolicies` / `Activating` step_started + step_completed
+    // events around empty blocks produced a mendacious timeline that
+    // confused operators reading the deploy_progress stream during
+    // post-incident reviews. The `DeployStep` variants stay defined in
+    // `telemetry/deploy.rs` for genuine consumers (contract-level flows
+    // that actually bind policies). The honest sequence emitted here
+    // is: Validating → ApplyingRoutes → Done.
 
-    // Step 4: Activating
-    emitter.step_started(
-        deployment_id,
-        DeployStep::Activating,
-        format!("Activating route '{}'", api_id),
-        aid,
-        tid,
-    );
-    emitter.step_completed(
-        deployment_id,
-        DeployStep::Activating,
-        format!("Route '{}' active", api_id),
-        aid,
-        tid,
-    );
-
-    // Step 5: Done
+    // Done
     emitter.step_completed(
         deployment_id,
         DeployStep::Done,
@@ -457,6 +436,57 @@ mod tests {
                 "missing error for {} in {:?}",
                 field,
                 errors
+            );
+        }
+    }
+
+    // ─── GW-1 P2-8: deploy step honesty ──────────────────────────────
+    //
+    // `upsert_api` does not apply policies and does not have a separate
+    // activation phase — `route_registry.upsert` both persists and
+    // activates the route in one call. Emitting fake `ApplyingPolicies`
+    // / `Activating` step_started + step_completed events around empty
+    // blocks produced a mendacious timeline that confused operators
+    // reading the `deploy_progress` stream during post-incident review.
+    //
+    // Capturing `tracing::debug!` events from inside an axum handler is
+    // unreliable (tower's Service futures can reattach the dispatcher
+    // across poll boundaries, defeating `subscriber::set_default`), so
+    // we assert source-level: the `upsert_api` function body must not
+    // reference the two enum variants the fake steps were built on.
+    // The variants stay defined in `telemetry/deploy.rs` for genuine
+    // consumers (contract-level flows) — this check is scoped to the
+    // `upsert_api` body, not the whole module.
+    #[test]
+    fn regression_upsert_api_source_does_not_emit_fake_policy_or_activating() {
+        let src = include_str!("apis.rs");
+
+        let handler_start = src
+            .find("pub async fn upsert_api")
+            .expect("upsert_api fn must exist");
+        let handler_tail = &src[handler_start..];
+        let handler_end = handler_tail
+            .find("\npub async fn list_apis")
+            .expect("list_apis fn must immediately follow upsert_api");
+        let body = &handler_tail[..handler_end];
+
+        assert!(
+            !body.contains("DeployStep::ApplyingPolicies"),
+            "upsert_api must not emit ApplyingPolicies (GW-1 P2-8 — was a fake step with no underlying work)"
+        );
+        assert!(
+            !body.contains("DeployStep::Activating"),
+            "upsert_api must not emit Activating (GW-1 P2-8 — was a fake step with no underlying work)"
+        );
+        for expected in [
+            "DeployStep::Validating",
+            "DeployStep::ApplyingRoutes",
+            "DeployStep::Done",
+        ] {
+            assert!(
+                body.contains(expected),
+                "upsert_api is expected to emit {} (honest step removed?)",
+                expected
             );
         }
     }

--- a/stoa-gateway/src/handlers/admin/circuit_breaker.rs
+++ b/stoa-gateway/src/handlers/admin/circuit_breaker.rs
@@ -42,11 +42,22 @@ pub async fn circuit_breaker_stats(
 }
 
 /// POST /admin/circuit-breaker/reset
+///
+/// GW-1 P2-6: the response now carries `previous_state` + `new_state`
+/// so admins can tell whether the reset actually changed anything
+/// (`closed` → `closed` reset is a no-op; `open` → `closed` is a real
+/// action). The capture is atomic under the CB write lock — no TOCTOU
+/// between reading the previous state and clearing it.
 pub async fn circuit_breaker_reset(State(state): State<AppState>) -> impl IntoResponse {
-    state.cp_circuit_breaker.reset();
+    let previous = state.cp_circuit_breaker.reset_with_previous();
     (
         StatusCode::OK,
-        Json(serde_json::json!({"status": "ok", "message": "Circuit breaker reset to closed"})),
+        Json(serde_json::json!({
+            "status": "ok",
+            "previous_state": previous.to_string(),
+            "new_state": "closed",
+            "message": "Circuit breaker reset to closed",
+        })),
     )
 }
 
@@ -62,24 +73,35 @@ pub async fn circuit_breakers_list(
 }
 
 /// POST /admin/circuit-breakers/:name/reset
+///
+/// GW-1 P2-6: returns `previous_state` + `new_state` on success so the
+/// caller knows whether the reset actually changed anything. The
+/// registry lookup + reset are atomic under the registry read lock,
+/// avoiding the TOCTOU a separate `state_for` + `reset` pair would
+/// introduce.
 pub async fn circuit_breaker_reset_by_name(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    if state.circuit_breakers.reset(&name) {
-        (
+    match state.circuit_breakers.reset_with_previous(&name) {
+        Some(previous) => (
             StatusCode::OK,
-            Json(
-                serde_json::json!({"status": "ok", "message": format!("Circuit breaker '{}' reset", name)}),
-            ),
-        )
-    } else {
-        (
+            Json(serde_json::json!({
+                "status": "ok",
+                "name": name,
+                "previous_state": previous.to_string(),
+                "new_state": "closed",
+                "message": format!("Circuit breaker '{}' reset", name),
+            })),
+        ),
+        None => (
             StatusCode::NOT_FOUND,
-            Json(
-                serde_json::json!({"status": "error", "message": format!("Circuit breaker '{}' not found", name)}),
-            ),
-        )
+            Json(serde_json::json!({
+                "status": "error",
+                "name": name,
+                "message": format!("Circuit breaker '{}' not found", name),
+            })),
+        ),
     }
 }
 
@@ -123,6 +145,75 @@ mod tests {
             .unwrap();
         let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(data["status"], "ok");
+    }
+
+    // GW-1 P2-6: the legacy CP reset response carries previous_state /
+    // new_state so admins can tell whether the reset actually changed
+    // anything. A closed-to-closed reset is a documented no-op; the
+    // fields must still be emitted.
+    #[tokio::test]
+    async fn regression_circuit_breaker_reset_reports_previous_state() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app
+            .oneshot(auth_req("POST", "/circuit-breaker/reset"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["new_state"], "closed");
+        assert!(
+            data["previous_state"].is_string(),
+            "previous_state must be serialised, got {:?}",
+            data["previous_state"]
+        );
+    }
+
+    // GW-1 P2-6: per-upstream reset reports previous_state + new_state,
+    // and the 404 path carries the name on the error body (the admin
+    // can distinguish "no such CB" from any other failure mode).
+    #[tokio::test]
+    async fn regression_circuit_breaker_reset_by_name_reports_previous_state() {
+        use crate::resilience::CircuitBreakerConfig;
+
+        let state = create_test_state(Some("secret"));
+        // Seed a breaker so the path is the "found" branch.
+        let _cb = state
+            .circuit_breakers
+            .get_or_create_with_config("my-upstream", CircuitBreakerConfig::default());
+
+        let app = build_full_admin_router(state);
+        let response = app
+            .oneshot(auth_req("POST", "/circuit-breakers/my-upstream/reset"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["name"], "my-upstream");
+        assert_eq!(data["new_state"], "closed");
+        assert!(data["previous_state"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_circuit_breaker_reset_by_name_not_found_carries_name() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app
+            .oneshot(auth_req("POST", "/circuit-breakers/unknown-cb/reset"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["name"], "unknown-cb");
     }
 
     #[tokio::test]

--- a/stoa-gateway/src/handlers/admin/federation.rs
+++ b/stoa-gateway/src/handlers/admin/federation.rs
@@ -38,16 +38,30 @@ pub async fn federation_cache_stats(
 }
 
 /// DELETE /admin/federation/cache/:sub_account_id -- invalidate cache for a sub-account (CAB-1371)
+///
+/// GW-1 P2-5: the response reports whether an entry was actually
+/// purged. The admin caller previously received a blanket 200 OK with a
+/// generic message, so typos or already-evicted ids were indistinguish-
+/// able from real invalidations. `invalidated` is computed from a
+/// pre-purge `contains` probe; the `status` + `message` fields stay
+/// backward-compatible with older tooling.
 pub async fn federation_cache_invalidate(
     State(state): State<AppState>,
     Path(sub_account_id): Path<String>,
 ) -> impl IntoResponse {
+    let existed = state.federation_cache.contains(&sub_account_id);
     state.federation_cache.invalidate(&sub_account_id).await;
     (
         StatusCode::OK,
         Json(serde_json::json!({
             "status": "ok",
-            "message": format!("Cache invalidated for sub-account '{}'", sub_account_id)
+            "sub_account_id": sub_account_id,
+            "invalidated": existed,
+            "message": if existed {
+                format!("Cache invalidated for sub-account '{}'", sub_account_id)
+            } else {
+                format!("Cache had no entry for sub-account '{}'", sub_account_id)
+            }
         })),
     )
 }
@@ -120,6 +134,36 @@ mod tests {
         let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(data["status"], "ok");
         assert!(data["message"].as_str().unwrap().contains("sub-acct-123"));
+    }
+
+    // GW-1 P2-5: the admin invalidation response must distinguish "entry
+    // purged" from "cache had no such key" so operators don't silently
+    // accept typos or no-op calls.
+    #[tokio::test]
+    async fn regression_federation_cache_invalidate_reports_false_when_missing() {
+        let state = create_test_state(Some("secret"));
+        let app = build_full_admin_router(state);
+        let response = app
+            .oneshot(auth_req("DELETE", "/federation/cache/never-seen"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["status"], "ok");
+        assert_eq!(data["invalidated"], false);
+        assert_eq!(data["sub_account_id"], "never-seen");
+        assert!(
+            data["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("no entry"),
+            "message should distinguish 'no entry' from a real purge, got {:?}",
+            data["message"]
+        );
     }
 
     #[tokio::test]

--- a/stoa-gateway/src/handlers/admin/health.rs
+++ b/stoa-gateway/src/handlers/admin/health.rs
@@ -1,4 +1,10 @@
 //! Admin health endpoint.
+//!
+//! This endpoint is **not** a Kubernetes liveness or readiness probe.
+//! It reports static metadata (version, git provider) plus registry
+//! counters for dashboards and operator-driven checks. K8s probes live
+//! on `/health`, `/health/live`, `/ready`, and `/health/ready` and are
+//! wired separately in `src/lib.rs::build_router`.
 
 use axum::{extract::State, Json};
 use serde::Serialize;
@@ -11,6 +17,14 @@ pub struct AdminHealthResponse {
     pub version: String,
     pub routes_count: usize,
     pub policies_count: usize,
+    /// GW-1 P2-1: number of registered UAC contracts.
+    pub contracts_count: usize,
+    /// GW-1 P2-1: number of stored skills in the resolver.
+    pub skills_count: usize,
+    /// GW-1 P2-1: seconds since this process started. Useful for
+    /// correlating admin observations with restart timestamps in
+    /// dashboards and post-incident reviews.
+    pub uptime_seconds: u64,
     pub git_provider: String,
 }
 
@@ -20,6 +34,9 @@ pub async fn admin_health(State(state): State<AppState>) -> Json<AdminHealthResp
         version: env!("CARGO_PKG_VERSION").to_string(),
         routes_count: state.route_registry.count(),
         policies_count: state.policy_registry.count(),
+        contracts_count: state.contract_registry.count(),
+        skills_count: state.skill_resolver.skill_count(),
+        uptime_seconds: state.start_time.elapsed().as_secs(),
         git_provider: state.config.git_provider.clone(),
     })
 }
@@ -62,6 +79,37 @@ mod tests {
         assert_eq!(data["routes_count"], 0);
         assert_eq!(data["policies_count"], 0);
         assert_eq!(data["git_provider"], "gitlab");
+    }
+
+    // GW-1 P2-1: enriched counters + uptime must be part of the response
+    // shape so dashboards can plot them without flag-guarding on version.
+    #[tokio::test]
+    async fn regression_admin_health_exposes_contracts_skills_uptime() {
+        let state = create_test_state(Some("secret"));
+        let app = build_admin_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .header("Authorization", "Bearer secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["contracts_count"], 0);
+        assert_eq!(data["skills_count"], 0);
+        assert!(
+            data["uptime_seconds"].is_u64(),
+            "uptime_seconds must be a number, got {:?}",
+            data["uptime_seconds"]
+        );
     }
 
     #[tokio::test]

--- a/stoa-gateway/src/handlers/admin/llm.rs
+++ b/stoa-gateway/src/handlers/admin/llm.rs
@@ -119,34 +119,139 @@ pub async fn llm_costs(State(state): State<AppState>) -> Json<LlmCostSnapshot> {
         });
     }
 
-    // Gather current metric values from Prometheus counters
-    let mut metrics = Vec::new();
-    let metric_families = prometheus::gather();
-    for mf in &metric_families {
-        if mf.get_name() == "gateway_llm_cost_total" {
-            for m in mf.get_metric() {
-                let labels = m.get_label();
-                let provider = labels
-                    .iter()
-                    .find(|l| l.get_name() == "provider")
-                    .map(|l| l.get_value().to_string())
-                    .unwrap_or_default();
-                let model = labels
-                    .iter()
-                    .find(|l| l.get_name() == "model")
-                    .map(|l| l.get_value().to_string())
-                    .unwrap_or_default();
-                metrics.push(LlmCostMetricEntry {
-                    provider,
-                    model,
-                    total_cost_usd: m.get_counter().get_value(),
-                });
+    // GW-1 P2-7: collect the `gateway_llm_cost_total` metric family
+    // directly from the `CounterVec` that owns it, instead of scanning
+    // every metric family in the global Prometheus registry with
+    // `prometheus::gather()`. The old implementation was an O(N) walk
+    // over the entire registry on every admin call; this one reads
+    // exactly the counter vec we care about. Lecteur-side only — no
+    // change to where `LLM_COST_TOTAL` is incremented, no change to
+    // labels or registration.
+    use prometheus::core::Collector;
+
+    let metrics: Vec<LlmCostMetricEntry> = crate::llm::cost::LLM_COST_TOTAL
+        .collect()
+        .iter()
+        .flat_map(|mf| mf.get_metric().to_vec())
+        .map(|m| {
+            let labels = m.get_label();
+            let provider = labels
+                .iter()
+                .find(|l| l.get_name() == "provider")
+                .map(|l| l.get_value().to_string())
+                .unwrap_or_default();
+            let model = labels
+                .iter()
+                .find(|l| l.get_name() == "model")
+                .map(|l| l.get_value().to_string())
+                .unwrap_or_default();
+            LlmCostMetricEntry {
+                provider,
+                model,
+                total_cost_usd: m.get_counter().get_value(),
             }
-        }
-    }
+        })
+        .collect();
 
     Json(LlmCostSnapshot {
         cost_tracking_enabled: true,
         metrics,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    //! GW-1 P2-7 regression tests for the LLM cost reader.
+    //!
+    //! The global Prometheus registry is a single process-wide
+    //! singleton, so these tests do not register ad-hoc metrics — they
+    //! would leak across parallel `cargo test` invocations. Instead
+    //! they exercise the production `LLM_COST_TOTAL` counter vec and
+    //! assert that the handler reads it correctly **without** doing a
+    //! full-registry scan.
+
+    use std::sync::Arc;
+
+    use axum::http::StatusCode;
+    use tower::ServiceExt;
+
+    use crate::config::Config;
+    use crate::handlers::admin::test_helpers::{auth_req, build_full_admin_router};
+    use crate::llm::cost::{CostCalculator, LLM_COST_TOTAL};
+    use crate::llm::providers::{ProviderConfig, ProviderRegistry};
+    use crate::state::AppState;
+
+    fn state_with_cost_tracking() -> AppState {
+        let config = Config {
+            admin_api_token: Some("secret".into()),
+            ..Config::default()
+        };
+        let mut state = AppState::new(config);
+        // `llm_costs` takes the "enabled" branch as soon as
+        // `cost_calculator` is `Some(_)`. Point it at an empty provider
+        // registry — the handler never reads the registry, only the
+        // Prometheus counter vec.
+        let registry = Arc::new(ProviderRegistry::new(Vec::<ProviderConfig>::new()));
+        state.cost_calculator = Some(Arc::new(CostCalculator::new(registry)));
+        state
+    }
+
+    // GW-1 P2-7: `/admin/llm/costs` captures recorded cost increments
+    // from `LLM_COST_TOTAL`. The unique `{provider, model}` label pair
+    // avoids collisions with other tests reusing the same counter vec.
+    #[tokio::test]
+    async fn regression_llm_costs_captures_recorded_increments() {
+        // Use a label pair no other test touches to stay deterministic.
+        let provider = "p2-7-regression";
+        let model = "canary-model";
+        LLM_COST_TOTAL
+            .with_label_values(&[provider, model])
+            .inc_by(2.5);
+
+        let state = state_with_cost_tracking();
+        let app = build_full_admin_router(state);
+        let response = app.oneshot(auth_req("GET", "/llm/costs")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["cost_tracking_enabled"], true);
+
+        let entry = data["metrics"]
+            .as_array()
+            .expect("metrics must be an array")
+            .iter()
+            .find(|m| m["provider"] == provider && m["model"] == model)
+            .expect("our canary (provider, model) must appear in the response");
+        assert!(
+            entry["total_cost_usd"].as_f64().unwrap_or(0.0) >= 2.5,
+            "total_cost_usd must reflect at least the 2.5 increment, got {:?}",
+            entry["total_cost_usd"]
+        );
+    }
+
+    // GW-1 P2-7: non-LLM metrics registered in the global registry must
+    // NOT leak into the `/admin/llm/costs` response. The handler reads
+    // `LLM_COST_TOTAL.collect()` directly, so any cross-pollution would
+    // indicate the old full-registry scan crept back in.
+    #[tokio::test]
+    async fn test_llm_costs_does_not_leak_unrelated_metrics() {
+        let state = state_with_cost_tracking();
+        let app = build_full_admin_router(state);
+        let response = app.oneshot(auth_req("GET", "/llm/costs")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        // Every entry must be shaped for cost — presence of `provider`,
+        // `model`, `total_cost_usd` fields.
+        for entry in data["metrics"].as_array().unwrap_or(&vec![]) {
+            assert!(entry.get("provider").is_some());
+            assert!(entry.get("model").is_some());
+            assert!(entry.get("total_cost_usd").is_some());
+            assert_eq!(entry.as_object().unwrap().len(), 3);
+        }
+    }
 }

--- a/stoa-gateway/src/handlers/admin/router.rs
+++ b/stoa-gateway/src/handlers/admin/router.rs
@@ -1,0 +1,304 @@
+//! Admin sub-router factory (GW-1 P2-test-1).
+//!
+//! Single source of truth for the wiring of the `/admin/*` surface.
+//! `lib.rs` mounts the returned router under `.nest("/admin", ...)`; the
+//! test harness in `test_helpers.rs` reuses the same factory un-nested so
+//! unit tests hit the exact set of routes + middleware that production
+//! serves. Keeping the wiring in one place removes the drift between the
+//! prod router and the previous hand-rolled `build_full_admin_router`.
+//!
+//! Middleware order (innermost → outermost): `handler` → `admin_auth` →
+//! `admin_rate_limit` → `admin_audit_log`. Axum's `Router::layer` only
+//! applies to routes declared *before* the layer call, so every `.route`
+//! must stay above the three `.layer` calls at the end of this function.
+
+use axum::{
+    middleware,
+    routing::{delete, get, post},
+    Router,
+};
+
+use super::{
+    admin_audit_log, admin_auth, admin_health, admin_rate_limit, cache_clear, cache_stats,
+    circuit_breaker_reset, circuit_breaker_reset_by_name, circuit_breaker_stats,
+    circuit_breakers_list, delete_api, delete_backend_credential, delete_consumer_credential,
+    delete_contract, delete_policy, federation_cache_invalidate, federation_cache_stats,
+    federation_status, federation_upstreams, get_api, get_consumer_quota, get_contract, list_apis,
+    list_backend_credentials, list_consumer_credentials, list_contracts, list_policies,
+    list_quotas, llm_costs, llm_providers, llm_status, mtls_config, mtls_stats, prompt_cache_get,
+    prompt_cache_invalidate, prompt_cache_load, prompt_cache_patterns, prompt_cache_stats,
+    reset_consumer_quota, routes_reload, session_stats, skills_delete, skills_delete_by_id,
+    skills_get_by_id, skills_health, skills_health_all, skills_health_reset, skills_list,
+    skills_resolve, skills_status, skills_sync, skills_update, skills_upsert, tracing_status,
+    upsert_api, upsert_backend_credential, upsert_consumer_credential, upsert_contract,
+    upsert_policy,
+};
+use crate::{
+    a2a, ebpf, handlers,
+    hegemon::{budget, claims, dashboard, dispatch, messaging, metering, registry},
+    proxy::list_api_proxy_backends,
+    state::AppState,
+};
+
+/// Build the admin sub-router.
+///
+/// Routes are declared **before** the three middleware layers at the end
+/// of the builder chain; layers added after `.route(...)` only apply to
+/// routes already present (Axum `Router::layer` contract). Callers are
+/// expected to mount the returned router under `/admin` (see `lib.rs`
+/// `build_router` and the test harness).
+///
+/// The returned router is **un-stated** (`Router<AppState>`) — the
+/// caller is responsible for attaching `.with_state(...)` at the top of
+/// its tree, matching the `build_router` composition in `lib.rs`.
+pub(crate) fn build_admin_router(state: AppState) -> Router<AppState> {
+    Router::<AppState>::new()
+        .route("/health", get(admin_health))
+        .route("/apis", get(list_apis).post(upsert_api))
+        .route("/apis/:id", get(get_api).delete(delete_api))
+        .route("/policies", get(list_policies).post(upsert_policy))
+        .route("/policies/:id", delete(delete_policy))
+        // Phase 6: Circuit Breaker admin
+        .route("/circuit-breaker/stats", get(circuit_breaker_stats))
+        .route("/circuit-breaker/reset", post(circuit_breaker_reset))
+        // Phase 6: Cache admin
+        .route("/cache/stats", get(cache_stats))
+        .route("/cache/clear", post(cache_clear))
+        // CAB-362: Session stats + per-upstream circuit breakers
+        .route("/sessions/stats", get(session_stats))
+        .route("/circuit-breakers", get(circuit_breakers_list))
+        .route(
+            "/circuit-breakers/:name/reset",
+            post(circuit_breaker_reset_by_name),
+        )
+        // CAB-864: mTLS admin
+        .route("/mtls/config", get(mtls_config))
+        .route("/mtls/stats", get(mtls_stats))
+        // CAB-1121 P4: Quota enforcement admin
+        .route("/quotas", get(list_quotas))
+        .route("/quotas/:consumer_id", get(get_consumer_quota))
+        .route("/quotas/:consumer_id/reset", post(reset_consumer_quota))
+        // CAB-1250: BYOK backend credentials
+        .route(
+            "/backend-credentials",
+            get(list_backend_credentials).post(upsert_backend_credential),
+        )
+        .route(
+            "/backend-credentials/:route_id",
+            delete(delete_backend_credential),
+        )
+        // CAB-1250 P3: Consumer credentials
+        .route(
+            "/consumer-credentials",
+            get(list_consumer_credentials).post(upsert_consumer_credential),
+        )
+        .route(
+            "/consumer-credentials/:route_id/:consumer_id",
+            delete(delete_consumer_credential),
+        )
+        // CAB-1299: UAC contracts
+        .route("/contracts", get(list_contracts).post(upsert_contract))
+        .route("/contracts/:key", get(get_contract).delete(delete_contract))
+        // CAB-1362: Federation admin
+        .route("/federation/status", get(federation_status))
+        .route("/federation/cache", get(federation_cache_stats))
+        // CAB-1371: Federation cache invalidation
+        .route(
+            "/federation/cache/:sub_account_id",
+            delete(federation_cache_invalidate),
+        )
+        // CAB-1123: Prompt cache admin
+        .route("/prompt-cache/stats", get(prompt_cache_stats))
+        .route("/prompt-cache/load", post(prompt_cache_load))
+        .route("/prompt-cache/get/:key", get(prompt_cache_get))
+        .route("/prompt-cache/invalidate", post(prompt_cache_invalidate))
+        .route("/prompt-cache/patterns", get(prompt_cache_patterns))
+        // CAB-1365/1366: Skills admin (literal paths before parametric `:id`)
+        .route("/skills/status", get(skills_status))
+        .route("/skills/resolve", get(skills_resolve))
+        .route("/skills/sync", post(skills_sync))
+        .route(
+            "/skills",
+            get(skills_list).post(skills_upsert).delete(skills_delete),
+        )
+        // CAB-1551: Skills health (literal path before parametric `:id`)
+        .route("/skills/health", get(skills_health_all))
+        .route(
+            "/skills/:id",
+            get(skills_get_by_id)
+                .put(skills_update)
+                .delete(skills_delete_by_id),
+        )
+        .route("/skills/:id/health", get(skills_health))
+        .route("/skills/:id/health/reset", post(skills_health_reset))
+        // CAB-1487: LLM cost-aware routing admin
+        .route("/llm/status", get(llm_status))
+        .route("/llm/providers", get(llm_providers))
+        .route("/llm/costs", get(llm_costs))
+        // CAB-1752: Distributed tracing admin
+        .route("/tracing/status", get(tracing_status))
+        // CAB-1752: Federation upstreams listing
+        .route("/federation/upstreams", get(federation_upstreams))
+        // CAB-1316: Diagnostic endpoint (CB states, uptime, route stats)
+        .route("/diagnostic", get(handlers::diagnostic::diagnostic_handler))
+        // CAB-1316: Per-request diagnostic report + aggregated summary
+        .route(
+            "/diagnostics/summary",
+            get(handlers::diagnostic::diagnostic_summary_handler),
+        )
+        .route(
+            "/diagnostics/:request_id",
+            get(handlers::diagnostic::diagnostic_report_handler),
+        )
+        // CAB-1710/1711: HEGEMON agent registry admin
+        .route("/hegemon/agents", get(registry::list_agents))
+        .route("/hegemon/agents/:name", get(registry::get_agent))
+        .route(
+            "/hegemon/agents/:name/tier",
+            post(registry::update_agent_tier),
+        )
+        // CAB-1713/1714: HEGEMON dispatch admin
+        .route("/hegemon/dispatches", get(dispatch::list_dispatches))
+        .route("/hegemon/dispatches/:id", get(dispatch::get_dispatch))
+        // CAB-1716: HEGEMON budget admin
+        .route("/hegemon/budget", get(budget::list_budgets))
+        // CAB-1718: HEGEMON claims admin
+        .route("/hegemon/claims", get(claims::list_claims))
+        .route("/hegemon/claims/:mega_id", get(claims::get_claims))
+        // CAB-1720/1721: HEGEMON metering + dashboard admin
+        .route("/hegemon/dashboard", get(dashboard::fleet_dashboard))
+        .route("/hegemon/events", get(metering::list_events))
+        // CAB-1709 P6: HEGEMON messaging admin
+        .route("/hegemon/messages", get(messaging::list_inboxes))
+        // CAB-1754: A2A agent registry admin
+        .route(
+            "/a2a/agents",
+            get(a2a::admin::list_agents).post(a2a::admin::register_agent),
+        )
+        .route(
+            "/a2a/agents/:name",
+            get(a2a::admin::get_agent).delete(a2a::admin::unregister_agent),
+        )
+        // CAB-1722: API proxy backends admin (moved here for admin_auth coverage — GW-1 P0-2)
+        .route("/api-proxy/backends", get(list_api_proxy_backends))
+        // CAB-1828: Route hot-reload
+        .route("/routes/reload", post(routes_reload))
+        // CAB-1645: Error snapshot capture
+        .route(
+            "/snapshots",
+            get(handlers::snapshot::list_snapshots).delete(handlers::snapshot::clear_snapshots),
+        )
+        .route(
+            "/snapshots/:request_id",
+            get(handlers::snapshot::get_snapshot),
+        )
+        // CAB-1848: eBPF kernel policy sync
+        .route("/ebpf/sync", post(ebpf::ebpf_sync))
+        .route("/ebpf/status", get(ebpf::ebpf_status))
+        // GW-1 P0-1 / P1-3-lite / P1-4 — middleware order from innermost
+        // (runs last) to outermost (runs first):
+        //   handler → admin_auth → admin_rate_limit → admin_audit_log
+        // Audit layer is outermost so rate-limited (429) and unauthenticated
+        // (401) attempts are part of the audit trail too. Rate-limit runs
+        // before auth so bearer probing is throttled without reaching the
+        // constant-time compare.
+        .layer(middleware::from_fn_with_state(state.clone(), admin_auth))
+        .layer(middleware::from_fn_with_state(state, admin_rate_limit))
+        .layer(middleware::from_fn(admin_audit_log))
+}
+
+#[cfg(test)]
+mod tests {
+    //! Factory-level regression tests.
+    //!
+    //! - `regression_delete_skills_status_returns_405_not_delete_by_id`
+    //!   verifies matchit's literal-over-param priority + Axum's default
+    //!   `MethodRouter` 405 behaviour (GW-1 P1-7): seeding a skill with
+    //!   key `"status"` and sending `DELETE /skills/status` must yield
+    //!   405 (no DELETE on `/skills/status`, which is GET-only) rather
+    //!   than dispatching to `skills_delete_by_id("status")`.
+    //! - The other tests verify that the factory produces a router that
+    //!   actually exposes routes previously missing from the old
+    //!   hand-rolled `build_full_admin_router` (GW-1 P2-test-1).
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    use super::build_admin_router;
+    use crate::handlers::admin::test_helpers::create_test_state;
+    use crate::skills::resolver::{SkillScope, StoredSkill};
+
+    fn auth_req(method: &str, uri: &str) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("Authorization", "Bearer secret")
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    // GW-1 P1-7: `DELETE /skills/status` must be 405, not a delete-by-id
+    // on a skill keyed `"status"`.
+    #[tokio::test]
+    async fn regression_delete_skills_status_returns_405_not_delete_by_id() {
+        let state = create_test_state(Some("secret"));
+        state.skill_resolver.upsert(StoredSkill {
+            key: "status".into(),
+            name: "canary".into(),
+            description: None,
+            tenant_id: "acme".into(),
+            scope: SkillScope::Tenant,
+            priority: 50,
+            instructions: None,
+            tool_ref: None,
+            user_ref: None,
+            enabled: true,
+        });
+
+        let app = build_admin_router(state.clone()).with_state(state.clone());
+        let response = app
+            .oneshot(auth_req("DELETE", "/skills/status"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert!(
+            response.headers().contains_key(axum::http::header::ALLOW),
+            "Axum MethodRouter must set `Allow` on 405 responses"
+        );
+        assert_eq!(
+            state.skill_resolver.get("status").map(|s| s.key.clone()),
+            Some("status".to_string()),
+            "DELETE /skills/status must not have removed the skill keyed `status`"
+        );
+    }
+
+    // GW-1 P2-test-1: `/skills/*` routes are reachable through the full
+    // factory router (they were absent from the old `build_full_admin_router`).
+    #[tokio::test]
+    async fn test_prod_admin_router_skills_routes_reachable_via_full_harness() {
+        let state = create_test_state(Some("secret"));
+        let app = build_admin_router(state.clone()).with_state(state);
+
+        let response = app
+            .oneshot(auth_req("GET", "/skills/status"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    // GW-1 P2-test-1: `/llm/*` routes are reachable through the factory
+    // router (previously absent from the test harness).
+    #[tokio::test]
+    async fn test_prod_admin_router_llm_routes_reachable_via_full_harness() {
+        let state = create_test_state(Some("secret"));
+        let app = build_admin_router(state.clone()).with_state(state);
+
+        let response = app.oneshot(auth_req("GET", "/llm/status")).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/stoa-gateway/src/handlers/admin/skills.rs
+++ b/stoa-gateway/src/handlers/admin/skills.rs
@@ -106,6 +106,12 @@ pub async fn skills_upsert(
         }
     };
 
+    // GW-1 P2-4: align with other admin upserts (apis, policies, credentials,
+    // contracts) — 201 CREATED on a brand-new key, 200 OK on an update.
+    // Probe with a read before the write so we return the right status
+    // without changing the resolver's upsert signature.
+    let existed = state.skill_resolver.get(&payload.key).is_some();
+
     let skill = StoredSkill {
         key: payload.key.clone(),
         name: payload.name,
@@ -120,11 +126,12 @@ pub async fn skills_upsert(
     };
 
     state.skill_resolver.upsert(skill);
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({"key": payload.key})),
-    )
-        .into_response()
+    let status = if existed {
+        StatusCode::OK
+    } else {
+        StatusCode::CREATED
+    };
+    (status, Json(serde_json::json!({"key": payload.key}))).into_response()
 }
 
 /// GET /admin/skills/:id — get a single skill by key (CAB-1542)
@@ -203,16 +210,58 @@ pub async fn skills_sync(
     (StatusCode::OK, Json(serde_json::json!({"synced": count}))).into_response()
 }
 
-/// DELETE /admin/skills?key=X — remove a skill by key (CAB-1366, legacy)
+/// DELETE /admin/skills?key=X — remove a skill by key (CAB-1366, legacy).
+///
+/// GW-1 P2-3: this query-param form is superseded by
+/// `DELETE /admin/skills/:id` and will be removed on **2026-10-24**.
+/// Responses carry:
+/// - `Deprecation: @1776988800` — RFC 9745 structured date for
+///   2026-04-24 00:00 UTC, the moment this endpoint became deprecated.
+/// - `Sunset: Sat, 24 Oct 2026 23:59:59 GMT` — RFC 8594 HTTP-date for
+///   the scheduled removal.
+/// - `Link: </admin/skills/{id}>; rel="successor-version"` — pointer to
+///   the replacement route.
+///
+/// The Rust handler itself is intentionally **not** annotated with the
+/// `#[deprecated]` attribute: the router still references it, and the
+/// `-D warnings` clippy gate would flip that into a build failure.
 pub async fn skills_delete(
     State(state): State<AppState>,
     axum::extract::Query(params): axum::extract::Query<SkillDeleteParams>,
 ) -> impl IntoResponse {
-    if state.skill_resolver.remove(&params.key) {
+    ::tracing::warn!(
+        deprecated_endpoint = "skills_delete_by_query",
+        replacement = "DELETE /admin/skills/{id}",
+        sunset = "2026-10-24",
+        key = %params.key,
+        "Legacy admin endpoint hit — migrate before Sunset",
+    );
+
+    let status = if state.skill_resolver.remove(&params.key) {
         StatusCode::NO_CONTENT
     } else {
         StatusCode::NOT_FOUND
-    }
+    };
+
+    let mut response = status.into_response();
+    let headers = response.headers_mut();
+    // `Deprecation` — RFC 9745 structured date. `@<epoch>` marks the
+    // moment the endpoint became deprecated.
+    headers.insert(
+        axum::http::HeaderName::from_static("deprecation"),
+        axum::http::HeaderValue::from_static("@1776988800"),
+    );
+    // `Sunset` — RFC 8594 HTTP-date for removal.
+    headers.insert(
+        axum::http::HeaderName::from_static("sunset"),
+        axum::http::HeaderValue::from_static("Sat, 24 Oct 2026 23:59:59 GMT"),
+    );
+    // `Link` — RFC 8288 relation pointing at the successor route.
+    headers.insert(
+        axum::http::header::LINK,
+        axum::http::HeaderValue::from_static("</admin/skills/{id}>; rel=\"successor-version\""),
+    );
+    response
 }
 
 /// PUT /admin/skills/:id — update an existing skill (CAB-1551)
@@ -409,7 +458,8 @@ mod tests {
     use tower::ServiceExt;
 
     use super::{
-        skills_health, skills_health_reset, skills_sync, skills_update, skills_upsert,
+        skills_delete, skills_health, skills_health_reset, skills_sync, skills_update,
+        skills_upsert,
     };
     use crate::handlers::admin::admin_auth;
     use crate::handlers::admin::test_helpers::create_test_state;
@@ -546,7 +596,9 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
+        // GW-1 P2-4: new key → 201 CREATED (200 OK is the update case,
+        // covered by `test_skills_upsert_returns_201_on_new_and_200_on_update`).
+        assert_eq!(response.status(), StatusCode::CREATED);
     }
 
     #[tokio::test]
@@ -730,5 +782,109 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(json["circuit_state"], "closed");
         assert_eq!(json["noop"], true);
+    }
+
+    // GW-1 P2-4: new skill → 201 CREATED, re-upsert of the same key → 200 OK.
+    #[tokio::test]
+    async fn test_skills_upsert_returns_201_on_new_and_200_on_update() {
+        let state = create_test_state(Some("secret"));
+        let app = router_with_route(state, "/skills", post(skills_upsert));
+
+        let first = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/skills")
+                    .header("Authorization", "Bearer secret")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&valid_skill_payload()).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::CREATED);
+
+        let second = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/skills")
+                    .header("Authorization", "Bearer secret")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&valid_skill_payload()).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::OK);
+    }
+
+    // GW-1 P2-3: legacy `?key=` delete returns 204 with Deprecation/Sunset
+    // headers announcing the 2026-10-24 removal + a successor-version Link
+    // pointing at the replacement `:id` route.
+    #[tokio::test]
+    async fn regression_skills_delete_legacy_sets_deprecation_headers() {
+        let state = create_test_state(Some("secret"));
+        seed_skill(&state, "acme/doomed");
+        let app = Router::new()
+            .route("/skills", axum::routing::delete(skills_delete))
+            .layer(middleware::from_fn_with_state(state.clone(), admin_auth))
+            .with_state(state);
+
+        let response = app
+            .oneshot(auth_req("DELETE", "/skills?key=acme%2Fdoomed"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        let headers = response.headers();
+        assert_eq!(
+            headers.get("deprecation").and_then(|v| v.to_str().ok()),
+            Some("@1776988800"),
+            "Deprecation must be an RFC 9745 structured date, not a boolean"
+        );
+        assert_eq!(
+            headers.get("sunset").and_then(|v| v.to_str().ok()),
+            Some("Sat, 24 Oct 2026 23:59:59 GMT")
+        );
+        let link = headers
+            .get(axum::http::header::LINK)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            link.contains("rel=\"successor-version\""),
+            "Link header must advertise successor-version, got {:?}",
+            link
+        );
+        assert!(
+            link.contains("/admin/skills/{id}"),
+            "Link header must point at the replacement route, got {:?}",
+            link
+        );
+    }
+
+    // Missing key on the legacy endpoint still carries the deprecation
+    // markers — a 404 hint must not silence the Sunset notice.
+    #[tokio::test]
+    async fn test_skills_delete_legacy_404_still_advertises_deprecation() {
+        let state = create_test_state(Some("secret"));
+        let app = Router::new()
+            .route("/skills", axum::routing::delete(skills_delete))
+            .layer(middleware::from_fn_with_state(state.clone(), admin_auth))
+            .with_state(state);
+
+        let response = app
+            .oneshot(auth_req("DELETE", "/skills?key=ghost"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert!(response.headers().contains_key("deprecation"));
+        assert!(response.headers().contains_key("sunset"));
     }
 }

--- a/stoa-gateway/src/handlers/admin/test_helpers.rs
+++ b/stoa-gateway/src/handlers/admin/test_helpers.rs
@@ -13,15 +13,8 @@ use axum::{
 };
 
 use super::{
-    admin_auth, admin_health, cache_clear, cache_stats, circuit_breaker_reset,
-    circuit_breaker_reset_by_name, circuit_breaker_stats, circuit_breakers_list, delete_api,
-    delete_backend_credential, delete_consumer_credential, delete_contract, delete_policy,
-    federation_cache_invalidate, federation_cache_stats, federation_status, federation_upstreams,
-    get_api, get_consumer_quota, get_contract, list_apis, list_backend_credentials,
-    list_consumer_credentials, list_contracts, list_policies, list_quotas, mtls_config, mtls_stats,
-    prompt_cache_get, prompt_cache_invalidate, prompt_cache_load, prompt_cache_patterns,
-    prompt_cache_stats, reset_consumer_quota, session_stats, tracing_status, upsert_api,
-    upsert_backend_credential, upsert_consumer_credential, upsert_contract, upsert_policy,
+    admin_auth, admin_health, delete_api, delete_policy, get_api, list_apis, list_policies, router,
+    upsert_api, upsert_policy,
 };
 use crate::config::Config;
 use crate::state::AppState;
@@ -34,6 +27,10 @@ pub(super) fn create_test_state(admin_token: Option<&str>) -> AppState {
     AppState::new(config)
 }
 
+/// Minimal admin router used by legacy tests that only need the
+/// `/apis` + `/policies` + `/health` surface. Kept as a narrow harness
+/// to avoid compiling every module's handler dependencies when a test
+/// only touches the CRUD happy path on apis/policies/health.
 pub(super) fn build_admin_router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(admin_health))
@@ -45,70 +42,12 @@ pub(super) fn build_admin_router(state: AppState) -> Router {
         .with_state(state)
 }
 
+/// Production-identical admin router (GW-1 P2-test-1). Delegates to the
+/// single factory in `src/handlers/admin/router.rs` so tests exercise
+/// the same route set and the same middleware chain (audit → rate-limit
+/// → auth) that `lib.rs::build_router` mounts.
 pub(super) fn build_full_admin_router(state: AppState) -> Router {
-    Router::new()
-        .route("/health", get(admin_health))
-        .route("/apis", get(list_apis).post(upsert_api))
-        .route("/apis/:id", get(get_api).delete(delete_api))
-        .route("/policies", get(list_policies).post(upsert_policy))
-        .route("/policies/:id", delete(delete_policy))
-        .route("/circuit-breaker/stats", get(circuit_breaker_stats))
-        .route(
-            "/circuit-breaker/reset",
-            axum::routing::post(circuit_breaker_reset),
-        )
-        .route("/cache/stats", get(cache_stats))
-        .route("/cache/clear", axum::routing::post(cache_clear))
-        .route("/sessions/stats", get(session_stats))
-        .route("/circuit-breakers", get(circuit_breakers_list))
-        .route(
-            "/circuit-breakers/:name/reset",
-            axum::routing::post(circuit_breaker_reset_by_name),
-        )
-        .route("/quotas", get(list_quotas))
-        .route("/quotas/:consumer_id", get(get_consumer_quota))
-        .route(
-            "/quotas/:consumer_id/reset",
-            axum::routing::post(reset_consumer_quota),
-        )
-        .route("/mtls/config", get(mtls_config))
-        .route("/mtls/stats", get(mtls_stats))
-        .route(
-            "/backend-credentials",
-            get(list_backend_credentials).post(upsert_backend_credential),
-        )
-        .route(
-            "/backend-credentials/:route_id",
-            delete(delete_backend_credential),
-        )
-        .route(
-            "/consumer-credentials",
-            get(list_consumer_credentials).post(upsert_consumer_credential),
-        )
-        .route(
-            "/consumer-credentials/:route_id/:consumer_id",
-            delete(delete_consumer_credential),
-        )
-        .route("/contracts", get(list_contracts).post(upsert_contract))
-        .route("/contracts/:key", get(get_contract).delete(delete_contract))
-        .route("/federation/status", get(federation_status))
-        .route("/federation/cache", get(federation_cache_stats))
-        .route(
-            "/federation/cache/:sub_account_id",
-            delete(federation_cache_invalidate),
-        )
-        .route("/prompt-cache/stats", get(prompt_cache_stats))
-        .route("/prompt-cache/load", axum::routing::post(prompt_cache_load))
-        .route("/prompt-cache/get/:key", get(prompt_cache_get))
-        .route(
-            "/prompt-cache/invalidate",
-            axum::routing::post(prompt_cache_invalidate),
-        )
-        .route("/prompt-cache/patterns", get(prompt_cache_patterns))
-        .route("/tracing/status", get(tracing_status))
-        .route("/federation/upstreams", get(federation_upstreams))
-        .layer(middleware::from_fn_with_state(state.clone(), admin_auth))
-        .with_state(state)
+    router::build_admin_router(state.clone()).with_state(state)
 }
 
 pub(super) fn auth_req(method: &str, uri: &str) -> Request<Body> {

--- a/stoa-gateway/src/lib.rs
+++ b/stoa-gateway/src/lib.rs
@@ -54,7 +54,7 @@ pub mod uac;
 pub mod ws;
 
 use axum::{
-    routing::{delete, get, post},
+    routing::{get, post},
     Router,
 };
 use tracing::warn;
@@ -71,7 +71,7 @@ use mcp::{
     sse::{handle_sse_delete, handle_sse_get, handle_sse_post, handle_streamable_http_post},
     ws::handle_ws_upgrade,
 };
-use proxy::{api_proxy_handler, dynamic_proxy, list_api_proxy_backends, llm_proxy_handler};
+use proxy::{api_proxy_handler, dynamic_proxy, llm_proxy_handler};
 use state::AppState;
 
 /// Build the Axum router with all routes.
@@ -90,183 +90,10 @@ pub fn build_router(state: AppState) -> Router {
     // Build TCP filter early (before state is moved into with_state)
     let tcp_filter = std::sync::Arc::new(tcp_filter::TcpFilter::from_config(&state.config));
 
-    // Admin API (shared across all modes)
-    let admin_router = Router::new()
-        .route("/health", get(admin::admin_health))
-        .route("/apis", get(admin::list_apis).post(admin::upsert_api))
-        .route("/apis/:id", get(admin::get_api).delete(admin::delete_api))
-        .route(
-            "/policies",
-            get(admin::list_policies).post(admin::upsert_policy),
-        )
-        .route("/policies/:id", delete(admin::delete_policy))
-        // Phase 6: Circuit Breaker admin
-        .route("/circuit-breaker/stats", get(admin::circuit_breaker_stats))
-        .route("/circuit-breaker/reset", post(admin::circuit_breaker_reset))
-        // Phase 6: Cache admin
-        .route("/cache/stats", get(admin::cache_stats))
-        .route("/cache/clear", post(admin::cache_clear))
-        // CAB-362: Session stats + per-upstream circuit breakers
-        .route("/sessions/stats", get(admin::session_stats))
-        .route("/circuit-breakers", get(admin::circuit_breakers_list))
-        .route(
-            "/circuit-breakers/:name/reset",
-            post(admin::circuit_breaker_reset_by_name),
-        )
-        // CAB-864: mTLS admin
-        .route("/mtls/config", get(admin::mtls_config))
-        .route("/mtls/stats", get(admin::mtls_stats))
-        // CAB-1121 P4: Quota enforcement admin
-        .route("/quotas", get(admin::list_quotas))
-        .route("/quotas/:consumer_id", get(admin::get_consumer_quota))
-        .route(
-            "/quotas/:consumer_id/reset",
-            post(admin::reset_consumer_quota),
-        )
-        // CAB-1250: BYOK backend credentials
-        .route(
-            "/backend-credentials",
-            get(admin::list_backend_credentials).post(admin::upsert_backend_credential),
-        )
-        .route(
-            "/backend-credentials/:route_id",
-            delete(admin::delete_backend_credential),
-        )
-        // CAB-1299: UAC contracts
-        .route(
-            "/contracts",
-            get(admin::list_contracts).post(admin::upsert_contract),
-        )
-        .route(
-            "/contracts/:key",
-            get(admin::get_contract).delete(admin::delete_contract),
-        )
-        // CAB-1362: Federation admin
-        .route("/federation/status", get(admin::federation_status))
-        .route("/federation/cache", get(admin::federation_cache_stats))
-        // CAB-1371: Federation cache invalidation
-        .route(
-            "/federation/cache/:sub_account_id",
-            delete(admin::federation_cache_invalidate),
-        )
-        // CAB-1123: Prompt cache admin
-        .route("/prompt-cache/stats", get(admin::prompt_cache_stats))
-        .route("/prompt-cache/load", post(admin::prompt_cache_load))
-        .route("/prompt-cache/get/:key", get(admin::prompt_cache_get))
-        .route(
-            "/prompt-cache/invalidate",
-            post(admin::prompt_cache_invalidate),
-        )
-        .route("/prompt-cache/patterns", get(admin::prompt_cache_patterns))
-        // CAB-1365/1366: Skills admin
-        .route("/skills/status", get(admin::skills_status))
-        .route("/skills/resolve", get(admin::skills_resolve))
-        .route("/skills/sync", post(admin::skills_sync))
-        .route(
-            "/skills",
-            get(admin::skills_list)
-                .post(admin::skills_upsert)
-                .delete(admin::skills_delete),
-        )
-        // CAB-1551: Skills health (literal path before parametric :id)
-        .route("/skills/health", get(admin::skills_health_all))
-        .route(
-            "/skills/:id",
-            get(admin::skills_get_by_id)
-                .put(admin::skills_update)
-                .delete(admin::skills_delete_by_id),
-        )
-        .route("/skills/:id/health", get(admin::skills_health))
-        .route("/skills/:id/health/reset", post(admin::skills_health_reset))
-        // CAB-1487: LLM cost-aware routing admin
-        .route("/llm/status", get(admin::llm_status))
-        .route("/llm/providers", get(admin::llm_providers))
-        .route("/llm/costs", get(admin::llm_costs))
-        // CAB-1752: Distributed tracing admin
-        .route("/tracing/status", get(admin::tracing_status))
-        // CAB-1752: Federation upstreams listing
-        .route("/federation/upstreams", get(admin::federation_upstreams))
-        // CAB-1316: Diagnostic endpoint (CB states, uptime, route stats)
-        .route("/diagnostic", get(handlers::diagnostic::diagnostic_handler))
-        // CAB-1316: Per-request diagnostic report + aggregated summary
-        .route(
-            "/diagnostics/summary",
-            get(handlers::diagnostic::diagnostic_summary_handler),
-        )
-        .route(
-            "/diagnostics/:request_id",
-            get(handlers::diagnostic::diagnostic_report_handler),
-        )
-        // CAB-1710/1711: HEGEMON agent registry admin
-        .route("/hegemon/agents", get(hegemon::registry::list_agents))
-        .route("/hegemon/agents/:name", get(hegemon::registry::get_agent))
-        .route(
-            "/hegemon/agents/:name/tier",
-            post(hegemon::registry::update_agent_tier),
-        )
-        // CAB-1713/1714: HEGEMON dispatch admin
-        .route(
-            "/hegemon/dispatches",
-            get(hegemon::dispatch::list_dispatches),
-        )
-        .route(
-            "/hegemon/dispatches/:id",
-            get(hegemon::dispatch::get_dispatch),
-        )
-        // CAB-1716: HEGEMON budget admin
-        .route("/hegemon/budget", get(hegemon::budget::list_budgets))
-        // CAB-1718: HEGEMON claims admin
-        .route("/hegemon/claims", get(hegemon::claims::list_claims))
-        .route("/hegemon/claims/:mega_id", get(hegemon::claims::get_claims))
-        // CAB-1720/1721: HEGEMON metering + dashboard admin
-        .route(
-            "/hegemon/dashboard",
-            get(hegemon::dashboard::fleet_dashboard),
-        )
-        .route("/hegemon/events", get(hegemon::metering::list_events))
-        // CAB-1709 P6: HEGEMON messaging admin
-        .route("/hegemon/messages", get(hegemon::messaging::list_inboxes))
-        // CAB-1754: A2A agent registry admin
-        .route(
-            "/a2a/agents",
-            get(a2a::admin::list_agents).post(a2a::admin::register_agent),
-        )
-        .route(
-            "/a2a/agents/:name",
-            get(a2a::admin::get_agent).delete(a2a::admin::unregister_agent),
-        )
-        // CAB-1722: API proxy backends admin (moved here for admin_auth coverage — GW-1 P0-2)
-        .route("/api-proxy/backends", get(list_api_proxy_backends))
-        // CAB-1828: Route hot-reload
-        .route("/routes/reload", post(admin::routes_reload))
-        // CAB-1645: Error snapshot capture
-        .route(
-            "/snapshots",
-            get(handlers::snapshot::list_snapshots).delete(handlers::snapshot::clear_snapshots),
-        )
-        .route(
-            "/snapshots/:request_id",
-            get(handlers::snapshot::get_snapshot),
-        )
-        // CAB-1848: eBPF kernel policy sync
-        .route("/ebpf/sync", post(ebpf::ebpf_sync))
-        .route("/ebpf/status", get(ebpf::ebpf_status))
-        // GW-1 P0-1 / P1-3-lite / P1-4 — middleware order from innermost
-        // (runs last) to outermost (runs first):
-        //   handler → admin_auth → admin_rate_limit → admin_audit_log
-        // Audit layer is outermost so rate-limited (429) and unauthenticated
-        // (401) attempts are part of the audit trail too. Rate-limit runs
-        // before auth so bearer probing is throttled without reaching the
-        // constant-time compare.
-        .layer(axum::middleware::from_fn_with_state(
-            state.clone(),
-            admin::admin_auth,
-        ))
-        .layer(axum::middleware::from_fn_with_state(
-            state.clone(),
-            admin::admin_rate_limit,
-        ))
-        .layer(axum::middleware::from_fn(admin::admin_audit_log));
+    // GW-1 P2-test-1: single source of truth for the `/admin/*` wiring.
+    // See `src/handlers/admin/router.rs` — the same factory is reused by
+    // the test harness so unit tests exercise every production route.
+    let admin_router = admin::build_admin_router(state.clone());
 
     // Common routes for all modes: health, metrics, admin
     let base = Router::new()

--- a/stoa-gateway/src/resilience/circuit_breaker.rs
+++ b/stoa-gateway/src/resilience/circuit_breaker.rs
@@ -329,14 +329,25 @@ impl CircuitBreaker {
 
     /// Reset the circuit breaker to closed state (admin operation)
     pub fn reset(&self) {
+        let _ = self.reset_with_previous();
+    }
+
+    /// Reset the circuit breaker to closed and return the state it was in
+    /// just before the reset (GW-1 P2-6). Atomic under the write lock, so
+    /// there is no TOCTOU between reading the previous state and clearing
+    /// it. Admin handlers use the return value to populate the
+    /// `previous_state` field of the response body.
+    pub fn reset_with_previous(&self) -> CircuitState {
         let mut state = self.state.write();
-        info!(circuit = %self.name, "Circuit manually reset to closed");
+        let previous = state.state;
+        info!(circuit = %self.name, previous_state = ?previous, "Circuit manually reset to closed");
         state.state = CircuitState::Closed;
         state.window.clear();
         state.half_open_successes = 0;
         state.last_failure_time = None;
         state.last_state_change = Some(Instant::now());
         metrics::update_circuit_breaker_state(&self.name, 0.0);
+        previous
     }
 
     /// Get the circuit breaker name
@@ -456,13 +467,17 @@ impl CircuitBreakerRegistry {
 
     /// Reset a specific circuit breaker by name.
     pub fn reset(&self, name: &str) -> bool {
+        self.reset_with_previous(name).is_some()
+    }
+
+    /// Reset a specific circuit breaker by name and return the state it
+    /// was in just before the reset (GW-1 P2-6). Returns `None` when no
+    /// circuit breaker exists under `name`. Admin handlers use this so
+    /// the response body carries both `previous_state` and `new_state`
+    /// without a separate lookup-then-reset TOCTOU.
+    pub fn reset_with_previous(&self, name: &str) -> Option<CircuitState> {
         let breakers = self.breakers.read();
-        if let Some(cb) = breakers.get(name) {
-            cb.reset();
-            true
-        } else {
-            false
-        }
+        breakers.get(name).map(|cb| cb.reset_with_previous())
     }
 }
 

--- a/stoa-gateway/tests/contract/health.rs
+++ b/stoa-gateway/tests/contract/health.rs
@@ -35,5 +35,8 @@ async fn test_admin_health_shape() {
     let json: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
     insta::assert_json_snapshot!("admin-health", json, {
         ".version" => "[version]",
+        // GW-1 P2-1: `uptime_seconds` is monotonic; redact so the
+        // snapshot stays reproducible across runs.
+        ".uptime_seconds" => "[uptime]",
     });
 }

--- a/stoa-gateway/tests/contract/snapshots/contract__health__admin-health.snap
+++ b/stoa-gateway/tests/contract/snapshots/contract__health__admin-health.snap
@@ -4,9 +4,12 @@ assertion_line: 36
 expression: json
 ---
 {
+  "contracts_count": 0,
   "git_provider": "gitlab",
   "policies_count": 0,
   "routes_count": 0,
+  "skills_count": 0,
   "status": "ok",
+  "uptime_seconds": "[uptime]",
   "version": "[version]"
 }


### PR DESCRIPTION
## Summary

Ferme le dernier batch GW-1 : 7 P2 cleanup bugs + 1 régression test (P1-7). Module **GW-1 officiellement clos** — 20/20 bugs shippés.

## Commits (ordre)

| # | SHA | Items fermés |
|---|-----|---|
| 1 | `4a29c7990` | **P1-7** routing regression + **P2-test-1** factory router (SSOT) |
| 2 | `0ac0e1671` | **P2-3** deprecation headers + **P2-4** 201/200 + **P2-5** cache invalidate body + **P2-6** CB previous_state |
| 3 | `0233e0598` | **P2-1** admin_health enrichi + **P2-8** fake deploy steps removed |
| 4 | `48a4e4a68` | **P2-7** LLM cost reader via `CounterVec::collect()` |
| 5 | `bc94f1eef` | docs: BUG-REPORT-GW-1.md — GW-1 CLOSED |

## Points notables

**Factory router (Commit 1)** — `src/handlers/admin/router.rs` devient SSOT pour le wiring `/admin/*`. `lib.rs` passe de ~175 LOC inline à un simple `.nest(\"/admin\", admin::build_admin_router(state.clone()))`. Le test harness délégue à la même factory : zéro drift possible entre prod et tests. Les 3 layers middleware (`admin_audit_log` → `admin_rate_limit` → `admin_auth`) restent bien à la fin de la factory, comme documenté par Axum `Router::layer`.

**Headers deprecation (Commit 2, P2-3)** — `Deprecation: @1776988800` (RFC 9745, epoch = 2026-04-24 UTC) + `Sunset: Sat, 24 Oct 2026 23:59:59 GMT` (RFC 8594) + `Link: </admin/skills/{id}>; rel=\"successor-version\"` (RFC 8288). `#[deprecated]` est volontairement évité côté Rust (clippy `-D warnings` le transformerait en fail CI).

**Atomic CB reset (Commit 2, P2-6)** — `CircuitBreaker::reset_with_previous` et `CircuitBreakerRegistry::reset_with_previous` capturent l'état sous le même write/read lock que le reset. Aucun TOCTOU entre state lookup et clear. `reset()` existant préservé comme thin wrapper pour les callers externes.

**Honest deploy steps (Commit 3, P2-8)** — `upsert_api` n'émet plus les 2 steps fictifs `ApplyingPolicies` et `Activating`. Séquence honnête désormais : `Validating` → `ApplyingRoutes` → `Done`. Les variantes enum restent définies pour les flows contract-level qui font réellement ce travail. Test de régression source-level parce que capturer `tracing::debug!` via tower Service est peu fiable (le dispatcher peut être ré-attaché au passage de poll).

**LLM costs reader-side only (Commit 4, P2-7)** — `prometheus::gather()` (O(all metric families)) remplacé par `LLM_COST_TOTAL.collect()` (O(label pairs du counter)). Aucun changement sur l'enregistrement du counter, les labels, ou les points d'incrémentation.

## Regression guards ajoutés (13 nouveaux tests)

- `regression_delete_skills_status_returns_405_not_delete_by_id` (P1-7)
- `test_prod_admin_router_skills_routes_reachable_via_full_harness` + `test_prod_admin_router_llm_routes_reachable_via_full_harness` (P2-test-1)
- `regression_skills_delete_legacy_sets_deprecation_headers` + `test_skills_delete_legacy_404_still_advertises_deprecation` (P2-3)
- `test_skills_upsert_returns_201_on_new_and_200_on_update` + update `test_skills_upsert_accepts_valid_payload` (P2-4)
- `regression_federation_cache_invalidate_reports_false_when_missing` (P2-5)
- `regression_circuit_breaker_reset_reports_previous_state` + `regression_circuit_breaker_reset_by_name_reports_previous_state` + `test_circuit_breaker_reset_by_name_not_found_carries_name` (P2-6)
- `regression_admin_health_exposes_contracts_skills_uptime` (P2-1)
- `regression_upsert_api_source_does_not_emit_fake_policy_or_activating` (P2-8)
- `regression_llm_costs_captures_recorded_increments` + `test_llm_costs_does_not_leak_unrelated_metrics` (P2-7)

## Invariants GW-1 maintenus

- Nouveau `src/handlers/admin/router.rs` = 304 LOC (< 400, seuil GW-1)
- Aucun fichier admin n'a changé de taille catégorielle par ce batch
- Façade `admin.rs` toujours ~84 LOC (re-exports seulement)
- 0 `unsafe` ajouté dans `src/handlers/admin/`
- Callers externes (`main.rs`, `state.rs`, `proxy/*`) unchanged
- `lib.rs` modifié **uniquement** pour remplacer le bloc inline admin_router par l'appel factory

## Validation locale

- `cargo check` → 0 warning
- `cargo clippy --all-targets -- -D warnings` → 0 issue
- `cargo fmt --check` → clean
- `cargo test` → **2406 tests pass** (2248 lib + 53 + 52 + 15 + 38, 0 failed)

## Test plan

- [ ] CI — required checks green
- [ ] Review commits individuellement (4 atomiques)
- [ ] Snapshot `admin-health.snap` — vérifier que les nouveaux champs sont bien inclus
- [ ] Post-merge : check `/admin/health` en staging expose `uptime_seconds` / `skills_count` / `contracts_count`
- [ ] Post-merge : `curl -X DELETE /admin/skills?key=X` retourne bien les headers Deprecation/Sunset/Link

Module **GW-1 officiellement CLOS** après ce merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)