### PR TITLE
fix(gateways): pin STOA Link sidecar image

### DIFF
--- a/k8s/gateways/base/stoa-link-wm/deployment.yaml
+++ b/k8s/gateways/base/stoa-link-wm/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: ghcr-creds
       containers:
         - name: stoa-gateway
-          image: ghcr.io/stoa-platform/stoa-gateway:latest
+          image: ghcr.io/stoa-platform/stoa-gateway:dev-d8b67cad540eba4d4337847eeddbc0161c6f32b0
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary\n- pin k8s/gateways stoa-link-wm to ghcr.io/stoa-platform/stoa-gateway:dev-d8b67cad540eba4d4337847eeddbc0161c6f32b0\n- align desired state with the live dev/staging sidecar rollout verified on K3s\n\n## Verification\n- kubectl kustomize k8s/gateways/overlays/dev\n- kubectl kustomize k8s/gateways/overlays/staging\n- kubectl kustomize k8s/gateways/overlays/production\n- live gateway DB check: dev/staging/prod STOA Link rows online, version 0.9.17, deployment_mode=connect, topology=remote-agent\n