### PR TITLE
feat(uac): enrich MCP tool description with endpoint.llm metadata

### DIFF
--- a/control-plane-api/src/services/uac_tool_generator.py
+++ b/control-plane-api/src/services/uac_tool_generator.py
@@ -106,9 +106,20 @@ class UacToolGenerator:
 
     @staticmethod
     def _build_description(endpoint: UacEndpointSpec, contract_display: str) -> str:
-        """Build human-readable description."""
+        """Build human-readable description, enriched with endpoint.llm if present."""
         methods = ", ".join(endpoint.methods) if endpoint.methods else "GET"
-        return f"{methods} {endpoint.path} — {contract_display}"
+        legacy = f"{methods} {endpoint.path} — {contract_display}"
+        if endpoint.llm is None:
+            return legacy
+        lines = [
+            legacy,
+            f"Summary: {endpoint.llm.summary}",
+            f"Intent: {endpoint.llm.intent}",
+            f"Side effects: {endpoint.llm.side_effects}",
+        ]
+        if endpoint.llm.requires_human_approval:
+            lines.append("HUMAN APPROVAL REQUIRED")
+        return "\n".join(lines)
 
     @staticmethod
     def _build_input_schema(endpoint: UacEndpointSpec) -> dict | None:

--- a/control-plane-api/tests/test_uac_tool_generator.py
+++ b/control-plane-api/tests/test_uac_tool_generator.py
@@ -144,6 +144,73 @@ class TestDescription:
         desc = UacToolGenerator._build_description(ep, "Item Service")
         assert desc == "GET, POST /items — Item Service"
 
+    def test_description_without_llm_unchanged(self):
+        """Endpoint without llm metadata: description is byte-identical to legacy format."""
+        ep = UacEndpointSpec(
+            path="/items",
+            methods=["GET"],
+            backend_url="https://b.com/items",
+        )
+        assert ep.llm is None
+        desc = UacToolGenerator._build_description(ep, "Item Service")
+        assert desc == "GET /items — Item Service"
+
+    def test_description_with_llm_metadata(self):
+        """Endpoint with llm metadata: description is enriched on additional lines."""
+        from src.schemas.uac import (
+            UacEndpointLlmExample,
+            UacEndpointLlmSpec,
+            UacEndpointSideEffects,
+        )
+
+        ep = UacEndpointSpec(
+            path="/items/{id}",
+            methods=["GET"],
+            backend_url="https://b.com/items/{id}",
+            llm=UacEndpointLlmSpec(
+                summary="Fetch an item.",
+                intent="Use to read an item by id.",
+                tool_name="example_get_item",
+                side_effects=UacEndpointSideEffects.READ,
+                safe_for_agents=True,
+                requires_human_approval=False,
+                examples=[UacEndpointLlmExample(input={"id": "x"})],
+            ),
+        )
+        desc = UacToolGenerator._build_description(ep, "Item Service")
+        assert desc == (
+            "GET /items/{id} — Item Service\n"
+            "Summary: Fetch an item.\n"
+            "Intent: Use to read an item by id.\n"
+            "Side effects: read"
+        )
+
+    def test_description_with_destructive_llm_includes_approval_marker(self):
+        """Destructive endpoints with requires_human_approval=true include the marker line."""
+        from src.schemas.uac import (
+            UacEndpointLlmExample,
+            UacEndpointLlmSpec,
+            UacEndpointSideEffects,
+        )
+
+        ep = UacEndpointSpec(
+            path="/items/{id}",
+            methods=["DELETE"],
+            backend_url="https://b.com/items/{id}",
+            llm=UacEndpointLlmSpec(
+                summary="Delete an item.",
+                intent="Use only when authorised.",
+                tool_name="example_delete_item",
+                side_effects=UacEndpointSideEffects.DESTRUCTIVE,
+                safe_for_agents=False,
+                requires_human_approval=True,
+                examples=[UacEndpointLlmExample(input={"id": "x"})],
+            ),
+        )
+        desc = UacToolGenerator._build_description(ep, "Item Service")
+        assert "Side effects: destructive" in desc
+        assert desc.endswith("HUMAN APPROVAL REQUIRED")
+
 
 # ---------------------------------------------------------------------------
 # Input schema tests


### PR DESCRIPTION
## Summary

Implements **PR 1** of the UAC V2 plan validated at [Decision Gate #9](../blob/main/docs/decisions/2026-04-26-uac-v2-mcp-projection.md). When a UAC endpoint declares `endpoint.llm`, the projected MCP tool description now exposes that metadata to agents.

### Before (legacy)
```
GET /items/{id} — Item Service
```

### After (with `endpoint.llm`)
```
GET /items/{id} — Item Service
Summary: Fetch an item.
Intent: Use to read an item by id.
Side effects: read
```

For destructive endpoints (`side_effects = "destructive"` + `requires_human_approval = true`), a final line is appended:
```
HUMAN APPROVAL REQUIRED
```

## Backwards compatibility

- Endpoints **without** `endpoint.llm` produce a description that is **byte-identical** to the legacy format. Verified by `test_description_without_llm_unchanged`.
- No schema change, no validator change, no API surface change.
- The two existing legacy tests (`test_single_method`, `test_multiple_methods`) remain green unchanged.

## Out of scope (intentional, per Decision Gate #9 reframe)

- **`examples[]` as a structured MCP tool field** — MCP spec not verified. Kept as plain text only via the description.
- **Rust generator parity (`stoa-gateway/src/uac/`)** — deferred to PR 3, conditional on confirming the Rust path is consumed in prod.
- **Smoke step + canary contract** — PR 2 (next).
- **V2 fields** (`do_not_use_when`, `permissions`, ...) — V2.1.

## Tests

- `test_description_without_llm_unchanged` — fallback byte-identical
- `test_description_with_llm_metadata` — enriched format (read, no approval)
- `test_description_with_destructive_llm_includes_approval_marker` — destructive branch + marker

Local run: **17/17 pass** in `tests/test_uac_tool_generator.py`. Lint clean (`ruff check`, `black --check`).

## Diff size

```
control-plane-api/src/services/uac_tool_generator.py | 15 ++-
control-plane-api/tests/test_uac_tool_generator.py   | 67 +++++++++++++
2 files changed, 80 insertions(+), 2 deletions(-)
```

## Plan reference

- Plan: [`docs/plans/2026-04-26-uac-v2-mcp-projection.md`](../blob/main/docs/plans/2026-04-26-uac-v2-mcp-projection.md) (`validation_status: validated`)
- Decision: [`docs/decisions/2026-04-26-uac-v2-mcp-projection.md`](../blob/main/docs/decisions/2026-04-26-uac-v2-mcp-projection.md) (Decision Gate #9, REFRAME)

## Test plan

- [ ] CI: License Compliance, SBOM, Signed Commits, Regression Test Guard
- [ ] cp-api unit tests + coverage ≥ 70%
- [ ] No schema or API surface change to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)