### PR TITLE
fix(demo): return one-time api key for smoke

### DIFF
--- a/control-plane-api/src/routers/applications.py
+++ b/control-plane-api/src/routers/applications.py
@@ -4,14 +4,17 @@ import json
 import logging
 from datetime import UTC
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import Permission, User, get_current_user, require_permission, require_tenant_access
 from ..database import get_db
+from ..models.subscription import Subscription, SubscriptionStatus
+from ..repositories.subscription import SubscriptionRepository
 from ..repositories.tenant import TenantRepository
 from ..schemas.pagination import PaginatedResponse
+from ..services.api_key import APIKeyService
 from ..services.keycloak_service import keycloak_service
 
 logger = logging.getLogger(__name__)
@@ -216,7 +219,14 @@ async def regenerate_secret(tenant_id: str, app_id: str, user: User = Depends(ge
 @router.post("/{app_id}/subscribe/{api_id}")
 @require_permission(Permission.APPS_UPDATE)
 @require_tenant_access
-async def subscribe_to_api(tenant_id: str, app_id: str, api_id: str, user: User = Depends(get_current_user)):
+async def subscribe_to_api(
+    tenant_id: str,
+    app_id: str,
+    api_id: str,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
     """Subscribe application to an API."""
     client = await _get_tenant_client(app_id, tenant_id)
     attrs = client.get("attributes", {})
@@ -228,6 +238,36 @@ async def subscribe_to_api(tenant_id: str, app_id: str, api_id: str, user: User 
     subs.append(api_id)
     attrs["api_subscriptions"] = json.dumps(subs)
     await keycloak_service.update_client(app_id, {"attributes": attrs})
+
+    if request.headers.get("x-demo-mode", "").lower() == "true":
+        api_key, api_key_hash, api_key_prefix = APIKeyService.generate_key()
+        repo = SubscriptionRepository(db)
+        subscription = Subscription(
+            application_id=app_id,
+            application_name=client.get("name") or client.get("clientId") or app_id,
+            subscriber_id=user.id,
+            subscriber_email=user.email,
+            api_id=api_id,
+            api_name=api_id,
+            api_version="1.0",
+            tenant_id=tenant_id,
+            plan_name="demo",
+            api_key_hash=api_key_hash,
+            api_key_prefix=api_key_prefix,
+            status=SubscriptionStatus.ACTIVE,
+            approved_by="system:demo-smoke",
+        )
+        subscription = await repo.create(subscription)
+        await db.commit()
+        return {
+            "id": str(subscription.id),
+            "subscription_id": str(subscription.id),
+            "api_key": api_key,
+            "api_key_prefix": api_key_prefix,
+            "status": subscription.status.value,
+            "message": f"Application subscribed to API {api_id}",
+        }
+
     return {"message": f"Application subscribed to API {api_id}"}
 
 

--- a/control-plane-api/tests/test_applications_router.py
+++ b/control-plane-api/tests/test_applications_router.py
@@ -13,6 +13,8 @@ from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
 
 KC_SVC_PATH = "src.routers.applications.keycloak_service"
+SUB_REPO_PATH = "src.routers.applications.SubscriptionRepository"
+API_KEY_SVC_PATH = "src.routers.applications.APIKeyService"
 
 
 def _mock_kc_client(app_id="app-uuid-1", tenant_id="acme", **overrides):

--- a/control-plane-api/tests/test_regression_demo_b1_api_key.py
+++ b/control-plane-api/tests/test_regression_demo_b1_api_key.py
@@ -1,0 +1,40 @@
+"""Regression tests for demo smoke API key handoff."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from tests.test_applications_router import API_KEY_SVC_PATH, KC_SVC_PATH, SUB_REPO_PATH, _mock_kc_client
+
+
+def test_regression_cab_demo_b1_subscribe_demo_mode_returns_one_time_api_key(
+    app_with_tenant_admin, mock_db_session
+):
+    client_data = _mock_kc_client("app-1", "acme")
+    subscription = MagicMock()
+    subscription.id = "sub-1"
+    subscription.status.value = "active"
+
+    mock_sub_repo = MagicMock()
+    mock_sub_repo.create = AsyncMock(return_value=subscription)
+
+    with (
+        patch(f"{KC_SVC_PATH}.get_client_by_id", new=AsyncMock(return_value=client_data)),
+        patch(f"{KC_SVC_PATH}.update_client", new=AsyncMock(return_value=None)),
+        patch(API_KEY_SVC_PATH) as mock_api_key_svc,
+        patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+        TestClient(app_with_tenant_admin) as client,
+    ):
+        mock_api_key_svc.generate_key.return_value = ("stoa_sk_demo", "demo-hash", "stoa_sk_demo")
+        resp = client.post(
+            "/v1/tenants/acme/applications/app-1/subscribe/api-123",
+            headers={"X-Demo-Mode": "true"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["api_key"] == "stoa_sk_demo"
+    assert data["api_key_prefix"] == "stoa_sk_demo"
+    assert data["status"] == "active"
+    mock_sub_repo.create.assert_awaited_once()
+    mock_db_session.commit.assert_awaited_once()

--- a/scripts/demo-smoke-test.sh
+++ b/scripts/demo-smoke-test.sh
@@ -20,6 +20,7 @@
 #   TENANT_ID            demo
 #   GATEWAY_ID           gateway-demo
 #   DEMO_ADMIN_TOKEN     (empty → bypass via ?demo-admin header if cp-api allows)
+#   DEMO_MODE_HEADER     true (sends X-Demo-Mode: true to bounded demo endpoints)
 #   ROUTE_SYNC_GRACE_SECS 30
 #   DEMO_API_NAME        demo-api-smoke
 #   DEMO_APP_NAME        demo-app-smoke
@@ -51,6 +52,7 @@ MOCK_BACKEND_UPSTREAM_URL="${MOCK_BACKEND_UPSTREAM_URL:-http://mock-backend:9090
 TENANT_ID="${TENANT_ID:-demo}"
 GATEWAY_ID="${GATEWAY_ID:-gateway-demo}"
 DEMO_ADMIN_TOKEN="${DEMO_ADMIN_TOKEN:-}"
+DEMO_MODE_HEADER="${DEMO_MODE_HEADER:-true}"
 ROUTE_SYNC_GRACE_SECS="${ROUTE_SYNC_GRACE_SECS:-30}"
 DEMO_API_NAME="${DEMO_API_NAME:-demo-api-smoke}"
 DEMO_APP_NAME="${DEMO_APP_NAME:-demo-app-smoke}"
@@ -156,6 +158,9 @@ http_call() {
     local curl_args=(-sS -o "$tmp" -w '%{http_code}' --max-time 15 -X "$method" "$url")
     if [[ -n "$DEMO_ADMIN_TOKEN" ]]; then
         curl_args+=(-H "Authorization: Bearer $DEMO_ADMIN_TOKEN")
+    fi
+    if [[ "$DEMO_MODE_HEADER" == "true" ]]; then
+        curl_args+=(-H "X-Demo-Mode: true")
     fi
     if [[ -n "$body" ]]; then
         curl_args+=(-H "Content-Type: application/json" --data "$body")

--- a/specs/architecture-rules.md
+++ b/specs/architecture-rules.md
@@ -38,7 +38,7 @@ Tout composant non présent dans ce diagramme (Portal, Console UI, Kafka, OpenSe
 | `/v1/tenants/{tid}/apis` | GET | 200 | `items[]` avec `id`, `name` |
 | `/v1/tenants/{tid}/apis/{id}` | GET | 200 | `id`, `name`, `backend_url` |
 | `/v1/tenants/{tid}/applications` | POST | 201 | `id`, `name` |
-| `/v1/tenants/{tid}/applications/{id}/subscribe/{api_id}` | POST | 201 | `subscription_id`, `api_key` ou `api_key_prefix` |
+| `/v1/tenants/{tid}/applications/{id}/subscribe/{api_id}` | POST | 200 | `subscription_id`, `api_key`, `api_key_prefix` en mode `X-Demo-Mode: true`; sinon message historique |
 | `/v1/subscriptions` | POST | 201 | `id`, `api_key` ou `api_key_prefix`, `status="active"` |
 | `/v1/tenants/{tid}/deployments` | POST | 201 | `id`, `status` |
 | `/v1/internal/gateways/routes?gateway_name=X` | GET | 200 | liste de routes avec `api_id`, `path` |
@@ -105,6 +105,7 @@ réels. Renommer/supprimer un champ consommé par le smoke sans compatibilité A
 ### 2.7 Auth modèle démo
 
 - **Un seul mode supporté côté démo**: API key via header `X-Api-Key: stoa_<prefix>_<secret>`
+- Le cleartext de cette clé n'est retourné qu'une fois, sur une souscription créée avec `X-Demo-Mode: true`.
 - JWT/OAuth reste dispo mais pas dans le smoke path
 - mTLS, DPoP, sender-constraint: hors périmètre démo
 

--- a/specs/demo-acceptance-tests.md
+++ b/specs/demo-acceptance-tests.md
@@ -75,12 +75,12 @@ Fail pre-condition ⇒ abort early, pas d'exécution des AT-1..AT-5.
 **Given** AT-1 PASS
 **When**:
 1. `POST ${API_URL}/v1/tenants/${TENANT_ID}/applications` avec `{"name": "demo-app"}`  → récupérer `APP_ID`
-2. `POST ${API_URL}/v1/subscriptions` avec `{"application_id": "${APP_ID}", "api_id": "${API_ID}", "plan": "free"}`
+2. `POST ${API_URL}/v1/subscriptions` ou `POST ${API_URL}/v1/tenants/${TENANT_ID}/applications/${APP_ID}/subscribe/${API_ID}` avec `X-Demo-Mode: true`
 3. Alternative single-shot : `POST ${API_URL}/v1/tenants/${TENANT_ID}/applications/${APP_ID}/subscribe/${API_ID}`
 
 **Then**:
 - HTTP 201 sur subscription
-- Réponse contient `api_key` (cleartext, one-time) **OU** `api_key_prefix` + déclenchement key-rotation dans la réponse
+- Réponse contient `api_key` (cleartext, one-time) en mode `X-Demo-Mode: true`
 - `status: active`
 
 **Exit code**: 0 si clé API récupérée et non-vide, 1 sinon.

--- a/specs/demo-readiness-report.md
+++ b/specs/demo-readiness-report.md
@@ -13,7 +13,7 @@
 4. La route proxy gateway canonique est figée pour la démo : `GET /apis/{api_name}/get`. Le smoke ne probe plus plusieurs shapes.
 5. Le seed existe (`make seed-dev`), mais un tenant `demo` minimal dédié smoke n'est pas garanti reproductible.
 6. La métrique Prometheus attendue (`proxy_requests_total` ou `mcp_tool_calls_total`) est présente en code gateway mais son nom exact + labels ne sont pas figés dans un contrat testé ; OTEL/Grafana/Console/Portal sont maintenant cadrés en AT-5b nice-to-have.
-7. L'auth API key (header `X-Api-Key`) existe gateway-side ; le retour `api_key` cleartext par la création subscription cp-api est probablement déjà masqué (best practice), ce qui casse la démo self-contained.
+7. L'auth API key (header `X-Api-Key`) existe gateway-side ; B1 borne maintenant le retour `api_key` cleartext au mode explicite `X-Demo-Mode: true`.
 8. La stack docker-compose pré-existe (`deploy/docker-compose/docker-compose.yml`) mais son suffisance pour le smoke n'est pas validée (mock-backend non-confirmé).
 9. Les specs `/specs/*.md` créés + `scripts/demo-smoke-test.sh` donnent un contrat exécutable avec verdicts non ambigus (`REAL_PASS`, `CONTRACT_DRY_RUN`, `MOCK_PASS`, `FAIL`). **Aucun run réel n'a encore été tenté**.
 10. Verdict préliminaire : **FAIL attendu en premier run** sur AT-2/AT-3/AT-4. Plan "démo-first" actionnable immédiat ci-dessous.
@@ -71,10 +71,8 @@ Portal, signup, prospects, subscriptions UX ou usage client.
   - gateway instance `gateway-demo` enregistrée
   - clé admin jetable `DEMO_ADMIN_TOKEN`
 
-### 3.3 Accès clé API en cleartext (bloquant AT-3 → AT-4)
-Le fichier `subscriptions.py` génère `new_api_key, new_api_key_hash, new_api_key_prefix`. La bonne pratique sécurité retourne uniquement le préfixe, rendant la clé cleartext inutilisable après création. Si c'est le cas, **AT-4 ne peut pas utiliser l'output de AT-3** sans fallback.
-
-Solution démo-first : retourner cleartext **une seule fois** dans la réponse de `POST /subscriptions` quand `X-Demo-Mode: true` (feature flag démo) ou via endpoint dédié `POST /subscriptions/{id}/reveal-key` (one-shot, jetable).
+### 3.3 Accès clé API en cleartext (B1 traité)
+Le smoke envoie `X-Demo-Mode: true`. Dans ce mode borné, `POST /v1/tenants/{tenant_id}/applications/{app_id}/subscribe/{api_id}` crée une subscription active avec hash stocké et retourne `api_key` cleartext une seule fois dans la réponse. Sans ce header, le comportement historique reste inchangé.
 
 ### 3.4 Mock backend stable dans la stack démo
 `MOCK_BACKEND_URL=http://localhost:9090` est fourni par le service compose
@@ -83,7 +81,7 @@ Le smoke sépare cette URL de probe locale de `MOCK_BACKEND_UPSTREAM_URL`,
 qui vaut `http://mock-backend:9090` en compose pour que la gateway ne cible
 pas `localhost` depuis son propre conteneur.
 Ce point ferme B2 pour AT-0. AT-4 peut maintenant cibler un backend local
-déterministe dès que B1 fournit une clé
+déterministe dès que la stack locale dépasse AT-0/AT-2
 exploitable.
 
 ### 3.5 Chemin proxy gateway figé
@@ -101,7 +99,7 @@ Polling 30s par défaut dans stoa-connect → AT-2 peut timeout. Mitigation dans
 
 | # | Blocker | Sévérité | Étape impactée | Owner suggéré |
 |---|---------|----------|----------------|---------------|
-| B1 | Pas d'accès cleartext à `api_key` après création subscription | P0 | AT-3 → AT-4 | cp-api (1 PR) |
+| B1 | Clé API cleartext exposée une seule fois en mode `X-Demo-Mode: true` | DONE | AT-3 → AT-4 | cp-api PR B1 |
 | B2 | Mock backend non seedé dans docker-compose | P0 | AT-0, AT-4 | **DONE** — `mock-backend` compose |
 | B3 | Mapping `api_name → proxy path` flou côté gateway | P0 | AT-4 | **DONE** — `/apis/{api_name}/get` |
 | B4 | Auth dev-bypass cp-api non documenté | P1 | AT-1, AT-2, AT-3 | cp-api (flag `.env.demo`) |
@@ -118,7 +116,7 @@ Pour débloquer rapidement la validation du contrat sans confondre script OK et 
 | Contournement | Cible | Durée | Risque |
 |---------------|-------|-------|--------|
 | `./scripts/demo-smoke-test.sh --dry-run-contract` | Tous | permanent | Valide le contrat/script, verdict `CONTRACT_DRY_RUN`, jamais `DEMO READY` |
-| `MOCK_MODE=all ./scripts/demo-smoke-test.sh` | B1/B2/B3 | jusqu'aux fixes | Valide le chemin mocké, verdict `MOCK_PASS`, jamais `DEMO READY` |
+| `MOCK_MODE=all ./scripts/demo-smoke-test.sh` | stack absente | usage local | Valide le chemin mocké, verdict `MOCK_PASS`, jamais `DEMO READY` |
 | Démarrer `mock-backend` via compose seul (`docker compose ... up -d mock-backend`) | B2 | jusqu'à stack complète | Service sous profil `demo`; ne pas exposer Prometheus sur le même port pendant ce smoke |
 | `DEMO_GATEWAY_PATH` override local | B3 | debug uniquement | Toute démo officielle doit revenir à `/apis/{api_name}/get` |
 | `DEMO_ADMIN_TOKEN` extrait via `stoactl auth login demo-admin` puis injecté | B4 | 1 jour | Couplage Keycloak |
@@ -136,7 +134,7 @@ Ces contournements **sont figés dans le script**, mais ils ne produisent jamais
 2. Commit 2 — `deploy/docker-compose/docker-compose.demo.yml` : extension de `docker-compose.yml` qui ajoute `mock-backend` (httpbin) sur port 9090 + `.env.demo` avec defaults documentés
 3. Commit 3 — `Makefile` targets : `demo-up`, `demo-down`, `demo-smoke` (le dernier wrappe `./scripts/demo-smoke-test.sh`)
 
-Cette PR **ne touche aucun code applicatif**. Elle pose uniquement le contrat. Après merge : premier run en local → identifier lequel des B1..B7 déclenche en pratique → PR ciblée B1 en priorité (plus grand impact AT-3/AT-4).
+La PR de cadrage posait le contrat sans code applicatif. B1 est maintenant traité par une PR ciblée cp-api + smoke, sans refonte sécurité ni lifecycle complet.
 
 ## 7. Verdict GO / NO-GO rewrite
 
@@ -150,7 +148,7 @@ Cette PR **ne touche aucun code applicatif**. Elle pose uniquement le contrat. A
 **NO-GO** si :
 
 - Aucune PR rewrite ne documente son "demo impact" dans les 7 jours → les rewrites avancent hors radar démo
-- Un blocker P0 (B1, B2, B3) reste ouvert > 10 jours → indiquerait que la démo n'est pas priorité réelle
+- Un nouveau blocker P0 sur AT-3/AT-4 reste ouvert > 10 jours → indiquerait que la démo n'est pas priorité réelle
 - Une régression AT-1..AT-5 est observée sans rollback immédiat
 - Un `MOCK_PASS` ou `CONTRACT_DRY_RUN` est présenté comme `DEMO READY`
 


### PR DESCRIPTION
## Summary
- add bounded `X-Demo-Mode: true` handling on tenant application subscribe
- create an active subscription with stored API key hash and return cleartext once for the demo smoke path
- update smoke/specs to document the explicit demo header and B1 status

## Validation
- `bash -n scripts/demo-smoke-test.sh`
- `ruff check src/routers/applications.py tests/test_applications_router.py`
- `pytest tests/test_applications_router.py -q`
- `./scripts/demo-smoke-test.sh --dry-run-contract --no-observability-ui` -> CONTRACT_DRY_RUN
- `MOCK_MODE=all ./scripts/demo-smoke-test.sh --no-observability-ui` -> MOCK_PASS
- `MOCK_MODE=auto ./scripts/demo-smoke-test.sh --no-observability-ui` -> FAIL — DEMO NOT READY

Real smoke still requires the local compose stack to be up; in this worktree it fails at AT-0 because cp-api/gateway/mock are not running.