### PR TITLE
fix(api): reconcile gateway deployment targets

### DIFF
--- a/control-plane-api/alembic/versions/102_runtime_target_reconciliation.py
+++ b/control-plane-api/alembic/versions/102_runtime_target_reconciliation.py
@@ -1,0 +1,102 @@
+"""runtime target reconciliation backfill
+
+Revision ID: 102_runtime_target_reconciliation
+Revises: 101_seed_portal_subscription_plans
+Create Date: 2026-05-01
+
+Backfills api_gateway_assignments from explicit catalog/runtime target state
+and expires old pending GatewayDeployment rows that predate the runtime
+acknowledgement contract.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "102_runtime_target_reconciliation"
+down_revision: str | tuple[str, ...] | None = "101_seed_portal_subscription_plans"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Existing catalog rows already carry explicit target_gateways. Materialize
+    # those as default auto-deploy assignments so promotion and Git boolean env
+    # markers can resolve concrete runtime targets without guessing.
+    conn.execute(
+        sa.text("""
+            INSERT INTO api_gateway_assignments (id, api_id, gateway_id, environment, auto_deploy, created_at)
+            SELECT gen_random_uuid(), ac.id, gi.id, gi.environment, true, NOW()
+            FROM api_catalog ac
+            JOIN LATERAL jsonb_array_elements_text(COALESCE(ac.target_gateways, '[]'::jsonb)) AS t(gateway_name)
+                ON true
+            JOIN gateway_instances gi
+                ON gi.name = t.gateway_name
+               AND gi.deleted_at IS NULL
+               AND gi.enabled IS TRUE
+            WHERE ac.deleted_at IS NULL
+            ON CONFLICT ON CONSTRAINT uq_api_gateway_env
+            DO UPDATE SET auto_deploy = EXCLUDED.auto_deploy
+        """)
+    )
+
+    # Preserve assignments for runtime deployments that already converged or are
+    # still waiting for an agent ack. This turns the observed runtime target into
+    # an explicit contract for subsequent promotions.
+    conn.execute(
+        sa.text("""
+            INSERT INTO api_gateway_assignments (id, api_id, gateway_id, environment, auto_deploy, created_at)
+            SELECT DISTINCT gen_random_uuid(), gd.api_catalog_id, gi.id, gi.environment, true, NOW()
+            FROM gateway_deployments gd
+            JOIN gateway_instances gi
+                ON gi.id = gd.gateway_instance_id
+               AND gi.deleted_at IS NULL
+               AND gi.enabled IS TRUE
+            WHERE gd.sync_status IN ('synced', 'pending', 'syncing')
+            ON CONFLICT ON CONSTRAINT uq_api_gateway_env
+            DO UPDATE SET auto_deploy = EXCLUDED.auto_deploy
+        """)
+    )
+
+    # Stop retrying deployments whose target gateway has been archived. They
+    # must be explicitly redeployed to an active gateway target.
+    conn.execute(
+        sa.text("""
+            UPDATE gateway_deployments gd
+            SET sync_status = 'error',
+                sync_error = 'Gateway instance is archived or missing; select an active gateway target and redeploy',
+                sync_attempts = GREATEST(sync_attempts, 3),
+                updated_at = NOW()
+            WHERE EXISTS (
+                SELECT 1
+                FROM gateway_instances gi
+                WHERE gi.id = gd.gateway_instance_id
+                  AND gi.deleted_at IS NOT NULL
+            )
+        """)
+    )
+
+    # Old pending rows from before the ack timeout contract are not meaningful
+    # in the Console. Mark them as failed so they can be force-synced or
+    # redeployed intentionally.
+    conn.execute(
+        sa.text("""
+            UPDATE gateway_deployments
+            SET sync_status = 'error',
+                sync_error = 'Gateway did not acknowledge deployment within 86400 seconds; force sync or redeploy',
+                sync_attempts = GREATEST(sync_attempts, 3),
+                updated_at = NOW()
+            WHERE sync_status IN ('pending', 'syncing')
+              AND COALESCE(last_sync_attempt, desired_at, created_at) < NOW() - INTERVAL '24 hours'
+        """)
+    )
+
+
+def downgrade() -> None:
+    # Data backfill is intentionally not reversed: assignments may have been
+    # edited by users after upgrade, and failed/pending runtime status is
+    # operational state.
+    pass

--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -1957,7 +1957,7 @@
             "type": "boolean"
           },
           "environment": {
-            "pattern": "^(dev|staging|production)$",
+            "pattern": "^(dev|staging|prod|production)$",
             "title": "Environment",
             "type": "string"
           },
@@ -6861,7 +6861,7 @@
         "description": "Request to deploy an API to gateways in a specific environment.",
         "properties": {
           "environment": {
-            "pattern": "^(dev|staging|production)$",
+            "pattern": "^(dev|staging|prod|production)$",
             "title": "Environment",
             "type": "string"
           },
@@ -47917,7 +47917,7 @@
             "schema": {
               "anyOf": [
                 {
-                  "pattern": "^(dev|staging|production)$",
+                  "pattern": "^(dev|staging|prod|production)$",
                   "type": "string"
                 },
                 {

--- a/control-plane-api/src/config.py
+++ b/control-plane-api/src/config.py
@@ -441,6 +441,7 @@ class Settings(BaseSettings):
     SYNC_ENGINE_INTERVAL_SECONDS: int = 300  # 5 minutes
     SYNC_ENGINE_MAX_CONCURRENT: int = 5
     SYNC_ENGINE_RETRY_MAX: int = 3
+    SYNC_ENGINE_PENDING_TIMEOUT_SECONDS: int = 3600
 
     # Drift auto-repair mode (CAB-2016)
     # none: log + Kafka event only (default)

--- a/control-plane-api/src/repositories/api_gateway_assignment.py
+++ b/control-plane-api/src/repositories/api_gateway_assignment.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models.api_gateway_assignment import ApiGatewayAssignment
 from ..models.gateway_instance import GatewayInstance
+from ..services.environment_aliases import deployment_environment_aliases
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ class ApiGatewayAssignmentRepository:
             .order_by(ApiGatewayAssignment.environment, GatewayInstance.name)
         )
         if environment:
-            query = query.where(ApiGatewayAssignment.environment == environment)
+            query = query.where(ApiGatewayAssignment.environment.in_(deployment_environment_aliases(environment)))
 
         result = await self.db.execute(query)
         rows = result.all()
@@ -73,7 +74,7 @@ class ApiGatewayAssignmentRepository:
         result = await self.db.execute(
             select(ApiGatewayAssignment).where(
                 ApiGatewayAssignment.api_id == api_id,
-                ApiGatewayAssignment.environment == environment,
+                ApiGatewayAssignment.environment.in_(deployment_environment_aliases(environment)),
                 ApiGatewayAssignment.auto_deploy.is_(True),
             )
         )

--- a/control-plane-api/src/repositories/gateway_deployment.py
+++ b/control-plane-api/src/repositories/gateway_deployment.py
@@ -9,6 +9,7 @@ from src.models.catalog import APICatalog
 from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment
 from src.models.gateway_instance import GatewayInstance
 from src.models.promotion import Promotion
+from src.services.environment_aliases import deployment_environment_aliases
 from src.services.gateway_topology import normalize_gateway_topology, wire_value
 
 
@@ -195,7 +196,7 @@ class GatewayDeploymentRepository:
         )
 
         if environment:
-            query = query.where(GatewayInstance.environment == environment)
+            query = query.where(GatewayInstance.environment.in_(deployment_environment_aliases(environment)))
         if gateway_type:
             query = query.where(GatewayInstance.gateway_type == gateway_type)
         if sync_status:

--- a/control-plane-api/src/repositories/gateway_instance.py
+++ b/control-plane-api/src/repositories/gateway_instance.py
@@ -7,6 +7,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.gateway_instance import GatewayInstance, GatewayInstanceStatus, GatewayType
+from src.services.environment_aliases import deployment_environment_aliases
 
 
 class GatewayInstanceRepository:
@@ -84,7 +85,7 @@ class GatewayInstanceRepository:
             GatewayInstance.deleted_at.is_(None),
         )
         if environment:
-            query = query.where(GatewayInstance.environment == environment)
+            query = query.where(GatewayInstance.environment.in_(deployment_environment_aliases(environment)))
         # Prefer the most recently updated entry
         query = query.order_by(GatewayInstance.updated_at.desc()).limit(1)
         result = await self.session.execute(query)
@@ -108,7 +109,7 @@ class GatewayInstanceRepository:
         if gateway_type:
             query = query.where(GatewayInstance.gateway_type == gateway_type)
         if environment:
-            query = query.where(GatewayInstance.environment == environment)
+            query = query.where(GatewayInstance.environment.in_(deployment_environment_aliases(environment)))
         if tenant_id:
             query = query.where((GatewayInstance.tenant_id == tenant_id) | (GatewayInstance.tenant_id.is_(None)))
 
@@ -162,7 +163,7 @@ class GatewayInstanceRepository:
         """
         query = select(GatewayInstance).where(
             GatewayInstance.mode == mode,
-            GatewayInstance.environment == environment,
+            GatewayInstance.environment.in_(deployment_environment_aliases(environment)),
             GatewayInstance.source == "self_register",
             GatewayInstance.deleted_at.is_(None),
         )

--- a/control-plane-api/src/routers/api_gateway_assignments.py
+++ b/control-plane-api/src/routers/api_gateway_assignments.py
@@ -84,7 +84,7 @@ async def create_assignment(
 async def list_assignments(
     tenant_id: str,
     api_id: UUID,
-    environment: str | None = Query(None, pattern="^(dev|staging|production)$"),
+    environment: str | None = Query(None, pattern="^(dev|staging|prod|production)$"),
     db: AsyncSession = Depends(get_db),
     user=Depends(require_role(["cpi-admin", "tenant-admin", "devops", "viewer"])),
 ):
@@ -116,7 +116,7 @@ async def delete_assignment(
 class DeployToEnvRequest(BaseModel):
     """Request to deploy an API to gateways in a specific environment."""
 
-    environment: str = Field(pattern="^(dev|staging|production)$")
+    environment: str = Field(pattern="^(dev|staging|prod|production)$")
     gateway_ids: list[UUID] | None = None  # None = use auto-deploy assignments
 
 

--- a/control-plane-api/src/schemas/api_gateway_assignment.py
+++ b/control-plane-api/src/schemas/api_gateway_assignment.py
@@ -10,7 +10,7 @@ class AssignmentCreate(BaseModel):
     """Create a default gateway target for an API/environment."""
 
     gateway_id: UUID
-    environment: str = Field(pattern="^(dev|staging|production)$")
+    environment: str = Field(pattern="^(dev|staging|prod|production)$")
     auto_deploy: bool = False
 
 

--- a/control-plane-api/src/services/catalog_deployment_reconciler.py
+++ b/control-plane-api/src/services/catalog_deployment_reconciler.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.models.catalog import APICatalog
 from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment
 from src.models.gateway_instance import GatewayInstance
+from src.repositories.api_gateway_assignment import ApiGatewayAssignmentRepository
 from src.repositories.gateway_deployment import GatewayDeploymentRepository
 from src.repositories.gateway_instance import GatewayInstanceRepository
 from src.services.catalog_api_definition import (
@@ -33,6 +34,7 @@ class CatalogDeploymentReconciler:
         self.db = db
         self.gw_repo = GatewayInstanceRepository(db)
         self.deploy_repo = GatewayDeploymentRepository(db)
+        self.assignment_repo = ApiGatewayAssignmentRepository(db)
 
     async def reconcile_api(
         self,
@@ -69,6 +71,19 @@ class CatalogDeploymentReconciler:
         base_desired_state = GatewayDeploymentService.build_desired_state(catalog_entry)
         for target in targets:
             if not target.instance:
+                assigned_gateways = await self._resolve_assignment_gateways(catalog_entry, target)
+                if assigned_gateways:
+                    for gateway in assigned_gateways:
+                        desired_state = {
+                            **base_desired_state,
+                            "activated": target.activated,
+                            "target_gateway_name": gateway.name,
+                            "target_environment": gateway.environment,
+                            "target_source": "assignment",
+                        }
+                        changed = await self._upsert_deployment(catalog_entry, gateway, desired_state) or changed
+                    continue
+
                 logger.warning(
                     "GitOps: deployment environment '%s' for API %s/%s has no gateway target; "
                     "add gateways: or deployments.<env>.gateways to make DR materializable",
@@ -127,6 +142,39 @@ class CatalogDeploymentReconciler:
         if gateway:
             return gateway
         return await self.gw_repo.get_self_registered_by_hostname(target.instance)
+
+    async def _resolve_assignment_gateways(
+        self,
+        catalog_entry: APICatalog,
+        target: CatalogDeploymentTarget,
+    ) -> list[GatewayInstance]:
+        if not target.environment:
+            return []
+
+        assignments = await self.assignment_repo.list_auto_deploy(catalog_entry.id, target.environment)
+        gateways: list[GatewayInstance] = []
+        for assignment in assignments:
+            gateway = await self.gw_repo.get_by_id(assignment.gateway_id)
+            if not gateway:
+                logger.warning(
+                    "GitOps: assignment gateway '%s' not found for API %s/%s — skipping",
+                    assignment.gateway_id,
+                    catalog_entry.tenant_id,
+                    catalog_entry.api_id,
+                )
+                continue
+            if not environment_matches(gateway.environment, target.environment):
+                logger.warning(
+                    "GitOps: assignment gateway '%s' environment '%s' does not match target '%s' for API %s/%s",
+                    gateway.name,
+                    gateway.environment,
+                    target.environment,
+                    catalog_entry.tenant_id,
+                    catalog_entry.api_id,
+                )
+                continue
+            gateways.append(gateway)
+        return gateways
 
     async def _upsert_deployment(
         self,

--- a/control-plane-api/src/services/credential_resolver.py
+++ b/control-plane-api/src/services/credential_resolver.py
@@ -18,9 +18,13 @@ AGENT_MANAGED_MESSAGE = (
     "Use the agent's heartbeat/sync-ack for status."
 )
 
-# Only pure "stoa" type gateways use the pull model (stoa-connect Go agent).
-# stoa_sidecar and stoa_edge_mcp are push-capable even when self-registered.
+# Pure "stoa" gateways use the pull model. STOA Link/Connect registrations may
+# also use STOA-specific gateway types while declaring deployment_mode=connect
+# or topology=remote-agent; those are agent-managed too and must be acked by the
+# agent instead of pushed from the Control Plane.
 _PULL_MODEL_GATEWAY_TYPES = {"stoa"}
+_PULL_MODEL_DEPLOYMENT_MODES = {"connect"}
+_PULL_MODEL_TOPOLOGIES = {"remote-agent"}
 
 
 class AgentManagedGatewayError(Exception):
@@ -113,7 +117,13 @@ async def create_adapter_with_credentials(
         ValueError: if credential resolution fails (e.g. Vault-only config with
             Vault unavailable).
     """
-    if source == "self_register" and gateway_type in _PULL_MODEL_GATEWAY_TYPES:
+    deployment_mode = str(extra_config.get("deployment_mode") or "").strip().lower()
+    topology = str(extra_config.get("topology") or "").strip().lower()
+    if source == "self_register" and (
+        gateway_type in _PULL_MODEL_GATEWAY_TYPES
+        or deployment_mode in _PULL_MODEL_DEPLOYMENT_MODES
+        or topology in _PULL_MODEL_TOPOLOGIES
+    ):
         logger.info(
             "Blocked adapter creation for agent-managed gateway %s (type=%s)",
             gateway_name or "unknown",

--- a/control-plane-api/src/services/deployment_orchestration_service.py
+++ b/control-plane-api/src/services/deployment_orchestration_service.py
@@ -20,6 +20,11 @@ from ..models.catalog import APICatalog
 from ..models.gateway_instance import GatewayInstance
 from ..models.promotion import Promotion, PromotionStatus
 from ..repositories.api_gateway_assignment import ApiGatewayAssignmentRepository
+from ..services.environment_aliases import (
+    deployment_environment_aliases,
+    deployment_environment_matches,
+    normalize_deployment_environment,
+)
 from ..services.gateway_deployment_service import GatewayDeploymentService
 from ..services.gateway_topology import normalize_gateway_topology
 
@@ -221,6 +226,8 @@ class DeploymentOrchestrationService:
         Raises:
             ValueError: If prerequisites are not met.
         """
+        environment = normalize_deployment_environment(environment) or environment
+
         # 1. Resolve API to catalog entry (sync from Git if needed)
         api_catalog = await self._resolve_api_catalog(tenant_id, api_identifier)
 
@@ -274,6 +281,8 @@ class DeploymentOrchestrationService:
         GatewayDeployment is created or any Kafka/SSE event is emitted.
         """
         api_catalog = await self._resolve_api_catalog(tenant_id, api_identifier)
+
+        environment = normalize_deployment_environment(environment) or environment
 
         if validate_promotion and environment != "dev":
             has_promotion = await self._has_active_promotion(api_catalog.api_id, api_catalog.tenant_id, environment)
@@ -402,14 +411,13 @@ class DeploymentOrchestrationService:
             return []
 
         # Get auto-deploy assignments
+        target_environment = normalize_deployment_environment(target_environment) or target_environment
         assignments = await self.assignment_repo.list_auto_deploy(api_catalog.id, target_environment)
         if not assignments:
-            logger.debug(
-                "No auto-deploy assignments for api=%s env=%s",
-                api_id,
-                target_environment,
+            raise ValueError(
+                f"Promotion to {target_environment} cannot be marked deployed: no auto-deploy gateway "
+                f"assignments exist for API '{api_catalog.api_name}'. Configure at least one target gateway."
             )
-            return []
 
         gateway_ids = [a.gateway_id for a in assignments]
         preflight = await self._preflight_gateway_ids(api_catalog, gateway_ids)
@@ -466,6 +474,8 @@ class DeploymentOrchestrationService:
                     gateway.auth_config,
                     source=gateway.source,
                     gateway_name=gateway.name,
+                    deployment_mode=getattr(gateway, "deployment_mode", None),
+                    topology=getattr(gateway, "topology", None),
                 )
                 await adapter.connect()
                 try:
@@ -514,6 +524,7 @@ class DeploymentOrchestrationService:
         gateway_ids: list[UUID] | None,
     ) -> list[UUID]:
         if gateway_ids is None:
+            environment = normalize_deployment_environment(environment) or environment
             assignments = await self.assignment_repo.list_auto_deploy(api_catalog.id, environment)
             if not assignments:
                 raise ValueError(
@@ -694,7 +705,7 @@ class DeploymentOrchestrationService:
             .where(
                 Promotion.api_id == api_id,
                 Promotion.tenant_id == tenant_id,
-                Promotion.target_environment == target_environment,
+                Promotion.target_environment.in_(deployment_environment_aliases(target_environment)),
                 Promotion.status == PromotionStatus.PROMOTED.value,
             )
             .limit(1)
@@ -707,7 +718,7 @@ class DeploymentOrchestrationService:
             .where(
                 Promotion.api_id == api_id,
                 Promotion.tenant_id == tenant_id,
-                Promotion.target_environment == target_environment,
+                Promotion.target_environment.in_(deployment_environment_aliases(target_environment)),
                 Promotion.status == PromotionStatus.PROMOTED.value,
             )
             .order_by(Promotion.completed_at.desc())
@@ -718,7 +729,7 @@ class DeploymentOrchestrationService:
     async def _validate_gateways_for_env(self, gateway_ids: list[UUID], environment: str) -> None:
         for gw_id in gateway_ids:
             gateway = await self._get_gateway_or_raise(gw_id)
-            if gateway.environment != environment:
+            if not deployment_environment_matches(gateway.environment, environment):
                 raise ValueError(
                     f"Gateway '{gateway.name}' is in environment '{gateway.environment}', "
                     f"not '{environment}'. Select gateways matching the target environment."

--- a/control-plane-api/src/services/environment_aliases.py
+++ b/control-plane-api/src/services/environment_aliases.py
@@ -1,0 +1,55 @@
+"""Environment alias helpers for deployment/runtime target selection."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+_ENVIRONMENT_ALIASES: dict[str, tuple[str, ...]] = {
+    "dev": ("dev", "development"),
+    "staging": ("staging", "stage"),
+    "production": ("production", "prod"),
+}
+
+_ENVIRONMENT_CANONICAL: dict[str, str] = {
+    alias: canonical for canonical, aliases in _ENVIRONMENT_ALIASES.items() for alias in aliases
+}
+
+
+def normalize_deployment_environment(value: object) -> str | None:
+    """Return the canonical CP deployment environment label.
+
+    Control Plane APIs historically use ``production`` while gateway inventory
+    often stores the shorter ``prod`` label. Runtime selection must treat both
+    as the same environment.
+    """
+    if value is None:
+        return None
+    env = str(value).strip().lower()
+    if not env:
+        return None
+    return _ENVIRONMENT_CANONICAL.get(env, env)
+
+
+def deployment_environment_aliases(value: object) -> tuple[str, ...]:
+    """Return accepted storage aliases for an environment filter."""
+    canonical = normalize_deployment_environment(value)
+    if canonical is None:
+        return ()
+    return _ENVIRONMENT_ALIASES.get(canonical, (canonical,))
+
+
+def deployment_environment_matches(left: object, right: object) -> bool:
+    """Return True when two environment labels identify the same target env."""
+    return normalize_deployment_environment(left) == normalize_deployment_environment(right)
+
+
+def unique_environment_aliases(values: Iterable[object]) -> tuple[str, ...]:
+    """Return unique aliases for several environment labels, preserving order."""
+    seen: set[str] = set()
+    aliases: list[str] = []
+    for value in values:
+        for alias in deployment_environment_aliases(value):
+            if alias not in seen:
+                seen.add(alias)
+                aliases.append(alias)
+    return tuple(aliases)

--- a/control-plane-api/src/services/gateway_deployment_service.py
+++ b/control-plane-api/src/services/gateway_deployment_service.py
@@ -103,6 +103,16 @@ class GatewayDeploymentService:
         environment = (getattr(gateway, "environment", "") or "").strip().lower()
         return environment in {"prod", "production"}
 
+    @classmethod
+    def build_desired_state_for_gateway(cls, api_catalog, gateway, *, target_source: str) -> dict:
+        """Build desired state and stamp the concrete gateway target."""
+        return {
+            **cls.build_desired_state(api_catalog),
+            "target_gateway_name": getattr(gateway, "name", None),
+            "target_environment": getattr(gateway, "environment", None),
+            "target_source": target_source,
+        }
+
     async def deploy_api(
         self,
         api_catalog_id: UUID,
@@ -138,8 +148,10 @@ class GatewayDeploymentService:
                 )
 
             existing = await self.deploy_repo.get_by_api_and_gateway(api_catalog_id, gw_id)
+            desired_state = self.build_desired_state_for_gateway(api_catalog, gateway, target_source="direct")
+
             if existing:
-                existing.desired_state = self.build_desired_state(api_catalog)
+                existing.desired_state = desired_state
                 existing.desired_at = now
                 existing.sync_status = DeploymentSyncStatus.PENDING
                 existing.sync_error = None
@@ -150,7 +162,7 @@ class GatewayDeploymentService:
                 deployment = GatewayDeployment(
                     api_catalog_id=api_catalog_id,
                     gateway_instance_id=gw_id,
-                    desired_state=self.build_desired_state(api_catalog),
+                    desired_state=desired_state,
                     desired_at=now,
                     sync_status=DeploymentSyncStatus.PENDING,
                 )

--- a/control-plane-api/src/workers/sync_engine.py
+++ b/control-plane-api/src/workers/sync_engine.py
@@ -239,9 +239,31 @@ class SyncEngine:
 
             logger.info("Reconciling %d deployments", len(deployments))
 
-            # Filter out ERROR deployments that exceeded max retries
+            now = datetime.now(UTC)
+            timeout_seconds = getattr(settings, "SYNC_ENGINE_PENDING_TIMEOUT_SECONDS", 0)
+            if not isinstance(timeout_seconds, int | float):
+                timeout_seconds = 0
+
+            # Fail old PENDING/SYNCING records explicitly instead of leaving
+            # them as an ambiguous in-progress state forever.
             actionable = []
             for dep in deployments:
+                if timeout_seconds > 0 and dep.sync_status in (
+                    DeploymentSyncStatus.PENDING,
+                    DeploymentSyncStatus.SYNCING,
+                ):
+                    stale_after = timedelta(seconds=timeout_seconds)
+                    reference_time = dep.last_sync_attempt or dep.desired_at or dep.created_at
+                    if reference_time and now - reference_time > stale_after:
+                        dep.sync_status = DeploymentSyncStatus.ERROR
+                        dep.sync_error = (
+                            f"Gateway did not acknowledge deployment within {timeout_seconds} seconds; "
+                            "force sync or redeploy after checking the target gateway."
+                        )
+                        dep.sync_attempts = max(dep.sync_attempts, settings.SYNC_ENGINE_RETRY_MAX)
+                        await repo.update(dep)
+                        continue
+
                 if (
                     dep.sync_status == DeploymentSyncStatus.ERROR
                     and dep.sync_attempts >= settings.SYNC_ENGINE_RETRY_MAX
@@ -255,7 +277,10 @@ class SyncEngine:
                 actionable.append(dep)
 
             if not actionable:
+                await session.commit()
                 return
+
+            await session.commit()
 
             # Dispatch bounded concurrent tasks
             tasks = [self._reconcile_one(dep.id) for dep in actionable]
@@ -288,7 +313,10 @@ class SyncEngine:
                 return
 
             # Generation check (CAB-1950): skip if this generation was already attempted
-            if deployment.attempted_generation >= deployment.desired_generation:
+            if (
+                deployment.attempted_generation >= deployment.desired_generation
+                and deployment.sync_status != DeploymentSyncStatus.ERROR
+            ):
                 logger.debug(
                     "Deployment %s: generation %d already attempted (desired=%d), skipping",
                     deployment_id,
@@ -315,6 +343,8 @@ class SyncEngine:
                     gateway.auth_config,
                     source=gateway.source,
                     gateway_name=gateway.name,
+                    deployment_mode=getattr(gateway, "deployment_mode", None),
+                    topology=getattr(gateway, "topology", None),
                 )
 
                 tracker.start("adapter_connected")
@@ -514,6 +544,8 @@ class SyncEngine:
                         gateway.auth_config,
                         source=gateway.source,
                         gateway_name=gateway.name,
+                        deployment_mode=getattr(gateway, "deployment_mode", None),
+                        topology=getattr(gateway, "topology", None),
                     )
                     await adapter.connect()
                     apis = await adapter.list_apis()

--- a/control-plane-api/tests/test_deployment_orchestration_service.py
+++ b/control-plane-api/tests/test_deployment_orchestration_service.py
@@ -326,8 +326,8 @@ class TestDeploymentOrchestrationService:
             mock_deploy.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_auto_deploy_skips_when_no_assignments(self):
-        """auto_deploy_on_promotion should return empty when no assignments."""
+    async def test_auto_deploy_fails_when_no_assignments(self):
+        """auto_deploy_on_promotion must not silently succeed with zero runtime targets."""
         from src.services.deployment_orchestration_service import DeploymentOrchestrationService
 
         catalog = self._make_catalog()
@@ -342,14 +342,26 @@ class TestDeploymentOrchestrationService:
 
             mock_assign.return_value = []
 
-            result = await svc.auto_deploy_on_promotion(
-                api_id="payments-v2",
-                tenant_id="acme",
-                target_environment="staging",
-                approved_by="admin",
-            )
+            with pytest.raises(ValueError, match="no auto-deploy gateway assignments"):
+                await svc.auto_deploy_on_promotion(
+                    api_id="payments-v2",
+                    tenant_id="acme",
+                    target_environment="staging",
+                    approved_by="admin",
+                )
 
-            assert result == []
+    @pytest.mark.asyncio
+    async def test_validate_gateways_accepts_prod_production_alias(self):
+        """Runtime gateway rows may store prod while public APIs pass production."""
+        from src.services.deployment_orchestration_service import DeploymentOrchestrationService
+
+        gw_id = uuid4()
+        gateway = self._make_gateway(id=gw_id, name="connect-webmethods-prod", environment="prod")
+        db = AsyncMock()
+        svc = DeploymentOrchestrationService(db)
+
+        with patch.object(svc, "_get_gateway_or_raise", new_callable=AsyncMock, return_value=gateway):
+            await svc._validate_gateways_for_env([gw_id], "production")
 
     @pytest.mark.asyncio
     async def test_get_deployable_environments(self):

--- a/control-plane-api/tests/test_regression_catalog_gateway_dr.py
+++ b/control-plane-api/tests/test_regression_catalog_gateway_dr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -60,3 +61,61 @@ async def test_regression_catalog_gateway_targets_rebuild_pending_deployment() -
     assert created[0].sync_status == DeploymentSyncStatus.PENDING
     assert created[0].desired_state["target_environment"] == "dev"
     db.flush.assert_awaited_once()
+
+
+async def test_regression_catalog_boolean_deployment_uses_gateway_assignments() -> None:
+    db = AsyncMock()
+    catalog_entry = MagicMock(
+        id=uuid4(),
+        tenant_id="acme",
+        api_id="billing-api",
+        target_gateways=[],
+    )
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = catalog_entry
+    db.execute = AsyncMock(return_value=result)
+
+    gateway_id = uuid4()
+    assignment = SimpleNamespace(gateway_id=gateway_id)
+    gateway = SimpleNamespace(id=gateway_id, name="connect-webmethods-dev", environment="dev")
+
+    gw_repo = MagicMock()
+    gw_repo.get_by_id = AsyncMock(return_value=gateway)
+
+    assignment_repo = MagicMock()
+    assignment_repo.list_auto_deploy = AsyncMock(return_value=[assignment])
+
+    created = []
+    deploy_repo = MagicMock()
+    deploy_repo.get_by_api_and_gateway = AsyncMock(return_value=None)
+    deploy_repo.create = AsyncMock(side_effect=lambda deployment: created.append(deployment))
+
+    api_content = {
+        "name": "Billing API",
+        "deployments": {
+            "dev": True,
+        },
+    }
+
+    with (
+        patch("src.services.catalog_deployment_reconciler.GatewayInstanceRepository", return_value=gw_repo),
+        patch("src.services.catalog_deployment_reconciler.GatewayDeploymentRepository", return_value=deploy_repo),
+        patch("src.services.catalog_deployment_reconciler.ApiGatewayAssignmentRepository", return_value=assignment_repo),
+        patch(
+            "src.services.catalog_deployment_reconciler.GatewayDeploymentService.build_desired_state",
+            return_value={"spec": "v1"},
+        ),
+    ):
+        changed = await CatalogDeploymentReconciler(db).reconcile_api(
+            tenant_id="acme",
+            api_id="billing-api",
+            api_content=api_content,
+        )
+
+    assert changed is True
+    assignment_repo.list_auto_deploy.assert_awaited_once_with(catalog_entry.id, "dev")
+    assert len(created) == 1
+    assert created[0].gateway_instance_id == gateway_id
+    assert created[0].desired_state["target_source"] == "assignment"
+    assert created[0].desired_state["target_gateway_name"] == "connect-webmethods-dev"
+    assert created[0].sync_status == DeploymentSyncStatus.PENDING

--- a/control-plane-api/tests/test_regression_inline_sync_self_register.py
+++ b/control-plane-api/tests/test_regression_inline_sync_self_register.py
@@ -39,6 +39,8 @@ async def test_regression_inline_sync_skips_self_register_gateways():
     gw.auth_config = {}
     gw.source = "self_register"
     gw.status = MagicMock(value="online")
+    gw.deployment_mode = "connect"
+    gw.topology = "remote-agent"
 
     with patch(
         "src.repositories.gateway_instance.GatewayInstanceRepository"
@@ -59,3 +61,40 @@ async def test_regression_inline_sync_skips_self_register_gateways():
             mock_adapter.assert_awaited_once()
             # Verify source was passed to the centralized guard
             assert mock_adapter.call_args.kwargs["source"] == "self_register"
+            assert mock_adapter.call_args.kwargs["deployment_mode"] == "connect"
+
+
+@pytest.mark.asyncio
+async def test_regression_self_registered_connect_topology_is_agent_managed():
+    """self_register + deployment_mode=connect must wait for agent ack, not CP push."""
+    from src.services.credential_resolver import create_adapter_with_credentials
+
+    with pytest.raises(AgentManagedGatewayError):
+        await create_adapter_with_credentials(
+            "stoa_sidecar",
+            "http://stoa-link-wm-dev:8080",
+            {},
+            source="self_register",
+            gateway_name="stoa-link-wm-dev-sidecar-dev",
+            deployment_mode="connect",
+            topology="remote-agent",
+        )
+
+
+@pytest.mark.asyncio
+async def test_regression_self_registered_edge_topology_remains_push_capable():
+    """self_register STOA edge gateways are still push-capable native edge targets."""
+    from src.services.credential_resolver import create_adapter_with_credentials
+
+    with patch("src.services.credential_resolver.AdapterRegistry.create") as mock_create:
+        await create_adapter_with_credentials(
+            "stoa_edge_mcp",
+            "http://stoa-gateway-dev:8080",
+            {},
+            source="self_register",
+            gateway_name="stoa-gateway-dev-edge-mcp-dev",
+            deployment_mode="edge",
+            topology="native-edge",
+        )
+
+    mock_create.assert_called_once()

--- a/control-plane-api/tests/test_sync_engine.py
+++ b/control-plane-api/tests/test_sync_engine.py
@@ -1,6 +1,6 @@
 """Tests for SyncEngine — reconciliation and drift detection."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -165,6 +165,55 @@ class TestSyncEngine:
             assert deployment.sync_attempts == 1
 
     @pytest.mark.asyncio
+    async def test_reconcile_error_retries_same_generation_before_max_retries(self):
+        """ERROR deployments must retry even when the current generation was already attempted."""
+        deployment = self._make_deployment(
+            sync_status=DeploymentSyncStatus.ERROR,
+            sync_attempts=1,
+            desired_generation=3,
+            attempted_generation=3,
+        )
+        gateway = self._make_gateway(id=deployment.gateway_instance_id)
+        adapter = self._make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id = AsyncMock(return_value=deployment)
+        mock_repo.update = AsyncMock(return_value=deployment)
+
+        mock_gw_repo = MagicMock()
+        mock_gw_repo.get_by_id = AsyncMock(return_value=gateway)
+
+        mock_factory = MagicMock(
+            return_value=MagicMock(
+                __aenter__=AsyncMock(return_value=mock_session),
+                __aexit__=AsyncMock(return_value=False),
+            )
+        )
+
+        with (
+            patch("src.workers.sync_engine._get_session_factory", return_value=mock_factory),
+            patch("src.workers.sync_engine.GatewayDeploymentRepository", return_value=mock_repo),
+            patch("src.workers.sync_engine.GatewayInstanceRepository", return_value=mock_gw_repo),
+            patch(
+                "src.workers.sync_engine.create_adapter_with_credentials", new_callable=AsyncMock, return_value=adapter
+            ),
+        ):
+            from src.workers.sync_engine import SyncEngine
+
+            engine = SyncEngine()
+            engine._semaphore = MagicMock()
+            engine._semaphore.__aenter__ = AsyncMock()
+            engine._semaphore.__aexit__ = AsyncMock()
+
+            await engine._reconcile_one(deployment.id)
+
+        adapter.sync_api.assert_awaited_once()
+        assert deployment.sync_status == DeploymentSyncStatus.SYNCED
+
+    @pytest.mark.asyncio
     async def test_reconcile_delete_success(self):
         """DELETING deployment is deleted from DB on adapter success."""
         deployment = self._make_deployment(
@@ -298,6 +347,49 @@ class TestSyncEngine:
 
             # _reconcile_one should NOT be called since deployment exceeded retries
             engine._reconcile_one.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reconcile_all_expires_stale_pending_deployment(self):
+        """PENDING/SYNCING deployments must not stay pending forever."""
+        deployment = self._make_deployment(
+            sync_status=DeploymentSyncStatus.PENDING,
+            sync_attempts=0,
+            last_sync_attempt=datetime.now(UTC) - timedelta(seconds=7200),
+        )
+
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_repo = MagicMock()
+        mock_repo.list_by_statuses = AsyncMock(return_value=[deployment])
+        mock_repo.update = AsyncMock(return_value=deployment)
+
+        mock_factory = MagicMock(
+            return_value=MagicMock(
+                __aenter__=AsyncMock(return_value=mock_session),
+                __aexit__=AsyncMock(return_value=False),
+            )
+        )
+
+        with (
+            patch("src.workers.sync_engine._get_session_factory", return_value=mock_factory),
+            patch("src.workers.sync_engine.GatewayDeploymentRepository", return_value=mock_repo),
+            patch("src.workers.sync_engine.settings") as mock_settings,
+        ):
+            mock_settings.SYNC_ENGINE_RETRY_MAX = 3
+            mock_settings.SYNC_ENGINE_INTERVAL_SECONDS = 300
+            mock_settings.SYNC_ENGINE_PENDING_TIMEOUT_SECONDS = 3600
+
+            from src.workers.sync_engine import SyncEngine
+
+            engine = SyncEngine()
+            engine._reconcile_one = AsyncMock()
+
+            await engine._reconcile_all()
+
+        assert deployment.sync_status == DeploymentSyncStatus.ERROR
+        assert "did not acknowledge" in deployment.sync_error
+        assert deployment.sync_attempts == 3
+        engine._reconcile_one.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_drift_detect_hash_mismatch(self):

--- a/specs/api-runtime-reconciliation-contract.md
+++ b/specs/api-runtime-reconciliation-contract.md
@@ -251,6 +251,10 @@ Invariants spécifiques:
   `GatewayDeployment.environment` doivent être identiques pour une même cible.
   Les alias `prod`/`production` doivent être normalisés avant toute sélection ou
   promotion.
+- Les APIs publiques peuvent continuer à accepter `production`, mais la
+  résolution runtime doit interroger les deux formes `production` et `prod`.
+  Une gateway stockée en `prod` est donc valide pour une action Console
+  `production`, et inversement.
 
 ## 3. Invariants
 
@@ -330,6 +334,10 @@ offline.
   UI de choix gateway. Le résultat `0 deployment` silencieux est interdit.
 - Un changement d'environnement ne doit jamais conserver une gateway sélectionnée
   dans un autre environnement.
+- Un bloc Git/UAC `deployments.<env>: true` ne crée pas de cible par devinette.
+  Il peut matérialiser des `GatewayDeployment` uniquement si des
+  `ApiGatewayAssignment(auto_deploy=true)` existent pour l'API et l'environnement
+  normalisé.
 
 ### 3.3 Promotion et sync
 
@@ -358,6 +366,9 @@ offline.
   En architecture cible ADR-059 SSE, une perte de connexion Link laisse
   l'intention en attente jusqu'au reconnect/catch-up, mais la Console doit
   rendre cette attente visible.
+- Le timeout par défaut côté CP est `SYNC_ENGINE_PENDING_TIMEOUT_SECONDS`.
+  Passé ce délai, un `pending/syncing` sans ack gateway devient `error`
+  actionnable; un `synced` déjà acquitté ne doit pas être dégradé par ce timeout.
 - La Console doit afficher un état actionnable: re-sync, inspect gateway, ou
   supprimer la cible.
 


### PR DESCRIPTION
## Summary
- normalize runtime environment aliases so prod/production resolve to the same gateway targets
- fail promotions with zero auto-deploy assignments instead of silently succeeding
- treat self-registered connect/remote-agent gateways as agent-managed ack targets, not CP push targets
- add sync pending timeout, retry same generation errors, assignment-based Git/UAC deployment materialization, and migration backfill/cleanup
- align specs/api-runtime-reconciliation-contract.md with the runtime target contract

## Validation
- cd control-plane-api && python3 -m pytest -q
- cd control-plane-api && python3 -m ruff check src tests/test_deployment_orchestration_service.py tests/test_regression_inline_sync_self_register.py tests/test_sync_engine.py tests/test_regression_catalog_gateway_dr.py tests/test_openapi_contract.py tests/test_regression_cab_1977_alembic_heads.py
- cd control-plane-api && python3 -m pytest tests/test_openapi_contract.py -q
- cd shared && npm run generate:api-types
- CI contract parity: generated /tmp OpenAPI types + inject-tsnocheck matched shared/api-types/generated.ts
- git diff --check