### PR TITLE
fix(stoa-connect): normalize webMethods externalDocs payload

### DIFF
--- a/stoa-go/internal/connect/adapters/webmethods_spec.go
+++ b/stoa-go/internal/connect/adapters/webmethods_spec.go
@@ -52,34 +52,39 @@ func downgradeOpenAPI31(spec []byte) []byte {
 	return safeMarshal(spec, parsed)
 }
 
-// wrapExternalDocs recursively walks any JSON value and wraps every
-// externalDocs single-object occurrence into a single-element array.
-// Returns true if any wrap was performed.
+// normalizeExternalDocs recursively walks any JSON value and normalizes
+// externalDocs to the mixed shape expected by webMethods imports.
+// Returns true if any normalization was performed.
 //
-// The recursion enters each map value and each array item, so nested
-// occurrences at arbitrary depth (tags[], paths[].<operation>,
-// components.schemas.<name>, Schema.properties.<field>, Schema.items,
-// Schema.{allOf|oneOf|anyOf}[*], even inside vendor extensions) are all
-// reached in one pass. Values that are already arrays, primitives, or null
+// webMethods expects the root RestAPI.externalDocs as a list, but nested OpenAPI
+// externalDocs fields (tags, operations, schemas) as a single object. Values
+// that are already in the expected shape, primitives, null, or multi-item arrays
 // are left untouched.
-func wrapExternalDocs(v interface{}) bool {
+func normalizeExternalDocs(v interface{}, root bool) bool {
 	modified := false
 	switch val := v.(type) {
 	case map[string]interface{}:
 		if ed, ok := val["externalDocs"]; ok {
-			if obj, isObj := ed.(map[string]interface{}); isObj {
-				val["externalDocs"] = []interface{}{obj}
-				modified = true
+			if root {
+				if obj, isObj := ed.(map[string]interface{}); isObj {
+					val["externalDocs"] = []interface{}{obj}
+					modified = true
+				}
+			} else if arr, isArr := ed.([]interface{}); isArr && len(arr) == 1 {
+				if obj, isObj := arr[0].(map[string]interface{}); isObj {
+					val["externalDocs"] = obj
+					modified = true
+				}
 			}
 		}
 		for _, child := range val {
-			if wrapExternalDocs(child) {
+			if normalizeExternalDocs(child, false) {
 				modified = true
 			}
 		}
 	case []interface{}:
 		for _, item := range val {
-			if wrapExternalDocs(item) {
+			if normalizeExternalDocs(item, false) {
 				modified = true
 			}
 		}
@@ -87,17 +92,13 @@ func wrapExternalDocs(v interface{}) bool {
 	return modified
 }
 
-// fixExternalDocs walks the full OpenAPI document and wraps every
-// externalDocs single-object occurrence into a single-element array.
-// webMethods expects externalDocs as an array at every level (root, tags[*],
-// paths[*].<operation>, components.schemas.<name>, nested Schemas via
-// allOf/oneOf/anyOf/items/properties.*/additionalProperties). OpenAPI and
-// Swagger specs default to a single object, which webMethods rejects with a
-// deserialization error on PUT.
+// fixExternalDocs walks the full OpenAPI document and keeps externalDocs in the
+// mixed shape accepted by webMethods. webMethods expects root externalDocs as a
+// list, but rejects list-shaped tag externalDocs while importing REST APIs.
 //
 // Closes GO-1 H.2 (BUG-REPORT-GO-1.md) — the previous implementation only
-// handled the root-level occurrence, letting FastAPI / Swaggerhub specs that
-// put externalDocs in tags[] or operations bubble up 500s on PUT.
+// handled the root-level occurrence, letting specs that put externalDocs in
+// tags[] or operations bubble up 500s on PUT.
 //
 // Malformed input (invalid JSON) is returned unchanged — defensive fallback.
 // If the walk produced no modification, the original bytes are returned to
@@ -107,7 +108,7 @@ func fixExternalDocs(spec []byte) []byte {
 	if err := json.Unmarshal(spec, &parsed); err != nil {
 		return spec
 	}
-	if !wrapExternalDocs(parsed) {
+	if !normalizeExternalDocs(parsed, true) {
 		return spec
 	}
 	return safeMarshal(spec, parsed)

--- a/stoa-go/internal/connect/adapters/webmethods_spec_external_docs_test.go
+++ b/stoa-go/internal/connect/adapters/webmethods_spec_external_docs_test.go
@@ -1,8 +1,6 @@
-// regression for CAB-1944 (GO-1 audit H.2 + H.1): fixExternalDocs must walk
-// the full OpenAPI tree (tags, operations, components.schemas and nested
-// schemas), not just the root. Also covers removal of the dead-code call
-// in webmethods_sync.go — the wrapper payload never carried externalDocs
-// at top level, so the previous post-marshal application was a no-op.
+// regression for webMethods OpenAPI import compatibility: fixExternalDocs must
+// walk the full OpenAPI tree (tags, operations, components.schemas and nested
+// schemas), not just the root.
 package adapters
 
 import (
@@ -22,6 +20,12 @@ func unmarshalTo(t *testing.T, data []byte) map[string]interface{} {
 	return m
 }
 
+// isObject returns true if v is a JSON object.
+func isObject(v interface{}) bool {
+	_, ok := v.(map[string]interface{})
+	return ok
+}
+
 // isArrayOfOneObject returns true if v is a []interface{} containing exactly
 // one map[string]interface{}.
 func isArrayOfOneObject(v interface{}) bool {
@@ -34,21 +38,21 @@ func isArrayOfOneObject(v interface{}) bool {
 }
 
 // ---------------------------------------------------------------------------
-// TestWebMethodsFixExternalDocs_TopLevel — baseline, preserves pre-GO-1
-// behaviour for specs whose only externalDocs lives at the root.
+// TestWebMethodsFixExternalDocs_TopLevel — webMethods expects root
+// externalDocs as a list on its RestAPI model.
 // ---------------------------------------------------------------------------
 func TestWebMethodsFixExternalDocs_TopLevel(t *testing.T) {
 	in := []byte(`{"openapi":"3.0.3","info":{"title":"t","version":"1"},"externalDocs":{"url":"https://a","description":"A"}}`)
 	out := fixExternalDocs(in)
 	m := unmarshalTo(t, out)
 	if !isArrayOfOneObject(m["externalDocs"]) {
-		t.Errorf("root externalDocs not wrapped: %v", m["externalDocs"])
+		t.Errorf("root externalDocs not normalized to one-object array: %v", m["externalDocs"])
 	}
 }
 
 // ---------------------------------------------------------------------------
-// TestWebMethodsFixExternalDocs_InTags — per-tag externalDocs must wrap;
-// tags that don't have externalDocs must be untouched.
+// TestWebMethodsFixExternalDocs_InTags — per-tag externalDocs must remain an
+// object; tags that don't have externalDocs must be untouched.
 // ---------------------------------------------------------------------------
 func TestWebMethodsFixExternalDocs_InTags(t *testing.T) {
 	in := []byte(`{"openapi":"3.0.3","info":{"title":"t","version":"1"},"tags":[{"name":"pets","externalDocs":{"url":"https://pets"}},{"name":"users"}],"paths":{}}`)
@@ -60,8 +64,8 @@ func TestWebMethodsFixExternalDocs_InTags(t *testing.T) {
 		t.Fatalf("expected 2 tags, got %v", m["tags"])
 	}
 	tag0 := tags[0].(map[string]interface{})
-	if !isArrayOfOneObject(tag0["externalDocs"]) {
-		t.Errorf("tag[0].externalDocs not wrapped: %v", tag0["externalDocs"])
+	if !isObject(tag0["externalDocs"]) {
+		t.Errorf("tag[0].externalDocs not normalized to object: %v", tag0["externalDocs"])
 	}
 	tag1 := tags[1].(map[string]interface{})
 	if _, has := tag1["externalDocs"]; has {
@@ -71,7 +75,7 @@ func TestWebMethodsFixExternalDocs_InTags(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // TestWebMethodsFixExternalDocs_InOperations — Operation Object externalDocs
-// (paths[*].<method>.externalDocs) must wrap.
+// (paths[*].<method>.externalDocs) must remain an object.
 // ---------------------------------------------------------------------------
 func TestWebMethodsFixExternalDocs_InOperations(t *testing.T) {
 	in := []byte(`{"openapi":"3.0.3","info":{"title":"t","version":"1"},"paths":{"/p":{"get":{"operationId":"g","externalDocs":{"url":"https://op"},"responses":{}}}}}`)
@@ -79,15 +83,16 @@ func TestWebMethodsFixExternalDocs_InOperations(t *testing.T) {
 	m := unmarshalTo(t, out)
 
 	op := m["paths"].(map[string]interface{})["/p"].(map[string]interface{})["get"].(map[string]interface{})
-	if !isArrayOfOneObject(op["externalDocs"]) {
-		t.Errorf("operation externalDocs not wrapped: %v", op["externalDocs"])
+	if !isObject(op["externalDocs"]) {
+		t.Errorf("operation externalDocs not normalized to object: %v", op["externalDocs"])
 	}
 }
 
 // ---------------------------------------------------------------------------
 // TestWebMethodsFixExternalDocs_InComponents — nested Schema externalDocs
 // (components.schemas.Pet.externalDocs and deep-nested
-// components.schemas.Pet.properties.owner.externalDocs) must both wrap.
+// components.schemas.Pet.properties.owner.externalDocs) must both remain
+// objects.
 // ---------------------------------------------------------------------------
 func TestWebMethodsFixExternalDocs_InComponents(t *testing.T) {
 	in := []byte(`{"openapi":"3.0.3","info":{"title":"t","version":"1"},"paths":{},"components":{"schemas":{"Pet":{"type":"object","externalDocs":{"url":"https://pet-doc"},"properties":{"owner":{"type":"object","externalDocs":{"url":"https://owner-doc"}}}}}}}`)
@@ -95,20 +100,20 @@ func TestWebMethodsFixExternalDocs_InComponents(t *testing.T) {
 	m := unmarshalTo(t, out)
 
 	pet := m["components"].(map[string]interface{})["schemas"].(map[string]interface{})["Pet"].(map[string]interface{})
-	if !isArrayOfOneObject(pet["externalDocs"]) {
-		t.Errorf("Pet.externalDocs not wrapped: %v", pet["externalDocs"])
+	if !isObject(pet["externalDocs"]) {
+		t.Errorf("Pet.externalDocs not normalized to object: %v", pet["externalDocs"])
 	}
 	owner := pet["properties"].(map[string]interface{})["owner"].(map[string]interface{})
-	if !isArrayOfOneObject(owner["externalDocs"]) {
-		t.Errorf("Pet.properties.owner.externalDocs not wrapped: %v", owner["externalDocs"])
+	if !isObject(owner["externalDocs"]) {
+		t.Errorf("Pet.properties.owner.externalDocs not normalized to object: %v", owner["externalDocs"])
 	}
 }
 
 // ---------------------------------------------------------------------------
 // TestWebMethodsFixExternalDocs_DeepNesting — combination: root + tags +
-// operation + components.schemas. A single call wraps all sites.
+// operation + components.schemas. A single call normalizes all sites.
 // ---------------------------------------------------------------------------
-func TestWebMethodsFixExternalDocs_DeepNesting(t *testing.T) {
+func TestRegressionWebMethodsFixExternalDocs_DeepNesting(t *testing.T) {
 	in := []byte(`{
 		"openapi":"3.0.3",
 		"info":{"title":"t","version":"1"},
@@ -121,19 +126,19 @@ func TestWebMethodsFixExternalDocs_DeepNesting(t *testing.T) {
 	m := unmarshalTo(t, out)
 
 	if !isArrayOfOneObject(m["externalDocs"]) {
-		t.Errorf("root externalDocs not wrapped: %v", m["externalDocs"])
+		t.Errorf("root externalDocs not normalized to one-object array: %v", m["externalDocs"])
 	}
 	tag0 := m["tags"].([]interface{})[0].(map[string]interface{})
-	if !isArrayOfOneObject(tag0["externalDocs"]) {
-		t.Errorf("tag[0].externalDocs not wrapped: %v", tag0["externalDocs"])
+	if !isObject(tag0["externalDocs"]) {
+		t.Errorf("tag[0].externalDocs not normalized to object: %v", tag0["externalDocs"])
 	}
 	op := m["paths"].(map[string]interface{})["/p"].(map[string]interface{})["get"].(map[string]interface{})
-	if !isArrayOfOneObject(op["externalDocs"]) {
-		t.Errorf("operation externalDocs not wrapped: %v", op["externalDocs"])
+	if !isObject(op["externalDocs"]) {
+		t.Errorf("operation externalDocs not normalized to object: %v", op["externalDocs"])
 	}
 	pet := m["components"].(map[string]interface{})["schemas"].(map[string]interface{})["Pet"].(map[string]interface{})
-	if !isArrayOfOneObject(pet["externalDocs"]) {
-		t.Errorf("Pet.externalDocs not wrapped: %v", pet["externalDocs"])
+	if !isObject(pet["externalDocs"]) {
+		t.Errorf("Pet.externalDocs not normalized to object: %v", pet["externalDocs"])
 	}
 }
 
@@ -151,21 +156,31 @@ func TestWebMethodsFixExternalDocs_NoExternalDocs(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestWebMethodsFixExternalDocs_AlreadyArray — an externalDocs that is
-// already a single-element array must NOT be double-wrapped.
+// TestWebMethodsFixExternalDocs_RootArrayOfOne — a root externalDocs that is
+// already a single-element array must be preserved.
 // ---------------------------------------------------------------------------
-func TestWebMethodsFixExternalDocs_AlreadyArray(t *testing.T) {
+func TestWebMethodsFixExternalDocs_RootArrayOfOne(t *testing.T) {
 	in := []byte(`{"openapi":"3.0.3","info":{"title":"t","version":"1"},"externalDocs":[{"url":"https://already"}]}`)
 	out := fixExternalDocs(in)
 	m := unmarshalTo(t, out)
 
-	arr, ok := m["externalDocs"].([]interface{})
-	if !ok || len(arr) != 1 {
-		t.Fatalf("expected 1-element array, got %v", m["externalDocs"])
+	if !isArrayOfOneObject(m["externalDocs"]) {
+		t.Fatalf("expected one-object array, got %v", m["externalDocs"])
 	}
-	// The element is the original object, not another array.
-	if _, isArr := arr[0].([]interface{}); isArr {
-		t.Errorf("double-wrap detected: externalDocs[0] is an array, want object")
+}
+
+// ---------------------------------------------------------------------------
+// TestWebMethodsFixExternalDocs_NestedArrayOfOne — nested externalDocs arrays
+// must be unwrapped to object shape for tag/operation/schema models.
+// ---------------------------------------------------------------------------
+func TestWebMethodsFixExternalDocs_NestedArrayOfOne(t *testing.T) {
+	in := []byte(`{"openapi":"3.0.3","info":{"title":"t","version":"1"},"tags":[{"name":"pets","externalDocs":[{"url":"https://pets"}]}]}`)
+	out := fixExternalDocs(in)
+	m := unmarshalTo(t, out)
+
+	tag0 := m["tags"].([]interface{})[0].(map[string]interface{})
+	if !isObject(tag0["externalDocs"]) {
+		t.Fatalf("expected object, got %v", tag0["externalDocs"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- normalize webMethods OpenAPI externalDocs as root array and nested objects
- update adapter regression tests for the live webMethods import contract

## Validation
- go test ./internal/connect/adapters -run 'TestWebMethodsFixExternalDocs|TestWebMethodsSyncRoutes'
- live stoa-connect hotfix deployed on webmethods-vps and webmethods-dev