### PR TITLE
[codex] Harden UAC LLM metadata v1 validation

### DIFF
--- a/control-plane-api/src/schemas/uac.py
+++ b/control-plane-api/src/schemas/uac.py
@@ -56,10 +56,12 @@ class UacEndpointSideEffects(StrEnum):
 
 
 class UacEndpointLlmExample(BaseModel):
-    """Example input for an LLM-facing endpoint tool."""
+    """Example input/output hint for an LLM-facing endpoint tool."""
 
     input: dict[str, Any] = Field(..., description="Example input object for the projected MCP tool")
-    description: str | None = Field(None, description="Optional explanation for the example")
+    expected_output_contains: dict[str, Any] | None = Field(
+        None, description="Optional partial output shape expected from the example"
+    )
 
 
 class UacEndpointLlmSpec(BaseModel):
@@ -74,7 +76,7 @@ class UacEndpointLlmSpec(BaseModel):
         ..., description="Whether a human approval step is required before invocation"
     )
     examples: list[UacEndpointLlmExample] = Field(
-        ..., description="Example inputs for MCP clients and smoke validation"
+        ..., min_length=1, description="Example inputs for MCP clients and smoke validation"
     )
 
 

--- a/control-plane-api/src/schemas/uac_contract_v1_schema.json
+++ b/control-plane-api/src/schemas/uac_contract_v1_schema.json
@@ -189,6 +189,7 @@
         "examples": {
           "type": "array",
           "items": { "$ref": "#/$defs/EndpointLlmExample" },
+          "minItems": 1,
           "description": "Example inputs for MCP clients and smoke validation."
         }
       },
@@ -202,9 +203,9 @@
           "type": "object",
           "description": "Example input object for the projected MCP tool."
         },
-        "description": {
-          "type": ["string", "null"],
-          "description": "Optional explanation for the example."
+        "expected_output_contains": {
+          "type": ["object", "null"],
+          "description": "Optional partial output shape expected from the example."
         }
       },
       "additionalProperties": false

--- a/control-plane-api/src/services/uac_validator.py
+++ b/control-plane-api/src/services/uac_validator.py
@@ -150,10 +150,16 @@ def _check_naming_conventions(document: dict, result: UacValidationResult) -> No
 def _check_endpoint_llm_rules(document: dict, result: UacValidationResult) -> None:
     """Validate cross-endpoint and effect rules for optional endpoint.llm."""
     tool_names: dict[str, int] = {}
+    published = document.get("status") == "published"
 
     for i, ep in enumerate(document.get("endpoints", [])):
         llm = ep.get("llm")
         if not llm:
+            if published:
+                result.add_warning(
+                    f"endpoints[{i}].llm missing: v1 recommends endpoint-level LLM metadata "
+                    "for MCP-projected operations"
+                )
             continue
 
         tool_name = llm.get("tool_name")

--- a/control-plane-api/tests/test_uac_schema.py
+++ b/control-plane-api/tests/test_uac_schema.py
@@ -11,8 +11,8 @@ from src.schemas.uac import (
     UacClassification,
     UacContractSpec,
     UacContractStatus,
-    UacEndpointSpec,
     UacEndpointSideEffects,
+    UacEndpointSpec,
 )
 
 # =============================================================================
@@ -78,13 +78,19 @@ class TestUacEndpointSpec:
                 "side_effects": "read",
                 "safe_for_agents": True,
                 "requires_human_approval": False,
-                "examples": [{"input": {"verbose": False}}],
+                "examples": [
+                    {
+                        "input": {"verbose": False},
+                        "expected_output_contains": {"status": "ok"},
+                    }
+                ],
             },
         )
         assert ep.llm is not None
         assert ep.llm.tool_name == "health_read"
         assert ep.llm.side_effects == UacEndpointSideEffects.READ
         assert ep.llm.examples[0].input == {"verbose": False}
+        assert ep.llm.examples[0].expected_output_contains == {"status": "ok"}
 
     def test_endpoint_llm_missing_examples_rejected(self):
         with pytest.raises(ValidationError):
@@ -99,6 +105,23 @@ class TestUacEndpointSpec:
                     "side_effects": "read",
                     "safe_for_agents": True,
                     "requires_human_approval": False,
+                },
+            )
+
+    def test_endpoint_llm_empty_examples_rejected(self):
+        with pytest.raises(ValidationError):
+            UacEndpointSpec(
+                path="/health",
+                methods=["GET"],
+                backend_url="https://api.example.com/health",
+                llm={
+                    "summary": "Read health",
+                    "intent": "Let agents inspect service health.",
+                    "tool_name": "health_read",
+                    "side_effects": "read",
+                    "safe_for_agents": True,
+                    "requires_human_approval": False,
+                    "examples": [],
                 },
             )
 

--- a/control-plane-api/tests/test_uac_validator.py
+++ b/control-plane-api/tests/test_uac_validator.py
@@ -309,7 +309,12 @@ def _endpoint_llm(**overrides: object) -> dict:
         "side_effects": "read",
         "safe_for_agents": True,
         "requires_human_approval": False,
-        "examples": [],
+        "examples": [
+            {
+                "input": {"verbose": False},
+                "expected_output_contains": {"status": "ok"},
+            }
+        ],
     }
     llm.update(overrides)
     return llm
@@ -321,12 +326,35 @@ class TestEndpointLlmValidation:
     def test_legacy_endpoint_without_llm_still_valid(self) -> None:
         result = validate_uac_contract(_minimal_contract())
         assert result.valid, result.errors
+        assert not any("endpoint-level LLM metadata" in w for w in result.warnings)
+
+    def test_published_endpoint_without_llm_warns_not_fails(self) -> None:
+        result = validate_uac_contract(
+            _minimal_contract(
+                status="published",
+                display_name="Test API",
+                description="Published test API.",
+            )
+        )
+        assert result.valid, result.errors
+        assert any("endpoint-level LLM metadata" in w for w in result.warnings)
 
     def test_endpoint_with_complete_llm_valid(self) -> None:
         doc = _minimal_contract()
         doc["endpoints"][0]["llm"] = _endpoint_llm()
         result = validate_uac_contract(doc)
         assert result.valid, result.errors
+
+    def test_published_endpoint_with_llm_has_no_llm_ready_warning(self) -> None:
+        doc = _minimal_contract(
+            status="published",
+            display_name="Test API",
+            description="Published test API.",
+        )
+        doc["endpoints"][0]["llm"] = _endpoint_llm()
+        result = validate_uac_contract(doc)
+        assert result.valid, result.errors
+        assert not any("endpoint-level LLM metadata" in w for w in result.warnings)
 
     def test_endpoint_llm_missing_required_field_fails(self) -> None:
         doc = _minimal_contract()
@@ -349,6 +377,13 @@ class TestEndpointLlmValidation:
         llm = _endpoint_llm()
         del llm["examples"]
         doc["endpoints"][0]["llm"] = llm
+        result = validate_uac_contract(doc)
+        assert not result.valid
+        assert any("examples" in e for e in result.errors)
+
+    def test_endpoint_llm_empty_examples_fails(self) -> None:
+        doc = _minimal_contract()
+        doc["endpoints"][0]["llm"] = _endpoint_llm(examples=[])
         result = validate_uac_contract(doc)
         assert not result.valid
         assert any("examples" in e for e in result.errors)

--- a/stoa-gateway/src/uac/schema.rs
+++ b/stoa-gateway/src/uac/schema.rs
@@ -31,14 +31,14 @@ pub enum EndpointSideEffects {
     Destructive,
 }
 
-/// Example input for an LLM-facing endpoint tool.
+/// Example input/output hint for an LLM-facing endpoint tool.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EndpointLlmExample {
     /// Example input object for the projected MCP tool
     pub input: Value,
-    /// Optional explanation for the example
+    /// Optional partial output shape expected from the example
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+    pub expected_output_contains: Option<Value>,
 }
 
 /// LLM-facing metadata for a UAC endpoint.
@@ -275,6 +275,27 @@ impl UacContractSpec {
                         i
                     ));
                 }
+                if llm.examples.is_empty() {
+                    errors.push(format!("endpoints[{}].llm.examples must not be empty", i));
+                }
+                for (j, example) in llm.examples.iter().enumerate() {
+                    if !example.input.is_object() {
+                        errors.push(format!(
+                            "endpoints[{}].llm.examples[{}].input must be an object",
+                            i, j
+                        ));
+                    }
+                    if example
+                        .expected_output_contains
+                        .as_ref()
+                        .is_some_and(|expected| !expected.is_object())
+                    {
+                        errors.push(format!(
+                            "endpoints[{}].llm.examples[{}].expected_output_contains must be an object",
+                            i, j
+                        ));
+                    }
+                }
             }
         }
 
@@ -310,6 +331,13 @@ mod tests {
         spec.description = Some("Process payments".to_string());
         spec.endpoints = vec![sample_endpoint()];
         spec
+    }
+
+    fn sample_llm_example() -> EndpointLlmExample {
+        EndpointLlmExample {
+            input: serde_json::json!({"id": "pay_123"}),
+            expected_output_contains: Some(serde_json::json!({"id": "pay_123"})),
+        }
     }
 
     #[test]
@@ -481,13 +509,17 @@ mod tests {
                 requires_human_approval: false,
                 examples: vec![EndpointLlmExample {
                     input: serde_json::json!({"verbose": false}),
-                    description: None,
+                    expected_output_contains: Some(serde_json::json!({"status": "ok"})),
                 }],
             }),
         };
 
         let json = serde_json::to_value(&endpoint).expect("serialize");
         assert_eq!(json["llm"]["tool_name"], "health_read");
+        assert_eq!(
+            json["llm"]["examples"][0]["expected_output_contains"]["status"],
+            "ok"
+        );
 
         let roundtrip: UacEndpoint = serde_json::from_value(json).expect("deserialize");
         let llm = roundtrip.llm.expect("llm metadata");
@@ -506,7 +538,7 @@ mod tests {
             side_effects: EndpointSideEffects::Read,
             safe_for_agents: true,
             requires_human_approval: false,
-            examples: vec![],
+            examples: vec![sample_llm_example()],
         });
         spec.endpoints[1].llm = Some(EndpointLlm {
             summary: "Read two".to_string(),
@@ -515,7 +547,7 @@ mod tests {
             side_effects: EndpointSideEffects::Read,
             safe_for_agents: true,
             requires_human_approval: false,
-            examples: vec![],
+            examples: vec![sample_llm_example()],
         });
 
         let errors = spec.validate();
@@ -532,13 +564,54 @@ mod tests {
             side_effects: EndpointSideEffects::Destructive,
             safe_for_agents: false,
             requires_human_approval: false,
-            examples: vec![],
+            examples: vec![sample_llm_example()],
         });
 
         let errors = spec.validate();
         assert!(errors
             .iter()
             .any(|e| e.contains("destructive") && e.contains("requires_human_approval")));
+    }
+
+    #[test]
+    fn test_validate_llm_examples_required() {
+        let mut spec = sample_contract();
+        spec.endpoints[0].llm = Some(EndpointLlm {
+            summary: "Read payment".to_string(),
+            intent: "Read one payment.".to_string(),
+            tool_name: "payment_read".to_string(),
+            side_effects: EndpointSideEffects::Read,
+            safe_for_agents: true,
+            requires_human_approval: false,
+            examples: vec![],
+        });
+
+        let errors = spec.validate();
+        assert!(errors
+            .iter()
+            .any(|e| e.contains("llm.examples must not be empty")));
+    }
+
+    #[test]
+    fn test_validate_llm_example_input_must_be_object() {
+        let mut spec = sample_contract();
+        spec.endpoints[0].llm = Some(EndpointLlm {
+            summary: "Read payment".to_string(),
+            intent: "Read one payment.".to_string(),
+            tool_name: "payment_read".to_string(),
+            side_effects: EndpointSideEffects::Read,
+            safe_for_agents: true,
+            requires_human_approval: false,
+            examples: vec![EndpointLlmExample {
+                input: serde_json::json!("pay_123"),
+                expected_output_contains: None,
+            }],
+        });
+
+        let errors = spec.validate();
+        assert!(errors
+            .iter()
+            .any(|e| e.contains("examples[0].input must be an object")));
     }
 
     // === LLM Config integration tests (CAB-709) ===

--- a/stoa-gateway/uac-contract-v1.schema.json
+++ b/stoa-gateway/uac-contract-v1.schema.json
@@ -150,6 +150,7 @@
         "examples": {
           "type": "array",
           "items": { "$ref": "#/$defs/EndpointLlmExample" },
+          "minItems": 1,
           "description": "Example inputs for MCP clients and smoke validation"
         }
       },
@@ -163,9 +164,9 @@
           "type": "object",
           "description": "Example input object for the projected MCP tool"
         },
-        "description": {
-          "type": ["string", "null"],
-          "description": "Optional explanation for the example"
+        "expected_output_contains": {
+          "type": ["object", "null"],
+          "description": "Optional partial output shape expected from the example"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary
- align endpoint.llm examples with the canonical llm-ready doc by supporting expected_output_contains
- require at least one llm example when metadata is present
- emit a V1 warning, not an error, for published endpoints missing endpoint.llm

## Tests
- pytest tests/test_uac_schema.py tests/test_uac_validator.py -q
- ruff check src/schemas/uac.py src/services/uac_validator.py tests/test_uac_schema.py tests/test_uac_validator.py
- cargo test uac::schema
- cargo fmt --check