### PR TITLE
chore(test): align CP API coverage threshold to 70

### DIFF
--- a/.github/workflows/control-plane-api-ci.yml
+++ b/.github/workflows/control-plane-api-ci.yml
@@ -71,7 +71,7 @@ jobs:
     with:
       component: control-plane-api
       python-version: '3.11'
-      coverage-threshold: 65
+      coverage-threshold: 70
       test-markers: not integration
       runner: ubuntu-latest
     permissions:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ test-all: ## Run all tests (parallel)
 	$(MAKE) -j test-api test-ui test-portal test-gateway test-cli
 
 test-api: ## Run control-plane-api tests
-	cd control-plane-api && pytest tests/ --cov=src --cov-fail-under=65 --ignore=tests/test_opensearch.py -q
+	cd control-plane-api && pytest tests/ --cov=src --cov-fail-under=70 --ignore=tests/test_opensearch.py -q
 
 test-ui: ## Run console UI tests
 	cd control-plane-ui && npm run test -- --run

--- a/control-plane-api/pyproject.toml
+++ b/control-plane-api/pyproject.toml
@@ -185,7 +185,7 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "if typing.TYPE_CHECKING:",
 ]
-fail_under = 60  # Temporarily lowered: CAB-1951 Phase 2 (mechanical test deletion). Restored in Phase 3.
+fail_under = 70
 show_missing = true
 skip_covered = true
 


### PR DESCRIPTION
## Summary

Aligns the Control Plane API coverage threshold to the documented 70% policy.

## Changes

- Update `Makefile` CP API pytest threshold from 65 to 70
- Update `control-plane-api-ci.yml` reusable CI threshold from 65 to 70
- Update `control-plane-api/pyproject.toml` coverage `fail_under` from 60 to 70

## Validation

Gate 5A preflight measured CP API coverage at 76.50%.

Gate 5B validation:

- `make test-api` passes with threshold 70
- 6600 tests passed
- 34 skipped, expected for integration/env-gated tests
- No `.coverage` artifact included
- No product code changed

## Scope

This PR only aligns existing coverage thresholds.

Out of scope:

- `.coverage` tracked-file cleanup
- `.gitignore` changes
- test additions
- product code changes

## Gate

Gate 5B — CP API coverage threshold alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)