### PR TITLE
chore(ai): add context lint and clean stale Claude docs

### DIFF
--- a/.claude/agents/content-reviewer.md
+++ b/.claude/agents/content-reviewer.md
@@ -25,7 +25,7 @@ Tu es un Content Compliance Reviewer specialise dans la verification du contenu 
 
 ## Reference
 
-Toujours consulter `.claude/rules/content-compliance.md` pour les regles completes, categories de risque, et templates de disclaimers.
+Toujours consulter `.claude/docs/content-compliance.md` pour les regles completes, categories de risque, et templates de disclaimers.
 
 ## Workflow
 
@@ -141,6 +141,6 @@ Produire un rapport structure:
 - Plus de 3 P0 ou un P0 structurel (approche fondamentalement risquee) = "Refaire"
 - Ne JAMAIS modifier le contenu — produire uniquement un rapport
 - Citer le fichier et la ligne pour chaque finding
-- Referer aux regles `.claude/rules/content-compliance.md` pour les categories et templates
+- Referer aux regles `.claude/docs/content-compliance.md` pour les categories et templates
 - En cas de doute sur un finding, classifier au niveau superieur (P2 → P1, P1 → P0)
 - Les disclaimers sont obligatoires, pas optionnels — absence = P1

--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -93,7 +93,7 @@ Tu es un Technical Writer specialise pour l'ecosysteme STOA Platform.
 
 ### Step 5: Conformite contenu
 Pour tout contenu mentionnant concurrents, reglementations, clients ou prix:
-- Consulter `.claude/rules/content-compliance.md` pour les regles completes
+- Consulter `.claude/docs/content-compliance.md` pour les regles completes
 - Verifier: sources publiques citees, dates "last verified" presentes, disclaimers adaptes
 - Verifier: pas de noms de clients non autorises, pas de claims tarifaires, pas de "compliant/certified"
 - Deleguer au `content-reviewer` pour validation formelle (Pattern 6 dans `ai-factory.md`)

--- a/.claude/agents/k8s-ops.md
+++ b/.claude/agents/k8s-ops.md
@@ -79,7 +79,7 @@ kubectl get events -n stoa-system --sort-by='.lastTimestamp' | tail -30
 | `nginx 502/503` | Backend DNS non resolu | `kubectl logs` nginx container |
 
 ### Step 3: Croiser avec les regles
-Lire `.claude/rules/k8s-deploy.md` et verifier chaque point de la checklist.
+Lire `.claude/docs/k8s-deploy.md` et verifier chaque point de la checklist.
 
 ### Step 4: Rapport
 ```markdown
@@ -135,7 +135,7 @@ kubectl get clustersecretstore vault-backend
 ```
 
 ESO sync interval: default 1h (configurable in Helm values `externalSecret.refreshInterval`).
-Vault paths: see `.claude/rules/secrets-management.md`.
+Vault paths: see `.claude/docs/secrets-management.md`.
 
 ## Regles
 - Ne JAMAIS appliquer de changements (`kubectl apply`, `helm upgrade`) — rapport uniquement

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -91,4 +91,4 @@ Produire un rapport structure:
 - Un seul P0 suffit pour verdict "Fix"
 - Ne JAMAIS modifier le code — produire uniquement un rapport
 - Citer le fichier et la ligne pour chaque finding
-- Referer aux regles `.claude/rules/security.md`, `.claude/rules/k8s-deploy.md`, et `.claude/rules/secrets-management.md`
+- Referer aux regles `.claude/docs/security-foundation.md`, `.claude/docs/k8s-deploy.md`, et `.claude/docs/secrets-management.md`

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -19,7 +19,6 @@ Tu es un Test Engineer specialise pour le monorepo STOA Platform.
 | control-plane-api | pytest + pytest-asyncio | `pytest --cov=src` | **53%** coverage | `tests/` |
 | control-plane-ui | vitest + React Testing Library | `npm run test` | ESLint max **93** warnings | `src/**/*.test.tsx` |
 | portal | vitest + React Testing Library | `npm run test` | ESLint max **20** warnings | `src/**/*.test.tsx` |
-| mcp-gateway | pytest + pytest-asyncio | `pytest --cov=src` | **40%** coverage | `tests/` |
 | stoa-gateway | cargo test | `cargo test --all-features` | **0** clippy warnings | `src/` (inline) |
 | e2e | Playwright + playwright-bdd | `npx playwright test` | - | `features/` + `steps/` |
 
@@ -30,7 +29,7 @@ Tu es un Test Engineer specialise pour le monorepo STOA Platform.
 - **MSW** (Mock Service Worker) pour les mocks reseau React
 - **React Testing Library** (JAMAIS Enzyme)
 - **Markers pytest**: `@slow`, `@integration`, `@unit`
-- **Coverage minimum**: 53% control-plane-api, 40% mcp-gateway (see `ci-quality-gates.md`)
+- **Coverage minimum**: 53% control-plane-api (see `ci-quality-gates.md`; stoa-gateway has its own gate in `stoa-gateway/CLAUDE.md`)
 - **ESLint ratchet**: control-plane-ui max 93 warnings, portal max 20 warnings
 
 ## Shared Test Helpers (React — OBLIGATOIRE)
@@ -109,9 +108,6 @@ npm run lint && npm run format:check && npm run test -- --run
 
 # Python (control-plane-api) — ignore integration-only tests
 pytest tests/ --cov=src --cov-fail-under=53 --ignore=tests/test_opensearch.py -v
-
-# Python (mcp-gateway)
-pytest tests/ --cov=src --cov-fail-under=40 -v
 
 # Rust (stoa-gateway) — all features for Kafka
 RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features -- -D warnings

--- a/.claude/agents/verify-app.md
+++ b/.claude/agents/verify-app.md
@@ -100,4 +100,4 @@ Produire un rapport structure:
 - Ne JAMAIS modifier le code ou l'infra — rapport uniquement
 - Si kubectl n'est pas accessible, signaler et continuer les checks HTTP
 - Timeout 10s par curl (ajouter `--max-time 10`)
-- Referer aux regles `.claude/rules/ci-quality-gates.md` et `.claude/rules/k8s-deploy.md`
+- Referer aux regles `.claude/docs/ci-quality-gates.md` et `.claude/docs/k8s-deploy.md`

--- a/.claude/docs/ai-factory.md
+++ b/.claude/docs/ai-factory.md
@@ -23,7 +23,7 @@ globs: ".claude/agents/**,.claude/skills/**"
 
 ## MCP Integrations (Claude.ai Native)
 
-Full reference: `.claude/rules/mcp-integrations.md`
+Full reference: `.claude/docs/mcp-integrations.md`
 
 | Service | Key Actions | When |
 |---------|-------------|------|

--- a/.claude/docs/ci-quality-gates.md
+++ b/.claude/docs/ci-quality-gates.md
@@ -57,7 +57,7 @@ A change is NOT done until ArgoCD has synced the new image. The complete lifecyc
 ### Path triggers
 
 Each workflow only triggers on its own component paths:
-- `control-plane-api/**`, `control-plane-ui/**` + `shared/**`, `portal/**` + `shared/**`, `stoa-gateway/**`, `mcp-gateway/**`
+- `control-plane-api/**`, `control-plane-ui/**` + `shared/**`, `portal/**` + `shared/**`, `stoa-gateway/**`
 - `e2e-a11y-gate.yml` triggers on `control-plane-ui/**`, `portal/**`, `e2e/smoke-mock/**`, `e2e/fixtures/axe-helper*`
 - `e2e-visual-regression.yml` triggers on `control-plane-ui/**`, `portal/**`, `e2e/visual/**`, `e2e/golden/**`
 - `e2e-cross-validation.yml` triggers daily 07:00 UTC + manual (self-hosted, `continue-on-error: true`)
@@ -124,15 +124,13 @@ curl -s -u admin:$AWX_PASS https://awx.gostoa.dev/api/v2/jobs/?order_by=-finishe
 | Component | Coverage | Line Length | Ruff Rules | Notes |
 |-----------|----------|-------------|------------|-------|
 | control-plane-api | **70%** | 120 | E,W,F,I,B,C4,UP,ARG,SIM,S,DTZ,LOG,RUF | `--ignore tests/test_opensearch.py` for integration |
-| mcp-gateway | **40%** | 100 | E,W,F,I,B,C4,UP | Simpler ruleset |
+
+Historical: the retired `mcp-gateway` Python service had its own coverage gate (≥40%) with a simpler ruleset; those thresholds no longer apply.
 
 Pre-push commands:
 ```bash
 # control-plane-api
 cd control-plane-api && pytest tests/ --cov=src --cov-fail-under=70 --ignore=tests/test_opensearch.py -q
-
-# mcp-gateway
-cd mcp-gateway && pytest tests/ --cov=src --cov-fail-under=40 -q
 ```
 
 ## TypeScript Thresholds
@@ -210,7 +208,7 @@ Runs on all PRs. Detects `fix()` PRs (via title prefix or body keywords) and **b
 | Tool | Scope | Blocking? |
 |------|-------|-----------|
 | Gitleaks | Entire repo, `.gitleaks.toml` config | Yes |
-| Bandit | control-plane-api, mcp-gateway, MEDIUM+ severity+confidence | Yes |
+| Bandit | control-plane-api, MEDIUM+ severity+confidence | Yes |
 | ESLint security plugin | control-plane-ui, portal (7 rules) | 2 critical rules blocking (`detect-eval-with-expression`, `detect-unsafe-regex`) |
 | Clippy SAST | stoa-gateway (strict rules above) | Yes (`-D` rules) |
 | Trivy | Container images, CRITICAL+HIGH, ignore-unfixed | Yes |
@@ -261,7 +259,7 @@ Source: `stoa-infra` Helm charts (`charts/<component>/values.yaml`).
 
 ## Pre-Commit Checklist by Component
 
-### Python (control-plane-api / mcp-gateway)
+### Python (control-plane-api)
 ```bash
 ruff check . && black --check . && pytest tests/ --cov=src --cov-fail-under=<threshold> -q
 ```

--- a/.claude/docs/code-style-python.md
+++ b/.claude/docs/code-style-python.md
@@ -9,7 +9,7 @@ globs: "control-plane-api/**,cli/**"
 ## Tools: ruff + black + isort + mypy
 
 ## Line Length
-- **100**: mcp-gateway, landing-api, cli
+- **100**: landing-api, cli
 - **120**: control-plane-api
 
 ## Ruff

--- a/.claude/docs/code-style-typescript.md
+++ b/.claude/docs/code-style-typescript.md
@@ -27,7 +27,7 @@ npm run lint && npm run format:check
 
 ## Conventions
 - Functional components + hooks (no class components)
-- React 18, TypeScript strict
+- React 19, TypeScript strict
 - Keycloak-js for auth
 - vitest (NOT Jest) for testing
 - Node 20 required

--- a/.claude/docs/cost-model.md
+++ b/.claude/docs/cost-model.md
@@ -2,7 +2,7 @@
 
 ---
 description: AI Factory cost controls, model routing, autonomous levels, Council gate, and token observatory
-globs: ".github/workflows/**,.claude/rules/**,.claude/hooks/**"
+globs: ".github/workflows/**,.claude/docs/**,.claude/hooks/**"
 ---
 
 # AI Factory — Cost Model & Autonomous Levels
@@ -23,7 +23,7 @@ Kill-switches via GitHub repo variables. No single master switch (intentional).
 
 ## Hardening (H24)
 
-Safety: `continue-on-error: true`, fallback comments, diff truncation (500 lines), Council gate, Ask mode for `.claude/rules/`, timeouts (15-60 min), concurrency groups.
+Safety: `continue-on-error: true`, fallback comments, diff truncation (500 lines), Council gate, Ask mode for `.claude/docs/` (superseded `.claude/rules/`), timeouts (15-60 min), concurrency groups.
 
 ### Council Label State Machine
 `[no labels] → council-validated (S1) → ship-fast-path (optional, ≤5pts) → plan-validated (S2)`

--- a/.claude/docs/crash-recovery.md
+++ b/.claude/docs/crash-recovery.md
@@ -122,8 +122,8 @@ Example: `2026-02-12T14-30-task-traceability.json`
   "steps_completed": ["branch", "code", "quality-gate", "pr", "ci"],
   "steps_remaining": ["merge", "verify-cd", "cleanup"],
   "context": {
-    "component": "rules",
-    "files_modified": [".claude/rules/ai-workflow.md", ".claude/rules/session-startup.md"],
+    "component": "docs",
+    "files_modified": [".claude/docs/ai-workflow.md", ".claude/docs/session-startup.md"],
     "notes": "CI green, ready to merge"
   },
   "progress": {

--- a/.claude/docs/documentation.md
+++ b/.claude/docs/documentation.md
@@ -71,7 +71,7 @@ Is it user-facing (customers, developers, partners)?
 | E2E Testing | `docs/E2E-TESTING.md` | Code-coupled, changes with tests |
 | GitOps Setup | `docs/GITOPS-SETUP.md` | Ops-specific, infra-coupled |
 | Secrets Rotation | `docs/SECRETS-ROTATION.md` | Ops procedures, sensitive |
-| AI Factory | `.claude/rules/`, `.claude/agents/` | Claude Code config |
+| AI Factory | `.claude/docs/`, `.claude/agents/`, `.claude/skills/` | Claude Code config |
 | Memory | `memory.md` | Session state, ephemeral |
 | Archive | `docs/archive/` | Historical, internal |
 

--- a/.claude/docs/mega-verification.md
+++ b/.claude/docs/mega-verification.md
@@ -2,7 +2,7 @@
 
 ---
 description: MEGA ticket close gate enforcement — prevents false Dones on multi-phase tickets
-globs: ".claude/rules/workflow-essentials.md,.claude/rules/instance-dispatch.md,.claude/rules/session-lifecycle.md,.github/workflows/linear-close-on-merge.yml,.github/workflows/claude-linear-dispatch.yml"
+globs: ".claude/docs/workflow-essentials.md,.claude/docs/instance-dispatch.md,.claude/docs/session-lifecycle.md,.github/workflows/linear-close-on-merge.yml,.github/workflows/claude-linear-dispatch.yml"
 ---
 
 # MEGA Verification — Close Gate Enforcement

--- a/.claude/docs/security-foundation.md
+++ b/.claude/docs/security-foundation.md
@@ -60,7 +60,7 @@ Agents MUST NEVER autonomously reset, change, or rotate any password or credenti
 - Sensitive AI Factory prompts (`.claude/prompts/*.txt` — blocked by .gitignore)
 
 ### Allowed in public repo
-- Code, tests, CI/CD, .claude/rules/agents/skills, legal templates with `[PLACEHOLDER]`
+- Code, tests, CI/CD, `.claude/docs/`, `.claude/agents/`, `.claude/skills/`, legal templates with `[PLACEHOLDER]`
 - `.claude/prompts/*.md` (tracked, non-sensitive)
 
 ### Code names for public references

--- a/.claude/docs/seo-content.md
+++ b/.claude/docs/seo-content.md
@@ -43,7 +43,7 @@ Tags: `release, announcement, feature, security, breaking-change, mcp, community
 | Pillar | Hub | Spokes |
 |--------|-----|--------|
 | API Gateway Migration | `api-gateway-migration-guide-2026` | 8 (webMethods, MuleSoft, DataPower, Apigee, Kong, Axway, WSO2, Layer7) |
-| MCP & AI Agents | `what-is-mcp-gateway` | 3 published + 2 TODO |
+| MCP & AI Agents | `what-is-mcp-gateway` (legacy slug — kept for SEO, superseded at the product level by `stoa-gateway`) | 3 published + 2 TODO |
 | Open Source API Mgmt | `open-source-api-gateway-2026` | 7 (sovereignty, DORA, multi-tenant, Apache-2, API keys, security, GitOps) |
 
 Rules: every spoke links to hub, every hub links to all spokes, cross-pillar encouraged, never guess links (verify with `npm run build`).

--- a/.claude/docs/testing-standards.md
+++ b/.claude/docs/testing-standards.md
@@ -12,7 +12,6 @@ globs: "**/tests/**,**/test_*,**/*.test.*,**/*.spec.*,e2e/**"
 | Component | Framework | Coverage | Run Command |
 |-----------|-----------|----------|-------------|
 | control-plane-api | pytest + pytest-asyncio (auto) | **70%** | `pytest --cov=src --cov-fail-under=70 --ignore=tests/test_opensearch.py -q` |
-| mcp-gateway | pytest | **40%** | `pytest --cov=src --cov-fail-under=40 -q` |
 | control-plane-ui | vitest + RTL | ESLint <100 warnings | `npm run test -- --run` |
 | portal | vitest + RTL | ESLint 0 warnings | `npm run test -- --run` |
 | stoa-gateway | cargo test | Zero clippy warnings | `cargo test --all-features` |

--- a/.claude/prompts/cab-1103-6d-test-loop.md
+++ b/.claude/prompts/cab-1103-6d-test-loop.md
@@ -1,3 +1,5 @@
+> **Historical prompt (retired):** references to `mcp-gateway` below reflect the old context from CAB-1103 and must not be used as current architecture guidance. The Python `mcp-gateway/` service was retired in Feb 2026 and superseded by `stoa-gateway/` (Rust). See `CLAUDE.md`.
+
 CAB-1103 Phase 6D: Test Loop Automation — smoke tests en CI + audit hebdo.
 
 Branch: `feat/cab-1103-6d-test-loop` (creer depuis main)

--- a/.claude/prompts/cab-1105-phase9-mode-dashboard.md
+++ b/.claude/prompts/cab-1105-phase9-mode-dashboard.md
@@ -1,3 +1,5 @@
+> **Historical prompt (retired):** references to React 18 / Python MCP Gateway below reflect the old context from the CAB-1105 delivery window and must not be used as current architecture guidance. Current stack: React 19, Rust `stoa-gateway/`. See `CLAUDE.md`.
+
 CAB-1105 Phase 9: Gateway Mode Dashboard — UI pour les 4 modes gateway.
 
 Branch: `feat/cab-1105-mode-dashboard` (creer depuis main, APRES merge de feat/cab-1105-kill-python)

--- a/.claude/skills/audit-component.md
+++ b/.claude/skills/audit-component.md
@@ -9,7 +9,7 @@ Quand on veut analyser un composant sans le modifier. Audit de code, detection d
 ## Workflow
 
 ### Step 1: Identifier le scope
-- Quel composant auditer (control-plane-api, mcp-gateway, portal, etc.)
+- Quel composant auditer (control-plane-api, stoa-gateway, portal, etc.)
 - Quel angle: securite, performance, qualite de code, architecture, dette technique
 
 ### Step 2: Lire le contexte

--- a/.github/workflows/ai-context-lint.yml
+++ b/.github/workflows/ai-context-lint.yml
@@ -1,0 +1,30 @@
+name: AI Context Lint
+
+on:
+  pull_request:
+    paths:
+      - "CLAUDE.md"
+      - "AGENTS.md"
+      - "README.md"
+      - ".claude/**"
+      - "scripts/ai_context_lint.py"
+      - ".github/workflows/ai-context-lint.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "CLAUDE.md"
+      - "AGENTS.md"
+      - "README.md"
+      - ".claude/**"
+      - "scripts/ai_context_lint.py"
+      - ".github/workflows/ai-context-lint.yml"
+
+jobs:
+  ai-context-lint:
+    name: AI Context Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run AI context lint
+        run: python3 scripts/ai_context_lint.py

--- a/scripts/ai_context_lint.py
+++ b/scripts/ai_context_lint.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""AI context lint — block regressions of AI-facing project context.
+
+Scans the AI-facing contract files (CLAUDE.md, AGENTS.md, README.md) and the
+.claude/ subtree for stale markers that must not reappear. The goal is to
+prevent an LLM-driven edit from reintroducing retired architecture or paths
+that no longer exist.
+
+Exit status:
+  0 — no blocking finding (warnings may still be printed to stderr)
+  1 — one or more blocking findings
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+TOP_LEVEL_FILES = ("CLAUDE.md", "AGENTS.md", "README.md")
+CLAUDE_SUBTREE_GLOB = ".claude/**/*.md"
+
+# Stale stack-version markers — always blocked (current stack: React 19, Go 1.25).
+# They never belong in an active context file; a genuinely historical prompt
+# must declare itself via a top-of-file banner (see HISTORICAL_BANNER_RE).
+STALE_VERSION_MARKERS = (
+    ("React 18", "stale React 18 reference"),
+    ("Go 1.22", "stale Go 1.22 reference"),
+)
+
+# Universally toxic markers — blocked wherever they appear, no exceptions.
+UNIVERSAL_MARKERS = (
+    ("MCP GW (Py)", "retired Python MCP Gateway reference"),
+    (".Codex/", "nonexistent .Codex/ path"),
+)
+
+# Standalone `.Codex` token (not `.CodexFoo`).
+CODEX_STANDALONE = re.compile(r"\.Codex(?![A-Za-z0-9_])")
+
+# Static "Next = ADR-<N>" reference — forbidden because ADR numbers are owned
+# by stoa-docs and the index is the source of truth.
+NEXT_ADR_STATIC = re.compile(r"Next\s*=\s*ADR-\d+")
+
+# Contextual tokens: blocked unless neighbored by a historical keyword.
+MCP_GATEWAY_TOKEN = re.compile(r"\bmcp-gateway\b")
+CLAUDE_RULES_TOKEN = re.compile(r"\.claude/rules\b")
+
+HISTORICAL_KEYWORDS = (
+    "historical", "history", "legacy", "retired", "deprecated",
+    "archived", "superseded", "replaced", "old",
+    "ancien", "historique", "retiré", "retire",
+    "déprécié", "deprecie", "remplacé", "remplace",
+)
+HISTORICAL_RE = re.compile(
+    r"(?i)\b(?:" + "|".join(re.escape(k) for k in HISTORICAL_KEYWORDS) + r")\b"
+)
+
+# Top-of-file banner: a file that declares itself historical in its first few
+# lines (e.g. `> **Historical prompt (retired):** ...`) gets whole-file
+# tolerance for mcp-gateway / .claude/rules mentions. The banner must explicitly
+# classify the file as a preserved historical artifact, not merely mention the
+# word `historical` in passing.
+HISTORICAL_BANNER_RE = re.compile(
+    r"(?im)^\s*>?\s*(?:\*\*)?historical\s+"
+    r"(?:prompt|note|file|snapshot|example|reference)\b"
+)
+BANNER_SCAN_LINES = 5
+
+CONTEXT_WINDOW = 2
+
+# Advisory thresholds.
+AGENTS_LINE_LIMIT = 80
+CLAUDE_LINE_LIMIT = 250
+
+REACT_VERSION = re.compile(r"React\s+(\d+)")
+GO_VERSION = re.compile(r"Go\s+(\d+\.\d+)")
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _collect_files() -> list[Path]:
+    seen: set[Path] = set()
+    ordered: list[Path] = []
+    for name in TOP_LEVEL_FILES:
+        p = REPO_ROOT / name
+        if p.is_file() and p not in seen:
+            seen.add(p)
+            ordered.append(p)
+    for p in sorted(REPO_ROOT.glob(CLAUDE_SUBTREE_GLOB)):
+        if p.is_file() and p not in seen:
+            seen.add(p)
+            ordered.append(p)
+    return ordered
+
+
+def _context_window(lines: list[str], idx: int, width: int) -> str:
+    start = max(0, idx - width)
+    end = min(len(lines), idx + width + 1)
+    return " ".join(lines[start:end])
+
+
+def _has_historical_banner(lines: list[str]) -> bool:
+    """True if the file declares itself historical in its first few lines."""
+    head = "\n".join(lines[:BANNER_SCAN_LINES])
+    return bool(HISTORICAL_BANNER_RE.search(head))
+
+
+def _check_stale_markers(path: Path, lines: list[str], errors: list[str]) -> None:
+    rel = _rel(path)
+    banner = _has_historical_banner(lines)
+    for lineno, line in enumerate(lines, start=1):
+        for marker, reason in UNIVERSAL_MARKERS:
+            if marker in line:
+                errors.append(f"{rel}:{lineno}: {reason}")
+        if CODEX_STANDALONE.search(line) and ".Codex/" not in line:
+            errors.append(f"{rel}:{lineno}: nonexistent .Codex reference")
+        if NEXT_ADR_STATIC.search(line):
+            errors.append(f"{rel}:{lineno}: static Next ADR reference")
+        if not banner:
+            for marker, reason in STALE_VERSION_MARKERS:
+                if marker in line:
+                    errors.append(f"{rel}:{lineno}: {reason}")
+
+
+def _check_contextual(path: Path, lines: list[str], errors: list[str]) -> None:
+    """Flag active mcp-gateway / .claude/rules mentions without historical framing."""
+    rel = _rel(path)
+    if _has_historical_banner(lines):
+        return
+    for idx, line in enumerate(lines):
+        lineno = idx + 1
+        ctx = _context_window(lines, idx, CONTEXT_WINDOW)
+        tolerated = bool(HISTORICAL_RE.search(ctx))
+        if MCP_GATEWAY_TOKEN.search(line) and not tolerated:
+            errors.append(
+                f"{rel}:{lineno}: active mcp-gateway reference "
+                "(retired Feb 2026 — mark as historical/retired/superseded)"
+            )
+        if CLAUDE_RULES_TOKEN.search(line) and not tolerated:
+            errors.append(
+                f"{rel}:{lineno}: active .claude/rules reference "
+                "(superseded by CLAUDE.md hierarchy)"
+            )
+
+
+def _check_agents_references_claude(errors: list[str]) -> None:
+    agents = REPO_ROOT / "AGENTS.md"
+    if not agents.is_file():
+        return
+    text = agents.read_text(encoding="utf-8")
+    if "CLAUDE.md" not in text:
+        errors.append(
+            f"{_rel(agents)}: must reference CLAUDE.md as the canonical contract"
+        )
+
+
+def _advisory_line_counts(warnings: list[str]) -> None:
+    claude = REPO_ROOT / "CLAUDE.md"
+    agents = REPO_ROOT / "AGENTS.md"
+    for path, limit in ((claude, CLAUDE_LINE_LIMIT), (agents, AGENTS_LINE_LIMIT)):
+        if not path.is_file():
+            continue
+        n = len(path.read_text(encoding="utf-8").splitlines())
+        if n > limit:
+            warnings.append(
+                f"{_rel(path)}: {n} lines exceeds advisory limit {limit}"
+            )
+
+
+def _advisory_version_drift(warnings: list[str]) -> None:
+    claude = REPO_ROOT / "CLAUDE.md"
+    readme = REPO_ROOT / "README.md"
+    if not (claude.is_file() and readme.is_file()):
+        return
+    claude_txt = claude.read_text(encoding="utf-8")
+    readme_txt = readme.read_text(encoding="utf-8")
+    for label, regex in (("React", REACT_VERSION), ("Go", GO_VERSION)):
+        c_vers = {m.group(1) for m in regex.finditer(claude_txt)}
+        r_vers = {m.group(1) for m in regex.finditer(readme_txt)}
+        if c_vers and r_vers and c_vers != r_vers:
+            warnings.append(
+                f"README.md: {label} version mismatch with CLAUDE.md "
+                f"(CLAUDE={sorted(c_vers)}, README={sorted(r_vers)})"
+            )
+
+
+def main() -> int:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    files = _collect_files()
+
+    for path in files:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        _check_stale_markers(path, lines, errors)
+        _check_contextual(path, lines, errors)
+
+    _check_agents_references_claude(errors)
+    _advisory_line_counts(warnings)
+    _advisory_version_drift(warnings)
+
+    for w in warnings:
+        print(f"warning: {w}", file=sys.stderr)
+
+    if errors:
+        print("AI context lint failed:", file=sys.stderr)
+        for e in errors:
+            print(f"- {e}", file=sys.stderr)
+        return 1
+
+    print("AI context lint passed.")
+    print(f"Checked {len(files)} files.")
+    print("No stale AI context markers.")
+    print("No active retired gateway references.")
+    print("No static Next ADR references.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds deterministic AI context linting and cleans stale `.claude/` context so agents cannot drift back to retired architecture or outdated stack versions.

## Changes

- Add `scripts/ai_context_lint.py`
- Add `.github/workflows/ai-context-lint.yml`
- Clean stale active references in `.claude/` docs, agents, prompts, and skills
- Replace active `.claude/rules/` references with `.claude/docs/` where appropriate
- Mark historical prompts/references explicitly as historical or retired
- Remove active `mcp-gateway` guidance now that it is retired and superseded by `stoa-gateway`
- Update active React guidance from React 18 to React 19 where found

## AI context lint blocks

- `React 18`
- `Go 1.22`
- `Next = ADR-NNN`
- `MCP GW (Py)`
- `.Codex/*`
- active `mcp-gateway`
- active `.claude/rules/`

Historical mentions are allowed only when clearly marked as historical, retired, superseded, deprecated, archived, or replaced.

## Validation

- `python3 scripts/ai_context_lint.py` passes
- `python3 -m py_compile scripts/ai_context_lint.py` passes
- Negative test: React 18 in `CLAUDE.md` fails
- Negative test: `.Codex/agents` in `AGENTS.md` fails
- Negative test: active `mcp-gateway` in `CLAUDE.md` fails
- Negative test: React 18 in `.claude/*.md` fails
- Negative test: active `.claude/rules/` in `.claude/*.md` fails
- Positive test: historical `mcp-gateway` note passes

## Scope

No product code changed.

Temporary audit/report files are not included.

## Gate

Gate 4B — AI context lint.