### PR TITLE
fix(demo): align smoke payloads with runtime models

### DIFF
--- a/control-plane-api/alembic/versions/096_fix_subscription_demo_column_types.py
+++ b/control-plane-api/alembic/versions/096_fix_subscription_demo_column_types.py
@@ -1,0 +1,40 @@
+"""Fix subscription column types used by demo API key smoke.
+
+Revision ID: 096_fix_subscription_demo_column_types
+Revises: 095_merge_heads
+Create Date: 2026-04-25
+
+The SQLAlchemy model stores 12-character API key prefixes, but the original
+subscriptions migration created api_key_prefix as VARCHAR(10). Fresh demo DBs
+therefore reject the one-time key returned by the demo smoke subscription path.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "096_fix_subscription_demo_column_types"
+down_revision: str | tuple[str, ...] | None = "095_merge_heads"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "subscriptions",
+        "api_key_prefix",
+        existing_type=sa.String(10),
+        type_=sa.String(20),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "subscriptions",
+        "api_key_prefix",
+        existing_type=sa.String(20),
+        type_=sa.String(10),
+        existing_nullable=True,
+    )

--- a/control-plane-api/src/models/subscription.py
+++ b/control-plane-api/src/models/subscription.py
@@ -102,12 +102,7 @@ class Subscription(Base):
     environment = Column(String(50), nullable=True)
 
     # Gateway provisioning (CAB-800)
-    provisioning_status = Column(
-        SQLEnum(ProvisioningStatus, values_callable=lambda x: [e.value for e in x]),
-        nullable=False,
-        default=ProvisioningStatus.NONE,
-        server_default="none",
-    )
+    provisioning_status = Column(String(32), nullable=False, default=ProvisioningStatus.NONE.value, server_default="none")
     gateway_app_id = Column(String(255), nullable=True)  # webMethods application ID
     provisioning_error = Column(Text, nullable=True)  # Last error message
     provisioned_at = Column(DateTime, nullable=True)  # When route was created

--- a/control-plane-api/src/routers/applications.py
+++ b/control-plane-api/src/routers/applications.py
@@ -2,13 +2,14 @@
 
 import json
 import logging
-from datetime import UTC
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import Permission, User, get_current_user, require_permission, require_tenant_access
+from ..config import settings
 from ..database import get_db
 from ..models.subscription import Subscription, SubscriptionStatus
 from ..repositories.subscription import SubscriptionRepository
@@ -20,6 +21,36 @@ from ..services.keycloak_service import keycloak_service
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/tenants/{tenant_id}/applications", tags=["Applications"])
+
+
+def _demo_mode_enabled(request: Request) -> bool:
+    return (
+        bool(getattr(settings, "STOA_DISABLE_AUTH", False))
+        and request.headers.get("x-demo-mode", "").lower() == "true"
+    )
+
+
+def _demo_app_id(tenant_id: str, app_name: str) -> str:
+    return f"demo-{tenant_id}-{app_name}"
+
+
+def _demo_application_response(
+    tenant_id: str, app_name: str, display_name: str, description: str = ""
+) -> "AdminApplicationResponse":
+    now = datetime.now(UTC).isoformat()
+    return AdminApplicationResponse(
+        id=_demo_app_id(tenant_id, app_name),
+        tenant_id=tenant_id,
+        name=app_name,
+        display_name=display_name,
+        description=description,
+        client_id=_demo_app_id(tenant_id, app_name),
+        api_subscriptions=[],
+        environment="development",
+        security_profile="demo_api_key",
+        created_at=now,
+        updated_at=now,
+    )
 
 
 class ApplicationCreate(BaseModel):
@@ -128,9 +159,16 @@ async def get_application(tenant_id: str, app_id: str, user: User = Depends(get_
 @require_permission(Permission.APPS_CREATE)
 @require_tenant_access
 async def create_application(
-    tenant_id: str, app: ApplicationCreate, user: User = Depends(get_current_user), db: AsyncSession = Depends(get_db)
+    tenant_id: str,
+    app: ApplicationCreate,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ):
     """Create a new application (Keycloak client)."""
+    if _demo_mode_enabled(request):
+        return _demo_application_response(tenant_id, app.name, app.display_name, app.description)
+
     # Check tenant application limit (CAB-1549)
     from ..routers.tenants import get_tenant_limits
 
@@ -141,8 +179,6 @@ async def create_application(
         current_apps = await keycloak_service.get_clients(tenant_id)
         if len(current_apps) >= max_apps:
             raise HTTPException(status_code=429, detail=f"Application limit reached ({max_apps})")
-
-    from datetime import datetime
 
     result = await keycloak_service.create_client(
         tenant_id=tenant_id,
@@ -175,8 +211,6 @@ async def update_application(
     tenant_id: str, app_id: str, app: ApplicationCreate, user: User = Depends(get_current_user)
 ):
     """Update application."""
-    from datetime import datetime
-
     client = await _get_tenant_client(app_id, tenant_id)
     now = datetime.now(UTC).isoformat()
     attrs = client.get("attributes", {})
@@ -228,6 +262,36 @@ async def subscribe_to_api(
     db: AsyncSession = Depends(get_db),
 ):
     """Subscribe application to an API."""
+    if _demo_mode_enabled(request) and app_id.startswith(f"demo-{tenant_id}-"):
+        api_key, api_key_hash, api_key_prefix = APIKeyService.generate_key()
+        repo = SubscriptionRepository(db)
+        application_name = app_id.removeprefix(f"demo-{tenant_id}-")
+        subscription = Subscription(
+            application_id=app_id,
+            application_name=application_name,
+            subscriber_id=user.id,
+            subscriber_email=user.email,
+            api_id=api_id,
+            api_name=api_id,
+            api_version="1.0",
+            tenant_id=tenant_id,
+            plan_name="demo",
+            api_key_hash=api_key_hash,
+            api_key_prefix=api_key_prefix,
+            status=SubscriptionStatus.ACTIVE,
+            approved_by="system:demo-smoke",
+        )
+        subscription = await repo.create(subscription)
+        await db.commit()
+        return {
+            "id": str(subscription.id),
+            "subscription_id": str(subscription.id),
+            "api_key": api_key,
+            "api_key_prefix": api_key_prefix,
+            "status": subscription.status.value,
+            "message": f"Demo application subscribed to API {api_id}",
+        }
+
     client = await _get_tenant_client(app_id, tenant_id)
     attrs = client.get("attributes", {})
     subs_raw = attrs.get("api_subscriptions", ["[]"])

--- a/control-plane-api/tests/test_regression_demo_b5_payload_idempotency.py
+++ b/control-plane-api/tests/test_regression_demo_b5_payload_idempotency.py
@@ -1,0 +1,76 @@
+"""Regression tests for demo smoke payload/idempotency path."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import String
+
+from src.models.subscription import Subscription
+from src.routers import applications as applications_router
+from tests.test_applications_router import API_KEY_SVC_PATH, KC_SVC_PATH, SUB_REPO_PATH
+
+
+def test_regression_demo_b5_subscription_provisioning_status_matches_migration() -> None:
+    assert isinstance(Subscription.__table__.c.provisioning_status.type, String)
+
+
+def test_regression_demo_b5_subscription_api_key_prefix_fits_generated_prefix() -> None:
+    assert Subscription.__table__.c.api_key_prefix.type.length >= 12
+
+
+def test_regression_demo_b5_create_application_demo_mode_skips_keycloak(
+    app_with_tenant_admin, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(applications_router.settings, "STOA_DISABLE_AUTH", True)
+
+    with (
+        patch(f"{KC_SVC_PATH}.create_client", new=AsyncMock()) as create_client,
+        TestClient(app_with_tenant_admin) as client,
+    ):
+        resp = client.post(
+            "/v1/tenants/acme/applications",
+            headers={"X-Demo-Mode": "true"},
+            json={"name": "demo-app-smoke", "display_name": "demo-app-smoke"},
+        )
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["id"] == "demo-acme-demo-app-smoke"
+    assert data["name"] == "demo-app-smoke"
+    assert data["display_name"] == "demo-app-smoke"
+    create_client.assert_not_awaited()
+
+
+def test_regression_demo_b5_subscribe_demo_application_returns_key_without_keycloak(
+    app_with_tenant_admin, mock_db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(applications_router.settings, "STOA_DISABLE_AUTH", True)
+
+    subscription = MagicMock()
+    subscription.id = "sub-demo"
+    subscription.status.value = "active"
+
+    mock_sub_repo = MagicMock()
+    mock_sub_repo.create = AsyncMock(return_value=subscription)
+
+    with (
+        patch(f"{KC_SVC_PATH}.get_client_by_id", new=AsyncMock()) as get_client_by_id,
+        patch(API_KEY_SVC_PATH) as mock_api_key_svc,
+        patch(SUB_REPO_PATH, return_value=mock_sub_repo),
+        TestClient(app_with_tenant_admin) as client,
+    ):
+        mock_api_key_svc.generate_key.return_value = ("stoa_sk_demo", "demo-hash", "stoa_sk_demo")
+        resp = client.post(
+            "/v1/tenants/acme/applications/demo-acme-demo-app-smoke/subscribe/demo-api-smoke",
+            headers={"X-Demo-Mode": "true"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["api_key"] == "stoa_sk_demo"
+    assert data["api_key_prefix"] == "stoa_sk_demo"
+    assert data["status"] == "active"
+    get_client_by_id.assert_not_awaited()
+    mock_sub_repo.create.assert_awaited_once()
+    mock_db_session.commit.assert_awaited_once()

--- a/scripts/demo-smoke-test.sh
+++ b/scripts/demo-smoke-test.sh
@@ -22,6 +22,7 @@
 #   DEMO_ADMIN_TOKEN     (empty → bypass via ?demo-admin header if cp-api allows)
 #   DEMO_MODE_HEADER     true (sends X-Demo-Mode: true to bounded demo endpoints)
 #   ROUTE_SYNC_GRACE_SECS 30
+#   DEMO_DEPLOY_ENV      dev
 #   DEMO_API_NAME        demo-api-smoke
 #   DEMO_APP_NAME        demo-app-smoke
 #   OBS_VISIBILITY_CHECK auto (auto | off)
@@ -54,6 +55,7 @@ GATEWAY_ID="${GATEWAY_ID:-gateway-demo}"
 DEMO_ADMIN_TOKEN="${DEMO_ADMIN_TOKEN:-}"
 DEMO_MODE_HEADER="${DEMO_MODE_HEADER:-true}"
 ROUTE_SYNC_GRACE_SECS="${ROUTE_SYNC_GRACE_SECS:-30}"
+DEMO_DEPLOY_ENV="${DEMO_DEPLOY_ENV:-dev}"
 DEMO_API_NAME="${DEMO_API_NAME:-demo-api-smoke}"
 DEMO_APP_NAME="${DEMO_APP_NAME:-demo-app-smoke}"
 DEMO_GATEWAY_PATH="${DEMO_GATEWAY_PATH:-/apis/${DEMO_API_NAME}/get}"
@@ -249,7 +251,13 @@ JSON
     if [[ "$HTTP_STATUS" == "409" ]]; then
         http_call GET "${API_URL}/v1/tenants/${TENANT_ID}/apis?name=${DEMO_API_NAME}" ""
         resp="$HTTP_BODY"
-        API_ID="$(echo "$resp" | jq -r '.items[0].id // .apis[0].id // empty' 2>/dev/null || true)"
+        API_ID="$(
+            echo "$resp" \
+                | jq -r --arg name "$DEMO_API_NAME" \
+                    '(.items // .apis // [])[] | select(.name == $name or .id == $name) | .id' \
+                    2>/dev/null \
+                | head -n 1
+        )"
     else
         API_ID="$(echo "$resp" | jq -r '.id // empty' 2>/dev/null || true)"
     fi
@@ -279,7 +287,7 @@ at2_provision_route() {
     body="$(cat <<JSON
 {
   "api_id": "${API_ID}",
-  "environment": "demo",
+  "environment": "${DEMO_DEPLOY_ENV}",
   "gateway_id": "${GATEWAY_ID}"
 }
 JSON
@@ -341,7 +349,13 @@ at3_subscription() {
 
     # Step 1: application
     local resp body
-    body="{\"name\":\"${DEMO_APP_NAME}\"}"
+    body="$(cat <<JSON
+{
+  "name": "${DEMO_APP_NAME}",
+  "display_name": "${DEMO_APP_NAME}"
+}
+JSON
+)"
     http_call POST "${API_URL}/v1/tenants/${TENANT_ID}/applications" "$body"
     resp="$HTTP_BODY"
     if [[ "$HTTP_STATUS" != "201" && "$HTTP_STATUS" != "200" && "$HTTP_STATUS" != "409" ]]; then
@@ -359,7 +373,13 @@ at3_subscription() {
     if [[ -z "$APP_ID" && "$HTTP_STATUS" == "409" ]]; then
         http_call GET "${API_URL}/v1/tenants/${TENANT_ID}/applications?name=${DEMO_APP_NAME}" ""
         resp="$HTTP_BODY"
-        APP_ID="$(echo "$resp" | jq -r '.items[0].id // .applications[0].id // empty' 2>/dev/null)"
+        APP_ID="$(
+            echo "$resp" \
+                | jq -r --arg name "$DEMO_APP_NAME" \
+                    '(.items // .applications // [])[] | select(.name == $name or .id == $name or .client_id == $name) | .id' \
+                    2>/dev/null \
+                | head -n 1
+        )"
     fi
     if [[ -z "$APP_ID" ]]; then
         record "AT-3" "FAIL" "no application id"

--- a/specs/architecture-rules.md
+++ b/specs/architecture-rules.md
@@ -39,6 +39,10 @@ Auth démo provider/runtime :
   `X-Demo-Mode: true` sur la requête.
 - `STOA_DISABLE_AUTH=true` est interdit en `ENVIRONMENT=production` et doit
   faire échouer le boot cp-api.
+- Dans ce mode explicite seulement, `POST /v1/tenants/{tid}/applications`
+  peut retourner une application synthétique `demo-{tenant}-{app}` sans créer
+  de client Keycloak. Hors smoke démo, les applications restent des clients
+  Keycloak réels.
 
 | Endpoint | Method | Status OK | Champs min réponse |
 |----------|--------|-----------|--------------------|

--- a/specs/demo-acceptance-tests.md
+++ b/specs/demo-acceptance-tests.md
@@ -60,7 +60,7 @@ Fail pre-condition ⇒ abort early, pas d'exécution des AT-1..AT-5.
 ```json
 {
   "api_id": "${API_ID}",
-  "environment": "demo",
+  "environment": "dev",
   "gateway_id": "${GATEWAY_ID}"
 }
 ```
@@ -75,9 +75,14 @@ Fail pre-condition ⇒ abort early, pas d'exécution des AT-1..AT-5.
 
 **Given** AT-1 PASS
 **When**:
-1. `POST ${API_URL}/v1/tenants/${TENANT_ID}/applications` avec `{"name": "demo-app"}`  → récupérer `APP_ID`
+1. `POST ${API_URL}/v1/tenants/${TENANT_ID}/applications` avec `{"name": "demo-app", "display_name": "demo-app"}`  → récupérer `APP_ID`
 2. `POST ${API_URL}/v1/subscriptions` ou `POST ${API_URL}/v1/tenants/${TENANT_ID}/applications/${APP_ID}/subscribe/${API_ID}` avec `X-Demo-Mode: true`
 3. Alternative single-shot : `POST ${API_URL}/v1/tenants/${TENANT_ID}/applications/${APP_ID}/subscribe/${API_ID}`
+
+En mode démo/dev borné (`STOA_DISABLE_AUTH=true` + `X-Demo-Mode: true`),
+la création d'application retourne une application déterministe sans client
+Keycloak pour éviter que le smoke dépende des credentials admin Keycloak locaux.
+Ce comportement est interdit hors mode démo explicite.
 
 **Then**:
 - HTTP 201 sur subscription

--- a/specs/demo-readiness-report.md
+++ b/specs/demo-readiness-report.md
@@ -103,7 +103,7 @@ Polling 30s par défaut dans stoa-connect → AT-2 peut timeout. Mitigation dans
 | B2 | Mock backend non seedé dans docker-compose | P0 | AT-0, AT-4 | **DONE** — `mock-backend` compose |
 | B3 | Mapping `api_name → proxy path` flou côté gateway | P0 | AT-4 | **DONE** — `/apis/{api_name}/get` |
 | B4 | Auth dev-bypass cp-api non documenté | DONE | AT-1, AT-2, AT-3 | `STOA_DISABLE_AUTH=true` dev-only + `X-Demo-Mode: true` |
-| B5 | Seed profile `demo-smoke` minimal absent | P1 | AT-0 | cp-api/scripts/seeder |
+| B5 | Payload/seed démo non aligné modèle réel | DONE | AT-2, AT-3 | `DEMO_DEPLOY_ENV=dev` + `display_name` application |
 | B6 | Métriques Prometheus noms non figés par test | P2 | AT-5 | gateway (test regression) |
 | B7 | Route-sync 30s est lent pour une démo live | P2 | AT-2 | stoa-connect (trigger endpoint) |
 | B8 | OTEL visible en UI non prouvé automatiquement | P3 | AT-5b | observability/ui (nice-to-have) |
@@ -120,7 +120,7 @@ Pour débloquer rapidement la validation du contrat sans confondre script OK et 
 | Démarrer `mock-backend` via compose seul (`docker compose ... up -d mock-backend`) | B2 | jusqu'à stack complète | Service sous profil `demo`; ne pas exposer Prometheus sur le même port pendant ce smoke |
 | `DEMO_GATEWAY_PATH` override local | B3 | debug uniquement | Toute démo officielle doit revenir à `/apis/{api_name}/get` |
 | `STOA_DISABLE_AUTH=true` + `X-Demo-Mode: true` | B4 | jusqu'à auth Keycloak démo stable | Refusé en `ENVIRONMENT=production`; ne jamais présenter comme auth réelle |
-| Script seed inline dans `demo-smoke-test.sh` qui crée tenant + gateway si absent | B5 | 1 jour | Pas idempotent si collisions |
+| Script seed inline dans `demo-smoke-test.sh` qui crée tenant + gateway si absent | Seed futur | 1 jour | Pas idempotent si collisions |
 | Check "au moins un counter `*_total`" sans figer nom | B6 | jusqu'à B6 | Drift silencieux toléré |
 
 Ces contournements **sont figés dans le script**, mais ils ne produisent jamais

--- a/specs/validation-commands.md
+++ b/specs/validation-commands.md
@@ -36,6 +36,7 @@ Variables d'environnement (defaults documentés dans le script) :
 | `TENANT_ID` | `demo` (slug, résolu en UUID par cp-api) | Tenant démo |
 | `DEMO_ADMIN_TOKEN` | vide | JWT admin pour écrire côté cp-api. Si vide, le compose démo doit activer `STOA_DISABLE_AUTH=true` (dev only, requiert `X-Demo-Mode: true`, interdit en prod) |
 | `ROUTE_SYNC_GRACE_SECS` | `30` | Délai d'attente pour route visible en gateway après AT-2 |
+| `DEMO_DEPLOY_ENV` | `dev` | Environnement AT-2 accepté par le modèle réel (`dev`, `staging`, `production`) |
 | `OBS_VISIBILITY_CHECK` | `auto` | Lance AT-5b nice-to-have (`off` pour désactiver) |
 | `GRAFANA_URL` | `http://localhost:3001` | Grafana local pour vérifier health + datasources |
 | `GRAFANA_USER` / `GRAFANA_PASSWORD` | `admin` / `admin` | Basic auth Grafana local |
@@ -53,6 +54,10 @@ OPENSEARCH_LOGWRITER_PASSWORD=admin OPENSEARCH_OIDC_CLIENT_SECRET=x \
 STOA_DISABLE_AUTH=true \
 docker compose -f deploy/docker-compose/docker-compose.yml --profile demo up --build -d \
     postgres keycloak control-plane-api stoa-gateway mock-backend
+
+# Avec STOA_DISABLE_AUTH=true, le smoke envoie X-Demo-Mode: true et peut
+# créer une application synthétique déterministe sans client Keycloak.
+# Ce mode sert uniquement à rendre AT-3 rejouable localement; il est refusé en prod.
 
 # Attendre healthy
 docker compose -f deploy/docker-compose/docker-compose.yml ps


### PR DESCRIPTION
## Summary
- use the real deployment enum via DEMO_DEPLOY_ENV=dev instead of environment=demo
- make the smoke application payload valid and resolve existing demo API/app by exact name for replayability
- add a bounded demo application path behind STOA_DISABLE_AUTH=true + X-Demo-Mode: true so AT-3 does not depend on local Keycloak admin credentials
- align subscription model/migration types used by the demo API key path

## Validation
- cd control-plane-api && pytest tests/test_applications_router.py tests/test_regression_cab_1967_apikey_subscription.py tests/test_regression_demo_b5_payload_idempotency.py tests/test_regression_demo_b1_api_key.py -q
- cd control-plane-api && pytest tests/test_regression_demo_b5_payload_idempotency.py tests/test_regression_demo_b1_api_key.py tests/test_regression_cab_2149_demo_auth_bypass.py -q
- cd control-plane-api && ruff check src/routers/applications.py src/models/subscription.py tests/test_regression_demo_b5_payload_idempotency.py alembic/versions/096_fix_subscription_demo_column_types.py
- python3 -m py_compile control-plane-api/src/routers/applications.py control-plane-api/src/models/subscription.py control-plane-api/tests/test_regression_demo_b5_payload_idempotency.py control-plane-api/alembic/versions/096_fix_subscription_demo_column_types.py
- bash -n scripts/demo-smoke-test.sh
- git diff --check
- gitleaks detect --source . --config .gitleaks.toml --verbose --redact --log-opts=origin/main..HEAD

## Demo impact
Before: AT-2 failed on environment=demo 422, AT-3 failed on missing display_name 422.
After local rebuild: AT-0 PASS, AT-1 PASS, AT-3 PASS with API_KEY acquired. Current next blocker is route sync/gateway: AT-2 route not synced in 30s, AT-4 /apis/demo-api-smoke/get returns 404.

This PR intentionally does not fix route sync or gateway 404; that should be the next blocker PR.