### PR TITLE
fix(gateway): isolate webMethods URLs by environment

### DIFF
--- a/control-plane-api/alembic/versions/100_fix_webmethods_nonprod_urls.py
+++ b/control-plane-api/alembic/versions/100_fix_webmethods_nonprod_urls.py
@@ -1,0 +1,113 @@
+"""fix non-prod webMethods gateway urls
+
+Revision ID: 100_fix_webmethods_nonprod_urls
+Revises: 099_catalog_release_versioning
+Create Date: 2026-05-01
+
+Non-prod webMethods GatewayInstance rows inherited prod UI/target URLs from
+older backfills. Keep prod URLs only on prod rows; use environment-specific
+runtime/target URLs for dev and staging.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "100_fix_webmethods_nonprod_urls"
+down_revision: str | tuple[str, ...] | None = "099_catalog_release_versioning"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_NONPROD_WEBMETHODS_URLS = (
+    ("connect-webmethods-dev", "dev", "https://dev-wm.gostoa.dev", "https://dev-wm.gostoa.dev"),
+    ("connect-webmethods-dev-connect-dev", "dev", "https://dev-wm.gostoa.dev", "https://dev-wm.gostoa.dev"),
+    ("stoa-link-wm-dev", "dev", "https://dev-wm-k3s.gostoa.dev", "https://dev-wm.gostoa.dev"),
+    (
+        "stoa-link-wm-dev-sidecar-dev",
+        "dev",
+        "https://dev-wm-k3s.gostoa.dev",
+        "https://dev-wm.gostoa.dev",
+    ),
+    (
+        "stoa-link-wm-sidecar-dev",
+        "dev",
+        "https://dev-wm-k3s.gostoa.dev",
+        "https://dev-wm.gostoa.dev",
+    ),
+    (
+        "connect-webmethods-staging",
+        "staging",
+        "https://staging-wm-k3s.gostoa.dev",
+        "https://staging-wm-k3s.gostoa.dev",
+    ),
+    (
+        "connect-webmethods-staging-connect-staging",
+        "staging",
+        "https://staging-wm-k3s.gostoa.dev",
+        "https://staging-wm-k3s.gostoa.dev",
+    ),
+    (
+        "stoa-link-wm-staging",
+        "staging",
+        "https://staging-wm-k3s.gostoa.dev",
+        "https://staging-wm-k3s.gostoa.dev",
+    ),
+    (
+        "stoa-link-wm-staging-sidecar-staging",
+        "staging",
+        "https://staging-wm-k3s.gostoa.dev",
+        "https://staging-wm-k3s.gostoa.dev",
+    ),
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for name, environment, public_url, target_gateway_url in _NONPROD_WEBMETHODS_URLS:
+        conn.execute(
+            sa.text("""
+                UPDATE gateway_instances
+                SET
+                  public_url = :public_url,
+                  target_gateway_url = :target_gateway_url,
+                  ui_url = NULL,
+                  endpoints = jsonb_strip_nulls(
+                    (COALESCE(endpoints, '{}'::jsonb) - 'ui_url' - 'uiUrl' - 'console_url'
+                      - 'consoleUrl' - 'web_ui_url' - 'webUiUrl')
+                    || jsonb_build_object(
+                      'public_url', :public_url,
+                      'target_gateway_url', :target_gateway_url
+                    )
+                  ),
+                  updated_at = NOW()
+                WHERE name = :name
+                  AND environment = :environment
+                  AND deleted_at IS NULL
+            """),
+            {
+                "name": name,
+                "environment": environment,
+                "public_url": public_url,
+                "target_gateway_url": target_gateway_url,
+            },
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for name, environment, _public_url, _target_gateway_url in _NONPROD_WEBMETHODS_URLS:
+        conn.execute(
+            sa.text("""
+                UPDATE gateway_instances
+                SET
+                  ui_url = NULL,
+                  endpoints = COALESCE(endpoints, '{}'::jsonb) - 'ui_url' - 'uiUrl'
+                    - 'console_url' - 'consoleUrl' - 'web_ui_url' - 'webUiUrl',
+                  updated_at = NOW()
+                WHERE name = :name
+                  AND environment = :environment
+                  AND deleted_at IS NULL
+            """),
+            {"name": name, "environment": environment},
+        )

--- a/control-plane-api/src/routers/gateway_internal.py
+++ b/control-plane-api/src/routers/gateway_internal.py
@@ -12,6 +12,7 @@ import json
 import logging
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
+from urllib.parse import urlparse
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
@@ -41,6 +42,15 @@ router = APIRouter(
     prefix="/v1/internal/gateways",
     tags=["Gateway Internal"],
 )
+
+_PROD_ENVIRONMENTS = {"prod", "production"}
+_PROD_WEBMETHODS_HOSTS = {
+    "vps-wm.gostoa.dev",
+    "vps-wm-ui.gostoa.dev",
+    "webmethods.gostoa.dev",
+}
+_UI_ENDPOINT_KEYS = {"ui_url", "uiUrl", "console_url", "consoleUrl", "web_ui_url", "webUiUrl"}
+_TARGET_ENDPOINT_KEYS = {"target_gateway_url", "targetGatewayUrl", "target_url", "targetUrl"}
 
 
 # --- Route Reload Endpoint (CAB-1828) ---
@@ -290,6 +300,69 @@ def _normalize_mode(mode: str) -> str:
     return mode_map.get(mode_lower, "edge-mcp")
 
 
+def _host(value: str | None) -> str | None:
+    if not value:
+        return None
+    try:
+        return urlparse(value).hostname
+    except ValueError:
+        return None
+
+
+def _drop_endpoint_keys(endpoints: dict | None, keys: set[str]) -> dict:
+    if not isinstance(endpoints, dict):
+        return {}
+    return {key: value for key, value in endpoints.items() if key not in keys}
+
+
+def _is_webmethods_registration(
+    payload: GatewayRegistration,
+    *,
+    instance_name: str,
+    target_gateway_type: str | None,
+) -> bool:
+    target = (payload.target_gateway_type or target_gateway_type or "").lower().replace("-", "_")
+    search_space = " ".join(
+        value
+        for value in [
+            target,
+            instance_name,
+            payload.hostname,
+            payload.target_gateway_url or "",
+            payload.public_url or "",
+            payload.admin_url,
+        ]
+        if value
+    ).lower()
+    return "webmethods" in search_space or "wm" in search_space
+
+
+def _apply_registration_urls(instance: GatewayInstance, payload: GatewayRegistration) -> None:
+    """Apply URL fields from registration and clear stale prod wM URLs in non-prod."""
+    sent_fields = payload.model_fields_set
+    for field_name in ("target_gateway_url", "public_url", "ui_url"):
+        if field_name in sent_fields:
+            setattr(instance, field_name, getattr(payload, field_name))
+
+    environment = (payload.environment or instance.environment or "").lower()
+    if environment in _PROD_ENVIRONMENTS:
+        return
+
+    if not _is_webmethods_registration(
+        payload,
+        instance_name=instance.name,
+        target_gateway_type=instance.target_gateway_type,
+    ):
+        return
+
+    if _host(instance.ui_url) in _PROD_WEBMETHODS_HOSTS:
+        instance.ui_url = None
+        instance.endpoints = _drop_endpoint_keys(instance.endpoints, _UI_ENDPOINT_KEYS)
+    if _host(instance.target_gateway_url) in _PROD_WEBMETHODS_HOSTS:
+        instance.target_gateway_url = None
+        instance.endpoints = _drop_endpoint_keys(instance.endpoints, _TARGET_ENDPOINT_KEYS)
+
+
 def _registration_topology(
     payload: GatewayRegistration,
     *,
@@ -391,12 +464,7 @@ async def register_gateway(
         # Preserve manually-set HTTPS base_url over auto-detected internal URL
         if not (existing.base_url and existing.base_url.startswith("https://")):
             existing.base_url = payload.admin_url
-        if payload.target_gateway_url:
-            existing.target_gateway_url = payload.target_gateway_url
-        if payload.public_url:
-            existing.public_url = payload.public_url
-        if payload.ui_url:
-            existing.ui_url = payload.ui_url
+        _apply_registration_urls(existing, payload)
         existing.status = GatewayInstanceStatus.ONLINE
         existing.last_health_check = now
         existing.mode = normalized_mode
@@ -436,12 +504,7 @@ async def register_gateway(
         deleted_entry.version = payload.version
         deleted_entry.capabilities = payload.capabilities
         deleted_entry.base_url = payload.admin_url
-        if payload.target_gateway_url:
-            deleted_entry.target_gateway_url = payload.target_gateway_url
-        if payload.public_url:
-            deleted_entry.public_url = payload.public_url
-        if payload.ui_url:
-            deleted_entry.ui_url = payload.ui_url
+        _apply_registration_urls(deleted_entry, payload)
         deleted_entry.status = GatewayInstanceStatus.ONLINE
         deleted_entry.last_health_check = now
         deleted_entry.mode = normalized_mode
@@ -504,12 +567,7 @@ async def register_gateway(
         argocd_entry.version = payload.version
         argocd_entry.capabilities = payload.capabilities
         argocd_entry.base_url = payload.admin_url
-        if payload.target_gateway_url:
-            argocd_entry.target_gateway_url = payload.target_gateway_url
-        if payload.public_url:
-            argocd_entry.public_url = payload.public_url
-        if payload.ui_url:
-            argocd_entry.ui_url = payload.ui_url
+        _apply_registration_urls(argocd_entry, payload)
         argocd_entry.status = GatewayInstanceStatus.ONLINE
         argocd_entry.last_health_check = now
         argocd_entry.mode = normalized_mode

--- a/control-plane-api/tests/test_regression_cab_1953_webmethods_nonprod_urls.py
+++ b/control-plane-api/tests/test_regression_cab_1953_webmethods_nonprod_urls.py
@@ -1,0 +1,63 @@
+"""Regression coverage for webMethods URL isolation by environment."""
+
+from unittest.mock import AsyncMock, patch
+
+from src.models.gateway_instance import GatewayType
+from tests.test_gateway_internal import (
+    GW_KEY_HEADER,
+    REGISTER_URL,
+    VALID_KEY,
+    _make_gateway_instance,
+    _registration_payload,
+)
+
+
+def test_regression_cab_1953_nonprod_webmethods_registration_clears_prod_ui_url(client):
+    """Non-prod webMethods registrations must not keep stale prod UI links."""
+    existing = _make_gateway_instance(
+        name="stoa-link-wm-dev-sidecar-dev",
+        gateway_type=GatewayType.STOA_SIDECAR,
+        environment="dev",
+        mode="sidecar",
+        deployment_mode="connect",
+        target_gateway_type="webmethods",
+        topology="remote-agent",
+        public_url="https://dev-wm-k3s.gostoa.dev",
+        target_gateway_url="https://webmethods.gostoa.dev",
+        ui_url="https://vps-wm-ui.gostoa.dev",
+        endpoints={
+            "public_url": "https://dev-wm-k3s.gostoa.dev",
+            "target_gateway_url": "https://webmethods.gostoa.dev",
+            "ui_url": "https://vps-wm-ui.gostoa.dev",
+        },
+    )
+
+    with (
+        patch("src.routers.gateway_internal.settings") as mock_settings,
+        patch("src.routers.gateway_internal.GatewayInstanceRepository") as MockRepo,
+    ):
+        mock_settings.gateway_api_keys_list = [VALID_KEY]
+
+        mock_repo = MockRepo.return_value
+        mock_repo.get_by_name = AsyncMock(return_value=existing)
+        mock_repo.update = AsyncMock(return_value=existing)
+
+        resp = client.post(
+            REGISTER_URL,
+            json=_registration_payload(
+                hostname="stoa-link-wm-dev",
+                mode="sidecar",
+                environment="dev",
+                target_gateway_type="webmethods",
+                target_gateway_url="https://dev-wm.gostoa.dev",
+                public_url="https://dev-wm-k3s.gostoa.dev",
+            ),
+            headers={GW_KEY_HEADER: VALID_KEY},
+        )
+
+        assert resp.status_code == 201
+        assert existing.ui_url is None
+        assert existing.target_gateway_url == "https://dev-wm.gostoa.dev"
+        assert existing.endpoints["target_gateway_url"] == "https://dev-wm.gostoa.dev"
+        assert "ui_url" not in existing.endpoints
+        mock_repo.update.assert_awaited_once()

--- a/k8s/gateways/overlays/dev/gateway-instances.yaml
+++ b/k8s/gateways/overlays/dev/gateway-instances.yaml
@@ -16,6 +16,8 @@ spec:
   targetGatewayType: webmethods
   topology: remote-agent
   endpoints:
+    publicUrl: https://dev-wm.gostoa.dev
+    targetGatewayUrl: https://dev-wm.gostoa.dev
     adminUrl: http://connect-webmethods-dev:8090
     healthUrl: http://connect-webmethods-dev:8090/health
   capabilities:
@@ -45,6 +47,7 @@ spec:
   topology: remote-agent
   endpoints:
     publicUrl: https://dev-wm-k3s.gostoa.dev
+    targetGatewayUrl: https://dev-wm.gostoa.dev
     adminUrl: http://stoa-link-wm-dev:8080
     healthUrl: http://stoa-link-wm-dev:8080/health
   capabilities:

--- a/k8s/gateways/overlays/dev/kustomization.yaml
+++ b/k8s/gateways/overlays/dev/kustomization.yaml
@@ -67,6 +67,8 @@ patches:
                     value: "https://dev-wm-k3s.gostoa.dev"
                   - name: STOA_GATEWAY_PUBLIC_URL
                     value: "https://dev-wm-k3s.gostoa.dev"
+                  - name: STOA_TARGET_GATEWAY_URL
+                    value: "https://dev-wm.gostoa.dev"
                   - name: STOA_DEPLOYMENT_MODE
                     value: "connect"
                   - name: STOA_TARGET_GATEWAY_TYPE

--- a/k8s/gateways/overlays/staging/gateway-instances.yaml
+++ b/k8s/gateways/overlays/staging/gateway-instances.yaml
@@ -16,6 +16,8 @@ spec:
   targetGatewayType: webmethods
   topology: remote-agent
   endpoints:
+    publicUrl: https://staging-wm-k3s.gostoa.dev
+    targetGatewayUrl: https://staging-wm-k3s.gostoa.dev
     adminUrl: http://connect-webmethods-staging:8090
     healthUrl: http://connect-webmethods-staging:8090/health
   capabilities:
@@ -74,6 +76,7 @@ spec:
   topology: remote-agent
   endpoints:
     publicUrl: https://staging-wm-k3s.gostoa.dev
+    targetGatewayUrl: https://staging-wm-k3s.gostoa.dev
     adminUrl: http://stoa-link-wm-staging:8080
     healthUrl: http://stoa-link-wm-staging:8080/health
   capabilities:

--- a/k8s/gateways/overlays/staging/kustomization.yaml
+++ b/k8s/gateways/overlays/staging/kustomization.yaml
@@ -67,6 +67,8 @@ patches:
                     value: "https://staging-wm-k3s.gostoa.dev"
                   - name: STOA_GATEWAY_PUBLIC_URL
                     value: "https://staging-wm-k3s.gostoa.dev"
+                  - name: STOA_TARGET_GATEWAY_URL
+                    value: "https://staging-wm-k3s.gostoa.dev"
                   - name: STOA_DEPLOYMENT_MODE
                     value: "connect"
                   - name: STOA_TARGET_GATEWAY_TYPE


### PR DESCRIPTION
## Summary\n- clear stale prod webMethods UI/target URLs during non-prod gateway registration\n- add a data migration to clean existing dev/staging webMethods gateway rows\n- send explicit dev/staging targetGatewayUrl values from K3s gateway manifests\n\n## Validation\n- pytest tests/test_gateway_internal.py tests/test_regression_gateway_url_contract.py -q\n- ruff check src/routers/gateway_internal.py tests/test_gateway_internal.py alembic/versions/100_fix_webmethods_nonprod_urls.py\n- kubectl kustomize k8s/gateways/overlays/dev\n- kubectl kustomize k8s/gateways/overlays/staging