### PR TITLE
docs: revert README to UAC-first positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 
 ---
 
-**STOA** is an open-source MCP gateway that deploys as a **sidecar** next to your existing API gateway. Your REST traffic keeps flowing through Kong, Gravitee, or Apigee — STOA adds an MCP layer so AI agents can discover and call the same APIs, with authentication, rate limiting, and audit built in.
+**STOA** is an open-source API management platform that bridges enterprise APIs to AI agents. Define your API once, expose it everywhere — REST + MCP.
 
-> **Keep your gateway. Add AI.** Define your API once, expose it as REST + MCP.
+> **Universal API Contract (UAC):** Define Once, Expose Everywhere.
 
 <p align="center">
   <img src="docs/assets/screenshot-call-flow.png" alt="STOA Console — Call Flow Dashboard with live traces and traffic heatmap" width="800">
@@ -37,42 +37,37 @@
 
 | Problem | STOA Solution |
 |---------|--------------|
-| AI agents can't use enterprise APIs | MCP sidecar: expose existing APIs as AI tools without changing your gateway |
 | 5 days to get API access | Self-service portal, instant credentials |
 | API catalog in Excel | Searchable catalog with OpenAPI specs |
-| "Rip and replace" to adopt AI | Sidecar deploys next to Kong, Gravitee, Apigee, Azure, AWS, webMethods |
+| Gateway = vendor lock-in | Open-source, full observability, Rust performance |
+| AI agents can't use enterprise APIs | MCP bridge: legacy API → AI agent tool |
 | Multi-org identity is a nightmare | Keycloak federation across organizations |
-| No governance for AI API calls | OAuth 2.1, per-consumer rate limits, audit trail for every MCP call |
+| Locked into one gateway vendor | Multi-gateway adapters: Kong, Gravitee, Apigee, Azure APIM, AWS, webMethods |
 
 ## Architecture
 
-STOA doesn't replace your existing gateway — it sits alongside it as a **sidecar**, adding MCP/AI capabilities to your current infrastructure.
-
 ```
-                        STOA Control Plane
 ┌──────────────────────────────────────────────────────────────────┐
+│                         STOA Platform                            │
+│                                                                  │
 │  Console ──── Control Plane API ──── Keycloak ──── Portal        │
 │  (React 19)    (Python/FastAPI)      (OIDC)      (React 19)     │
-└──────────────────────────┬───────────────────────────────────────┘
-                           │ sync
-              ┌────────────┴────────────┐
-              │                         │
-              ▼                         ▼
-┌─────────────────────┐   ┌─────────────────────────────────────┐
-│    STOA Gateway      │   │     Your Existing Gateway            │
-│   (Rust · sidecar)   │   │  Kong · Gravitee · Apigee · Azure   │
-│                      │   │  AWS API GW · webMethods             │
-│  MCP Bridge          │   │                                     │
-│  AI Tool Discovery   │   │  ◄── Adapter sync (APIs, policies,  │
-│  OAuth 2.1 + PKCE    │   │      consumers, subscriptions)      │
-│  mTLS · Rate Limits  │   │                                     │
-└──────────┬───────────┘   └──────────────┬──────────────────────┘
-           │                              │
-           ▼                              ▼
-     AI Agents (MCP)              Existing Clients (REST)
+│                       │                                          │
+│             ┌─────────┴─────────┐                                │
+│             │   Rust Gateway    │ ◄── MCP + JWT + mTLS + Quotas  │
+│             │  (Tokio + axum)   │                                │
+│             └─────────┬─────────┘                                │
+│                       │                                          │
+│   ┌───────────────────┼───────────────────┐                      │
+│   │                   │                   │                      │
+│   ▼                   ▼                   ▼                      │
+│  Kong            Gravitee            webMethods    ◄── Adapters  │
+│  Apigee          Azure APIM         AWS API GW                   │
+│                                                                  │
+│  Prometheus ── Grafana ── Loki ── OpenSearch                     │
+│  (Metrics)   (Dashboards) (Logs) (Error Tracking)                │
+└──────────────────────────────────────────────────────────────────┘
 ```
-
-**Key idea:** your REST traffic keeps flowing through your current gateway. STOA adds an MCP sidecar so AI agents can discover and call the same APIs — with authentication, rate limiting, and audit built in.
 
 ## Quick Start
 
@@ -111,21 +106,22 @@ For component-by-component local development (without Docker), see [DEVELOPMENT.
 - **Self-Service Portal** — developers discover, subscribe, and test APIs without tickets
 - **Admin Console** — manage tenants, APIs, consumers, and subscriptions
 - **Multi-Tenant** — full isolation between organizations with RBAC
+- **Multi-Gateway** — 7 adapter integrations (Kong, Gravitee, Apigee, Azure APIM, AWS, webMethods, STOA native)
 
-### MCP Sidecar Gateway (Rust, 93K LOC, 2,300+ tests)
-- **Sidecar deployment** — deploys next to your existing gateway, no rip-and-replace
-- **Universal API Contract** — define an API once, expose it as REST + MCP tool
-- **Tool discovery** — AI agents discover available tools via MCP protocol
-- **MCP OAuth 2.1** — RFC 9728 discovery, PKCE, dynamic client registration
+### Rust Gateway (93K LOC, 2,300+ tests)
+- **Sub-millisecond proxy** — built with Tokio + axum for maximum throughput
+- **JWT validation** — Keycloak OIDC integration with JWKS caching
 - **Per-consumer rate limiting** — plan-based quotas with 429 responses
 - **mTLS support** — RFC 8705 certificate-bound tokens
-- **Sub-millisecond proxy** — built with Tokio + axum for maximum throughput
-- **5 CRDs** — Tools, ToolSets, Skills, Gateways, GatewayBindings (Kubernetes-native)
+- **MCP OAuth 2.1** — RFC 9728 discovery, PKCE, dynamic client registration
+- **4-mode architecture** — edge-mcp (active), sidecar, proxy, shadow
 
-### Multi-Gateway Adapters
-- **7 adapters** — Kong, Gravitee, Apigee, Azure APIM, AWS API Gateway, webMethods, STOA native
-- **Bidirectional sync** — APIs, policies, consumers, and subscriptions stay in sync
-- **Single control plane** — manage all your gateways from one console
+### MCP Bridge (AI-Native)
+- **Universal API Contract** — define an API once, expose it as REST + MCP tool
+- **Tool discovery** — AI agents discover available tools via MCP protocol
+- **SSE transport** — real-time streaming for agent communication
+- **Governance** — authentication, rate limiting, and audit trail for AI calls
+- **5 CRDs** — Tools, ToolSets, Skills, Gateways, GatewayBindings (Kubernetes-native)
 
 ### Observability
 - **Grafana dashboards** — gateway metrics, tenant analytics, error tracking, arena benchmarks


### PR DESCRIPTION
## Summary

Reverts the README rewrite from #2227 (`d1600b58`, Apr 7) which repositioned the project from *"API management platform with UAC"* → *"MCP sidecar next to your existing gateway"*.

## Why revert

- **UAC is the documented kill feature.** `CLAUDE.md:4` — *"Kill feature: UAC (Universal API Contract) — Define Once, Expose Everywhere"*. The rewrite buried it under "MCP Sidecar Gateway" and replaced the tagline with "Keep your gateway. Add AI."
- **README ≠ LLM pitch.** PR #2227 was Claude-generated (`Co-authored-by: Claude Opus 4.6`) with a 2-line test plan ("Markdown renders correctly"). HLFH Decision Challenge Gate (CLAUDE.md) requires challenger validation for positioning content; it was not exercised.
- **Sidecar is a mode, not the product.** ADR-024 lists 4 gateway modes (edge-mcp active, sidecar, proxy, shadow). Headlining sidecar narrows the pitch and hides 6/7 adapter integrations under a sub-bullet.

## What changes

| Section | Before this PR (post-#2227) | After this PR (revert) |
|---|---|---|
| Tagline | "Keep your gateway. Add AI." | "Universal API Contract (UAC): Define Once, Expose Everywhere" |
| Pitch | "open-source MCP gateway that deploys as a sidecar" | "open-source API management platform that bridges enterprise APIs to AI agents" |
| Architecture diagram | Two-column STOA-vs-existing-gateway | Single platform with 7-adapter fanout |
| Sections | "MCP Sidecar Gateway" + "Multi-Gateway Adapters" | "Rust Gateway" + "MCP Bridge" |

## Regression guard

- Pre-#2227 tagline said `REST, GraphQL, MCP`. STOA does not ship GraphQL — fixed to `REST + MCP` in this PR to avoid reintroducing the claim.
- LOC/test/ADR counts (93K LOC, 2,300+ tests, 7,100+ pytest, 77 features, 57+ ADRs) identical pre/post.
- Screenshots, sections (Quick Start, Components, Test Suite, Deployment, Repo Structure, Related Repos, Benchmark, Docs, Security, Contributing, Community, License) identical pre/post.
- Net diff: +34 / -38.

## Test plan

- [x] Markdown renders (verified locally)
- [x] No broken links (no link changes vs pre-#2227)
- [x] No factual regressions (LOC, test counts, ADR counts cross-checked vs CLAUDE.md)
- [x] GraphQL claim not reintroduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)