### PR TITLE
fix(portal): expose provider plans for subscriptions

### DIFF
--- a/control-plane-api/alembic/versions/101_seed_portal_subscription_plans.py
+++ b/control-plane-api/alembic/versions/101_seed_portal_subscription_plans.py
@@ -1,0 +1,133 @@
+"""seed default Portal subscription plans for published API tenants
+
+Revision ID: 101_seed_portal_subscription_plans
+Revises: 100_fix_webmethods_nonprod_urls
+Create Date: 2026-05-01
+
+Prod catalog tenants can expose Portal APIs before any subscription plans are
+created for that provider tenant. The Portal then cannot complete the
+subscription flow because plan selection is empty. This migration inserts a
+minimal active self-service plan set only for tenants that currently publish at
+least one Portal API and have zero active plans.
+"""
+
+import json
+from collections.abc import Sequence
+from uuid import NAMESPACE_DNS, uuid5
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "101_seed_portal_subscription_plans"
+down_revision: str | tuple[str, ...] | None = "100_fix_webmethods_nonprod_urls"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_CREATED_BY = "alembic:101_seed_portal_subscription_plans"
+_SOURCE = "alembic-101-portal-default-plans"
+
+_DEFAULT_PLANS = (
+    {
+        "slug": "portal-standard",
+        "name": "Portal Standard",
+        "description": "Self-service plan for validating a Portal subscription flow.",
+        "rate_limit_per_second": 10,
+        "rate_limit_per_minute": 600,
+        "daily_request_limit": 50_000,
+        "monthly_request_limit": 1_000_000,
+        "burst_limit": 20,
+        "requires_approval": False,
+    },
+    {
+        "slug": "portal-premium",
+        "name": "Portal Premium",
+        "description": "Higher-volume plan for production-like Portal validation.",
+        "rate_limit_per_second": 50,
+        "rate_limit_per_minute": 3_000,
+        "daily_request_limit": 500_000,
+        "monthly_request_limit": 10_000_000,
+        "burst_limit": 100,
+        "requires_approval": True,
+    },
+)
+
+
+def _plan_id(tenant_id: str, slug: str) -> str:
+    return str(uuid5(NAMESPACE_DNS, f"stoa:portal-default-plan:{tenant_id}:{slug}"))
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    tenant_ids = (
+        conn.execute(
+            sa.text("""
+                SELECT DISTINCT c.tenant_id
+                FROM api_catalog c
+                WHERE c.portal_published IS TRUE
+                  AND c.deleted_at IS NULL
+                  AND COALESCE(c.tenant_id, '') <> ''
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM plans p
+                    WHERE p.tenant_id = c.tenant_id
+                      AND p.status = 'active'
+                  )
+                ORDER BY c.tenant_id
+            """)
+        )
+        .scalars()
+        .all()
+    )
+
+    for tenant_id in tenant_ids:
+        for plan in _DEFAULT_PLANS:
+            metadata = {
+                "source": _SOURCE,
+                "scope": "portal-default",
+                "tenant_id": tenant_id,
+                "requests_per_minute": plan["rate_limit_per_minute"],
+            }
+            conn.execute(
+                sa.text("""
+                    INSERT INTO plans (
+                        id, slug, name, description, tenant_id,
+                        rate_limit_per_second, rate_limit_per_minute,
+                        daily_request_limit, monthly_request_limit, burst_limit,
+                        requires_approval, status, pricing_metadata, created_by
+                    )
+                    VALUES (
+                        :id, :slug, :name, :description, :tenant_id,
+                        :rate_limit_per_second, :rate_limit_per_minute,
+                        :daily_request_limit, :monthly_request_limit, :burst_limit,
+                        :requires_approval, 'active', CAST(:pricing_metadata AS json), :created_by
+                    )
+                    ON CONFLICT (tenant_id, slug) DO NOTHING
+                """),
+                {
+                    "id": _plan_id(str(tenant_id), str(plan["slug"])),
+                    "slug": plan["slug"],
+                    "name": plan["name"],
+                    "description": plan["description"],
+                    "tenant_id": tenant_id,
+                    "rate_limit_per_second": plan["rate_limit_per_second"],
+                    "rate_limit_per_minute": plan["rate_limit_per_minute"],
+                    "daily_request_limit": plan["daily_request_limit"],
+                    "monthly_request_limit": plan["monthly_request_limit"],
+                    "burst_limit": plan["burst_limit"],
+                    "requires_approval": plan["requires_approval"],
+                    "pricing_metadata": json.dumps(metadata),
+                    "created_by": _CREATED_BY,
+                },
+            )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text("""
+            DELETE FROM plans
+            WHERE created_by = :created_by
+              AND pricing_metadata->>'source' = :source
+        """),
+        {"created_by": _CREATED_BY, "source": _SOURCE},
+    )

--- a/control-plane-api/src/routers/portal.py
+++ b/control-plane-api/src/routers/portal.py
@@ -22,7 +22,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..auth.dependencies import User, get_current_user
 from ..database import get_db as get_async_db
 from ..models.mcp_subscription import MCPServer, MCPServerCategory, MCPServerStatus, MCPServerTool
+from ..models.plan import PlanStatus
 from ..repositories.catalog import CatalogRepository, escape_like, get_allowed_audiences
+from ..repositories.plan import PlanRepository
+from ..schemas.plan import PlanListResponse, PlanResponse
 from ..schemas.portal import APIListItem, MCPServerListItem
 from ..services.mcp_tool_expander import expand_api
 
@@ -286,6 +289,53 @@ class PortalMCPServersResponse(BaseModel):
 # ============================================================================
 # API Catalog Endpoints (CAB-682: Now using PostgreSQL cache)
 # ============================================================================
+
+
+@router.get("/plans/{tenant_id}", response_model=PlanListResponse)
+async def list_portal_plans(
+    tenant_id: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+):
+    """List active subscription plans for a provider tenant visible in Portal.
+
+    The admin plans endpoint remains tenant-scoped. Portal users can browse
+    cross-tenant APIs, so they also need read-only access to the active plans
+    for tenants that expose at least one visible Portal API.
+    """
+    try:
+        catalog_repo = CatalogRepository(db)
+        _visible_apis, visible_total = await catalog_repo.get_portal_apis(
+            tenant_id=tenant_id,
+            user_roles=list(user.roles or []),
+            page=1,
+            page_size=1,
+        )
+        if visible_total == 0:
+            raise HTTPException(status_code=404, detail="No visible Portal APIs for this tenant")
+
+        plan_repo = PlanRepository(db)
+        plans, total = await plan_repo.list_by_tenant(
+            tenant_id=tenant_id,
+            status=PlanStatus.ACTIVE,
+            page=page,
+            page_size=page_size,
+        )
+
+        return PlanListResponse(
+            items=[PlanResponse.model_validate(p) for p in plans],
+            total=total,
+            page=page,
+            page_size=page_size,
+            total_pages=((total + page_size - 1) // page_size) if total > 0 else 1,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to list Portal plans for tenant {tenant_id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to list plans")
 
 
 @router.get("/apis", response_model=PortalAPIsResponse)

--- a/control-plane-api/tests/test_regression_portal_provider_plans.py
+++ b/control-plane-api/tests/test_regression_portal_provider_plans.py
@@ -1,0 +1,115 @@
+"""Regression tests for Portal provider plan discovery.
+
+The Developer Portal can show APIs from provider tenants other than the
+consumer's tenant. Plan selection must therefore use a read-only Portal surface
+instead of the tenant-admin plans endpoint.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from src.models.plan import PlanStatus
+
+
+def _make_plan(**overrides):
+    plan = MagicMock()
+    now = datetime.now(UTC).replace(tzinfo=None)
+    defaults = {
+        "id": uuid4(),
+        "slug": "portal-standard",
+        "name": "Portal Standard",
+        "description": "Self-service plan",
+        "tenant_id": "acme",
+        "rate_limit_per_second": 10,
+        "rate_limit_per_minute": 600,
+        "daily_request_limit": 50_000,
+        "monthly_request_limit": 1_000_000,
+        "burst_limit": 20,
+        "requires_approval": False,
+        "auto_approve_roles": None,
+        "status": PlanStatus.ACTIVE,
+        "pricing_metadata": {"source": "test"},
+        "created_at": now,
+        "updated_at": now,
+        "created_by": "test",
+    }
+    defaults.update(overrides)
+    for key, value in defaults.items():
+        setattr(plan, key, value)
+    return plan
+
+
+class TestPortalProviderPlans:
+    def test_portal_plans_allows_visible_cross_tenant_provider(self, client_as_other_tenant):
+        catalog_repo = MagicMock()
+        catalog_repo.get_portal_apis = AsyncMock(return_value=([MagicMock()], 1))
+        plan_repo = MagicMock()
+        plan_repo.list_by_tenant = AsyncMock(return_value=([_make_plan()], 1))
+
+        with (
+            patch("src.routers.portal.CatalogRepository", return_value=catalog_repo),
+            patch("src.routers.portal.PlanRepository", return_value=plan_repo),
+        ):
+            response = client_as_other_tenant.get("/v1/portal/plans/acme")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["items"][0]["slug"] == "portal-standard"
+        plan_repo.list_by_tenant.assert_awaited_once_with(
+            tenant_id="acme",
+            status=PlanStatus.ACTIVE,
+            page=1,
+            page_size=50,
+        )
+
+    def test_portal_plans_hide_tenants_without_visible_portal_api(self, client_as_other_tenant):
+        catalog_repo = MagicMock()
+        catalog_repo.get_portal_apis = AsyncMock(return_value=([], 0))
+        plan_repo = MagicMock()
+        plan_repo.list_by_tenant = AsyncMock()
+
+        with (
+            patch("src.routers.portal.CatalogRepository", return_value=catalog_repo),
+            patch("src.routers.portal.PlanRepository", return_value=plan_repo),
+        ):
+            response = client_as_other_tenant.get("/v1/portal/plans/acme")
+
+        assert response.status_code == 404
+        plan_repo.list_by_tenant.assert_not_awaited()
+
+
+_MIGRATION_PATH = Path(__file__).parent.parent / "alembic" / "versions" / "101_seed_portal_subscription_plans.py"
+_SPEC = importlib.util.spec_from_file_location("migration_101", _MIGRATION_PATH)
+_MIGRATION = importlib.util.module_from_spec(_SPEC)
+sys.modules["migration_101"] = _MIGRATION
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_MIGRATION)
+
+
+class TestPortalPlanSeedMigration:
+    def test_seed_migration_chains_after_current_head(self):
+        assert _MIGRATION.down_revision == "100_fix_webmethods_nonprod_urls"
+
+    def test_seed_migration_targets_only_published_tenants_without_active_plans(self):
+        source = _MIGRATION_PATH.read_text(encoding="utf-8")
+        assert "c.portal_published IS TRUE" in source
+        assert "c.deleted_at IS NULL" in source
+        assert "NOT EXISTS" in source
+        assert "p.status = 'active'" in source
+        assert "portal-standard" in source
+        assert "portal-premium" in source
+
+    def test_seed_plan_ids_are_deterministic_per_tenant_and_slug(self):
+        first = _MIGRATION._plan_id("high-five", "portal-standard")
+        second = _MIGRATION._plan_id("high-five", "portal-standard")
+        other = _MIGRATION._plan_id("ioi", "portal-standard")
+
+        assert first == second
+        assert first != other

--- a/portal/src/services/plans.test.ts
+++ b/portal/src/services/plans.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { plansService } from './plans';
+import { apiClient } from './api';
+
+vi.mock('./api', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+describe('plansService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists plans through the read-only Portal provider endpoint', async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({
+      data: {
+        items: [],
+        total: 0,
+        page: 1,
+        page_size: 50,
+        total_pages: 1,
+      },
+    });
+
+    await plansService.list('acme', { status: 'active' });
+
+    expect(apiClient.get).toHaveBeenCalledWith('/v1/portal/plans/acme', {
+      params: {
+        page: 1,
+        page_size: 50,
+        status: 'active',
+      },
+    });
+  });
+});

--- a/portal/src/services/plans.ts
+++ b/portal/src/services/plans.ts
@@ -1,8 +1,8 @@
 /**
  * STOA Developer Portal - Plans Service
  *
- * Service for listing subscription plans.
- * Uses Control Plane API endpoints (/v1/plans).
+ * Service for listing subscription plans in the Developer Portal.
+ * Uses read-only Portal endpoints for cross-tenant provider plans.
  *
  * Reference: CAB-1121 Phase 5
  */
@@ -18,11 +18,11 @@ export interface ListPlansParams {
 
 export const plansService = {
   /**
-   * List plans for a tenant
-   * GET /v1/plans/{tenant_id}
+   * List active plans for a Portal-visible provider tenant
+   * GET /v1/portal/plans/{tenant_id}
    */
   list: async (tenantId: string, params?: ListPlansParams): Promise<PlanListResponse> => {
-    const response = await apiClient.get<PlanListResponse>(`/v1/plans/${tenantId}`, {
+    const response = await apiClient.get<PlanListResponse>(`/v1/portal/plans/${tenantId}`, {
       params: {
         page: params?.page || 1,
         page_size: params?.pageSize || 50,


### PR DESCRIPTION
## Summary
- add a read-only Portal endpoint for active provider plans so cross-tenant API subscriptions do not use the tenant-admin plans endpoint
- switch the Portal plan service to /v1/portal/plans/{tenant_id}
- add an idempotent Alembic seed for published API tenants that currently have zero active plans
- add backend and frontend regression coverage

## Validation
- ruff check src/routers/portal.py tests/test_regression_portal_provider_plans.py alembic/versions/101_seed_portal_subscription_plans.py
- python3 -m pytest tests/test_regression_portal_provider_plans.py -q
- python3 -m pytest tests/test_plans_router.py tests/test_portal_apis.py tests/test_regression_cab_1977_alembic_heads.py -q
- python3 -m pytest tests/test_openapi_contract.py -q
- npx eslint src/services/plans.ts src/services/plans.test.ts --max-warnings 0
- npm test -- src/services/plans.test.ts src/hooks/usePlans.test.tsx src/components/consumers/SubscribeWithPlanModal.test.tsx
- npx tsc -p tsconfig.app.json --noEmit
- npm run build