### PR TITLE
fix(deployments): materialize UAC catalog contract

### DIFF
--- a/control-plane-api/src/routers/apis.py
+++ b/control-plane-api/src/routers/apis.py
@@ -123,6 +123,19 @@ def _validate_openapi_spec(spec_str: str) -> None:
         )
 
 
+def _parse_openapi_spec(spec_str: str | None) -> dict | None:
+    """Parse JSON/YAML OpenAPI input into the DB/event shape."""
+    if not spec_str:
+        return None
+    import yaml
+
+    try:
+        parsed = json.loads(spec_str) if spec_str.strip().startswith("{") else yaml.safe_load(spec_str)
+    except (json.JSONDecodeError, yaml.YAMLError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
 def _api_from_catalog(api: APICatalog) -> APIResponse:
     """Convert APICatalog DB model to APIResponse."""
     metadata = api.api_metadata or {}
@@ -272,12 +285,7 @@ async def create_api(
         "deployments": {"dev": False, "staging": False},
     }
 
-    openapi_spec = None
-    if api.openapi_spec:
-        try:
-            openapi_spec = json.loads(api.openapi_spec)
-        except (json.JSONDecodeError, TypeError):
-            openapi_spec = None
+    openapi_spec = _parse_openapi_spec(api.openapi_spec)
 
     try:
         stmt = insert(APICatalog).values(
@@ -300,8 +308,13 @@ async def create_api(
             tenant_id=tenant_id,
             api_data={
                 "id": api_id,
-                "name": api.name,
+                "name": api_id,
+                "display_name": api.display_name,
                 "version": api.version,
+                "description": api.description,
+                "backend_url": api.backend_url,
+                "tags": tags,
+                "openapi_spec": openapi_spec,
             },
             user_id=user.id,
         )
@@ -386,10 +399,7 @@ async def update_api(
             promotion_tags = {"portal:published", "promoted:portal", "portal-promoted"}
             current.portal_published = any(tag.lower() in promotion_tags for tag in updates["tags"])
         if "openapi_spec" in updates:
-            try:
-                current.openapi_spec = json.loads(updates["openapi_spec"]) if updates["openapi_spec"] else None
-            except (json.JSONDecodeError, TypeError):
-                current.openapi_spec = None
+            current.openapi_spec = _parse_openapi_spec(updates["openapi_spec"])
 
         current.api_metadata = metadata
         current.synced_at = datetime.now(UTC)
@@ -399,7 +409,16 @@ async def update_api(
         # Emit Kafka event
         await kafka_service.emit_api_updated(
             tenant_id=tenant_id,
-            api_data={"id": api_id, **updates},
+            api_data={
+                "id": api_id,
+                "name": current.api_id,
+                "display_name": current.api_name,
+                "version": current.version,
+                "description": metadata.get("description", ""),
+                "backend_url": metadata.get("backend_url", ""),
+                "tags": current.tags or [],
+                "openapi_spec": current.openapi_spec,
+            },
             user_id=user.id,
         )
 

--- a/control-plane-api/src/services/github_service.py
+++ b/control-plane-api/src/services/github_service.py
@@ -34,6 +34,7 @@ import yaml
 from github import Auth, BadCredentialsException, Github, GithubException, InputGitTreeElement
 
 from ..config import settings
+from ..schemas.uac import UacContractSpec
 from .git_credentials import askpass_env, redact_token
 from .git_executor import (
     BATCH_TIMEOUT_S,
@@ -44,6 +45,7 @@ from .git_executor import (
     run_sync,
 )
 from .git_provider import BranchRef, CommitRef, GitProvider, MergeRequestRef, TreeEntry
+from .uac_transformer import transform_openapi_to_uac
 
 logger = logging.getLogger(__name__)
 
@@ -65,9 +67,7 @@ async def _gh_contents_write(
     timeout: float = DEFAULT_TIMEOUT_S,
 ) -> _GHT:
     """Run a sync PyGithub Contents-API write under the serial (1) semaphore."""
-    return await run_sync(
-        fn, semaphore=GITHUB_CONTENTS_WRITE_SEMAPHORE, timeout=timeout, op_name=op_name
-    )
+    return await run_sync(fn, semaphore=GITHUB_CONTENTS_WRITE_SEMAPHORE, timeout=timeout, op_name=op_name)
 
 
 async def _gh_meta_write(
@@ -76,9 +76,7 @@ async def _gh_meta_write(
     timeout: float = DEFAULT_TIMEOUT_S,
 ) -> _GHT:
     """Run a sync PyGithub non-Contents write under the meta-write semaphore (5)."""
-    return await run_sync(
-        fn, semaphore=GITHUB_META_WRITE_SEMAPHORE, timeout=timeout, op_name=op_name
-    )
+    return await run_sync(fn, semaphore=GITHUB_META_WRITE_SEMAPHORE, timeout=timeout, op_name=op_name)
 
 
 # CP-1 P2 (M.5): transient error classifier for connect() retries. Kept
@@ -191,6 +189,73 @@ def _normalize_mcp_server_data(raw_data: dict, git_path: str) -> dict:
     }
 
 
+def _uac_name(raw: str) -> str:
+    """Normalize an API identifier to UAC kebab-case."""
+    value = re.sub(r"[^a-z0-9]+", "-", raw.lower()).strip("-")
+    if not value:
+        return "api"
+    return f"{value}-api" if len(value) < 2 else value
+
+
+def _coerce_openapi_spec(raw: Any) -> dict | None:
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw.strip():
+        try:
+            loaded = json.loads(raw) if raw.lstrip().startswith("{") else yaml.safe_load(raw)
+        except (json.JSONDecodeError, yaml.YAMLError):
+            return None
+        return loaded if isinstance(loaded, dict) else None
+    return None
+
+
+def _openapi_file_content(raw: Any) -> str | None:
+    spec = _coerce_openapi_spec(raw)
+    if spec is not None:
+        return yaml.dump(spec, default_flow_style=False, allow_unicode=True)
+    return raw if isinstance(raw, str) and raw.strip() else None
+
+
+def _uac_json_content(tenant_id: str, api_name: str, api_data: dict) -> str:
+    """Build the canonical Git UAC JSON artifact for an API catalog entry."""
+    contract_name = _uac_name(api_data.get("id") or api_name)
+    openapi_spec = _coerce_openapi_spec(api_data.get("openapi_spec"))
+    if openapi_spec:
+        try:
+            contract = transform_openapi_to_uac(
+                openapi_spec,
+                tenant_id=tenant_id,
+                backend_base_url=api_data.get("backend_url") or None,
+            )
+            contract = contract.model_copy(
+                update={
+                    "name": contract_name,
+                    "display_name": api_data.get("display_name") or api_name,
+                    "version": api_data.get("version", contract.version),
+                }
+            )
+        except ValueError:
+            contract = UacContractSpec(
+                name=contract_name,
+                tenant_id=tenant_id,
+                version=api_data.get("version", "1.0.0"),
+                display_name=api_data.get("display_name") or api_name,
+                description=api_data.get("description") or None,
+            )
+    else:
+        contract = UacContractSpec(
+            name=contract_name,
+            tenant_id=tenant_id,
+            version=api_data.get("version", "1.0.0"),
+            display_name=api_data.get("display_name") or api_name,
+            description=api_data.get("description") or None,
+        )
+        contract.refresh_policies()
+    if not contract.required_policies:
+        contract.refresh_policies()
+    return json.dumps(contract.model_dump(mode="json", exclude_none=True), indent=2, sort_keys=True) + "\n"
+
+
 class GitHubService(GitProvider):
     """GitHub implementation of GitProvider — GitOps source of truth."""
 
@@ -228,13 +293,17 @@ class GitHubService(GitProvider):
                     delay = backoffs[attempt]
                     logger.warning(
                         "GitHub connect attempt %d/%d failed (transient): %s. Retrying in %ds.",
-                        attempt + 1, max_attempts, exc, delay,
+                        attempt + 1,
+                        max_attempts,
+                        exc,
+                        delay,
                     )
                     await asyncio.sleep(delay)
                 else:
                     logger.error(
                         "Failed to connect to GitHub after %d attempts: %s",
-                        max_attempts, exc,
+                        max_attempts,
+                        exc,
                     )
         assert last_error is not None  # loop always assigns on failure
         raise last_error
@@ -533,9 +602,7 @@ class GitHubService(GitProvider):
                     return json.loads(content)
                 return yaml.safe_load(content)
             except (json.JSONDecodeError, yaml.YAMLError) as exc:
-                logger.error(
-                    "Failed to parse OpenAPI spec for %s/%s (%s): %s", tenant_id, api_name, filename, exc
-                )
+                logger.error("Failed to parse OpenAPI spec for %s/%s (%s): %s", tenant_id, api_name, filename, exc)
                 return None
 
         return None
@@ -614,9 +681,7 @@ class GitHubService(GitProvider):
         gh = self._require_gh()
         project_id = self._catalog_project_id()
         base_path = (
-            "platform/mcp-servers"
-            if tenant_id == "_platform"
-            else f"{self._get_tenant_path(tenant_id)}/mcp-servers"
+            "platform/mcp-servers" if tenant_id == "_platform" else f"{self._get_tenant_path(tenant_id)}/mcp-servers"
         )
 
         default_ref = settings.git.default_branch
@@ -647,9 +712,7 @@ class GitHubService(GitProvider):
         """
         platform_servers_task = asyncio.create_task(self.list_mcp_servers("_platform"))
         tenant_ids = await self.list_tenants()
-        tenant_results = await asyncio.gather(
-            *[self.list_mcp_servers(tid) for tid in tenant_ids]
-        )
+        tenant_results = await asyncio.gather(*[self.list_mcp_servers(tid) for tid in tenant_ids])
         platform_servers = await platform_servers_task
         return list(itertools.chain(platform_servers, *tenant_results))
 
@@ -705,9 +768,7 @@ class GitHubService(GitProvider):
                 existing = repo.get_contents(file_path, ref=effective_branch)
                 if isinstance(existing, list):
                     raise ValueError(f"{file_path} is a directory, not a file")
-                result = repo.update_file(
-                    file_path, commit_message, content, existing.sha, branch=effective_branch
-                )
+                result = repo.update_file(file_path, commit_message, content, existing.sha, branch=effective_branch)
                 return {"sha": result["commit"].sha, "url": result["commit"].html_url}
             except GithubException as exc:
                 if exc.status == 404:
@@ -789,7 +850,10 @@ class GitHubService(GitProvider):
             ref.edit(new_commit.sha)
             logger.info(
                 "Batch commit %s on %s/%s (%d actions)",
-                new_commit.sha[:8], project_id, effective_branch, len(actions),
+                new_commit.sha[:8],
+                project_id,
+                effective_branch,
+                len(actions),
             )
             return {"sha": new_commit.sha, "url": new_commit.html_url}
 
@@ -924,7 +988,7 @@ class GitHubService(GitProvider):
         layer via the serial Contents-write semaphore.
         """
         project_id = self._catalog_project_id()
-        api_name = api_data["name"]
+        api_name = api_data.get("id") or api_data["name"]
         api_path = self._get_api_path(tenant_id, api_name)
 
         await self._ensure_tenant_exists(tenant_id)
@@ -948,13 +1012,17 @@ class GitHubService(GitProvider):
 
         actions: list[dict[str, Any]] = [
             {"action": "create", "file_path": f"{api_path}/api.yaml", "content": api_yaml},
+            {
+                "action": "create",
+                "file_path": f"{api_path}/uac.json",
+                "content": _uac_json_content(tenant_id, api_name, api_data),
+            },
             {"action": "create", "file_path": f"{api_path}/policies/.gitkeep", "content": ""},
         ]
 
-        if api_data.get("openapi_spec"):
-            actions.append(
-                {"action": "create", "file_path": f"{api_path}/openapi.yaml", "content": api_data["openapi_spec"]}
-            )
+        openapi_content = _openapi_file_content(api_data.get("openapi_spec"))
+        if openapi_content:
+            actions.append({"action": "create", "file_path": f"{api_path}/openapi.yaml", "content": openapi_content})
 
         overrides: dict[str, dict] = api_data.get("overrides", {})
         for env_name, env_config in overrides.items():
@@ -983,24 +1051,38 @@ class GitHubService(GitProvider):
         except FileNotFoundError:
             raise FileNotFoundError(f"API '{api_name}' not found for tenant '{tenant_id}'")
 
+        api_data = dict(api_data)
         overrides: dict[str, dict] = api_data.pop("overrides", {})
 
         current = yaml.safe_load(current_content)
-        current.update(api_data)
+        current.update({k: v for k, v in api_data.items() if k != "openapi_spec"})
         updated_yaml = yaml.dump(current, default_flow_style=False, allow_unicode=True)
 
-        if overrides:
-            actions: list[dict[str, Any]] = [
-                {"action": "update", "file_path": file_path, "content": updated_yaml}
-            ]
-            for env_name, env_config in overrides.items():
-                override_path = f"{api_path}/overrides/{env_name}.yaml"
-                override_yaml = yaml.dump(env_config, default_flow_style=False, allow_unicode=True)
-                action = "update" if await self._file_exists(project_id, override_path) else "create"
-                actions.append({"action": action, "file_path": override_path, "content": override_yaml})
-            await self.batch_commit(project_id, actions=actions, commit_message=f"Update API {api_name}")
-        else:
-            await self.update_file(project_id, file_path, updated_yaml, f"Update API {api_name}")
+        actions: list[dict[str, Any]] = [{"action": "update", "file_path": file_path, "content": updated_yaml}]
+        uac_path = f"{api_path}/uac.json"
+        actions.append(
+            {
+                "action": "update" if await self._file_exists(project_id, uac_path) else "create",
+                "file_path": uac_path,
+                "content": _uac_json_content(tenant_id, api_name, {**current, **api_data}),
+            }
+        )
+        openapi_content = _openapi_file_content(api_data.get("openapi_spec"))
+        if openapi_content:
+            openapi_path = f"{api_path}/openapi.yaml"
+            actions.append(
+                {
+                    "action": "update" if await self._file_exists(project_id, openapi_path) else "create",
+                    "file_path": openapi_path,
+                    "content": openapi_content,
+                }
+            )
+        for env_name, env_config in overrides.items():
+            override_path = f"{api_path}/overrides/{env_name}.yaml"
+            override_yaml = yaml.dump(env_config, default_flow_style=False, allow_unicode=True)
+            action = "update" if await self._file_exists(project_id, override_path) else "create"
+            actions.append({"action": action, "file_path": override_path, "content": override_yaml})
+        await self.batch_commit(project_id, actions=actions, commit_message=f"Update API {api_name}")
 
         logger.info("Updated API %s for tenant %s", api_name, tenant_id)
         return True
@@ -1155,9 +1237,7 @@ class GitHubService(GitProvider):
                     files_to_delete.append(item.path)
             return files_to_delete
 
-        files_to_delete = await _gh_read(
-            _collect_files, "github.delete_mcp_server.collect", timeout=BATCH_TIMEOUT_S
-        )
+        files_to_delete = await _gh_read(_collect_files, "github.delete_mcp_server.collect", timeout=BATCH_TIMEOUT_S)
 
         if not files_to_delete:
             return True
@@ -1235,11 +1315,7 @@ class GitHubService(GitProvider):
                     author = c.author.login
                 elif c.commit and c.commit.author and c.commit.author.name:
                     author = c.commit.author.name
-                date = (
-                    c.commit.author.date.isoformat()
-                    if c.commit and c.commit.author and c.commit.author.date
-                    else ""
-                )
+                date = c.commit.author.date.isoformat() if c.commit and c.commit.author and c.commit.author.date else ""
                 refs.append(
                     CommitRef(sha=c.sha, message=c.commit.message if c.commit else "", author=author, date=date)
                 )
@@ -1359,17 +1435,13 @@ class GitHubService(GitProvider):
 
         ``target_branch=None`` resolves to ``settings.git.default_branch`` (CP-1 P2 M.4).
         """
-        effective_target = (
-            target_branch if target_branch is not None else settings.git.default_branch
-        )
+        effective_target = target_branch if target_branch is not None else settings.git.default_branch
         gh = self._require_gh()
         project_id = self._catalog_project_id()
 
         def _create() -> MergeRequestRef:
             repo = gh.get_repo(project_id)
-            pr = repo.create_pull(
-                title=title, body=description, head=source_branch, base=effective_target
-            )
+            pr = repo.create_pull(title=title, body=description, head=source_branch, base=effective_target)
             return self._pr_to_ref(pr)
 
         return await _gh_meta_write(_create, "github.create_merge_request")

--- a/control-plane-api/tests/test_apis_router.py
+++ b/control-plane-api/tests/test_apis_router.py
@@ -138,6 +138,41 @@ class TestCreateAPI:
         body = resp.json()
         assert body["name"] == "new-api"
         assert body["status"] == "draft"
+        event_payload = mock_kafka.emit_api_created.call_args.kwargs["api_data"]
+        assert event_payload["backend_url"] == "https://api.example.com"
+        assert event_payload["display_name"] == "New API"
+        assert "openapi_spec" in event_payload
+
+    def test_create_event_contains_parsed_openapi(self, app_with_tenant_admin, client_as_tenant_admin):
+        openapi_yaml = """
+openapi: 3.0.0
+info:
+  title: New API
+  version: 1.0.0
+paths:
+  /quotes:
+    get:
+      operationId: listQuotes
+      responses:
+        "200":
+          description: ok
+"""
+        with patch(CATALOG_REPO_PATH), patch(KAFKA_PATH) as mock_kafka:
+            mock_kafka.emit_api_created = AsyncMock(return_value="evt-1")
+            mock_kafka.emit_audit_event = AsyncMock(return_value="evt-2")
+            resp = client_as_tenant_admin.post(
+                "/v1/tenants/acme/apis",
+                json={
+                    "name": "quotes-api",
+                    "display_name": "Quotes API",
+                    "backend_url": "https://quotes.example.com",
+                    "openapi_spec": openapi_yaml,
+                },
+            )
+
+        assert resp.status_code == 200
+        event_payload = mock_kafka.emit_api_created.call_args.kwargs["api_data"]
+        assert event_payload["openapi_spec"]["paths"]["/quotes"]["get"]["operationId"] == "listQuotes"
 
     def test_create_duplicate_returns_409(self, app_with_tenant_admin, client_as_tenant_admin):
         from src.database import get_db

--- a/control-plane-api/tests/test_github_service.py
+++ b/control-plane-api/tests/test_github_service.py
@@ -1,5 +1,6 @@
 """Tests for GitHubService (CAB-1890 Wave 2, CAB-2011 write methods)."""
 
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -497,6 +498,7 @@ class TestCreateApi:
         actions = mock_batch.call_args[1]["actions"]
         paths = [a["file_path"] for a in actions]
         assert "tenants/acme/apis/billing-api/api.yaml" in paths
+        assert "tenants/acme/apis/billing-api/uac.json" in paths
         assert "tenants/acme/apis/billing-api/policies/.gitkeep" in paths
 
     @pytest.mark.asyncio
@@ -516,29 +518,44 @@ class TestCreateApi:
         mock_exists.return_value = False
         mock_batch.return_value = {"sha": "abc", "url": ""}
 
-        api_data = {"name": "pet-api", "openapi_spec": "openapi: 3.0.0\ninfo:\n  title: Pets"}
+        api_data = {
+            "id": "pet-api",
+            "name": "pet-api",
+            "display_name": "Pet API",
+            "backend_url": "https://pets.example.com",
+            "openapi_spec": {
+                "openapi": "3.0.0",
+                "info": {"title": "Pets", "version": "1.0.0"},
+                "paths": {"/pets": {"get": {"operationId": "listPets", "responses": {"200": {"description": "ok"}}}}},
+            },
+        }
         await service.create_api("demo", api_data)
 
         actions = mock_batch.call_args[1]["actions"]
-        paths = [a["file_path"] for a in actions]
+        paths = {a["file_path"]: a["content"] for a in actions}
         assert "tenants/demo/apis/pet-api/openapi.yaml" in paths
+        uac = json.loads(paths["tenants/demo/apis/pet-api/uac.json"])
+        assert uac["name"] == "pet-api"
+        assert uac["endpoints"][0]["backend_url"] == "https://pets.example.com/pets"
 
 
 class TestUpdateApi:
     @pytest.mark.asyncio
-    @patch.object(GitHubService, "update_file", new_callable=AsyncMock)
+    @patch.object(GitHubService, "batch_commit", new_callable=AsyncMock)
+    @patch.object(GitHubService, "_file_exists", new_callable=AsyncMock)
     @patch.object(GitHubService, "get_file_content", new_callable=AsyncMock)
-    async def test_update_api_success(self, mock_get, mock_update, service):
+    async def test_update_api_success(self, mock_get, mock_exists, mock_batch, service):
         mock_get.return_value = "name: billing-api\nversion: 1.0.0\n"
-        mock_update.return_value = {"sha": "new", "url": ""}
+        mock_exists.return_value = True
+        mock_batch.return_value = {"sha": "new", "url": ""}
 
         result = await service.update_api("acme", "billing-api", {"version": "2.0.0"})
 
         assert result is True
-        mock_update.assert_called_once()
-        # Verify the YAML content includes merged data
-        call_args = mock_update.call_args[0]
-        assert "2.0.0" in call_args[2]
+        mock_batch.assert_called_once()
+        actions = mock_batch.call_args[1]["actions"]
+        assert any(a["file_path"].endswith("/api.yaml") and "2.0.0" in a["content"] for a in actions)
+        assert any(a["file_path"].endswith("/uac.json") for a in actions)
 
     @pytest.mark.asyncio
     @patch.object(GitHubService, "get_file_content", new_callable=AsyncMock)

--- a/control-plane-api/tests/test_regression_catalog_uac_git_write.py
+++ b/control-plane-api/tests/test_regression_catalog_uac_git_write.py
@@ -1,0 +1,48 @@
+"""Regression tests for Git-backed UAC catalog materialization."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.services.github_service import GitHubService
+
+
+@pytest.mark.asyncio
+@patch.object(GitHubService, "batch_commit", new_callable=AsyncMock)
+@patch.object(GitHubService, "_file_exists", new_callable=AsyncMock)
+@patch.object(GitHubService, "_ensure_tenant_exists", new_callable=AsyncMock)
+async def test_api_create_writes_canonical_uac_json(mock_tenant, mock_exists, mock_batch):
+    service = GitHubService()
+    service._gh = AsyncMock()
+    mock_exists.return_value = False
+    mock_batch.return_value = {"sha": "abc", "url": ""}
+
+    await service.create_api(
+        "banking-demo",
+        {
+            "id": "alpha-vantage-stock-data",
+            "name": "Alpha Vantage Stock Data",
+            "display_name": "Alpha Vantage Stock Data",
+            "version": "1.2.0",
+            "backend_url": "https://stocks.example.com",
+            "openapi_spec": {
+                "openapi": "3.0.0",
+                "info": {"title": "Alpha Vantage", "version": "1.2.0"},
+                "paths": {
+                    "/quote": {
+                        "get": {
+                            "operationId": "getQuote",
+                            "responses": {"200": {"description": "ok"}},
+                        }
+                    }
+                },
+            },
+        },
+    )
+
+    actions = {a["file_path"]: a["content"] for a in mock_batch.call_args.kwargs["actions"]}
+    uac = json.loads(actions["tenants/banking-demo/apis/alpha-vantage-stock-data/uac.json"])
+    assert uac["name"] == "alpha-vantage-stock-data"
+    assert uac["tenant_id"] == "banking-demo"
+    assert uac["endpoints"][0]["backend_url"] == "https://stocks.example.com/quote"

--- a/specs/api-runtime-reconciliation-contract.md
+++ b/specs/api-runtime-reconciliation-contract.md
@@ -135,10 +135,17 @@ Format attendu pour les contrats et fixtures de test:
 
 ```text
 specs/uac/*.uac.json
+tenants/{tenant_id}/apis/{api_id}/uac.json
 ```
 
 Les tests contractuels doivent donc valider le JSON UAC, puis vérifier que CP
 matérialise la même génération/hash vers les targets runtime.
+
+Tout événement `api-created`/`api-updated` consommé par le worker Git doit porter
+le contrat complet nécessaire à cette écriture: `id`, `name`, `display_name`,
+`version`, `description`, `backend_url`, `tags` et `openapi_spec` parsé si
+présent. Un événement réduit à `id/name/version` est invalide car il ne permet
+pas de maintenir `stoa-catalog` comme vérité configurationnelle.
 
 Chaîne conceptuelle:
 


### PR DESCRIPTION
## Summary
- enrich `/apis` lifecycle events with backend metadata and parsed OpenAPI specs so Git sync has enough desired-state context
- write canonical `tenants/{tenant}/apis/{api_id}/uac.json` in the GitHub catalog writer alongside `api.yaml` and `openapi.yaml`
- update the runtime reconciliation spec to make full API lifecycle event payloads mandatory for stoa-catalog freshness

## Validation
- `pytest tests/test_regression_catalog_uac_git_write.py tests/test_github_service.py tests/test_spec_cab_2012.py tests/test_apis_router.py -q`
- `ruff check src/routers/apis.py src/services/github_service.py tests/test_github_service.py tests/test_apis_router.py tests/test_regression_catalog_uac_git_write.py`
