### PR TITLE
fix(api): allow recreating archived tenant after failed bootstrap (CAB-2196)

### DIFF
--- a/control-plane-api/src/routers/tenants.py
+++ b/control-plane-api/src/routers/tenants.py
@@ -391,7 +391,26 @@ async def create_tenant(
         # Check if tenant already exists
         existing = await repo.get_by_id(tenant_id)
         if existing:
-            raise HTTPException(status_code=409, detail=f"Tenant '{tenant_id}' already exists")
+            # CAB-2196: an archived row with no kc_group_id is a failed-bootstrap
+            # tombstone (DELETE archived a tenant that never finished provisioning).
+            # Recreate is safe: hard-purge the old row then create fresh. Archived
+            # rows that DID provision (kc_group_id set) stay 409 — those are real
+            # decommissioned tenants and re-using the ID is a compliance concern.
+            if (
+                existing.status == TenantStatus.ARCHIVED.value
+                and existing.kc_group_id is None
+            ):
+                await repo.delete(existing)
+                await kafka_service.emit_audit_event(
+                    tenant_id=tenant_id,
+                    action="recreate-from-failed-bootstrap",
+                    resource_type="tenant",
+                    resource_id=tenant_id,
+                    user_id=user.id,
+                    details={"prev_provisioning_status": existing.provisioning_status},
+                )
+            else:
+                raise HTTPException(status_code=409, detail=f"Tenant '{tenant_id}' already exists")
 
         # Create tenant in database with PENDING provisioning status
         tenant = Tenant(

--- a/control-plane-api/tests/test_regression_cab_2196.py
+++ b/control-plane-api/tests/test_regression_cab_2196.py
@@ -1,0 +1,103 @@
+"""Regression tests for CAB-2196 (archived tenant blocks recreate even after failed bootstrap)."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from src.models.tenant import Tenant
+
+
+def _archived_tenant(tenant_id, kc_group_id, provisioning_status="failed"):
+    t = MagicMock(spec=Tenant)
+    t.id = tenant_id
+    t.name = "Whatever"
+    t.description = ""
+    t.status = "archived"
+    t.provisioning_status = provisioning_status
+    t.kc_group_id = kc_group_id
+    t.settings = {"owner_email": "x@x.com"}
+    t.created_at = datetime(2025, 1, 1, tzinfo=UTC)
+    t.updated_at = datetime(2025, 1, 1, tzinfo=UTC)
+    return t
+
+
+PAYLOAD = {
+    "name": "demo-gitops",
+    "display_name": "Demo GitOps",
+    "description": "x",
+    "owner_email": "owner@x.com",
+}
+
+
+class TestRegressionCab2196:
+    def test_regression_cab_2196_recreate_when_archived_and_kc_group_id_null(
+        self, app_with_cpi_admin, mock_db_session
+    ):
+        # Tenant row archived after a failed bootstrap (never got a KC group).
+        # Re-applying the same name must succeed: the old row is purged and a
+        # fresh row is created. Without this gate, POST /v1/tenants 409s and
+        # the ID is permanently locked. Surfaced by CAB-2195.
+        archived = _archived_tenant("demo-gitops", kc_group_id=None)
+        created = MagicMock(spec=Tenant)
+        created.id = "demo-gitops"
+        created.name = "Demo GitOps"
+        created.description = "x"
+        created.status = "active"
+        created.provisioning_status = "pending"
+        created.settings = {"owner_email": "owner@x.com"}
+        created.created_at = datetime(2025, 1, 1, tzinfo=UTC)
+        created.updated_at = datetime(2025, 1, 1, tzinfo=UTC)
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=archived)
+        mock_repo.delete = AsyncMock()
+        mock_repo.create = AsyncMock(return_value=created)
+
+        with (
+            patch("src.routers.tenants.TenantRepository", return_value=mock_repo),
+            patch("src.routers.tenants.provision_tenant", new_callable=AsyncMock),
+            patch("src.routers.tenants.kafka_service") as mock_kafka,
+        ):
+            mock_kafka.publish = AsyncMock(return_value=True)
+            mock_kafka.emit_audit_event = AsyncMock(return_value=True)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.post("/v1/tenants", json=PAYLOAD)
+
+        assert response.status_code == 200, response.text
+        mock_repo.delete.assert_awaited_once_with(archived)
+        mock_repo.create.assert_awaited_once()
+        # Audit event for the recreate must be emitted in addition to the
+        # normal "create" event.
+        actions = [c.kwargs.get("action") for c in mock_kafka.emit_audit_event.await_args_list]
+        assert "recreate-from-failed-bootstrap" in actions
+
+    def test_regression_cab_2196_archived_with_kc_group_id_still_409(
+        self, app_with_cpi_admin, mock_db_session
+    ):
+        # Archived row that DID successfully provision (has a kc_group_id) is
+        # a real decommissioned tenant — re-using the ID is a compliance
+        # concern and must remain blocked.
+        archived = _archived_tenant(
+            "ex-tenant", kc_group_id="aaaa-bbbb-cccc", provisioning_status="ready"
+        )
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=archived)
+        mock_repo.delete = AsyncMock()
+        mock_repo.create = AsyncMock()
+
+        with (
+            patch("src.routers.tenants.TenantRepository", return_value=mock_repo),
+            TestClient(app_with_cpi_admin) as client,
+        ):
+            response = client.post(
+                "/v1/tenants",
+                json={**PAYLOAD, "name": "ex-tenant"},
+            )
+
+        assert response.status_code == 409
+        assert "already exists" in response.json()["detail"]
+        mock_repo.delete.assert_not_called()
+        mock_repo.create.assert_not_called()


### PR DESCRIPTION
## Summary

`POST /v1/tenants` 409s on any existing row regardless of `status`. When provisioning fails (e.g. KC group creation errors), the row is created with `provisioning_status='failed'` and `kc_group_id=None`. A subsequent DELETE archives it (`status='archived'`) but never hard-purges. The ID is then **permanently unusable** — even though the tenant never actually existed in Keycloak.

Allow the create path to recover such tombstones.

## Behaviour change

`POST /v1/tenants` with an existing-but-archived row:

- `kc_group_id IS NULL` → hard-DELETE the tombstone, create fresh, emit audit event `tenant.recreate-from-failed-bootstrap`. Returns 200.
- `kc_group_id IS NOT NULL` → still 409. Real decommissioned tenant; re-using ID is a compliance concern.

Active tenants still 409 unchanged.

## Why this gate

A row that was archived without a `kc_group_id` never finished bootstrap. There's nothing to "preserve" for compliance — the tenant never existed in Keycloak, never had APIs/subscriptions/users, never produced audit trail beyond its create + delete events. Re-creating with the same ID is observably a fresh tenant.

A row that DID get a `kc_group_id` represents a real tenant that was active in KC, may have had federated users/clients/groups, and was deliberately decommissioned. That class of archive needs an explicit purge path with stronger gates (separate ticket if needed).

## Test plan

- [ ] `tests/test_regression_cab_2196.py` — 2 cases
  - POSITIVE: archived + `kc_group_id=None` → 200, `repo.delete` called, audit event `recreate-from-failed-bootstrap` emitted
  - NEGATIVE: archived + `kc_group_id="..."` → 409, `repo.delete` NOT called
- [ ] `tests/test_tenants.py` (16 existing) all pass — active-tenant 409 unchanged
- [ ] CI green
- [ ] Live verify post-deploy: re-apply `demo-gitops` in prod, observe `provisioning_status=ready` + `kc_group_id` non-NULL

## Refs

- Linear: [CAB-2196](https://linear.app/hlfh-workspace/issue/CAB-2196/cp-api-allow-recreate-of-archived-tenant-when-never-successfully)
- Out-of-scope finding from CAB-2195 — surfaced when `demo-gitops` and `stoa-demo` archived rows blocked re-create
- Code: `src/routers/tenants.py:391-414`

🤖 Generated with [Claude Code](https://claude.com/claude-code)