### PR TITLE
fix(subscriptions): align Portal Console Gateway UAC flow

### DIFF
--- a/control-plane-api/src/services/provisioning_service.py
+++ b/control-plane-api/src/services/provisioning_service.py
@@ -384,6 +384,18 @@ async def _deprovision_with_session(
     await db.commit()
 
     adapter = await _resolve_adapter(db, subscription.api_id, subscription.tenant_id)
+    if adapter is None:
+        subscription.provisioning_status = ProvisioningStatus.FAILED
+        subscription.provisioning_error = (
+            "Deprovision failed: no gateway adapter resolved for existing gateway_app_id"
+        )
+        await db.commit()
+        logger.error(
+            "Deprovision failed for subscription %s: no gateway adapter resolved",
+            subscription.id,
+            extra={"correlation_id": correlation_id, "tenant_id": subscription.tenant_id},
+        )
+        return
 
     try:
         # Clean up rate-limit policy first (CAB-1121 Phase 3)

--- a/control-plane-api/src/services/uac_tool_generator.py
+++ b/control-plane-api/src/services/uac_tool_generator.py
@@ -94,6 +94,9 @@ class UacToolGenerator:
         endpoint: UacEndpointSpec,
     ) -> str:
         """Build MCP tool name: {tenant}:{contract}:{operation}."""
+        if endpoint.llm and endpoint.llm.tool_name:
+            return endpoint.llm.tool_name
+
         if endpoint.operation_id:
             op_id = re.sub(r"[^a-zA-Z0-9_]", "_", endpoint.operation_id).lower()
         else:
@@ -116,6 +119,8 @@ class UacToolGenerator:
             f"Summary: {endpoint.llm.summary}",
             f"Intent: {endpoint.llm.intent}",
             f"Side effects: {endpoint.llm.side_effects}",
+            f"Safe for agents: {endpoint.llm.safe_for_agents}",
+            f"Requires human approval: {endpoint.llm.requires_human_approval}",
         ]
         if endpoint.llm.requires_human_approval:
             lines.append("HUMAN APPROVAL REQUIRED")

--- a/control-plane-api/tests/test_provisioning_service.py
+++ b/control-plane-api/tests/test_provisioning_service.py
@@ -402,6 +402,23 @@ class TestDeprovisionOnRevocation:
         # No adapter calls, no status change
         db.commit.assert_not_called()
 
+    async def test_existing_gateway_app_without_adapter_sets_failed(self):
+        db = _make_db()
+        sub = _make_subscription(gateway_app_id="app-123")
+
+        with (
+            patch("src.services.provisioning_service._resolve_adapter", new_callable=AsyncMock, return_value=None),
+            patch("src.services.provisioning_service._cleanup_rate_limit_policy", new_callable=AsyncMock) as cleanup,
+        ):
+            await deprovision_on_revocation(db, sub, "token", "corr-1")
+
+        from src.models.subscription import ProvisioningStatus
+
+        assert sub.provisioning_status == ProvisioningStatus.FAILED
+        assert "no gateway adapter resolved" in sub.provisioning_error
+        assert sub.gateway_app_id == "app-123"
+        cleanup.assert_not_called()
+
     async def test_adapter_failure_sets_failed(self):
         db = _make_db()
         sub = _make_subscription(gateway_app_id="app-123")

--- a/control-plane-api/tests/test_uac_tool_generator.py
+++ b/control-plane-api/tests/test_uac_tool_generator.py
@@ -123,6 +123,32 @@ class TestToolNaming:
         name = UacToolGenerator._build_tool_name("acme", "iam-api", ep)
         assert name == "acme:iam-api:delete_orgs_org_id_users_user_id"
 
+    def test_tool_name_uses_endpoint_llm_tool_name(self):
+        from src.schemas.uac import (
+            UacEndpointLlmExample,
+            UacEndpointLlmSpec,
+            UacEndpointSideEffects,
+        )
+
+        ep = UacEndpointSpec(
+            path="/customers",
+            methods=["GET"],
+            backend_url="https://b.com/customers",
+            operation_id="legacy_list_customers",
+            llm=UacEndpointLlmSpec(
+                summary="List customers.",
+                intent="Use to inspect customers.",
+                tool_name="list_customers_for_agent",
+                side_effects=UacEndpointSideEffects.READ,
+                safe_for_agents=True,
+                requires_human_approval=False,
+                examples=[UacEndpointLlmExample(input={})],
+            ),
+        )
+
+        name = UacToolGenerator._build_tool_name("acme", "customer-api", ep)
+        assert name == "list_customers_for_agent"
+
 
 # ---------------------------------------------------------------------------
 # Description tests
@@ -182,7 +208,9 @@ class TestDescription:
             "GET /items/{id} — Item Service\n"
             "Summary: Fetch an item.\n"
             "Intent: Use to read an item by id.\n"
-            "Side effects: read"
+            "Side effects: read\n"
+            "Safe for agents: True\n"
+            "Requires human approval: False"
         )
 
     def test_description_with_destructive_llm_includes_approval_marker(self):

--- a/control-plane-ui/src/pages/Subscriptions.test.tsx
+++ b/control-plane-ui/src/pages/Subscriptions.test.tsx
@@ -56,6 +56,10 @@ const mockGetSubscriptions = vi.fn().mockResolvedValue({
       revoked_at: null,
       revoked_by: null,
       expires_at: null,
+      api_key_prefix: null,
+      provisioning_status: 'failed',
+      gateway_app_id: 'wm-app-1',
+      provisioning_error: 'Gateway timeout',
     },
   ],
   total: 1,
@@ -86,6 +90,9 @@ vi.mock('../services/api', () => ({
     getSubscriptionStats: (...args: unknown[]) => mockGetSubscriptionStats(...args),
     approveSubscription: vi.fn().mockResolvedValue({}),
     rejectSubscription: vi.fn().mockResolvedValue({}),
+    revokeSubscription: vi.fn().mockResolvedValue({}),
+    suspendSubscription: vi.fn().mockResolvedValue({}),
+    reactivateSubscription: vi.fn().mockResolvedValue({}),
     bulkSubscriptionAction: vi.fn().mockResolvedValue({ succeeded: 1, failed: [] }),
   },
 }));
@@ -157,6 +164,10 @@ describe('Subscriptions', () => {
           revoked_at: null,
           revoked_by: null,
           expires_at: null,
+          api_key_prefix: null,
+          provisioning_status: 'failed',
+          gateway_app_id: 'wm-app-1',
+          provisioning_error: 'Gateway timeout',
         },
       ],
       total: 1,
@@ -200,6 +211,13 @@ describe('Subscriptions', () => {
     expect(screen.getByText('Weather API')).toBeInTheDocument();
     expect(screen.getByText('dev@example.com')).toBeInTheDocument();
     expect(screen.getByText('Basic Plan')).toBeInTheDocument();
+  });
+
+  it('renders provisioning status and gateway details', async () => {
+    renderSubscriptions();
+    expect(await screen.findByText('failed')).toBeInTheDocument();
+    expect(screen.getByText('wm-app-1')).toBeInTheDocument();
+    expect(screen.getByText('Gateway timeout')).toBeInTheDocument();
   });
 
   it('renders stats cards', async () => {

--- a/control-plane-ui/src/pages/Subscriptions.tsx
+++ b/control-plane-ui/src/pages/Subscriptions.tsx
@@ -34,6 +34,16 @@ const statusColors: Record<SubscriptionStatus, string> = {
   rejected: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
 };
 
+const provisioningColors: Record<string, string> = {
+  none: 'bg-neutral-100 text-neutral-700 dark:bg-neutral-700/30 dark:text-neutral-300',
+  pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+  provisioning: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  ready: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  failed: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+  deprovisioning: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400',
+  deprovisioned: 'bg-neutral-100 text-neutral-700 dark:bg-neutral-700/30 dark:text-neutral-300',
+};
+
 export function Subscriptions() {
   const { isReady } = useAuth();
   const { canEdit } = useEnvironmentMode();
@@ -168,6 +178,69 @@ export function Subscriptions() {
       reload();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to reject subscription');
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleSuspend(sub: Subscription) {
+    const ok = await confirm({
+      title: 'Suspend Subscription',
+      message: `Suspend ${sub.application_name}'s subscription to ${sub.api_name}?`,
+      confirmLabel: 'Suspend',
+    });
+    if (!ok) return;
+    try {
+      setActionLoading(true);
+      await apiService.suspendSubscription(sub.id);
+      toast.success('Subscription suspended');
+      reload();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to suspend subscription');
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleReactivate(sub: Subscription) {
+    const ok = await confirm({
+      title: 'Reactivate Subscription',
+      message: `Reactivate ${sub.application_name}'s subscription to ${sub.api_name}?`,
+      confirmLabel: 'Reactivate',
+    });
+    if (!ok) return;
+    try {
+      setActionLoading(true);
+      await apiService.reactivateSubscription(sub.id);
+      toast.success('Subscription reactivated');
+      reload();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to reactivate subscription');
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleRevoke(sub: Subscription) {
+    const reason = window.prompt(
+      `Reason for revoking ${sub.application_name}'s subscription to ${sub.api_name}:`
+    );
+    if (!reason?.trim()) return;
+
+    const ok = await confirm({
+      title: 'Revoke Subscription',
+      message: `Permanently revoke ${sub.application_name}'s subscription to ${sub.api_name}?`,
+      confirmLabel: 'Revoke',
+    });
+    if (!ok) return;
+
+    try {
+      setActionLoading(true);
+      await apiService.revokeSubscription(sub.id, reason.trim());
+      toast.success('Subscription revoked');
+      reload();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to revoke subscription');
     } finally {
       setActionLoading(false);
     }
@@ -353,7 +426,7 @@ export function Subscriptions() {
 
       {/* Table */}
       {loading ? (
-        <TableSkeleton rows={5} columns={7} />
+        <TableSkeleton rows={5} columns={8} />
       ) : filteredSubscriptions.length === 0 ? (
         <EmptyState
           title="No subscriptions"
@@ -394,6 +467,9 @@ export function Subscriptions() {
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Status
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                  Provisioning
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
                   Created
@@ -437,6 +513,35 @@ export function Subscriptions() {
                     </span>
                   </td>
                   <td className="px-4 py-3 text-sm text-neutral-500 dark:text-neutral-400">
+                    <div className="flex flex-col gap-1">
+                      <span
+                        title={sub.provisioning_error || undefined}
+                        className={`w-fit inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                          provisioningColors[sub.provisioning_status || 'none'] ||
+                          provisioningColors.none
+                        }`}
+                      >
+                        {sub.provisioning_status || 'none'}
+                      </span>
+                      {sub.gateway_app_id && (
+                        <span
+                          title={sub.gateway_app_id}
+                          className="max-w-[12rem] truncate text-xs text-neutral-400 dark:text-neutral-500 font-mono"
+                        >
+                          {sub.gateway_app_id}
+                        </span>
+                      )}
+                      {sub.provisioning_error && (
+                        <span
+                          title={sub.provisioning_error}
+                          className="max-w-[12rem] truncate text-xs text-red-600 dark:text-red-400"
+                        >
+                          {sub.provisioning_error}
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-neutral-500 dark:text-neutral-400">
                     {new Date(sub.created_at).toLocaleDateString()}
                   </td>
                   <td className="px-4 py-3 text-right">
@@ -458,6 +563,46 @@ export function Subscriptions() {
                             className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm font-medium disabled:opacity-50"
                           >
                             Reject
+                          </button>
+                        </>
+                      )}
+                      {sub.status === 'active' && (
+                        <>
+                          <button
+                            onClick={() => handleSuspend(sub)}
+                            disabled={actionLoading || !canEdit}
+                            title={!canEdit ? 'Read-only environment' : undefined}
+                            className="text-orange-600 hover:text-orange-800 dark:text-orange-400 dark:hover:text-orange-300 text-sm font-medium disabled:opacity-50"
+                          >
+                            Suspend
+                          </button>
+                          <button
+                            onClick={() => handleRevoke(sub)}
+                            disabled={actionLoading || !canEdit}
+                            title={!canEdit ? 'Read-only environment' : undefined}
+                            className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm font-medium disabled:opacity-50"
+                          >
+                            Revoke
+                          </button>
+                        </>
+                      )}
+                      {sub.status === 'suspended' && (
+                        <>
+                          <button
+                            onClick={() => handleReactivate(sub)}
+                            disabled={actionLoading || !canEdit}
+                            title={!canEdit ? 'Read-only environment' : undefined}
+                            className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300 text-sm font-medium disabled:opacity-50"
+                          >
+                            Reactivate
+                          </button>
+                          <button
+                            onClick={() => handleRevoke(sub)}
+                            disabled={actionLoading || !canEdit}
+                            title={!canEdit ? 'Read-only environment' : undefined}
+                            className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm font-medium disabled:opacity-50"
+                          >
+                            Revoke
                           </button>
                         </>
                       )}

--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -1092,6 +1092,18 @@ class ApiService {
     return subscriptionsClient.reject(id, reason);
   }
 
+  async revokeSubscription(id: string, reason: string): Promise<Subscription> {
+    return subscriptionsClient.revoke(id, reason);
+  }
+
+  async suspendSubscription(id: string): Promise<Subscription> {
+    return subscriptionsClient.suspend(id);
+  }
+
+  async reactivateSubscription(id: string): Promise<Subscription> {
+    return subscriptionsClient.reactivate(id);
+  }
+
   async bulkSubscriptionAction(
     payload: Schemas['BulkSubscriptionAction']
   ): Promise<Schemas['BulkActionResult']> {

--- a/control-plane-ui/src/services/api/subscriptions.ts
+++ b/control-plane-ui/src/services/api/subscriptions.ts
@@ -43,6 +43,21 @@ export const subscriptionsClient = {
     return data;
   },
 
+  async revoke(id: string, reason: string): Promise<Subscription> {
+    const { data } = await httpClient.post(path('v1', 'subscriptions', id, 'revoke'), { reason });
+    return data;
+  },
+
+  async suspend(id: string): Promise<Subscription> {
+    const { data } = await httpClient.post(path('v1', 'subscriptions', id, 'suspend'));
+    return data;
+  },
+
+  async reactivate(id: string): Promise<Subscription> {
+    const { data } = await httpClient.post(path('v1', 'subscriptions', id, 'reactivate'));
+    return data;
+  },
+
   async bulkAction(
     payload: Schemas['BulkSubscriptionAction']
   ): Promise<Schemas['BulkActionResult']> {

--- a/control-plane-ui/src/test/services/api/ui2-s2b-clients.test.ts
+++ b/control-plane-ui/src/test/services/api/ui2-s2b-clients.test.ts
@@ -44,6 +44,9 @@ describe('UI-2 S2b domain clients', () => {
     mockHttpClient.post
       .mockResolvedValueOnce({ data: subscription })
       .mockResolvedValueOnce({ data: subscription })
+      .mockResolvedValueOnce({ data: subscription })
+      .mockResolvedValueOnce({ data: subscription })
+      .mockResolvedValueOnce({ data: subscription })
       .mockResolvedValueOnce({ data: bulkResult });
 
     await expect(subscriptionsClient.list('tenant-1', 'approved', 2, 50, 'prod')).resolves.toBe(
@@ -53,6 +56,9 @@ describe('UI-2 S2b domain clients', () => {
     await expect(subscriptionsClient.getStats('tenant-1')).resolves.toBe(stats);
     await expect(subscriptionsClient.approve('sub-1', '2026-04-30')).resolves.toBe(subscription);
     await expect(subscriptionsClient.reject('sub-1', 'missing docs')).resolves.toBe(subscription);
+    await expect(subscriptionsClient.revoke('sub-1', 'retired')).resolves.toBe(subscription);
+    await expect(subscriptionsClient.suspend('sub-1')).resolves.toBe(subscription);
+    await expect(subscriptionsClient.reactivate('sub-1')).resolves.toBe(subscription);
     await expect(
       subscriptionsClient.bulkAction({
         subscription_ids: ['sub-1'],
@@ -85,7 +91,12 @@ describe('UI-2 S2b domain clients', () => {
     expect(mockHttpClient.post).toHaveBeenNthCalledWith(2, '/v1/subscriptions/sub-1/reject', {
       reason: 'missing docs',
     });
-    expect(mockHttpClient.post).toHaveBeenNthCalledWith(3, '/v1/subscriptions/bulk', {
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(3, '/v1/subscriptions/sub-1/revoke', {
+      reason: 'retired',
+    });
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(4, '/v1/subscriptions/sub-1/suspend');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(5, '/v1/subscriptions/sub-1/reactivate');
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(6, '/v1/subscriptions/bulk', {
       subscription_ids: ['sub-1'],
       action: 'approve',
     });

--- a/portal/src/components/consumers/SubscribeWithPlanModal.test.tsx
+++ b/portal/src/components/consumers/SubscribeWithPlanModal.test.tsx
@@ -183,6 +183,18 @@ describe('SubscribeWithPlanModal', () => {
     expect(screen.getByText('Subscribe')).toBeDisabled();
   });
 
+  it('should block mTLS subscription until certificate binding is available', async () => {
+    const user = userEvent.setup();
+    const mtlsApi = { ...mockApi, tags: ['payments', 'mtls'] };
+    renderWithProviders(<SubscribeWithPlanModal {...defaultProps} api={mtlsApi} />);
+
+    await user.selectOptions(screen.getByRole('combobox'), 'app-1');
+    await user.click(screen.getByTestId('plan-plan-1'));
+
+    expect(screen.getByText(/requires mTLS/)).toBeInTheDocument();
+    expect(screen.getByText('Subscribe')).toBeDisabled();
+  });
+
   it('should show approval notice when plan requires approval', async () => {
     const user = userEvent.setup();
     renderWithProviders(<SubscribeWithPlanModal {...defaultProps} />);

--- a/portal/src/components/consumers/SubscribeWithPlanModal.tsx
+++ b/portal/src/components/consumers/SubscribeWithPlanModal.tsx
@@ -43,9 +43,11 @@ export function SubscribeWithPlanModal({
   const { user } = useAuth();
   const [selectedAppId, setSelectedAppId] = useState<string>('');
   const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
+  const planTenantId = api.tenantId || user?.tenant_id;
+  const requiresMtls = api.tags?.includes('mtls') ?? false;
 
   const { data: applications, isLoading: appsLoading } = useApplications();
-  const { data: plansData, isLoading: plansLoading } = usePlans(user?.tenant_id);
+  const { data: plansData, isLoading: plansLoading } = usePlans(planTenantId);
 
   const activePlans = useMemo(
     () => plansData?.items.filter((p) => p.status === 'active') || [],
@@ -140,6 +142,16 @@ export function SubscribeWithPlanModal({
                 </div>
               )}
 
+              {requiresMtls && (
+                <div className="flex items-start gap-2 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+                  <AlertCircle className="h-5 w-5 text-amber-500 mt-0.5 flex-shrink-0" />
+                  <p className="text-sm text-amber-700 dark:text-amber-300">
+                    This API requires mTLS. Subscription is blocked until certificate binding is
+                    available in the Control Plane.
+                  </p>
+                </div>
+              )}
+
               {/* Select Application */}
               <div>
                 <label
@@ -222,7 +234,9 @@ export function SubscribeWithPlanModal({
               </Button>
               <Button
                 type="submit"
-                disabled={!selectedAppId || !selectedPlanId || activeApps.length === 0}
+                disabled={
+                  requiresMtls || !selectedAppId || !selectedPlanId || activeApps.length === 0
+                }
                 loading={isLoading}
               >
                 Subscribe

--- a/portal/src/hooks/useSubscriptions.ts
+++ b/portal/src/hooks/useSubscriptions.ts
@@ -244,7 +244,13 @@ export function useSubscribe() {
         apiName: response.api_name,
         apiVersion: response.api_version,
         tenantId: response.tenant_id,
+        planId: response.plan_id || undefined,
+        planName: response.plan_name || undefined,
         status: response.status,
+        apiKeyPrefix: response.api_key_prefix || undefined,
+        provisioningStatus: response.provisioning_status || undefined,
+        provisioningError: response.provisioning_error || undefined,
+        gatewayAppId: response.gateway_app_id || undefined,
         createdAt: response.created_at,
         expiresAt: response.expires_at || undefined,
       };
@@ -302,6 +308,9 @@ export function useApplicationSubscriptions(applicationId: string | undefined) {
         planName: item.plan_name || undefined,
         status: item.status,
         apiKeyPrefix: item.api_key_prefix || undefined,
+        provisioningStatus: item.provisioning_status || undefined,
+        provisioningError: item.provisioning_error || undefined,
+        gatewayAppId: item.gateway_app_id || undefined,
         createdAt: item.created_at,
         expiresAt: item.expires_at || undefined,
       }));

--- a/portal/src/pages/__tests__/APIDetail.test.tsx
+++ b/portal/src/pages/__tests__/APIDetail.test.tsx
@@ -47,6 +47,10 @@ vi.mock('../../components/subscriptions/SubscribeModal', () => ({
   SubscribeModal: () => <div data-testid="subscribe-modal">Subscribe Modal</div>,
 }));
 
+vi.mock('../../components/consumers/SubscribeWithPlanModal', () => ({
+  SubscribeWithPlanModal: () => <div data-testid="subscribe-with-plan-modal">Subscribe Modal</div>,
+}));
+
 describe('APIDetail', () => {
   describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
     '%s persona',

--- a/portal/src/pages/apis/APIDetail.tsx
+++ b/portal/src/pages/apis/APIDetail.tsx
@@ -29,6 +29,10 @@ import {
 import { useAPI, useOpenAPISpec } from '../../hooks/useAPIs';
 import { useSubscribe, type SubscribeToAPIResponse } from '../../hooks/useSubscriptions';
 import { SubscribeModal, SubscribeFormData } from '../../components/subscriptions/SubscribeModal';
+import {
+  SubscribeWithPlanModal,
+  type SubscribeWithPlanFormData,
+} from '../../components/consumers/SubscribeWithPlanModal';
 import { config } from '../../config';
 import { ChatCompletionsEnrichment } from '../../components/apis/ChatCompletionsEnrichment';
 import {
@@ -89,6 +93,30 @@ export function APIDetail() {
         apiVersion: api.version,
         tenantId: api.tenantId || 'default',
         planName: data.plan,
+      });
+      setSubscriptionResult(result);
+      setIsSubscribeModalOpen(false);
+    } catch (err) {
+      setSubscribeError((err as Error)?.message || 'Failed to subscribe to API');
+    }
+  };
+
+  const handleSubscribeWithPlan = async (data: SubscribeWithPlanFormData) => {
+    setSubscribeError(null);
+    if (!api) {
+      setSubscribeError('API not loaded');
+      return;
+    }
+    try {
+      const result = await subscribeMutation.mutateAsync({
+        applicationId: data.applicationId,
+        applicationName: data.applicationName,
+        apiId: data.apiId,
+        apiName: api.name,
+        apiVersion: api.version,
+        tenantId: api.tenantId || 'default',
+        planId: data.planId,
+        planName: data.planName,
       });
       setSubscriptionResult(result);
       setIsSubscribeModalOpen(false);
@@ -575,22 +603,35 @@ export function APIDetail() {
       </div>
 
       {/* Subscribe Modal */}
-      <SubscribeModal
-        isOpen={isSubscribeModalOpen}
-        onClose={() => {
-          setIsSubscribeModalOpen(false);
-          setSubscribeError(null);
-          setPreselectedPlan(undefined);
-        }}
-        onSubmit={handleSubscribe}
-        api={api}
-        isLoading={subscribeMutation.isPending}
-        error={subscribeError}
-        customPlans={
-          api.name === CHAT_COMPLETIONS_API_NAME ? chatCompletionsCustomPlans : undefined
-        }
-        defaultPlan={preselectedPlan}
-      />
+      {api.name === CHAT_COMPLETIONS_API_NAME ? (
+        <SubscribeModal
+          isOpen={isSubscribeModalOpen}
+          onClose={() => {
+            setIsSubscribeModalOpen(false);
+            setSubscribeError(null);
+            setPreselectedPlan(undefined);
+          }}
+          onSubmit={handleSubscribe}
+          api={api}
+          isLoading={subscribeMutation.isPending}
+          error={subscribeError}
+          customPlans={chatCompletionsCustomPlans}
+          defaultPlan={preselectedPlan}
+        />
+      ) : (
+        <SubscribeWithPlanModal
+          isOpen={isSubscribeModalOpen}
+          onClose={() => {
+            setIsSubscribeModalOpen(false);
+            setSubscribeError(null);
+            setPreselectedPlan(undefined);
+          }}
+          onSubmit={handleSubscribeWithPlan}
+          api={api}
+          isLoading={subscribeMutation.isPending}
+          error={subscribeError}
+        />
+      )}
 
       {/* Subscription Success Modal */}
       {subscriptionResult && (

--- a/portal/src/services/apiSubscriptions.ts
+++ b/portal/src/services/apiSubscriptions.ts
@@ -14,7 +14,13 @@ import type { APISubscription } from '../types';
 
 // ============ Types ============
 
-export type APISubscriptionStatus = 'pending' | 'active' | 'suspended' | 'revoked' | 'expired';
+export type APISubscriptionStatus =
+  | 'pending'
+  | 'active'
+  | 'suspended'
+  | 'revoked'
+  | 'expired'
+  | 'rejected';
 
 export interface CreateAPISubscriptionRequest {
   application_id: string;
@@ -25,7 +31,6 @@ export interface CreateAPISubscriptionRequest {
   tenant_id: string;
   plan_id?: string;
   plan_name?: string;
-  certificate_fingerprint?: string;
 }
 
 export interface APISubscriptionResponse {
@@ -52,6 +57,7 @@ export interface APISubscriptionResponse {
   approved_by: string | null;
   revoked_by: string | null;
   provisioning_status: string | null;
+  gateway_app_id: string | null;
   provisioning_error: string | null;
 }
 
@@ -85,6 +91,9 @@ function transformToAPISubscription(response: APISubscriptionResponse): APISubsc
     planName: response.plan_name || undefined,
     status: response.status,
     apiKeyPrefix: response.api_key_prefix || undefined,
+    provisioningStatus: response.provisioning_status || undefined,
+    provisioningError: response.provisioning_error || undefined,
+    gatewayAppId: response.gateway_app_id || undefined,
     createdAt: response.created_at,
     expiresAt: response.expires_at || undefined,
   };

--- a/portal/src/types/index.ts
+++ b/portal/src/types/index.ts
@@ -288,9 +288,12 @@ export interface APISubscription {
   tenantId?: string;
   planId?: string;
   planName?: string;
-  status: 'pending' | 'active' | 'suspended' | 'cancelled' | 'revoked' | 'expired';
+  status: 'pending' | 'active' | 'suspended' | 'cancelled' | 'revoked' | 'expired' | 'rejected';
   plan?: 'free' | 'basic' | 'premium' | 'enterprise';
   apiKeyPrefix?: string;
+  provisioningStatus?: string;
+  provisioningError?: string;
+  gatewayAppId?: string;
   rateLimit?: {
     requests: number;
     period: string;

--- a/stoa-gateway/src/uac/binders/mcp.rs
+++ b/stoa-gateway/src/uac/binders/mcp.rs
@@ -4,11 +4,14 @@
 //! Each endpoint in the contract becomes a DynamicTool with the naming pattern:
 //! `{tenant_id}_{contract_name}_{operation_id}`
 
+use std::collections::HashMap;
 use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::mcp::tools::dynamic_tool::DynamicTool;
 use crate::mcp::tools::{ToolAnnotations, ToolDefinition, ToolRegistry, ToolSchema};
-use crate::uac::schema::UacContractSpec;
+use crate::uac::schema::{EndpointSideEffects, UacContractSpec, UacEndpoint};
 use crate::uac::Action;
 
 use super::{BindingOutput, ProtocolBinder};
@@ -16,12 +19,16 @@ use super::{BindingOutput, ProtocolBinder};
 /// MCP protocol binder — generates MCP tools from UAC contracts.
 pub struct McpBinder {
     tool_registry: Arc<ToolRegistry>,
+    contract_tool_names: RwLock<HashMap<String, Vec<String>>>,
 }
 
 impl McpBinder {
     /// Create a new MCP binder backed by the given tool registry.
     pub fn new(tool_registry: Arc<ToolRegistry>) -> Self {
-        Self { tool_registry }
+        Self {
+            tool_registry,
+            contract_tool_names: RwLock::new(HashMap::new()),
+        }
     }
 
     /// Tool name prefix for a contract (used for cascade deletion).
@@ -42,6 +49,75 @@ impl McpBinder {
         }
     }
 
+    /// Resolve the tool action from endpoint-level LLM metadata when present.
+    fn endpoint_action(endpoint: &UacEndpoint, primary_method: &str) -> Action {
+        match endpoint.llm.as_ref().map(|llm| llm.side_effects) {
+            Some(EndpointSideEffects::None) | Some(EndpointSideEffects::Read) => Action::Read,
+            Some(EndpointSideEffects::Destructive) => Action::Delete,
+            Some(EndpointSideEffects::Write) | None => Self::method_to_action(primary_method),
+        }
+    }
+
+    fn side_effects_label(side_effects: EndpointSideEffects) -> &'static str {
+        match side_effects {
+            EndpointSideEffects::None => "none",
+            EndpointSideEffects::Read => "read",
+            EndpointSideEffects::Write => "write",
+            EndpointSideEffects::Destructive => "destructive",
+        }
+    }
+
+    /// Build the generated MCP tool name.
+    ///
+    /// For LLM-ready endpoints, endpoint.llm.tool_name is the stable MCP tool
+    /// name. Legacy endpoints keep the namespaced UAC fallback.
+    fn tool_name(contract: &UacContractSpec, endpoint: &UacEndpoint, index: usize) -> String {
+        if let Some(llm) = endpoint.llm.as_ref() {
+            return llm.tool_name.clone();
+        }
+
+        let op_id = endpoint
+            .operation_id
+            .clone()
+            .unwrap_or_else(|| format!("{}-{}", contract.name, index));
+
+        format!("uac:{}:{}:{}", contract.tenant_id, contract.name, op_id)
+    }
+
+    /// Build the agent-facing tool description.
+    fn description(
+        contract: &UacContractSpec,
+        endpoint: &UacEndpoint,
+        primary_method: &str,
+    ) -> String {
+        let legacy = format!(
+            "{} {} — {} [{}]",
+            primary_method, endpoint.path, contract.name, contract.tenant_id
+        );
+
+        let Some(llm) = endpoint.llm.as_ref() else {
+            return legacy;
+        };
+
+        let mut lines = vec![
+            legacy,
+            format!("Summary: {}", llm.summary),
+            format!("Intent: {}", llm.intent),
+            format!(
+                "Side effects: {}",
+                Self::side_effects_label(llm.side_effects)
+            ),
+            format!("Safe for agents: {}", llm.safe_for_agents),
+            format!("Requires human approval: {}", llm.requires_human_approval),
+        ];
+
+        if llm.requires_human_approval {
+            lines.push("HUMAN APPROVAL REQUIRED".to_string());
+        }
+
+        lines.join("\n")
+    }
+
     /// Generate tool definitions from a contract (pure function, no side effects).
     pub fn generate_tool_definitions(contract: &UacContractSpec) -> Vec<ToolDefinition> {
         contract
@@ -49,25 +125,15 @@ impl McpBinder {
             .iter()
             .enumerate()
             .map(|(i, endpoint)| {
-                let op_id = endpoint
-                    .operation_id
-                    .clone()
-                    .unwrap_or_else(|| format!("{}-{}", contract.name, i));
-
-                let tool_name = format!("uac:{}:{}:{}", contract.tenant_id, contract.name, op_id);
-
                 // Use first method for action hint (most endpoints have one primary method)
                 let primary_method = endpoint
                     .methods
                     .first()
                     .map(|m| m.as_str())
                     .unwrap_or("GET");
-                let action = Self::method_to_action(primary_method);
-
-                let description = format!(
-                    "{} {} — {} [{}]",
-                    primary_method, endpoint.path, contract.name, contract.tenant_id
-                );
+                let action = Self::endpoint_action(endpoint, primary_method);
+                let tool_name = Self::tool_name(contract, endpoint, i);
+                let description = Self::description(contract, endpoint, primary_method);
 
                 // Build input schema from endpoint schema or default empty object
                 let input_schema = endpoint
@@ -99,24 +165,14 @@ impl McpBinder {
             .iter()
             .enumerate()
             .map(|(i, endpoint)| {
-                let op_id = endpoint
-                    .operation_id
-                    .clone()
-                    .unwrap_or_else(|| format!("{}-{}", contract.name, i));
-
-                let tool_name = format!("uac:{}:{}:{}", contract.tenant_id, contract.name, op_id);
-
                 let primary_method = endpoint
                     .methods
                     .first()
                     .map(|m| m.as_str())
                     .unwrap_or("GET");
-                let action = Self::method_to_action(primary_method);
-
-                let description = format!(
-                    "{} {} — {} [{}]",
-                    primary_method, endpoint.path, contract.name, contract.tenant_id
-                );
+                let action = Self::endpoint_action(endpoint, primary_method);
+                let tool_name = Self::tool_name(contract, endpoint, i);
+                let description = Self::description(contract, endpoint, primary_method);
 
                 let input_schema = endpoint
                     .input_schema
@@ -152,14 +208,24 @@ impl ProtocolBinder for McpBinder {
 
         // Remove existing tools for this contract (idempotent re-bind)
         self.tool_registry.remove_by_prefix(&prefix);
+        if let Some(previous_names) = self.contract_tool_names.write().remove(&contract_key) {
+            for name in previous_names {
+                self.tool_registry.unregister(&name);
+            }
+        }
 
         // Create and register new tools
         let tools = Self::create_dynamic_tools(contract);
         let count = tools.len();
+        let definitions = Self::generate_tool_definitions(contract);
 
         for tool in &tools {
             self.tool_registry.register(Arc::clone(tool));
         }
+        self.contract_tool_names.write().insert(
+            contract_key.clone(),
+            definitions.iter().map(|d| d.name.clone()).collect(),
+        );
 
         tracing::info!(
             contract = %contract_key,
@@ -167,14 +233,19 @@ impl ProtocolBinder for McpBinder {
             "MCP binder: tools generated"
         );
 
-        // Return definitions for the response
-        let definitions = Self::generate_tool_definitions(contract);
         Ok(BindingOutput::Tools(definitions))
     }
 
     async fn unbind(&self, contract_key: &str) -> Result<usize, String> {
         let prefix = Self::tool_prefix(contract_key);
-        let removed = self.tool_registry.remove_by_prefix(&prefix);
+        let mut removed = self.tool_registry.remove_by_prefix(&prefix);
+        if let Some(previous_names) = self.contract_tool_names.write().remove(contract_key) {
+            for name in previous_names {
+                if self.tool_registry.unregister(&name) {
+                    removed += 1;
+                }
+            }
+        }
 
         tracing::info!(
             contract = %contract_key,
@@ -190,7 +261,10 @@ impl ProtocolBinder for McpBinder {
 mod tests {
     use super::*;
     use crate::uac::classifications::Classification;
-    use crate::uac::schema::{ContractStatus, UacContractSpec, UacEndpoint};
+    use crate::uac::schema::{
+        ContractStatus, EndpointLlm, EndpointLlmExample, EndpointSideEffects, UacContractSpec,
+        UacEndpoint,
+    };
 
     fn sample_contract() -> UacContractSpec {
         let mut spec = UacContractSpec::new("payments", "acme");
@@ -256,6 +330,26 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_definitions_uses_llm_tool_name() {
+        let mut contract = sample_contract();
+        contract.endpoints[0].llm = Some(EndpointLlm {
+            summary: "List customer payments.".to_string(),
+            intent: "Use to inspect payments without changing state.".to_string(),
+            tool_name: "list_customer_payments".to_string(),
+            side_effects: EndpointSideEffects::Read,
+            safe_for_agents: true,
+            requires_human_approval: false,
+            examples: vec![EndpointLlmExample {
+                input: serde_json::json!({}),
+                expected_output_contains: None,
+            }],
+        });
+
+        let defs = McpBinder::generate_tool_definitions(&contract);
+        assert_eq!(defs[0].name, "list_customer_payments");
+    }
+
+    #[test]
     fn test_generate_definitions_name_fallback() {
         let mut contract = sample_contract();
         contract.endpoints[0].operation_id = None;
@@ -270,6 +364,34 @@ mod tests {
         assert!(defs[0].description.contains("GET"));
         assert!(defs[0].description.contains("/payments"));
         assert!(defs[0].description.contains("acme"));
+    }
+
+    #[test]
+    fn test_generate_definitions_description_uses_llm_metadata() {
+        let mut contract = sample_contract();
+        contract.endpoints[1].llm = Some(EndpointLlm {
+            summary: "Delete a payment.".to_string(),
+            intent: "Use only after a human has approved permanent removal.".to_string(),
+            tool_name: "delete_payment_after_approval".to_string(),
+            side_effects: EndpointSideEffects::Destructive,
+            safe_for_agents: false,
+            requires_human_approval: true,
+            examples: vec![EndpointLlmExample {
+                input: serde_json::json!({ "id": "pay-123" }),
+                expected_output_contains: None,
+            }],
+        });
+
+        let defs = McpBinder::generate_tool_definitions(&contract);
+        assert!(defs[1].description.contains("Summary: Delete a payment."));
+        assert!(defs[1]
+            .description
+            .contains("Intent: Use only after a human has approved permanent removal."));
+        assert!(defs[1].description.contains("Side effects: destructive"));
+        assert!(defs[1]
+            .description
+            .contains("Requires human approval: true"));
+        assert!(defs[1].description.contains("HUMAN APPROVAL REQUIRED"));
     }
 
     #[test]
@@ -355,6 +477,33 @@ mod tests {
         let contract = sample_contract();
         binder.bind(&contract).await.expect("bind");
         assert_eq!(registry.count(), 2);
+
+        let removed = binder.unbind("acme:payments").await.expect("unbind");
+        assert_eq!(removed, 2);
+        assert_eq!(registry.count(), 0);
+    }
+
+    #[tokio::test]
+    async fn regression_unbind_removes_llm_named_tools() {
+        let registry = Arc::new(ToolRegistry::new());
+        let binder = McpBinder::new(registry.clone());
+
+        let mut contract = sample_contract();
+        contract.endpoints[0].llm = Some(EndpointLlm {
+            summary: "List customer payments.".to_string(),
+            intent: "Use to inspect payments without changing state.".to_string(),
+            tool_name: "list_customer_payments".to_string(),
+            side_effects: EndpointSideEffects::Read,
+            safe_for_agents: true,
+            requires_human_approval: false,
+            examples: vec![EndpointLlmExample {
+                input: serde_json::json!({}),
+                expected_output_contains: None,
+            }],
+        });
+
+        binder.bind(&contract).await.expect("bind");
+        assert!(registry.exists("list_customer_payments"));
 
         let removed = binder.unbind("acme:payments").await.expect("unbind");
         assert_eq!(removed, 2);


### PR DESCRIPTION
## Summary
- route generic Portal API subscription through plan-aware SubscribeWithPlanModal and surface provisioning metadata
- add Console lifecycle actions for suspend/reactivate/revoke with gateway/provisioning status visibility
- align cp-api and Rust gateway UAC/MCP projection around exact LLM tool names, agent safety metadata, and explicit provisioning failure handling

## Validation
- control-plane-api: pytest -q tests/test_uac_tool_generator.py tests/test_provisioning_service.py
- stoa-gateway: cargo test --manifest-path stoa-gateway/Cargo.toml uac::binders::mcp --lib
- portal: npm test -- src/components/consumers/SubscribeWithPlanModal.test.tsx src/pages/__tests__/APIDetail.test.tsx
- control-plane-ui: npm test -- src/pages/Subscriptions.test.tsx src/test/services/api/ui2-s2b-clients.test.ts
- portal: npm run build
- control-plane-ui: npm run build
- repo: git diff --check