### PR TITLE
fix(api): prevent GET /v1/admin/gateways 500 on enum drift (CAB-2169)

### DIFF
--- a/control-plane-api/src/schemas/gateway.py
+++ b/control-plane-api/src/schemas/gateway.py
@@ -1,13 +1,17 @@
 """Pydantic schemas for gateway instance and deployment endpoints."""
 
+import logging
 from datetime import datetime
-from typing import Literal
+from typing import Literal, get_args
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+logger = logging.getLogger(__name__)
+
 # CAB-2159 BUG-2 — narrowed enums so the UI can branch on exact values rather
 # than carrying wire/UI adapter casts. Keep synchronized with:
+#   - src/models/gateway_instance.py:GatewayType (regression: test_gateway_type_literal_matches_orm)
 #   - src/models/gateway_instance.py:GatewayInstanceStatus
 #   - src/models/gateway_instance.py:source column
 #   - ADR-024 (Gateway 4-mode split)
@@ -16,6 +20,8 @@ GatewayTypeLiteral = Literal[
     "kong",
     "apigee",
     "aws_apigateway",
+    "azure_apim",
+    "gravitee",
     "stoa",
     "stoa_edge_mcp",
     "stoa_sidecar",
@@ -118,6 +124,38 @@ class GatewayInstanceResponse(BaseModel):
         if not isinstance(v, list):
             return [str(v)]
         return list(v)
+
+    @field_validator("mode", mode="before")
+    @classmethod
+    def coerce_mode(cls, v: object) -> str | None:
+        """Coerce unknown ``mode`` values to ``None`` instead of 500ing the response.
+
+        ``mode`` is a free-form ``String(50)`` on the ORM (`models/gateway_instance.py:105`),
+        so drift between stored values and the Literal whitelist is possible. A bad row
+        must not nuke the whole list endpoint — log + return ``None`` so the UI can
+        surface the other gateways.
+        """
+        if v is None or v == "":
+            return None
+        if v in get_args(GatewayModeLiteral):
+            return v  # type: ignore[return-value]
+        logger.warning("Unknown gateway mode %r — coerced to None. Update GatewayModeLiteral if this is valid.", v)
+        return None
+
+    @field_validator("source", mode="before")
+    @classmethod
+    def coerce_source(cls, v: object) -> str:
+        """Coerce unknown ``source`` values to ``"manual"`` instead of 500ing.
+
+        ``source`` is a free-form ``String(50)`` on the ORM with a ``self_register``
+        default. Unknown values (drift, manual inserts) fall back to ``"manual"``.
+        """
+        if v in get_args(GatewaySourceLiteral):
+            return v  # type: ignore[return-value]
+        logger.warning(
+            "Unknown gateway source %r — coerced to 'manual'. Update GatewaySourceLiteral if this is valid.", v
+        )
+        return "manual"
 
 
 class GatewayHealthCheckResponse(BaseModel):

--- a/control-plane-api/tests/test_gateway_instances_router.py
+++ b/control-plane-api/tests/test_gateway_instances_router.py
@@ -578,3 +578,80 @@ class TestGatewayInstancesRouter:
         assert "gw-public" in names
         assert "gw-acme" in names
         assert "gw-other" not in names
+
+
+class TestGatewayLiteralDriftGuard(TestGatewayInstancesRouter):
+    """Regression guards against schema-vs-ORM enum drift.
+
+    Origin: prod 500 on ``GET /v1/admin/gateways`` when a row's ``gateway_type`` was
+    outside ``GatewayTypeLiteral`` (CAB-2159 narrowed the Literal and missed
+    ``azure_apim`` + ``gravitee``). Response-validation raised, FastAPI returned 500.
+    """
+
+    def test_gateway_type_literal_covers_every_orm_enum_value(self):
+        """Every ORM ``GatewayType`` value must be accepted by ``GatewayTypeLiteral``."""
+        from typing import get_args
+
+        from src.models.gateway_instance import GatewayType
+        from src.schemas.gateway import GatewayTypeLiteral
+
+        orm_values = {t.value for t in GatewayType}
+        literal_values = set(get_args(GatewayTypeLiteral))
+        missing = orm_values - literal_values
+        assert not missing, (
+            f"GatewayTypeLiteral missing ORM values {missing}. "
+            "Any gateway row with one of these types would 500 the list endpoint."
+        )
+
+    def test_gateway_status_literal_covers_every_orm_enum_value(self):
+        """Every ORM ``GatewayInstanceStatus`` value must be accepted by ``GatewayStatusLiteral``."""
+        from typing import get_args
+
+        from src.models.gateway_instance import GatewayInstanceStatus
+        from src.schemas.gateway import GatewayStatusLiteral
+
+        orm_values = {s.value for s in GatewayInstanceStatus}
+        literal_values = set(get_args(GatewayStatusLiteral))
+        missing = orm_values - literal_values
+        assert not missing, f"GatewayStatusLiteral missing ORM values {missing}."
+
+    def test_list_gateways_succeeds_for_every_orm_gateway_type(self, app_with_cpi_admin, mock_db_session):
+        """GET / must 200 for every ``GatewayType`` — prevents a re-run of the prod 500."""
+        from src.models.gateway_instance import GatewayType
+
+        mocks = [self._mock_gateway_instance(name=f"gw-{t.value}", gateway_type=t.value) for t in GatewayType]
+
+        with patch("src.routers.gateway_instances.GatewayInstanceService") as MockSvc:
+            MockSvc.return_value.list = AsyncMock(return_value=(mocks, len(mocks)))
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/admin/gateways")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["total"] == len(mocks)
+
+    def test_list_gateways_coerces_unknown_mode_to_none(self, app_with_cpi_admin, mock_db_session):
+        """An unknown ``mode`` value must not 500 — coerced to ``None`` with a warning."""
+        gw = self._mock_gateway_instance(mode="some-future-mode")
+
+        with patch("src.routers.gateway_instances.GatewayInstanceService") as MockSvc:
+            MockSvc.return_value.list = AsyncMock(return_value=([gw], 1))
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/admin/gateways")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["items"][0]["mode"] is None
+
+    def test_list_gateways_coerces_unknown_source_to_manual(self, app_with_cpi_admin, mock_db_session):
+        """An unknown ``source`` value must not 500 — coerced to ``"manual"`` with a warning."""
+        gw = self._mock_gateway_instance(source="legacy_importer")
+
+        with patch("src.routers.gateway_instances.GatewayInstanceService") as MockSvc:
+            MockSvc.return_value.list = AsyncMock(return_value=([gw], 1))
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/admin/gateways")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["items"][0]["source"] == "manual"

--- a/control-plane-api/tests/test_regression_cab_2169_gateway_list_literal_drift.py
+++ b/control-plane-api/tests/test_regression_cab_2169_gateway_list_literal_drift.py
@@ -1,0 +1,68 @@
+from datetime import UTC, datetime
+from typing import get_args
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from src.models.gateway_instance import GatewayType
+from src.schemas.gateway import GatewayTypeLiteral
+
+
+def _mock_gateway_instance(**overrides):
+    mock = MagicMock()
+    defaults = {
+        "id": uuid4(),
+        "name": "kong-standalone",
+        "display_name": "Kong DB-less",
+        "gateway_type": "kong",
+        "base_url": "https://kong.gostoa.dev",
+        "status": "online",
+        "environment": "production",
+        "mode": None,
+        "tenant_id": None,
+        "last_health_check": None,
+        "auth_config": {},
+        "health_details": None,
+        "capabilities": [],
+        "version": None,
+        "tags": [],
+        "target_gateway_url": None,
+        "public_url": None,
+        "ui_url": None,
+        "protected": False,
+        "enabled": True,
+        "visibility": None,
+        "source": "self_register",
+        "deleted_at": None,
+        "deleted_by": None,
+        "created_at": datetime(2026, 2, 1, tzinfo=UTC),
+        "updated_at": datetime(2026, 2, 1, tzinfo=UTC),
+    }
+    for key, value in {**defaults, **overrides}.items():
+        setattr(mock, key, value)
+    return mock
+
+
+def test_regression_cab_2169_gateway_type_literal_covers_every_orm_value():
+    orm_values = {gateway_type.value for gateway_type in GatewayType}
+    literal_values = set(get_args(GatewayTypeLiteral))
+    missing = orm_values - literal_values
+
+    assert not missing, f"GatewayTypeLiteral missing ORM values {missing}."
+
+
+def test_regression_cab_2169_list_gateways_accepts_every_orm_gateway_type(app_with_cpi_admin, mock_db_session):
+    mocks = [
+        _mock_gateway_instance(name=f"gw-{gateway_type.value}", gateway_type=gateway_type.value)
+        for gateway_type in GatewayType
+    ]
+
+    with patch("src.routers.gateway_instances.GatewayInstanceService") as mock_service:
+        mock_service.return_value.list = AsyncMock(return_value=(mocks, len(mocks)))
+
+        with TestClient(app_with_cpi_admin) as client:
+            response = client.get("/v1/admin/gateways")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["total"] == len(mocks)


### PR DESCRIPTION
## Summary

- Prod 500 on `GET https://api.gostoa.dev/v1/admin/gateways?page_size=100`. Root cause: `GatewayTypeLiteral` was narrowed in CAB-2159 (#2473, `c6abef8f2`) but missed two ORM enum values with registered adapters — `azure_apim` and `gravitee`. Any row with those types makes Pydantic response-validation raise → 500.
- Align `GatewayTypeLiteral` with the ORM `GatewayType` enum.
- Safety net: `field_validator(mode=\"before\")` on `GatewayInstanceResponse.mode` and `.source` (both free-form `String(50)` columns on the ORM) — unknown values coerced (to `None` / `\"manual\"`) with a warning log, so a single bad row can never nuke the list endpoint again.
- Regression tests guard against future drift (every `GatewayType` / `GatewayInstanceStatus` value must be accepted by its Literal) plus an end-to-end list call asserting 200 for every `GatewayType` value.

Linear: CAB-2169

## Files changed

- `control-plane-api/src/schemas/gateway.py` — Literal alignment + 2 coercion validators.
- `control-plane-api/tests/test_gateway_instances_router.py` — new `TestGatewayLiteralDriftGuard` class (5 tests).

## Test plan

- [x] `pytest tests/test_gateway_instances_router.py::TestGatewayLiteralDriftGuard` — 5/5 green.
- [x] `pytest tests/test_gateway_instances_router.py tests/test_openapi_contract.py tests/test_gateway_observability_router.py tests/test_regression_contract_routers.py` — 149 passed, 2 skipped (pre-existing CAB-2055 CI ghost skip).
- [x] `ruff check` + `black --check` clean on modified files.
- [ ] CI green.
- [ ] Post-deploy: `GET /v1/admin/gateways` returns 200 on prod.
- [ ] Post-deploy diagnostic: surface which row(s) had the offending `gateway_type` / `mode` / `source` so we can decide if any DB cleanup is needed (tracked as a follow-up in CAB-2169 out-of-scope section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)