### PR TITLE
fix(api): backfill API catalog GitOps state

### DIFF
--- a/control-plane-api/scripts/backfill_api_catalog_gitops.py
+++ b/control-plane-api/scripts/backfill_api_catalog_gitops.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Backfill active API catalog rows into ``stoa-catalog``.
+
+Run from the control-plane-api environment so ``DATABASE_URL`` and the GitHub
+catalog credentials come from the same settings used by production.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from collections import Counter
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description="Backfill DB-only APIs into stoa-catalog GitOps files")
+    parser.add_argument("--tenant", default=None, help="Restrict to one tenant_id")
+    parser.add_argument("--api-id", default=None, help="Restrict to one api_id")
+    parser.add_argument("--limit", type=int, default=None, help="Maximum rows to process")
+    parser.add_argument("--dry-run", action="store_true", help="Read DB/Git and report only")
+    parser.add_argument(
+        "--include-git-tracked",
+        action="store_true",
+        help="Also re-project rows that already have git_path, git_commit_sha and catalog_content_hash",
+    )
+    parser.add_argument(
+        "--overwrite-conflicts",
+        action="store_true",
+        help="Update an existing remote api.yaml when it differs from the DB projection",
+    )
+    args = parser.parse_args()
+
+    from src.config import settings
+    from src.services.catalog_git_client.github_contents import GitHubContentsCatalogClient
+    from src.services.github_service import GitHubService
+    from src.services.gitops_writer.backfill import GitOpsCatalogBackfill
+
+    engine = create_async_engine(settings.DATABASE_URL, echo=False)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    github_service = GitHubService()
+    await github_service.connect()
+    try:
+        git_client = GitHubContentsCatalogClient(github_service=github_service)
+        async with session_factory() as session:
+            backfill = GitOpsCatalogBackfill(
+                catalog_git_client=git_client,
+                db_session=session,
+                actor="catalog-backfill-script",
+                overwrite_conflicts=args.overwrite_conflicts,
+            )
+            results = await backfill.backfill(
+                tenant_id=args.tenant,
+                api_id=args.api_id,
+                include_git_tracked=args.include_git_tracked,
+                limit=args.limit,
+                dry_run=args.dry_run,
+            )
+            if args.dry_run:
+                await session.rollback()
+            else:
+                await session.commit()
+
+        counts = Counter(result.status for result in results)
+        logger.info("Processed %d API rows", len(results))
+        for status, count in sorted(counts.items()):
+            logger.info("%s: %d", status, count)
+        for result in results:
+            logger.info(
+                "%s/%s status=%s git_path=%s commit=%s detail=%s",
+                result.tenant_id,
+                result.api_id,
+                result.status,
+                result.git_path or "-",
+                result.git_commit_sha or "-",
+                result.detail or "-",
+            )
+
+        blocking_statuses = {
+            "invalid_committed_yaml",
+            "read_after_commit_failed",
+            "remote_conflict",
+            "skipped_invalid_row",
+            "skipped_uuid_hard_drift",
+        }
+        if any(result.status in blocking_statuses for result in results):
+            logger.error("Backfill completed with blocking statuses; inspect rows above")
+            return 2
+        return 0
+    finally:
+        await github_service.disconnect()
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/control-plane-api/src/routers/apis.py
+++ b/control-plane-api/src/routers/apis.py
@@ -36,6 +36,7 @@ from ..services.gitops_writer import (
     InvalidApiNameError,
     LegacyCollisionError,
 )
+from ..services.gitops_writer.eligibility import is_gitops_create_eligible
 from ..services.kafka_service import kafka_service
 
 # CAB-2159 BUG-4 — keep in sync with src/models/catalog.py:AudienceEnum
@@ -281,7 +282,11 @@ async def create_api(
     ``False`` and the eligible-tenant list is empty by default — production
     behaviour is unchanged until Phase 6 strangler.
     """
-    if settings.GITOPS_CREATE_API_ENABLED and tenant_id in settings.GITOPS_ELIGIBLE_TENANTS:
+    if is_gitops_create_eligible(
+        enabled=settings.GITOPS_CREATE_API_ENABLED,
+        tenant_id=tenant_id,
+        eligible_tenants=settings.GITOPS_ELIGIBLE_TENANTS,
+    ):
         return await _create_api_gitops(tenant_id=tenant_id, api=api, user=user, db=db)
 
     return await _create_api_legacy(tenant_id=tenant_id, api=api, user=user, db=db)

--- a/control-plane-api/src/services/catalog/write_api_yaml.py
+++ b/control-plane-api/src/services/catalog/write_api_yaml.py
@@ -49,6 +49,8 @@ def render_api_yaml(
     description: str | None = None,
     category: str | None = None,
     tags: list[str] | None = None,
+    status: str = "active",
+    deployments: dict[str, bool] | None = None,
 ) -> str:
     """Render the canonical ``api.yaml`` content per spec §6.9 mapping.
 
@@ -78,6 +80,8 @@ def render_api_yaml(
         raise ValueError("version must be non-empty")
     if not backend_url:
         raise ValueError("backend_url must be non-empty")
+    if not status:
+        raise ValueError("status must be non-empty")
 
     data: dict[str, object] = {
         "id": api_name,
@@ -85,8 +89,8 @@ def render_api_yaml(
         "display_name": display_name or api_name,
         "version": version,
         "backend_url": backend_url,
-        "status": "active",
-        "deployments": {"dev": True, "staging": False},
+        "status": status,
+        "deployments": deployments or {"dev": True, "staging": False},
     }
     if description:
         data["description"] = description

--- a/control-plane-api/src/services/catalog_reconciler/projection.py
+++ b/control-plane-api/src/services/catalog_reconciler/projection.py
@@ -11,8 +11,10 @@ single async function on the DB side. The reconciler tick (Phase 4-2) feeds
 
 Contract:
 
-* The projection NEVER reads or writes ``target_gateways``, ``openapi_spec``
-  or ``metadata`` (preserved fields, owned by deployment / UAC V2).
+* The projection NEVER reads or writes ``target_gateways`` or ``openapi_spec``
+  (preserved fields, owned by deployment / UAC V2).
+* ``metadata`` is projected from ``api.yaml`` because Console fields such as
+  ``backend_url`` and ``display_name`` are read from that JSONB column.
 * The projection NEVER touches ``id`` (PK UUID) on UPDATE.
 * The projection rejects ``id != name`` content (§6.10) and UUID-shaped names.
 """
@@ -37,9 +39,9 @@ _DEFAULT_STATUS = "active"
 class ApiCatalogProjection:
     """Immutable projection of one ``api.yaml`` for ``api_catalog`` upsert.
 
-    Spec §6.9 mapping table. Fields ``target_gateways``, ``openapi_spec`` and
-    ``metadata`` are intentionally absent — they are owned by other flows and
-    preserved on UPDATE.
+    Spec §6.9 mapping table. Fields ``target_gateways`` and ``openapi_spec``
+    are intentionally absent — they are owned by other flows and preserved on
+    UPDATE.
     """
 
     tenant_id: str
@@ -51,6 +53,7 @@ class ApiCatalogProjection:
     tags: list[str]
     portal_published: bool
     audience: str
+    api_metadata: dict[str, Any]
     git_path: str
     git_commit_sha: str
     catalog_content_hash: str
@@ -122,6 +125,41 @@ def render_api_catalog_projection(
     if not isinstance(audience, str) or not audience:
         audience = _DEFAULT_AUDIENCE
 
+    backend_url = parsed_content.get("backend_url")
+    if not isinstance(backend_url, str) or not backend_url:
+        raise ValueError("api.yaml 'backend_url' must be a non-empty string")
+
+    display_name = parsed_content.get("display_name", name)
+    if not isinstance(display_name, str) or not display_name:
+        display_name = name
+
+    description = parsed_content.get("description", "")
+    if description is None:
+        description = ""
+    if not isinstance(description, str):
+        raise ValueError("api.yaml 'description' must be a string when present")
+
+    deployments = parsed_content.get("deployments", {})
+    if deployments is None:
+        deployments = {}
+    if not isinstance(deployments, dict):
+        raise ValueError("api.yaml 'deployments' must be an object when present")
+
+    api_metadata: dict[str, Any] = {
+        "name": name,
+        "display_name": display_name,
+        "version": version,
+        "description": description,
+        "backend_url": backend_url,
+        "status": status_value,
+        "deployments": deployments,
+        "tags": tags,
+    }
+    if category:
+        api_metadata["category"] = category
+    if audience:
+        api_metadata["audience"] = audience
+
     return ApiCatalogProjection(
         tenant_id=tenant_id,
         api_id=name,
@@ -132,6 +170,7 @@ def render_api_catalog_projection(
         tags=tags,
         portal_published=portal_published,
         audience=audience,
+        api_metadata=api_metadata,
         git_path=git_path,
         git_commit_sha=git_commit_sha,
         catalog_content_hash=catalog_content_hash,
@@ -146,15 +185,18 @@ def row_matches_projection(
 
     Compares only the projected fields (spec §6.6 + §6.9):
     ``api_id``, ``tenant_id``, ``api_name``, ``version``, ``status``,
-    ``category``, ``tags``, ``portal_published``, ``audience``, ``git_path``,
-    ``git_commit_sha``, ``catalog_content_hash``.
+    ``category``, ``tags``, ``portal_published``, ``audience``,
+    ``api_metadata``, ``git_path``, ``git_commit_sha``,
+    ``catalog_content_hash``.
 
-    Fields ``target_gateways``, ``openapi_spec``, ``metadata``, ``id``,
-    ``synced_at`` and ``deleted_at`` are ignored — they are not under GitOps
-    write authority.
+    Fields ``target_gateways``, ``openapi_spec``, ``id``, ``synced_at`` and
+    ``deleted_at`` are ignored — they are not under GitOps write authority.
     """
     expected_tags = list(expected.tags)
     actual_tags = list(actual_row.get("tags") or [])
+    actual_metadata = actual_row.get("api_metadata")
+    if actual_metadata is None:
+        actual_metadata = actual_row.get("metadata")
 
     return (
         actual_row.get("tenant_id") == expected.tenant_id
@@ -166,6 +208,7 @@ def row_matches_projection(
         and actual_tags == expected_tags
         and bool(actual_row.get("portal_published")) == expected.portal_published
         and actual_row.get("audience") == expected.audience
+        and actual_metadata == expected.api_metadata
         and actual_row.get("git_path") == expected.git_path
         and actual_row.get("git_commit_sha") == expected.git_commit_sha
         and actual_row.get("catalog_content_hash") == expected.catalog_content_hash
@@ -179,12 +222,12 @@ async def project_to_api_catalog(
     """Upsert ``projection`` into ``api_catalog`` transactionally.
 
     INSERT path: a new row is created with ``id = gen_random_uuid()`` (default),
-    ``metadata = {}``, ``openapi_spec = NULL``, ``target_gateways = []``
-    (defaults from the schema).
+    ``metadata`` comes from ``api.yaml``, ``openapi_spec = NULL`` and
+    ``target_gateways = []`` (defaults from the schema).
 
     UPDATE path: only the projected columns are written. ``target_gateways``,
-    ``openapi_spec``, ``metadata`` and the PK ``id`` are preserved by virtue
-    of NOT being listed in the ``.values()`` clause.
+    ``openapi_spec`` and the PK ``id`` are preserved by virtue of NOT being
+    listed in the ``.values()`` clause.
 
     Spec §6.5 step 14, §6.9. NOT wired to the HTTP handler in Phase 4-1.
 
@@ -226,7 +269,7 @@ async def project_to_api_catalog(
             tags=list(projection.tags),
             portal_published=projection.portal_published,
             audience=projection.audience,
-            api_metadata={},
+            api_metadata=dict(projection.api_metadata),
             git_path=projection.git_path,
             git_commit_sha=projection.git_commit_sha,
             catalog_content_hash=projection.catalog_content_hash,
@@ -246,6 +289,7 @@ async def project_to_api_catalog(
             tags=list(projection.tags),
             portal_published=projection.portal_published,
             audience=projection.audience,
+            api_metadata=dict(projection.api_metadata),
             git_path=projection.git_path,
             git_commit_sha=projection.git_commit_sha,
             catalog_content_hash=projection.catalog_content_hash,

--- a/control-plane-api/src/services/catalog_reconciler/worker.py
+++ b/control-plane-api/src/services/catalog_reconciler/worker.py
@@ -410,6 +410,7 @@ class CatalogReconcilerWorker:
             "tags": list(row.tags or []),
             "portal_published": bool(row.portal_published),
             "audience": row.audience,
+            "api_metadata": dict(row.api_metadata or {}),
             "git_path": row.git_path,
             "git_commit_sha": row.git_commit_sha,
             "catalog_content_hash": row.catalog_content_hash,

--- a/control-plane-api/src/services/gitops_writer/__init__.py
+++ b/control-plane-api/src/services/gitops_writer/__init__.py
@@ -9,6 +9,8 @@ so production behaviour is unchanged until Phase 6.
 """
 
 from .advisory_lock import advisory_lock_key
+from .backfill import BackfillApiResult, GitOpsCatalogBackfill
+from .eligibility import is_gitops_create_eligible
 from .exceptions import (
     GitOpsConflictError,
     GitOpsRaceExhaustedError,
@@ -23,8 +25,10 @@ from .writer import GitOpsWriter
 
 __all__ = [
     "ApiCreatePayload",
+    "BackfillApiResult",
     "CatalogContentHash",
     "CreateApiResult",
+    "GitOpsCatalogBackfill",
     "GitOpsConflictError",
     "GitOpsRaceExhaustedError",
     "GitOpsWriter",
@@ -34,6 +38,7 @@ __all__ = [
     "advisory_lock_key",
     "canonical_catalog_path",
     "compute_catalog_content_hash",
+    "is_gitops_create_eligible",
     "is_uuid_shaped",
     "parse_canonical_path",
 ]

--- a/control-plane-api/src/services/gitops_writer/backfill.py
+++ b/control-plane-api/src/services/gitops_writer/backfill.py
@@ -83,14 +83,13 @@ def _render_row_api_yaml(row: APICatalog) -> bytes:
     api_name = cast(str, row.api_name)
     metadata = cast(dict[str, Any], row.api_metadata or {})
     tags = cast(list[Any], row.tags or [])
-    openapi_spec = cast(Any, row.openapi_spec)
     row_category = cast(str | None, row.category)
     row_status = cast(str | None, row.status)
     row_version = cast(str | None, row.version)
     backend_url = _first_string(
         metadata.get("backend_url"),
         metadata.get("backendUrl"),
-        _backend_url_from_openapi(openapi_spec),
+        _backend_url_from_openapi(cast(Any, row.openapi_spec)),
     )
     if backend_url is None:
         raise ValueError("missing backend_url")

--- a/control-plane-api/src/services/gitops_writer/backfill.py
+++ b/control-plane-api/src/services/gitops_writer/backfill.py
@@ -1,0 +1,279 @@
+"""Controlled DB-only API backfill into ``stoa-catalog``.
+
+This module is intentionally separate from ``GitOpsWriter.create_api``. The
+HTTP create path still refuses pre-GitOps rows so user traffic cannot silently
+adopt legacy drift. Ops can run this backfill as an explicit maintenance action:
+write a canonical ``api.yaml`` from the current DB row, read it back from Git,
+then project the Git content into ``api_catalog``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+import yaml
+from sqlalchemy import or_, select
+
+from src.logging_config import get_logger
+from src.models.catalog import APICatalog
+from src.services.catalog.write_api_yaml import render_api_yaml
+from src.services.catalog_reconciler.projection import (
+    project_to_api_catalog,
+    render_api_catalog_projection,
+)
+
+from .hashing import compute_catalog_content_hash
+from .paths import canonical_catalog_path, is_uuid_shaped
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from ..catalog_git_client.protocol import CatalogGitClient
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class BackfillApiResult:
+    tenant_id: str
+    api_id: str
+    status: str
+    git_path: str | None = None
+    git_commit_sha: str | None = None
+    detail: str = ""
+
+
+def _first_string(*values: Any) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _backend_url_from_openapi(openapi_spec: Any) -> str | None:
+    if not isinstance(openapi_spec, dict):
+        return None
+    servers = openapi_spec.get("servers")
+    if not isinstance(servers, list):
+        return None
+    for server in servers:
+        if not isinstance(server, dict):
+            continue
+        url = _first_string(server.get("url"))
+        if url:
+            return url
+    return None
+
+
+def _deployments_from_metadata(metadata: dict[str, Any]) -> dict[str, bool] | None:
+    deployments = metadata.get("deployments")
+    if not isinstance(deployments, dict):
+        return None
+    clean: dict[str, bool] = {}
+    for key, value in deployments.items():
+        if isinstance(key, str) and isinstance(value, bool):
+            clean[key] = value
+    return clean or None
+
+
+def _render_row_api_yaml(row: APICatalog) -> bytes:
+    tenant_id = cast(str, row.tenant_id)
+    api_id = cast(str, row.api_id)
+    api_name = cast(str, row.api_name)
+    metadata = cast(dict[str, Any], row.api_metadata or {})
+    tags = cast(list[Any], row.tags or [])
+    openapi_spec = cast(Any, row.openapi_spec)
+    row_category = cast(str | None, row.category)
+    row_status = cast(str | None, row.status)
+    row_version = cast(str | None, row.version)
+    backend_url = _first_string(
+        metadata.get("backend_url"),
+        metadata.get("backendUrl"),
+        _backend_url_from_openapi(openapi_spec),
+    )
+    if backend_url is None:
+        raise ValueError("missing backend_url")
+
+    yaml_str = render_api_yaml(
+        tenant_id=tenant_id,
+        api_name=api_id,
+        version=row_version or str(metadata.get("version") or "1.0.0"),
+        backend_url=backend_url,
+        display_name=_first_string(metadata.get("display_name"), metadata.get("name"), api_name, api_id),
+        description=_first_string(metadata.get("description")),
+        category=row_category,
+        tags=[str(tag) for tag in tags],
+        status=row_status or str(metadata.get("status") or "active"),
+        deployments=_deployments_from_metadata(metadata),
+    )
+    return yaml_str.encode("utf-8")
+
+
+class GitOpsCatalogBackfill:
+    """Backfill active ``api_catalog`` rows into canonical GitOps files."""
+
+    def __init__(
+        self,
+        *,
+        catalog_git_client: CatalogGitClient,
+        db_session: AsyncSession,
+        actor: str = "catalog-backfill",
+        overwrite_conflicts: bool = False,
+    ) -> None:
+        self._catalog_git_client = catalog_git_client
+        self._db_session = db_session
+        self._actor = actor
+        self._overwrite_conflicts = overwrite_conflicts
+
+    async def backfill(
+        self,
+        *,
+        tenant_id: str | None = None,
+        api_id: str | None = None,
+        include_git_tracked: bool = False,
+        limit: int | None = None,
+        dry_run: bool = False,
+    ) -> list[BackfillApiResult]:
+        stmt = select(APICatalog).where(APICatalog.deleted_at.is_(None)).order_by(APICatalog.tenant_id, APICatalog.api_id)
+        if tenant_id:
+            stmt = stmt.where(APICatalog.tenant_id == tenant_id)
+        if api_id:
+            stmt = stmt.where(APICatalog.api_id == api_id)
+        if not include_git_tracked:
+            stmt = stmt.where(
+                or_(
+                    APICatalog.git_path.is_(None),
+                    APICatalog.git_commit_sha.is_(None),
+                    APICatalog.catalog_content_hash.is_(None),
+                )
+            )
+        if limit is not None:
+            stmt = stmt.limit(limit)
+
+        rows = (await self._db_session.execute(stmt)).scalars().all()
+        results: list[BackfillApiResult] = []
+        for row in rows:
+            result = await self.backfill_row(row, dry_run=dry_run)
+            results.append(result)
+        return results
+
+    async def backfill_row(self, row: APICatalog, *, dry_run: bool = False) -> BackfillApiResult:
+        tenant_id = cast(str, row.tenant_id)
+        api_id = cast(str, row.api_id)
+        row_git_path = cast(str | None, row.git_path)
+        if is_uuid_shaped(api_id) or (row_git_path and _git_path_api_segment_is_uuid(row_git_path)):
+            return BackfillApiResult(
+                tenant_id=tenant_id,
+                api_id=api_id,
+                status="skipped_uuid_hard_drift",
+                git_path=row_git_path,
+                detail="api_id or git_path contains a UUID-shaped API segment",
+            )
+
+        try:
+            git_path = canonical_catalog_path(tenant_id, api_id)
+            api_yaml_bytes = _render_row_api_yaml(row)
+        except ValueError as exc:
+            return BackfillApiResult(
+                tenant_id=tenant_id,
+                api_id=api_id,
+                status="skipped_invalid_row",
+                git_path=row_git_path,
+                detail=str(exc),
+            )
+
+        attempted_hash = compute_catalog_content_hash(api_yaml_bytes)
+        remote = await self._catalog_git_client.get(git_path)
+        if dry_run:
+            if remote is None:
+                return BackfillApiResult(tenant_id, api_id, "dry_run_would_create", git_path=git_path)
+            remote_hash = compute_catalog_content_hash(remote.content)
+            status = "dry_run_would_project" if remote_hash == attempted_hash else "dry_run_remote_conflict"
+            return BackfillApiResult(tenant_id, api_id, status, git_path=git_path)
+
+        if remote is None:
+            commit = await self._catalog_git_client.create_or_update(
+                path=git_path,
+                content=api_yaml_bytes,
+                expected_sha=None,
+                actor=self._actor,
+                message=f"backfill api {tenant_id}/{api_id}",
+            )
+            file_commit_sha = commit.commit_sha
+            status = "created"
+        else:
+            remote_hash = compute_catalog_content_hash(remote.content)
+            if remote_hash != attempted_hash and not self._overwrite_conflicts:
+                return BackfillApiResult(
+                    tenant_id=tenant_id,
+                    api_id=api_id,
+                    status="remote_conflict",
+                    git_path=git_path,
+                    detail="remote api.yaml differs from DB projection",
+                )
+            if remote_hash != attempted_hash:
+                commit = await self._catalog_git_client.create_or_update(
+                    path=git_path,
+                    content=api_yaml_bytes,
+                    expected_sha=remote.sha,
+                    actor=self._actor,
+                    message=f"backfill update api {tenant_id}/{api_id}",
+                )
+                file_commit_sha = commit.commit_sha
+                status = "updated"
+            else:
+                file_commit_sha = await self._catalog_git_client.latest_file_commit(git_path)
+                status = "projected"
+
+        committed_bytes = await self._catalog_git_client.read_at_commit(git_path, file_commit_sha)
+        if committed_bytes is None:
+            return BackfillApiResult(
+                tenant_id=tenant_id,
+                api_id=api_id,
+                status="read_after_commit_failed",
+                git_path=git_path,
+                git_commit_sha=file_commit_sha,
+                detail="api.yaml not readable at returned commit",
+            )
+
+        parsed = yaml.safe_load(committed_bytes)
+        if not isinstance(parsed, dict):
+            return BackfillApiResult(
+                tenant_id=tenant_id,
+                api_id=api_id,
+                status="invalid_committed_yaml",
+                git_path=git_path,
+                git_commit_sha=file_commit_sha,
+            )
+
+        projection = render_api_catalog_projection(
+            parsed_content=parsed,
+            git_commit_sha=file_commit_sha,
+            catalog_content_hash=compute_catalog_content_hash(committed_bytes),
+            git_path=git_path,
+        )
+        await project_to_api_catalog(self._db_session, projection)
+        logger.info(
+            "gitops_catalog_backfill.projected",
+            tenant_id=tenant_id,
+            api_id=api_id,
+            status=status,
+            git_path=git_path,
+            git_commit_sha=file_commit_sha,
+        )
+        return BackfillApiResult(
+            tenant_id=tenant_id,
+            api_id=api_id,
+            status=status,
+            git_path=git_path,
+            git_commit_sha=file_commit_sha,
+        )
+
+
+def _git_path_api_segment_is_uuid(git_path: str) -> bool:
+    parts = git_path.rstrip("/").split("/")
+    return len(parts) >= 2 and is_uuid_shaped(parts[-2])
+
+
+__all__ = ["BackfillApiResult", "GitOpsCatalogBackfill"]

--- a/control-plane-api/src/services/gitops_writer/eligibility.py
+++ b/control-plane-api/src/services/gitops_writer/eligibility.py
@@ -1,0 +1,23 @@
+"""Tenant eligibility helpers for the GitOps create path."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def is_gitops_create_eligible(
+    *,
+    enabled: bool,
+    tenant_id: str,
+    eligible_tenants: Iterable[str],
+) -> bool:
+    """Return True when ``POST /apis`` must use the Git-first writer.
+
+    ``GITOPS_ELIGIBLE_TENANTS`` remains default-empty for conservative rollout,
+    but ops can now set ``*`` to route every tenant through the GitOps path once
+    the backfill has made the catalog authoritative.
+    """
+    if not enabled:
+        return False
+    eligible = {tenant.strip() for tenant in eligible_tenants if tenant and tenant.strip()}
+    return "*" in eligible or tenant_id in eligible

--- a/control-plane-api/tests/services/catalog_reconciler/test_projection.py
+++ b/control-plane-api/tests/services/catalog_reconciler/test_projection.py
@@ -24,16 +24,23 @@ def _minimal_yaml(
     id_value: str | None = None,
     version: str = "1.0.0",
     status: str = "active",
+    display_name: str = "Petstore",
+    description: str = "",
+    backend_url: str = "http://example.invalid",
     category: str | None = None,
     tags: list[str] | None = None,
     audience: str | None = None,
+    deployments: dict[str, bool] | None = None,
 ) -> dict[str, Any]:
     parsed: dict[str, Any] = {
         "id": id_value if id_value is not None else name,
         "name": name,
+        "display_name": display_name,
         "version": version,
         "status": status,
-        "backend_url": "http://example.invalid",
+        "description": description,
+        "backend_url": backend_url,
+        "deployments": deployments or {"dev": True, "staging": False},
     }
     if category is not None:
         parsed["category"] = category
@@ -61,6 +68,17 @@ class TestRenderApiCatalogProjection:
         assert proj.tags == []
         assert proj.portal_published is False
         assert proj.audience == "public"
+        assert proj.api_metadata == {
+            "name": "petstore",
+            "display_name": "Petstore",
+            "version": "1.0.0",
+            "description": "",
+            "backend_url": "http://example.invalid",
+            "status": "active",
+            "deployments": {"dev": True, "staging": False},
+            "tags": [],
+            "audience": "public",
+        }
         assert proj.git_path == "tenants/demo/apis/petstore/api.yaml"
         assert proj.git_commit_sha == "a" * 40
         assert proj.catalog_content_hash == "b" * 64
@@ -101,6 +119,16 @@ class TestRenderApiCatalogProjection:
             git_path="tenants/demo/apis/petstore/api.yaml",
         )
         assert proj.audience == "internal"
+        assert proj.api_metadata["audience"] == "internal"
+
+    def test_backend_url_is_required_for_console_projection(self) -> None:
+        with pytest.raises(ValueError, match="'backend_url'"):
+            render_api_catalog_projection(
+                parsed_content=_minimal_yaml(backend_url=""),
+                git_commit_sha="a" * 40,
+                catalog_content_hash="b" * 64,
+                git_path="tenants/demo/apis/petstore/api.yaml",
+            )
 
     def test_id_not_equal_name_rejected(self) -> None:
         with pytest.raises(ValueError, match="id != name"):
@@ -187,6 +215,17 @@ class TestRowMatchesProjection:
             tags=["portal:published"],
             portal_published=True,
             audience="public",
+            api_metadata={
+                "name": "petstore",
+                "display_name": "Petstore",
+                "version": "1.0.0",
+                "description": "",
+                "backend_url": "http://example.invalid",
+                "status": "active",
+                "deployments": {"dev": True, "staging": False},
+                "tags": ["portal:published"],
+                "audience": "public",
+            },
             git_path="tenants/demo/apis/petstore/api.yaml",
             git_commit_sha="a" * 40,
             catalog_content_hash="b" * 64,
@@ -204,6 +243,7 @@ class TestRowMatchesProjection:
             "tags": list(projection.tags),
             "portal_published": projection.portal_published,
             "audience": projection.audience,
+            "api_metadata": dict(projection.api_metadata),
             "git_path": projection.git_path,
             "git_commit_sha": projection.git_commit_sha,
             "catalog_content_hash": projection.catalog_content_hash,
@@ -216,7 +256,6 @@ class TestRowMatchesProjection:
         # Add unrelated columns — projection ignores them.
         matching_row["target_gateways"] = ["webmethods-prod"]
         matching_row["openapi_spec"] = {"openapi": "3.0.0"}
-        matching_row["metadata"] = {"display_name": "Pet Store"}
         matching_row["id"] = "00000000-0000-0000-0000-000000000001"
         matching_row["synced_at"] = "2026-04-27T00:00:00Z"
         matching_row["deleted_at"] = None
@@ -226,6 +265,12 @@ class TestRowMatchesProjection:
         self, projection: ApiCatalogProjection, matching_row: dict[str, Any]
     ) -> None:
         matching_row["git_path"] = "tenants/demo/apis/00000000-0000-0000-0000-000000000000/api.yaml"
+        assert row_matches_projection(matching_row, projection) is False
+
+    def test_api_metadata_mismatch_returns_false(
+        self, projection: ApiCatalogProjection, matching_row: dict[str, Any]
+    ) -> None:
+        matching_row["api_metadata"] = {**projection.api_metadata, "backend_url": "https://other.example"}
         assert row_matches_projection(matching_row, projection) is False
 
     def test_catalog_content_hash_mismatch_returns_false(

--- a/control-plane-api/tests/services/catalog_reconciler/test_projection_db.py
+++ b/control-plane-api/tests/services/catalog_reconciler/test_projection_db.py
@@ -39,6 +39,18 @@ def _projection(
         tags=["portal:published", "banking"],
         portal_published=True,
         audience="public",
+        api_metadata={
+            "name": api_id,
+            "display_name": api_id,
+            "version": version,
+            "description": "",
+            "backend_url": "http://example.invalid",
+            "status": "active",
+            "deployments": {"dev": True, "staging": False},
+            "tags": ["portal:published", "banking"],
+            "category": "Banking",
+            "audience": "public",
+        },
         git_path=git_path or f"tenants/{tenant_id}/apis/{api_id}/api.yaml",
         git_commit_sha=git_commit_sha,
         catalog_content_hash=catalog_content_hash,
@@ -70,8 +82,7 @@ async def test_insert_creates_row_with_defaults(integration_db) -> None:
     assert row.git_path == "tenants/demo-gitops/apis/petstore/api.yaml"
     assert row.git_commit_sha == "a" * 40
     assert row.catalog_content_hash == "b" * 64
-    # Preserved-by-default columns
-    assert row.api_metadata == {}
+    assert row.api_metadata["backend_url"] == "http://example.invalid"
     assert row.openapi_spec is None
     assert row.target_gateways == []
 
@@ -115,7 +126,8 @@ async def test_update_preserves_target_gateways(integration_db) -> None:
     # Non-projected fields preserved
     assert row.target_gateways == ["webmethods-prod", "kong-staging"]
     assert row.openapi_spec == {"openapi": "3.0.0", "info": {"title": "Pet"}}
-    assert row.api_metadata == {"display_name": "Manually set", "backend_url": "http://legacy"}
+    assert row.api_metadata["display_name"] == "petstore"
+    assert row.api_metadata["backend_url"] == "http://example.invalid"
 
 
 @pytest.mark.integration

--- a/control-plane-api/tests/services/gitops_writer/test_backfill_unit.py
+++ b/control-plane-api/tests/services/gitops_writer/test_backfill_unit.py
@@ -1,0 +1,85 @@
+import pytest
+import yaml
+
+from src.models.catalog import APICatalog
+from src.services.gitops_writer.backfill import GitOpsCatalogBackfill, _render_row_api_yaml
+from tests.services._fakes import InMemoryCatalogGitClient
+
+
+def _row(**overrides) -> APICatalog:
+    defaults = {
+        "tenant_id": "demo",
+        "api_id": "petstore",
+        "api_name": "Petstore",
+        "version": "1.0.0",
+        "status": "draft",
+        "tags": ["demo"],
+        "portal_published": False,
+        "audience": "public",
+        "api_metadata": {
+            "display_name": "Petstore",
+            "description": "Demo API",
+            "backend_url": "https://petstore.example",
+            "deployments": {"dev": True, "staging": False},
+        },
+        "openapi_spec": None,
+        "target_gateways": [],
+        "git_path": None,
+        "git_commit_sha": None,
+        "catalog_content_hash": None,
+    }
+    defaults.update(overrides)
+    return APICatalog(**defaults)
+
+
+def test_render_row_api_yaml_preserves_console_fields() -> None:
+    parsed = yaml.safe_load(_render_row_api_yaml(_row()))
+
+    assert parsed["id"] == "petstore"
+    assert parsed["name"] == "petstore"
+    assert parsed["display_name"] == "Petstore"
+    assert parsed["backend_url"] == "https://petstore.example"
+    assert parsed["status"] == "draft"
+    assert parsed["deployments"] == {"dev": True, "staging": False}
+
+
+def test_render_row_api_yaml_uses_openapi_server_fallback() -> None:
+    parsed = yaml.safe_load(
+        _render_row_api_yaml(
+            _row(
+                api_metadata={"display_name": "Petstore"},
+                openapi_spec={"servers": [{"url": "https://from-openapi.example"}]},
+            )
+        )
+    )
+
+    assert parsed["backend_url"] == "https://from-openapi.example"
+
+
+def test_render_row_api_yaml_requires_backend_url() -> None:
+    with pytest.raises(ValueError, match="missing backend_url"):
+        _render_row_api_yaml(_row(api_metadata={}, openapi_spec=None))
+
+
+@pytest.mark.asyncio
+async def test_backfill_dry_run_reports_would_create_for_pre_gitops_row() -> None:
+    fake_git = InMemoryCatalogGitClient()
+    backfill = GitOpsCatalogBackfill(catalog_git_client=fake_git, db_session=None)  # type: ignore[arg-type]
+
+    result = await backfill.backfill_row(_row(), dry_run=True)
+
+    assert result.status == "dry_run_would_create"
+    assert result.git_path == "tenants/demo/apis/petstore/api.yaml"
+
+
+@pytest.mark.asyncio
+async def test_backfill_dry_run_skips_uuid_hard_drift() -> None:
+    fake_git = InMemoryCatalogGitClient()
+    backfill = GitOpsCatalogBackfill(catalog_git_client=fake_git, db_session=None)  # type: ignore[arg-type]
+
+    result = await backfill.backfill_row(
+        _row(api_id="00000000-0000-0000-0000-000000000000"),
+        dry_run=True,
+    )
+
+    assert result.status == "skipped_uuid_hard_drift"

--- a/control-plane-api/tests/services/gitops_writer/test_eligibility.py
+++ b/control-plane-api/tests/services/gitops_writer/test_eligibility.py
@@ -1,0 +1,25 @@
+from src.services.gitops_writer.eligibility import is_gitops_create_eligible
+
+
+def test_disabled_flag_never_routes_to_gitops() -> None:
+    assert (
+        is_gitops_create_eligible(
+            enabled=False,
+            tenant_id="demo-gitops",
+            eligible_tenants=["demo-gitops", "*"],
+        )
+        is False
+    )
+
+
+def test_empty_eligible_list_routes_no_tenant() -> None:
+    assert is_gitops_create_eligible(enabled=True, tenant_id="demo-gitops", eligible_tenants=[]) is False
+
+
+def test_explicit_tenant_routes_to_gitops() -> None:
+    assert is_gitops_create_eligible(enabled=True, tenant_id="demo-gitops", eligible_tenants=["demo-gitops"]) is True
+
+
+def test_wildcard_routes_all_tenants_to_gitops() -> None:
+    assert is_gitops_create_eligible(enabled=True, tenant_id="__all__", eligible_tenants=["*"]) is True
+    assert is_gitops_create_eligible(enabled=True, tenant_id="banking-demo", eligible_tenants=["*"]) is True

--- a/control-plane-api/tests/test_regression_gitops_catalog_backfill.py
+++ b/control-plane-api/tests/test_regression_gitops_catalog_backfill.py
@@ -1,0 +1,16 @@
+import pytest
+
+from src.services.gitops_writer.backfill import GitOpsCatalogBackfill
+from tests.services._fakes import InMemoryCatalogGitClient
+from tests.services.gitops_writer.test_backfill_unit import _row
+
+
+@pytest.mark.asyncio
+async def test_regression_gitops_backfill_creates_canonical_api_yaml_for_legacy_db_api() -> None:
+    fake_git = InMemoryCatalogGitClient()
+    backfill = GitOpsCatalogBackfill(catalog_git_client=fake_git, db_session=None)  # type: ignore[arg-type]
+
+    result = await backfill.backfill_row(_row(tenant_id="__all__", api_id="demo-petstore"), dry_run=True)
+
+    assert result.status == "dry_run_would_create"
+    assert result.git_path == "tenants/__all__/apis/demo-petstore/api.yaml"


### PR DESCRIPTION
## Summary

- routes API creation eligibility through a shared GitOps tenant matcher with wildcard support
- preserves `api_metadata` when Git catalog rows are projected back into `api_catalog`
- adds a controlled API catalog backfill command to write missing canonical `api.yaml` files to `stoa-catalog` and refresh DB Git pointers

## Why

API creation and demo publication could succeed in Console while the API never appeared in `stoa-catalog`. The runtime state then drifted from the GitOps contract: Git/UAC should be the configuration truth, while `GatewayDeployment` remains runtime truth.

## Backfill plan after deploy

Run from the deployed `control-plane-api` container:

```bash
python scripts/backfill_api_catalog_gitops.py --dry-run --include-git-tracked
python scripts/backfill_api_catalog_gitops.py --include-git-tracked
```

Then set `GITOPS_ELIGIBLE_TENANTS=*` so future API creates are Git-first for all tenants.

## Validation

- `python3 -m pytest tests/services/gitops_writer/test_eligibility.py tests/services/gitops_writer/test_backfill_unit.py tests/services/catalog_reconciler/test_projection.py tests/services/catalog_reconciler/test_projection_db.py tests/services/test_phase4_2_invariants.py -q`
- `python3 -m pytest tests/test_apis_router.py::TestCreateAPI tests/e2e/test_gitops_create_flow_mocked.py::TestFlagOffUsesLegacyPath tests/e2e/test_gitops_create_flow_mocked.py::TestUuidShapedNameRejected -q`
- `python3 -m ruff check src/routers/apis.py src/services/catalog/write_api_yaml.py src/services/catalog_reconciler/projection.py src/services/catalog_reconciler/worker.py src/services/gitops_writer/__init__.py src/services/gitops_writer/backfill.py src/services/gitops_writer/eligibility.py scripts/backfill_api_catalog_gitops.py tests/services/gitops_writer/test_backfill_unit.py tests/services/gitops_writer/test_eligibility.py tests/services/catalog_reconciler/test_projection.py tests/services/catalog_reconciler/test_projection_db.py`
- `python3 -m mypy src/services/gitops_writer/backfill.py src/services/gitops_writer/eligibility.py`