### PR TITLE
[codex] feat(uac): validate endpoint llm metadata

### DIFF
--- a/control-plane-api/src/schemas/uac.py
+++ b/control-plane-api/src/schemas/uac.py
@@ -6,6 +6,7 @@ Cross-language parity is enforced via `uac-contract-v1.schema.json`.
 """
 
 from enum import StrEnum
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -45,6 +46,38 @@ class UacContractStatus(StrEnum):
     DEPRECATED = "deprecated"
 
 
+class UacEndpointSideEffects(StrEnum):
+    """Effect level for LLM-facing endpoint metadata."""
+
+    NONE = "none"
+    READ = "read"
+    WRITE = "write"
+    DESTRUCTIVE = "destructive"
+
+
+class UacEndpointLlmExample(BaseModel):
+    """Example input for an LLM-facing endpoint tool."""
+
+    input: dict[str, Any] = Field(..., description="Example input object for the projected MCP tool")
+    description: str | None = Field(None, description="Optional explanation for the example")
+
+
+class UacEndpointLlmSpec(BaseModel):
+    """LLM-facing metadata for a UAC endpoint."""
+
+    summary: str = Field(..., min_length=1, description="Short human-readable tool summary")
+    intent: str = Field(..., min_length=1, description="Agent-facing intent describing when to use this endpoint")
+    tool_name: str = Field(..., min_length=1, description="Stable MCP tool name to expose for this endpoint")
+    side_effects: UacEndpointSideEffects = Field(..., description="Effect level of invoking this endpoint")
+    safe_for_agents: bool = Field(..., description="Whether autonomous agents may use this endpoint")
+    requires_human_approval: bool = Field(
+        ..., description="Whether a human approval step is required before invocation"
+    )
+    examples: list[UacEndpointLlmExample] = Field(
+        ..., description="Example inputs for MCP clients and smoke validation"
+    )
+
+
 class UacEndpointSpec(BaseModel):
     """A single API endpoint within a UAC contract."""
 
@@ -60,6 +93,9 @@ class UacEndpointSpec(BaseModel):
     )
     input_schema: dict | None = Field(None, description="JSON Schema for request body")
     output_schema: dict | None = Field(None, description="JSON Schema for response body")
+    llm: UacEndpointLlmSpec | None = Field(
+        None, description="Optional LLM-facing metadata for MCP tool projection"
+    )
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/control-plane-api/src/schemas/uac_contract_v1_schema.json
+++ b/control-plane-api/src/schemas/uac_contract_v1_schema.json
@@ -138,6 +138,73 @@
         "output_schema": {
           "type": ["object", "null"],
           "description": "JSON Schema for response body."
+        },
+        "llm": {
+          "$ref": "#/$defs/EndpointLlm",
+          "description": "Optional LLM-facing metadata for MCP tool projection."
+        }
+      },
+      "additionalProperties": false
+    },
+    "EndpointLlm": {
+      "type": "object",
+      "required": [
+        "summary",
+        "intent",
+        "tool_name",
+        "side_effects",
+        "safe_for_agents",
+        "requires_human_approval",
+        "examples"
+      ],
+      "properties": {
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short human-readable tool summary."
+        },
+        "intent": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Agent-facing intent describing when to use this endpoint."
+        },
+        "tool_name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable MCP tool name to expose for this endpoint."
+        },
+        "side_effects": {
+          "type": "string",
+          "enum": ["none", "read", "write", "destructive"],
+          "description": "Effect level of invoking this endpoint."
+        },
+        "safe_for_agents": {
+          "type": "boolean",
+          "description": "Whether autonomous agents may use this endpoint."
+        },
+        "requires_human_approval": {
+          "type": "boolean",
+          "description": "Whether a human approval step is required before invocation."
+        },
+        "examples": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/EndpointLlmExample" },
+          "description": "Example inputs for MCP clients and smoke validation."
+        }
+      },
+      "additionalProperties": false
+    },
+    "EndpointLlmExample": {
+      "type": "object",
+      "required": ["input"],
+      "properties": {
+        "input": {
+          "type": "object",
+          "description": "Example input object for the projected MCP tool."
+        },
+        "description": {
+          "type": ["string", "null"],
+          "description": "Optional explanation for the example."
         }
       },
       "additionalProperties": false

--- a/control-plane-api/src/services/uac_validator.py
+++ b/control-plane-api/src/services/uac_validator.py
@@ -94,6 +94,7 @@ def _validate_semantics(document: dict, result: UacValidationResult) -> None:
     _check_classification_policy_consistency(document, result)
     _check_endpoint_uniqueness(document, result)
     _check_naming_conventions(document, result)
+    _check_endpoint_llm_rules(document, result)
     _check_published_readiness(document, result)
 
 
@@ -143,6 +144,31 @@ def _check_naming_conventions(document: dict, result: UacValidationResult) -> No
         if op_id and not op_id.replace("_", "").replace("-", "").isalnum():
             result.add_warning(
                 f"endpoints[{i}].operation_id '{op_id}' contains " f"non-alphanumeric characters beyond _ and -"
+            )
+
+
+def _check_endpoint_llm_rules(document: dict, result: UacValidationResult) -> None:
+    """Validate cross-endpoint and effect rules for optional endpoint.llm."""
+    tool_names: dict[str, int] = {}
+
+    for i, ep in enumerate(document.get("endpoints", [])):
+        llm = ep.get("llm")
+        if not llm:
+            continue
+
+        tool_name = llm.get("tool_name")
+        if tool_name:
+            if tool_name in tool_names:
+                result.add_error(
+                    f"endpoints[{i}].llm.tool_name duplicate tool_name '{tool_name}' "
+                    f"already used by endpoints[{tool_names[tool_name]}]"
+                )
+            else:
+                tool_names[tool_name] = i
+
+        if llm.get("side_effects") == "destructive" and llm.get("requires_human_approval") is not True:
+            result.add_error(
+                f"endpoints[{i}].llm destructive side_effects requires requires_human_approval=true"
             )
 
 

--- a/control-plane-api/tests/test_uac_schema.py
+++ b/control-plane-api/tests/test_uac_schema.py
@@ -12,6 +12,7 @@ from src.schemas.uac import (
     UacContractSpec,
     UacContractStatus,
     UacEndpointSpec,
+    UacEndpointSideEffects,
 )
 
 # =============================================================================
@@ -63,6 +64,43 @@ class TestUacEndpointSpec:
         assert ep.operation_id is None
         assert ep.input_schema is None
         assert ep.output_schema is None
+        assert ep.llm is None
+
+    def test_endpoint_llm_metadata(self):
+        ep = UacEndpointSpec(
+            path="/health",
+            methods=["GET"],
+            backend_url="https://api.example.com/health",
+            llm={
+                "summary": "Read health",
+                "intent": "Let agents inspect service health.",
+                "tool_name": "health_read",
+                "side_effects": "read",
+                "safe_for_agents": True,
+                "requires_human_approval": False,
+                "examples": [{"input": {"verbose": False}}],
+            },
+        )
+        assert ep.llm is not None
+        assert ep.llm.tool_name == "health_read"
+        assert ep.llm.side_effects == UacEndpointSideEffects.READ
+        assert ep.llm.examples[0].input == {"verbose": False}
+
+    def test_endpoint_llm_missing_examples_rejected(self):
+        with pytest.raises(ValidationError):
+            UacEndpointSpec(
+                path="/health",
+                methods=["GET"],
+                backend_url="https://api.example.com/health",
+                llm={
+                    "summary": "Read health",
+                    "intent": "Let agents inspect service health.",
+                    "tool_name": "health_read",
+                    "side_effects": "read",
+                    "safe_for_agents": True,
+                    "requires_human_approval": False,
+                },
+            )
 
 
 # =============================================================================

--- a/control-plane-api/tests/test_uac_validator.py
+++ b/control-plane-api/tests/test_uac_validator.py
@@ -296,6 +296,106 @@ class TestSemanticValidation:
 
 
 # =============================================================================
+# Endpoint LLM metadata validation
+# =============================================================================
+
+
+def _endpoint_llm(**overrides: object) -> dict:
+    """Create a minimal valid endpoint.llm metadata block."""
+    llm = {
+        "summary": "Read backend health",
+        "intent": "Let agents inspect backend availability without changing state.",
+        "tool_name": "demo_health_read",
+        "side_effects": "read",
+        "safe_for_agents": True,
+        "requires_human_approval": False,
+        "examples": [],
+    }
+    llm.update(overrides)
+    return llm
+
+
+class TestEndpointLlmValidation:
+    """Strict V1 validation for optional endpoint.llm metadata."""
+
+    def test_legacy_endpoint_without_llm_still_valid(self) -> None:
+        result = validate_uac_contract(_minimal_contract())
+        assert result.valid, result.errors
+
+    def test_endpoint_with_complete_llm_valid(self) -> None:
+        doc = _minimal_contract()
+        doc["endpoints"][0]["llm"] = _endpoint_llm()
+        result = validate_uac_contract(doc)
+        assert result.valid, result.errors
+
+    def test_endpoint_llm_missing_required_field_fails(self) -> None:
+        doc = _minimal_contract()
+        llm = _endpoint_llm()
+        del llm["intent"]
+        doc["endpoints"][0]["llm"] = llm
+        result = validate_uac_contract(doc)
+        assert not result.valid
+        assert any("intent" in e for e in result.errors)
+
+    def test_endpoint_llm_empty_tool_name_fails(self) -> None:
+        doc = _minimal_contract()
+        doc["endpoints"][0]["llm"] = _endpoint_llm(tool_name="")
+        result = validate_uac_contract(doc)
+        assert not result.valid
+        assert any("tool_name" in e for e in result.errors)
+
+    def test_endpoint_llm_examples_absent_fails(self) -> None:
+        doc = _minimal_contract()
+        llm = _endpoint_llm()
+        del llm["examples"]
+        doc["endpoints"][0]["llm"] = llm
+        result = validate_uac_contract(doc)
+        assert not result.valid
+        assert any("examples" in e for e in result.errors)
+
+    def test_endpoint_llm_duplicate_tool_name_fails(self) -> None:
+        doc = _minimal_contract(
+            endpoints=[
+                {
+                    "path": "/health",
+                    "methods": ["GET"],
+                    "backend_url": "https://backend.example.com/health",
+                    "llm": _endpoint_llm(tool_name="duplicate_tool"),
+                },
+                {
+                    "path": "/status",
+                    "methods": ["GET"],
+                    "backend_url": "https://backend.example.com/status",
+                    "llm": _endpoint_llm(tool_name="duplicate_tool"),
+                },
+            ]
+        )
+        result = validate_uac_contract(doc)
+        assert not result.valid
+        assert any("duplicate tool_name" in e for e in result.errors)
+
+    def test_endpoint_llm_destructive_requires_human_approval(self) -> None:
+        doc = _minimal_contract()
+        doc["endpoints"][0]["llm"] = _endpoint_llm(
+            side_effects="destructive",
+            requires_human_approval=False,
+        )
+        result = validate_uac_contract(doc)
+        assert not result.valid
+        assert any("destructive" in e and "requires_human_approval" in e for e in result.errors)
+
+    def test_endpoint_llm_destructive_with_human_approval_valid(self) -> None:
+        doc = _minimal_contract()
+        doc["endpoints"][0]["llm"] = _endpoint_llm(
+            side_effects="destructive",
+            requires_human_approval=True,
+            safe_for_agents=False,
+        )
+        result = validate_uac_contract(doc)
+        assert result.valid, result.errors
+
+
+# =============================================================================
 # Strict wrapper
 # =============================================================================
 

--- a/stoa-gateway/src/handlers/admin/contracts/tests.rs
+++ b/stoa-gateway/src/handlers/admin/contracts/tests.rs
@@ -546,6 +546,7 @@ mod transactional {
             operation_id: Some("tx".to_string()),
             input_schema: None,
             output_schema: None,
+            llm: None,
         }];
         spec
     }

--- a/stoa-gateway/src/uac/binders/mcp.rs
+++ b/stoa-gateway/src/uac/binders/mcp.rs
@@ -205,6 +205,7 @@ mod tests {
                 operation_id: Some("list_payments".to_string()),
                 input_schema: None,
                 output_schema: None,
+                llm: None,
             },
             UacEndpoint {
                 path: "/payments/{id}".to_string(),
@@ -215,6 +216,7 @@ mod tests {
                 operation_id: Some("delete_payment".to_string()),
                 input_schema: None,
                 output_schema: None,
+                llm: None,
             },
         ];
         spec

--- a/stoa-gateway/src/uac/binders/rest.rs
+++ b/stoa-gateway/src/uac/binders/rest.rs
@@ -126,6 +126,7 @@ mod tests {
                 operation_id: Some("list_payments".to_string()),
                 input_schema: None,
                 output_schema: None,
+                llm: None,
             },
             UacEndpoint {
                 path: "/payments/{id}".to_string(),
@@ -136,6 +137,7 @@ mod tests {
                 operation_id: Some("get_payment".to_string()),
                 input_schema: None,
                 output_schema: None,
+                llm: None,
             },
         ];
         spec

--- a/stoa-gateway/src/uac/llm.rs
+++ b/stoa-gateway/src/uac/llm.rs
@@ -157,6 +157,7 @@ impl LlmConfig {
                     operation_id: Some(cap.capability.operation_id().to_string()),
                     input_schema: None,
                     output_schema: None,
+                    llm: None,
                 })
             })
             .collect()

--- a/stoa-gateway/src/uac/registry.rs
+++ b/stoa-gateway/src/uac/registry.rs
@@ -81,6 +81,7 @@ mod tests {
             operation_id: None,
             input_schema: None,
             output_schema: None,
+            llm: None,
         }];
         spec
     }

--- a/stoa-gateway/src/uac/schema.rs
+++ b/stoa-gateway/src/uac/schema.rs
@@ -8,12 +8,56 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 
 use super::classifications::Classification;
 use super::llm::LlmConfig;
 
 fn default_tenant_id() -> String {
     "default".to_string()
+}
+
+// =============================================================================
+// Endpoint LLM Metadata
+// =============================================================================
+
+/// Effect level for LLM-facing endpoint metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EndpointSideEffects {
+    None,
+    Read,
+    Write,
+    Destructive,
+}
+
+/// Example input for an LLM-facing endpoint tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EndpointLlmExample {
+    /// Example input object for the projected MCP tool
+    pub input: Value,
+    /// Optional explanation for the example
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// LLM-facing metadata for a UAC endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EndpointLlm {
+    /// Short human-readable tool summary
+    pub summary: String,
+    /// Agent-facing intent describing when to use this endpoint
+    pub intent: String,
+    /// Stable MCP tool name to expose for this endpoint
+    pub tool_name: String,
+    /// Effect level of invoking this endpoint
+    pub side_effects: EndpointSideEffects,
+    /// Whether autonomous agents may use this endpoint
+    pub safe_for_agents: bool,
+    /// Whether a human approval step is required before invocation
+    pub requires_human_approval: bool,
+    /// Example inputs for MCP clients and smoke validation
+    pub examples: Vec<EndpointLlmExample>,
 }
 
 // =============================================================================
@@ -73,6 +117,9 @@ pub struct UacEndpoint {
     /// JSON Schema for response body
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_schema: Option<Value>,
+    /// Optional LLM-facing metadata for MCP tool projection
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm: Option<EndpointLlm>,
 }
 
 // =============================================================================
@@ -191,6 +238,7 @@ impl UacContractSpec {
         }
 
         // Validate each endpoint
+        let mut llm_tool_names: HashMap<&str, usize> = HashMap::new();
         for (i, ep) in self.endpoints.iter().enumerate() {
             if ep.path.is_empty() {
                 errors.push(format!("endpoints[{}].path must not be empty", i));
@@ -201,6 +249,32 @@ impl UacContractSpec {
             // backend_url only required for Published contracts — Draft/Deprecated can omit it
             if ep.backend_url.is_empty() && self.status == ContractStatus::Published {
                 errors.push(format!("endpoints[{}].backend_url must not be empty", i));
+            }
+            if let Some(llm) = &ep.llm {
+                if llm.summary.is_empty() {
+                    errors.push(format!("endpoints[{}].llm.summary must not be empty", i));
+                }
+                if llm.intent.is_empty() {
+                    errors.push(format!("endpoints[{}].llm.intent must not be empty", i));
+                }
+                if llm.tool_name.is_empty() {
+                    errors.push(format!("endpoints[{}].llm.tool_name must not be empty", i));
+                } else if let Some(previous_index) =
+                    llm_tool_names.insert(llm.tool_name.as_str(), i)
+                {
+                    errors.push(format!(
+                        "endpoints[{}].llm.tool_name duplicate tool_name '{}' already used by endpoints[{}]",
+                        i, llm.tool_name, previous_index
+                    ));
+                }
+                if llm.side_effects == EndpointSideEffects::Destructive
+                    && !llm.requires_human_approval
+                {
+                    errors.push(format!(
+                        "endpoints[{}].llm destructive side_effects requires requires_human_approval=true",
+                        i
+                    ));
+                }
             }
         }
 
@@ -226,6 +300,7 @@ mod tests {
             operation_id: Some("get_payment".to_string()),
             input_schema: None,
             output_schema: None,
+            llm: None,
         }
     }
 
@@ -357,6 +432,7 @@ mod tests {
                     "name": {"type": "string"}
                 }
             })),
+            llm: None,
         };
 
         let json = serde_json::to_value(&endpoint).expect("serialize");
@@ -375,12 +451,94 @@ mod tests {
             operation_id: None,
             input_schema: None,
             output_schema: None,
+            llm: None,
         };
 
         let json = serde_json::to_value(&endpoint).expect("serialize");
         assert!(json.get("operation_id").is_none());
         assert!(json.get("input_schema").is_none());
         assert!(json.get("output_schema").is_none());
+        assert!(json.get("llm").is_none());
+    }
+
+    #[test]
+    fn test_endpoint_with_llm_metadata() {
+        let endpoint = UacEndpoint {
+            path: "/health".to_string(),
+            methods: vec!["GET".to_string()],
+            backend_url: "https://api.example.com/health".to_string(),
+            method: None,
+            description: None,
+            operation_id: Some("health".to_string()),
+            input_schema: None,
+            output_schema: None,
+            llm: Some(EndpointLlm {
+                summary: "Read health".to_string(),
+                intent: "Let agents inspect service health.".to_string(),
+                tool_name: "health_read".to_string(),
+                side_effects: EndpointSideEffects::Read,
+                safe_for_agents: true,
+                requires_human_approval: false,
+                examples: vec![EndpointLlmExample {
+                    input: serde_json::json!({"verbose": false}),
+                    description: None,
+                }],
+            }),
+        };
+
+        let json = serde_json::to_value(&endpoint).expect("serialize");
+        assert_eq!(json["llm"]["tool_name"], "health_read");
+
+        let roundtrip: UacEndpoint = serde_json::from_value(json).expect("deserialize");
+        let llm = roundtrip.llm.expect("llm metadata");
+        assert_eq!(llm.side_effects, EndpointSideEffects::Read);
+        assert_eq!(llm.examples.len(), 1);
+    }
+
+    #[test]
+    fn test_validate_duplicate_llm_tool_name() {
+        let mut spec = sample_contract();
+        spec.endpoints.push(sample_endpoint());
+        spec.endpoints[0].llm = Some(EndpointLlm {
+            summary: "Read one".to_string(),
+            intent: "Read one payment.".to_string(),
+            tool_name: "payments_read".to_string(),
+            side_effects: EndpointSideEffects::Read,
+            safe_for_agents: true,
+            requires_human_approval: false,
+            examples: vec![],
+        });
+        spec.endpoints[1].llm = Some(EndpointLlm {
+            summary: "Read two".to_string(),
+            intent: "Read another payment.".to_string(),
+            tool_name: "payments_read".to_string(),
+            side_effects: EndpointSideEffects::Read,
+            safe_for_agents: true,
+            requires_human_approval: false,
+            examples: vec![],
+        });
+
+        let errors = spec.validate();
+        assert!(errors.iter().any(|e| e.contains("duplicate tool_name")));
+    }
+
+    #[test]
+    fn test_validate_destructive_llm_requires_approval() {
+        let mut spec = sample_contract();
+        spec.endpoints[0].llm = Some(EndpointLlm {
+            summary: "Delete payment".to_string(),
+            intent: "Delete a payment permanently.".to_string(),
+            tool_name: "payment_delete".to_string(),
+            side_effects: EndpointSideEffects::Destructive,
+            safe_for_agents: false,
+            requires_human_approval: false,
+            examples: vec![],
+        });
+
+        let errors = spec.validate();
+        assert!(errors
+            .iter()
+            .any(|e| e.contains("destructive") && e.contains("requires_human_approval")));
     }
 
     // === LLM Config integration tests (CAB-709) ===

--- a/stoa-gateway/uac-contract-v1.schema.json
+++ b/stoa-gateway/uac-contract-v1.schema.json
@@ -100,8 +100,75 @@
         },
         "output_schema": {
           "description": "JSON Schema for response body"
+        },
+        "llm": {
+          "$ref": "#/$defs/EndpointLlm",
+          "description": "Optional LLM-facing metadata for MCP tool projection"
         }
       }
+    },
+    "EndpointLlm": {
+      "type": "object",
+      "required": [
+        "summary",
+        "intent",
+        "tool_name",
+        "side_effects",
+        "safe_for_agents",
+        "requires_human_approval",
+        "examples"
+      ],
+      "properties": {
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short human-readable tool summary"
+        },
+        "intent": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Agent-facing intent describing when to use this endpoint"
+        },
+        "tool_name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable MCP tool name to expose for this endpoint"
+        },
+        "side_effects": {
+          "type": "string",
+          "enum": ["none", "read", "write", "destructive"],
+          "description": "Effect level of invoking this endpoint"
+        },
+        "safe_for_agents": {
+          "type": "boolean",
+          "description": "Whether autonomous agents may use this endpoint"
+        },
+        "requires_human_approval": {
+          "type": "boolean",
+          "description": "Whether a human approval step is required before invocation"
+        },
+        "examples": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/EndpointLlmExample" },
+          "description": "Example inputs for MCP clients and smoke validation"
+        }
+      },
+      "additionalProperties": false
+    },
+    "EndpointLlmExample": {
+      "type": "object",
+      "required": ["input"],
+      "properties": {
+        "input": {
+          "type": "object",
+          "description": "Example input object for the projected MCP tool"
+        },
+        "description": {
+          "type": ["string", "null"],
+          "description": "Optional explanation for the example"
+        }
+      },
+      "additionalProperties": false
     }
   }
 }


### PR DESCRIPTION
## Summary
- adds optional endpoint.llm metadata to UAC v1 schemas and typed models
- validates strict V1 rules for incomplete metadata, duplicate tool_name, and destructive approval
- keeps legacy endpoints without llm valid and leaves MCP/smoke/runtime unchanged

## Validation
- control-plane-api: pytest tests/test_uac_validator.py tests/test_uac_schema.py -q
- stoa-gateway: cargo test uac::schema --lib
- stoa-gateway: cargo fmt --check
- repo: git diff --check

## Expected
PR 1 only proves schema + validator behavior. MCP projection and smoke proof stay for follow-up PRs.