### PR TITLE
fix(gateway): close CAB-2165 GW-3 cleanup — 3 bundles (enum migration + path warn + DpopConfig docs)

### DIFF
--- a/stoa-gateway/BUG-REPORT-GW-2.md
+++ b/stoa-gateway/BUG-REPORT-GW-2.md
@@ -1,8 +1,8 @@
 # BUG-REPORT-GW-2 — Gateway Rust config (src/config/*)
 
 > **MODULE GW-2 CLOSED** (fixes on `fix/gw-2-bug-hunt-batch`).
-> **10 fixed** in-commit · **2 deferred → GW-3** (P2-9, P2-11) · **2 backlog** (P3-13, P3-14).
-> Status per finding called out inline below (`FIXED`, `DEFERRED → GW-3`, `BACKLOG`).
+> **10 fixed** in-commit · **2 fixed in GW-3 cleanup** (P2-9, P2-11 — CAB-2165 on `fix/cab-2165-gw-3-cleanup`) · **2 backlog** (P3-13, P3-14).
+> Status per finding called out inline below (`FIXED`, `FIXED (CAB-2165)`, `BACKLOG`).
 > Retrospective pointer: [`REWRITE-BUGS.md`](./REWRITE-BUGS.md).
 
 > Audit fonctionnel post-rewrite GW-2 (split `src/config.rs` 1973 LOC → 9 sous-modules + façade 828 LOC).
@@ -275,7 +275,7 @@ La Phase 2 a préféré une fn locale. Pas d'impact fonctionnel (même valeur), 
 
 ---
 
-### P2-9 — `git_provider: String` accepte n'importe quoi, fallthrough silencieux — **DEFERRED → GW-3**
+### P2-9 — `git_provider: String` accepte n'importe quoi, fallthrough silencieux — **FIXED (CAB-2165 Bundle 1, commit e059e0c92)**
 **Catégorie** : A (pas d'enum, typage trop permissif)
 **Fichier** : `src/config.rs:132–133`, test `src/config/tests.rs:200–209`.
 
@@ -327,7 +327,7 @@ Pas de bug catastrophique (pas de crash, pas d'allocation illimitée), juste un 
 
 ---
 
-### P2-11 — Pas de validation de path sur `policy_path`, `ip_blocklist_file`, `prompt_cache_watch_dir` — **DEFERRED → GW-3**
+### P2-11 — Pas de validation de path sur `policy_path`, `ip_blocklist_file`, `prompt_cache_watch_dir` — **FIXED (CAB-2165 Bundle 2, commit d430d1215)**
 **Catégorie** : D (path traversal via config — théorique, scope opérateur)
 **Fichier** : `src/config.rs:170` (`policy_path`), `785–786` (`ip_blocklist_file`), `580–581` (`prompt_cache_watch_dir`).
 

--- a/stoa-gateway/Cargo.toml
+++ b/stoa-gateway/Cargo.toml
@@ -110,6 +110,7 @@ pcap = ["pnet"]                              # Port mirror capture (raw packets)
 
 [dev-dependencies]
 criterion = "0.8"
+figment = { version = "0.10", features = ["yaml", "env", "test"] }  # "test" gates figment::Jail for hermetic env-var tests (CAB-2165 Bundle 1)
 insta = { version = "1", features = ["json", "redactions"] }
 tokio-test = "0.4"
 tower = { version = "0.5", features = ["util"] }

--- a/stoa-gateway/FIX-PLAN-CAB-2165.md
+++ b/stoa-gateway/FIX-PLAN-CAB-2165.md
@@ -1,0 +1,425 @@
+# FIX-PLAN — CAB-2165 GW-3 Gateway config cleanup
+
+**Branch target**: `fix/cab-2165-gw-3-cleanup` (to be cut from `main` after current GW-2 PR #2523 merge — currently `80017fb9d`).
+**Current working branch**: `fix/cab-2164-ui-3-cleanup` — Phase 1 only, no code yet.
+**Scope**: 3 bundles absorbed from GW-2 deferrals — P2-9 (String→enum), P2-11 (path allow-list), plus DpopConfig doc completion from P0-1 GW-2.
+**Estimate**: ~450 LOC across Bundle 1 (largest), ~40 LOC Bundle 2, ~15 LOC Bundle 3.
+
+---
+
+## A. Bundle 1 — String → enum (7 fields)
+
+### A.1 Evidence gathered
+
+| Field | Line | Defaults | Consumers (real) | Chart/env usage |
+|-------|------|----------|------------------|-----------------|
+| `git_provider: String` | `config.rs:142` | `"gitlab"` | `lib.rs:362`, `handlers/admin/health.rs:40`, `git/mod.rs:62` (match on "github" else GitLab) | No chart value; `STOA_GIT_PROVIDER` env only |
+| `log_level: Option<String>` | `config.rs:188` | `Some("info")` | **0 real** (tracing uses `RUST_LOG` via `EnvFilter` at `main.rs:224`) | `charts/…-deployment.yaml:65`, `k8s/deployment.yaml:49`, docker-compose multiple |
+| `log_format: Option<String>` | `config.rs:191` | `Some("json")` | **0 real** | `charts/…-deployment.yaml:67`, `k8s/deployment.yaml:51` |
+| `environment: String` | `config.rs:266` | `"dev"` | `control_plane/registration.rs:170` (clone into registration payload) | `charts/values.yaml:123,211,409,530`, docker-compose multiple |
+| `shadow_capture_source: Option<String>` | `config.rs:250` | `None` | **0 real** | Not in any chart/env — doc-only field |
+| `supervision_default_tier: String` | `config.rs:655` | `"autopilot"` | `supervision/mod.rs:128` (`from_config_default` takes `&str`, internally maps to `SupervisionTier` enum — already has "co-pilot" alias) | Not in chart defaults |
+| `llm_proxy_provider: Option<String>` | `config.rs:687` | `None` | **0 real** | Not in chart defaults |
+
+**Pattern to follow** — `config/expansion.rs` (`ExpansionMode`): enum with `#[serde(rename_all = "kebab-case")]` + `#[serde(alias = "snake_form")]` for backward compat.
+
+### A.2 YAML fixtures and production values
+
+Grep across `charts/`, `deploy/`, `stoa-gateway/tests/fixtures/`, `k8s/`:
+- `log_level`: `"info"`, `"debug"`, `{{ .Values… | default "info" }}` → all lowercase canonical values.
+- `log_format`: `"json"` only.
+- `environment`: `"dev"`, `"staging"`, `"prod"` — **all lowercase canonical**.
+- `git_provider`: no values set in chart/env fixtures — only the default `"gitlab"` via `default_git_provider`.
+- `supervision_default_tier`: no values set in chart/env fixtures — only default `"autopilot"`.
+- `shadow_capture_source`: no values set in chart/env fixtures.
+- `llm_proxy_provider`: no values set in chart/env fixtures.
+
+**Conclusion**: no deployed YAML/env uses non-canonical casing. Strict enums won't break any known config.
+
+### A.3 Proposed enum shapes
+
+All enums use `#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]` + `#[serde(rename_all = "snake_case")]` by default (kebab for `shadow_capture_source` since the documented values include a hyphen).
+
+```rust
+// src/config/enums.rs (new file; re-exports from `config` façade)
+
+/// Git provider for UAC sync. Env: STOA_GIT_PROVIDER (canonical: "gitlab" | "github").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum GitProvider {
+    #[default]
+    Gitlab,
+    Github,
+}
+
+/// Tracing verbosity level (informational — tracing itself is driven by RUST_LOG).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    #[default]
+    Info,
+    Warn,
+    Error,
+}
+
+/// Log output format (informational — formatter wiring lives in main.rs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LogFormat {
+    #[default]
+    Json,
+    Pretty,
+    Compact,
+}
+
+/// Deployment environment label for registration + observability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Environment {
+    #[default]
+    Dev,
+    Staging,
+    Prod,
+}
+
+/// Shadow mode traffic capture source (ADR-024 §5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ShadowCaptureSource {
+    Inline,
+    EnvoyTap,
+    PortMirror,
+    Kafka,
+}
+
+/// Default supervision tier when X-Hegemon-Supervision header is absent (CAB-1636).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SupervisionDefaultTier {
+    #[default]
+    Autopilot,
+    // Back-compat: `SupervisionTier::from_header` at supervision/mod.rs:52 accepts
+    // both "copilot" and "co-pilot" today. Keep parity by aliasing.
+    #[serde(alias = "co-pilot")]
+    Copilot,
+    Command,
+}
+
+/// LLM proxy provider format (CAB-1568).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LlmProxyProvider {
+    Anthropic,
+    Mistral,
+    Openai,
+}
+```
+
+### A.4 Consumer migration
+
+- `git/mod.rs:62` `match config.git_provider.as_str()` → `match config.git_provider`.
+- `lib.rs:362` similar — pattern-match on enum.
+- `handlers/admin/health.rs:40` — field currently `git_provider: String`; the health payload is serialized JSON, so changing the source type to `GitProvider` either:
+  - preserves the wire-format via `Serialize` on the enum (snake_case JSON — same string as today); **or**
+  - we add a `.to_string_canonical()` helper. Reco: rely on the enum's `Serialize` impl, no wrapper.
+- `control_plane/registration.rs:170` payload `environment: String` — registration struct lives locally, change its field to `Environment` enum or call `config.environment.to_string()`. Reco: change registration payload type too for cleanliness.
+- `supervision/mod.rs:128` `from_config_default(&self.config.supervision_default_tier)` takes `&str` — refactor to take `SupervisionDefaultTier` and map 1:1 to `SupervisionTier`. No behavior change.
+
+### A.5 Regression guards (Bundle 1)
+
+Add under `src/config/tests.rs`:
+
+1. `test_git_provider_rejects_unknown_value` — `git_provider: "bitbucket"` YAML parse → `Err` with "unknown variant" in message. **Replaces** existing `test_git_provider_unknown_value_treated_as_gitlab` (line 200) which locks in the silent-fallback anti-pattern.
+2. `test_git_provider_default_is_gitlab` — `Config::default().git_provider == GitProvider::Gitlab`.
+3. `test_environment_accepts_dev_staging_prod` — all three parse.
+4. `test_environment_rejects_unknown_value` — "mordor" → `Err`.
+5. `test_log_level_all_standard_values` — trace/debug/info/warn/error all parse.
+6. `test_log_format_rejects_unknown` — "xml" → `Err`.
+7. `test_shadow_capture_source_kebab` — "envoy-tap" → `EnvoyTap`.
+8. `test_supervision_tier_copilot_alias` — "co-pilot" + "copilot" both → `Copilot` (parity with `SupervisionTier::from_header`).
+9. `test_llm_proxy_provider_all_variants` — anthropic/mistral/openai all parse.
+
+### A.6 Insta snapshot drift
+
+`snapshot_default_config.snap` lines 39/40/51/54/158/164 currently serialize string values ("info"/"json"/"dev"/"autopilot"/null). Since `#[serde(rename_all = "snake_case")]` + `Default` on enums produces the same JSON strings, **the snapshot should NOT drift** for fields that previously defaulted to a canonical string. Verification step in Phase 3: `cargo test snapshot_default_config` must pass without review. If diff appears, something is off — investigate rather than accept.
+
+**Edge case**: `shadow_capture_source` and `llm_proxy_provider` default to `None` → snapshot stays `null`. No drift.
+
+---
+
+## B. Bundle 2 — Path warning (P2-11)
+
+### B.1 Evidence
+
+| Field | Line | Consumed by | Usage |
+|-------|------|-------------|-------|
+| `policy_path: Option<String>` | `config.rs:179` | `state.rs:172`, `policy/opa.rs:120/240` | Rego policy file load |
+| `ip_blocklist_file: Option<String>` | `config.rs:801` | `tcp_filter.rs:53` | IP/CIDR list read at startup |
+| `prompt_cache_watch_dir: Option<String>` | `config.rs:593` | `state.rs:680` | Directory watcher (notify) |
+
+### B.2 Decision D.2 — Option C (warn-only) recommended
+
+Rationale from BUG-REPORT GW-2 P2-11: operator configuring the pod already has FS access. Defense-in-depth only.
+
+- **Option A** (hard allow-list via `STOA_CONFIG_ALLOWED_PATHS`) — would break any existing deployment with `policy_path: /tmp/...` or custom mount paths. Not shipped for CAB-2165 today.
+- **Option C** (warn-only) — logs a `tracing::warn!` at startup for any path not under `/etc/stoa/` or `/var/stoa/` or relative-path-in-cwd. Visible in structured logs; doesn't break anything. **Chosen.**
+
+### B.3 Shape
+
+New module `src/config/path_safety.rs`:
+
+```rust
+//! Defense-in-depth path validation for filesystem-backed Config fields.
+//! Logs a warning when a configured path sits outside canonical STOA prefixes.
+//! Does NOT reject — operator retains full control (see CAB-2165 Bundle 2 / P2-11 GW-2).
+
+use std::path::Path;
+use tracing::warn;
+
+/// Paths under any of these prefixes are considered "safe" (no warning).
+const SAFE_PREFIXES: &[&str] = &["/etc/stoa/", "/var/stoa/", "/opt/stoa/"];
+
+/// Emit a warning if `path` is outside the safe prefix set.
+/// Relative paths are always allowed (treated as explicit operator intent within cwd).
+pub(crate) fn warn_if_unsafe(field: &str, path: &str) {
+    let p = Path::new(path);
+    if p.is_relative() {
+        return;
+    }
+    let canonical_ok = SAFE_PREFIXES.iter().any(|prefix| path.starts_with(prefix));
+    if !canonical_ok {
+        warn!(
+            field = field,
+            path = path,
+            "config path outside canonical /etc/stoa/ — defense-in-depth warning (CAB-2165)"
+        );
+    }
+}
+```
+
+Wire the check from `Config::validate()` (or equivalent startup hook — verify existing shape) for each of the 3 fields. No functional change; log only.
+
+### B.4 Regression guards (Bundle 2)
+
+Under `src/config/path_safety.rs` `#[cfg(test)] mod tests`:
+1. `test_safe_prefix_no_warn` — `/etc/stoa/policies/default.rego` → no-op (use `tracing_test` or probe log capture).
+2. `test_unsafe_prefix_emits_warn` — `/tmp/custom.rego` → 1 warn event captured.
+3. `test_relative_path_no_warn` — `policies/default.rego` → no-op.
+
+If `tracing_test` isn't already a dev-dep, we fall back to a direct unit check: `warn_if_unsafe` returns `bool` (or `Option<&'static str>` describing the reason) and we assert the predicate — logging stays a side effect.
+
+---
+
+## C. Bundle 3 — DpopConfig doc completion (P0-1 GW-2 completion)
+
+### C.1 Evidence
+
+- Sister structs — `MtlsConfig` (src/config/mtls.rs:12–70), `SenderConstraintConfig` (16/21/26), `LlmRouterConfig` (11/16/21), `ApiProxyConfig` (13/19/24) — **all have per-field `/// Env: STOA_X__Y` doc comments** post-GW-2 P0-1 (double underscore).
+- `DpopConfig` lives in `src/auth/dpop.rs:39–66` — outside `src/config/` — **has ZERO per-field env-var doc comments**.
+- Top-level `config.rs:360–362` mentions `STOA_DPOP__ENABLED`/`STOA_DPOP__REQUIRED` but the nested struct itself does not document any.
+- `grep -rnE "STOA_DPOP_[A-Z]" src/ | grep -v "__"` → 0 hits for single-underscore. Clean, just the per-field docs are absent.
+
+### C.2 Fix
+
+Add a module-level doc header on `DpopConfig` and per-field `/// Env: STOA_DPOP__<FIELD>` comments on all 6 fields, mirroring the MtlsConfig pattern. No logic change.
+
+Fields to document:
+- `enabled` → `STOA_DPOP__ENABLED`
+- `required` → `STOA_DPOP__REQUIRED`
+- `max_age_secs` → `STOA_DPOP__MAX_AGE_SECS`
+- `clock_skew_secs` → `STOA_DPOP__CLOCK_SKEW_SECS`
+- `jti_cache_ttl_secs` → `STOA_DPOP__JTI_CACHE_TTL_SECS`
+- `jti_cache_max` → `STOA_DPOP__JTI_CACHE_MAX`
+
+### C.3 No test needed
+
+Pure doc change.
+
+---
+
+## D. Arbitrages to resolve
+
+### D.1 — Bundle 1 fallback strategy per field
+
+**Recommendation: strict enum across the board, no legacy aliases except `co-pilot` for `SupervisionDefaultTier`.**
+
+Rationale:
+- No deployed YAML/env uses non-canonical casing (A.2 grep).
+- Silent fallthrough is a known foot-gun (P2-9 called it out).
+- `SupervisionTier::from_header` at `supervision/mod.rs:52` already accepts "co-pilot" as a hyphenated form — preserving the alias avoids a user-visible break for anyone who copy-pasted from an HTTP header example.
+
+**Field-by-field:**
+| Field | Strategy | Alias |
+|-------|----------|-------|
+| `git_provider` | Strict | none |
+| `log_level` | Strict | none |
+| `log_format` | Strict | none |
+| `environment` | Strict | none |
+| `shadow_capture_source` | Strict | none |
+| `supervision_default_tier` | Strict | `co-pilot → Copilot` |
+| `llm_proxy_provider` | Strict | none |
+
+### D.2 — Bundle 2 scope
+
+**Option C (warn-only). ~30 LOC for module + wiring + 3 tests.** Confirmed in B.2.
+
+### D.3 — Bundle 3 scope
+
+**Grep confirms**: per-field doc comments missing on all 6 `DpopConfig` fields. Bundle 3 IS in scope — not `ALREADY-FIXED`. ~15 LOC of doc comments.
+
+---
+
+## E. Commit strategy
+
+Execute in ascending-risk order. Commits are numbered in execution order (1 → 3):
+
+### Commit 1 (smallest) — `docs(gateway/config)`
+```
+docs(gateway/config): complete DpopConfig env-var doc alignment
+
+GW-2 P0-1 migrated 30+ doc-comments to the STOA_*__* (double underscore)
+pattern for MtlsConfig, SenderConstraintConfig, LlmRouterConfig, and
+ApiProxyConfig. DpopConfig (src/auth/dpop.rs, not src/config/) was
+outside that pass — its 6 fields had zero env-var documentation.
+
+This completes the alignment with per-field `/// Env: STOA_DPOP__<FIELD>`
+comments mirroring the MtlsConfig pattern.
+
+No behavior change.
+
+Refs: CAB-2165 Bundle 3 / P0-1 GW-2 completion
+```
+
+### Commit 2 (isolated) — `feat(gateway/config)`
+```
+feat(gateway/config): defense-in-depth warning on filesystem paths
+
+New `src/config/path_safety.rs` module + startup-time check on
+policy_path, ip_blocklist_file, and prompt_cache_watch_dir. Emits a
+tracing::warn! when any of these point outside /etc/stoa/, /var/stoa/,
+or /opt/stoa/ (absolute paths only; relative paths are trusted as
+explicit operator intent within cwd).
+
+Does NOT reject or fail startup. Purely observability.
+
+Regression guards: 3 new tests under path_safety::tests.
+
+Closes: P2-11 GW-2 / CAB-2165 Bundle 2
+```
+
+### Commit 3 (largest) — `refactor(gateway/config)`
+```
+refactor(gateway/config): type 7 soft String fields as enums
+
+Fields migrated (strict parsing, no silent fallthrough):
+- git_provider: GitProvider { Gitlab, Github }
+- log_level: LogLevel { Trace, Debug, Info, Warn, Error }
+- log_format: LogFormat { Json, Pretty, Compact }
+- environment: Environment { Dev, Staging, Prod }
+- shadow_capture_source: ShadowCaptureSource (kebab-case; Inline,
+  EnvoyTap, PortMirror, Kafka)
+- supervision_default_tier: SupervisionDefaultTier (alias `co-pilot`
+  for parity with SupervisionTier::from_header)
+- llm_proxy_provider: LlmProxyProvider { Anthropic, Mistral, Openai }
+
+Consumer sites updated: git/mod.rs, lib.rs, handlers/admin/health.rs,
+control_plane/registration.rs, supervision/mod.rs.
+
+Breaking semantic: unknown values (e.g. git_provider: "bitbucket")
+now fail `Config::load()` with a clear "unknown variant" error
+instead of silently falling through to a default. Prod YAML grep
+confirms no deployed config uses non-canonical casing.
+
+Regression guards: 9 new tests replacing the legacy
+test_git_provider_unknown_value_treated_as_gitlab which encoded the
+silent-fallthrough anti-pattern.
+
+Closes: P2-9 GW-2 / CAB-2165 Bundle 1
+```
+
+---
+
+## F. Risks identified
+
+1. **Bundle 1 insta snapshot drift** — `Config::default()` serializes each new enum's default variant. Expected: same JSON strings as today (`"info"`, `"json"`, `"dev"`, `"autopilot"`, `null` for the `Option`s). If diff surfaces, Option-to-Option wrapping may be off and needs `#[serde(default)]` on the inner type rather than `#[serde(default = "…")]` helper. Verification step F.ext: run `cargo test snapshot_default_config` before clicking-through any `cargo insta review`.
+2. **Bundle 1 consumer API mismatch** — `handlers/admin/health.rs:40` serializes `git_provider` into a payload already shipped to CP API. Mitigation: snake_case serialization preserves wire format 1:1 — `GitProvider::Gitlab` → `"gitlab"`. Registration payload at `control_plane/registration.rs:170` similar. Verify via `cargo test --package stoa-gateway --test '*'` (contract tests if any) and CI green.
+3. **Bundle 1 dormant fields' footprint** — 4 of 7 fields (`log_level`, `log_format`, `llm_proxy_provider`, `shadow_capture_source`) have ZERO real consumers in-tree. Migration is risk-free on those, but one may wonder whether to delete them outright. **Out of scope for CAB-2165** — pure dead-code removal is a separate cleanup.
+4. **Bundle 2 wiring point** — `Config::validate()` may not exist yet; if so, call sites: `Config::load()` return path in `loader.rs` or `main_wiring.rs` startup. Phase 2 must locate the single startup-time validation hook and thread warnings there, not scatter them.
+5. **Bundle 3 is near-zero risk** — 6 lines of doc comment insertion.
+6. **CI clippy/fmt** — all 3 commits must pass `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check`. Zero `#[allow(...)]` without justification (repo rule).
+
+---
+
+## G. Phase 2 execution plan
+
+After plan approval (commits numbered in execution order):
+
+1. Rebranch from fresh `main`: `git checkout main && git pull && git checkout -b fix/cab-2165-gw-3-cleanup`.
+2. **Commit 1** (docs, trivial) — add 6 doc-comment lines + module-level `//! Env-var prefix` header on `DpopConfig`.
+3. **Commit 2** (path warn) — create `src/config/path_safety.rs`, register it in `src/config.rs` mod list, wire `warn_if_unsafe` into startup, add 3 tests on the `bool` predicate (no tracing capture).
+4. **Commit 3** (enum migration) — add `src/config/enums.rs`, update 7 fields + defaults + 5 consumer sites, swap 1 legacy test for 9+ new strict-parse tests, run insta snapshot check.
+5. Run full validation suite (see H).
+6. Push + open PR `fix(gateway): close CAB-2165 GW-3 cleanup — 3 bundles` with per-commit bullet list in description.
+
+**STOP after Phase 2** for review before Phase 3 validation commands.
+
+### G.1 Adjustments from review (2026-04-24)
+
+1. **Commit numbering**: commits now numbered 1→3 in execution order (was 3→2→1). Less confusing in logs/PR.
+2. **Defaults typed end-to-end**: helpers migrate with the fields — no lingering `Some("info".to_string())` in `defaults.rs`. New shapes:
+   ```rust
+   fn default_log_level() -> Option<LogLevel> { Some(LogLevel::Info) }
+   fn default_log_format() -> Option<LogFormat> { Some(LogFormat::Json) }
+   fn default_environment() -> Environment { Environment::Dev }
+   fn default_git_provider() -> GitProvider { GitProvider::Gitlab }
+   fn default_supervision_tier() -> SupervisionDefaultTier { SupervisionDefaultTier::Autopilot }
+   ```
+3. **`Display` / `as_str` on enums consumed as string**: `GitProvider`, `Environment`, `SupervisionDefaultTier` get either `impl Display` or `fn as_str(self) -> &'static str`. For `control_plane/registration.rs:170`, explicit `config.environment.to_string()` at the payload boundary — keep the payload struct's `environment: String` field unchanged to avoid touching the wire contract.
+4. **`SupervisionDefaultTier` alias**: canonical `copilot` via `#[serde(rename_all = "snake_case")]` + `#[serde(alias = "co-pilot")]`. Test both values.
+5. **No implicit aliases**: strict parsing per D.1 — no `GitHub`/`GITHUB`/`production` tolerant forms. Only the explicit `co-pilot` alias survives.
+6. **Path safety uses `Path::starts_with`**: component-aware, avoids `/etc/stoa-malicious` false negative:
+   ```rust
+   let safe_prefixes = [Path::new("/etc/stoa"), Path::new("/var/stoa"), Path::new("/opt/stoa")];
+   let safe = safe_prefixes.iter().any(|prefix| p.starts_with(prefix));
+   ```
+7. **Testable predicate for path safety**:
+   ```rust
+   pub(crate) fn is_path_outside_safe_prefixes(path: &str) -> bool { … }
+   pub(crate) fn warn_if_unsafe(field: &str, path: &str) {
+       if is_path_outside_safe_prefixes(path) { warn!(field, path, "…"); }
+   }
+   ```
+   Tests assert on the predicate — no `tracing_test` dev-dep, no capture fragility.
+8. **Env-var deserialization tests (Bundle 1)**: add at least `STOA_GIT_PROVIDER=github` and `STOA_ENVIRONMENT=prod` via Figment (`tests/fixtures` or inline `Jail::expect_with`). Verifies enums parse from env, not just YAML.
+9. **Snapshot drift = investigate, never auto-accept**: if `snapshot_default_config.snap` diffs, stop and trace back to a defaults helper or a `rename_all` mismatch. No `cargo insta accept` by reflex.
+
+---
+
+## H. Phase 3 validation gate
+
+```bash
+cargo check                                                # 0 warnings
+cargo clippy --all-targets -- -D warnings                  # 0 issues
+cargo fmt --check                                          # clean
+cargo test --package stoa-gateway                          # all pass
+cargo test --package stoa-gateway snapshot_default_config  # no drift (or justified review)
+```
+
+Smoke:
+- Load `tests/fixtures/config_production.yaml` → parse OK (no enum rejection).
+- Load synthetic `environment: "mordor"` YAML → `Err` with "unknown variant" in message.
+- Startup with `policy_path: /tmp/custom.rego` → 1 warn log line "config path outside canonical…".
+- Linear CAB-2165 → Done + commit SHAs linked.
+- `BUG-REPORT-GW-2.md` → mark P2-9 and P2-11 as `FIXED` (currently `DEFERRED → GW-3`).
+
+**STOP after Phase 3.** Validation evidence + SHA list → Linear comment.
+
+---
+
+## I. Out of scope (deliberately deferred)
+
+- Deleting dead-code fields `log_level`, `log_format`, `llm_proxy_provider`, `shadow_capture_source` (0 consumers) — separate cleanup ticket if desired.
+- Path Option A (hard allow-list via `STOA_CONFIG_ALLOWED_PATHS`) — revisit if Option C warnings accumulate in prod.
+- P3-13 / P3-14 (`detailed_tracing` doc vs code, `default_*` helper consolidation) — `BACKLOG` per GW-2, not claimed here.

--- a/stoa-gateway/src/auth/dpop.rs
+++ b/stoa-gateway/src/auth/dpop.rs
@@ -35,32 +35,43 @@ use crate::metrics;
 // =============================================================================
 
 /// DPoP configuration.
+///
+/// All fields are configurable via `STOA_DPOP__*` environment variables
+/// (note the **double underscore** between the prefix and the field — required
+/// by the nested-struct env-var mapping installed in `src/config/loader.rs`).
+/// Single-underscore forms (`STOA_DPOP_ENABLED`) are silently ignored.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DpopConfig {
-    /// Enable DPoP validation (default: false — opt-in)
+    /// Enable DPoP validation (default: false — opt-in).
+    /// Env: STOA_DPOP__ENABLED
     #[serde(default)]
     pub enabled: bool,
 
     /// Require DPoP proof on all token-authenticated requests.
     /// When false, DPoP is optional (opportunistic binding).
+    /// Env: STOA_DPOP__REQUIRED
     #[serde(default)]
     pub required: bool,
 
     /// Maximum age of DPoP proof in seconds (default: 300 = 5 min).
     /// Proofs with `iat` older than this are rejected.
+    /// Env: STOA_DPOP__MAX_AGE_SECS
     #[serde(default = "default_max_age_secs")]
     pub max_age_secs: u64,
 
     /// Maximum clock skew tolerance in seconds (default: 30).
+    /// Env: STOA_DPOP__CLOCK_SKEW_SECS
     #[serde(default = "default_clock_skew_secs")]
     pub clock_skew_secs: u64,
 
     /// JTI cache TTL in seconds (for replay prevention). Default: 600 = 10 min.
     /// Should be >= 2 * max_age_secs to catch all replays.
+    /// Env: STOA_DPOP__JTI_CACHE_TTL_SECS
     #[serde(default = "default_jti_cache_ttl_secs")]
     pub jti_cache_ttl_secs: u64,
 
     /// Maximum JTI cache entries (default: 100_000).
+    /// Env: STOA_DPOP__JTI_CACHE_MAX
     #[serde(default = "default_jti_cache_max")]
     pub jti_cache_max: u64,
 }

--- a/stoa-gateway/src/config.rs
+++ b/stoa-gateway/src/config.rs
@@ -13,6 +13,7 @@ use crate::mode::GatewayMode;
 mod api_proxy;
 mod defaults;
 mod deserializers;
+mod enums;
 mod expansion;
 mod federation;
 mod llm_router;
@@ -23,6 +24,10 @@ mod redact;
 mod sender_constraint;
 
 pub use api_proxy::{ApiProxyConfig, ProxyBackendConfig};
+pub use enums::{
+    Environment, GitProvider, LlmProxyProvider, LogFormat, LogLevel, ShadowCaptureSource,
+    SupervisionDefaultTier,
+};
 pub use expansion::ExpansionMode;
 pub use federation::FederationUpstreamConfig;
 pub use llm_router::LlmRouterConfig;
@@ -137,10 +142,11 @@ pub struct Config {
     #[serde(default)]
     pub github_webhook_secret: Option<String>,
 
-    /// Git provider selector for UAC sync: "gitlab" (default) or "github".
+    /// Git provider selector for UAC sync: `gitlab` (default) or `github`.
+    /// Strict parsing — unknown values fail `Config::load()`.
     /// Env: GIT_PROVIDER / STOA_GIT_PROVIDER
     #[serde(default = "default_git_provider")]
-    pub git_provider: String,
+    pub git_provider: GitProvider,
 
     // === Rate Limiting ===
     #[serde(default = "default_rate_limit_default")]
@@ -185,11 +191,15 @@ pub struct Config {
     pub policy_enabled: bool,
 
     // === Observability ===
+    /// Informational log level (tracing itself is driven by `RUST_LOG`).
+    /// Env: STOA_LOG_LEVEL (values: trace | debug | info | warn | error)
     #[serde(default = "default_log_level")]
-    pub log_level: Option<String>,
+    pub log_level: Option<LogLevel>,
 
+    /// Informational log format hint.
+    /// Env: STOA_LOG_FORMAT (values: json | pretty | compact)
     #[serde(default = "default_log_format")]
-    pub log_format: Option<String>,
+    pub log_format: Option<LogFormat>,
 
     #[serde(default)]
     pub otel_endpoint: Option<String>,
@@ -245,10 +255,10 @@ pub struct Config {
     pub attestation_interval: u64,
 
     // === Shadow Mode ===
-    /// Traffic capture source for shadow mode
-    /// Env: STOA_SHADOW_CAPTURE_SOURCE (inline, envoy-tap, port-mirror, kafka)
+    /// Traffic capture source for shadow mode.
+    /// Env: STOA_SHADOW_CAPTURE_SOURCE (values: inline | envoy-tap | port-mirror | kafka)
     #[serde(default)]
-    pub shadow_capture_source: Option<String>,
+    pub shadow_capture_source: Option<ShadowCaptureSource>,
 
     /// Minimum samples before generating UAC
     /// Env: STOA_SHADOW_MIN_SAMPLES
@@ -261,10 +271,11 @@ pub struct Config {
     pub shadow_gitlab_project: Option<String>,
 
     // === Auto-Registration (ADR-028) ===
-    /// Environment identifier for registration (dev, staging, prod)
+    /// Environment identifier for registration (canonical: dev | staging | prod).
+    /// Strict parsing — unknown values fail `Config::load()`.
     /// Env: STOA_ENVIRONMENT
     #[serde(default = "default_environment")]
-    pub environment: String,
+    pub environment: Environment,
 
     /// Enable auto-registration with Control Plane on startup
     /// Env: STOA_AUTO_REGISTER
@@ -650,10 +661,12 @@ pub struct Config {
     pub supervision_webhook_url: Option<String>,
 
     /// Default supervision tier when X-Hegemon-Supervision header is absent.
-    /// Values: "autopilot" (default), "copilot", "command".
+    /// Canonical values: `autopilot` (default), `copilot`, `command`.
+    /// Accepts `co-pilot` as a deprecated alias for parity with
+    /// `SupervisionTier::from_header`.
     /// Env: STOA_SUPERVISION_DEFAULT_TIER
     #[serde(default = "default_supervision_tier")]
-    pub supervision_default_tier: String,
+    pub supervision_default_tier: SupervisionDefaultTier,
 
     // === LLM Proxy (CAB-1568: STOA Dogfood) ===
     /// Enable the LLM API proxy (passthrough to upstream LLM provider).
@@ -681,11 +694,12 @@ pub struct Config {
     #[serde(default)]
     pub llm_proxy_metering_url: Option<String>,
 
-    /// Default LLM proxy provider format: "anthropic" | "mistral" | "openai".
-    /// Controls header injection and response parsing for the default upstream.
+    /// Default LLM proxy provider format (canonical: `anthropic` | `mistral`
+    /// | `openai`). Controls header injection and response parsing for the
+    /// default upstream.
     /// Env: STOA_LLM_PROXY_PROVIDER
     #[serde(default)]
-    pub llm_proxy_provider: Option<String>,
+    pub llm_proxy_provider: Option<LlmProxyProvider>,
 
     /// API key for Mistral upstream (when provider=mistral or for /v1/chat/completions).
     /// Env: STOA_LLM_PROXY_MISTRAL_API_KEY

--- a/stoa-gateway/src/config.rs
+++ b/stoa-gateway/src/config.rs
@@ -18,6 +18,7 @@ mod federation;
 mod llm_router;
 mod loader;
 mod mtls;
+mod path_safety;
 mod redact;
 mod sender_constraint;
 

--- a/stoa-gateway/src/config/defaults.rs
+++ b/stoa-gateway/src/config/defaults.rs
@@ -6,7 +6,8 @@
 //! new root-level field only ever touches this module plus `config.rs`.
 
 use super::{
-    ApiProxyConfig, Config, ExpansionMode, LlmRouterConfig, MtlsConfig, SenderConstraintConfig,
+    ApiProxyConfig, Config, Environment, ExpansionMode, GitProvider, LlmRouterConfig, LogFormat,
+    LogLevel, MtlsConfig, SenderConstraintConfig, SupervisionDefaultTier,
 };
 use crate::mode::GatewayMode;
 
@@ -58,8 +59,8 @@ pub(super) fn default_shadow_min_samples() -> usize {
     10 // Minimum samples before pattern is considered stable
 }
 
-pub(super) fn default_environment() -> String {
-    "dev".to_string()
+pub(super) fn default_environment() -> Environment {
+    Environment::Dev
 }
 
 pub(super) fn default_auto_register() -> bool {
@@ -214,8 +215,8 @@ pub(super) fn default_mcp_discovery_cache_max_entries() -> u64 {
     256
 }
 
-pub(super) fn default_supervision_tier() -> String {
-    "autopilot".to_string()
+pub(super) fn default_supervision_tier() -> SupervisionDefaultTier {
+    SupervisionDefaultTier::Autopilot
 }
 
 pub(super) fn default_llm_timeout_ms() -> u64 {
@@ -266,8 +267,8 @@ pub(super) fn default_snapshot_body_max_bytes() -> usize {
     4096
 }
 
-pub(super) fn default_git_provider() -> String {
-    "gitlab".to_string() // backward compatible default
+pub(super) fn default_git_provider() -> GitProvider {
+    GitProvider::Gitlab
 }
 
 pub(super) fn default_rate_limit_default() -> Option<usize> {
@@ -278,12 +279,12 @@ pub(super) fn default_rate_limit_window_seconds() -> Option<u64> {
     Some(60)
 }
 
-pub(super) fn default_log_level() -> Option<String> {
-    Some("info".to_string())
+pub(super) fn default_log_level() -> Option<LogLevel> {
+    Some(LogLevel::Info)
 }
 
-pub(super) fn default_log_format() -> Option<String> {
-    Some("json".to_string())
+pub(super) fn default_log_format() -> Option<LogFormat> {
+    Some(LogFormat::Json)
 }
 
 impl Default for Config {
@@ -319,8 +320,8 @@ impl Default for Config {
             websocket_enabled: false,
             policy_path: None,
             policy_enabled: default_policy_enabled(),
-            log_level: Some("info".to_string()),
-            log_format: Some("json".to_string()),
+            log_level: default_log_level(),
+            log_format: default_log_format(),
             otel_enabled: default_otel_enabled(),
             otel_endpoint: None,
             otel_sample_rate: default_otel_sample_rate(),

--- a/stoa-gateway/src/config/enums.rs
+++ b/stoa-gateway/src/config/enums.rs
@@ -174,10 +174,11 @@ mod tests {
     }
 
     #[test]
-    fn git_provider_rejects_unknown_value() {
+    fn regression_cab_2165_git_provider_rejects_unknown_value() {
+        // Regression for CAB-2165 Bundle 1 / P2-9 GW-2.
         // Replaces the legacy test_git_provider_unknown_value_treated_as_gitlab
         // anti-pattern: strict parsing now surfaces typos instead of silently
-        // falling through to the default (CAB-2165 Bundle 1 / P2-9 GW-2).
+        // falling through to the default.
         let err = serde_json::from_str::<GitProvider>("\"bitbucket\"")
             .expect_err("unknown variant should not deserialize");
         let msg = err.to_string();

--- a/stoa-gateway/src/config/enums.rs
+++ b/stoa-gateway/src/config/enums.rs
@@ -1,0 +1,326 @@
+//! Typed enums for Config fields that were previously `String` with
+//! documented-but-unenforced value sets (CAB-2165 Bundle 1 / P2-9 GW-2).
+//!
+//! Each enum uses `#[serde(rename_all = "snake_case")]` (or `kebab-case`
+//! where the documented value contains a hyphen) so the serialized form is
+//! identical to the strings previously accepted in YAML / env vars. No
+//! implicit aliases — strict parsing rejects unknown values with a clear
+//! "unknown variant" error at `Config::load()` time, instead of silently
+//! falling through to a default.
+//!
+//! One explicit alias is kept: `co-pilot → Copilot` on
+//! [`SupervisionDefaultTier`] for parity with
+//! `supervision::SupervisionTier::from_header`.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Git provider selector for UAC sync.
+///
+/// Env: `STOA_GIT_PROVIDER` (canonical values: `gitlab` | `github`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum GitProvider {
+    #[default]
+    Gitlab,
+    Github,
+}
+
+impl GitProvider {
+    /// Canonical lowercase string form (matches the serde `rename_all` output).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Gitlab => "gitlab",
+            Self::Github => "github",
+        }
+    }
+}
+
+impl fmt::Display for GitProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Tracing verbosity level.
+///
+/// Informational only: `tracing` itself is driven by `RUST_LOG`
+/// (`EnvFilter::try_from_default_env`) in `main.rs`. This field documents the
+/// operator-intended level and appears in the health / debug snapshots.
+/// Env: `STOA_LOG_LEVEL`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    #[default]
+    Info,
+    Warn,
+    Error,
+}
+
+/// Log output format.
+///
+/// Informational only: the formatter is selected in `main.rs` based on
+/// `RUST_LOG` / build flags. Env: `STOA_LOG_FORMAT`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LogFormat {
+    #[default]
+    Json,
+    Pretty,
+    Compact,
+}
+
+/// Deployment environment label for registration + observability.
+///
+/// Env: `STOA_ENVIRONMENT` (canonical values: `dev` | `staging` | `prod`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Environment {
+    #[default]
+    Dev,
+    Staging,
+    Prod,
+}
+
+impl Environment {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Dev => "dev",
+            Self::Staging => "staging",
+            Self::Prod => "prod",
+        }
+    }
+}
+
+impl fmt::Display for Environment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Shadow-mode traffic capture source (ADR-024 §5).
+///
+/// Env: `STOA_SHADOW_CAPTURE_SOURCE` (kebab-case values: `inline` |
+/// `envoy-tap` | `port-mirror` | `kafka`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ShadowCaptureSource {
+    Inline,
+    EnvoyTap,
+    PortMirror,
+    Kafka,
+}
+
+/// Default supervision tier when the `X-Hegemon-Supervision` header is absent
+/// (CAB-1636).
+///
+/// Env: `STOA_SUPERVISION_DEFAULT_TIER` (canonical: `autopilot` | `copilot` |
+/// `command`). Accepts `co-pilot` as a deprecated alias for parity with
+/// `supervision::SupervisionTier::from_header`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SupervisionDefaultTier {
+    #[default]
+    Autopilot,
+    #[serde(alias = "co-pilot")]
+    Copilot,
+    Command,
+}
+
+impl SupervisionDefaultTier {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Autopilot => "autopilot",
+            Self::Copilot => "copilot",
+            Self::Command => "command",
+        }
+    }
+}
+
+impl fmt::Display for SupervisionDefaultTier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// LLM proxy upstream provider format (CAB-1568).
+///
+/// Env: `STOA_LLM_PROXY_PROVIDER` (canonical: `anthropic` | `mistral` |
+/// `openai`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LlmProxyProvider {
+    Anthropic,
+    Mistral,
+    Openai,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn git_provider_parses_canonical_values() {
+        assert_eq!(
+            serde_json::from_str::<GitProvider>("\"gitlab\"").unwrap(),
+            GitProvider::Gitlab
+        );
+        assert_eq!(
+            serde_json::from_str::<GitProvider>("\"github\"").unwrap(),
+            GitProvider::Github
+        );
+    }
+
+    #[test]
+    fn git_provider_rejects_unknown_value() {
+        // Replaces the legacy test_git_provider_unknown_value_treated_as_gitlab
+        // anti-pattern: strict parsing now surfaces typos instead of silently
+        // falling through to the default (CAB-2165 Bundle 1 / P2-9 GW-2).
+        let err = serde_json::from_str::<GitProvider>("\"bitbucket\"")
+            .expect_err("unknown variant should not deserialize");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unknown variant") && msg.contains("bitbucket"),
+            "error message should name the rejected variant; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn git_provider_rejects_typo_with_case_mismatch() {
+        // "GitHub" (mixed case) is not canonical and must be rejected —
+        // deployed YAML/env is all lowercase (verified pre-migration grep).
+        assert!(serde_json::from_str::<GitProvider>("\"GitHub\"").is_err());
+        assert!(serde_json::from_str::<GitProvider>("\"GITLAB\"").is_err());
+    }
+
+    #[test]
+    fn git_provider_default_is_gitlab() {
+        assert_eq!(GitProvider::default(), GitProvider::Gitlab);
+    }
+
+    #[test]
+    fn log_level_parses_all_standard_values() {
+        for (s, expected) in [
+            ("trace", LogLevel::Trace),
+            ("debug", LogLevel::Debug),
+            ("info", LogLevel::Info),
+            ("warn", LogLevel::Warn),
+            ("error", LogLevel::Error),
+        ] {
+            let parsed: LogLevel = serde_json::from_str(&format!("\"{s}\"")).unwrap();
+            assert_eq!(parsed, expected, "failed to parse {s}");
+        }
+    }
+
+    #[test]
+    fn log_level_rejects_uppercase() {
+        // No implicit case-folding alias (D.1 strict).
+        assert!(serde_json::from_str::<LogLevel>("\"WARN\"").is_err());
+    }
+
+    #[test]
+    fn log_format_rejects_unknown() {
+        assert!(serde_json::from_str::<LogFormat>("\"xml\"").is_err());
+    }
+
+    #[test]
+    fn environment_accepts_dev_staging_prod() {
+        assert_eq!(
+            serde_json::from_str::<Environment>("\"dev\"").unwrap(),
+            Environment::Dev
+        );
+        assert_eq!(
+            serde_json::from_str::<Environment>("\"staging\"").unwrap(),
+            Environment::Staging
+        );
+        assert_eq!(
+            serde_json::from_str::<Environment>("\"prod\"").unwrap(),
+            Environment::Prod
+        );
+    }
+
+    #[test]
+    fn environment_rejects_unknown() {
+        assert!(serde_json::from_str::<Environment>("\"mordor\"").is_err());
+        assert!(serde_json::from_str::<Environment>("\"production\"").is_err());
+    }
+
+    #[test]
+    fn shadow_capture_source_is_kebab_case() {
+        assert_eq!(
+            serde_json::from_str::<ShadowCaptureSource>("\"envoy-tap\"").unwrap(),
+            ShadowCaptureSource::EnvoyTap
+        );
+        assert_eq!(
+            serde_json::from_str::<ShadowCaptureSource>("\"port-mirror\"").unwrap(),
+            ShadowCaptureSource::PortMirror
+        );
+        // Snake-case form is NOT accepted (no implicit alias).
+        assert!(serde_json::from_str::<ShadowCaptureSource>("\"envoy_tap\"").is_err());
+    }
+
+    #[test]
+    fn supervision_tier_copilot_alias() {
+        // Canonical snake_case form.
+        assert_eq!(
+            serde_json::from_str::<SupervisionDefaultTier>("\"copilot\"").unwrap(),
+            SupervisionDefaultTier::Copilot
+        );
+        // Explicit alias from D.1 — parity with SupervisionTier::from_header.
+        assert_eq!(
+            serde_json::from_str::<SupervisionDefaultTier>("\"co-pilot\"").unwrap(),
+            SupervisionDefaultTier::Copilot
+        );
+    }
+
+    #[test]
+    fn supervision_tier_all_canonical_variants() {
+        assert_eq!(
+            serde_json::from_str::<SupervisionDefaultTier>("\"autopilot\"").unwrap(),
+            SupervisionDefaultTier::Autopilot
+        );
+        assert_eq!(
+            serde_json::from_str::<SupervisionDefaultTier>("\"command\"").unwrap(),
+            SupervisionDefaultTier::Command
+        );
+    }
+
+    #[test]
+    fn llm_proxy_provider_all_variants() {
+        for (s, expected) in [
+            ("anthropic", LlmProxyProvider::Anthropic),
+            ("mistral", LlmProxyProvider::Mistral),
+            ("openai", LlmProxyProvider::Openai),
+        ] {
+            let parsed: LlmProxyProvider = serde_json::from_str(&format!("\"{s}\"")).unwrap();
+            assert_eq!(parsed, expected, "failed to parse {s}");
+        }
+    }
+
+    #[test]
+    fn llm_proxy_provider_rejects_unknown() {
+        assert!(serde_json::from_str::<LlmProxyProvider>("\"google\"").is_err());
+    }
+
+    #[test]
+    fn git_provider_display_matches_serde() {
+        assert_eq!(GitProvider::Gitlab.to_string(), "gitlab");
+        assert_eq!(GitProvider::Github.to_string(), "github");
+    }
+
+    #[test]
+    fn environment_display_matches_serde() {
+        assert_eq!(Environment::Dev.to_string(), "dev");
+        assert_eq!(Environment::Staging.to_string(), "staging");
+        assert_eq!(Environment::Prod.to_string(), "prod");
+    }
+
+    #[test]
+    fn supervision_tier_display_matches_serde() {
+        assert_eq!(SupervisionDefaultTier::Autopilot.to_string(), "autopilot");
+        assert_eq!(SupervisionDefaultTier::Copilot.to_string(), "copilot");
+        assert_eq!(SupervisionDefaultTier::Command.to_string(), "command");
+    }
+}

--- a/stoa-gateway/src/config/loader.rs
+++ b/stoa-gateway/src/config/loader.rs
@@ -180,6 +180,20 @@ impl Config {
             tracing::warn!("No JWT_SECRET or KEYCLOAK_URL - auth will be limited");
         }
 
+        // CAB-2165 Bundle 2 / P2-11 GW-2 defense-in-depth: warn when a
+        // filesystem path field resolves outside canonical STOA prefixes
+        // (/etc/stoa, /var/stoa, /opt/stoa). Never rejects — operator keeps
+        // control; the warning surfaces typos and misconfigured mounts.
+        if let Some(ref p) = self.policy_path {
+            super::path_safety::warn_if_unsafe("policy_path", p);
+        }
+        if let Some(ref p) = self.ip_blocklist_file {
+            super::path_safety::warn_if_unsafe("ip_blocklist_file", p);
+        }
+        if let Some(ref p) = self.prompt_cache_watch_dir {
+            super::path_safety::warn_if_unsafe("prompt_cache_watch_dir", p);
+        }
+
         Ok(())
     }
 }

--- a/stoa-gateway/src/config/loader.rs
+++ b/stoa-gateway/src/config/loader.rs
@@ -237,6 +237,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::result_large_err)] // figment::Jail closure returns Result<(), figment::Error>
     fn test_load_with_defaults() {
         // Wrap in figment::Jail so this test takes the same global LOCK as
         // the enum env-var tests below (CAB-2165 Bundle 1). Without it, a
@@ -376,6 +377,7 @@ mod tests {
     // these tests don't race with others that `set_var`/`remove_var` globally.
 
     #[test]
+    #[allow(clippy::result_large_err)] // figment::Jail closure returns Result<(), figment::Error>
     fn env_var_sets_git_provider_to_github() {
         use figment::providers::{Env, Serialized};
         use figment::{Figment, Jail};
@@ -392,6 +394,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::result_large_err)] // figment::Jail closure returns Result<(), figment::Error>
     fn env_var_sets_environment_to_prod() {
         use figment::providers::{Env, Serialized};
         use figment::{Figment, Jail};
@@ -408,6 +411,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::result_large_err)] // figment::Jail closure returns Result<(), figment::Error>
     fn env_var_rejects_unknown_git_provider() {
         use figment::providers::{Env, Serialized};
         use figment::{Figment, Jail};

--- a/stoa-gateway/src/config/loader.rs
+++ b/stoa-gateway/src/config/loader.rs
@@ -238,10 +238,17 @@ mod tests {
 
     #[test]
     fn test_load_with_defaults() {
-        // This should work even without any config file or env vars
-        std::env::remove_var("STOA_PORT");
-        let config = Config::load().expect("Should load defaults");
-        assert_eq!(config.port, 8080);
+        // Wrap in figment::Jail so this test takes the same global LOCK as
+        // the enum env-var tests below (CAB-2165 Bundle 1). Without it, a
+        // parallel Jail test that sets `STOA_GIT_PROVIDER=bitbucket` can
+        // leak into this test's `Config::load()` call and trip the strict
+        // enum parser.
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            let config = Config::load().expect("Should load defaults");
+            assert_eq!(config.port, 8080);
+            Ok(())
+        });
     }
 
     #[test]

--- a/stoa-gateway/src/config/loader.rs
+++ b/stoa-gateway/src/config/loader.rs
@@ -363,4 +363,62 @@ mod tests {
         };
         config.validate().expect("positive finite must validate");
     }
+
+    // CAB-2165 Bundle 1: verify that env vars pick up the enum deserialization
+    // path too, not just YAML. `figment::Jail` provides a hermetic env scope so
+    // these tests don't race with others that `set_var`/`remove_var` globally.
+
+    #[test]
+    fn env_var_sets_git_provider_to_github() {
+        use figment::providers::{Env, Serialized};
+        use figment::{Figment, Jail};
+
+        Jail::expect_with(|jail| {
+            jail.set_env("STOA_GIT_PROVIDER", "github");
+            let figment = Figment::new()
+                .merge(Serialized::defaults(Config::default()))
+                .merge(Env::prefixed("STOA_").split("__"));
+            let cfg: Config = figment.extract()?;
+            assert_eq!(cfg.git_provider, super::super::GitProvider::Github);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn env_var_sets_environment_to_prod() {
+        use figment::providers::{Env, Serialized};
+        use figment::{Figment, Jail};
+
+        Jail::expect_with(|jail| {
+            jail.set_env("STOA_ENVIRONMENT", "prod");
+            let figment = Figment::new()
+                .merge(Serialized::defaults(Config::default()))
+                .merge(Env::prefixed("STOA_").split("__"));
+            let cfg: Config = figment.extract()?;
+            assert_eq!(cfg.environment, super::super::Environment::Prod);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn env_var_rejects_unknown_git_provider() {
+        use figment::providers::{Env, Serialized};
+        use figment::{Figment, Jail};
+
+        Jail::expect_with(|jail| {
+            jail.set_env("STOA_GIT_PROVIDER", "bitbucket");
+            let figment = Figment::new()
+                .merge(Serialized::defaults(Config::default()))
+                .merge(Env::prefixed("STOA_").split("__"));
+            let err = figment
+                .extract::<Config>()
+                .expect_err("unknown variant must not deserialize");
+            let msg = format!("{err:?}");
+            assert!(
+                msg.contains("unknown variant") || msg.contains("bitbucket"),
+                "error should surface the rejected value: {msg}"
+            );
+            Ok(())
+        });
+    }
 }

--- a/stoa-gateway/src/config/path_safety.rs
+++ b/stoa-gateway/src/config/path_safety.rs
@@ -1,0 +1,88 @@
+//! Defense-in-depth path warnings for filesystem-backed Config fields.
+//!
+//! `policy_path`, `ip_blocklist_file`, and `prompt_cache_watch_dir` each accept
+//! arbitrary filesystem paths today (CAB-2165 Bundle 2 / P2-11 GW-2). The
+//! operator who configures the pod already has access to the container FS, so
+//! path traversal is not an external attack vector — but a configuration typo
+//! pointing at `/tmp/blocklist.txt` or a secret mount outside
+//! `/etc/stoa/` / `/var/stoa/` / `/opt/stoa/` can silently degrade security
+//! posture.
+//!
+//! This module emits a `tracing::warn!` at startup when any of those fields
+//! resolves outside the canonical STOA prefixes. It never rejects — the
+//! operator keeps full control. Relative paths are trusted as explicit intent
+//! within the process working directory and produce no warning.
+//!
+//! The predicate [`is_path_outside_safe_prefixes`] is exposed as a
+//! `pub(crate)` pure function so regression guards assert on the boolean
+//! directly, without relying on `tracing` log capture.
+
+use std::path::Path;
+use tracing::warn;
+
+/// Absolute-path prefixes considered "safe" (no warning emitted).
+///
+/// Uses component-aware [`Path::starts_with`] so `/etc/stoa-malicious` does
+/// NOT match `/etc/stoa` (unlike a naive `str::starts_with`).
+const SAFE_PREFIXES: &[&str] = &["/etc/stoa", "/var/stoa", "/opt/stoa"];
+
+/// Returns `true` if `path` is an absolute path that does not begin with any
+/// [`SAFE_PREFIXES`] component.
+///
+/// Relative paths always return `false` (no warning) — they are treated as
+/// explicit operator intent within the process working directory.
+pub(crate) fn is_path_outside_safe_prefixes(path: &str) -> bool {
+    let p = Path::new(path);
+    if !p.is_absolute() {
+        return false;
+    }
+    !SAFE_PREFIXES
+        .iter()
+        .any(|prefix| p.starts_with(Path::new(prefix)))
+}
+
+/// Emit a defense-in-depth warning when `path` is outside canonical STOA
+/// prefixes. No-op for paths inside the safe set, relative paths, or when the
+/// operator has opted into a non-standard mount knowingly.
+pub(crate) fn warn_if_unsafe(field: &'static str, path: &str) {
+    if is_path_outside_safe_prefixes(path) {
+        warn!(
+            field = field,
+            path = path,
+            "config path outside canonical /etc/stoa/ — defense-in-depth warning (CAB-2165)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_path_outside_safe_prefixes;
+
+    #[test]
+    fn safe_prefix_is_not_flagged() {
+        assert!(!is_path_outside_safe_prefixes(
+            "/etc/stoa/policies/default.rego"
+        ));
+        assert!(!is_path_outside_safe_prefixes("/var/stoa/blocklist.txt"));
+        assert!(!is_path_outside_safe_prefixes("/opt/stoa/watch"));
+        // Exact-match at the prefix itself.
+        assert!(!is_path_outside_safe_prefixes("/etc/stoa"));
+    }
+
+    #[test]
+    fn unsafe_absolute_prefix_is_flagged() {
+        assert!(is_path_outside_safe_prefixes("/tmp/custom.rego"));
+        assert!(is_path_outside_safe_prefixes("/etc/passwd"));
+        // Sibling-prefix trap: /etc/stoa-malicious must NOT be treated as safe.
+        assert!(is_path_outside_safe_prefixes(
+            "/etc/stoa-malicious/foo.yaml"
+        ));
+    }
+
+    #[test]
+    fn relative_path_is_not_flagged() {
+        assert!(!is_path_outside_safe_prefixes("policies/default.rego"));
+        assert!(!is_path_outside_safe_prefixes("./data/watch"));
+        assert!(!is_path_outside_safe_prefixes("../custom.yaml"));
+    }
+}

--- a/stoa-gateway/src/config/tests.rs
+++ b/stoa-gateway/src/config/tests.rs
@@ -152,8 +152,8 @@ fn test_default_github_config() {
     assert!(config.github_catalog_repo.is_none());
     assert!(config.github_gitops_repo.is_none());
     assert!(config.github_webhook_secret.is_none());
-    // git_provider defaults to "gitlab" for backward compatibility
-    assert_eq!(config.git_provider, "gitlab");
+    // git_provider defaults to GitProvider::Gitlab for backward compatibility
+    assert_eq!(config.git_provider, super::GitProvider::Gitlab);
     // GitLab fields are unaffected
     assert!(config.gitlab_url.is_none());
     assert!(config.gitlab_token.is_none());
@@ -163,7 +163,7 @@ fn test_default_github_config() {
 fn test_git_provider_github_config_complete() {
     // Verify that a fully-configured GitHub setup has all expected fields
     let config = Config {
-        git_provider: "github".into(),
+        git_provider: super::GitProvider::Github,
         github_token: Some("ghp_test123".into()),
         github_org: Some("stoa-platform".into()),
         github_catalog_repo: Some("stoa".into()),
@@ -171,7 +171,7 @@ fn test_git_provider_github_config_complete() {
         github_webhook_secret: Some("whsec_test".into()),
         ..Config::default()
     };
-    assert_eq!(config.git_provider, "github");
+    assert_eq!(config.git_provider, super::GitProvider::Github);
     assert_eq!(config.github_token.as_deref(), Some("ghp_test123"));
     assert_eq!(config.github_org.as_deref(), Some("stoa-platform"));
     assert_eq!(config.github_catalog_repo.as_deref(), Some("stoa"));
@@ -183,7 +183,7 @@ fn test_git_provider_github_config_complete() {
 fn test_git_provider_gitlab_and_github_coexist() {
     // During migration, both provider configs can coexist
     let config = Config {
-        git_provider: "github".into(),
+        git_provider: super::GitProvider::Github,
         github_token: Some("ghp_tok".into()),
         github_org: Some("acme".into()),
         gitlab_url: Some("https://gitlab.example.com".into()),
@@ -192,21 +192,17 @@ fn test_git_provider_gitlab_and_github_coexist() {
         ..Config::default()
     };
     // git_provider selects github even though gitlab fields are present
-    assert_eq!(config.git_provider, "github");
+    assert_eq!(config.git_provider, super::GitProvider::Github);
     // GitLab fields remain accessible (for shadow mode fallback)
     assert!(config.gitlab_token.is_some());
 }
 
-#[test]
-fn test_git_provider_unknown_value_treated_as_gitlab() {
-    // Any value other than "github" falls through to gitlab
-    let config = Config {
-        git_provider: "bitbucket".into(),
-        ..Config::default()
-    };
-    // GitProvider::from_config would treat this as GitLab (the catch-all)
-    assert_ne!(config.git_provider, "github");
-}
+// CAB-2165 Bundle 1 / P2-9 GW-2: the legacy
+// `test_git_provider_unknown_value_treated_as_gitlab` test locked in the
+// silent-fallthrough anti-pattern. It was replaced by strict-parse coverage
+// in `config::enums::tests::git_provider_rejects_unknown_value` — unknown
+// YAML/env values now surface as a clear deserialize error at Config::load()
+// time instead of decaying to the Gitlab default.
 
 /// Serialized snapshot of `Config::default()`. Drift of any default or field
 /// order will show up as a diff in the .snap file during `cargo insta review`.

--- a/stoa-gateway/src/control_plane/registration.rs
+++ b/stoa-gateway/src/control_plane/registration.rs
@@ -167,7 +167,7 @@ impl GatewayRegistrar {
             hostname: hostname.clone(),
             mode: mode.clone(),
             version: env!("CARGO_PKG_VERSION").to_string(),
-            environment: config.environment.clone(),
+            environment: config.environment.to_string(),
             capabilities,
             admin_url: config
                 .advertise_url

--- a/stoa-gateway/src/git/mod.rs
+++ b/stoa-gateway/src/git/mod.rs
@@ -56,11 +56,11 @@ pub enum GitProvider {
 impl GitProvider {
     /// Build a provider from gateway config.
     ///
-    /// `config.git_provider == "github"` → `GitProvider::GitHub`.
-    /// Any other value (including the `"gitlab"` default) → `GitProvider::GitLab`.
+    /// `config.git_provider == GitProvider::Github` → `GitProvider::GitHub`.
+    /// `config.git_provider == GitProvider::Gitlab` → `GitProvider::GitLab`.
     pub fn from_config(config: &Config) -> Result<Self, GitProviderError> {
-        match config.git_provider.as_str() {
-            "github" => {
+        match config.git_provider {
+            crate::config::GitProvider::Github => {
                 let token = config
                     .github_token
                     .as_deref()
@@ -72,7 +72,7 @@ impl GitProvider {
                 let client = GitHubClient::new(token, org)?;
                 Ok(GitProvider::GitHub(client))
             }
-            _ => {
+            crate::config::GitProvider::Gitlab => {
                 let api_url = config
                     .gitlab_url
                     .clone()
@@ -146,7 +146,7 @@ mod tests {
 
     fn github_config(token: Option<&str>, org: Option<&str>) -> Config {
         Config {
-            git_provider: "github".into(),
+            git_provider: crate::config::GitProvider::Github,
             github_token: token.map(|s| s.to_string()),
             github_org: org.map(|s| s.to_string()),
             ..Default::default()
@@ -207,39 +207,13 @@ mod tests {
         assert!(!gl.is_github());
     }
 
-    #[test]
-    fn test_from_config_unknown_provider_falls_back_to_gitlab() {
-        let config = Config {
-            git_provider: "bitbucket".into(),
-            ..Config::default()
-        };
-        let provider = GitProvider::from_config(&config).unwrap();
-        assert!(provider.is_gitlab());
-    }
-
-    #[test]
-    fn test_from_config_empty_provider_falls_back_to_gitlab() {
-        let config = Config {
-            git_provider: String::new(),
-            ..Config::default()
-        };
-        let provider = GitProvider::from_config(&config).unwrap();
-        assert!(provider.is_gitlab());
-    }
-
-    #[test]
-    fn test_from_config_github_case_sensitive() {
-        // "GitHub" (capitalized) should NOT match — only "github" is valid
-        let config = Config {
-            git_provider: "GitHub".into(),
-            github_token: Some("tok".into()),
-            github_org: Some("org".into()),
-            ..Config::default()
-        };
-        let provider = GitProvider::from_config(&config).unwrap();
-        // Falls through to GitLab because match is case-sensitive
-        assert!(provider.is_gitlab());
-    }
+    // NOTE: the legacy silent-fallthrough tests
+    // (test_from_config_unknown_provider_falls_back_to_gitlab,
+    //  test_from_config_empty_provider_falls_back_to_gitlab,
+    //  test_from_config_github_case_sensitive) were removed in CAB-2165
+    // Bundle 1. The String→GitProvider enum migration makes invalid values
+    // unrepresentable at the type level; strict-parse coverage lives in
+    // `config::enums::tests::git_provider_rejects_unknown_value`.
 
     #[test]
     fn test_provider_error_display() {

--- a/stoa-gateway/src/handlers/admin/health.rs
+++ b/stoa-gateway/src/handlers/admin/health.rs
@@ -37,7 +37,7 @@ pub async fn admin_health(State(state): State<AppState>) -> Json<AdminHealthResp
         contracts_count: state.contract_registry.count(),
         skills_count: state.skill_resolver.skill_count(),
         uptime_seconds: state.start_time.elapsed().as_secs(),
-        git_provider: state.config.git_provider.clone(),
+        git_provider: state.config.git_provider.to_string(),
     })
 }
 
@@ -116,7 +116,7 @@ mod tests {
     async fn test_admin_health_reports_github_provider() {
         let config = Config {
             admin_api_token: Some("secret".into()),
-            git_provider: "github".into(),
+            git_provider: crate::config::GitProvider::Github,
             ..Config::default()
         };
         let state = AppState::new(config);

--- a/stoa-gateway/src/supervision/mod.rs
+++ b/stoa-gateway/src/supervision/mod.rs
@@ -57,9 +57,16 @@ impl SupervisionTier {
         }
     }
 
-    /// Parse from the config default tier string.
-    pub fn from_config_default(value: &str) -> Self {
-        Self::from_header(value).unwrap_or(Self::Autopilot)
+    /// Map the typed config default (`SupervisionDefaultTier`) to the runtime
+    /// `SupervisionTier`. 1:1 mapping — strict parsing at `Config::load()`
+    /// already rejected anything outside the documented set.
+    pub fn from_config_default(value: crate::config::SupervisionDefaultTier) -> Self {
+        use crate::config::SupervisionDefaultTier as C;
+        match value {
+            C::Autopilot => Self::Autopilot,
+            C::Copilot => Self::CoPilot,
+            C::Command => Self::Command,
+        }
     }
 }
 
@@ -125,7 +132,7 @@ pub async fn supervision_middleware(
         .and_then(|v| v.to_str().ok())
         .and_then(SupervisionTier::from_header)
         .unwrap_or_else(|| {
-            SupervisionTier::from_config_default(&state.config.supervision_default_tier)
+            SupervisionTier::from_config_default(state.config.supervision_default_tier)
         });
 
     let method = request.method().clone();
@@ -242,17 +249,20 @@ mod tests {
     fn create_test_state(enabled: bool) -> AppState {
         let config = Config {
             supervision_enabled: enabled,
-            supervision_default_tier: "autopilot".to_string(),
+            supervision_default_tier: crate::config::SupervisionDefaultTier::Autopilot,
             supervision_webhook_url: None,
             ..Config::default()
         };
         AppState::new(config)
     }
 
-    fn create_test_state_with_tier(enabled: bool, default_tier: &str) -> AppState {
+    fn create_test_state_with_tier(
+        enabled: bool,
+        default_tier: crate::config::SupervisionDefaultTier,
+    ) -> AppState {
         let config = Config {
             supervision_enabled: enabled,
-            supervision_default_tier: default_tier.to_string(),
+            supervision_default_tier: default_tier,
             supervision_webhook_url: None,
             ..Config::default()
         };
@@ -319,10 +329,22 @@ mod tests {
     }
 
     #[test]
-    fn test_tier_from_config_default_fallback() {
+    fn test_tier_from_config_default_maps_all_variants() {
+        // CAB-2165 Bundle 1: input is now a typed enum, so invalid strings
+        // cannot reach this function — strict parsing rejects them at
+        // Config::load() time. Verify the 1:1 mapping instead.
+        use crate::config::SupervisionDefaultTier as C;
         assert_eq!(
-            SupervisionTier::from_config_default("invalid"),
+            SupervisionTier::from_config_default(C::Autopilot),
             SupervisionTier::Autopilot
+        );
+        assert_eq!(
+            SupervisionTier::from_config_default(C::Copilot),
+            SupervisionTier::CoPilot
+        );
+        assert_eq!(
+            SupervisionTier::from_config_default(C::Command),
+            SupervisionTier::Command
         );
     }
 
@@ -509,7 +531,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_no_header_with_command_default_blocks_post() {
-        let state = create_test_state_with_tier(true, "command");
+        let state =
+            create_test_state_with_tier(true, crate::config::SupervisionDefaultTier::Command);
         let router = build_test_router(state);
 
         // POST without header, but default_tier = command → blocked
@@ -525,7 +548,8 @@ mod tests {
     #[tokio::test]
     async fn test_header_overrides_default_tier() {
         // Default is command, but header says autopilot → should pass
-        let state = create_test_state_with_tier(true, "command");
+        let state =
+            create_test_state_with_tier(true, crate::config::SupervisionDefaultTier::Command);
         let router = build_test_router(state);
 
         let request = Request::builder()

--- a/stoa-gateway/tests/config_regression_guards.rs
+++ b/stoa-gateway/tests/config_regression_guards.rs
@@ -260,7 +260,7 @@ fn test_fixture_minimal_parses() {
     let cfg: Config = serde_yaml::from_str(&raw).expect("parse minimal fixture");
     assert_eq!(cfg.port, 9090);
     assert_eq!(cfg.host, "127.0.0.1");
-    assert_eq!(cfg.log_level.as_deref(), Some("debug"));
+    assert_eq!(cfg.log_level, Some(stoa_gateway::config::LogLevel::Debug));
     // Unset fields keep their Config::default() value.
     assert!(cfg.rate_limit_default.is_some(), "default propagates");
 }


### PR DESCRIPTION
## Summary

Closes CAB-2165 — the GW-3 cleanup ticket that absorbed 3 items deferred during the GW-2 bug hunt. 5 commits on top of `main`, 15 files touched, all in `stoa-gateway/`.

- **Bundle 1 — String → enum migration** (P2-9 GW-2). 7 Config fields (`git_provider`, `log_level`, `log_format`, `environment`, `shadow_capture_source`, `supervision_default_tier`, `llm_proxy_provider`) moved from `String` to typed enums with strict parsing. Unknown values now fail `Config::load()` with a clear `unknown variant` error instead of silently falling through to a default.
- **Bundle 2 — Path safety warning** (P2-11 GW-2). New `src/config/path_safety.rs` emits `tracing::warn!` at startup when `policy_path` / `ip_blocklist_file` / `prompt_cache_watch_dir` resolve outside canonical `/etc/stoa`, `/var/stoa`, `/opt/stoa`. Uses `Path::starts_with` (component-aware, so `/etc/stoa-malicious` is NOT treated as safe). Defense-in-depth only — never rejects startup.
- **Bundle 3 — DpopConfig doc alignment**. Completes GW-2 P0-1: per-field `/// Env: STOA_DPOP__<FIELD>` doc comments on all 6 `DpopConfig` fields (which live in `src/auth/dpop.rs`, outside the `src/config/` scope of the P0-1 pass).

## Commits

| SHA | Type | Scope |
|-----|------|-------|
| `c48664768` | `docs` | DpopConfig env-var doc alignment + FIX-PLAN |
| `6e0d0969e` | `feat` | Path safety warnings |
| `c40d15e18` | `refactor` | 7-field String→enum migration |
| `195a98d6f` | `test` | `test_load_with_defaults` wrapped in `figment::Jail` (race fix) |
| `eb6fb4c87` | `docs` | Mark GW-2 P2-9/P2-11 FIXED in `BUG-REPORT-GW-2.md` |

## Arbitrages (documented in `stoa-gateway/FIX-PLAN-CAB-2165.md`)

- **D.1 strict parsing** across all 7 enums. No implicit aliases — one explicit exception: `co-pilot → Copilot` on `SupervisionDefaultTier` for parity with `SupervisionTier::from_header`.
- **D.2 Option C (warn-only)** for path safety. No hard allow-list that could break existing `/tmp/*.yaml` mounts.
- **D.3 DpopConfig docs in scope**. Grep confirmed 6 fields with zero env-var documentation; sister structs (MtlsConfig / SenderConstraintConfig / LlmRouterConfig / ApiProxyConfig) were all documented by GW-2.

## Breaking semantic

Unknown Config values that previously silently fell through now fail `Config::load()`:
- `git_provider: "bitbucket"` → before: treated as `gitlab`; after: `unknown variant "bitbucket"` error.
- `log_level: "WARN"` (uppercase) → before: accepted but ignored by tracing; after: rejected.
- `environment: "production"` → before: accepted and passed to CP; after: rejected (canonical is `"prod"`).

Pre-migration grep confirmed no deployed YAML / chart values / env fixtures use non-canonical casing. `charts/`, `deploy/`, `k8s/`, `tests/fixtures/` all use lowercase canonical forms.

Legacy `test_git_provider_unknown_value_treated_as_gitlab` removed — it encoded the silent-fallthrough anti-pattern. Replaced by strict `git_provider_rejects_unknown_value` in the new `config::enums::tests` module.

## Wire format preserved

- `AdminHealthResponse.git_provider: String` — payload unchanged. Uses `config.git_provider.to_string()` at the boundary.
- `RegistrationPayload.environment: String` — same pattern.
- Insta snapshot `snapshot_default_config.snap` unchanged — enum `Serialize` with `#[serde(rename_all = "snake_case")]` emits the exact same JSON strings as before. **No consumer-visible drift.**

## Test plan

- [x] `cargo check --tests` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` → 2462 tests pass (2292 lib + 170 integration + 0 doc)
- [x] `snapshot_default_config` — no drift
- [x] `regression_fixture_production_parses_and_validates` — production YAML still parses + validates
- [x] 17 new `config::enums::tests` covering canonical parsing, unknown-value rejection, case sensitivity, `co-pilot` alias, Display parity
- [x] 3 new `figment::Jail` env-var tests verifying `STOA_GIT_PROVIDER=github` + `STOA_ENVIRONMENT=prod` round-trip and `STOA_GIT_PROVIDER=bitbucket` is rejected
- [x] 3 new `path_safety::tests` covering safe prefix, unsafe prefix (incl. `/etc/stoa-malicious` sibling-prefix trap), relative paths

## Note on the figment `test` dev-dependency feature

Added `features = ["test"]` to the `figment` line in `[dev-dependencies]` so `figment::Jail` is accessible in tests. `Jail` holds a global `parking_lot::Mutex` serializing env-mutating tests. This required wrapping the pre-existing `test_load_with_defaults` in `Jail::expect_with` + `clear_env()` so it takes the same LOCK — otherwise parallel execution could leak `STOA_GIT_PROVIDER=bitbucket` from the strict-parse-rejection test into the defaults test. Surfaced in commit `195a98d6f`.

## Out of scope

- Deleting dead-code fields `log_level` / `log_format` / `llm_proxy_provider` / `shadow_capture_source` (0 in-tree consumers; tracing is driven by `RUST_LOG`). Separate cleanup if desired.
- Hard allow-list via `STOA_CONFIG_ALLOWED_PATHS` (P2-11 Option A). Revisit if Option C warnings accumulate in prod.
- P3-13 / P3-14 (backlog per GW-2).

Linear: CAB-2165
Refs: P2-9 GW-2, P2-11 GW-2, P0-1 GW-2 (completion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)