### PR TITLE
chore(demo): recover demo-first smoke stack

### DIFF
--- a/deploy/docker-compose/config/grafana/provisioning/datasources/datasources.yml
+++ b/deploy/docker-compose/config/grafana/provisioning/datasources/datasources.yml
@@ -54,3 +54,44 @@ datasources:
       basicAuthPassword: "${OPENSEARCH_PASSWORD:-admin}"
     basicAuth: true
     basicAuthUser: "${OPENSEARCH_USER:-admin}"
+
+  # ---------------------------------------------------------------------------
+  # OpenSearch - OTEL Traces
+  # ---------------------------------------------------------------------------
+  - name: OpenSearch Traces
+    type: grafana-opensearch-datasource
+    uid: opensearch-traces
+    access: proxy
+    url: https://opensearch:9200
+    editable: false
+    jsonData:
+      database: "otel-v1-apm-span-*"
+      flavor: opensearch
+      version: "2.11.0"
+      pplEnabled: true
+      timeField: "@timestamp"
+      tlsSkipVerify: true
+      logMessageField: name
+      logLevelField: status.code
+    secureJsonData:
+      basicAuthPassword: "${OPENSEARCH_PASSWORD:-admin}"
+    basicAuth: true
+    basicAuthUser: "${OPENSEARCH_USER:-admin}"
+
+  # ---------------------------------------------------------------------------
+  # Tempo - Distributed Traces
+  # ---------------------------------------------------------------------------
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      httpMethod: GET
+      serviceMap:
+        datasourceUid: prometheus
+      tracesToLogsV2:
+        datasourceUid: loki
+        filterByTraceID: true
+        filterBySpanID: false

--- a/deploy/docker-compose/config/mock-backend/nginx.conf
+++ b/deploy/docker-compose/config/mock-backend/nginx.conf
@@ -1,0 +1,26 @@
+server {
+    listen 9090;
+    server_name _;
+
+    add_header X-Stoa-Mock-Backend "demo-smoke" always;
+
+    location = /health {
+        default_type application/json;
+        return 200 '{"status":"healthy","ok":true,"service":"mock-backend"}';
+    }
+
+    location = /ping {
+        default_type application/json;
+        return 200 '{"ok":true,"path":"/ping","service":"mock-backend"}';
+    }
+
+    location = /get {
+        default_type application/json;
+        return 200 '{"ok":true,"path":"/get","service":"mock-backend"}';
+    }
+
+    location / {
+        default_type application/json;
+        return 200 '{"ok":true,"path":"$request_uri","service":"mock-backend"}';
+    }
+}

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -24,6 +24,7 @@
 #   --profile federation:      + openldap (1389) + federation-gateway (9000)
 #   --profile monitoring-oidc: + oauth2-proxy (4180) — requires OIDC setup
 #   --profile seed:            + stoa-seeder (one-shot, SEED_PROFILE=dev|staging|prod)
+#   --profile demo:            + mock-backend (9090) for demo smoke tests
 #
 # Total RAM: ~3.3GB base (+ ~256MB with federation profile)
 # =============================================================================
@@ -495,6 +496,28 @@ services:
       interval: 10s
       timeout: 3s
       retries: 3
+    restart: unless-stopped
+
+  # ==========================================================================
+  # Demo Mock Backend — stable target for demo smoke AT-0/AT-4
+  # ==========================================================================
+  mock-backend:
+    image: nginx:1.25-alpine
+    container_name: stoa-mock-backend
+    profiles:
+      - demo
+    ports:
+      - "${PORT_MOCK_BACKEND:-9090}:9090"
+    volumes:
+      - ./config/mock-backend/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    networks:
+      - stoa-network
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:9090/ping || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
     restart: unless-stopped
 
   # ==========================================================================

--- a/scripts/demo-smoke-test.sh
+++ b/scripts/demo-smoke-test.sh
@@ -1,0 +1,634 @@
+#!/usr/bin/env bash
+# =============================================================================
+# STOA Demo Smoke Test — contrat minimal exécutable
+# =============================================================================
+# Canonical source: specs/demo-scope.md + specs/demo-acceptance-tests.md
+#
+# Usage:
+#   ./scripts/demo-smoke-test.sh                      # verbose summary
+#   ./scripts/demo-smoke-test.sh --quiet              # only exit code + 1-line verdict
+#   ./scripts/demo-smoke-test.sh --dry-run-contract   # validate script/spec flow without a live stack
+#   MOCK_MODE=all ./scripts/demo-smoke-test.sh        # run explicit mocks; verdict MOCK_PASS, not DEMO READY
+#   AT=1,2,3 ./scripts/demo-smoke-test.sh             # run subset of AT steps
+#
+# Env vars (with defaults):
+#   API_URL              http://localhost:8000
+#   GATEWAY_URL          http://localhost:8080
+#   MOCK_BACKEND_URL     http://localhost:9090
+#   MOCK_BACKEND_UPSTREAM_URL http://mock-backend:9090
+#   DEMO_GATEWAY_PATH    /apis/${DEMO_API_NAME}/get
+#   TENANT_ID            demo
+#   GATEWAY_ID           gateway-demo
+#   DEMO_ADMIN_TOKEN     (empty → bypass via ?demo-admin header if cp-api allows)
+#   ROUTE_SYNC_GRACE_SECS 30
+#   DEMO_API_NAME        demo-api-smoke
+#   DEMO_APP_NAME        demo-app-smoke
+#   OBS_VISIBILITY_CHECK auto (auto | off)
+#   GRAFANA_URL          http://localhost:3001
+#   GRAFANA_USER         admin
+#   GRAFANA_PASSWORD     admin
+#   CONSOLE_URL          http://localhost:3000
+#   PORTAL_URL           http://localhost:3002
+#
+# Exit codes:
+#   0 — REAL_PASS, CONTRACT_DRY_RUN, or MOCK_PASS (see verdict label)
+#   1 — at least one AT FAIL (demo NOT ready)
+#   2 — pre-conditions failed (cannot run)
+#
+# =============================================================================
+
+set -uo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Config ───────────────────────────────────────────────────────────────────
+API_URL="${API_URL:-http://localhost:8000}"
+GATEWAY_URL="${GATEWAY_URL:-http://localhost:8080}"
+MOCK_BACKEND_URL="${MOCK_BACKEND_URL:-http://localhost:9090}"
+MOCK_BACKEND_UPSTREAM_URL="${MOCK_BACKEND_UPSTREAM_URL:-http://mock-backend:9090}"
+TENANT_ID="${TENANT_ID:-demo}"
+GATEWAY_ID="${GATEWAY_ID:-gateway-demo}"
+DEMO_ADMIN_TOKEN="${DEMO_ADMIN_TOKEN:-}"
+ROUTE_SYNC_GRACE_SECS="${ROUTE_SYNC_GRACE_SECS:-30}"
+DEMO_API_NAME="${DEMO_API_NAME:-demo-api-smoke}"
+DEMO_APP_NAME="${DEMO_APP_NAME:-demo-app-smoke}"
+DEMO_GATEWAY_PATH="${DEMO_GATEWAY_PATH:-/apis/${DEMO_API_NAME}/get}"
+MOCK_MODE="${MOCK_MODE:-none}"     # none | all | auto (auto is treated as none)
+DRY_RUN_CONTRACT="${DRY_RUN_CONTRACT:-0}"
+OBS_VISIBILITY_CHECK="${OBS_VISIBILITY_CHECK:-auto}" # auto | off
+GRAFANA_URL="${GRAFANA_URL:-http://localhost:3001}"
+GRAFANA_USER="${GRAFANA_USER:-admin}"
+GRAFANA_PASSWORD="${GRAFANA_PASSWORD:-admin}"
+CONSOLE_URL="${CONSOLE_URL:-http://localhost:3000}"
+PORTAL_URL="${PORTAL_URL:-http://localhost:3002}"
+QUIET="${QUIET:-0}"
+AT_FILTER="${AT:-1,2,3,4,5}"       # comma-separated AT numbers to run
+
+for arg in "$@"; do
+    case "$arg" in
+        --quiet) QUIET=1 ;;
+        --dry-run-contract) DRY_RUN_CONTRACT=1; MOCK_MODE=all ;;
+        --mock-all) MOCK_MODE=all ;;
+        --mock-none) MOCK_MODE=none ;;
+        --no-observability-ui) OBS_VISIBILITY_CHECK=off ;;
+    esac
+done
+
+# ── State ────────────────────────────────────────────────────────────────────
+declare -a RESULTS=()
+declare -a NOTES=()
+TOTAL=0
+PASSED=0
+FAILED=0
+MOCK_USED=0
+
+# Collected during steps, used by later steps
+API_ID=""
+APP_ID=""
+SUBSCRIPTION_ID=""
+API_KEY=""
+DEPLOYMENT_ID=""
+LAST_REQUEST_ID=""
+HTTP_BODY=""
+HTTP_STATUS=""
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+log() {
+    if [[ "$QUIET" == "0" ]]; then echo "$@"; fi
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 2
+}
+
+check_deps() {
+    local missing=0
+    for cmd in curl jq; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            echo "missing: $cmd" >&2
+            missing=1
+        fi
+    done
+    [[ "$missing" == "1" ]] && die "install missing dependencies (curl, jq)"
+}
+
+at_filter_match() {
+    local n="$1"
+    [[ ",${AT_FILTER}," == *",${n},"* ]]
+}
+
+record() {
+    # record ID STATUS DETAIL
+    local id="$1" status="$2" detail="${3:-}"
+    TOTAL=$((TOTAL + 1))
+    if [[ "$status" == "PASS" ]]; then
+        PASSED=$((PASSED + 1))
+        RESULTS+=("[PASS] $id $detail")
+    elif [[ "$status" == "MOCK" ]]; then
+        MOCK_USED=1
+        PASSED=$((PASSED + 1))
+        RESULTS+=("[MOCK] $id $detail")
+    else
+        FAILED=$((FAILED + 1))
+        RESULTS+=("[FAIL] $id $detail")
+    fi
+}
+
+mock_allowed() {
+    [[ "$MOCK_MODE" == "all" || "$DRY_RUN_CONTRACT" == "1" ]]
+}
+
+note() {
+    # note LEVEL DETAIL
+    local level="$1" detail="$2"
+    NOTES+=("[${level}] ${detail}")
+}
+
+# HTTP with auth header injection. Sets $HTTP_BODY and $HTTP_STATUS.
+http_call() {
+    local method="$1" url="$2" body="${3:-}"
+    local tmp
+    tmp="$(mktemp)"
+    local curl_args=(-sS -o "$tmp" -w '%{http_code}' --max-time 15 -X "$method" "$url")
+    if [[ -n "$DEMO_ADMIN_TOKEN" ]]; then
+        curl_args+=(-H "Authorization: Bearer $DEMO_ADMIN_TOKEN")
+    fi
+    if [[ -n "$body" ]]; then
+        curl_args+=(-H "Content-Type: application/json" --data "$body")
+    fi
+
+    HTTP_STATUS="$(
+        curl "${curl_args[@]}" 2>/dev/null || echo 000
+    )"
+    HTTP_BODY="$(cat "$tmp")"
+    rm -f "$tmp"
+}
+
+# ── AT-0 pré-conditions ─────────────────────────────────────────────────────
+
+at0_preconditions() {
+    log ""
+    log "=== AT-0  Pre-conditions ==="
+    local ok=1
+    local detail=""
+
+    # cp-api health
+    local code
+    code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "${API_URL}/health" 2>/dev/null || echo 000)"
+    if [[ "$code" != "200" ]]; then
+        ok=0; detail="${detail}cp-api=${code} "
+    fi
+
+    # gateway health
+    code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "${GATEWAY_URL}/health" 2>/dev/null || echo 000)"
+    if [[ "$code" != "200" ]]; then
+        ok=0; detail="${detail}gateway=${code} "
+    fi
+
+    # mock backend
+    code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "${MOCK_BACKEND_URL}/ping" 2>/dev/null || echo 000)"
+    if [[ "$code" != "200" ]]; then
+        ok=0; detail="${detail}mock=${code} "
+    fi
+
+    if [[ "$ok" == "1" ]]; then
+        record "AT-0" "PASS" "cp-api+gateway+mock reachable"
+        return 0
+    elif mock_allowed; then
+        record "AT-0" "MOCK" "preconditions mocked for explicit non-real mode (${detail})"
+        return 0
+    else
+        record "AT-0" "FAIL" "$detail"
+        return 1
+    fi
+}
+
+# ── AT-1 Declare API ────────────────────────────────────────────────────────
+
+at1_declare_api() {
+    log ""
+    log "=== AT-1  Declare API ==="
+    at_filter_match 1 || { log "  (skipped by AT filter)"; return 0; }
+
+    local body
+    body="$(cat <<JSON
+{
+  "name": "${DEMO_API_NAME}",
+  "version": "1.0.0",
+  "protocol": "http",
+  "backend_url": "${MOCK_BACKEND_UPSTREAM_URL}",
+  "paths": [{"path": "/get", "methods": ["GET"]}]
+}
+JSON
+)"
+
+    local resp
+    http_call POST "${API_URL}/v1/tenants/${TENANT_ID}/apis" "$body"
+    resp="$HTTP_BODY"
+    if [[ "$HTTP_STATUS" != "201" && "$HTTP_STATUS" != "200" && "$HTTP_STATUS" != "409" ]]; then
+        if mock_allowed; then
+            API_ID="mock-api-id-00000000"
+            record "AT-1" "MOCK" "HTTP=${HTTP_STATUS}, mocked API_ID=${API_ID}"
+            return 0
+        fi
+        record "AT-1" "FAIL" "HTTP=${HTTP_STATUS}, body=${resp:0:200}"
+        return 1
+    fi
+
+    # 409 conflict = already exists → fetch
+    if [[ "$HTTP_STATUS" == "409" ]]; then
+        http_call GET "${API_URL}/v1/tenants/${TENANT_ID}/apis?name=${DEMO_API_NAME}" ""
+        resp="$HTTP_BODY"
+        API_ID="$(echo "$resp" | jq -r '.items[0].id // .apis[0].id // empty' 2>/dev/null || true)"
+    else
+        API_ID="$(echo "$resp" | jq -r '.id // empty' 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$API_ID" ]]; then
+        record "AT-1" "FAIL" "no id in response (HTTP=${HTTP_STATUS})"
+        return 1
+    fi
+
+    record "AT-1" "PASS" "API_ID=${API_ID}"
+    return 0
+}
+
+# ── AT-2 Provision route ────────────────────────────────────────────────────
+
+at2_provision_route() {
+    log ""
+    log "=== AT-2  Provision gateway route ==="
+    at_filter_match 2 || { log "  (skipped by AT filter)"; return 0; }
+
+    if [[ -z "$API_ID" ]]; then
+        record "AT-2" "FAIL" "API_ID empty (AT-1 skipped?)"
+        return 1
+    fi
+
+    local body resp
+    body="$(cat <<JSON
+{
+  "api_id": "${API_ID}",
+  "environment": "demo",
+  "gateway_id": "${GATEWAY_ID}"
+}
+JSON
+)"
+    http_call POST "${API_URL}/v1/tenants/${TENANT_ID}/deployments" "$body"
+    resp="$HTTP_BODY"
+
+    if [[ "$HTTP_STATUS" != "201" && "$HTTP_STATUS" != "200" ]]; then
+        if mock_allowed; then
+            DEPLOYMENT_ID="mock-deploy-id"
+            record "AT-2" "MOCK" "HTTP=${HTTP_STATUS}, mocked deployment"
+            return 0
+        fi
+        record "AT-2" "FAIL" "HTTP=${HTTP_STATUS}, body=${resp:0:200}"
+        return 1
+    fi
+
+    DEPLOYMENT_ID="$(echo "$resp" | jq -r '.id // empty' 2>/dev/null || true)"
+
+    # Wait for route to appear in gateway route table (polling via cp-api internal)
+    local elapsed=0
+    local route_ready=0
+    while [[ $elapsed -lt $ROUTE_SYNC_GRACE_SECS ]]; do
+        local routes_resp
+        http_call GET "${API_URL}/v1/internal/gateways/routes?gateway_name=${GATEWAY_ID}" ""
+        routes_resp="$HTTP_BODY"
+        if [[ "$HTTP_STATUS" == "200" ]] && echo "$routes_resp" | jq -e --arg id "$API_ID" '.[]? | select(.api_id == $id)' >/dev/null 2>&1; then
+            route_ready=1
+            break
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+
+    if [[ "$route_ready" != "1" ]]; then
+        if mock_allowed; then
+            record "AT-2" "MOCK" "deployment 201 but route not synced in ${ROUTE_SYNC_GRACE_SECS}s (accepted in mock_mode=${MOCK_MODE})"
+            return 0
+        fi
+        record "AT-2" "FAIL" "route not synced in ${ROUTE_SYNC_GRACE_SECS}s"
+        return 1
+    fi
+
+    record "AT-2" "PASS" "DEPLOYMENT_ID=${DEPLOYMENT_ID}, route synced in ~${elapsed}s"
+    return 0
+}
+
+# ── AT-3 Subscription ───────────────────────────────────────────────────────
+
+at3_subscription() {
+    log ""
+    log "=== AT-3  Create subscription ==="
+    at_filter_match 3 || { log "  (skipped by AT filter)"; return 0; }
+
+    if [[ -z "$API_ID" ]]; then
+        record "AT-3" "FAIL" "API_ID empty"
+        return 1
+    fi
+
+    # Step 1: application
+    local resp body
+    body="{\"name\":\"${DEMO_APP_NAME}\"}"
+    http_call POST "${API_URL}/v1/tenants/${TENANT_ID}/applications" "$body"
+    resp="$HTTP_BODY"
+    if [[ "$HTTP_STATUS" != "201" && "$HTTP_STATUS" != "200" && "$HTTP_STATUS" != "409" ]]; then
+        if mock_allowed; then
+            APP_ID="mock-app-id"
+            SUBSCRIPTION_ID="mock-sub-id"
+            API_KEY="stoa_mock_demokey"
+            record "AT-3" "MOCK" "HTTP=${HTTP_STATUS}, mocked app+sub+key"
+            return 0
+        fi
+        record "AT-3" "FAIL" "applications HTTP=${HTTP_STATUS}, body=${resp:0:200}"
+        return 1
+    fi
+    APP_ID="$(echo "$resp" | jq -r '.id // empty' 2>/dev/null)"
+    if [[ -z "$APP_ID" && "$HTTP_STATUS" == "409" ]]; then
+        http_call GET "${API_URL}/v1/tenants/${TENANT_ID}/applications?name=${DEMO_APP_NAME}" ""
+        resp="$HTTP_BODY"
+        APP_ID="$(echo "$resp" | jq -r '.items[0].id // .applications[0].id // empty' 2>/dev/null)"
+    fi
+    if [[ -z "$APP_ID" ]]; then
+        record "AT-3" "FAIL" "no application id"
+        return 1
+    fi
+
+    # Step 2: subscribe (single-shot endpoint)
+    http_call POST "${API_URL}/v1/tenants/${TENANT_ID}/applications/${APP_ID}/subscribe/${API_ID}" ""
+    resp="$HTTP_BODY"
+    if [[ "$HTTP_STATUS" != "201" && "$HTTP_STATUS" != "200" ]]; then
+        # fallback to /v1/subscriptions
+        body="{\"application_id\":\"${APP_ID}\",\"api_id\":\"${API_ID}\",\"plan\":\"free\"}"
+        http_call POST "${API_URL}/v1/subscriptions" "$body"
+        resp="$HTTP_BODY"
+    fi
+
+    if [[ "$HTTP_STATUS" != "201" && "$HTTP_STATUS" != "200" ]]; then
+        if mock_allowed; then
+            SUBSCRIPTION_ID="mock-sub-id"
+            API_KEY="stoa_mock_demokey"
+            record "AT-3" "MOCK" "HTTP=${HTTP_STATUS}, mocked sub+key"
+            return 0
+        fi
+        record "AT-3" "FAIL" "subscribe HTTP=${HTTP_STATUS}, body=${resp:0:200}"
+        return 1
+    fi
+
+    SUBSCRIPTION_ID="$(echo "$resp" | jq -r '.id // .subscription_id // empty' 2>/dev/null)"
+    API_KEY="$(echo "$resp" | jq -r '.api_key // .new_api_key // empty' 2>/dev/null)"
+    local prefix
+    prefix="$(echo "$resp" | jq -r '.api_key_prefix // empty' 2>/dev/null)"
+
+    if [[ -z "$API_KEY" ]]; then
+        # prefix-only response: accept with mock warning
+        if [[ -n "$prefix" ]]; then
+            record "AT-3" "MOCK" "only api_key_prefix returned (${prefix}), cleartext unavailable. Demo must surface full key."
+            API_KEY="__NO_CLEARTEXT_AVAILABLE__"
+            return 0
+        fi
+        record "AT-3" "FAIL" "no api_key/prefix in response"
+        return 1
+    fi
+
+    record "AT-3" "PASS" "SUBSCRIPTION_ID=${SUBSCRIPTION_ID}, API_KEY acquired"
+    return 0
+}
+
+# ── AT-4 Gateway call ───────────────────────────────────────────────────────
+
+at4_gateway_call() {
+    log ""
+    log "=== AT-4  Call API via gateway ==="
+    at_filter_match 4 || { log "  (skipped by AT filter)"; return 0; }
+
+    if [[ "$DRY_RUN_CONTRACT" == "1" || ( "$MOCK_MODE" == "all" && "$API_KEY" == stoa_mock* ) ]]; then
+        LAST_REQUEST_ID="mock-req-id"
+        record "AT-4" "MOCK" "gateway call skipped for explicit non-real mode"
+        return 0
+    fi
+
+    if [[ -z "$API_KEY" || "$API_KEY" == "__NO_CLEARTEXT_AVAILABLE__" ]]; then
+        if mock_allowed; then
+            LAST_REQUEST_ID="mock-req-id"
+            record "AT-4" "MOCK" "no real API_KEY, call skipped (mock_mode=all)"
+            return 0
+        fi
+        record "AT-4" "FAIL" "no usable API_KEY"
+        return 1
+    fi
+
+    # Canonical demo gateway mapping (B3): one official path, no shape probing.
+    local hdr_file body_file
+    hdr_file="$(mktemp)"; body_file="$(mktemp)"
+    local attempt=0 status=""
+    while [[ $attempt -lt 5 ]]; do
+        status="$(
+            curl -sS -o "$body_file" -D "$hdr_file" -w '%{http_code}' --max-time 10 \
+                 -H "X-Api-Key: ${API_KEY}" \
+                 "${GATEWAY_URL}${DEMO_GATEWAY_PATH}" 2>/dev/null || echo 000
+        )"
+        if [[ "$status" == "200" ]]; then break; fi
+        attempt=$((attempt + 1))
+        sleep 2
+    done
+
+    if [[ "$status" == "200" ]]; then
+        LAST_REQUEST_ID="$(grep -i '^x-stoa-request-id:' "$hdr_file" | awk '{print $2}' | tr -d '\r' || true)"
+        record "AT-4" "PASS" "HTTP 200 on ${DEMO_GATEWAY_PATH}, request_id=${LAST_REQUEST_ID:-n/a}"
+        rm -f "$hdr_file" "$body_file"
+        return 0
+    fi
+
+    if mock_allowed; then
+        record "AT-4" "MOCK" "canonical gateway path ${DEMO_GATEWAY_PATH} returned ${status}"
+        rm -f "$hdr_file" "$body_file"
+        return 0
+    fi
+
+    record "AT-4" "FAIL" "canonical gateway path ${DEMO_GATEWAY_PATH} returned ${status}"
+    rm -f "$hdr_file" "$body_file"
+    return 1
+}
+
+# ── AT-5 Observable proof ───────────────────────────────────────────────────
+
+at5_observable() {
+    log ""
+    log "=== AT-5  Observable proof ==="
+    at_filter_match 5 || { log "  (skipped by AT filter)"; return 0; }
+
+    local metrics
+    metrics="$(curl -sS --max-time 5 "${GATEWAY_URL}/metrics" 2>/dev/null || true)"
+    if [[ -z "$metrics" ]]; then
+        if mock_allowed; then
+            record "AT-5" "MOCK" "no /metrics body; observable proof skipped in mock/contract mode"
+            return 0
+        fi
+        record "AT-5" "FAIL" "no /metrics body"
+        return 1
+    fi
+
+    local counter
+    counter="$(echo "$metrics" | grep -E '^(proxy_requests_total|mcp_tool_calls_total)\{' | head -1)"
+
+    if [[ -z "$counter" ]]; then
+        if mock_allowed; then
+            record "AT-5" "MOCK" "no proxy_requests_total/mcp_tool_calls_total counter. Either names diverged or no traffic. Spec requires at least one."
+            return 0
+        fi
+        record "AT-5" "FAIL" "no counter proxy_requests_total|mcp_tool_calls_total"
+        return 1
+    fi
+
+    # Extract value (last field on the line)
+    local value
+    value="$(echo "$counter" | awk '{print $NF}')"
+    if ! echo "$value" | grep -Eq '^[0-9]+(\.[0-9]+)?$' || [[ "${value%.*}" == "0" ]]; then
+        if mock_allowed; then
+            record "AT-5" "MOCK" "counter found but value=${value} (likely no traffic in AT-4). Spec expects >0."
+            return 0
+        fi
+        record "AT-5" "FAIL" "counter value=${value} (expected >0)"
+        return 1
+    fi
+
+    local log_proof="no-log-check"
+    # If running in compose, try to correlate with docker logs
+    if command -v docker >/dev/null 2>&1 && [[ -n "$LAST_REQUEST_ID" ]]; then
+        if docker logs stoa-gateway 2>&1 | grep -q "$LAST_REQUEST_ID"; then
+            log_proof="request_id matched in docker logs"
+        fi
+    fi
+
+    record "AT-5" "PASS" "counter=${counter%%\{*}, value=${value}, log=${log_proof}"
+    return 0
+}
+
+# ── AT-5b Optional observability visibility ─────────────────────────────────
+
+at5b_observability_visibility() {
+    log ""
+    log "=== AT-5b Observability visibility (nice-to-have) ==="
+
+    if [[ "$OBS_VISIBILITY_CHECK" == "off" ]]; then
+        note "INFO" "AT-5b skipped (OBS_VISIBILITY_CHECK=off)"
+        return 0
+    fi
+
+    local grafana_code
+    grafana_code="$(
+        curl -sS -o /dev/null -w '%{http_code}' --max-time 5 \
+             -u "${GRAFANA_USER}:${GRAFANA_PASSWORD}" \
+             "${GRAFANA_URL}/api/health" 2>/dev/null || echo 000
+    )"
+    if [[ "$grafana_code" != "200" ]]; then
+        note "WARN" "AT-5b Grafana not reachable at ${GRAFANA_URL} (HTTP=${grafana_code}); UI visibility not proven"
+        return 0
+    fi
+
+    local prom_code traces_code tempo_code
+    prom_code="$(
+        curl -sS -o /dev/null -w '%{http_code}' --max-time 5 \
+             -u "${GRAFANA_USER}:${GRAFANA_PASSWORD}" \
+             "${GRAFANA_URL}/api/datasources/uid/prometheus" 2>/dev/null || echo 000
+    )"
+    traces_code="$(
+        curl -sS -o /dev/null -w '%{http_code}' --max-time 5 \
+             -u "${GRAFANA_USER}:${GRAFANA_PASSWORD}" \
+             "${GRAFANA_URL}/api/datasources/uid/opensearch-traces" 2>/dev/null || echo 000
+    )"
+    tempo_code="$(
+        curl -sS -o /dev/null -w '%{http_code}' --max-time 5 \
+             -u "${GRAFANA_USER}:${GRAFANA_PASSWORD}" \
+             "${GRAFANA_URL}/api/datasources/uid/tempo" 2>/dev/null || echo 000
+    )"
+
+    local console_code portal_code
+    console_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "${CONSOLE_URL}/monitoring" 2>/dev/null || echo 000)"
+    portal_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "${PORTAL_URL}/usage" 2>/dev/null || echo 000)"
+
+    local detail
+    detail="Grafana=${grafana_code}, prometheus-ds=${prom_code}, opensearch-traces-ds=${traces_code}, tempo-ds=${tempo_code}, console=/monitoring:${console_code}, portal=/usage:${portal_code}"
+
+    if [[ "$prom_code" == "200" && ( "$traces_code" == "200" || "$tempo_code" == "200" ) ]]; then
+        note "PASS" "AT-5b observability UI reachable (${detail})"
+    else
+        note "WARN" "AT-5b observability UI partial (${detail}); OTEL visibility remains nice-to-have"
+    fi
+    return 0
+}
+
+# ── Report ──────────────────────────────────────────────────────────────────
+
+print_report() {
+    echo ""
+    echo "================================================================"
+    echo "  STOA Demo Smoke Test — Results"
+    echo "  Generated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+    echo "  API_URL=${API_URL}"
+    echo "  GATEWAY_URL=${GATEWAY_URL}"
+    echo "  MOCK_MODE=${MOCK_MODE}"
+    echo "  DRY_RUN_CONTRACT=${DRY_RUN_CONTRACT}"
+    echo "================================================================"
+    for line in "${RESULTS[@]}"; do
+        echo "  $line"
+    done
+    if [[ ${#NOTES[@]} -gt 0 ]]; then
+        echo "----------------------------------------------------------------"
+        for line in "${NOTES[@]}"; do
+            echo "  $line"
+        done
+    fi
+    echo "----------------------------------------------------------------"
+    echo "  Score: ${PASSED}/${TOTAL}"
+    if [[ $FAILED -ne 0 ]]; then
+        echo "  Verdict: FAIL — DEMO NOT READY (${FAILED} fail)"
+    elif [[ "$DRY_RUN_CONTRACT" == "1" ]]; then
+        echo "  Verdict: CONTRACT_DRY_RUN — contract validated, demo not proven"
+    elif [[ "$MOCK_USED" == "1" ]]; then
+        echo "  Verdict: MOCK_PASS — script coherent, demo not proven"
+    else
+        echo "  Verdict: REAL_PASS — DEMO READY"
+    fi
+    echo "================================================================"
+}
+
+# ── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+    check_deps
+
+    if [[ "$MOCK_MODE" == "auto" ]]; then
+        note "INFO" "MOCK_MODE=auto is treated as strict real mode; blockers will FAIL, not mock-pass"
+        MOCK_MODE="none"
+    fi
+
+    if ! at0_preconditions; then
+        print_report
+        exit 2
+    fi
+
+    at1_declare_api      || true
+    at2_provision_route  || true
+    at3_subscription     || true
+    at4_gateway_call     || true
+    at5_observable       || true
+    at5b_observability_visibility || true
+
+    print_report
+
+    if [[ $FAILED -eq 0 ]]; then
+        exit 0
+    else
+        exit 1
+    fi
+}
+
+main "$@"

--- a/specs/architecture-rules.md
+++ b/specs/architecture-rules.md
@@ -1,0 +1,142 @@
+# STOA Demo — Architecture Rules (contrats figés)
+
+> **Statut**: v1.0 — 2026-04-24. Ces contrats sont figés pendant toute la durée du rewrite.
+> **Règle dure**: toute PR qui enfreint un contrat figé est **NO-GO par défaut**, même si elle améliore autre chose.
+
+## 1. Périmètre architectural démo (verticale unique)
+
+```
+┌────────────────┐        ┌──────────────────┐       ┌───────────────┐
+│   stoactl /    │  HTTPS │  control-plane-  │       │               │
+│   curl (CLI)   ├───────►│  api (FastAPI)   │◄─────►│   Postgres    │
+└────────────────┘   REST │  port 8000       │       │   (api,app,   │
+                          └──────┬───────────┘       │    sub,depl)  │
+                                 │ route-sync        └───────────────┘
+                                 │ (polling GET OR SSE)
+                                 ▼
+                          ┌──────────────────┐
+                          │  stoa-gateway    │       ┌───────────────┐
+  client démo ────HTTP───►│  (Rust, Axum)    ├──────►│  mock-backend │
+  + X-Api-Key             │  port 8080       │       │  (httpbin)    │
+                          │  /apis/*path     │       │  port 9090    │
+                          └──────┬───────────┘       └───────────────┘
+                                 │
+                                 ▼
+                     Prometheus /metrics + JSON stdout logs
+                     + optional OTEL visibility in Grafana/Console/Portal
+```
+
+Tout composant non présent dans ce diagramme (Portal, Console UI, Kafka, OpenSearch, vault-gostoa, Keycloak-federation, stoa-catalog, stoa-connect en scope restreint) est **hors chemin démo provider/runtime**. Peut exister, ne doit pas être requis pour `demo-smoke-test.sh` `REAL_PASS`.
+
+## 2. Contrats figés (ne JAMAIS casser en rewrite)
+
+### 2.1 HTTP endpoints cp-api (URL + method + status code + shape minimal)
+
+| Endpoint | Method | Status OK | Champs min réponse |
+|----------|--------|-----------|--------------------|
+| `/v1/tenants/{tid}/apis` | POST | 201 | `id`, `name` |
+| `/v1/tenants/{tid}/apis` | GET | 200 | `items[]` avec `id`, `name` |
+| `/v1/tenants/{tid}/apis/{id}` | GET | 200 | `id`, `name`, `backend_url` |
+| `/v1/tenants/{tid}/applications` | POST | 201 | `id`, `name` |
+| `/v1/tenants/{tid}/applications/{id}/subscribe/{api_id}` | POST | 201 | `subscription_id`, `api_key` ou `api_key_prefix` |
+| `/v1/subscriptions` | POST | 201 | `id`, `api_key` ou `api_key_prefix`, `status="active"` |
+| `/v1/tenants/{tid}/deployments` | POST | 201 | `id`, `status` |
+| `/v1/internal/gateways/routes?gateway_name=X` | GET | 200 | liste de routes avec `api_id`, `path` |
+| `/health` | GET | 200 | n/a |
+
+### 2.2 HTTP endpoints gateway
+
+| Endpoint | Method | Status OK | Comportement |
+|----------|--------|-----------|---------------|
+| `/health` | GET | 200 | body indifférent |
+| `/metrics` | GET | 200 | format Prometheus text |
+| `/apis/{api_name}/{*path}` | GET/POST/… | 200/…  | chemin gateway canonique démo. `api_name` est le slug retourné par `POST /v1/tenants/{tid}/apis`; proxy vers backend configuré, header `X-Stoa-Request-Id` en réponse, vérifie `X-Api-Key` (ou `Authorization: Bearer`) |
+
+### 2.3 Format métriques Prometheus
+
+Nom obligatoirement présent: **au moins un** de
+- `proxy_requests_total{tenant,api,method,status}`
+- `mcp_tool_calls_total{...}`
+
+incrémenté à chaque appel proxyé. Changement de nom = breaking contract démo.
+
+### 2.4 Format logs
+
+Logs gateway en **JSON par ligne**, stdout, contenant au minimum :
+- `timestamp`
+- `level`
+- `message`
+- `tenant` (si dispo)
+- `api_id` (si dispo) OU `route_prefix`
+- `request_id` (UUID, identique à header `X-Stoa-Request-Id`)
+
+Le format `tracing-subscriber` JSON actuel convient.
+
+### 2.5 Visibilité observabilité UI (nice-to-have)
+
+Ces surfaces doivent rester compatibles avec la démo, sans être bloquantes pour le `REAL_PASS` v1:
+
+| Surface | URL locale | Source de données attendue | Preuve |
+|---------|------------|----------------------------|--------|
+| Grafana | `http://localhost:3001` | `Prometheus`, `Loki`, `OpenSearch Traces`, `Tempo` | `/api/health` OK + datasource provisionnée |
+| Console | `http://localhost:3000/monitoring` | `GET /v1/monitoring/transactions` | Page routable + liste transactions quand OTEL existe |
+| Portal | `http://localhost:3002/usage` | `GET /v1/usage/me*` + dashboard Grafana embarqué optionnel | Page routable + usage visible pour le consommateur |
+
+Si `STOA_OTEL_ENDPOINT` est défini, la stack compose doit permettre de retrouver la trace via `OpenSearch Traces` (`otel-v1-apm-span-*`) ou `Tempo`. Absence d'OTEL = warning, pas cassage AT-5.
+
+### 2.6 Compatibilité DB consommée par le smoke
+
+Le smoke ne fige pas tout le modèle relationnel. Il fige uniquement la
+compatibilité fonctionnelle nécessaire aux endpoints de §2.1 et aux assertions
+AT-1..AT-5.
+
+Champs consommés directement ou indirectement par le smoke:
+- API: identifiant, tenant, nom, version, backend URL
+- Application: identifiant, tenant, nom
+- Subscription: identifiant, application, API, statut actif, hash/prefix de clé
+- Deployment: identifiant, API, environnement, gateway, statut
+- API key: hash/prefix/état actif si les clés sont stockées dans une table séparée
+
+Une migration Alembic peut ajouter des colonnes ou refactorer le stockage interne
+si les endpoints de §2.1 gardent leur shape minimale et si AT-1..AT-5 restent
+réels. Renommer/supprimer un champ consommé par le smoke sans compatibilité API
+= contrat cassé.
+
+### 2.7 Auth modèle démo
+
+- **Un seul mode supporté côté démo**: API key via header `X-Api-Key: stoa_<prefix>_<secret>`
+- JWT/OAuth reste dispo mais pas dans le smoke path
+- mTLS, DPoP, sender-constraint: hors périmètre démo
+
+## 3. Règles structurelles (rewrite peut bouger, mais pas casser les contrats)
+
+1. **Le Config flat gateway (§1 GW-2 REWRITE-PLAN) est figé** tant que la démo n'est pas stable. Le split `config.rs → config/*.rs` (GW-2) est OK car il préserve le contrat TOML/env. Toute nouvelle sous-struct qui casserait un `STOA_*` env var = NO-GO.
+2. **Les migrations Alembic** sont additives uniquement pendant le rewrite. Renommage colonne ⟹ Council obligatoire.
+3. **Les endpoints listés §2.1 gardent leur URL**. Route rename ⟹ alias 301 pendant ≥ 1 cycle.
+4. **stoa-connect** peut évoluer son protocole SSE, mais doit conserver le fallback polling `GET /v1/internal/gateways/routes` pour la démo locale sans SSE.
+5. **Feature flags Cargo du gateway** (`kafka`, `k8s`) : la démo tourne en build **default (community, no features)**. Toute dépendance à `kafka` ou `k8s` dans le chemin démo = cassage.
+
+## 4. Contraintes opérationnelles démo
+
+- Démarre **en moins de 60s** sur un laptop (docker-compose + cargo run + pytest minimal startup)
+- Tourne **offline** une fois les dépendances pulled (pas besoin réseau externe pendant exécution)
+- N'exige **aucun secret en prod** (utilise `.env.demo` figé, clés jetables)
+- Utilise **un seul tenant** nommé `demo`, un seul environnement `demo`
+
+## 5. Anti-règles (patterns à refuser en PR)
+
+- "Je refactore et je casse la compatibilité DB consommée par le smoke (§2.6) au passage" → STOP. Split en 2 PR.
+- "J'ajoute un middleware obligatoire qui exige X" où X n'est pas seedé dans la démo → STOP.
+- "Je remplace `X-Api-Key` par un JWT obligatoire" → STOP, casse AT-4.
+- "Je change le format Prometheus pour OpenMetrics+labels différents" → STOP, casse AT-5.
+- "Je mets la route `/apis/{api_name}/{*path}` sous un feature flag" → STOP.
+
+## 6. Escalade
+
+Si un rewrite a besoin de casser un contrat figé :
+1. Ouvrir une ADR dans `stoa-docs/docs/architecture/adr/` qui documente le breaking change
+2. Council obligatoire (seuil 8/10)
+3. Mettre à jour `demo-scope.md` §6 et `architecture-rules.md` §2 en même temps que la PR qui casse
+4. Ajouter un test de régression qui verrouille le nouveau contrat
+
+Pas d'exception silencieuse.

--- a/specs/client-prospect-demo-scope.md
+++ b/specs/client-prospect-demo-scope.md
@@ -1,0 +1,187 @@
+# STOA Demo — Client / Prospect Scope
+
+> **Statut**: v1.0 — 2026-04-24. Complément au contrat technique `demo-scope.md`.
+> **But**: couvrir la démo commerciale côté prospect/client, sans remplacer le smoke provider CLI.
+
+## 1. Pourquoi ce contrat
+
+`demo-scope.md` prouve que la verticale technique fonctionne: API déclarée,
+route gateway provisionnée, subscription créée, appel gateway OK, preuve observable.
+
+La démo client/prospect doit prouver autre chose: un prospect peut découvrir STOA,
+s'onboarder, trouver une API, obtenir un accès, faire un premier appel, puis voir
+son usage pendant que l'équipe STOA voit la conversion dans la Console.
+
+Ces deux démos sont complémentaires:
+- `demo-smoke-test.sh`: contrat provider/runtime, binaire, bloquant.
+- Ce fichier: contrat client/prospect, humain-visible, à automatiser ensuite en Playwright.
+
+## 2. Scénario cible client/prospect
+
+| # | Étape | Surface | Commande/API | Preuve |
+|---|-------|---------|--------------|--------|
+| C0 | Seed démo client | cp-api + DB | seed `prospect-demo`, tenant, user, API publiée | Données idempotentes prêtes |
+| C1 | Signup prospect | Portal public | `POST /v1/self-service/tenants` puis status | `202` puis tenant `ready` |
+| C2 | Voir la conversion prospect | Console | `/admin/prospects` + `/v1/admin/prospects/metrics` | Prospect visible, funnel mis à jour |
+| C3 | Parcours onboarding | Portal | `/onboarding` | 4 étapes visibles: use case, app, subscribe, first call |
+| C4 | Découvrir l'API | Portal | `/discover`, `/apis/{id}` + `GET /v1/portal/apis` | API démo publiée visible |
+| C5 | Créer une application client | Portal | `/workspace?tab=apps` ou onboarding | Application créée avec credentials affichables |
+| C6 | Souscrire à l'API | Portal + cp-api | `POST /v1/subscriptions` | Subscription créée (`pending` ou `active`) |
+| C7 | Approbation si nécessaire | Console | `/subscriptions` + `POST /v1/subscriptions/{id}/approve` | Subscription active |
+| C8 | Premier appel client | Portal sandbox ou curl | `/apis/{id}/test` ou gateway URL | HTTP 2xx, payload backend |
+| C9 | Usage client visible | Portal | `/usage`, `/executions` | Appel visible dans calls/usage |
+| C10 | Monitoring opérateur visible | Console/Grafana | `/monitoring`, Grafana traces/metrics | Transaction corrélée visible |
+
+## 3. Surfaces et contrats à préserver
+
+### 3.1 Portal public / client
+
+| Surface | Route UI | API backend |
+|---------|----------|-------------|
+| Signup | `/signup` | `POST /v1/self-service/tenants`, `GET /v1/self-service/tenants/{tenant_id}/status` |
+| Onboarding | `/onboarding` | apps + catalog + subscriptions |
+| Catalogue | `/discover`, `/apis/{id}` | `GET /v1/portal/apis`, `GET /v1/portal/apis/{id}` |
+| Sandbox | `/apis/{id}/test` | gateway URL issue de l'API ou du deployment |
+| Workspace apps | `/workspace?tab=apps` | `GET/POST /v1/applications` |
+| Subscriptions | `/workspace?tab=subscriptions` | `GET /v1/subscriptions/my`, `POST /v1/subscriptions` |
+| Usage | `/usage`, `/executions` | `GET /v1/usage/me*`, `GET /v1/usage/me/executions*` |
+
+### 3.2 Console opérateur / prospect
+
+| Surface | Route UI | API backend |
+|---------|----------|-------------|
+| Prospects | `/admin/prospects` | `GET /v1/admin/prospects`, `GET /v1/admin/prospects/metrics` |
+| Subscription approvals | `/subscriptions` | `GET /v1/subscriptions/tenant/{tenant_id}/pending`, `POST /v1/subscriptions/{id}/approve` |
+| Monitoring | `/monitoring` | `GET /v1/monitoring/transactions` |
+| Grafana embed | `/observability/grafana` | Grafana datasources `prometheus`, `opensearch-traces`, `tempo` |
+
+## 4. Deltas versus `demo-scope.md`
+
+| Delta | Impact | Décision |
+|-------|--------|----------|
+| `demo-scope.md` exclut le Portal public et la UI | Incompatible avec une démo prospect | Ce fichier devient le contrat dédié client/prospect |
+| Smoke provider exige API key cleartext utilisable | Le Portal REST subscription annonce OAuth2/no API key | Le scénario client doit choisir explicitement API key demo ou OAuth2, pas les deux |
+| Catalogue Portal lit `/v1/portal/apis` | Le smoke crée via `/v1/tenants/{tid}/apis` | Le seed client doit publier/promouvoir l'API démo au Portal |
+| Subscription peut être `pending` | Le smoke attend `active` | C7 couvre l'approbation Console si nécessaire |
+| Usage/executions ne sont pas vérifiés par AT-5 | La démo client doit montrer la valeur après appel | C9 devient preuve obligatoire du parcours client |
+| Prospects dashboard existe mais n'est pas relié au signup | Conversion non prouvée | C0/C1/C2 doivent créer un lien `invite/prospect → tenant/user` |
+
+## 5. Acceptance tests client/prospect
+
+### CPD-0 — Seed client idempotent
+
+Préparer:
+- tenant `demo-client`
+- user client `client-demo@gostoa.local`
+- prospect/invite `prospect-demo@gostoa.local`
+- API publiée `demo-api-client` visible dans `/v1/portal/apis`
+- gateway route active vers mock backend
+- credentials admin Console + client Portal documentés dans `.env.demo`
+
+PASS si le seed est relançable sans doublons et retourne les IDs utiles.
+
+### CPD-1 — Signup self-service
+
+`POST /v1/self-service/tenants` avec un payload prospect de test retourne `202`
+et un `poll_url`. Le polling retourne `ready` dans un délai borné.
+
+Pour une démo locale rapide, ce test peut être SKIP si le tenant est pré-seedé,
+mais le skip doit être explicite dans le rapport.
+
+### CPD-2 — Prospect visible dans la Console
+
+`GET /v1/admin/prospects` contient le prospect démo et
+`GET /v1/admin/prospects/metrics` expose un funnel non vide.
+
+PASS humain: `/admin/prospects` montre le prospect, son statut et une timeline.
+
+### CPD-3 — Onboarding Portal
+
+Le client accède à `/onboarding` et voit les 4 étapes:
+1. choix du use case
+2. création application
+3. sélection API
+4. premier appel / configuration
+
+PASS si le parcours n'aboutit pas à une page vide, une erreur auth, ou une API list vide.
+
+### CPD-4 — Catalogue API visible
+
+`GET /v1/portal/apis?search=demo-api-client` retourne au moins une API publiée.
+`/apis/{id}` affiche nom, version, description, auth type et environnement déployé.
+
+### CPD-5 — Application client créée
+
+Créer une application depuis le Portal ou l'API client. PASS si l'app est listée
+dans `/workspace?tab=apps` et si les credentials requis pour l'étape C8 sont
+disponibles selon le mode choisi.
+
+### CPD-6 — Subscription client active
+
+Créer une subscription via `POST /v1/subscriptions`.
+
+PASS si:
+- `active`: continuer directement vers CPD-8
+- `pending`: CPD-7 doit l'approuver
+
+FAIL si aucune clé, aucun client OAuth, et aucune URL d'appel ne permettent de
+réaliser le premier appel.
+
+### CPD-7 — Approval Console si nécessaire
+
+Si CPD-6 retourne `pending`, la Console `/subscriptions` doit permettre
+l'approbation. L'API `POST /v1/subscriptions/{id}/approve` doit retourner
+une subscription active.
+
+### CPD-8 — Premier appel client
+
+Le client appelle l'API depuis `/apis/{id}/test` ou via curl gateway documenté.
+
+PASS si:
+- HTTP 2xx
+- payload du mock backend reçu
+- `X-Stoa-Request-Id` présent
+
+### CPD-9 — Usage visible côté client
+
+Après CPD-8, `/usage` ou `/executions` montre l'appel du client dans un délai
+raisonnable.
+
+PASS si l'appel est attribuable à l'application ou subscription créée.
+
+### CPD-10 — Monitoring visible côté opérateur
+
+Après CPD-8, `/monitoring` et/ou Grafana montrent la transaction avec
+`request_id`, `tenant`, `api` ou `route`.
+
+PASS si la même activité peut être expliquée à un prospect: appel → métrique/log/trace.
+
+## 6. Blockers spécifiques client/prospect
+
+| # | Blocker | Sévérité | Étapes impactées |
+|---|---------|----------|------------------|
+| C-B1 | Pas de seed `demo-client` + prospect + API publiée | P0 | CPD-0..CPD-4 |
+| C-B2 | Lien signup → prospect conversion non garanti | P1 | CPD-1, CPD-2 |
+| C-B3 | Mode d'auth client non tranché (API key vs OAuth2) | P0 | CPD-6, CPD-8 |
+| C-B4 | Subscription Portal peut rester pending sans chemin d'approbation démo | P1 | CPD-6, CPD-7 |
+| C-B5 | Portal sandbox peut appeler API detail au lieu de gateway réelle | P0 | CPD-8 |
+| C-B6 | Usage/executions dépend de Prometheus/Loki et peut rester vide localement | P1 | CPD-9 |
+| C-B7 | Prospects dashboard admin existe mais pas inclus dans smoke/Playwright | P2 | CPD-2 |
+
+## 7. Validation recommandée
+
+Court terme:
+- garder `demo-smoke-test.sh` pour AT-0..AT-5 provider
+- créer ensuite `scripts/client-prospect-demo-smoke.sh` pour CPD-0..CPD-10 API-level
+- créer un test Playwright `e2e/client-prospect-demo.spec.ts` pour les surfaces UI
+
+Critère GO démo client:
+- CPD-0, CPD-3, CPD-4, CPD-6, CPD-8 passent
+- CPD-2, CPD-9, CPD-10 visibles humainement ou marqués WARN explicite
+- aucun blocker C-B1/C-B3/C-B5 ouvert
+
+## 8. Révisions
+
+| Date | Auteur | Changement |
+|------|--------|------------|
+| 2026-04-24 | Codex | Création initiale du contrat client/prospect |

--- a/specs/demo-acceptance-tests.md
+++ b/specs/demo-acceptance-tests.md
@@ -1,0 +1,157 @@
+# STOA Demo — Acceptance Tests
+
+> **Statut**: v1.0 — 2026-04-24. Référence exécutable du contrat démo.
+> **Script canonique**: `scripts/demo-smoke-test.sh` (voir `validation-commands.md`).
+
+## Principe
+
+Chaque étape du scénario démo (`demo-scope.md` §2) a un test d'acceptance binaire : **PASS ou FAIL** en mode réel. Les étapes sont idempotentes et réexécutables. Les mocks autorisés sont marqués `[MOCK OK]`, mais un mock ne peut jamais produire le verdict `DEMO READY`.
+
+## Sémantique des verdicts
+
+| Verdict | Exit | Signification |
+|---------|------|---------------|
+| `REAL_PASS — DEMO READY` | 0 | AT-0..AT-5 passent sans mock critique ; la démo est réellement prouvée |
+| `CONTRACT_DRY_RUN` | 0 | `--dry-run-contract` valide la structure script/spec sans stack live ; la démo n'est pas prouvée |
+| `MOCK_PASS` | 0 | `MOCK_MODE=all` valide le chemin mocké ; la démo n'est pas prouvée |
+| `FAIL — DEMO NOT READY` | 1 ou 2 | Au moins un blocker réel empêche le scénario |
+
+`MOCK_MODE=auto` est traité comme un mode réel strict : il ne convertit jamais un blocker en PASS silencieux.
+
+## Pré-conditions (AT-0)
+
+Avant lancement, ces ressources doivent exister (seed minimal) :
+
+- Base cp-api démarrée (port 8000) avec healthz 200
+- Gateway démarrée (port 8080) avec healthz 200
+- Un tenant `demo` (UUID déterministe) en DB
+- Un backend HTTP mock démarré (port 9090) qui répond `200 {"ok":true}` sur `GET /ping`
+- **[MOCK OK]** `GIT_SYNC_ON_WRITE=false` — le sync vers `stoa-catalog` est désactivé pour la démo
+- **[MOCK OK]** `STOA_OTEL_ENDPOINT` vide si pas de collecteur OTEL → no-op, acceptable pour AT-5 ; AT-5b sera marqué INFO/WARN
+- Auth: Keycloak local OU bypass dev `STOA_DISABLE_AUTH=true` pour cp-api écriture (à proscrire en prod)
+
+Fail pre-condition ⇒ abort early, pas d'exécution des AT-1..AT-5.
+
+## AT-1 — Déclarer une API
+
+**Given** pre-conditions OK
+**When** `POST ${API_URL}/v1/tenants/${TENANT_ID}/apis` avec body:
+```json
+{
+  "name": "demo-api",
+  "version": "1.0.0",
+  "protocol": "http",
+  "backend_url": "http://mock-backend:9090",
+  "paths": [{"path": "/ping", "methods": ["GET"]}]
+}
+```
+**Then**:
+- HTTP 201
+- Réponse contient `id` (UUID) et `name=demo-api`
+- `GET /v1/tenants/${TENANT_ID}/apis/${API_ID}` renvoie 200 avec le même payload
+
+**Exit code**: 0 si les 3 assertions passent, 1 sinon.
+
+## AT-2 — Provisionner la route gateway
+
+**Given** AT-1 PASS, `API_ID` connu
+**When** `POST ${API_URL}/v1/tenants/${TENANT_ID}/deployments` avec body:
+```json
+{
+  "api_id": "${API_ID}",
+  "environment": "demo",
+  "gateway_id": "${GATEWAY_ID}"
+}
+```
+**Then**:
+- HTTP 201
+- Dans un délai ≤ 30s : `GET ${GATEWAY_URL}/health` reste 200 ET la route est atteignable (retry AT-4 peut valider)
+- **[MOCK OK]** Le polling route-sync peut être forcé par SIGHUP à la gateway (`kill -HUP $PID`) si on ne veut pas attendre le tick
+
+**Exit code**: 0 si 201 + route active avant timeout, 1 sinon.
+
+## AT-3 — Créer une souscription applicative
+
+**Given** AT-1 PASS
+**When**:
+1. `POST ${API_URL}/v1/tenants/${TENANT_ID}/applications` avec `{"name": "demo-app"}`  → récupérer `APP_ID`
+2. `POST ${API_URL}/v1/subscriptions` avec `{"application_id": "${APP_ID}", "api_id": "${API_ID}", "plan": "free"}`
+3. Alternative single-shot : `POST ${API_URL}/v1/tenants/${TENANT_ID}/applications/${APP_ID}/subscribe/${API_ID}`
+
+**Then**:
+- HTTP 201 sur subscription
+- Réponse contient `api_key` (cleartext, one-time) **OU** `api_key_prefix` + déclenchement key-rotation dans la réponse
+- `status: active`
+
+**Exit code**: 0 si clé API récupérée et non-vide, 1 sinon.
+
+## AT-4 — Appeler l'API via la gateway
+
+**Given** AT-2 PASS ET AT-3 PASS, `API_KEY` connu
+**When**: `GET ${GATEWAY_URL}/apis/${DEMO_API_NAME}/get -H "X-Api-Key: ${API_KEY}"`
+
+Chemin canonique figé: `/apis/{api_name}/{*path}`. Le smoke ne probe plus
+plusieurs shapes.
+
+**Then**:
+- HTTP 200
+- Body contient `"ok": true` (payload du mock backend)
+- Headers de réponse incluent `X-Stoa-Request-Id` (header corrélation injecté par la gateway)
+
+**Retry policy**: 5 tentatives espacées de 2s pour absorber le lag de route-sync. Après 10s = FAIL.
+
+**Exit code**: 0 si 200 + body mock attendu, 1 sinon.
+
+## AT-5 — Preuve observable
+
+**Given** AT-4 PASS (au moins 1 appel effectué)
+**When**:
+1. `GET ${GATEWAY_URL}/metrics | grep -E 'proxy_requests_total|mcp_tool_calls_total'`
+2. Récupérer les logs stdout de la gateway (ou `docker logs stoa-gateway`) sur les 60 dernières secondes
+
+**Then**:
+- Au moins une métrique Prometheus avec `_total` strictement > 0 (compteur incrémenté par AT-4)
+- Au moins une ligne log JSON contenant `api_id=${API_ID}` OU `tenant=demo` OU `request_id=${X_STOA_REQUEST_ID}` issue d'AT-4
+- **[MOCK OK]** Trace OTEL = non bloquant (no-op si endpoint vide), mais vérifié par AT-5b quand la stack observabilité est disponible
+
+**Exit code**: 0 si métrique > 0 ET log corrélé trouvé, 1 sinon.
+
+## AT-5b — Visibilité observabilité (nice-to-have)
+
+**Given** AT-4 PASS et AT-5 PASS
+**When** une ou plusieurs surfaces sont configurées:
+1. `GET ${GRAFANA_URL}/api/health`
+2. `GET ${GRAFANA_URL}/api/datasources/uid/prometheus`
+3. `GET ${GRAFANA_URL}/api/datasources/uid/opensearch-traces` OU `GET ${GRAFANA_URL}/api/datasources/uid/tempo`
+4. `GET ${CONSOLE_URL}/monitoring`
+5. `GET ${PORTAL_URL}/usage`
+
+**Then**:
+- Grafana est joignable et a au moins la datasource Prometheus
+- Si OTEL est actif, Grafana expose `OpenSearch Traces` ou `Tempo`
+- Console `/monitoring` est routable côté UI
+- Portal `/usage` est routable côté UI, et le dashboard Grafana embarqué est activable via `VITE_GRAFANA_URL`
+
+**Exit code**: non-bloquant. AT-5b ne change pas le verdict `demo-smoke-test.sh` v1 ; il produit seulement une ligne `[INFO]`, `[PASS]` ou `[WARN]`.
+
+## AT-6 — Cleanup (optionnel, non-bloquant)
+
+`DELETE` subscription → application → api (reverse order). Non-bloquant : le script laisse les ressources si échec cleanup, signale en warning.
+
+## Règle d'agrégation
+
+- `demo-smoke-test.sh` affiche `REAL_PASS — DEMO READY` ⟺ AT-0 à AT-5 tous PASS sans mock
+- `demo-smoke-test.sh --dry-run-contract` peut exit 0 avec `CONTRACT_DRY_RUN`, jamais `DEMO READY`
+- `MOCK_MODE=all demo-smoke-test.sh` peut exit 0 avec `MOCK_PASS`, jamais `DEMO READY`
+- AT-6 peut FAIL sans impacter le verdict (warning seulement)
+- Chaque AT est logué avec timestamp + durée + détail FAIL
+
+## Évolution
+
+Toute modification du contrat implique:
+1. Mettre à jour `demo-scope.md` §2 (source de vérité)
+2. Mettre à jour cet AT
+3. Mettre à jour `scripts/demo-smoke-test.sh`
+4. Mention dans `demo-readiness-report.md` "Historique"
+
+Jamais l'inverse (ne jamais réaligner la spec sur un test adhoc).

--- a/specs/demo-readiness-report.md
+++ b/specs/demo-readiness-report.md
@@ -1,0 +1,163 @@
+# STOA Demo — Readiness Report
+
+> **Date**: 2026-04-24
+> **Scope**: Évaluation du chemin démo minimal (`demo-scope.md` §2) versus état réel du monorepo.
+> **Méthode**: inspection statique repo + revue `REWRITE-PLAN.md` actifs (GW-2, GO-2) + mapping endpoints cp-api et gateway.
+> **Script de référence**: `scripts/demo-smoke-test.sh`
+
+## 1. Résumé exécutif (10 lignes)
+
+1. Les briques démo existent toutes en code : cp-api (routes apis/apps/subs/deployments présentes), stoa-gateway (`/apis/{api_name}/{*path}`, `/health`, `/metrics`), stoactl (apply/get/subscription).
+2. Il n'y a **aucun test bout-en-bout** qui exerce les 5 étapes dans l'ordre sur la même instance. Le rewrite a recertifié chaque brique isolément.
+3. Les rewrites actifs (GW-1 closed, GW-2 open, GO-2 validated) respectent leurs contrats internes mais aucun garde-fou démo ne protège le chemin vertical.
+4. La route proxy gateway canonique est figée pour la démo : `GET /apis/{api_name}/get`. Le smoke ne probe plus plusieurs shapes.
+5. Le seed existe (`make seed-dev`), mais un tenant `demo` minimal dédié smoke n'est pas garanti reproductible.
+6. La métrique Prometheus attendue (`proxy_requests_total` ou `mcp_tool_calls_total`) est présente en code gateway mais son nom exact + labels ne sont pas figés dans un contrat testé ; OTEL/Grafana/Console/Portal sont maintenant cadrés en AT-5b nice-to-have.
+7. L'auth API key (header `X-Api-Key`) existe gateway-side ; le retour `api_key` cleartext par la création subscription cp-api est probablement déjà masqué (best practice), ce qui casse la démo self-contained.
+8. La stack docker-compose pré-existe (`deploy/docker-compose/docker-compose.yml`) mais son suffisance pour le smoke n'est pas validée (mock-backend non-confirmé).
+9. Les specs `/specs/*.md` créés + `scripts/demo-smoke-test.sh` donnent un contrat exécutable avec verdicts non ambigus (`REAL_PASS`, `CONTRACT_DRY_RUN`, `MOCK_PASS`, `FAIL`). **Aucun run réel n'a encore été tenté**.
+10. Verdict préliminaire : **FAIL attendu en premier run** sur AT-2/AT-3/AT-4. Plan "démo-first" actionnable immédiat ci-dessous.
+
+## 2. Ce qui marche déjà (inspection statique)
+
+### 2.1 Côté cp-api
+- `POST /v1/tenants/{tid}/apis` — endpoint + tests unitaires présents (`control-plane-api/src/routers/apis.py`)
+- `POST /v1/tenants/{tid}/applications` + `POST /applications/{id}/subscribe/{api_id}` — endpoint + tests
+- `POST /v1/subscriptions` + logique clé API (`generate_key`, prefix) — fichier `subscriptions.py` complet
+- `POST /v1/tenants/{tid}/deployments` — endpoint + schéma `DeploymentResponse`
+- `GET /v1/internal/gateways/routes?gateway_name=X` — endpoint polling disponible
+- `/health` sur cp-api — reconnu par scripts existants (smoke-test.sh)
+
+### 2.2 Côté gateway
+- `Router::new()` dans `src/lib.rs` :
+  - `/health`, `/health/ready`, `/health/live`, `/ready`, `/metrics`
+  - `/apis/{api_name}/{*path}` — fallback dynamique gateway via `RouteRegistry`
+  - Mode edge-mcp par défaut (ADR-024)
+- Instrumentation `tracing-subscriber` JSON par ligne (via CLAUDE.md gateway)
+- Prometheus metrics registry (`src/metrics.rs`)
+- Stack observabilité compose existante : Grafana, Prometheus, Loki, Data Prepper, OpenSearch, Tempo. Les datasources `OpenSearch Traces` et `Tempo` sont requises pour rendre OTEL visible dans Grafana.
+- SIGHUP handler pour hot-reload routes depuis cp-api
+
+### 2.3 Côté stoactl
+- Commandes requises démo disponibles : `auth login`, `apply`, `get`, `subscription`, `gateway`, `deploy`
+- Client HTTP `pkg/client/client.go` avec sous-clients catalog, audit, quota
+
+### 2.4 Outils périphériques
+- `Makefile` racine : `run-api`, `run-gateway`, `seed-dev`, `lint-*`, `test-*`
+- `scripts/smoke-test.sh` (CAB-1043) — gate smoke niveau 1 basé sur URLs publiques (portal.gostoa.dev etc.) ; **pas adapté au chemin démo local** mais bon template
+- `deploy/docker-compose/docker-compose.yml` — stack locale pré-existante
+
+## 3. Ce qui manque (gap analysis)
+
+### 3.0 Démo client/prospect séparée du smoke provider
+
+Le parcours client/prospect n'était pas couvert par le contrat initial. Il est
+maintenant cadré dans `specs/client-prospect-demo-scope.md` avec CPD-0..CPD-10.
+Ce parcours couvre signup, Portal onboarding, catalogue, subscription, premier
+appel, usage client, monitoring opérateur et dashboard prospects.
+
+Il reste non bloquant pour `demo-smoke-test.sh` tant que les blockers provider
+P0 ne sont pas fermés, mais il devient la référence pour toute PR touchant
+Portal, signup, prospects, subscriptions UX ou usage client.
+
+### 3.1 Contrats figés non documentés
+- `architecture-rules.md` §2.2 affirme que `/apis/{api_name}/{*path}` est la surface démo officielle.
+- `demo-smoke-test.sh` utilise un seul chemin canonique: `/apis/${DEMO_API_NAME}/get`.
+- Format Prometheus attendu (`proxy_requests_total`) pas testé en intégration — probable drift silencieux si renommé
+
+### 3.2 Seed démo reproductible
+- `make seed-dev` seed un profile plus large que démo minimale. Besoin d'un profile `demo-smoke` qui seed UNIQUEMENT :
+  - tenant `demo` avec UUID déterministe
+  - gateway instance `gateway-demo` enregistrée
+  - clé admin jetable `DEMO_ADMIN_TOKEN`
+
+### 3.3 Accès clé API en cleartext (bloquant AT-3 → AT-4)
+Le fichier `subscriptions.py` génère `new_api_key, new_api_key_hash, new_api_key_prefix`. La bonne pratique sécurité retourne uniquement le préfixe, rendant la clé cleartext inutilisable après création. Si c'est le cas, **AT-4 ne peut pas utiliser l'output de AT-3** sans fallback.
+
+Solution démo-first : retourner cleartext **une seule fois** dans la réponse de `POST /subscriptions` quand `X-Demo-Mode: true` (feature flag démo) ou via endpoint dédié `POST /subscriptions/{id}/reveal-key` (one-shot, jetable).
+
+### 3.4 Mock backend stable dans la stack démo
+`MOCK_BACKEND_URL=http://localhost:9090` est fourni par le service compose
+`mock-backend`, qui expose `/ping` et `/get` en JSON stable avec `ok:true`.
+Le smoke sépare cette URL de probe locale de `MOCK_BACKEND_UPSTREAM_URL`,
+qui vaut `http://mock-backend:9090` en compose pour que la gateway ne cible
+pas `localhost` depuis son propre conteneur.
+Ce point ferme B2 pour AT-0. AT-4 peut maintenant cibler un backend local
+déterministe dès que B1 fournit une clé
+exploitable.
+
+### 3.5 Chemin proxy gateway figé
+Le chemin gateway démo est canonique : `{GATEWAY_URL}/apis/{api_name}/get`.
+`api_name` désigne le slug retourné par `POST /v1/tenants/{tid}/apis`
+(`demo-api-smoke` par défaut). Le smoke utilise ce chemin unique.
+
+### 3.6 Auth bypass dev non documenté
+Le script smoke autorise `DEMO_ADMIN_TOKEN=""` en fallback, mais aucune variable `STOA_DISABLE_AUTH` ou flag équivalent n'est documenté côté cp-api. Probable que la démo échoue silencieusement en 401/403 sur AT-1 sans JWT Keycloak valide.
+
+### 3.7 Route-sync latence
+Polling 30s par défaut dans stoa-connect → AT-2 peut timeout. Mitigation dans script : `ROUTE_SYNC_GRACE_SECS=30` + probe explicite de `GET /v1/internal/gateways/routes`. En prod démo, ajouter un `POST /internal/gateways/{id}/trigger-sync` dédié ferait gagner du temps.
+
+## 4. Blockers réels (à résoudre avant smoke `REAL_PASS`)
+
+| # | Blocker | Sévérité | Étape impactée | Owner suggéré |
+|---|---------|----------|----------------|---------------|
+| B1 | Pas d'accès cleartext à `api_key` après création subscription | P0 | AT-3 → AT-4 | cp-api (1 PR) |
+| B2 | Mock backend non seedé dans docker-compose | P0 | AT-0, AT-4 | **DONE** — `mock-backend` compose |
+| B3 | Mapping `api_name → proxy path` flou côté gateway | P0 | AT-4 | **DONE** — `/apis/{api_name}/get` |
+| B4 | Auth dev-bypass cp-api non documenté | P1 | AT-1, AT-2, AT-3 | cp-api (flag `.env.demo`) |
+| B5 | Seed profile `demo-smoke` minimal absent | P1 | AT-0 | cp-api/scripts/seeder |
+| B6 | Métriques Prometheus noms non figés par test | P2 | AT-5 | gateway (test regression) |
+| B7 | Route-sync 30s est lent pour une démo live | P2 | AT-2 | stoa-connect (trigger endpoint) |
+| B8 | OTEL visible en UI non prouvé automatiquement | P3 | AT-5b | observability/ui (nice-to-have) |
+| C-B1 | Démo client/prospect non automatisée (seed + UI + conversion) | P1 | CPD-0..CPD-10 | portal/console/cp-api |
+
+## 5. Contournements acceptables pendant le rewrite
+
+Pour débloquer rapidement la validation du contrat sans confondre script OK et démo prête :
+
+| Contournement | Cible | Durée | Risque |
+|---------------|-------|-------|--------|
+| `./scripts/demo-smoke-test.sh --dry-run-contract` | Tous | permanent | Valide le contrat/script, verdict `CONTRACT_DRY_RUN`, jamais `DEMO READY` |
+| `MOCK_MODE=all ./scripts/demo-smoke-test.sh` | B1/B2/B3 | jusqu'aux fixes | Valide le chemin mocké, verdict `MOCK_PASS`, jamais `DEMO READY` |
+| Démarrer `mock-backend` via compose seul (`docker compose ... up -d mock-backend`) | B2 | jusqu'à stack complète | Service sous profil `demo`; ne pas exposer Prometheus sur le même port pendant ce smoke |
+| `DEMO_GATEWAY_PATH` override local | B3 | debug uniquement | Toute démo officielle doit revenir à `/apis/{api_name}/get` |
+| `DEMO_ADMIN_TOKEN` extrait via `stoactl auth login demo-admin` puis injecté | B4 | 1 jour | Couplage Keycloak |
+| Script seed inline dans `demo-smoke-test.sh` qui crée tenant + gateway si absent | B5 | 1 jour | Pas idempotent si collisions |
+| Check "au moins un counter `*_total`" sans figer nom | B6 | jusqu'à B6 | Drift silencieux toléré |
+
+Ces contournements **sont figés dans le script**, mais ils ne produisent jamais
+`REAL_PASS`. À chaque blocker fermé, on resserre la vérification.
+
+## 6. Prochaine PR prioritaire
+
+**PR `chore(demo): add demo-first scaffolding`** — PR de cadrage demo-first :
+
+1. Commit 1 — specs+script : ce batch de fichiers `/specs/*.md` + `/scripts/demo-smoke-test.sh` (créé dans cette session)
+2. Commit 2 — `deploy/docker-compose/docker-compose.demo.yml` : extension de `docker-compose.yml` qui ajoute `mock-backend` (httpbin) sur port 9090 + `.env.demo` avec defaults documentés
+3. Commit 3 — `Makefile` targets : `demo-up`, `demo-down`, `demo-smoke` (le dernier wrappe `./scripts/demo-smoke-test.sh`)
+
+Cette PR **ne touche aucun code applicatif**. Elle pose uniquement le contrat. Après merge : premier run en local → identifier lequel des B1..B7 déclenche en pratique → PR ciblée B1 en priorité (plus grand impact AT-3/AT-4).
+
+## 7. Verdict GO / NO-GO rewrite
+
+**GO** sur la poursuite du rewrite actuel, **sous les 4 conditions**:
+
+1. La PR prioritaire §6 est mergée dans la semaine (contrat démo actif en repo)
+2. Chaque PR rewrite en cours (GW-2, GO-2, CP-*) ajoute la section "Demo impact" dans sa description (cf. `rewrite-guardrails.md` §4)
+3. Dès le 1er run smoke `REAL_PASS` localement, `scripts/demo-smoke-test.sh` est ajouté en CI (workflow `.github/workflows/demo-smoke.yml`) avec `docker-compose.demo.yml` comme stack de test
+4. Le parcours client/prospect a au minimum un seed idempotent + une checklist CPD-0..CPD-10 exécutable manuellement avant toute démo commerciale
+
+**NO-GO** si :
+
+- Aucune PR rewrite ne documente son "demo impact" dans les 7 jours → les rewrites avancent hors radar démo
+- Un blocker P0 (B1, B2, B3) reste ouvert > 10 jours → indiquerait que la démo n'est pas priorité réelle
+- Une régression AT-1..AT-5 est observée sans rollback immédiat
+- Un `MOCK_PASS` ou `CONTRACT_DRY_RUN` est présenté comme `DEMO READY`
+
+**Recommandation opérationnelle** : **GO conditionnel**. Le rewrite est qualitatif (plans GW-2/GO-2 rigoureux), mais il s'exécute sans contrat démo vérifiable. Les fichiers `/specs/` + `scripts/demo-smoke-test.sh` posés aujourd'hui sont le minimum pour transformer le rewrite en livraison démo-first.
+
+## 8. Historique
+
+| Date | Version | Auteur | Delta |
+|------|---------|--------|-------|
+| 2026-04-24 | v1.0 | Claude (session `/demo-scope`) | Création initiale, 7 blockers identifiés, verdict GO conditionnel |

--- a/specs/demo-scope.md
+++ b/specs/demo-scope.md
@@ -1,0 +1,97 @@
+# STOA Demo Scope — Contrat minimal exécutable
+
+> **Statut**: v1.0 — 2026-04-24. Contrat figé pendant le rewrite.
+> **Owner**: humain (Christophe). Les agents n'élargissent pas ce scope sans décision écrite.
+> **Source de vérité**: ce fichier. Toute autre spec démo doit y renvoyer.
+> **Complément**: le parcours commercial client/prospect est cadré dans `client-prospect-demo-scope.md`.
+
+## 1. Pourquoi ce contrat
+
+Le rewrite STOA produit des PR plus qualitatives (GW-1/GW-2 Rust, GO-1/GO-2 Go, UI-2 React, CP-2 Python), mais chaque module est re-certifié isolément. Il manque **un chemin vertical exécutable** qui prouve que l'ensemble livre encore la proposition de valeur STOA : *"déclarer une API et l'exposer à un consommateur via la gateway, avec preuve observable"*.
+
+Ce scope fige ce chemin. Tant qu'il n'est pas vert bout-en-bout, **aucune autre feature n'est merge-acceptable**.
+
+## 2. Scénario démo cible (5 étapes, non négociables)
+
+| # | Étape | Composant(s) | Commande/API | Preuve |
+|---|-------|--------------|--------------|--------|
+| 1 | Déclarer une API | cp-api + DB | `POST /v1/tenants/{t}/apis` (ou `stoactl apply -f api.yaml`) | API visible dans `GET /v1/tenants/{t}/apis` |
+| 2 | Provisionner la route gateway | cp-api + stoa-gateway | `POST /v1/tenants/{t}/deployments` → gateway polling `GET /v1/internal/gateways/routes` OU `stoa-connect` SSE `GET /v1/internal/gateways/{id}/events` | Route active dans la table gateway (log `Route table reloaded` + réponse non-404 au step 4) |
+| 3 | Créer une souscription applicative | cp-api | `POST /v1/tenants/{t}/applications` + `POST /v1/subscriptions` (ou `POST /applications/{id}/subscribe/{api_id}`) | Subscription `active`, clé API retournée (préfixe visible) |
+| 4 | Appeler l'API via la gateway | stoa-gateway | `GET {GATEWAY_URL}/apis/{api_name}/get` avec header `X-Api-Key: ${KEY}` (ou JWT OAuth) | HTTP 2xx, payload backend |
+| 5 | Preuve observable | stoa-gateway + cp-api | `GET {GATEWAY_URL}/metrics` + logs JSON stdout | Compteur Prometheus incrémenté (`proxy_requests_total` ou `mcp_tool_calls_total`) + ligne log corrélée (request_id, tenant, route) |
+| 5b | Visibilité observabilité (nice-to-have) | Grafana + Console + Portal | Grafana datasource/dashboard, Console `/monitoring`, Portal `/usage` ou dashboard embarqué | La même activité démo est visible dans au moins une surface UI si la stack observabilité est démarrée |
+
+## 3. Surface in-scope (et rien d'autre)
+
+**Binaires**:
+- `control-plane-api` (FastAPI) — endpoints listés §2
+- `stoa-gateway` (Rust) — routes `/apis/{api_name}/{*path}`, `/health`, `/metrics`
+- `stoactl` (Go) — sous-commandes `apply`, `get`, `subscription`, `auth login` seulement
+
+**Backend cible pour l'appel démo**: un mock HTTP (ex. `mock-backends/` ou `httpbin` en conteneur) qui répond 200 JSON. Pas de backend externe réseau.
+
+**Auth**: API key (préfixe `stoa_…`) OU JWT Keycloak — un seul mode suffit pour la démo. Choisir API key (plus simple à reproduire).
+
+**Observabilité minimale acceptée**: Prometheus `/metrics` + logs JSON stdout.
+
+**Visibilité nice-to-have**: si Grafana, Console et Portal sont démarrés, la démo doit exposer un chemin humain vérifiable:
+- Grafana: dashboard ou Explore utilisant `Prometheus`, `Loki`, `OpenSearch Traces` ou `Tempo`
+- Console: page `/monitoring` alimentée par `GET /v1/monitoring/transactions`
+- Portal: page `/usage` et/ou dashboard Grafana embarqué si `VITE_GRAFANA_URL` est configuré
+
+OTEL reste non bloquant pour le PASS démo v1, mais il doit être visible dès que `STOA_OTEL_ENDPOINT` et la stack Data Prepper/OpenSearch/Tempo sont actifs.
+
+## 4. Out-of-scope (règles dures — refuser toute PR qui élargit)
+
+Explicitement exclus du contrat provider/runtime. Ces sujets peuvent être couverts
+par `client-prospect-demo-scope.md`, mais ne doivent pas devenir requis pour
+`demo-smoke-test.sh` `REAL_PASS`:
+
+- Multi-tenant complet (RBAC cross-tenant, invitations, ACL fines)
+- RBAC fin (rôles custom, scopes dynamiques) — seul `tenant-admin` suffit
+- Portal public (developer portal / catalogue self-service) — voir `client-prospect-demo-scope.md`
+- Federation / multi-gateway
+- GitOps E2E (sync `stoa-catalog` ↔ DB) — on coupe via `GIT_SYNC_ON_WRITE=false`
+- Policies OPA, rate-limiting configurable, MCP, webhooks, Kafka events
+- OpenSearch, error snapshots, call-flow pipeline
+- UI (Console, Portal) — hors smoke provider, voir `client-prospect-demo-scope.md`
+- Benchmarks performance, canary, shadow mode, mTLS
+- Multi-env (prod/staging/dev) — un seul env local suffit
+- Toute nouvelle feature non cochée au §2
+
+Si une PR rewrite introduit un changement hors de §2 ou §3, la règle par défaut est **NO-GO** sauf décision humaine explicite.
+
+## 5. Cible de validation
+
+Un seul critère binaire, exécuté par `scripts/demo-smoke-test.sh`:
+
+```
+$ ./scripts/demo-smoke-test.sh
+[PASS] 1/5 API declared
+[PASS] 2/5 Route provisioned
+[PASS] 3/5 Subscription active
+[PASS] 4/5 Gateway call 200
+[PASS] 5/5 Observable proof (metric + log)
+Verdict: REAL_PASS — DEMO READY
+```
+
+Tant que ce script n'affiche pas `REAL_PASS — DEMO READY`, la démo réelle
+n'existe pas. `CONTRACT_DRY_RUN` et `MOCK_PASS` peuvent retourner exit 0, mais
+signifient seulement que le contrat ou le chemin mocké est cohérent.
+
+## 6. Dépendances figées pendant le rewrite
+
+Voir `rewrite-guardrails.md` §Contrats figés:
+- Compatibilité DB consommée par le smoke (`apis`, `applications`, `subscriptions`, `deployments`, `api_keys`)
+- Endpoints listés §2 (URL + status codes + shape minimal de réponse)
+- Route `/apis/{api_name}/{*path}` gateway + comportement auth-header
+- Format métrique Prometheus (nom `_total`, labels `tenant`, `api`, `method`, `status`)
+
+Tout autre aspect peut bouger.
+
+## 7. Révisions
+
+| Date | Auteur | Changement |
+|------|--------|------------|
+| 2026-04-24 | Claude (via `/demo-scope`) | Création initiale |

--- a/specs/rewrite-guardrails.md
+++ b/specs/rewrite-guardrails.md
@@ -1,0 +1,119 @@
+# STOA Rewrite — Guardrails
+
+> **Statut**: v1.0 — 2026-04-24. Ces garde-fous s'appliquent à TOUTE PR tant que `demo-smoke-test.sh` n'est pas `REAL_PASS` en CI.
+> **Objectif unique**: protéger la démo minimale pendant que le rewrite (GW-*, GO-*, UI-*, CP-*) continue.
+
+## 1. Principe directeur
+
+**Chaque PR doit rapprocher ou préserver le verdict `REAL_PASS` du smoke démo.** Aucune autre mesure de qualité (coverage, clippy, tests ajoutés) ne prime si la démo régresse.
+
+Décision tree à appliquer pour chaque PR :
+
+```
+demo-smoke AVANT = REAL_PASS ?
+ ├─ OUI → demo-smoke APRÈS doit rester REAL_PASS. Sinon NO-GO.
+ └─ NON → demo-smoke APRÈS doit rester au même verdict OU améliorer vers REAL_PASS.
+           Régression (REAL_PASS→FAIL/MOCK_PASS/CONTRACT_DRY_RUN ou étapes réelles qui deviennent mockées) = NO-GO.
+```
+
+## 2. Freeze list (composants / fichiers / contrats figés)
+
+Les éléments suivants sont **figés** : toute modification demande Council 8/10 + ADR :
+
+### 2.1 Contrats code (tests de régression à écrire si absents)
+- Schéma URL des endpoints listés dans `architecture-rules.md` §2.1
+- Format métriques Prometheus `proxy_requests_total` / `mcp_tool_calls_total`
+- Header `X-Api-Key` accepté par gateway `/apis/{api_name}/{*path}`
+- Header de réponse `X-Stoa-Request-Id` injecté par gateway
+- Datasources Grafana `prometheus`, `loki`, `opensearch-traces`, `tempo` si la stack observabilité est touchée
+- Compatibilité DB consommée par le smoke (§2.6 de `architecture-rules.md`)
+
+### 2.2 Scripts critiques
+- `scripts/demo-smoke-test.sh` (v1 = ce sprint)
+- `Makefile` targets : `run-api`, `run-gateway`, `seed-dev`, `lint-*`, `test-*`
+- `deploy/docker-compose/docker-compose.yml` (services : postgres, keycloak, cp-api, gateway, mock-backend)
+
+### 2.3 Dépendances
+- Gateway : pas de nouvelle crate majeure (tokio, axum, serde, figment, reqwest) en version X → Y pendant le rewrite hors Council
+- cp-api : pas de changement FastAPI / SQLAlchemy / Alembic major
+- stoa-go : pas de migration keyring / cobra major
+
+## 3. Règles actives sur les rewrites en cours
+
+### 3.1 GW-* (stoa-gateway Rust)
+- GW-2 (split `config.rs`) : OK car plan respecte §1 amendement 1 (façade conservée, contrat TOML/env intact). **Autoriser** tant que `cargo test` vert + `insta` snapshot `Config::default()` inchangé.
+- Tout GW-3+ doit commencer par : "ce changement affecte-t-il `/apis/{api_name}/{*path}`, `/health`, `/metrics`, `X-Api-Key` handling ?" → si oui, Council obligatoire.
+- Feature flags Cargo : démo tourne en build **default**. Pas de dépendance runtime à `kafka` ou `k8s` dans le chemin démo.
+
+### 3.2 GO-* (stoa-go / stoactl + stoa-connect)
+- GO-2 (hardening `internal/connect/`) : OK tant que le polling `GET /v1/internal/gateways/routes` reste fonctionnel (fallback démo si SSE down).
+- stoactl commands minimales nécessaires à la démo : `auth login`, `apply`, `get`, `subscription list|create`. Les autres peuvent bouger librement.
+
+### 3.3 CP-* (control-plane-api)
+- CP-2 (batch de fixes) : OK si aucun rename de colonne DB ni breaking de routes §2.1.
+- Tout nouveau middleware obligatoire sur routes démo → test smoke vérifie qu'il passe avec les credentials démo.
+
+### 3.4 UI-*
+- Hors chemin démo (démo pilotée en CLI). UI peut bouger librement.
+- **Exception** : si la démo pivote vers un chemin UI (non prévu v1), `demo-scope.md` §2 doit être mis à jour EN MÊME TEMPS.
+
+## 4. PR template : section "démo impact" obligatoire
+
+Chaque PR touchant cp-api, stoa-gateway, stoa-go, charts, deploy/ doit inclure dans sa description :
+
+```markdown
+## Demo impact
+
+- [ ] Vérifié : aucune modification de `specs/architecture-rules.md` §2 (contrats figés)
+- [ ] `./scripts/demo-smoke-test.sh` exécuté avant cette PR : REAL_PASS / CONTRACT_DRY_RUN / MOCK_PASS / FAIL (préciser)
+- [ ] `./scripts/demo-smoke-test.sh` exécuté après cette PR : REAL_PASS / CONTRACT_DRY_RUN / MOCK_PASS / FAIL (préciser)
+- [ ] Si non-REAL_PASS ou régression : quelle étape AT-N échoue ou est mockée et pourquoi est-ce acceptable ?
+```
+
+PR sans cette section = NO-GO automatique si touche un composant listé §2.
+
+## 5. Interdits pendant la période rewrite (défaut NO-GO)
+
+1. **Rewrite cosmétique** : rename global, reflow imports, nettoyage sans impact démo → merge plus tard, pas maintenant.
+2. **Nouvelles features** (MCP expansion, federation, LLM router enrichi, OPA policies nouvelles) → queue dans le backlog, pas dans le sprint démo.
+3. **Refactor d'architecture** non cité dans un REWRITE-PLAN.md validé → stop.
+4. **"Tant que j'y suis..."** → stop. 1 PR = 1 intention.
+5. **Suppression d'un endpoint ou colonne** listé §2 → Council + ADR + période de dépréciation.
+6. **Changement de port démo** (8000, 8080, 9090) → casse smoke, stop.
+
+## 6. Exceptions tolérées (pas de Council)
+
+- Bug fix P0 prod (documenté en commit message)
+- Typo / comment / docstring
+- Dependabot mineur (patch-level)
+- Test ajouté sans toucher code prod
+- ADR nouvelle (stoa-docs)
+
+Ces PR peuvent sauter la section §4 mais doivent mentionner "demo-impact: none" dans le titre ou la description.
+
+## 7. Escalade et décision humaine
+
+Tout désaccord sur "cette PR est-elle acceptable démo-wise ?" remonte à humain (Christophe). Pas d'interprétation agent.
+
+Signes qui déclenchent escalade automatique :
+- PR modifie `specs/*.md`
+- PR modifie une route §2 ou un nom de métrique §2.3
+- PR modifie `scripts/demo-smoke-test.sh`
+- PR touche `Makefile` target `run-*` ou `test-*`
+
+## 8. Journal des breaches (à alimenter)
+
+| Date | PR | Type breach | Décision | Follow-up |
+|------|-----|-------------|----------|-----------|
+| 2026-04-24 | — | — | Création initiale | — |
+
+Chaque entrée sert de jurisprudence pour calibrer les décisions futures.
+
+## 9. Sortie du régime guardrails
+
+Conditions pour relâcher ces règles :
+1. `./scripts/demo-smoke-test.sh` `REAL_PASS` en CI ≥ 5 jours consécutifs
+2. Une démo réelle a été exécutée avec succès devant un témoin humain
+3. `specs/demo-readiness-report.md` conclut GO en verdict final sans blockers
+
+Avant ces 3 conditions = garde-fous actifs.

--- a/specs/validation-commands.md
+++ b/specs/validation-commands.md
@@ -1,0 +1,204 @@
+# STOA Demo — Validation Commands
+
+> **Statut**: v1.0 — 2026-04-24. Commandes exécutables alignées sur `Makefile` racine et `scripts/`.
+> Toute divergence entre ce fichier et le Makefile = bug à signaler, pas à ignorer.
+
+## 1. Vérification du chemin démo (la commande qui compte)
+
+```bash
+./scripts/demo-smoke-test.sh
+```
+
+Affiche `REAL_PASS — DEMO READY` uniquement si AT-0..AT-5 de
+`demo-acceptance-tests.md` passent sans mock critique.
+
+Modes non réels explicites:
+
+```bash
+# Valide le contrat/script sans stack live. Ne prouve pas la démo.
+./scripts/demo-smoke-test.sh --dry-run-contract
+
+# Valide le chemin mocké. Ne prouve pas la démo.
+MOCK_MODE=all ./scripts/demo-smoke-test.sh
+```
+
+`MOCK_MODE=auto` est strict: il ne transforme pas un blocker réel en PASS.
+
+Variables d'environnement (defaults documentés dans le script) :
+
+| Var | Default | Description |
+|-----|---------|-------------|
+| `API_URL` | `http://localhost:8000` | Base URL cp-api |
+| `GATEWAY_URL` | `http://localhost:8080` | Base URL stoa-gateway |
+| `MOCK_BACKEND_URL` | `http://localhost:9090` | Mock HTTP backend vu par le poste dev pour AT-0 |
+| `MOCK_BACKEND_UPSTREAM_URL` | `http://mock-backend:9090` | Mock HTTP backend vu par la gateway en compose |
+| `DEMO_GATEWAY_PATH` | `/apis/${DEMO_API_NAME}/get` | Chemin gateway canonique AT-4 |
+| `TENANT_ID` | `demo` (slug, résolu en UUID par cp-api) | Tenant démo |
+| `DEMO_ADMIN_TOKEN` | vide | JWT admin pour écrire côté cp-api. Si vide, le script passe en `STOA_DISABLE_AUTH=true` mode (dev only) |
+| `ROUTE_SYNC_GRACE_SECS` | `30` | Délai d'attente pour route visible en gateway après AT-2 |
+| `OBS_VISIBILITY_CHECK` | `auto` | Lance AT-5b nice-to-have (`off` pour désactiver) |
+| `GRAFANA_URL` | `http://localhost:3001` | Grafana local pour vérifier health + datasources |
+| `GRAFANA_USER` / `GRAFANA_PASSWORD` | `admin` / `admin` | Basic auth Grafana local |
+| `CONSOLE_URL` | `http://localhost:3000` | Console UI locale (`/monitoring`) |
+| `PORTAL_URL` | `http://localhost:3002` | Developer Portal local (`/usage`) |
+
+## 2. Boot local démo (pré-requis avant AT-0)
+
+### Option A — docker-compose (recommandé)
+```bash
+# Stack minimale: postgres, keycloak, cp-api, gateway, mock-backend
+docker compose -f deploy/docker-compose/docker-compose.yml up -d \
+    postgres keycloak control-plane-api stoa-gateway mock-backend
+
+# Attendre healthy
+docker compose -f deploy/docker-compose/docker-compose.yml ps
+
+# Seed minimal (tenant demo + gateway enregistrée)
+make seed-dev  # OU: SEED_PROFILE=demo python3 -m control-plane-api/scripts.seeder
+```
+
+### Option B — native (dev rapide)
+```bash
+# Terminal 1
+make run-api             # cp-api sur :8000
+
+# Terminal 2
+make run-gateway         # stoa-gateway sur :8080
+
+# Terminal 3 (backend mock only, if compose is not used)
+docker compose -f deploy/docker-compose/docker-compose.yml up -d mock-backend
+export MOCK_BACKEND_UPSTREAM_URL=http://localhost:9090
+```
+
+## 3. Lint (pré-conditions PR démo-ready)
+
+```bash
+# Tous les linters de la démo (cp-api + gateway + CLI)
+make lint-api            # ruff + black (cp-api)
+make lint-gateway        # cargo fmt --check + clippy -D warnings
+cd stoa-go && make lint  # ou golangci-lint run ./...
+```
+
+Règle : **aucun warning clippy** côté gateway (`-D warnings`). Pas de `#[allow(...)]` ajouté sans justification.
+
+## 4. Tests (scope démo uniquement)
+
+```bash
+# Gateway unit + tests ciblés démo
+cd stoa-gateway && cargo test --lib                   # default features, no kafka/k8s
+cd stoa-gateway && cargo test --test integration_*    # intégration légère
+
+# cp-api tests qui touchent apis/deployments/subscriptions/applications
+cd control-plane-api && pytest tests/routers/test_apis.py tests/routers/test_subscriptions.py \
+    tests/routers/test_deployments.py tests/routers/test_applications.py \
+    --cov=src --cov-fail-under=70 -q
+
+# stoa-go CLI tests apply/get/subscription
+cd stoa-go && go test ./internal/cli/cmd/apply/... ./internal/cli/cmd/get/... \
+    ./internal/cli/cmd/subscription/... ./pkg/client/...
+```
+
+## 5. Build (démo peut-elle se déployer ?)
+
+```bash
+# Gateway image community (no features)
+cd stoa-gateway && cargo build --release
+
+# cp-api image
+cd control-plane-api && docker build -t stoa/cp-api:demo .
+
+# stoactl binary
+cd stoa-go && make build-stoactl
+# produit bin/stoactl
+```
+
+## 6. Ordre de validation avant d'ouvrir une PR "démo-related"
+
+1. `./scripts/demo-smoke-test.sh` sur main → baseline (doit être soit `REAL_PASS`, soit `FAIL` figé documenté)
+2. Appliquer la PR localement
+3. `make lint-api lint-gateway` (plus `go lint` si touche stoactl)
+4. Tests du §4 pertinents (au minimum la surface touchée)
+5. `./scripts/demo-smoke-test.sh` après PR → verdict
+6. Delta documenté dans description PR : `REAL_PASS` avant + après, ou `FAIL` → `REAL_PASS` si bug-fix
+
+Une PR qui fait dégrader le verdict smoke (`REAL_PASS` → `FAIL`, `MOCK_PASS`, ou `CONTRACT_DRY_RUN`) est **NO-GO automatique**.
+
+## 7. Commandes de debug ciblées démo
+
+```bash
+# État DB minimal démo
+psql $DATABASE_URL -c "SELECT count(*) FROM apis WHERE tenant_id='${TENANT_ID}';"
+psql $DATABASE_URL -c "SELECT status, count(*) FROM subscriptions GROUP BY status;"
+
+# Route table live gateway
+curl -s http://localhost:8080/admin/routes | jq .      # si admin API exposée
+curl -s http://localhost:8000/v1/internal/gateways/routes?gateway_name=demo | jq .
+curl -sI http://localhost:8080/apis/demo-api-smoke/get
+
+# Logs gateway corrélés à un request_id
+docker logs stoa-gateway 2>&1 | grep "request_id=${REQUEST_ID}"
+
+# Grafana datasources visibles pour la démo
+curl -s -u "${GRAFANA_USER}:${GRAFANA_PASSWORD}" http://localhost:3001/api/datasources/uid/prometheus | jq .name
+curl -s -u "${GRAFANA_USER}:${GRAFANA_PASSWORD}" http://localhost:3001/api/datasources/uid/opensearch-traces | jq .name
+curl -s -u "${GRAFANA_USER}:${GRAFANA_PASSWORD}" http://localhost:3001/api/datasources/uid/tempo | jq .name
+
+# Console / Portal surfaces humaines
+curl -sI http://localhost:3000/monitoring
+curl -sI http://localhost:3002/usage
+
+# Forcer reload route côté gateway sans attendre tick
+kill -HUP $(pgrep stoa-gateway)
+```
+
+## 8. Matrix de couverture commandes → étapes démo
+
+| Commande | AT couvert |
+|----------|-----------|
+| `make seed-dev` | AT-0 pré-conditions |
+| `docker compose up …` | AT-0 pré-conditions |
+| `./scripts/demo-smoke-test.sh` | AT-0 → AT-5 réel (`REAL_PASS` seulement si aucun mock) |
+| `./scripts/demo-smoke-test.sh --dry-run-contract` | Contrat script/spec (`CONTRACT_DRY_RUN`, pas démo prête) |
+| `MOCK_MODE=all ./scripts/demo-smoke-test.sh` | Chemin mocké (`MOCK_PASS`, pas démo prête) |
+| `OBS_VISIBILITY_CHECK=auto ./scripts/demo-smoke-test.sh` | AT-5b nice-to-have Grafana/Console/Portal |
+| `make lint-api lint-gateway` | gate PR, pas runtime démo |
+| `make test-api test-gateway` | confiance PR, pas runtime démo |
+| `cargo build --release` | emballage image démo |
+| `make build-stoactl` | emballage CLI démo |
+
+## 9. Intégration CI (future, out-of-scope v1)
+
+Placeholder : une fois le smoke stable, ajouter un workflow `.github/workflows/demo-smoke.yml` qui :
+- Boot docker-compose minimal
+- Exécute `demo-smoke-test.sh`
+- Upload `specs/demo-readiness-report.md` mis à jour en artifact
+- Fail le build si exit != 0
+
+À NE PAS faire tant que le smoke n'est pas `REAL_PASS` au moins une fois en local.
+
+## 10. Démo client/prospect
+
+Le parcours client/prospect est spécifié séparément dans
+`specs/client-prospect-demo-scope.md`.
+
+Validation cible future:
+
+```bash
+# API-level, à créer
+./scripts/client-prospect-demo-smoke.sh
+
+# UI-level, à créer
+cd e2e && npx playwright test client-prospect-demo.spec.ts
+```
+
+Surfaces à vérifier manuellement tant que ces scripts n'existent pas:
+
+```bash
+curl -s http://localhost:8000/v1/portal/apis | jq .
+curl -sI http://localhost:3002/signup
+curl -sI http://localhost:3002/onboarding
+curl -sI http://localhost:3002/discover
+curl -sI http://localhost:3002/usage
+curl -sI http://localhost:3000/admin/prospects
+curl -sI http://localhost:3000/subscriptions
+```


### PR DESCRIPTION
## Summary
- Recover the already-approved demo-first stack onto `main` after `fix/cab-2165-gw-3-cleanup` was merged and deleted before #2532 could land.
- Includes the previously merged demo scaffolding (#2530), B2 mock backend (#2531), and B3 canonical gateway mapping.
- Official demo gateway surface is now `GET /apis/{api_name}/{*path}`; the smoke test no longer probes multiple route shapes.

## Validation
- `git diff --check origin/main..HEAD`
- `bash -n scripts/demo-smoke-test.sh`
- `./scripts/demo-smoke-test.sh --dry-run-contract --no-observability-ui` => `CONTRACT_DRY_RUN`
- `MOCK_MODE=auto ./scripts/demo-smoke-test.sh --no-observability-ui` => `FAIL — DEMO NOT READY`
- `docker compose -f deploy/docker-compose/docker-compose.yml config mock-backend`

## Demo impact
This is a recovery PR. It does not expand scope beyond the PRs already reviewed: demo-first scaffolding, B2 mock backend, and B3 canonical mapping. B1 remains the next blocker.
