### PR TITLE
ci(demo): add observation smoke workflow

### DIFF
--- a/.github/workflows/demo-smoke.yml
+++ b/.github/workflows/demo-smoke.yml
@@ -1,0 +1,105 @@
+name: Demo Smoke Observation
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      blocking:
+        description: "Fail the job when the demo smoke fails"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  contents: read
+
+jobs:
+  demo-smoke:
+    name: Demo Smoke (observation)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      DEMO_SMOKE_BLOCKING: ${{ inputs.blocking || vars.DEMO_SMOKE_BLOCKING || 'false' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Run demo smoke in observation mode
+        id: smoke
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          mkdir -p artifacts/demo-smoke
+          SYNTAX_LOG="artifacts/demo-smoke/bash-n.log"
+          SMOKE_LOG="artifacts/demo-smoke/demo-smoke.log"
+          TAIL_LOG="artifacts/demo-smoke/demo-smoke-tail.log"
+
+          echo "## Demo Smoke Observation" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Blocking mode | \`${DEMO_SMOKE_BLOCKING}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Command | \`./scripts/demo-smoke-test.sh --no-observability-ui\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          bash -n scripts/demo-smoke-test.sh >"$SYNTAX_LOG" 2>&1
+          SYNTAX_EXIT=$?
+
+          set +e
+          ./scripts/demo-smoke-test.sh --no-observability-ui >"$SMOKE_LOG" 2>&1
+          SMOKE_EXIT=$?
+          set -e
+
+          tail -n 80 "$SMOKE_LOG" > "$TAIL_LOG"
+          VERDICT="$(grep -E 'Verdict:' "$SMOKE_LOG" | tail -1 | sed 's/^[[:space:]]*//')"
+          BLOCKER="$(grep -E '\[FAIL\]' "$SMOKE_LOG" | tail -1 | sed 's/^[[:space:]]*//')"
+          VERDICT="${VERDICT:-Verdict: UNKNOWN}"
+          BLOCKER="${BLOCKER:-No [FAIL] line found in log tail}"
+
+          echo "syntax_exit=$SYNTAX_EXIT" >> "$GITHUB_OUTPUT"
+          echo "smoke_exit=$SMOKE_EXIT" >> "$GITHUB_OUTPUT"
+          {
+            echo "verdict<<EOF"
+            echo "$VERDICT"
+            echo "EOF"
+            echo "blocker<<EOF"
+            echo "$BLOCKER"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "| bash -n exit | \`${SYNTAX_EXIT}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| smoke exit | \`${SMOKE_EXIT}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| verdict | \`${VERDICT}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| blocker | \`${BLOCKER}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Last 80 Log Lines" >> "$GITHUB_STEP_SUMMARY"
+          echo '```text' >> "$GITHUB_STEP_SUMMARY"
+          cat "$TAIL_LOG" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$DEMO_SMOKE_BLOCKING" == "true" ]]; then
+            if [[ "$SYNTAX_EXIT" -ne 0 || "$SMOKE_EXIT" -ne 0 ]]; then
+              echo "::error::Demo smoke blocking mode failed (bash-n=${SYNTAX_EXIT}, smoke=${SMOKE_EXIT})"
+              exit 1
+            fi
+          fi
+
+          if [[ "$SMOKE_EXIT" -ne 0 ]]; then
+            echo "::notice::Demo smoke is observation-only for now: ${VERDICT}; blocker=${BLOCKER}; exit=${SMOKE_EXIT}"
+          fi
+
+      - name: Upload demo smoke logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: demo-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/demo-smoke/
+          retention-days: 7

--- a/specs/validation-commands.md
+++ b/specs/validation-commands.md
@@ -166,15 +166,39 @@ kill -HUP $(pgrep stoa-gateway)
 | `cargo build --release` | emballage image démo |
 | `make build-stoactl` | emballage CLI démo |
 
-## 9. Intégration CI (future, out-of-scope v1)
+## 9. Intégration CI observationnelle
 
-Placeholder : une fois le smoke stable, ajouter un workflow `.github/workflows/demo-smoke.yml` qui :
-- Boot docker-compose minimal
-- Exécute `demo-smoke-test.sh`
-- Upload `specs/demo-readiness-report.md` mis à jour en artifact
-- Fail le build si exit != 0
+Le workflow `.github/workflows/demo-smoke.yml` est volontairement
+**observationnel** tant que le smoke réel n'a pas produit au moins un
+`REAL_PASS — DEMO READY` local.
 
-À NE PAS faire tant que le smoke n'est pas `REAL_PASS` au moins une fois en local.
+À chaque PR, il exécute :
+
+```bash
+bash -n scripts/demo-smoke-test.sh
+./scripts/demo-smoke-test.sh --no-observability-ui
+```
+
+Il publie dans `$GITHUB_STEP_SUMMARY` :
+- le code de sortie de `bash -n`
+- le code de sortie du smoke réel
+- la ligne `Verdict: ...`
+- le dernier blocker `[FAIL] ...`
+- les 80 dernières lignes du log
+
+Il upload aussi les logs en artifact `demo-smoke-*`.
+
+Tant que `DEMO_SMOKE_BLOCKING` vaut `false` (défaut), un verdict
+`FAIL — DEMO NOT READY` ne fait **pas** échouer le job GitHub. Le résultat
+sert à observer le prochain blocker réel sans bloquer la cadence des PR IA.
+
+Passage en gate bloquant, uniquement après premier `REAL_PASS` local :
+
+```text
+GitHub variable DEMO_SMOKE_BLOCKING=true
+```
+
+ou lancement manuel du workflow avec `blocking=true`.
 
 ## 10. Démo client/prospect
 


### PR DESCRIPTION
## Summary
- add non-blocking `.github/workflows/demo-smoke.yml` for PR smoke observation
- publish syntax/smoke exit codes, verdict, blocker, and log tail in `GITHUB_STEP_SUMMARY`
- upload smoke logs as artifacts
- document the workflow as observation-only until first local `REAL_PASS — DEMO READY`

## Behavior
- default: advisory, does not fail on `FAIL — DEMO NOT READY`
- future blocking switch: GitHub variable `DEMO_SMOKE_BLOCKING=true` or manual dispatch input `blocking=true`

## Validation
- `git diff --check`
- `bash -n scripts/demo-smoke-test.sh`
- YAML parse with Ruby stdlib
- `./scripts/demo-smoke-test.sh --no-observability-ui` currently fails at AT-0 locally as expected: cp-api=000000 gateway=404 mock=000000