### PR TITLE
feat(demo): derive smoke path from UAC contract

### DIFF
--- a/scripts/demo-smoke-test.sh
+++ b/scripts/demo-smoke-test.sh
@@ -16,7 +16,8 @@
 #   GATEWAY_URL          http://localhost:8081
 #   MOCK_BACKEND_URL     http://localhost:9090
 #   MOCK_BACKEND_UPSTREAM_URL http://mock-backend:9090
-#   DEMO_GATEWAY_PATH    /apis/${DEMO_API_NAME}/get
+#   DEMO_UAC_CONTRACT    (empty → legacy fallback; set specs/uac/demo-httpbin.uac.json for UAC-driven smoke)
+#   DEMO_GATEWAY_PATH    /apis/${DEMO_API_NAME}/get (derived from UAC when DEMO_UAC_CONTRACT is set)
 #   TENANT_ID            demo
 #   GATEWAY_ID           gateway-demo
 #   DEMO_ADMIN_TOKEN     (empty → bypass via ?demo-admin header if cp-api allows)
@@ -50,6 +51,7 @@ API_URL="${API_URL:-http://localhost:8000}"
 GATEWAY_URL="${GATEWAY_URL:-http://localhost:8081}"
 MOCK_BACKEND_URL="${MOCK_BACKEND_URL:-http://localhost:9090}"
 MOCK_BACKEND_UPSTREAM_URL="${MOCK_BACKEND_UPSTREAM_URL:-http://mock-backend:9090}"
+DEMO_UAC_CONTRACT="${DEMO_UAC_CONTRACT:-}"
 TENANT_ID="${TENANT_ID:-demo}"
 GATEWAY_ID="${GATEWAY_ID:-gateway-demo}"
 DEMO_ADMIN_TOKEN="${DEMO_ADMIN_TOKEN:-}"
@@ -58,6 +60,9 @@ ROUTE_SYNC_GRACE_SECS="${ROUTE_SYNC_GRACE_SECS:-30}"
 DEMO_DEPLOY_ENV="${DEMO_DEPLOY_ENV:-dev}"
 DEMO_API_NAME="${DEMO_API_NAME:-demo-api-smoke}"
 DEMO_APP_NAME="${DEMO_APP_NAME:-demo-app-smoke}"
+DEMO_ENDPOINT_PATH="${DEMO_ENDPOINT_PATH:-/get}"
+DEMO_ENDPOINT_METHOD="${DEMO_ENDPOINT_METHOD:-GET}"
+DEMO_OPERATION_ID="${DEMO_OPERATION_ID:-}"
 DEMO_GATEWAY_PATH="${DEMO_GATEWAY_PATH:-/apis/${DEMO_API_NAME}/get}"
 MOCK_MODE="${MOCK_MODE:-none}"     # none | all | auto (auto is treated as none)
 DRY_RUN_CONTRACT="${DRY_RUN_CONTRACT:-0}"
@@ -175,6 +180,75 @@ http_call() {
     rm -f "$tmp"
 }
 
+load_uac_contract() {
+    if [[ -z "$DEMO_UAC_CONTRACT" ]]; then
+        log "WARN — smoke not UAC-driven"
+        note "WARN" "smoke not UAC-driven; using legacy fallback DEMO_API_NAME=${DEMO_API_NAME}, path=${DEMO_ENDPOINT_PATH}"
+        return 0
+    fi
+
+    local contract_path="$DEMO_UAC_CONTRACT"
+    if [[ "$contract_path" != /* ]]; then
+        contract_path="${REPO_ROOT}/${contract_path}"
+    fi
+
+    if [[ ! -f "$contract_path" ]]; then
+        record "UAC" "FAIL" "contract not found: ${DEMO_UAC_CONTRACT}"
+        return 1
+    fi
+
+    if ! jq -e . "$contract_path" >/dev/null 2>&1; then
+        record "UAC" "FAIL" "contract is not valid JSON: ${DEMO_UAC_CONTRACT}"
+        return 1
+    fi
+
+    local endpoint_count contract_status contract_name contract_version contract_tenant
+    local endpoint_path endpoint_method endpoint_backend operation_id
+    endpoint_count="$(jq -r '.endpoints | if type == "array" then length else 0 end' "$contract_path")"
+    contract_status="$(jq -r '.status // empty' "$contract_path")"
+    contract_name="$(jq -r '.name // empty' "$contract_path")"
+    contract_version="$(jq -r '.version // empty' "$contract_path")"
+    contract_tenant="$(jq -r '.tenant_id // empty' "$contract_path")"
+    endpoint_path="$(jq -r '.endpoints[0].path // empty' "$contract_path")"
+    endpoint_method="$(jq -r '.endpoints[0].methods[0] // empty' "$contract_path")"
+    endpoint_backend="$(jq -r '.endpoints[0].backend_url // empty' "$contract_path")"
+    operation_id="$(jq -r '.endpoints[0].operation_id // empty' "$contract_path")"
+
+    if [[ "$endpoint_count" -lt 1 ]]; then
+        record "UAC" "FAIL" "contract has no endpoints: ${DEMO_UAC_CONTRACT}"
+        return 1
+    fi
+    if [[ "$contract_status" != "published" ]]; then
+        record "UAC" "FAIL" "contract status=${contract_status:-empty}; expected published for real smoke"
+        return 1
+    fi
+    if [[ -z "$contract_name" || -z "$contract_version" || -z "$contract_tenant" ]]; then
+        record "UAC" "FAIL" "contract name/version/tenant_id must be non-empty"
+        return 1
+    fi
+    if [[ -z "$endpoint_method" || -z "$endpoint_path" || -z "$endpoint_backend" ]]; then
+        record "UAC" "FAIL" "endpoint method/path/backend_url must be non-empty"
+        return 1
+    fi
+    if [[ "$endpoint_path" != /* ]]; then
+        record "UAC" "FAIL" "endpoint path must start with / (got ${endpoint_path})"
+        return 1
+    fi
+
+    DEMO_API_NAME="$contract_name"
+    TENANT_ID="$contract_tenant"
+    DEMO_ENDPOINT_PATH="$endpoint_path"
+    DEMO_ENDPOINT_METHOD="$endpoint_method"
+    DEMO_OPERATION_ID="$operation_id"
+    MOCK_BACKEND_UPSTREAM_URL="$endpoint_backend"
+    DEMO_GATEWAY_PATH="/apis/${DEMO_API_NAME}${DEMO_ENDPOINT_PATH}"
+
+    record "UAC" "PASS" "contract loaded ${DEMO_API_NAME} v${contract_version}"
+    record "UAC" "PASS" "endpoint ${DEMO_ENDPOINT_METHOD} ${DEMO_ENDPOINT_PATH} selected operation_id=${DEMO_OPERATION_ID:-n/a}"
+    record "UAC" "PASS" "Gateway call derived from UAC ${DEMO_GATEWAY_PATH}"
+    return 0
+}
+
 # ── AT-0 pré-conditions ─────────────────────────────────────────────────────
 
 at0_preconditions() {
@@ -222,17 +296,21 @@ at1_declare_api() {
     at_filter_match 1 || { log "  (skipped by AT filter)"; return 0; }
 
     local body
-    body="$(cat <<JSON
-{
-  "name": "${DEMO_API_NAME}",
-  "display_name": "${DEMO_API_NAME}",
-  "version": "1.0.0",
-  "protocol": "http",
-  "backend_url": "${MOCK_BACKEND_UPSTREAM_URL}",
-  "paths": [{"path": "/get", "methods": ["GET"]}]
-}
-JSON
-)"
+    body="$(
+        jq -n \
+            --arg name "$DEMO_API_NAME" \
+            --arg backend_url "$MOCK_BACKEND_UPSTREAM_URL" \
+            --arg path "$DEMO_ENDPOINT_PATH" \
+            --arg method "$DEMO_ENDPOINT_METHOD" \
+            '{
+              name: $name,
+              display_name: $name,
+              version: "1.0.0",
+              protocol: "http",
+              backend_url: $backend_url,
+              paths: [{path: $path, methods: [$method]}]
+            }'
+    )"
 
     local resp
     http_call POST "${API_URL}/v1/tenants/${TENANT_ID}/apis" "$body"
@@ -457,6 +535,7 @@ at4_gateway_call() {
     while [[ $attempt -lt 5 ]]; do
         status="$(
             curl -sS -o "$body_file" -D "$hdr_file" -w '%{http_code}' --max-time 10 \
+                 -X "$DEMO_ENDPOINT_METHOD" \
                  -H "X-Api-Key: ${API_KEY}" \
                  "${GATEWAY_URL}${DEMO_GATEWAY_PATH}" 2>/dev/null || echo 000
         )"
@@ -467,7 +546,7 @@ at4_gateway_call() {
 
     if [[ "$status" == "200" ]]; then
         LAST_REQUEST_ID="$(grep -i '^x-stoa-request-id:' "$hdr_file" | awk '{print $2}' | tr -d '\r' || true)"
-        record "AT-4" "PASS" "HTTP 200 on ${DEMO_GATEWAY_PATH}, request_id=${LAST_REQUEST_ID:-n/a}"
+        record "AT-4" "PASS" "${DEMO_ENDPOINT_METHOD} ${DEMO_GATEWAY_PATH} HTTP 200, request_id=${LAST_REQUEST_ID:-n/a}"
         rm -f "$hdr_file" "$body_file"
         return 0
     fi
@@ -600,6 +679,8 @@ print_report() {
     echo "  Generated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
     echo "  API_URL=${API_URL}"
     echo "  GATEWAY_URL=${GATEWAY_URL}"
+    echo "  DEMO_UAC_CONTRACT=${DEMO_UAC_CONTRACT:-<none>}"
+    echo "  DEMO_GATEWAY_PATH=${DEMO_GATEWAY_PATH}"
     echo "  MOCK_MODE=${MOCK_MODE}"
     echo "  DRY_RUN_CONTRACT=${DRY_RUN_CONTRACT}"
     echo "================================================================"
@@ -634,6 +715,11 @@ main() {
     if [[ "$MOCK_MODE" == "auto" ]]; then
         note "INFO" "MOCK_MODE=auto is treated as strict real mode; blockers will FAIL, not mock-pass"
         MOCK_MODE="none"
+    fi
+
+    if ! load_uac_contract; then
+        print_report
+        exit 2
     fi
 
     if ! at0_preconditions; then

--- a/specs/architecture-rules.md
+++ b/specs/architecture-rules.md
@@ -64,6 +64,29 @@ Auth démo provider/runtime :
 | `/metrics` | GET | 200 | format Prometheus text |
 | `/apis/{api_name}/{*path}` | GET/POST/… | 200/…  | chemin gateway canonique démo. `api_name` est le slug retourné par `POST /v1/tenants/{tid}/apis`; proxy vers backend configuré, header `X-Stoa-Request-Id` en réponse, vérifie `X-Api-Key` (ou `Authorization: Bearer`) |
 
+### 2.2bis Contrat UAC démo minimal
+
+Le smoke réel peut être UAC-driven via `DEMO_UAC_CONTRACT=specs/uac/demo-httpbin.uac.json`.
+Ce contrat ne généralise pas toute l'architecture STOA; il verrouille seulement
+la première preuve fonctionnelle "Define once, expose everywhere" sur un contrat,
+un endpoint, un chemin gateway:
+
+| Champ | Valeur figée |
+|-------|--------------|
+| `name` | `demo-httpbin` |
+| `tenant_id` | `demo` |
+| `version` | `1.0.0` |
+| `status` | `published` |
+| `classification` | `H` |
+| `endpoints[0].methods[0]` | `GET` |
+| `endpoints[0].path` | `/get` |
+| `endpoints[0].backend_url` | `http://mock-backend:9090` |
+| `endpoints[0].operation_id` | `demo_httpbin_get` |
+| chemin gateway dérivé | `/apis/demo-httpbin/get` |
+
+Le fallback sans `DEMO_UAC_CONTRACT` reste autorisé pour debug local, mais doit
+afficher `WARN — smoke not UAC-driven`.
+
 ### 2.3 Format métriques Prometheus
 
 Nom obligatoirement présent: **au moins un** de

--- a/specs/demo-acceptance-tests.md
+++ b/specs/demo-acceptance-tests.md
@@ -18,6 +18,31 @@ Chaque étape du scénario démo (`demo-scope.md` §2) a un test d'acceptance bi
 
 `MOCK_MODE=auto` est traité comme un mode réel strict : il ne convertit jamais un blocker en PASS silencieux.
 
+## Contrat UAC démo
+
+Le smoke peut être lancé en mode UAC-driven avec:
+
+```bash
+DEMO_UAC_CONTRACT=specs/uac/demo-httpbin.uac.json ./scripts/demo-smoke-test.sh
+```
+
+Dans ce mode, le script valide que le fichier est un JSON valide, contient au
+moins un endpoint, a `status=published`, puis dérive le nom API, la méthode, le
+path, le `backend_url` et le chemin gateway canonique depuis le premier endpoint.
+
+Contrat démo figé:
+- `name=demo-httpbin`
+- `tenant_id=demo`
+- `version=1.0.0`
+- endpoint `GET /get`
+- `backend_url=http://mock-backend:9090`
+- `operation_id=demo_httpbin_get`
+- chemin gateway dérivé: `/apis/demo-httpbin/get`
+
+Si `DEMO_UAC_CONTRACT` n'est pas fourni, le smoke garde son fallback historique
+et affiche `WARN — smoke not UAC-driven`. Ce fallback ne signifie pas que STOA
+est déjà UAC-driven de bout en bout.
+
 ## Pré-conditions (AT-0)
 
 Avant lancement, ces ressources doivent exister (seed minimal) :
@@ -38,17 +63,17 @@ Fail pre-condition ⇒ abort early, pas d'exécution des AT-1..AT-5.
 **When** `POST ${API_URL}/v1/tenants/${TENANT_ID}/apis` avec body:
 ```json
 {
-  "name": "demo-api",
-  "display_name": "demo-api",
+  "name": "demo-httpbin",
+  "display_name": "demo-httpbin",
   "version": "1.0.0",
   "protocol": "http",
   "backend_url": "http://mock-backend:9090",
-  "paths": [{"path": "/ping", "methods": ["GET"]}]
+  "paths": [{"path": "/get", "methods": ["GET"]}]
 }
 ```
 **Then**:
 - HTTP 201
-- Réponse contient `id` (UUID) et `name=demo-api`
+- Réponse contient `id` (UUID) et `name=demo-httpbin`
 - `GET /v1/tenants/${TENANT_ID}/apis/${API_ID}` renvoie 200 avec le même payload
 
 **Exit code**: 0 si les 3 assertions passent, 1 sinon.
@@ -96,8 +121,10 @@ Ce comportement est interdit hors mode démo explicite.
 **Given** AT-2 PASS ET AT-3 PASS, `API_KEY` connu
 **When**: `GET ${GATEWAY_URL}/apis/${DEMO_API_NAME}/get -H "X-Api-Key: ${API_KEY}"`
 
-Chemin canonique figé: `/apis/{api_name}/{*path}`. Le smoke ne probe plus
-plusieurs shapes.
+Chemin canonique figé: `/apis/{api_name}/{*path}`. En mode UAC-driven, le smoke
+construit ce chemin depuis `name` + `endpoints[0].path`, soit
+`/apis/demo-httpbin/get` pour le contrat démo. Le smoke ne probe plus plusieurs
+shapes.
 
 **Then**:
 - HTTP 200

--- a/specs/demo-readiness-report.md
+++ b/specs/demo-readiness-report.md
@@ -10,12 +10,12 @@
 1. Les briques démo existent toutes en code : cp-api (routes apis/apps/subs/deployments présentes), stoa-gateway (`/apis/{api_name}/{*path}`, `/health`, `/metrics`), stoactl (apply/get/subscription).
 2. Il n'y a **aucun test bout-en-bout** qui exerce les 5 étapes dans l'ordre sur la même instance. Le rewrite a recertifié chaque brique isolément.
 3. Les rewrites actifs (GW-1 closed, GW-2 open, GO-2 validated) respectent leurs contrats internes mais aucun garde-fou démo ne protège le chemin vertical.
-4. La route proxy gateway canonique est figée pour la démo : `GET /apis/{api_name}/get`. Le smoke ne probe plus plusieurs shapes.
+4. La route proxy gateway canonique est figée pour la démo : `GET /apis/demo-httpbin/get` en mode UAC-driven. Le smoke ne probe plus plusieurs shapes.
 5. Le seed existe (`make seed-dev`), mais un tenant `demo` minimal dédié smoke n'est pas garanti reproductible.
 6. La métrique Prometheus attendue (`proxy_requests_total` ou `mcp_tool_calls_total`) est présente en code gateway mais son nom exact + labels ne sont pas figés dans un contrat testé ; OTEL/Grafana/Console/Portal sont maintenant cadrés en AT-5b nice-to-have.
 7. L'auth API key (header `X-Api-Key`) existe gateway-side ; B1 borne maintenant le retour `api_key` cleartext au mode explicite `X-Demo-Mode: true`.
 8. La stack docker-compose pré-existe (`deploy/docker-compose/docker-compose.yml`) mais son suffisance pour le smoke n'est pas validée (mock-backend non-confirmé).
-9. Les specs `/specs/*.md` créés + `scripts/demo-smoke-test.sh` donnent un contrat exécutable avec verdicts non ambigus (`REAL_PASS`, `CONTRACT_DRY_RUN`, `MOCK_PASS`, `FAIL`). **Aucun run réel n'a encore été tenté**.
+9. Les specs `/specs/*.md` + `scripts/demo-smoke-test.sh` donnent un contrat exécutable avec verdicts non ambigus (`REAL_PASS`, `CONTRACT_DRY_RUN`, `MOCK_PASS`, `FAIL`) et une première vérité UAC fonctionnelle via `specs/uac/demo-httpbin.uac.json`.
 10. Verdict préliminaire : **FAIL attendu en premier run** sur AT-2/AT-3/AT-4. Plan "démo-first" actionnable immédiat ci-dessous.
 
 ## 2. Ce qui marche déjà (inspection statique)
@@ -60,9 +60,10 @@ Il reste non bloquant pour `demo-smoke-test.sh` tant que les blockers provider
 P0 ne sont pas fermés, mais il devient la référence pour toute PR touchant
 Portal, signup, prospects, subscriptions UX ou usage client.
 
-### 3.1 Contrats figés non documentés
+### 3.1 Contrats figés
 - `architecture-rules.md` §2.2 affirme que `/apis/{api_name}/{*path}` est la surface démo officielle.
-- `demo-smoke-test.sh` utilise un seul chemin canonique: `/apis/${DEMO_API_NAME}/get`.
+- `architecture-rules.md` §2.2bis fige le contrat UAC démo `demo-httpbin` publié.
+- `demo-smoke-test.sh` utilise un seul chemin canonique dérivé du UAC quand `DEMO_UAC_CONTRACT` est fourni: `/apis/demo-httpbin/get`.
 - Format Prometheus attendu (`proxy_requests_total`) pas testé en intégration — probable drift silencieux si renommé
 
 ### 3.2 Seed démo reproductible
@@ -84,10 +85,12 @@ Ce point ferme B2 pour AT-0. AT-4 peut maintenant cibler un backend local
 déterministe dès que la stack locale dépasse AT-0/AT-2
 exploitable.
 
-### 3.5 Chemin proxy gateway figé
+### 3.5 Chemin proxy gateway figé et UAC-driven
 Le chemin gateway démo est canonique : `{GATEWAY_URL}/apis/{api_name}/get`.
-`api_name` désigne le slug retourné par `POST /v1/tenants/{tid}/apis`
-(`demo-api-smoke` par défaut). Le smoke utilise ce chemin unique.
+En mode UAC-driven, `api_name` vient de `specs/uac/demo-httpbin.uac.json`
+(`name=demo-httpbin`) et le path vient de `endpoints[0].path` (`/get`), soit
+`/apis/demo-httpbin/get`. Sans `DEMO_UAC_CONTRACT`, le smoke conserve le
+fallback historique `demo-api-smoke` et affiche `WARN — smoke not UAC-driven`.
 
 ### 3.6 Auth bypass dev non documenté
 Le script smoke autorise `DEMO_ADMIN_TOKEN=""` en fallback, mais aucune variable `STOA_DISABLE_AUTH` ou flag équivalent n'est documenté côté cp-api. Probable que la démo échoue silencieusement en 401/403 sur AT-1 sans JWT Keycloak valide.
@@ -109,6 +112,10 @@ Polling 30s par défaut dans stoa-connect → AT-2 peut timeout. Mitigation dans
 | B8 | OTEL visible en UI non prouvé automatiquement | P3 | AT-5b | observability/ui (nice-to-have) |
 | C-B1 | Démo client/prospect non automatisée (seed + UI + conversion) | P1 | CPD-0..CPD-10 | portal/console/cp-api |
 
+Le premier lien UAC → smoke est traité: `demo-httpbin` `GET /get` est chargé,
+validé, puis utilisé pour construire `/apis/demo-httpbin/get`. Cela ne ferme pas
+les blockers runtime AT-0..AT-5.
+
 ## 5. Contournements acceptables pendant le rewrite
 
 Pour débloquer rapidement la validation du contrat sans confondre script OK et démo prête :
@@ -116,6 +123,7 @@ Pour débloquer rapidement la validation du contrat sans confondre script OK et 
 | Contournement | Cible | Durée | Risque |
 |---------------|-------|-------|--------|
 | `./scripts/demo-smoke-test.sh --dry-run-contract` | Tous | permanent | Valide le contrat/script, verdict `CONTRACT_DRY_RUN`, jamais `DEMO READY` |
+| `DEMO_UAC_CONTRACT=specs/uac/demo-httpbin.uac.json ./scripts/demo-smoke-test.sh --dry-run-contract` | UAC | permanent | Valide la preuve UAC minimale sans stack live |
 | `MOCK_MODE=all ./scripts/demo-smoke-test.sh` | stack absente | usage local | Valide le chemin mocké, verdict `MOCK_PASS`, jamais `DEMO READY` |
 | Démarrer `mock-backend` via compose seul (`docker compose ... up -d mock-backend`) | B2 | jusqu'à stack complète | Service sous profil `demo`; ne pas exposer Prometheus sur le même port pendant ce smoke |
 | `DEMO_GATEWAY_PATH` override local | B3 | debug uniquement | Toute démo officielle doit revenir à `/apis/{api_name}/get` |
@@ -159,3 +167,4 @@ La PR de cadrage posait le contrat sans code applicatif. B1 est maintenant trait
 | Date | Version | Auteur | Delta |
 |------|---------|--------|-------|
 | 2026-04-24 | v1.0 | Claude (session `/demo-scope`) | Création initiale, 7 blockers identifiés, verdict GO conditionnel |
+| 2026-04-24 | v1.1 | Codex | Ajout du contrat UAC démo `demo-httpbin` et du chemin smoke dérivé `/apis/demo-httpbin/get` |

--- a/specs/demo-scope.md
+++ b/specs/demo-scope.md
@@ -15,10 +15,10 @@ Ce scope fige ce chemin. Tant qu'il n'est pas vert bout-en-bout, **aucune autre 
 
 | # | Étape | Composant(s) | Commande/API | Preuve |
 |---|-------|--------------|--------------|--------|
-| 1 | Déclarer une API | cp-api + DB | `POST /v1/tenants/{t}/apis` (ou `stoactl apply -f api.yaml`) | API visible dans `GET /v1/tenants/{t}/apis` |
+| 1 | Déclarer une API | cp-api + DB | `POST /v1/tenants/{t}/apis`, dérivé du contrat `specs/uac/demo-httpbin.uac.json` quand `DEMO_UAC_CONTRACT` est fourni | API visible dans `GET /v1/tenants/{t}/apis` |
 | 2 | Provisionner la route gateway | cp-api + stoa-gateway | `POST /v1/tenants/{t}/deployments` → gateway polling `GET /v1/internal/gateways/routes` OU `stoa-connect` SSE `GET /v1/internal/gateways/{id}/events` | Route active dans la table gateway (log `Route table reloaded` + réponse non-404 au step 4) |
 | 3 | Créer une souscription applicative | cp-api | `POST /v1/tenants/{t}/applications` + `POST /v1/subscriptions` (ou `POST /applications/{id}/subscribe/{api_id}`) | Subscription `active`, clé API retournée (préfixe visible) |
-| 4 | Appeler l'API via la gateway | stoa-gateway | `GET {GATEWAY_URL}/apis/{api_name}/get` avec header `X-Api-Key: ${KEY}` (ou JWT OAuth) | HTTP 2xx, payload backend |
+| 4 | Appeler l'API via la gateway | stoa-gateway | `GET {GATEWAY_URL}/apis/demo-httpbin/get` avec header `X-Api-Key: ${KEY}` en mode UAC-driven | HTTP 2xx, payload backend |
 | 5 | Preuve observable | stoa-gateway + cp-api | `GET {GATEWAY_URL}/metrics` + logs JSON stdout | Compteur Prometheus incrémenté (`proxy_requests_total` ou `mcp_tool_calls_total`) + ligne log corrélée (request_id, tenant, route) |
 | 5b | Visibilité observabilité (nice-to-have) | Grafana + Console + Portal | Grafana datasource/dashboard, Console `/monitoring`, Portal `/usage` ou dashboard embarqué | La même activité démo est visible dans au moins une surface UI si la stack observabilité est démarrée |
 
@@ -30,6 +30,11 @@ Ce scope fige ce chemin. Tant qu'il n'est pas vert bout-en-bout, **aucune autre 
 - `stoactl` (Go) — sous-commandes `apply`, `get`, `subscription`, `auth login` seulement
 
 **Backend cible pour l'appel démo**: un mock HTTP (ex. `mock-backends/` ou `httpbin` en conteneur) qui répond 200 JSON. Pas de backend externe réseau.
+
+**Contrat UAC cible**: `specs/uac/demo-httpbin.uac.json`. Le smoke n'est pas
+encore une preuve UAC globale: il charge un seul contrat publié, sélectionne le
+premier endpoint `GET /get`, et dérive un seul chemin gateway
+`/apis/demo-httpbin/get`.
 
 **Auth**: API key (préfixe `stoa_…`) OU JWT Keycloak — un seul mode suffit pour la démo. Choisir API key (plus simple à reproduire).
 
@@ -80,12 +85,23 @@ Tant que ce script n'affiche pas `REAL_PASS — DEMO READY`, la démo réelle
 n'existe pas. `CONTRACT_DRY_RUN` et `MOCK_PASS` peuvent retourner exit 0, mais
 signifient seulement que le contrat ou le chemin mocké est cohérent.
 
+Commande de référence UAC-driven:
+
+```
+$ DEMO_UAC_CONTRACT=specs/uac/demo-httpbin.uac.json ./scripts/demo-smoke-test.sh
+[PASS] UAC contract loaded demo-httpbin v1.0.0
+[PASS] UAC endpoint GET /get selected operation_id=demo_httpbin_get
+[PASS] UAC Gateway call derived from UAC /apis/demo-httpbin/get
+...
+```
+
 ## 6. Dépendances figées pendant le rewrite
 
 Voir `rewrite-guardrails.md` §Contrats figés:
 - Compatibilité DB consommée par le smoke (`apis`, `applications`, `subscriptions`, `deployments`, `api_keys`)
 - Endpoints listés §2 (URL + status codes + shape minimal de réponse)
 - Route `/apis/{api_name}/{*path}` gateway + comportement auth-header
+- Contrat UAC démo `specs/uac/demo-httpbin.uac.json` pour `demo-httpbin` `GET /get`
 - Format métrique Prometheus (nom `_total`, labels `tenant`, `api`, `method`, `status`)
 
 Tout autre aspect peut bouger.
@@ -95,3 +111,4 @@ Tout autre aspect peut bouger.
 | Date | Auteur | Changement |
 |------|--------|------------|
 | 2026-04-24 | Claude (via `/demo-scope`) | Création initiale |
+| 2026-04-24 | Codex | Ajout du premier lien UAC-driven: `demo-httpbin` `GET /get` → `/apis/demo-httpbin/get` |

--- a/specs/rewrite-guardrails.md
+++ b/specs/rewrite-guardrails.md
@@ -25,6 +25,7 @@ Les éléments suivants sont **figés** : toute modification demande Council 8/1
 - Format métriques Prometheus `proxy_requests_total` / `mcp_tool_calls_total`
 - Header `X-Api-Key` accepté par gateway `/apis/{api_name}/{*path}`
 - Header de réponse `X-Stoa-Request-Id` injecté par gateway
+- Contrat UAC démo `specs/uac/demo-httpbin.uac.json` et chemin dérivé `/apis/demo-httpbin/get`
 - Datasources Grafana `prometheus`, `loki`, `opensearch-traces`, `tempo` si la stack observabilité est touchée
 - Compatibilité DB consommée par le smoke (§2.6 de `architecture-rules.md`)
 
@@ -65,8 +66,8 @@ Chaque PR touchant cp-api, stoa-gateway, stoa-go, charts, deploy/ doit inclure d
 ## Demo impact
 
 - [ ] Vérifié : aucune modification de `specs/architecture-rules.md` §2 (contrats figés)
-- [ ] `./scripts/demo-smoke-test.sh` exécuté avant cette PR : REAL_PASS / CONTRACT_DRY_RUN / MOCK_PASS / FAIL (préciser)
-- [ ] `./scripts/demo-smoke-test.sh` exécuté après cette PR : REAL_PASS / CONTRACT_DRY_RUN / MOCK_PASS / FAIL (préciser)
+- [ ] `DEMO_UAC_CONTRACT=specs/uac/demo-httpbin.uac.json ./scripts/demo-smoke-test.sh` exécuté avant cette PR : REAL_PASS / CONTRACT_DRY_RUN / MOCK_PASS / FAIL (préciser)
+- [ ] `DEMO_UAC_CONTRACT=specs/uac/demo-httpbin.uac.json ./scripts/demo-smoke-test.sh` exécuté après cette PR : REAL_PASS / CONTRACT_DRY_RUN / MOCK_PASS / FAIL (préciser)
 - [ ] Si non-REAL_PASS ou régression : quelle étape AT-N échoue ou est mockée et pourquoi est-ce acceptable ?
 ```
 

--- a/specs/uac/demo-httpbin.uac.json
+++ b/specs/uac/demo-httpbin.uac.json
@@ -1,0 +1,30 @@
+{
+  "name": "demo-httpbin",
+  "version": "1.0.0",
+  "tenant_id": "demo",
+  "status": "published",
+  "classification": "H",
+  "endpoints": [
+    {
+      "path": "/get",
+      "methods": ["GET"],
+      "backend_url": "http://mock-backend:9090",
+      "operation_id": "demo_httpbin_get",
+      "input_schema": {
+        "type": "object",
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": ["ok", "path", "service"],
+        "properties": {
+          "ok": { "type": "boolean" },
+          "path": { "type": "string" },
+          "service": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    }
+  ],
+  "spec_hash": "515839b4b1e23631e9699a9608e8e0f54e01f14572a513c8f514f6ee55da7e39"
+}

--- a/specs/validation-commands.md
+++ b/specs/validation-commands.md
@@ -12,6 +12,15 @@
 Affiche `REAL_PASS — DEMO READY` uniquement si AT-0..AT-5 de
 `demo-acceptance-tests.md` passent sans mock critique.
 
+Mode UAC-driven réel:
+
+```bash
+DEMO_UAC_CONTRACT=specs/uac/demo-httpbin.uac.json ./scripts/demo-smoke-test.sh
+```
+
+Le smoke valide alors le contrat UAC minimal, sélectionne `GET /get`, et appelle
+la gateway sur `/apis/demo-httpbin/get`.
+
 Modes non réels explicites:
 
 ```bash
@@ -32,7 +41,8 @@ Variables d'environnement (defaults documentés dans le script) :
 | `GATEWAY_URL` | `http://localhost:8081` | Base URL stoa-gateway exposée par le compose démo |
 | `MOCK_BACKEND_URL` | `http://localhost:9090` | Mock HTTP backend vu par le poste dev pour AT-0 |
 | `MOCK_BACKEND_UPSTREAM_URL` | `http://mock-backend:9090` | Mock HTTP backend vu par la gateway en compose |
-| `DEMO_GATEWAY_PATH` | `/apis/${DEMO_API_NAME}/get` | Chemin gateway canonique AT-4 |
+| `DEMO_UAC_CONTRACT` | vide | Contrat UAC démo à charger, par exemple `specs/uac/demo-httpbin.uac.json` |
+| `DEMO_GATEWAY_PATH` | `/apis/${DEMO_API_NAME}/get` | Chemin gateway canonique AT-4, dérivé du UAC quand `DEMO_UAC_CONTRACT` est fourni |
 | `TENANT_ID` | `demo` (slug, résolu en UUID par cp-api) | Tenant démo |
 | `DEMO_ADMIN_TOKEN` | vide | JWT admin pour écrire côté cp-api. Si vide, le compose démo doit activer `STOA_DISABLE_AUTH=true` (dev only, requiert `X-Demo-Mode: true`, interdit en prod) |
 | `ROUTE_SYNC_GRACE_SECS` | `30` | Délai d'attente pour route visible en gateway après AT-2 |
@@ -143,7 +153,7 @@ psql $DATABASE_URL -c "SELECT status, count(*) FROM subscriptions GROUP BY statu
 # Route table live gateway
 curl -s http://localhost:8081/admin/routes | jq .      # si admin API exposée
 curl -s http://localhost:8000/v1/internal/gateways/routes?gateway_name=demo | jq .
-curl -sI http://localhost:8081/apis/demo-api-smoke/get
+curl -sI http://localhost:8081/apis/demo-httpbin/get
 
 # Logs gateway corrélés à un request_id
 docker logs stoa-gateway 2>&1 | grep "request_id=${REQUEST_ID}"
@@ -167,7 +177,8 @@ kill -HUP $(pgrep stoa-gateway)
 |----------|-----------|
 | `make seed-dev` | AT-0 pré-conditions |
 | `docker compose up …` | AT-0 pré-conditions |
-| `./scripts/demo-smoke-test.sh` | AT-0 → AT-5 réel (`REAL_PASS` seulement si aucun mock) |
+| `DEMO_UAC_CONTRACT=specs/uac/demo-httpbin.uac.json ./scripts/demo-smoke-test.sh` | UAC + AT-0 → AT-5 réel (`REAL_PASS` seulement si aucun mock) |
+| `./scripts/demo-smoke-test.sh` | AT-0 → AT-5 réel en fallback historique avec warning `WARN — smoke not UAC-driven` |
 | `./scripts/demo-smoke-test.sh --dry-run-contract` | Contrat script/spec (`CONTRACT_DRY_RUN`, pas démo prête) |
 | `MOCK_MODE=all ./scripts/demo-smoke-test.sh` | Chemin mocké (`MOCK_PASS`, pas démo prête) |
 | `OBS_VISIBILITY_CHECK=auto ./scripts/demo-smoke-test.sh` | AT-5b nice-to-have Grafana/Console/Portal |
@@ -187,7 +198,7 @@ Le workflow `.github/workflows/demo-smoke.yml` est volontairement
 
 ```bash
 bash -n scripts/demo-smoke-test.sh
-./scripts/demo-smoke-test.sh --no-observability-ui
+DEMO_UAC_CONTRACT=specs/uac/demo-httpbin.uac.json ./scripts/demo-smoke-test.sh --no-observability-ui
 ```
 
 Il publie dans `$GITHUB_STEP_SUMMARY` :


### PR DESCRIPTION
## Summary

- add the minimal `demo-httpbin` UAC contract for the demo smoke
- load `DEMO_UAC_CONTRACT` in `scripts/demo-smoke-test.sh` and derive API name, method, path, backend URL, operation id, and gateway path from it
- update demo specs and guardrails so the UAC-driven smoke command is the reference path

## Validation

- `bash -n scripts/demo-smoke-test.sh`
- `jq -e . specs/uac/demo-httpbin.uac.json`
- `git diff --check -- scripts/demo-smoke-test.sh specs/demo-acceptance-tests.md specs/validation-commands.md specs/architecture-rules.md specs/demo-scope.md specs/demo-readiness-report.md specs/rewrite-guardrails.md specs/uac/demo-httpbin.uac.json`
- `DEMO_UAC_CONTRACT=specs/uac/demo-httpbin.uac.json ./scripts/demo-smoke-test.sh --dry-run-contract --no-observability-ui`
- `DEMO_UAC_CONTRACT=specs/uac/demo-httpbin.uac.json ./scripts/demo-smoke-test.sh --no-observability-ui` fails at AT-0 as expected without local stack (`cp-api=000000 gateway=000000 mock=000000`)

## Demo impact

- [x] Verified: preserves `specs/architecture-rules.md` contracts by adding the UAC demo contract explicitly
- [x] `DEMO_UAC_CONTRACT=specs/uac/demo-httpbin.uac.json ./scripts/demo-smoke-test.sh` after this PR: FAIL at AT-0 locally because no stack is running; UAC contract loading and derived gateway path pass first
- [x] Non-REAL_PASS reason: local stack not running; blocker is named AT-0, not masked
