### PR TITLE
fix(cp-api/config): close CP-2 bug hunt batch (11 tracked items)

### DIFF
--- a/control-plane-api/BUG-REPORT-CP-2.md
+++ b/control-plane-api/BUG-REPORT-CP-2.md
@@ -1,0 +1,551 @@
+# BUG-REPORT-CP-2 — Git provider config source of truth
+
+## CP-2 CLOSED — 2026-04-24
+
+**11 tracked items handled**: 9 fixed in-commit, 1 staged as patch file
+(G-1 blocked by local `.env*` write guard — see `FIX-G1-env-example.patch`),
+1 deferred cross-repo (C-2 → CAB-1890 GitHub flip).
+
+| Finding | Status | Notes |
+|---|---|---|
+| **B-1** (P0) repr-leak | ✅ FIXED | credentials wrapped in `SecretStr` on flat ingress |
+| **A-1** (P1) whitespace tokens | ✅ FIXED | `.strip()` at hydration boundary |
+| **C-1** (P1) case-sensitive `GIT_PROVIDER` | ✅ FIXED | `@field_validator(mode="before")` does `strip().lower()` |
+| **C-2** (P1) Helm chart GitHub env wiring | ⏩ DEFERRED | cross-repo → CAB-1890 |
+| **E-1** (P2) validator identity + URL shape | ✅ FIXED | org/repo non-empty, `urlparse` for `GITLAB_URL` |
+| **H-1** (P2) test fixture silent kwarg drop | ✅ FIXED | fixture uses `org`/`catalog_repo` fields |
+| **H-2** (P2) conftest misleading comment | ✅ FIXED | comment reflects reality (prod is default) |
+| **A-2** (P2) `_VALIDATE_GIT_CONFIG` kill-switch | ✅ FIXED | flag removed entirely |
+| **G-1** (P2) `.env.example` out of sync | 📋 STAGED | `FIX-G1-env-example.patch` — user runs `git apply` (local `.env*` write guard blocks Claude Code) |
+| **I-1** (P3) sub-models accept unknown kwargs | ✅ FIXED | `ConfigDict(extra="forbid")` on 3 models |
+| **I-2** (P3) redundant `or "main"` | ✅ FIXED | dropped; Field default covers it |
+
+Regression guards: 9 new tests + 1 existing-test update (SecretStr defaults).
+Invariants re-verified post-fix: grep-gate green, `settings.git.*` is the
+only consumer entry point, `mypy src/config.py` clean, ruff clean on
+touched files.
+
+---
+
+Audit of `src/config.py` + consumers + tests + deployment artifacts after the
+CAB-1889 CP-2 rewrite (PR #2480, commit `551bd4560`). Target module: the new
+`GitProviderConfig` single-source-of-truth and `_hydrate_and_validate_git`
+startup validator.
+
+## Executive summary
+
+- **Total findings**: 9 (1 P0 · 3 P1 · 5 P2)
+- **Nothing broken by the rewrite** — migration to `settings.git.*` is clean,
+  grep-gate active in CI, consumers fully cut over, 7 dead env vars dropped.
+- **Top 3 risks**:
+  1. **P0 · `repr(Settings)` leaks plaintext tokens**. The nine flat ingress
+     fields (`GITHUB_TOKEN`, `GITHUB_WEBHOOK_SECRET`, `GITLAB_TOKEN`,
+     `GITLAB_WEBHOOK_SECRET`, …) are declared `str`, not `SecretStr`.
+     `exclude=True` only hides them from `model_dump()`; they remain in
+     attribute access and in Pydantic's default `__repr__`. Reproduced end-to-end
+     — see B-1 below.
+  2. **P1 · Whitespace-only tokens silently pass the validator** in production.
+     `GITHUB_TOKEN="   "` boots the app; first catalog call 401s. Single-char
+     `strip()` fix.
+  3. **P1 · `Literal["github", "gitlab"]` is case-sensitive** and consumers no
+     longer call `.lower()`. Any existing deployment that had `GIT_PROVIDER=GITHUB`
+     or `Gitlab` (pre-rewrite silently accepted) will now refuse to boot on
+     first rollout. Not hypothetical — the rewrite explicitly removed the
+     `.lower()` call.
+
+None of the findings block the rewrite from staying on main. B-1 and A-1 are
+worth a P0/P1 batch before the next routine prod rollout; the rest can ride
+with the next cleanup sweep.
+
+**Scope of what was checked**
+- `src/config.py` (full, 566 lines) — every `Field`, validator, and the two
+  `@model_validator(mode="after")` hooks.
+- All 108 `settings.git*` consumer sites across `src/` (grep-gate is green).
+- `tests/test_config_git_provider_validation.py`,
+  `tests/test_dual_provider_smoke.py`, `tests/test_git_provider.py`,
+  `tests/test_regression_cp1_token_leak.py`, `tests/conftest.py`.
+- Deployment artifacts: `.env.example`, `k8s/configmap.yaml`,
+  `charts/stoa-platform/values.yaml`,
+  `stoa-infra/charts/control-plane-api/{values,templates/deployment}.yaml`.
+- `scripts/check_git_config_access.sh` + CI gate in
+  `.github/workflows/control-plane-api-ci.yml:50-66`.
+
+Explicitly out of scope (not bugs, risks tracked elsewhere):
+- R-1 singleton `git_service = GitLabService()` at `git_service.py:1396` —
+  REWRITE-PLAN §F defers to CP-3.
+- `_project` leak cleanup in `iam_sync_service.py` / `deployment_orchestration_service.py` —
+  shipped (regression markers confirmed `iam_sync_service.py:205`,
+  `deployment_orchestration_service.py:102`).
+- CP-1 findings (BUG-03, BUG-05, BUG-06 in `REWRITE-BUGS.md`) — unrelated
+  to CP-2 scope.
+
+---
+
+## Critical (P0)
+
+### B-1 — `repr(Settings)` leaks plaintext tokens and webhook secrets
+
+**Category**: D — security (token logging)
+**File**: `src/config.py:141-149`
+**Reproduction** (confirmed):
+
+```python
+import os
+os.environ['GIT_PROVIDER'] = 'github'
+os.environ['GITHUB_TOKEN'] = 'ghp_realsecret_MUST_NOT_LEAK_123456789'
+os.environ['GITHUB_WEBHOOK_SECRET'] = 'whsec_very_secret_456'
+os.environ['ENVIRONMENT'] = 'production'
+from src.config import Settings
+s = Settings()
+r = repr(s)
+# → GITHUB_TOKEN='ghp_realsecret_MUST_NOT_LEAK_123456789', GITHUB_WEBHOOK_SECRET='whsec_very_secret_456'
+```
+
+**Root cause**: the nine flat ingress fields are typed `str`, not `SecretStr`.
+The `exclude=True` keyword only filters `model_dump()` / `model_dump_json()` —
+it does not hide the field from attribute access nor from Pydantic's default
+`__repr__`. Only the *hydrated* `settings.git.github.token` is a `SecretStr`
+(wrapped at line 476), so the secrets live in memory twice: once masked, once
+plaintext.
+
+**Attack surface** (theoretical):
+- Any `logger.debug(f"config={settings}")`, unhandled exception capturing
+  `self.settings` in its locals dict, or a future diagnostic endpoint that
+  happens to `str(settings)` will emit the token. The `SecretRedactor` root
+  log filter (`main.py:157-160`) is defense-in-depth — it regex-matches `ghp_`
+  and `glpat-` prefixes, but does **not** cover custom tokens (enterprise
+  GitHub tokens, PAT formats that aren't the GitHub pattern, webhook
+  secrets with no fixed prefix).
+
+**Exploitable today**: no caller currently `repr()`s `settings`. But the field
+is a live plaintext copy — the rewrite explicitly wanted secrets wrapped at
+the boundary, and the boundary here is the flat ingress field.
+
+**Fix direction**: declare the four credential flat fields as `SecretStr`:
+```python
+GITHUB_TOKEN: SecretStr = Field(default=SecretStr(""), exclude=True)
+GITHUB_WEBHOOK_SECRET: SecretStr = Field(default=SecretStr(""), exclude=True)
+GITLAB_TOKEN: SecretStr = Field(default=SecretStr(""), exclude=True)
+GITLAB_WEBHOOK_SECRET: SecretStr = Field(default=SecretStr(""), exclude=True)
+```
+Update the hydrator at lines 474-488 to call `.get_secret_value()` when
+unwrapping into the SecretStr at the inner model boundary (or just pass the
+SecretStr through — the SecretStr chains).
+
+**Regression test**: `repr(Settings(...))` must not contain the raw token
+string. Ideally assert on `'ghp_'`, `'glpat-'`, and `'whsec_'` prefixes.
+
+---
+
+## High (P1)
+
+### A-1 — Whitespace-only tokens silently pass the validator
+
+**Category**: A — startup validation gap
+**File**: `src/config.py:498-509`
+**Reproduction** (confirmed):
+
+```python
+os.environ['GIT_PROVIDER'] = 'github'
+os.environ['GITHUB_TOKEN'] = '   '        # 3 spaces
+os.environ['ENVIRONMENT'] = 'production'
+Settings()  # passes — should raise
+```
+
+The validator uses `if not git.github.token.get_secret_value()` (falsy check).
+Python `bool("   ") is True`, so whitespace-only strings slip through. Same
+applies to `GITLAB_TOKEN`, `GITLAB_PROJECT_ID`, and trailing-newline secrets
+from K8s file-mounted secrets (`echo -n` omitted in the manifest → trailing
+`\n` in the decoded value).
+
+**Why it matters**: K8s Secret mounts that were populated via `kubectl create
+secret generic --from-file=token=…` include the file's trailing newline. A
+token pasted into a Helm value with a stray space at the end survives today.
+Runtime failure mode is a cryptic 401 from GitHub/GitLab rather than the
+clear "refusing to boot" message the validator is supposed to give.
+
+**Fix direction**: swap `not token.get_secret_value()` for
+`not token.get_secret_value().strip()`. Apply the `.strip()` at the
+hydration boundary (lines 473-488) so every downstream consumer sees the
+normalised value — otherwise the provider client still receives the
+whitespace and fails.
+
+**Regression test**: add two cases to
+`tests/test_config_git_provider_validation.py::TestProductionValidationCrashes`:
+`GITHUB_TOKEN="   "` and `GITHUB_TOKEN="token\n"` — both should raise
+`ValidationError("empty")`.
+
+---
+
+### C-1 — Mixed-case `GIT_PROVIDER` now crashes on boot (backward compat regression)
+
+**Category**: C — backward compat
+**File**: `src/config.py:141` (`Literal["github", "gitlab"]`) + consumer
+migration in `src/services/git_provider.py:426` (pre-rewrite used
+`.lower()`).
+**Reproduction** (confirmed):
+
+```python
+os.environ['GIT_PROVIDER'] = 'GitHub'  # mixed case
+Settings()
+# pydantic_core._pydantic_core.ValidationError:
+# GIT_PROVIDER Input should be 'github' or 'gitlab' [type=literal_error, input_value='GitHub']
+```
+
+Before the rewrite, `git_provider_factory()` did
+`settings.GIT_PROVIDER.lower()` so `"GITHUB"`, `"GitLab"`, etc. were all
+accepted. The rewrite removed the `.lower()` (REWRITE-PLAN §C.2#4) because
+`Literal` guarantees casing — which means any ConfigMap/Helm value that
+happened to carry uppercase now blocks startup.
+
+**Blast radius**: unknown without scanning every historical override. The
+only confirmed usage is `stoa-infra/charts/control-plane-api/values.yaml:11`
+(`GIT_PROVIDER: gitlab` — lowercase, safe). But self-hosted quickstart
+users, external customers, or ancient dev `.env` files may carry uppercase.
+There is no migration note in the CHANGELOG warning ops.
+
+**Fix direction**: either
+- (preferred, documented) keep `Literal["github", "gitlab"]`, add a CHANGELOG
+  breaking-change note + a migration warning in the rewrite PR description,
+  and leave it; *or*
+- re-introduce a `@field_validator("GIT_PROVIDER", mode="before")` that
+  lowercases the raw env value before Literal narrowing. One-liner fix that
+  preserves compat forever at almost no cost:
+  ```python
+  @field_validator("GIT_PROVIDER", mode="before")
+  @classmethod
+  def _normalise_provider_case(cls, v: str) -> str:
+      return v.lower() if isinstance(v, str) else v
+  ```
+
+**HYPOTHÈSE À VÉRIFIER**: I have not enumerated every prod/staging deployment.
+If a `helm get values` sweep confirms all deployments are lowercase, this
+drops to P2 (ops documentation only). If *any* deployment had uppercase,
+this is P1 and blocks the next rollout.
+
+---
+
+### C-2 — Helm chart cannot run `GIT_PROVIDER=github` in prod (cross-repo)
+
+**Category**: C — backward compat (operational)
+**File**: `stoa-infra/charts/control-plane-api/templates/deployment.yaml:34-83`
+(NOT in this repo; cross-repo finding)
+
+The chart passes only six Git env vars to the container:
+- `GIT_PROVIDER`, `GITLAB_URL` (from `values.env`)
+- `GITLAB_TOKEN`, `GITLAB_PROJECT_ID`, `GITLAB_WEBHOOK_SECRET` (from `gitlabSecret`)
+
+The four GitHub env vars (`GITHUB_TOKEN`, `GITHUB_ORG`,
+`GITHUB_CATALOG_REPO`, `GITHUB_WEBHOOK_SECRET`) and the new
+`GIT_DEFAULT_BRANCH` are **not wired**. Flipping `GIT_PROVIDER: github` in
+`values.yaml` would now cause the validator to raise `GITHUB_TOKEN is empty`
+and crash-loop the pod, with no obvious hint to ops that the chart is
+incomplete.
+
+This is documented in REWRITE-PLAN as R-5 ("prod reste gitlab, flip vers
+github = CAB-1890"). Noting here so the CP-2 audit paper-trail captures it:
+the rewrite's startup validator turned what used to be a silent misconfig
+(runtime 401) into a hard crash, which surfaces the missing chart wiring as
+an operational incident rather than a latent bug. That's an improvement —
+just one that arrives before the chart catches up.
+
+**Fix direction**: open a `stoa-infra` PR that:
+1. Adds `GITHUB_*` env passthrough and a `githubSecret` Helm value analogous
+   to `gitlabSecret`.
+2. Adds `GIT_DEFAULT_BRANCH` env passthrough (currently hard-defaults to
+   `"main"` via the config).
+3. Leaves `GIT_PROVIDER: gitlab` default in `values.yaml` so nothing changes
+   for existing installs.
+
+Alternatively, gate on CAB-1890 which already owns the GitHub flip.
+
+---
+
+## Medium (P2)
+
+### E-1 — Validator only checks tokens + `GITLAB_PROJECT_ID`; other required fields unchecked
+
+**Category**: E/A — partial validation
+**File**: `src/config.py:497-514`
+**Reproduction**:
+
+```python
+os.environ['GIT_PROVIDER'] = 'github'
+os.environ['GITHUB_TOKEN'] = 'ghp_valid'
+os.environ['GITHUB_ORG'] = ''           # empty
+os.environ['GITHUB_CATALOG_REPO'] = ''  # empty
+os.environ['ENVIRONMENT'] = 'production'
+Settings()  # passes
+# → settings.git.github.catalog_project_id == '/' (malformed)
+```
+
+`GITHUB_ORG` and `GITHUB_CATALOG_REPO` default to non-empty strings, so the
+common case is fine, but explicit overrides to empty values survive
+validation and produce a malformed `org/repo` slug (`"/"`) that breaks
+downstream `github_service.py:838`. Same class of issue for `GITLAB_URL=""`
+or `GITLAB_URL="not a url"`.
+
+**Fix direction**: tighten the validator to assert non-empty-after-strip
+for the selected provider's required identity fields:
+- github: `GITHUB_TOKEN`, `GITHUB_ORG`, `GITHUB_CATALOG_REPO`
+- gitlab: `GITLAB_TOKEN`, `GITLAB_PROJECT_ID`, `GITLAB_URL` (plus a URL shape
+  check — `urllib.parse.urlparse(url).scheme in {"https", "http"}`)
+
+Low-urgency because the default values are sensible; only surfaces on
+explicit empty override.
+
+---
+
+### H-1 — Test helper `_patched_git_settings` silently drops `catalog_project_id` kwarg
+
+**Category**: H — test intent/behaviour divergence
+**File**: `tests/test_regression_cp1_token_leak.py:66-68`
+
+```python
+return GitProviderConfig(
+    provider="github",
+    github=GitHubConfig(
+        token=SecretStr(token),
+        catalog_project_id="org/catalog",   # ← silently ignored
+        webhook_secret=SecretStr("whsec"),
+    ),
+)
+```
+
+`GitHubConfig.catalog_project_id` is a `@property`
+(`src/config.py:45-48`), not a field. Pydantic `BaseModel`'s default
+`extra="ignore"` drops the unrecognised kwarg without warning, so the test
+fixture is configured with the *default* catalog (`"stoa-platform/stoa-catalog"`)
+rather than the intended `"org/catalog"`. Verified end-to-end:
+
+```python
+g = GitHubConfig(token=SecretStr('t'), catalog_project_id='org/catalog', webhook_secret=SecretStr('w'))
+# org='stoa-platform', catalog_repo='stoa-catalog',
+# catalog_project_id='stoa-platform/stoa-catalog'   ← not 'org/catalog'
+```
+
+**Why it matters**: the test file is a security regression suite (token
+leak scenarios). The affected tests don't assert on the catalog value
+directly, so they still pass — but the fixture's intent is wrong, and the
+pattern is copy-pasteable into future tests that *do* rely on the catalog
+identity. This is the kind of silent fixture drift that hides bugs for
+months.
+
+**Fix direction**: two complementary changes.
+1. Fix the fixture (P2): override the underlying fields —
+   ```python
+   github=GitHubConfig(token=SecretStr(token), org="org", catalog_repo="catalog", …)
+   ```
+2. Prevent recurrence (P3): add `model_config = ConfigDict(extra="forbid")`
+   on `GitHubConfig`, `GitLabConfig`, `GitProviderConfig` so any future
+   typo explodes loudly at test time.
+
+---
+
+### H-2 — `conftest.py` comment claims tests don't run under `ENVIRONMENT=production`, but they do
+
+**Category**: H — test setup fragility
+**File**: `tests/conftest.py:40-47`
+
+Quoted comment: *"Tests do not run under `ENVIRONMENT=production`, so this
+only avoids the dev-mode warning spam during the suite."*
+
+Verified false: `Settings.ENVIRONMENT` defaults to `"production"` (config.py:92),
+conftest does **not** override it (no `os.environ.setdefault("ENVIRONMENT", "dev")`),
+pytest config has no env injection, and no `pytest_plugins` set it either.
+The suite has been running under production semantics all along — which is
+why the `_hydrate_and_validate_git` + `_gate_sensitive_debug_flags_in_prod`
+validators both fire their prod branch. The conftest's
+`GITLAB_TOKEN=test-token` + `GITLAB_PROJECT_ID=1` is exactly what keeps
+the git validator quiet; if either were missing, the whole suite would
+crash at `from src.config import Settings`.
+
+**Why it matters**: when a future dev adds a new prod-gated invariant
+and the suite crashes unexpectedly, the conftest comment misleads the
+debugger. Tests that *need* non-prod env explicitly set it via
+`Settings(ENVIRONMENT="dev")` or `monkeypatch.setenv` — the global
+default is incidental and load-bearing.
+
+**Fix direction**: either
+- set `os.environ.setdefault("ENVIRONMENT", "test")` in conftest
+  alongside the git defaults (document "test" as a non-production sentinel
+  that dev/staging branches treat identically to dev); *or*
+- fix the comment to say "tests run as production by default; we set the
+  gitlab creds so the validator is satisfied".
+
+Second option is lower risk — changing the env at test scope could
+silently reshape validator behaviour for dozens of tests.
+
+---
+
+### G-1 — `.env.example` out of sync with `Settings` (9 Git vars)
+
+**Category**: G / C — operational doc drift
+**File**: `.env.example:80-83`
+
+Current state:
+```ini
+# ── GitLab (optional, for UAC catalog sync) ──────────────────────────────────
+# GITLAB_URL=https://gitlab.com
+# GITLAB_TOKEN=
+# GITLAB_PROJECT_ID=
+```
+
+Missing: `GIT_PROVIDER`, `GITHUB_TOKEN`, `GITHUB_ORG`, `GITHUB_CATALOG_REPO`,
+`GITHUB_WEBHOOK_SECRET`, `GITLAB_WEBHOOK_SECRET`, `GIT_DEFAULT_BRANCH`.
+REWRITE-PLAN §C.4 called for an explicit "Git Provider" section covering all
+nine. The merging PR description notes this was blocked by a local `.env*`
+write guard and flagged as "needs manual follow-up commit". That commit
+hasn't landed.
+
+**Why it matters**: a new self-hoster follows `.env.example`, never sees
+`GIT_PROVIDER`, takes the default (`github`), and crashes on boot because
+`GITHUB_TOKEN` is empty. The new prod validator makes the failure loud
+(good), but the root cause is documentation debt.
+
+**Fix direction**: append the missing section, keeping all lines commented
+so existing self-hosted setups are unaffected:
+```ini
+# ── Git Provider (UAC catalog sync) — CAB-1889 CP-2 ──────────────────────────
+# GIT_PROVIDER=github           # github | gitlab
+# GIT_DEFAULT_BRANCH=main
+# GITHUB_TOKEN=
+# GITHUB_ORG=stoa-platform
+# GITHUB_CATALOG_REPO=stoa-catalog
+# GITHUB_WEBHOOK_SECRET=
+# GITLAB_URL=https://gitlab.com
+# GITLAB_TOKEN=
+# GITLAB_PROJECT_ID=
+# GITLAB_WEBHOOK_SECRET=
+```
+
+---
+
+### A-2 — `_VALIDATE_GIT_CONFIG` kill-switch has no guardrail test
+
+**Category**: A / G — startup validation hygiene
+**File**: `src/config.py:34`, `src/config.py:491-492`
+
+```python
+_VALIDATE_GIT_CONFIG: bool = True
+...
+if not _VALIDATE_GIT_CONFIG:
+    return self
+```
+
+A one-line flip of this module-level constant disables all Git prod
+validation silently. There is **no test** asserting the flag is `True`, and
+no CI check. If a future "hotfix" flips it to `False` to quiet a noisy boot
+warning on a rollout, the guard is gone and nobody notices.
+
+**Why it matters**: the flag was supposed to be a migration scaffold
+(REWRITE-PLAN §C.1 called for flipping it in C.3 once consumers migrated).
+C.3 flipped it on the same commit; the flag now has no purpose. Leaving it
+as a live toggle is a foot-gun.
+
+**Fix direction**: either
+- remove the flag entirely (inline the validation; the consumers are
+  all migrated — the grep-gate in CI enforces this); or
+- keep it and add a regression test
+  `tests/test_config_git_provider_validation.py::test_validation_flag_is_on`:
+  ```python
+  from src.config import _VALIDATE_GIT_CONFIG
+  assert _VALIDATE_GIT_CONFIG is True, "Git validation must stay on in prod builds"
+  ```
+
+Preferred: remove. The flag has done its job.
+
+---
+
+## Low (P2/P3 — informational)
+
+### I-1 — `GitHubConfig` / `GitLabConfig` / `GitProviderConfig` accept arbitrary kwargs
+
+**Category**: H — design hygiene
+**File**: `src/config.py:37`, `src/config.py:51`, `src/config.py:64`
+
+None of the three sub-models declare `model_config = ConfigDict(extra="forbid")`.
+Pydantic `BaseModel` default is `extra="ignore"`, so a typo like
+`GitHubConfig(tokne=...)` is silently discarded. Not a bug today (no caller
+has a typo), but it's the mechanism that enabled H-1 to slip past review.
+
+**Fix direction**: add `model_config = ConfigDict(extra="forbid")` to all
+three models. Matches the intent of "source of truth" — unknown keys
+should raise.
+
+---
+
+### I-2 — `default_branch=self.GIT_DEFAULT_BRANCH or "main"` redundant fallback
+
+**Category**: cosmetic (not a bug)
+**File**: `src/config.py:487`
+
+```python
+default_branch=self.GIT_DEFAULT_BRANCH or "main",
+```
+
+`GIT_DEFAULT_BRANCH` is declared `Field(default="main")`, so `self.GIT_DEFAULT_BRANCH`
+is never the empty string unless someone explicitly sets
+`GIT_DEFAULT_BRANCH=""` in env. In that corner case, the `or "main"` silently
+overrides the operator's explicit empty choice — arguably a footgun, but
+more likely just dead code.
+
+**Fix**: drop the `or "main"` — let the operator's choice stand and let
+downstream fail loudly if the branch doesn't exist.
+
+---
+
+## Scope — notes de design (non-bugs)
+
+- **`settings.git.provider` vs `GIT_PROVIDER` at startup**: the singleton
+  `git_service = GitLabService()` at `git_service.py:1396` still runs a
+  GitLab connect in the FastAPI lifespan regardless of `GIT_PROVIDER`. This
+  is the R-1 risk explicitly deferred to CP-3 — not a CP-2 regression.
+  Confirmed `iam_sync_service.py:205` and `deployment_orchestration_service.py:102`
+  now go through the provider-agnostic ABC (regression markers present), so
+  the leak is walled off to the one lifespan call.
+- **`Literal` case-sensitivity**: covered by C-1 but worth noting that the
+  CHANGELOG for this rewrite should carry a breaking-change note even if
+  the `.lower()` shim is re-introduced, because downstream catalogues or
+  tests that string-matched `"GitLab"` may also break.
+- **SecretStr shared default**: `Field(default=SecretStr(""))` reuses one
+  `SecretStr` instance across all default-constructed models. Safe because
+  `SecretStr` is effectively immutable — mentioned only because it's the
+  kind of thing that trips code reviews.
+- **`get_git_provider()` `lru_cache`** at `git_provider.py:443` caches the
+  factory output for the process lifetime. Tests clear the cache via
+  `get_git_provider.cache_clear()` — correct. Not a bug, but worth being
+  aware that `settings.git.provider` changes at runtime (which shouldn't
+  happen — it's env-set at boot) would *not* rebuild the cached provider.
+
+---
+
+## Priorité de fix suggérée
+
+1. **B-1** (P0) — wrap flat credential fields in `SecretStr`. Single-file
+   change, tests should drive it (`repr(Settings(...))` must not contain
+   token/webhook secret values). ~30 min.
+2. **A-1** (P1) — `.strip()` the token + project-id at the hydration
+   boundary. Two regression tests. ~15 min.
+3. **C-1** (P1) — decide: keep strict `Literal` + add CHANGELOG + ops
+   comms, OR add the `mode="before"` lowercasing field validator. Either
+   way, get a PR out before the next prod rollout. ~15 min + comms.
+4. **C-2** (P1) — cross-repo `stoa-infra` follow-up for GitHub env
+   passthrough. Pair with CAB-1890 since that ticket already owns the
+   GitHub flip. ~1h.
+5. **E-1** (P2) — tighten validator to cover `GITHUB_ORG` / `GITHUB_CATALOG_REPO`
+   + URL shape. ~20 min.
+6. **G-1** (P2) — `.env.example` section append. Write-guard unlock or
+   manual edit. ~5 min.
+7. **H-1** + **I-1** (P2/P3) — test fixture fix + `extra="forbid"`. ~15 min.
+8. **H-2** (P2) — conftest comment fix (or the more ambitious env default
+   set). ~5 min.
+9. **A-2** (P2) — remove `_VALIDATE_GIT_CONFIG` flag (or add its guardrail
+   test). ~10 min.
+
+Total estimated IA time for everything P0+P1+P2: **under 3h**. Under 1h if
+C-2 is deferred to the CAB-1890 track.
+
+---
+
+**Audit end — phase 1 (no fixes applied). Awaiting triage.**

--- a/control-plane-api/FIX-G1-env-example.patch
+++ b/control-plane-api/FIX-G1-env-example.patch
@@ -1,0 +1,25 @@
+--- a/control-plane-api/.env.example
++++ b/control-plane-api/.env.example
+@@ -78,7 +78,20 @@
+ # GRAFANA_URL=https://grafana.gostoa.dev
+ # PROMETHEUS_URL=https://prometheus.gostoa.dev
+
+-# ── GitLab (optional, for UAC catalog sync) ──────────────────────────────────
++# ── Git Provider (UAC catalog sync) — CAB-1889 CP-2 ──────────────────────────
++# The control plane persists its UAC catalog on either GitHub or GitLab.
++# Pick one via GIT_PROVIDER, then populate only the matching block.
++# In ENVIRONMENT=production, startup fails fast on missing/inconsistent creds.
++# GIT_PROVIDER=github              # github | gitlab (case-insensitive)
++# GIT_DEFAULT_BRANCH=main
++
++# ── GitHub block (active when GIT_PROVIDER=github) ─────────────────
++# GITHUB_TOKEN=
++# GITHUB_ORG=stoa-platform
++# GITHUB_CATALOG_REPO=stoa-catalog
++# GITHUB_WEBHOOK_SECRET=
++
++# ── GitLab block (active when GIT_PROVIDER=gitlab) ─────────────────
+ # GITLAB_URL=https://gitlab.com
+ # GITLAB_TOKEN=
+ # GITLAB_PROJECT_ID=
++# GITLAB_WEBHOOK_SECRET=

--- a/control-plane-api/FIX-PLAN-CP2.md
+++ b/control-plane-api/FIX-PLAN-CP2.md
@@ -1,0 +1,278 @@
+# FIX-PLAN-CP2 — All-in-One close of CP-2 bug hunt (9 findings)
+
+> **Scope**: 1 atomic commit on `fix/cp-2-bug-hunt-batch` branched from fresh
+> `main`. Total est. ≤ 3h IA time. Branching from `main` is mandatory — current
+> session sits on `fix/gw-1-p2-batch` (GW-1 PR #2512 still open), so Phase 2
+> must start with `git fetch origin && git switch main && git pull && git
+> switch -c fix/cp-2-bug-hunt-batch`.
+
+Ref: `control-plane-api/BUG-REPORT-CP-2.md` for the finding-by-finding
+write-up.
+
+---
+
+## A. Ordre d'exécution dans le commit
+
+All 10 edits (9 findings + explicit C-2 trace in commit body) land in one
+commit. Within that commit, edits are applied in an order that keeps each
+step locally coherent — so if Phase 2 is interrupted and diffs are inspected
+mid-flight, nothing mid-edit looks broken.
+
+| # | Item | File | Depends on | Notes |
+|---|------|------|------------|-------|
+| 1 | **H-1** fix test fixture first | `tests/test_regression_cp1_token_leak.py` | — | Replace silently-dropped `catalog_project_id=` kwarg with `org="org", catalog_repo="catalog"`. Must land **before** step 2. |
+| 2 | **I-1** `extra="forbid"` on 3 sub-models | `src/config.py` | #1 | Without #1 first, this step would make the test fixture crash. |
+| 3 | **B-1** wrap 4 credential flat fields in `SecretStr` | `src/config.py` | — | Types change for `GITHUB_TOKEN`, `GITHUB_WEBHOOK_SECRET`, `GITLAB_TOKEN`, `GITLAB_WEBHOOK_SECRET`. Updates hydrator lines 475-488. |
+| 4 | **A-1** `.strip()` at hydration boundary | `src/config.py` | #3 | Chain `.get_secret_value().strip()` then re-wrap in SecretStr. Applies to tokens + webhook secrets + `GITLAB_PROJECT_ID`. |
+| 5 | **C-1** `@field_validator("GIT_PROVIDER", mode="before")` | `src/config.py` | — | Lowercase raw value before Literal narrowing. Restores pre-rewrite backward compat. |
+| 6 | **E-1** tighten validator (org/repo/url) | `src/config.py` | #3/#4 | New checks inside `_hydrate_and_validate_git`: non-empty after strip for org + repo; URL shape check for `GITLAB_URL`. |
+| 7 | **A-2** remove `_VALIDATE_GIT_CONFIG` kill-switch | `src/config.py` + `tests/conftest.py` | — | Delete the module constant + the `if not _VALIDATE_GIT_CONFIG: return self` guard; update conftest comment that still mentions the flag. Grep-verified: no other reference in code. |
+| 8 | **I-2** drop redundant `or "main"` | `src/config.py` | — | One-line change at the `default_branch=…` site. |
+| 9 | **G-1** sync `.env.example` | `control-plane-api/.env.example` | — | Append explicit Git Provider section (9 vars, all commented). |
+| 10 | **H-2** fix conftest comment | `tests/conftest.py` | #7 | Merge with step #7's conftest edit — both touch the same comment block. |
+
+**All 8 regression guards** (see §C) added alongside the production code in
+the same commit.
+
+---
+
+## B. Arbitrages à résoudre
+
+### B.1 — B-1 hydrator path after SecretStr wrap
+
+The current hydrator wraps the plain `str` fields in `SecretStr` at
+`src/config.py:475-488`:
+
+```python
+token=SecretStr(self.GITHUB_TOKEN),
+```
+
+After B-1, `self.GITHUB_TOKEN` is itself a `SecretStr`. Double-wrapping
+(`SecretStr(SecretStr(...))`) is invalid. We also need A-1's `.strip()`.
+The minimal coherent shape:
+
+```python
+token=SecretStr(self.GITHUB_TOKEN.get_secret_value().strip()),
+```
+
+This:
+- unwraps the SecretStr once,
+- strips whitespace/newlines (A-1),
+- re-wraps at the inner-model boundary.
+
+`GITHUB_ORG`, `GITHUB_CATALOG_REPO`, `GITLAB_URL`, `GITLAB_PROJECT_ID`,
+`GIT_DEFAULT_BRANCH` stay `str`. Apply `.strip()` to them too (cheap, fixes
+K8s mount newlines for non-secrets).
+
+**Decision**: pass all string inputs through `.strip()`; re-wrap only the
+four credential ones in `SecretStr`. No other touch of the inner models
+needed.
+
+### B.2 — C-1 field_validator location
+
+`@field_validator("GIT_PROVIDER", mode="before")` on `Settings` is correct:
+
+- `mode="before"` runs prior to Literal narrowing, so `"GITHUB"` → `"github"`
+  before the `Literal["github", "gitlab"]` check fires.
+- Guard for non-str inputs (defensive; Pydantic may pass a default or
+  kwarg-typed value): `return v.lower() if isinstance(v, str) else v`.
+- Located right after the credential field declarations (after line 154) so
+  anyone reading `Settings` sees the normalisation next to the field.
+
+No need to touch the inner `GitProviderConfig.provider` Literal — the flat
+ingress is the only ingestion path.
+
+### B.3 — H-2 conftest choice
+
+Two options:
+
+- **Option A (recommended)**: fix the comment. Change the false claim to
+  the actual mechanism. Zero behavioural risk.
+  > "Tests run under `ENVIRONMENT=production` by default (Settings default).
+  > We set gitlab creds here so `_hydrate_and_validate_git` is satisfied and
+  > the suite imports `src.config` without crashing."
+
+- **Option B**: `os.environ.setdefault("ENVIRONMENT", "test")` and make the
+  validators treat `"test"` like `"dev"`. Broader blast radius — any test
+  that indirectly relied on prod-gated behaviour (the CORS origins
+  stripper, the sensitive debug flag gate, the git validator) would flip.
+
+**Decision**: Option A. Matches BUG-REPORT recommendation. Bundle the
+comment fix with the A-2 edit since both touch the same conftest block.
+
+### B.4 — A-2 suppression vs guardrail test
+
+Grep audit before Phase 2:
+
+| Location | Kind | Action |
+|----------|------|--------|
+| `src/config.py:34` | declaration | delete |
+| `src/config.py:468` | docstring mention in validator | rephrase (remove "when _VALIDATE… is True") |
+| `src/config.py:491-492` | `if not _VALIDATE_GIT_CONFIG: return self` | delete |
+| `tests/conftest.py:41` | comment reference | rephrase (bundle with H-2) |
+| `REWRITE-PLAN.md` / `BUG-REPORT-CP-2.md` | historical docs | leave untouched (they document the migration) |
+
+No test imports the flag. No runtime code outside `config.py` references it.
+**Safe to delete outright.**
+
+### B.5 — C-2 trace format in commit body
+
+Already mirrored in the user-provided Phase 2 template:
+
+> ```
+> Deferred cross-repo:
+> - C-2 (P1): stoa-infra Helm chart needs GITHUB_* env passthrough.
+>   Tracked under CAB-1890 (GitHub flip).
+> ```
+
+Confirmed this is sufficient — CAB-1890 already owns the GitHub flip, so
+pairing the chart wiring with it is natural.
+
+---
+
+## C. Régression guards (8 new tests)
+
+All in `tests/test_config_git_provider_validation.py` (extend existing
+classes) except the fixture test which belongs in
+`tests/test_regression_cp1_token_leak.py` and the `extra="forbid"` test
+which belongs in `tests/test_git_provider.py` next to `TestGitProviderConfig`.
+
+| # | Test | File / location | Asserts |
+|---|------|-----------------|---------|
+| 1 | `test_repr_settings_does_not_leak_tokens` | `test_config_git_provider_validation.py` | `repr(Settings(...))` with `GITHUB_TOKEN=ghp_x`, `GITHUB_WEBHOOK_SECRET=whsec_y`, `GITLAB_TOKEN=glpat_z`, `GITLAB_WEBHOOK_SECRET=whsec_w` never contains any of those literals |
+| 2 | `test_whitespace_only_token_rejected` | same | `GITHUB_TOKEN="   "` + prod → `ValidationError` matching "empty" |
+| 3 | `test_trailing_newline_token_stripped` | same | `GITHUB_TOKEN="ghp_x\n"` + prod → `Settings()` succeeds AND `settings.git.github.token.get_secret_value() == "ghp_x"` (stripped) |
+| 4 | `test_git_provider_accepts_mixed_case` | same | `GIT_PROVIDER="GitHub"` with full github creds + prod → `settings.git.provider == "github"` |
+| 5 | `test_github_org_empty_rejected` | same | `GITHUB_ORG=""` + github + token + prod → `ValidationError` mentioning `GITHUB_ORG` |
+| 6 | `test_invalid_gitlab_url_rejected` | same | `GITLAB_URL="not-a-url"` + gitlab + token + project_id + prod → `ValidationError` mentioning `GITLAB_URL` shape |
+| 7 | `test_fixture_uses_correct_github_org` | `test_regression_cp1_token_leak.py` | New test; builds via `_patched_git_settings("github", "ghp_x")`, asserts `cfg.github.org == "org"` and `cfg.github.catalog_repo == "catalog"` — proves the fixture fix landed |
+| 8 | `test_githubconfig_rejects_unknown_kwargs` | `test_git_provider.py` under `TestGitProviderConfig` | `GitHubConfig(tokne=SecretStr("x"))` raises `ValidationError`; same for `GitLabConfig` and `GitProviderConfig` |
+
+**No dedicated test** for the trivial items:
+- G-1 (`.env.example`): content-only, no runtime effect.
+- H-2 (conftest comment): pure doc.
+- A-2 (flag removal): coverage already provided by existing
+  `TestProductionValidationCrashes` — if the flag were re-introduced and
+  flipped off, those tests would start passing despite bad creds → caught.
+- I-2 (redundant `or "main"`): existing `default_branch` tests cover it.
+
+**Existing test updates required** (not net-new):
+
+- `tests/test_git_provider.py:115-118` — asserts
+  `Settings.model_fields["GITHUB_TOKEN"].default == ""`. After B-1 the
+  default becomes `SecretStr("")`, so the assertion must change to
+  `.default.get_secret_value() == ""`. Same for
+  `GITHUB_WEBHOOK_SECRET`. This is a 2-line edit; include it in the commit.
+
+---
+
+## D. Risques identifiés
+
+### D.1 — H-1 ordering vs I-1
+
+Already folded into §A order (H-1 step #1, I-1 step #2). Without this
+order, the `tests/test_regression_cp1_token_leak.py` fixture would crash at
+collection time once `extra="forbid"` lands.
+
+### D.2 — C-1 silent breaking-change masked
+
+Adding the `.lower()` field_validator restores backward compat — but it
+also hides from future readers that the Literal is case-sensitive. A
+reader who sets `GIT_PROVIDER=GITHUB` in a test kwarg `Settings(GIT_PROVIDER="GITHUB")`
+will get it normalised, not rejected. Acceptable trade-off; mention in the
+commit message so the behaviour is search-grep-able.
+
+### D.3 — A-2 removal beyond grep's reach
+
+Grep in §B.4 covers all in-tree refs. Out-of-tree ops tooling (ansible
+playbooks in stoa-infra, runbook snippets in stoa-docs) may mention the
+flag name. I checked `stoa-infra/charts/control-plane-api/` — no mention.
+stoa-docs: out of audit scope, but the flag has never been documented
+user-facing (it was a migration scaffold). **Low residual risk.**
+
+### D.4 — B-1 flat `SecretStr` defaults + Pydantic Settings env ingestion
+
+Declaring `GITHUB_TOKEN: SecretStr = Field(default=SecretStr(""), exclude=True)`:
+
+- Env var ingestion: `pydantic-settings` v2 auto-wraps a plain string env
+  value into `SecretStr` at field validation — confirmed by existing
+  `GitHubConfig.token: SecretStr` usage in the rewrite. **No ingestion
+  regression.**
+- Default-factory concern: `Field(default=SecretStr(""))` shares one
+  `SecretStr("")` instance across all default-constructed `Settings()`
+  — safe because `SecretStr` is effectively immutable.
+- Tests that patch `settings.GITHUB_TOKEN = "x"` would break (type
+  mismatch). **Grep confirms zero such patches** in `tests/` — everyone
+  goes via `monkeypatch.setenv` (string env var, auto-wrapped) or via
+  `mock_settings.git.github.token = SecretStr(...)`.
+
+### D.5 — E-1 URL validation scope
+
+The URL shape check for `GITLAB_URL` should be tolerant:
+- Accept `http://` and `https://` schemes.
+- Non-empty netloc required.
+- No deep path/query validation (gitlab.com works; self-hosted
+  `https://gitlab.corp/path/subpath/` also works).
+
+Use `urllib.parse.urlparse`. Only raise when both scheme is `http(s)` and
+netloc is empty, or scheme is unset entirely. Err on the side of permissive
+so valid self-hosted URLs aren't rejected.
+
+---
+
+## E. Commit message
+
+```
+fix(cp-api/config): close CP-2 bug hunt batch (9 findings)
+
+Security, validation and hygiene fixes on GitProviderConfig source of truth:
+- B-1 (P0): wrap credentials in SecretStr to prevent repr() leak
+- A-1 (P1): strip whitespace/newlines on tokens at hydration boundary
+- C-1 (P1): field_validator restores case-insensitive GIT_PROVIDER for compat
+- E-1 (P2): tighten validator on GITHUB_ORG, GITHUB_CATALOG_REPO, GITLAB_URL
+- G-1 (P2): sync .env.example with full Git Provider section
+- H-1 (P2): fix test fixture to use correct GitHubConfig fields
+- H-2 (P2): correct misleading conftest comment
+- A-2 (P2): remove _VALIDATE_GIT_CONFIG kill-switch (migration done)
+- I-1 (P3): extra="forbid" on Git* sub-models prevents silent kwarg drop
+- I-2 (P3): remove redundant `or "main"` fallback
+
+Regression guards: 8 new tests covering repr-leak, whitespace rejection,
+trailing-newline normalisation, case-insensitive GIT_PROVIDER, empty-field
+rejection, URL shape, fixture correctness, extra="forbid".
+
+Deferred cross-repo:
+- C-2 (P1): stoa-infra Helm chart needs GITHUB_* env passthrough.
+  Tracked under CAB-1890 (GitHub flip).
+
+Module CP-2 CLOSED — 9/9 findings handled (1 P0 + 2 P1 + 5 P2 + 2 P3 +
+1 deferred).
+
+Closes: B-1, A-1, C-1, E-1, G-1, H-1, H-2, A-2, I-1, I-2 (BUG-REPORT-CP-2.md)
+Deferred: C-2 → CAB-1890
+```
+
+Note: the header count in the report summary will be updated to match
+(1 P0 + 2 P1 fixed + 1 P1 deferred + 5 P2 + 2 P3 = 10 items; findings
+are labelled 9 in the report because I-1/I-2 were listed together as
+"Low" — I'll reconcile that in the report header so it reads as "10/10
+findings handled, 9 in-scope fixed + 1 cross-repo deferred".
+
+---
+
+## F. Phase 3 validation checklist
+
+1. `pytest tests/ -x -v` — all green incl. 8 net-new tests + 1 existing-test update.
+2. `ruff check src/` — clean.
+3. `mypy src/config.py` — no new errors.
+4. CP-2 invariant: `grep -rn "os\.getenv.*\(GITHUB\|GITLAB\|GIT_PROVIDER\)" src/ --include="*.py" | grep -v "src/config.py"` → empty.
+5. `bash scripts/check_git_config_access.sh src` → "OK: no direct access".
+6. Smoke: `GITHUB_TOKEN="   " python -c "from src.config import Settings; Settings()"` → `ValidationError`.
+7. Smoke: `python -c "import os; os.environ.update({'GIT_PROVIDER':'github','GITHUB_TOKEN':'ghp_x','ENVIRONMENT':'production'}); from src.config import Settings; s=Settings(); assert 'ghp_x' not in repr(s)"` → exits 0.
+8. Smoke: `GIT_PROVIDER=GitHub python -c "from src.config import Settings; print(Settings().git.provider)"` → prints `github`.
+9. Update `BUG-REPORT-CP-2.md`:
+   - Add "## CP-2 CLOSED" block at the top (date, commit SHA, 9 FIXED + 1 DEFERRED summary).
+   - Annotate each finding section with `**Status**: FIXED — commit <sha>` or `**Status**: DEFERRED — CAB-1890`.
+10. Final recap: commit SHA + per-finding status.
+
+**Phase 2 starts only after explicit validation of this plan.**

--- a/control-plane-api/src/config.py
+++ b/control-plane-api/src/config.py
@@ -8,8 +8,9 @@ import json
 import logging
 import os
 from typing import Literal
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field, SecretStr, model_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings
 
 # Base domain - used to construct default URLs
@@ -29,13 +30,29 @@ SENSITIVE_DEBUG_FLAGS_IN_PROD: tuple[str, ...] = (
     "LOG_DEBUG_HTTP_HEADERS",
 )
 
-# CAB-1889 CP-2: startup validation gate. Activated in C.3 once all consumers
-# migrated to `settings.git.*` (verified by scripts/check_git_config_access.sh).
-_VALIDATE_GIT_CONFIG: bool = True
+
+def _is_valid_http_url(url: str) -> bool:
+    """CAB-1889 CP-2 E-1: accept http(s) with non-empty netloc.
+
+    Permissive on path/query/fragment so self-hosted GitLab under a
+    sub-path (``https://gitlab.corp/path/subpath/``) remains valid.
+    Rejects missing scheme (``gitlab.corp``), non-http schemes
+    (``ftp://...``), and empty netloc (``https://``).
+    """
+    try:
+        parsed = urlparse(url)
+    except (ValueError, TypeError):
+        return False
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
 
 
 class GitHubConfig(BaseModel):
     """GitHub provider config — hydrated from flat env vars by Settings validator."""
+
+    # CAB-1889 CP-2 I-1: reject unknown kwargs so fixture typos (e.g. the
+    # dropped ``catalog_project_id=`` kwarg in the CP-1 token-leak suite)
+    # raise loudly instead of being silently ignored.
+    model_config = ConfigDict(extra="forbid")
 
     token: SecretStr = Field(default=SecretStr(""))
     org: str = "stoa-platform"
@@ -50,6 +67,8 @@ class GitHubConfig(BaseModel):
 
 class GitLabConfig(BaseModel):
     """GitLab provider config — hydrated from flat env vars by Settings validator."""
+
+    model_config = ConfigDict(extra="forbid")
 
     url: str = "https://gitlab.com"
     token: SecretStr = Field(default=SecretStr(""))
@@ -67,6 +86,8 @@ class GitProviderConfig(BaseModel):
     Consumers must read from ``settings.git.*`` only. A grep gate in CI
     enforces this (see ``scripts/check_git_config_access.sh``).
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     provider: Literal["github", "gitlab"] = "github"
     github: GitHubConfig = Field(default_factory=GitHubConfig)
@@ -132,26 +153,44 @@ class Settings(BaseSettings):
     SLACK_CHANNEL_ID: str = ""  # Target channel ID for Bot API
 
     # ── Git Provider — legacy flat ingress (CAB-1889 CP-2) ───────────────
-    # These 9 fields exist only so Pydantic Settings can hydrate them from
+    # These 10 fields exist only so Pydantic Settings can hydrate them from
     # env vars, .env and K8s ConfigMap. They are `exclude=True` so they
     # never appear in model_dump() or JSON schema.
     #
     # Consumers MUST read `settings.git.*` instead. A grep gate in CI
     # enforces this (see scripts/check_git_config_access.sh).
+    #
+    # CAB-1889 CP-2 B-1: the four credential fields are `SecretStr` so
+    # `repr(Settings(...))` can't leak them. They are unwrapped, stripped
+    # and re-wrapped at the hydration boundary in `_hydrate_and_validate_git`.
     GIT_PROVIDER: Literal["github", "gitlab"] = Field(default="github", exclude=True)
-    GITHUB_TOKEN: str = Field(default="", exclude=True)
+    GITHUB_TOKEN: SecretStr = Field(default=SecretStr(""), exclude=True)
     GITHUB_ORG: str = Field(default="stoa-platform", exclude=True)
     GITHUB_CATALOG_REPO: str = Field(default="stoa-catalog", exclude=True)
-    GITHUB_WEBHOOK_SECRET: str = Field(default="", exclude=True)
+    GITHUB_WEBHOOK_SECRET: SecretStr = Field(default=SecretStr(""), exclude=True)
     GITLAB_URL: str = Field(default="https://gitlab.com", exclude=True)
-    GITLAB_TOKEN: str = Field(default="", exclude=True)
+    GITLAB_TOKEN: SecretStr = Field(default=SecretStr(""), exclude=True)
     GITLAB_PROJECT_ID: str = Field(default="", exclude=True)
-    GITLAB_WEBHOOK_SECRET: str = Field(default="", exclude=True)
+    GITLAB_WEBHOOK_SECRET: SecretStr = Field(default=SecretStr(""), exclude=True)
     # CP-1 P2 (M.4): catalog repo default branch, provider-agnostic.
     GIT_DEFAULT_BRANCH: str = Field(default="main", exclude=True)
 
     # ── Git Provider — single source of truth for consumers ──────────────
     git: GitProviderConfig = Field(default_factory=GitProviderConfig)
+
+    @field_validator("GIT_PROVIDER", mode="before")
+    @classmethod
+    def _normalize_git_provider(cls, v: object) -> object:
+        """CAB-1889 CP-2 C-1: restore case-insensitive GIT_PROVIDER for
+        backward compat with deployments that pre-date the ``Literal``
+        narrowing (which removed the consumer-side ``.lower()`` shim).
+
+        Also strips so K8s-mounted values with trailing newlines survive.
+        Non-string inputs are passed through untouched for Pydantic to
+        handle (e.g. ``Settings(GIT_PROVIDER=None)`` still raises a
+        proper ``literal_error``).
+        """
+        return v.strip().lower() if isinstance(v, str) else v
 
     # Kafka/Redpanda Event Streaming
     KAFKA_ENABLED: bool = True  # Set to False to skip Kafka health checks
@@ -462,41 +501,50 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def _hydrate_and_validate_git(self) -> "Settings":
-        """CAB-1889 CP-2: hydrate ``settings.git`` from legacy flat env vars.
+        """CAB-1889 CP-2: hydrate ``settings.git`` from legacy flat env vars,
+        then fail fast in production if the selected provider is
+        misconfigured (warn in dev/staging).
 
-        Runs unconditionally so consumers see a coherent ``settings.git.*``
-        tree. When ``_VALIDATE_GIT_CONFIG`` is True (flipped in C.3), also
-        fails fast in production if the selected provider is misconfigured,
-        and warns in dev/staging.
+        CP-2 B-1/A-1: unwrap the credential ``SecretStr`` flat fields,
+        ``.strip()`` whitespace and newlines (K8s file-mounted secrets
+        often include a trailing ``\\n``), then re-wrap at the inner
+        model boundary so consumers always see a clean ``SecretStr``.
+
+        CP-2 E-1: the validator asserts non-empty identity fields
+        (``GITHUB_ORG``, ``GITHUB_CATALOG_REPO``) and a syntactically
+        valid ``GITLAB_URL`` — catches explicit empty overrides that
+        previously produced malformed ``org/repo`` slugs or URLs at
+        runtime.
         """
-        # Step 1 — hydration (always, wrapping SecretStr at the boundary).
+        # Step 1 — hydration (always, stripping + re-wrapping SecretStr).
         self.git = GitProviderConfig(
             provider=self.GIT_PROVIDER,
             github=GitHubConfig(
-                token=SecretStr(self.GITHUB_TOKEN),
-                org=self.GITHUB_ORG,
-                catalog_repo=self.GITHUB_CATALOG_REPO,
-                webhook_secret=SecretStr(self.GITHUB_WEBHOOK_SECRET),
+                token=SecretStr(self.GITHUB_TOKEN.get_secret_value().strip()),
+                org=self.GITHUB_ORG.strip(),
+                catalog_repo=self.GITHUB_CATALOG_REPO.strip(),
+                webhook_secret=SecretStr(self.GITHUB_WEBHOOK_SECRET.get_secret_value().strip()),
             ),
             gitlab=GitLabConfig(
-                url=self.GITLAB_URL,
-                token=SecretStr(self.GITLAB_TOKEN),
-                project_id=self.GITLAB_PROJECT_ID,
-                webhook_secret=SecretStr(self.GITLAB_WEBHOOK_SECRET),
+                url=self.GITLAB_URL.strip(),
+                token=SecretStr(self.GITLAB_TOKEN.get_secret_value().strip()),
+                project_id=self.GITLAB_PROJECT_ID.strip(),
+                webhook_secret=SecretStr(self.GITLAB_WEBHOOK_SECRET.get_secret_value().strip()),
             ),
-            default_branch=self.GIT_DEFAULT_BRANCH or "main",
+            default_branch=self.GIT_DEFAULT_BRANCH.strip(),
         )
 
-        # Step 2 — validation (gated; flipped in C.3).
-        if not _VALIDATE_GIT_CONFIG:
-            return self
-
+        # Step 2 — validation.
         git = self.git
         offender_msgs: list[str] = []
 
         if git.provider == "github":
             if not git.github.token.get_secret_value():
                 offender_msgs.append("GIT_PROVIDER=github but GITHUB_TOKEN is empty")
+            if not git.github.org:
+                offender_msgs.append("GIT_PROVIDER=github but GITHUB_ORG is empty")
+            if not git.github.catalog_repo:
+                offender_msgs.append("GIT_PROVIDER=github but GITHUB_CATALOG_REPO is empty")
             if git.gitlab.token.get_secret_value():
                 _logger.warning(
                     "GIT_PROVIDER=github but GITLAB_TOKEN is also set. "
@@ -507,6 +555,11 @@ class Settings(BaseSettings):
                 offender_msgs.append("GIT_PROVIDER=gitlab but GITLAB_TOKEN is empty")
             if not git.gitlab.project_id:
                 offender_msgs.append("GIT_PROVIDER=gitlab but GITLAB_PROJECT_ID is empty")
+            if not _is_valid_http_url(git.gitlab.url):
+                offender_msgs.append(
+                    f"GIT_PROVIDER=gitlab but GITLAB_URL is not a valid http(s) URL "
+                    f"(got {git.gitlab.url!r})"
+                )
             if git.github.token.get_secret_value():
                 _logger.warning(
                     "GIT_PROVIDER=gitlab but GITHUB_TOKEN is also set. "

--- a/control-plane-api/tests/conftest.py
+++ b/control-plane-api/tests/conftest.py
@@ -38,10 +38,12 @@ os.environ["STOA_ENABLE_KAFKA_CONSUMERS"] = "false"
 # Explicit Git provider config for test determinism (CAB-1890 dual-provider).
 # Tests that need GIT_PROVIDER=github override this via monkeypatch.setenv().
 #
-# CAB-1889 CP-2: since _VALIDATE_GIT_CONFIG is now active, the Settings
-# instantiation crashes in ENVIRONMENT=production if the selected provider
-# lacks creds. Tests do not run under ENVIRONMENT=production, so this only
-# avoids the dev-mode warning spam during the suite.
+# CAB-1889 CP-2 H-2: the test suite runs under `ENVIRONMENT=production`
+# by default (that is the Settings field default, and nothing in pytest
+# config or in this conftest overrides it). These three env vars exist
+# so `_hydrate_and_validate_git` finds a coherent gitlab config at import
+# time; without them, `from src.config import Settings` would crash the
+# whole test collection.
 os.environ.setdefault("GIT_PROVIDER", "gitlab")
 os.environ.setdefault("GITLAB_TOKEN", "test-token")
 os.environ.setdefault("GITLAB_PROJECT_ID", "1")

--- a/control-plane-api/tests/test_config_git_provider_validation.py
+++ b/control-plane-api/tests/test_config_git_provider_validation.py
@@ -8,7 +8,17 @@ Verifies the `_hydrate_and_validate_git` model validator on Settings:
 - The default code (GIT_PROVIDER=github) without a GITHUB_TOKEN also
   crashes in prod — documents R-3 (conftest.py default is gitlab while
   Settings default is github).
+- CP-2 B-1: `repr(Settings())` does not leak credentials.
+- CP-2 A-1: whitespace-only tokens are rejected; trailing newlines stripped.
+- CP-2 C-1: GIT_PROVIDER accepts mixed case + whitespace (backward compat).
+- CP-2 E-1: GITHUB_ORG / GITHUB_CATALOG_REPO non-empty; GITLAB_URL shape.
 """
+
+# ruff: noqa: S106
+# The whole point of this test file is to exercise the config validator
+# with fake credential strings. Every `_settings_env(..., GITHUB_TOKEN=...)`
+# would otherwise trip S106 "possible hardcoded password". Scope the waiver
+# to this file (file-level directive above) rather than tagging ~20 lines.
 
 from __future__ import annotations
 
@@ -24,12 +34,21 @@ def _settings_env(monkeypatch, **overrides) -> None:
     Using monkeypatch so each test is isolated; conftest sets the
     GITLAB defaults at import time but they live in os.environ and
     need explicit unsetting per test.
+
+    CAB-1889 CP-2 E-1: also resets GITHUB_ORG, GITHUB_CATALOG_REPO
+    and GITLAB_URL so tests can assert the validator's new
+    identity/URL-shape checks without inheriting shell env.
     """
     keys = [
         "GIT_PROVIDER",
         "GITHUB_TOKEN",
+        "GITHUB_ORG",
+        "GITHUB_CATALOG_REPO",
+        "GITHUB_WEBHOOK_SECRET",
+        "GITLAB_URL",
         "GITLAB_TOKEN",
         "GITLAB_PROJECT_ID",
+        "GITLAB_WEBHOOK_SECRET",
         "ENVIRONMENT",
     ]
     for key in keys:
@@ -183,19 +202,6 @@ class TestLiteralRejectsUnknownProvider:
         with pytest.raises(ValidationError, match="Input should be 'github' or 'gitlab'"):
             Settings()
 
-    def test_mixed_case_rejected(self, monkeypatch):
-        """CAB-1889 CP-2: Literal is case-sensitive. 'GitHub' is rejected."""
-        _settings_env(
-            monkeypatch,
-            ENVIRONMENT="dev",
-            GIT_PROVIDER="GitHub",
-        )
-
-        from src.config import Settings
-
-        with pytest.raises(ValidationError, match="Input should be 'github' or 'gitlab'"):
-            Settings()
-
 
 class TestValidConfigDoesNotWarn:
     """Sanity: a fully coherent config boots clean."""
@@ -237,3 +243,225 @@ class TestValidConfigDoesNotWarn:
         assert not any(
             "GITHUB_" in rec.message or "GITLAB_" in rec.message for rec in caplog.records
         )
+
+
+class TestReprDoesNotLeakCredentials:
+    """CAB-1889 CP-2 B-1: the four credential flat fields are ``SecretStr``
+    so ``repr(Settings(...))`` never exposes raw tokens or webhook secrets.
+
+    Previously the fields were ``str`` and a single ``logger.debug(settings)``
+    or an unhandled exception carrying the instance in its locals dict would
+    emit the plaintext secret into structured logs, where the defense-in-depth
+    ``SecretRedactor`` filter only covers known PAT prefixes.
+    """
+
+    def test_repr_does_not_leak_any_credential(self, monkeypatch):
+        _settings_env(
+            monkeypatch,
+            ENVIRONMENT="production",
+            GIT_PROVIDER="github",
+            GITHUB_TOKEN="ghp_should_never_leak_123456",
+            GITHUB_WEBHOOK_SECRET="whsec_github_should_not_leak",
+            GITLAB_TOKEN="glpat_should_never_leak_abc",
+            GITLAB_WEBHOOK_SECRET="whsec_gitlab_should_not_leak",
+            GITLAB_PROJECT_ID="1",
+        )
+
+        from src.config import Settings
+
+        rendered = repr(Settings())
+        for secret in (
+            "ghp_should_never_leak_123456",
+            "whsec_github_should_not_leak",
+            "glpat_should_never_leak_abc",
+            "whsec_gitlab_should_not_leak",
+        ):
+            assert secret not in rendered, f"repr(Settings()) leaked {secret!r}"
+
+
+class TestTokenWhitespaceHandling:
+    """CAB-1889 CP-2 A-1: tokens are stripped at the hydration boundary.
+
+    Whitespace-only values are rejected; trailing newlines from K8s
+    file-mounted secrets are normalised away so the downstream provider
+    client sees the raw credential rather than ``"ghp_x\\n"``.
+    """
+
+    def test_whitespace_only_github_token_rejected_in_prod(self, monkeypatch):
+        _settings_env(
+            monkeypatch,
+            ENVIRONMENT="production",
+            GIT_PROVIDER="github",
+            GITHUB_TOKEN="   ",
+            GITHUB_ORG="stoa-platform",
+            GITHUB_CATALOG_REPO="stoa-catalog",
+        )
+
+        from src.config import Settings
+
+        with pytest.raises(ValidationError, match="GITHUB_TOKEN is empty"):
+            Settings()
+
+    def test_whitespace_only_gitlab_token_rejected_in_prod(self, monkeypatch):
+        _settings_env(
+            monkeypatch,
+            ENVIRONMENT="production",
+            GIT_PROVIDER="gitlab",
+            GITLAB_TOKEN="  \n",
+            GITLAB_PROJECT_ID="1",
+        )
+
+        from src.config import Settings
+
+        with pytest.raises(ValidationError, match="GITLAB_TOKEN is empty"):
+            Settings()
+
+    def test_trailing_newline_token_is_stripped(self, monkeypatch):
+        _settings_env(
+            monkeypatch,
+            ENVIRONMENT="production",
+            GIT_PROVIDER="github",
+            GITHUB_TOKEN="ghp_valid_token\n",
+        )
+
+        from src.config import Settings
+
+        settings = Settings()
+        assert settings.git.github.token.get_secret_value() == "ghp_valid_token"
+
+
+class TestGitProviderCaseInsensitive:
+    """CAB-1889 CP-2 C-1: backward compat for deployments that pre-date
+    the ``Literal`` narrowing. The ``field_validator`` lowercases + strips
+    the raw ``GIT_PROVIDER`` env value before Literal narrowing fires.
+    """
+
+    def test_mixed_case_provider_accepted(self, monkeypatch):
+        _settings_env(
+            monkeypatch,
+            ENVIRONMENT="production",
+            GIT_PROVIDER="GitHub",
+            GITHUB_TOKEN="ghp_x",
+        )
+
+        from src.config import Settings
+
+        settings = Settings()
+        assert settings.git.provider == "github"
+
+    def test_uppercase_provider_accepted(self, monkeypatch):
+        _settings_env(
+            monkeypatch,
+            ENVIRONMENT="production",
+            GIT_PROVIDER="GITLAB",
+            GITLAB_TOKEN="glpat_x",
+            GITLAB_PROJECT_ID="1",
+        )
+
+        from src.config import Settings
+
+        settings = Settings()
+        assert settings.git.provider == "gitlab"
+
+    def test_provider_with_whitespace_and_mixed_case(self, monkeypatch):
+        """Locks both C-1 (case) and A-1 (whitespace) on the most sensitive
+        field: ``GIT_PROVIDER=" GitHub\\n"`` from a badly quoted ConfigMap
+        must normalise to ``"github"`` and boot cleanly.
+        """
+        _settings_env(
+            monkeypatch,
+            ENVIRONMENT="production",
+            GIT_PROVIDER=" GitHub\n",
+            GITHUB_TOKEN="ghp_x",
+        )
+
+        from src.config import Settings
+
+        settings = Settings()
+        assert settings.git.provider == "github"
+
+
+class TestIdentityAndUrlValidation:
+    """CAB-1889 CP-2 E-1: identity fields (org, repo) must be non-empty
+    for the selected provider, and GITLAB_URL must be syntactically valid
+    http(s) with a non-empty netloc.
+    """
+
+    def test_empty_github_org_rejected_in_prod(self, monkeypatch):
+        _settings_env(
+            monkeypatch,
+            ENVIRONMENT="production",
+            GIT_PROVIDER="github",
+            GITHUB_TOKEN="ghp_x",
+            GITHUB_ORG="",
+            GITHUB_CATALOG_REPO="stoa-catalog",
+        )
+
+        from src.config import Settings
+
+        with pytest.raises(ValidationError, match="GITHUB_ORG is empty"):
+            Settings()
+
+    def test_empty_github_catalog_repo_rejected_in_prod(self, monkeypatch):
+        _settings_env(
+            monkeypatch,
+            ENVIRONMENT="production",
+            GIT_PROVIDER="github",
+            GITHUB_TOKEN="ghp_x",
+            GITHUB_ORG="stoa-platform",
+            GITHUB_CATALOG_REPO="",
+        )
+
+        from src.config import Settings
+
+        with pytest.raises(ValidationError, match="GITHUB_CATALOG_REPO is empty"):
+            Settings()
+
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "not-a-url",
+            "gitlab.corp",
+            "ftp://gitlab.corp",
+            "https://",
+            "",
+        ],
+    )
+    def test_invalid_gitlab_url_rejected_in_prod(self, monkeypatch, bad_url):
+        _settings_env(
+            monkeypatch,
+            ENVIRONMENT="production",
+            GIT_PROVIDER="gitlab",
+            GITLAB_TOKEN="glpat_x",
+            GITLAB_PROJECT_ID="1",
+            GITLAB_URL=bad_url,
+        )
+
+        from src.config import Settings
+
+        with pytest.raises(ValidationError, match="GITLAB_URL is not a valid http"):
+            Settings()
+
+    @pytest.mark.parametrize(
+        "good_url",
+        [
+            "https://gitlab.com",
+            "http://gitlab.corp",
+            "https://gitlab.corp/path/subpath/",
+            "https://gitlab.corp:8443/",
+        ],
+    )
+    def test_valid_gitlab_url_accepted(self, monkeypatch, good_url):
+        _settings_env(
+            monkeypatch,
+            ENVIRONMENT="production",
+            GIT_PROVIDER="gitlab",
+            GITLAB_TOKEN="glpat_x",
+            GITLAB_PROJECT_ID="1",
+            GITLAB_URL=good_url,
+        )
+
+        from src.config import Settings
+
+        settings = Settings()
+        assert settings.git.gitlab.url == good_url

--- a/control-plane-api/tests/test_git_provider.py
+++ b/control-plane-api/tests/test_git_provider.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 import pytest
-from pydantic import SecretStr
+from pydantic import SecretStr, ValidationError
 
 from src.config import GitHubConfig, GitLabConfig, GitProviderConfig
 from src.services.git_provider import GitProvider, git_provider_factory
@@ -109,10 +109,55 @@ class TestGitProviderConfig:
         assert field.default == "github"
 
     def test_github_config_defaults(self):
-        """GitHub config fields must have sensible defaults."""
+        """GitHub config fields must have sensible defaults.
+
+        CAB-1889 CP-2 B-1: GITHUB_TOKEN and GITHUB_WEBHOOK_SECRET are
+        ``SecretStr`` on the flat ingress (not plain ``str``), so the
+        default compares via ``.get_secret_value()``.
+        """
         from src.config import Settings
 
-        assert Settings.model_fields["GITHUB_TOKEN"].default == ""
+        assert Settings.model_fields["GITHUB_TOKEN"].default.get_secret_value() == ""
         assert Settings.model_fields["GITHUB_ORG"].default == "stoa-platform"
         assert Settings.model_fields["GITHUB_CATALOG_REPO"].default == "stoa-catalog"
-        assert Settings.model_fields["GITHUB_WEBHOOK_SECRET"].default == ""
+        assert Settings.model_fields["GITHUB_WEBHOOK_SECRET"].default.get_secret_value() == ""
+
+
+class TestSubModelsRejectUnknownKwargs:
+    """CAB-1889 CP-2 I-1: ``extra="forbid"`` on GitHubConfig / GitLabConfig /
+    GitProviderConfig prevents the class of silent typo drops that let the
+    CP-1 token-leak fixture pass a non-existent ``catalog_project_id=``
+    kwarg unnoticed. Each test supplies a complete valid payload and adds
+    one extra key so the failure is unambiguously about ``extra_forbidden``,
+    not ``missing``.
+    """
+
+    def test_github_config_rejects_unknown_kwargs(self):
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            GitHubConfig(
+                token=SecretStr("x"),
+                org="org",
+                catalog_repo="catalog",
+                webhook_secret=SecretStr("y"),
+                tokne=SecretStr("z"),  # typo
+            )
+
+    def test_gitlab_config_rejects_unknown_kwargs(self):
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            GitLabConfig(
+                url="https://gitlab.com",
+                token=SecretStr("x"),
+                project_id="1",
+                webhook_secret=SecretStr("y"),
+                tokne=SecretStr("z"),  # typo
+            )
+
+    def test_git_provider_config_rejects_unknown_kwargs(self):
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            GitProviderConfig(
+                provider="github",
+                github=GitHubConfig(),
+                gitlab=GitLabConfig(),
+                default_branch="main",
+                bogus_field="nope",  # unknown
+            )

--- a/control-plane-api/tests/test_regression_cp1_token_leak.py
+++ b/control-plane-api/tests/test_regression_cp1_token_leak.py
@@ -64,10 +64,31 @@ def _patched_git_settings(provider: str, token: str) -> GitProviderConfig:
         provider="github",
         github=GitHubConfig(
             token=SecretStr(token),
-            catalog_project_id="org/catalog",
+            org="org",
+            catalog_repo="catalog",
             webhook_secret=SecretStr("whsec"),
         ),
     )
+
+
+class TestPatchedGitSettingsFixture:
+    """CAB-1889 CP-2 H-1: guard against the silent-kwarg-drop regression.
+
+    Before CP-2, ``_patched_git_settings`` passed ``catalog_project_id=``
+    as a kwarg to ``GitHubConfig``, which is a read-only ``@property``.
+    Pydantic's default ``extra="ignore"`` silently discarded it and the
+    fixture ended up using the production defaults — invisible to every
+    test in this file that relies on the helper. CP-2 fixes the fixture
+    to populate the real fields and activates ``extra="forbid"`` (see
+    ``test_git_provider.py``) so a future typo raises instead of drifting.
+    """
+
+    def test_github_fixture_uses_requested_org_and_catalog_repo(self):
+        cfg = _patched_git_settings("github", _GITHUB_TOKEN)
+        assert cfg.provider == "github"
+        assert cfg.github.org == "org"
+        assert cfg.github.catalog_repo == "catalog"
+        assert cfg.github.catalog_project_id == "org/catalog"
 
 
 # ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the CP-2 bug hunt on `GitProviderConfig` source of truth — 11 tracked findings handled: **9 fixed in-commit, 1 staged as patch (G-1), 1 deferred cross-repo (C-2 → CAB-1890)**.

Follows the GW-1 batch pattern: full audit → FIX-PLAN → one atomic commit with regression guards.

| Finding | Severity | Status | What |
|---|---|---|---|
| **B-1** | P0 | ✅ FIXED | Wrap 4 credential flat fields in `SecretStr` so `repr(Settings())` no longer leaks tokens/webhook secrets |
| **A-1** | P1 | ✅ FIXED | `.strip()` at hydration boundary — whitespace-only tokens rejected; K8s-mounted trailing `\n` normalised |
| **C-1** | P1 | ✅ FIXED | `@field_validator("GIT_PROVIDER", mode="before")` does `strip().lower()` — restores backward compat with deployments that pre-date the rewrite's `.lower()` removal |
| **C-2** | P1 | ⏩ DEFERRED | `stoa-infra` Helm chart needs `GITHUB_*` env passthrough — tracked under CAB-1890 (GitHub flip) |
| **E-1** | P2 | ✅ FIXED | Validator now asserts `GITHUB_ORG` / `GITHUB_CATALOG_REPO` non-empty and `GITLAB_URL` is a syntactically valid http(s) URL (`urllib.parse.urlparse`) |
| **H-1** | P2 | ✅ FIXED | Test fixture `_patched_git_settings` was passing `catalog_project_id=` (a read-only property) — kwarg silently dropped. Now uses `org`/`catalog_repo` fields |
| **H-2** | P2 | ✅ FIXED | Conftest comment claimed "tests don't run under `ENVIRONMENT=production`"; wrong — prod is the default. Comment corrected to reflect reality |
| **A-2** | P2 | ✅ FIXED | `_VALIDATE_GIT_CONFIG` kill-switch removed — migration done, no test/runtime references, no need for a one-line bypass that silently disables prod validation |
| **G-1** | P2 | 📋 STAGED | `.env.example` append blocked by local `.env*` write guard (same blocker that stalled the original CP-2 rewrite — see PR #2480). Patch staged at `control-plane-api/FIX-G1-env-example.patch` for manual apply |
| **I-1** | P3 | ✅ FIXED | `model_config = ConfigDict(extra="forbid")` on `GitHubConfig` / `GitLabConfig` / `GitProviderConfig` — prevents future recurrences of H-1 |
| **I-2** | P3 | ✅ FIXED | Dropped redundant `or "main"` — `Field(default="main")` already covers unset |

### Key design notes

- **C-1 backward-compat shim**: adding the `mode="before"` validator makes the `Literal["github", "gitlab"]` case-sensitivity invisible to future readers. `Settings(GIT_PROVIDER="GITHUB")` now normalises silently — intentional.
- **B-1 + A-1 combined at hydration boundary**: hydrator does `SecretStr(self.GITHUB_TOKEN.get_secret_value().strip())` — one round-trip unwraps the flat `SecretStr`, strips, re-wraps at the inner model boundary.
- **E-1 URL validation is permissive**: accepts `http://` and `https://` with non-empty netloc; self-hosted `https://gitlab.corp/path/subpath/` and `https://gitlab.corp:8443/` remain valid. Rejects missing scheme (`gitlab.corp`), non-http (`ftp://`), and empty netloc (`https://`).

### Regression guards (9 new tests + 1 existing-test update)

- `TestReprDoesNotLeakCredentials::test_repr_does_not_leak_any_credential` — locks B-1 across all 4 credential types
- `TestTokenWhitespaceHandling::test_whitespace_only_github_token_rejected_in_prod` + `_gitlab_*` + `_trailing_newline_token_is_stripped`
- `TestGitProviderCaseInsensitive::test_mixed_case_provider_accepted` + `_uppercase_provider_accepted` + `_provider_with_whitespace_and_mixed_case` (locks both C-1 and A-1 on the most sensitive field)
- `TestIdentityAndUrlValidation::test_empty_github_org_rejected_in_prod` + `_empty_github_catalog_repo_*` + `_invalid_gitlab_url_rejected_in_prod[5 params]` + `_valid_gitlab_url_accepted[4 params]`
- `TestSubModelsRejectUnknownKwargs::test_{github,gitlab,git_provider}_config_rejects_unknown_kwargs` — each payload is complete + 1 typo kwarg, so the raise is unambiguously about `extra_forbidden`
- `TestPatchedGitSettingsFixture::test_github_fixture_uses_requested_org_and_catalog_repo` — locks H-1
- `test_github_config_defaults` updated for `SecretStr` defaults (existing assertion)

Obsoleted by C-1: `TestLiteralRejectsUnknownProvider::test_mixed_case_rejected` — removed (superseded by the case-insensitive acceptance).

### CP-2 invariant re-verified

```
$ bash scripts/check_git_config_access.sh src
OK: no direct access to settings.GIT_PROVIDER / GITHUB_* / GITLAB_* outside src/config.py
```

## Test plan

- [x] `pytest tests/test_config_git_provider_validation.py tests/test_git_provider.py tests/test_regression_cp1_token_leak.py` — 55 passed
- [x] Full suite: 6609 passed (12 `test_provisioning*` failures pre-exist on `main`, unrelated to this batch — verified via `git stash` + re-run)
- [x] `ruff check src/` — clean
- [x] `ruff check` on touched tests — clean (file-level `# ruff: noqa: S106` on `test_config_git_provider_validation.py`; justified — whole point of the file is fake-credential fuzzing)
- [x] `mypy src/config.py` — clean (zero errors, project baseline is 1568 errors across 142 files)
- [x] CP-2 grep gate: no legacy `settings.GIT_PROVIDER|GITHUB_*|GITLAB_*` reads outside `src/config.py`
- [x] Smoke: `GITHUB_TOKEN="   " GIT_PROVIDER=github ENVIRONMENT=production python -c …` → `ValidationError("GITHUB_TOKEN is empty")`
- [x] Smoke: `repr(Settings())` with 4 populated credentials → none of them appears in the rendered string
- [x] Smoke: `GIT_PROVIDER=GitHub GITHUB_TOKEN=ghp_x python -c …` → `settings.git.provider == "github"`

## Manual follow-up

1. `cd control-plane-api && git apply FIX-G1-env-example.patch` — lands the G-1 `.env.example` section. Blocked by local harness `.env*` write guard, same blocker as PR #2480.
2. CAB-1890 (GitHub flip) — open `stoa-infra` PR adding `GITHUB_*` env passthrough + `githubSecret` Helm value. Closes C-2.

## Artifacts

- `control-plane-api/BUG-REPORT-CP-2.md` — audit report, updated with CLOSED block
- `control-plane-api/FIX-PLAN-CP2.md` — execution plan (Phase 1)
- `control-plane-api/FIX-G1-env-example.patch` — staged `.env.example` append

Module CP-2 CLOSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)