### PR TITLE
fix(gateways): surface external URLs for link and connect

### DIFF
--- a/control-plane-api/src/schemas/gateway.py
+++ b/control-plane-api/src/schemas/gateway.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from src.services.gateway_topology import normalize_gateway_topology
+from src.services.gateway_topology import endpoint_value, normalize_gateway_topology
 
 logger = logging.getLogger(__name__)
 
@@ -206,6 +206,9 @@ class GatewayInstanceResponse(BaseModel):
         self.target_gateway_type = normalized.target_gateway_type  # type: ignore[assignment]
         self.topology = normalized.topology  # type: ignore[assignment]
         self.endpoints = normalized.endpoints
+        self.public_url = self.public_url or endpoint_value(self.endpoints, "public_url")
+        self.ui_url = self.ui_url or endpoint_value(self.endpoints, "ui_url")
+        self.target_gateway_url = self.target_gateway_url or endpoint_value(self.endpoints, "target_gateway_url")
         return self
 
     @field_validator("mode", mode="before")
@@ -335,7 +338,9 @@ class ConsoleGatewayTarget(BaseModel):
     name: str
     display_name: str
     environment: str
-    deployment_mode: GatewayDeploymentModeLiteral = Field(..., description="Canonical topology: edge, connect, or sidecar")
+    deployment_mode: GatewayDeploymentModeLiteral = Field(
+        ..., description="Canonical topology: edge, connect, or sidecar"
+    )
     target_gateway_type: str = Field(..., description="Gateway technology: stoa, kong, webmethods, gravitee, ...")
     topology: GatewayTopologyLiteral = Field(..., description="Execution topology: native-edge, remote-agent, same-pod")
     source: str = Field(..., description="Gateway source of truth: argocd, self_register, or manual")

--- a/control-plane-api/src/services/gateway_topology.py
+++ b/control-plane-api/src/services/gateway_topology.py
@@ -25,6 +25,15 @@ TARGET_GATEWAY_TYPES = {
 
 _THIRD_PARTY_TARGETS = TARGET_GATEWAY_TYPES - {"stoa"}
 
+_ENDPOINT_ALIASES: dict[str, tuple[str, ...]] = {
+    "public_url": ("publicUrl", "public", "runtime_url", "runtimeUrl", "external_url", "externalUrl"),
+    "ui_url": ("uiUrl", "console_url", "consoleUrl", "web_ui_url", "webUiUrl"),
+    "target_gateway_url": ("targetGatewayUrl", "target_url", "targetUrl"),
+    "admin_url": ("adminUrl", "admin", "base_url", "baseUrl"),
+    "internal_url": ("internalUrl", "internal"),
+    "health_url": ("healthUrl", "health"),
+}
+
 
 @dataclass(frozen=True)
 class GatewayTopology:
@@ -46,7 +55,28 @@ def _string_value(value: object) -> str | None:
     if value is None:
         return None
     raw = value.value if hasattr(value, "value") else value
-    return raw if isinstance(raw, str) else None
+    if not isinstance(raw, str):
+        return None
+    raw = raw.strip()
+    return raw or None
+
+
+def _endpoint_map(endpoints: dict | None) -> dict[str, str]:
+    return {
+        str(key): str(value).strip()
+        for key, value in (endpoints if isinstance(endpoints, dict) else {}).items()
+        if value is not None and str(value).strip()
+    }
+
+
+def endpoint_value(endpoints: dict | None, canonical_key: str) -> str | None:
+    """Return a canonical endpoint value from snake_case or legacy/camel aliases."""
+    normalized = _endpoint_map(endpoints)
+    for key in (canonical_key, *_ENDPOINT_ALIASES.get(canonical_key, ())):
+        value = normalized.get(key)
+        if value:
+            return value
+    return None
 
 
 def normalize_mode(mode: object | None) -> str:
@@ -153,25 +183,30 @@ def build_endpoints(
     base_url: object | None = None,
     public_url: object | None = None,
     ui_url: object | None = None,
+    target_gateway_url: object | None = None,
 ) -> dict[str, str]:
     """Return a normalized endpoint map while preserving existing explicit keys."""
-    normalized: dict[str, str] = {
-        str(key): str(value)
-        for key, value in (endpoints if isinstance(endpoints, dict) else {}).items()
-        if value is not None and str(value).strip()
-    }
+    normalized = _endpoint_map(endpoints)
+    for canonical_key in _ENDPOINT_ALIASES:
+        value = endpoint_value(normalized, canonical_key)
+        if value:
+            normalized.setdefault(canonical_key, value)
+
     public_url = _string_value(public_url)
     base_url = _string_value(base_url)
     ui_url = _string_value(ui_url)
+    target_gateway_url = _string_value(target_gateway_url)
     if public_url:
-        normalized.setdefault("public_url", public_url)
+        normalized["public_url"] = public_url
     if base_url:
-        normalized.setdefault("admin_url", base_url)
+        normalized["admin_url"] = base_url
         if ".svc.cluster.local" in base_url or "://" not in base_url:
             normalized.setdefault("internal_url", base_url)
         normalized.setdefault("health_url", f"{base_url.rstrip('/')}/health")
     if ui_url:
-        normalized.setdefault("ui_url", ui_url)
+        normalized["ui_url"] = ui_url
+    if target_gateway_url:
+        normalized["target_gateway_url"] = target_gateway_url
     return normalized
 
 
@@ -204,7 +239,13 @@ def normalize_gateway_topology(
         target_gateway_url=target_gateway_url,
         base_url=base_url,
     )
-    endpoint_map = build_endpoints(endpoints=endpoints, base_url=base_url, public_url=public_url, ui_url=ui_url)
+    endpoint_map = build_endpoints(
+        endpoints=endpoints,
+        base_url=base_url,
+        public_url=public_url,
+        ui_url=ui_url,
+        target_gateway_url=target_gateway_url,
+    )
     proof = health_details.get("topology_proof") if isinstance(health_details, dict) else None
 
     if normalized_deployment == "sidecar" or normalized_topology == "same-pod":

--- a/control-plane-api/tests/test_regression_gateway_url_contract.py
+++ b/control-plane-api/tests/test_regression_gateway_url_contract.py
@@ -1,0 +1,96 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from src.schemas.gateway import GatewayInstanceResponse
+from src.services.gateway_topology import build_endpoints, endpoint_value
+
+
+def _gateway_payload(**overrides):
+    now = datetime(2026, 5, 1, tzinfo=UTC)
+    payload = {
+        "id": uuid4(),
+        "name": "stoa-link-wm-prod-sidecar-production",
+        "display_name": "STOA Link webMethods",
+        "gateway_type": "stoa_sidecar",
+        "environment": "production",
+        "tenant_id": None,
+        "base_url": "http://stoa-link-wm.stoa-dataplane.svc.cluster.local:8080",
+        "target_gateway_url": None,
+        "public_url": None,
+        "ui_url": None,
+        "endpoints": {},
+        "deployment_mode": None,
+        "target_gateway_type": None,
+        "topology": None,
+        "auth_config": {},
+        "status": "online",
+        "last_health_check": now,
+        "health_details": {},
+        "capabilities": [],
+        "version": "0.1.0",
+        "tags": ["mode:sidecar"],
+        "mode": "sidecar",
+        "protected": False,
+        "enabled": True,
+        "visibility": None,
+        "source": "self_register",
+        "deleted_at": None,
+        "deleted_by": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_endpoint_aliases_are_exposed_as_canonical_urls():
+    endpoints = build_endpoints(
+        endpoints={
+            "publicUrl": "https://runtime.example.com",
+            "uiUrl": "https://ui.example.com",
+            "targetGatewayUrl": "https://target.example.com",
+        },
+        base_url="http://gateway.stoa-system.svc.cluster.local:8080",
+    )
+
+    assert endpoint_value(endpoints, "public_url") == "https://runtime.example.com"
+    assert endpoint_value(endpoints, "ui_url") == "https://ui.example.com"
+    assert endpoint_value(endpoints, "target_gateway_url") == "https://target.example.com"
+    assert endpoints["internal_url"] == "http://gateway.stoa-system.svc.cluster.local:8080"
+
+
+def test_gateway_response_backfills_top_level_urls_from_endpoints():
+    gateway = GatewayInstanceResponse.model_validate(
+        _gateway_payload(
+            endpoints={
+                "publicUrl": "https://wm-runtime.gostoa.dev",
+                "uiUrl": "https://wm-ui.gostoa.dev",
+                "targetGatewayUrl": "https://vps-wm.gostoa.dev",
+            }
+        )
+    )
+
+    assert gateway.public_url == "https://wm-runtime.gostoa.dev"
+    assert gateway.ui_url == "https://wm-ui.gostoa.dev"
+    assert gateway.target_gateway_url == "https://vps-wm.gostoa.dev"
+    assert gateway.endpoints["public_url"] == "https://wm-runtime.gostoa.dev"
+    assert gateway.endpoints["ui_url"] == "https://wm-ui.gostoa.dev"
+    assert gateway.endpoints["target_gateway_url"] == "https://vps-wm.gostoa.dev"
+
+
+def test_top_level_urls_override_stale_endpoint_values():
+    gateway = GatewayInstanceResponse.model_validate(
+        _gateway_payload(
+            public_url="https://wm-runtime.gostoa.dev",
+            ui_url="https://wm-ui.gostoa.dev",
+            endpoints={
+                "public_url": "https://stale-runtime.gostoa.dev",
+                "ui_url": "https://stale-ui.gostoa.dev",
+            },
+        )
+    )
+
+    assert gateway.public_url == "https://wm-runtime.gostoa.dev"
+    assert gateway.ui_url == "https://wm-ui.gostoa.dev"
+    assert gateway.endpoints["public_url"] == "https://wm-runtime.gostoa.dev"
+    assert gateway.endpoints["ui_url"] == "https://wm-ui.gostoa.dev"

--- a/control-plane-ui/src/pages/Gateways/GatewayList.test.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayList.test.tsx
@@ -74,6 +74,36 @@ const { mockGateways } = vi.hoisted(() => ({
       created_at: '2024-03-01T00:00:00Z',
       updated_at: '2024-03-11T00:00:00Z',
     },
+    {
+      id: 'gw-4',
+      name: 'connect-webmethods-connect-production',
+      display_name: 'STOA Connect webMethods',
+      gateway_type: 'stoa',
+      environment: 'production',
+      base_url: 'http://localhost:8080',
+      target_gateway_url: null,
+      public_url: null,
+      ui_url: null,
+      endpoints: {
+        publicUrl: 'https://wm-runtime.gostoa.dev',
+        uiUrl: 'https://wm-ui.gostoa.dev',
+        targetGatewayUrl: 'https://vps-wm.gostoa.dev',
+      },
+      deployment_mode: 'connect',
+      target_gateway_type: 'webmethods',
+      topology: 'remote-agent',
+      auth_config: {},
+      status: 'online',
+      last_health_check: new Date().toISOString(),
+      health_details: {},
+      capabilities: ['rest'],
+      tags: ['auto-registered'],
+      source: 'self_register',
+      mode: 'connect',
+      version: '0.1.0',
+      created_at: '2024-03-01T00:00:00Z',
+      updated_at: '2024-03-11T00:00:00Z',
+    },
   ],
 }));
 
@@ -102,7 +132,7 @@ vi.mock('../../services/api', () => ({
   apiService: {
     getGatewayInstances: vi.fn().mockResolvedValue({
       items: mockGateways,
-      total: 3,
+      total: 4,
     }),
     checkGatewayHealth: vi.fn().mockResolvedValue({ status: 'online' }),
     deleteGatewayInstance: vi.fn().mockResolvedValue(undefined),
@@ -205,7 +235,7 @@ describe('GatewayList', () => {
   it('renders the gateway type labels', async () => {
     renderGatewayList();
     expect(await screen.findByText('STOA Edge MCP')).toBeInTheDocument();
-    expect(screen.getByText('webMethods')).toBeInTheDocument();
+    expect(screen.getAllByText('webMethods').length).toBeGreaterThanOrEqual(1);
   });
 
   it('renders gateway base URLs (protocol stripped)', async () => {
@@ -214,6 +244,25 @@ describe('GatewayList', () => {
     // New UI strips protocol from URLs in the row view
     expect(screen.getByText('mcp.gostoa.dev')).toBeInTheDocument();
     expect(screen.getByText('wm.example.com')).toBeInTheDocument();
+  });
+
+  it('renders external runtime, UI, and target URLs from endpoint aliases', async () => {
+    renderGatewayList();
+    expect(await screen.findByText('STOA Connect webMethods')).toBeInTheDocument();
+
+    expect(screen.getByText('wm-runtime.gostoa.dev')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /runtime/i })).toHaveAttribute(
+      'href',
+      'https://wm-runtime.gostoa.dev'
+    );
+    expect(screen.getByRole('link', { name: /^ui/i })).toHaveAttribute(
+      'href',
+      'https://wm-ui.gostoa.dev'
+    );
+    expect(screen.getByRole('link', { name: /target/i })).toHaveAttribute(
+      'href',
+      'https://vps-wm.gostoa.dev'
+    );
   });
 
   it('renders status dot with title for live gateway', async () => {

--- a/control-plane-ui/src/pages/Gateways/GatewayList.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayList.tsx
@@ -188,6 +188,95 @@ function timeAgo(dateStr: string): string {
   return `${Math.floor(hrs / 24)}d ago`;
 }
 
+const ENDPOINT_ALIASES: Record<string, string[]> = {
+  public_url: ['public_url', 'publicUrl', 'public', 'runtime_url', 'runtimeUrl', 'external_url'],
+  ui_url: ['ui_url', 'uiUrl', 'console_url', 'consoleUrl', 'web_ui_url', 'webUiUrl'],
+  target_gateway_url: ['target_gateway_url', 'targetGatewayUrl', 'target_url', 'targetUrl'],
+  admin_url: ['admin_url', 'adminUrl', 'admin', 'base_url', 'baseUrl'],
+  internal_url: ['internal_url', 'internalUrl', 'internal'],
+};
+
+type GatewayUrls = {
+  publicUrl: string | null;
+  uiUrl: string | null;
+  targetUrl: string | null;
+  baseUrl: string | null;
+  primaryUrl: string | null;
+};
+
+function cleanUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function endpointValue(gw: GatewayInstance, canonicalKey: string): string | null {
+  const endpoints = gw.endpoints ?? {};
+  for (const key of ENDPOINT_ALIASES[canonicalKey] ?? [canonicalKey]) {
+    const value = cleanUrl(endpoints[key]);
+    if (value) return value;
+  }
+  return null;
+}
+
+function isInternalUrl(value: string): boolean {
+  if (!/^https?:\/\//i.test(value)) return true;
+  try {
+    const host = new URL(value).hostname.toLowerCase();
+    return (
+      host === 'localhost' ||
+      host === '127.0.0.1' ||
+      host === '0.0.0.0' ||
+      host.endsWith('.svc') ||
+      host.includes('.svc.cluster.local') ||
+      host.endsWith('.cluster.local')
+    );
+  } catch {
+    return true;
+  }
+}
+
+function externalUrl(value: unknown): string | null {
+  const url = cleanUrl(value);
+  return url && !isInternalUrl(url) ? url : null;
+}
+
+function displayUrl(value: string | null): string {
+  return value?.replace(/^https?:\/\//, '') ?? '--';
+}
+
+function gatewayUrls(gw: GatewayInstance): GatewayUrls {
+  const publicUrl = externalUrl(gw.public_url) ?? externalUrl(endpointValue(gw, 'public_url'));
+  const uiUrl = externalUrl(gw.ui_url) ?? externalUrl(endpointValue(gw, 'ui_url'));
+  const targetUrl =
+    externalUrl(gw.target_gateway_url) ?? externalUrl(endpointValue(gw, 'target_gateway_url'));
+  const baseUrl = cleanUrl(gw.base_url) ?? endpointValue(gw, 'admin_url');
+  const externalBaseUrl = baseUrl ? externalUrl(baseUrl) : null;
+
+  return {
+    publicUrl,
+    uiUrl,
+    targetUrl,
+    baseUrl,
+    primaryUrl: publicUrl ?? targetUrl ?? uiUrl ?? externalBaseUrl ?? baseUrl,
+  };
+}
+
+function gatewayExternalLinks(
+  urls: GatewayUrls
+): { label: string; href: string; icon: typeof Zap }[] {
+  const seen = new Set<string>();
+  return [
+    { label: 'Runtime', href: urls.publicUrl, icon: Zap },
+    { label: 'UI', href: urls.uiUrl, icon: Globe },
+    { label: 'Target', href: urls.targetUrl, icon: Server },
+  ].flatMap((link) => {
+    if (!link.href || seen.has(link.href)) return [];
+    seen.add(link.href);
+    return [{ ...link, href: link.href }];
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Main Component
 // ---------------------------------------------------------------------------
@@ -685,6 +774,8 @@ function GatewayRow({
   const modeLabel = deploymentLabel(gw);
   const target = targetLabel(gw, typeInfo.label);
   const topology = topologyLabel(gw);
+  const urls = gatewayUrls(gw);
+  const links = gatewayExternalLinks(urls);
 
   return (
     <div
@@ -764,37 +855,25 @@ function GatewayRow({
           )}
           <span className="text-neutral-300 dark:text-neutral-600">&middot;</span>
           <span className="text-xs font-mono text-neutral-400 dark:text-neutral-500 truncate">
-            {gw.base_url.replace(/^https?:\/\//, '')}
+            {displayUrl(urls.primaryUrl)}
           </span>
         </div>
-        {(gw.ui_url || gw.public_url) && (
+        {links.length > 0 && (
           <div className="flex items-center gap-3 mt-0.5">
-            {gw.ui_url && (
+            {links.map(({ label, href, icon: LinkIcon }) => (
               <a
-                href={gw.ui_url}
+                key={`${label}-${href}`}
+                href={href}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-[11px] text-blue-600 dark:text-blue-400 hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
-                <Globe className="w-3 h-3" />
-                UI
+                <LinkIcon className="w-3 h-3" />
+                {label}
                 <ExternalLink className="w-2.5 h-2.5" />
               </a>
-            )}
-            {gw.public_url && (
-              <a
-                href={gw.public_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-[11px] text-blue-600 dark:text-blue-400 hover:underline"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Zap className="w-3 h-3" />
-                Runtime
-                <ExternalLink className="w-2.5 h-2.5" />
-              </a>
-            )}
+            ))}
           </div>
         )}
       </div>
@@ -894,6 +973,7 @@ function GatewayDetailPanel({
   const modeLabel = deploymentLabel(gw);
   const target = targetLabel(gw, typeInfo.label);
   const topology = topologyLabel(gw);
+  const urls = gatewayUrls(gw);
 
   return (
     <div
@@ -996,55 +1076,14 @@ function GatewayDetailPanel({
               <DetailRow label="Name" value={gw.name} mono />
               <DetailRow label="Type" value={typeInfo.label} />
               <DetailRow label="Environment" value={gw.environment} />
-              <DetailRow
-                label="Base URL"
-                value={
-                  <a
-                    href={gw.base_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline truncate max-w-[220px]"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    {gw.base_url.replace(/^https?:\/\//, '')}
-                    <ExternalLink className="w-3 h-3 flex-shrink-0" />
-                  </a>
-                }
-              />
-              {gw.target_gateway_url && (
-                <DetailRow
-                  label="Target Gateway"
-                  value={
-                    <a
-                      href={gw.target_gateway_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline truncate max-w-[220px]"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      {gw.target_gateway_url.replace(/^https?:\/\//, '')}
-                      <ExternalLink className="w-3 h-3 flex-shrink-0" />
-                    </a>
-                  }
-                />
+              <DetailRow label="Base URL" value={<UrlValue url={urls.baseUrl} />} />
+              {urls.publicUrl && (
+                <DetailRow label="Runtime URL" value={<UrlValue url={urls.publicUrl} />} />
               )}
-              {gw.ui_url && (
-                <DetailRow
-                  label="Gateway UI"
-                  value={
-                    <a
-                      href={gw.ui_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline truncate max-w-[220px]"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      {gw.ui_url.replace(/^https?:\/\//, '')}
-                      <ExternalLink className="w-3 h-3 flex-shrink-0" />
-                    </a>
-                  }
-                />
+              {urls.targetUrl && (
+                <DetailRow label="Target Gateway" value={<UrlValue url={urls.targetUrl} />} />
               )}
+              {urls.uiUrl && <DetailRow label="Gateway UI" value={<UrlValue url={urls.uiUrl} />} />}
               {gw.source && (
                 <DetailRow
                   label="Source"
@@ -1156,5 +1195,29 @@ function DetailRow({
         {value}
       </dd>
     </div>
+  );
+}
+
+function UrlValue({ url }: { url: string | null }) {
+  const href = url ? externalUrl(url) : null;
+  if (!url) return <span className="text-neutral-400">--</span>;
+  if (!href) {
+    return (
+      <span className="font-mono text-xs text-neutral-500 dark:text-neutral-400">
+        {displayUrl(url)}
+      </span>
+    );
+  }
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline truncate max-w-[220px]"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {displayUrl(href)}
+      <ExternalLink className="w-3 h-3 flex-shrink-0" />
+    </a>
   );
 }

--- a/control-plane-ui/src/pages/Gateways/__snapshots__/GatewayList.test.tsx.snap
+++ b/control-plane-ui/src/pages/Gateways/__snapshots__/GatewayList.test.tsx.snap
@@ -6,10 +6,11 @@ exports[`GatewayList > snapshot: cpi-admin persona > matches structural snapshot
     "Show deleted",
     "Refresh",
     "+ Register Gateway",
-    "All32",
-    "Production22",
+    "All43",
+    "Production33",
     "Staging101",
     "Development0",
+    "",
     "",
     "",
     "",
@@ -34,6 +35,18 @@ exports[`GatewayList > snapshot: cpi-admin persona > matches structural snapshot
     {
       "href": "/drift",
       "text": "Config Sync",
+    },
+    {
+      "href": "https://wm-runtime.gostoa.dev",
+      "text": "Runtime",
+    },
+    {
+      "href": "https://wm-ui.gostoa.dev",
+      "text": "UI",
+    },
+    {
+      "href": "https://vps-wm.gostoa.dev",
+      "text": "Target",
     },
   ],
 }
@@ -44,10 +57,11 @@ exports[`GatewayList > snapshot: devops persona > matches structural snapshot 1`
   "buttons": [
     "Refresh",
     "+ Register Gateway",
-    "All32",
-    "Production22",
+    "All43",
+    "Production33",
     "Staging101",
     "Development0",
+    "",
     "",
     "",
     "",
@@ -72,6 +86,18 @@ exports[`GatewayList > snapshot: devops persona > matches structural snapshot 1`
     {
       "href": "/drift",
       "text": "Config Sync",
+    },
+    {
+      "href": "https://wm-runtime.gostoa.dev",
+      "text": "Runtime",
+    },
+    {
+      "href": "https://wm-ui.gostoa.dev",
+      "text": "UI",
+    },
+    {
+      "href": "https://vps-wm.gostoa.dev",
+      "text": "Target",
     },
   ],
 }
@@ -82,10 +108,11 @@ exports[`GatewayList > snapshot: tenant-admin persona > matches structural snaps
   "buttons": [
     "Refresh",
     "+ Register Gateway",
-    "All32",
-    "Production22",
+    "All43",
+    "Production33",
     "Staging101",
     "Development0",
+    "",
     "",
     "",
     "",
@@ -110,6 +137,18 @@ exports[`GatewayList > snapshot: tenant-admin persona > matches structural snaps
     {
       "href": "/drift",
       "text": "Config Sync",
+    },
+    {
+      "href": "https://wm-runtime.gostoa.dev",
+      "text": "Runtime",
+    },
+    {
+      "href": "https://wm-ui.gostoa.dev",
+      "text": "UI",
+    },
+    {
+      "href": "https://vps-wm.gostoa.dev",
+      "text": "Target",
     },
   ],
 }
@@ -120,10 +159,11 @@ exports[`GatewayList > snapshot: viewer persona > matches structural snapshot 1`
   "buttons": [
     "Refresh",
     "+ Register Gateway",
-    "All32",
-    "Production22",
+    "All43",
+    "Production33",
     "Staging101",
     "Development0",
+    "",
     "",
     "",
     "",
@@ -148,6 +188,18 @@ exports[`GatewayList > snapshot: viewer persona > matches structural snapshot 1`
     {
       "href": "/drift",
       "text": "Config Sync",
+    },
+    {
+      "href": "https://wm-runtime.gostoa.dev",
+      "text": "Runtime",
+    },
+    {
+      "href": "https://wm-ui.gostoa.dev",
+      "text": "UI",
+    },
+    {
+      "href": "https://vps-wm.gostoa.dev",
+      "text": "Target",
     },
   ],
 }

--- a/stoa-gateway/src/config.rs
+++ b/stoa-gateway/src/config.rs
@@ -306,6 +306,12 @@ pub struct Config {
     #[serde(default)]
     pub gateway_public_url: Option<String>,
 
+    /// Web UI URL of the third-party gateway managed by this Link/sidecar instance.
+    /// Sent to Control Plane during auto-registration for Console display.
+    /// Env: STOA_GATEWAY_UI_URL
+    #[serde(default)]
+    pub gateway_ui_url: Option<String>,
+
     /// Canonical deployment mode sent to the Control Plane.
     /// Separate from `gateway_mode`: a runtime can expose sidecar routes while
     /// being deployed as a remote-agent topology.
@@ -945,6 +951,7 @@ impl fmt::Debug for Config {
             .field("heartbeat_interval_secs", &self.heartbeat_interval_secs)
             .field("target_gateway_url", &self.target_gateway_url)
             .field("gateway_public_url", &self.gateway_public_url)
+            .field("gateway_ui_url", &self.gateway_ui_url)
             .field("deployment_mode", &self.deployment_mode)
             .field("target_gateway_type", &self.target_gateway_type)
             .field("topology", &self.topology)

--- a/stoa-gateway/src/config/defaults.rs
+++ b/stoa-gateway/src/config/defaults.rs
@@ -341,6 +341,7 @@ impl Default for Config {
             heartbeat_interval_secs: default_heartbeat_interval(),
             target_gateway_url: None,
             gateway_public_url: None,
+            gateway_ui_url: None,
             deployment_mode: None,
             target_gateway_type: None,
             topology: None,

--- a/stoa-gateway/src/config/snapshots/stoa_gateway__config__tests__snapshot_default_config.snap
+++ b/stoa-gateway/src/config/snapshots/stoa_gateway__config__tests__snapshot_default_config.snap
@@ -57,6 +57,7 @@ expression: "Config::default()"
   "heartbeat_interval_secs": 30,
   "target_gateway_url": null,
   "gateway_public_url": null,
+  "gateway_ui_url": null,
   "deployment_mode": null,
   "target_gateway_type": null,
   "topology": null,

--- a/stoa-gateway/src/config/tests.rs
+++ b/stoa-gateway/src/config/tests.rs
@@ -26,6 +26,9 @@ fn test_default_gateway_mode() {
 #[test]
 fn test_default_topology_registration_fields_absent() {
     let config = Config::default();
+    assert!(config.target_gateway_url.is_none());
+    assert!(config.gateway_public_url.is_none());
+    assert!(config.gateway_ui_url.is_none());
     assert!(config.deployment_mode.is_none());
     assert!(config.target_gateway_type.is_none());
     assert!(config.topology.is_none());

--- a/stoa-gateway/src/control_plane/registration.rs
+++ b/stoa-gateway/src/control_plane/registration.rs
@@ -62,6 +62,10 @@ pub struct RegistrationPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub public_url: Option<String>,
 
+    /// Web UI URL of the third-party gateway managed by this Link instance
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ui_url: Option<String>,
+
     /// Canonical deployment topology mode (edge, connect, sidecar)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deployment_mode: Option<String>,
@@ -203,6 +207,7 @@ impl GatewayRegistrar {
             tenant_id: None, // Platform-wide gateway
             target_gateway_url: config.target_gateway_url.clone(),
             public_url: config.gateway_public_url.clone(),
+            ui_url: config.gateway_ui_url.clone(),
             deployment_mode: config.deployment_mode.clone(),
             target_gateway_type: config.target_gateway_type.clone(),
             topology: config.topology.clone(),
@@ -514,6 +519,7 @@ mod tests {
             tenant_id: None,
             target_gateway_url: None,
             public_url: None,
+            ui_url: None,
             deployment_mode: None,
             target_gateway_type: None,
             topology: None,
@@ -526,6 +532,7 @@ mod tests {
         assert!(!json.contains("tenant_id")); // None should be skipped
         assert!(!json.contains("target_gateway_url")); // None should be skipped
         assert!(!json.contains("public_url")); // None should be skipped
+        assert!(!json.contains("ui_url")); // None should be skipped
         assert!(!json.contains("deployment_mode")); // None should be skipped
     }
 
@@ -541,6 +548,7 @@ mod tests {
             tenant_id: Some("acme".to_string()),
             target_gateway_url: Some("https://webmethods-prod:5555".to_string()),
             public_url: Some("https://vps-wm-link.gostoa.dev".to_string()),
+            ui_url: Some("https://vps-wm-ui.gostoa.dev".to_string()),
             deployment_mode: Some("connect".to_string()),
             target_gateway_type: Some("webmethods".to_string()),
             topology: Some("remote-agent".to_string()),
@@ -554,6 +562,8 @@ mod tests {
         assert!(json.contains("webmethods-prod:5555"));
         assert!(json.contains("public_url"));
         assert!(json.contains("vps-wm-link.gostoa.dev"));
+        assert!(json.contains("ui_url"));
+        assert!(json.contains("vps-wm-ui.gostoa.dev"));
         assert!(json.contains("deployment_mode"));
         assert!(json.contains("remote-agent"));
     }


### PR DESCRIPTION
## Summary\n- normalize gateway endpoint URL aliases and backfill public/ui/target URLs in API responses\n- show Runtime/UI/Target links in the Console from top-level fields or endpoints\n- include ui_url in Rust gateway auto-registration\n\n## Tests\n- pytest -q tests/test_gateway_url_contract.py && ruff check src/schemas/gateway.py src/services/gateway_topology.py tests/test_gateway_url_contract.py\n- npx vitest run GatewayList.test.tsx\n- npm run build\n- cargo test registration_payload && cargo test test_default_topology_registration_fields_absent