### PR TITLE
refactor(api): unify GitOps reconciler logging on structlog (CAB-2208)

### DIFF
--- a/control-plane-api/src/services/catalog_git_client/github_contents.py
+++ b/control-plane-api/src/services/catalog_git_client/github_contents.py
@@ -16,7 +16,6 @@ re-introduce sync-in-async blocking.
 from __future__ import annotations
 
 import fnmatch
-import logging
 from typing import TYPE_CHECKING
 
 from github import GithubException
@@ -32,8 +31,6 @@ from .models import RemoteCommit, RemoteFile
 
 if TYPE_CHECKING:
     from src.services.github_service import GitHubService
-
-logger = logging.getLogger(__name__)
 
 
 class CatalogShaConflictError(Exception):

--- a/control-plane-api/src/services/catalog_reconciler/metrics.py
+++ b/control-plane-api/src/services/catalog_reconciler/metrics.py
@@ -1,0 +1,55 @@
+"""Prometheus metrics for the GitOps catalog sync surface (CAB-2208).
+
+Single Counter exposed by both the writer (``services/gitops_writer``) and the
+reconciler (``services/catalog_reconciler``) to mirror every
+``catalog_sync_status`` log emission. Logs lose their structlog ``extra=``
+fields when the emitting module is wired on stdlib ``logging`` (root cause
+fixed by CAB-2208); the counter is the durable observability surface that
+§7bis and Phase 7-9 smoke/regression tests assert against.
+
+Cardinality is the cross product of ``status`` (5 values), ``tenant_id`` and
+``api_id``. With ~10 tenants and ~50 APIs in scope through Phase 10 this stays
+well below 100k series — comfortably inside Prometheus' single-instance budget.
+Re-evaluate the labels if the platform ever crosses ~100 tenants AND ~1000 APIs.
+
+Legacy counters in ``src/workers/git_sync_worker.py`` (``GIT_SYNC_TOTAL``,
+``GIT_SYNC_DURATION_SECONDS``, ``GIT_SYNC_RETRIES_TOTAL``) and
+``src/workers/sync_engine.py`` (``DRIFT_DETECTED_TOTAL``,
+``DRIFT_REPAIRED_TOTAL``) instrument the pre-rewrite DB-first + Kafka path.
+They stay incrementing for tenants still on the legacy flow and are out of
+scope here; their removal is conditioned on Phase 10 (all eligible tenants
+migrated to the GitOps flow), not on a calendar trigger.
+"""
+
+from __future__ import annotations
+
+from prometheus_client import Counter
+
+VALID_SYNC_STATUSES: frozenset[str] = frozenset(
+    {
+        "synced",
+        "failed",
+        "drift_detected",
+        "drift_pre_gitops",
+        "drift_orphan",
+    }
+)
+"""Status values emitted by ``_log_sync_status`` in writer.py + worker.py.
+
+Kept as a frozenset constant so unit tests and the invariant suite can assert
+against the exact emission surface without re-discovering it from the source.
+"""
+
+
+CATALOG_SYNC_STATUS_TOTAL: Counter = Counter(
+    "catalog_sync_status_total",
+    "GitOps catalog sync status transitions per (tenant, api, status).",
+    ["tenant_id", "api_id", "status"],
+)
+"""Increment paired with every ``catalog_sync_status`` log line.
+
+Status values are the 5 listed in :data:`VALID_SYNC_STATUSES`. The counter is
+incremented inside the two ``_log_sync_status`` helpers (writer + reconciler);
+it intentionally duplicates the structured log so observers can choose either
+surface (logs for narrative, metric for time-series and alerts).
+"""

--- a/control-plane-api/src/services/catalog_reconciler/worker.py
+++ b/control-plane-api/src/services/catalog_reconciler/worker.py
@@ -15,17 +15,18 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import logging
 from typing import TYPE_CHECKING, Any
 
 import yaml
 from sqlalchemy import select, text
 
+from src.logging_config import get_logger
 from src.services.gitops_writer.advisory_lock import advisory_lock_key
 from src.services.gitops_writer.hashing import compute_catalog_content_hash
 from src.services.gitops_writer.paths import is_uuid_shaped, parse_canonical_path
 
 from .classifier import LegacyCategory, classify_legacy
+from .metrics import CATALOG_SYNC_STATUS_TOTAL
 from .projection import (
     project_to_api_catalog,
     render_api_catalog_projection,
@@ -40,7 +41,7 @@ if TYPE_CHECKING:
 
     from ..catalog_git_client.protocol import CatalogGitClient
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class CatalogReconcilerWorker:
@@ -71,7 +72,7 @@ class CatalogReconcilerWorker:
         """Run the reconciler loop until :meth:`stop` is called."""
         logger.info(
             "catalog_reconciler.start",
-            extra={"interval_seconds": self._interval_seconds},
+            interval_seconds=self._interval_seconds,
         )
         while not self._shutdown.is_set():
             try:
@@ -99,7 +100,7 @@ class CatalogReconcilerWorker:
             except Exception:
                 logger.exception(
                     "catalog_reconciler.path_failed",
-                    extra={"git_path": git_path},
+                    git_path=git_path,
                 )
 
         try:
@@ -139,7 +140,8 @@ class CatalogReconcilerWorker:
         except ValueError as exc:
             logger.warning(
                 "catalog_reconciler.non_canonical_path",
-                extra={"git_path": git_path, "error": str(exc)},
+                git_path=git_path,
+                error=str(exc),
             )
             return None
 
@@ -422,7 +424,9 @@ class CatalogReconcilerWorker:
         if not acquired:
             logger.info(
                 "catalog_reconciler.lock_skipped",
-                extra={"tenant_id": tenant_id, "api_id": api_id, "lock_key": key},
+                tenant_id=tenant_id,
+                api_id=api_id,
+                lock_key=key,
             )
         return acquired
 
@@ -440,18 +444,23 @@ class CatalogReconcilerWorker:
         """Spec §6.6 ``update_status``.
 
         See the writer's ``_log_sync_status`` for the rationale: persistent
-        ``api_sync_status`` is deferred; logs are the surface in Phase 4-2.
+        ``api_sync_status`` is deferred; the structured log plus
+        ``catalog_sync_status_total`` Prometheus counter (CAB-2208) are the
+        observability surface in Phase 4-2.
         """
+        CATALOG_SYNC_STATUS_TOTAL.labels(
+            tenant_id=tenant_id,
+            api_id=api_id,
+            status=status,
+        ).inc()
         logger.info(
             "catalog_sync_status",
-            extra={
-                "tenant_id": tenant_id,
-                "api_id": api_id,
-                "target": "api_catalog",
-                "status": status,
-                "git_commit_sha": git_commit_sha,
-                "catalog_content_hash": catalog_content_hash,
-                "git_path": git_path,
-                "last_error": last_error,
-            },
+            tenant_id=tenant_id,
+            api_id=api_id,
+            target="api_catalog",
+            status=status,
+            git_commit_sha=git_commit_sha,
+            catalog_content_hash=catalog_content_hash,
+            git_path=git_path,
+            last_error=last_error,
         )

--- a/control-plane-api/src/services/gitops_writer/writer.py
+++ b/control-plane-api/src/services/gitops_writer/writer.py
@@ -18,14 +18,15 @@ UPDATE (spec §6.9). The writer never derives ``git_path`` from any UUID source
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
 
 import yaml
 from sqlalchemy import select, text
 
+from src.logging_config import get_logger
 from src.services.catalog.write_api_yaml import render_api_yaml
 from src.services.catalog_reconciler.classifier import LegacyCategory, classify_legacy
+from src.services.catalog_reconciler.metrics import CATALOG_SYNC_STATUS_TOTAL
 from src.services.catalog_reconciler.projection import (
     project_to_api_catalog,
     render_api_catalog_projection,
@@ -48,7 +49,7 @@ if TYPE_CHECKING:
 
     from ..catalog_git_client.protocol import CatalogGitClient
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 _MAX_RACE_RETRIES = 3
 """Spec §6.5 step 10: cap optimistic-CAS retry attempts at 3.
@@ -225,7 +226,9 @@ class GitOpsWriter:
             except Exception:
                 logger.exception(
                     "gitops_writer.collision_check_git_read_failed",
-                    extra={"tenant_id": tenant_id, "api_id": api_name, "git_path": row.git_path},
+                    tenant_id=tenant_id,
+                    api_id=api_name,
+                    git_path=row.git_path,
                 )
                 git_file_exists = False
 
@@ -279,12 +282,10 @@ class GitOpsWriter:
                     last_exc = exc
                     logger.info(
                         "gitops_writer.optimistic_cas_race_retry",
-                        extra={
-                            "tenant_id": tenant_id,
-                            "api_id": api_name,
-                            "attempt": attempt + 1,
-                            "max_attempts": _MAX_RACE_RETRIES,
-                        },
+                        tenant_id=tenant_id,
+                        api_id=api_name,
+                        attempt=attempt + 1,
+                        max_attempts=_MAX_RACE_RETRIES,
                     )
                     continue
 
@@ -327,7 +328,8 @@ class GitOpsWriter:
         except Exception as exc:
             logger.warning(
                 "gitops_writer.advisory_unlock_failed",
-                extra={"lock_key": key, "error": str(exc)},
+                lock_key=key,
+                error=str(exc),
             )
 
     @staticmethod
@@ -345,19 +347,23 @@ class GitOpsWriter:
 
         Persistent ``api_sync_status`` table is intentionally deferred to a
         follow-up migration; Phase 4-2 surfaces sync state via structured
-        logs so dashboards and tests can observe transitions without a
-        schema change in this PR.
+        logs and the ``catalog_sync_status_total`` Prometheus counter
+        (CAB-2208) so dashboards and tests can observe transitions without
+        a schema change.
         """
+        CATALOG_SYNC_STATUS_TOTAL.labels(
+            tenant_id=tenant_id,
+            api_id=api_id,
+            status=status,
+        ).inc()
         logger.info(
             "catalog_sync_status",
-            extra={
-                "tenant_id": tenant_id,
-                "api_id": api_id,
-                "target": "api_catalog",
-                "status": status,
-                "git_commit_sha": git_commit_sha,
-                "catalog_content_hash": catalog_content_hash,
-                "git_path": git_path,
-                "last_error": last_error,
-            },
+            tenant_id=tenant_id,
+            api_id=api_id,
+            target="api_catalog",
+            status=status,
+            git_commit_sha=git_commit_sha,
+            catalog_content_hash=catalog_content_hash,
+            git_path=git_path,
+            last_error=last_error,
         )

--- a/control-plane-api/tests/services/catalog_reconciler/test_metrics.py
+++ b/control-plane-api/tests/services/catalog_reconciler/test_metrics.py
@@ -1,0 +1,100 @@
+"""Unit tests for ``CATALOG_SYNC_STATUS_TOTAL`` (CAB-2208).
+
+The Prometheus counter is the durable observability surface paired with the
+``catalog_sync_status`` log line. These tests pin the wiring contract:
+
+* both ``_log_sync_status`` helpers (writer + reconciler) increment exactly
+  one sample per call,
+* every status value declared in ``VALID_SYNC_STATUSES`` is accepted by the
+  counter labels,
+* the literal status values emitted in the source remain a subset of
+  ``VALID_SYNC_STATUSES`` — protects against silent drift if a new status
+  is introduced at an emission site without being registered.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from src.services.catalog_reconciler.metrics import (
+    CATALOG_SYNC_STATUS_TOTAL,
+    VALID_SYNC_STATUSES,
+)
+from src.services.catalog_reconciler.worker import CatalogReconcilerWorker
+from src.services.gitops_writer.writer import GitOpsWriter
+
+SERVICES_ROOT = Path(__file__).parent.parent.parent.parent / "src/services"
+WRITER_FILE = SERVICES_ROOT / "gitops_writer/writer.py"
+WORKER_FILE = SERVICES_ROOT / "catalog_reconciler/worker.py"
+
+
+def _read_counter(*, tenant_id: str, api_id: str, status: str) -> float:
+    sample = CATALOG_SYNC_STATUS_TOTAL.labels(
+        tenant_id=tenant_id,
+        api_id=api_id,
+        status=status,
+    )
+    return sample._value.get()
+
+
+@pytest.mark.parametrize("status", sorted(VALID_SYNC_STATUSES))
+def test_writer_log_sync_status_increments_counter(status: str) -> None:
+    tenant_id, api_id = "tenant-writer", f"api-{status}"
+    before = _read_counter(tenant_id=tenant_id, api_id=api_id, status=status)
+
+    GitOpsWriter._log_sync_status(
+        tenant_id=tenant_id,
+        api_id=api_id,
+        status=status,
+        git_commit_sha=None,
+        catalog_content_hash=None,
+        git_path=None,
+    )
+
+    after = _read_counter(tenant_id=tenant_id, api_id=api_id, status=status)
+    assert after - before == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("status", sorted(VALID_SYNC_STATUSES))
+def test_reconciler_log_sync_status_increments_counter(status: str) -> None:
+    tenant_id, api_id = "tenant-reconciler", f"api-{status}"
+    before = _read_counter(tenant_id=tenant_id, api_id=api_id, status=status)
+
+    CatalogReconcilerWorker._log_sync_status(
+        tenant_id=tenant_id,
+        api_id=api_id,
+        status=status,
+        git_commit_sha="deadbeef",
+        catalog_content_hash="cafebabe",
+        git_path=f"tenants/tenant-reconciler/apis/api-{status}/api.yaml",
+        last_error=None,
+    )
+
+    after = _read_counter(tenant_id=tenant_id, api_id=api_id, status=status)
+    assert after - before == pytest.approx(1.0)
+
+
+def test_emitted_status_literals_are_a_subset_of_valid_statuses() -> None:
+    """Static check: every ``status="<literal>"`` adjacent to a
+    ``_log_sync_status`` call must be enumerated in ``VALID_SYNC_STATUSES``.
+
+    If a new status literal lands at an emission site without being added
+    to ``VALID_SYNC_STATUSES``, this test fails loudly. The reconciler also
+    has a dynamic branch (``status=status``) where ``status`` is bound to a
+    literal a few lines above; those literals are picked up by the same
+    regex because they appear as ``status = "<literal>"`` assignments.
+    """
+    literal = re.compile(r'status\s*=\s*"([^"]+)"')
+    found: set[str] = set()
+    for src in (WRITER_FILE, WORKER_FILE):
+        for match in literal.finditer(src.read_text()):
+            found.add(match.group(1))
+
+    extras = found - VALID_SYNC_STATUSES
+    assert not extras, (
+        f"Source emits status literals not declared in VALID_SYNC_STATUSES: {sorted(extras)}. "
+        "Update src/services/catalog_reconciler/metrics.py::VALID_SYNC_STATUSES."
+    )

--- a/control-plane-api/tests/services/catalog_reconciler/test_worker_loop.py
+++ b/control-plane-api/tests/services/catalog_reconciler/test_worker_loop.py
@@ -16,12 +16,12 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import logging
 import os
 
 import pytest
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from structlog.testing import capture_logs
 
 from src.models.catalog import APICatalog
 from src.services.catalog.write_api_yaml import render_api_yaml
@@ -120,7 +120,7 @@ class TestProjectsAbsent:
 
 
 class TestUuidHardDriftCatB:
-    async def test_iteration_does_not_repair_uuid_drift(self, session_factory, caplog) -> None:
+    async def test_iteration_does_not_repair_uuid_drift(self, session_factory) -> None:
         tenant = f"{_TEST_TENANT_PREFIX}b"
         # DB row with UUID-shaped git_path → cat B
         async with session_factory() as session:
@@ -146,20 +146,20 @@ class TestUuidHardDriftCatB:
         fake_git.seed(path, _render_yaml(tenant_id=tenant, api_name="petstore"))
 
         worker = _new_worker(session_factory, fake_git)
-        with caplog.at_level(logging.INFO):
+        with capture_logs() as cap_logs:
             await worker._reconcile_iteration()
 
         # Row unchanged.
         row = await _select_row(session_factory, tenant, "petstore")
         assert row is not None
         assert row.git_path.endswith("00000000-0000-0000-0000-000000000000/api.yaml")
-        # drift_detected logged.
-        statuses = [rec.__dict__.get("status") for rec in caplog.records if rec.message == "catalog_sync_status"]
+        # drift_detected logged (CAB-2208: structlog event dict).
+        statuses = [e.get("status") for e in cap_logs if e.get("event") == "catalog_sync_status"]
         assert "drift_detected" in statuses
 
 
 class TestOrphanCatC:
-    async def test_iteration_reports_orphan_for_db_row_without_git_file(self, session_factory, caplog) -> None:
+    async def test_iteration_reports_orphan_for_db_row_without_git_file(self, session_factory) -> None:
         tenant = f"{_TEST_TENANT_PREFIX}c"
         async with session_factory() as session:
             session.add(
@@ -180,18 +180,14 @@ class TestOrphanCatC:
             await session.commit()
         fake_git = InMemoryCatalogGitClient()  # empty Git tree → orphan.
         worker = _new_worker(session_factory, fake_git)
-        with caplog.at_level(logging.INFO):
+        with capture_logs() as cap_logs:
             await worker._reconcile_iteration()
-        statuses = [
-            (rec.__dict__.get("status"), rec.__dict__.get("api_id"))
-            for rec in caplog.records
-            if rec.message == "catalog_sync_status"
-        ]
+        statuses = [(e.get("status"), e.get("api_id")) for e in cap_logs if e.get("event") == "catalog_sync_status"]
         assert ("drift_orphan", "banking-services-v1-2") in statuses
 
 
 class TestPreGitopsCatD:
-    async def test_iteration_reports_pre_gitops_for_null_pointers(self, session_factory, caplog) -> None:
+    async def test_iteration_reports_pre_gitops_for_null_pointers(self, session_factory) -> None:
         tenant = f"{_TEST_TENANT_PREFIX}d"
         async with session_factory() as session:
             session.add(
@@ -212,18 +208,14 @@ class TestPreGitopsCatD:
             await session.commit()
         fake_git = InMemoryCatalogGitClient()
         worker = _new_worker(session_factory, fake_git)
-        with caplog.at_level(logging.INFO):
+        with capture_logs() as cap_logs:
             await worker._reconcile_iteration()
-        statuses = [
-            (rec.__dict__.get("status"), rec.__dict__.get("api_id"))
-            for rec in caplog.records
-            if rec.message == "catalog_sync_status"
-        ]
+        statuses = [(e.get("status"), e.get("api_id")) for e in cap_logs if e.get("event") == "catalog_sync_status"]
         assert ("drift_pre_gitops", "legacy-api") in statuses
 
 
 class TestProjectionDriftRepair:
-    async def test_iteration_repairs_drift_on_backend_url_via_projection(self, session_factory, caplog) -> None:
+    async def test_iteration_repairs_drift_on_backend_url_via_projection(self, session_factory) -> None:
         tenant = f"{_TEST_TENANT_PREFIX}drift"
         path = f"tenants/{tenant}/apis/petstore/api.yaml"
 
@@ -250,15 +242,15 @@ class TestProjectionDriftRepair:
             )
             await session.commit()
         worker = _new_worker(session_factory, fake_git)
-        with caplog.at_level(logging.INFO):
+        with capture_logs() as cap_logs:
             await worker._reconcile_iteration()
 
         row = await _select_row(session_factory, tenant, "petstore")
         assert row is not None
         # tags is no longer ``["wrong-tag"]``; projection consumed Git's empty tag list.
         assert row.tags == []
-        # sync_status logged drift_detected then synced.
-        statuses = [rec.__dict__.get("status") for rec in caplog.records if rec.message == "catalog_sync_status"]
+        # sync_status logged drift_detected then synced (CAB-2208).
+        statuses = [e.get("status") for e in cap_logs if e.get("event") == "catalog_sync_status"]
         assert "drift_detected" in statuses
         assert "synced" in statuses
 
@@ -297,7 +289,7 @@ class TestProjectionDriftRepair:
 
 
 class TestNonCanonicalPaths:
-    async def test_uuid_shaped_path_in_git_logged_as_failed(self, session_factory, caplog) -> None:
+    async def test_uuid_shaped_path_in_git_logged_as_failed(self, session_factory) -> None:
         tenant = f"{_TEST_TENANT_PREFIX}uuid-git"
         # Simulate a corrupted Git tree where api_name is UUID-shaped.
         uuid_path = f"tenants/{tenant}/apis/00000000-0000-0000-0000-000000000000/api.yaml"
@@ -305,7 +297,7 @@ class TestNonCanonicalPaths:
         # The path will fail parse_canonical_path because of the UUID slot.
         fake_git.seed(uuid_path, _render_yaml(tenant_id=tenant, api_name="petstore"))
         worker = _new_worker(session_factory, fake_git)
-        with caplog.at_level(logging.INFO):
+        with capture_logs():
             await worker._reconcile_iteration()
         # No row is created.
         async with session_factory() as session:

--- a/control-plane-api/tests/services/catalog_reconciler/test_worker_metier_branches.py
+++ b/control-plane-api/tests/services/catalog_reconciler/test_worker_metier_branches.py
@@ -23,13 +23,13 @@ Spec §6.6 / §6.14 + audit-informed §11 (CAB-2186 B-WORKER, CAB-2188 B12).
 
 from __future__ import annotations
 
-import logging
 import os
 from typing import Any
 
 import pytest
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from structlog.testing import capture_logs
 
 from src.models.catalog import APICatalog
 from src.services.catalog.write_api_yaml import render_api_yaml
@@ -80,17 +80,20 @@ def _new_worker(session_factory: Any, fake_git: InMemoryCatalogGitClient) -> Cat
     )
 
 
-def _sync_status_records(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]:
-    """Extract structured ``catalog_sync_status`` log payloads from caplog."""
+def _sync_status_records(cap_logs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract structured ``catalog_sync_status`` event dicts from a structlog
+    capture. CAB-2208: structured fields are kwargs on the BoundLogger and live
+    in the captured event dict, not on a stdlib LogRecord.
+    """
     return [
         {
-            "tenant_id": rec.__dict__.get("tenant_id"),
-            "api_id": rec.__dict__.get("api_id"),
-            "status": rec.__dict__.get("status"),
-            "last_error": rec.__dict__.get("last_error"),
+            "tenant_id": e.get("tenant_id"),
+            "api_id": e.get("api_id"),
+            "status": e.get("status"),
+            "last_error": e.get("last_error"),
         }
-        for rec in caplog.records
-        if rec.message == "catalog_sync_status"
+        for e in cap_logs
+        if e.get("event") == "catalog_sync_status"
     ]
 
 
@@ -103,9 +106,7 @@ class TestUuidShapedGitPath:
     such paths.
     """
 
-    async def test_uuid_path_emits_failed_status_no_mutation(
-        self, session_factory, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    async def test_uuid_path_emits_failed_status_no_mutation(self, session_factory) -> None:
         tenant = f"{_TEST_TENANT_PREFIX}uuid-path"
         uuid_segment = "00000000-0000-0000-0000-000000000000"
         uuid_git_path = f"tenants/{tenant}/apis/{uuid_segment}/api.yaml"
@@ -115,11 +116,11 @@ class TestUuidShapedGitPath:
         fake_git.seed(uuid_git_path, b"id: x\nname: x\nversion: 1.0.0\nbackend_url: http://x\n")
 
         worker = _new_worker(session_factory, fake_git)
-        with caplog.at_level(logging.INFO):
+        with capture_logs() as cap_logs:
             await worker._reconcile_iteration()
 
         # Status=failed logged with the spec's ``last_error`` string.
-        statuses = _sync_status_records(caplog)
+        statuses = _sync_status_records(cap_logs)
         assert any(
             r["status"] == "failed"
             and r["api_id"] == uuid_segment
@@ -144,9 +145,7 @@ class TestNameMismatchYaml:
     error handler. No ``api_catalog`` mutation.
     """
 
-    async def test_name_mismatch_yields_failed_status_no_mutation(
-        self, session_factory, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    async def test_name_mismatch_yields_failed_status_no_mutation(self, session_factory) -> None:
         tenant = f"{_TEST_TENANT_PREFIX}mismatch"
         path = f"tenants/{tenant}/apis/petstore/api.yaml"
         # Path slug = ``petstore`` but YAML ``name`` = ``other-api`` → mismatch.
@@ -161,10 +160,10 @@ class TestNameMismatchYaml:
         fake_git.seed(path, bad_yaml)
 
         worker = _new_worker(session_factory, fake_git)
-        with caplog.at_level(logging.INFO):
+        with capture_logs() as cap_logs:
             await worker._reconcile_iteration()
 
-        statuses = _sync_status_records(caplog)
+        statuses = _sync_status_records(cap_logs)
         failed = [r for r in statuses if r["status"] == "failed" and r["api_id"] == "petstore"]
         assert failed, f"expected status=failed on name mismatch; got {statuses}"
         # The ``last_error`` quotes the §6.10 diagnostic; assertion stays loose
@@ -185,7 +184,7 @@ class TestDetectLegacyOrphansCatC:
     and never DELETE / soft-delete (§9.13 + §9.15).
     """
 
-    async def test_orphan_detection_identifies_cat_c(self, session_factory, caplog: pytest.LogCaptureFixture) -> None:
+    async def test_orphan_detection_identifies_cat_c(self, session_factory) -> None:
         tenant = f"{_TEST_TENANT_PREFIX}orphan-c"
         async with session_factory() as session:
             session.add(
@@ -207,12 +206,12 @@ class TestDetectLegacyOrphansCatC:
 
         fake_git = InMemoryCatalogGitClient()  # empty tree → row is orphan.
         worker = _new_worker(session_factory, fake_git)
-        with caplog.at_level(logging.INFO):
+        with capture_logs() as cap_logs:
             # The orphan sweep runs after the canonical-path scan; calling
             # the iteration once is enough.
             await worker._reconcile_iteration()
 
-        statuses = _sync_status_records(caplog)
+        statuses = _sync_status_records(cap_logs)
         assert any(
             r["status"] == "drift_orphan"
             and r["api_id"] == "banking-services-v1-2"
@@ -239,7 +238,7 @@ class TestDetectLegacyOrphansCatD:
     place. Detection only — never auto-repair (§9.13).
     """
 
-    async def test_orphan_detection_identifies_cat_d(self, session_factory, caplog: pytest.LogCaptureFixture) -> None:
+    async def test_orphan_detection_identifies_cat_d(self, session_factory) -> None:
         tenant = f"{_TEST_TENANT_PREFIX}orphan-d"
         async with session_factory() as session:
             session.add(
@@ -261,10 +260,10 @@ class TestDetectLegacyOrphansCatD:
 
         fake_git = InMemoryCatalogGitClient()
         worker = _new_worker(session_factory, fake_git)
-        with caplog.at_level(logging.INFO):
+        with capture_logs() as cap_logs:
             await worker._reconcile_iteration()
 
-        statuses = _sync_status_records(caplog)
+        statuses = _sync_status_records(cap_logs)
         assert any(
             r["status"] == "drift_pre_gitops"
             and r["api_id"] == "legacy-pre-gitops-api"
@@ -297,9 +296,7 @@ class TestPreGitopsViaCanonicalScan:
     (e.g. someone hand-committed it).
     """
 
-    async def test_main_scan_classifies_cat_d_and_logs_drift(
-        self, session_factory, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    async def test_main_scan_classifies_cat_d_and_logs_drift(self, session_factory) -> None:
         tenant = f"{_TEST_TENANT_PREFIX}cat-d-scan"
         canonical = f"tenants/{tenant}/apis/legacy-api/api.yaml"
         fake_git = InMemoryCatalogGitClient()
@@ -333,10 +330,10 @@ class TestPreGitopsViaCanonicalScan:
             await session.commit()
 
         worker = _new_worker(session_factory, fake_git)
-        with caplog.at_level(logging.INFO):
+        with capture_logs() as cap_logs:
             await worker._reconcile_iteration()
 
-        statuses = _sync_status_records(caplog)
+        statuses = _sync_status_records(cap_logs)
         assert any(
             r["status"] == "drift_pre_gitops"
             and r["api_id"] == "legacy-api"
@@ -363,7 +360,7 @@ class TestUuidHardDriftViaOrphanSweep:
     sweep must surface drift_detected with the cat B context.
     """
 
-    async def test_orphan_sweep_classifies_cat_b(self, session_factory, caplog: pytest.LogCaptureFixture) -> None:
+    async def test_orphan_sweep_classifies_cat_b(self, session_factory) -> None:
         tenant = f"{_TEST_TENANT_PREFIX}cat-b-orphan"
         # Row api_id is itself UUID-shaped → cat B via the api_id check.
         # No canonical Git file exists for this api_id, so the main scan
@@ -388,10 +385,10 @@ class TestUuidHardDriftViaOrphanSweep:
 
         fake_git = InMemoryCatalogGitClient()  # no canonical paths at all
         worker = _new_worker(session_factory, fake_git)
-        with caplog.at_level(logging.INFO):
+        with capture_logs() as cap_logs:
             await worker._reconcile_iteration()
 
-        statuses = _sync_status_records(caplog)
+        statuses = _sync_status_records(cap_logs)
         assert any(
             r["status"] == "drift_detected"
             and r["api_id"] == "11111111-2222-3333-4444-555555555555"
@@ -412,9 +409,7 @@ class TestUuidHardDriftViaCanonicalScan:
     classifier.
     """
 
-    async def test_main_scan_classifies_cat_b_and_logs_drift(
-        self, session_factory, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    async def test_main_scan_classifies_cat_b_and_logs_drift(self, session_factory) -> None:
         tenant = f"{_TEST_TENANT_PREFIX}cat-b-scan"
         canonical = f"tenants/{tenant}/apis/petstore/api.yaml"
         # Seed Git with the canonical (slug-keyed) path so the scan visits it.
@@ -451,10 +446,10 @@ class TestUuidHardDriftViaCanonicalScan:
             await session.commit()
 
         worker = _new_worker(session_factory, fake_git)
-        with caplog.at_level(logging.INFO):
+        with capture_logs() as cap_logs:
             await worker._reconcile_iteration()
 
-        statuses = _sync_status_records(caplog)
+        statuses = _sync_status_records(cap_logs)
         # The UUID hard drift status must mention both the row's drift git_path
         # and the real (canonical) git_name so operators can spot the mismatch
         # without an extra DB query.

--- a/control-plane-api/tests/services/test_phase4_2_invariants.py
+++ b/control-plane-api/tests/services/test_phase4_2_invariants.py
@@ -19,6 +19,12 @@ APIS_ROUTER = Path(__file__).parent.parent.parent / "src/routers/apis.py"
 MAIN_PY = Path(__file__).parent.parent.parent / "src/main.py"
 WRITER_FILE = NEW_MODULES_ROOT / "gitops_writer/writer.py"
 RECONCILER_DIR = NEW_MODULES_ROOT / "catalog_reconciler"
+GITOPS_MODULE_DIRS = (
+    NEW_MODULES_ROOT / "gitops_writer",
+    NEW_MODULES_ROOT / "catalog_reconciler",
+    NEW_MODULES_ROOT / "catalog_git_client",
+    NEW_MODULES_ROOT / "catalog",
+)
 
 
 def _code_only(source: str) -> str:
@@ -243,3 +249,55 @@ def test_main_py_passes_session_factory_to_reconciler() -> None:
     ), "main.py must pass db_session_factory to CatalogReconcilerWorker (Phase 4-2 wiring)"
     # Phase 3 used ``db=None`` — that line must not survive Phase 4-2.
     assert "db=None" not in raw, "Phase 3 stub ``db=None`` must be replaced by db_session_factory in Phase 4-2."
+
+
+def test_gitops_modules_use_structlog_only() -> None:
+    """CAB-2208: GitOps modules must wire on structlog via the central wrapper.
+
+    Phase 4-1/4-2 introduced ``services/gitops_writer``, ``services/catalog_reconciler``,
+    ``services/catalog_git_client`` and the ``services/catalog`` helper. These
+    modules emit ``catalog_sync_status`` and must use ``get_logger`` from
+    ``src.logging_config`` so ``extra=`` fields survive in production. stdlib
+    ``logging.getLogger`` was used during the Phase 4-1/4-2 scaffold and
+    silently drops kwargs, leaving only the bare event name in the JSON log
+    stream — masking ``status`` transitions from §7bis and Phase 7-9 smokes.
+    """
+    forbidden_patterns = [
+        (re.compile(r"\bimport\s+logging\b"), "import logging"),
+        (re.compile(r"\bfrom\s+logging\s+import\b"), "from logging import"),
+        (re.compile(r"\blogging\s*\.\s*getLogger\b"), "logging.getLogger"),
+    ]
+    offenders: list[str] = []
+    for d in GITOPS_MODULE_DIRS:
+        for f in d.rglob("*.py"):
+            code = _code_only(f.read_text())
+            for pat, label in forbidden_patterns:
+                if pat.search(code):
+                    offenders.append(f"{f}: {label}")
+    assert not offenders, (
+        f"GitOps modules use stdlib logging: {offenders}. "
+        "Use ``from src.logging_config import get_logger`` instead "
+        "(structlog wrapper, CAB-2208)."
+    )
+
+
+def test_catalog_sync_status_counter_wired_in_log_helpers() -> None:
+    """CAB-2208: ``_log_sync_status`` increments the Prometheus counter.
+
+    The structured log is the narrative surface but loses fields when the
+    structlog pipeline isn't bound; the ``catalog_sync_status_total`` counter
+    is the durable observability surface §7bis and Phase 7-9 smokes assert
+    against. The helper in writer.py and worker.py must call
+    ``CATALOG_SYNC_STATUS_TOTAL.labels(...).inc()`` before the log line so the
+    metric is incremented even if structured logging fails.
+    """
+    pattern = re.compile(r"CATALOG_SYNC_STATUS_TOTAL\s*\.\s*labels\s*\(")
+    helpers = (
+        WRITER_FILE,
+        RECONCILER_DIR / "worker.py",
+    )
+    for f in helpers:
+        code = _code_only(f.read_text())
+        assert pattern.search(code), (
+            f"{f} must call ``CATALOG_SYNC_STATUS_TOTAL.labels(...)`` inside " "``_log_sync_status`` (CAB-2208)."
+        )


### PR DESCRIPTION
## Summary

The Phase 4-1/4-2 GitOps modules were wired on stdlib `logging.getLogger`, which silently drops `extra=` kwargs in production where the global handler emits only `%(message)s`. Result: every `catalog_sync_status` line in prod logs was the bare event name with zero context — masking status transitions from §7bis observation and Phase 7-9 smokes.

This PR fixes the production observability gap, adds a Prometheus counter as durable backup surface, and pins the invariant so Phase 7+ scaffolding cannot regress.

## Changes

**Production code (3 files)**
- `services/gitops_writer/writer.py` — swap stdlib → `src.logging_config.get_logger` (structlog wrapper); reform 4 call sites from `extra={...}` to kwargs; wire counter inside `_log_sync_status`.
- `services/catalog_reconciler/worker.py` — same swap; 6 call sites reformed (2 bare `logger.exception` left untouched); wire counter inside `_log_sync_status`.
- `services/catalog_git_client/github_contents.py` — delete dead `import logging` + `logger = ...` (Phase 4-1 scaffold artefact, zero call sites).

**New Prometheus surface**
- `services/catalog_reconciler/metrics.py` — exposes `catalog_sync_status_total{tenant_id, api_id, status}`. Mirrors every `catalog_sync_status` log line; survives a structlog misconfiguration. Cardinality stays well below 100k series through Phase 10.

**Invariants (test_phase4_2_invariants.py)**
- `test_gitops_modules_use_structlog_only` — bans stdlib `logging` in the 4 GitOps module dirs.
- `test_catalog_sync_status_counter_wired_in_log_helpers` — pins the counter call inside both helpers.

**Unit tests (test_metrics.py)**
- Counter increments correctly for all 5 status values × {writer, reconciler}.
- Static guard that source `status="..."` literals stay a subset of `VALID_SYNC_STATUSES`.

**Caplog migration (test_worker_loop.py + test_worker_metier_branches.py)**
- `BoundLogger.info("event", k=v)` no longer surfaces fields on stdlib `LogRecord.__dict__`. Migrate to `structlog.testing.capture_logs` which is config-agnostic and captures the full event dict. 5 call sites in `test_worker_loop.py`; 1 helper used by 7 tests in `test_worker_metier_branches.py`.

## Out of scope

The legacy counters in `workers/git_sync_worker.py` and `workers/sync_engine.py` (`GIT_SYNC_TOTAL`, `DRIFT_DETECTED_TOTAL`, etc.) instrument the pre-rewrite DB-first + Kafka path. They stay live for tenants still on the legacy flow. Their removal is conditioned on Phase 10 (all eligible tenants migrated to GitOps), not on a calendar trigger.

## Test plan

- [x] `pytest tests/services/test_phase4_2_invariants.py tests/services/catalog_reconciler/test_metrics.py` — 26 passed
- [x] `pytest tests/services/catalog_reconciler/ tests/services/gitops_writer/ tests/services/test_phase{3,4_1,4_2}_invariants.py` — 100 passed, 34 skipped (integration tests need DATABASE_URL)
- [x] Full cp-api suite — 6892 passed (1 failure + 7 errors are pre-existing local-env issues: missing respx/aiosqlite modules)
- [x] `ruff check` + `black --check` — clean on touched files
- [ ] CI: integration tests with DATABASE_URL set (will exercise the structlog → capture_logs migration)
- [ ] Council validation
- [ ] Smoke prod after merge: `kubectl exec deployment/stoa-control-plane-api -- curl -s localhost:8000/metrics | grep catalog_sync_status_total` shows the new counter exposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)