### PR TITLE
fix(api): harden snapshot conflict scanner (cab-2199 3-b)

### DIFF
--- a/control-plane-api/CLAUDE.md
+++ b/control-plane-api/CLAUDE.md
@@ -158,20 +158,38 @@ pydantic-settings source. Legacy usage emits at boot:
 - a Prometheus Counter `stoa_deprecated_config_used_total{name="STOA_SNAPSHOTS_*"}`
   (one-shot per `(key, process)` via `_METRIC_EMITTED_KEYS` set + Lock).
 
-**Conflict gate**: setting both prefixes for the same suffix with different
-values fails boot with `ValueError`. The conflict scanner reads BOTH
-`os.environ` AND the configured `.env` file (so a `.env`-only legacy setting
-also triggers the gate — verified by `test_conflict_between_new_env_and_old_dotenv_fails`).
+**Conflict gate** (Phase 3-B hardened): setting both prefixes for the same
+suffix with different values fails boot with `ValueError`. Behaviour:
 
-**Council Stage 2 #1+#2 secret masking**: env keys matching
-`*SECRET*` / `*KEY*` / `*TOKEN*` / `*PASSWORD*` (case-insensitive substring)
-have their VALUES redacted to `<REDACTED>` in BOTH:
-- the raised `ValueError` message (the part we control), and
-- the input-dict that Pydantic dumps as `input_value=` in
-  `ValidationError.__str__` (mutation in the validator scrubs the data
-  before the error wraps).
+- **Scoped to declared field suffixes.** The scanner enumerates
+  `SnapshotSettings.model_fields` and only checks suffixes
+  corresponding to real fields. Leftover env vars matching the prefix
+  but no declared field (e.g. `STOA_SNAPSHOTS_FOO_REMOVED_LAST_RELEASE`)
+  do NOT trigger spurious boot failures.
+- **Honors the `_env_file=` runtime override.** Pydantic-Settings
+  consumes that kwarg internally; `SnapshotSettings.__init__` stashes
+  it in a `ContextVar` so the validator scans the same dotenv used
+  for field resolution (not just the static cwd `.env`). Pass
+  `_env_file=None` to disable the dotenv pass entirely.
+- **Value-blind error format.** The `ValueError` message lists the
+  source key names only — never the conflicting values. Eliminates the
+  need for a substring-match secret heuristic at the error boundary
+  (which had known false negatives like `DB_DSN`/`JWT_SIG_INPUT`).
 
-The key NAMES remain visible — operator debugging needs them.
+Example error:
+
+```
+ValueError: Conflicting config for suffix 'STORAGE_BUCKET': sources
+['env:STOA_API_SNAPSHOT_STORAGE_BUCKET', 'env:STOA_SNAPSHOTS_STORAGE_BUCKET']
+have different values. Remove the legacy STOA_SNAPSHOTS_* key or align
+both prefixes to the same value. (Values are intentionally omitted
+from this message to avoid leaking secrets.)
+```
+
+**Defence-in-depth helpers** (`_is_secret_env_key`, `_redact_value`)
+remain available in the module for any future log path that includes
+values. They are NOT called by the Phase 3-B validator — the design
+contract is "values never leave the process via this path".
 
 **Sunset**: tracked on **CAB-2203** — the alias surface (per-field
 `AliasChoices`, conflict scanner, masking helpers) can be removed once the

--- a/control-plane-api/src/features/error_snapshots/config.py
+++ b/control-plane-api/src/features/error_snapshots/config.py
@@ -9,6 +9,26 @@ one release, with deprecation warning + Prometheus metric. Setting both
 prefixes for the same field with different values fails boot — the conflict
 scanner reads from BOTH process env and the dotenv file.
 
+CAB-2199 Phase 3-B: conflict scanner hardened
+(see ``docs/infra/INFRA-1a-BUG-HUNT.md`` Family C):
+
+- Filtered to declared field suffixes (introspect ``model_fields``) so
+  leftover env vars that match the prefix but no real field do not
+  trigger spurious boot failures.
+- Runtime ``_env_file=`` override is honored: ``SnapshotSettings.__init__``
+  captures the kwarg and runs the scanner post-``super().__init__()`` so
+  it scans the same dotenv Pydantic-Settings just used for field
+  resolution.
+- Conflict error message is **value-blind**: it lists source key names
+  only, never the conflicting values. The scanner raises a plain
+  ``ValueError`` (NOT a ``model_validator``-wrapped ``ValidationError``)
+  so Pydantic does not dump ``input_value=`` into the rendered exception.
+  The ``_is_secret_env_key`` / ``_redact_value`` helpers are kept as
+  defence-in-depth for any future log path that includes values, but
+  are no longer referenced by the scanner.
+- No mutate-on-raise side effect on the input dict (closes BH-017
+  without needing the Phase 2 redaction loop).
+
 All settings have sensible defaults for development.
 """
 
@@ -18,10 +38,10 @@ import os
 from functools import lru_cache
 from pathlib import Path
 from threading import Lock
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Final, Literal
 
 from prometheus_client import Counter
-from pydantic import AliasChoices, Field, field_validator, model_validator
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .masking import MaskingConfig
@@ -47,10 +67,15 @@ _METRIC_LOCK = Lock()
 _OLD_PREFIX = "STOA_SNAPSHOTS_"
 _NEW_PREFIX = "STOA_API_SNAPSHOT_"
 
-# Council Stage 2 #1+#2 — values for env keys carrying secrets are redacted
-# before they enter any error message or log line. Substring match on the
-# env-var name; deliberately conservative (false positives = mask a
-# non-secret = harmless; false negatives = leak a secret = unacceptable).
+# Council Stage 2 #1+#2 (Phase 2 design) — secret-name heuristic kept as
+# defence-in-depth ONLY. The Phase 3-B conflict scanner is value-blind
+# (no raw values in the error message), so neither helper is currently
+# referenced from the validator path. They remain available for any
+# future log path that needs to mask values by env-var name.
+#
+# Substring match on the env-var name; deliberately conservative (false
+# positives = mask a non-secret = harmless; false negatives = leak a
+# secret = unacceptable).
 _SECRET_NAME_TOKENS: tuple[str, ...] = (
     "SECRET",
     "KEY",
@@ -60,14 +85,28 @@ _SECRET_NAME_TOKENS: tuple[str, ...] = (
 
 
 def _is_secret_env_key(env_key: str) -> bool:
-    """True if the env-var name suggests it carries a secret value."""
+    """True if the env-var name suggests it carries a secret value.
+
+    Defence-in-depth helper. Not called by the Phase 3-B conflict
+    scanner (which is value-blind) but kept available for any future
+    log path that includes values.
+    """
     upper = env_key.upper()
     return any(token in upper for token in _SECRET_NAME_TOKENS)
 
 
 def _redact_value(env_key: str, value: str) -> str:
-    """Return ``value`` if ``env_key`` is non-secret, else ``"<REDACTED>"``."""
+    """Return ``value`` if ``env_key`` is non-secret, else ``"<REDACTED>"``.
+
+    Defence-in-depth helper. See ``_is_secret_env_key`` for the contract.
+    """
     return "<REDACTED>" if _is_secret_env_key(env_key) else value
+
+
+# Sentinel used by ``SnapshotSettings.__init__`` to distinguish "caller
+# didn't pass ``_env_file=``" from "caller passed ``_env_file=None`` to
+# explicitly disable the dotenv scan".
+_UNSET: Final[object] = object()
 
 
 def _read_dotenv(path: Path | str) -> dict[str, str]:
@@ -107,11 +146,15 @@ class SnapshotSettings(BaseSettings):
     ``STOA_SNAPSHOTS_*``). Legacy prefix is honored as a per-field
     ``AliasChoices`` for one release, with deprecation warning + Prometheus
     metric. Setting both prefixes for the same field with different values
-    fails boot — the conflict scanner reads from BOTH process env and dotenv.
+    fails boot — the conflict scanner reads from BOTH process env and the
+    dotenv file (resolved via the runtime ``_env_file=`` override when
+    provided, otherwise the static class-level default).
 
-    Secret values are never logged or surfaced in error messages. The conflict
-    scanner redacts values for env keys whose name matches the secret heuristic
-    (``*SECRET*``, ``*KEY*``, ``*TOKEN*``, ``*PASSWORD*``).
+    Phase 3-B contract: the conflict error message lists source key names
+    only — values are never surfaced (avoids leaking secrets via env-var
+    contents that don't match any heuristic). The scanner is also scoped
+    to declared field suffixes so leftover env vars matching the prefix
+    but no field do not trigger spurious failures.
     """
 
     model_config = SettingsConfigDict(
@@ -125,6 +168,116 @@ class SnapshotSettings(BaseSettings):
     DEPRECATED_PREFIX_ALIASES: ClassVar[dict[str, str]] = {
         _OLD_PREFIX: _NEW_PREFIX,
     }
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Phase 3-B — run the conflict scan in ``__init__`` post-super().
+
+        The Phase 2 scanner lived in a ``model_validator(mode="before")``
+        and raised ``ValueError`` from there. Pydantic wraps that into a
+        ``ValidationError`` and dumps the input dict as ``input_value=...``
+        in the rendered exception — which leaks the conflicting values
+        even when our own error message omits them. To honor the
+        value-blind contract end-to-end, we move the scan here:
+
+        1. Capture the runtime ``_env_file`` override (pydantic-settings
+           consumes it internally for field resolution but does not pass
+           it to validators).
+        2. Run ``super().__init__(**kwargs)`` — pydantic-settings resolves
+           fields via ``AliasChoices``; either prefix populates the
+           model.
+        3. Scan ``os.environ`` + the dotenv directly for cross-prefix
+           conflicts on declared field suffixes. Raise a plain
+           ``ValueError`` (NOT ``ValidationError``) on conflict — no
+           Pydantic wrapper, no input-dict dump, no leak.
+        4. Emit deprecation log + Prometheus counter for legacy-prefix
+           usage (one-shot per (key, process) via ``_METRIC_EMITTED_KEYS``).
+        """
+        env_file_kwarg = kwargs.get("_env_file", _UNSET)
+        super().__init__(**kwargs)
+        # Resolve dotenv path: runtime override (post-super; safe because
+        # super has already consumed the kwarg) wins over the static
+        # class-level default. ``_env_file=None`` means "no dotenv".
+        if env_file_kwarg is _UNSET:
+            env_file_path: object = self.model_config.get("env_file") or ".env"
+        else:
+            env_file_path = env_file_kwarg
+        self._scan_for_conflicts_and_log_deprecation(env_file_path)
+
+    @classmethod
+    def _scan_for_conflicts_and_log_deprecation(cls, env_file_path: object) -> None:
+        """Scan declared field suffixes across process env AND dotenv.
+
+        Phase 3-B contract (CAB-2199 BH-INFRA1a-003 / 004 / 014 / 017):
+
+        - **Scoped to declared field suffixes.** Iterates ``cls.model_fields``
+          to derive the canonical uppercase suffix for each field, then
+          filters the env scan to those. Leftover env vars matching a
+          legacy prefix but NO declared field do not trigger spurious
+          boot failures (BH-003).
+        - **Honors the runtime ``_env_file=`` override** received from
+          ``__init__`` (BH-004). ``_env_file=None`` disables the dotenv
+          scan.
+        - **Value-blind error.** Conflict raises ``ValueError`` (plain,
+          NOT ``ValidationError``) listing source key names only — never
+          the conflicting values. Eliminates the ``_is_secret_env_key``
+          heuristic at the error boundary (BH-014). Because we raise
+          plain ``ValueError`` outside the validator path, Pydantic does
+          NOT wrap and does NOT dump ``input_value=`` (no leak via the
+          wrapped exception either — closes BH-017 without needing a
+          mutate-on-raise).
+        """
+        declared_suffixes = {name.upper() for name in cls.model_fields}
+
+        sources: list[tuple[str, dict[str, str]]] = [("env", dict(os.environ))]
+        if env_file_path:
+            sources.append(("dotenv", _read_dotenv(env_file_path)))
+
+        # Collect (suffix → {source_key: value}) for declared suffixes only.
+        seen: dict[str, dict[str, str]] = {}
+        for source_label, source_map in sources:
+            for env_key, env_value in source_map.items():
+                for prefix in (_OLD_PREFIX, _NEW_PREFIX):
+                    if env_key.startswith(prefix):
+                        suffix = env_key[len(prefix):]
+                        if suffix in declared_suffixes:
+                            seen.setdefault(suffix, {})[
+                                f"{source_label}:{env_key}"
+                            ] = env_value
+                        break
+
+        deprecated_keys_emitted: list[str] = []
+        for suffix, source_values in seen.items():
+            distinct_values = set(source_values.values())
+            if len(distinct_values) > 1:
+                # Value-blind conflict report: list source keys only,
+                # never the conflicting values. Key names are intentionally
+                # not secret; only their values can be (and those are kept
+                # out of every error / log path).
+                source_keys_listed = sorted(source_values.keys())
+                raise ValueError(
+                    f"Conflicting config for suffix {suffix!r}: "
+                    f"sources {source_keys_listed} have different values. "
+                    f"Remove the legacy {_OLD_PREFIX}* key or align both "
+                    f"prefixes to the same value. (Values are intentionally "
+                    f"omitted from this message to avoid leaking secrets.)"
+                )
+            for source_key in source_values:
+                if _OLD_PREFIX in source_key:
+                    deprecated_keys_emitted.append(source_key.split(":", 1)[1])
+
+        if deprecated_keys_emitted:
+            with _METRIC_LOCK:
+                for key in deprecated_keys_emitted:
+                    if key not in _METRIC_EMITTED_KEYS:
+                        DEPRECATED_CONFIG_USED.labels(name=key).inc()
+                        _METRIC_EMITTED_KEYS.add(key)
+            logger.warning(
+                "Deprecated config prefix %s used (keys: %s). "
+                "Rename to %s before next release. Tracked: CAB-2199 / INFRA-1a / CAB-2203 sunset.",
+                _OLD_PREFIX,
+                ",".join(sorted(set(deprecated_keys_emitted))),
+                _NEW_PREFIX,
+            )
 
     # Feature flag
     enabled: bool = Field(
@@ -241,88 +394,6 @@ class SnapshotSettings(BaseSettings):
         description="JSON array of additional body paths to mask",
         validation_alias=_alias("MASKING_EXTRA_BODY_PATHS"),
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _detect_conflicts_and_emit_deprecation(cls, values: object) -> object:
-        """Scan BOTH process env AND dotenv for legacy-prefix usage.
-
-        - Process env: ``os.environ``.
-        - Dotenv: parse the configured ``env_file`` (default ``.env``) — does
-          NOT depend on whether pydantic-settings has already merged it.
-
-        Conflict (same suffix, different value across old/new prefix in any
-        source) raises ValueError with secret-aware redaction. Otherwise emits
-        deprecation log (KEYS only, never values) + Counter increment
-        (one-shot per key per process).
-        """
-        env_file_path = cls.model_config.get("env_file") or ".env"
-        sources: list[tuple[str, dict[str, str]]] = [
-            ("env", dict(os.environ)),
-            ("dotenv", _read_dotenv(env_file_path)),
-        ]
-
-        # Collect all (suffix → {source_key: value}) where suffix is the
-        # field-name tail after either prefix.
-        seen: dict[str, dict[str, str]] = {}
-        for source_label, source_map in sources:
-            for env_key, env_value in source_map.items():
-                if env_key.startswith(_OLD_PREFIX):
-                    suffix = env_key[len(_OLD_PREFIX):]
-                    seen.setdefault(suffix, {})[f"{source_label}:{env_key}"] = env_value
-                elif env_key.startswith(_NEW_PREFIX):
-                    suffix = env_key[len(_NEW_PREFIX):]
-                    seen.setdefault(suffix, {})[f"{source_label}:{env_key}"] = env_value
-
-        deprecated_keys_emitted: list[str] = []
-        for suffix, source_values in seen.items():
-            distinct_values = set(source_values.values())
-            if len(distinct_values) > 1:
-                # Conflict — multiple sources disagree.
-                # Council Stage 2 #1+#2: redact values for secret-name keys
-                # before assembling the error message. The env-var name itself
-                # is not a secret — only its value is.
-                redacted_sources = {
-                    sk: _redact_value(sk.split(":", 1)[1], sv)
-                    for sk, sv in source_values.items()
-                }
-                # Also scrub any secret-bearing key in the input ``values``
-                # dict so Pydantic's ValidationError ``input_value=`` dump —
-                # which it appends verbatim to ``str(e)`` — does not leak the
-                # raw secret. Mutation is acceptable here because we are
-                # about to raise; the model never sees the redacted dict
-                # successfully.
-                if isinstance(values, dict):
-                    for k in list(values.keys()):
-                        if _is_secret_env_key(k):
-                            values[k] = "<REDACTED>"
-                raise ValueError(
-                    f"Conflicting config for suffix {suffix!r}: "
-                    f"{redacted_sources!r}. Resolve before boot — the legacy "
-                    f"{_OLD_PREFIX}* prefix is deprecated."
-                )
-            # Track legacy-prefix usage for metric/log (independent of conflict).
-            for source_key in source_values:
-                if _OLD_PREFIX in source_key:
-                    deprecated_keys_emitted.append(source_key.split(":", 1)[1])
-
-        if deprecated_keys_emitted:
-            with _METRIC_LOCK:
-                for key in deprecated_keys_emitted:
-                    if key not in _METRIC_EMITTED_KEYS:
-                        DEPRECATED_CONFIG_USED.labels(name=key).inc()
-                        _METRIC_EMITTED_KEYS.add(key)
-            # Council Stage 2 #1+#2 contract: this log line emits KEYS only
-            # (never values). If the format ever changes to include values,
-            # apply ``_redact_value`` per-key to honor the masking guarantee.
-            logger.warning(
-                "Deprecated config prefix %s used (keys: %s). "
-                "Rename to %s before next release. Tracked: CAB-2199 / INFRA-1a / CAB-2203 sunset.",
-                _OLD_PREFIX,
-                ",".join(sorted(deprecated_keys_emitted)),
-                _NEW_PREFIX,
-            )
-        return values
 
     @field_validator("exclude_paths", mode="before")
     @classmethod

--- a/control-plane-api/tests/test_regression_cab_2199_snapshot_conflict_scanner.py
+++ b/control-plane-api/tests/test_regression_cab_2199_snapshot_conflict_scanner.py
@@ -1,0 +1,53 @@
+"""Regression tests for CAB-2199 snapshot conflict scanner hardening."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.features.error_snapshots.config import _METRIC_EMITTED_KEYS, SnapshotSettings
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(tmp_path, monkeypatch):
+    """Run with no ambient snapshot env vars or cwd dotenv leakage."""
+    monkeypatch.chdir(tmp_path)
+    declared_suffixes = {name.upper() for name in SnapshotSettings.model_fields}
+    for prefix in ("STOA_SNAPSHOTS_", "STOA_API_SNAPSHOT_"):
+        for suffix in declared_suffixes:
+            monkeypatch.delenv(f"{prefix}{suffix}", raising=False)
+    _METRIC_EMITTED_KEYS.clear()
+
+
+def test_regression_cab_2199_snapshot_scanner_ignores_unknown_suffixes(monkeypatch):
+    """Prefix-matching keys for undeclared fields must not block boot."""
+    monkeypatch.setenv("STOA_SNAPSHOTS_NOT_A_FIELD", "legacy")
+    monkeypatch.setenv("STOA_API_SNAPSHOT_NOT_A_FIELD", "canonical")
+
+    settings = SnapshotSettings()
+
+    assert settings.enabled is True
+
+
+def test_regression_cab_2199_snapshot_scanner_honors_runtime_env_file(tmp_path, monkeypatch):
+    """The conflict scanner must inspect the same runtime _env_file as pydantic-settings."""
+    env_file = tmp_path / "runtime.env"
+    env_file.write_text("STOA_SNAPSHOTS_ENABLED=false\n", encoding="utf-8")
+    monkeypatch.setenv("STOA_API_SNAPSHOT_ENABLED", "true")
+
+    with pytest.raises(ValueError, match="Conflicting config"):
+        SnapshotSettings(_env_file=str(env_file))
+
+
+def test_regression_cab_2199_snapshot_conflict_error_omits_values(monkeypatch):
+    """Conflict errors may show source keys, but never the conflicting values."""
+    monkeypatch.setenv("STOA_SNAPSHOTS_STORAGE_BUCKET", "legacy-bucket-value")
+    monkeypatch.setenv("STOA_API_SNAPSHOT_STORAGE_BUCKET", "canonical-bucket-value")
+
+    with pytest.raises(ValueError) as exc_info:
+        SnapshotSettings()
+
+    msg = str(exc_info.value)
+    assert "STOA_SNAPSHOTS_STORAGE_BUCKET" in msg
+    assert "STOA_API_SNAPSHOT_STORAGE_BUCKET" in msg
+    assert "legacy-bucket-value" not in msg
+    assert "canonical-bucket-value" not in msg

--- a/control-plane-api/tests/test_snapshot_config_alias.py
+++ b/control-plane-api/tests/test_snapshot_config_alias.py
@@ -1,4 +1,4 @@
-"""CAB-2199 / INFRA-1a S6 — regression guards for STOA_API_SNAPSHOT_* rename + alias.
+"""CAB-2199 / INFRA-1a S6 + Phase 3-B — regression guards for STOA_API_SNAPSHOT_* rename + alias.
 
 The S6 sub-scope renames the error-snapshot env prefix from
 ``STOA_SNAPSHOTS_`` (plural, conflicts with the unrelated Rust gateway
@@ -7,21 +7,34 @@ scope). Legacy prefix is honored as a per-field ``AliasChoices`` for one
 release with deprecation warning + Prometheus metric. Conflicts (same
 suffix, different value across old/new prefix in any source) fail boot.
 
-Council Stage 2 #1+#2 secret masking covered: env keys matching
-``*SECRET*``/``*KEY*``/``*TOKEN*``/``*PASSWORD*`` have their VALUES
-redacted in the conflict ValueError. Key NAMES remain visible.
+**Phase 3-B hardening covered** (BH-INFRA1a-003 / 004 / 009 / 011 / 014 / 017):
+
+- Scanner scoped to declared field suffixes — extraneous env vars matching
+  the prefix but no real field do NOT trigger spurious boot failures.
+- ``_env_file=`` runtime override is honored by the scanner (not just by
+  Pydantic-Settings field resolution).
+- Conflict error message is **value-blind**: lists source key names only,
+  never the conflicting values. Eliminates the need for a secret-name
+  heuristic at the error boundary.
+- No mutate-on-raise side effect — ``_is_secret_env_key`` /
+  ``_redact_value`` are kept as defence-in-depth helpers (still tested
+  here so the contract for any future log path stays valid).
 
 Tests:
 - new prefix (``STOA_API_SNAPSHOT_*``) resolves.
 - legacy alias (``STOA_SNAPSHOTS_*``) resolves with deprecation log.
 - legacy alias increments Prometheus metric exactly once per (key, process).
-- conflicting old/new values fail boot.
+- conflicting old/new values fail boot with value-blind error.
 - matching old/new values do not raise.
-- legacy alias surface covers dotenv (not just process env).
-- conflict scanner reads BOTH process env and dotenv.
-- secret-bearing values redacted in conflict error message.
-- non-secret values remain visible (counter-test).
-- ``_is_secret_env_key`` heuristic direct unit test.
+- legacy alias surface covers dotenv (cwd path).
+- conflict scanner reads BOTH process env AND cwd dotenv.
+- runtime ``_env_file=`` non-cwd path honored for alias resolution AND
+  for the conflict scanner (BH-INFRA1a-004).
+- ``_env_file=None`` disables the dotenv scan.
+- extraneous prefix-matching env vars (no declared field) do NOT trigger
+  spurious conflicts (BH-INFRA1a-003).
+- ``_is_secret_env_key`` heuristic direct unit test (defence-in-depth
+  helper; not called by the validator path post Phase 3-B).
 """
 
 from __future__ import annotations
@@ -39,17 +52,18 @@ from src.features.error_snapshots.config import (
 @pytest.fixture(autouse=True)
 def _isolated_env(tmp_path, monkeypatch):
     """Each test in tmp cwd with no .env + cleared snapshot env vars +
-    cleared one-shot Counter guard so tests are order-independent."""
+    cleared one-shot Counter guard so tests are order-independent.
+
+    Phase 3-B: clear ALL declared field suffixes (not the partial 6 of
+    Phase 2) by introspecting ``SnapshotSettings.model_fields``. Closes
+    BH-INFRA1a-011 — the partial fixture would let an inherited
+    ``STOA_SNAPSHOTS_CAPTURE_ON_4XX=true`` from a parent shell trip the
+    scanner during unrelated tests.
+    """
     monkeypatch.chdir(tmp_path)
+    declared_suffixes = {name.upper() for name in SnapshotSettings.model_fields}
     for prefix in ("STOA_SNAPSHOTS_", "STOA_API_SNAPSHOT_"):
-        for suffix in (
-            "ENABLED",
-            "RETENTION_DAYS",
-            "STORAGE_BUCKET",
-            "STORAGE_SECRET_KEY",
-            "STORAGE_ACCESS_KEY",
-            "MASKING_EXTRA_HEADERS",
-        ):
+        for suffix in declared_suffixes:
             monkeypatch.delenv(f"{prefix}{suffix}", raising=False)
     _METRIC_EMITTED_KEYS.clear()
 
@@ -118,62 +132,137 @@ def test_matching_old_and_new_values_no_error(monkeypatch):
     assert s.enabled is False
 
 
-def test_legacy_alias_from_dotenv_file_is_honored(tmp_path, monkeypatch):
-    """Regression — the alias surface must cover dotenv, not just process env.
-
-    Critical: a developer who keeps `STOA_SNAPSHOTS_*` in their local `.env`
-    after the rename ships must not silently lose their config. This is the
-    most-likely real-world scenario for the legacy prefix surviving past PR-E.
-    """
-    env_file = tmp_path / ".env"
-    env_file.write_text("STOA_SNAPSHOTS_ENABLED=false\n")
-    s = SnapshotSettings(_env_file=str(env_file))
+def test_legacy_alias_from_cwd_dotenv_is_honored(tmp_path):
+    """Default-cwd ``.env`` is read by the scanner. Critical: a developer
+    who keeps ``STOA_SNAPSHOTS_*`` in their local ``.env`` after the rename
+    ships must not silently lose their config."""
+    # Fixture chdirs to tmp_path; write the cwd .env there.
+    (tmp_path / ".env").write_text("STOA_SNAPSHOTS_ENABLED=false\n")
+    s = SnapshotSettings()  # default _env_file=".env" → cwd
     assert s.enabled is False
 
 
-def test_conflict_between_new_env_and_old_dotenv_fails(tmp_path, monkeypatch):
-    """Conflict scanner must read BOTH process env AND dotenv."""
-    env_file = tmp_path / ".env"
+def test_conflict_between_new_env_and_old_cwd_dotenv_fails(tmp_path, monkeypatch):
+    """Conflict scanner must read BOTH process env AND the cwd dotenv."""
+    (tmp_path / ".env").write_text("STOA_SNAPSHOTS_ENABLED=false\n")
+    monkeypatch.setenv("STOA_API_SNAPSHOT_ENABLED", "true")
+    with pytest.raises(ValueError, match="Conflicting config"):
+        SnapshotSettings()
+
+
+def test_runtime_env_file_override_honored_for_alias_resolution(tmp_path):
+    """Phase 3-B BH-INFRA1a-004 — the ``_env_file=`` runtime override
+    points at a non-cwd dotenv; the scanner AND the alias resolution
+    must both see it.
+
+    Setup distinguishes cwd (no .env) from the override path so the
+    test cannot pass coincidentally via cwd-fallback.
+    """
+    other_dir = tmp_path / "config"
+    other_dir.mkdir()
+    env_file = other_dir / "snapshots.env"
     env_file.write_text("STOA_SNAPSHOTS_ENABLED=false\n")
+    # cwd is tmp_path (fixture chdir); cwd has no .env
+    assert not (tmp_path / ".env").exists()
+
+    s = SnapshotSettings(_env_file=str(env_file))
+    assert s.enabled is False  # legacy alias from non-cwd dotenv resolved
+
+
+def test_runtime_env_file_override_seen_by_conflict_scanner(tmp_path, monkeypatch):
+    """Phase 3-B BH-INFRA1a-004 — the conflict scanner reads the runtime
+    ``_env_file=`` override, not just cwd ``.env``.
+
+    Pre-Phase-3-B the scanner only opened the static class-level
+    ``.env`` from cwd, so a conflict between env (new prefix) and a
+    non-cwd dotenv (legacy prefix) was silently missed.
+    """
+    other_dir = tmp_path / "config"
+    other_dir.mkdir()
+    env_file = other_dir / "snapshots.env"
+    env_file.write_text("STOA_SNAPSHOTS_ENABLED=false\n")
+    assert not (tmp_path / ".env").exists()
+
     monkeypatch.setenv("STOA_API_SNAPSHOT_ENABLED", "true")
     with pytest.raises(ValueError, match="Conflicting config"):
         SnapshotSettings(_env_file=str(env_file))
 
 
-def test_conflict_redacts_secret_values_in_error_message(monkeypatch):
-    """Council #1+#2 — error message must NOT leak secret values for
-    SECRET/KEY/TOKEN/PASSWORD env keys. The key NAME is NOT secret —
-    it remains visible for ops debugging."""
+def test_env_file_none_disables_dotenv_scan(tmp_path, monkeypatch):
+    """Phase 3-B — passing ``_env_file=None`` to disable dotenv resolution
+    (Pydantic-Settings convention) ALSO suppresses the scanner's dotenv
+    pass so a stale cwd ``.env`` is not read against the caller's intent.
+    """
+    (tmp_path / ".env").write_text("STOA_SNAPSHOTS_ENABLED=false\n")
+    monkeypatch.setenv("STOA_API_SNAPSHOT_ENABLED", "true")
+    # With _env_file=None, the dotenv (which would conflict) is ignored.
+    s = SnapshotSettings(_env_file=None)
+    assert s.enabled is True
+
+
+def test_extraneous_prefix_no_spurious_conflict(monkeypatch):
+    """Phase 3-B BH-INFRA1a-003 — env vars matching either prefix but no
+    declared field MUST NOT trigger a boot fail.
+
+    Pre-Phase-3-B, the scanner iterated all prefix-matching env vars and
+    raised on any same-suffix divergence regardless of whether the
+    suffix corresponded to a real field. Leftover legacy keys on shared
+    K8s namespaces or CI runners would block boot for unrelated reasons.
+    """
+    monkeypatch.setenv("STOA_SNAPSHOTS_NOT_A_DECLARED_FIELD", "old-value")
+    monkeypatch.setenv("STOA_API_SNAPSHOT_NOT_A_DECLARED_FIELD", "new-value")
+    # Must not raise — neither suffix matches any SnapshotSettings field.
+    s = SnapshotSettings()
+    assert s.enabled is True  # default preserved
+
+
+def test_conflict_error_format_value_blind(monkeypatch):
+    """Phase 3-B BH-INFRA1a-014 — conflict errors list source key names
+    only, NEVER the conflicting values.
+
+    Replaces the Phase 2 secret-name heuristic that masked values for
+    ``*SECRET*``/``*KEY*``/``*TOKEN*``/``*PASSWORD*`` keys but leaked
+    raw values for everything else (including non-heuristic-matching
+    secret-bearing keys like ``DB_DSN`` containing a Postgres URL with
+    embedded password).
+    """
+    monkeypatch.setenv("STOA_SNAPSHOTS_STORAGE_BUCKET", "old-bucket-name")
+    monkeypatch.setenv("STOA_API_SNAPSHOT_STORAGE_BUCKET", "new-bucket-name")
+    with pytest.raises(ValueError) as exc_info:
+        SnapshotSettings()
+    msg = str(exc_info.value)
+
+    # Key names ARE shown — operators need them to debug.
+    assert "STOA_SNAPSHOTS_STORAGE_BUCKET" in msg
+    assert "STOA_API_SNAPSHOT_STORAGE_BUCKET" in msg
+
+    # Values are NEVER shown — neither secret-named nor non-secret.
+    assert "old-bucket-name" not in msg
+    assert "new-bucket-name" not in msg
+
+    # Message points to the actionable remedy.
+    assert "Remove the legacy" in msg or "remove the legacy" in msg.lower()
+
+
+def test_conflict_error_value_blind_for_secret_named_keys_too(monkeypatch):
+    """Counter-test of the value-blind contract: secret-bearing key names
+    ALSO get value-omitted treatment (same code path)."""
     monkeypatch.setenv("STOA_SNAPSHOTS_STORAGE_SECRET_KEY", "oldval-aaaa")
     monkeypatch.setenv("STOA_API_SNAPSHOT_STORAGE_SECRET_KEY", "newval-bbbb")
     with pytest.raises(ValueError) as exc_info:
         SnapshotSettings()
     msg = str(exc_info.value)
-    # Both values masked because the env-key name matches the secret heuristic
-    assert "oldval-aaaa" not in msg
-    assert "newval-bbbb" not in msg
-    assert "<REDACTED>" in msg
-    # The key NAMES remain visible for ops
+    # Key names visible; values absent regardless of secret-name match.
     assert "STOA_SNAPSHOTS_STORAGE_SECRET_KEY" in msg
     assert "STOA_API_SNAPSHOT_STORAGE_SECRET_KEY" in msg
-
-
-def test_conflict_does_not_redact_non_secret_values(monkeypatch):
-    """Counter-test — non-secret keys (ENABLED) keep their values visible
-    so ops can see what is conflicting and decide which side wins."""
-    monkeypatch.setenv("STOA_SNAPSHOTS_ENABLED", "false")
-    monkeypatch.setenv("STOA_API_SNAPSHOT_ENABLED", "true")
-    with pytest.raises(ValueError) as exc_info:
-        SnapshotSettings()
-    msg = str(exc_info.value)
-    # Non-secret values remain — debugging needs them
-    assert "false" in msg
-    assert "true" in msg
-    assert "<REDACTED>" not in msg
+    assert "oldval-aaaa" not in msg
+    assert "newval-bbbb" not in msg
 
 
 def test_secret_helper_substring_match():
-    """Direct test of `_is_secret_env_key` — SECRET/KEY/TOKEN/PASSWORD substring."""
+    """Direct test of `_is_secret_env_key` — defence-in-depth helper kept
+    for any future log path that includes values. NOT called by the
+    Phase 3-B conflict scanner (which is value-blind by design)."""
     # Positive matches
     assert _is_secret_env_key("STOA_SNAPSHOTS_STORAGE_SECRET_KEY")
     assert _is_secret_env_key("FOO_API_TOKEN")


### PR DESCRIPTION
## Summary

**Phase 3-B** of CAB-2199 INFRA-1a Bug Hunt remediation. Closes 6
findings from `docs/infra/INFRA-1a-BUG-HUNT.md` (Family C, audit PR
#2633).

The Phase 2 snapshot conflict scanner had three consistency gaps and
two security-adjacent quirks that all collapse into one root-cause
redesign: **the scanner needs to be value-blind, scoped to declared
fields, and honor the runtime `_env_file=` override**.

## Findings closed

- **BH-INFRA1a-003 (P2)** — spurious boot fail on prefix-matching env
  vars not corresponding to a real field (e.g.
  `STOA_SNAPSHOTS_FOO_NOT_A_FIELD`). Closed by scoping the scanner to
  `model_fields` declared suffixes.
- **BH-INFRA1a-004 (P2)** — scanner ignored `_env_file=` runtime
  override; opened cwd `.env` regardless. Closed by capturing the
  kwarg in `__init__` and passing it through to the scanner.
- **BH-INFRA1a-009 (P2)** — two existing tests passed coincidentally
  via fixture `chdir`. Closed by adding non-cwd dotenv tests that
  exercise the actual override path.
- **BH-INFRA1a-011 (P3)** — fixture cleared 6 of 17 declared field
  suffixes. Closed by enumerating from `model_fields`.
- **BH-INFRA1a-014 (P3)** — `_is_secret_env_key` heuristic at the
  conflict error boundary had known false negatives (`DSN`, `JWT`,
  `BEARER` substrings not in the secret-name token list). Closed by
  removing values from the error message entirely (value-blind format).
- **BH-INFRA1a-017 (P3)** — mutate-on-raise side effect on the input
  dict (Phase 2 mitigation for Pydantic's `input_value=...` dump).
  Closed by moving the scan into `__init__` post-super so a plain
  `ValueError` is raised outside Pydantic's validator wrapper — no
  `ValidationError` wrap, no dump, no leak.

## Design change

| Aspect | Phase 2 | Phase 3-B |
|---|---|---|
| Scan trigger | `model_validator(mode="before")` | `__init__` post-super(), via `_scan_for_conflicts_and_log_deprecation` classmethod |
| Conflict surface | All prefix-matching env vars | Only declared field suffixes (`model_fields` introspection) |
| Dotenv source | `cls.model_config.get("env_file") or ".env"` (cwd) | Runtime `_env_file=` kwarg (or static default if absent); `_env_file=None` disables |
| Error message | Raised `ValueError` from validator (Pydantic wraps as `ValidationError` with `input_value=...` dump) | Raised plain `ValueError` from `__init__` (no Pydantic wrap, no dump) |
| Conflict message values | Heuristic-redacted for `*SECRET*`/`*KEY*`/`*TOKEN*`/`*PASSWORD*` keys; raw for others | Never shown — value-blind by design (closes the heuristic blind-spot) |
| Input-dict mutation | Mutate-on-raise to scrub secret-name keys | Not needed — Pydantic doesn't dump anything |
| Defence-in-depth helpers | `_is_secret_env_key` + `_redact_value` called by validator | Helpers retained but **not called by the scanner** — kept for any future log path |

## Tests rewritten / added

`test_snapshot_config_alias.py` (15 cases, +193/-66):

- **New** — `test_extraneous_prefix_no_spurious_conflict` (BH-003).
- **New** — `test_runtime_env_file_override_honored_for_alias_resolution`
  (BH-004 part 1: alias resolution).
- **New** — `test_runtime_env_file_override_seen_by_conflict_scanner`
  (BH-004 part 2: conflict gate).
- **New** — `test_env_file_none_disables_dotenv_scan` (corner case).
- **New** — `test_conflict_error_format_value_blind` (BH-014 contract).
- **New** — `test_conflict_error_value_blind_for_secret_named_keys_too`
  (counter-test).
- **Renamed** — `test_legacy_alias_from_dotenv_file_is_honored` →
  `test_legacy_alias_from_cwd_dotenv_is_honored` (clarifies the cwd
  path; non-cwd path covered by the new override tests).
- **Renamed** — `test_conflict_between_new_env_and_old_dotenv_fails`
  → `test_conflict_between_new_env_and_old_cwd_dotenv_fails` (same
  reason).
- Existing `test_secret_helper_substring_match` retained: helper is
  defence-in-depth, contract worth pinning.

Fixture `_isolated_env`: now enumerates declared suffixes via
`SnapshotSettings.model_fields` (BH-011).

## Test plan

- [x] Targeted suite: 51/51 snapshot tests + 15/15 alias regression
  tests pass.
- [x] Combined config + snapshot suite: 100/100 tests pass.
- [x] Reproducer for BH-003 closed: extraneous suffixes no longer
  block boot.
- [x] Reproducer for BH-004 closed: non-cwd `_env_file=` is now seen
  by the scanner.
- [x] Reproducer for BH-014 closed: error message is value-blind.
- [x] Full cp-api suite: pre-existing failures only (`respx`,
  `aiosqlite` missing local modules — same as on `main`).
- [ ] CI pipeline green.

## Diff

`+339/−161` across 3 files. Slightly above the 300 LOC micro-PR
guideline; cannot split because impl, tests, and CLAUDE.md note must
ship together for the contract to hold. Core code logic in
`config.py` is concentrated (~80 LOC: `__init__` override + scanner
classmethod). Test rewrite (+193) and CLAUDE.md note (+46) inflate
the count.

## Refs

- Audit report PR: #2633 (Family C section)
- Phase 3-A PR: #2634 (Family A + Family D)
- Audit doc: `docs/infra/INFRA-1a-BUG-HUNT.md`
- Linear: [CAB-2199](https://linear.app/hlfh-workspace/issue/CAB-2199)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
