### PR TITLE
docs(decisions): close UAC V2 — audit signal #1 NOGO on Rust parity

### DIFF
--- a/docs/decisions/2026-04-26-uac-v2-mcp-projection.md
+++ b/docs/decisions/2026-04-26-uac-v2-mcp-projection.md
@@ -54,3 +54,45 @@ Le Decision Gate #9 valide une fois de plus le pattern "preuve d'abord, parité 
 ## External index
 
 Le log cross-repo `stoa-docs/HEGEMON/DECISION_GATE.md` s'arrête à #7 ; #8 n'y a pas été enregistré. Conformément à la décision opérationnelle (2026-04-26) de ne pas rétablir une mécanique cross-repo abandonnée, **#9 reste self-contained ici**. Si la pratique cross-repo est reprise un jour, #8 et #9 seront enregistrés à ce moment-là dans le même mouvement.
+
+## Audit du signal #1 (2026-04-26, post PR 2)
+
+Audit lecture du chemin runtime `tools/list` côté `stoa-gateway`, exécuté juste après le merge de PR 2 (`d368ae4a4`).
+
+**Verdict : NOGO confirmé sur PR 3 (Rust parity).** Le gateway Rust est un *consumer* de la projection cp-api, pas un *generator*. Aucun équivalent Rust de `_build_description` (cp-api Python) ne s'exécute sur le chemin chaud `/mcp/tools/list`.
+
+### Chaîne runtime confirmée
+
+```
+client MCP → GET /mcp/tools/list
+  → stoa-gateway/src/mcp/handlers.rs:314      state.tool_registry.list(...)
+  → registry rempli au boot par stoa_tools.rs:298  refresh_tools_for_tenant()
+  → tool_proxy.rs:340                         GET /v1/internal/gateways/tools/generated
+  → cp-api lit la table mcp_generated_tools
+  → tools projetés par UacToolGenerator._build_description (modifié en PR 1, #2585)
+```
+
+Le gateway réutilise tel quel le champ `description` reçu de cp-api (`stoa_tools.rs:48,93-96`). Pas de re-projection Rust en chemin chaud.
+
+### Code Rust qui ressemble à une projection mais ne l'est pas
+
+- `stoa-gateway/src/uac/binders/mcp.rs:46-93` — `McpBinder::generate_tool_definitions()` construit bien des descriptions, mais appelé uniquement depuis `handlers/admin/contracts.rs:72-76` (POST `/admin/contracts`), jamais sur `tools/list`.
+- `stoa-gateway/src/mcp/tools/stoa_tools.rs:114-130` — `infer_action()` est une inférence d'action, pas un équivalent de `_build_description`.
+
+### Implications
+
+- **Signal #1 : NON.** Le chemin gateway → `tools/list` ne consomme pas de projection Rust.
+- **Signal #2** (canary mergé + retour client agent) : partiellement satisfait (canary mergé via PR 2). Pas encore de retour agent en prod, mais sans projection Rust, la question ne se pose plus.
+- **Signal #3** : aucune régression de parité possible (pas de double projection à comparer).
+
+**Décision : PR 3 fermée, aucun ticket backlog ouvert.** Le gateway Rust restera consumer de cp-api pour la metadata projetée. Le seul lieu de maintenance des descriptions reste `control-plane-api/src/services/uac_tool_generator.py`.
+
+### Plan UAC V2 = exécuté
+
+| PR | État | Merge |
+|---|---|---|
+| PR 1 — cp-api generator enrichi | ✅ Merged | `82c5ebb49` (#2585) |
+| PR 2 — smoke + canary | ✅ Merged | `d368ae4a4` (#2588) |
+| PR 3 — Rust parity | ✅ Closed (audit signal #1 NOGO) | n/a |
+
+Go criteria du plan ("`tools/list` expose `Intent` + `Side effects` sur le canary, sans casser les tools legacy") atteint à 100%.

--- a/docs/plans/2026-04-26-uac-v2-mcp-projection.md
+++ b/docs/plans/2026-04-26-uac-v2-mcp-projection.md
@@ -1,11 +1,13 @@
 ---
 id: plan-2026-04-26-uac-v2-mcp-projection
 triggers: [a, b]
-validation_status: validated
+validation_status: executed
 challenge_ref: docs/decisions/2026-04-26-uac-v2-mcp-projection.md
 ---
 
 > **Reframed after Decision Gate #9** (2026-04-26). Original draft proposed Python+Rust parity in lockstep. Reframe: Python first, smoke/canary second, Rust **only if usage confirmed**. See `challenge_ref` for full arbitrage.
+>
+> **Status (2026-04-26, end of day) : EXECUTED.** PR 1 merged (`82c5ebb49`, #2585). PR 2 merged (`d368ae4a4`, #2588). PR 3 closed by signal #1 audit (NOGO Rust parity — gateway is a consumer of cp-api projection, not a generator). Go criteria atteint. Voir la section "Audit du signal #1" dans `challenge_ref`.
 
 # Plan — UAC V2, projection MCP de la metadata `endpoint.llm`
 


### PR DESCRIPTION
## Summary

Closure governance pour UAC V2. Annotations dans la décision Gate #9 + bandeau de clôture sur le plan, après l'audit lecture-de-code du chemin runtime Rust effectué post-PR 2.

## Audit signal #1 — verdict

> **NOGO confirmé sur PR 3 (Rust parity).** Le gateway Rust est un *consumer* de la projection cp-api, pas un *generator*.

Chaîne runtime tracée :
```
client MCP → GET /mcp/tools/list
  → stoa-gateway/src/mcp/handlers.rs:314      state.tool_registry.list(...)
  → registry rempli au boot par stoa_tools.rs:298 refresh_tools_for_tenant()
  → tool_proxy.rs:340                         GET /v1/internal/gateways/tools/generated
  → cp-api UacToolGenerator._build_description (modifié en PR 1, #2585)
```

Le `description` revient tel quel de cp-api ; aucune re-projection Rust en chemin chaud.

`McpBinder` (stoa-gateway/src/uac/binders/mcp.rs:46-93) ressemble à une projection mais n'est appelé que sur `POST /admin/contracts`, jamais sur `tools/list`.

## Conséquence

| Signal de réouverture PR 3 | État |
|---|---|
| #1 — chemin Rust runtime | NON |
| #2 — canary cp-api mergé + retour agent | partiellement (canary mergé, mais moot sans Rust path) |
| #3 — régression de parité | N/A (pas de double projection) |

**PR 3 fermée. Pas de ticket backlog.** Le seul lieu de maintenance des descriptions projetées reste `control-plane-api/src/services/uac_tool_generator.py`.

## Plan UAC V2 final

| PR | État | Merge |
|---|---|---|
| PR 1 — cp-api generator enrichi | ✅ Merged | `82c5ebb49` (#2585) |
| PR 2 — smoke + canary | ✅ Merged | `d368ae4a4` (#2588) |
| PR 3 — Rust parity | ✅ Closed (NOGO audit) | n/a |

Go criteria du plan atteint à 100% : `tools/list` expose `Intent` + `Side effects` sur le canary, sans casser les tools legacy.

## Diff

```
docs/decisions/2026-04-26-uac-v2-mcp-projection.md | 42 ++++++++
docs/plans/2026-04-26-uac-v2-mcp-projection.md     |  4 +-
2 files changed, 45 insertions(+), 1 deletion(-)
```

`validation_status` du plan passé de `validated` à `executed`.

## Test plan

- [ ] CI: License Compliance, SBOM, Signed Commits, Regression Test Guard
- [ ] No code, no schema change to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)