### PR TITLE
fix(api): fail-closed env + base_domain validators (cab-2199 3-a)

### DIFF
--- a/control-plane-api/.env.example
+++ b/control-plane-api/.env.example
@@ -10,9 +10,10 @@
 # existing dump command exists.
 
 # ── Core ─────────────────────────────────────────────────────────────────────
-# ENVIRONMENT=dev                         # dev | staging | production (or `prod`, normalized to `production`)
+# ENVIRONMENT=dev                         # Accepted (case-insensitive): dev | development | staging | test | prod | production.
+                                          # Unknown values fail at boot (Phase 3-A fail-closed validator — CAB-2199).
 # DEBUG=false
-# BASE_DOMAIN=gostoa.dev                  # Used to construct default URLs
+# BASE_DOMAIN=gostoa.dev                  # Used to construct default URLs. Empty / whitespace-only rejected at boot (Phase 3-A).
 
 # ── Database (PostgreSQL) ────────────────────────────────────────────────────
 DATABASE_URL=postgresql+asyncpg://stoa:stoa@localhost:5432/stoa

--- a/control-plane-api/CLAUDE.md
+++ b/control-plane-api/CLAUDE.md
@@ -102,6 +102,35 @@ If you add a new derived URL field, register it in the validator's `derived`
 dict. **Do NOT add new `gostoa.dev` literals** outside the `BASE_DOMAIN`
 default and the validator's fallback — Q6 multi-env-ready rule.
 
+**Phase 3-A — empty BASE_DOMAIN rejected**: `Settings(BASE_DOMAIN="")`
+(or whitespace-only) now raises a `ValidationError` instead of falling
+back silently to `gostoa.dev`. The pre-Phase-3-A behavior masked
+mis-templated Helm values (`baseDomain: ""`).
+
+## ENVIRONMENT — fail-closed alias map (Phase 3-A)
+
+Per CAB-2199 / INFRA-1a Phase 3-A, the `_normalize_environment` validator
+is fail-closed:
+
+- Whitespace-strip + casefold the input.
+- If it matches a documented alias
+  (`dev` | `development` | `staging` | `test` | `prod` | `production`),
+  return the canonical form. `prod` and `development` map to
+  `production` and `dev` respectively. Case variations are accepted —
+  `PROD`, `Prod`, `Staging`, `PRODUCTION` are all normalized.
+- Otherwise raise `ValidationError("ENVIRONMENT=… is not recognized")`.
+
+**Why fail-closed**: `ENVIRONMENT` drives four security gates
+(`_gate_sensitive_debug_flags_in_prod`, `_gate_auth_bypass_in_prod`,
+`_hydrate_and_validate_git`, `cors_origins_list`) which all
+literal-check `== "production"`. Pre-Phase-3-A, any unknown value
+(typo `produciton`, alias `live`, case variation `PROD`) silently
+bypassed every gate. The fail-closed validator ensures unknown values
+never reach the gates with a non-prod meaning.
+
+An `INFO` ops-signal log fires whenever the input differs from the
+canonical output (e.g., `prod` → `production`, `Prod` → `production`).
+
 ## OpenSearch — audit endpoint vs docs/embedding endpoint
 
 Per CAB-2199 / INFRA-1a S3 (Christophe arbitrage 2026-04-29 §3.1 = Option A),

--- a/control-plane-api/src/config.py
+++ b/control-plane-api/src/config.py
@@ -7,7 +7,7 @@ For Kubernetes deployments, set these in ConfigMaps/Secrets.
 import json
 import logging
 import os
-from typing import Literal
+from typing import Final, Literal
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator, model_validator
@@ -36,6 +36,24 @@ SENSITIVE_DEBUG_FLAGS_IN_PROD: tuple[str, ...] = (
     "LOG_DEBUG_HTTP_BODY",
     "LOG_DEBUG_HTTP_HEADERS",
 )
+
+# CAB-2199 / INFRA-1a Phase 3-A — fail-closed ENVIRONMENT alias map.
+# `ENVIRONMENT` drives four security-relevant gates (sensitive debug flags,
+# auth bypass, git provider validation, CORS localhost stripping) which
+# all literal-check `== "production"`. Phase 2 S5 surgically mapped only
+# the bare lowercase `prod` token, so any other spelling (`PROD`, `Prod`,
+# `produciton`, `live`) silently bypassed every gate. Phase 3-A widens
+# the validator into a fail-closed alias map: case-insensitive accept
+# for documented values, hard reject for everything else (the prod
+# gates can never see an unrecognized environment string).
+_ENVIRONMENT_ALIASES: Final[dict[str, str]] = {
+    "dev": "dev",
+    "development": "dev",
+    "staging": "staging",
+    "test": "test",
+    "prod": "production",
+    "production": "production",
+}
 
 
 def _is_valid_http_url(url: str) -> bool:
@@ -256,6 +274,24 @@ class Settings(BaseSettings):
     # ── OpenSearch — single source of truth for consumers ────────────────
     opensearch_audit: OpenSearchAuditConfig = Field(default_factory=OpenSearchAuditConfig)
 
+    @field_validator("BASE_DOMAIN")
+    @classmethod
+    def _base_domain_must_not_be_empty(cls, v: str) -> str:
+        """CAB-2199 Phase 3-A — reject explicit empty BASE_DOMAIN.
+
+        The BASE_DOMAIN derivation validator (``_derive_urls_from_base_domain``)
+        falls back to ``"gostoa.dev"`` when ``data.get("BASE_DOMAIN")`` is
+        falsy, but the BASE_DOMAIN field itself preserved the empty
+        string — producing an inconsistent state where derived URLs
+        used ``gostoa.dev`` while ``settings.BASE_DOMAIN`` reported
+        ``""``. An empty domain is never a valid configuration; reject
+        it at validation so a mis-templated Helm value (``baseDomain: ""``)
+        fails loudly instead of masking the misconfiguration.
+        """
+        if not v.strip():
+            raise ValueError("BASE_DOMAIN must not be empty")
+        return v
+
     @field_validator("GIT_PROVIDER", mode="before")
     @classmethod
     def _normalize_git_provider(cls, v: object) -> object:
@@ -273,33 +309,46 @@ class Settings(BaseSettings):
     @field_validator("ENVIRONMENT", mode="before")
     @classmethod
     def _normalize_environment(cls, v: object) -> object:
-        """CAB-2199 / INFRA-1a §3.4 — surgical ``prod → production`` mapping.
+        """CAB-2199 Phase 3-A — fail-closed ENVIRONMENT alias map.
 
-        stoa-gateway uses ``ENVIRONMENT=prod`` while cp-api historically
-        validated against the literal ``"production"``. This validator
-        funnels exactly the bare ``prod`` token (whitespace-stripped) into
-        the canonical ``production`` so existing ``== "production"`` checks
-        keep working for both spellings. All other values pass through
-        untouched (``Staging``, ``PRODUCTION``, ``dev`` preserve caller
-        spelling — BH-8 mitigation: avoid silent case-fold of unrelated
-        values).
+        Replaces the Phase 2 S5 surgical ``prod → production`` mapping,
+        which left every other spelling (``PROD``, ``Prod``, typo
+        ``produciton``, alias ``live``) silently bypassing the four
+        ``== "production"`` security gates downstream
+        (``_gate_sensitive_debug_flags_in_prod``,
+        ``_gate_auth_bypass_in_prod``, ``_hydrate_and_validate_git``,
+        ``cors_origins_list``).
 
-        Christophe arbitrage 2026-04-29 §3.4 nuance: emit a
-        ``logger.info`` line at boot when normalization is applied so an
-        operator inspecting the boot logs sees the rewrite explicitly
-        (avoids the "I set prod, why does the log say production?" trap).
+        Behaviour:
+        - Whitespace-strip + casefold the input.
+        - If the normalized key matches a documented alias, return the
+          canonical form. Emit a ``logger.info`` ops-signal whenever the
+          stored value differs from the caller's input (case-fold or
+          ``prod`` → ``production``).
+        - Otherwise raise ``ValueError`` — unknown values must NEVER
+          silently mean "non-prod" because they would bypass the gates.
         """
-        if isinstance(v, str):
-            stripped = v.strip()
-            if stripped == "prod":
+        if not isinstance(v, str):
+            return v  # let Pydantic surface the type error
+
+        stripped = v.strip()
+        key = stripped.casefold()
+        if key in _ENVIRONMENT_ALIASES:
+            canonical = _ENVIRONMENT_ALIASES[key]
+            if stripped != canonical:
                 _logger.info(
-                    "ENVIRONMENT normalized: 'prod' → 'production' "
-                    "(CAB-2199 / INFRA-1a §3.4 — gateway uses 'prod', "
-                    "cp-api stores the canonical 'production'; both spellings accepted)."
+                    "ENVIRONMENT normalized: %r → %r "
+                    "(CAB-2199 Phase 3-A — case-insensitive accept).",
+                    v,
+                    canonical,
                 )
-                return "production"
-            return stripped
-        return v
+            return canonical
+
+        accepted = sorted(set(_ENVIRONMENT_ALIASES))
+        raise ValueError(
+            f"ENVIRONMENT={v!r} is not recognized. "
+            f"Accepted values (case-insensitive): {accepted}."
+        )
 
     # Kafka/Redpanda Event Streaming
     KAFKA_ENABLED: bool = True  # Set to False to skip Kafka health checks

--- a/control-plane-api/tests/test_config_base_domain_derivation.py
+++ b/control-plane-api/tests/test_config_base_domain_derivation.py
@@ -1,10 +1,16 @@
-"""CAB-2199 / INFRA-1a S2 — regression guards for the BASE_DOMAIN derivation validator.
+"""CAB-2199 / INFRA-1a S2 + Phase 3-A — regression guards for the BASE_DOMAIN derivation validator.
 
 Replaces the prior load-time ``_BASE_DOMAIN = os.getenv(...)`` freeze with a
 ``model_validator(mode="before")`` that fills in BASE_DOMAIN-derived URL
 defaults at instantiation time. The validator uses ``setdefault`` so it
 distinguishes ABSENT (derive) from EXPLICITLY-PROVIDED (preserve, including
-empty string).
+empty string for derived URLs).
+
+Phase 3-A adds a ``_base_domain_must_not_be_empty`` field validator that
+rejects an explicit empty BASE_DOMAIN — closes the BH-INFRA1a-005
+inconsistent-state bug where ``Settings(BASE_DOMAIN="")`` preserved the
+empty string on the field but the derivation lookup fell back to
+``"gostoa.dev"``.
 
 Tests cover:
 - Default (no override) — every derived URL renders from ``gostoa.dev``.
@@ -15,14 +21,16 @@ Tests cover:
 - ``CORS_ORIGINS`` recompute via ``BASE_DOMAIN`` env override + local entries
   preserved.
 - ``model_dump()`` exposes resolved URLs (not the empty sentinel).
-- Empty-string explicit override preserved (caller intent honored — this is
-  a behavior expansion vs. the old frozen-default code, documented in
-  CLAUDE.md note #1).
+- Empty-string explicit override preserved for **derived URLs** (caller
+  intent honored on KEYCLOAK_URL etc.; documented in CLAUDE.md note #1).
+- Empty/whitespace BASE_DOMAIN itself **rejected** at validation
+  (Phase 3-A — closes BH-INFRA1a-005).
 """
 
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from src.config import Settings
 
@@ -156,3 +164,18 @@ def test_env_var_override_short_circuits_derivation(monkeypatch):
     assert s.KEYCLOAK_URL == "https://auth.from-env.io"
     # GATEWAY_URL still derives from BASE_DOMAIN (env did not set it)
     assert s.GATEWAY_URL == "https://vps-wm.stage.gostoa.dev"
+
+
+@pytest.mark.parametrize("value", ["", "   ", "\n", "\t", " \n\t "])
+def test_base_domain_empty_rejected(value):
+    """Phase 3-A — explicit empty / whitespace-only BASE_DOMAIN is rejected.
+
+    Closes BH-INFRA1a-005: pre-Phase 3-A, ``Settings(BASE_DOMAIN="")``
+    preserved the empty string on the field but the derivation lookup
+    (``data.get("BASE_DOMAIN") or "gostoa.dev"``) fell back to
+    ``gostoa.dev`` — producing an inconsistent state where derived URLs
+    used ``gostoa.dev`` while ``settings.BASE_DOMAIN == ""``. The new
+    field validator rejects empty/whitespace at boot.
+    """
+    with pytest.raises(ValidationError, match="BASE_DOMAIN must not be empty"):
+        Settings(BASE_DOMAIN=value)

--- a/control-plane-api/tests/test_config_validators.py
+++ b/control-plane-api/tests/test_config_validators.py
@@ -1,20 +1,27 @@
-"""CAB-2199 / INFRA-1a S5 — regression guards for tightened Pydantic validators.
+"""CAB-2199 / INFRA-1a S5 + Phase 3-A — regression guards for tightened Pydantic validators.
 
 Two changes covered:
 - ``LOG_FORMAT: Literal["json", "text"]`` (was bare ``str``) — typos like
   ``LOG_FORMAT=jsno`` now fail fast at boot instead of silently degrading.
-- ``ENVIRONMENT`` validator: surgical ``prod → production`` mapping
-  (gateway uses ``prod``, cp-api stores the canonical ``production``).
-  Christophe arbitrage 2026-04-29 §3.4 nuance: emit ``logger.info`` line at
-  boot when normalization is applied so an operator sees the rewrite
-  explicitly.
+- ``ENVIRONMENT`` validator: **fail-closed alias map** (Phase 3-A
+  upgrade of the Phase 2 surgical normalize). Whitespace-strip +
+  casefold + lookup in the alias map; unknown values raise. Replaces
+  the Phase 2 partial-fix that mapped only the bare lowercase ``prod``
+  token and let `PROD`/`Prod`/typos silently bypass the four
+  ``== "production"`` security gates downstream.
 
 Tests:
 - LOG_FORMAT: invalid value rejected by Literal narrowing.
 - LOG_FORMAT: both ``json`` and ``text`` accepted.
 - ENVIRONMENT: ``prod`` → ``production`` with INFO log emitted.
-- ENVIRONMENT: ``production``, ``dev``, ``Staging`` pass through (no
-  case-fold of unrelated values — BH-8 mitigation).
+- ENVIRONMENT: case-insensitive accept (`PROD`, `Prod`, `Staging`,
+  `Development` all map to a canonical form).
+- ENVIRONMENT: unknown value (`produciton`, `live`, `on-prem-prod`)
+  rejected with a clear error message.
+- ENVIRONMENT: whitespace stripped.
+- Prod gate (`_gate_auth_bypass_in_prod`) fires on case variations
+  — regression guard for the Phase 3-A bypass fix (covers BH-INFRA1a-001
+  scenario: `STOA_DISABLE_AUTH=true` + `ENVIRONMENT=Prod` must raise).
 """
 
 from __future__ import annotations
@@ -50,59 +57,98 @@ def test_log_format_accepts_valid_values():
     assert s.LOG_FORMAT == "text"
 
 
-def test_environment_prod_normalized_to_production(caplog):
+def test_environment_prod_normalized_to_production():
     """``ENVIRONMENT=prod`` → canonical ``production`` (gateway uses 'prod')."""
-    with caplog.at_level("INFO", logger="src.config"):
-        s = Settings(ENVIRONMENT="prod", GITHUB_TOKEN="fake")
+    s = Settings(ENVIRONMENT="prod", GITHUB_TOKEN="fake")
     assert s.ENVIRONMENT == "production"
 
 
 def test_environment_prod_emits_normalization_info_log(caplog):
-    """§3.4 ops-signal nuance: emit a ``logger.info`` line whenever
-    normalization is applied so the operator inspecting the boot logs sees
-    the rewrite explicitly."""
+    """Phase 3-A ops-signal: emit a ``logger.info`` line whenever
+    normalization is applied so the operator inspecting the boot logs
+    sees the rewrite explicitly."""
     with caplog.at_level("INFO", logger="src.config"):
         Settings(ENVIRONMENT="prod", GITHUB_TOKEN="fake")
     matching = [
         r for r in caplog.records
-        if "ENVIRONMENT normalized" in r.message and "'prod' → 'production'" in r.message
+        if "ENVIRONMENT normalized" in r.message and "'prod'" in r.message and "'production'" in r.message
     ]
     assert matching, f"expected normalization log line, got records: {[r.message for r in caplog.records]}"
-    # The log line cites CAB-2199 / INFRA-1a for traceability.
+    # The log line cites CAB-2199 for traceability.
     assert "CAB-2199" in matching[0].message
 
 
 def test_environment_production_no_normalization_log(caplog):
     """Setting ``ENVIRONMENT=production`` directly (no normalization needed)
-    must NOT emit the §3.4 ops-signal log line."""
+    must NOT emit the ops-signal log line."""
     with caplog.at_level("INFO", logger="src.config"):
         Settings(ENVIRONMENT="production", GITHUB_TOKEN="fake")
     matching = [r for r in caplog.records if "ENVIRONMENT normalized" in r.message]
     assert not matching, "log line fired unexpectedly for non-normalized value"
 
 
-def test_environment_other_values_pass_through_no_case_fold():
-    """``Staging``, ``PRODUCTION``, ``dev`` pass through with caller spelling
-    preserved — BH-8 mitigation: avoid silent case-fold of unrelated values."""
-    s = Settings(ENVIRONMENT="Staging")
-    assert s.ENVIRONMENT == "Staging"  # case preserved
+@pytest.mark.parametrize(
+    "value,expected_canonical",
+    [
+        ("PROD", "production"),
+        ("Prod", "production"),
+        ("PRODUCTION", "production"),
+        ("Production", "production"),
+        ("Staging", "staging"),
+        ("STAGING", "staging"),
+        ("Development", "dev"),
+        ("DEV", "dev"),
+        ("Test", "test"),
+    ],
+)
+def test_environment_case_insensitive_mapping(value, expected_canonical):
+    """Phase 3-A — case-insensitive accept for documented values.
 
-    s = Settings(ENVIRONMENT="dev")
-    assert s.ENVIRONMENT == "dev"
+    Replaces the Phase 2 BH-8-mitigation behavior where any non-`prod`
+    spelling preserved caller case and silently fell through the
+    ``== "production"`` security gates.
+    """
+    s = Settings(ENVIRONMENT=value, GITHUB_TOKEN="fake")
+    assert s.ENVIRONMENT == expected_canonical
 
-    # PRODUCTION (uppercase) is NOT mapped to production — only the bare
-    # `prod` token is. PRODUCTION will fail the prod-gate elsewhere because
-    # `is_production` checks `== "production"` literal — but THIS validator
-    # does not silently rewrite it.
-    s = Settings(ENVIRONMENT="PRODUCTION")
-    assert s.ENVIRONMENT == "PRODUCTION"  # caller spelling preserved
+
+@pytest.mark.parametrize(
+    "value",
+    ["produciton", "live", "on-prem-prod", "PROD-EU", "qa", ""],
+)
+def test_environment_unknown_value_rejected(value):
+    """Phase 3-A — fail-closed: unknown ENVIRONMENT values raise at boot.
+
+    Covers the BH-INFRA1a-001 typo bypass: `produciton` / `live` /
+    `on-prem-prod` must NEVER silently fall through the prod gates.
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(ENVIRONMENT=value, GITHUB_TOKEN="fake")
+    msg = str(exc_info.value)
+    assert "ENVIRONMENT" in msg
+    assert "not recognized" in msg
 
 
 def test_environment_whitespace_stripped():
     """Leading/trailing whitespace is stripped (K8s-mounted values with
     trailing newlines survive — same pattern as ``_normalize_git_provider``)."""
-    s = Settings(ENVIRONMENT="   dev   ")
+    s = Settings(ENVIRONMENT="   dev   ", GITHUB_TOKEN="fake")
     assert s.ENVIRONMENT == "dev"
 
     s = Settings(ENVIRONMENT="\nprod\t", GITHUB_TOKEN="fake")
     assert s.ENVIRONMENT == "production"
+
+
+def test_prod_gate_fires_on_case_variations():
+    """Phase 3-A regression guard for BH-INFRA1a-001 — case variations
+    of ``ENVIRONMENT=prod``/`production` MUST trigger the prod gates.
+
+    Pre-Phase 3-A, ``Settings(ENVIRONMENT="Prod", STOA_DISABLE_AUTH=True)``
+    booted silently because the validator preserved caller case and the
+    auth-bypass gate literal-checked ``ENVIRONMENT == "production"``.
+    Post Phase 3-A, the validator normalizes the value first, so the
+    gate sees the canonical ``production`` and refuses boot.
+    """
+    for spelling in ("Prod", "PROD", "PRODUCTION", "Production"):
+        with pytest.raises(ValidationError, match="STOA_DISABLE_AUTH"):
+            Settings(ENVIRONMENT=spelling, STOA_DISABLE_AUTH=True, GITHUB_TOKEN="fake")

--- a/control-plane-api/tests/test_regression_cab_2199_environment_fail_closed.py
+++ b/control-plane-api/tests/test_regression_cab_2199_environment_fail_closed.py
@@ -1,0 +1,29 @@
+"""Regression tests for CAB-2199 ENVIRONMENT fail-closed validation."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.config import Settings
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(tmp_path, monkeypatch):
+    """Run with no ambient .env or ENVIRONMENT/GITHUB_TOKEN leakage."""
+    monkeypatch.chdir(tmp_path)
+    for key in ("ENVIRONMENT", "GITHUB_TOKEN"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_regression_cab_2199_environment_case_variation_triggers_prod_auth_gate():
+    """Case variations of prod/production must not bypass production gates."""
+    for spelling in ("Prod", "PROD", "PRODUCTION", "Production"):
+        with pytest.raises(ValidationError, match="STOA_DISABLE_AUTH"):
+            Settings(ENVIRONMENT=spelling, STOA_DISABLE_AUTH=True, GITHUB_TOKEN="fake")
+
+
+def test_regression_cab_2199_environment_unknown_value_rejected():
+    """Unknown ENVIRONMENT values must fail closed instead of becoming non-prod."""
+    with pytest.raises(ValidationError, match="not recognized"):
+        Settings(ENVIRONMENT="produciton", GITHUB_TOKEN="fake")


### PR DESCRIPTION
## Summary

**Phase 3-A** of CAB-2199 INFRA-1a Bug Hunt remediation. Closes 4
findings from `docs/infra/INFRA-1a-BUG-HUNT.md` (Family A + Family D,
audit PR #2633).

The Phase 2 S5 surgical normalize mapped only the bare lowercase
`prod` token to canonical `production`. Any other spelling
(`PROD`/`Prod`, typo `produciton`, alias `live`/`on-prem-prod`) passed
through and bypassed the four `== "production"` security gates
downstream (sensitive-debug, auth bypass, git provider, CORS localhost
stripping). This PR upgrades the validator into a **fail-closed alias
map** + adds a non-empty BASE_DOMAIN guard.

Christophe arbitrated Option B (fail-closed) over Option A
(case-insensitive only) — `ENVIRONMENT` drives security gates, so an
unknown value should never silently mean "non-prod".

## Findings closed

- **BH-INFRA1a-001 (P1)** — any unrecognized ENVIRONMENT value
  bypassed all four prod gates. Verified by reproducer in audit
  report §2.A.
- **BH-INFRA1a-005 (P2)** — `Settings(BASE_DOMAIN="")` preserved the
  empty string on the field but the derivation lookup fell back to
  `gostoa.dev`, producing an inconsistent state.
- **BH-INFRA1a-006 (P2)** —
  `test_environment_other_values_pass_through_no_case_fold` enshrined
  the BH-001 bug as the contract. Replaced with positive regression
  tests.
- **BH-INFRA1a-016 (P3, COVERED-BY-A)** — `.env.example` comment
  encouraged the case trap. Updated to list accepted values.

## Implementation

```python
_ENVIRONMENT_ALIASES: Final[dict[str, str]] = {
    "dev": "dev", "development": "dev",
    "staging": "staging", "test": "test",
    "prod": "production", "production": "production",
}

# whitespace-strip + casefold + lookup
# unknown values → ValidationError
# INFO ops-signal log when input differs from canonical output
```

```python
@field_validator("BASE_DOMAIN")
def _base_domain_must_not_be_empty(cls, v: str) -> str:
    if not v.strip():
        raise ValueError("BASE_DOMAIN must not be empty")
    return v
```

## Tests

| Added | Purpose |
|---|---|
| `test_environment_case_insensitive_mapping` (parametric × 9) | PROD/Prod/PRODUCTION/Staging/STAGING/Development/DEV/Test |
| `test_environment_unknown_value_rejected` (parametric × 6) | produciton, live, on-prem-prod, PROD-EU, qa, "" |
| `test_prod_gate_fires_on_case_variations` | The regression guard the original test never provided. `Settings(ENVIRONMENT="Prod", STOA_DISABLE_AUTH=True)` MUST raise. |
| `test_base_domain_empty_rejected` (parametric × 5) | "", "   ", "\n", "\t", " \n\t " |

| Removed | Reason |
|---|---|
| `test_environment_other_values_pass_through_no_case_fold` | Enshrined the BH-001 bug as the contract. |

## Test plan

- [x] Targeted suite: 116/116 config + snapshot tests pass.
- [x] Full cp-api suite: 6919 passed, 1 pre-existing failure
  (`respx` missing locally), 7 pre-existing errors (`aiosqlite`
  missing locally) — confirmed identical on `main` HEAD.
- [x] Reproducer for BH-001 closed: `ENVIRONMENT=PROD STOA_DISABLE_AUTH=true`
  now raises ValidationError.
- [ ] CI pipeline green.

## Diff

`+213/−65` across 5 files (under the 300 LOC micro-PR rule).

## Refs

- Audit report PR: #2633
- Audit doc: `docs/infra/INFRA-1a-BUG-HUNT.md` Family A + Family D
- Linear: [CAB-2199](https://linear.app/hlfh-workspace/issue/CAB-2199)

🤖 Generated with [Claude Code](https://claude.com/claude-code)