### PR TITLE
fix(deployments): expose Git desired state freshness

### DIFF
--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -11105,6 +11105,10 @@
             "title": "Desired State",
             "type": "object"
           },
+          "desired_source": {"anyOf": [{"type": "string"}, {"type": "null"}], "title": "Desired Source"},
+          "git_sync_status": {"anyOf": [{"type": "string"}, {"type": "null"}], "title": "Git Sync Status"},
+          "desired_commit_sha": {"anyOf": [{"type": "string"}, {"type": "null"}], "title": "Desired Commit Sha"},
+          "desired_git_path": {"anyOf": [{"type": "string"}, {"type": "null"}], "title": "Desired Git Path"},
           "gateway_display_name": {
             "anyOf": [
               {

--- a/control-plane-api/src/repositories/gateway_deployment.py
+++ b/control-plane-api/src/repositories/gateway_deployment.py
@@ -42,6 +42,23 @@ def _target_gateway_type(gateway_type: object) -> str:
     return normalized_type
 
 
+def _desired_git_fields(
+    desired_state: dict | None,
+    api_git_path: str | None = None,
+    api_git_commit_sha: str | None = None,
+) -> dict[str, object]:
+    """Return stable Git provenance fields for deployment list responses."""
+    desired = desired_state or {}
+    desired_commit_sha = desired.get("desired_commit_sha") or api_git_commit_sha
+    desired_git_path = desired.get("desired_git_path") or api_git_path
+    return {
+        "desired_source": desired.get("desired_source") or ("git" if desired_commit_sha else "unknown"),
+        "git_sync_status": desired.get("git_sync_status") or ("up_to_date" if desired_commit_sha else "unknown"),
+        "desired_commit_sha": desired_commit_sha,
+        "desired_git_path": desired_git_path,
+    }
+
+
 class GatewayDeploymentRepository:
     """Repository for gateway deployment database operations."""
 
@@ -111,6 +128,8 @@ class GatewayDeploymentRepository:
         # Always join GatewayInstance for name/type/environment
         query = select(
             GatewayDeployment,
+            APICatalog.git_path.label("api_git_path"),
+            APICatalog.git_commit_sha.label("api_git_commit_sha"),
             GatewayInstance.name.label("gateway_name"),
             GatewayInstance.display_name.label("gateway_display_name"),
             GatewayInstance.gateway_type.label("gateway_type"),
@@ -118,6 +137,9 @@ class GatewayDeploymentRepository:
         ).join(
             GatewayInstance,
             GatewayDeployment.gateway_instance_id == GatewayInstance.id,
+        ).join(
+            APICatalog,
+            GatewayDeployment.api_catalog_id == APICatalog.id,
         )
 
         if environment:
@@ -142,6 +164,7 @@ class GatewayDeploymentRepository:
         deployments = []
         for row in rows:
             dep = row.GatewayDeployment
+            git_fields = _desired_git_fields(dep.desired_state, row.api_git_path, row.api_git_commit_sha)
             deployments.append({
                 "id": dep.id,
                 "api_catalog_id": dep.api_catalog_id,
@@ -163,6 +186,7 @@ class GatewayDeploymentRepository:
                 "gateway_display_name": row.gateway_display_name,
                 "gateway_type": row.gateway_type.value if hasattr(row.gateway_type, "value") else row.gateway_type,
                 "gateway_environment": row.gateway_environment,
+                **git_fields,
             })
         return deployments, total
 
@@ -182,6 +206,8 @@ class GatewayDeploymentRepository:
                 APICatalog.api_id.label("api_id"),
                 APICatalog.api_name.label("api_name"),
                 APICatalog.tenant_id.label("tenant_id"),
+                APICatalog.git_path.label("api_git_path"),
+                APICatalog.git_commit_sha.label("api_git_commit_sha"),
                 GatewayInstance.id.label("gateway_id"),
                 GatewayInstance.name.label("gateway_name"),
                 GatewayInstance.display_name.label("gateway_display_name"),
@@ -215,6 +241,8 @@ class GatewayDeploymentRepository:
         items = []
         for row in result.all():
             dep = row.GatewayDeployment
+            desired_state = dep.desired_state or {}
+            git_fields = _desired_git_fields(desired_state, row.api_git_path, row.api_git_commit_sha)
             items.append(
                 {
                     "deployment_id": dep.id,
@@ -223,7 +251,8 @@ class GatewayDeploymentRepository:
                     "api_name": row.api_name,
                     "tenant_id": row.tenant_id,
                     "environment": row.gateway_environment,
-                    "desired_state": dep.desired_state,
+                    "desired_state": desired_state,
+                    **git_fields,
                     "gateway_target": {
                         "id": row.gateway_id,
                         "name": row.gateway_name,

--- a/control-plane-api/src/routers/gateway_deployments.py
+++ b/control-plane-api/src/routers/gateway_deployments.py
@@ -26,11 +26,16 @@ logger = logging.getLogger(__name__)
 
 def _deployment_to_dict(dep) -> dict:
     """Convert a GatewayDeployment ORM object to a dict compatible with GatewayDeploymentResponse."""
+    desired_state = dep.desired_state or {}
     return {
         "id": dep.id,
         "api_catalog_id": dep.api_catalog_id,
         "gateway_instance_id": dep.gateway_instance_id,
-        "desired_state": dep.desired_state,
+        "desired_state": desired_state,
+        "desired_source": desired_state.get("desired_source"),
+        "git_sync_status": desired_state.get("git_sync_status"),
+        "desired_commit_sha": desired_state.get("desired_commit_sha"),
+        "desired_git_path": desired_state.get("desired_git_path"),
         "desired_at": dep.desired_at,
         "actual_state": dep.actual_state,
         "actual_at": dep.actual_at,

--- a/control-plane-api/src/schemas/gateway.py
+++ b/control-plane-api/src/schemas/gateway.py
@@ -208,6 +208,10 @@ class GatewayDeploymentResponse(BaseModel):
     api_catalog_id: UUID
     gateway_instance_id: UUID
     desired_state: dict
+    desired_source: str | None = None
+    git_sync_status: str | None = None
+    desired_commit_sha: str | None = None
+    desired_git_path: str | None = None
     desired_at: datetime
     actual_state: dict | None = None
     actual_at: datetime | None = None
@@ -267,6 +271,13 @@ class ConsoleDeploymentRow(BaseModel):
     tenant_id: str
     environment: str
     desired_state: dict
+    desired_source: str = Field(..., description="Configuration source: git, db_shortcut, or unknown")
+    git_sync_status: str = Field(
+        ...,
+        description="Catalog freshness: up_to_date, missing_commit, git_sync_disabled, or unknown",
+    )
+    desired_commit_sha: str | None = None
+    desired_git_path: str | None = None
     gateway_target: ConsoleGatewayTarget
     deployment_status: str
     gateway_health: str

--- a/control-plane-api/src/services/gateway_deployment_service.py
+++ b/control-plane-api/src/services/gateway_deployment_service.py
@@ -33,6 +33,27 @@ class GatewayDeploymentService:
         self.gw_repo = GatewayInstanceRepository(db)
 
     @staticmethod
+    def _desired_state_git_metadata(api_catalog) -> dict:
+        """Return Git provenance metadata for a materialized desired state."""
+        git_path = getattr(api_catalog, "git_path", None) or (
+            f"tenants/{api_catalog.tenant_id}/apis/{api_catalog.api_name}"
+        )
+        git_commit_sha = getattr(api_catalog, "git_commit_sha", None)
+        if git_commit_sha:
+            return {
+                "desired_source": "git",
+                "git_sync_status": "up_to_date",
+                "desired_commit_sha": git_commit_sha,
+                "desired_git_path": git_path,
+            }
+        return {
+            "desired_source": "db_shortcut",
+            "git_sync_status": "git_sync_disabled" if not settings.GIT_SYNC_ON_WRITE else "missing_commit",
+            "desired_commit_sha": None,
+            "desired_git_path": git_path,
+        }
+
+    @staticmethod
     def build_desired_state(api_catalog) -> dict:
         """Build desired state dict from an API catalog entry.
 
@@ -73,7 +94,14 @@ class GatewayDeploymentService:
             "methods": sorted(methods) if methods else ["GET", "POST", "PUT", "DELETE"],
             "activated": True,
             "openapi_spec": spec_data if spec_data else None,
+            **GatewayDeploymentService._desired_state_git_metadata(api_catalog),
         }
+
+    @staticmethod
+    def _requires_git_backed_desired_state(gateway) -> bool:
+        """Return True for environments where direct DB-only deployment is forbidden."""
+        environment = (getattr(gateway, "environment", "") or "").strip().lower()
+        return environment in {"prod", "production"}
 
     async def deploy_api(
         self,
@@ -103,6 +131,11 @@ class GatewayDeploymentService:
                 raise ValueError(f"Gateway instance {gw_id} not found")
             if not gateway.enabled:
                 raise PermissionError(f"Gateway '{gateway.name}' is disabled. " f"Enable it before deploying.")
+            if self._requires_git_backed_desired_state(gateway) and not getattr(api_catalog, "git_commit_sha", None):
+                raise PermissionError(
+                    "Production deployment requires a Git-backed UAC/catalog desired state "
+                    f"before targeting gateway '{gateway.name}'."
+                )
 
             existing = await self.deploy_repo.get_by_api_and_gateway(api_catalog_id, gw_id)
             if existing:

--- a/control-plane-api/tests/test_gateway_deployment_service.py
+++ b/control-plane-api/tests/test_gateway_deployment_service.py
@@ -1,8 +1,8 @@
 """Tests for GatewayDeploymentService — deploy, undeploy, force_sync."""
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
-from datetime import datetime, timezone
+
+import pytest
 
 
 class TestGatewayDeploymentService:
@@ -18,6 +18,8 @@ class TestGatewayDeploymentService:
             "version": "2.0.0",
             "openapi_spec": {"openapi": "3.0.0", "info": {"title": "Payments"}},
             "api_metadata": None,
+            "git_path": None,
+            "git_commit_sha": None,
             "status": "active",
         }
         defaults.update(overrides)
@@ -34,6 +36,7 @@ class TestGatewayDeploymentService:
             "gateway_type": MagicMock(value="webmethods"),
             "base_url": "https://gw.example.com",
             "auth_config": {},
+            "environment": "dev",
             "enabled": True,
         }
         defaults.update(overrides)
@@ -99,6 +102,8 @@ class TestGatewayDeploymentService:
             assert len(deployments) == 1
             mock_deploy_repo.create.assert_awaited_once()
             mock_kafka.publish.assert_awaited()
+            assert deployments[0].desired_state["desired_source"] == "db_shortcut"
+            assert deployments[0].desired_state["desired_commit_sha"] is None
 
     @pytest.mark.asyncio
     async def test_deploy_multiple_gateways(self):

--- a/control-plane-api/tests/test_gateway_deployments_router.py
+++ b/control-plane-api/tests/test_gateway_deployments_router.py
@@ -134,6 +134,10 @@ class TestConsoleDeploymentContract:
             "tenant_id": "banking-demo",
             "environment": "dev",
             "desired_state": {"api_name": "fapi-banking", "spec_hash": "abc123"},
+            "desired_source": "db_shortcut",
+            "git_sync_status": "missing_commit",
+            "desired_commit_sha": None,
+            "desired_git_path": "tenants/banking-demo/apis/fapi-banking",
             "gateway_target": {
                 "id": str(uuid4()),
                 "name": "connect-webmethods-dev",
@@ -160,6 +164,8 @@ class TestConsoleDeploymentContract:
         item = body["items"][0]
         assert item["deployment_status"] == "synced"
         assert item["gateway_health"] == "offline"
+        assert item["desired_source"] == "db_shortcut"
+        assert item["git_sync_status"] == "missing_commit"
         assert item["gateway_target"]["deployment_mode"] == "connect"
         assert item["gateway_target"]["target_gateway_type"] == "webmethods"
 

--- a/control-plane-api/tests/test_regression_catalog_git_freshness.py
+++ b/control-plane-api/tests/test_regression_catalog_git_freshness.py
@@ -1,0 +1,58 @@
+"""Regression tests for catalog Git freshness on gateway deployments."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+
+def test_regression_cab_2583_git_commit_marks_desired_state_as_git_backed():
+    """A runtime deployment must carry the catalog commit when Git is current."""
+    from src.services.gateway_deployment_service import GatewayDeploymentService
+
+    catalog = SimpleNamespace(
+        id=uuid4(),
+        api_name="payments",
+        api_id="payments",
+        tenant_id="acme",
+        version="1.0.0",
+        openapi_spec={"openapi": "3.0.0"},
+        api_metadata={},
+        git_path="tenants/acme/apis/payments",
+        git_commit_sha="abc123def456",
+    )
+
+    desired = GatewayDeploymentService.build_desired_state(catalog)
+
+    assert desired["desired_source"] == "git"
+    assert desired["git_sync_status"] == "up_to_date"
+    assert desired["desired_commit_sha"] == "abc123def456"
+
+
+@pytest.mark.asyncio
+async def test_regression_cab_2583_production_rejects_db_only_desired_state():
+    """Production must not accept a direct gateway deployment without a catalog commit."""
+    from src.services.gateway_deployment_service import GatewayDeploymentService
+
+    catalog = SimpleNamespace(id=uuid4(), git_commit_sha=None)
+    gateway = SimpleNamespace(id=uuid4(), name="webmethods-prod", environment="production", enabled=True)
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = catalog
+    db.execute = AsyncMock(return_value=result)
+
+    with patch("src.services.gateway_deployment_service.GatewayDeploymentRepository") as MockDeployRepo, \
+         patch("src.services.gateway_deployment_service.GatewayInstanceRepository") as MockGwRepo:
+        deploy_repo = MockDeployRepo.return_value
+        deploy_repo.create = AsyncMock()
+        gw_repo = MockGwRepo.return_value
+        gw_repo.get_by_id = AsyncMock(return_value=gateway)
+        svc = GatewayDeploymentService(db)
+        svc.deploy_repo = deploy_repo
+        svc.gw_repo = gw_repo
+
+        with pytest.raises(PermissionError, match="Production deployment requires"):
+            await svc.deploy_api(catalog.id, [gateway.id])
+
+        deploy_repo.create.assert_not_awaited()

--- a/control-plane-ui/src/pages/ApiDeployments/ApiDeploymentsDashboard.test.tsx
+++ b/control-plane-ui/src/pages/ApiDeployments/ApiDeploymentsDashboard.test.tsx
@@ -165,6 +165,10 @@ describe('ApiDeploymentsDashboard', () => {
           api_catalog_id: 'api-1',
           gateway_instance_id: 'gw-1',
           desired_state: { api_name: 'Payments' },
+          desired_source: 'db_shortcut',
+          git_sync_status: 'missing_commit',
+          desired_commit_sha: undefined,
+          desired_git_path: 'tenants/oasis-gunters/apis/Payments',
           desired_at: '2026-04-25T10:00:00Z',
           actual_state: { api_name: 'Payments' },
           sync_status: 'synced',
@@ -183,6 +187,8 @@ describe('ApiDeploymentsDashboard', () => {
 
     expect(await screen.findByText('Payments')).toBeInTheDocument();
     expect(screen.getByText('synced')).toBeInTheDocument();
+    expect(screen.getByText('db_shortcut/missing_commit')).toBeInTheDocument();
+    expect(screen.getByText('No Git commit')).toBeInTheDocument();
     expect(screen.getByText(/2026/)).toBeInTheDocument();
   });
 });

--- a/control-plane-ui/src/pages/ApiDeployments/ApiDeploymentsDashboard.tsx
+++ b/control-plane-ui/src/pages/ApiDeployments/ApiDeploymentsDashboard.tsx
@@ -59,6 +59,31 @@ function canonicalSortValue(env: CanonicalEnvironment): number {
   return 2;
 }
 
+function deploymentGitStatus(d: GatewayDeployment): {
+  source: string;
+  status: string;
+  commit?: string;
+} {
+  const source =
+    d.desired_source || (d.desired_state?.desired_source as string | undefined) || 'unknown';
+  const status =
+    d.git_sync_status || (d.desired_state?.git_sync_status as string | undefined) || 'unknown';
+  const commit =
+    d.desired_commit_sha ||
+    (d.desired_state?.desired_commit_sha as string | undefined) ||
+    undefined;
+  return { source, status, commit };
+}
+
+function gitStatusClass(status: string): string {
+  if (status === 'up_to_date')
+    return 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300';
+  if (status === 'missing_commit' || status === 'git_sync_disabled') {
+    return 'bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-300';
+  }
+  return 'bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300';
+}
+
 export function ApiDeploymentsDashboard() {
   const { isReady } = useAuth();
   const { activeEnvironment, environments, switchEnvironment } = useEnvironment();
@@ -315,7 +340,7 @@ export function ApiDeploymentsDashboard() {
 
       {/* Table */}
       {loading ? (
-        <TableSkeleton rows={5} columns={5} />
+        <TableSkeleton rows={5} columns={6} />
       ) : deployments.length === 0 ? (
         <EmptyState
           title="No deployments found"
@@ -344,6 +369,9 @@ export function ApiDeploymentsDashboard() {
                     Status
                   </th>
                   <th className="text-left px-4 py-3 text-neutral-500 dark:text-neutral-400 font-medium">
+                    Desired
+                  </th>
+                  <th className="text-left px-4 py-3 text-neutral-500 dark:text-neutral-400 font-medium">
                     Last Sync
                   </th>
                   <th className="text-right px-4 py-3 text-neutral-500 dark:text-neutral-400 font-medium">
@@ -352,53 +380,68 @@ export function ApiDeploymentsDashboard() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-neutral-100 dark:divide-neutral-800">
-                {deployments.map((d) => (
-                  <tr
-                    key={d.id}
-                    onClick={() => setSelectedDeployment(d)}
-                    className="hover:bg-neutral-50 dark:hover:bg-neutral-800/30 cursor-pointer"
-                  >
-                    <td className="px-4 py-3 text-neutral-900 dark:text-white font-medium">
-                      {(d.desired_state?.api_name as string) || d.api_catalog_id?.slice(0, 8)}
-                    </td>
-                    <td className="px-4 py-3 text-neutral-600 dark:text-neutral-300">
-                      {d.gateway_name || d.gateway_instance_id?.slice(0, 8)}
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className="text-xs font-semibold uppercase px-2 py-0.5 rounded bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400">
-                        {d.gateway_environment || '—'}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <SyncStatusBadge status={d.sync_status} />
-                    </td>
-                    <td className="px-4 py-3 text-xs text-neutral-500 dark:text-neutral-400">
-                      {d.last_sync_success ? new Date(d.last_sync_success).toLocaleString() : '—'}
-                    </td>
-                    <td className="px-4 py-3 text-right" onClick={(e) => e.stopPropagation()}>
-                      <div className="flex items-center justify-end gap-1">
-                        {(d.sync_status === 'drifted' || d.sync_status === 'error') && (
-                          <button
-                            onClick={() => handleForceSync(d.id)}
-                            disabled={actionLoading === d.id}
-                            className="p-1.5 rounded text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20"
-                            title="Re-sync"
+                {deployments.map((d) => {
+                  const gitStatus = deploymentGitStatus(d);
+                  return (
+                    <tr
+                      key={d.id}
+                      onClick={() => setSelectedDeployment(d)}
+                      className="hover:bg-neutral-50 dark:hover:bg-neutral-800/30 cursor-pointer"
+                    >
+                      <td className="px-4 py-3 text-neutral-900 dark:text-white font-medium">
+                        {(d.desired_state?.api_name as string) || d.api_catalog_id?.slice(0, 8)}
+                      </td>
+                      <td className="px-4 py-3 text-neutral-600 dark:text-neutral-300">
+                        {d.gateway_name || d.gateway_instance_id?.slice(0, 8)}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="text-xs font-semibold uppercase px-2 py-0.5 rounded bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400">
+                          {d.gateway_environment || '—'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <SyncStatusBadge status={d.sync_status} />
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex flex-col gap-1">
+                          <span
+                            className={`w-fit rounded px-2 py-0.5 text-xs font-semibold ${gitStatusClass(gitStatus.status)}`}
                           >
-                            <RotateCcw className="h-4 w-4" />
+                            {gitStatus.source}/{gitStatus.status}
+                          </span>
+                          <span className="text-xs text-neutral-500 dark:text-neutral-400">
+                            {gitStatus.commit ? gitStatus.commit.slice(0, 8) : 'No Git commit'}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-neutral-500 dark:text-neutral-400">
+                        {d.last_sync_success ? new Date(d.last_sync_success).toLocaleString() : '—'}
+                      </td>
+                      <td className="px-4 py-3 text-right" onClick={(e) => e.stopPropagation()}>
+                        <div className="flex items-center justify-end gap-1">
+                          {(d.sync_status === 'drifted' || d.sync_status === 'error') && (
+                            <button
+                              onClick={() => handleForceSync(d.id)}
+                              disabled={actionLoading === d.id}
+                              className="p-1.5 rounded text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20"
+                              title="Re-sync"
+                            >
+                              <RotateCcw className="h-4 w-4" />
+                            </button>
+                          )}
+                          <button
+                            onClick={() => handleUndeploy(d.id)}
+                            disabled={actionLoading === d.id}
+                            className="p-1.5 rounded text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20"
+                            title="Undeploy"
+                          >
+                            <Trash2 className="h-4 w-4" />
                           </button>
-                        )}
-                        <button
-                          onClick={() => handleUndeploy(d.id)}
-                          disabled={actionLoading === d.id}
-                          className="p-1.5 rounded text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20"
-                          title="Undeploy"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/control-plane-ui/src/types/index.ts
+++ b/control-plane-ui/src/types/index.ts
@@ -1102,6 +1102,10 @@ export interface GatewayDeployment {
   api_catalog_id: string;
   gateway_instance_id: string;
   desired_state: GatewayDeploymentState;
+  desired_source?: string;
+  git_sync_status?: string;
+  desired_commit_sha?: string;
+  desired_git_path?: string;
   desired_at: string;
   actual_state?: GatewayDeploymentState;
   actual_at?: string;

--- a/shared/api-types/generated.ts
+++ b/shared/api-types/generated.ts
@@ -14118,6 +14118,14 @@ export interface components {
             desired_state: {
                 [key: string]: unknown;
             };
+            /** Desired Source */
+            desired_source?: string | null;
+            /** Git Sync Status */
+            git_sync_status?: string | null;
+            /** Desired Commit Sha */
+            desired_commit_sha?: string | null;
+            /** Desired Git Path */
+            desired_git_path?: string | null;
             /** Gateway Display Name */
             gateway_display_name?: string | null;
             /** Gateway Environment */

--- a/specs/api-runtime-reconciliation-contract.md
+++ b/specs/api-runtime-reconciliation-contract.md
@@ -95,7 +95,33 @@ La Console affiche desired vs observed, jamais un simple état UI.
 | Gateway health | connectivité/heartbeat/reboot | vérité connectivité seulement |
 | Promotion | intention/lifecycle env -> env | jamais preuve runtime seule |
 
-### 1.2.1 Format canonique
+### 1.2.1 Fraîcheur Git obligatoire
+
+`Git/UAC JSON source of truth` n'est vrai que si CP peut prouver le lien entre
+le desired state matérialisé et un commit du catalog. Sinon le flux doit être
+affiché comme raccourci DB/runtime, jamais comme GitOps complet.
+
+Toute projection Console ou API de déploiement doit exposer:
+
+| Champ | Valeurs | Contrat |
+|-------|---------|---------|
+| `desired_source` | `git`, `db_shortcut`, `unknown` | provenance du desired state matérialisé |
+| `git_sync_status` | `up_to_date`, `missing_commit`, `git_sync_disabled`, `unknown` | fraîcheur du catalog Git pour cette génération |
+| `desired_commit_sha` | SHA Git ou `null` | commit exact qui porte le desired state |
+| `desired_git_path` | chemin catalog ou `null` | fichier/dossier Git attendu |
+
+Invariants:
+- `deployment_status=synced` prouve uniquement l'ack runtime gateway. Il ne
+  prouve pas que `stoa-catalog` est à jour.
+- `desired_source=db_shortcut` est autorisé pour dev/demo, mais doit être
+  visible dans la Console.
+- En production, une action directe vers une gateway doit être refusée tant que
+  `desired_source != git` ou `desired_commit_sha` est absent. La Console doit
+  générer/attendre une PR GitOps conformément à ADR-040.
+- En staging, un raccourci peut rester toléré pendant la démo, mais la ligne doit
+  rester marquée `db_shortcut` tant qu'aucun commit catalog n'est attaché.
+
+### 1.2.2 Format canonique
 
 L'UAC canonique est un document JSON validé par JSON Schema. La spec ne doit pas
 présenter `stoa.yaml` comme source de vérité UAC.
@@ -259,6 +285,7 @@ Axes UI obligatoires pour une ligne `/api-deployments`:
 
 | Axe | Source | Exemple | Ne doit pas masquer |
 |-----|--------|---------|---------------------|
+| Fraîcheur Git | `desired_source`, `git_sync_status`, `desired_commit_sha`, `desired_git_path` | `git/up_to_date`, `db_shortcut/missing_commit` | le statut runtime gateway |
 | Déploiement | `GatewayDeployment.sync_status`, `desired_generation`, `last_synced_generation` | `synced`, `pending`, `failed` | le nom API et la gateway cible |
 | Connectivité gateway | heartbeat, route-sync poll, dernier ack agent | `online`, `restarting`, `offline`, `stale` | un deployment déjà `synced` |
 | Runtime call optionnel | test manuel ou smoke ciblé | `2xx`, `404`, backend unreachable | la preuve d'ack gateway |
@@ -422,11 +449,16 @@ Réconcilier le desired state dans CP.
 PASS si CP expose une projection matérialisée contenant:
 - API/catalog identity
 - desired generation/hash
+- desired source (`git` ou `db_shortcut`)
+- Git freshness (`git_sync_status`, `desired_commit_sha`, `desired_git_path`)
 - environment overlay résolu
 - gateway targets candidates
 
 FAIL si CP invente une configuration runtime qui ne peut pas être retracée vers
 un UAC JSON versionné dans Git, sauf raccourci dev/demo explicitement marqué.
+
+FAIL si un déploiement production est accepté avec `desired_source=db_shortcut`
+ou sans `desired_commit_sha`.
 
 ### ADF-G3 — Assignments et capabilities résolus
 
@@ -537,10 +569,15 @@ PASS si la ligne affiche:
 - environnement gateway
 - statut dérivé de `GatewayDeployment.sync_status`
 - statut de connectivité gateway séparé du statut deployment
+- provenance Git/DB du desired state (`desired_source`, `git_sync_status`,
+  `desired_commit_sha`)
 - last sync basé sur `last_sync_success`
 
 FAIL si la page affiche un succès basé uniquement sur `Deployment.completed_at`
 ou `Promotion.completed_at`.
+
+FAIL si la page affiche un deployment `synced` comme GitOps complet alors que
+`git_sync_status != up_to_date`.
 
 FAIL si une gateway offline/restarting fait repasser une API déjà `synced` en
 `failed` sans nouvelle génération, undeploy, ou drift confirmé.
@@ -793,6 +830,7 @@ Critère GO pour toute PR touchant ce flux:
 | A-B10 | flow staging/prod insuffisamment contracté côté assignments, promotion et ack | P0 | ADF-5, ADF-6, ADF-13, ADF-16 |
 | A-B11 | `/apis` recrée un chemin de déploiement parallèle à `/api-deployments` | P0 | ADF-17 |
 | A-B12 | spec encore trop `GatewayDeployment`-first si Git/UAC JSON desired state n'est pas vérifié avant matérialisation | P0 | ADF-G1, ADF-G2, ADF-G3, ADF-G4, ADF-G5 |
+| A-B14 | `stoa-catalog` n'est pas mis à jour ou aucun commit SHA n'est attaché au desired state runtime | P0 | ADF-G1, ADF-G2, ADF-3, ADF-16 |
 
 ## 7. Révisions
 
@@ -806,3 +844,4 @@ Critère GO pour toute PR touchant ce flux:
 | 2026-04-26 | Codex | Ajout du preflight adapter WebMethods avant dispatch Kafka/SSE |
 | 2026-04-26 | Codex | Renommage en Runtime Reconciliation Contract et clarification connect/edge/sidecar |
 | 2026-04-26 | Codex | Clarification UAC JSON canonique; YAML réservé au packaging infra/GitOps |
+| 2026-04-26 | Codex | Ajout du contrat de fraîcheur Git et refus prod sans desired state Git-backed |


### PR DESCRIPTION
## Summary
- expose Git desired-state provenance on deployment API responses
- mark DB-only deployments as db_shortcut/missing_commit instead of implying GitOps freshness
- block direct production gateway deployments when no catalog commit is attached
- show desired source/freshness on /api-deployments and align the runtime reconciliation spec

## Validation
- pytest tests/test_gateway_deployment_service.py tests/test_gateway_deployments_router.py -q
- ruff check control-plane-api/src/services/gateway_deployment_service.py control-plane-api/src/repositories/gateway_deployment.py control-plane-api/src/routers/gateway_deployments.py control-plane-api/tests/test_gateway_deployment_service.py control-plane-api/tests/test_gateway_deployments_router.py
- npx vitest run src/pages/ApiDeployments/ApiDeploymentsDashboard.test.tsx
- npm run build