### PR TITLE
fix(api): reconcile catalog gateway deployments

### DIFF
--- a/control-plane-api/src/services/catalog_api_definition.py
+++ b/control-plane-api/src/services/catalog_api_definition.py
@@ -1,0 +1,296 @@
+"""Helpers for catalog ``api.yaml`` normalization and deployment targets.
+
+The catalog currently contains two API shapes:
+
+* flat legacy entries (``name``, ``backend_url``, ``deployments``)
+* Kubernetes-style entries (``apiVersion/kind/metadata/spec``)
+
+Control Plane sync paths must consume both shapes consistently.  These helpers
+produce the flat read-model shape used by ``api_catalog`` while preserving
+deployment-target metadata for the runtime reconciler.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+_DEFAULT_ENV_ALIASES: dict[str, str] = {
+    "dev": "dev",
+    "development": "dev",
+    "staging": "staging",
+    "stage": "staging",
+    "prod": "production",
+    "production": "production",
+}
+
+
+@dataclass(frozen=True)
+class CatalogDeploymentTarget:
+    """One desired runtime target declared by catalog metadata."""
+
+    instance: str | None
+    environment: str | None = None
+    activated: bool = True
+    source: str = "gateways"
+
+
+def normalize_environment(value: object) -> str | None:
+    """Return the canonical environment label used by runtime reconciliation."""
+    if value is None:
+        return None
+    env = str(value).strip().lower()
+    if not env:
+        return None
+    return _DEFAULT_ENV_ALIASES.get(env, env)
+
+
+def normalize_api_definition(raw_data: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize raw catalog YAML into the flat sync format.
+
+    The function intentionally preserves fields such as ``deployments`` and
+    ``gateways`` instead of reducing them to a legacy ``dev/staging`` boolean
+    map.  Runtime recovery depends on those fields surviving the Git -> CP
+    projection.
+    """
+    if "apiVersion" not in raw_data or "kind" not in raw_data:
+        return raw_data if isinstance(raw_data, dict) else dict(raw_data)
+
+    raw = dict(raw_data)
+
+    metadata = _mapping(raw.get("metadata"))
+    spec = _mapping(raw.get("spec"))
+    backend = _mapping(spec.get("backend"))
+
+    deployments = spec.get("deployments", {"dev": False, "staging": False})
+    if deployments is None:
+        deployments = {}
+
+    normalized: dict[str, Any] = {
+        "id": metadata.get("name", ""),
+        "name": metadata.get("name", ""),
+        "display_name": spec.get("displayName", metadata.get("name", "")),
+        "version": metadata.get("version", "1.0.0"),
+        "description": spec.get("description", ""),
+        "backend_url": backend.get("url", ""),
+        "status": spec.get("status", "draft"),
+        "category": spec.get("category"),
+        "tags": spec.get("tags", []),
+        "deployments": deployments,
+    }
+
+    # Preferred explicit target fields.  ``spec.gateway`` in current catalog
+    # files describes webMethods API settings, not a target instance, so it is
+    # deliberately not treated as a deployment target.
+    for key in ("gateways", "gateway_targets", "deployment_targets"):
+        if key in spec:
+            normalized["gateways"] = spec[key]
+            break
+
+    if "audience" in spec:
+        normalized["audience"] = spec["audience"]
+    if "documentation" in spec:
+        normalized["documentation"] = spec["documentation"]
+    if "routing" in spec:
+        normalized["routing"] = spec["routing"]
+    if "policies" in spec:
+        normalized["policies"] = spec["policies"]
+
+    return normalized
+
+
+def extract_deployment_targets(raw_api: Mapping[str, Any]) -> list[CatalogDeploymentTarget]:
+    """Extract deployment targets from normalized or raw catalog API content.
+
+    Supported target declarations:
+
+    * ``gateways: [{instance: connect-webmethods-dev, environment: dev}]``
+    * ``gateways: [connect-webmethods-dev]``
+    * ``gateways: {connect-webmethods-dev: {activated: true}}``
+    * ``deployments.dev.gateways: [...]``
+    * ``deployments.dev.gateway: connect-webmethods-dev``
+    * ``deployments.dev: [connect-webmethods-dev]``
+
+    Boolean ``deployments: {dev: true}`` is retained as an environment marker
+    but does not identify a gateway instance.  The reconciler logs it as
+    non-materializable rather than guessing a target.
+    """
+    api = normalize_api_definition(raw_api)
+    targets: list[CatalogDeploymentTarget] = []
+    targets.extend(_parse_targets_block(api.get("gateways"), default_environment=None, source="gateways"))
+    targets.extend(_parse_deployments_block(api.get("deployments")))
+    return _dedupe_targets(targets)
+
+
+def extract_target_gateway_names(raw_api: Mapping[str, Any]) -> list[str]:
+    """Return explicit gateway instance names declared by the catalog API."""
+    names: list[str] = []
+    seen: set[str] = set()
+    for target in extract_deployment_targets(raw_api):
+        if not target.instance or target.instance in seen:
+            continue
+        seen.add(target.instance)
+        names.append(target.instance)
+    return names
+
+
+def environment_matches(gateway_environment: object, target_environment: object) -> bool:
+    """Return True when a gateway environment satisfies a target environment."""
+    target = normalize_environment(target_environment)
+    if target is None:
+        return True
+    gateway = normalize_environment(gateway_environment)
+    return gateway == target
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _parse_deployments_block(value: object) -> list[CatalogDeploymentTarget]:
+    if not isinstance(value, Mapping):
+        return []
+
+    targets: list[CatalogDeploymentTarget] = []
+    for env_name, env_config in value.items():
+        env = normalize_environment(env_name)
+        if env_config is False or env_config is None:
+            continue
+        if env_config is True:
+            targets.append(CatalogDeploymentTarget(instance=None, environment=env, source="deployments"))
+            continue
+        targets.extend(_parse_targets_block(env_config, default_environment=env, source="deployments"))
+    return targets
+
+
+def _parse_targets_block(
+    value: object,
+    *,
+    default_environment: str | None,
+    source: str,
+) -> list[CatalogDeploymentTarget]:
+    if value is None:
+        return []
+
+    if isinstance(value, str):
+        name = value.strip()
+        return [CatalogDeploymentTarget(instance=name, environment=default_environment, source=source)] if name else []
+
+    if isinstance(value, list):
+        targets: list[CatalogDeploymentTarget] = []
+        for entry in value:
+            targets.extend(_parse_target_entry(entry, default_environment=default_environment, source=source))
+        return targets
+
+    if isinstance(value, Mapping):
+        data = dict(value)
+        nested = _first_present(data, ("gateways", "gateway_targets", "deployment_targets", "instances"))
+        if nested is not None:
+            env = normalize_environment(data.get("environment")) or default_environment
+            has_activation = _has_activation_key(data)
+            activated = _coerce_activated(data, default=True)
+            return [
+                CatalogDeploymentTarget(
+                    instance=t.instance,
+                    environment=t.environment or env,
+                    activated=activated if has_activation else t.activated,
+                    source=t.source,
+                )
+                for t in _parse_targets_block(nested, default_environment=env, source=source)
+            ]
+
+        explicit_name = _target_name(data)
+        if explicit_name:
+            return [
+                CatalogDeploymentTarget(
+                    instance=explicit_name,
+                    environment=normalize_environment(data.get("environment")) or default_environment,
+                    activated=_coerce_activated(data, default=True),
+                    source=source,
+                )
+            ]
+
+        if _looks_like_name_map(data):
+            targets: list[CatalogDeploymentTarget] = []
+            for name, config in data.items():
+                if isinstance(config, Mapping):
+                    entry = {"instance": name, **dict(config)}
+                elif config is False or config is None:
+                    continue
+                else:
+                    entry = {"instance": name, "activated": bool(config)}
+                targets.extend(_parse_target_entry(entry, default_environment=default_environment, source=source))
+            return targets
+
+    return []
+
+
+def _parse_target_entry(
+    entry: object,
+    *,
+    default_environment: str | None,
+    source: str,
+) -> list[CatalogDeploymentTarget]:
+    if isinstance(entry, str):
+        name = entry.strip()
+        return [CatalogDeploymentTarget(instance=name, environment=default_environment, source=source)] if name else []
+    if not isinstance(entry, Mapping):
+        return []
+    if entry.get("enabled") is False or entry.get("deployed") is False:
+        return []
+    return _parse_targets_block(entry, default_environment=default_environment, source=source)
+
+
+def _target_name(data: Mapping[str, Any]) -> str | None:
+    for key in ("instance", "name", "gateway", "gateway_name", "gatewayInstance", "gateway_instance"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _first_present(data: Mapping[str, Any], keys: tuple[str, ...]) -> object | None:
+    for key in keys:
+        if key in data:
+            return data[key]
+    return None
+
+
+def _coerce_activated(data: Mapping[str, Any], *, default: bool) -> bool:
+    for key in ("activated", "active", "enabled", "deployed"):
+        value = data.get(key)
+        if isinstance(value, bool):
+            return value
+    return default
+
+
+def _has_activation_key(data: Mapping[str, Any]) -> bool:
+    return any(key in data for key in ("activated", "active", "enabled", "deployed"))
+
+
+def _looks_like_name_map(data: Mapping[str, Any]) -> bool:
+    reserved = {
+        "environment",
+        "activated",
+        "active",
+        "enabled",
+        "deployed",
+        "gateways",
+        "gateway_targets",
+        "deployment_targets",
+        "instances",
+    }
+    return bool(data) and not any(key in reserved for key in data)
+
+
+def _dedupe_targets(targets: list[CatalogDeploymentTarget]) -> list[CatalogDeploymentTarget]:
+    seen: set[tuple[str | None, str | None]] = set()
+    result: list[CatalogDeploymentTarget] = []
+    for target in targets:
+        key = (target.instance, target.environment)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(target)
+    return result

--- a/control-plane-api/src/services/catalog_deployment_reconciler.py
+++ b/control-plane-api/src/services/catalog_deployment_reconciler.py
@@ -1,0 +1,171 @@
+"""Reconcile catalog deployment targets into ``GatewayDeployment`` rows."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.catalog import APICatalog
+from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment
+from src.models.gateway_instance import GatewayInstance
+from src.repositories.gateway_deployment import GatewayDeploymentRepository
+from src.repositories.gateway_instance import GatewayInstanceRepository
+from src.services.catalog_api_definition import (
+    CatalogDeploymentTarget,
+    environment_matches,
+    extract_deployment_targets,
+    extract_target_gateway_names,
+    normalize_api_definition,
+)
+from src.services.gateway_deployment_service import GatewayDeploymentService
+
+logger = logging.getLogger(__name__)
+
+
+class CatalogDeploymentReconciler:
+    """Materialize Git catalog runtime targets into GatewayDeployment rows."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.gw_repo = GatewayInstanceRepository(db)
+        self.deploy_repo = GatewayDeploymentRepository(db)
+
+    async def reconcile_api(
+        self,
+        *,
+        tenant_id: str,
+        api_id: str,
+        api_content: dict[str, Any],
+        catalog_entry: APICatalog | None = None,
+    ) -> bool:
+        """Reconcile one API's catalog targets.
+
+        Returns True when the DB session was mutated.  The caller owns commit /
+        rollback so this can run inside the same transaction as api_catalog
+        projection.
+        """
+        api = normalize_api_definition(api_content)
+        targets = extract_deployment_targets(api)
+        desired_target_names = extract_target_gateway_names(api)
+        if not targets and not desired_target_names:
+            return False
+
+        catalog_entry = catalog_entry or await self._get_catalog_entry(tenant_id, api_id)
+        if catalog_entry is None:
+            return False
+
+        changed = False
+        if list(catalog_entry.target_gateways or []) != desired_target_names:
+            catalog_entry.target_gateways = desired_target_names
+            changed = True
+
+        if not targets:
+            return changed
+
+        base_desired_state = GatewayDeploymentService.build_desired_state(catalog_entry)
+        for target in targets:
+            if not target.instance:
+                logger.warning(
+                    "GitOps: deployment environment '%s' for API %s/%s has no gateway target; "
+                    "add gateways: or deployments.<env>.gateways to make DR materializable",
+                    target.environment,
+                    tenant_id,
+                    api_id,
+                )
+                continue
+
+            gateway = await self._resolve_gateway(target)
+            if not gateway:
+                logger.warning(
+                    "GitOps: gateway instance '%s' not found for API %s/%s — skipping",
+                    target.instance,
+                    tenant_id,
+                    api_id,
+                )
+                continue
+            if not environment_matches(getattr(gateway, "environment", None), target.environment):
+                logger.warning(
+                    "GitOps: gateway instance '%s' environment '%s' does not match target '%s' for API %s/%s",
+                    target.instance,
+                    getattr(gateway, "environment", None),
+                    target.environment,
+                    tenant_id,
+                    api_id,
+                )
+                continue
+
+            desired_state = {
+                **base_desired_state,
+                "activated": target.activated,
+                "target_gateway_name": target.instance,
+                "target_environment": target.environment,
+                "target_source": target.source,
+            }
+            changed = await self._upsert_deployment(catalog_entry, gateway, desired_state) or changed
+
+        if changed:
+            await self.db.flush()
+        return changed
+
+    async def _get_catalog_entry(self, tenant_id: str, api_id: str) -> APICatalog | None:
+        result = await self.db.execute(
+            select(APICatalog).where(
+                APICatalog.tenant_id == tenant_id,
+                APICatalog.api_id == api_id,
+                APICatalog.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def _resolve_gateway(self, target: CatalogDeploymentTarget) -> GatewayInstance | None:
+        assert target.instance is not None
+        gateway = await self.gw_repo.get_by_name(target.instance)
+        if gateway:
+            return gateway
+        return await self.gw_repo.get_self_registered_by_hostname(target.instance)
+
+    async def _upsert_deployment(
+        self,
+        catalog_entry: APICatalog,
+        gateway: GatewayInstance,
+        desired_state: dict[str, Any],
+    ) -> bool:
+        existing = await self.deploy_repo.get_by_api_and_gateway(catalog_entry.id, gateway.id)
+        now = datetime.now(UTC)
+        if existing:
+            if existing.desired_state == desired_state:
+                return False
+            existing.desired_state = desired_state
+            existing.desired_at = now
+            existing.sync_status = DeploymentSyncStatus.PENDING
+            existing.sync_error = None
+            existing.sync_attempts = 0
+            existing.desired_generation = (existing.desired_generation or 0) + 1
+            await self.deploy_repo.update(existing)
+            logger.info(
+                "GitOps: updated deployment for %s/%s -> %s",
+                catalog_entry.tenant_id,
+                catalog_entry.api_id,
+                getattr(gateway, "name", gateway.id),
+            )
+            return True
+
+        deployment = GatewayDeployment(
+            api_catalog_id=catalog_entry.id,
+            gateway_instance_id=gateway.id,
+            desired_state=desired_state,
+            desired_at=now,
+            sync_status=DeploymentSyncStatus.PENDING,
+        )
+        await self.deploy_repo.create(deployment)
+        logger.info(
+            "GitOps: created deployment for %s/%s -> %s",
+            catalog_entry.tenant_id,
+            catalog_entry.api_id,
+            getattr(gateway, "name", gateway.id),
+        )
+        return True

--- a/control-plane-api/src/services/catalog_reconciler/README.md
+++ b/control-plane-api/src/services/catalog_reconciler/README.md
@@ -18,6 +18,9 @@ is never started in production until a tenant is added to
 `specs/api-creation-gitops-rewrite.md` §6.5 step 14, §6.6, §6.9, §6.14, §11
 (CAB-2186 B-WORKER + CAB-2188 B12 + CAB-2180 B-CATALOG).
 
+Gateway runtime DR coverage is specified separately in
+`specs/catalog-gateway-dr-reconciliation.md`.
+
 ## Modules
 
 - `worker.py` — `CatalogReconcilerWorker.start()` loop. Each tick:
@@ -37,6 +40,10 @@ is never started in production until a tenant is added to
     `openapi_spec`, `metadata`, `id`)
   - `project_to_api_catalog()` — transactional upsert (preserves
     `target_gateways`, `openapi_spec`, `metadata`, `id` PK on UPDATE)
+- `../catalog_api_definition.py` — shared catalog API normalization and
+  gateway target extraction for flat and Kubernetes-style `api.yaml`
+- `../catalog_deployment_reconciler.py` — materializes explicit Git catalog
+  gateway targets into `GatewayDeployment(sync_status=PENDING)` rows
 
 ## What's NOT in this PR (out-of-scope, Phase 5+)
 

--- a/control-plane-api/src/services/catalog_reconciler/worker.py
+++ b/control-plane-api/src/services/catalog_reconciler/worker.py
@@ -21,6 +21,8 @@ import yaml
 from sqlalchemy import select, text
 
 from src.logging_config import get_logger
+from src.services.catalog_api_definition import normalize_api_definition
+from src.services.catalog_deployment_reconciler import CatalogDeploymentReconciler
 from src.services.gitops_writer.advisory_lock import advisory_lock_key
 from src.services.gitops_writer.hashing import compute_catalog_content_hash
 from src.services.gitops_writer.paths import is_uuid_shaped, parse_canonical_path
@@ -166,6 +168,7 @@ class CatalogReconcilerWorker:
         )
         if parsed is None:
             return (tenant_id, api_name)
+        parsed = normalize_api_definition(parsed)
 
         try:
             # ``render_api_catalog_projection`` is the schema-validation step
@@ -198,6 +201,7 @@ class CatalogReconcilerWorker:
             commit_sha=commit_sha,
             content_hash=content_hash,
             expected=expected,
+            api_content=parsed,
         )
         return (tenant_id, api_name)
 
@@ -253,6 +257,7 @@ class CatalogReconcilerWorker:
         commit_sha: str,
         content_hash: str,
         expected: Any,
+        api_content: dict[str, Any],
     ) -> None:
         """Apply the §6.6 per-row decision tree against the DB.
 
@@ -310,6 +315,13 @@ class CatalogReconcilerWorker:
             if category == LegacyCategory.ABSENT:
                 if await self._try_advisory_lock(session, tenant_id, api_name):
                     await project_to_api_catalog(session, expected)
+                    row = await self._get_catalog_row(session, tenant_id, api_name)
+                    await CatalogDeploymentReconciler(session).reconcile_api(
+                        tenant_id=tenant_id,
+                        api_id=api_name,
+                        api_content=api_content,
+                        catalog_entry=row,
+                    )
                     await session.commit()
                     self._log_sync_status(
                         tenant_id=tenant_id,
@@ -334,6 +346,13 @@ class CatalogReconcilerWorker:
                         last_error="projection drift",
                     )
                     await project_to_api_catalog(session, expected)
+                    row = await self._get_catalog_row(session, tenant_id, api_name)
+                    await CatalogDeploymentReconciler(session).reconcile_api(
+                        tenant_id=tenant_id,
+                        api_id=api_name,
+                        api_content=api_content,
+                        catalog_entry=row,
+                    )
                     await session.commit()
                     self._log_sync_status(
                         tenant_id=tenant_id,
@@ -352,6 +371,14 @@ class CatalogReconcilerWorker:
                     catalog_content_hash=content_hash,
                     git_path=git_path,
                 )
+                changed = await CatalogDeploymentReconciler(session).reconcile_api(
+                    tenant_id=tenant_id,
+                    api_id=api_name,
+                    api_content=api_content,
+                    catalog_entry=row,
+                )
+                if changed:
+                    await session.commit()
 
     async def _detect_legacy_orphans(self, seen_keys: set[tuple[str, str]]) -> None:
         """Iterate active DB rows not seen in the Git tree this tick.
@@ -415,6 +442,19 @@ class CatalogReconcilerWorker:
             "git_commit_sha": row.git_commit_sha,
             "catalog_content_hash": row.catalog_content_hash,
         }
+
+    @staticmethod
+    async def _get_catalog_row(session: AsyncSession, tenant_id: str, api_id: str) -> Any:
+        from src.models.catalog import APICatalog
+
+        result = await session.execute(
+            select(APICatalog).where(
+                APICatalog.tenant_id == tenant_id,
+                APICatalog.api_id == api_id,
+                APICatalog.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one_or_none()
 
     @staticmethod
     async def _try_advisory_lock(session: AsyncSession, tenant_id: str, api_id: str) -> bool:

--- a/control-plane-api/src/services/catalog_sync_service.py
+++ b/control-plane-api/src/services/catalog_sync_service.py
@@ -10,7 +10,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
 from src.models.catalog import APICatalog, CatalogSyncStatus, SyncStatus, SyncType
-from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment
 from src.models.mcp_subscription import (
     MCPServer,
     MCPServerCategory,
@@ -19,9 +18,11 @@ from src.models.mcp_subscription import (
     MCPServerTool,
 )
 from src.models.tenant import Tenant, TenantProvisioningStatus, TenantStatus
-from src.repositories.gateway_deployment import GatewayDeploymentRepository
-from src.repositories.gateway_instance import GatewayInstanceRepository
-from src.services.gateway_deployment_service import GatewayDeploymentService
+from src.services.catalog_api_definition import (
+    extract_target_gateway_names,
+    normalize_api_definition,
+)
+from src.services.catalog_deployment_reconciler import CatalogDeploymentReconciler
 from src.services.git_provider import GitProvider
 
 logger = logging.getLogger(__name__)
@@ -270,20 +271,20 @@ class CatalogSyncService:
         commit_sha: str | None,
     ) -> None:
         """Upsert a single API into the catalog."""
+        api = normalize_api_definition(api)
         # CAB-2015: merge per-environment override if present
         override = await self.git.get_api_override(tenant_id, api_id, settings.ENVIRONMENT)
-        api = resolve_api_config(api, override)
+        api = normalize_api_definition(resolve_api_config(api, override))
 
         git_path = f"tenants/{tenant_id}/apis/{api_id}"
         tags = api.get("tags", [])
         promotion_tags = {"portal:published", "promoted:portal", "portal-promoted"}
         portal_published = any(tag.lower() in promotion_tags for tag in tags)
 
-        # Extract target gateways from api.yaml gateways: block
-        gateways_block = api.get("gateways", [])
-        target_gateways = [
-            g.get("instance", g.get("name", "")) for g in gateways_block if g.get("instance") or g.get("name")
-        ]
+        # Extract explicit target gateways from api.yaml. Environment-only
+        # deployments (e.g. deployments.dev=true) are not enough to identify a
+        # runtime target, so they stay out of target_gateways.
+        target_gateways = extract_target_gateway_names(api)
 
         stmt = (
             insert(APICatalog)
@@ -326,89 +327,12 @@ class CatalogSyncService:
         await self.db.execute(stmt)
 
     async def _reconcile_gateway_deployments(self, tenant_id: str, api_id: str, api: dict) -> None:
-        """Create/update GatewayDeployment records from api.yaml gateways: block.
-
-        For each gateway entry, resolves the GatewayInstance by name and
-        creates a PENDING deployment. The Sync Engine periodic loop picks
-        up PENDING records automatically — no Kafka emission needed here.
-        """
-        gateways_block = api.get("gateways", [])
-        if not gateways_block:
-            return
-
-        gw_repo = GatewayInstanceRepository(self.db)
-        deploy_repo = GatewayDeploymentRepository(self.db)
-
-        # Resolve APICatalog record (just upserted)
-        result = await self.db.execute(
-            select(APICatalog).where(
-                APICatalog.tenant_id == tenant_id,
-                APICatalog.api_id == api_id,
-                APICatalog.deleted_at.is_(None),
-            )
+        """Create/update GatewayDeployment records from catalog targets."""
+        await CatalogDeploymentReconciler(self.db).reconcile_api(
+            tenant_id=tenant_id,
+            api_id=api_id,
+            api_content=api,
         )
-        catalog_entry = result.scalar_one_or_none()
-        if not catalog_entry:
-            return
-
-        desired_state = GatewayDeploymentService.build_desired_state(catalog_entry)
-
-        for gw_entry in gateways_block:
-            instance_name = gw_entry.get("instance", gw_entry.get("name", ""))
-            if not instance_name:
-                continue
-
-            gateway = await gw_repo.get_by_name(instance_name)
-            if not gateway:
-                logger.warning(
-                    "GitOps: gateway instance '%s' not found for API %s/%s — skipping",
-                    instance_name,
-                    tenant_id,
-                    api_id,
-                )
-                continue
-
-            # Override activated from yaml if specified
-            if "activated" in gw_entry:
-                desired_state_copy = {**desired_state, "activated": gw_entry["activated"]}
-            else:
-                desired_state_copy = desired_state
-
-            # Check for existing deployment
-            existing = await deploy_repo.get_by_api_and_gateway(catalog_entry.id, gateway.id)
-            now = datetime.now(UTC)
-
-            if existing:
-                # Only reset to PENDING if desired_state actually changed
-                if existing.desired_state != desired_state_copy:
-                    existing.desired_state = desired_state_copy
-                    existing.desired_at = now
-                    existing.sync_status = DeploymentSyncStatus.PENDING
-                    existing.sync_error = None
-                    existing.sync_attempts = 0
-                    existing.desired_generation = (existing.desired_generation or 0) + 1
-                    await deploy_repo.update(existing)
-                    logger.info(
-                        "GitOps: updated deployment for %s/%s → %s",
-                        tenant_id,
-                        api_id,
-                        instance_name,
-                    )
-            else:
-                deployment = GatewayDeployment(
-                    api_catalog_id=catalog_entry.id,
-                    gateway_instance_id=gateway.id,
-                    desired_state=desired_state_copy,
-                    desired_at=now,
-                    sync_status=DeploymentSyncStatus.PENDING,
-                )
-                await deploy_repo.create(deployment)
-                logger.info(
-                    "GitOps: created deployment for %s/%s → %s",
-                    tenant_id,
-                    api_id,
-                    instance_name,
-                )
 
     async def _sync_tenant_apis(self, tenant_id: str, commit_sha: str | None, seen_apis: set[tuple[str, str]]) -> int:
         """Sync all APIs for a tenant (legacy sequential, used by sync_tenant)"""

--- a/control-plane-api/src/services/git_service.py
+++ b/control-plane-api/src/services/git_service.py
@@ -95,27 +95,9 @@ def _normalize_api_data(raw_data: dict) -> dict:
 
     Supports both simple format and Kubernetes-style format (apiVersion/kind/spec).
     """
-    if "apiVersion" in raw_data and "kind" in raw_data:
-        metadata = raw_data.get("metadata", {})
-        spec = raw_data.get("spec", {})
-        backend = spec.get("backend", {})
-        deployments = spec.get("deployments", {})
+    from src.services.catalog_api_definition import normalize_api_definition
 
-        return {
-            "id": metadata.get("name", ""),
-            "name": metadata.get("name", ""),
-            "display_name": spec.get("displayName", metadata.get("name", "")),
-            "version": metadata.get("version", "1.0.0"),
-            "description": spec.get("description", ""),
-            "backend_url": backend.get("url", ""),
-            "status": spec.get("status", "draft"),
-            "deployments": {
-                "dev": deployments.get("dev", False),
-                "staging": deployments.get("staging", False),
-            },
-        }
-
-    return raw_data
+    return normalize_api_definition(raw_data)
 
 
 _GLT = TypeVar("_GLT")

--- a/control-plane-api/src/services/github_service.py
+++ b/control-plane-api/src/services/github_service.py
@@ -110,29 +110,9 @@ def _is_transient_github_error(exc: BaseException) -> bool:
 
 def _normalize_api_data(raw_data: dict) -> dict:
     """Normalize API data from GitHub YAML to the catalog sync format."""
-    if "apiVersion" in raw_data and "kind" in raw_data:
-        metadata = raw_data.get("metadata", {})
-        spec = raw_data.get("spec", {})
-        backend = spec.get("backend", {})
-        deployments = spec.get("deployments", {})
+    from src.services.catalog_api_definition import normalize_api_definition
 
-        return {
-            "id": metadata.get("name", ""),
-            "name": metadata.get("name", ""),
-            "display_name": spec.get("displayName", metadata.get("name", "")),
-            "version": metadata.get("version", "1.0.0"),
-            "description": spec.get("description", ""),
-            "backend_url": backend.get("url", ""),
-            "status": spec.get("status", "draft"),
-            "category": spec.get("category"),
-            "tags": spec.get("tags", []),
-            "deployments": {
-                "dev": deployments.get("dev", False),
-                "staging": deployments.get("staging", False),
-            },
-        }
-
-    return raw_data
+    return normalize_api_definition(raw_data)
 
 
 def _normalize_mcp_server_data(raw_data: dict, git_path: str) -> dict:

--- a/control-plane-api/tests/services/test_catalog_api_definition.py
+++ b/control-plane-api/tests/services/test_catalog_api_definition.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from src.services.catalog_api_definition import (
+    extract_deployment_targets,
+    extract_target_gateway_names,
+    normalize_api_definition,
+)
+
+
+def test_normalize_kubernetes_style_api_preserves_deployment_targets() -> None:
+    raw = {
+        "apiVersion": "stoa.cab-i.com/v1",
+        "kind": "API",
+        "metadata": {"name": "control-plane-api", "version": "2.0"},
+        "spec": {
+            "displayName": "Control Plane API",
+            "backend": {"url": "https://api.gostoa.dev"},
+            "status": "published",
+            "tags": ["internal"],
+            "deployments": {
+                "dev": {"gateways": ["connect-webmethods-dev"]},
+                "prod": {"gateway": "connect-webmethods"},
+            },
+            "gateways": [{"instance": "stoa-prod", "environment": "prod"}],
+            "gateway": {"type": "REST"},
+        },
+    }
+
+    normalized = normalize_api_definition(raw)
+
+    assert normalized["name"] == "control-plane-api"
+    assert normalized["backend_url"] == "https://api.gostoa.dev"
+    assert normalized["deployments"]["dev"]["gateways"] == ["connect-webmethods-dev"]
+    assert normalized["gateways"] == [{"instance": "stoa-prod", "environment": "prod"}]
+    assert "gateway" not in normalized
+
+
+def test_extract_targets_from_gateways_list_and_name_map() -> None:
+    api = {
+        "name": "payments",
+        "gateways": [
+            {"instance": "connect-webmethods-dev", "environment": "dev"},
+            "stoa-prod",
+        ],
+    }
+
+    targets = extract_deployment_targets(api)
+
+    assert [(t.instance, t.environment, t.activated) for t in targets] == [
+        ("connect-webmethods-dev", "dev", True),
+        ("stoa-prod", None, True),
+    ]
+    assert extract_target_gateway_names(api) == ["connect-webmethods-dev", "stoa-prod"]
+
+
+def test_extract_targets_from_deployments_gateway_shapes() -> None:
+    api = {
+        "name": "payments",
+        "deployments": {
+            "dev": {
+                "gateways": [
+                    {"instance": "connect-webmethods-dev", "activated": False},
+                    "stoa-dev",
+                ]
+            },
+            "prod": {"gateway": "connect-webmethods"},
+            "staging": False,
+        },
+    }
+
+    targets = extract_deployment_targets(api)
+
+    assert [(t.instance, t.environment, t.activated, t.source) for t in targets] == [
+        ("connect-webmethods-dev", "dev", False, "deployments"),
+        ("stoa-dev", "dev", True, "deployments"),
+        ("connect-webmethods", "production", True, "deployments"),
+    ]
+
+
+def test_parent_deployment_activation_applies_to_nested_gateways() -> None:
+    api = {
+        "name": "payments",
+        "deployments": {
+            "dev": {
+                "activated": False,
+                "gateways": ["connect-webmethods-dev"],
+            }
+        },
+    }
+
+    targets = extract_deployment_targets(api)
+
+    assert [(t.instance, t.environment, t.activated) for t in targets] == [
+        ("connect-webmethods-dev", "dev", False)
+    ]
+
+
+def test_boolean_deployments_are_environment_markers_not_gateway_names() -> None:
+    api = {"name": "payments", "deployments": {"dev": True, "staging": False}}
+
+    targets = extract_deployment_targets(api)
+
+    assert [(t.instance, t.environment) for t in targets] == [(None, "dev")]
+    assert extract_target_gateway_names(api) == []

--- a/control-plane-api/tests/test_catalog_sync_gateways.py
+++ b/control-plane-api/tests/test_catalog_sync_gateways.py
@@ -3,10 +3,12 @@
 Step 28 (Phase 5): Verifies that the `gateways:` block in api.yaml triggers
 automatic GatewayDeployment creation/update during catalog sync.
 """
-import pytest
-from datetime import datetime, timezone
+
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
+
+import pytest
 
 from src.models.gateway_deployment import DeploymentSyncStatus
 
@@ -25,6 +27,9 @@ class TestCatalogSyncGatewayReconciliation:
             "version": "2.1.0",
             "openapi_spec": {"openapi": "3.0.0"},
             "api_metadata": {"name": "Billing API"},
+            "target_gateways": [],
+            "git_path": "tenants/acme/apis/billing-api/api.yaml",
+            "git_commit_sha": "a" * 40,
         }
         defaults.update(overrides)
         mock = MagicMock()
@@ -54,7 +59,7 @@ class TestCatalogSyncGatewayReconciliation:
             "api_catalog_id": uuid4(),
             "gateway_instance_id": uuid4(),
             "desired_state": {"spec_hash": "old_hash", "activated": True},
-            "desired_at": datetime.now(timezone.utc),
+            "desired_at": datetime.now(UTC),
             "sync_status": DeploymentSyncStatus.SYNCED,
             "sync_error": None,
             "sync_attempts": 0,
@@ -91,21 +96,27 @@ class TestCatalogSyncGatewayReconciliation:
         mock_db.execute = AsyncMock(return_value=mock_execute_result)
 
         mock_gw_repo = MagicMock()
-        mock_gw_repo.get_by_name = AsyncMock(side_effect=lambda name: {
-            "webmethods-prod": gw1,
-            "stoa-dev": gw2,
-        }.get(name))
+        mock_gw_repo.get_by_name = AsyncMock(
+            side_effect=lambda name: {
+                "webmethods-prod": gw1,
+                "stoa-dev": gw2,
+            }.get(name)
+        )
+        mock_gw_repo.get_self_registered_by_hostname = AsyncMock(return_value=None)
 
         mock_deploy_repo = MagicMock()
         mock_deploy_repo.get_by_api_and_gateway = AsyncMock(return_value=None)
         mock_deploy_repo.create = AsyncMock(side_effect=lambda d: d)
 
-        with patch(
-            "src.services.catalog_sync_service.GatewayInstanceRepository",
-            return_value=mock_gw_repo,
-        ), patch(
-            "src.services.catalog_sync_service.GatewayDeploymentRepository",
-            return_value=mock_deploy_repo,
+        with (
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayInstanceRepository",
+                return_value=mock_gw_repo,
+            ),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentRepository",
+                return_value=mock_deploy_repo,
+            ),
         ):
             await svc._reconcile_gateway_deployments("acme", "billing-api", api)
 
@@ -133,17 +144,21 @@ class TestCatalogSyncGatewayReconciliation:
 
         mock_gw_repo = MagicMock()
         mock_gw_repo.get_by_name = AsyncMock(return_value=gw)
+        mock_gw_repo.get_self_registered_by_hostname = AsyncMock(return_value=None)
 
         mock_deploy_repo = MagicMock()
         mock_deploy_repo.get_by_api_and_gateway = AsyncMock(return_value=None)
         mock_deploy_repo.create = AsyncMock(side_effect=lambda d: d)
 
-        with patch(
-            "src.services.catalog_sync_service.GatewayInstanceRepository",
-            return_value=mock_gw_repo,
-        ), patch(
-            "src.services.catalog_sync_service.GatewayDeploymentRepository",
-            return_value=mock_deploy_repo,
+        with (
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayInstanceRepository",
+                return_value=mock_gw_repo,
+            ),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentRepository",
+                return_value=mock_deploy_repo,
+            ),
         ):
             await svc._reconcile_gateway_deployments("acme", "billing-api", api)
 
@@ -152,7 +167,6 @@ class TestCatalogSyncGatewayReconciliation:
     async def test_create_deployment_pending(self):
         """New deployment is created with sync_status=PENDING."""
         from src.services.catalog_sync_service import CatalogSyncService
-        from src.models.gateway_deployment import GatewayDeployment
 
         mock_db = AsyncMock()
         mock_git = MagicMock()
@@ -172,18 +186,22 @@ class TestCatalogSyncGatewayReconciliation:
 
         mock_gw_repo = MagicMock()
         mock_gw_repo.get_by_name = AsyncMock(return_value=gw)
+        mock_gw_repo.get_self_registered_by_hostname = AsyncMock(return_value=None)
 
         created_deployments = []
         mock_deploy_repo = MagicMock()
         mock_deploy_repo.get_by_api_and_gateway = AsyncMock(return_value=None)
         mock_deploy_repo.create = AsyncMock(side_effect=lambda d: (created_deployments.append(d), d)[1])
 
-        with patch(
-            "src.services.catalog_sync_service.GatewayInstanceRepository",
-            return_value=mock_gw_repo,
-        ), patch(
-            "src.services.catalog_sync_service.GatewayDeploymentRepository",
-            return_value=mock_deploy_repo,
+        with (
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayInstanceRepository",
+                return_value=mock_gw_repo,
+            ),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentRepository",
+                return_value=mock_deploy_repo,
+            ),
         ):
             await svc._reconcile_gateway_deployments("acme", "billing-api", api)
 
@@ -214,19 +232,22 @@ class TestCatalogSyncGatewayReconciliation:
 
         mock_gw_repo = MagicMock()
         mock_gw_repo.get_by_name = AsyncMock(return_value=None)
+        mock_gw_repo.get_self_registered_by_hostname = AsyncMock(return_value=None)
 
         mock_deploy_repo = MagicMock()
         mock_deploy_repo.create = AsyncMock()
 
-        with patch(
-            "src.services.catalog_sync_service.GatewayInstanceRepository",
-            return_value=mock_gw_repo,
-        ), patch(
-            "src.services.catalog_sync_service.GatewayDeploymentRepository",
-            return_value=mock_deploy_repo,
-        ), patch(
-            "src.services.catalog_sync_service.logger"
-        ) as mock_logger:
+        with (
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayInstanceRepository",
+                return_value=mock_gw_repo,
+            ),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentRepository",
+                return_value=mock_deploy_repo,
+            ),
+            patch("src.services.catalog_deployment_reconciler.logger") as mock_logger,
+        ):
             await svc._reconcile_gateway_deployments("acme", "billing-api", api)
 
         mock_deploy_repo.create.assert_not_awaited()
@@ -246,17 +267,115 @@ class TestCatalogSyncGatewayReconciliation:
         mock_gw_repo = MagicMock()
         mock_deploy_repo = MagicMock()
 
-        with patch(
-            "src.services.catalog_sync_service.GatewayInstanceRepository",
-            return_value=mock_gw_repo,
-        ), patch(
-            "src.services.catalog_sync_service.GatewayDeploymentRepository",
-            return_value=mock_deploy_repo,
+        with (
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayInstanceRepository",
+                return_value=mock_gw_repo,
+            ),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentRepository",
+                return_value=mock_deploy_repo,
+            ),
         ):
             await svc._reconcile_gateway_deployments("acme", "simple-api", api)
 
         # No DB calls should have been made — early return
         mock_db.execute.assert_not_awaited()
+
+    async def test_deployments_block_with_gateway_creates_deployment(self):
+        """deployments.dev.gateways is a materializable DR target."""
+        from src.services.catalog_sync_service import CatalogSyncService
+
+        mock_db = AsyncMock()
+        mock_git = MagicMock()
+        svc = CatalogSyncService(mock_db, mock_git)
+
+        catalog_entry = self._make_catalog_entry()
+        gw = self._make_gateway_instance(name="connect-webmethods-dev", environment="dev")
+
+        api = {
+            "name": "API",
+            "deployments": {
+                "dev": {
+                    "gateways": [{"instance": "connect-webmethods-dev", "activated": False}],
+                }
+            },
+        }
+
+        mock_execute_result = MagicMock()
+        mock_execute_result.scalar_one_or_none.return_value = catalog_entry
+        mock_db.execute = AsyncMock(return_value=mock_execute_result)
+
+        mock_gw_repo = MagicMock()
+        mock_gw_repo.get_by_name = AsyncMock(return_value=gw)
+        mock_gw_repo.get_self_registered_by_hostname = AsyncMock(return_value=None)
+
+        created_deployments = []
+        mock_deploy_repo = MagicMock()
+        mock_deploy_repo.get_by_api_and_gateway = AsyncMock(return_value=None)
+        mock_deploy_repo.create = AsyncMock(side_effect=lambda d: (created_deployments.append(d), d)[1])
+
+        with (
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayInstanceRepository",
+                return_value=mock_gw_repo,
+            ),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentRepository",
+                return_value=mock_deploy_repo,
+            ),
+        ):
+            await svc._reconcile_gateway_deployments("acme", "billing-api", api)
+
+        assert len(created_deployments) == 1
+        assert catalog_entry.target_gateways == ["connect-webmethods-dev"]
+        assert created_deployments[0].desired_state["activated"] is False
+        assert created_deployments[0].desired_state["target_environment"] == "dev"
+        assert created_deployments[0].desired_state["target_source"] == "deployments"
+
+    async def test_resolve_self_registered_gateway_by_hostname(self):
+        """Catalog targets can use STOA_INSTANCE_NAME before CP suffixes the row name."""
+        from src.services.catalog_sync_service import CatalogSyncService
+
+        mock_db = AsyncMock()
+        mock_git = MagicMock()
+        svc = CatalogSyncService(mock_db, mock_git)
+
+        catalog_entry = self._make_catalog_entry()
+        gw = self._make_gateway_instance(name="connect-webmethods-dev-connect-dev", environment="dev")
+
+        api = {
+            "name": "API",
+            "gateways": [{"instance": "connect-webmethods-dev", "environment": "dev"}],
+        }
+
+        mock_execute_result = MagicMock()
+        mock_execute_result.scalar_one_or_none.return_value = catalog_entry
+        mock_db.execute = AsyncMock(return_value=mock_execute_result)
+
+        mock_gw_repo = MagicMock()
+        mock_gw_repo.get_by_name = AsyncMock(return_value=None)
+        mock_gw_repo.get_self_registered_by_hostname = AsyncMock(return_value=gw)
+
+        mock_deploy_repo = MagicMock()
+        mock_deploy_repo.get_by_api_and_gateway = AsyncMock(return_value=None)
+        mock_deploy_repo.create = AsyncMock(side_effect=lambda d: d)
+
+        with (
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayInstanceRepository",
+                return_value=mock_gw_repo,
+            ),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentRepository",
+                return_value=mock_deploy_repo,
+            ),
+        ):
+            await svc._reconcile_gateway_deployments("acme", "billing-api", api)
+
+        mock_gw_repo.get_by_name.assert_awaited_once_with("connect-webmethods-dev")
+        mock_gw_repo.get_self_registered_by_hostname.assert_awaited_once_with("connect-webmethods-dev")
+        mock_deploy_repo.create.assert_awaited_once()
 
     async def test_update_existing_deployment(self):
         """Existing deployment with changed state → reset to PENDING; unchanged → left alone."""
@@ -271,7 +390,14 @@ class TestCatalogSyncGatewayReconciliation:
 
         # Build the desired_state that the service would compute
         from src.services.gateway_deployment_service import GatewayDeploymentService
-        expected_desired = GatewayDeploymentService.build_desired_state(catalog_entry)
+
+        expected_desired = {
+            **GatewayDeploymentService.build_desired_state(catalog_entry),
+            "activated": True,
+            "target_gateway_name": "webmethods-prod",
+            "target_environment": None,
+            "target_source": "gateways",
+        }
 
         # Existing deployment with DIFFERENT desired_state (should be updated)
         existing_dep = self._make_deployment(
@@ -292,18 +418,22 @@ class TestCatalogSyncGatewayReconciliation:
 
         mock_gw_repo = MagicMock()
         mock_gw_repo.get_by_name = AsyncMock(return_value=gw)
+        mock_gw_repo.get_self_registered_by_hostname = AsyncMock(return_value=None)
 
         mock_deploy_repo = MagicMock()
         mock_deploy_repo.get_by_api_and_gateway = AsyncMock(return_value=existing_dep)
         mock_deploy_repo.update = AsyncMock(return_value=existing_dep)
         mock_deploy_repo.create = AsyncMock()
 
-        with patch(
-            "src.services.catalog_sync_service.GatewayInstanceRepository",
-            return_value=mock_gw_repo,
-        ), patch(
-            "src.services.catalog_sync_service.GatewayDeploymentRepository",
-            return_value=mock_deploy_repo,
+        with (
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayInstanceRepository",
+                return_value=mock_gw_repo,
+            ),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentRepository",
+                return_value=mock_deploy_repo,
+            ),
         ):
             await svc._reconcile_gateway_deployments("acme", "billing-api", api)
 

--- a/control-plane-api/tests/test_catalog_sync_service.py
+++ b/control-plane-api/tests/test_catalog_sync_service.py
@@ -6,6 +6,7 @@ _sync_tenant_apis, _soft_delete_missing_apis, get_last_sync_status,
 get_sync_history, sync_mcp_servers, _sync_tenant_mcp_servers,
 _upsert_mcp_server, _sync_server_tools, _mark_orphan_mcp_servers.
 """
+
 import uuid
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -20,7 +21,6 @@ from src.models.mcp_subscription import (
     MCPServerSyncStatus,
 )
 from src.services.catalog_sync_service import CatalogSyncService
-
 
 # ─────────────────────────────────────────────
 # Shared helpers / factories
@@ -70,6 +70,9 @@ def _make_catalog_entry(**overrides) -> MagicMock:
         "version": "1.0.0",
         "openapi_spec": {"openapi": "3.0.0"},
         "api_metadata": {"name": "Billing API"},
+        "target_gateways": [],
+        "git_path": "tenants/acme/apis/billing-api/api.yaml",
+        "git_commit_sha": "sha123",
     }
     defaults.update(overrides)
     mock = MagicMock()
@@ -142,11 +145,12 @@ class TestSyncAll:
 
         svc = CatalogSyncService(db, git, enable_gateway_reconciliation=False)
 
-        with patch.object(svc, "_ensure_tenant_from_git", AsyncMock(return_value=False)), patch.object(
-            svc, "_sync_tenant_apis_parallel", AsyncMock(return_value=(1, 0))
-        ) as mock_parallel, patch.object(
-            svc, "_soft_delete_missing_apis", AsyncMock(return_value=0)
-        ), patch.object(svc, "sync_mcp_servers", AsyncMock(return_value={"servers_synced": 0, "servers_failed": 0})):
+        with (
+            patch.object(svc, "_ensure_tenant_from_git", AsyncMock(return_value=False)),
+            patch.object(svc, "_sync_tenant_apis_parallel", AsyncMock(return_value=(1, 0))) as mock_parallel,
+            patch.object(svc, "_soft_delete_missing_apis", AsyncMock(return_value=0)),
+            patch.object(svc, "sync_mcp_servers", AsyncMock(return_value={"servers_synced": 0, "servers_failed": 0})),
+        ):
             status = await svc.sync_all()
 
         assert mock_parallel.await_count == 2
@@ -193,11 +197,12 @@ class TestSyncAll:
 
         svc = CatalogSyncService(db, git, enable_gateway_reconciliation=False)
 
-        with patch.object(svc, "_ensure_tenant_from_git", AsyncMock(return_value=False)), patch.object(
-            svc, "_sync_tenant_apis_parallel", side_effect=mock_parallel
-        ), patch.object(
-            svc, "_soft_delete_missing_apis", AsyncMock(return_value=0)
-        ), patch.object(svc, "sync_mcp_servers", AsyncMock(return_value={"servers_synced": 0, "servers_failed": 0})):
+        with (
+            patch.object(svc, "_ensure_tenant_from_git", AsyncMock(return_value=False)),
+            patch.object(svc, "_sync_tenant_apis_parallel", side_effect=mock_parallel),
+            patch.object(svc, "_soft_delete_missing_apis", AsyncMock(return_value=0)),
+            patch.object(svc, "sync_mcp_servers", AsyncMock(return_value={"servers_synced": 0, "servers_failed": 0})),
+        ):
             status = await svc.sync_all()
 
         assert call_count["n"] == 2
@@ -216,9 +221,11 @@ class TestSyncAll:
         svc = CatalogSyncService(db, git, enable_gateway_reconciliation=False)
         mcp_mock = AsyncMock(return_value={"servers_synced": 3, "servers_failed": 0})
 
-        with patch.object(svc, "_ensure_tenant_from_git", AsyncMock(return_value=False)), patch.object(
-            svc, "_soft_delete_missing_apis", AsyncMock(return_value=0)
-        ), patch.object(svc, "sync_mcp_servers", mcp_mock):
+        with (
+            patch.object(svc, "_ensure_tenant_from_git", AsyncMock(return_value=False)),
+            patch.object(svc, "_soft_delete_missing_apis", AsyncMock(return_value=0)),
+            patch.object(svc, "sync_mcp_servers", mcp_mock),
+        ):
             await svc.sync_all()
 
         mcp_mock.assert_awaited_once()
@@ -234,11 +241,12 @@ class TestSyncAll:
         svc = CatalogSyncService(db, git, enable_gateway_reconciliation=False)
         delete_mock = AsyncMock(return_value=2)
 
-        with patch.object(svc, "_ensure_tenant_from_git", AsyncMock(return_value=False)), patch.object(
-            svc, "_sync_tenant_apis_parallel", AsyncMock(return_value=(1, 0))
-        ), patch.object(
-            svc, "_soft_delete_missing_apis", delete_mock
-        ), patch.object(svc, "sync_mcp_servers", AsyncMock(return_value={"servers_synced": 0, "servers_failed": 0})):
+        with (
+            patch.object(svc, "_ensure_tenant_from_git", AsyncMock(return_value=False)),
+            patch.object(svc, "_sync_tenant_apis_parallel", AsyncMock(return_value=(1, 0))),
+            patch.object(svc, "_soft_delete_missing_apis", delete_mock),
+            patch.object(svc, "sync_mcp_servers", AsyncMock(return_value={"servers_synced": 0, "servers_failed": 0})),
+        ):
             await svc.sync_all()
 
         delete_mock.assert_awaited_once()
@@ -293,9 +301,11 @@ class TestSyncTenant:
 
         svc = CatalogSyncService(db, git)
 
-        with patch.object(svc, "_sync_tenant_apis", AsyncMock(side_effect=RuntimeError("boom"))):
-            with pytest.raises(RuntimeError, match="boom"):
-                await svc.sync_tenant("acme")
+        with (
+            patch.object(svc, "_sync_tenant_apis", AsyncMock(side_effect=RuntimeError("boom"))),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            await svc.sync_tenant("acme")
 
         db.add.assert_called_once()
         db.commit.assert_called()
@@ -481,8 +491,9 @@ class TestSyncTenantApisParallel:
         reconcile_mock = AsyncMock()
         seen: set[tuple[str, str]] = set()
 
-        with patch.object(svc, "_upsert_api", AsyncMock()), patch.object(
-            svc, "_reconcile_gateway_deployments", reconcile_mock
+        with (
+            patch.object(svc, "_upsert_api", AsyncMock()),
+            patch.object(svc, "_reconcile_gateway_deployments", reconcile_mock),
         ):
             await svc._sync_tenant_apis_parallel("acme", ["api-1"], "sha", seen)
 
@@ -574,7 +585,6 @@ class TestReconcileGatewayDeployments:
 
     async def test_new_deployment_created_pending(self):
         """No existing deployment → create with PENDING status."""
-        from src.models.gateway_deployment import GatewayDeployment
 
         db = _make_db()
         git = _make_git()
@@ -587,6 +597,7 @@ class TestReconcileGatewayDeployments:
 
         mock_gw_repo = MagicMock()
         mock_gw_repo.get_by_name = AsyncMock(return_value=gw)
+        mock_gw_repo.get_self_registered_by_hostname = AsyncMock(return_value=None)
 
         created = []
         mock_deploy_repo = MagicMock()
@@ -595,9 +606,16 @@ class TestReconcileGatewayDeployments:
 
         api = {"name": "API", "gateways": [{"instance": "kong-prod"}]}
 
-        with patch("src.services.catalog_sync_service.GatewayInstanceRepository", return_value=mock_gw_repo), patch(
-            "src.services.catalog_sync_service.GatewayDeploymentRepository", return_value=mock_deploy_repo
-        ), patch("src.services.catalog_sync_service.GatewayDeploymentService.build_desired_state", return_value={"spec": "v1"}):
+        with (
+            patch("src.services.catalog_deployment_reconciler.GatewayInstanceRepository", return_value=mock_gw_repo),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentRepository", return_value=mock_deploy_repo
+            ),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentService.build_desired_state",
+                return_value={"spec": "v1"},
+            ),
+        ):
             await svc._reconcile_gateway_deployments("acme", "billing-api", api)
 
         assert len(created) == 1
@@ -622,6 +640,7 @@ class TestReconcileGatewayDeployments:
 
         mock_gw_repo = MagicMock()
         mock_gw_repo.get_by_name = AsyncMock(return_value=gw)
+        mock_gw_repo.get_self_registered_by_hostname = AsyncMock(return_value=None)
 
         mock_deploy_repo = MagicMock()
         mock_deploy_repo.get_by_api_and_gateway = AsyncMock(return_value=existing_dep)
@@ -630,11 +649,15 @@ class TestReconcileGatewayDeployments:
 
         api = {"name": "API", "gateways": [{"instance": "kong-prod"}]}
 
-        with patch("src.services.catalog_sync_service.GatewayInstanceRepository", return_value=mock_gw_repo), patch(
-            "src.services.catalog_sync_service.GatewayDeploymentRepository", return_value=mock_deploy_repo
-        ), patch(
-            "src.services.catalog_sync_service.GatewayDeploymentService.build_desired_state",
-            return_value={"spec": "new"},
+        with (
+            patch("src.services.catalog_deployment_reconciler.GatewayInstanceRepository", return_value=mock_gw_repo),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentRepository", return_value=mock_deploy_repo
+            ),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentService.build_desired_state",
+                return_value={"spec": "new"},
+            ),
         ):
             await svc._reconcile_gateway_deployments("acme", "billing-api", api)
 
@@ -650,7 +673,14 @@ class TestReconcileGatewayDeployments:
 
         catalog_entry = _make_catalog_entry()
         gw = _make_gateway()
-        same_state = {"spec": "unchanged"}
+        base_state = {"spec": "unchanged"}
+        same_state = {
+            **base_state,
+            "activated": True,
+            "target_gateway_name": "kong-prod",
+            "target_environment": None,
+            "target_source": "gateways",
+        }
         existing_dep = _make_deployment(
             desired_state=same_state,
             sync_status=DeploymentSyncStatus.SYNCED,
@@ -660,6 +690,7 @@ class TestReconcileGatewayDeployments:
 
         mock_gw_repo = MagicMock()
         mock_gw_repo.get_by_name = AsyncMock(return_value=gw)
+        mock_gw_repo.get_self_registered_by_hostname = AsyncMock(return_value=None)
 
         mock_deploy_repo = MagicMock()
         mock_deploy_repo.get_by_api_and_gateway = AsyncMock(return_value=existing_dep)
@@ -668,11 +699,15 @@ class TestReconcileGatewayDeployments:
 
         api = {"name": "API", "gateways": [{"instance": "kong-prod"}]}
 
-        with patch("src.services.catalog_sync_service.GatewayInstanceRepository", return_value=mock_gw_repo), patch(
-            "src.services.catalog_sync_service.GatewayDeploymentRepository", return_value=mock_deploy_repo
-        ), patch(
-            "src.services.catalog_sync_service.GatewayDeploymentService.build_desired_state",
-            return_value=same_state,
+        with (
+            patch("src.services.catalog_deployment_reconciler.GatewayInstanceRepository", return_value=mock_gw_repo),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentRepository", return_value=mock_deploy_repo
+            ),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentService.build_desired_state",
+                return_value=base_state,
+            ),
         ):
             await svc._reconcile_gateway_deployments("acme", "billing-api", api)
 
@@ -690,17 +725,22 @@ class TestReconcileGatewayDeployments:
 
         mock_gw_repo = MagicMock()
         mock_gw_repo.get_by_name = AsyncMock(return_value=None)  # not found
+        mock_gw_repo.get_self_registered_by_hostname = AsyncMock(return_value=None)
 
         mock_deploy_repo = MagicMock()
         mock_deploy_repo.create = AsyncMock()
 
         api = {"name": "API", "gateways": [{"instance": "ghost-gw"}]}
 
-        with patch("src.services.catalog_sync_service.GatewayInstanceRepository", return_value=mock_gw_repo), patch(
-            "src.services.catalog_sync_service.GatewayDeploymentRepository", return_value=mock_deploy_repo
-        ), patch(
-            "src.services.catalog_sync_service.GatewayDeploymentService.build_desired_state",
-            return_value={},
+        with (
+            patch("src.services.catalog_deployment_reconciler.GatewayInstanceRepository", return_value=mock_gw_repo),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentRepository", return_value=mock_deploy_repo
+            ),
+            patch(
+                "src.services.catalog_deployment_reconciler.GatewayDeploymentService.build_desired_state",
+                return_value={},
+            ),
         ):
             await svc._reconcile_gateway_deployments("acme", "billing-api", api)
 
@@ -825,14 +865,16 @@ class TestSyncMcpServers:
 
         svc = CatalogSyncService(db, git)
 
-        with patch.object(svc, "_list_tenants", AsyncMock(return_value=["acme", "beta"])), patch.object(
-            svc, "_sync_tenant_mcp_servers", AsyncMock(return_value=(2, 0))
-        ) as mock_sync, patch.object(svc, "_mark_orphan_mcp_servers", AsyncMock(return_value=0)):
+        with (
+            patch.object(svc, "_list_tenants", AsyncMock(return_value=["acme", "beta"])),
+            patch.object(svc, "_sync_tenant_mcp_servers", AsyncMock(return_value=(2, 0))) as mock_sync,
+            patch.object(svc, "_mark_orphan_mcp_servers", AsyncMock(return_value=0)),
+        ):
             stats = await svc.sync_mcp_servers()
 
         # Should sync _platform, acme, beta → 3 calls
         assert mock_sync.await_count == 3
-        assert stats["servers_synced"] == 6  # 2 × 3
+        assert stats["servers_synced"] == 6  # 2 x 3
 
     async def test_single_tenant_sync(self):
         """With tenant_id → only that tenant synced, no orphan check."""
@@ -843,8 +885,9 @@ class TestSyncMcpServers:
         svc = CatalogSyncService(db, git)
 
         orphan_mock = AsyncMock(return_value=0)
-        with patch.object(svc, "_sync_tenant_mcp_servers", AsyncMock(return_value=(1, 0))), patch.object(
-            svc, "_mark_orphan_mcp_servers", orphan_mock
+        with (
+            patch.object(svc, "_sync_tenant_mcp_servers", AsyncMock(return_value=(1, 0))),
+            patch.object(svc, "_mark_orphan_mcp_servers", orphan_mock),
         ):
             stats = await svc.sync_mcp_servers(tenant_id="acme")
 
@@ -867,9 +910,11 @@ class TestSyncMcpServers:
                 raise RuntimeError("platform error")
             return 1, 0
 
-        with patch.object(svc, "_list_tenants", AsyncMock(return_value=["acme"])), patch.object(
-            svc, "_sync_tenant_mcp_servers", side_effect=flaky_sync
-        ), patch.object(svc, "_mark_orphan_mcp_servers", AsyncMock(return_value=0)):
+        with (
+            patch.object(svc, "_list_tenants", AsyncMock(return_value=["acme"])),
+            patch.object(svc, "_sync_tenant_mcp_servers", side_effect=flaky_sync),
+            patch.object(svc, "_mark_orphan_mcp_servers", AsyncMock(return_value=0)),
+        ):
             stats = await svc.sync_mcp_servers()
 
         assert call_n["n"] == 2  # _platform + acme
@@ -885,9 +930,11 @@ class TestSyncMcpServers:
         svc = CatalogSyncService(db, git)
         orphan_mock = AsyncMock(return_value=3)
 
-        with patch.object(svc, "_list_tenants", AsyncMock(return_value=[])), patch.object(
-            svc, "_sync_tenant_mcp_servers", AsyncMock(return_value=(0, 0))
-        ), patch.object(svc, "_mark_orphan_mcp_servers", orphan_mock):
+        with (
+            patch.object(svc, "_list_tenants", AsyncMock(return_value=[])),
+            patch.object(svc, "_sync_tenant_mcp_servers", AsyncMock(return_value=(0, 0))),
+            patch.object(svc, "_mark_orphan_mcp_servers", orphan_mock),
+        ):
             stats = await svc.sync_mcp_servers()
 
         orphan_mock.assert_awaited_once()

--- a/control-plane-api/tests/test_regression_catalog_gateway_dr.py
+++ b/control-plane-api/tests/test_regression_catalog_gateway_dr.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from src.models.gateway_deployment import DeploymentSyncStatus
+from src.services.catalog_deployment_reconciler import CatalogDeploymentReconciler
+
+
+async def test_regression_catalog_gateway_targets_rebuild_pending_deployment() -> None:
+    db = AsyncMock()
+    catalog_entry = MagicMock(
+        id=uuid4(),
+        tenant_id="acme",
+        api_id="billing-api",
+        target_gateways=[],
+    )
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = catalog_entry
+    db.execute = AsyncMock(return_value=result)
+
+    gateway = MagicMock(id=uuid4(), name="connect-webmethods-dev", environment="dev")
+    gw_repo = MagicMock()
+    gw_repo.get_by_name = AsyncMock(return_value=gateway)
+    gw_repo.get_self_registered_by_hostname = AsyncMock(return_value=None)
+
+    created = []
+    deploy_repo = MagicMock()
+    deploy_repo.get_by_api_and_gateway = AsyncMock(return_value=None)
+    deploy_repo.create = AsyncMock(side_effect=lambda deployment: created.append(deployment))
+
+    api_content = {
+        "name": "Billing API",
+        "deployments": {
+            "dev": {
+                "gateways": [{"instance": "connect-webmethods-dev"}],
+            }
+        },
+    }
+
+    with (
+        patch("src.services.catalog_deployment_reconciler.GatewayInstanceRepository", return_value=gw_repo),
+        patch("src.services.catalog_deployment_reconciler.GatewayDeploymentRepository", return_value=deploy_repo),
+        patch(
+            "src.services.catalog_deployment_reconciler.GatewayDeploymentService.build_desired_state",
+            return_value={"spec": "v1"},
+        ),
+    ):
+        changed = await CatalogDeploymentReconciler(db).reconcile_api(
+            tenant_id="acme",
+            api_id="billing-api",
+            api_content=api_content,
+        )
+
+    assert changed is True
+    assert catalog_entry.target_gateways == ["connect-webmethods-dev"]
+    assert len(created) == 1
+    assert created[0].api_catalog_id == catalog_entry.id
+    assert created[0].gateway_instance_id == gateway.id
+    assert created[0].sync_status == DeploymentSyncStatus.PENDING
+    assert created[0].desired_state["target_environment"] == "dev"
+    db.flush.assert_awaited_once()

--- a/specs/catalog-gateway-dr-reconciliation.md
+++ b/specs/catalog-gateway-dr-reconciliation.md
@@ -1,0 +1,81 @@
+# Spec: Catalog Gateway DR Reconciliation
+
+> Status: implemented in `control-plane-api` on 2026-05-01.
+> Related docs: `specs/api-creation-gitops-rewrite.md`, ADR-035 Gateway Adapter Pattern, ADR-057 `stoa-connect`.
+
+## Problem
+
+`stoa-catalog` can reconstruct `api_catalog`, but a platform rebuild must also recover the runtime deployment queue. Before this spec, the Git catalog projection preserved `target_gateways` and `openapi_spec`, but did not recreate `GatewayDeployment` rows from Git. A rebuilt Control Plane could therefore know that an API exists without knowing which gateway should receive it.
+
+## Goal
+
+When catalog sync or the in-tree catalog reconciler reads an API definition from Git, explicit gateway targets in `api.yaml` are materialized into `GatewayDeployment` rows with `sync_status=PENDING`. The existing gateway sync engine and `stoa-connect` then converge the data plane through the normal Control Plane path.
+
+## Contract
+
+The source of truth is the API definition file in `stoa-catalog`:
+
+```yaml
+gateways:
+  - instance: connect-webmethods-dev
+    environment: dev
+    activated: true
+```
+
+or:
+
+```yaml
+deployments:
+  dev:
+    gateways:
+      - instance: connect-webmethods-dev
+        activated: true
+```
+
+Supported target shapes:
+
+| Shape | Meaning |
+|---|---|
+| `gateways: [{instance, environment?, activated?}]` | Explicit gateway targets |
+| `gateways: [gateway-name]` | Explicit gateway target names |
+| `gateways: {gateway-name: {activated: true}}` | Explicit name map |
+| `deployments.<env>.gateways` | Explicit gateway targets scoped to an environment |
+| `deployments.<env>.gateway` | Single explicit gateway target scoped to an environment |
+| `deployments.<env>: true` | Environment marker only; not materializable without a gateway instance |
+
+`spec.gateway` in Kubernetes-style catalog entries describes webMethods API settings and is not interpreted as a STOA gateway deployment target.
+
+## Acceptance Criteria
+
+- [x] AC1: GitHub and GitLab catalog providers normalize Kubernetes-style and flat API definitions through the same helper.
+- [x] AC2: `api_catalog.target_gateways` is populated only from explicit gateway target declarations.
+- [x] AC3: Manual catalog sync creates a `GatewayDeployment(PENDING)` for each explicit target gateway.
+- [x] AC4: The in-tree catalog reconciler also creates/updates `GatewayDeployment` rows on absent rows, projection drift, and healthy rows whose deployment targets drifted.
+- [x] AC5: Existing deployments are reset to `PENDING` only when the computed desired state changes.
+- [x] AC6: A target gateway can resolve by registered name or by self-registered hostname/instance id.
+- [x] AC7: Environment-only deployment markers log a warning and do not guess a gateway.
+- [x] AC8: Data-plane rebuild still goes through the Control Plane; the data plane does not pull Git directly.
+
+## ADR Compliance
+
+This keeps ADR-035 intact: the Control Plane remains the orchestrator, `GatewayDeployment` is the desired-state queue, and gateway adapters/agents perform runtime application. It also keeps ADR-057 intact: `stoa-connect` synchronizes routes from the Control Plane and acknowledges results back to it.
+
+The data plane deliberately does not rebuild itself from Git. Letting every gateway read `stoa-catalog` directly would duplicate auth, tenancy, promotion, policy, and audit decisions outside the Control Plane.
+
+## UAC Applicability
+
+No new UAC contract is introduced here. This spec changes an internal reconciliation path behind existing admin catalog sync behavior; it is not an MCP-exposed or agent-facing API operation.
+
+If STOA later exposes "resync catalog/gateways" as an agent tool, that operation must get a UAC contract with `endpoint.llm` metadata before it is projected to MCP:
+
+- `side_effects: "write"`
+- `safe_for_agents: false`
+- `requires_human_approval: true`
+
+## Out of Scope
+
+- Soft-delete/prune when a gateway target is removed from Git.
+- Direct Git pull from the data plane.
+- Guessing gateway targets from `deployments.dev: true`.
+- Migrating existing catalog entries to add explicit gateway targets.
+- Changing promotion approval semantics or the public deployment APIs.


### PR DESCRIPTION
## Summary

- Normalize flat and Kubernetes-style catalog API definitions through a shared helper.
- Materialize explicit Git catalog gateway targets into `GatewayDeployment(PENDING)` during manual catalog sync and the in-tree catalog reconciler.
- Document the DR contract and UAC applicability for catalog gateway reconciliation.

## Verification

- `python3 -m pytest tests/services/test_catalog_api_definition.py tests/test_catalog_sync_gateways.py tests/test_github_service_catalog_parity.py tests/test_catalog_sync_service.py tests/test_catalog_sync_override.py -q`
- `python3 -m pytest tests/services/catalog_reconciler/test_worker_loop.py tests/services/catalog_reconciler/test_projection.py tests/services/catalog_reconciler/test_projection_db.py -q`
- `python3 -m ruff check ...`
- `python3 -m py_compile ...`