### PR TITLE
fix(ci): verify-stage1 trusts label only, comment fallback removed (CAB-2177)

### DIFF
--- a/.github/actions/verify-stage1/action.yml
+++ b/.github/actions/verify-stage1/action.yml
@@ -1,0 +1,35 @@
+name: 'Verify Stage 1 Council'
+description: >-
+  Confirm Stage 1 Council validation by checking for the
+  `council-validated` label on the issue. CAB-2177 replaces the
+  legacy inline verify-stage1 step that had an unguarded
+  comment-fallback (any prior "Council Score" comment satisfied the
+  gate, even from verdict-gated runs that never applied the label,
+  or after a deliberate label removal in a redo flow). Now the label
+  is the single source of truth, mirroring the freshness pattern
+  CAB-2175 introduced in council-run.
+
+inputs:
+  issue-number:
+    description: 'GitHub issue number to check.'
+    required: true
+  github-token:
+    description: 'GitHub token for `gh issue view` (needs issues:read).'
+    required: true
+
+outputs:
+  validated:
+    description: '"true" if `council-validated` is currently set on the issue, else "false".'
+    value: ${{ steps.check.outputs.validated }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check council-validated label
+      id: check
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+      run: |
+        "${GITHUB_WORKSPACE}/scripts/ci/verify_stage1.sh" "$ISSUE_NUMBER"

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -271,32 +271,20 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - name: Verify Stage 1 Council
-        # Legacy parity: prevent /go on a fresh issue from running Stage
-        # 2 without Stage 1 ever firing. Outputs `validated=true|false`;
-        # downstream operational steps gate on it (no silent exit).
+      - uses: ./.github/actions/verify-stage1
+        # CAB-2177: prevent /go (or workflow_dispatch stage=plan) from
+        # running Stage 2 without a current Stage 1 pass. Outputs
+        # `validated=true|false`; downstream operational steps gate
+        # on it. The composite checks only the `council-validated`
+        # label — the legacy comment-fallback was removed because a
+        # stale Council comment can exist without a corresponding
+        # label apply (verdict-gated, race, manual removal), making
+        # it unreliable evidence whenever the label is currently
+        # absent.
         id: verify-stage1
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ISSUE_NUMBER: ${{ needs.prepare.outputs.number }}
-        run: |
-          set -uo pipefail
-          LABELS=$(gh issue view "$ISSUE_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
-          if echo "$LABELS" | grep -q "council-validated"; then
-            echo "Stage 1 confirmed via label"
-            echo "validated=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # Fallback: scan comments for "Council Score" (legacy behaviour).
-          HAS_COMMENT=$(gh issue view "$ISSUE_NUMBER" --json comments \
-            --jq '[.comments[].body | select(contains("Council Score"))] | length')
-          if [ "${HAS_COMMENT:-0}" -gt 0 ]; then
-            echo "Stage 1 confirmed via comment fallback"
-            echo "validated=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::No Stage 1 Council on this issue — skipping plan validation"
-            echo "validated=false" >> "$GITHUB_OUTPUT"
-          fi
+        with:
+          issue-number: ${{ needs.prepare.outputs.number }}
+          github-token: ${{ github.token }}
 
       - uses: ./.github/actions/label-guard
         id: guard

--- a/scripts/ci/tests/test_regression_cab_2177_verify_stage1_label_only.py
+++ b/scripts/ci/tests/test_regression_cab_2177_verify_stage1_label_only.py
@@ -1,0 +1,176 @@
+"""Regression tests for CAB-2177.
+
+Pre-fix: the inline `Verify Stage 1 Council` step in
+`.github/workflows/claude-issue-to-pr.yml` had a comment-fallback
+that scanned every issue comment for "Council Score" with no
+freshness guard. Any stale Council comment — including one from a
+verdict-gated run that did NOT apply the `council-validated` label,
+or one left behind after a deliberate label removal — satisfied the
+gate and let Stage 2 proceed against stale evidence.
+
+Surfaced during the post-merge §H.2 Smoke 4 attempt for CI-1
+Phase 2d (run 24953872143 on issue #2570): the issue had no
+`council-validated` label but its 2026-04-25T23:57:02Z comment
+from the CAB-2175 pre-fix run satisfied the fallback. Stage 2
+ran for real, applying `plan-validated` against a negative-smoke
+issue.
+
+Post-fix: the comment-fallback is removed. The `council-validated`
+label is the single source of truth, mirroring CAB-2175's
+freshness pattern in `council-run`.
+
+Tests target `scripts/ci/verify_stage1.sh` with subprocess + a
+stubbed `gh` binary on PATH (same harness as
+`test_wait_for_label.py`).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "verify_stage1.sh"
+
+
+def _run_script(
+    args: list[str],
+    tmp_path: Path,
+    *,
+    fake_gh_body: str,
+    env: dict | None = None,
+) -> subprocess.CompletedProcess:
+    """Invoke verify_stage1.sh with a stubbed gh binary.
+
+    Logs every gh invocation's argv to ``$FAKE_GH_LOG`` if set, so
+    tests can assert the script never fetches comments.
+    """
+    fake_gh = tmp_path / "gh"
+    fake_gh.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            if [ -n "${{FAKE_GH_LOG:-}}" ]; then
+                printf '%s\\n' "$*" >> "$FAKE_GH_LOG"
+            fi
+            {fake_gh_body}
+            """
+        )
+    )
+    fake_gh.chmod(0o755)
+
+    full_env = os.environ.copy()
+    full_env["GH"] = str(fake_gh)
+    if env:
+        full_env.update(env)
+
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=full_env,
+        check=False,
+    )
+
+
+def test_label_present_validates(tmp_path):
+    result = _run_script(
+        ["2570"],
+        tmp_path,
+        fake_gh_body='echo "council-validated"; exit 0',
+    )
+    assert result.returncode == 0
+    assert "validated=true" in result.stdout
+    assert "Stage 1 confirmed via council-validated label" in result.stdout
+
+
+def test_label_absent_does_not_validate_and_never_reads_comments(tmp_path):
+    # CAB-2177 regression: an issue with NO `council-validated`
+    # label must NOT validate, regardless of any prior "Council
+    # Score" comment in its history. The script must never fetch
+    # comments — proven by the absence of `comments` in the gh
+    # call log.
+    log = tmp_path / "calls.log"
+    result = _run_script(
+        ["2570"],
+        tmp_path,
+        fake_gh_body='echo ""; exit 0',
+        env={"FAKE_GH_LOG": str(log)},
+    )
+    assert result.returncode == 0
+    assert "validated=false" in result.stdout
+    calls = log.read_text().splitlines()
+    assert calls, "expected at least one gh invocation (the labels lookup)"
+    assert all("comments" not in c for c in calls), (
+        f"verify_stage1 must not fetch comments — got: {calls}"
+    )
+
+
+def test_substring_label_does_not_match(tmp_path):
+    # `council-validated-old` must NOT count as `council-validated`.
+    # Mirrors the strict `grep -Fxq` exact-match used by
+    # `wait_for_label.sh` (Phase 2c parity).
+    result = _run_script(
+        ["2570"],
+        tmp_path,
+        fake_gh_body='echo "council-validated-old"; exit 0',
+    )
+    assert result.returncode == 0
+    assert "validated=false" in result.stdout
+
+
+def test_writes_to_github_output(tmp_path):
+    github_output = tmp_path / "out.txt"
+    github_output.write_text("")
+    result = _run_script(
+        ["2570"],
+        tmp_path,
+        fake_gh_body='printf "bug\\ncouncil-validated\\nfeature\\n"; exit 0',
+        env={"GITHUB_OUTPUT": str(github_output)},
+    )
+    assert result.returncode == 0
+    assert github_output.read_text().strip() == "validated=true"
+
+
+def test_writes_validated_false_to_github_output_when_absent(tmp_path):
+    github_output = tmp_path / "out.txt"
+    github_output.write_text("")
+    result = _run_script(
+        ["2570"],
+        tmp_path,
+        fake_gh_body='echo ""; exit 0',
+        env={"GITHUB_OUTPUT": str(github_output)},
+    )
+    assert result.returncode == 0
+    assert github_output.read_text().strip() == "validated=false"
+
+
+def test_gh_failure_fails_closed(tmp_path):
+    # gh exiting non-zero (auth issue, network, etc.) must NOT
+    # bubble up as Stage 1 valid. Output is validated=false.
+    result = _run_script(
+        ["2570"],
+        tmp_path,
+        fake_gh_body='echo "boom" >&2; exit 4',
+    )
+    assert result.returncode == 0
+    assert "validated=false" in result.stdout
+
+
+def test_missing_arg(tmp_path):
+    result = _run_script([], tmp_path, fake_gh_body="exit 0")
+    assert result.returncode == 2
+    assert "usage" in result.stderr
+
+
+def test_council_validated_among_other_labels_validates(tmp_path):
+    # Real issues carry multiple labels; the council-validated entry
+    # must be detected on its own line via grep -Fxq.
+    result = _run_script(
+        ["2570"],
+        tmp_path,
+        fake_gh_body='printf "claude-implement\\ntype:infra\\ncouncil-validated\\n"; exit 0',
+    )
+    assert result.returncode == 0
+    assert "validated=true" in result.stdout

--- a/scripts/ci/verify_stage1.sh
+++ b/scripts/ci/verify_stage1.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Verify Stage 1 Council validation by checking the council-validated
+# label on a GitHub issue.
+#
+# CAB-2177: replaces the legacy inline verify-stage1 logic in
+# .github/workflows/claude-issue-to-pr.yml (Phase 2d). The legacy
+# version scanned issue comments for "Council Score" without any
+# freshness guard, so any prior Council comment satisfied the gate —
+# including a comment from a verdict-gated run that did NOT apply the
+# label, or a comment left behind after a deliberate label removal
+# (redo flow). Result: stale evidence permanently validated the issue
+# for Stage 2.
+#
+# Mirror of CAB-2175's pattern (freshness guard on council-run): the
+# label is the single source of truth. A Council comment without a
+# corresponding `labeled council-validated` event is stale evidence
+# by definition — Phase 2d's verdict gate ensures comment + label
+# are atomic for valid runs; label removal afterwards is an explicit
+# redo signal.
+#
+# Usage:
+#   verify_stage1.sh <issue-number>
+#
+# Behaviour:
+#   - Calls `gh issue view <issue> --json labels --jq '.labels[].name'`.
+#   - Outputs `validated=true` if `council-validated` is present
+#     (exact match — `council-validated-old` does NOT count), else
+#     `validated=false`.
+#   - Writes the same line to $GITHUB_OUTPUT if set.
+#   - Exit 0 always (gate state is the output value, not the exit
+#     code) except on bad args (exit 2). Failures of `gh` are treated
+#     as fail-closed (validated=false).
+#
+# Test hooks:
+#   GH — path to gh binary (default: gh).
+
+set -uo pipefail
+
+: "${GH:=gh}"
+
+_emit_output() {
+    local value="$1"
+    printf 'validated=%s\n' "$value"
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+        printf 'validated=%s\n' "$value" >> "$GITHUB_OUTPUT"
+    fi
+}
+
+verify_stage1() {
+    local issue_num="${1:-}"
+    if [ -z "$issue_num" ]; then
+        echo "verify_stage1: usage: verify_stage1 <issue-number>" >&2
+        return 2
+    fi
+
+    local labels
+    labels=$("$GH" issue view "$issue_num" --json labels --jq '.labels[].name' 2>/dev/null || true)
+    if printf '%s\n' "$labels" | grep -Fxq "council-validated"; then
+        echo "Stage 1 confirmed via council-validated label on issue ${issue_num}"
+        _emit_output "true"
+        return 0
+    fi
+
+    echo "::notice::No council-validated label on issue ${issue_num} — Stage 2 plan validation skipped (CAB-2177: comment fallback removed; re-run Stage 1 if needed)"
+    _emit_output "false"
+    return 0
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    verify_stage1 "$@"
+    exit $?
+fi


### PR DESCRIPTION
## Summary

Mirror of CAB-2175's freshness pattern, in the `verify-stage1` path. Removes the inline comment-fallback that let stale Council comments perma-validate Stage 2.

Linear: [CAB-2177](https://linear.app/hlfh-workspace/issue/CAB-2177/ci-1-phase-2d-verify-stage1-comment-fallback-has-no-createdat-floor)

## Why

Surfaced during the post-merge §H.2 Smoke 4 attempt for CI-1 Phase 2d ([run 24953872143](https://github.com/stoa-platform/stoa/actions/runs/24953872143)) immediately after CAB-2175 landed.

The inline `Verify Stage 1 Council` step in `.github/workflows/claude-issue-to-pr.yml` (post-Phase-2d, line 274 of `dec89d1e`) had a comment-fallback that scanned every issue comment for `"Council Score"` with **no freshness guard**:

```yaml
if echo "$LABELS" | grep -q "council-validated"; then ... validated=true ...
fi
HAS_COMMENT=$(gh issue view ... --jq '[.comments[].body | select(contains("Council Score"))] | length')
if [ "${HAS_COMMENT:-0}" -gt 0 ]; then ... validated=true ...
fi
```

This fired in three buggy ways:
1. **Verdict-gated comment without label** (the §H.2 Smoke 4 case): Stage 1 ran, posted a Council comment, but the parser couldn't extract a verdict so the verdict gate suppressed label-apply. Comment exists, label doesn't. Fallback wrongly accepted.
2. **Redo flow**: `council-validated` was applied by a Stage 1 pass, then deliberately removed by a human/automation to force re-validation. Old comment still in timeline. Fallback wrongly accepted.
3. **Substring match**: `grep -q "council-validated"` (no `-x`) returned true for `council-validated-old` or any superset label — minor, but a real over-trigger.

In all three, Stage 2 ran for real against stale evidence — `plan-validated` was applied (post-CAB-2175) on an issue that had no current Stage 1 sign-off.

## Fix

The `council-validated` label is the single source of truth. Phase 2d's verdict gate already ensures comment + label are atomic for valid Stage 1 runs, so a Council comment without a current label apply is stale evidence by definition. The legacy fallback is removed; redo / race / verdict-gated states require an explicit Stage 1 re-run.

This is the equivalent freshness guard CAB-2175 introduced for `council-run` (`createdAt >= start-ts`), expressed in the verify-stage1 context where the only correct guard reduces to "trust the label".

## Implementation

- **New** `scripts/ci/verify_stage1.sh` — bash script with `GH=` test hook, mirrors `wait_for_label.sh` (Phase 2c). Strict exact-match via `grep -Fxq "council-validated"`. Outputs `validated=true|false` to stdout and `$GITHUB_OUTPUT`. `gh` failure → fail-closed.
- **New** `.github/actions/verify-stage1/action.yml` — composite that wraps the script. Inputs: `issue-number`, `github-token`. Output: `validated`.
- **Modified** `.github/workflows/claude-issue-to-pr.yml` — replaces the inline `Verify Stage 1 Council` step (26 lines) with `uses: ./.github/actions/verify-stage1` (4 lines + comment). Output reference `steps.verify-stage1.outputs.validated` is preserved (composite output is wired through).
- **New** `scripts/ci/tests/test_regression_cab_2177_verify_stage1_label_only.py` — 8 pytest+subprocess tests with stubbed `gh` binary (same harness as `test_wait_for_label.py`). Asserts the comments path is **never** queried via the gh-call log.

## Local verification

- `pytest scripts/ci/tests/` → **111 passed** (8 new in this regression file, 103 prior).
- `action-validator v0.9.0` on `.github/actions/verify-stage1/action.yml` + the modified workflow → OK.
- `yamllint` on both YAML files → clean.

## Acceptance criteria (from CAB-2177)

- [x] `verify-stage1` no longer returns `validated=true` solely on the basis of a stale "Council Score" comment.
- [x] The fix is consistent with CAB-2175's freshness-guard pattern (label is sole source of truth, justified in workflow comment).
- [x] Regression test covers the §H.2 Smoke 4 failure mode: an issue with a "Council Score" comment but no `council-validated` label currently set must yield `validated=false` — `test_label_absent_does_not_validate_and_never_reads_comments`.
- [ ] Re-run §H.2 Smoke 4 (negative dispatch on a fresh test issue) returns `validated=false` with no Claude call, no labels, no Linear/Slack writes — *post-merge*.
- [ ] §H.2 Smoke 1-3 sequence proceeds cleanly through the standard primary-label path on the fresh test issue — *post-merge*.

## Behaviour change

**Any in-flight issue that currently has a `Council Score` comment but no `council-validated` label will fail Stage 2 advancement until Stage 1 is re-run.** This is the intended posture: the label is what carries Stage 1 state. Issues with the label keep working unchanged. Issue #2570 (currently contaminated) is retained as evidence per agreement, and a fresh test issue will be created post-merge for §H.2 re-run.

## Out of scope

- CAB-2175 is already merged at `dec89d1e` and validated in production; this PR builds on it.
- CAB-2176 (two-layer pause doc) is independent.
- Issue #2570 stays in its current state (contaminated evidence; do not modify).

## Operational state at PR open

- Workflow `claude-issue-to-pr.yml`: `disabled_manually` ✓
- `vars.DISABLE_L1_IMPLEMENT`: `true` ✓
- Other 15 workflows: untouched ✓
- No dispatches ✓

## Test plan (post-merge)

- [ ] Re-enable `claude-issue-to-pr.yml`.
- [ ] Create a **fresh** test issue (no comment history).
- [ ] §H.2 Smoke 4 (negative, `stage=plan`, no labels) → expect `validated=false`, no Claude call, no labels, no Linear/Slack writes. Confirms CAB-2177 fix works.
- [ ] §H.2 Smoke 1 (`stage=council`) → Stage 1 runs, applies `council-validated`.
- [ ] §H.2 Smoke 2 (`stage=plan`) → primary label path validates; Stage 2 runs; applies `plan-validated`.
- [ ] §H.2 Smoke 3 (`stage=implement`) → Stage 3 runs; PR created (close without merge).
- [ ] Re-disable workflow if §H.3 not authorized in same window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)