### PR TITLE
docs(decisions): add UAC V2 MCP projection plan and Decision Gate #9

### DIFF
--- a/docs/decisions/2026-04-26-uac-v2-mcp-projection.md
+++ b/docs/decisions/2026-04-26-uac-v2-mcp-projection.md
@@ -1,0 +1,56 @@
+---
+id: decision-2026-04-26-uac-v2-mcp-projection
+plan_ref: docs/plans/2026-04-26-uac-v2-mcp-projection.md
+challenger: "GPT-5.5 Thinking (ChatGPT review, synthesised by Christophe)"
+verdict: REFRAME
+decision_gate_log: "#9"
+---
+
+# Decision — UAC V2, projection MCP de la metadata `endpoint.llm`
+
+## Challenger output (verbatim)
+
+> GO sur l'idée. NO-GO sur PR 2 Rust obligatoire tout de suite.
+> Tu dois d'abord prouver la valeur côté chemin réellement utilisé.
+>
+> **Ajustement recommandé :**
+>
+> - **PR 1 — Python generator uniquement.**
+>   Si `endpoint.llm` existe : description MCP enrichie. Sinon : fallback legacy inchangé. Tests `avec/sans llm`.
+> - **PR 2 — Smoke + canary.**
+>   `demo-httpbin.uac.json` + `endpoint.llm`. `tools/list` contient `Intent:` + `Side effects:`. Là tu prouves la chaîne utile.
+> - **PR 3 — Rust parity seulement si nécessaire.**
+>   Avant de modifier Rust, répondre à l'assumption 4 : *"le Rust generator est-il réellement utilisé dans le chemin démo/prod ?"* Si oui → PR Rust. Si non → ticket backlog, pas maintenant.
+>
+> **Point important :** la spec MCP n'est pas vérifiée pour `examples` au niveau tool. En V1, ne pas pousser `examples` comme champ structuré. Faire simple : `description = summary + intent + side_effects`. Éventuellement `Examples: ...` en texte, mais pas comme contrat MCP normatif.
+>
+> **Go criteria recadré :** "tools/list expose Intent + Side effects sur le canary, sans casser les tools legacy." Pas "3 PRs en 7 jours".
+>
+> **Logique à garder :** preuve d'abord, parité ensuite, gouvernance plus tard.
+
+## Arbitrage
+
+- **Verdict :** REFRAME
+- **Reframe applied :**
+  - Découplage du Rust generator (PR 3 conditionnelle, non bloquante).
+  - Ordre des PRs : Python → Smoke+canary → Rust. La preuve de valeur passe avant la parité.
+  - Suppression du push structuré d'`examples` au niveau tool MCP (spec non vérifiée). Repli sur description texte.
+  - Go criteria axé sur le résultat observable (`Intent:` + `Side effects:` dans `tools/list` du canary) plutôt que sur le calendrier.
+
+## Conditions de réouverture pour PR 3 (Rust parity)
+
+PR 3 (Rust generator) revient à l'agenda **uniquement si l'un des trois signaux est observé** :
+
+1. Le chemin gateway → `tools/list` en prod consomme effectivement la projection Rust (à vérifier par lecture du code d'appel + un test runtime).
+2. Le canary cp-api est mergé et un client agent (Claude/Codex) confirme la lisibilité ; on veut alors la même expérience côté gateway autonome.
+3. Une régression de parité est détectée par un test cross-langage existant ou une revue.
+
+Sinon, ticket backlog (pas de pression cycle).
+
+## Meta-signal
+
+Le Decision Gate #9 valide une fois de plus le pattern "preuve d'abord, parité ensuite". Cohérent avec le Gate #6 (per-op CRDs annulé après bench RED) et le Gate #7 (3 tools dev gateway NO-GO car alternative sans gateway plus simple).
+
+## External index
+
+Le log cross-repo `stoa-docs/HEGEMON/DECISION_GATE.md` s'arrête à #7 ; #8 n'y a pas été enregistré. Conformément à la décision opérationnelle (2026-04-26) de ne pas rétablir une mécanique cross-repo abandonnée, **#9 reste self-contained ici**. Si la pratique cross-repo est reprise un jour, #8 et #9 seront enregistrés à ce moment-là dans le même mouvement.

--- a/docs/plans/2026-04-26-uac-v2-mcp-projection.md
+++ b/docs/plans/2026-04-26-uac-v2-mcp-projection.md
@@ -1,0 +1,79 @@
+---
+id: plan-2026-04-26-uac-v2-mcp-projection
+triggers: [a, b]
+validation_status: validated
+challenge_ref: docs/decisions/2026-04-26-uac-v2-mcp-projection.md
+---
+
+> **Reframed after Decision Gate #9** (2026-04-26). Original draft proposed Python+Rust parity in lockstep. Reframe: Python first, smoke/canary second, Rust **only if usage confirmed**. See `challenge_ref` for full arbitrage.
+
+# Plan — UAC V2, projection MCP de la metadata `endpoint.llm`
+
+## Objectif
+
+Faire arriver la metadata `endpoint.llm` (summary, intent, side_effects, requires_human_approval, examples) jusqu'aux agents qui appellent `tools/list` côté gateway, **sans changer le schéma UAC ni la doctrine V1**. Bénéficiaire : tout LLM/agent consommant la gateway STOA — il voit aujourd'hui une description pauvre (`"GET /catalog/items/{id} — Example Catalog"`) et devra voir une description structurée portant l'intent et les side_effects.
+
+## Scope
+
+- **In** :
+  - Modifier le générateur Python `control-plane-api/src/services/uac_tool_generator.py` pour enrichir `description` à partir de `endpoint.llm.*`. Format simple : `description = summary + intent + side_effects` (texte concaténé, pas de champ structuré). Fallback inchangé si `endpoint.llm` absent.
+  - Tests unitaires : 2 cas dans cp-api (avec/sans `endpoint.llm`).
+  - Ajouter un step "LLM-readiness" à `scripts/demo-smoke-test.sh` qui valide que la description projetée contient `Intent:` + `Side effects:`.
+  - Enrichir `specs/uac/demo-httpbin.uac.json` avec un bloc `endpoint.llm` (sinon le smoke ne prouve rien).
+
+- **Out** :
+  - **PR Rust generator (parité `stoa-gateway/src/uac/`)** — déféré à *si nécessaire* (cf. conditions de réouverture dans `challenge_ref`). Tant que le chemin gateway réellement utilisé n'est pas vérifié, on ne touche pas Rust.
+  - **Champ `examples[]` structuré au niveau tool MCP** — la spec MCP n'est pas confirmée sur ce point. En V1, on n'expose pas d'`examples` comme contrat normatif. Éventuellement `Examples: ...` en texte dans la `description`, jamais comme champ MCP séparé.
+  - Champs V2 listés dans `.claude/docs/uac-llm-ready.md` mais non normatifs (`do_not_use_when`, `permissions`, `rate_limit_policy`, `approval_policy`, `test_generation_hints`) — V2.1.
+  - Endpoint `/uac/<contract>/<endpoint>/metadata` LLM-optimisé séparé — déféré.
+  - Toute modification du schéma `UacEndpointLlmSpec`.
+  - Migration des contrats existants pour ajouter `endpoint.llm` rétroactivement (V1 reste : warning si absent, pas d'erreur).
+
+## Phases
+
+1. **PR 1 — Generator Python (cp-api)** *(prouve la mécanique)*
+   - Modifier `uac_tool_generator.py:108-111` pour enrichir `description` quand `endpoint.llm` est présent. Format : `summary` + `\nIntent: <intent>` + `\nSide effects: <side_effects>` (+ mention `HUMAN APPROVAL REQUIRED` si applicable).
+   - 2 tests unitaires (avec/sans metadata).
+   - Pas de changement de signature ni d'`inputSchema` MCP. Pas de champ `examples` au niveau tool.
+   - **Critère d'acceptance** : tests passent, fallback legacy inchangé sur les contrats sans `endpoint.llm`.
+
+2. **PR 2 — Smoke + canary** *(prouve la chaîne utile)*
+   - Enrichir `specs/uac/demo-httpbin.uac.json` avec un bloc `endpoint.llm` (un seul endpoint, conforme aux exemples canoniques de `specs/uac/examples/`).
+   - Ajouter un step au `scripts/demo-smoke-test.sh` qui exerce `tools/list` et grep `Intent:` + `Side effects:`.
+   - **Critère d'acceptance** : `bash scripts/demo-smoke-test.sh` passe en local k3d, le step LLM-readiness sort vert, les tools sans metadata gardent leur description legacy intacte.
+
+3. **PR 3 — Rust parity** *(seulement si nécessaire)*
+   - **Pré-requis avant ouverture** : confirmer que le chemin gateway → `tools/list` en prod/démo consomme effectivement la projection Rust (lecture du code d'appel + test runtime).
+   - Si confirmé : miroir de PR 1 dans `stoa-gateway/src/uac/` + test cross-langage.
+   - Si non confirmé : ticket backlog, pas d'ouverture cycle. Décision tracée par un commentaire dans la décision liée.
+
+## Go / No-Go criteria
+
+- **Go** si : `tools/list` expose `Intent:` + `Side effects:` sur le contrat canary (`demo-httpbin`), sans casser les tools legacy (qui restent sur leur description fallback). C'est le critère unique. Le calendrier n'est pas un critère.
+- **No-Go** si : le protocole MCP tronque ou rejette la description multi-lignes côté un client cible (Claude Code, Codex, Inspector) — découvert au step canary. Réversion = revert PR 1 + ré-ouverture du plan avec contrainte de format.
+
+## Assumptions
+
+À stress-tester par le challenger :
+
+1. **La vraie valeur est lisible côté agent, pas côté humain.** Si aucun agent en prod (Claude, Codex, autres) ne consomme aujourd'hui `tools/list` STOA, le ROI immédiat est nul et le travail compte pour la démo juin uniquement.
+2. **Le protocole MCP supporte des descriptions multi-lignes** sans tronquage côté client. Non vérifié — c'est une affirmation que j'ai faite plus tôt sans certitude. À confirmer en lisant la spec MCP avant PR 1.
+3. **Le protocole MCP supporte un champ `examples` au niveau tool.** Idem — non vérifié. Si non supporté, on ne pousse les `examples` que via `description` (texte) et on perd le bénéfice "few-shot structuré".
+4. **Les deux générateurs (Python + Rust) doivent être modifiés en parité.** Si le Rust generator est en réalité dead code aujourd'hui (la projection prod passe par cp-api → cache → gateway sans regénération côté Rust), on peut faire seulement Python et économiser PR 2.
+5. **Modifier la description des MCP tools n'est pas un breaking change** pour les clients existants. Si un client downstream parse la description en regex (peu probable mais possible), enrichir = casser.
+6. **Le smoke test démo accepte un step supplémentaire** sans dépasser le budget temps actuel du runner CI/local.
+7. **Les contrats existants en prod (s'il y en a)** restent valides en V1 (warning, pas erreur) — le validator confirme ça aujourd'hui mais à re-vérifier si on touche le smoke.
+8. **La démo juin (multi-client UAC 5 étapes)** bénéficie réellement de cette enrichissement. Si la démo se concentre sur le parcours REST (déclarer → router → souscrire → appeler → métriques) sans toucher MCP/agent, ce travail est hors-chemin critique.
+
+## Risques mineurs (pas des assumptions, juste des points d'attention)
+
+- Le `description` enrichi peut faire passer `tools/list` d'une réponse compacte à une réponse plus volumineuse. Pas de risque fonctionnel mais à mesurer si on a des tools count élevés (>50).
+- Le smoke step ajouté augmente le temps total du smoke démo de quelques secondes. Acceptable.
+- Le Rust generator pourrait avoir un test snapshot qui casse. Refresh trivial mais à anticiper.
+
+## Estimation grossière (post-reframe)
+
+- PR 1 (cp-api generator + tests) : ~3h
+- PR 2 (smoke + canary + contrat démo enrichi) : ~2h
+- PR 3 (Rust parity, conditionnelle) : ~6h **si activée**, sinon 0h
+- Total chemin critique (PR 1 + PR 2) : **~5h**. PR 3 sort du chemin critique tant que l'usage Rust n'est pas confirmé.


### PR DESCRIPTION
## Summary

Two paired governance artefacts for the UAC V2 work, after challenger arbitrage:

- **`docs/plans/2026-04-26-uac-v2-mcp-projection.md`** — reframed plan. `validation_status: validated`. Critical path is now PR 1 (cp-api generator) + PR 2 (smoke + canary), ~5h. PR 3 (Rust parity) is deferred until the gateway-side projection path is proven to be the one actually consumed by `tools/list` in prod/démo.
- **`docs/decisions/2026-04-26-uac-v2-mcp-projection.md`** — Decision Gate **#9**, verdict **REFRAME**. Challenger: GPT-5.5 Thinking (ChatGPT review, synthesised by Christophe).

## What changed vs the original draft

| | Draft | Reframed |
|---|---|---|
| Generator scope | Python + Rust in lockstep | Python first, Rust **only if needed** |
| `examples[]` at MCP tool level | Pushed as structured field | Skipped (MCP spec not verified). Description = `summary` + `intent` + `side_effects`. |
| Go criteria | "3 PRs in 7 days" | "tools/list exposes Intent + Side effects on canary, no legacy regression" |
| Effort on critical path | ~12h | ~5h |

## Cross-repo HEGEMON log

Skipped intentionally. The `stoa-docs/HEGEMON/DECISION_GATE.md` log stops at #7 — #8 (validated 2026-04-22, demo multi-client) was never registered there. Re-establishing the cross-repo mechanic for #9 alone would be inconsistent. The decision is self-contained in this repo. If the cross-repo practice resumes, #8 and #9 will be backfilled together.

## Scope

- Pure docs. No code, no schema, no validator, no implementation.
- 2 files, 135 LOC (well under the 300 LOC ceiling).

## Next step (post-merge)

Execute PR 1 (`uac_tool_generator.py` enrichment) following the validated plan.

## Test plan

- [ ] CI passes (License Compliance, SBOM, Signed Commits, Regression Test Guard)
- [ ] Markdown frontmatter valid (validation_status / challenge_ref / plan_ref consistent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)