### PR TITLE
docs(uac): document specs hierarchy and LLM-ready examples scaffold

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,33 @@
+# `specs/` — Index technique
+
+Ce dossier contient les **spécifications structurantes** du projet STOA :
+contrats produit (UAC), périmètre démo, règles d'architecture, garde-fous
+de rewrite, et contrats inter-composants.
+
+> Audience : développeurs internes STOA.
+> Pour la vitrine produit (pitch, quickstart, architecture publique),
+> voir le [`README.md`](../README.md) à la racine du repo.
+> Pour la documentation utilisateur, voir [docs.gostoa.dev](https://docs.gostoa.dev).
+
+## Inventaire
+
+| Fichier | Rôle | Statut |
+|---|---|---|
+| [`uac/`](./uac/) | Contrat produit canonique (UAC v1) — schémas, doctrine, exemples | Référence |
+| [`demo-scope.md`](./demo-scope.md) | Périmètre minimal exécutable de la démo (5 étapes non négociables) | Figé |
+| [`client-prospect-demo-scope.md`](./client-prospect-demo-scope.md) | Parcours commercial client/prospect | Figé |
+| [`demo-acceptance-tests.md`](./demo-acceptance-tests.md) | Tests d'acceptation de la démo | Figé |
+| [`demo-readiness-report.md`](./demo-readiness-report.md) | Rapport de readiness démo | Suivi |
+| [`api-runtime-reconciliation-contract.md`](./api-runtime-reconciliation-contract.md) | Contrat de réconciliation runtime (Console `/api-deployments`) | Référence |
+| [`gateway-topology-normalization.md`](./gateway-topology-normalization.md) | Normalisation de la topologie gateway | Référence |
+| [`gateway-sidecar-contract.md`](./gateway-sidecar-contract.md) | Contrat sidecar gateway | Référence |
+| [`architecture-rules.md`](./architecture-rules.md) | Règles d'architecture transverses | Référence |
+| [`rewrite-guardrails.md`](./rewrite-guardrails.md) | Garde-fous applicables pendant le rewrite | Actif |
+| [`validation-commands.md`](./validation-commands.md) | Commandes de validation locales/CI | Référence |
+
+## Conventions
+
+- **Une spec = un sujet**. Pas de spec "fourre-tout".
+- **Statuts** : *Figé* (ne change pas sans décision écrite), *Actif* (vivant, suivi en cycle), *Référence* (mis à jour à la demande), *Suivi* (rapport périodique).
+- **Toute spec démo renvoie à `demo-scope.md`** comme source de vérité.
+- **Les ADR vivent dans `stoa-docs`** (pas ici). Cf. [stoa-docs/docs/architecture/adr/](https://github.com/stoa-platform/stoa-docs/tree/main/docs/architecture/adr).

--- a/specs/uac/README.md
+++ b/specs/uac/README.md
@@ -1,0 +1,78 @@
+# UAC — Universal API Contract
+
+> **Audience** : développeurs STOA écrivant ou modifiant un contrat UAC.
+> Pour le corpus pédagogique destiné aux agents/LLMs, voir [`examples/`](./examples/).
+
+## Doctrine
+
+Règle canonique (ADR-067) :
+
+```
+UAC describes.
+MCP projects.
+Smoke proves.
+```
+
+- **UAC est le contrat produit primaire.** Toute opération exposée à un agent
+  doit être attachée à un contrat UAC ou à un flow contract.
+- **Les MCP tools sont des projections** d'opérations UAC. Elles ne se déclarent
+  pas indépendamment.
+- **La metadata LLM est endpoint-level**, pas contract-level. Chaque endpoint
+  exposé à un agent porte son propre bloc `endpoint.llm`.
+- **Règle dure** : `side_effects = "destructive"` ⇒ `requires_human_approval = true`.
+  Le validator rejette l'inverse.
+
+## Schéma
+
+| Source | Chemin |
+|---|---|
+| JSON Schema canonique | [`../../control-plane-api/src/schemas/uac_contract_v1_schema.json`](../../control-plane-api/src/schemas/uac_contract_v1_schema.json) |
+| Pydantic (cp-api) | [`../../control-plane-api/src/schemas/uac.py`](../../control-plane-api/src/schemas/uac.py) |
+| Rust (gateway, parité) | [`../../stoa-gateway/src/uac/schema.rs`](../../stoa-gateway/src/uac/schema.rs) |
+| Validator sémantique | [`../../control-plane-api/src/services/uac_validator.py`](../../control-plane-api/src/services/uac_validator.py) |
+
+La parité cross-langage est enforced par le JSON Schema. Toute évolution doit
+toucher les trois représentations dans la même PR.
+
+## Bloc `endpoint.llm` (V1)
+
+Champs requis lorsque le bloc est présent :
+
+| Champ | Type | Description |
+|---|---|---|
+| `summary` | string | Résumé court orienté humain. |
+| `intent` | string | Quand un agent doit utiliser cet endpoint. |
+| `tool_name` | string | Nom MCP stable, unique dans le contrat. |
+| `side_effects` | enum | `none` \| `read` \| `write` \| `destructive`. |
+| `safe_for_agents` | bool | Un agent autonome peut-il l'appeler ? |
+| `requires_human_approval` | bool | Approbation humaine requise avant invocation. |
+| `examples[]` | list (≥1) | Exemples `{ input, expected_output_contains? }`. |
+
+### Statut V1 vs V2
+
+- **V1 (actuel)** : metadata absente = *warning*. Metadata malformée = *erreur*.
+- **V2 (cible)** : tout nouvel endpoint MCP-exposé doit être LLM-ready avant merge.
+  Champs additionnels prévus (non normatifs aujourd'hui) : `do_not_use_when`,
+  `permissions`, `rate_limit_policy`, `approval_policy`, `test_generation_hints`.
+
+## Écrire un contrat
+
+1. Partir d'un endpoint réel (path, méthode, backend).
+2. Écrire `input_schema` / `output_schema` (JSON Schema strict, `additionalProperties: false` par défaut).
+3. Si l'endpoint est destiné à un agent, ajouter le bloc `endpoint.llm` complet.
+4. Choisir la classification (`H` / `VH` / `VVH`) en fonction du risque ICT (DORA).
+5. Valider localement : le contrat doit charger sans erreur via le validator cp-api.
+
+## Exemple minimal de référence
+
+[`demo-httpbin.uac.json`](./demo-httpbin.uac.json) — contrat consommé par le
+smoke démo (`scripts/demo-smoke-test.sh`).
+
+> **Note** : ce contrat n'expose pas encore de bloc `endpoint.llm`. Il sert à
+> prouver le chemin REST minimal. Les exemples LLM-ready vivront dans
+> [`examples/`](./examples/) (PR suivante).
+
+## Voir aussi
+
+- [`specs/demo-scope.md`](../demo-scope.md) — où ce contrat est consommé.
+- `.claude/docs/uac-llm-ready.md` — checklist détaillée et notes V2.

--- a/specs/uac/examples/README.md
+++ b/specs/uac/examples/README.md
@@ -1,0 +1,82 @@
+# UAC Examples — Corpus d'apprentissage LLM
+
+> Ce dossier n'est pas un index. C'est un **corpus pédagogique** destiné aux
+> agents et aux LLMs qui scannent le repo pour apprendre les patterns UAC
+> acceptables sans avoir à être rebriefés à chaque session.
+
+## Pourquoi un corpus, pas une doc ?
+
+La doctrine UAC vit dans [`../README.md`](../README.md) et dans le schéma. Ce
+dossier joue un rôle différent : fournir des **contrats complets, validés,
+annotés** qui montrent comment la doctrine s'applique sur des cas concrets.
+
+Un agent qui découvre STOA doit pouvoir, en lisant ce dossier, répondre seul à :
+
+- Quand mettre `side_effects: "read"` plutôt que `"none"` ?
+- Pourquoi cet endpoint est `safe_for_agents: false` alors qu'il ne mute rien ?
+- À quoi ressemble un `intent` utile vs un `intent` qui répète juste le path ?
+- Quel niveau de détail attendre dans `examples[]` ?
+
+## Format attendu pour chaque exemple
+
+Chaque exemple est composé de **deux fichiers** :
+
+```
+NN-<slug>.uac.json    # contrat UAC complet, valide, exécutable
+NN-<slug>.md          # rationale annotée, lue par humains et agents
+```
+
+Le `.md` n'est pas une description du `.json` — le schéma le fait déjà. Il
+explique les **choix** : pourquoi cette valeur de `side_effects`, pourquoi
+ce nombre d'`examples`, quels anti-patterns ont été évités.
+
+### Squelette du `.md` annoté
+
+```markdown
+# NN — <titre>
+
+**Cas d'usage** : <situation concrète où ce pattern s'applique>.
+
+## Choix structurants
+
+- `side_effects: <valeur>` — *parce que* …
+- `safe_for_agents: <bool>` — *parce que* …
+- `requires_human_approval: <bool>` — *parce que* …
+
+## Pourquoi ces `examples[]`
+
+- Exemple 1 couvre <happy path / cas limite>.
+- Exemple 2 couvre <erreur attendue / edge case>.
+
+## Anti-patterns évités
+
+- Ne pas <…> : <conséquence concrète>.
+```
+
+## Exemples planifiés (PR suivante)
+
+| Slug | Cas | Side effects | Approval |
+|---|---|---|---|
+| `01-read-only` | GET idempotent, lecture catalogue | `read` | `false` |
+| `02-write-mutating` | POST création de ressource non-critique | `write` | `false` |
+| `03-destructive` | DELETE ressource critique | `destructive` | `true` (forcé) |
+| `04-flow-multistep` | Enchaînement d'opérations cohérent (flow contract) | mixte | mixte |
+
+> Cette table fixe le périmètre du corpus initial. Tout ajout au-delà passe par
+> une décision écrite (Council ou ADR), pour éviter que ce dossier ne devienne
+> un dépôt fourre-tout.
+
+## Garde-fous
+
+- **Validés** : chaque `.json` doit charger sans erreur via le validator cp-api
+  ([`uac_validator.py`](../../../control-plane-api/src/services/uac_validator.py)).
+  Un exemple cassé est pire qu'un exemple absent — il enseigne du faux.
+- **Stables** : ces contrats sont des références. Toute modification doit
+  préserver la pédagogie ; sinon créer un nouveau slug numéroté.
+- **Pas de PII, pas de secrets** : examples synthétiques uniquement.
+
+## Voir aussi
+
+- [`../README.md`](../README.md) — doctrine UAC.
+- [`../../../control-plane-api/src/schemas/uac.py`](../../../control-plane-api/src/schemas/uac.py) — schéma autoritatif.
+- ADR-067 (stoa-docs) — *UAC describes. MCP projects. Smoke proves.*


### PR DESCRIPTION
## Summary

- Adds three structuring READMEs to `specs/` clarifying the hierarchy:
  - `specs/README.md` — technical index for STOA devs (audience: humans, internal)
  - `specs/uac/README.md` — UAC doctrine for contract authors (ADR-067, V1 vs V2)
  - `specs/uac/examples/README.md` — pedagogical corpus format for LLMs/agents
- No code, no schema, no validator change. Pure docs scaffolding.
- The `examples/` README defines the expected pattern (paired `.uac.json` + annotated `.md`) and lists the four planned examples (read-only / write / destructive / flow). Actual JSON examples land in a follow-up PR to keep doctrine and contracts separate.

## Why now

`specs/` had no README and the UAC doctrine was scattered across `CLAUDE.md`, `.claude/docs/uac-llm-ready.md`, and the schema. A reader (human or agent) discovering the repo had no entry point to understand "what is UAC, where does it live, how do I add an example".

This PR establishes the structure without touching the schema or validator (deliberate scope split — UAC V2 implementation comes later).

## Audience separation

| File | Audience |
|---|---|
| Repo root `README.md` | Marketing / public / GitHub visitors |
| `specs/README.md` | STOA devs (internal) |
| `specs/uac/README.md` | Contract authors |
| `specs/uac/examples/README.md` | LLMs / agents scanning the repo |

## Test plan

- [ ] CI passes (License Compliance, SBOM, Signed Commits, Regression Test Guard)
- [ ] Markdown links resolve (relative paths)
- [ ] No schema or behavior change to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)