### PR TITLE
chore(demo): add mock backend for smoke

### DIFF
--- a/deploy/docker-compose/config/mock-backend/nginx.conf
+++ b/deploy/docker-compose/config/mock-backend/nginx.conf
@@ -1,0 +1,26 @@
+server {
+    listen 9090;
+    server_name _;
+
+    add_header X-Stoa-Mock-Backend "demo-smoke" always;
+
+    location = /health {
+        default_type application/json;
+        return 200 '{"status":"healthy","ok":true,"service":"mock-backend"}';
+    }
+
+    location = /ping {
+        default_type application/json;
+        return 200 '{"ok":true,"path":"/ping","service":"mock-backend"}';
+    }
+
+    location = /get {
+        default_type application/json;
+        return 200 '{"ok":true,"path":"/get","service":"mock-backend"}';
+    }
+
+    location / {
+        default_type application/json;
+        return 200 '{"ok":true,"path":"$request_uri","service":"mock-backend"}';
+    }
+}

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -24,6 +24,7 @@
 #   --profile federation:      + openldap (1389) + federation-gateway (9000)
 #   --profile monitoring-oidc: + oauth2-proxy (4180) — requires OIDC setup
 #   --profile seed:            + stoa-seeder (one-shot, SEED_PROFILE=dev|staging|prod)
+#   --profile demo:            + mock-backend (9090) for demo smoke tests
 #
 # Total RAM: ~3.3GB base (+ ~256MB with federation profile)
 # =============================================================================
@@ -495,6 +496,28 @@ services:
       interval: 10s
       timeout: 3s
       retries: 3
+    restart: unless-stopped
+
+  # ==========================================================================
+  # Demo Mock Backend — stable target for demo smoke AT-0/AT-4
+  # ==========================================================================
+  mock-backend:
+    image: nginx:1.25-alpine
+    container_name: stoa-mock-backend
+    profiles:
+      - demo
+    ports:
+      - "${PORT_MOCK_BACKEND:-9090}:9090"
+    volumes:
+      - ./config/mock-backend/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    networks:
+      - stoa-network
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:9090/ping || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
     restart: unless-stopped
 
   # ==========================================================================

--- a/scripts/demo-smoke-test.sh
+++ b/scripts/demo-smoke-test.sh
@@ -15,6 +15,7 @@
 #   API_URL              http://localhost:8000
 #   GATEWAY_URL          http://localhost:8080
 #   MOCK_BACKEND_URL     http://localhost:9090
+#   MOCK_BACKEND_UPSTREAM_URL http://mock-backend:9090
 #   TENANT_ID            demo
 #   GATEWAY_ID           gateway-demo
 #   DEMO_ADMIN_TOKEN     (empty → bypass via ?demo-admin header if cp-api allows)
@@ -45,6 +46,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 API_URL="${API_URL:-http://localhost:8000}"
 GATEWAY_URL="${GATEWAY_URL:-http://localhost:8080}"
 MOCK_BACKEND_URL="${MOCK_BACKEND_URL:-http://localhost:9090}"
+MOCK_BACKEND_UPSTREAM_URL="${MOCK_BACKEND_UPSTREAM_URL:-http://mock-backend:9090}"
 TENANT_ID="${TENANT_ID:-demo}"
 GATEWAY_ID="${GATEWAY_ID:-gateway-demo}"
 DEMO_ADMIN_TOKEN="${DEMO_ADMIN_TOKEN:-}"
@@ -186,12 +188,9 @@ at0_preconditions() {
     fi
 
     # mock backend
-    code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "${MOCK_BACKEND_URL}/" 2>/dev/null || echo 000)"
-    if [[ "$code" != "200" && "$code" != "404" ]]; then
-        # httpbin returns 404 on / but 200 on /get; accept non-000
-        if [[ "$code" == "000" ]]; then
-            ok=0; detail="${detail}mock=unreachable "
-        fi
+    code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "${MOCK_BACKEND_URL}/ping" 2>/dev/null || echo 000)"
+    if [[ "$code" != "200" ]]; then
+        ok=0; detail="${detail}mock=${code} "
     fi
 
     if [[ "$ok" == "1" ]]; then
@@ -219,7 +218,7 @@ at1_declare_api() {
   "name": "${DEMO_API_NAME}",
   "version": "1.0.0",
   "protocol": "http",
-  "backend_url": "${MOCK_BACKEND_URL}",
+  "backend_url": "${MOCK_BACKEND_UPSTREAM_URL}",
   "paths": [{"path": "/get", "methods": ["GET"]}]
 }
 JSON

--- a/specs/demo-readiness-report.md
+++ b/specs/demo-readiness-report.md
@@ -76,8 +76,15 @@ Le fichier `subscriptions.py` génère `new_api_key, new_api_key_hash, new_api_k
 
 Solution démo-first : retourner cleartext **une seule fois** dans la réponse de `POST /subscriptions` quand `X-Demo-Mode: true` (feature flag démo) ou via endpoint dédié `POST /subscriptions/{id}/reveal-key` (one-shot, jetable).
 
-### 3.4 Mock backend manquant dans la stack démo
-`MOCK_BACKEND_URL=http://localhost:9090` n'est pas garanti présent dans docker-compose.yml. Solution : ajouter un service `mock-backend: image: kennethreitz/httpbin:latest` dans un `docker-compose.demo.yml` dédié.
+### 3.4 Mock backend stable dans la stack démo
+`MOCK_BACKEND_URL=http://localhost:9090` est fourni par le service compose
+`mock-backend`, qui expose `/ping` et `/get` en JSON stable avec `ok:true`.
+Le smoke sépare cette URL de probe locale de `MOCK_BACKEND_UPSTREAM_URL`,
+qui vaut `http://mock-backend:9090` en compose pour que la gateway ne cible
+pas `localhost` depuis son propre conteneur.
+Ce point ferme B2 pour AT-0. AT-4 peut maintenant cibler un backend local
+déterministe dès que B3 expose le mapping gateway et B1 fournit une clé
+exploitable.
 
 ### 3.5 Chemin proxy gateway pas exposé via cp-api
 La création d'API dans cp-api ne semble pas retourner l'URL gateway où elle est joignable (à confirmer — le champ `gateway_route_url` n'apparaît pas dans les routes vues). Gap : le client démo doit pouvoir lire "mon API est à `{GATEWAY_URL}/proxy/<slug>`".
@@ -93,7 +100,7 @@ Polling 30s par défaut dans stoa-connect → AT-2 peut timeout. Mitigation dans
 | # | Blocker | Sévérité | Étape impactée | Owner suggéré |
 |---|---------|----------|----------------|---------------|
 | B1 | Pas d'accès cleartext à `api_key` après création subscription | P0 | AT-3 → AT-4 | cp-api (1 PR) |
-| B2 | Mock backend non seedé dans docker-compose | P0 | AT-0, AT-4 | deploy (1 PR) |
+| B2 | Mock backend non seedé dans docker-compose | P0 | AT-0, AT-4 | **DONE** — `mock-backend` compose |
 | B3 | Mapping `api_name → proxy path` flou côté gateway | P0 | AT-4 | gateway (spec ADR si inconnu) |
 | B4 | Auth dev-bypass cp-api non documenté | P1 | AT-1, AT-2, AT-3 | cp-api (flag `.env.demo`) |
 | B5 | Seed profile `demo-smoke` minimal absent | P1 | AT-0 | cp-api/scripts/seeder |
@@ -110,7 +117,7 @@ Pour débloquer rapidement la validation du contrat sans confondre script OK et 
 |---------------|-------|-------|--------|
 | `./scripts/demo-smoke-test.sh --dry-run-contract` | Tous | permanent | Valide le contrat/script, verdict `CONTRACT_DRY_RUN`, jamais `DEMO READY` |
 | `MOCK_MODE=all ./scripts/demo-smoke-test.sh` | B1/B2/B3 | jusqu'aux fixes | Valide le chemin mocké, verdict `MOCK_PASS`, jamais `DEMO READY` |
-| Démarrer `mock-backend` en shell séparé (`docker run kennethreitz/httpbin`) | B2 | 1 jour | `make` targets absents |
+| Démarrer `mock-backend` via compose seul (`docker compose ... up -d mock-backend`) | B2 | jusqu'à stack complète | Service sous profil `demo`; ne pas exposer Prometheus sur le même port pendant ce smoke |
 | Probe 4 shapes proxy dans le script, 1 seul doit répondre 200 | B3 | 1 semaine | Fragile, réduit la confiance |
 | `DEMO_ADMIN_TOKEN` extrait via `stoactl auth login demo-admin` puis injecté | B4 | 1 jour | Couplage Keycloak |
 | Script seed inline dans `demo-smoke-test.sh` qui crée tenant + gateway si absent | B5 | 1 jour | Pas idempotent si collisions |

--- a/specs/validation-commands.md
+++ b/specs/validation-commands.md
@@ -30,7 +30,8 @@ Variables d'environnement (defaults documentés dans le script) :
 |-----|---------|-------------|
 | `API_URL` | `http://localhost:8000` | Base URL cp-api |
 | `GATEWAY_URL` | `http://localhost:8080` | Base URL stoa-gateway |
-| `MOCK_BACKEND_URL` | `http://localhost:9090` | Mock HTTP backend |
+| `MOCK_BACKEND_URL` | `http://localhost:9090` | Mock HTTP backend vu par le poste dev pour AT-0 |
+| `MOCK_BACKEND_UPSTREAM_URL` | `http://mock-backend:9090` | Mock HTTP backend vu par la gateway en compose |
 | `TENANT_ID` | `demo` (slug, résolu en UUID par cp-api) | Tenant démo |
 | `DEMO_ADMIN_TOKEN` | vide | JWT admin pour écrire côté cp-api. Si vide, le script passe en `STOA_DISABLE_AUTH=true` mode (dev only) |
 | `ROUTE_SYNC_GRACE_SECS` | `30` | Délai d'attente pour route visible en gateway après AT-2 |
@@ -63,8 +64,9 @@ make run-api             # cp-api sur :8000
 # Terminal 2
 make run-gateway         # stoa-gateway sur :8080
 
-# Terminal 3 (backend mock)
-docker run --rm -p 9090:80 kennethreitz/httpbin
+# Terminal 3 (backend mock only, if compose is not used)
+docker compose -f deploy/docker-compose/docker-compose.yml up -d mock-backend
+export MOCK_BACKEND_UPSTREAM_URL=http://localhost:9090
 ```
 
 ## 3. Lint (pré-conditions PR démo-ready)


### PR DESCRIPTION
## Summary
- Add a compose `mock-backend` service under the `demo` profile with stable `/ping` and `/get` JSON responses.
- Make AT-0 probe `/ping` instead of accepting ambiguous httpbin root behavior.
- Split local probe URL (`MOCK_BACKEND_URL`) from gateway upstream URL (`MOCK_BACKEND_UPSTREAM_URL`) so compose routes target `http://mock-backend:9090`.
- Update demo docs/readiness to mark B2 closed while leaving B3/B1 as the next blockers.

## Validation
- `git diff --check`
- `bash -n scripts/demo-smoke-test.sh`
- `docker compose -f deploy/docker-compose/docker-compose.yml config mock-backend`
- `docker compose -f deploy/docker-compose/docker-compose.yml up -d mock-backend`
- `curl -sS http://127.0.0.1:9090/ping` => `{"ok":true,...}`
- `curl -sS http://127.0.0.1:9090/get` => `{"ok":true,...}`
- `./scripts/demo-smoke-test.sh --no-observability-ui` => `FAIL — DEMO NOT READY`, now only cp-api/gateway are reported in AT-0; mock backend is no longer the blocker.

## Demo impact
B2 only. This PR makes AT-0/AT-4 able to find a stable local backend. It does not solve B3 route mapping or B1 demo API key cleartext.
