### PR TITLE
fix(demo): add bounded auth bypass for smoke

### DIFF
--- a/.github/workflows/demo-smoke.yml
+++ b/.github/workflows/demo-smoke.yml
@@ -31,6 +31,7 @@ jobs:
       OPENSEARCH_DASHBOARDS_PASSWORD: admin
       OPENSEARCH_LOGWRITER_PASSWORD: admin
       OPENSEARCH_OIDC_CLIENT_SECRET: x
+      STOA_DISABLE_AUTH: "true"
       GATEWAY_URL: http://localhost:8081
 
     steps:

--- a/control-plane-api/src/auth/dependencies.py
+++ b/control-plane-api/src/auth/dependencies.py
@@ -55,6 +55,34 @@ class User(BaseModel):
     tenant_id: str | None = None
 
 
+def _demo_auth_bypass_enabled(request: Request) -> bool:
+    return bool(getattr(settings, "STOA_DISABLE_AUTH", False)) and request.headers.get("X-Demo-Mode", "").lower() == "true"
+
+
+def _demo_bypass_user(request: Request) -> User:
+    user = User(
+        id="demo-dev-bypass",
+        email="demo-dev-bypass@stoa.local",
+        username="demo-dev-bypass",
+        roles=["cpi-admin"],
+        tenant_id=None,
+    )
+    bind_request_context(user_id=user.id, tenant_id=user.tenant_id)
+    request.state.user = {
+        "sub": user.id,
+        "email": user.email,
+        "name": user.username,
+        "tenant_id": user.tenant_id,
+    }
+    logger.warning(
+        "Demo/dev auth bypass accepted",
+        path=request.url.path,
+        method=request.method,
+        environment=settings.ENVIRONMENT,
+    )
+    return user
+
+
 async def get_keycloak_public_key() -> str:
     """Fetch Keycloak realm public key, cached in-memory for 5 minutes."""
     url = _kc_public_key_url()
@@ -83,6 +111,9 @@ async def get_current_user(
 
     Supports service-to-service auth via X-Operator-Key header (ADR-042).
     """
+    if _demo_auth_bypass_enabled(request):
+        return _demo_bypass_user(request)
+
     # Service-to-service auth for internal operators (ADR-042)
     operator_key = request.headers.get("X-Operator-Key")
     if operator_key and operator_key in settings.gateway_api_keys_list:

--- a/control-plane-api/src/config.py
+++ b/control-plane-api/src/config.py
@@ -132,6 +132,9 @@ class Settings(BaseSettings):
     KEYCLOAK_CLIENT_ID: str = "control-plane-api"
     KEYCLOAK_CLIENT_SECRET: str = ""
     KEYCLOAK_VERIFY_SSL: bool = True
+    # Demo/dev-only bypass for executable smoke tests. This is rejected at
+    # startup in production and still requires X-Demo-Mode: true per request.
+    STOA_DISABLE_AUTH: bool = False
 
     @property
     def keycloak_internal_url(self) -> str:
@@ -609,6 +612,22 @@ class Settings(BaseSettings):
             joined,
             self.ENVIRONMENT,
         )
+        return self
+
+    @model_validator(mode="after")
+    def _gate_auth_bypass_in_prod(self) -> "Settings":
+        """Fail fast if the demo/dev auth bypass is enabled in production."""
+        if self.ENVIRONMENT == "production" and self.STOA_DISABLE_AUTH:
+            raise ValueError(
+                "Refusing to boot: STOA_DISABLE_AUTH=true while ENVIRONMENT=production. "
+                "This bypass is demo/dev only and must never be deployed to prod."
+            )
+        if self.STOA_DISABLE_AUTH:
+            _logger.warning(
+                "STOA_DISABLE_AUTH=true (ENVIRONMENT=%s). Auth bypass is demo/dev only "
+                "and is honored only when requests send X-Demo-Mode: true.",
+                self.ENVIRONMENT,
+            )
         return self
 
     class Config:

--- a/control-plane-api/tests/test_regression_cab_2149_demo_auth_bypass.py
+++ b/control-plane-api/tests/test_regression_cab_2149_demo_auth_bypass.py
@@ -1,0 +1,54 @@
+"""Regression tests for demo/dev auth bypass used by the executable smoke."""
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from src.auth import dependencies as auth_deps
+from src.auth.dependencies import User, get_current_user
+from src.config import Settings
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+
+    @app.post("/protected")
+    async def protected(user: User = Depends(get_current_user)) -> dict[str, object]:
+        return {"id": user.id, "roles": user.roles}
+
+    return TestClient(app)
+
+
+def test_regression_cab_2149_demo_bypass_requires_explicit_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth_deps.settings, "STOA_DISABLE_AUTH", False)
+
+    response = _client().post("/protected", headers={"X-Demo-Mode": "true"})
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Not authenticated"
+
+
+def test_regression_cab_2149_demo_bypass_requires_demo_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth_deps.settings, "STOA_DISABLE_AUTH", True)
+
+    response = _client().post("/protected")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Not authenticated"
+
+
+def test_regression_cab_2149_demo_bypass_returns_cpi_admin_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth_deps.settings, "ENVIRONMENT", "development")
+    monkeypatch.setattr(auth_deps.settings, "STOA_DISABLE_AUTH", True)
+
+    response = _client().post("/protected", headers={"X-Demo-Mode": "true"})
+
+    assert response.status_code == 200
+    assert response.json() == {"id": "demo-dev-bypass", "roles": ["cpi-admin"]}
+
+
+def test_regression_cab_2149_demo_bypass_rejected_in_production() -> None:
+    with pytest.raises(ValueError) as exc:
+        Settings(ENVIRONMENT="production", STOA_DISABLE_AUTH=True)
+
+    assert "STOA_DISABLE_AUTH=true" in str(exc.value)

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -202,6 +202,8 @@ services:
       KEYCLOAK_CLIENT_ID: control-plane-api
       KEYCLOAK_VERIFY_SSL: "false"
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?KEYCLOAK_ADMIN_PASSWORD is required (set in .env or Vault)}
+      # Demo/dev only: requires X-Demo-Mode: true on each request and is rejected in production.
+      STOA_DISABLE_AUTH: "${STOA_DISABLE_AUTH:-false}"
       # Observability (Prometheus + Loki + Tempo for Usage/Call Flow Dashboard)
       PROMETHEUS_INTERNAL_URL: http://prometheus:9090
       LOKI_INTERNAL_URL: http://loki:3100

--- a/scripts/demo-smoke-test.sh
+++ b/scripts/demo-smoke-test.sh
@@ -223,6 +223,7 @@ at1_declare_api() {
     body="$(cat <<JSON
 {
   "name": "${DEMO_API_NAME}",
+  "display_name": "${DEMO_API_NAME}",
   "version": "1.0.0",
   "protocol": "http",
   "backend_url": "${MOCK_BACKEND_UPSTREAM_URL}",

--- a/specs/architecture-rules.md
+++ b/specs/architecture-rules.md
@@ -32,6 +32,14 @@ Tout composant non présent dans ce diagramme (Portal, Console UI, Kafka, OpenSe
 
 ### 2.1 HTTP endpoints cp-api (URL + method + status code + shape minimal)
 
+Auth démo provider/runtime :
+
+- Auth réelle : JWT Keycloak valide via `Authorization: Bearer`.
+- Bypass démo/dev borné : `STOA_DISABLE_AUTH=true` côté cp-api **et** header
+  `X-Demo-Mode: true` sur la requête.
+- `STOA_DISABLE_AUTH=true` est interdit en `ENVIRONMENT=production` et doit
+  faire échouer le boot cp-api.
+
 | Endpoint | Method | Status OK | Champs min réponse |
 |----------|--------|-----------|--------------------|
 | `/v1/tenants/{tid}/apis` | POST | 201 | `id`, `name` |

--- a/specs/demo-acceptance-tests.md
+++ b/specs/demo-acceptance-tests.md
@@ -39,6 +39,7 @@ Fail pre-condition ⇒ abort early, pas d'exécution des AT-1..AT-5.
 ```json
 {
   "name": "demo-api",
+  "display_name": "demo-api",
   "version": "1.0.0",
   "protocol": "http",
   "backend_url": "http://mock-backend:9090",

--- a/specs/demo-readiness-report.md
+++ b/specs/demo-readiness-report.md
@@ -102,7 +102,7 @@ Polling 30s par défaut dans stoa-connect → AT-2 peut timeout. Mitigation dans
 | B1 | Clé API cleartext exposée une seule fois en mode `X-Demo-Mode: true` | DONE | AT-3 → AT-4 | cp-api PR B1 |
 | B2 | Mock backend non seedé dans docker-compose | P0 | AT-0, AT-4 | **DONE** — `mock-backend` compose |
 | B3 | Mapping `api_name → proxy path` flou côté gateway | P0 | AT-4 | **DONE** — `/apis/{api_name}/get` |
-| B4 | Auth dev-bypass cp-api non documenté | P1 | AT-1, AT-2, AT-3 | cp-api (flag `.env.demo`) |
+| B4 | Auth dev-bypass cp-api non documenté | DONE | AT-1, AT-2, AT-3 | `STOA_DISABLE_AUTH=true` dev-only + `X-Demo-Mode: true` |
 | B5 | Seed profile `demo-smoke` minimal absent | P1 | AT-0 | cp-api/scripts/seeder |
 | B6 | Métriques Prometheus noms non figés par test | P2 | AT-5 | gateway (test regression) |
 | B7 | Route-sync 30s est lent pour une démo live | P2 | AT-2 | stoa-connect (trigger endpoint) |
@@ -119,7 +119,7 @@ Pour débloquer rapidement la validation du contrat sans confondre script OK et 
 | `MOCK_MODE=all ./scripts/demo-smoke-test.sh` | stack absente | usage local | Valide le chemin mocké, verdict `MOCK_PASS`, jamais `DEMO READY` |
 | Démarrer `mock-backend` via compose seul (`docker compose ... up -d mock-backend`) | B2 | jusqu'à stack complète | Service sous profil `demo`; ne pas exposer Prometheus sur le même port pendant ce smoke |
 | `DEMO_GATEWAY_PATH` override local | B3 | debug uniquement | Toute démo officielle doit revenir à `/apis/{api_name}/get` |
-| `DEMO_ADMIN_TOKEN` extrait via `stoactl auth login demo-admin` puis injecté | B4 | 1 jour | Couplage Keycloak |
+| `STOA_DISABLE_AUTH=true` + `X-Demo-Mode: true` | B4 | jusqu'à auth Keycloak démo stable | Refusé en `ENVIRONMENT=production`; ne jamais présenter comme auth réelle |
 | Script seed inline dans `demo-smoke-test.sh` qui crée tenant + gateway si absent | B5 | 1 jour | Pas idempotent si collisions |
 | Check "au moins un counter `*_total`" sans figer nom | B6 | jusqu'à B6 | Drift silencieux toléré |
 

--- a/specs/validation-commands.md
+++ b/specs/validation-commands.md
@@ -34,7 +34,7 @@ Variables d'environnement (defaults documentés dans le script) :
 | `MOCK_BACKEND_UPSTREAM_URL` | `http://mock-backend:9090` | Mock HTTP backend vu par la gateway en compose |
 | `DEMO_GATEWAY_PATH` | `/apis/${DEMO_API_NAME}/get` | Chemin gateway canonique AT-4 |
 | `TENANT_ID` | `demo` (slug, résolu en UUID par cp-api) | Tenant démo |
-| `DEMO_ADMIN_TOKEN` | vide | JWT admin pour écrire côté cp-api. Si vide, le script passe en `STOA_DISABLE_AUTH=true` mode (dev only) |
+| `DEMO_ADMIN_TOKEN` | vide | JWT admin pour écrire côté cp-api. Si vide, le compose démo doit activer `STOA_DISABLE_AUTH=true` (dev only, requiert `X-Demo-Mode: true`, interdit en prod) |
 | `ROUTE_SYNC_GRACE_SECS` | `30` | Délai d'attente pour route visible en gateway après AT-2 |
 | `OBS_VISIBILITY_CHECK` | `auto` | Lance AT-5b nice-to-have (`off` pour désactiver) |
 | `GRAFANA_URL` | `http://localhost:3001` | Grafana local pour vérifier health + datasources |
@@ -50,6 +50,7 @@ Variables d'environnement (defaults documentés dans le script) :
 POSTGRES_PASSWORD=stoa KEYCLOAK_ADMIN_PASSWORD=admin \
 OPENSEARCH_ADMIN_PASSWORD=admin OPENSEARCH_DASHBOARDS_PASSWORD=admin \
 OPENSEARCH_LOGWRITER_PASSWORD=admin OPENSEARCH_OIDC_CLIENT_SECRET=x \
+STOA_DISABLE_AUTH=true \
 docker compose -f deploy/docker-compose/docker-compose.yml --profile demo up --build -d \
     postgres keycloak control-plane-api stoa-gateway mock-backend
 


### PR DESCRIPTION
## Summary
- add explicit cp-api demo/dev auth bypass via STOA_DISABLE_AUTH=true
- require X-Demo-Mode: true per request for the bypass to apply
- reject STOA_DISABLE_AUTH=true at startup when ENVIRONMENT=production
- wire the demo smoke compose/workflow to use the bypass explicitly
- align AT-1 smoke payload with cp-api display_name contract

## Validation
- python3 -m py_compile control-plane-api/src/config.py control-plane-api/src/auth/dependencies.py control-plane-api/tests/test_regression_cab_2149_demo_auth_bypass.py
- bash -n scripts/demo-smoke-test.sh
- YAML parse: .github/workflows/demo-smoke.yml
- git diff --check
- cd control-plane-api && pytest tests/test_regression_cab_2149_demo_auth_bypass.py tests/test_regression_cab_2145_debug_flag_env_gating.py -q
- cd control-plane-api && ruff check src/auth/dependencies.py src/config.py tests/test_regression_cab_2149_demo_auth_bypass.py
- docker compose config with STOA_DISABLE_AUTH=true
- gitleaks detect on PR diff
- local compose boot with --profile demo up --build
- ./scripts/demo-smoke-test.sh --no-observability-ui

## Smoke result
B4 is closed locally: AT-1 no longer fails with 401.

```text
[PASS] AT-0 cp-api+gateway+mock reachable
[PASS] AT-1 API_ID=demo-api-smoke
[FAIL] AT-2 HTTP=422, body=environment enum expects dev/staging/production, got demo
[FAIL] AT-3 applications HTTP=422, body=display_name missing
Verdict: FAIL — DEMO NOT READY
```

Next blocker is no longer auth; it is the AT-2/AT-3 payload contract drift exposed by the smoke.