### PR TITLE
docs(uac): add four canonical LLM-ready contract examples

### DIFF
--- a/specs/uac/examples/01-read-only.md
+++ b/specs/uac/examples/01-read-only.md
@@ -1,0 +1,20 @@
+# 01 — Read-only
+
+**Cas d'usage** : un agent doit lire l'état d'une ressource connue. GET idempotent, sans mutation.
+
+## Choix structurants
+
+- `side_effects: "read"` — *parce que* l'opération lit un état existant. `none` est réservé aux endpoints qui ne touchent pas l'API métier (ex: health, version) ; `read` documente une lecture métier observable.
+- `safe_for_agents: true` — *parce que* l'opération est idempotente et ne consomme pas de quota destructif. Un agent peut la rejouer sans risque.
+- `requires_human_approval: false` — *parce que* lire un catalogue ne porte aucun risque irréversible. Demander une approbation humaine sur une lecture est un anti-pattern (friction sans bénéfice).
+
+## Pourquoi ces `examples[]`
+
+- **`{ item_id: "sku-1234" }`** — happy path, avec `expected_output_contains` qui ancre la forme minimale de la réponse.
+- **`{ item_id: "missing" }`** — cas limite (ressource absente). Pas d'`expected_output_contains` : on documente que l'agent doit gérer une 404 sans inférer le payload.
+
+## Anti-patterns évités
+
+- Ne pas mettre `safe_for_agents: false` "par prudence" sur un GET pur — ça signale à tort un danger et empêche l'usage légitime.
+- Ne pas mettre `requires_human_approval: true` sur une lecture — ce flag existe pour les opérations destructives, pas pour gérer la confidentialité (qui se traite via classification + RBAC).
+- Ne pas omettre `output_schema` : sans lui, l'agent ne peut pas valider la réponse et `examples[].expected_output_contains` perd son ancrage.

--- a/specs/uac/examples/01-read-only.uac.json
+++ b/specs/uac/examples/01-read-only.uac.json
@@ -1,0 +1,53 @@
+{
+  "name": "example-catalog-read",
+  "version": "1.0.0",
+  "tenant_id": "example",
+  "display_name": "Example Catalog — Read",
+  "description": "Canonical UAC example for an idempotent GET endpoint safe for autonomous agents.",
+  "classification": "H",
+  "required_policies": ["rate-limit", "auth-jwt"],
+  "status": "published",
+  "endpoints": [
+    {
+      "path": "/catalog/items/{item_id}",
+      "methods": ["GET"],
+      "backend_url": "https://backend.example.local/v1/catalog",
+      "operation_id": "get_catalog_item",
+      "input_schema": {
+        "type": "object",
+        "required": ["item_id"],
+        "properties": {
+          "item_id": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "price": { "type": "number" }
+        },
+        "additionalProperties": true
+      },
+      "llm": {
+        "summary": "Fetch a catalog item by id.",
+        "intent": "Use when the agent needs read-only details about a known catalog item. Idempotent and side-effect free.",
+        "tool_name": "example_catalog_get_item",
+        "side_effects": "read",
+        "safe_for_agents": true,
+        "requires_human_approval": false,
+        "examples": [
+          {
+            "input": { "item_id": "sku-1234" },
+            "expected_output_contains": { "id": "sku-1234" }
+          },
+          {
+            "input": { "item_id": "missing" }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/specs/uac/examples/02-write-mutating.md
+++ b/specs/uac/examples/02-write-mutating.md
@@ -1,0 +1,19 @@
+# 02 — Write (non-destructive mutation)
+
+**Cas d'usage** : un agent crée une ressource. L'opération mute l'état mais reste réversible (la ressource peut être supprimée a posteriori).
+
+## Choix structurants
+
+- `side_effects: "write"` — *parce que* l'opération crée un nouvel état persistant. À distinguer de `destructive` : un `write` peut être annulé par l'opération inverse, un `destructive` non.
+- `safe_for_agents: true` — *parce que* la création de ressource ne porte pas de risque irréversible si elle est rate-limitée et auditée (ce que la classification `H` impose via `required_policies`).
+- `requires_human_approval: false` — *parce que* l'opération est réversible et que demander une approbation humaine sur chaque création briserait l'autonomie utile de l'agent. L'approbation se traite au niveau de la classification (`VH`/`VVH`) si la ressource créée porte un risque métier.
+
+## Pourquoi ces `examples[]`
+
+- **Un seul exemple complet, avec `expected_output_contains`** — pour les `write`, un exemple précis est plus utile qu'un volume d'exemples partiels. L'agent voit le shape exact de l'input attendu et peut l'imiter.
+
+## Anti-patterns évités
+
+- Ne pas marquer un `write` réversible comme `destructive` — ça déclenche `requires_human_approval=true` (règle dure) et casse l'autonomie d'un agent qui pourrait gérer le cas seul.
+- Ne pas omettre `additionalProperties: false` sur l'`input_schema` d'un write — sinon l'agent peut envoyer des champs hors-contrat qui passeront silencieusement.
+- Ne pas confondre `safe_for_agents` avec "l'opération est sûre dans l'absolu". Le flag dit : *un agent autonome peut l'invoquer sans superviseur humain*. Une création de ressource sensible (paiement, contrat) devrait être `safe_for_agents: false` même si techniquement réversible.

--- a/specs/uac/examples/02-write-mutating.uac.json
+++ b/specs/uac/examples/02-write-mutating.uac.json
@@ -1,0 +1,52 @@
+{
+  "name": "example-catalog-write",
+  "version": "1.0.0",
+  "tenant_id": "example",
+  "display_name": "Example Catalog — Write",
+  "description": "Canonical UAC example for a non-destructive write (resource creation).",
+  "classification": "H",
+  "required_policies": ["rate-limit", "auth-jwt"],
+  "status": "published",
+  "endpoints": [
+    {
+      "path": "/catalog/items",
+      "methods": ["POST"],
+      "backend_url": "https://backend.example.local/v1/catalog",
+      "operation_id": "create_catalog_item",
+      "input_schema": {
+        "type": "object",
+        "required": ["name", "price"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "price": { "type": "number", "minimum": 0 },
+          "sku": { "type": "string" }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "price": { "type": "number" }
+        },
+        "additionalProperties": true
+      },
+      "llm": {
+        "summary": "Create a new catalog item.",
+        "intent": "Use when the agent needs to add a new item to the catalog. Mutating but reversible (the created item can be deleted via the destructive endpoint).",
+        "tool_name": "example_catalog_create_item",
+        "side_effects": "write",
+        "safe_for_agents": true,
+        "requires_human_approval": false,
+        "examples": [
+          {
+            "input": { "name": "Espresso 250g", "price": 12.5, "sku": "esp-250" },
+            "expected_output_contains": { "name": "Espresso 250g" }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/specs/uac/examples/03-destructive.md
+++ b/specs/uac/examples/03-destructive.md
@@ -1,0 +1,20 @@
+# 03 — Destructive
+
+**Cas d'usage** : un agent doit supprimer une ressource. Opération irréversible, soumise à approbation humaine obligatoire.
+
+## Choix structurants
+
+- `side_effects: "destructive"` — *parce que* la suppression est définitive et ne peut pas être annulée par une opération inverse de l'API. Le validator UAC enforce la règle dure : `destructive` ⇒ `requires_human_approval: true`.
+- `safe_for_agents: false` — *parce que* même avec approbation humaine, le flag signale au runtime MCP que l'agent ne doit pas chaîner cet appel dans une boucle autonome. L'approbation reste une étape explicite pilotée par un humain.
+- `requires_human_approval: true` — *forcé par le validator*. Toute tentative de mettre `false` ici déclenche une erreur de validation, pas un warning.
+- `classification: "VH"` — *parce que* la sensibilité d'une suppression justifie `mtls` + `audit-logging` en plus de `rate-limit` + `auth-jwt`. La classification doit suivre la criticité métier, pas seulement le verbe HTTP.
+
+## Pourquoi ces `examples[]`
+
+- **Un seul exemple, avec sortie booléenne explicite** — sur un `destructive`, on veut documenter le contrat de retour minimal (`deleted: true`) pour que l'agent puisse vérifier que l'opération a bien abouti avant de notifier l'utilisateur.
+
+## Anti-patterns évités
+
+- Ne pas tenter de contourner la règle dure en passant `requires_human_approval: false` sur un `destructive`. Le validator rejette le contrat à la publication.
+- Ne pas requalifier en `write` ce qui est réellement `destructive` pour éviter l'approbation humaine — c'est une violation de doctrine et le code en aval (UI, audit) compte sur la sémantique correcte.
+- Ne pas baisser la classification (`H` au lieu de `VH`) pour réduire la liste de policies. La classification reflète le risque ICT, pas l'effort opérationnel.

--- a/specs/uac/examples/03-destructive.uac.json
+++ b/specs/uac/examples/03-destructive.uac.json
@@ -1,0 +1,49 @@
+{
+  "name": "example-catalog-delete",
+  "version": "1.0.0",
+  "tenant_id": "example",
+  "display_name": "Example Catalog — Delete",
+  "description": "Canonical UAC example for a destructive operation requiring human approval.",
+  "classification": "VH",
+  "required_policies": ["rate-limit", "auth-jwt", "mtls", "audit-logging"],
+  "status": "published",
+  "endpoints": [
+    {
+      "path": "/catalog/items/{item_id}",
+      "methods": ["DELETE"],
+      "backend_url": "https://backend.example.local/v1/catalog",
+      "operation_id": "delete_catalog_item",
+      "input_schema": {
+        "type": "object",
+        "required": ["item_id"],
+        "properties": {
+          "item_id": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": ["deleted"],
+        "properties": {
+          "deleted": { "type": "boolean" },
+          "id": { "type": "string" }
+        },
+        "additionalProperties": true
+      },
+      "llm": {
+        "summary": "Delete a catalog item by id.",
+        "intent": "Use only when an authorised human has confirmed the deletion. The operation is irreversible — the item and its history cannot be recovered automatically.",
+        "tool_name": "example_catalog_delete_item",
+        "side_effects": "destructive",
+        "safe_for_agents": false,
+        "requires_human_approval": true,
+        "examples": [
+          {
+            "input": { "item_id": "sku-1234" },
+            "expected_output_contains": { "deleted": true }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/specs/uac/examples/04-flow-multistep.md
+++ b/specs/uac/examples/04-flow-multistep.md
@@ -1,0 +1,21 @@
+# 04 — Flow multi-step
+
+**Cas d'usage** : un agent enchaîne plusieurs opérations cohérentes (ici : créer un brouillon → vérifier le statut → confirmer). Le flow est cadré par un seul contrat UAC qui en porte les trois endpoints.
+
+## Choix structurants
+
+- **Trois endpoints dans un même contrat** — *parce que* leur cycle de vie est lié (un draft expire, un draft confirmé devient billable). Splitter en trois contrats casse la traçabilité du flow et duplique `tenant_id` / `classification`.
+- `intent` qui se référence l'autre — chaque `intent` cite explicitement le `tool_name` de l'étape suivante ou précédente. C'est ce qui transforme une liste d'endpoints en *flow* lisible pour un agent.
+- `side_effects` mixtes (`write` / `read` / `write`) — *parce que* la sémantique de chaque étape est indépendante. Un agent qui n'a accès qu'à `read` peut quand même observer le statut sans pouvoir confirmer.
+- Tous `safe_for_agents: true`, aucun `requires_human_approval` — *parce que* la confirmation est elle-même la décision explicite (l'agent doit la déclencher après vérification). L'approbation humaine est gérée par le métier au-dessus du contrat, pas par chaque endpoint.
+
+## Pourquoi ces `examples[]`
+
+- **Un exemple par endpoint, alignés sur le même `order_id` fictif (`ord-abc`)** — un agent qui lit le contrat reconstitue mentalement l'enchaînement. Si chaque exemple utilisait un id différent, le flow deviendrait illisible.
+- `expected_output_contains.status` enforce la transition d'état attendue à chaque étape (`draft` → observable → `confirmed`).
+
+## Anti-patterns évités
+
+- Ne pas exposer un `tool_name` qui décrit l'objet (`order`) plutôt que l'action (`create_draft`, `get_status`, `confirm`). Les agents raisonnent en verbes.
+- Ne pas mettre une logique de timeout (`expire after 15 minutes`) uniquement dans `intent` — c'est un rappel utile pour le LLM, mais la garantie technique vit dans le backend, pas dans le contrat.
+- Ne pas chaîner trois contrats séparés "pour la propreté". Un flow cohérent = un contrat. Trois contrats = trois cycles de vie indépendants à orchestrer en aval.

--- a/specs/uac/examples/04-flow-multistep.uac.json
+++ b/specs/uac/examples/04-flow-multistep.uac.json
@@ -1,0 +1,124 @@
+{
+  "name": "example-orders-flow",
+  "version": "1.0.0",
+  "tenant_id": "example",
+  "display_name": "Example Orders — Multi-step Flow",
+  "description": "Canonical UAC example for a chained agent workflow: create draft → check status → confirm.",
+  "classification": "H",
+  "required_policies": ["rate-limit", "auth-jwt"],
+  "status": "published",
+  "endpoints": [
+    {
+      "path": "/orders",
+      "methods": ["POST"],
+      "backend_url": "https://backend.example.local/v1/orders",
+      "operation_id": "create_order_draft",
+      "input_schema": {
+        "type": "object",
+        "required": ["item_id", "quantity"],
+        "properties": {
+          "item_id": { "type": "string", "minLength": 1 },
+          "quantity": { "type": "integer", "minimum": 1 }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": ["order_id", "status"],
+        "properties": {
+          "order_id": { "type": "string" },
+          "status": { "type": "string", "enum": ["draft"] }
+        },
+        "additionalProperties": true
+      },
+      "llm": {
+        "summary": "Create an order draft.",
+        "intent": "First step of the order flow. Creates a draft that must be confirmed within 15 minutes via example_orders_confirm. Drafts auto-expire and are not billable.",
+        "tool_name": "example_orders_create_draft",
+        "side_effects": "write",
+        "safe_for_agents": true,
+        "requires_human_approval": false,
+        "examples": [
+          {
+            "input": { "item_id": "sku-1234", "quantity": 2 },
+            "expected_output_contains": { "status": "draft" }
+          }
+        ]
+      }
+    },
+    {
+      "path": "/orders/{order_id}",
+      "methods": ["GET"],
+      "backend_url": "https://backend.example.local/v1/orders",
+      "operation_id": "get_order_status",
+      "input_schema": {
+        "type": "object",
+        "required": ["order_id"],
+        "properties": {
+          "order_id": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": ["order_id", "status"],
+        "properties": {
+          "order_id": { "type": "string" },
+          "status": { "type": "string", "enum": ["draft", "confirmed", "expired"] }
+        },
+        "additionalProperties": true
+      },
+      "llm": {
+        "summary": "Read the current status of an order.",
+        "intent": "Intermediate step of the order flow. Use to verify that a draft is still alive before calling confirm, or to observe the final state after confirm.",
+        "tool_name": "example_orders_get_status",
+        "side_effects": "read",
+        "safe_for_agents": true,
+        "requires_human_approval": false,
+        "examples": [
+          {
+            "input": { "order_id": "ord-abc" },
+            "expected_output_contains": { "order_id": "ord-abc" }
+          }
+        ]
+      }
+    },
+    {
+      "path": "/orders/{order_id}/confirm",
+      "methods": ["POST"],
+      "backend_url": "https://backend.example.local/v1/orders",
+      "operation_id": "confirm_order",
+      "input_schema": {
+        "type": "object",
+        "required": ["order_id"],
+        "properties": {
+          "order_id": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "required": ["order_id", "status"],
+        "properties": {
+          "order_id": { "type": "string" },
+          "status": { "type": "string", "enum": ["confirmed"] }
+        },
+        "additionalProperties": true
+      },
+      "llm": {
+        "summary": "Confirm an order draft.",
+        "intent": "Final step of the order flow. Promotes a draft to a billable order. Only call after example_orders_get_status confirmed status=draft. Confirming an expired draft returns 409.",
+        "tool_name": "example_orders_confirm",
+        "side_effects": "write",
+        "safe_for_agents": true,
+        "requires_human_approval": false,
+        "examples": [
+          {
+            "input": { "order_id": "ord-abc" },
+            "expected_output_contains": { "status": "confirmed" }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Populates `specs/uac/examples/` with the four canonical exemplars defined in the scaffold README (PR #2581):

| File | Pattern | `side_effects` | `requires_human_approval` |
|---|---|---|---|
| `01-read-only` | GET idempotent | `read` | `false` |
| `02-write-mutating` | POST create (reversible) | `write` | `false` |
| `03-destructive` | DELETE irreversible | `destructive` | `true` (forced by validator) |
| `04-flow-multistep` | 3 chained endpoints (draft → status → confirm) | mixed | `false` (action is the explicit decision) |

Each example is a paired `(.uac.json + .md)`:
- The `.uac.json` is a valid `UacContractSpec`.
- The `.md` annotates the **rationale**: why this `side_effects`, why these `examples[]`, anti-patterns avoided.

This is the corpus pédagogique announced in the scaffold README. Agents discovering the repo can study these patterns instead of guessing.

## Validation

All four contracts validate clean against:
- `control-plane-api` Pydantic `UacContractSpec` model
- `control-plane-api` semantic validator (`uac_validator.validate_uac_contract`)

Result: **0 errors, 0 warnings** on each contract.

## Notes on size

358 LOC. Above the usual 300 LOC ceiling but indivisible: each contract is a coherent, validated artifact + its annotation. Splitting would either fragment a coherent doctrine across PRs or strip the annotations that give the examples value. Reviewer can read each `.md` independently — they are intentionally self-contained.

## Synthetic data only

- `tenant_id: "example"`, `backend_url: https://backend.example.local/...`
- No PII, no secrets, no real customer references.

## Test plan

- [ ] CI passes (License Compliance, SBOM, Signed Commits, Regression Test Guard)
- [ ] Markdown links resolve
- [ ] No code/schema/validator change to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)