### PR TITLE
chore(ci): register claude-issue-to-pr-v2.yml stub for workflow_dispatch

### DIFF
--- a/.github/workflows/claude-issue-to-pr-v2.yml
+++ b/.github/workflows/claude-issue-to-pr-v2.yml
@@ -1,0 +1,58 @@
+# CI-1 Phase 2b dispatch stub.
+#
+# This file exists on main only to register the workflow id so that
+# `gh workflow run claude-issue-to-pr-v2.yml --ref <feature-branch>`
+# can find and dispatch the real implementation that lives on the
+# feature branch (`refactor/ci-1-phase-2b-composites` at time of
+# writing).
+#
+# GitHub Actions requires workflow_dispatch files to be present on the
+# repository's default branch for `gh workflow run` (and the REST
+# /actions/workflows/:id/dispatches endpoint) to resolve the workflow
+# id. See the note in `.github/CI-1-REWRITE-PLAN.md §F.2`.
+#
+# Phase 2d of the CI-1 rewrite will REPLACE this stub with the real
+# orchestrator. Do not delete + recreate: keep the same file name so
+# the workflow id remains stable.
+
+name: Claude Code Issue-to-PR v2 (Phase 2b smoke)
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Existing issue number to process end-to-end.'
+        required: true
+        type: string
+      run_implement:
+        description: 'Run the implement stage? (default false — smoke the Council path first).'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Explain that this is a stub
+        run: |
+          echo "::notice::This is the CI-1 Phase 2b dispatch stub on main."
+          echo "::notice::It intentionally does no work. Its only purpose is to"
+          echo "::notice::register the workflow id so that a dispatch against a"
+          echo "::notice::feature branch can resolve."
+          echo ""
+          echo "To dispatch the REAL Phase 2b workflow, run:"
+          echo "  gh workflow run claude-issue-to-pr-v2.yml \\"
+          echo "    --ref refactor/ci-1-phase-2b-composites \\"
+          echo "    -f issue_number=<N> -f run_implement=<true|false>"
+          echo ""
+          echo "Phase 2d will replace this stub with the real orchestrator"
+          echo "at the same path, preserving the workflow id."
+          echo ""
+          echo "Received inputs:"
+          echo "  issue_number=${{ inputs.issue_number }}"
+          echo "  run_implement=${{ inputs.run_implement }}"


### PR DESCRIPTION
## Summary

Lands a minimal `claude-issue-to-pr-v2.yml` stub on `main` so that
`gh workflow run --ref <feature-branch>` can resolve the workflow id.
Required to unblock the Phase 2b smoke test of the CI-1 rewrite
([CAB-2166](https://linear.app/hlfh-workspace/issue/CAB-2166)); the
real orchestrator lives on `refactor/ci-1-phase-2b-composites` and
will replace this stub at Phase 2d.

## Why this PR exists

GitHub Actions resolves the workflow id via the file on the default
branch. Dispatching a workflow that only exists on a feature branch
yields HTTP 404 from `gh workflow run`. Documented in CI-1-REWRITE-PLAN.md
§F.2 as part of this series.

## What the stub does

- Declares the same `workflow_dispatch` inputs (`issue_number`,
  `run_implement`) as the feature-branch orchestrator so dispatches
  with `--ref refactor/ci-1-phase-2b-composites` run the real file
  without missing-input errors.
- Uses `permissions: contents: read` only.
- Runs a single step that prints a `::notice::` explaining it is a
  stub and how to dispatch the real workflow.
- Consumes zero secrets, zero other side effects.

## Safety

- No triggers other than `workflow_dispatch` — cannot self-fire on
  pushes, issue events, or schedules.
- No write permissions.
- Honours the same pattern as other `workflow_dispatch` stubs.

## Test plan

- [x] Stub is not triggered by pushes to any branch (no `on: push`).
- [ ] After merge, `gh workflow run claude-issue-to-pr-v2.yml --ref refactor/ci-1-phase-2b-composites -f issue_number=2537 -f run_implement=false` resolves and runs the feature-branch orchestrator.
- [ ] The resulting run uses the feature branch's file (not this stub).

## Follow-up

Phase 2d merges `refactor/ci-1-phase-2b-composites` (after Phase 2c
tests ship) to `main`, replacing this stub in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)