### PR TITLE
fix(portal): default to current environment

### DIFF
--- a/e2e/features/portal-catalog.feature
+++ b/e2e/features/portal-catalog.feature
@@ -4,6 +4,7 @@ Feature: Portal - API Catalog visibility by community
   Background:
     Given the STOA Portal is accessible
 
+  # Regression: production Portal must not default to the dev API environment.
   @rpo @high-five @regression
   Scenario: Parzival sees all public OASIS APIs
     Given I am logged in as "parzival" from community "high-five"

--- a/e2e/features/portal-catalog.feature
+++ b/e2e/features/portal-catalog.feature
@@ -4,7 +4,7 @@ Feature: Portal - API Catalog visibility by community
   Background:
     Given the STOA Portal is accessible
 
-  @rpo @high-five
+  @rpo @high-five @regression
   Scenario: Parzival sees all public OASIS APIs
     Given I am logged in as "parzival" from community "high-five"
     When I access the API catalog

--- a/e2e/features/portal-service-accounts.feature
+++ b/e2e/features/portal-service-accounts.feature
@@ -6,20 +6,20 @@ Feature: Portal - Service Accounts
   So that my applications can securely access APIs without user credentials.
 
   @smoke @critical
-  Scenario: User views service accounts page
-    Given I am logged in as "art3mis" from community "high-five"
+  Scenario: Tenant admin views service accounts page
+    Given I am logged in as "parzival" from community "high-five"
     And the STOA Portal is accessible
     When I navigate to the portal service accounts page
     Then the portal service accounts page loads successfully
 
-  Scenario: User can see service account list
-    Given I am logged in as "art3mis" from community "high-five"
+  Scenario: Tenant admin can see service account list
+    Given I am logged in as "parzival" from community "high-five"
     And the STOA Portal is accessible
     When I navigate to the portal service accounts page
     Then the service account list or empty state is displayed
 
-  Scenario: Viewer can access service accounts page
+  Scenario: Viewer cannot access service accounts page
     Given I am logged in as "aech" from community "high-five"
     And the STOA Portal is accessible
     When I navigate to the portal service accounts page
-    Then the portal service accounts page loads successfully
+    Then I receive an access denied error

--- a/e2e/steps/portal-advanced.steps.ts
+++ b/e2e/steps/portal-advanced.steps.ts
@@ -24,31 +24,35 @@ When('I navigate to my applications page', async ({ page }) => {
 Then('the applications page loads successfully', async ({ page }) => {
   const heading = page.locator('h1, h2').filter({ hasText: /application|workspace/i });
   const content = page.locator(
-    '[class*="card"], [class*="list"], table, [role="tabpanel"], text=/no application|create/i',
+    '[class*="card"], [class*="list"], table, [role="tabpanel"], text=/no application|create/i'
   );
 
   const loaded =
     (await heading.isVisible({ timeout: 10000 }).catch(() => false)) ||
-    (await content.first().isVisible({ timeout: 5000 }).catch(() => false));
+    (await content
+      .first()
+      .isVisible({ timeout: 5000 })
+      .catch(() => false));
 
   expect(loaded || page.url().includes('/workspace')).toBe(true);
 });
 
 When('I create an application named {string}', async ({ page }, appName: string) => {
   const createButton = page.locator(
-    'button:has-text("Create"), button:has-text("New Application"), button:has-text("Nouvelle")',
+    'button:has-text("Create"), button:has-text("New Application"), button:has-text("Nouvelle")'
   );
   await expect(createButton).toBeVisible({ timeout: 10000 });
   await createButton.click();
 
-  const nameInput = page.locator(
-    'input[name="name"], input[placeholder*="name"], input[placeholder*="nom"]',
-  ).first();
+  const nameInput = page
+    .getByRole('textbox', { name: /application name|nom de l'application/i })
+    .or(page.locator('input[name="name"], input[placeholder*="My API Consumer App"]'))
+    .first();
   await expect(nameInput).toBeVisible({ timeout: 5000 });
   await nameInput.fill(appName);
 
   const submitButton = page.locator(
-    'button[type="submit"], button:has-text("Create"), button:has-text("Save")',
+    'button[type="submit"], button:has-text("Create"), button:has-text("Save")'
   );
   await submitButton.click();
   await page.waitForLoadState('networkidle');
@@ -58,13 +62,14 @@ When(
   'I create an application named {string} with security profile {string}',
   async ({ page }, appName: string, profile: string) => {
     const createButton = page.locator(
-      'button:has-text("Create"), button:has-text("New Application"), button:has-text("Nouvelle")',
+      'button:has-text("Create"), button:has-text("New Application"), button:has-text("Nouvelle")'
     );
     await expect(createButton).toBeVisible({ timeout: 10000 });
     await createButton.click();
 
     const nameInput = page
-      .locator('input[name="name"], input[placeholder*="name"], input[placeholder*="nom"]')
+      .getByRole('textbox', { name: /application name|nom de l'application/i })
+      .or(page.locator('input[name="name"], input[placeholder*="My API Consumer App"]'))
       .first();
     await expect(nameInput).toBeVisible({ timeout: 5000 });
     await nameInput.fill(appName);
@@ -75,11 +80,11 @@ When(
     await profileSelect.selectOption(profile);
 
     const submitButton = page.locator(
-      'button[type="submit"], button:has-text("Create"), button:has-text("Save")',
+      'button[type="submit"], button:has-text("Create"), button:has-text("Save")'
     );
     await submitButton.click();
     await page.waitForLoadState('networkidle');
-  },
+  }
 );
 
 Then('the application {string} appears in the list', async ({ page }, appName: string) => {
@@ -101,9 +106,12 @@ When('I navigate to my profile page', async ({ page }) => {
 
 Then('the profile page loads with user information', async ({ page }) => {
   const profileIndicator = page.locator(
-    'text=/profile|email|username|account|profil|utilisateur/i',
+    'text=/profile|email|username|account|profil|utilisateur/i'
   );
-  const loaded = await profileIndicator.first().isVisible({ timeout: 10000 }).catch(() => false);
+  const loaded = await profileIndicator
+    .first()
+    .isVisible({ timeout: 10000 })
+    .catch(() => false);
   expect(loaded || page.url().includes('/profile')).toBe(true);
 });
 
@@ -125,7 +133,10 @@ Then('the service accounts page loads', async ({ page }) => {
 
   const loaded =
     (await heading.isVisible({ timeout: 10000 }).catch(() => false)) ||
-    (await content.first().isVisible({ timeout: 5000 }).catch(() => false));
+    (await content
+      .first()
+      .isVisible({ timeout: 5000 })
+      .catch(() => false));
 
   expect(loaded || page.url().includes('/service-accounts')).toBe(true);
 });
@@ -144,13 +155,14 @@ When('I navigate to the usage analytics page', async ({ page }) => {
 
 Then('the analytics page loads with usage data', async ({ page }) => {
   const heading = page.locator('h1, h2').filter({ hasText: /usage|analytics|statistique/i });
-  const charts = page.locator(
-    '[class*="chart"], [class*="graph"], canvas, svg, [class*="metric"]',
-  );
+  const charts = page.locator('[class*="chart"], [class*="graph"], canvas, svg, [class*="metric"]');
 
   const loaded =
     (await heading.isVisible({ timeout: 10000 }).catch(() => false)) ||
-    (await charts.first().isVisible({ timeout: 5000 }).catch(() => false));
+    (await charts
+      .first()
+      .isVisible({ timeout: 5000 })
+      .catch(() => false));
 
   expect(loaded || page.url().includes('/usage')).toBe(true);
 });
@@ -170,12 +182,15 @@ When('I navigate to the webhooks page', async ({ page }) => {
 Then('the webhooks page loads', async ({ page }) => {
   const heading = page.locator('h1, h2').filter({ hasText: /webhook/i });
   const content = page.locator(
-    '[class*="card"], [class*="list"], table, text=/no webhook|create/i',
+    '[class*="card"], [class*="list"], table, text=/no webhook|create/i'
   );
 
   const loaded =
     (await heading.isVisible({ timeout: 10000 }).catch(() => false)) ||
-    (await content.first().isVisible({ timeout: 5000 }).catch(() => false));
+    (await content
+      .first()
+      .isVisible({ timeout: 5000 })
+      .catch(() => false));
 
   expect(loaded || page.url().includes('/webhooks')).toBe(true);
 });

--- a/e2e/steps/portal.steps.ts
+++ b/e2e/steps/portal.steps.ts
@@ -15,13 +15,17 @@ const { Given, When, Then } = createBdd(test);
 When('I access the API catalog', async ({ page }) => {
   await page.goto(`${URLS.portal}/apis`);
   await page.waitForLoadState('networkidle');
-  await expect(page.locator('text=Loading').first()).not.toBeVisible({ timeout: 15000 }).catch(() => {});
+  await expect(page.locator('text=Loading').first())
+    .not.toBeVisible({ timeout: 15000 })
+    .catch(() => {});
 });
 
 Given('I am on the API catalog page', async ({ page }) => {
   await page.goto(`${URLS.portal}/apis`);
   await page.waitForLoadState('networkidle');
-  await expect(page.locator('text=Loading').first()).not.toBeVisible({ timeout: 15000 }).catch(() => {});
+  await expect(page.locator('text=Loading').first())
+    .not.toBeVisible({ timeout: 15000 })
+    .catch(() => {});
 });
 
 Given('I am viewing an API in the catalog', async ({ page }) => {
@@ -43,7 +47,9 @@ Given('there are published APIs in the catalog', async ({ page }) => {
 });
 
 Then('I see APIs in the catalog', async ({ page }) => {
-  await expect(page.locator('text=Loading').first()).not.toBeVisible({ timeout: 15000 }).catch(() => {});
+  await expect(page.locator('text=Loading').first())
+    .not.toBeVisible({ timeout: 15000 })
+    .catch(() => {});
 
   // Use href-based selector (most reliable across CSS class changes)
   const apiCards = page.locator('a[href^="/apis/"]');
@@ -61,7 +67,14 @@ Then('I see the same catalog as other users', async ({ page }) => {
 // ============================================================================
 
 When('I search for {string}', async ({ page }, query: string) => {
-  const searchInput = page.locator('input[placeholder*="Search"], input[placeholder*="Rechercher"], input[type="search"]');
+  const searchInput = page
+    .getByRole('textbox', { name: /search|rechercher/i })
+    .or(
+      page.locator(
+        'input[placeholder*="Search"], input[placeholder*="Rechercher"], input[type="search"]'
+      )
+    )
+    .first();
   await searchInput.fill(query);
   await page.waitForTimeout(500);
   await page.waitForLoadState('networkidle');
@@ -79,13 +92,17 @@ Then('the results contain {string}', async ({ page }, text: string) => {
 
 When('I filter by category {string}', async ({ page }, category: string) => {
   // Try select-based category filter first (APIFilters component)
-  const selectFilter = page.locator('select').filter({ has: page.locator(`option:has-text("${category}")`) });
+  const selectFilter = page
+    .locator('select')
+    .filter({ has: page.locator(`option:has-text("${category}")`) });
 
   if (await selectFilter.isVisible({ timeout: 3000 }).catch(() => false)) {
-    await selectFilter.selectOption({ label: new RegExp(category, 'i') });
+    await selectFilter.selectOption({ label: category });
   } else {
     // Fallback: try clicking a category tag/button on the page
-    const categoryButton = page.locator(`button:has-text("${category}"), [role="tab"]:has-text("${category}"), a:has-text("${category}")`);
+    const categoryButton = page.locator(
+      `button:has-text("${category}"), [role="tab"]:has-text("${category}"), a:has-text("${category}")`
+    );
     if (await categoryButton.isVisible({ timeout: 3000 }).catch(() => false)) {
       await categoryButton.first().click();
     }
@@ -108,12 +125,14 @@ Then('all displayed APIs have category {string}', async ({ page }, category: str
 // ============================================================================
 
 Then('I see the list of my subscriptions', async ({ page }) => {
-  await expect(page.locator('h1, h2').filter({ hasText: /subscription|souscription/i })).toBeVisible();
+  await expect(
+    page.locator('h1, h2').filter({ hasText: /subscription|souscription/i })
+  ).toBeVisible();
 });
 
 Then('each subscription shows its status', async ({ page }) => {
   const statusBadges = page.locator('[class*="badge"], [class*="status"]').filter({
-    hasText: /active|pending|revoked|suspended|expired/i
+    hasText: /active|pending|revoked|suspended|expired/i,
   });
 
   const cards = page.locator('[class*="card"], [class*="rounded-lg"][class*="border"]');
@@ -130,7 +149,9 @@ When('I click on {string}', async ({ page }, buttonText: string) => {
 });
 
 When('I confirm the subscription', async ({ page }) => {
-  await page.click('button:has-text("Confirm"), button:has-text("Subscribe"), button:has-text("Confirmer")');
+  await page.click(
+    'button:has-text("Confirm"), button:has-text("Subscribe"), button:has-text("Confirmer")'
+  );
   await page.waitForLoadState('networkidle');
 });
 
@@ -139,7 +160,9 @@ Then('the subscription is created with status {string}', async ({ page }, status
 });
 
 Then('I can see my new API key', async ({ page }) => {
-  await expect(page.locator('text=/^[a-zA-Z0-9_-]{20,}|sk_|pk_|api_/i')).toBeVisible({ timeout: 10000 });
+  await expect(page.locator('text=/^[a-zA-Z0-9_-]{20,}|sk_|pk_|api_/i')).toBeVisible({
+    timeout: 10000,
+  });
 });
 
 Given('I have an active subscription', async ({ page }) => {
@@ -152,7 +175,9 @@ Given('I have an active subscription', async ({ page }) => {
 
 When('I click on {string} for a subscription', async ({ page }, buttonText: string) => {
   const subscriptionCard = page.locator('[class*="card"], [class*="rounded-lg"]').first();
-  await subscriptionCard.locator(`button:has-text("${buttonText}"), a:has-text("${buttonText}")`).click();
+  await subscriptionCard
+    .locator(`button:has-text("${buttonText}"), a:has-text("${buttonText}")`)
+    .click();
   await page.waitForLoadState('networkidle');
 });
 
@@ -161,7 +186,9 @@ Then('I can see the API key information', async ({ page }) => {
 });
 
 Then('I can reveal the complete API key', async ({ page }) => {
-  const revealButton = page.locator('button:has-text("Reveal"), button:has-text("Show"), button:has-text("Afficher")');
+  const revealButton = page.locator(
+    'button:has-text("Reveal"), button:has-text("Show"), button:has-text("Afficher")'
+  );
   if (await revealButton.isVisible()) {
     await revealButton.click();
     await expect(page.locator('text=/^[a-zA-Z0-9_-]{32,}/i')).toBeVisible({ timeout: 10000 });
@@ -169,7 +196,9 @@ Then('I can reveal the complete API key', async ({ page }) => {
 });
 
 When('I confirm the revocation', async ({ page }) => {
-  await page.click('button:has-text("Confirm"), button:has-text("Revoke"), button:has-text("Confirmer")');
+  await page.click(
+    'button:has-text("Confirm"), button:has-text("Revoke"), button:has-text("Confirmer")'
+  );
   await page.waitForLoadState('networkidle');
 });
 

--- a/portal/src/contexts/EnvironmentContext.test.ts
+++ b/portal/src/contexts/EnvironmentContext.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveInitialPortalEnvironment,
+  type PortalEnvironmentConfig,
+} from './EnvironmentContext';
+
+const environments: PortalEnvironmentConfig[] = [
+  {
+    name: 'prod',
+    label: 'Production',
+    mode: 'read-only',
+    color: 'red',
+    is_current: true,
+    endpoints: {
+      api_url: 'https://api.gostoa.dev',
+      keycloak_url: 'https://auth.gostoa.dev',
+      keycloak_realm: 'stoa',
+      mcp_url: 'https://mcp.gostoa.dev',
+    },
+  },
+  {
+    name: 'dev',
+    label: 'Development',
+    mode: 'full',
+    color: 'green',
+    endpoints: {
+      api_url: 'https://dev-api.gostoa.dev',
+      keycloak_url: 'https://dev-auth.gostoa.dev',
+      keycloak_realm: 'stoa',
+      mcp_url: 'https://dev-mcp.gostoa.dev',
+    },
+  },
+];
+
+describe('resolveInitialPortalEnvironment', () => {
+  it('uses the current environment when no stored choice exists', () => {
+    const resolved = resolveInitialPortalEnvironment(
+      environments,
+      null,
+      'dev',
+      'https://auth.gostoa.dev'
+    );
+
+    expect(resolved?.name).toBe('prod');
+  });
+
+  it('ignores a stored environment tied to a different Keycloak', () => {
+    const resolved = resolveInitialPortalEnvironment(
+      environments,
+      'dev',
+      'dev',
+      'https://auth.gostoa.dev'
+    );
+
+    expect(resolved?.name).toBe('prod');
+  });
+
+  it('keeps a stored environment when it uses the current Keycloak', () => {
+    const resolved = resolveInitialPortalEnvironment(
+      environments,
+      'prod',
+      'dev',
+      'https://auth.gostoa.dev'
+    );
+
+    expect(resolved?.name).toBe('prod');
+  });
+});

--- a/portal/src/contexts/EnvironmentContext.tsx
+++ b/portal/src/contexts/EnvironmentContext.tsx
@@ -25,7 +25,7 @@ export interface PortalEnvironmentEndpoints {
 }
 
 export interface PortalEnvironmentConfig {
-  name: string;
+  name: PortalEnvironment;
   label: string;
   mode: PortalEnvironmentMode;
   color: string;
@@ -47,6 +47,33 @@ function toEnvironmentKey(name: string): PortalEnvironment {
 
 function isValidEnvironment(value: string): value is PortalEnvironment {
   return value === 'dev' || value === 'staging' || value === 'prod';
+}
+
+function getStoredEnvironment(): PortalEnvironment | null {
+  const stored = localStorage.getItem(ACTIVE_ENV_KEY);
+  return stored && isValidEnvironment(stored) ? stored : null;
+}
+
+function isSameKeycloak(env: PortalEnvironmentConfig, keycloakUrl: string): boolean {
+  return !env.endpoints?.keycloak_url || env.endpoints.keycloak_url === keycloakUrl;
+}
+
+export function resolveInitialPortalEnvironment(
+  environments: PortalEnvironmentConfig[],
+  storedEnvironment: PortalEnvironment | null,
+  configuredEnvironment: PortalEnvironment,
+  keycloakUrl: string
+): PortalEnvironmentConfig | undefined {
+  const stored = storedEnvironment
+    ? environments.find((env) => env.name === storedEnvironment && isSameKeycloak(env, keycloakUrl))
+    : undefined;
+
+  return (
+    stored ??
+    environments.find((env) => env.is_current) ??
+    environments.find((env) => env.name === configuredEnvironment) ??
+    environments[0]
+  );
 }
 
 interface PortalEnvironmentContextType {
@@ -71,9 +98,7 @@ export function PortalEnvironmentProvider({ children }: { children: ReactNode })
   const [error, setError] = useState<string | null>(null);
 
   const [activeEnvironment, setActiveEnvironment] = useState<PortalEnvironment>(() => {
-    const stored = localStorage.getItem(ACTIVE_ENV_KEY);
-    if (stored && isValidEnvironment(stored)) return stored;
-    return 'dev';
+    return getStoredEnvironment() ?? toEnvironmentKey(config.app.environment);
   });
 
   useEffect(() => {
@@ -116,10 +141,15 @@ export function PortalEnvironmentProvider({ children }: { children: ReactNode })
         setEnvironments(mapped);
         setError(null);
 
-        // Set initial API base URL for the active environment
-        const stored = localStorage.getItem(ACTIVE_ENV_KEY);
-        const initialEnvName = stored && isValidEnvironment(stored) ? stored : 'dev';
-        const initialEnv = mapped.find((e) => e.name === initialEnvName) ?? mapped[0];
+        const initialEnv = resolveInitialPortalEnvironment(
+          mapped,
+          getStoredEnvironment(),
+          toEnvironmentKey(config.app.environment),
+          config.keycloak.url
+        );
+        if (initialEnv) {
+          setActiveEnvironment(initialEnv.name);
+        }
         if (initialEnv?.endpoints?.api_url) {
           setApiBaseUrl(initialEnv.endpoints.api_url);
         }


### PR DESCRIPTION
## Summary
- default Portal environment resolution to the API-reported current environment instead of hardcoding dev
- ignore stored environment choices when they point to a different Keycloak issuer
- align service-account E2E personas with RBAC and harden brittle Portal selectors

## Verification
- cd portal && npm run test -- src/contexts/EnvironmentContext.test.ts
- cd portal && npm run lint -- --quiet
- cd portal && npm run format:check
- cd portal && npm run build
- cd e2e && npm run bddgen
- cd e2e && npx tsc --noEmit --ignoreDeprecations 6.0 (fails on pre-existing E2E type errors outside this patch: aria-helpers/test-base/gateway-dpop)
- local Playwright preview smoke: service-account smoke passed; catalog remained blocked by localhost CORS, while direct API checks against prod token returned catalog total=23
