### PR TITLE
fix(ui): make API deployment workflow visible

### DIFF
--- a/control-plane-ui/src/__tests__/regression/CAB-2575-deployment-deep-link.test.tsx
+++ b/control-plane-ui/src/__tests__/regression/CAB-2575-deployment-deep-link.test.tsx
@@ -1,12 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
 import { createAuthMock, renderWithProviders } from '../../test/helpers';
 import { useAuth } from '../../contexts/AuthContext';
+import { ApiDeploymentsDashboard } from '../../pages/ApiDeployments/ApiDeploymentsDashboard';
 
 vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
 
 const envMock = vi.hoisted(() => ({
-  activeEnvironment: 'prod',
+  activeEnvironment: 'dev',
   switchEnvironment: vi.fn(),
 }));
 
@@ -45,7 +46,7 @@ vi.mock('../../services/api', () => ({
   },
 }));
 
-vi.mock('../GatewayDeployments/DeployAPIDialog', () => ({
+vi.mock('../../pages/GatewayDeployments/DeployAPIDialog', () => ({
   DeployAPIDialog: (props: { preselectedApiKey?: string; preselectedEnvironment?: string }) => {
     mockDeployDialog(props);
     return <div data-testid="deploy-dialog">Deploy Dialog</div>;
@@ -84,12 +85,10 @@ vi.mock('@stoa/shared/components/StatCard', () => ({
   ),
 }));
 
-import { ApiDeploymentsDashboard } from './ApiDeploymentsDashboard';
-
-describe('ApiDeploymentsDashboard', () => {
+describe('regression/CAB-2575', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    envMock.activeEnvironment = 'prod';
+    envMock.activeEnvironment = 'dev';
     vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
     mockGetGatewayDeployments.mockResolvedValue({ items: [], total: 0 });
     mockGetDeploymentStatusSummary.mockResolvedValue({
@@ -101,46 +100,15 @@ describe('ApiDeploymentsDashboard', () => {
       deleting: 0,
       total: 0,
     });
-    mockDeployDialog.mockClear();
   });
 
-  it('uses the global environment as the default runtime filter', async () => {
-    renderWithProviders(<ApiDeploymentsDashboard />);
-
-    await waitFor(() => {
-      expect(mockGetGatewayDeployments).toHaveBeenCalledWith({
-        page: 1,
-        page_size: 20,
-        environment: 'production',
-      });
-    });
-  });
-
-  it('keeps the page filter and global environment selector in sync', async () => {
-    renderWithProviders(<ApiDeploymentsDashboard />);
-
-    fireEvent.change(await screen.findByDisplayValue('Production'), {
-      target: { value: 'staging' },
-    });
-
-    expect(envMock.switchEnvironment).toHaveBeenCalledWith('staging');
-    await waitFor(() => {
-      expect(mockGetGatewayDeployments).toHaveBeenCalledWith({
-        page: 1,
-        page_size: 20,
-        environment: 'staging',
-      });
-    });
-  });
-
-  it('opens the deployment workflow prefilled from /apis query params', async () => {
+  it('opens /api-deployments as a prefilled deployment workflow from the API catalog', async () => {
     renderWithProviders(<ApiDeploymentsDashboard />, {
       route:
         '/api-deployments?api_id=api-1&api_name=payment-api&environment=staging&open_deploy=true&tenant_id=oasis-gunters',
     });
 
     expect(await screen.findByTestId('deploy-dialog')).toBeInTheDocument();
-    expect(screen.getByText(/Deployment workflow loaded for/)).toBeInTheDocument();
     expect(mockDeployDialog).toHaveBeenCalledWith(
       expect.objectContaining({
         preselectedApiKey: 'oasis-gunters:payment-api',
@@ -149,40 +117,9 @@ describe('ApiDeploymentsDashboard', () => {
     );
     expect(envMock.switchEnvironment).toHaveBeenCalledWith('staging');
     await waitFor(() => {
-      expect(mockGetGatewayDeployments).toHaveBeenCalledWith({
-        page: 1,
-        page_size: 20,
-        environment: 'staging',
-      });
+      expect(mockGetGatewayDeployments).toHaveBeenCalledWith(
+        expect.objectContaining({ environment: 'staging' })
+      );
     });
-  });
-
-  it('renders runtime sync status and last sync from GatewayDeployment fields', async () => {
-    mockGetGatewayDeployments.mockResolvedValue({
-      items: [
-        {
-          id: 'dep-1',
-          api_catalog_id: 'api-1',
-          gateway_instance_id: 'gw-1',
-          desired_state: { api_name: 'Payments' },
-          desired_at: '2026-04-25T10:00:00Z',
-          actual_state: { api_name: 'Payments' },
-          sync_status: 'synced',
-          last_sync_success: '2026-04-25T10:01:00Z',
-          sync_attempts: 1,
-          created_at: '2026-04-25T10:00:00Z',
-          updated_at: '2026-04-25T10:01:00Z',
-          gateway_name: 'stoa-prod',
-          gateway_environment: 'production',
-        },
-      ],
-      total: 1,
-    });
-
-    renderWithProviders(<ApiDeploymentsDashboard />);
-
-    expect(await screen.findByText('Payments')).toBeInTheDocument();
-    expect(screen.getByText('synced')).toBeInTheDocument();
-    expect(screen.getByText(/2026/)).toBeInTheDocument();
   });
 });

--- a/control-plane-ui/src/pages/APIs.test.tsx
+++ b/control-plane-ui/src/pages/APIs.test.tsx
@@ -267,10 +267,10 @@ describe('APIs', () => {
   it('links writable users to the deployment workflow', async () => {
     renderAPIs();
     await screen.findByText('Payment API');
-    const deploymentLinks = screen.getAllByRole('link', { name: 'Deployments' });
+    const deploymentLinks = screen.getAllByRole('link', { name: 'Open Deployments' });
     expect(deploymentLinks[0]).toHaveAttribute(
       'href',
-      '/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&tenant_id=oasis-gunters'
+      '/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters'
     );
   });
 
@@ -280,7 +280,7 @@ describe('APIs', () => {
     await screen.findByText('Payment API');
     expect(screen.queryByText('Deploy DEV')).not.toBeInTheDocument();
     expect(screen.queryByText('Deploy STG')).not.toBeInTheDocument();
-    expect(screen.queryByText('Deployments')).not.toBeInTheDocument();
+    expect(screen.queryByText('Open Deployments')).not.toBeInTheDocument();
   });
 
   // 4-persona coverage

--- a/control-plane-ui/src/pages/APIs.tsx
+++ b/control-plane-ui/src/pages/APIs.tsx
@@ -141,6 +141,7 @@ export function APIs() {
         api_id: api.id,
         api_name: api.name,
         environment: activeEnvironment,
+        open_deploy: 'true',
       });
       const tenantId = api.tenant_id || (selectedTenant !== ALL_TENANTS ? selectedTenant : '');
       if (tenantId) {
@@ -451,7 +452,7 @@ export function APIs() {
                       href={getDeploymentWorkflowHref(api)}
                       className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300 text-sm py-1"
                     >
-                      Deployments
+                      Open Deployments
                     </a>
                   )}
                   {canEdit && (
@@ -579,7 +580,7 @@ export function APIs() {
                             className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300"
                             title="Open deployment workflow"
                           >
-                            Deployments
+                            Open Deployments
                           </a>
                         )}
                         {canEdit && (

--- a/control-plane-ui/src/pages/ApiDeployments/ApiDeploymentsDashboard.tsx
+++ b/control-plane-ui/src/pages/ApiDeployments/ApiDeploymentsDashboard.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { RefreshCw, Plus, Trash2, RotateCcw } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { useEnvironment } from '../../contexts/EnvironmentContext';
@@ -61,7 +62,16 @@ function canonicalSortValue(env: CanonicalEnvironment): number {
 export function ApiDeploymentsDashboard() {
   const { isReady } = useAuth();
   const { activeEnvironment, environments, switchEnvironment } = useEnvironment();
+  const [searchParams, setSearchParams] = useSearchParams();
   const toast = useToastActions();
+  const preselectedTenantId = searchParams.get('tenant_id') || '';
+  const preselectedApiName = searchParams.get('api_name') || '';
+  const preselectedEnvironment = searchParams.get('environment') || '';
+  const shouldOpenDeployWorkflow = searchParams.get('open_deploy') === 'true';
+  const preselectedApiKey =
+    preselectedTenantId && preselectedApiName
+      ? `${preselectedTenantId}:${preselectedApiName}`
+      : undefined;
   const [confirm, ConfirmDialog] = useConfirm();
   const [deployments, setDeployments] = useState<GatewayDeployment[]>([]);
   const [summary, setSummary] = useState<Schemas['DeploymentStatusSummary'] | null>(null);
@@ -73,7 +83,9 @@ export function ApiDeploymentsDashboard() {
   );
   const [currentPage, setCurrentPage] = useState(1);
   const [total, setTotal] = useState(0);
-  const [showDeployDialog, setShowDeployDialog] = useState(false);
+  const [showDeployDialog, setShowDeployDialog] = useState(
+    shouldOpenDeployWorkflow && !!preselectedApiKey
+  );
   const [selectedDeployment, setSelectedDeployment] = useState<GatewayDeployment | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const latestLoadRef = useRef(0);
@@ -100,6 +112,29 @@ export function ApiDeploymentsDashboard() {
     setEnvFilter(toApiEnvironment(activeEnvironment));
     setCurrentPage(1);
   }, [activeEnvironment]);
+
+  useEffect(() => {
+    if (!preselectedEnvironment) return;
+    const nextEnv = toApiEnvironment(preselectedEnvironment);
+    setEnvFilter(nextEnv);
+    setCurrentPage(1);
+    switchEnvironment(toContextEnvironment(nextEnv));
+  }, [preselectedEnvironment, switchEnvironment]);
+
+  useEffect(() => {
+    if (shouldOpenDeployWorkflow && preselectedApiKey) {
+      setShowDeployDialog(true);
+    }
+  }, [preselectedApiKey, shouldOpenDeployWorkflow]);
+
+  const closeDeployDialog = useCallback(() => {
+    setShowDeployDialog(false);
+    if (shouldOpenDeployWorkflow) {
+      const nextParams = new URLSearchParams(searchParams);
+      nextParams.delete('open_deploy');
+      setSearchParams(nextParams, { replace: true });
+    }
+  }, [searchParams, setSearchParams, shouldOpenDeployWorkflow]);
 
   const loadData = useCallback(async () => {
     const requestId = latestLoadRef.current + 1;
@@ -262,6 +297,15 @@ export function ApiDeploymentsDashboard() {
         </select>
       </div>
 
+      {/* Deep-link context */}
+      {preselectedApiKey && (
+        <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-200">
+          Deployment workflow loaded for <span className="font-semibold">{preselectedApiName}</span>
+          {preselectedEnvironment ? ` in ${getEnvLabel(preselectedEnvironment)}` : ''}. Select the
+          target gateways from this page.
+        </div>
+      )}
+
       {/* Error */}
       {error && (
         <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 px-4 py-3 rounded-lg text-sm">
@@ -389,12 +433,14 @@ export function ApiDeploymentsDashboard() {
       {/* Deploy Dialog */}
       {showDeployDialog && (
         <DeployAPIDialog
-          onClose={() => setShowDeployDialog(false)}
+          onClose={closeDeployDialog}
           onDeployed={() => {
-            setShowDeployDialog(false);
+            closeDeployDialog();
             loadData();
             toast.success('Deployment initiated');
           }}
+          preselectedApiKey={preselectedApiKey}
+          preselectedEnvironment={preselectedEnvironment}
         />
       )}
 

--- a/control-plane-ui/src/pages/GatewayDeployments/DeployAPIDialog.tsx
+++ b/control-plane-ui/src/pages/GatewayDeployments/DeployAPIDialog.tsx
@@ -33,13 +33,20 @@ interface DeployAPIDialogProps {
   onDeployed: () => void;
   /** Pre-select an API (from API Detail page). Format: "tenantId:apiName" */
   preselectedApiKey?: string;
+  /** Pre-select the target environment when opening from the API catalog. */
+  preselectedEnvironment?: string;
 }
 
 function sameEnvironment(left: string, right: string): boolean {
   return normalizeEnvironment(left) === normalizeEnvironment(right);
 }
 
-export function DeployAPIDialog({ onClose, onDeployed, preselectedApiKey }: DeployAPIDialogProps) {
+export function DeployAPIDialog({
+  onClose,
+  onDeployed,
+  preselectedApiKey,
+  preselectedEnvironment,
+}: DeployAPIDialogProps) {
   const [tenants, setTenants] = useState<Tenant[]>([]);
   const [selectedTenant, setSelectedTenant] = useState('');
   const [apis, setApis] = useState<API[]>([]);
@@ -134,8 +141,17 @@ export function DeployAPIDialog({ onClose, onDeployed, preselectedApiKey }: Depl
       .getDeployableEnvironments(selectedTenant, selectedApi)
       .then((result) => {
         setDeployableEnvs(result.environments);
+        const requestedEnv = preselectedEnvironment
+          ? result.environments.find(
+              (env) => env.deployable && sameEnvironment(env.environment, preselectedEnvironment)
+            )
+          : undefined;
         const firstDeployable = result.environments.find((e) => e.deployable);
-        if (firstDeployable) setSelectedEnv(firstDeployable.environment);
+        if (requestedEnv) {
+          setSelectedEnv(requestedEnv.environment);
+        } else if (firstDeployable) {
+          setSelectedEnv(firstDeployable.environment);
+        }
       })
       .catch(() => {
         // If API not in catalog yet, dev is always deployable
@@ -144,10 +160,14 @@ export function DeployAPIDialog({ onClose, onDeployed, preselectedApiKey }: Depl
           { environment: 'staging', deployable: false, promotion_status: 'not_promoted' },
           { environment: 'production', deployable: false, promotion_status: 'not_promoted' },
         ]);
-        setSelectedEnv('dev');
+        setSelectedEnv(
+          preselectedEnvironment && sameEnvironment(preselectedEnvironment, 'dev')
+            ? preselectedEnvironment
+            : 'dev'
+        );
       })
       .finally(() => setLoadingEnvs(false));
-  }, [selectedApi, selectedTenant]);
+  }, [selectedApi, selectedTenant, preselectedEnvironment]);
 
   // Load existing deployments when env changes
   useEffect(() => {

--- a/control-plane-ui/src/pages/__snapshots__/APIs.test.tsx.snap
+++ b/control-plane-ui/src/pages/__snapshots__/APIs.test.tsx.snap
@@ -12,12 +12,12 @@ exports[`APIs > snapshot: cpi-admin persona > matches structural snapshot 1`] = 
   "headings": [],
   "links": [
     {
-      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&tenant_id=oasis-gunters",
-      "text": "Deployments",
+      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
+      "text": "Open Deployments",
     },
     {
-      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&tenant_id=oasis-gunters",
-      "text": "Deployments",
+      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
+      "text": "Open Deployments",
     },
   ],
 }
@@ -35,12 +35,12 @@ exports[`APIs > snapshot: devops persona > matches structural snapshot 1`] = `
   "headings": [],
   "links": [
     {
-      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&tenant_id=oasis-gunters",
-      "text": "Deployments",
+      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
+      "text": "Open Deployments",
     },
     {
-      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&tenant_id=oasis-gunters",
-      "text": "Deployments",
+      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
+      "text": "Open Deployments",
     },
   ],
 }
@@ -58,12 +58,12 @@ exports[`APIs > snapshot: tenant-admin persona > matches structural snapshot 1`]
   "headings": [],
   "links": [
     {
-      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&tenant_id=oasis-gunters",
-      "text": "Deployments",
+      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
+      "text": "Open Deployments",
     },
     {
-      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&tenant_id=oasis-gunters",
-      "text": "Deployments",
+      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
+      "text": "Open Deployments",
     },
   ],
 }
@@ -81,12 +81,12 @@ exports[`APIs > snapshot: viewer persona > matches structural snapshot 1`] = `
   "headings": [],
   "links": [
     {
-      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&tenant_id=oasis-gunters",
-      "text": "Deployments",
+      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
+      "text": "Open Deployments",
     },
     {
-      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&tenant_id=oasis-gunters",
-      "text": "Deployments",
+      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
+      "text": "Open Deployments",
     },
   ],
 }


### PR DESCRIPTION
## Summary
- make /apis links explicitly open the deployment workflow
- pass API, tenant, and environment query params into /api-deployments
- auto-open the deployment dialog with preselected API/environment when launched from /apis

## Tests
- npx vitest run src/pages/APIs.test.tsx src/pages/ApiDeployments/ApiDeploymentsDashboard.test.tsx src/pages/GatewayDeployments/DeployAPIDialog.test.tsx
- npx vite build