### PR TITLE
fix(ci): restore green post-merge workflows

### DIFF
--- a/.github/workflows/linear-review-drift-detector.yml
+++ b/.github/workflows/linear-review-drift-detector.yml
@@ -75,14 +75,15 @@ jobs:
               ZOMBIE_COUNT=$((ZOMBIE_COUNT + 1))
 
               # Post warning comment via Linear GraphQL (use jq for safe JSON encoding)
-              COMMENT_TEXT="Review drift detected — this ticket is in 'In Review' but no GitHub PR references ${TICKET_ID} in its title.
-
-Per feedback_linear_in_review.md: 'In Review' requires an open PR. Either:
-1. Create a PR and reference ${TICKET_ID} in the title
-2. Move back to 'Todo' if work hasn't started
-3. Move to 'Done' if the work was completed via another ticket's PR
-
-Auto-detected by review-drift-detector workflow"
+              COMMENT_TEXT=$(printf '%s\n' \
+                "Review drift detected — this ticket is in 'In Review' but no GitHub PR references ${TICKET_ID} in its title." \
+                "" \
+                "Per feedback_linear_in_review.md: 'In Review' requires an open PR. Either:" \
+                "1. Create a PR and reference ${TICKET_ID} in the title" \
+                "2. Move back to 'Todo' if work hasn't started" \
+                "3. Move to 'Done' if the work was completed via another ticket's PR" \
+                "" \
+                "Auto-detected by review-drift-detector workflow")
 
               MUTATION=$(jq -n --arg iid "$ISSUE_UUID" --arg body "$COMMENT_TEXT" '{
                 query: "mutation($iid: String!, $body: String!) { commentCreate(input: { issueId: $iid, body: $body }) { success } }",

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -109,14 +109,6 @@ jobs:
             echo "| stoa-go | ${{ steps.release.outputs['stoa-go--version'] }} | ${{ steps.release.outputs['stoa-go--tag_name'] }} |" >> $GITHUB_STEP_SUMMARY
           fi
 
-  trigger-docker:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.any_release_created == 'true' }}
-    uses: ./.github/workflows/docker-publish.yml
-    secrets: inherit
-    with:
-      services: ${{ needs.release-please.outputs.released_services }}
-
   trigger-goreleaser:
     needs: release-please
     if: ${{ needs.release-please.outputs.stoa_go_release_created == 'true' }}


### PR DESCRIPTION
Fixes the invalid Linear drift detector YAML and removes the duplicate Release Please docker workflow call; Docker images still publish from release tag pushes. Local verification: actionlint on both touched workflows.