### PR TITLE
fix(demo): bridge route sync for smoke

### DIFF
--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -12146,6 +12146,11 @@
             "title": "Activated",
             "type": "boolean"
           },
+          "api_id": {
+            "default": "",
+            "title": "Api Id",
+            "type": "string"
+          },
           "backend_url": {
             "title": "Backend Url",
             "type": "string"

--- a/control-plane-api/src/adapters/stoa/mappers.py
+++ b/control-plane-api/src/adapters/stoa/mappers.py
@@ -14,6 +14,7 @@ def map_api_spec_to_stoa(api_spec: dict, tenant_id: str) -> dict:
     api_id = api_spec.get("api_id", api_name)
     result: dict = {
         "id": api_spec.get("api_catalog_id", ""),
+        "api_id": api_id,
         "name": api_name,
         "tenant_id": tenant_id,
         "path_prefix": f"/apis/{api_id}",

--- a/control-plane-api/src/routers/deployments.py
+++ b/control-plane-api/src/routers/deployments.py
@@ -31,8 +31,10 @@ git_service = git_provider_factory()
 router = APIRouter(prefix="/v1/tenants/{tenant_id}/deployments", tags=["Deployments"])
 
 
-def _demo_mode_enabled(request: Request) -> bool:
+def _demo_mode_enabled(request: Request | None) -> bool:
     """Demo/dev bypass is explicit and per-request."""
+    if request is None:
+        return False
     return settings.STOA_DISABLE_AUTH and request.headers.get("X-Demo-Mode", "").lower() == "true"
 
 
@@ -89,7 +91,7 @@ async def get_deployment(
 async def create_deployment(
     tenant_id: str,
     request: DeploymentCreate,
-    http_request: Request,
+    http_request: Request = None,  # type: ignore[assignment]
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
     git: GitProvider = Depends(get_git_provider),

--- a/control-plane-api/src/routers/deployments.py
+++ b/control-plane-api/src/routers/deployments.py
@@ -3,10 +3,11 @@
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import Permission, User, get_current_user, require_permission, require_tenant_access
+from ..config import settings
 from ..database import get_db
 from ..schemas.deployment import (
     DeploymentCreate,
@@ -28,6 +29,11 @@ logger = logging.getLogger(__name__)
 git_service = git_provider_factory()
 
 router = APIRouter(prefix="/v1/tenants/{tenant_id}/deployments", tags=["Deployments"])
+
+
+def _demo_mode_enabled(request: Request) -> bool:
+    """Demo/dev bypass is explicit and per-request."""
+    return settings.STOA_DISABLE_AUTH and request.headers.get("X-Demo-Mode", "").lower() == "true"
 
 
 @router.get("", response_model=DeploymentListResponse)
@@ -83,6 +89,7 @@ async def get_deployment(
 async def create_deployment(
     tenant_id: str,
     request: DeploymentCreate,
+    http_request: Request,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
     git: GitProvider = Depends(get_git_provider),
@@ -121,6 +128,15 @@ async def create_deployment(
         gateway_id=request.gateway_id,
     )
     await db.commit()
+
+    if _demo_mode_enabled(http_request) and request.gateway_id:
+        await service.ensure_demo_gateway_deployment(
+            tenant_id=tenant_id,
+            api_id=request.api_id,
+            api_name=api_name,
+            gateway_name=request.gateway_id,
+        )
+        await db.commit()
 
     # Update deployment flag in git so the API appears in the environment view
     env = request.environment.value

--- a/control-plane-api/src/routers/gateway_internal.py
+++ b/control-plane-api/src/routers/gateway_internal.py
@@ -94,6 +94,7 @@ class GatewayRouteItem(BaseModel):
     """Route in stoa-gateway ApiRoute format for hot-reload."""
 
     id: str
+    api_id: str = ""
     deployment_id: str = ""
     name: str
     tenant_id: str

--- a/control-plane-api/src/services/deployment_service.py
+++ b/control-plane-api/src/services/deployment_service.py
@@ -4,8 +4,10 @@ import logging
 from datetime import datetime
 from uuid import UUID
 
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.config import settings
 from src.events.deployment_producer import (
     emit_deployment_completed,
     emit_deployment_failed,
@@ -13,10 +15,14 @@ from src.events.deployment_producer import (
     emit_deployment_rolledback,
     emit_deployment_started,
 )
+from src.models.catalog import APICatalog
 from src.models.deployment import Deployment, DeploymentStatus
 from src.models.deployment_log import DeploymentLog
+from src.models.gateway_instance import GatewayInstance, GatewayInstanceStatus, GatewayType
 from src.repositories.deployment import DeploymentRepository
 from src.repositories.deployment_log import DeploymentLogRepository
+from src.repositories.gateway_instance import GatewayInstanceRepository
+from src.services.gateway_deployment_service import GatewayDeploymentService
 from src.services.kafka_service import Topics, kafka_service
 
 logger = logging.getLogger(__name__)
@@ -83,6 +89,52 @@ class DeploymentService:
             step="init",
         )
         return deployment
+
+    async def ensure_demo_gateway_deployment(
+        self,
+        tenant_id: str,
+        api_id: str,
+        api_name: str,
+        gateway_name: str,
+    ) -> None:
+        """Bridge the legacy demo deployment endpoint to GatewayDeployment routes.
+
+        This is only called by the router after the explicit demo/dev header
+        gate. It lets the smoke test keep using the public deployment endpoint
+        while the gateway route table continues to read GatewayDeployment.
+        """
+        result = await self.db.execute(
+            select(APICatalog).where(
+                APICatalog.tenant_id == tenant_id,
+                APICatalog.deleted_at.is_(None),
+                or_(APICatalog.api_id == api_id, APICatalog.api_name == api_name),
+            )
+        )
+        api_catalog = result.scalar_one_or_none()
+        if not api_catalog:
+            logger.warning("Demo gateway deployment skipped: API catalog not found tenant=%s api=%s", tenant_id, api_id)
+            return
+
+        gw_repo = GatewayInstanceRepository(self.db)
+        gateway = await gw_repo.get_by_name(gateway_name)
+        if not gateway:
+            gateway = GatewayInstance(
+                name=gateway_name,
+                display_name=gateway_name,
+                gateway_type=GatewayType.STOA_EDGE_MCP,
+                environment="dev",
+                tenant_id=None,
+                base_url=settings.MCP_GATEWAY_URL,
+                public_url=settings.MCP_GATEWAY_URL,
+                auth_config={},
+                status=GatewayInstanceStatus.ONLINE,
+                capabilities=["rest", "mcp"],
+                mode="edge-mcp",
+                source="demo_smoke",
+            )
+            gateway = await gw_repo.create(gateway)
+
+        await GatewayDeploymentService(self.db).deploy_api(api_catalog.id, [gateway.id])
 
     async def rollback_deployment(
         self,

--- a/control-plane-api/src/services/deployment_service.py
+++ b/control-plane-api/src/services/deployment_service.py
@@ -134,7 +134,11 @@ class DeploymentService:
             )
             gateway = await gw_repo.create(gateway)
 
-        await GatewayDeploymentService(self.db).deploy_api(api_catalog.id, [gateway.id])
+        await GatewayDeploymentService(self.db).deploy_api(
+            api_catalog.id,
+            [gateway.id],
+            emit_sync_requests=False,
+        )
 
     async def rollback_deployment(
         self,

--- a/control-plane-api/src/services/gateway_deployment_service.py
+++ b/control-plane-api/src/services/gateway_deployment_service.py
@@ -79,6 +79,7 @@ class GatewayDeploymentService:
         self,
         api_catalog_id: UUID,
         gateway_instance_ids: list[UUID],
+        emit_sync_requests: bool = True,
     ) -> list[GatewayDeployment]:
         """Deploy an API to one or more gateways.
 
@@ -123,7 +124,7 @@ class GatewayDeploymentService:
                 deployment = await self.deploy_repo.create(deployment)
                 deployments.append(deployment)
 
-        if settings.is_sync_engine_enabled:
+        if emit_sync_requests and settings.is_sync_engine_enabled:
             await self._emit_sync_requests(deployments, api_catalog.tenant_id)
 
         if settings.is_sse_enabled:
@@ -135,7 +136,7 @@ class GatewayDeploymentService:
             tracker.start("event_emitted")
             tracker.complete(
                 "event_emitted",
-                detail=f"kafka={'yes' if settings.is_sync_engine_enabled else 'no'} "
+                detail=f"kafka={'yes' if emit_sync_requests and settings.is_sync_engine_enabled else 'no'} "
                 f"sse={'yes' if settings.is_sse_enabled else 'no'}",
             )
             dep.sync_steps = tracker.to_list()

--- a/control-plane-api/tests/test_deployments_router.py
+++ b/control-plane-api/tests/test_deployments_router.py
@@ -312,6 +312,63 @@ class TestCreateDeployment:
         assert call_kwargs["api_name"] == "Git API Name"
         assert call_kwargs["version"] == "2.0.0"
 
+    def test_create_demo_mode_bridges_legacy_deployment_to_gateway_route(
+        self, app_with_tenant_admin, mock_db_session, monkeypatch
+    ):
+        """Demo smoke must create the GatewayDeployment read by /internal/gateways/routes."""
+        from src.routers import deployments as deployments_router
+        from src.services.git_provider import GitProvider, get_git_provider
+
+        monkeypatch.setattr(deployments_router.settings, "STOA_DISABLE_AUTH", True)
+
+        deployment = _mock_deployment(api_id="demo-api-smoke", api_name="demo-api-smoke", environment="dev")
+        mock_svc = MagicMock()
+        mock_svc.create_deployment = AsyncMock(return_value=deployment)
+        mock_svc.ensure_demo_gateway_deployment = AsyncMock()
+
+        mock_git = MagicMock(spec=GitProvider)
+        mock_git._project = object()
+        mock_git.get_api = AsyncMock(return_value=None)
+        app_with_tenant_admin.dependency_overrides[get_git_provider] = lambda: mock_git
+
+        with (
+            patch(DEPLOY_SVC_PATH, return_value=mock_svc),
+            TestClient(app_with_tenant_admin) as client,
+        ):
+            resp = client.post(
+                "/v1/tenants/acme/deployments",
+                headers={"X-Demo-Mode": "true"},
+                json={"api_id": "demo-api-smoke", "environment": "dev", "gateway_id": "gateway-demo"},
+            )
+
+        app_with_tenant_admin.dependency_overrides.pop(get_git_provider, None)
+
+        assert resp.status_code == 201
+        mock_svc.ensure_demo_gateway_deployment.assert_awaited_once_with(
+            tenant_id="acme",
+            api_id="demo-api-smoke",
+            api_name="demo-api-smoke",
+            gateway_name="gateway-demo",
+        )
+
+    def test_create_without_demo_header_does_not_bridge_gateway_route(self, app_with_tenant_admin, mock_db_session):
+        deployment = _mock_deployment(api_id="demo-api-smoke", api_name="demo-api-smoke", environment="dev")
+        mock_svc = MagicMock()
+        mock_svc.create_deployment = AsyncMock(return_value=deployment)
+        mock_svc.ensure_demo_gateway_deployment = AsyncMock()
+
+        with (
+            patch(DEPLOY_SVC_PATH, return_value=mock_svc),
+            TestClient(app_with_tenant_admin) as client,
+        ):
+            resp = client.post(
+                "/v1/tenants/acme/deployments",
+                json={"api_id": "demo-api-smoke", "environment": "dev", "gateway_id": "gateway-demo"},
+            )
+
+        assert resp.status_code == 201
+        mock_svc.ensure_demo_gateway_deployment.assert_not_awaited()
+
 
 # ============== Rollback Deployment ==============
 

--- a/control-plane-api/tests/test_gateway_internal_router.py
+++ b/control-plane-api/tests/test_gateway_internal_router.py
@@ -687,6 +687,7 @@ class TestListGatewayRoutes:
         assert resp.status_code == 200
         routes = resp.json()
         assert len(routes) == 1
+        assert routes[0]["api_id"] == "petstore"
         assert routes[0]["name"] == "petstore"
         assert routes[0]["spec_hash"] == "abc123"
         assert routes[0]["openapi_spec"] is None

--- a/control-plane-api/tests/test_regression_demo_route_sync.py
+++ b/control-plane-api/tests/test_regression_demo_route_sync.py
@@ -1,0 +1,61 @@
+"""Regression tests for the demo smoke route-sync bridge."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from src.adapters.stoa.mappers import map_api_spec_to_stoa
+from src.routers import deployments as deployments_router
+from src.services.git_provider import GitProvider, get_git_provider
+from tests.test_deployments_router import DEPLOY_SVC_PATH, _mock_deployment
+
+
+def test_regression_demo_route_sync_exposes_api_id_for_smoke_polling() -> None:
+    route = map_api_spec_to_stoa(
+        {
+            "api_catalog_id": "catalog-id",
+            "api_id": "demo-api-smoke",
+            "api_name": "demo-api-smoke",
+            "backend_url": "http://mock-backend:9090",
+        },
+        tenant_id="demo",
+    )
+
+    assert route["api_id"] == "demo-api-smoke"
+    assert route["path_prefix"] == "/apis/demo-api-smoke"
+
+
+def test_regression_demo_route_sync_bridges_legacy_deployment_endpoint(
+    app_with_tenant_admin, monkeypatch
+) -> None:
+    monkeypatch.setattr(deployments_router.settings, "STOA_DISABLE_AUTH", True)
+
+    deployment = _mock_deployment(api_id="demo-api-smoke", api_name="demo-api-smoke", environment="dev")
+    mock_svc = MagicMock()
+    mock_svc.create_deployment = AsyncMock(return_value=deployment)
+    mock_svc.ensure_demo_gateway_deployment = AsyncMock()
+
+    mock_git = MagicMock(spec=GitProvider)
+    mock_git._project = object()
+    mock_git.get_api = AsyncMock(return_value=None)
+    app_with_tenant_admin.dependency_overrides[get_git_provider] = lambda: mock_git
+
+    with (
+        patch(DEPLOY_SVC_PATH, return_value=mock_svc),
+        TestClient(app_with_tenant_admin) as client,
+    ):
+        resp = client.post(
+            "/v1/tenants/acme/deployments",
+            headers={"X-Demo-Mode": "true"},
+            json={"api_id": "demo-api-smoke", "environment": "dev", "gateway_id": "gateway-demo"},
+        )
+
+    app_with_tenant_admin.dependency_overrides.pop(get_git_provider, None)
+
+    assert resp.status_code == 201
+    mock_svc.ensure_demo_gateway_deployment.assert_awaited_once_with(
+        tenant_id="acme",
+        api_id="demo-api-smoke",
+        api_name="demo-api-smoke",
+        gateway_name="gateway-demo",
+    )

--- a/control-plane-api/tests/test_regression_demo_route_sync.py
+++ b/control-plane-api/tests/test_regression_demo_route_sync.py
@@ -1,11 +1,14 @@
 """Regression tests for the demo smoke route-sync bridge."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 
 from src.adapters.stoa.mappers import map_api_spec_to_stoa
 from src.routers import deployments as deployments_router
+from src.services.deployment_service import DeploymentService
 from src.services.git_provider import GitProvider, get_git_provider
 from tests.test_deployments_router import DEPLOY_SVC_PATH, _mock_deployment
 
@@ -58,4 +61,38 @@ def test_regression_demo_route_sync_bridges_legacy_deployment_endpoint(
         api_id="demo-api-smoke",
         api_name="demo-api-smoke",
         gateway_name="gateway-demo",
+    )
+
+
+@pytest.mark.asyncio
+async def test_regression_demo_route_sync_does_not_emit_push_sync() -> None:
+    db = AsyncMock()
+    catalog = MagicMock()
+    catalog.id = uuid4()
+    gateway = MagicMock()
+    gateway.id = uuid4()
+
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = catalog
+    db.execute = AsyncMock(return_value=result)
+
+    with (
+        patch("src.services.deployment_service.GatewayInstanceRepository") as MockGatewayRepo,
+        patch("src.services.deployment_service.GatewayDeploymentService") as MockGatewayDeploySvc,
+    ):
+        MockGatewayRepo.return_value.get_by_name = AsyncMock(return_value=gateway)
+        deploy_svc = MockGatewayDeploySvc.return_value
+        deploy_svc.deploy_api = AsyncMock(return_value=[])
+
+        await DeploymentService(db).ensure_demo_gateway_deployment(
+            tenant_id="demo",
+            api_id="demo-api-smoke",
+            api_name="demo-api-smoke",
+            gateway_name="gateway-demo",
+        )
+
+    deploy_svc.deploy_api.assert_awaited_once_with(
+        catalog.id,
+        [gateway.id],
+        emit_sync_requests=False,
     )

--- a/control-plane-ui/src/pages/FederationAccounts/ToolAllowListModal.test.tsx
+++ b/control-plane-ui/src/pages/FederationAccounts/ToolAllowListModal.test.tsx
@@ -124,18 +124,18 @@ describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
     it('pre-checks currently allowed tools', async () => {
       renderModal();
       await waitFor(() => {
-        expect(screen.getByText('weather-lookup')).toBeInTheDocument();
+        const checkboxes = screen.getAllByRole('checkbox');
+        const weatherCb = checkboxes.find((cb) =>
+          cb.closest('label')?.textContent?.includes('weather-lookup')
+        ) as HTMLInputElement | undefined;
+        const codeCb = checkboxes.find((cb) =>
+          cb.closest('label')?.textContent?.includes('code-exec')
+        ) as HTMLInputElement | undefined;
+        expect(weatherCb).toBeDefined();
+        expect(codeCb).toBeDefined();
+        expect(weatherCb?.checked).toBe(true);
+        expect(codeCb?.checked).toBe(false);
       });
-      const checkboxes = screen.getAllByRole('checkbox');
-      // weather-lookup and file-search should be checked
-      const weatherCb = checkboxes.find((cb) =>
-        cb.closest('label')?.textContent?.includes('weather-lookup')
-      ) as HTMLInputElement;
-      const codeCb = checkboxes.find((cb) =>
-        cb.closest('label')?.textContent?.includes('code-exec')
-      ) as HTMLInputElement;
-      expect(weatherCb.checked).toBe(true);
-      expect(codeCb.checked).toBe(false);
     });
 
     it('calls updateToolAllowList on save', async () => {

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -322,10 +322,12 @@ services:
       STOA_LOG_FORMAT: json
       STOA_GATEWAY_MODE: edge-mcp
       STOA_AUTO_REGISTER: "${STOA_AUTO_REGISTER:-false}"
-      STOA_INSTANCE_NAME: "stoa-quickstart"
+      STOA_INSTANCE_NAME: "${GATEWAY_ID:-gateway-demo}"
       STOA_ENVIRONMENT: "dev"
       STOA_CONTROL_PLANE_API_KEY: "${GATEWAY_API_KEY:-local-dev-key}"
       STOA_ADMIN_API_TOKEN: "${GATEWAY_ADMIN_TOKEN:-local-dev-key}"
+      STOA_ROUTE_RELOAD_ENABLED: "${STOA_ROUTE_RELOAD_ENABLED:-true}"
+      STOA_ROUTE_RELOAD_INTERVAL_SECS: "${STOA_ROUTE_RELOAD_INTERVAL_SECS:-2}"
       # Kafka metering (Redpanda)
       STOA_KAFKA_ENABLED: "true"
       STOA_KAFKA_BROKERS: redpanda:9092

--- a/shared/api-types/generated.ts
+++ b/shared/api-types/generated.ts
@@ -14565,6 +14565,11 @@ export interface components {
              * @default true
              */
             activated: boolean;
+            /**
+             * Api Id
+             * @default
+             */
+            api_id: string;
             /** Backend Url */
             backend_url: string;
             /**

--- a/specs/architecture-rules.md
+++ b/specs/architecture-rules.md
@@ -52,7 +52,7 @@ Auth démo provider/runtime :
 | `/v1/tenants/{tid}/applications` | POST | 201 | `id`, `name` |
 | `/v1/tenants/{tid}/applications/{id}/subscribe/{api_id}` | POST | 200 | `subscription_id`, `api_key`, `api_key_prefix` en mode `X-Demo-Mode: true`; sinon message historique |
 | `/v1/subscriptions` | POST | 201 | `id`, `api_key` ou `api_key_prefix`, `status="active"` |
-| `/v1/tenants/{tid}/deployments` | POST | 201 | `id`, `status`; en mode démo explicite, crée aussi le `GatewayDeployment` lu par la gateway |
+| `/v1/tenants/{tid}/deployments` | POST | 201 | `id`, `status`; en mode démo explicite, crée aussi le `GatewayDeployment` lu par la gateway sans déclencher le push sync admin |
 | `/v1/internal/gateways/routes?gateway_name=X` | GET | 200 | liste de routes avec `api_id`, `path_prefix` |
 | `/health` | GET | 200 | n/a |
 

--- a/specs/architecture-rules.md
+++ b/specs/architecture-rules.md
@@ -52,8 +52,8 @@ Auth démo provider/runtime :
 | `/v1/tenants/{tid}/applications` | POST | 201 | `id`, `name` |
 | `/v1/tenants/{tid}/applications/{id}/subscribe/{api_id}` | POST | 200 | `subscription_id`, `api_key`, `api_key_prefix` en mode `X-Demo-Mode: true`; sinon message historique |
 | `/v1/subscriptions` | POST | 201 | `id`, `api_key` ou `api_key_prefix`, `status="active"` |
-| `/v1/tenants/{tid}/deployments` | POST | 201 | `id`, `status` |
-| `/v1/internal/gateways/routes?gateway_name=X` | GET | 200 | liste de routes avec `api_id`, `path` |
+| `/v1/tenants/{tid}/deployments` | POST | 201 | `id`, `status`; en mode démo explicite, crée aussi le `GatewayDeployment` lu par la gateway |
+| `/v1/internal/gateways/routes?gateway_name=X` | GET | 200 | liste de routes avec `api_id`, `path_prefix` |
 | `/health` | GET | 200 | n/a |
 
 ### 2.2 HTTP endpoints gateway

--- a/specs/demo-acceptance-tests.md
+++ b/specs/demo-acceptance-tests.md
@@ -66,8 +66,9 @@ Fail pre-condition ⇒ abort early, pas d'exécution des AT-1..AT-5.
 ```
 **Then**:
 - HTTP 201
-- Dans un délai ≤ 30s : `GET ${GATEWAY_URL}/health` reste 200 ET la route est atteignable (retry AT-4 peut valider)
-- **[MOCK OK]** Le polling route-sync peut être forcé par SIGHUP à la gateway (`kill -HUP $PID`) si on ne veut pas attendre le tick
+- Dans un délai ≤ 30s : `GET ${API_URL}/v1/internal/gateways/routes?gateway_name=${GATEWAY_ID}` contient `api_id=${API_ID}`
+- En stack compose démo, `STOA_ROUTE_RELOAD_INTERVAL_SECS=2` réduit l'attente côté gateway; AT-4 prouve l'activation runtime.
+- **[MOCK OK]** Le polling route-sync peut être remplacé par mock uniquement en mode dry-run/contract explicite.
 
 **Exit code**: 0 si 201 + route active avant timeout, 1 sinon.
 

--- a/specs/demo-readiness-report.md
+++ b/specs/demo-readiness-report.md
@@ -93,7 +93,7 @@ Le chemin gateway démo est canonique : `{GATEWAY_URL}/apis/{api_name}/get`.
 Le script smoke autorise `DEMO_ADMIN_TOKEN=""` en fallback, mais aucune variable `STOA_DISABLE_AUTH` ou flag équivalent n'est documenté côté cp-api. Probable que la démo échoue silencieusement en 401/403 sur AT-1 sans JWT Keycloak valide.
 
 ### 3.7 Route-sync latence
-Polling 30s par défaut dans stoa-connect → AT-2 peut timeout. Mitigation dans script : `ROUTE_SYNC_GRACE_SECS=30` + probe explicite de `GET /v1/internal/gateways/routes`. En prod démo, ajouter un `POST /internal/gateways/{id}/trigger-sync` dédié ferait gagner du temps.
+Polling 30s par défaut dans stoa-connect → AT-2 pouvait timeout. Mitigation démo actuelle : en mode `STOA_DISABLE_AUTH=true` + `X-Demo-Mode: true`, `POST /v1/tenants/{tid}/deployments` crée le `GatewayDeployment` consommé par `GET /v1/internal/gateways/routes`, et la gateway compose recharge les routes toutes les 2s. Le run local passe maintenant AT-2 et AT-4; le prochain blocker réel est AT-5 métriques.
 
 ## 4. Blockers réels (à résoudre avant smoke `REAL_PASS`)
 
@@ -105,7 +105,7 @@ Polling 30s par défaut dans stoa-connect → AT-2 peut timeout. Mitigation dans
 | B4 | Auth dev-bypass cp-api non documenté | DONE | AT-1, AT-2, AT-3 | `STOA_DISABLE_AUTH=true` dev-only + `X-Demo-Mode: true` |
 | B5 | Payload/seed démo non aligné modèle réel | DONE | AT-2, AT-3 | `DEMO_DEPLOY_ENV=dev` + `display_name` application |
 | B6 | Métriques Prometheus noms non figés par test | P2 | AT-5 | gateway (test regression) |
-| B7 | Route-sync 30s est lent pour une démo live | P2 | AT-2 | stoa-connect (trigger endpoint) |
+| B7 | Route-sync 30s est lent pour une démo live | DONE | AT-2 | demo reload borné + route `api_id` exposée |
 | B8 | OTEL visible en UI non prouvé automatiquement | P3 | AT-5b | observability/ui (nice-to-have) |
 | C-B1 | Démo client/prospect non automatisée (seed + UI + conversion) | P1 | CPD-0..CPD-10 | portal/console/cp-api |
 

--- a/specs/demo-readiness-report.md
+++ b/specs/demo-readiness-report.md
@@ -96,7 +96,7 @@ fallback historique `demo-api-smoke` et affiche `WARN — smoke not UAC-driven`.
 Le script smoke autorise `DEMO_ADMIN_TOKEN=""` en fallback, mais aucune variable `STOA_DISABLE_AUTH` ou flag équivalent n'est documenté côté cp-api. Probable que la démo échoue silencieusement en 401/403 sur AT-1 sans JWT Keycloak valide.
 
 ### 3.7 Route-sync latence
-Polling 30s par défaut dans stoa-connect → AT-2 pouvait timeout. Mitigation démo actuelle : en mode `STOA_DISABLE_AUTH=true` + `X-Demo-Mode: true`, `POST /v1/tenants/{tid}/deployments` crée le `GatewayDeployment` consommé par `GET /v1/internal/gateways/routes`, et la gateway compose recharge les routes toutes les 2s. Le run local passe maintenant AT-2 et AT-4; le prochain blocker réel est AT-5 métriques.
+Polling 30s par défaut dans stoa-connect → AT-2 pouvait timeout. Mitigation démo actuelle : en mode `STOA_DISABLE_AUTH=true` + `X-Demo-Mode: true`, `POST /v1/tenants/{tid}/deployments` crée le `GatewayDeployment` consommé par `GET /v1/internal/gateways/routes` sans déclencher le push sync admin `/admin/apis`, et la gateway compose recharge les routes toutes les 2s. Le run local passe maintenant AT-2 et AT-4; le prochain blocker réel est AT-5 métriques.
 
 ## 4. Blockers réels (à résoudre avant smoke `REAL_PASS`)
 

--- a/specs/validation-commands.md
+++ b/specs/validation-commands.md
@@ -57,7 +57,9 @@ docker compose -f deploy/docker-compose/docker-compose.yml --profile demo up --b
 
 # Avec STOA_DISABLE_AUTH=true, le smoke envoie X-Demo-Mode: true et peut
 # créer une application synthétique déterministe sans client Keycloak.
-# Ce mode sert uniquement à rendre AT-3 rejouable localement; il est refusé en prod.
+# Ce mode sert uniquement à rendre AT-2/AT-3 rejouables localement; il est refusé en prod.
+# La gateway compose active STOA_ROUTE_RELOAD_ENABLED=true avec intervalle 2s;
+# AT-2 vérifie /internal/gateways/routes et AT-4 prouve le reload runtime.
 
 # Attendre healthy
 docker compose -f deploy/docker-compose/docker-compose.yml ps


### PR DESCRIPTION
## Summary
- bridge demo-mode legacy deployments into GatewayDeployment so /internal/gateways/routes exposes the smoke route
- expose api_id in the internal route contract and enable fast route reload in compose
- update smoke/specs so AT-2 validates the CP route and AT-4 proves runtime activation

## Validation
- bash -n scripts/demo-smoke-test.sh
- git diff --check
- cd control-plane-api && ruff check src/routers/deployments.py src/services/deployment_service.py src/routers/gateway_internal.py src/adapters/stoa/mappers.py tests/test_deployments_router.py tests/test_gateway_internal_router.py
- cd control-plane-api && python3 -m py_compile src/routers/deployments.py src/services/deployment_service.py src/routers/gateway_internal.py src/adapters/stoa/mappers.py tests/test_deployments_router.py tests/test_gateway_internal_router.py
- cd control-plane-api && pytest tests/test_deployments_router.py::TestCreateDeployment tests/test_gateway_internal_router.py::TestListGatewayRoutes tests/test_deployment_service.py::TestCreateDeployment tests/test_regression_demo_b5_payload_idempotency.py -q
- gitleaks detect --source . --config .gitleaks.toml --verbose --redact --log-opts="0e4939343ec349b31880caac912f3c61f841e033..HEAD"
- GATEWAY_URL=http://localhost:18082 MOCK_BACKEND_URL=http://localhost:19090 ./scripts/demo-smoke-test.sh --no-observability-ui

Smoke result: AT-0/1/2/3/4 PASS; AT-5 FAIL on missing Prometheus counter, so the next blocker is metrics proof.