### PR TITLE
fix(cp-api): deliver routes to self-registered agents by hostname

### DIFF
--- a/control-plane-api/src/repositories/gateway_instance.py
+++ b/control-plane-api/src/repositories/gateway_instance.py
@@ -40,6 +40,26 @@ class GatewayInstanceRepository:
         )
         return result.scalar_one_or_none()
 
+    async def get_self_registered_by_hostname(self, hostname: str) -> GatewayInstance | None:
+        """Get the latest self-registered gateway by original registration hostname.
+
+        stoa-connect sends ``STOA_INSTANCE_NAME`` as the registration hostname,
+        while the Control Plane stores the canonical instance name as
+        ``{hostname}-{mode}-{environment}``. Route polling clients still filter
+        by their configured hostname, so route delivery must support both forms.
+        """
+        result = await self.session.execute(
+            select(GatewayInstance)
+            .where(
+                GatewayInstance.source == "self_register",
+                GatewayInstance.health_details["hostname"].as_string() == hostname,
+                GatewayInstance.deleted_at.is_(None),
+            )
+            .order_by(GatewayInstance.updated_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
     async def get_by_name_including_deleted(self, name: str) -> GatewayInstance | None:
         """Get gateway instance by name, including soft-deleted entries."""
         result = await self.session.execute(

--- a/control-plane-api/src/routers/gateway_internal.py
+++ b/control-plane-api/src/routers/gateway_internal.py
@@ -134,6 +134,8 @@ async def list_gateway_routes(
     if gateway_name:
         gw_repo = GatewayInstanceRepository(db)
         gateway = await gw_repo.get_by_name(gateway_name)
+        if not gateway:
+            gateway = await gw_repo.get_self_registered_by_hostname(gateway_name)
         if gateway:
             deployments = await deploy_repo.list_by_statuses_and_gateway(statuses, gateway.id)
         else:

--- a/control-plane-api/tests/test_gateway_internal_router.py
+++ b/control-plane-api/tests/test_gateway_internal_router.py
@@ -654,6 +654,8 @@ class TestInternalToolDiscovery:
 def _make_deployment(desired_state: dict):
     """Build a minimal mock GatewayDeployment."""
     m = MagicMock()
+    m.id = uuid4()
+    m.desired_generation = 1
     m.desired_state = desired_state
     return m
 
@@ -754,3 +756,47 @@ class TestListGatewayRoutes:
 
         assert resp.status_code == 200
         assert resp.json() == []
+
+    def test_routes_filter_falls_back_to_self_registered_hostname(self, client):
+        """stoa-connect route polling accepts the agent hostname as gateway_name.
+
+        The CP stores self-registered gateways under the canonical name
+        ``{hostname}-{mode}-{environment}``, but existing agents poll with their
+        configured ``STOA_INSTANCE_NAME``. Route delivery must resolve that
+        hostname or the gateway stays online with zero routes to ack.
+        """
+        gateway = MagicMock()
+        gateway.id = uuid4()
+        dep = _make_deployment(
+            {
+                "api_catalog_id": "cat-4",
+                "api_name": "fapi-banking",
+                "backend_url": "http://banking-mock:8080",
+                "methods": ["GET", "POST"],
+                "spec_hash": "sha-banking",
+                "activated": True,
+                "tenant_id": "banking-demo",
+            }
+        )
+
+        with (
+            patch("src.routers.gateway_internal.settings") as mock_settings,
+            patch("src.routers.gateway_internal.GatewayInstanceRepository") as MockGatewayRepo,
+            patch("src.routers.gateway_internal.GatewayDeploymentRepository") as MockDeploymentRepo,
+        ):
+            mock_settings.GATEWAY_ADMIN_KEY = None
+            gw_repo = MockGatewayRepo.return_value
+            gw_repo.get_by_name = AsyncMock(return_value=None)
+            gw_repo.get_self_registered_by_hostname = AsyncMock(return_value=gateway)
+            deploy_repo = MockDeploymentRepo.return_value
+            deploy_repo.list_by_statuses_and_gateway = AsyncMock(return_value=[dep])
+
+            resp = client.get("/v1/internal/gateways/routes?gateway_name=connect-webmethods-dev")
+
+        assert resp.status_code == 200
+        routes = resp.json()
+        assert len(routes) == 1
+        assert routes[0]["name"] == "fapi-banking"
+        gw_repo.get_by_name.assert_awaited_once_with("connect-webmethods-dev")
+        gw_repo.get_self_registered_by_hostname.assert_awaited_once_with("connect-webmethods-dev")
+        deploy_repo.list_by_statuses_and_gateway.assert_awaited_once()

--- a/control-plane-api/tests/test_regression_agent_route_delivery_hostname.py
+++ b/control-plane-api/tests/test_regression_agent_route_delivery_hostname.py
@@ -1,0 +1,44 @@
+"""Regression tests for self-registered agent route delivery."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+
+def test_regression_agent_route_polling_uses_registration_hostname(client):
+    """Existing stoa-connect agents poll routes with their registration hostname."""
+    gateway = MagicMock()
+    gateway.id = uuid4()
+
+    deployment = MagicMock()
+    deployment.id = uuid4()
+    deployment.desired_generation = 1
+    deployment.desired_state = {
+        "api_catalog_id": "cat-fapi",
+        "api_name": "fapi-banking",
+        "backend_url": "http://banking-mock:8080",
+        "methods": ["GET", "POST"],
+        "spec_hash": "sha-banking",
+        "activated": True,
+        "tenant_id": "banking-demo",
+    }
+
+    with (
+        patch("src.routers.gateway_internal.settings") as mock_settings,
+        patch("src.routers.gateway_internal.GatewayInstanceRepository") as MockGatewayRepo,
+        patch("src.routers.gateway_internal.GatewayDeploymentRepository") as MockDeploymentRepo,
+    ):
+        mock_settings.GATEWAY_ADMIN_KEY = None
+        gw_repo = MockGatewayRepo.return_value
+        gw_repo.get_by_name = AsyncMock(return_value=None)
+        gw_repo.get_self_registered_by_hostname = AsyncMock(return_value=gateway)
+        deploy_repo = MockDeploymentRepo.return_value
+        deploy_repo.list_by_statuses_and_gateway = AsyncMock(return_value=[deployment])
+
+        resp = client.get("/v1/internal/gateways/routes?gateway_name=connect-webmethods-dev")
+
+    assert resp.status_code == 200
+    routes = resp.json()
+    assert len(routes) == 1
+    assert routes[0]["name"] == "fapi-banking"
+    gw_repo.get_self_registered_by_hostname.assert_awaited_once_with("connect-webmethods-dev")
+    deploy_repo.list_by_statuses_and_gateway.assert_awaited_once()


### PR DESCRIPTION
## Summary
- resolve self-registered gateways by registration hostname when stoa-connect polls /v1/internal/gateways/routes
- preserve exact gateway name matching first to avoid cross-gateway route leakage
- add regression coverage for the route delivery lookup used by existing agents

## Verification
- pytest control-plane-api/tests/test_gateway_internal_router.py::TestListGatewayRoutes -q
- python3 -m ruff check control-plane-api/src/repositories/gateway_instance.py control-plane-api/src/routers/gateway_internal.py control-plane-api/tests/test_gateway_internal_router.py

## Prod symptom
Current prod returns an empty route list for the live agent hostname even though the GatewayDeployment is pending on the canonical self-registered gateway name. This patch makes that lookup compatible without redeploying the external agent.