### PR TITLE
fix(api): pin KC auth to master realm via user_realm_name (CAB-2195)

### DIFF
--- a/control-plane-api/src/services/keycloak_service.py
+++ b/control-plane-api/src/services/keycloak_service.py
@@ -45,22 +45,24 @@ class KeycloakService:
         """Initialize Keycloak admin connection.
 
         Uses Resource Owner Password Grant with admin-cli (public client).
-        Authenticates on master realm, then targets the configured realm
-        for client/user management.
+        ``user_realm_name`` pins the auth realm to ``master`` (where the admin
+        user lives) while ``realm_name`` targets the operational realm — token
+        refresh hits the master token endpoint instead of the operational
+        realm where ``admin`` does not exist (CAB-2195).
         """
         try:
             # CAB-2094: admin API uses the internal SVC URL when configured,
             # avoiding hairpin NAT on OVH MKS.
             conn = KeycloakOpenIDConnection(
                 server_url=settings.keycloak_internal_url,
-                realm_name="master",
+                realm_name=settings.KEYCLOAK_REALM,
+                user_realm_name="master",
                 client_id=settings.KEYCLOAK_ADMIN_CLIENT_ID,
                 username="admin",
                 password=settings.KEYCLOAK_ADMIN_CLIENT_SECRET,
                 verify=settings.KEYCLOAK_VERIFY_SSL,
             )
             self._admin = KeycloakAdmin(connection=conn)
-            self._admin.connection.realm_name = settings.KEYCLOAK_REALM
             logger.info(f"Connected to Keycloak realm: {settings.KEYCLOAK_REALM}")
         except Exception as e:
             logger.error(f"Failed to connect to Keycloak: {e}")

--- a/control-plane-api/tests/test_keycloak_service.py
+++ b/control-plane-api/tests/test_keycloak_service.py
@@ -38,22 +38,6 @@ class TestConnect:
         ):
                 await svc.connect()
 
-    async def test_regression_cab_2195_connect_uses_user_realm_name(self):
-        # Authenticate against master (where the admin user lives) and operate on
-        # the configured realm. Mutating connection.realm_name post-init breaks
-        # token refresh because python-keycloak hits the token endpoint of the
-        # mutated realm — where `admin` does not exist — yielding 401
-        # invalid_grant on every refresh.
-        from src.config import settings
-
-        svc = KeycloakService()
-        with patch("src.services.keycloak_service.KeycloakOpenIDConnection") as mock_conn, \
-             patch("src.services.keycloak_service.KeycloakAdmin"):
-            await svc.connect()
-            kwargs = mock_conn.call_args.kwargs
-            assert kwargs["realm_name"] == settings.KEYCLOAK_REALM
-            assert kwargs["user_realm_name"] == "master"
-
 
 class TestDisconnect:
     async def test_disconnect_clears_admin(self, svc):

--- a/control-plane-api/tests/test_keycloak_service.py
+++ b/control-plane-api/tests/test_keycloak_service.py
@@ -38,6 +38,22 @@ class TestConnect:
         ):
                 await svc.connect()
 
+    async def test_regression_cab_2195_connect_uses_user_realm_name(self):
+        # Authenticate against master (where the admin user lives) and operate on
+        # the configured realm. Mutating connection.realm_name post-init breaks
+        # token refresh because python-keycloak hits the token endpoint of the
+        # mutated realm — where `admin` does not exist — yielding 401
+        # invalid_grant on every refresh.
+        from src.config import settings
+
+        svc = KeycloakService()
+        with patch("src.services.keycloak_service.KeycloakOpenIDConnection") as mock_conn, \
+             patch("src.services.keycloak_service.KeycloakAdmin"):
+            await svc.connect()
+            kwargs = mock_conn.call_args.kwargs
+            assert kwargs["realm_name"] == settings.KEYCLOAK_REALM
+            assert kwargs["user_realm_name"] == "master"
+
 
 class TestDisconnect:
     async def test_disconnect_clears_admin(self, svc):

--- a/control-plane-api/tests/test_regression_cab_2195.py
+++ b/control-plane-api/tests/test_regression_cab_2195.py
@@ -1,0 +1,24 @@
+"""Regression tests for CAB-2195 (KeycloakService realm-mutation token refresh bug)."""
+
+from unittest.mock import patch
+
+from src.config import settings
+from src.services.keycloak_service import KeycloakService
+
+
+class TestRegressionCab2195:
+    async def test_regression_cab_2195_connect_uses_user_realm_name(self):
+        # Authenticate against master (where the admin user lives) and operate
+        # on the configured realm. Mutating connection.realm_name post-init
+        # breaks token refresh because python-keycloak hits the token endpoint
+        # of the mutated realm — where `admin` does not exist — yielding 401
+        # invalid_grant on every refresh.
+        svc = KeycloakService()
+        with (
+            patch("src.services.keycloak_service.KeycloakOpenIDConnection") as mock_conn,
+            patch("src.services.keycloak_service.KeycloakAdmin"),
+        ):
+            await svc.connect()
+            kwargs = mock_conn.call_args.kwargs
+            assert kwargs["realm_name"] == settings.KEYCLOAK_REALM
+            assert kwargs["user_realm_name"] == "master"


### PR DESCRIPTION
## Summary

Companion PR to **stoa-infra#61** (which fixed the wrong `KEYCLOAK_ADMIN_CLIENT_ID`). That fix was correct but exposed a second bug in `KeycloakService.connect()`: token refresh was failing with 401 `invalid_grant` because the lib was looking up the `admin` user in the operational realm (where it doesn't exist) instead of `master`.

## Root cause

`src/services/keycloak_service.py:54-63` (before this PR):

```python
conn = KeycloakOpenIDConnection(
    server_url=...,
    realm_name="master",        # auth realm at init
    client_id=..., username="admin", password=...,
)
self._admin = KeycloakAdmin(connection=conn)
self._admin.connection.realm_name = settings.KEYCLOAK_REALM   # mutate
```

When python-keycloak refreshes the token (per-request `_refresh_if_required` → `refresh_token` → `get_token`), it constructs the token endpoint URL from the **current** `connection.realm_name` — which has been mutated to `stoa`. The `admin` user does not exist in `stoa`, so refresh returns `401 invalid_grant`.

## Fix

Use python-keycloak's native `user_realm_name` parameter (supported since well before 7.1.1, the version we run) to pin the auth realm independently of the target realm:

```python
conn = KeycloakOpenIDConnection(
    server_url=...,
    realm_name=settings.KEYCLOAK_REALM,   # operational realm
    user_realm_name="master",             # auth realm
    ...
)
self._admin = KeycloakAdmin(connection=conn)
# no mutation needed
```

Token refresh now hits the master token endpoint regardless of how many ops have run on the operational realm.

## Verification

Reproduced live in prod cp-api pod (mock-free, same env as the failing saga):

```
# before
admin.get_groups() → 401 invalid_grant "Invalid user credentials"

# after
admin.get_groups() → 8 groups returned (free-aech-364b, free-alex-6ee0, ...)
```

`tests/test_keycloak_service.py::TestConnect::test_regression_cab_2195_connect_uses_user_realm_name` asserts the correct kwargs are passed at init — fails on `main`, passes on this branch.

## Test plan

- [ ] `test_keycloak_service.py` regression test passes (84/84 KC tests green locally)
- [ ] CI green
- [ ] After merge: image deploy → ArgoCD sync → cp-api roll
- [ ] Re-create a test tenant in prod, verify `provisioning_status=ready` + `kc_group_id` non-NULL
- [ ] Mark CAB-2195 Done

## Refs

- Linear: [CAB-2195](https://linear.app/hlfh-workspace/issue/CAB-2195/kc-service-account-credentials-desync-after-re-bootstrap-blocks-tenant)
- Companion: stoa-infra#61 (admin-cli client_id) — already merged
- Unblocks: api-creation-gitops-rewrite Phase 6 (strangler activation on `demo-gitops`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)