### PR TITLE
docs: add UAC LLM-ready agent doctrine

### DIFF
--- a/.claude/docs/uac-llm-ready.md
+++ b/.claude/docs/uac-llm-ready.md
@@ -1,0 +1,93 @@
+# UAC LLM-ready metadata
+
+Use this note when touching UAC schemas, UAC examples, MCP tool generation,
+MCP smoke tests, or API operations exposed to agents.
+
+Canonical rule from ADR-067:
+
+```text
+UAC describes.
+MCP projects.
+Smoke proves.
+```
+
+## Doctrine
+
+- UAC is the primary product contract.
+- MCP tools are projections of UAC operations.
+- Smoke tests prove that the projection exists and behaves safely at runtime.
+- LLM metadata is endpoint-level because intent, side effects, approval, and
+  examples differ per operation.
+- V1 is progressive: missing metadata is a warning/review note, not a blanket
+  blocker for existing contracts.
+- Malformed metadata is an error when present.
+- V2 target: new MCP-exposed endpoints must be LLM-ready before merge.
+
+## V1 endpoint metadata
+
+When `endpoint.llm` is present, it should contain:
+
+```yaml
+llm:
+  summary: "Retrieve one customer by id."
+  intent: "Use when an agent needs customer details before answering or preparing a follow-up action."
+  tool_name: "customer_get_customer"
+  side_effects: "read" # none | read | write | destructive
+  safe_for_agents: true
+  requires_human_approval: false
+  examples:
+    - input:
+        id: "cust_123"
+      expected_output_contains:
+        id: "cust_123"
+```
+
+Keep `summary` and `intent` short. Do not turn them into policy prose or a
+prompt. Prefer one synthetic example, two only when it removes real ambiguity.
+
+## Hard rule
+
+```text
+side_effects=destructive -> requires_human_approval=true
+```
+
+Examples of destructive operations: delete, revoke, overwrite, rotate, external
+business commitment, payment movement, irreversible workflow trigger, or any
+operation with high blast radius.
+
+## Deferred to v2
+
+Do not add these fields in v1 unless a later ADR updates the contract:
+
+- `sensitive_data`
+- `do_not_use_when`
+- `permissions`
+- `rate_limit_policy`
+- `approval_policy`
+- `test_generation_hints`
+
+## Review checklist
+
+For an API or MCP-exposed change:
+
+- Is the changed behavior attached to a UAC operation or flow contract?
+- If it is MCP-exposed, does `endpoint.llm` exist or is its absence explicitly
+  accepted as a v1 warning?
+- If `endpoint.llm` exists, are all v1 fields present?
+- Is `tool_name` stable and unique for the tenant/API namespace?
+- Do `side_effects` and MCP annotations agree?
+- If destructive, is `requires_human_approval=true`?
+- Is there smoke proof that the UAC projection is discoverable?
+- Are examples synthetic and free of secrets/customer data?
+
+## Smoke expectation
+
+The smoke test should prove at least:
+
+- the tool appears in `tools/list`;
+- the expected name is discoverable;
+- the description reflects `summary`/`intent` when metadata is present;
+- annotations match `side_effects`;
+- example input validates against `input_schema`;
+- read-only safe examples can run in deterministic smoke;
+- write/destructive examples are not blindly executed and expose gating instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,17 @@ CONTROL PLANE (Cloud)                    DATA PLANE (On-Premise)
 For component paths, runtime versions, RBAC roles, rules, skills, and repo
 map, see `CLAUDE.md`.
 
+## Agent-facing API doctrine
+
+When touching an API operation exposed to agents, load the canonical rule in
+`CLAUDE.md` and `.claude/docs/uac-llm-ready.md`:
+
+```
+UAC describes.
+MCP projects.
+Smoke proves.
+```
+
 ## Historical note
 
 The Python `mcp-gateway/` service was retired in Feb 2026 and superseded by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,26 @@
 - Kill feature: UAC (Universal API Contract) — "Define Once, Expose Everywhere"
 - Legacy-to-MCP Bridge: connect traditional APIs to AI agents
 
+## UAC / Agent Contract Doctrine
+
+Canonical rule from ADR-067:
+
+```text
+UAC describes.
+MCP projects.
+Smoke proves.
+```
+
+For any API operation exposed to agents:
+- UAC is the primary product contract; MCP tools are projections of UAC operations.
+- LLM metadata is endpoint-level, not contract-level.
+- V1: missing `endpoint.llm` metadata is a warning/review note; malformed metadata is an error.
+- V2 target: new MCP-exposed endpoints must be LLM-ready before merge.
+- `side_effects=destructive` requires `requires_human_approval=true`.
+- A feature exposed to an agent should not exist only in code; it must be attached to a UAC operation or flow contract.
+
+Load `.claude/docs/uac-llm-ready.md` when touching UAC schemas, UAC examples, MCP tool generation, smoke tests for MCP projections, or API operations exposed to agents.
+
 ## Architecture
 
 ```

--- a/memory.md
+++ b/memory.md
@@ -1,6 +1,6 @@
 # STOA Memory
 
-> Dernière MAJ: 2026-04-22. Archive complète (cycles passés, DONE, etc.) → `memory-archive.md`.
+> Dernière MAJ: 2026-04-25. Archive complète (cycles passés, DONE, etc.) → `memory-archive.md`.
 
 ## ✅ FREEZE LEVÉ (2026-04-19)
 
@@ -96,8 +96,9 @@ Phase 0 ✅ baseline (PR #2362). Phase 1 pending: Agent Teams flag + canary MEGA
 ## Clés transversales
 
 - Linear team ID: `624a9948-a160-4e47-aba5-7f9404d23506`
-- ADR numbering: stoa-docs owns 001-060. Next = **ADR-061**
+- ADR numbering: stoa-docs owns the ADR index; check `stoa-docs/docs/architecture/adr/` before creating a new ADR.
 - Docs user-facing → stoa-docs. Runbooks/ops-only → stoa/docs/
+- ADR-067 doctrine added to agent context (2026-04-25): `UAC describes. MCP projects. Smoke proves.` V1 `endpoint.llm` metadata is warning/recommended for MCP-exposed operations; malformed metadata is an error when present; V2 target = mandatory for new MCP endpoints. Local references: `CLAUDE.md`, `AGENTS.md`, `.claude/docs/uac-llm-ready.md`.
 - stoa-docs branch protection requires Vercel deploy check
 
 ## Key Gotchas (détails → `gotchas.md`)

--- a/scripts/council-prompts/contract_impact.md
+++ b/scripts/council-prompts/contract_impact.md
@@ -4,6 +4,17 @@ Score 1-10 based strictly on whether the change breaks, extends, or is neutral t
 the project's externally-visible contracts. "External" means any boundary a caller
 depends on — HTTP API, database schema, CLI flags, env vars, K8s CRDs, Kafka events.
 
+UAC/MCP doctrine from ADR-067:
+- UAC describes.
+- MCP projects.
+- Smoke proves.
+
+For API operations exposed as MCP tools, check endpoint-level `llm` metadata
+when it is in scope. In v1, missing `endpoint.llm` metadata is a warning/review
+note, not an automatic blocker for existing contracts. If `endpoint.llm` is
+present but malformed, treat it as a contract error. If `side_effects` is
+`destructive`, `requires_human_approval` must be `true`.
+
 Breaking-change signals (these FORCE a score <= 5 unless explicitly justified):
 - HTTP: removed route, changed method, renamed path param, removed response field,
   made an optional request field required, changed status code semantics
@@ -17,6 +28,8 @@ Breaking-change signals (these FORCE a score <= 5 unless explicitly justified):
 - CRD (gostoa.dev/v1alpha1): removed spec field, changed validation, version bump without conversion
 - Kafka: removed topic, changed schema without backward-compat, removed event field
 - Semantic change: same signature, different side effects (e.g. now writes audit log)
+- UAC/LLM metadata: malformed `endpoint.llm`, unstable MCP `tool_name` rename,
+  or `side_effects=destructive` without `requires_human_approval=true`
 
 Non-breaking extensions (ADD-only) are safe and can score 9-10:
 - New optional field, new route, new env var with default, new CLI subcommand


### PR DESCRIPTION
Summary:
- Add the ADR-066 UAC/MCP/smoke doctrine to AGENTS.md and CLAUDE.md.
- Add a compact .claude/docs/uac-llm-ready.md note for agents touching UAC, MCP tools, or smoke tests.
- Teach the contract-impact council prompt to treat malformed endpoint.llm metadata as a contract error while keeping missing metadata as v1 warning.

Validation:
- git diff --check
- doctrine rg checks