### PR TITLE
fix(api): make git_service singleton provider-aware (CAB-2197)

### DIFF
--- a/control-plane-api/src/routers/apis.py
+++ b/control-plane-api/src/routers/apis.py
@@ -25,8 +25,8 @@ from ..models.catalog import APICatalog
 from ..repositories.catalog import CatalogRepository
 from ..repositories.tenant import TenantRepository
 from ..schemas.pagination import PaginatedResponse
+from ..services import git_service
 from ..services.catalog_git_client.github_contents import GitHubContentsCatalogClient
-from ..services.git_provider import git_provider_factory
 from ..services.gitops_writer import (
     ApiCreatePayload,
     GitOpsConflictError,
@@ -43,17 +43,16 @@ AudienceLiteral = Literal["public", "internal", "partner"]
 
 logger = logging.getLogger(__name__)
 
-# Backward-compat shim for test patching (see conftest.py _git_di_bridge)
-git_service = git_provider_factory()
-
 
 def _build_catalog_git_client() -> GitHubContentsCatalogClient:
     """Construct the :class:`CatalogGitClient` used by the GitOps create path.
 
     Extracted so tests can patch it (E2E mocked tests inject an in-memory
     fake client without touching PyGithub). Production deployments wire
-    ``GIT_PROVIDER=github`` and the module-level ``git_service`` resolves to
-    a connected :class:`GitHubService`.
+    ``GIT_PROVIDER=github`` and the module-level ``git_service`` is the
+    same connected :class:`GitHubService` the catalog reconciler consumes
+    — sharing one singleton across the create path and the reconciler
+    ensures both observe the same connection state.
     """
     from ..services.github_service import GitHubService
 

--- a/control-plane-api/src/services/git_service.py
+++ b/control-plane-api/src/services/git_service.py
@@ -1392,5 +1392,11 @@ settings:
         return await _gl_run(_merge, "gitlab.merge_merge_request")
 
 
-# Global instance
-git_service = GitLabService()
+# Provider-aware global instance — must NOT be hardcoded to a single
+# provider. The catalog reconciler and GitOps create path consume this
+# singleton through GitHub-only adapters, so under GIT_PROVIDER=github
+# this must resolve to GitHubService(). Lazy import below avoids the
+# import cycle (git_provider lazy-imports back into this module).
+from .git_provider import git_provider_factory  # noqa: E402
+
+git_service = git_provider_factory()

--- a/control-plane-api/tests/test_regression_cab_2197_catalog_reconciler_wiring.py
+++ b/control-plane-api/tests/test_regression_cab_2197_catalog_reconciler_wiring.py
@@ -1,0 +1,129 @@
+"""Regression tests for CAB-2197 (catalog_git_client wired to GitLabService).
+
+Phase 6 strangler activation crashed the reconciler every 10s because
+``main.py:343`` constructed ``GitHubContentsCatalogClient`` with the legacy
+module-level ``git_service`` singleton from ``services.git_service`` — which
+was hardcoded to a ``GitLabService`` instance. The GitHub adapter calls
+``self._github_service._require_gh()``, which doesn't exist on
+``GitLabService``, hence:
+
+    AttributeError: 'GitLabService' object has no attribute '_require_gh'
+
+Phase 4-2 (CAB-2185) and Phase 5 (CAB-2186) tests injected an in-memory
+fake ``CatalogGitClient`` directly, so the production wiring (settings →
+factory → connect → adapter) was never exercised in CI.
+
+These tests pin the post-fix invariants:
+  1. ``services.git_service.git_service`` resolves to whichever provider
+     ``settings.git.provider`` selects (here: ``GitHubService`` for the
+     prod default).
+  2. Passing that singleton into ``GitHubContentsCatalogClient`` and
+     calling ``.list()`` does NOT raise ``AttributeError`` on
+     ``_require_gh``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from src.config import GitHubConfig, GitLabConfig, GitProviderConfig
+
+
+def _github_cfg() -> GitProviderConfig:
+    """Build a github-flavoured GitProviderConfig for factory tests."""
+    return GitProviderConfig.model_construct(
+        provider="github",
+        github=GitHubConfig(
+            token=SecretStr("test-token"),
+            org="stoa-platform",
+            catalog_repo="stoa-catalog",
+        ),
+        gitlab=GitLabConfig(
+            url="https://gitlab.com",
+            token=SecretStr(""),
+            project_id="",
+        ),
+    )
+
+
+class TestRegressionCab2197CatalogReconcilerWiring:
+    """Pin the contract: factory(github) → catalog client → .list() works."""
+
+    @pytest.mark.asyncio
+    async def test_factory_to_catalog_client_no_attribute_error(self):
+        """Pre-fix: ``main.py`` passed the GitLab singleton, ``.list()`` raised
+        ``AttributeError`` because GitLabService has no ``_require_gh``.
+
+        Post-fix: the factory yields ``GitHubService`` under
+        ``GIT_PROVIDER=github``, and the adapter chain runs to completion.
+        """
+        from src.services.catalog_git_client.github_contents import (
+            GitHubContentsCatalogClient,
+        )
+        from src.services.git_provider import git_provider_factory
+        from src.services.github_service import GitHubService
+
+        with patch("src.services.git_provider.settings") as mock_settings:
+            mock_settings.git = _github_cfg()
+            provider = git_provider_factory()
+
+        # Guard: factory must return a GitHubService — otherwise the
+        # legacy mis-wiring (GitLabService into a GitHub adapter) is back.
+        assert isinstance(provider, GitHubService)
+
+        # Bypass real PyGithub auth — _require_gh just returns self._gh
+        # when set, so we can inject a fake client directly.
+        fake_gh = MagicMock()
+        fake_repo = MagicMock()
+        fake_ref = MagicMock()
+        fake_ref.object.sha = "deadbeef"
+        fake_tree = MagicMock()
+        fake_tree.tree = []  # empty repo
+        fake_repo.get_git_ref.return_value = fake_ref
+        fake_repo.get_git_tree.return_value = fake_tree
+        fake_gh.get_repo.return_value = fake_repo
+        provider._gh = fake_gh
+
+        client = GitHubContentsCatalogClient(github_service=provider)
+
+        # Pre-fix this raised AttributeError on _require_gh; post-fix
+        # the adapter consumes the GitHubService, fans out to PyGithub
+        # (here mocked), and returns an empty list for the empty tree.
+        with patch("src.services.git_provider.settings") as mock_settings:
+            mock_settings.git = _github_cfg()
+            mock_settings.git.default_branch = "main"
+            result = await client.list("tenants/*/apis/*/api.yaml")
+
+        assert result == []
+
+    def test_singleton_assignment_uses_provider_factory(self):
+        """Structural pin: ``services/git_service.py`` must build its
+        module-level ``git_service`` singleton via ``git_provider_factory()``,
+        not by hardcoding ``GitLabService()``.
+
+        A behavioural test through ``importlib.reload`` is unreliable here
+        because ``services/__init__.py`` re-exports the singleton symbol,
+        which shadows the submodule of the same name in attribute lookup.
+        We resolve the module via ``sys.modules`` and grep its source — the
+        bug was a single hardcoded line, so a source-level pin is the most
+        targeted regression guard.
+        """
+        import sys
+        from pathlib import Path
+
+        gs_module = sys.modules["src.services.git_service"]
+        src = Path(gs_module.__file__).read_text()
+
+        assert "git_service = git_provider_factory()" in src, (
+            "services/git_service.py must build the singleton via "
+            "git_provider_factory(); pre-fix it hardcoded GitLabService(), "
+            "causing CAB-2197 AttributeError on _require_gh in the catalog "
+            "reconciler under GIT_PROVIDER=github."
+        )
+        assert "git_service = GitLabService()" not in src, (
+            "Hardcoded GitLabService() singleton found — CAB-2197 regression. "
+            "Use git_provider_factory() so the singleton is provider-aware."
+        )


### PR DESCRIPTION
## Summary

Phase 6 strangler activation crashed the catalog reconciler every 10s on OVH prod (2026-04-27 ~16:46 UTC). Root cause: the legacy module-level `git_service` singleton at `services/git_service.py:1396` was hardcoded to `GitLabService()`, but `main.py:343` passed it into `GitHubContentsCatalogClient` — a GitHub-only adapter that calls `_require_gh()`. Under `GIT_PROVIDER=github` the reconciler raised on every tick:

```
AttributeError: 'GitLabService' object has no attribute '_require_gh'
```

This PR makes the singleton provider-aware via `git_provider_factory()` and consolidates the GitOps create path onto the same instance, so both the reconciler and the write path observe one connected `GitHubService`.

## Changes

- **`services/git_service.py:1396`** — replace `git_service = GitLabService()` with `git_service = git_provider_factory()` (lazy import to avoid the cycle through `git_provider`).
- **`routers/apis.py`** — replace the per-router `git_provider_factory()` call (which returned a separate, never-connected `GitHubService`) with `from ..services import git_service`, sharing the connected singleton with the reconciler. The `_build_catalog_git_client` `isinstance` guard is preserved.
- **`tests/test_regression_cab_2197_catalog_reconciler_wiring.py`** — two regression tests:
  1. **Behavioural**: factory(github) → `GitHubContentsCatalogClient` → `.list()` runs without `AttributeError`.
  2. **Structural**: pin that line 1396 calls `git_provider_factory()` and never re-introduces a hardcoded `GitLabService()` — closes the test gap from Phase 4-2 / Phase 5 (CAB-2185 / CAB-2186) which mocked the catalog client directly and never exercised the production wiring chain.

## Risk / blast radius

- Singleton type now resolves at import time from `settings.git.provider` (default: `github`). All downstream callers consume `GitProvider` interface methods only — audit confirmed no GitLab-private API leakage:
  - `services/deployment_orchestration_service.py:145` uses `is_connected`/`connect`/`get_api`/`get_api_openapi_spec` (provider-agnostic).
  - `services/catalog_sync_service.py` accepts the provider as a dependency.
  - `routers/webhooks.py` only validates GitLab webhook tokens (separate endpoint, doesn't touch the singleton).
- Conftest patches target the symbol path (`src.services.git_service.git_service`, `src.main.git_service`), unchanged. Per-test patches like `patch("src.routers.apis.git_service")` continue to work because the imported name is still bound on `apis`.

## Test plan

- [x] cp-api full suite: 6844 passed / 71 skipped, coverage 76.40% (gate ≥70%). 12 pre-existing failures in `test_provisioning*` reproduce on clean `main` without these changes — unrelated.
- [x] New regression test fails pre-fix (asserts factory call site at line 1396) and passes post-fix.
- [x] Targeted re-run of `test_regression_cab_2197`, `test_regression_cab_1917_api_creation`, `test_git_provider`, and `services/catalog_reconciler/` → 61 passed / 21 skipped.
- [ ] Live verify on OVH prod post-merge: `kubectl logs <cp-api-pod> | grep catalog_reconciler.iteration_failed` → 0 hits over 2 min after rollout.

## Out of scope

- Path 3 from the ticket (lift `_require_gh` into the protocol) — deferred. The factory + shared singleton is enough to stop the crash loop.
- Decision on whether to keep `GITOPS_CREATE_API_ENABLED=true` during rollout: leaving as-is. Bug is contained (only `demo-gitops` eligible, 0 APIs on it). Fix-forward.

Linear: [CAB-2197]

🤖 Generated with [Claude Code](https://claude.com/claude-code)