### PR TITLE
fix(ci): propagate DX benchmark failures

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,7 +45,10 @@ jobs:
         working-directory: stoa-quickstart
         run: |
           chmod +x benchmark.sh
+          set +e
           ./benchmark.sh --ci | tee benchmark-output.txt
+          benchmark_status=${PIPESTATUS[0]}
+          set -e
 
           # Extract results for summary
           {
@@ -54,7 +57,10 @@ jobs:
             cat benchmark-output.txt
           } >> "$GITHUB_STEP_SUMMARY"
 
+          exit "$benchmark_status"
+
       - name: Upload Benchmark Results
+        if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: benchmark-results-${{ github.sha }}


### PR DESCRIPTION
## Summary
- preserve the benchmark script exit code when piping output through tee
- keep benchmark artifacts uploaded even when the benchmark fails

## Verification
- actionlint .github/workflows/benchmark.yml
- git diff --check