### PR TITLE
ci(e2e): disable visual regression on PR until mock auth is fixed (CAB-2178)

### DIFF
--- a/.github/workflows/e2e-visual-regression.yml
+++ b/.github/workflows/e2e-visual-regression.yml
@@ -4,24 +4,30 @@
 # Compares Console + Portal screenshots against golden baselines.
 # Runs in Playwright Docker container for pixel-consistent rendering.
 # No live backend required (mocked API responses).
+#
+# DISABLED on pull_request — see CAB-2178 (2026-04-26).
+#
+# Why:
+#   The mock auth path in `e2e/smoke-mock/mock-routes.ts` does not actually
+#   authenticate cp-ui / portal at boot. Every route renders the React error
+#   boundary ("Something went wrong"), so all goldens captured via this config
+#   are screenshots of that same error screen. CI therefore reports either
+#   ~83% pixel diff (placeholder goldens, since CAB-1994 / 2026-04-05) or a
+#   fake-green pass against an error-boundary baseline.
+#
+# Re-enable when:
+#   1. Mock OIDC client init is fixed so cp-ui + portal render real pages
+#   2. Goldens are regenerated under that path (mcr.microsoft.com/playwright:
+#      v1.58.2-jammy with --update-snapshots)
+#   3. MD5s of regenerated goldens are distinct per page (sanity check)
+#
+# To run manually in the meantime: `gh workflow run e2e-visual-regression.yml`
 # =============================================================================
 
 name: E2E Visual Regression
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'control-plane-ui/**'
-      - 'portal/**'
-      - 'shared/**'
-      - 'e2e/visual/**'
-      - 'e2e/golden/**'
-      - '.github/workflows/e2e-visual-regression.yml'
-      - '!control-plane-ui/**/*.md'
-      - '!portal/**/*.md'
-      - '!shared/**/*.md'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

- Switches `e2e-visual-regression.yml` trigger from `pull_request` to `workflow_dispatch` only — stops the red/fake-green noise on every UI PR while [CAB-2178](https://linear.app/hlfh-workspace/issue/CAB-2178/repair-e2e-visual-regression-mock-auth-bypass-regen-real-goldens) repairs the mock auth path and regenerates real goldens.
- Keeps the job runnable on demand: `gh workflow run e2e-visual-regression.yml`.

## Why

The suite has been broken since CAB-1994 (2026-04-05). Verified today by regenerating goldens via `mcr.microsoft.com/playwright:v1.58.2-jammy --update-snapshots`:

```
console-visual/{dashboard,tenants,gateways}.png  → all MD5 874e2c7a…
portal-visual/{home,subscriptions}.png           → both MD5 8bf2cd41…
```

All identical. Reading any of the PNGs shows the React error boundary ("Something went wrong / Try Again / Go Home"). The mock OIDC path in `e2e/smoke-mock/mock-routes.ts` does not actually authenticate cp-ui or portal — every protected route lands on the same error screen.

CI behaviour today on UI PRs: `~83% pixel diff` (placeholder goldens vs real error boundary) → red. CI behaviour if I had shipped fresh goldens: green vs same error boundary → fake-green badge that tests nothing.

The honest move is to disable until the mock is fixed, which is what this PR does.

## Scope

- Single file: `.github/workflows/e2e-visual-regression.yml`
- `on:` block changed; preamble comment expanded with the diagnosis and a re-enable checklist
- No code changes, no goldens touched

## Test plan

- [ ] Required checks (License Compliance, SBOM, Verify Signed Commits, Regression Test Guard) green
- [ ] Visual Regression no longer appears on the PR check rollup once merged (only `workflow_dispatch`)
- [ ] CAB-2178 owns the actual repair work

## Refs

- Closes the noise; tracker: CAB-2178
- Original (broken) baseline: CAB-1994 / PR #2211 (2026-04-05)

🤖 Generated with [Claude Code](https://claude.com/claude-code)