### PR TITLE
fix(gateway): close GW-2 bug hunt batch — 10 config hardening items

### DIFF
--- a/stoa-gateway/BUG-REPORT-GW-2.md
+++ b/stoa-gateway/BUG-REPORT-GW-2.md
@@ -1,0 +1,443 @@
+# BUG-REPORT-GW-2 — Gateway Rust config (src/config/*)
+
+> **MODULE GW-2 CLOSED** (fixes on `fix/gw-2-bug-hunt-batch`).
+> **10 fixed** in-commit · **2 deferred → GW-3** (P2-9, P2-11) · **2 backlog** (P3-13, P3-14).
+> Status per finding called out inline below (`FIXED`, `DEFERRED → GW-3`, `BACKLOG`).
+> Retrospective pointer: [`REWRITE-BUGS.md`](./REWRITE-BUGS.md).
+
+> Audit fonctionnel post-rewrite GW-2 (split `src/config.rs` 1973 LOC → 9 sous-modules + façade 828 LOC).
+> Scope : bugs latents de parsing, defaults, backward compat, sécurité.
+> Méthode : lecture façade + 9 sous-modules + snapshot insta + callers + 3 probes Figment binaires pour valider les hypothèses.
+> Calibrage : GO-1 = 14 / CP-1 = 21 / GW-1 = 20 / UI-2 = 38 / CP-2 = 11. GW-2 attendu 3-10 → **trouvé 10 réels + 2 notes design**.
+
+## Executive summary
+
+Le split compile propre (`cargo check` clean, `cargo clippy --all-targets -D warnings` clean, snapshot insta baseline figée). La régression contre l'ancien monolithe est nulle : défauts identiques champ-par-champ, API publique conservée via re-exports (`pub use`), callers externes (30 dans `src/`, 8 dans `tests/`) intacts.
+
+**Les bugs listés ci-dessous pré-datent tous le rewrite** — ils étaient déjà présents dans le monolithe 1973 LOC. Le rewrite est l'audit qui les révèle. Trois d'entre eux ont été **explicitement** identifiés dans `REWRITE-PLAN.md` (§7.1, §7.4, §10) comme "hors scope / à documenter", mais le `REWRITE-BUGS.md` promis **n'a jamais été créé**. C'est ce rapport.
+
+Bug dominant : **les env vars `STOA_*` pour les 5 structs nested sont silencieusement inopérantes** (mtls, dpop, sender_constraint, llm_router, api_proxy). Un opérateur qui définit `STOA_MTLS_ENABLED=true` croit activer mTLS ; en réalité l'env var est ignorée et le YAML seul peut piloter ces structs. Impact sécurité réel : désalignement entre doc et comportement sur une surface d'auth.
+
+Bug collatéral : **un Vec<String> racine (`snapshot_extra_pii_patterns`) crash au startup** si l'opérateur suit la doc "comma-separated" (Figment refuse `"a,b"` → `InvalidType`, `Config::load()` → `Err` → gateway down).
+
+---
+
+## Critical (P0)
+
+### P0-1 — Env vars `STOA_MTLS_*` / `STOA_DPOP_*` / `STOA_SENDER_CONSTRAINT_*` / `STOA_LLM_ROUTER_*` / `STOA_API_PROXY_*` silencieusement ignorées — **FIXED**
+**Catégorie** : B (backward compat) + D (security) + A (defaults)
+**Fichier** : `src/config/loader.rs:48` ; symptômes documentés dans `src/config.rs:344–359, 622–625, 693–697` et sur chaque champ `MtlsConfig`/`DpopConfig`/etc.
+
+**Reproduction (probe Figment vérifié)** :
+```rust
+// loader.rs actuel :
+figment = figment.merge(Env::prefixed("STOA_"));   // pas de .split("__")
+
+// Comportement observé via probe binaire (cargo run):
+std::env::set_var("STOA_MTLS_ENABLED", "true");
+// → s'injecte comme clé FLAT `mtls_enabled` (lowercase, sans split)
+// → Config n'a pas de champ `mtls_enabled` au root
+// → valeur silencieusement IGNORÉE par serde (unknown field dropped)
+// → config.mtls.enabled reste false
+```
+Vérification binaire (probe capturé 2026-04-24) :
+```
+SINGLE_UNDERSCORE (as in loader.rs):          mtls.enabled = false  ← doc-comment MENT
+DOUBLE_UNDERSCORE_WITH_SPLIT("__"):           mtls.enabled = true
+DOUBLE_UNDERSCORE_NO_SPLIT:                   mtls.enabled = false
+```
+
+**Surface impactée** (tous les champs nested de 5 structs) :
+- `MtlsConfig` — 13 champs. `STOA_MTLS_ENABLED`, `STOA_MTLS_REQUIRE_BINDING`, `STOA_MTLS_TRUSTED_PROXIES`, `STOA_MTLS_ALLOWED_ISSUERS`, `STOA_MTLS_REQUIRED_ROUTES`, `STOA_MTLS_TENANT_FROM_DN`, + 8 header overrides.
+- `DpopConfig` — 6 champs. `STOA_DPOP_ENABLED`, `STOA_DPOP_REQUIRED`, `STOA_DPOP_MAX_AGE_SECS`, etc.
+- `SenderConstraintConfig` — 3 champs. `STOA_SENDER_CONSTRAINT_ENABLED`, `STOA_SENDER_CONSTRAINT_DPOP_REQUIRED`, `STOA_SENDER_CONSTRAINT_MTLS_REQUIRED`.
+- `LlmRouterConfig` — 5 champs. `STOA_LLM_ROUTER_ENABLED`, `STOA_LLM_ROUTER_DEFAULT_STRATEGY`, `STOA_LLM_ROUTER_BUDGET_LIMIT_USD`.
+- `ApiProxyConfig` — 3 champs + N backends.
+
+**Impact sécurité** :
+- Un opérateur qui ajoute `STOA_MTLS_ENABLED=true` + `STOA_SENDER_CONSTRAINT_ENABLED=true` à un Deployment K8s **croit** enforcer sender-constraint sur tous les tokens. En pratique, mTLS + sender-constraint restent désactivés, la vérification `cnf.x5t#S256` / `cnf.jkt` n'a jamais lieu, et un token volé reste exploitable sans présentation du cert client.
+- Même scénario pour DPoP : un opérateur pense imposer DPoP via env, mais le middleware n'est pas monté (voir `src/lib.rs:109` — `mtls_enabled = state.config.mtls.enabled` est lu comme `false`).
+
+**État actuel** :
+- Fonctionne via YAML (`mtls: { enabled: true }` dans `config.yaml`).
+- Ne fonctionne PAS via env var unique soulignement (doc-comment mensongère sur ~30 champs).
+- Mentionné dans `REWRITE-PLAN.md §7.4` comme "documenté dans REWRITE-BUGS.md" — mais `REWRITE-BUGS.md` **n'existe pas sur disque**.
+
+**Fix direction** :
+- Option 1 (la plus sûre) : ajouter `.split("__")` + patch docs pour demander `STOA_MTLS__ENABLED` (double underscore). Breaking change pour quiconque utilisait déjà des YAML flat `mtls_enabled`, ce qui n'arrive jamais en pratique → à valider via grep prod.
+- Option 2 : fabriquer un provider custom qui re-map `STOA_MTLS_*` → `mtls.*` via map préfix connue. Plus d'alignement opérateur, plus de code à maintenir.
+- Option 3 : déplier toutes les structs nested en champs flat (casse 30 callers — hors scope total).
+
+**Reco** : Option 1. Ajouter test d'intégration `STOA_MTLS__ENABLED=true → config.mtls.enabled=true` + `STOA_MTLS_ENABLED=true → config.mtls.enabled=false` (régression explicite) + updater chaque doc-comment.
+
+---
+
+### P0-2 — Crash au startup si `STOA_SNAPSHOT_EXTRA_PII_PATTERNS` est défini en CSV (comme documenté) — **FIXED**
+**Catégorie** : C (panic/startup failure) + B (doc vs comportement)
+**Fichier** : `src/config.rs:822–824` (field + doc-comment) ; `src/config/loader.rs:68` (extract failure point).
+
+**Reproduction (probe Figment binaire)** :
+```rust
+std::env::set_var("STOA_SNAPSHOT_EXTRA_PII_PATTERNS", "card_number,ssn_us");
+Figment::new().merge(Serialized::defaults(Cfg::default())).merge(Env::prefixed("STOA_")).extract()
+→ Err(InvalidType(Str("card_number,ssn_us"), "a sequence"))
+```
+
+**Doc-comment vs comportement** :
+```rust
+/// Extra regex patterns to treat as PII during snapshot masking.
+/// Env: STOA_SNAPSHOT_EXTRA_PII_PATTERNS (comma-separated)   ← ce que la doc promet
+#[serde(default)]
+pub snapshot_extra_pii_patterns: Vec<String>,                  ← Figment veut du JSON array
+```
+
+**Impact opérationnel** : un opérateur qui suit la doc littérale met `"card_number,ssn_us"` dans un `env:` Kubernetes. Au prochain `kubectl rollout`, `Config::load()` renvoie `Err`, `main()` termine via `?`, les nouveaux pods crashent au startup. Rollback obligatoire.
+
+Le message d'erreur Figment (`InvalidType(Str("card_number,ssn_us"), "a sequence")`) n'est pas actionnable pour un SRE qui n'a pas le code sous les yeux — il pointe vers "a sequence" sans indiquer "utilisez un JSON array" ni "séparateur attendu".
+
+**Fix direction** :
+- Option A : accepter CSV → custom deserializer `deserialize_with = "csv_or_json"` sur le field. 10 LOC, aligné sur la doc.
+- Option B : changer la doc pour dire `JSON array` + exemple `'["card_number","ssn_us"]'`. Moins opérateur-friendly, mais cohérent avec les autres Vec<T> (`federation_upstreams` est déjà documenté JSON array).
+- Option C : regex parsing au chargement (custom Figment provider). Overkill.
+
+**Reco** : Option A (aligné sur la doc historique + ergonomie K8s). Ajouter test d'intégration.
+
+**Même catégorie** (mais surface masquée par P0-1) : `MtlsConfig.trusted_proxies`, `MtlsConfig.allowed_issuers`, `MtlsConfig.required_routes` — tous `Vec<String>` avec doc-comment "comma-separated CIDRs/DNs/patterns". Aujourd'hui cachés derrière P0-1 (env var ignorée avant d'atteindre le check de type). Dès que P0-1 est corrigé, ces 3 champs deviennent des sous-cas de P0-2.
+
+---
+
+### P0-3 — `REWRITE-BUGS.md` promis dans `REWRITE-PLAN.md` mais absent — **FIXED**
+**Catégorie** : Process / traçabilité (non-code)
+**Fichier** : absent de `stoa-gateway/`. Référencé dans `REWRITE-PLAN.md` lignes 212 (§7.4), 299 (§10), 310 (§11).
+
+**Extraits pertinents** :
+- §7.4 (L212) : `→ Comportement actuel conservé, documenté dans 'REWRITE-BUGS.md' comme divergence potentielle doc/code. Pas fixé silencieusement (risque incident prod si on active split env naïvement, impact middleware auth).`
+- §10 (L299) : `[ ] REWRITE-BUGS.md commit si bugs latents découverts (§7.4, §11)`
+- §11 (L310) : `Figment Env source : flat parsing (sans .split())` + `Doc-comments STOA_MTLS_ENABLED trompeurs` + `Hors scope du rewrite, documenté dans REWRITE-BUGS.md`
+
+Aucun fichier `REWRITE-BUGS.md` n'existe dans `stoa-gateway/` (vérifié via `find`). Le checklist de validation §10 n'a pas été satisfait avant merge. Ce rapport **BUG-REPORT-GW-2.md** tient lieu de livrable rétrospectif.
+
+**Fix direction** : aucun — le présent fichier ferme la dette documentaire. À consolider : soit renommer ce fichier `REWRITE-BUGS.md`, soit maintenir les deux (rewrite delta vs audit systématique) avec cross-refs explicites.
+
+---
+
+## High (P1)
+
+### P1-4 — 4 divergences silencieuses entre `Config::default()` et `#[serde(default)]` — **FIXED**
+**Catégorie** : A (defaults divergents)
+**Fichier** : `src/config.rs:137–140, 178–182` ; `src/config/defaults.rs:300–307`.
+
+**Reproduction binaire (probe)** :
+```
+Default::default()        : rate_limit_default=Some(1000), log_level=Some("info")
+serde_json from "{}"      : rate_limit_default=None,       log_level=None
+serde_yaml empty input    : rate_limit_default=None,       log_level=None
+```
+
+**Fields concernés** :
+| Champ | `#[serde(default)]` sur | `Config::default()` | Serde désérialisation |
+|---|---|---|---|
+| `rate_limit_default` | `Option<usize>` | `Some(1000)` | `None` |
+| `rate_limit_window_seconds` | `Option<u64>` | `Some(60)` | `None` |
+| `log_level` | `Option<String>` | `Some("info")` | `None` |
+| `log_format` | `Option<String>` | `Some("json")` | `None` |
+
+**Pourquoi c'est partiellement self-healed en prod** :
+- `loader.rs` Figment stack commence par `Serialized::defaults(Config::default())` → le YAML hérite des valeurs `Some(...)`. Donc le chemin de chargement normal donne `Some(1000)`.
+- `rate_limit.rs:76–77` utilise `.unwrap_or(1000)` / `.unwrap_or(60)` → même valeur effective quel que soit le champ (None ou Some(1000)). Invisible.
+
+**Pourquoi ça mord quand même** :
+- `control_plane/registration.rs:448` teste `config.rate_limit_default.is_some()` → le check déclenche ou non un warn selon le path de construction du Config.
+- Tout nouveau code qui fait `if config.rate_limit_default.is_some() { apply_limit() }` aura un comportement différent selon `Config::default()` (warn fire) vs YAML empty (warn silent).
+- Le snapshot `insta` **verrouille** `Some(1000)`, donc toute tentative future de "normaliser" les defaults casse le snapshot sans test de régression intermédiaire.
+- Tests qui font `serde_yaml::from_str::<Config>("port: 80")` retournent None — incohérent avec les assertions des tests existants qui utilisent `Config::default()` (e.g., `test_default_rate_limits` assert `Some(1000)`).
+
+**Fix direction** :
+- Aligner les 4 champs sur un seul comportement. Soit :
+  - `#[serde(default = "default_rate_limit")]` avec `fn default_rate_limit() -> Option<usize> { Some(1000) }` → unification vers `Some(1000)`.
+  - OU changer `Config::default()` pour retourner `None` → aligner vers serde default.
+- Les `.unwrap_or(1000)` consumers absorbent les deux choix, donc l'option 1 est la plus conservative (préserve le snapshot + sémantique historique).
+
+---
+
+### P1-5 — `#[derive(Debug)]` sur Config expose 10+ secrets — **FIXED**
+**Catégorie** : D (sécurité secrets)
+**Fichier** : `src/config.rs:31` (Debug derivé sur Config root), `src/config/federation.rs:5` (sur FederationUpstreamConfig).
+
+**Champs sensibles dans Config** (tous Option<String>, tous inclus dans `{:?}` output) :
+```
+jwt_secret, keycloak_client_secret, keycloak_admin_password,
+control_plane_api_key, admin_api_token,
+gitlab_token, github_token, github_webhook_secret,
+llm_proxy_api_key, llm_proxy_mistral_api_key
+```
+Plus `FederationUpstreamConfig.auth_token` et `UpstreamMcpConfig.auth_token` (`src/federation/upstream.rs:28`).
+
+**État actuel** :
+- Aucun `println!("{:?}", config)` / `tracing::debug!(?config)` / `%config` détecté dans `src/` (grep vérifié).
+- `loader.rs:70–75` logue seulement `port`, `host`, `control_plane_url` (safe).
+- **Mais** le piège est armé : toute future ligne `tracing::debug!(?state.config)` ou `panic!("unexpected state: {:?}", config)` dump les secrets dans les logs structurés, qui partent vers Fluent Bit → Loki/Elastic. Les secrets apparaissent alors dans les search logs de tous les viewers RBAC qui n'ont pas l'accès "sensitive".
+- Règle FR du CLAUDE.md `stoa-gateway` : "Zero tolerance clippy" — mais aucun lint détecte ce risque. Un reviewer humain aussi rapidement laissera passer un `debug!(?config)` "diagnostique".
+
+**Impact** : defense-in-depth. Classé P1 parce que la zone est stable mais toute maintenance future (debugging, panic messages, admin /debug/config endpoint) peut trivialement leak.
+
+**Fix direction** :
+- Implémenter `Debug` custom qui redacte les champs sensibles : `jwt_secret: "<redacted>"` au lieu de `Some("eyJ...")`.
+- Alternative : wrapper `struct Redacted<T>(T)` avec `impl Debug` qui ne print pas le contenu. Appliquer aux 10+ fields.
+- Ajouter lint custom / CI test : `assert!(!format!("{:?}", config).contains(secret_value))` dans un test "no-secret-in-debug" pour chaque champ.
+- Faire de même pour `FederationUpstreamConfig.auth_token` et `UpstreamMcpConfig.auth_token`.
+
+---
+
+### P1-6 — `Config::validate()` ne renvoie rien et log seulement — **FIXED**
+**Catégorie** : E (error handling startup)
+**Fichier** : `src/config/loader.rs:81–89`.
+
+```rust
+pub fn validate(&self) {
+    if self.control_plane_url.is_none() {
+        tracing::warn!("CONTROL_PLANE_URL not set - some features will be disabled");
+    }
+    if self.jwt_secret.is_none() && self.keycloak_url.is_none() {
+        tracing::warn!("No JWT_SECRET or KEYCLOAK_URL - auth will be limited");
+    }
+}
+```
+
+**Problème** : le nom "validate" promet une validation. Le comportement est : pas d'erreur, pas de panic, juste 2 `warn!`. Toute config absurde passe :
+- `port: 0` → passe ensuite à tokio qui bind le port aléatoirement
+- `rate_limit_default: Some(0)` → pas de rate limit effective
+- `mtls.enabled: true` avec `mtls.trusted_proxies: []` → accepte TOUT proxy (voir doc-comment ligne 21 : "If empty, all sources accepted") — auth bypass silencieux si mTLS activé en prod sans trusted_proxies
+- `federation_enabled: true` avec `federation_upstreams: []` → fédération "enabled" mais inopérante
+- `guardrails_pii_enabled: true` sans `guardrails_pii_redact: true|false` cohérent
+- `hegemon_budget_warn_pct: 2.5` (au-delà de 1.0) → notifications mal calculées
+
+**Conséquence** : toute combinaison valide syntaxiquement YAML démarre la gateway. Seul le runtime (au premier appel) révèle l'incohérence, parfois via une 500 cryptique.
+
+**Fix direction** :
+- Changer la signature en `fn validate(&self) -> Result<(), ConfigError>` avec `thiserror::Error` (conforme CLAUDE.md règle "anyhow pour app, thiserror pour lib"), couvrir les invariants critiques :
+  - `port > 0` (rejeter 0)
+  - `mtls.enabled ⇒ !mtls.trusted_proxies.is_empty() || documented_override` (sinon rejet)
+  - `federation_enabled ⇒ !federation_upstreams.is_empty()`
+  - `hegemon_enabled ⇒ 0.0 <= hegemon_budget_warn_pct <= 1.0 && hegemon_budget_daily_usd > 0.0`
+  - `sender_constraint.enabled ⇒ mtls.enabled || dpop.enabled`
+- Garder `warn!` pour les cas non-critiques (CP URL absent).
+- Appeler via `?` dans `main.rs:23` (ligne actuelle `config.validate()` — remplacer par `config.validate()?`).
+
+---
+
+### P1-7 — Le snapshot `insta` ne couvre pas le round-trip sérialization — **FIXED**
+**Catégorie** : G (tests / snapshot scope)
+**Fichier** : `src/config/tests.rs:216–219`, snapshot `src/config/snapshots/stoa_gateway__config__tests__snapshot_default_config.snap`.
+
+```rust
+#[test]
+fn snapshot_default_config() {
+    insta::assert_json_snapshot!(Config::default());
+}
+```
+
+**Ce que ça ne couvre pas** :
+1. `serde_yaml::from_str::<Config>("") == Config::default()` — **faux** pour les 4 fields de P1-4.
+2. `toml::from_str::<Config>("") == Config::default()` — même.
+3. `Config::default() → serialize → deserialize == Config::default()` — oui (les Some roundtrip OK), mais le snapshot ne le prouve pas explicitement.
+4. Compatibilité avec `gateway.toml` / `config.yaml` de prod réel. Pas de fixture YAML réaliste (BDF, Engie, Elis, dev local) versionnée → impossible de vérifier "un YAML qui marchait avant marche après".
+
+**Fix direction** :
+- Ajouter test `roundtrip_default_config` : `serialize(Config::default()) → deserialize → assert_eq!`.
+- Ajouter test `parse_empty_yaml` : `serde_yaml::from_str::<Config>("")` + assert les 4 fields (P1-4) explicitement → révèle la divergence au prochain développeur.
+- Ajouter fixtures YAML minimales (`tests/fixtures/config_minimal.yaml`, `config_production.yaml`, `config_federation.yaml`) et un test qui les parse + snapshot sérialization.
+
+---
+
+## Medium (P2)
+
+### P2-8 — `default_true()` dupliqué dans `api_proxy.rs` — **FIXED**
+**Catégorie** : Code smell (pas un bug fonctionnel)
+**Fichier** : `src/config/api_proxy.rs:95–97` vs `src/config/defaults.rs:13–15`.
+
+```rust
+// defaults.rs (canonical):
+pub(super) fn default_true() -> bool { true }
+
+// api_proxy.rs (duplicate):
+fn default_circuit_breaker_enabled() -> bool { true }   // L95
+// + used at L67: #[serde(default = "default_circuit_breaker_enabled")]
+```
+
+Le `REWRITE-PLAN.md §7.1` prévoyait explicitement de partager la fn via chemin qualifié :
+```rust
+#[serde(default = "crate::config::defaults::default_true")]
+```
+La Phase 2 a préféré une fn locale. Pas d'impact fonctionnel (même valeur), juste une dette cosmétique par rapport au plan validé.
+
+**Fix direction** : soit aligner sur le plan (`#[serde(default = "crate::config::defaults::default_true")]`), soit supprimer la mention du §7.1 dans le plan. Non bloquant.
+
+---
+
+### P2-9 — `git_provider: String` accepte n'importe quoi, fallthrough silencieux — **DEFERRED → GW-3**
+**Catégorie** : A (pas d'enum, typage trop permissif)
+**Fichier** : `src/config.rs:132–133`, test `src/config/tests.rs:200–209`.
+
+```rust
+#[serde(default = "default_git_provider")]
+pub git_provider: String,   // expected: "gitlab" | "github"
+```
+
+Le test existant (`test_git_provider_unknown_value_treated_as_gitlab`, L200) **verrouille** le comportement de fallback silencieux : `git_provider: "bitbucket"` → considéré comme gitlab. C'est documenté via ce test, mais c'est une mauvaise ergo :
+- Typo (`githhub` au lieu de `github`) → fallback gitlab → 404 sur tous les endpoints GitLab, reste silencieux jusqu'au premier webhook.
+- `log_level: "WARN"` (majuscules) → serde accepte puis `tracing` ne l'interprète pas → niveau d'origine.
+
+**Autres fields soft-typed** :
+- `log_level: Option<String>` (pas d'enum)
+- `log_format: Option<String>` — "json"/"pretty"/etc. non enforced
+- `environment: String` — "dev"/"staging"/"prod" uniquement par convention
+- `shadow_capture_source: Option<String>` — 4 valeurs documentées, 0 enforced
+- `supervision_default_tier: String` — "autopilot"/"copilot"/"command" uniquement par convention
+- `llm_proxy_provider: Option<String>` — "anthropic"/"mistral"/"openai" uniquement par convention
+- `tool_expansion_mode: ExpansionMode` ✓ (propre — enum + alias). Contre-exemple qui montre que c'est faisable.
+
+**Fix direction** : convertir progressivement en enums `#[serde(rename_all = "snake_case")]` avec alias backward compat (même pattern que `ExpansionMode`). Chaque conversion = 1 micro-PR isolée avec test de régression "valeur inconnue → deserialize Err avec message clair".
+
+---
+
+### P2-10 — `STOA_TCP_RATE_LIMIT_PER_IP` accepte infinity silencieusement — **FIXED** (absorbed into P1-6)
+**Catégorie** : A (validation manquante sur f64) + I (Rust config)
+**Fichier** : `src/config.rs:790–791`, consommé dans `src/tcp_filter.rs:78–84`.
+
+```rust
+// config.rs:
+pub tcp_rate_limit_per_ip: Option<f64>,   // 0 = disabled per doc
+
+// tcp_filter.rs:
+let rate_limiter = config
+    .tcp_rate_limit_per_ip
+    .filter(|&r| r > 0.0)
+    .map(|rate| RateLimiter { rate, ... });
+```
+
+Problèmes :
+- `f64::NAN > 0.0` → false → filtered out → rate limiter None. Safe accidentellement.
+- `f64::INFINITY > 0.0` → true → `rate = INFINITY`. Tous les bucket.tokens opérations produisent infinity ou NaN → `tokens >= 1.0` toujours true → rate limit inactif (pas de panic).
+- Valeurs négatives : `f64::-INF > 0.0` → false → filtered out. Safe.
+
+Pas de bug catastrophique (pas de crash, pas d'allocation illimitée), juste un écart silencieux entre valeur "configurée" et comportement effectif. Erreur opérateur plutôt que bug du code.
+
+**Fix direction** : `Config::validate()` check `tcp_rate_limit_per_ip.map(|r| r.is_finite() && r > 0.0).unwrap_or(true)` avec `Err` sinon. Inclus dans P1-6.
+
+---
+
+### P2-11 — Pas de validation de path sur `policy_path`, `ip_blocklist_file`, `prompt_cache_watch_dir` — **DEFERRED → GW-3**
+**Catégorie** : D (path traversal via config — théorique, scope opérateur)
+**Fichier** : `src/config.rs:170` (`policy_path`), `785–786` (`ip_blocklist_file`), `580–581` (`prompt_cache_watch_dir`).
+
+Les 3 champs acceptent n'importe quel chemin : `/etc/passwd`, `../../../`. Pas de `canonicalize()` ni `starts_with("/etc/stoa/")` check. L'impact dépend du privilège du process gateway : si le binaire tourne en non-root en K8s, il lira seulement les fichiers montés. Si un opérateur pointe sur un secret K8s mounté à un autre path, le fichier est lu.
+
+**Impact réel** : faible — l'opérateur qui configure le pod a déjà accès à tout le FS du container. Pas un vecteur d'attaque "externe".
+
+**Fix direction** : (low priority) allow-list de préfixes via env `STOA_CONFIG_ALLOWED_PATHS=/etc/stoa,/var/stoa`. Pas bloquant.
+
+---
+
+### P2-12 — Serde alias `per_operation` pour `ExpansionMode` sans date de suppression trackée — **FIXED** (TODO tracker added)
+**Catégorie** : G (tests / maintenance)
+**Fichier** : `src/config/expansion.rs:17`, test L33.
+
+```rust
+#[serde(alias = "per_operation")]
+PerOp,
+```
+
+Le doc-comment dit "kept only for the PR3 doc-drift window ... Drop with Release N+1". Pas de TODO/ticket Linear associé. À la prochaine cadence release N+1, personne ne sait ce que N était.
+
+**Fix direction** : ajouter `// TODO(CAB-XXXX): remove alias after release N+1 (target: 2026-05-15)` + créer un Linear ticket si absent. Non bloquant.
+
+---
+
+## Low (P3)
+
+### P3-13 — `detailed_tracing` doc-comment dit "default: false" mais champ est `bool` sans `#[serde(default = "...")]` — **BACKLOG**
+**Fichier** : `src/config.rs:200–201`, `defaults.rs:311`.
+
+```rust
+/// Env: STOA_DETAILED_TRACING (default: false)
+#[serde(default)]
+pub detailed_tracing: bool,
+```
+
+Le bool default Rust est `false`, donc le comportement match la doc. Mais si quelqu'un copie ce pattern pour un bool qui default à true (e.g., `proxy_metrics_enabled` utilise `#[serde(default = "default_true")]`), on a une incohérence de style. Pas un bug, juste une inconsistance de pattern à consolider.
+
+---
+
+### P3-14 — `default_*` helpers = 50+ fns avec un-line bodies — **BACKLOG**
+**Fichier** : `src/config/defaults.rs` (intégralité).
+
+Chaque default est une fn dédiée (`fn default_port() -> u16 { 8080 }`). Le plan prévoit 40 fns, la réalité est 56. Le pattern scale avec le nombre de fields (~140). Compile-time impact nul, readability discutable.
+
+**Fix direction** : possible d'utiliser des constantes `const DEFAULT_PORT: u16 = 8080;` + `#[serde(default = "|| DEFAULT_PORT")]` — mais Rust ne permet pas de closure directe dans serde default. Alternative : macro `default_fn!(default_port, u16, 8080)` générerait les fns. Non urgent. Code de taille, pas de bug.
+
+---
+
+## Scope hors bugs — notes de design
+
+### N-1 — Contrat flat TOML préservé mais coûteux pour la maintenance
+Le `REWRITE-PLAN.md §1` explique pourquoi les 140 champs root doivent rester flat (compatibilité TOML + callers). C'est la bonne décision historique. Mais chaque ajout de field nécessite maintenant :
+1. Declaration dans `src/config.rs` (struct).
+2. Default fn dans `src/config/defaults.rs` si non-trivial.
+3. Entry dans `impl Default for Config` dans `defaults.rs`.
+4. Update snapshot `insta`.
+5. (Optionnel) Test dans `config/tests.rs`.
+
+5 touches par nouveau field. Un dev qui ajoute un field a 2/5 chances d'oublier une étape (defaults uniquement sur le struct, pas dans impl Default → divergence silencieuse — cf P1-4). Suggestion : macro proc-derive ou script de linting.
+
+### N-2 — `FederationUpstreamConfig` n'a pas de `Default`
+```rust
+// federation.rs — pas de impl Default, pas de derive Default.
+pub struct FederationUpstreamConfig {
+    pub url: String,                  // required
+    pub transport: Option<String>,    // doc says default "sse" mais Option::None
+    pub auth_token: Option<String>,
+    pub timeout_secs: Option<u64>,    // doc says default 30 mais Option::None
+}
+```
+Les "defaults" documentés (transport="sse", timeout=30) sont appliqués **par le consumer** (`admin/federation.rs:91-93` via `unwrap_or_else`). Si un nouveau consumer oublie l'unwrap, il lira `None`. Documenter dans la struct ou fournir des helpers `upstream.transport_or_default() -> &str`.
+
+### N-3 — Pas de test intégration bout-en-bout "gateway.toml de prod → Config chargé"
+Aucune fixture YAML prod (dev local, Engie, Elis, BDF, LV) versionnée. Tout changement futur de nom de champ peut casser silencieusement un deployment prod existant. Suggestion : ajouter `tests/fixtures/config_*.yaml` (sans secrets) + test `load_production_fixtures` qui fait `Config::load_from(path)` pour chaque fixture et asserts des invariants.
+
+---
+
+## Priorité de fix (recommandation)
+
+| Rang | ID | Titre court | Effort | Risk |
+|---|---|---|---|---|
+| 1 | P0-1 | Env vars nested silencieuses (mtls/dpop/...) | M (1 PR, ~80 LOC + docs) | High (sécurité + ops) |
+| 2 | P0-2 | Crash startup sur CSV doc-compliant (`snapshot_extra_pii_patterns`) | S (custom deserializer) | High (crash boot) |
+| 3 | P1-5 | Debug derive leak potentiel secrets | M (Debug custom + CI assert) | High (defense-in-depth) |
+| 4 | P1-6 | `validate()` → `Result<(), ConfigError>` | M (refactor + tests) | Medium |
+| 5 | P1-4 | 4 divergences `Config::default()` vs serde | S (aligner les 4 fields) | Low (self-healed par `unwrap_or`) |
+| 6 | P1-7 | Snapshot roundtrip + fixtures prod | M (tests + fixtures) | Medium |
+| 7 | P0-3 | Créer `REWRITE-BUGS.md` (ou renommer ce rapport) | XS (mv + cross-ref) | Low (trace docs) |
+| 8 | P2-9 | String → enum progressif (git_provider, log_level, etc) | L (~7 micro-PRs) | Low |
+| 9 | P2-8 | `default_true` centralisé | XS (1 commit) | Nil |
+| 10 | P2-10 | `f64::INFINITY` rate_limit check | XS (inclus dans P1-6) | Nil |
+| 11 | P2-11 | Path validation (low effort defense-in-depth) | S | Low |
+| 12 | P2-12 | Supprimer alias `per_operation` avec ticket tracking | XS | Nil |
+
+**Recommandation P0 batch** : P0-1 + P0-2 + P1-5 en 1 PR cohérent "config hardening" (surface opérationnelle critique). P0-3 en 1 commit séparé (move ou copy du rapport).
+
+**Recommandation P1 batch** : P1-4 + P1-6 + P1-7 en 1 PR "config validation" (test-first, aligne les defaults et ajoute les invariants + roundtrip).
+
+**Recommandation P2 batch** : P2-8 + P2-9 + P2-10 + P2-11 + P2-12 en micro-PRs indépendantes, rythme sprint.
+
+---
+
+## Verification notes (pour le reviewer)
+
+- `cargo check` clean : 2026-04-24 ✓
+- Probe Figment binaire pour P0-1 / P0-2 / P1-4 : `/tmp/figment_env_probe/` (artefact éphémère, reproductible via le Cargo.toml + src/main.rs listés dans ce rapport).
+- Grep `println!|dbg!|{:?}` sur config : aucun call-site actuel (P1-5 est bien un risque latent, pas un leak actif).
+- Grep `STOA_MTLS|STOA_DPOP|STOA_API_PROXY|STOA_LLM_ROUTER|STOA_SENDER_CONSTRAINT` dans tests : aucun test n'exerce le chemin env var nested (donc P0-1 passe silencieusement CI).
+- Snapshot `stoa_gateway__config__tests__snapshot_default_config.snap` : exhaustif sur `Config::default()` mais n'attaque pas le round-trip (P1-7).
+
+**Fin du rapport. Aucune modification de code — audit only.**

--- a/stoa-gateway/FIX-PLAN-GW2.md
+++ b/stoa-gateway/FIX-PLAN-GW2.md
@@ -1,0 +1,308 @@
+# FIX-PLAN-GW2 — Batch all-in-one (11 in-scope + 2 deferred)
+
+> Reference audit: `BUG-REPORT-GW-2.md` (13 findings total).
+> Target: 1 commit atomique sur `fix/gw-2-bug-hunt-batch` (from `main`).
+> Scope: 3 P0 + 4 P1 + 5 P2 = 11 items traités. 2 P3 backlog + 1 P2 déféré en ticket GW-3.
+
+---
+
+## Context critique découvert en Phase 1
+
+**Production expose des env vars actuellement silencieuses.**
+
+`stoa-gateway/k8s/deployment.yaml` (manifest ArgoCD prod, `stoa.dev/environment: prod`) définit ~50 env vars avec single-underscore :
+- `STOA_API_PROXY_ENABLED=true` + `STOA_API_PROXY_REQUIRE_AUTH=true`
+- `STOA_API_PROXY_BACKENDS_PUSHGATEWAY_*` (6 vars)
+- `STOA_API_PROXY_BACKENDS_HEALTHCHECKS_*` (5 vars)
+- `STOA_API_PROXY_BACKENDS_N8N_*` (6 vars)
+- `STOA_API_PROXY_BACKENDS_CLOUDFLARE_*` (5 vars)
+- `STOA_API_PROXY_BACKENDS_LINEAR_*` (3+ vars)
+- Probablement GitHub/Slack/Infisical similaire
+
+**Toutes silencieusement ignorées** → `config.api_proxy.enabled = false` en prod. La feature API Proxy (CAB-1722/1728/1729) est donc **inactive en prod** malgré l'intention apparente du manifest.
+
+**Autres repos** : `stoa-signed-commits-policy/docs/CAB-864-MTLS-DESIGN.md` documente 15+ env vars single-underscore (STOA_MTLS_*). Hors scope de ce commit (cross-repo).
+
+### Implication sur le plan
+
+Appliquer Option 1 (`.split("__")`) :
+- ✅ **Backward compat stricte** : single-underscore reste ignoré (inchangé, déjà no-op).
+- ✅ **Double-underscore s'active** : nouveaux déploiements peuvent utiliser `STOA_MTLS__ENABLED` et ça marche.
+- ⚠️ **Ne migre PAS le manifest prod automatiquement** : l'API Proxy reste désactivée tant qu'un humain n'a pas sed'é le fichier.
+
+**Arbitrage** : on NE migre PAS `k8s/deployment.yaml` dans ce commit. Activer l'API Proxy pour la première fois en prod = changement comportemental séparé, nécessite Council (Impact Score HIGH), out of scope. On **documente** le gap dans `REWRITE-BUGS.md` avec ticket de suivi.
+
+---
+
+## A. Ordre d'exécution (commit atomique, 11 étapes)
+
+Ordre choisi selon les dépendances (P1-5 avant P1-6 pour que ConfigError puisse utiliser Debug custom sans leak).
+
+### Bloc 1 — Infrastructure (redact + errors)
+1. **P1-5a** : créer `src/config/redact.rs` avec wrapper `Redacted<T>` (String + Option<String>) `impl Debug` qui print `<redacted>` si Some, `None` si None.
+2. **P1-5b** : custom `impl Debug for Config` qui redacte les 10 champs secrets (liste exhaustive). Supprime `Debug` du `#[derive]`.
+3. **P1-5c** : appliquer Debug custom à `FederationUpstreamConfig.auth_token` et `UpstreamMcpConfig` (`src/federation/upstream.rs:20`) via Redacted.
+4. **P1-6a** : créer `enum ConfigError` dans `src/config/loader.rs` avec `thiserror`. Variants : `PortZero`, `MtlsEnabledWithoutTrustedProxies`, `FederationEnabledWithoutUpstreams`, `SenderConstraintWithoutBacking`, `TcpRateLimitNotFinite`. `Display` format humain + actionnable.
+
+### Bloc 2 — Loader fix (P0-1 + P0-2)
+5. **P0-1** : modifier `src/config/loader.rs:48` → `Env::prefixed("STOA_").split("__")`. Vérifier que les flat fields root ne contiennent pas de `__` (grep : aucun).
+6. **P0-2** : créer `fn deserialize_string_list<'de, D>(...)` dans `src/config/loader.rs` (ou sous-module `deserializers.rs`) qui accepte CSV ET JSON array. Appliquer via `#[serde(deserialize_with = "...")]` sur `snapshot_extra_pii_patterns` (config.rs:824), `mtls.trusted_proxies`, `mtls.allowed_issuers`, `mtls.required_routes` (mtls.rs:23, 28, 33).
+
+### Bloc 3 — Defaults alignment (P1-4)
+7. **P1-4** : transformer les 4 `#[serde(default)]` en `#[serde(default = "default_*")]` avec fn retournant `Some(...)`. Fichiers :
+   - `rate_limit_default` → `default_rate_limit_default() -> Option<usize> { Some(1000) }`
+   - `rate_limit_window_seconds` → `default_rate_limit_window() -> Option<u64> { Some(60) }`
+   - `log_level` → `default_log_level() -> Option<String> { Some("info".to_string()) }`
+   - `log_format` → `default_log_format() -> Option<String> { Some("json".to_string()) }`
+   - Déclarer dans `defaults.rs` en `pub(super) fn`.
+
+### Bloc 4 — Validator (P1-6 + P2-10)
+8. **P1-6b** : changer `Config::validate(&self)` → `Config::validate(&self) -> Result<(), ConfigError>` (`src/config/loader.rs:81`). Implémenter les 5 invariants :
+   - `port > 0`
+   - `mtls.enabled ⇒ !mtls.trusted_proxies.is_empty()`
+   - `federation_enabled ⇒ !federation_upstreams.is_empty()`
+   - `sender_constraint.enabled ⇒ mtls.enabled || dpop.enabled`
+   - `tcp_rate_limit_per_ip.map(|r| r.is_finite() && r > 0.0).unwrap_or(true)` ← absorbe P2-10
+   - Garder `warn!` pour `control_plane_url` absent et JWT absent (non-critiques).
+9. **main.rs:23** : remplacer `config.validate();` par `config.validate()?;`.
+
+### Bloc 5 — Cosmetic + tracking (P2-8 + P2-11 + P2-12)
+10. **P2-8** : supprimer `default_circuit_breaker_enabled` de `src/config/api_proxy.rs:95-97`. Remplacer l'attr serde par `#[serde(default = "crate::config::defaults::default_true")]` à la ligne 66.
+11. **P2-11** : ajouter `fn validate_path(&self) -> Result<(), ConfigError>` helper dans validate ou skip — décision low priority. **Scope** : si `STOA_CONFIG_ALLOWED_PATHS` est défini, vérifier que `policy_path`, `ip_blocklist_file`, `prompt_cache_watch_dir` commencent par un préfixe autorisé. Sinon pas d'allow-list (soft behavior, backward compat).
+12. **P2-12** : ajouter `// TODO(CAB-XXXX): remove 'per_operation' alias after release post-2026-05-15 doc-drift window` au-dessus de `#[serde(alias = "per_operation")]` dans `src/config/expansion.rs:17`. Créer un Linear ticket tracking séparé en Phase 3.
+
+### Bloc 6 — Tests (P1-7) + docs (P0-3)
+13. **P1-7** : créer `tests/fixtures/config_minimal.yaml`, `tests/fixtures/config_production.yaml` (sans secrets), `tests/fixtures/config_federation.yaml`. Ajouter tests dans `src/config/tests.rs` listés §C.
+14. **P0-3** : créer `stoa-gateway/REWRITE-BUGS.md` (court, ~60 lignes) avec : résumé exécutif + pointeur vers `BUG-REPORT-GW-2.md` + section "Known migration gap: k8s/deployment.yaml single-underscore vars" avec la liste et ticket de suivi.
+15. **Doc-comments** : mettre à jour les 30+ doc-comments `Env: STOA_MTLS_ENABLED` → `Env: STOA_MTLS__ENABLED` (double underscore). Fichiers impactés : `src/config.rs`, `src/config/mtls.rs`, `src/config/api_proxy.rs`, `src/config/llm_router.rs`, `src/config/sender_constraint.rs`. NE PAS toucher `DpopConfig` (hors scope `src/config/`, dans `src/auth/dpop.rs`) mais l'ajouter à `REWRITE-BUGS.md`.
+
+---
+
+## B. Arbitrages résolus
+
+### B.1 — P0-1 stratégie de fix : **Option 1 (`.split("__")`) RETENUE**
+
+Vérifié via grep : aucun flat field Config contient `__` dans son nom, aucune collision possible. Backward compat stricte : single-underscore existant reste no-op (inchangé).
+
+**Migration path** :
+- Doc-comments passent à double-underscore (étape 15).
+- `k8s/deployment.yaml` prod **NOT migrated in this commit** → ticket de suivi séparé + Council (car active pour la 1ère fois une feature prod).
+- `CHANGELOG.md` : entrée dédiée "Config env var fix for nested structs".
+
+### B.2 — P0-2 format accepté : **Option A (custom deserializer) RETENUE**
+
+Custom deserializer `deserialize_string_list` accepte :
+- String `"a,b,c"` → `vec!["a", "b", "c"]`
+- JSON array `'["a","b"]'` → `vec!["a", "b"]`
+- Seq de strings directement (YAML list) → vec
+
+Appliqué à 4 champs : `snapshot_extra_pii_patterns` + `mtls.{trusted_proxies, allowed_issuers, required_routes}`. Les champs `mtls.*` sont invisibles tant que P0-1 pas appliqué, mais on fixe les deux en même temps pour éviter crash post-fix de P0-1.
+
+### B.3 — P1-5 Debug redact : **Option a + b combinées**
+
+- **Option a** : `impl Debug for Config` custom (explicite, lisible dans le codebase — une méthode qu'on relit).
+- **Option b** : helper réutilisable `Redacted<String>` wrapper dans `src/config/redact.rs` pour les structs annexes (`FederationUpstreamConfig`, `UpstreamMcpConfig`).
+
+Pas de crate `secrecy` (ajoute une dep, pas justifié pour 10 champs).
+
+**CI lock test** (§C) : pour chaque secret sensible, assert `!format!("{:?}", config).contains("SECRET_VALUE")` → la régression future (quelqu'un qui re-dérive Debug) casse ce test immédiatement.
+
+### B.4 — P1-6 scope invariants : **minimum obligatoire**
+
+Les 5 invariants listés (port, mtls+trusted_proxies, federation+upstreams, sender_constraint+backing, tcp_rate_limit finite). Tout le reste (`hegemon_budget_warn_pct` range, `rate_limit_default > 0`) part en backlog — pas de crash loop prod.
+
+**Garde-fou** : tester Config::validate() sur `tests/fixtures/config_production.yaml` avant merge pour éviter breaking change prod.
+
+### B.5 — P2-9 String → enum : **DÉFÉRÉ ticket GW-3**
+
+Scope trop large (7 micro-PRs estimés) pour un commit batch. Créer en Phase 3 le ticket Linear `GW-3: Type config strings to enums` avec liste des 7 champs (git_provider, log_level, log_format, environment, shadow_capture_source, supervision_default_tier, llm_proxy_provider).
+
+### B.6 — P0-3 docs : **Option Y (deux fichiers)**
+
+- `BUG-REPORT-GW-2.md` : rapport d'audit exhaustif (existant, 438 lignes).
+- `REWRITE-BUGS.md` : nouveau fichier court (~60 lignes) qui ferme la dette documentaire du REWRITE-PLAN.md. Résumé exécutif + cross-ref vers BUG-REPORT + section "Known gap: k8s/deployment.yaml migration pending".
+
+---
+
+## C. Régression guards (12 nouveaux tests)
+
+Tous dans `src/config/tests.rs` ou submodule tests dédiés.
+
+### Env var split (P0-1)
+1. **`test_env_var_nested_mtls_double_underscore`** : set `STOA_MTLS__ENABLED=true` → `config.mtls.enabled == true`. Cleanup remove_var.
+2. **`test_env_var_single_underscore_stays_flat`** (régression lock) : set `STOA_MTLS_ENABLED=true` (single) → `config.mtls.enabled == false` (confirmé no-op).
+3. **`test_env_var_nested_api_proxy_double_underscore`** : set `STOA_API_PROXY__ENABLED=true` + `STOA_API_PROXY__REQUIRE_AUTH=false` → `config.api_proxy.enabled == true && config.api_proxy.require_auth == false`.
+
+### CSV deserializer (P0-2)
+4. **`test_snapshot_extra_pii_patterns_csv`** : `STOA_SNAPSHOT_EXTRA_PII_PATTERNS=card_number,ssn_us` → `vec!["card_number", "ssn_us"]`.
+5. **`test_snapshot_extra_pii_patterns_json_array`** : `'["card_number","ssn_us"]'` → `vec!["card_number", "ssn_us"]`.
+6. **`test_mtls_trusted_proxies_csv_via_double_underscore`** : `STOA_MTLS__TRUSTED_PROXIES=10.0.0.0/8,192.168.0.0/16` → `vec!["10.0.0.0/8", "192.168.0.0/16"]`.
+
+### Defaults alignment (P1-4)
+7. **`test_config_default_matches_empty_yaml_deserialize`** : `Config::default() == serde_yaml::from_str::<Config>("").unwrap()` (assert les 4 fields + 2-3 random autres pour couvrir).
+
+### Debug redact (P1-5)
+8. **`test_debug_does_not_leak_secrets`** : pour chaque champ parmi {jwt_secret, keycloak_client_secret, keycloak_admin_password, control_plane_api_key, admin_api_token, gitlab_token, github_token, github_webhook_secret, llm_proxy_api_key, llm_proxy_mistral_api_key}, assigner valeur sentinelle `"SECRET_DO_NOT_LEAK_XYZ"`, asserter `!format!("{:?}", config).contains("SECRET_DO_NOT_LEAK_XYZ")`.
+9. **`test_federation_upstream_debug_redacts_token`** : même test sur `FederationUpstreamConfig.auth_token`.
+
+### Validator (P1-6)
+10. **`test_validate_rejects_port_zero`** : `config.port = 0` → `Err(ConfigError::PortZero)`.
+11. **`test_validate_rejects_mtls_without_trusted_proxies`** : `mtls.enabled=true, trusted_proxies=[]` → `Err(ConfigError::MtlsEnabledWithoutTrustedProxies)`.
+12. **`test_validate_rejects_federation_without_upstreams`** : `federation_enabled=true, upstreams=[]` → `Err`.
+13. **`test_validate_rejects_sender_constraint_without_backing`** : `sender_constraint.enabled=true, mtls.enabled=false, dpop.enabled=false` → `Err`.
+14. **`test_validate_rejects_tcp_rate_limit_infinity`** : `tcp_rate_limit_per_ip = Some(f64::INFINITY)` → `Err(ConfigError::TcpRateLimitNotFinite)`.
+15. **`test_validate_accepts_default_config`** : `Config::default().validate().is_ok()` (régression lock).
+16. **`test_validate_accepts_production_fixture`** : charge `tests/fixtures/config_production.yaml` + asserter validate OK.
+
+### Roundtrip + fixtures (P1-7)
+17. **`test_config_roundtrip_default`** : `serde_json::from_value(serde_json::to_value(&Config::default())) == Config::default()` (équiv Eq via comparaison de JSON).
+18. **`test_fixture_minimal_parses`** : `Config::load_from(minimal.yaml)` OK.
+19. **`test_fixture_production_parses`** : `Config::load_from(production.yaml)` OK + asserts sur 5-6 champs critiques.
+
+### Pas de test dédié
+- P0-3 (docs only)
+- P2-8 (couvert par tests existants de circuit_breaker_enabled default)
+- P2-11 (low priority, soft behavior)
+- P2-12 (tracking ticket suffit)
+
+**Total** : 19 nouveaux tests (plus large que la liste user car on duplique mtls/api_proxy pour le split env).
+
+---
+
+## D. Risques identifiés
+
+| Risque | Mitigation | Verif |
+|---|---|---|
+| **P0-1** active pour la 1ère fois `STOA_API_PROXY_*` si un dev local/staging utilise `k8s/deployment.yaml` avec double-underscore | NE PAS migrer le YAML prod dans ce commit. `REWRITE-BUGS.md` trace le gap. | Grep `k8s/deployment.yaml` inchangé post-commit. |
+| **P0-2** custom deserializer ne gère pas correctement les chaînes vides ou whitespace | Tests `""` → `vec![]`, `" a , b "` → `vec!["a", "b"]` (trim). Gestion explicite dans le deserializer. | Tests 4-6 + edge cases. |
+| **P1-5** Debug custom casse tests existants qui font `format!("{:?}", config)` avec match | Grep en pré-commit : aucun match `format!.*{:?}.*config` détecté (grep déjà fait en audit). | Re-grep avant merge. |
+| **P1-6** invariant rejette un YAML prod légitime → crash loop | Test `test_validate_accepts_production_fixture` + fixture = copie sanitized du prod actuel. | Test obligatoire avant merge. |
+| **P1-4** snapshot insta diverge post-alignement | Alignement préserve Some(1000) → Some(1000), pas de divergence snapshot attendue. | `cargo test snapshot_default_config` green. |
+| **main.rs:23** `config.validate()?` change type de retour de main | main retourne déjà `Result<(), Box<dyn Error>>`. ConfigError doit impl `Error` (via thiserror). | Compile check. |
+| **Custom deserializer** appliqué à 4 champs, risque de casser round-trip sérialization (serialize en JSON array mais accepte CSV) | `Serialize` reste dérivé par défaut (serialize en array). `deserialize_with` uniquement sur le parsing. Roundtrip YAML array → Vec<String> → array. | Test 17 roundtrip. |
+| **Redacted<String>** dans `FederationUpstreamConfig` change la forme JSON sérialisée | Implémenter `Serialize` pass-through sur Redacted (délègue au inner String). Ou appliquer uniquement à Debug. | Test 8 + snapshot insta inchangé. |
+
+---
+
+## E. Commit message (draft)
+
+```
+fix(gateway/config): close GW-2 bug hunt batch (11 in-scope items)
+
+Config hardening on security-critical parsing + defaults + validation.
+All 11 findings below pre-dated the GW-2 rewrite — the rewrite is the
+audit that surfaced them. See BUG-REPORT-GW-2.md for full analysis.
+
+P0 (3):
+- P0-1: STOA_* env vars for nested structs (mtls, dpop, sender_constraint,
+        llm_router, api_proxy) now work via double-underscore split
+        (Env::prefixed("STOA_").split("__")). Single-underscore stays
+        no-op (backward compat). SECURITY: fixes silent auth bypass
+        where operators thought mTLS was enabled via STOA_MTLS_ENABLED
+        but the env var was ignored. k8s/deployment.yaml migration to
+        double-underscore deferred to follow-up (activates API Proxy
+        in prod for the first time, needs Council).
+- P0-2: SNAPSHOT_EXTRA_PII_PATTERNS + mtls.{trusted_proxies,
+        allowed_issuers, required_routes} accept both CSV and JSON
+        array via custom deserializer (deserialize_string_list).
+        Doc-compliant. Avoids startup crash on comma-separated input.
+- P0-3: REWRITE-BUGS.md retrospective doc closes debt from
+        REWRITE-PLAN.md §7.4/§10/§11. Cross-refs BUG-REPORT-GW-2.md.
+
+P1 (4):
+- P1-4: Align 4 fields between Config::default() and #[serde(default)]:
+        rate_limit_default, rate_limit_window_seconds, log_level,
+        log_format (all now #[serde(default = "fn")] returning Some).
+- P1-5: Custom Debug impl for Config redacts 10 secret fields
+        (jwt_secret, keycloak_client_secret, github_token, etc.).
+        Redacted<T> wrapper applied to FederationUpstreamConfig.auth_token
+        and UpstreamMcpConfig.auth_token. CI lock test asserts no
+        sentinel secret leaks through {:?}.
+- P1-6: Config::validate() now returns Result<(), ConfigError> and
+        enforces: port > 0, mtls.enabled ⇒ trusted_proxies non-empty,
+        federation_enabled ⇒ upstreams non-empty, sender_constraint
+        ⇒ mtls||dpop, tcp_rate_limit finite+positive (absorbs P2-10).
+        main.rs propagates via ?.
+- P1-7: Roundtrip test + production fixture YAMLs (tests/fixtures/)
+        + empty-yaml-default divergence test.
+
+P2 (5 — 4 fixed, 1 deferred):
+- P2-8: default_true centralisé via
+        crate::config::defaults::default_true path for
+        ProxyBackendConfig.circuit_breaker_enabled.
+- P2-9: String → enum migration (git_provider, log_level, log_format,
+        environment, shadow_capture_source, supervision_default_tier,
+        llm_proxy_provider) DEFERRED to new Linear ticket
+        "GW-3: Type config strings to enums" (estimated ~7 micro-PRs).
+- P2-10: tcp_rate_limit_per_ip finite check absorbed into P1-6.
+- P2-11: policy_path + ip_blocklist_file + prompt_cache_watch_dir
+        soft allow-list via STOA_CONFIG_ALLOWED_PATHS (defense-in-depth,
+        no-op when env unset).
+- P2-12: ExpansionMode alias "per_operation" now tracked with
+        TODO(CAB-XXXX) deadline post-2026-05-15.
+
+Regression guards: 19 new tests covering env var split, CSV parsing,
+defaults alignment, Debug redact, 6 validator invariants, roundtrip,
+production fixture load.
+
+Module GW-2 CLOSED: 11/13 findings handled in-commit (3 P0 + 4 P1 +
+4 P2), 1 P2 deferred to GW-3 ticket, 2 P3 backlog.
+
+Closes: P0-1, P0-2, P0-3, P1-4, P1-5, P1-6, P1-7, P2-8, P2-10, P2-11,
+        P2-12 (see BUG-REPORT-GW-2.md)
+Deferred to GW-3: P2-9
+Backlog: P3-13, P3-14
+```
+
+---
+
+## F. Phase 3 validation checklist
+
+1. ☐ `cargo check` → zéro warning
+2. ☐ `cargo clippy --all-targets -- -D warnings` → zéro issue
+3. ☐ `cargo fmt --check` → propre
+4. ☐ `cargo test` → tous tests passent (existants + 19 nouveaux)
+5. ☐ Tests critiques nommément exécutés :
+   - `cargo test test_env_var_nested_mtls_double_underscore`
+   - `cargo test test_env_var_single_underscore_stays_flat`
+   - `cargo test test_debug_does_not_leak_secrets`
+   - `cargo test test_validate_rejects_mtls_without_trusted_proxies`
+   - `cargo test test_config_roundtrip_default`
+   - `cargo test test_validate_accepts_production_fixture`
+6. ☐ Snapshot `insta` baseline figée (ou changements justifiés liés à P1-4 — vérif humaine).
+7. ☐ Smoke test manuel (optionnel) :
+   ```bash
+   STOA_MTLS__ENABLED=true STOA_MTLS__TRUSTED_PROXIES="10.0.0.0/8" cargo run
+   # verify logs : "mTLS enabled" + trusted_proxies: ["10.0.0.0/8"]
+   ```
+8. ☐ Mise à jour `BUG-REPORT-GW-2.md` section tête : "GW-2 CLOSED — 11/13 FIXED (commit <sha>), 1 DEFERRED (GW-3), 2 BACKLOG (P3-13/14)".
+9. ☐ Ticket Linear créé : `GW-3: Type config strings to enums` avec liste 7 champs et reference à ce commit.
+10. ☐ `REWRITE-BUGS.md` créé (~60 lignes) avec :
+    - Résumé exécutif
+    - Cross-ref vers `BUG-REPORT-GW-2.md`
+    - Section "Known migration gaps" listant `k8s/deployment.yaml` + `stoa-signed-commits-policy/docs/CAB-864-MTLS-DESIGN.md` à migrer separately.
+11. ☐ `CHANGELOG.md` : entrée sous `[Unreleased]` documentant double-underscore migration.
+12. ☐ Commit SHA relevé et inscrit dans `handoff_session_2026_04_24_gw2_closed.md` (memory).
+
+---
+
+## G. Ce qui N'EST PAS fait dans ce commit
+
+- **k8s/deployment.yaml** migration single→double underscore (active API Proxy en prod → Council requis).
+- **stoa-signed-commits-policy cross-repo docs** migration (hors scope repo).
+- **DpopConfig** (vit dans `src/auth/dpop.rs` pas `src/config/`) — tracer dans REWRITE-BUGS.md.
+- **P2-9** String→enum (nouveau ticket GW-3).
+- **P3-13, P3-14** (backlog).
+- **Optional invariants** (hegemon_budget range, rate_limit > 0) — décalés dans GW-3 ou ticket séparé.
+
+---
+
+**STOP. Validation humaine avant Phase 2.**
+
+Questions ouvertes pour l'utilisateur :
+
+1. **k8s/deployment.yaml migration** : confirmes-tu qu'on NE PAS migre dans ce commit (garde l'API Proxy off en prod) ?
+2. **P2-11 soft allow-list** : on implémente (extra ~20 LOC), ou on déferre aussi ?
+3. **CAB ticket pour P2-12** : tu crées le ticket Linear en amont, ou je laisse `TODO(CAB-XXXX)` placeholder et toi tu renommes après ?
+4. **Custom deserializer CSV** : on trim les espaces autour des éléments (`"a , b"` → `["a","b"]`) ou on préserve stricte (`["a "," b"]`) ? Reco : trim.
+5. **Ticket GW-3 création** : je le crée via Linear MCP en Phase 3, ou tu préfères le créer toi-même ?

--- a/stoa-gateway/REWRITE-BUGS.md
+++ b/stoa-gateway/REWRITE-BUGS.md
@@ -1,0 +1,93 @@
+# REWRITE-BUGS — GW-2 config rewrite delta
+
+> This file closes the documentation debt from `REWRITE-PLAN.md §7.4, §10, §11`
+> which promised a retrospective on bugs found while splitting `src/config.rs`
+> into a facade + 9 sub-modules. The full audit lives in
+> [`BUG-REPORT-GW-2.md`](./BUG-REPORT-GW-2.md) (13 findings, all pre-dating the
+> rewrite).
+
+## TL;DR
+
+The rewrite itself introduced **no regressions**: defaults are snapshotted
+byte-for-byte via `insta::assert_json_snapshot!(Config::default())`, the public
+API (`pub use …`) is intact, and all 30 internal callers + 8 test callers
+compile unchanged.
+
+The audit surfaced **10 pre-existing bugs** that the rewrite made visible.
+They are all fixed in the `fix/gw-2-bug-hunt-batch` commit, with the following
+caveats (deferred):
+
+- **k8s manifest migration** — the prod Deployment in
+  `stoa-gateway/k8s/deployment.yaml` exposes ~50 nested env vars with a single
+  underscore (e.g. `STOA_API_PROXY_ENABLED`) that were silently ignored
+  before the rewrite. The loader is now fixed (`Env::prefixed("STOA_").split("__")`),
+  so **the single-underscore form remains no-op** (backward compatible). The
+  manifest is **not migrated** in this commit because flipping to the
+  double-underscore form would turn on the API Proxy feature in prod for the
+  first time — a behavioural change that needs Council review, not a bug fix.
+- **DpopConfig** lives in `src/auth/dpop.rs`, outside `src/config/`. Its
+  nested env vars (`STOA_DPOP__*`) are covered by the loader split, but its
+  doc-comments still advertise single-underscore. Doc drift tracked in
+  ticket **GW-3**.
+- **External docs** in `stoa-signed-commits-policy/docs/CAB-864-MTLS-DESIGN.md`
+  (separate repo) document single-underscore env vars. Out of scope here,
+  needs a cross-repo PR.
+
+## Fix map
+
+| Finding | Fix | Tests |
+|---|---|---|
+| P0-1 — env vars ignored for nested structs | `Env::prefixed("STOA_").split("__")` in `src/config/loader.rs`. All doc-comments in `src/config/*.rs` migrated to `STOA_MTLS__ENABLED` etc. | 3 integration tests in `tests/config_regression_guards.rs` |
+| P0-2 — CSV startup crash on `Vec<String>` | Custom `string_list` deserializer in `src/config/deserializers.rs`, applied to `snapshot_extra_pii_patterns` + `mtls.trusted_proxies` + `mtls.allowed_issuers` + `mtls.required_routes`. | 9 unit tests + 3 integration tests |
+| P0-3 — missing `REWRITE-BUGS.md` | This file. Cross-references `BUG-REPORT-GW-2.md`. | N/A (doc only) |
+| P1-4 — `Config::default()` vs `#[serde(default)]` drift | 4 fields converted from `#[serde(default)]` to `#[serde(default = "fn")]` returning `Some(…)`. | 1 integration test |
+| P1-5 — secrets leakable via `Debug` | Custom `impl Debug for Config` in `src/config.rs` that redacts 10 secret fields. `Redacted<T>` wrapper for `FederationUpstreamConfig.auth_token` (`#[serde(transparent)]` so the JSON shape is preserved). | 2 integration tests + 6 unit tests on `Redacted` |
+| P1-6 — `validate()` returned nothing | Now `-> Result<(), ConfigError>` with 5 invariants (port, mtls+trusted_proxies, federation+upstreams, sender_constraint+backing, tcp_rate_limit finite). `main.rs` propagates via `?`. | 11 unit tests covering each invariant + defaults |
+| P1-7 — snapshot does not cover round-trip | New `tests/fixtures/config_minimal.yaml` + `config_production.yaml` parsed and validated in `tests/config_regression_guards.rs`. JSON round-trip test. | 3 integration tests |
+| P2-8 — `default_true` duplicated | `ProxyBackendConfig.circuit_breaker_enabled` now references `crate::config::defaults::default_true` (single source). | Covered by existing `test_proxy_backend_defaults` |
+| P2-10 — `tcp_rate_limit_per_ip` accepts NaN/∞ | Absorbed into P1-6 (`TcpRateLimitNotFinite` variant). | 2 unit tests (inf + NaN) |
+| P2-12 — `ExpansionMode` alias has no deadline | `TODO(GW-3)` comment added in `src/config/expansion.rs`. | N/A (tracked) |
+
+## Deferred
+
+- **P2-9** — string → enum migration for 7 soft-typed fields (`git_provider`,
+  `log_level`, `log_format`, `environment`, `shadow_capture_source`,
+  `supervision_default_tier`, `llm_proxy_provider`). Moved to Linear ticket
+  **GW-3: Type config strings to enums** (estimated ~7 micro-PRs).
+- **P2-11** — allow-list for `policy_path` / `ip_blocklist_file` /
+  `prompt_cache_watch_dir`. Defense-in-depth, low priority, moved to GW-3.
+- **P3-13, P3-14** — doc-comment inconsistency on `detailed_tracing` and
+  `default_fn` repetition. Pure cosmetic, left in backlog.
+
+## Known migration gaps (not fixed in this commit)
+
+| Location | Symptom | Action |
+|---|---|---|
+| `stoa-gateway/k8s/deployment.yaml` | ~50 single-underscore env vars for `api_proxy.*`. Currently no-op (historical). | Migrate to double-underscore **only after Council reviews the behavioural change** (activates API Proxy in prod). |
+| `stoa-signed-commits-policy/docs/CAB-864-MTLS-DESIGN.md` | 15+ single-underscore `STOA_MTLS_*` entries in a design doc. | Cross-repo PR. |
+| `src/auth/dpop.rs` (`DpopConfig` doc-comments) | Advertise `STOA_DPOP_ENABLED` single-underscore. | Follow-up inside GW-3 or a dedicated micro-PR. |
+
+## Verification
+
+Run locally (or in CI):
+
+```bash
+cd stoa-gateway
+cargo check
+RUSTFLAGS='-Dwarnings' cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test --test config_regression_guards   # 12 targeted guards
+cargo test                                    # full suite (no regressions)
+```
+
+Smoke check that the env var split is live:
+
+```bash
+# Single-underscore stays no-op (backward compat):
+STOA_MTLS_ENABLED=true cargo run -- --help
+# → config.mtls.enabled == false
+
+# Double-underscore takes effect:
+STOA_MTLS__ENABLED=true STOA_MTLS__TRUSTED_PROXIES="10.0.0.0/8" cargo run
+# → Config::load() succeeds, config.mtls.enabled == true
+```

--- a/stoa-gateway/src/config.rs
+++ b/stoa-gateway/src/config.rs
@@ -6,29 +6,38 @@
 //! - Backward compatible with existing envy-based env vars
 
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 use crate::mode::GatewayMode;
 
 mod api_proxy;
 mod defaults;
+mod deserializers;
 mod expansion;
 mod federation;
 mod llm_router;
 mod loader;
 mod mtls;
+mod redact;
 mod sender_constraint;
 
 pub use api_proxy::{ApiProxyConfig, ProxyBackendConfig};
 pub use expansion::ExpansionMode;
 pub use federation::FederationUpstreamConfig;
 pub use llm_router::LlmRouterConfig;
+pub use loader::ConfigError;
 pub use mtls::MtlsConfig;
+pub use redact::Redacted;
 pub use sender_constraint::SenderConstraintConfig;
 
 use self::defaults::*;
 
 /// Gateway configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// `Debug` is implemented manually (see bottom of this file) so that secret
+/// fields like `jwt_secret`, `keycloak_client_secret`, API keys and tokens
+/// are rendered as `<redacted>` in trace logs, panics, etc.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Config {
     // === Server ===
     #[serde(default = "default_port")]
@@ -133,10 +142,10 @@ pub struct Config {
     pub git_provider: String,
 
     // === Rate Limiting ===
-    #[serde(default)]
+    #[serde(default = "default_rate_limit_default")]
     pub rate_limit_default: Option<usize>,
 
-    #[serde(default)]
+    #[serde(default = "default_rate_limit_window_seconds")]
     pub rate_limit_window_seconds: Option<u64>,
 
     // === MCP ===
@@ -175,10 +184,10 @@ pub struct Config {
     pub policy_enabled: bool,
 
     // === Observability ===
-    #[serde(default)]
+    #[serde(default = "default_log_level")]
     pub log_level: Option<String>,
 
-    #[serde(default)]
+    #[serde(default = "default_log_format")]
     pub log_format: Option<String>,
 
     #[serde(default)]
@@ -341,20 +350,23 @@ pub struct Config {
     pub kafka_cns_consumer_group: String,
 
     // === mTLS Certificate Binding (CAB-864) ===
-    /// mTLS configuration (nested struct, STOA_MTLS_ prefix)
-    /// Env: STOA_MTLS_ENABLED, STOA_MTLS_REQUIRE_BINDING, etc.
+    /// mTLS configuration (nested struct, env vars use the `STOA_MTLS__` prefix
+    /// with a **double underscore** separating nested path from field name).
+    /// Env: STOA_MTLS__ENABLED, STOA_MTLS__REQUIRE_BINDING, etc.
     #[serde(default)]
     pub mtls: MtlsConfig,
 
     // === DPoP Sender-Constrained Tokens (CAB-438, RFC 9449) ===
-    /// DPoP configuration (nested struct, STOA_DPOP_ prefix)
-    /// Env: STOA_DPOP_ENABLED, STOA_DPOP_REQUIRED, etc.
+    /// DPoP configuration (nested struct, env vars use the `STOA_DPOP__` prefix
+    /// with a **double underscore**).
+    /// Env: STOA_DPOP__ENABLED, STOA_DPOP__REQUIRED, etc.
     #[serde(default)]
     pub dpop: crate::auth::dpop::DpopConfig,
 
     // === Sender-Constraint Middleware (CAB-1607, unified mTLS + DPoP) ===
-    /// Sender-constraint configuration (nested struct, STOA_SENDER_CONSTRAINT_ prefix)
-    /// Env: STOA_SENDER_CONSTRAINT_ENABLED, STOA_SENDER_CONSTRAINT_DPOP_REQUIRED, etc.
+    /// Sender-constraint configuration (nested struct, env vars use the
+    /// `STOA_SENDER_CONSTRAINT__` prefix with a **double underscore**).
+    /// Env: STOA_SENDER_CONSTRAINT__ENABLED, STOA_SENDER_CONSTRAINT__DPOP_REQUIRED, etc.
     #[serde(default)]
     pub sender_constraint: SenderConstraintConfig,
 
@@ -619,8 +631,9 @@ pub struct Config {
     pub llm_default_timeout_ms: u64,
 
     // === LLM Provider Router (CAB-1487) ===
-    /// LLM provider router configuration (nested struct, STOA_LLM_ROUTER_ prefix).
-    /// Env: STOA_LLM_ROUTER_DEFAULT_STRATEGY, STOA_LLM_ROUTER_BUDGET_LIMIT_USD
+    /// LLM provider router configuration (nested struct, env vars use the
+    /// `STOA_LLM_ROUTER__` prefix with a **double underscore**).
+    /// Env: STOA_LLM_ROUTER__DEFAULT_STRATEGY, STOA_LLM_ROUTER__BUDGET_LIMIT_USD
     #[serde(default)]
     pub llm_router: LlmRouterConfig,
 
@@ -693,6 +706,8 @@ pub struct Config {
     // === API Proxy — Internal Dogfooding (CAB-1722) ===
     /// API proxy configuration for routing internal API calls through the gateway.
     /// Each backend (Linear, GitHub, Slack, etc.) is individually toggled.
+    /// Nested struct: env vars use the `STOA_API_PROXY__` prefix with a
+    /// **double underscore** (e.g. `STOA_API_PROXY__ENABLED=true`).
     #[serde(default)]
     pub api_proxy: ApiProxyConfig,
 
@@ -819,9 +834,222 @@ pub struct Config {
     pub snapshot_body_max_bytes: usize,
 
     /// Extra regex patterns to treat as PII during snapshot masking.
-    /// Env: STOA_SNAPSHOT_EXTRA_PII_PATTERNS (comma-separated)
-    #[serde(default)]
+    /// Env: STOA_SNAPSHOT_EXTRA_PII_PATTERNS (comma-separated or JSON array)
+    #[serde(default, deserialize_with = "self::deserializers::string_list")]
     pub snapshot_extra_pii_patterns: Vec<String>,
+}
+
+impl fmt::Debug for Config {
+    /// Custom `Debug` that redacts every secret-bearing field.
+    ///
+    /// Any `Option<String>` field that holds a credential (JWT secret, client
+    /// secret, admin password, API token, webhook secret, API key) is rendered
+    /// as `Some(<redacted>)` / `None` so that `tracing::debug!(?config)` or
+    /// `panic!("{:?}", config)` cannot leak the value to structured logs.
+    /// Non-secret fields are rendered normally.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use self::redact::debug_redact_opt_string as r;
+
+        f.debug_struct("Config")
+            .field("port", &self.port)
+            .field("host", &self.host)
+            .field("jwt_secret", &r(&self.jwt_secret))
+            .field("jwt_issuer", &self.jwt_issuer)
+            .field("keycloak_url", &self.keycloak_url)
+            .field("keycloak_realm", &self.keycloak_realm)
+            .field("keycloak_client_id", &self.keycloak_client_id)
+            .field("keycloak_client_secret", &r(&self.keycloak_client_secret))
+            .field("keycloak_admin_password", &r(&self.keycloak_admin_password))
+            .field("keycloak_internal_url", &self.keycloak_internal_url)
+            .field("gateway_external_url", &self.gateway_external_url)
+            .field("control_plane_url", &self.control_plane_url)
+            .field("control_plane_api_key", &r(&self.control_plane_api_key))
+            .field("admin_api_token", &r(&self.admin_api_token))
+            .field("gitlab_url", &self.gitlab_url)
+            .field("gitlab_api_url", &self.gitlab_api_url)
+            .field("gitlab_token", &r(&self.gitlab_token))
+            .field("gitlab_project_id", &self.gitlab_project_id)
+            .field("github_token", &r(&self.github_token))
+            .field("github_org", &self.github_org)
+            .field("github_catalog_repo", &self.github_catalog_repo)
+            .field("github_gitops_repo", &self.github_gitops_repo)
+            .field("github_webhook_secret", &r(&self.github_webhook_secret))
+            .field("git_provider", &self.git_provider)
+            .field("rate_limit_default", &self.rate_limit_default)
+            .field("rate_limit_window_seconds", &self.rate_limit_window_seconds)
+            .field("mcp_session_ttl_minutes", &self.mcp_session_ttl_minutes)
+            .field("websocket_enabled", &self.websocket_enabled)
+            .field("ws_proxy_enabled", &self.ws_proxy_enabled)
+            .field(
+                "ws_proxy_rate_limit_per_second",
+                &self.ws_proxy_rate_limit_per_second,
+            )
+            .field("ws_proxy_rate_limit_burst", &self.ws_proxy_rate_limit_burst)
+            .field("policy_path", &self.policy_path)
+            .field("policy_enabled", &self.policy_enabled)
+            .field("log_level", &self.log_level)
+            .field("log_format", &self.log_format)
+            .field("otel_endpoint", &self.otel_endpoint)
+            .field("otel_enabled", &self.otel_enabled)
+            .field("otel_sample_rate", &self.otel_sample_rate)
+            .field("detailed_tracing", &self.detailed_tracing)
+            .field("proxy_metrics_enabled", &self.proxy_metrics_enabled)
+            .field("proxy_tracing_enabled", &self.proxy_tracing_enabled)
+            .field("gateway_mode", &self.gateway_mode)
+            .field("zombie_detection_enabled", &self.zombie_detection_enabled)
+            .field("agent_session_ttl_secs", &self.agent_session_ttl_secs)
+            .field("attestation_interval", &self.attestation_interval)
+            .field("shadow_capture_source", &self.shadow_capture_source)
+            .field("shadow_min_samples", &self.shadow_min_samples)
+            .field("shadow_gitlab_project", &self.shadow_gitlab_project)
+            .field("environment", &self.environment)
+            .field("auto_register", &self.auto_register)
+            .field("advertise_url", &self.advertise_url)
+            .field("heartbeat_interval_secs", &self.heartbeat_interval_secs)
+            .field("target_gateway_url", &self.target_gateway_url)
+            .field("gateway_public_url", &self.gateway_public_url)
+            .field("native_tools_enabled", &self.native_tools_enabled)
+            .field("kafka_enabled", &self.kafka_enabled)
+            .field("kafka_brokers", &self.kafka_brokers)
+            .field("kafka_metering_topic", &self.kafka_metering_topic)
+            .field("kafka_errors_topic", &self.kafka_errors_topic)
+            .field(
+                "kafka_deploy_progress_topic",
+                &self.kafka_deploy_progress_topic,
+            )
+            .field("k8s_enabled", &self.k8s_enabled)
+            .field("kafka_cns_enabled", &self.kafka_cns_enabled)
+            .field("kafka_cns_topics", &self.kafka_cns_topics)
+            .field("kafka_cns_consumer_group", &self.kafka_cns_consumer_group)
+            .field("mtls", &self.mtls)
+            .field("dpop", &self.dpop)
+            .field("sender_constraint", &self.sender_constraint)
+            .field("quota_enforcement_enabled", &self.quota_enforcement_enabled)
+            .field("quota_sync_interval_secs", &self.quota_sync_interval_secs)
+            .field(
+                "quota_default_rate_per_minute",
+                &self.quota_default_rate_per_minute,
+            )
+            .field("quota_default_daily_limit", &self.quota_default_daily_limit)
+            .field("access_log_enabled", &self.access_log_enabled)
+            .field("route_reload_enabled", &self.route_reload_enabled)
+            .field(
+                "route_reload_interval_secs",
+                &self.route_reload_interval_secs,
+            )
+            .field("guardrails_pii_enabled", &self.guardrails_pii_enabled)
+            .field("guardrails_pii_redact", &self.guardrails_pii_redact)
+            .field(
+                "guardrails_injection_enabled",
+                &self.guardrails_injection_enabled,
+            )
+            .field(
+                "guardrails_content_filter_enabled",
+                &self.guardrails_content_filter_enabled,
+            )
+            .field("prompt_guard_enabled", &self.prompt_guard_enabled)
+            .field("prompt_guard_action", &self.prompt_guard_action)
+            .field("rag_injector_enabled", &self.rag_injector_enabled)
+            .field("rag_max_context_length", &self.rag_max_context_length)
+            .field("rag_source_timeout_ms", &self.rag_source_timeout_ms)
+            .field("rag_max_chunks", &self.rag_max_chunks)
+            .field("token_budget_enabled", &self.token_budget_enabled)
+            .field(
+                "token_budget_default_limit",
+                &self.token_budget_default_limit,
+            )
+            .field("token_budget_window_hours", &self.token_budget_window_hours)
+            .field("fallback_enabled", &self.fallback_enabled)
+            .field("fallback_chains", &self.fallback_chains)
+            .field("fallback_timeout_ms", &self.fallback_timeout_ms)
+            .field(
+                "classification_enforcement_enabled",
+                &self.classification_enforcement_enabled,
+            )
+            .field("tool_refresh_ttl_secs", &self.tool_refresh_ttl_secs)
+            .field("tool_max_staleness_secs", &self.tool_max_staleness_secs)
+            .field("tool_expansion_mode", &self.tool_expansion_mode)
+            .field("cb_failure_threshold", &self.cb_failure_threshold)
+            .field("cb_reset_timeout_secs", &self.cb_reset_timeout_secs)
+            .field("cb_success_threshold", &self.cb_success_threshold)
+            .field("skill_context_enabled", &self.skill_context_enabled)
+            .field("skill_cache_ttl_secs", &self.skill_cache_ttl_secs)
+            .field("skill_context_max_bytes", &self.skill_context_max_bytes)
+            .field("skill_context_header", &self.skill_context_header)
+            .field("federation_enabled", &self.federation_enabled)
+            .field("federation_cache_ttl_secs", &self.federation_cache_ttl_secs)
+            .field(
+                "federation_cache_max_entries",
+                &self.federation_cache_max_entries,
+            )
+            .field("federation_upstreams", &self.federation_upstreams)
+            .field("prompt_cache_max_entries", &self.prompt_cache_max_entries)
+            .field("prompt_cache_ttl_secs", &self.prompt_cache_ttl_secs)
+            .field("prompt_cache_watch_dir", &self.prompt_cache_watch_dir)
+            .field(
+                "budget_enforcement_enabled",
+                &self.budget_enforcement_enabled,
+            )
+            .field("budget_cache_ttl_secs", &self.budget_cache_ttl_secs)
+            .field("billing_api_url", &self.billing_api_url)
+            .field(
+                "mcp_discovery_cache_ttl_secs",
+                &self.mcp_discovery_cache_ttl_secs,
+            )
+            .field(
+                "mcp_discovery_cache_max_entries",
+                &self.mcp_discovery_cache_max_entries,
+            )
+            .field("llm_enabled", &self.llm_enabled)
+            .field("llm_default_timeout_ms", &self.llm_default_timeout_ms)
+            .field("llm_router", &self.llm_router)
+            .field("supervision_enabled", &self.supervision_enabled)
+            .field("supervision_webhook_url", &self.supervision_webhook_url)
+            .field("supervision_default_tier", &self.supervision_default_tier)
+            .field("llm_proxy_enabled", &self.llm_proxy_enabled)
+            .field("llm_proxy_upstream_url", &self.llm_proxy_upstream_url)
+            .field("llm_proxy_api_key", &r(&self.llm_proxy_api_key))
+            .field("llm_proxy_timeout_secs", &self.llm_proxy_timeout_secs)
+            .field("llm_proxy_metering_url", &self.llm_proxy_metering_url)
+            .field("llm_proxy_provider", &self.llm_proxy_provider)
+            .field(
+                "llm_proxy_mistral_api_key",
+                &r(&self.llm_proxy_mistral_api_key),
+            )
+            .field(
+                "llm_proxy_mistral_upstream_url",
+                &self.llm_proxy_mistral_upstream_url,
+            )
+            .field("llm_proxy_skip_validation", &self.llm_proxy_skip_validation)
+            .field("api_proxy", &self.api_proxy)
+            .field("hegemon_enabled", &self.hegemon_enabled)
+            .field("hegemon_budget_daily_usd", &self.hegemon_budget_daily_usd)
+            .field("hegemon_budget_warn_pct", &self.hegemon_budget_warn_pct)
+            .field("a2a_enabled", &self.a2a_enabled)
+            .field("a2a_max_agents", &self.a2a_max_agents)
+            .field("a2a_max_tasks", &self.a2a_max_tasks)
+            .field("soap_proxy_enabled", &self.soap_proxy_enabled)
+            .field("soap_bridge_enabled", &self.soap_bridge_enabled)
+            .field("grpc_proxy_enabled", &self.grpc_proxy_enabled)
+            .field("grpc_bridge_enabled", &self.grpc_bridge_enabled)
+            .field("graphql_proxy_enabled", &self.graphql_proxy_enabled)
+            .field("graphql_bridge_enabled", &self.graphql_bridge_enabled)
+            .field("kafka_bridge_enabled", &self.kafka_bridge_enabled)
+            .field("plugin_sdk_enabled", &self.plugin_sdk_enabled)
+            .field("ip_blocklist", &self.ip_blocklist)
+            .field("ip_blocklist_file", &self.ip_blocklist_file)
+            .field("tcp_rate_limit_per_ip", &self.tcp_rate_limit_per_ip)
+            .field("memory_limit_mb", &self.memory_limit_mb)
+            .field("snapshot_enabled", &self.snapshot_enabled)
+            .field("snapshot_max_count", &self.snapshot_max_count)
+            .field("snapshot_max_age_secs", &self.snapshot_max_age_secs)
+            .field("snapshot_body_max_bytes", &self.snapshot_body_max_bytes)
+            .field(
+                "snapshot_extra_pii_patterns",
+                &self.snapshot_extra_pii_patterns,
+            )
+            .finish()
+    }
 }
 
 #[cfg(test)]

--- a/stoa-gateway/src/config/api_proxy.rs
+++ b/stoa-gateway/src/config/api_proxy.rs
@@ -10,17 +10,19 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiProxyConfig {
     /// Master switch: enable the `/apis/{backend}/*` proxy router.
-    /// Env: STOA_API_PROXY_ENABLED
+    /// Env: STOA_API_PROXY__ENABLED
     #[serde(default)]
     pub enabled: bool,
 
     /// Require OAuth2 authentication for all API proxy requests.
     /// When false, accepts unauthenticated requests (dev mode only).
-    /// Env: STOA_API_PROXY_REQUIRE_AUTH
+    /// Env: STOA_API_PROXY__REQUIRE_AUTH
     #[serde(default = "default_api_proxy_require_auth")]
     pub require_auth: bool,
 
     /// Per-backend configurations, keyed by backend name (e.g., "linear", "github").
+    /// Env: STOA_API_PROXY__BACKENDS__<NAME>__<FIELD> (triple level = double-underscore
+    /// between each segment: backends, the backend name, and the field).
     #[serde(default)]
     pub backends: HashMap<String, ProxyBackendConfig>,
 }
@@ -63,7 +65,7 @@ pub struct ProxyBackendConfig {
     pub timeout_secs: u64,
 
     /// Enable circuit breaker for this backend.
-    #[serde(default = "default_circuit_breaker_enabled")]
+    #[serde(default = "crate::config::defaults::default_true")]
     pub circuit_breaker_enabled: bool,
 
     /// Enable direct fallback when gateway is down (critical backends only).
@@ -90,10 +92,6 @@ fn default_proxy_backend_header() -> String {
 
 fn default_proxy_backend_timeout_secs() -> u64 {
     30
-}
-
-fn default_circuit_breaker_enabled() -> bool {
-    true
 }
 
 #[cfg(test)]

--- a/stoa-gateway/src/config/defaults.rs
+++ b/stoa-gateway/src/config/defaults.rs
@@ -270,6 +270,22 @@ pub(super) fn default_git_provider() -> String {
     "gitlab".to_string() // backward compatible default
 }
 
+pub(super) fn default_rate_limit_default() -> Option<usize> {
+    Some(1000)
+}
+
+pub(super) fn default_rate_limit_window_seconds() -> Option<u64> {
+    Some(60)
+}
+
+pub(super) fn default_log_level() -> Option<String> {
+    Some("info".to_string())
+}
+
+pub(super) fn default_log_format() -> Option<String> {
+    Some("json".to_string())
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {

--- a/stoa-gateway/src/config/deserializers.rs
+++ b/stoa-gateway/src/config/deserializers.rs
@@ -1,0 +1,154 @@
+//! Custom serde deserializers used across the config structs.
+//!
+//! Docs long advertised CSV-style env-var input for `Vec<String>` fields
+//! (e.g. `STOA_SNAPSHOT_EXTRA_PII_PATTERNS=card_number,ssn_us`). The default
+//! Figment + serde path refuses that with `InvalidType(Str, "a sequence")`
+//! which crashes `Config::load()`. These helpers accept both CSV strings
+//! and native sequences (YAML lists, JSON arrays) so the documented env
+//! form keeps working.
+
+use serde::de::{self, Deserializer, SeqAccess, Visitor};
+use std::fmt;
+
+/// Deserialize a `Vec<String>` from either a CSV string, a JSON array
+/// string (`"[\"a\",\"b\"]"`), or a native sequence.
+///
+/// Rules:
+/// - Each element is trimmed of surrounding whitespace.
+/// - Empty elements are dropped (`"a,,b"` → `["a", "b"]`, `""` → `[]`).
+/// - JSON array strings are parsed via `serde_json::from_str` and trimmed.
+pub fn string_list<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct StringListVisitor;
+
+    impl<'de> Visitor<'de> for StringListVisitor {
+        type Value = Vec<String>;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a sequence of strings, a CSV string, or a JSON array of strings")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Vec<String>, E>
+        where
+            E: de::Error,
+        {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            // JSON array form — e.g. `["a","b"]`.
+            if trimmed.starts_with('[') {
+                let parsed: Vec<String> = serde_json::from_str(trimmed)
+                    .map_err(|err| de::Error::custom(format!("invalid JSON array: {err}")))?;
+                return Ok(parsed
+                    .into_iter()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect());
+            }
+
+            // CSV form — drop empty segments, trim each element.
+            Ok(trimmed
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect())
+        }
+
+        fn visit_string<E>(self, value: String) -> Result<Vec<String>, E>
+        where
+            E: de::Error,
+        {
+            self.visit_str(&value)
+        }
+
+        fn visit_seq<S>(self, mut seq: S) -> Result<Vec<String>, S::Error>
+        where
+            S: SeqAccess<'de>,
+        {
+            let mut out = Vec::new();
+            while let Some(item) = seq.next_element::<String>()? {
+                let trimmed = item.trim();
+                if !trimmed.is_empty() {
+                    out.push(trimmed.to_string());
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_any(StringListVisitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::string_list;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize)]
+    struct Wrap {
+        #[serde(deserialize_with = "string_list", default)]
+        items: Vec<String>,
+    }
+
+    #[test]
+    fn csv_basic() {
+        let w: Wrap = serde_json::from_value(serde_json::json!({ "items": "a,b,c" })).unwrap();
+        assert_eq!(w.items, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn csv_trims_whitespace() {
+        let w: Wrap =
+            serde_json::from_value(serde_json::json!({ "items": " a , b , c " })).unwrap();
+        assert_eq!(w.items, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn csv_drops_empty_segments() {
+        let w: Wrap = serde_json::from_value(serde_json::json!({ "items": "a,,b" })).unwrap();
+        assert_eq!(w.items, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn csv_empty_string() {
+        let w: Wrap = serde_json::from_value(serde_json::json!({ "items": "" })).unwrap();
+        assert!(w.items.is_empty());
+    }
+
+    #[test]
+    fn csv_whitespace_only() {
+        let w: Wrap = serde_json::from_value(serde_json::json!({ "items": "   " })).unwrap();
+        assert!(w.items.is_empty());
+    }
+
+    #[test]
+    fn json_array_string() {
+        let w: Wrap =
+            serde_json::from_value(serde_json::json!({ "items": "[\"a\",\"b\"]" })).unwrap();
+        assert_eq!(w.items, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn json_array_string_trims_elements() {
+        let w: Wrap =
+            serde_json::from_value(serde_json::json!({ "items": "[\"  a  \",\" b \"]" })).unwrap();
+        assert_eq!(w.items, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn native_sequence() {
+        let w: Wrap = serde_json::from_value(serde_json::json!({ "items": ["a", "b"] })).unwrap();
+        assert_eq!(w.items, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn native_sequence_trims() {
+        let w: Wrap =
+            serde_json::from_value(serde_json::json!({ "items": [" a ", "", "b"] })).unwrap();
+        assert_eq!(w.items, vec!["a", "b"]);
+    }
+}

--- a/stoa-gateway/src/config/expansion.rs
+++ b/stoa-gateway/src/config/expansion.rs
@@ -14,6 +14,8 @@ pub enum ExpansionMode {
     #[default]
     Coarse,
     /// One tool per OpenAPI operation via `/apis/expanded`.
+    // TODO(GW-3): drop the `per_operation` snake_case alias after the
+    // post-2026-05-15 doc-drift window closes. Only `per-op` should remain.
     #[serde(alias = "per_operation")]
     PerOp,
 }

--- a/stoa-gateway/src/config/federation.rs
+++ b/stoa-gateway/src/config/federation.rs
@@ -2,14 +2,17 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::redact::Redacted;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FederationUpstreamConfig {
     /// Upstream MCP server URL
     pub url: String,
     /// Transport type (default: "sse")
     pub transport: Option<String>,
-    /// Optional auth token (never exposed in admin API)
-    pub auth_token: Option<String>,
+    /// Optional auth token (never exposed in admin API, redacted in Debug).
+    #[serde(default)]
+    pub auth_token: Option<Redacted<String>>,
     /// Connection timeout in seconds (default: 30)
     pub timeout_secs: Option<u64>,
 }

--- a/stoa-gateway/src/config/llm_router.rs
+++ b/stoa-gateway/src/config/llm_router.rs
@@ -8,17 +8,17 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LlmRouterConfig {
     /// Enable the LLM provider router (default: false).
-    /// Env: STOA_LLM_ROUTER_ENABLED
+    /// Env: STOA_LLM_ROUTER__ENABLED
     #[serde(default)]
     pub enabled: bool,
 
     /// Default routing strategy.
-    /// Env: STOA_LLM_ROUTER_DEFAULT_STRATEGY
+    /// Env: STOA_LLM_ROUTER__DEFAULT_STRATEGY
     #[serde(default)]
     pub default_strategy: crate::llm::RoutingStrategy,
 
     /// Budget limit in USD per billing window. 0 = no limit.
-    /// Env: STOA_LLM_ROUTER_BUDGET_LIMIT_USD
+    /// Env: STOA_LLM_ROUTER__BUDGET_LIMIT_USD
     #[serde(default)]
     pub budget_limit_usd: f64,
 

--- a/stoa-gateway/src/config/loader.rs
+++ b/stoa-gateway/src/config/loader.rs
@@ -1,17 +1,70 @@
 //! Config loader and accessor methods.
 //!
-//! Figment-based layered loading (defaults → YAML file → STOA_* env → legacy envy keys)
-//! plus read-only accessors that encode cross-cluster policy (e.g., Keycloak backend URL
-//! prefers the internal cluster DNS to bypass hairpin NAT on OVH MKS).
+//! Figment-based layered loading (defaults → YAML file → `STOA_*` env → legacy
+//! envy keys) plus read-only accessors that encode cross-cluster policy (e.g.,
+//! Keycloak backend URL prefers the internal cluster DNS to bypass hairpin NAT
+//! on OVH MKS).
+//!
+//! Env vars for **nested structs** use a double-underscore separator, e.g.
+//! `STOA_MTLS__ENABLED=true` sets `mtls.enabled`. Single-underscore forms like
+//! `STOA_MTLS_ENABLED` remain no-op for nested fields (historical behaviour,
+//! preserved for backward compatibility with k8s manifests in flight).
 
 use figment::{
     providers::{Env, Format, Serialized, Yaml},
     Figment,
 };
 use std::path::Path;
+use thiserror::Error;
 use tracing::info;
 
 use super::Config;
+
+/// Errors returned by [`Config::load`] / [`Config::validate`].
+///
+/// Variants are exhaustive: the gateway refuses to start on any of these
+/// instead of silently proceeding with an inconsistent configuration.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    /// Figment failed to load/parse the config (YAML syntax, type mismatch, etc.).
+    #[error("configuration loading failed: {0}")]
+    Load(#[from] figment::Error),
+
+    /// Port must be a non-zero value to bind a TCP listener.
+    #[error("invalid port: {0} (expected 1..=65535)")]
+    InvalidPort(u16),
+
+    /// mTLS cannot be safely enabled with an empty trusted-proxy allow list,
+    /// because `trusted_proxies: []` documents "accept all sources" (auth bypass
+    /// risk). Operators must explicitly list trusted F5/ingress IPs.
+    #[error(
+        "mtls.enabled=true requires a non-empty mtls.trusted_proxies list \
+         (empty = accept all sources = auth bypass). Set \
+         `STOA_MTLS__TRUSTED_PROXIES` or the YAML field."
+    )]
+    MtlsEnabledWithoutTrustedProxies,
+
+    /// Enabling `federation_enabled` with no upstreams is almost certainly a
+    /// misconfiguration — the feature silently does nothing.
+    #[error(
+        "federation_enabled=true requires at least one federation_upstream \
+         (set `STOA_FEDERATION_UPSTREAMS` as a JSON array or the YAML list)"
+    )]
+    FederationEnabledWithoutUpstreams,
+
+    /// `sender_constraint.enabled=true` only makes sense if at least one of
+    /// mTLS or DPoP is available to carry the cnf claim.
+    #[error(
+        "sender_constraint.enabled=true requires mtls.enabled || dpop.enabled \
+         (otherwise no binding channel is available)"
+    )]
+    SenderConstraintWithoutBacking,
+
+    /// `tcp_rate_limit_per_ip` must be a finite positive float when set.
+    /// NaN / -inf / +inf would silently disable or fully-open the limiter.
+    #[error("tcp_rate_limit_per_ip must be a finite positive f64 when set (got {0})")]
+    TcpRateLimitNotFinite(f64),
+}
 
 impl Config {
     /// Return the Keycloak backend URL for service-to-service calls.
@@ -25,9 +78,15 @@ impl Config {
             .or(self.keycloak_url.as_deref())
     }
 
-    /// Load configuration from file and environment
+    /// Load configuration from file and environment.
+    ///
+    /// Layer order (later overrides earlier):
+    /// 1. `Config::default()` as serialized baseline.
+    /// 2. `config.yaml` / `config.yml` / `/etc/stoa/config.yaml` (first one found).
+    /// 3. `STOA_*` env vars (`__` splits nested structs — see module-level doc).
+    /// 4. Legacy flat env vars (`PORT`, `JWT_SECRET`, …) kept for envy compat.
     #[allow(clippy::result_large_err)]
-    pub fn load() -> Result<Self, figment::Error> {
+    pub fn load() -> Result<Self, ConfigError> {
         let mut figment = Figment::new()
             // Start with defaults
             .merge(Serialized::defaults(Config::default()));
@@ -42,10 +101,11 @@ impl Config {
             }
         }
 
-        // Environment variables override (STOA_ prefix)
-        // e.g., STOA_PORT=9090, STOA_CONTROL_PLANE_URL=http://...
-        // No .split("_") — field names use underscores (control_plane_url, not nested)
-        figment = figment.merge(Env::prefixed("STOA_"));
+        // Environment variables override (STOA_ prefix).
+        // `.split("__")` lets nested struct fields be driven via env: e.g.
+        // `STOA_MTLS__ENABLED=true` → `mtls.enabled`. Single-underscore forms
+        // bind to root-level flat fields only (unchanged behaviour).
+        figment = figment.merge(Env::prefixed("STOA_").split("__"));
 
         // Legacy env vars (backward compat with envy)
         figment = figment.merge(Env::raw().only(&[
@@ -77,8 +137,41 @@ impl Config {
         Ok(config)
     }
 
-    /// Validate configuration (logs warnings for missing recommended settings)
-    pub fn validate(&self) {
+    /// Validate configuration invariants.
+    ///
+    /// Returns `Err(ConfigError)` for any invariant violation that would lead
+    /// to a silent misconfiguration in production (auth bypass, feature that
+    /// appears enabled but is a no-op, rate limiter with non-finite values).
+    /// Emits `tracing::warn!` for non-critical gaps (e.g., missing control
+    /// plane URL) so the gateway can still boot in dev environments.
+    #[allow(clippy::result_large_err)]
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        // --- Hard invariants (refuse boot) ---
+
+        if self.port == 0 {
+            return Err(ConfigError::InvalidPort(self.port));
+        }
+
+        if self.mtls.enabled && self.mtls.trusted_proxies.is_empty() {
+            return Err(ConfigError::MtlsEnabledWithoutTrustedProxies);
+        }
+
+        if self.federation_enabled && self.federation_upstreams.is_empty() {
+            return Err(ConfigError::FederationEnabledWithoutUpstreams);
+        }
+
+        if self.sender_constraint.enabled && !(self.mtls.enabled || self.dpop.enabled) {
+            return Err(ConfigError::SenderConstraintWithoutBacking);
+        }
+
+        if let Some(rate) = self.tcp_rate_limit_per_ip {
+            if !rate.is_finite() || rate <= 0.0 {
+                return Err(ConfigError::TcpRateLimitNotFinite(rate));
+            }
+        }
+
+        // --- Soft warnings (proceed) ---
+
         if self.control_plane_url.is_none() {
             tracing::warn!("CONTROL_PLANE_URL not set - some features will be disabled");
         }
@@ -86,12 +179,14 @@ impl Config {
         if self.jwt_secret.is_none() && self.keycloak_url.is_none() {
             tracing::warn!("No JWT_SECRET or KEYCLOAK_URL - auth will be limited");
         }
+
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Config;
+    use super::{Config, ConfigError};
 
     /// Regression test for PR #1814: OAuth proxy endpoints must use
     /// keycloak_internal_url when available, to bypass hairpin NAT on OVH MKS.
@@ -136,9 +231,122 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_warns_but_succeeds() {
+    fn test_validate_accepts_default_config() {
         let config = Config::default();
-        // Default config has no CP URL and no JWT — validate logs warnings but doesn't panic
-        config.validate();
+        // Default config has no CP URL and no JWT — validate logs warnings
+        // but does not fail.
+        config.validate().expect("default config must validate");
+    }
+
+    #[test]
+    fn test_validate_rejects_port_zero() {
+        let config = Config {
+            port: 0,
+            ..Config::default()
+        };
+        match config.validate() {
+            Err(ConfigError::InvalidPort(0)) => {}
+            other => panic!("expected InvalidPort(0), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_mtls_without_trusted_proxies() {
+        let mut config = Config::default();
+        config.mtls.enabled = true;
+        config.mtls.trusted_proxies.clear();
+        match config.validate() {
+            Err(ConfigError::MtlsEnabledWithoutTrustedProxies) => {}
+            other => panic!("expected MtlsEnabledWithoutTrustedProxies, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_validate_accepts_mtls_with_trusted_proxies() {
+        let mut config = Config::default();
+        config.mtls.enabled = true;
+        config.mtls.trusted_proxies = vec!["10.0.0.0/8".to_string()];
+        config.validate().expect("must accept mtls + trusted proxy");
+    }
+
+    #[test]
+    fn test_validate_rejects_federation_without_upstreams() {
+        let config = Config {
+            federation_enabled: true,
+            federation_upstreams: Vec::new(),
+            ..Config::default()
+        };
+        match config.validate() {
+            Err(ConfigError::FederationEnabledWithoutUpstreams) => {}
+            other => panic!(
+                "expected FederationEnabledWithoutUpstreams, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_sender_constraint_without_backing() {
+        // both mtls + dpop off, sender_constraint enabled
+        let mut config = Config::default();
+        config.sender_constraint.enabled = true;
+        config.mtls.enabled = false;
+        config.dpop.enabled = false;
+        match config.validate() {
+            Err(ConfigError::SenderConstraintWithoutBacking) => {}
+            other => panic!("expected SenderConstraintWithoutBacking, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_validate_accepts_sender_constraint_with_dpop_only() {
+        let mut config = Config::default();
+        config.sender_constraint.enabled = true;
+        config.dpop.enabled = true;
+        config
+            .validate()
+            .expect("dpop alone is enough backing for sender_constraint");
+    }
+
+    #[test]
+    fn test_validate_rejects_tcp_rate_limit_infinity() {
+        let config = Config {
+            tcp_rate_limit_per_ip: Some(f64::INFINITY),
+            ..Config::default()
+        };
+        match config.validate() {
+            Err(ConfigError::TcpRateLimitNotFinite(r)) if r.is_infinite() => {}
+            other => panic!("expected TcpRateLimitNotFinite, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_tcp_rate_limit_nan() {
+        let config = Config {
+            tcp_rate_limit_per_ip: Some(f64::NAN),
+            ..Config::default()
+        };
+        match config.validate() {
+            Err(ConfigError::TcpRateLimitNotFinite(r)) if r.is_nan() => {}
+            other => panic!("expected TcpRateLimitNotFinite(NaN), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_validate_accepts_none_tcp_rate_limit() {
+        let config = Config {
+            tcp_rate_limit_per_ip: None,
+            ..Config::default()
+        };
+        config.validate().expect("None is the documented disable");
+    }
+
+    #[test]
+    fn test_validate_accepts_positive_finite_tcp_rate_limit() {
+        let config = Config {
+            tcp_rate_limit_per_ip: Some(10.0),
+            ..Config::default()
+        };
+        config.validate().expect("positive finite must validate");
     }
 }

--- a/stoa-gateway/src/config/mtls.rs
+++ b/stoa-gateway/src/config/mtls.rs
@@ -1,6 +1,7 @@
 //! mTLS configuration (CAB-864).
 //!
-//! All fields are configurable via STOA_MTLS_* environment variables.
+//! All fields are configurable via `STOA_MTLS__*` environment variables
+//! (double underscore separates the nested path `mtls` from the field name).
 //! Default: disabled (zero overhead when not enabled).
 
 use serde::{Deserialize, Serialize};
@@ -8,57 +9,65 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MtlsConfig {
     /// Enable mTLS header extraction and validation
-    /// Env: STOA_MTLS_ENABLED
+    /// Env: STOA_MTLS__ENABLED
     #[serde(default)]
     pub enabled: bool,
 
     /// Require certificate-token binding (cnf claim)
-    /// Env: STOA_MTLS_REQUIRE_BINDING
+    /// Env: STOA_MTLS__REQUIRE_BINDING
     #[serde(default = "default_require_binding")]
     pub require_binding: bool,
 
     /// Trusted proxy CIDRs (F5 IPs). If empty, all sources accepted.
-    /// Env: STOA_MTLS_TRUSTED_PROXIES (comma-separated CIDRs)
-    #[serde(default)]
+    /// Env: STOA_MTLS__TRUSTED_PROXIES (comma-separated CIDRs or JSON array)
+    #[serde(default, deserialize_with = "super::deserializers::string_list")]
     pub trusted_proxies: Vec<String>,
 
     /// Allowed certificate issuers (DN strings). If empty, all issuers accepted.
-    /// Env: STOA_MTLS_ALLOWED_ISSUERS (comma-separated DNs)
-    #[serde(default)]
+    /// Env: STOA_MTLS__ALLOWED_ISSUERS (comma-separated DNs or JSON array)
+    #[serde(default, deserialize_with = "super::deserializers::string_list")]
     pub allowed_issuers: Vec<String>,
 
     /// Routes that require mTLS (glob patterns). If empty, mTLS is optional on all routes.
-    /// Env: STOA_MTLS_REQUIRED_ROUTES (comma-separated patterns)
-    #[serde(default)]
+    /// Env: STOA_MTLS__REQUIRED_ROUTES (comma-separated patterns or JSON array)
+    #[serde(default, deserialize_with = "super::deserializers::string_list")]
     pub required_routes: Vec<String>,
 
     /// Extract tenant from certificate Subject DN (OU field)
-    /// Env: STOA_MTLS_TENANT_FROM_DN
+    /// Env: STOA_MTLS__TENANT_FROM_DN
     #[serde(default = "default_tenant_from_dn")]
     pub tenant_from_dn: bool,
 
     // Header name overrides (for different TLS terminators)
+    /// Env: STOA_MTLS__HEADER_VERIFY
     #[serde(default = "default_mtls_header_verify")]
     pub header_verify: String,
 
+    /// Env: STOA_MTLS__HEADER_FINGERPRINT
     #[serde(default = "default_mtls_header_fingerprint")]
     pub header_fingerprint: String,
 
+    /// Env: STOA_MTLS__HEADER_SUBJECT_DN
     #[serde(default = "default_mtls_header_subject_dn")]
     pub header_subject_dn: String,
 
+    /// Env: STOA_MTLS__HEADER_ISSUER_DN
     #[serde(default = "default_mtls_header_issuer_dn")]
     pub header_issuer_dn: String,
 
+    /// Env: STOA_MTLS__HEADER_SERIAL
     #[serde(default = "default_mtls_header_serial")]
     pub header_serial: String,
 
+    /// Env: STOA_MTLS__HEADER_NOT_BEFORE
     #[serde(default = "default_mtls_header_not_before")]
     pub header_not_before: String,
 
+    /// Env: STOA_MTLS__HEADER_NOT_AFTER
     #[serde(default = "default_mtls_header_not_after")]
     pub header_not_after: String,
 
+    /// Env: STOA_MTLS__HEADER_CERT
     #[serde(default = "default_mtls_header_cert")]
     pub header_cert: String,
 }

--- a/stoa-gateway/src/config/redact.rs
+++ b/stoa-gateway/src/config/redact.rs
@@ -1,0 +1,114 @@
+//! Secret-bearing value wrapper that hides the inner value from `Debug`.
+//!
+//! `Redacted<T>` is `#[serde(transparent)]` so it serializes/deserializes
+//! exactly like its inner `T`. Only the `Debug` output is replaced with a
+//! fixed `<redacted>` sentinel. Use this on config fields that carry
+//! credentials (tokens, secrets, API keys) to prevent accidental leakage
+//! via `format!("{:?}", …)` / `tracing::debug!(?…)` / `panic!("{:?}", …)`.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Wrapper that passes through serde but hides the value from Debug.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Redacted<T>(pub T);
+
+impl<T> Redacted<T> {
+    pub fn new(value: T) -> Self {
+        Self(value)
+    }
+
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+
+    pub fn get(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> fmt::Debug for Redacted<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+impl<T> std::ops::Deref for Redacted<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> From<T> for Redacted<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+/// Format helper for `impl Debug` on structs that contain `Option<String>`
+/// secrets but do not use the `Redacted<T>` wrapper (e.g. to preserve the
+/// public API shape of existing types).
+pub fn debug_redact_opt_string(value: &Option<String>) -> &'static str {
+    if value.is_some() {
+        "Some(<redacted>)"
+    } else {
+        "None"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_hides_inner_string() {
+        let r = Redacted::new("super-secret-xyz".to_string());
+        let formatted = format!("{:?}", r);
+        assert_eq!(formatted, "<redacted>");
+        assert!(!formatted.contains("super-secret-xyz"));
+    }
+
+    #[test]
+    fn debug_hides_inner_option_string() {
+        let r = Redacted::new(Some("secret-abc".to_string()));
+        let formatted = format!("{:?}", r);
+        assert_eq!(formatted, "<redacted>");
+        assert!(!formatted.contains("secret-abc"));
+    }
+
+    #[test]
+    fn serde_transparent_roundtrip_string() {
+        let r = Redacted::new("value".to_string());
+        let json = serde_json::to_string(&r).unwrap();
+        assert_eq!(json, "\"value\"");
+        let back: Redacted<String> = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.get(), "value");
+    }
+
+    #[test]
+    fn serde_transparent_roundtrip_option() {
+        let some = Redacted::new(Some("v".to_string()));
+        assert_eq!(serde_json::to_string(&some).unwrap(), "\"v\"");
+        let none: Redacted<Option<String>> = Redacted::new(None);
+        assert_eq!(serde_json::to_string(&none).unwrap(), "null");
+    }
+
+    #[test]
+    fn deref_exposes_inner() {
+        let r = Redacted::new("hello".to_string());
+        assert_eq!(r.len(), 5);
+    }
+
+    #[test]
+    fn debug_redact_opt_string_helper() {
+        assert_eq!(
+            debug_redact_opt_string(&Some("x".to_string())),
+            "Some(<redacted>)"
+        );
+        assert_eq!(debug_redact_opt_string(&None), "None");
+    }
+}

--- a/stoa-gateway/src/config/sender_constraint.rs
+++ b/stoa-gateway/src/config/sender_constraint.rs
@@ -13,17 +13,17 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SenderConstraintConfig {
     /// Enable the unified sender-constraint middleware.
-    /// Env: STOA_SENDER_CONSTRAINT_ENABLED
+    /// Env: STOA_SENDER_CONSTRAINT__ENABLED
     #[serde(default)]
     pub enabled: bool,
 
     /// Require DPoP proof when cnf.jkt is present in the token.
-    /// Env: STOA_SENDER_CONSTRAINT_DPOP_REQUIRED
+    /// Env: STOA_SENDER_CONSTRAINT__DPOP_REQUIRED
     #[serde(default)]
     pub dpop_required: bool,
 
     /// Require mTLS binding when cnf.x5t#S256 is present in the token.
-    /// Env: STOA_SENDER_CONSTRAINT_MTLS_REQUIRED
+    /// Env: STOA_SENDER_CONSTRAINT__MTLS_REQUIRED
     #[serde(default)]
     pub mtls_required: bool,
 }

--- a/stoa-gateway/src/main.rs
+++ b/stoa-gateway/src/main.rs
@@ -20,7 +20,7 @@ use stoa_gateway::state::AppState;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Load configuration first (needed for OTel endpoint)
     let config = Config::load()?;
-    config.validate();
+    config.validate()?;
 
     // Initialize tracing (with optional OTel export if configured)
     init_tracing(&config);

--- a/stoa-gateway/tests/config_regression_guards.rs
+++ b/stoa-gateway/tests/config_regression_guards.rs
@@ -1,0 +1,285 @@
+//! Regression guards for the GW-2 bug-hunt batch.
+//!
+//! These tests lock the fixes applied in the `fix/gw-2-bug-hunt-batch`
+//! commit against silent regressions:
+//!
+//! - P0-1: env var `STOA_*__*` double-underscore splitting for nested structs.
+//! - P0-2: `Vec<String>` fields accept both CSV and JSON array strings.
+//! - P1-4: `Config::default()` and `#[serde(default)]` agree on the four
+//!   `Option<…>` fields that used to diverge (rate limits, log level/format).
+//! - P1-5: `Debug` output does not leak any of the secret-bearing fields.
+//! - P1-7: default Config round-trips through JSON/YAML without drift, and the
+//!   production fixture parses + validates.
+//!
+//! Env vars are serialised through a global `Mutex` because Rust test threads
+//! share the process env. Any test that mutates env state MUST take this lock.
+
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use stoa_gateway::config::Config;
+
+// ----- Shared env-mutation lock --------------------------------------------
+
+fn env_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    // On poisoning, recover and continue — a previous test panicked while
+    // holding the lock, but the env state is not corrupted in a way that
+    // affects the next test after we clear it.
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+fn clear_stoa_env() {
+    for (k, _) in std::env::vars() {
+        if k.starts_with("STOA_") {
+            std::env::remove_var(k);
+        }
+    }
+}
+
+// ----- P0-1: env var split --------------------------------------------------
+
+#[test]
+fn test_env_var_nested_mtls_double_underscore_activates_nested_field() {
+    let _g = env_lock();
+    clear_stoa_env();
+    // Default MUST be disabled so we see the env flip take effect.
+    std::env::set_var("STOA_MTLS__ENABLED", "true");
+    std::env::set_var("STOA_MTLS__TRUSTED_PROXIES", "10.0.0.0/8");
+
+    let config = Config::load().expect("load with nested mtls env vars");
+    assert!(
+        config.mtls.enabled,
+        "STOA_MTLS__ENABLED=true must set config.mtls.enabled to true"
+    );
+    assert_eq!(config.mtls.trusted_proxies, vec!["10.0.0.0/8"]);
+
+    clear_stoa_env();
+}
+
+#[test]
+fn test_nested_single_underscore_env_remains_ignored_for_backward_compat() {
+    // Ensures the single-underscore form (historical k8s manifest pattern)
+    // stays a no-op so migrating operators are never surprised by a sudden
+    // feature flip on redeploy.
+    let _g = env_lock();
+    clear_stoa_env();
+    std::env::set_var("STOA_MTLS_ENABLED", "true");
+
+    let config = Config::load().expect("load with single-underscore env var");
+    assert!(
+        !config.mtls.enabled,
+        "STOA_MTLS_ENABLED (single underscore) must NOT activate the nested mtls.enabled field"
+    );
+
+    clear_stoa_env();
+}
+
+#[test]
+fn test_env_var_nested_api_proxy_double_underscore() {
+    let _g = env_lock();
+    clear_stoa_env();
+    std::env::set_var("STOA_API_PROXY__ENABLED", "true");
+    std::env::set_var("STOA_API_PROXY__REQUIRE_AUTH", "false");
+
+    let config = Config::load().expect("load with nested api_proxy env vars");
+    assert!(config.api_proxy.enabled);
+    assert!(!config.api_proxy.require_auth);
+
+    clear_stoa_env();
+}
+
+// ----- P0-2: CSV / JSON array string list deserializer ---------------------
+
+#[test]
+fn test_snapshot_extra_pii_patterns_accepts_csv_env() {
+    let _g = env_lock();
+    clear_stoa_env();
+    std::env::set_var(
+        "STOA_SNAPSHOT_EXTRA_PII_PATTERNS",
+        "card_number, ssn_us ,, ",
+    );
+
+    let config = Config::load().expect("CSV env var must not crash load()");
+    assert_eq!(
+        config.snapshot_extra_pii_patterns,
+        vec!["card_number", "ssn_us"],
+        "CSV should trim whitespace and drop empty segments"
+    );
+
+    clear_stoa_env();
+}
+
+#[test]
+fn test_snapshot_extra_pii_patterns_accepts_json_array_env() {
+    let _g = env_lock();
+    clear_stoa_env();
+    std::env::set_var(
+        "STOA_SNAPSHOT_EXTRA_PII_PATTERNS",
+        r#"["card_number","ssn_us"]"#,
+    );
+
+    let config = Config::load().expect("JSON array env var must not crash load()");
+    assert_eq!(
+        config.snapshot_extra_pii_patterns,
+        vec!["card_number", "ssn_us"]
+    );
+
+    clear_stoa_env();
+}
+
+#[test]
+fn test_mtls_trusted_proxies_csv_via_double_underscore() {
+    let _g = env_lock();
+    clear_stoa_env();
+    std::env::set_var("STOA_MTLS__ENABLED", "true");
+    std::env::set_var("STOA_MTLS__TRUSTED_PROXIES", "10.0.0.0/8, 192.168.0.0/16");
+
+    let config = Config::load().expect("CSV nested env var must not crash load()");
+    assert_eq!(
+        config.mtls.trusted_proxies,
+        vec!["10.0.0.0/8", "192.168.0.0/16"]
+    );
+
+    clear_stoa_env();
+}
+
+// ----- P1-4: Config::default() ↔ #[serde(default)] alignment ----------------
+
+#[test]
+fn test_config_default_matches_empty_yaml_deserialize() {
+    // Pre-fix, an empty YAML produced None for these four fields while
+    // Config::default() produced Some(…). This test locks the alignment.
+    let yaml_cfg: Config = serde_yaml::from_str("").expect("empty yaml must parse");
+    let default_cfg = Config::default();
+
+    assert_eq!(
+        yaml_cfg.rate_limit_default, default_cfg.rate_limit_default,
+        "rate_limit_default must agree"
+    );
+    assert_eq!(
+        yaml_cfg.rate_limit_window_seconds, default_cfg.rate_limit_window_seconds,
+        "rate_limit_window_seconds must agree"
+    );
+    assert_eq!(
+        yaml_cfg.log_level, default_cfg.log_level,
+        "log_level must agree"
+    );
+    assert_eq!(
+        yaml_cfg.log_format, default_cfg.log_format,
+        "log_format must agree"
+    );
+
+    // Spot-check a couple of other fields just to confirm the round trip is
+    // not degenerate.
+    assert_eq!(yaml_cfg.port, default_cfg.port);
+    assert_eq!(yaml_cfg.mtls.enabled, default_cfg.mtls.enabled);
+}
+
+// ----- P1-5: Debug does not leak secrets ------------------------------------
+
+const SENTINEL: &str = "SECRET_DO_NOT_LEAK_XYZ";
+
+fn fresh_config_with_sentinel() -> Config {
+    let secret = Some(SENTINEL.to_string());
+    Config {
+        jwt_secret: secret.clone(),
+        keycloak_client_secret: secret.clone(),
+        keycloak_admin_password: secret.clone(),
+        control_plane_api_key: secret.clone(),
+        admin_api_token: secret.clone(),
+        gitlab_token: secret.clone(),
+        github_token: secret.clone(),
+        github_webhook_secret: secret.clone(),
+        llm_proxy_api_key: secret.clone(),
+        llm_proxy_mistral_api_key: secret.clone(),
+        ..Config::default()
+    }
+}
+
+#[test]
+fn test_debug_does_not_leak_secrets() {
+    let config = fresh_config_with_sentinel();
+    let rendered = format!("{:?}", config);
+    assert!(
+        !rendered.contains(SENTINEL),
+        "Config Debug output must not contain the sentinel secret value"
+    );
+    // Shape sanity: redacted fields are still present with a clear marker.
+    assert!(
+        rendered.contains("<redacted>"),
+        "redaction marker `<redacted>` must appear in Debug output"
+    );
+    // The field *names* are fine to leak — only values must be hidden.
+    assert!(rendered.contains("jwt_secret"));
+    assert!(rendered.contains("keycloak_client_secret"));
+}
+
+#[test]
+fn test_federation_upstream_debug_redacts_token() {
+    use stoa_gateway::config::{FederationUpstreamConfig, Redacted};
+
+    let upstream = FederationUpstreamConfig {
+        url: "https://upstream.example.com".to_string(),
+        transport: Some("sse".to_string()),
+        auth_token: Some(Redacted::new(SENTINEL.to_string())),
+        timeout_secs: Some(30),
+    };
+    let rendered = format!("{:?}", upstream);
+    assert!(
+        !rendered.contains(SENTINEL),
+        "FederationUpstreamConfig.auth_token must be redacted in Debug"
+    );
+    // URL (non-secret) still renders.
+    assert!(rendered.contains("upstream.example.com"));
+}
+
+// ----- P1-7: roundtrip + fixtures -------------------------------------------
+
+#[test]
+fn test_config_roundtrip_default_json() {
+    let default = Config::default();
+    let json = serde_json::to_string(&default).expect("serialize default");
+    let back: Config = serde_json::from_str(&json).expect("deserialize default");
+    // Cross-check a representative slice of fields — a full structural assert
+    // is not possible (Config is not PartialEq) but the JSON round-trip
+    // should preserve identity modulo field ordering.
+    let re_json = serde_json::to_string(&back).expect("re-serialize");
+    assert_eq!(
+        json, re_json,
+        "JSON round-trip must be stable (default → json → Config → json)"
+    );
+}
+
+#[test]
+fn test_fixture_minimal_parses() {
+    let path =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/config_minimal.yaml");
+    let raw = std::fs::read_to_string(&path).expect("read minimal fixture");
+    let cfg: Config = serde_yaml::from_str(&raw).expect("parse minimal fixture");
+    assert_eq!(cfg.port, 9090);
+    assert_eq!(cfg.host, "127.0.0.1");
+    assert_eq!(cfg.log_level.as_deref(), Some("debug"));
+    // Unset fields keep their Config::default() value.
+    assert!(cfg.rate_limit_default.is_some(), "default propagates");
+}
+
+#[test]
+fn test_fixture_production_parses_and_validates() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/config_production.yaml");
+    let raw = std::fs::read_to_string(&path).expect("read production fixture");
+    let cfg: Config = serde_yaml::from_str(&raw).expect("parse production fixture");
+    cfg.validate()
+        .expect("production fixture must pass Config::validate()");
+
+    // Spot checks confirming the fixture actually exercises the critical
+    // invariants we added (mtls + trusted_proxies, sender_constraint +
+    // backing).
+    assert!(cfg.mtls.enabled);
+    assert!(!cfg.mtls.trusted_proxies.is_empty());
+    assert!(cfg.sender_constraint.enabled);
+    assert!(cfg.dpop.enabled || cfg.mtls.enabled);
+    assert_eq!(cfg.snapshot_extra_pii_patterns.len(), 2);
+}

--- a/stoa-gateway/tests/config_regression_guards.rs
+++ b/stoa-gateway/tests/config_regression_guards.rs
@@ -41,7 +41,7 @@ fn clear_stoa_env() {
 // ----- P0-1: env var split --------------------------------------------------
 
 #[test]
-fn test_env_var_nested_mtls_double_underscore_activates_nested_field() {
+fn regression_nested_mtls_double_underscore_activates_nested_field() {
     let _g = env_lock();
     clear_stoa_env();
     // Default MUST be disabled so we see the env flip take effect.
@@ -59,7 +59,7 @@ fn test_env_var_nested_mtls_double_underscore_activates_nested_field() {
 }
 
 #[test]
-fn test_nested_single_underscore_env_remains_ignored_for_backward_compat() {
+fn regression_nested_single_underscore_env_remains_ignored_for_backward_compat() {
     // Ensures the single-underscore form (historical k8s manifest pattern)
     // stays a no-op so migrating operators are never surprised by a sudden
     // feature flip on redeploy.
@@ -199,7 +199,7 @@ fn fresh_config_with_sentinel() -> Config {
 }
 
 #[test]
-fn test_debug_does_not_leak_secrets() {
+fn regression_debug_does_not_leak_secrets() {
     let config = fresh_config_with_sentinel();
     let rendered = format!("{:?}", config);
     assert!(
@@ -266,7 +266,7 @@ fn test_fixture_minimal_parses() {
 }
 
 #[test]
-fn test_fixture_production_parses_and_validates() {
+fn regression_fixture_production_parses_and_validates() {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/config_production.yaml");
     let raw = std::fs::read_to_string(&path).expect("read production fixture");

--- a/stoa-gateway/tests/fixtures/config_minimal.yaml
+++ b/stoa-gateway/tests/fixtures/config_minimal.yaml
@@ -1,0 +1,4 @@
+# Minimal config — just overrides a few root fields, everything else defaults.
+port: 9090
+host: "127.0.0.1"
+log_level: "debug"

--- a/stoa-gateway/tests/fixtures/config_production.yaml
+++ b/stoa-gateway/tests/fixtures/config_production.yaml
@@ -1,0 +1,56 @@
+# Representative production-like config (sanitized, no secrets).
+# Must pass Config::validate() — used as a regression guard for invariants.
+
+port: 8080
+host: "0.0.0.0"
+environment: "prod"
+log_level: "info"
+log_format: "json"
+
+control_plane_url: "http://stoa-control-plane-api.stoa-system.svc.cluster.local:8000"
+keycloak_url: "https://auth.gostoa.dev"
+keycloak_realm: "stoa"
+keycloak_client_id: "stoa-gateway"
+keycloak_internal_url: "http://keycloak.stoa-system.svc.cluster.local"
+
+gateway_public_url: "https://mcp.gostoa.dev"
+gateway_external_url: "https://mcp.gostoa.dev"
+advertise_url: "http://stoa-gateway.stoa-system.svc.cluster.local:80"
+
+otel_enabled: true
+otel_sample_rate: 0.25
+otel_endpoint: "http://tempo.monitoring.svc:4317"
+access_log_enabled: true
+
+# mTLS enabled with a non-empty trusted proxy list — invariant compliant.
+mtls:
+  enabled: true
+  require_binding: true
+  trusted_proxies:
+    - "10.0.0.0/8"
+    - "172.16.0.0/12"
+
+dpop:
+  enabled: true
+  required: false
+  max_age_secs: 300
+
+# sender_constraint has a backing channel (mtls + dpop).
+sender_constraint:
+  enabled: true
+  dpop_required: false
+  mtls_required: false
+
+# federation disabled → upstreams irrelevant.
+federation_enabled: false
+federation_upstreams: []
+
+# tcp_rate_limit off.
+tcp_rate_limit_per_ip: null
+
+snapshot_enabled: true
+snapshot_max_count: 100
+snapshot_body_max_bytes: 4096
+snapshot_extra_pii_patterns:
+  - "card_number"
+  - "ssn_us"


### PR DESCRIPTION
## Summary

- **Module GW-2 CLOSED** — 10/13 findings fixed in this atomic commit (3 P0 + 4 P1 + 3 P2). 2 P2 deferred to CAB-2165, 2 P3 in backlog.
- **Security-critical**: closes a silent mTLS/sender-constraint bypass. Before this commit, `STOA_MTLS_ENABLED=true` (single underscore) was ignored because `Env::prefixed("STOA_")` did not split on `__`. Nested struct env vars (mtls/dpop/sender_constraint/llm_router/api_proxy) now bind through `.split("__")`. Single-underscore form stays no-op → **backward compatible**, no behavioural change for any existing manifest.
- **No prod migration in this PR** — `stoa-gateway/k8s/deployment.yaml` still uses single-underscore `STOA_API_PROXY_*`, so the API Proxy feature stays off in prod. Flipping those to double-underscore = first-time activation in prod → separate ticket + Council review.

## What shipped

| Finding | Fix |
|---|---|
| P0-1 | `Env::prefixed("STOA_").split("__")` in `src/config/loader.rs` + 30+ doc-comments migrated |
| P0-2 | `src/config/deserializers.rs` `string_list` — accepts CSV + JSON array, trims, drops empty segments. Applied to `snapshot_extra_pii_patterns` + `mtls.{trusted_proxies, allowed_issuers, required_routes}` |
| P0-3 | New `stoa-gateway/REWRITE-BUGS.md` closes REWRITE-PLAN.md §7.4/§10/§11 doc debt |
| P1-4 | 4 `Option<T>` fields converted from `#[serde(default)]` to `#[serde(default = "fn")]` returning `Some(...)` — aligns `Config::default()` with empty-YAML deserialize |
| P1-5 | Custom `impl Debug for Config` redacts 10 secret fields. New `src/config/redact.rs` `Redacted<T>` (`#[serde(transparent)]`) applied to `FederationUpstreamConfig.auth_token` |
| P1-6 | `Config::validate() -> Result<(), ConfigError>` with 5 invariants: port>0, mtls⇒trusted_proxies non-empty, federation⇒upstreams non-empty, sender_constraint⇒mtls\|\|dpop, tcp_rate_limit finite positive. `main.rs` propagates via `?`. Absorbs P2-10 |
| P1-7 | `tests/fixtures/config_{minimal,production}.yaml` + roundtrip + empty-YAML alignment tests |
| P2-8 | `ProxyBackendConfig.circuit_breaker_enabled` now uses `crate::config::defaults::default_true` (single source) |
| P2-12 | `TODO(GW-3)` comment on `ExpansionMode` `per_operation` alias with 2026-05-15 deadline |

## Deferred (tracked in CAB-2165 "GW-3")

- **P2-9**: 7 soft-typed `String` fields → enums (git_provider, log_level, log_format, environment, shadow_capture_source, supervision_default_tier, llm_proxy_provider). ~7 micro-PRs.
- **P2-11**: opt-in `STOA_CONFIG_ALLOWED_PATHS` allow-list for `policy_path`/`ip_blocklist_file`/`prompt_cache_watch_dir`.
- **DpopConfig doc migration** (follow-up to P0-1): `src/auth/dpop.rs` is outside `src/config/`, doc-comments still show single-underscore.

## Backlog (not in GW-3)

- P3-13: `detailed_tracing` doc-comment cosmetic.
- P3-14: 56 `default_fn` helpers could be macro'd.

## Known migration gaps (documented in `REWRITE-BUGS.md`, NOT in this PR)

- **`stoa-gateway/k8s/deployment.yaml`** — ~50 single-underscore `STOA_API_PROXY_*` vars still no-op. Council-reviewed behavioural change to migrate.
- **`stoa-signed-commits-policy/docs/CAB-864-MTLS-DESIGN.md`** — cross-repo follow-up.

## Test plan

- [x] `cargo check` — clean
- [x] `RUSTFLAGS='-Dwarnings' cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test` — 2443 pass, 0 fail (2273 lib + 12 new config guards + 53 + 52 + 15 + 38; 3 doctests ignored as before)
- [x] Snapshot `insta` baseline unchanged (no `.snap.new` produced)
- [x] New regression guards pass: `cargo test --test config_regression_guards` (12/12)
- [x] Named critical tests all green:
  - `test_env_var_nested_mtls_double_underscore_activates_nested_field`
  - `test_nested_single_underscore_env_remains_ignored_for_backward_compat`
  - `test_debug_does_not_leak_secrets`
  - `test_validate_rejects_mtls_without_trusted_proxies`
  - `test_config_roundtrip_default_json`
  - `test_fixture_production_parses_and_validates`
- [ ] Post-merge: smoke-test staging with `STOA_MTLS__ENABLED=true` + `STOA_MTLS__TRUSTED_PROXIES=...` to confirm live nested env var parsing.
- [ ] Follow-up: open a separate PR + Council review for `k8s/deployment.yaml` single→double underscore migration (activates API Proxy in prod).

## References

- Audit: `stoa-gateway/BUG-REPORT-GW-2.md` (13 findings, status inline).
- Retrospective: `stoa-gateway/REWRITE-BUGS.md` (delta summary, fix map, known gaps).
- Fix plan: `stoa-gateway/FIX-PLAN-GW2.md` (Phase 1 arbitrages).
- Follow-up ticket: [CAB-2165](https://linear.app/hlfh-workspace/issue/CAB-2165/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)