### PR TITLE
fix(ci): checkout quickstart benchmark repo

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Checkout quickstart benchmark
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: stoa-platform/stoa-quickstart
+          path: stoa-quickstart
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -42,9 +48,11 @@ jobs:
           ./benchmark.sh --ci | tee benchmark-output.txt
 
           # Extract results for summary
-          echo "## DX Benchmark Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          cat benchmark-output.txt >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## DX Benchmark Results"
+            echo ""
+            cat benchmark-output.txt
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Benchmark Results
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
## Summary
- checkout stoa-platform/stoa-quickstart into stoa-quickstart/ before running DX Benchmark
- clean up benchmark summary redirection for actionlint

## Verification
- actionlint .github/workflows/benchmark.yml
- git diff --check

Fixes the release DX Benchmark failure where the workflow tried to run in a missing stoa-quickstart directory.