### PR TITLE
fix: align API deployment workflow contract

### DIFF
--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -42,6 +42,8 @@ on:
 permissions:
   contents: read
   actions: read
+  # reusable-promote verifies GHCR manifests before dispatching GitOps.
+  packages: read
 
 concurrency:
   group: promote-to-prod

--- a/control-plane-ui/src/pages/APIs.test.tsx
+++ b/control-plane-ui/src/pages/APIs.test.tsx
@@ -264,12 +264,23 @@ describe('APIs', () => {
     expect(screen.queryByText('Delete')).not.toBeInTheDocument();
   });
 
-  it('hides Deploy buttons in read-only mode', async () => {
+  it('links writable users to the deployment workflow', async () => {
+    renderAPIs();
+    await screen.findByText('Payment API');
+    const deploymentLinks = screen.getAllByRole('link', { name: 'Deployments' });
+    expect(deploymentLinks[0]).toHaveAttribute(
+      'href',
+      '/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&tenant_id=oasis-gunters'
+    );
+  });
+
+  it('hides deployment workflow links in read-only mode', async () => {
     mockUseEnvironmentMode.mockReturnValue(READ_ONLY_MODE);
     renderAPIs();
     await screen.findByText('Payment API');
     expect(screen.queryByText('Deploy DEV')).not.toBeInTheDocument();
     expect(screen.queryByText('Deploy STG')).not.toBeInTheDocument();
+    expect(screen.queryByText('Deployments')).not.toBeInTheDocument();
   });
 
   // 4-persona coverage

--- a/control-plane-ui/src/pages/APIs.tsx
+++ b/control-plane-ui/src/pages/APIs.tsx
@@ -135,30 +135,51 @@ export function APIs() {
     queryClient.invalidateQueries({ queryKey: ['apis', selectedTenant, activeEnvironment] });
   }, [queryClient, selectedTenant, activeEnvironment]);
 
+  const getDeploymentWorkflowHref = useCallback(
+    (api: { id: string; name: string; tenant_id?: string }) => {
+      const params = new URLSearchParams({
+        api_id: api.id,
+        api_name: api.name,
+        environment: activeEnvironment,
+      });
+      const tenantId = api.tenant_id || (selectedTenant !== ALL_TENANTS ? selectedTenant : '');
+      if (tenantId) {
+        params.set('tenant_id', tenantId);
+      }
+      return `/api-deployments?${params.toString()}`;
+    },
+    [activeEnvironment, selectedTenant]
+  );
+
   // Memoized handlers to prevent unnecessary re-renders
   const handleCreate = useCallback(
-    async (api: APICreate, deployToDev: boolean) => {
+    async (api: APICreate, openDeploymentWorkflow: boolean) => {
       try {
         const wasFirstApi = isFirstApi;
         const created = await apiService.createApi(selectedTenant, api);
 
-        // Auto-deploy to DEV if requested
-        if (deployToDev) {
-          await apiService.createDeployment(selectedTenant, {
-            api_id: created.id,
-            api_name: api.name,
-            environment: 'dev',
-            version: api.version,
-          });
-        }
-
         setShowCreateModal(false);
         invalidateApis();
+
+        if (openDeploymentWorkflow) {
+          navigate(
+            getDeploymentWorkflowHref({
+              id: created.id,
+              name: api.name,
+              tenant_id: selectedTenant !== ALL_TENANTS ? selectedTenant : undefined,
+            })
+          );
+        }
 
         // Celebrate first API creation
         if (wasFirstApi) {
           celebrate();
-          toast.success('Welcome!', 'You created your first API. Explore the Deploy options next.');
+          toast.success(
+            'Welcome!',
+            openDeploymentWorkflow
+              ? 'You created your first API. Complete deployment from the Deployments page.'
+              : 'You created your first API. Explore the Deployments page next.'
+          );
         } else {
           toast.success('API created', `${api.display_name || api.name} has been created`);
         }
@@ -166,7 +187,15 @@ export function APIs() {
         toast.error('Creation failed', err.message || 'Failed to create API');
       }
     },
-    [selectedTenant, isFirstApi, celebrate, toast, invalidateApis]
+    [
+      selectedTenant,
+      isFirstApi,
+      celebrate,
+      toast,
+      invalidateApis,
+      navigate,
+      getDeploymentWorkflowHref,
+    ]
   );
 
   const handleUpdate = useCallback(
@@ -202,27 +231,6 @@ export function APIs() {
       }
     },
     [selectedTenant, confirm, toast, invalidateApis]
-  );
-
-  const handleDeploy = useCallback(
-    async (api: API, environment: 'dev' | 'staging') => {
-      try {
-        await apiService.createDeployment(selectedTenant, {
-          api_id: api.id,
-          api_name: api.name,
-          environment,
-          version: api.version,
-        });
-        toast.success(
-          `Deployment started`,
-          `${api.name} is being deployed to ${environment.toUpperCase()}`
-        );
-        invalidateApis();
-      } catch (err: any) {
-        toast.error('Deployment failed', err.message || 'Failed to deploy API');
-      }
-    },
-    [selectedTenant, toast, invalidateApis]
   );
 
   // Memoized filter clear handler
@@ -439,20 +447,12 @@ export function APIs() {
 
                 <div className="flex flex-wrap gap-3 pt-1">
                   {canDeploy && (
-                    <>
-                      <button
-                        onClick={() => handleDeploy(api, 'dev')}
-                        className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300 text-sm py-1"
-                      >
-                        Deploy DEV
-                      </button>
-                      <button
-                        onClick={() => handleDeploy(api, 'staging')}
-                        className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 text-sm py-1"
-                      >
-                        Deploy STG
-                      </button>
-                    </>
+                    <a
+                      href={getDeploymentWorkflowHref(api)}
+                      className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300 text-sm py-1"
+                    >
+                      Deployments
+                    </a>
                   )}
                   {canEdit && (
                     <button
@@ -574,22 +574,13 @@ export function APIs() {
                     >
                       <div className="flex gap-2">
                         {canDeploy && (
-                          <>
-                            <button
-                              onClick={() => handleDeploy(api, 'dev')}
-                              className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300"
-                              title="Deploy to DEV"
-                            >
-                              Deploy DEV
-                            </button>
-                            <button
-                              onClick={() => handleDeploy(api, 'staging')}
-                              className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-                              title="Deploy to Staging"
-                            >
-                              Deploy STG
-                            </button>
-                          </>
+                          <a
+                            href={getDeploymentWorkflowHref(api)}
+                            className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300"
+                            title="Open deployment workflow"
+                          >
+                            Deployments
+                          </a>
                         )}
                         {canEdit && (
                           <button
@@ -678,7 +669,7 @@ export function APIs() {
 interface APIFormModalProps {
   api?: API;
   onClose: () => void;
-  onSubmit: (data: APICreate, deployToDev: boolean) => Promise<void>;
+  onSubmit: (data: APICreate, openDeploymentWorkflow: boolean) => Promise<void>;
   title: string;
   isEdit?: boolean;
 }
@@ -687,7 +678,7 @@ type CreateMode = 'manual' | 'openapi';
 
 function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalProps) {
   const [mode, setMode] = useState<CreateMode>('manual');
-  const [deployToDev, setDeployToDev] = useState(!isEdit);
+  const [openDeploymentWorkflow, setOpenDeploymentWorkflow] = useState(!isEdit);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formData, setFormData] = useState<APICreate>({
     name: api?.name || '',
@@ -794,7 +785,7 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
 
     setIsSubmitting(true);
     try {
-      await onSubmit(submitData, deployToDev);
+      await onSubmit(submitData, openDeploymentWorkflow);
     } finally {
       setIsSubmitting(false);
     }
@@ -1090,27 +1081,27 @@ paths:
                 </div>
               </div>
 
-              {/* Deploy to DEV checkbox */}
+              {/* Deployment workflow shortcut */}
               {!isEdit && (
                 <div className="flex items-start gap-3 pt-3 border-t dark:border-neutral-700">
                   <div className="flex items-center h-5">
                     <input
                       type="checkbox"
-                      id="deployToDev"
-                      checked={deployToDev}
-                      onChange={(e) => setDeployToDev(e.target.checked)}
+                      id="openDeploymentWorkflow"
+                      checked={openDeploymentWorkflow}
+                      onChange={(e) => setOpenDeploymentWorkflow(e.target.checked)}
                       className="w-4 h-4 text-blue-600 border-neutral-300 rounded focus:ring-blue-500"
                     />
                   </div>
                   <div className="flex-1">
                     <label
-                      htmlFor="deployToDev"
+                      htmlFor="openDeploymentWorkflow"
                       className="text-sm font-medium text-neutral-700 dark:text-neutral-300"
                     >
-                      Deploy to DEV environment
+                      Open deployment workflow after creation
                     </label>
                     <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-                      Automatically deploy this API to the DEV environment after creation.
+                      Choose the target environment and gateway from the dedicated Deployments page.
                     </p>
                   </div>
                 </div>
@@ -1123,7 +1114,11 @@ paths:
               Cancel
             </Button>
             <Button type="submit" loading={isSubmitting}>
-              {isEdit ? 'Update API' : deployToDev ? 'Create & Deploy' : 'Create API'}
+              {isEdit
+                ? 'Update API'
+                : openDeploymentWorkflow
+                  ? 'Create & Open Deployments'
+                  : 'Create API'}
             </Button>
           </div>
         </form>

--- a/control-plane-ui/src/pages/__snapshots__/APIs.test.tsx.snap
+++ b/control-plane-ui/src/pages/__snapshots__/APIs.test.tsx.snap
@@ -4,17 +4,22 @@ exports[`APIs > snapshot: cpi-admin persona > matches structural snapshot 1`] = 
 {
   "buttons": [
     "Create API",
-    "Deploy DEV",
-    "Deploy STG",
     "Edit",
     "Delete",
-    "Deploy DEV",
-    "Deploy STG",
     "Edit",
     "Delete",
   ],
   "headings": [],
-  "links": [],
+  "links": [
+    {
+      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&tenant_id=oasis-gunters",
+      "text": "Deployments",
+    },
+    {
+      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&tenant_id=oasis-gunters",
+      "text": "Deployments",
+    },
+  ],
 }
 `;
 
@@ -22,17 +27,22 @@ exports[`APIs > snapshot: devops persona > matches structural snapshot 1`] = `
 {
   "buttons": [
     "Create API",
-    "Deploy DEV",
-    "Deploy STG",
     "Edit",
     "Delete",
-    "Deploy DEV",
-    "Deploy STG",
     "Edit",
     "Delete",
   ],
   "headings": [],
-  "links": [],
+  "links": [
+    {
+      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&tenant_id=oasis-gunters",
+      "text": "Deployments",
+    },
+    {
+      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&tenant_id=oasis-gunters",
+      "text": "Deployments",
+    },
+  ],
 }
 `;
 
@@ -40,17 +50,22 @@ exports[`APIs > snapshot: tenant-admin persona > matches structural snapshot 1`]
 {
   "buttons": [
     "Create API",
-    "Deploy DEV",
-    "Deploy STG",
     "Edit",
     "Delete",
-    "Deploy DEV",
-    "Deploy STG",
     "Edit",
     "Delete",
   ],
   "headings": [],
-  "links": [],
+  "links": [
+    {
+      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&tenant_id=oasis-gunters",
+      "text": "Deployments",
+    },
+    {
+      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&tenant_id=oasis-gunters",
+      "text": "Deployments",
+    },
+  ],
 }
 `;
 
@@ -58,16 +73,21 @@ exports[`APIs > snapshot: viewer persona > matches structural snapshot 1`] = `
 {
   "buttons": [
     "Create API",
-    "Deploy DEV",
-    "Deploy STG",
     "Edit",
     "Delete",
-    "Deploy DEV",
-    "Deploy STG",
     "Edit",
     "Delete",
   ],
   "headings": [],
-  "links": [],
+  "links": [
+    {
+      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&tenant_id=oasis-gunters",
+      "text": "Deployments",
+    },
+    {
+      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&tenant_id=oasis-gunters",
+      "text": "Deployments",
+    },
+  ],
 }
 `;

--- a/specs/api-deployment-flow.md
+++ b/specs/api-deployment-flow.md
@@ -114,7 +114,32 @@ n'est pas un push CP -> gateway. Pour les chemins dev/demo, `POST /deploy` est
 un raccourci qui crée ou matérialise une intention de desired state; il ne doit
 pas devenir le chemin canonique prod.
 
-## 2.1 Modes gateway supportés
+## 2.1 Propriété des surfaces Console
+
+Le contrat sépare catalogue, runtime et lifecycle. Aucune surface ne doit
+dupliquer une autre avec un vocabulaire différent.
+
+| Surface | Rôle canonique | Actions autorisées | Actions interdites |
+|---------|----------------|--------------------|--------------------|
+| `/apis` | catalogue API, édition du contrat API, publication portail | créer/éditer/supprimer l'API, afficher des badges de statut en lecture seule, ouvrir `/api-deployments` préfiltré sur l'API | déclencher directement un déploiement env -> env, créer un `Deployment` legacy, afficher `Deploy DEV`/`Deploy STG` comme preuve runtime |
+| `/api-deployments` | vérité runtime desired vs observed | choisir env/gateway, matérialiser le raccourci dev/demo, forcer sync, undeploy, afficher statut par gateway et agrégat | masquer le nom de la gateway cible, assimiler health gateway à statut déployé |
+| `/promotions` | lifecycle env -> env | créer/approuver une promotion, générer PR GitOps prod ou refuser sans chemin conforme | marquer `success` sans `GatewayDeployment` + ack runtime |
+
+Règles UX obligatoires:
+- `/apis` ne poste jamais directement vers `createDeployment` pour une action de
+  ligne. Son action navigue vers `/api-deployments` avec au minimum `tenant_id`,
+  `api_id`, `api_name` et l'environnement courant.
+- Le raccourci de création d'API peut ouvrir le workflow de déploiement après la
+  création, mais il ne déploie pas automatiquement en DEV sans sélection des
+  gateways cibles.
+- Les libellés `Deploy DEV` et `Deploy STG` sont interdits sur `/apis`: ils
+  mélangent catalogue et réconciliation runtime et donnent l'impression d'une
+  promotion concurrente à `/api-deployments` ou `/promotions`.
+- Une promotion vers staging/prod est toujours un lifecycle env -> env. Elle ne
+  devient réussie qu'après matérialisation runtime et ack des gateways cibles,
+  conformément aux règles ADF-5 à ADF-7.
+
+## 2.2 Modes gateway supportés
 
 Le contrat de déploiement est commun, mais le transport et la preuve d'ack
 dépendent du mode de gateway. La Console ne doit pas assimiler `online` à
@@ -590,6 +615,20 @@ PASS si:
 FAIL si prod est marqué promoted avec `0` deployment, avec une gateway cross-env,
 ou avec une gateway seulement healthcheckée mais jamais ack.
 
+### ADF-17 — `/apis` délègue au workflow de déploiement
+
+Depuis la page `/apis`, ouvrir l'action de déploiement d'une API.
+
+PASS si:
+- l'utilisateur est envoyé vers `/api-deployments` avec le tenant, l'API et
+  l'environnement courant dans l'URL
+- aucun appel `createDeployment`/`POST /deploy` n'est émis par `/apis`
+- la sélection de gateway et le statut runtime restent gérés par
+  `/api-deployments`
+
+FAIL si `/apis` expose des boutons `Deploy DEV`/`Deploy STG`, déclenche une
+promotion, ou crée un `Deployment` historique sans cible gateway explicite.
+
 Court terme:
 - ajouter un smoke API-level ciblé, par exemple
   `scripts/api-deployment-flow-smoke.sh`
@@ -614,8 +653,8 @@ Critère GO pour toute PR touchant ce flux:
 - ADF-5, ADF-6, ADF-7 passent pour toute PR promotion/assignment/sync
 - ADF-8 passe pour toute PR Console deploy dialog ou environment selector
 - ADF-9 passe pour toute PR rollback/undeploy
-- ADF-14, ADF-15, ADF-16 passent pour toute PR qui touche healthcheck gateway,
-  drift detection, promotion, ou la table `/api-deployments`
+- ADF-14, ADF-15, ADF-16, ADF-17 passent pour toute PR qui touche healthcheck
+  gateway, drift detection, promotion, ou la table `/api-deployments`
 
 ## 6. Blockers connus
 
@@ -631,7 +670,8 @@ Critère GO pour toute PR touchant ce flux:
 | A-B8 | capacité de déploiement gateway non exposée/normalisée (`agent_pull_ack`, `stoa_gateway_registry`, `direct_adapter`) | P0 | ADF-10, ADF-11, ADF-12, ADF-13 |
 | A-B9 | statut de déploiement et healthcheck gateway mélangés dans la Console | P0 | ADF-3, ADF-14, ADF-15 |
 | A-B10 | flow staging/prod insuffisamment contracté côté assignments, promotion et ack | P0 | ADF-5, ADF-6, ADF-13, ADF-16 |
-| A-B11 | spec encore trop `GatewayDeployment`-first si Git/UAC desired state n'est pas vérifié avant matérialisation | P0 | ADF-G1, ADF-G2, ADF-G3, ADF-G4, ADF-G5 |
+| A-B11 | `/apis` recrée un chemin de déploiement parallèle à `/api-deployments` | P0 | ADF-17 |
+| A-B12 | spec encore trop `GatewayDeployment`-first si Git/UAC desired state n'est pas vérifié avant matérialisation | P0 | ADF-G1, ADF-G2, ADF-G3, ADF-G4, ADF-G5 |
 
 ## 7. Révisions
 


### PR DESCRIPTION
## Summary
- grant promote-to-prod access to GHCR package metadata required by reusable promotion
- clarify the API deployment flow contract: /apis is catalog, /api-deployments is runtime truth, /promotions is env lifecycle
- replace direct Deploy DEV/STG actions on /apis with links into the dedicated deployment workflow

## Verification
- npx vitest run src/pages/APIs.test.tsx
- npx vite build