### PR TITLE
fix(e2e): route gateway smoke to MCP host

### DIFF
--- a/.github/docs/vault-setup.md
+++ b/.github/docs/vault-setup.md
@@ -79,7 +79,7 @@ vault write auth/jwt/role/github-actions \
 vault kv put secret/e2e/urls \
   PORTAL_URL="https://portal.gostoa.dev" \
   CONSOLE_URL="https://console.gostoa.dev" \
-  GATEWAY_URL="https://api.gostoa.dev" \
+  GATEWAY_URL="https://mcp.gostoa.dev" \
   KEYCLOAK_URL="https://auth.gostoa.dev"
 ```
 

--- a/.github/scripts/setup-vault-e2e.sh
+++ b/.github/scripts/setup-vault-e2e.sh
@@ -107,7 +107,7 @@ echo "Creating secret/e2e/urls..."
 vault kv put secret/e2e/urls \
     PORTAL_URL="https://portal.gostoa.dev" \
     CONSOLE_URL="https://console.gostoa.dev" \
-    GATEWAY_URL="https://api.gostoa.dev" \
+    GATEWAY_URL="https://mcp.gostoa.dev" \
     KEYCLOAK_URL="https://auth.gostoa.dev"
 
 # Default password for demo environment

--- a/.github/workflows/e2e-audit.yml
+++ b/.github/workflows/e2e-audit.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           STOA_PORTAL_URL: ${{ secrets.E2E_PORTAL_URL || 'https://portal.gostoa.dev' }}
           STOA_CONSOLE_URL: ${{ secrets.E2E_CONSOLE_URL || 'https://console.gostoa.dev' }}
-          STOA_GATEWAY_URL: ${{ secrets.E2E_GATEWAY_URL || 'https://api.gostoa.dev' }}
+          STOA_GATEWAY_URL: ${{ (secrets.E2E_GATEWAY_URL != 'https://api.gostoa.dev' && secrets.E2E_GATEWAY_URL) || 'https://mcp.gostoa.dev' }}
           KEYCLOAK_URL: ${{ secrets.E2E_KEYCLOAK_URL || 'https://auth.gostoa.dev' }}
           KEYCLOAK_REALM: stoa
           PARZIVAL_USER: ${{ secrets.PARZIVAL_USER }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -118,6 +118,31 @@ jobs:
             secret/data/e2e/personas/alex password | ALEX_PASSWORD ;
             secret/data/e2e/api-keys test | TEST_API_KEY
 
+      - name: Normalize E2E URLs
+        env:
+          SECRET_PORTAL_URL: ${{ secrets.E2E_PORTAL_URL }}
+          SECRET_CONSOLE_URL: ${{ secrets.E2E_CONSOLE_URL }}
+          SECRET_GATEWAY_URL: ${{ secrets.E2E_GATEWAY_URL }}
+          SECRET_KEYCLOAK_URL: ${{ secrets.E2E_KEYCLOAK_URL }}
+        run: |
+          portal_url="${E2E_PORTAL_URL:-${SECRET_PORTAL_URL:-https://portal.gostoa.dev}}"
+          console_url="${E2E_CONSOLE_URL:-${SECRET_CONSOLE_URL:-https://console.gostoa.dev}}"
+          gateway_url="${E2E_GATEWAY_URL:-${SECRET_GATEWAY_URL:-https://mcp.gostoa.dev}}"
+          keycloak_url="${E2E_KEYCLOAK_URL:-${SECRET_KEYCLOAK_URL:-https://auth.gostoa.dev}}"
+
+          # The control-plane API lives on api.gostoa.dev; gateway/MCP/LLM routes live on mcp.gostoa.dev.
+          # Older Vault/GitHub E2E secrets used the API host and caused broad 404s in gateway smoke tests.
+          if [ -z "$gateway_url" ] || [ "$gateway_url" = "https://api.gostoa.dev" ]; then
+            gateway_url="https://mcp.gostoa.dev"
+          fi
+
+          {
+            echo "STOA_PORTAL_URL=$portal_url"
+            echo "STOA_CONSOLE_URL=$console_url"
+            echo "STOA_GATEWAY_URL=$gateway_url"
+            echo "KEYCLOAK_URL=$keycloak_url"
+          } >> "$GITHUB_ENV"
+
       - name: Setup E2E environment
         uses: ./.github/actions/e2e-setup
 
@@ -126,11 +151,7 @@ jobs:
         continue-on-error: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
         working-directory: e2e
         env:
-          # URLs - Vault values take precedence, then secrets, then defaults
-          STOA_PORTAL_URL: ${{ env.E2E_PORTAL_URL || secrets.E2E_PORTAL_URL || 'https://portal.gostoa.dev' }}
-          STOA_CONSOLE_URL: ${{ env.E2E_CONSOLE_URL || secrets.E2E_CONSOLE_URL || 'https://console.gostoa.dev' }}
-          STOA_GATEWAY_URL: ${{ env.E2E_GATEWAY_URL || secrets.E2E_GATEWAY_URL || 'https://api.gostoa.dev' }}
-          KEYCLOAK_URL: ${{ env.E2E_KEYCLOAK_URL || secrets.E2E_KEYCLOAK_URL || 'https://auth.gostoa.dev' }}
+          # STOA_* URLs and KEYCLOAK_URL are normalized through $GITHUB_ENV above.
           KEYCLOAK_REALM: stoa
 
           # Personas - High-Five (Vault values take precedence)

--- a/.github/workflows/reusable-smoke-test.yml
+++ b/.github/workflows/reusable-smoke-test.yml
@@ -69,7 +69,7 @@ jobs:
           # URLs — GitHub Secrets with sane defaults
           STOA_PORTAL_URL: ${{ secrets.E2E_PORTAL_URL || 'https://portal.gostoa.dev' }}
           STOA_CONSOLE_URL: ${{ secrets.E2E_CONSOLE_URL || 'https://console.gostoa.dev' }}
-          STOA_GATEWAY_URL: ${{ secrets.E2E_GATEWAY_URL || 'https://api.gostoa.dev' }}
+          STOA_GATEWAY_URL: ${{ (secrets.E2E_GATEWAY_URL != 'https://api.gostoa.dev' && secrets.E2E_GATEWAY_URL) || 'https://mcp.gostoa.dev' }}
           KEYCLOAK_URL: ${{ secrets.E2E_KEYCLOAK_URL || 'https://auth.gostoa.dev' }}
           KEYCLOAK_REALM: stoa
           # Personas — from GitHub Secrets (see scripts/dev/setup-e2e-secrets.sh)

--- a/e2e/features/gateway-mcp-resources.feature
+++ b/e2e/features/gateway-mcp-resources.feature
@@ -4,7 +4,8 @@ Feature: Gateway - MCP Resource Discovery (MCP 2025-11-25)
   REST endpoints: POST /mcp/resources/list, POST /mcp/resources/read,
   POST /mcp/resources/templates/list (CAB-1472).
 
-  @smoke @mcp
+  @smoke @mcp @regression
+  # Regression: E2E gateway smoke must target the MCP gateway host, not the control-plane API host.
   Scenario: MCP capabilities advertise resource support
     When I request MCP capabilities
     Then the MCP response status is 200

--- a/e2e/fixtures/test-base.ts
+++ b/e2e/fixtures/test-base.ts
@@ -19,7 +19,7 @@ const __dirname = path.dirname(__filename);
 // URLs
 const PORTAL_URL = process.env.STOA_PORTAL_URL || 'https://portal.gostoa.dev';
 const CONSOLE_URL = process.env.STOA_CONSOLE_URL || 'https://console.gostoa.dev';
-const GATEWAY_URL = process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev';
+const GATEWAY_URL = process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev';
 
 /**
  * Mutable auth session that can be swapped when BDD steps switch personas.

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -101,7 +101,7 @@ export default defineConfig({
     {
       name: 'gateway',
       use: {
-        baseURL: process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev',
+        baseURL: process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev',
       },
       testMatch: /gateway-(access|mtls|uac|federation|credential|dpop|mcp|llm|sender)/,
     },

--- a/e2e/steps/credential-mapping.steps.ts
+++ b/e2e/steps/credential-mapping.steps.ts
@@ -15,7 +15,7 @@ import { test, expect, URLS } from '../fixtures/test-base';
 const { Given, When, Then } = createBdd(test);
 
 // Admin API base URL (uses gateway URL which serves admin endpoints)
-const ADMIN_URL = process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev';
+const ADMIN_URL = process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev';
 const ADMIN_TOKEN = process.env.STOA_ADMIN_TOKEN || '';
 
 // Store for test context

--- a/e2e/steps/gateway-dpop.steps.ts
+++ b/e2e/steps/gateway-dpop.steps.ts
@@ -161,7 +161,7 @@ async function sendGatewayRequest(
 ): Promise<{ status: number; body: any }> {
   const [method, ...pathParts] = methodAndPath.split(' ');
   const urlPath = pathParts.join(' ');
-  const baseUrl = process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev';
+  const baseUrl = process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev';
   const fullUrl = `${baseUrl}${urlPath}`;
 
   const headers: Record<string, string> = {
@@ -275,7 +275,7 @@ When(
   'I send a DPoP-protected request to {string}',
   async ({ request }, methodAndPath: string) => {
     const [method] = methodAndPath.split(' ');
-    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev';
+    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev';
     const urlPath = methodAndPath.split(' ').slice(1).join(' ');
 
     const proof = buildDpopProof({
@@ -300,7 +300,7 @@ When(
   'I send a DPoP proof with algorithm {string} to {string}',
   async ({ request }, algorithm: string, methodAndPath: string) => {
     const [method] = methodAndPath.split(' ');
-    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev';
+    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev';
     const urlPath = methodAndPath.split(' ').slice(1).join(' ');
 
     // For HS256: we build a structurally valid JWT but with symmetric alg
@@ -320,7 +320,7 @@ When(
   'I send an expired DPoP proof to {string}',
   async ({ request }, methodAndPath: string) => {
     const [method] = methodAndPath.split(' ');
-    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev';
+    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev';
     const urlPath = methodAndPath.split(' ').slice(1).join(' ');
 
     const proof = buildDpopProof({
@@ -338,7 +338,7 @@ When(
   'I send a future-dated DPoP proof to {string}',
   async ({ request }, methodAndPath: string) => {
     const [method] = methodAndPath.split(' ');
-    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev';
+    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev';
     const urlPath = methodAndPath.split(' ').slice(1).join(' ');
 
     const proof = buildDpopProof({
@@ -355,7 +355,7 @@ When(
 When(
   'I send a DPoP proof with htm {string} to {string}',
   async ({ request }, wrongMethod: string, methodAndPath: string) => {
-    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev';
+    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev';
     const urlPath = methodAndPath.split(' ').slice(1).join(' ');
 
     // Use the WRONG method in the proof while the actual request uses the correct one
@@ -389,7 +389,7 @@ When(
   'I send a DPoP proof and replay it to {string}',
   async ({ request }, methodAndPath: string) => {
     const [method] = methodAndPath.split(' ');
-    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev';
+    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev';
     const urlPath = methodAndPath.split(' ').slice(1).join(' ');
     const fixedJti = crypto.randomUUID();
 
@@ -412,7 +412,7 @@ When(
   'I send a DPoP proof without ath claim to {string}',
   async ({ request }, methodAndPath: string) => {
     const [method] = methodAndPath.split(' ');
-    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev';
+    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev';
     const urlPath = methodAndPath.split(' ').slice(1).join(' ');
 
     const proof = buildDpopProof({
@@ -430,7 +430,7 @@ When(
   'I send a DPoP proof with wrong ath to {string}',
   async ({ request }, methodAndPath: string) => {
     const [method] = methodAndPath.split(' ');
-    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev';
+    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev';
     const urlPath = methodAndPath.split(' ').slice(1).join(' ');
 
     const proof = buildDpopProof({
@@ -448,7 +448,7 @@ When(
   'I send a dual-bound request with mTLS and DPoP to {string}',
   async ({ request }, methodAndPath: string) => {
     const [method] = methodAndPath.split(' ');
-    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev';
+    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev';
     const urlPath = methodAndPath.split(' ').slice(1).join(' ');
 
     const proof = buildDpopProof({
@@ -466,7 +466,7 @@ When(
   'I send a DPoP proof with private key in jwk to {string}',
   async ({ request }, methodAndPath: string) => {
     const [method] = methodAndPath.split(' ');
-    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev';
+    const baseUrl = process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev';
     const urlPath = methodAndPath.split(' ').slice(1).join(' ');
 
     const proof = buildDpopProof({

--- a/e2e/steps/integration.steps.ts
+++ b/e2e/steps/integration.steps.ts
@@ -19,7 +19,7 @@ const { Given, When, Then } = createBdd(test);
 
 const API_URL = process.env.STOA_API_URL || 'https://api.gostoa.dev';
 const AUTH_URL = process.env.STOA_AUTH_URL || 'https://auth.gostoa.dev';
-const GATEWAY_URL = process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev';
+const GATEWAY_URL = process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev';
 
 // ---------------------------------------------------------------------------
 // State (module-scoped, independent from other step files)

--- a/e2e/tests/diagnostic-cab1039.ts
+++ b/e2e/tests/diagnostic-cab1039.ts
@@ -396,7 +396,7 @@ async function run() {
 
     for (const endpoint of endpoints) {
       try {
-        const apiUrl = `${process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev'}${endpoint}`;
+        const apiUrl = `${process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev'}${endpoint}`;
         const response = await page.request.fetch(apiUrl, {
           headers: {
             'Authorization': `Bearer ${extractedToken}`,
@@ -435,7 +435,7 @@ async function run() {
         }
       }
       return results;
-    }, process.env.STOA_GATEWAY_URL || 'https://api.gostoa.dev');
+    }, process.env.STOA_GATEWAY_URL || 'https://mcp.gostoa.dev');
 
     fs.writeFileSync(
       path.join(DIAG_DIR, 'api-session-response.json'),

--- a/scripts/dev/setup-e2e-secrets.sh
+++ b/scripts/dev/setup-e2e-secrets.sh
@@ -26,7 +26,7 @@ echo ""
 # --- URLs (with defaults — optional, but explicit is better) ---
 gh secret set E2E_PORTAL_URL  --repo "$REPO" --body "https://portal.gostoa.dev"
 gh secret set E2E_CONSOLE_URL --repo "$REPO" --body "https://console.gostoa.dev"
-gh secret set E2E_GATEWAY_URL --repo "$REPO" --body "https://api.gostoa.dev"
+gh secret set E2E_GATEWAY_URL --repo "$REPO" --body "https://mcp.gostoa.dev"
 gh secret set E2E_KEYCLOAK_URL --repo "$REPO" --body "https://auth.gostoa.dev"
 echo "  URLs configured"
 


### PR DESCRIPTION
## Summary
- normalize E2E gateway URL away from `api.gostoa.dev` to `mcp.gostoa.dev` after Vault/GitHub secret load
- align gateway defaults in E2E fixtures, Playwright config, diagnostics, and setup docs/scripts
- keep control-plane API URL defaults on `api.gostoa.dev`

## Verification
- `cd e2e && npm run bddgen`
- `cd e2e && npx playwright test --project=gateway --grep "MCP capabilities advertise resource support"`
- `actionlint -ignore SC2086 -ignore SC2129 .github/workflows/e2e-tests.yml .github/workflows/reusable-smoke-test.yml .github/workflows/e2e-audit.yml`
- `cd e2e && npx tsc --noEmit --ignoreDeprecations 6.0` still reports pre-existing E2E type errors in aria helpers, token profile typing, and DPoP crypto types

## Root cause
Main E2E was sending gateway/MCP/LLM/admin checks to `https://api.gostoa.dev`, which is the control-plane API host. Those routes live on `https://mcp.gostoa.dev`; the wrong host returns 404 for `/mcp/capabilities`, `/v1/chat/completions`, and `/admin/contracts`.
