### PR TITLE
fix(api): preflight admin gateway deployments

### DIFF
--- a/control-plane-api/src/routers/gateway_deployments.py
+++ b/control-plane-api/src/routers/gateway_deployments.py
@@ -19,6 +19,7 @@ from src.schemas.gateway import (
     PaginatedConsoleDeployments,
     PaginatedGatewayDeployments,
 )
+from src.services.deployment_orchestration_service import DeploymentOrchestrationService
 from src.services.gateway_deployment_service import GatewayDeploymentService
 
 logger = logging.getLogger(__name__)
@@ -77,6 +78,23 @@ async def deploy_api(
     user=Depends(require_role(["cpi-admin"])),
 ):
     """Deploy an API to one or more gateways. Rejects if any target gateway is disabled (409)."""
+    orch = DeploymentOrchestrationService(db)
+    try:
+        preflight = await orch.preflight_api_to_gateways(data.api_catalog_id, data.gateway_instance_ids)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    failed = [result for result in preflight if not result.deployable]
+    if failed:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "deployment_preflight_failed",
+                "message": "Deployment preflight failed before GatewayDeployment creation",
+                "targets": [result.as_dict() for result in failed],
+            },
+        )
+
     svc = GatewayDeploymentService(db)
     try:
         deployments = await svc.deploy_api(data.api_catalog_id, data.gateway_instance_ids)

--- a/control-plane-api/src/services/deployment_orchestration_service.py
+++ b/control-plane-api/src/services/deployment_orchestration_service.py
@@ -286,6 +286,30 @@ class DeploymentOrchestrationService:
         resolved_gateway_ids = await self._resolve_target_gateway_ids(api_catalog, environment, gateway_ids)
         return await self._preflight_gateway_ids(api_catalog, resolved_gateway_ids)
 
+    async def preflight_api_to_gateways(
+        self,
+        api_catalog_id: UUID,
+        gateway_ids: list[UUID],
+    ) -> list[DeploymentPreflightResult]:
+        """Validate an explicit API catalog entry against explicit gateway targets.
+
+        Used by admin-level deployment entrypoints that already resolve target
+        gateways in the request body. This keeps the ADF-G6/ADF-13b preflight
+        contract in front of GatewayDeploymentService even when the caller does
+        not go through the environment-aware /deploy route.
+        """
+        result = await self.db.execute(
+            select(APICatalog).where(
+                APICatalog.id == api_catalog_id,
+                APICatalog.deleted_at.is_(None),
+            )
+        )
+        api_catalog = result.scalar_one_or_none()
+        if not api_catalog:
+            raise ValueError("API catalog entry not found")
+
+        return await self._preflight_gateway_ids(api_catalog, gateway_ids)
+
     async def _preflight_gateway_ids(
         self,
         api_catalog: APICatalog,
@@ -388,6 +412,11 @@ class DeploymentOrchestrationService:
             return []
 
         gateway_ids = [a.gateway_id for a in assignments]
+        preflight = await self._preflight_gateway_ids(api_catalog, gateway_ids)
+        failed = [result for result in preflight if not result.deployable]
+        if failed:
+            raise ValueError(self._format_preflight_failure(failed))
+
         logger.info(
             "Auto-deploying api=%s to %d gateways in %s (triggered by promotion, approved by %s)",
             api_id,

--- a/control-plane-api/tests/test_deployment_orchestration_service.py
+++ b/control-plane-api/tests/test_deployment_orchestration_service.py
@@ -1,4 +1,5 @@
 """Tests for DeploymentOrchestrationService — deploy_api_to_env, auto_deploy, deployable_environments."""
+
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -233,19 +234,21 @@ class TestDeploymentOrchestrationService:
         db = AsyncMock()
         svc = DeploymentOrchestrationService(db)
 
-        with patch.object(
-            svc,
-            "_resolve_api_catalog",
-            new_callable=AsyncMock,
-            side_effect=ValueError(f"API '{api_id}' not found for tenant 'acme'."),
+        with (
+            patch.object(
+                svc,
+                "_resolve_api_catalog",
+                new_callable=AsyncMock,
+                side_effect=ValueError(f"API '{api_id}' not found for tenant 'acme'."),
+            ),
+            pytest.raises(ValueError, match="not found for tenant"),
         ):
-            with pytest.raises(ValueError, match="not found for tenant"):
-                await svc.deploy_api_to_env(
-                    tenant_id="acme",
-                    api_identifier=api_id,
-                    environment="dev",
-                    gateway_ids=[uuid4()],
-                )
+            await svc.deploy_api_to_env(
+                tenant_id="acme",
+                api_identifier=api_id,
+                environment="dev",
+                gateway_ids=[uuid4()],
+            )
 
     @pytest.mark.asyncio
     async def test_auto_deploy_on_promotion_triggers_deploy(self):
@@ -262,6 +265,7 @@ class TestDeploymentOrchestrationService:
 
         with (
             patch.object(svc.assignment_repo, "list_auto_deploy", new_callable=AsyncMock) as mock_assign,
+            patch.object(svc, "_preflight_gateway_ids", new_callable=AsyncMock) as mock_preflight,
             patch.object(svc.deploy_svc, "deploy_api", new_callable=AsyncMock) as mock_deploy,
         ):
             mock_result = MagicMock()
@@ -269,6 +273,7 @@ class TestDeploymentOrchestrationService:
             db.execute.return_value = mock_result
 
             mock_assign.return_value = assignments
+            mock_preflight.return_value = [MagicMock(deployable=True)]
             mock_deploy.return_value = deployments
 
             result = await svc.auto_deploy_on_promotion(
@@ -279,7 +284,46 @@ class TestDeploymentOrchestrationService:
             )
 
             assert len(result) == 1
+            mock_preflight.assert_awaited_once_with(catalog, [gw_id])
             mock_deploy.assert_called_once_with(catalog.id, [gw_id])
+
+    @pytest.mark.asyncio
+    async def test_auto_deploy_on_promotion_blocks_preflight_failure(self):
+        """auto_deploy_on_promotion must not create deployments when adapter preflight fails."""
+        from src.services.deployment_orchestration_service import DeploymentOrchestrationService
+
+        catalog = self._make_catalog()
+        gw_id = uuid4()
+        assignments = [self._make_assignment(gateway_id=gw_id)]
+
+        db = AsyncMock()
+        svc = DeploymentOrchestrationService(db)
+
+        failed_preflight = MagicMock(deployable=False)
+        failed_preflight.errors = [MagicMock(code="openapi_operation_responses_missing")]
+        failed_preflight.gateway_name = "connect-webmethods-dev"
+
+        with (
+            patch.object(svc.assignment_repo, "list_auto_deploy", new_callable=AsyncMock) as mock_assign,
+            patch.object(svc, "_preflight_gateway_ids", new_callable=AsyncMock) as mock_preflight,
+            patch.object(svc.deploy_svc, "deploy_api", new_callable=AsyncMock) as mock_deploy,
+        ):
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = catalog
+            db.execute.return_value = mock_result
+
+            mock_assign.return_value = assignments
+            mock_preflight.return_value = [failed_preflight]
+
+            with pytest.raises(ValueError, match="Deployment preflight failed"):
+                await svc.auto_deploy_on_promotion(
+                    api_id="payments-v2",
+                    tenant_id="acme",
+                    target_environment="dev",
+                    approved_by="admin",
+                )
+
+            mock_deploy.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_auto_deploy_skips_when_no_assignments(self):
@@ -317,9 +361,7 @@ class TestDeploymentOrchestrationService:
         db = AsyncMock()
         svc = DeploymentOrchestrationService(db)
 
-        with (
-            patch.object(svc, "_get_latest_promotion", new_callable=AsyncMock) as mock_promo,
-        ):
+        with (patch.object(svc, "_get_latest_promotion", new_callable=AsyncMock) as mock_promo,):
             mock_result = MagicMock()
             mock_result.scalar_one_or_none.return_value = catalog
             db.execute.return_value = mock_result
@@ -360,9 +402,7 @@ class TestRegressionCab1889:
 
         with (
             patch("src.services.git_service.git_service") as mock_git,
-            patch(
-                "src.services.catalog_sync_service.CatalogSyncService"
-            ) as mock_catalog_cls,
+            patch("src.services.catalog_sync_service.CatalogSyncService") as mock_catalog_cls,
         ):
             mock_git.is_connected.return_value = True
             mock_git.connect = AsyncMock()
@@ -382,4 +422,3 @@ class TestRegressionCab1889:
             assert not any(
                 "_project" in str(call) for call in mock_git.mock_calls
             ), f"_project leaked into calls: {mock_git.mock_calls}"
-

--- a/control-plane-api/tests/test_gateway_deployments_router.py
+++ b/control-plane-api/tests/test_gateway_deployments_router.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 SVC_PATH = "src.routers.gateway_deployments.GatewayDeploymentService"
+ORCH_PATH = "src.routers.gateway_deployments.DeploymentOrchestrationService"
 REPO_PATH = "src.routers.gateway_deployments.GatewayDeploymentRepository"
 
 
@@ -31,7 +32,12 @@ def _mock_deployment(**overrides):
 class TestDeployAPI:
     def test_deploy_success(self, client_as_cpi_admin, mock_db_session):
         dep = _mock_deployment()
-        with patch(SVC_PATH) as MockSvc:
+        with (
+            patch(ORCH_PATH) as MockOrch,
+            patch(SVC_PATH) as MockSvc,
+        ):
+            orch = MockOrch.return_value
+            orch.preflight_api_to_gateways = AsyncMock(return_value=[MagicMock(deployable=True)])
             instance = MockSvc.return_value
             instance.deploy_api = AsyncMock(return_value=[dep])
             resp = client_as_cpi_admin.post(
@@ -45,9 +51,9 @@ class TestDeployAPI:
         assert resp.status_code == 201
 
     def test_deploy_not_found(self, client_as_cpi_admin, mock_db_session):
-        with patch(SVC_PATH) as MockSvc:
-            instance = MockSvc.return_value
-            instance.deploy_api = AsyncMock(side_effect=ValueError("API not found"))
+        with patch(ORCH_PATH) as MockOrch:
+            orch = MockOrch.return_value
+            orch.preflight_api_to_gateways = AsyncMock(side_effect=ValueError("API not found"))
             resp = client_as_cpi_admin.post(
                 "/v1/admin/deployments",
                 json={
@@ -68,21 +74,78 @@ class TestDeployAPI:
         )
         assert resp.status_code == 403
 
+    def test_deploy_preflight_failure_blocks_dispatch(self, client_as_cpi_admin, mock_db_session):
+        gateway_id = uuid4()
+        with (
+            patch(ORCH_PATH) as MockOrch,
+            patch(SVC_PATH) as MockSvc,
+        ):
+            orch = MockOrch.return_value
+            orch.preflight_api_to_gateways = AsyncMock(
+                return_value=[
+                    MagicMock(
+                        deployable=False,
+                        as_dict=MagicMock(
+                            return_value={
+                                "gateway_id": str(gateway_id),
+                                "gateway_name": "connect-webmethods-dev",
+                                "target_gateway_type": "webmethods",
+                                "deployable": False,
+                                "errors": [
+                                    {
+                                        "gateway_id": str(gateway_id),
+                                        "gateway_name": "connect-webmethods-dev",
+                                        "target_gateway_type": "webmethods",
+                                        "code": "openapi_operation_responses_missing",
+                                        "message": "webMethods requires each OpenAPI operation to declare non-empty responses",
+                                        "path": "openapi_spec.paths./query.get.responses",
+                                    }
+                                ],
+                            }
+                        ),
+                    )
+                ]
+            )
+            svc = MockSvc.return_value
+            svc.deploy_api = AsyncMock()
+
+            resp = client_as_cpi_admin.post(
+                "/v1/admin/deployments",
+                json={
+                    "api_catalog_id": str(uuid4()),
+                    "gateway_instance_ids": [str(gateway_id)],
+                },
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["code"] == "deployment_preflight_failed"
+        assert resp.json()["detail"]["targets"][0]["errors"][0]["code"] == "openapi_operation_responses_missing"
+        svc.deploy_api.assert_not_awaited()
+
 
 class TestListDeployments:
     def test_list_returns_paginated(self, client_as_cpi_admin, mock_db_session):
         dep = _mock_deployment()
         dep_dict = {
-            "id": dep.id, "api_catalog_id": dep.api_catalog_id,
+            "id": dep.id,
+            "api_catalog_id": dep.api_catalog_id,
             "gateway_instance_id": dep.gateway_instance_id,
-            "desired_state": dep.desired_state, "desired_at": dep.desired_at,
-            "actual_state": dep.actual_state, "actual_at": dep.actual_at,
-            "sync_status": dep.sync_status, "last_sync_attempt": dep.last_sync_attempt,
-            "last_sync_success": dep.last_sync_success, "sync_error": dep.sync_error,
-            "sync_attempts": dep.sync_attempts, "gateway_resource_id": dep.gateway_resource_id,
-            "created_at": dep.created_at, "updated_at": dep.updated_at,
-            "gateway_name": None, "gateway_display_name": None,
-            "gateway_type": None, "gateway_environment": None,
+            "desired_state": dep.desired_state,
+            "desired_at": dep.desired_at,
+            "actual_state": dep.actual_state,
+            "actual_at": dep.actual_at,
+            "sync_status": dep.sync_status,
+            "last_sync_attempt": dep.last_sync_attempt,
+            "last_sync_success": dep.last_sync_success,
+            "sync_error": dep.sync_error,
+            "sync_attempts": dep.sync_attempts,
+            "gateway_resource_id": dep.gateway_resource_id,
+            "created_at": dep.created_at,
+            "updated_at": dep.updated_at,
+            "gateway_name": None,
+            "gateway_display_name": None,
+            "gateway_type": None,
+            "gateway_environment": None,
         }
         with patch(REPO_PATH) as MockRepo:
             instance = MockRepo.return_value

--- a/control-plane-api/tests/test_integration_promotion_chain.py
+++ b/control-plane-api/tests/test_integration_promotion_chain.py
@@ -11,14 +11,13 @@ from uuid import uuid4
 
 import pytest
 
-from src.models.catalog import APICatalog
 from src.models.api_gateway_assignment import ApiGatewayAssignment
+from src.models.catalog import APICatalog
 from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment
 from src.models.gateway_instance import GatewayInstance, GatewayInstanceStatus, GatewayType
 from src.models.promotion import Promotion, PromotionStatus
 from src.services.deployment_orchestration_service import DeploymentOrchestrationService
 from src.services.promotion_service import PromotionService
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -187,6 +186,7 @@ class TestPromotionChainIntegration:
         # Mock _resolve_api_catalog
         orch_svc._resolve_api_catalog = AsyncMock(return_value=api)
         orch_svc.assignment_repo.list_auto_deploy = AsyncMock(return_value=[assignment])
+        orch_svc._preflight_gateway_ids = AsyncMock(return_value=[MagicMock(deployable=True)])
         orch_svc.deploy_svc.deploy_api = AsyncMock(return_value=[deployment])
 
         deployments = await orch_svc.auto_deploy_on_promotion(
@@ -265,8 +265,9 @@ class TestPromotionChainIntegration:
 
         orch_svc = DeploymentOrchestrationService(mock_db)
         orch_svc._resolve_api_catalog = AsyncMock(return_value=api)
-        orch_svc.assignment_repo.list_auto_deploy = AsyncMock(
-            return_value=[assignment1, assignment2]
+        orch_svc.assignment_repo.list_auto_deploy = AsyncMock(return_value=[assignment1, assignment2])
+        orch_svc._preflight_gateway_ids = AsyncMock(
+            return_value=[MagicMock(deployable=True), MagicMock(deployable=True)]
         )
         orch_svc.deploy_svc.deploy_api = AsyncMock(return_value=[dep1, dep2])
 
@@ -418,7 +419,6 @@ class TestPromotionChainIntegration:
 
         await svc.check_promotion_completion(promo.id)
         assert promo.status == PromotionStatus.PROMOTED.value
-        first_completed_at = promo.completed_at
 
         # Second call → should be idempotent (complete_promotion is called again
         # but the ValueError catch in check_promotion_completion handles it).

--- a/control-plane-api/tests/test_regression_deployment_preflight.py
+++ b/control-plane-api/tests/test_regression_deployment_preflight.py
@@ -118,3 +118,32 @@ async def test_regression_webmethods_preflight_reports_targeted_error():
     assert results[0].target_gateway_type == "webmethods"
     assert results[0].errors[0].code == "openapi_operation_responses_missing"
     assert results[0].errors[0].path.endswith(".responses")
+
+
+@pytest.mark.asyncio
+async def test_regression_admin_preflight_reports_targeted_error_for_explicit_gateways():
+    from src.services.deployment_orchestration_service import DeploymentOrchestrationService
+
+    catalog = _catalog(
+        {
+            "openapi": "3.0.3",
+            "info": {"title": "Alpha Vantage Stock Data", "version": "1.0.0"},
+            "paths": {"/query": {"get": {"summary": "Fetch stock data"}}},
+        }
+    )
+    gateway = _webmethods_gateway()
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_result(catalog), _result(gateway)])
+    svc = DeploymentOrchestrationService(db)
+
+    results = await svc.preflight_api_to_gateways(
+        api_catalog_id=catalog.id,
+        gateway_ids=[gateway.id],
+    )
+
+    assert len(results) == 1
+    assert results[0].deployable is False
+    assert results[0].gateway_name == "connect-webmethods-dev"
+    assert results[0].target_gateway_type == "webmethods"
+    assert results[0].errors[0].code == "openapi_operation_responses_missing"


### PR DESCRIPTION
## Summary
- run the existing deployment preflight before /v1/admin/deployments creates GatewayDeployment rows
- expose structured 400 errors for adapter preflight failures instead of dispatching invalid WebMethods OpenAPI specs
- add the same preflight guard to promotion auto-deploy before GatewayDeploymentService.deploy_api()

## Contract
- aligns /v1/admin/deployments and promotion auto-deploy with specs/api-runtime-reconciliation-contract.md ADF-G6 and ADF-13b
- invalid WebMethods OpenAPI desired state is now rejected before GatewayDeployment creation, Kafka/SSE event emission, or agent sync

## Tests
- pytest control-plane-api/tests/test_gateway_deployments_router.py control-plane-api/tests/test_deployment_orchestration_service.py control-plane-api/tests/test_regression_deployment_preflight.py control-plane-api/tests/test_gateway_deployment_service.py -q
- ruff check control-plane-api/src/routers/gateway_deployments.py control-plane-api/src/services/deployment_orchestration_service.py control-plane-api/tests/test_gateway_deployments_router.py control-plane-api/tests/test_deployment_orchestration_service.py control-plane-api/tests/test_regression_deployment_preflight.py
- black --check control-plane-api/src/routers/gateway_deployments.py control-plane-api/src/services/deployment_orchestration_service.py control-plane-api/tests/test_gateway_deployments_router.py control-plane-api/tests/test_deployment_orchestration_service.py control-plane-api/tests/test_regression_deployment_preflight.py