### PR TITLE
fix(api): keep synced route ack stable

### DIFF
--- a/control-plane-api/src/routers/gateway_internal.py
+++ b/control-plane-api/src/routers/gateway_internal.py
@@ -693,6 +693,31 @@ async def route_sync_ack(
             )
             continue
 
+        desired_generation = (
+            deployment.desired_generation if isinstance(deployment.desired_generation, int) else 1
+        )
+        synced_generation = (
+            deployment.synced_generation if isinstance(deployment.synced_generation, int) else 0
+        )
+
+        if (
+            result.status == "failed"
+            and deployment.sync_status == DeploymentSyncStatus.SYNCED
+            and deployment.last_sync_success is not None
+            and synced_generation >= desired_generation
+        ):
+            logger.info(
+                "route-sync-ack: preserving synced deployment %s after failed re-ack for generation %s",
+                result.deployment_id,
+                result.generation,
+            )
+            if result.generation is not None:
+                deployment.attempted_generation = max(deployment.attempted_generation, result.generation)
+            deployment.last_sync_attempt = now
+            await deploy_repo.update(deployment)
+            processed += 1
+            continue
+
         if result.status == "applied":
             deployment.sync_status = DeploymentSyncStatus.SYNCED
             deployment.last_sync_success = now

--- a/control-plane-api/tests/test_regression_route_sync_ack_stability.py
+++ b/control-plane-api/tests/test_regression_route_sync_ack_stability.py
@@ -1,0 +1,55 @@
+"""Regression tests for route sync ack stability."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+from src.models.gateway_deployment import DeploymentSyncStatus
+from tests.test_gateway_internal import GW_KEY_HEADER, VALID_KEY, _make_deployment
+
+
+def test_regression_route_sync_ack_failed_does_not_downgrade_stable_synced_deployment(client):
+    """A transient failed re-ack must not turn an already applied route red."""
+    last_success = datetime.now(UTC)
+    dep = _make_deployment(
+        sync_status=DeploymentSyncStatus.SYNCED,
+        last_sync_success=last_success,
+        sync_error=None,
+        sync_attempts=0,
+    )
+    dep.desired_generation = 3
+    dep.synced_generation = 3
+    dep.attempted_generation = 3
+
+    with (
+        patch("src.routers.gateway_internal.settings") as mock_settings,
+        patch("src.routers.gateway_internal.GatewayDeploymentRepository") as MockDeployRepo,
+    ):
+        mock_settings.gateway_api_keys_list = [VALID_KEY]
+        mock_deploy_repo = MockDeployRepo.return_value
+        mock_deploy_repo.get_by_id = AsyncMock(return_value=dep)
+        mock_deploy_repo.update = AsyncMock()
+
+        resp = client.post(
+            f"/v1/internal/gateways/{dep.gateway_instance_id}/route-sync-ack",
+            json={
+                "synced_routes": [
+                    {
+                        "deployment_id": str(dep.id),
+                        "status": "failed",
+                        "error": "webmethods rebooting",
+                        "generation": 3,
+                    },
+                ],
+                "sync_timestamp": "2026-03-27T12:00:00Z",
+            },
+            headers={GW_KEY_HEADER: VALID_KEY},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["processed"] == 1
+        assert dep.sync_status == DeploymentSyncStatus.SYNCED
+        assert dep.last_sync_success == last_success
+        assert dep.sync_error is None
+        assert dep.sync_attempts == 0
+        mock_deploy_repo.update.assert_awaited_once()


### PR DESCRIPTION
## Summary
- prevent transient failed route re-acks from downgrading an already synced deployment for the same desired generation
- keep deployment_status independent from gateway connectivity/reboot noise after a route has been acknowledged
- add regression coverage for WebMethods/Connect style reboot re-ack failures

## Validation
- pytest tests/test_gateway_internal.py tests/test_regression_route_sync_ack_stability.py -q
- ruff check src/routers/gateway_internal.py tests/test_gateway_internal.py tests/test_regression_route_sync_ack_stability.py