### PR TITLE
Align API deployments flow contract

### DIFF
--- a/control-plane-ui/src/pages/ApiDeployments/ApiDeploymentsDashboard.test.tsx
+++ b/control-plane-ui/src/pages/ApiDeployments/ApiDeploymentsDashboard.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { createAuthMock, renderWithProviders } from '../../test/helpers';
+import { useAuth } from '../../contexts/AuthContext';
+
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+
+const envMock = vi.hoisted(() => ({
+  activeEnvironment: 'prod',
+  switchEnvironment: vi.fn(),
+}));
+
+vi.mock('../../contexts/EnvironmentContext', () => ({
+  useEnvironment: () => ({
+    activeEnvironment: envMock.activeEnvironment,
+    switchEnvironment: envMock.switchEnvironment,
+    environments: [
+      { name: 'dev', label: 'Development', mode: 'full', color: 'green' },
+      { name: 'staging', label: 'Staging', mode: 'full', color: 'amber' },
+      { name: 'prod', label: 'Production', mode: 'read-only', color: 'red' },
+    ],
+  }),
+}));
+
+const mockGetGatewayDeployments = vi.fn().mockResolvedValue({ items: [], total: 0 });
+const mockGetDeploymentStatusSummary = vi.fn().mockResolvedValue({
+  synced: 0,
+  pending: 0,
+  drifted: 0,
+  error: 0,
+  syncing: 0,
+  deleting: 0,
+  total: 0,
+});
+
+vi.mock('../../services/api', () => ({
+  apiService: {
+    getGatewayDeployments: (...args: unknown[]) => mockGetGatewayDeployments(...args),
+    getDeploymentStatusSummary: (...args: unknown[]) => mockGetDeploymentStatusSummary(...args),
+    forceSyncDeployment: vi.fn().mockResolvedValue(undefined),
+    undeployFromGateway: vi.fn().mockResolvedValue(undefined),
+    setAuthToken: vi.fn(),
+    clearAuthToken: vi.fn(),
+  },
+}));
+
+vi.mock('../GatewayDeployments/DeployAPIDialog', () => ({
+  DeployAPIDialog: () => <div data-testid="deploy-dialog">Deploy Dialog</div>,
+}));
+
+vi.mock('../../components/SubNav', () => ({
+  SubNav: () => <nav data-testid="sub-nav" />,
+}));
+
+vi.mock('../../components/SyncStatusBadge', () => ({
+  SyncStatusBadge: ({ status }: { status: string }) => <span>{status}</span>,
+}));
+
+vi.mock('@stoa/shared/components/Toast', () => ({
+  useToastActions: () => ({ success: vi.fn(), error: vi.fn(), info: vi.fn() }),
+}));
+
+vi.mock('@stoa/shared/components/ConfirmDialog', () => ({
+  useConfirm: () => [vi.fn().mockResolvedValue(false), null],
+}));
+
+vi.mock('@stoa/shared/components/EmptyState', () => ({
+  EmptyState: ({ title }: { title?: string }) => <div data-testid="empty-state">{title}</div>,
+}));
+
+vi.mock('@stoa/shared/components/Skeleton', () => ({
+  TableSkeleton: () => <div data-testid="table-skeleton" />,
+}));
+
+vi.mock('@stoa/shared/components/StatCard', () => ({
+  StatCard: ({ label, value }: { label: string; value: number }) => (
+    <div>
+      {label}: {value}
+    </div>
+  ),
+}));
+
+import { ApiDeploymentsDashboard } from './ApiDeploymentsDashboard';
+
+describe('ApiDeploymentsDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    envMock.activeEnvironment = 'prod';
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+    mockGetGatewayDeployments.mockResolvedValue({ items: [], total: 0 });
+    mockGetDeploymentStatusSummary.mockResolvedValue({
+      synced: 0,
+      pending: 0,
+      drifted: 0,
+      error: 0,
+      syncing: 0,
+      deleting: 0,
+      total: 0,
+    });
+  });
+
+  it('uses the global environment as the default runtime filter', async () => {
+    renderWithProviders(<ApiDeploymentsDashboard />);
+
+    await waitFor(() => {
+      expect(mockGetGatewayDeployments).toHaveBeenCalledWith({
+        page: 1,
+        page_size: 20,
+        environment: 'production',
+      });
+    });
+  });
+
+  it('keeps the page filter and global environment selector in sync', async () => {
+    renderWithProviders(<ApiDeploymentsDashboard />);
+
+    fireEvent.change(await screen.findByDisplayValue('Production'), {
+      target: { value: 'staging' },
+    });
+
+    expect(envMock.switchEnvironment).toHaveBeenCalledWith('staging');
+    await waitFor(() => {
+      expect(mockGetGatewayDeployments).toHaveBeenCalledWith({
+        page: 1,
+        page_size: 20,
+        environment: 'staging',
+      });
+    });
+  });
+
+  it('renders runtime sync status and last sync from GatewayDeployment fields', async () => {
+    mockGetGatewayDeployments.mockResolvedValue({
+      items: [
+        {
+          id: 'dep-1',
+          api_catalog_id: 'api-1',
+          gateway_instance_id: 'gw-1',
+          desired_state: { api_name: 'Payments' },
+          desired_at: '2026-04-25T10:00:00Z',
+          actual_state: { api_name: 'Payments' },
+          sync_status: 'synced',
+          last_sync_success: '2026-04-25T10:01:00Z',
+          sync_attempts: 1,
+          created_at: '2026-04-25T10:00:00Z',
+          updated_at: '2026-04-25T10:01:00Z',
+          gateway_name: 'stoa-prod',
+          gateway_environment: 'production',
+        },
+      ],
+      total: 1,
+    });
+
+    renderWithProviders(<ApiDeploymentsDashboard />);
+
+    expect(await screen.findByText('Payments')).toBeInTheDocument();
+    expect(screen.getByText('synced')).toBeInTheDocument();
+    expect(screen.getByText(/2026/)).toBeInTheDocument();
+  });
+});

--- a/control-plane-ui/src/pages/ApiDeployments/ApiDeploymentsDashboard.tsx
+++ b/control-plane-ui/src/pages/ApiDeployments/ApiDeploymentsDashboard.tsx
@@ -5,9 +5,10 @@
  * Replaces the gateway-scoped view with an API-centric deployment view.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { RefreshCw, Plus, Trash2, RotateCcw } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
+import { useEnvironment } from '../../contexts/EnvironmentContext';
 import { apiService } from '../../services/api';
 import { SyncStatusBadge } from '../../components/SyncStatusBadge';
 import { DeployAPIDialog } from '../GatewayDeployments/DeployAPIDialog';
@@ -21,9 +22,12 @@ import { SubNav } from '../../components/SubNav';
 import { apiDeploymentTabs } from '../../components/subNavGroups';
 import type { GatewayDeployment } from '../../types';
 import type { Schemas } from '@stoa/shared/api-types';
+import { getEnvLabel, normalizeEnvironment } from '@stoa/shared/constants/environments';
+import type { CanonicalEnvironment } from '@stoa/shared/constants/environments';
 
 const PAGE_SIZE = 20;
 const AUTO_REFRESH_INTERVAL = 30_000;
+type EnvironmentFilter = '' | 'dev' | 'staging' | 'production';
 
 const statusFilterOptions = [
   { value: '', label: 'All Statuses' },
@@ -35,15 +39,28 @@ const statusFilterOptions = [
   { value: 'deleting', label: 'Deleting' },
 ];
 
-const envFilterOptions = [
-  { value: '', label: 'All Environments' },
-  { value: 'dev', label: 'Development' },
-  { value: 'staging', label: 'Staging' },
-  { value: 'production', label: 'Production' },
-];
+function toApiEnvironment(env: string): Exclude<EnvironmentFilter, ''> {
+  const canonical = normalizeEnvironment(env);
+  if (canonical === 'development') return 'dev';
+  return canonical;
+}
+
+function toContextEnvironment(env: string): 'dev' | 'staging' | 'prod' {
+  const canonical = normalizeEnvironment(env);
+  if (canonical === 'production') return 'prod';
+  if (canonical === 'staging') return 'staging';
+  return 'dev';
+}
+
+function canonicalSortValue(env: CanonicalEnvironment): number {
+  if (env === 'development') return 0;
+  if (env === 'staging') return 1;
+  return 2;
+}
 
 export function ApiDeploymentsDashboard() {
   const { isReady } = useAuth();
+  const { activeEnvironment, environments, switchEnvironment } = useEnvironment();
   const toast = useToastActions();
   const [confirm, ConfirmDialog] = useConfirm();
   const [deployments, setDeployments] = useState<GatewayDeployment[]>([]);
@@ -51,14 +68,42 @@ export function ApiDeploymentsDashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState('');
-  const [envFilter, setEnvFilter] = useState('');
+  const [envFilter, setEnvFilter] = useState<EnvironmentFilter>(
+    toApiEnvironment(activeEnvironment)
+  );
   const [currentPage, setCurrentPage] = useState(1);
   const [total, setTotal] = useState(0);
   const [showDeployDialog, setShowDeployDialog] = useState(false);
   const [selectedDeployment, setSelectedDeployment] = useState<GatewayDeployment | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const latestLoadRef = useRef(0);
+
+  const envFilterOptions = useMemo(() => {
+    const seen = new Set<CanonicalEnvironment>();
+    const options = environments
+      .map((env) => normalizeEnvironment(env.name))
+      .filter((env) => {
+        if (seen.has(env)) return false;
+        seen.add(env);
+        return true;
+      })
+      .sort((a, b) => canonicalSortValue(a) - canonicalSortValue(b))
+      .map((env) => ({
+        value: toApiEnvironment(env),
+        label: getEnvLabel(env),
+      }));
+
+    return [{ value: '', label: 'All Environments' }, ...options];
+  }, [environments]);
+
+  useEffect(() => {
+    setEnvFilter(toApiEnvironment(activeEnvironment));
+    setCurrentPage(1);
+  }, [activeEnvironment]);
 
   const loadData = useCallback(async () => {
+    const requestId = latestLoadRef.current + 1;
+    latestLoadRef.current = requestId;
     const params: Record<string, string | number> = { page: currentPage, page_size: PAGE_SIZE };
     if (statusFilter) params.sync_status = statusFilter;
     if (envFilter) params.environment = envFilter;
@@ -68,6 +113,8 @@ export function ApiDeploymentsDashboard() {
       apiService.getGatewayDeployments(params),
       apiService.getDeploymentStatusSummary(),
     ]);
+
+    if (requestId !== latestLoadRef.current) return;
 
     if (deploymentsResult.status === 'fulfilled') {
       setDeployments(deploymentsResult.value.items);
@@ -186,8 +233,10 @@ export function ApiDeploymentsDashboard() {
         <select
           value={envFilter}
           onChange={(e) => {
-            setEnvFilter(e.target.value);
+            const nextEnv = e.target.value as EnvironmentFilter;
+            setEnvFilter(nextEnv);
             setCurrentPage(1);
+            if (nextEnv) switchEnvironment(toContextEnvironment(nextEnv));
           }}
           className="border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-neutral-700 dark:text-white"
         >

--- a/control-plane-ui/src/pages/GatewayDeployments/DeployAPIDialog.test.tsx
+++ b/control-plane-ui/src/pages/GatewayDeployments/DeployAPIDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createAuthMock } from '../../test/helpers';
 import { useAuth } from '../../contexts/AuthContext';
 import type { PersonaRole } from '../../test/helpers';
@@ -25,15 +25,26 @@ const mockGetGatewayInstances = vi.fn().mockResolvedValue({
     },
   ],
 });
+const mockGetApis = vi.fn().mockResolvedValue([]);
+const mockGetGatewayDeployments = vi.fn().mockResolvedValue({ items: [] });
+const mockGetDeployableEnvironments = vi.fn().mockResolvedValue({
+  environments: [{ environment: 'dev', deployable: true, promotion_status: 'not_required' }],
+});
+const mockDeployApiToEnv = vi.fn().mockResolvedValue({
+  deployed: 1,
+  environment: 'dev',
+  deployment_ids: ['dep-1'],
+});
 
 vi.mock('../../services/api', () => ({
   apiService: {
     getCatalogEntries: (...args: unknown[]) => mockGetCatalogEntries(...args),
     getTenants: (...args: unknown[]) => mockGetTenants(...args),
     getGatewayInstances: (...args: unknown[]) => mockGetGatewayInstances(...args),
-    getApis: vi.fn().mockResolvedValue([]),
-    getGatewayDeployments: vi.fn().mockResolvedValue({ items: [] }),
-    getDeployableEnvironments: vi.fn().mockResolvedValue([]),
+    getApis: (...args: unknown[]) => mockGetApis(...args),
+    getGatewayDeployments: (...args: unknown[]) => mockGetGatewayDeployments(...args),
+    getDeployableEnvironments: (...args: unknown[]) => mockGetDeployableEnvironments(...args),
+    deployApiToEnv: (...args: unknown[]) => mockDeployApiToEnv(...args),
     deployApiToGateways: vi.fn().mockResolvedValue(undefined),
     setAuthToken: vi.fn(),
     clearAuthToken: vi.fn(),
@@ -49,6 +60,31 @@ describe('DeployAPIDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+    mockGetCatalogEntries.mockResolvedValue([
+      { id: 'cat-1', api_name: 'Payment API', tenant_id: 'oasis-gunters', version: '1.0.0' },
+    ]);
+    mockGetTenants.mockResolvedValue([{ id: 'oasis-gunters', name: 'Oasis Gunters' }]);
+    mockGetGatewayInstances.mockResolvedValue({
+      items: [
+        {
+          id: 'gw-1',
+          name: 'stoa-edge',
+          display_name: 'STOA Edge MCP',
+          gateway_type: 'stoa_edge_mcp',
+          environment: 'dev',
+        },
+      ],
+    });
+    mockGetApis.mockResolvedValue([]);
+    mockGetGatewayDeployments.mockResolvedValue({ items: [] });
+    mockGetDeployableEnvironments.mockResolvedValue({
+      environments: [{ environment: 'dev', deployable: true, promotion_status: 'not_required' }],
+    });
+    mockDeployApiToEnv.mockResolvedValue({
+      deployed: 1,
+      environment: 'dev',
+      deployment_ids: ['dep-1'],
+    });
   });
 
   it('renders the dialog title', async () => {
@@ -72,6 +108,57 @@ describe('DeployAPIDialog', () => {
     render(<DeployAPIDialog onClose={onClose} onDeployed={onDeployed} />);
     await waitFor(() => {
       expect(screen.getByText(/failed/i)).toBeInTheDocument();
+    });
+  });
+
+  it('clears selected gateways when environment changes and accepts prod/production aliases', async () => {
+    mockGetApis.mockResolvedValue([
+      { id: 'api-1', name: 'payments', version: '1.0.0', tenant_id: 'oasis-gunters' },
+    ]);
+    mockGetGatewayInstances.mockResolvedValue({
+      items: [
+        {
+          id: 'gw-dev',
+          name: 'stoa-dev',
+          display_name: 'STOA Dev',
+          gateway_type: 'stoa_edge_mcp',
+          environment: 'dev',
+        },
+        {
+          id: 'gw-prod',
+          name: 'stoa-prod',
+          display_name: 'STOA Prod',
+          gateway_type: 'stoa_edge_mcp',
+          environment: 'prod',
+        },
+      ],
+    });
+    mockGetDeployableEnvironments.mockResolvedValue({
+      environments: [
+        { environment: 'dev', deployable: true, promotion_status: 'not_required' },
+        { environment: 'production', deployable: true, promotion_status: 'promoted' },
+      ],
+    });
+
+    render(<DeployAPIDialog onClose={onClose} onDeployed={onDeployed} />);
+
+    const apiSelect = (await screen.findAllByRole('combobox'))[0];
+    fireEvent.change(apiSelect, { target: { value: 'payments' } });
+
+    expect(await screen.findByText('STOA Dev')).toBeInTheDocument();
+    const devInput = screen.getByText('STOA Dev').closest('label')?.querySelector('input');
+    expect(devInput).toBeTruthy();
+    fireEvent.click(devInput as HTMLInputElement);
+    expect(screen.getByRole('button', { name: /Deploy to 1 gateway/ })).toBeEnabled();
+
+    const environmentSelect = (await screen.findAllByRole('combobox'))[1];
+    fireEvent.change(environmentSelect, {
+      target: { value: 'production' },
+    });
+
+    expect(await screen.findByText('STOA Prod')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Deploy to 0 gateways/ })).toBeDisabled();
     });
   });
 

--- a/control-plane-ui/src/pages/GatewayDeployments/DeployAPIDialog.tsx
+++ b/control-plane-ui/src/pages/GatewayDeployments/DeployAPIDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { X, AlertCircle, CheckCircle2, Search } from 'lucide-react';
 import { apiService } from '../../services/api';
 import type { API, GatewayDeployment } from '../../types';
+import { getEnvLabel, normalizeEnvironment } from '@stoa/shared/constants/environments';
 
 interface GatewayOption {
   id: string;
@@ -32,6 +33,10 @@ interface DeployAPIDialogProps {
   onDeployed: () => void;
   /** Pre-select an API (from API Detail page). Format: "tenantId:apiName" */
   preselectedApiKey?: string;
+}
+
+function sameEnvironment(left: string, right: string): boolean {
+  return normalizeEnvironment(left) === normalizeEnvironment(right);
 }
 
 export function DeployAPIDialog({ onClose, onDeployed, preselectedApiKey }: DeployAPIDialogProps) {
@@ -180,8 +185,27 @@ export function DeployAPIDialog({ onClose, onDeployed, preselectedApiKey }: Depl
     );
   }, [apis, apiSearchTerm]);
 
-  // Filter gateways by selected environment
-  const filteredGateways = gateways.filter((gw) => selectedEnv && gw.environment === selectedEnv);
+  // Filter gateways by selected environment, accepting both `prod` and
+  // `production` wire shapes. ADF-8 forbids keeping cross-env gateway targets.
+  const filteredGateways = useMemo(
+    () => gateways.filter((gw) => selectedEnv && sameEnvironment(gw.environment, selectedEnv)),
+    [gateways, selectedEnv]
+  );
+
+  const selectedGatewayIdsForEnv = useMemo(() => {
+    const validGatewayIds = new Set(filteredGateways.map((gw) => gw.id));
+    return selectedGateways.filter((id) => validGatewayIds.has(id));
+  }, [filteredGateways, selectedGateways]);
+
+  useEffect(() => {
+    if (!selectedEnv) return;
+    const validGatewayIds = new Set(filteredGateways.map((gw) => gw.id));
+    setSelectedGateways((prev) => {
+      const next = prev.filter((id) => validGatewayIds.has(id));
+      if (next.length === prev.length) return prev;
+      return next;
+    });
+  }, [filteredGateways, selectedEnv]);
 
   const isAlreadyDeployed = (gwId: string) =>
     existingDeployments.some((d) => d.gateway_instance_id === gwId && d.sync_status === 'synced');
@@ -194,7 +218,9 @@ export function DeployAPIDialog({ onClose, onDeployed, preselectedApiKey }: Depl
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!selectedApi || !selectedEnv || !selectedTenant || selectedGateways.length === 0) return;
+    if (!selectedApi || !selectedEnv || !selectedTenant || selectedGatewayIdsForEnv.length === 0) {
+      return;
+    }
 
     setSubmitting(true);
     setError(null);
@@ -202,7 +228,7 @@ export function DeployAPIDialog({ onClose, onDeployed, preselectedApiKey }: Depl
     try {
       await apiService.deployApiToEnv(selectedTenant, selectedApi, {
         environment: selectedEnv,
-        gateway_ids: selectedGateways,
+        gateway_ids: selectedGatewayIdsForEnv,
       });
       onDeployed();
     } catch {
@@ -212,11 +238,7 @@ export function DeployAPIDialog({ onClose, onDeployed, preselectedApiKey }: Depl
     }
   };
 
-  const envLabels: Record<string, string> = {
-    dev: 'Development',
-    staging: 'Staging',
-    production: 'Production',
-  };
+  const getEnvironmentLabel = (env: string) => getEnvLabel(env);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
@@ -364,7 +386,7 @@ export function DeployAPIDialog({ onClose, onDeployed, preselectedApiKey }: Depl
                           value={env.environment}
                           disabled={!env.deployable}
                         >
-                          {envLabels[env.environment] || env.environment}
+                          {getEnvironmentLabel(env.environment)}
                           {!env.deployable ? ' (not promoted)' : ''}
                         </option>
                       ))}
@@ -377,11 +399,11 @@ export function DeployAPIDialog({ onClose, onDeployed, preselectedApiKey }: Depl
               {selectedEnv && (
                 <div>
                   <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
-                    Target Gateways ({envLabels[selectedEnv] || selectedEnv})
+                    Target Gateways ({getEnvironmentLabel(selectedEnv)})
                   </label>
                   {filteredGateways.length === 0 ? (
                     <p className="text-sm text-neutral-500 dark:text-neutral-400">
-                      No gateways registered in {envLabels[selectedEnv] || selectedEnv}.
+                      No gateways registered in {getEnvironmentLabel(selectedEnv)}.
                     </p>
                   ) : (
                     <div className="space-y-2 max-h-48 overflow-y-auto border border-neutral-200 dark:border-neutral-600 rounded-lg p-3">
@@ -438,12 +460,16 @@ export function DeployAPIDialog({ onClose, onDeployed, preselectedApiKey }: Depl
             </button>
             <button
               type="submit"
-              disabled={submitting || !selectedApi || !selectedEnv || selectedGateways.length === 0}
+              disabled={
+                submitting || !selectedApi || !selectedEnv || selectedGatewayIdsForEnv.length === 0
+              }
               className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-700 disabled:opacity-50"
             >
               {submitting
                 ? 'Deploying...'
-                : `Deploy to ${selectedGateways.length} gateway${selectedGateways.length !== 1 ? 's' : ''}`}
+                : `Deploy to ${selectedGatewayIdsForEnv.length} gateway${
+                    selectedGatewayIdsForEnv.length !== 1 ? 's' : ''
+                  }`}
             </button>
           </div>
         </form>

--- a/specs/api-deployment-flow.md
+++ b/specs/api-deployment-flow.md
@@ -1,0 +1,289 @@
+# STOA Demo — API Deployment Flow Contract
+
+> **Statut**: v0.1 — 2026-04-25. Contrat transverse pour garder le flux Console
+> `/api-deployments` fonctionnel.
+> **Relation au scope démo**: complément à `demo-scope.md`, non bloquant pour
+> `scripts/demo-smoke-test.sh` tant qu'une décision écrite ne l'ajoute pas au
+> smoke minimal provider/runtime.
+> **ADRs sources**: ADR-040 (Born GitOps multi-environment), ADR-059
+> (Promotion Deploy Chain — closed loop), ADR-059 stoa-docs (single deployment
+> path via SSE), ADR-035 (Gateway Adapter Pattern), ADR-036 (Gateway
+> Auto-Registration).
+
+## 1. Pourquoi ce contrat
+
+La page Console `/api-deployments` traverse plusieurs concepts backend:
+`Deployment`, `Promotion`, `GatewayDeployment` et `ApiGatewayAssignment`.
+Ces objets ne représentent pas le même niveau de vérité:
+
+- `Deployment` et `Promotion` décrivent une intention ou un lifecycle métier.
+- `GatewayDeployment` décrit l'état réel attendu/observé sur une gateway.
+- `ApiGatewayAssignment` décrit les cibles par défaut d'une API dans un environnement.
+
+Le risque principal est qu'une PR corrige une surface locale tout en cassant le
+flux complet: promotion acceptée mais aucun déploiement gateway créé, statut
+Console interprété comme "synced" sans ack gateway, sélection d'environnement
+incohérente, ou rollback qui laisse une route active.
+
+Ce fichier fige le contrat transverse. Il sert de référence pour les PR qui
+touchent promotions, assignments, gateway deployments, sync engine, gateways ou
+la page Console `/api-deployments`.
+
+## 1.1 Alignement ADR
+
+Ce contrat est un contrat de flux Console/runtime. Il ne remplace pas les ADRs:
+
+- **ADR-040 — Born GitOps multi-environment**: Git/UAC reste la source de
+  gouvernance pour les changements de configuration, particulièrement en
+  production. Le flux de cette spec ne doit pas réintroduire un "UI click to
+  prod" sans approbation. En dev/staging, l'UI peut créer une intention de
+  déploiement; en production, elle doit suivre le mode read/promote défini par
+  l'environnement.
+- **ADR-059 — Promotion Deploy Chain**: une promotion n'est complète qu'après
+  boucle fermée `promote -> deploy -> ack -> promoted|failed`. Le lien direct
+  `GatewayDeployment.promotion_id` est contractuel pour lever l'ambiguïté
+  `api_id + target_environment`.
+- **ADR-059 — Single Path via SSE**: la cible d'architecture est
+  `Console -> CP API -> STOA Link SSE -> gateway -> callback -> CP API`. Le
+  SyncEngine et l'inline sync sont des chemins legacy/de transition, pas des
+  dépendances que ce contrat doit préserver.
+- **ADR-035 / ADR-036**: les gateways restent abstraites par adapter/capability
+  et auto-enregistrées avec identité d'environnement. Le filtre env/gateway de
+  la Console doit respecter cette identité.
+
+## 2. Scénario cible
+
+| # | Étape | Surface | API/Commande | Preuve |
+|---|-------|---------|--------------|--------|
+| ADF-0 | Seed flux deployment | cp-api + DB | seed tenant, API catalogue, gateway dev/staging | Données idempotentes prêtes |
+| ADF-1 | Déployer en dev | Console/API | `POST /v1/tenants/{t}/apis/{api}/deploy` avec `gateway_ids` | `GatewayDeployment` créé `pending/syncing` |
+| ADF-2 | Ack gateway | STOA Link/gateway + cp-api | callback Link ou `route-sync-ack` legacy | `sync_status=synced`, `last_sync_success` non nul |
+| ADF-3 | Voir l'état Console | Console | `/api-deployments` | Ligne API/gateway/env visible, statut runtime affiché |
+| ADF-4 | Préparer auto-deploy env cible | cp-api | assignment `auto_deploy=true` pour target env | assignment listé avec gateway du même env |
+| ADF-5 | Promouvoir dev→staging | Console/API | create + approve promotion | promotion `promoting`, deployments gateway créés |
+| ADF-6 | Compléter promotion après ack | cp-api | gateway deployments liés tous `synced` | promotion `promoted` seulement après sync réel |
+| ADF-7 | Gérer absence de cible | Console/API | promotion sans assignment target | erreur/warning explicite, jamais succès silencieux |
+| ADF-8 | Changer d'environnement | Console | global env selector ou filtre local | gateway invalide désélectionnée, aucune cible cross-env |
+| ADF-9 | Rollback/undeploy | Console/API | reverse promotion, Git revert, ou undeploy | intention de suppression puis route absente gateway |
+
+## 3. Invariants
+
+### 3.1 Source de vérité des statuts
+
+`GatewayDeployment.sync_status` est la source de vérité runtime pour la Console.
+`Promotion.status=promoted` ne signifie jamais "gateway synced" sans
+`GatewayDeployment` lié et acquitté.
+
+Statuts utilisateur canoniques à exposer sur `/api-deployments`:
+
+| Statut UI | Condition minimale |
+|-----------|--------------------|
+| `not_deployed` | aucun `GatewayDeployment` pour API + env |
+| `no_target_gateway` | promotion/deploy demandé mais aucune cible gateway valide |
+| `pending` | `GatewayDeployment.sync_status=pending` |
+| `syncing` | `GatewayDeployment.sync_status=syncing` |
+| `synced` | tous les `GatewayDeployment` attendus sont `synced` |
+| `partial` | au moins un gateway `synced`, au moins un non-synced |
+| `failed` | au moins un `error`, aucun `pending/syncing` récupérable |
+| `drifted` | au moins un `drifted` |
+| `deleting` | undeploy/rollback en suppression active |
+
+### 3.2 Assignments et gateways
+
+- Un `ApiGatewayAssignment.environment` doit correspondre à
+  `GatewayInstance.environment`.
+- Une promotion avec `auto_deploy` attendu mais sans assignment cible doit
+  retourner un signal explicite: erreur bloquante, warning actionnable, ou étape
+  UI de choix gateway. Le résultat `0 deployment` silencieux est interdit.
+- Un changement d'environnement ne doit jamais conserver une gateway sélectionnée
+  dans un autre environnement.
+
+### 3.3 Promotion et sync
+
+- L'approbation d'une promotion qui déclenche des deployments doit lier chaque
+  `GatewayDeployment.promotion_id` à la promotion source.
+- La promotion ne peut passer à `promoted` automatiquement que si les
+  `GatewayDeployment` liés sont tous `synced`.
+- Si au moins un deployment lié passe `error` et qu'aucun n'est encore
+  `pending/syncing`, la promotion doit devenir `failed`, conformément à
+  ADR-059. Le détail de failure doit indiquer le nombre de gateways en échec.
+
+### 3.4 Rollback et suppression
+
+- Un rollback qui retire une API d'un environnement doit créer une intention
+  explicite côté gateway: reverse promotion, Git revert réconcilié, ou
+  `GatewayDeployment.sync_status=deleting` selon le chemin retenu par
+  l'environnement.
+- Une route gateway encore active après rollback doit apparaître comme drift ou
+  suppression en attente, pas comme succès.
+
+### 3.5 Timeouts et gateway down
+
+- Une gateway down ne doit pas être confondue avec une dérive métier.
+- Un deployment bloqué en `pending/syncing` doit avoir un délai maximal
+  observable et une transition explicite vers `error`, `stale`, ou `retrying`.
+  En architecture cible ADR-059 SSE, une perte de connexion Link laisse
+  l'intention en attente jusqu'au reconnect/catch-up, mais la Console doit
+  rendre cette attente visible.
+- La Console doit afficher un état actionnable: re-sync, inspect gateway, ou
+  supprimer la cible.
+
+## 4. Acceptance tests
+
+### ADF-0 — Seed idempotent
+
+Préparer:
+- tenant `demo`
+- API catalogue `demo-api-deploy-flow`
+- gateway `gateway-dev-demo` en `dev`
+- gateway `gateway-staging-demo` en `staging`
+- aucun `GatewayDeployment` résiduel pour cette API, sauf si le test les nettoie
+
+PASS si le seed est relançable sans doublons et retourne les IDs utiles.
+
+### ADF-1 — Deploy dev direct crée un GatewayDeployment
+
+`POST /v1/tenants/{tenant}/apis/{api}/deploy` avec
+`{"environment":"dev","gateway_ids":["gateway-dev-demo"]}` retourne `201`.
+
+PASS si un `GatewayDeployment` existe pour API + gateway dev avec statut
+`pending` ou `syncing`.
+
+### ADF-2 — Ack gateway synchronise l'état runtime
+
+Après exécution par STOA Link et callback CP, ou via `route-sync-ack` dans le
+chemin legacy encore présent:
+
+PASS si le deployment a:
+- `sync_status=synced`
+- `last_sync_success` non nul
+- `actual_state` renseigné ou preuve équivalente que la gateway a appliqué la route
+
+NOTE: un passage par SyncEngine ou inline sync peut être accepté comme compat
+legacy pendant la migration, mais ne doit pas devenir le contrat cible.
+
+### ADF-3 — Console affiche la vérité runtime
+
+La page `/api-deployments` charge les gateway deployments.
+
+PASS si la ligne affiche:
+- nom API issu de `desired_state.api_name` ou du catalog
+- gateway cible
+- environnement gateway
+- statut dérivé de `GatewayDeployment.sync_status`
+- last sync basé sur `last_sync_success`
+
+FAIL si la page affiche un succès basé uniquement sur `Deployment.completed_at`
+ou `Promotion.completed_at`.
+
+### ADF-4 — Assignment target env valide
+
+Créer un assignment staging `auto_deploy=true` vers `gateway-staging-demo`.
+
+PASS si:
+- l'assignment est listé par
+  `GET /v1/tenants/{tenant}/apis/{api}/gateway-assignments?environment=staging`
+- le backend refuse ou signale toute gateway dont `GatewayInstance.environment`
+  ne correspond pas à l'environnement de l'assignment
+
+### ADF-5 — Promotion crée les GatewayDeployments attendus
+
+Créer puis approuver une promotion `dev -> staging`.
+
+PASS si:
+- la promotion passe `promoting`
+- au moins un `GatewayDeployment` est créé pour chaque assignment
+  `auto_deploy=true` de l'environnement cible
+- chaque deployment créé référence la promotion via `promotion_id`
+- l'intention de déploiement est livrée au Link/gateway par le chemin cible
+  SSE/callback, ou par `route-sync-ack` legacy tant que la migration n'est pas
+  terminée
+
+### ADF-6 — Promotion complétée après sync réel
+
+Quand tous les `GatewayDeployment` liés à la promotion sont `synced`:
+
+PASS si la promotion devient `promoted` et expose une preuve de completion.
+
+FAIL si la promotion devient `promoted` alors qu'aucun deployment gateway lié
+n'existe ou qu'un deployment lié est encore `pending/syncing/error`.
+
+Si un deployment lié est `error` et qu'aucun deployment lié n'est encore
+`pending/syncing`, la promotion doit devenir `failed`.
+
+### ADF-7 — Promotion sans assignment ne réussit pas silencieusement
+
+Supprimer les assignments staging puis approuver une promotion `dev -> staging`.
+
+PASS si le système retourne ou expose explicitement:
+- `no_target_gateway`
+- ou une erreur bloquante
+- ou une tâche d'action utilisateur "configure target gateway"
+
+FAIL si la promotion peut être comprise comme réussie alors que `0`
+`GatewayDeployment` a été créé.
+
+### ADF-8 — Changement d'environnement ne garde pas une gateway invalide
+
+Dans le dialog de deploy Console:
+1. choisir `dev`
+2. sélectionner une gateway dev
+3. changer vers `staging`
+
+PASS si la sélection gateway est remise à zéro ou remplacée uniquement par des
+gateways staging.
+
+FAIL si une gateway dev peut être soumise pour un déploiement staging.
+
+### ADF-9 — Rollback/undeploy retire la route gateway
+
+Déclencher rollback ou undeploy d'un deployment synced.
+
+PASS si:
+- le deployment devient `deleting` ou une intention équivalente est créée par
+  reverse promotion / Git revert selon l'environnement
+- la gateway retire la route
+- la Console n'affiche plus l'ancienne route comme `synced`
+
+## 5. Validation cible
+
+Court terme:
+- ajouter un smoke API-level ciblé, par exemple
+  `scripts/api-deployment-flow-smoke.sh`
+- ajouter un test Playwright Console ciblé sur `/api-deployments`
+- garder ce contrat non bloquant pour `demo-smoke-test.sh`
+
+Commandes cibles:
+
+```bash
+# API-level, à créer
+./scripts/api-deployment-flow-smoke.sh
+
+# UI-level, à créer
+cd e2e && npx playwright test api-deployment-flow.spec.ts
+```
+
+Critère GO pour toute PR touchant ce flux:
+- ADF-1, ADF-2, ADF-3 passent ou restent explicitement inchangés par la PR
+- ADF-5, ADF-6, ADF-7 passent pour toute PR promotion/assignment/sync
+- ADF-8 passe pour toute PR Console deploy dialog ou environment selector
+- ADF-9 passe pour toute PR rollback/undeploy
+
+## 6. Blockers connus
+
+| # | Blocker | Sévérité | Étapes impactées |
+|---|---------|----------|------------------|
+| A-B1 | `auto_deploy_on_promotion()` peut retourner `[]` sans signal utilisateur clair | P0 | ADF-5, ADF-7 |
+| A-B2 | `promotion_id` n'est pas garanti sur tous les deployments créés par approval direct | P0 | ADF-5, ADF-6 |
+| A-B3 | assignment env/gateway non validé comme contrainte métier forte | P1 | ADF-4, ADF-8 |
+| A-B4 | timeout explicite de sync adapter non contractuel | P1 | ADF-2, ADF-6 |
+| A-B5 | rollback ne garantit pas une intention `deleting` sur les anciens deployments | P1 | ADF-9 |
+| A-B6 | `/api-deployments` n'est pas encore couvert par un smoke transverse | P1 | ADF-3, ADF-8 |
+| A-B7 | chemins legacy SyncEngine/inline sync encore visibles dans le code malgré ADR-059 SSE cible | P1 | ADF-2, ADF-5 |
+
+## 7. Révisions
+
+| Date | Auteur | Changement |
+|------|--------|------------|
+| 2026-04-25 | Codex | Création initiale du contrat API deployment flow |
+| 2026-04-25 | Codex | Alignement explicite ADR-040/ADR-059/ADR-035/ADR-036 |

--- a/specs/validation-commands.md
+++ b/specs/validation-commands.md
@@ -232,3 +232,23 @@ curl -sI http://localhost:3002/usage
 curl -sI http://localhost:3000/admin/prospects
 curl -sI http://localhost:3000/subscriptions
 ```
+
+## 11. Flux API deployments Console
+
+Le flux transverse Console `/api-deployments` est spécifié séparément dans
+`specs/api-deployment-flow.md`.
+
+Ce contrat couvre le chemin API catalogue -> gateway assignment -> deploy direct
+ou promotion -> gateway sync ack -> affichage Console. Il reste non bloquant
+pour `scripts/demo-smoke-test.sh` tant qu'il n'est pas explicitement ajouté au
+scope minimal `demo-scope.md`.
+
+Validation cible future:
+
+```bash
+# API-level, à créer
+./scripts/api-deployment-flow-smoke.sh
+
+# UI-level, à créer
+cd e2e && npx playwright test api-deployment-flow.spec.ts
+```


### PR DESCRIPTION
## Summary

- add `specs/api-deployment-flow.md` as the transverse demo contract for Console `/api-deployments`
- align the contract with ADR-040, ADR-059, ADR-035, and ADR-036
- align the Console deployment UI with the contract for environment selection, gateway filtering, stale response guards, and runtime sync status display

## Validation

- `cd control-plane-ui && npx tsc -p tsconfig.app.json --noEmit`
- `cd control-plane-ui && npx vitest run src/pages/ApiDeployments/ApiDeploymentsDashboard.test.tsx src/pages/GatewayDeployments/DeployAPIDialog.test.tsx`
