### PR TITLE
feat(uac): smoke step + canary contract for endpoint.llm projection

### DIFF
--- a/scripts/demo-smoke-test.sh
+++ b/scripts/demo-smoke-test.sh
@@ -677,6 +677,78 @@ at5b_observability_visibility() {
     return 0
 }
 
+# ── AT-LLM LLM-readiness ────────────────────────────────────────────────────
+
+at_llm_readiness() {
+    log ""
+    log "=== AT-LLM  LLM-readiness ==="
+
+    if [[ -z "$DEMO_UAC_CONTRACT" ]]; then
+        note "INFO" "AT-LLM skipped (no DEMO_UAC_CONTRACT)"
+        return 0
+    fi
+
+    local contract_path="$DEMO_UAC_CONTRACT"
+    if [[ "$contract_path" != /* ]]; then
+        contract_path="${REPO_ROOT}/${contract_path}"
+    fi
+
+    # Static check: contract carries endpoint.llm with intent + side_effects
+    local llm_intent llm_side
+    llm_intent="$(jq -r '.endpoints[0].llm.intent // empty' "$contract_path")"
+    llm_side="$(jq -r '.endpoints[0].llm.side_effects // empty' "$contract_path")"
+
+    if [[ -z "$llm_intent" || -z "$llm_side" ]]; then
+        if mock_allowed; then
+            record "AT-LLM" "MOCK" "contract has no endpoint.llm metadata (V1 warning)"
+            return 0
+        fi
+        record "AT-LLM" "FAIL" "contract has no endpoint.llm.intent or .side_effects"
+        return 1
+    fi
+    record "AT-LLM" "PASS" "contract.endpoints[0].llm declares intent + side_effects=${llm_side}"
+
+    # Optional runtime check: cp-api projects Intent + Side effects in tools/generated description
+    if [[ -z "${GATEWAY_INTERNAL_KEY:-}" ]]; then
+        note "INFO" "AT-LLM runtime projection check skipped (set GATEWAY_INTERNAL_KEY to enable)"
+        return 0
+    fi
+
+    local tools_resp
+    tools_resp="$(curl -sS --max-time 5 \
+        -H "X-Gateway-Key: ${GATEWAY_INTERNAL_KEY}" \
+        "${API_URL}/v1/internal/gateways/tools/generated?tenant_id=${TENANT_ID}" 2>/dev/null || echo '')"
+
+    if [[ -z "$tools_resp" ]]; then
+        if mock_allowed; then
+            record "AT-LLM" "MOCK" "cp-api unreachable for tools/generated"
+            return 0
+        fi
+        record "AT-LLM" "FAIL" "cp-api unreachable for /v1/internal/gateways/tools/generated"
+        return 1
+    fi
+
+    local enriched
+    enriched="$(echo "$tools_resp" | jq -r --arg api "$DEMO_API_NAME" '
+        .tools[]?
+        | select(.tool_name | contains($api))
+        | .description
+        | select(contains("Intent:") and contains("Side effects:"))
+    ' | head -1)"
+
+    if [[ -n "$enriched" ]]; then
+        record "AT-LLM" "PASS" "tools/generated description carries Intent + Side effects (runtime projection live)"
+        return 0
+    fi
+
+    if mock_allowed; then
+        record "AT-LLM" "MOCK" "runtime projection not found (contract not synced or legacy generator)"
+        return 0
+    fi
+    record "AT-LLM" "FAIL" "tools/generated description missing Intent/Side effects (legacy projection?)"
+    return 1
+}
+
 # ── Report ──────────────────────────────────────────────────────────────────
 
 print_report() {
@@ -740,6 +812,7 @@ main() {
     at4_gateway_call     || true
     at5_observable       || true
     at5b_observability_visibility || true
+    at_llm_readiness     || true
 
     print_report
 

--- a/specs/uac/demo-httpbin.uac.json
+++ b/specs/uac/demo-httpbin.uac.json
@@ -23,6 +23,20 @@
           "service": { "type": "string" }
         },
         "additionalProperties": true
+      },
+      "llm": {
+        "summary": "Fetch a deterministic JSON echo from the demo backend.",
+        "intent": "Use to verify that the gateway → backend path is alive on the demo tenant. Idempotent and side-effect free.",
+        "tool_name": "demo_httpbin_get",
+        "side_effects": "read",
+        "safe_for_agents": true,
+        "requires_human_approval": false,
+        "examples": [
+          {
+            "input": {},
+            "expected_output_contains": { "ok": true }
+          }
+        ]
       }
     }
   ],


### PR DESCRIPTION
## Summary

**PR 2** of the UAC V2 plan ([Decision Gate #9](../blob/main/docs/decisions/2026-04-26-uac-v2-mcp-projection.md)). Proves the chain that PR 1 ([#2585](https://github.com/stoa-platform/stoa/pull/2585)) enabled:

```
contract.endpoint.llm → cp-api generator (PR 1) → tools/generated description
```

## Changes

### `specs/uac/demo-httpbin.uac.json`
Adds `endpoint.llm` to the single canary endpoint (read, safe, no approval). Conforms to the canonical pattern documented in `specs/uac/examples/`. Validates clean against `UacContractSpec` + semantic validator.

### `scripts/demo-smoke-test.sh`
Adds `at_llm_readiness()`, called after AT-5b, with **two layers**:

| Layer | When | What it checks |
|---|---|---|
| **Static** | always (when `DEMO_UAC_CONTRACT` is set) | `endpoint.llm.intent` and `.side_effects` are present in the contract |
| **Runtime** | opt-in via `GATEWAY_INTERNAL_KEY` env var | `GET /v1/internal/gateways/tools/generated` returns a tool whose `description` contains `Intent:` and `Side effects:` |

Mock-mode aware: returns `MOCK` (not `FAIL`) when cp-api is unreachable, consistent with the rest of the smoke.

## Local verification

```
$ DEMO_UAC_CONTRACT=specs/uac/demo-httpbin.uac.json ./scripts/demo-smoke-test.sh --dry-run-contract
[PASS] AT-LLM contract.endpoints[0].llm declares intent + side_effects=read
[INFO] AT-LLM runtime projection check skipped (set GATEWAY_INTERNAL_KEY to enable)
Score: 5/5 — Verdict: CONTRACT_DRY_RUN
```

`bash -n` clean. ShellCheck clean on the added function (pre-existing SC2034 on line 46 untouched).

## Go criteria (from plan)

> "tools/list expose Intent + Side effects sur le canary, sans casser les tools legacy."

- ✅ Canary contract (`demo-httpbin`) carries `endpoint.llm`.
- ✅ Smoke step asserts the static contract shape.
- ✅ Smoke step asserts the runtime projection shape (when key provided).
- ✅ Tools without `endpoint.llm` keep their legacy description (already enforced by PR 1's `test_description_without_llm_unchanged`).

## Out of scope (per Decision Gate #9 reframe)

- `examples[]` as a structured MCP tool field — MCP spec unverified.
- Rust generator parity (`stoa-gateway/src/uac/`) — PR 3, conditional on confirmed prod usage.
- `required_policies` hygiene on `demo-httpbin` (pre-existing semantic warning, untouched per "no opportunistic improvement" rule).

## Diff size

```
scripts/demo-smoke-test.sh      | 73 +++++++++++++++++++++
specs/uac/demo-httpbin.uac.json | 14 +++++
2 files changed, 87 insertions(+)
```

## Test plan

- [ ] CI: License Compliance, SBOM, Signed Commits, Regression Test Guard
- [ ] Demo Smoke (observation) job stays green (or at parity with previous main)
- [ ] No code path change to cp-api (only canary contract + smoke script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)