### PR TITLE
fix(gateways): pin STOA Gateway image

### DIFF
--- a/k8s/gateways/base/stoa-gateway/deployment.yaml
+++ b/k8s/gateways/base/stoa-gateway/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         - name: ghcr-creds
       containers:
         - name: stoa-gateway
-          image: ghcr.io/stoa-platform/stoa-gateway:latest
+          image: ghcr.io/stoa-platform/stoa-gateway:dev-d8b67cad540eba4d4337847eeddbc0161c6f32b0
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary\n- pin native k8s/gateways stoa-gateway to ghcr.io/stoa-platform/stoa-gateway:dev-d8b67cad540eba4d4337847eeddbc0161c6f32b0\n- keep desired state aligned with live dev/staging edge gateway rollout\n\n## Verification\n- live K3s dev/staging stoa-gateway pods rolled out on digest sha256:06fd4289ef6ad5d0ff59ceb7e3bbdc7d43c1f64bb299bd36f76f079157791b69\n- dev edge gateway registered in Console as stoa-gateway-dev-edge-mcp-dev\n- prod runtime already on same digest and public URL consolidated on stoa-gateway-edge-mcp-prod\n