### PR TITLE
fix(api): preserve synced route steps on failed re-ack

### DIFF
--- a/control-plane-api/src/routers/gateway_internal.py
+++ b/control-plane-api/src/routers/gateway_internal.py
@@ -672,7 +672,10 @@ async def route_sync_ack(
             not_found += 1
             continue
 
-        # Store step trace — merge CP steps with agent steps (CAB-1947)
+        # Build the merged step trace, but only persist it once the ack is accepted
+        # as canonical. Failed re-acks for an already synced generation are
+        # connectivity observations, not deployment-state changes.
+        merged_steps = None
         if result.steps is not None:
             from src.services.sync_step_tracker import SyncStepTracker
 
@@ -681,7 +684,6 @@ async def route_sync_ack(
             cp_tracker.start("event_emitted")
             cp_tracker.complete("event_emitted", detail="deployment dispatched to agent")
             merged_steps = cp_tracker.to_list() + result.steps
-            deployment.sync_steps = merged_steps
 
         # CAB-1950: reject stale generation acks
         if result.generation is not None and result.generation < deployment.desired_generation:
@@ -693,12 +695,8 @@ async def route_sync_ack(
             )
             continue
 
-        desired_generation = (
-            deployment.desired_generation if isinstance(deployment.desired_generation, int) else 1
-        )
-        synced_generation = (
-            deployment.synced_generation if isinstance(deployment.synced_generation, int) else 0
-        )
+        desired_generation = deployment.desired_generation if isinstance(deployment.desired_generation, int) else 1
+        synced_generation = deployment.synced_generation if isinstance(deployment.synced_generation, int) else 0
 
         if (
             result.status == "failed"
@@ -722,6 +720,8 @@ async def route_sync_ack(
             deployment.sync_status = DeploymentSyncStatus.SYNCED
             deployment.last_sync_success = now
             deployment.sync_error = None
+            if merged_steps is not None:
+                deployment.sync_steps = merged_steps
             if result.generation is not None:
                 deployment.synced_generation = result.generation
                 deployment.attempted_generation = result.generation
@@ -729,9 +729,11 @@ async def route_sync_ack(
             deployment.sync_status = DeploymentSyncStatus.ERROR
             if result.generation is not None:
                 deployment.attempted_generation = result.generation
+            if merged_steps is not None:
+                deployment.sync_steps = merged_steps
             # Derive sync_error from step trace if available, else use scalar error
-            if result.steps:
-                tracker = SyncStepTracker.from_list(result.steps)
+            if merged_steps:
+                tracker = SyncStepTracker.from_list(merged_steps)
                 deployment.sync_error = tracker.first_error() or result.error
             else:
                 deployment.sync_error = result.error

--- a/control-plane-api/tests/test_regression_route_sync_ack_stability.py
+++ b/control-plane-api/tests/test_regression_route_sync_ack_stability.py
@@ -10,10 +10,26 @@ from tests.test_gateway_internal import GW_KEY_HEADER, VALID_KEY, _make_deployme
 def test_regression_route_sync_ack_failed_does_not_downgrade_stable_synced_deployment(client):
     """A transient failed re-ack must not turn an already applied route red."""
     last_success = datetime.now(UTC)
+    successful_steps = [
+        {"name": "event_emitted", "status": "success", "detail": "deployment dispatched to agent"},
+        {"name": "agent_received", "status": "success"},
+        {"name": "adapter_connected", "status": "success"},
+        {"name": "api_synced", "status": "success"},
+    ]
+    failed_reack_steps = [
+        {"name": "agent_received", "status": "success"},
+        {"name": "adapter_connected", "status": "success"},
+        {
+            "name": "api_synced",
+            "status": "failed",
+            "detail": "webmethods rebooting",
+        },
+    ]
     dep = _make_deployment(
         sync_status=DeploymentSyncStatus.SYNCED,
         last_sync_success=last_success,
         sync_error=None,
+        sync_steps=successful_steps,
         sync_attempts=0,
     )
     dep.desired_generation = 3
@@ -37,6 +53,7 @@ def test_regression_route_sync_ack_failed_does_not_downgrade_stable_synced_deplo
                         "deployment_id": str(dep.id),
                         "status": "failed",
                         "error": "webmethods rebooting",
+                        "steps": failed_reack_steps,
                         "generation": 3,
                     },
                 ],
@@ -51,5 +68,6 @@ def test_regression_route_sync_ack_failed_does_not_downgrade_stable_synced_deplo
         assert dep.sync_status == DeploymentSyncStatus.SYNCED
         assert dep.last_sync_success == last_success
         assert dep.sync_error is None
+        assert dep.sync_steps == successful_steps
         assert dep.sync_attempts == 0
         mock_deploy_repo.update.assert_awaited_once()


### PR DESCRIPTION
## Summary
- preserve canonical successful sync steps when a failed re-ack arrives for an already synced generation
- keep failed re-ack attempts as connectivity observations instead of deployment-state changes
- extend the route-sync-ack regression test to cover failed re-ack steps

## Scope
This replaces #2625, which accidentally included gateway topology commits. This PR contains one commit on top of main and only two files.

## Tests
- pytest control-plane-api/tests/test_regression_route_sync_ack_stability.py -q
- pytest control-plane-api/tests/test_gateway_internal.py -k route_sync_ack -q
- pytest control-plane-api/tests/test_gateway_internal.py control-plane-api/tests/test_regression_route_sync_ack_stability.py -q
- ruff check control-plane-api/src/routers/gateway_internal.py control-plane-api/tests/test_regression_route_sync_ack_stability.py
- black --check control-plane-api/src/routers/gateway_internal.py control-plane-api/tests/test_regression_route_sync_ack_stability.py