### PR TITLE
fix(sync): enforce route ack step consistency

### DIFF
--- a/control-plane-api/alembic/versions/103_route_sync_ack_consistency.py
+++ b/control-plane-api/alembic/versions/103_route_sync_ack_consistency.py
@@ -1,0 +1,50 @@
+"""route sync ack consistency repair
+
+Revision ID: 103_route_sync_ack_consistency
+Revises: 102_runtime_target_reconciliation
+Create Date: 2026-05-01
+
+Repairs GatewayDeployment rows that were marked synced even though their
+stored route-sync step trace contains a failed step.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "103_route_sync_ack_consistency"
+down_revision: str | tuple[str, ...] | None = "102_runtime_target_reconciliation"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text("""
+            UPDATE gateway_deployments gd
+            SET sync_status = 'error',
+                sync_error = COALESCE(
+                    (
+                        SELECT NULLIF(step ->> 'detail', '')
+                        FROM jsonb_array_elements(COALESCE(gd.sync_steps, '[]'::jsonb)) AS step
+                        WHERE step ->> 'status' = 'failed'
+                        LIMIT 1
+                    ),
+                    'Gateway ack contained a failed sync step while deployment was marked synced'
+                ),
+                updated_at = NOW()
+            WHERE gd.sync_status = 'synced'
+              AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(COALESCE(gd.sync_steps, '[]'::jsonb)) AS step
+                  WHERE step ->> 'status' = 'failed'
+              )
+        """)
+    )
+
+
+def downgrade() -> None:
+    # Data repair is intentionally not reversible: previous "synced" rows were
+    # internally contradictory and cannot be reconstructed safely.
+    pass

--- a/control-plane-api/src/routers/gateway_internal.py
+++ b/control-plane-api/src/routers/gateway_internal.py
@@ -881,6 +881,20 @@ async def route_sync_ack(
             cp_tracker.start("event_emitted")
             cp_tracker.complete("event_emitted", detail="deployment dispatched to agent")
             merged_steps = cp_tracker.to_list() + result.steps
+        step_error = None
+        if merged_steps:
+            from src.services.sync_step_tracker import SyncStepTracker
+
+            step_error = SyncStepTracker.from_list(merged_steps).first_error()
+        effective_status = result.status
+        effective_error = result.error
+        if result.status == "applied" and step_error:
+            logger.warning(
+                "route-sync-ack: applied result contains failed step for deployment=%s, treating as failed",
+                result.deployment_id,
+            )
+            effective_status = "failed"
+            effective_error = step_error
 
         # CAB-1950: reject stale generation acks
         if result.generation is not None and result.generation < deployment.desired_generation:
@@ -896,7 +910,7 @@ async def route_sync_ack(
         synced_generation = deployment.synced_generation if isinstance(deployment.synced_generation, int) else 0
 
         if (
-            result.status == "failed"
+            effective_status == "failed"
             and deployment.sync_status == DeploymentSyncStatus.SYNCED
             and deployment.last_sync_success is not None
             and synced_generation >= desired_generation
@@ -913,7 +927,7 @@ async def route_sync_ack(
             processed += 1
             continue
 
-        if result.status == "applied":
+        if effective_status == "applied":
             deployment.sync_status = DeploymentSyncStatus.SYNCED
             deployment.last_sync_success = now
             deployment.sync_error = None
@@ -922,18 +936,14 @@ async def route_sync_ack(
             if result.generation is not None:
                 deployment.synced_generation = result.generation
                 deployment.attempted_generation = result.generation
-        elif result.status == "failed":
+        elif effective_status == "failed":
             deployment.sync_status = DeploymentSyncStatus.ERROR
             if result.generation is not None:
                 deployment.attempted_generation = result.generation
             if merged_steps is not None:
                 deployment.sync_steps = merged_steps
             # Derive sync_error from step trace if available, else use scalar error
-            if merged_steps:
-                tracker = SyncStepTracker.from_list(merged_steps)
-                deployment.sync_error = tracker.first_error() or result.error
-            else:
-                deployment.sync_error = result.error
+            deployment.sync_error = step_error or effective_error
         else:
             logger.warning("route-sync-ack: unknown status=%s for deployment=%s", result.status, result.deployment_id)
             continue

--- a/control-plane-api/tests/test_gateway_internal.py
+++ b/control-plane-api/tests/test_gateway_internal.py
@@ -1168,6 +1168,48 @@ class TestRouteSyncAck:
             assert dep.sync_status == DeploymentSyncStatus.ERROR
             assert dep.sync_error == "connection refused"
 
+    def test_route_sync_ack_applied_with_failed_step_fails_closed(self, client):
+        """Contradictory applied ack with failed steps must not mark deployment synced."""
+        from src.models.gateway_deployment import DeploymentSyncStatus
+
+        dep = _make_deployment()
+
+        with (
+            patch("src.routers.gateway_internal.settings") as mock_settings,
+            patch("src.routers.gateway_internal.GatewayDeploymentRepository") as MockDeployRepo,
+        ):
+            mock_settings.gateway_api_keys_list = [VALID_KEY]
+            mock_deploy_repo = MockDeployRepo.return_value
+            mock_deploy_repo.get_by_id = AsyncMock(return_value=dep)
+            mock_deploy_repo.update = AsyncMock()
+
+            agent_steps = [
+                {"name": "agent_received", "status": "success", "started_at": "2026-04-02T12:00:01Z"},
+                {"name": "adapter_connected", "status": "success", "started_at": "2026-04-02T12:00:02Z"},
+                {
+                    "name": "api_synced",
+                    "status": "failed",
+                    "started_at": "2026-04-02T12:00:03Z",
+                    "detail": "webmethods activation failed",
+                },
+            ]
+
+            resp = client.post(
+                f"/v1/internal/gateways/{dep.gateway_instance_id}/route-sync-ack",
+                json={
+                    "synced_routes": [
+                        {"deployment_id": str(dep.id), "status": "applied", "steps": agent_steps},
+                    ],
+                    "sync_timestamp": "2026-04-02T12:00:04Z",
+                },
+                headers={GW_KEY_HEADER: VALID_KEY},
+            )
+
+            assert resp.status_code == 200
+            assert dep.sync_status == DeploymentSyncStatus.ERROR
+            assert dep.last_sync_success is None
+            assert dep.sync_error == "webmethods activation failed"
+
 
 class TestHelperFunctions:
     """Unit tests for internal helper functions."""

--- a/control-plane-api/tests/test_regression_route_sync_ack_stability.py
+++ b/control-plane-api/tests/test_regression_route_sync_ack_stability.py
@@ -71,3 +71,65 @@ def test_regression_route_sync_ack_failed_does_not_downgrade_stable_synced_deplo
         assert dep.sync_steps == successful_steps
         assert dep.sync_attempts == 0
         mock_deploy_repo.update.assert_awaited_once()
+
+
+def test_regression_route_sync_ack_contradictory_applied_reack_preserves_stable_synced_deployment(client):
+    """A bad applied ack trace must not overwrite an already stable synced route."""
+    last_success = datetime.now(UTC)
+    successful_steps = [
+        {"name": "event_emitted", "status": "success", "detail": "deployment dispatched to agent"},
+        {"name": "agent_received", "status": "success"},
+        {"name": "adapter_connected", "status": "success"},
+        {"name": "api_synced", "status": "success"},
+    ]
+    failed_applied_steps = [
+        {"name": "agent_received", "status": "success"},
+        {"name": "adapter_connected", "status": "success"},
+        {
+            "name": "api_synced",
+            "status": "failed",
+            "detail": "batch contained another failed route",
+        },
+    ]
+    dep = _make_deployment(
+        sync_status=DeploymentSyncStatus.SYNCED,
+        last_sync_success=last_success,
+        sync_error=None,
+        sync_steps=successful_steps,
+        sync_attempts=0,
+    )
+    dep.desired_generation = 3
+    dep.synced_generation = 3
+    dep.attempted_generation = 3
+
+    with (
+        patch("src.routers.gateway_internal.settings") as mock_settings,
+        patch("src.routers.gateway_internal.GatewayDeploymentRepository") as MockDeployRepo,
+    ):
+        mock_settings.gateway_api_keys_list = [VALID_KEY]
+        mock_deploy_repo = MockDeployRepo.return_value
+        mock_deploy_repo.get_by_id = AsyncMock(return_value=dep)
+        mock_deploy_repo.update = AsyncMock()
+
+        resp = client.post(
+            f"/v1/internal/gateways/{dep.gateway_instance_id}/route-sync-ack",
+            json={
+                "synced_routes": [
+                    {
+                        "deployment_id": str(dep.id),
+                        "status": "applied",
+                        "steps": failed_applied_steps,
+                        "generation": 3,
+                    },
+                ],
+                "sync_timestamp": "2026-03-27T12:00:00Z",
+            },
+            headers={GW_KEY_HEADER: VALID_KEY},
+        )
+
+        assert resp.status_code == 200
+        assert dep.sync_status == DeploymentSyncStatus.SYNCED
+        assert dep.last_sync_success == last_success
+        assert dep.sync_error is None
+        assert dep.sync_steps == successful_steps
+        mock_deploy_repo.update.assert_awaited_once()

--- a/specs/api-runtime-reconciliation-contract.md
+++ b/specs/api-runtime-reconciliation-contract.md
@@ -281,6 +281,14 @@ Un `GatewayDeployment` déjà `synced` ne peut changer vers `error`, `drifted` o
   n'existe plus ou ne correspond plus au desired state;
 - un opérateur force un resync et l'ack de cette nouvelle tentative échoue.
 
+Un ack gateway est atomique par `deployment_id`. Si `route-sync-ack` annonce
+`status=applied`, tous les steps attachés à ce résultat doivent être cohérents
+avec ce statut (`api_synced=success`, aucun step `failed`). Un ack contradictoire
+`status=applied` avec un step `failed` est refusé comme preuve de succès et doit
+être traité comme échec, sauf s'il s'agit d'un re-ack d'une génération déjà
+synced, auquel cas l'état `synced` précédent est préservé et l'observation est
+consignée sans remplacer la dernière preuve de succès.
+
 Statuts utilisateur canoniques à exposer sur `/api-deployments`:
 
 | Statut UI | Condition minimale |
@@ -576,6 +584,8 @@ PASS si le deployment a:
 - `sync_status=synced`
 - `last_sync_success` non nul
 - `actual_state` renseigné ou preuve équivalente que la gateway a appliqué la route
+- un ack par `deployment_id` dont le statut et les `sync_steps` sont cohérents
+  (`applied` ne peut pas contenir `api_synced=failed`)
 
 NOTE: un passage par SyncEngine ou inline sync peut être accepté comme compat
 legacy pendant la migration, mais ne doit pas devenir le contrat cible.
@@ -866,3 +876,4 @@ Critère GO pour toute PR touchant ce flux:
 | 2026-04-26 | Codex | Renommage en Runtime Reconciliation Contract et clarification connect/edge/sidecar |
 | 2026-04-26 | Codex | Clarification UAC JSON canonique; YAML réservé au packaging infra/GitOps |
 | 2026-04-26 | Codex | Ajout du contrat de fraîcheur Git et refus prod sans desired state Git-backed |
+| 2026-05-01 | Codex | Ajout de l'invariant route-sync-ack: statut par deployment_id cohérent avec les steps |

--- a/stoa-go/internal/connect/sync_route.go
+++ b/stoa-go/internal/connect/sync_route.go
@@ -61,14 +61,6 @@ func (s *routeSyncer) Sync(ctx context.Context, adminURL string, routes []adapte
 
 	syncOutcome, syncErr := s.adapter.SyncRoutes(ctx, adminURL, routes)
 
-	var apiStep SyncStep
-	if syncErr != nil {
-		apiStep = newSyncStep("api_synced", "failed", syncErr.Error())
-	} else {
-		apiStep = newSyncStep("api_synced", "success", "")
-	}
-	steps := []SyncStep{agentStep, adapterStep, apiStep}
-
 	failedMap := syncOutcome.FailedRoutes
 
 	var results []SyncedRouteResult
@@ -77,20 +69,23 @@ func (s *routeSyncer) Sync(ctx context.Context, adminURL string, routes []adapte
 			log.Printf("route-sync: skipping route %q — missing deployment_id (CP contract drift?)", r.Name)
 			continue
 		}
+		apiStep := newSyncStep("api_synced", "success", "")
 		result := SyncedRouteResult{
 			DeploymentID: r.DeploymentID,
-			Steps:        steps,
 			Generation:   r.Generation, // CAB-1950 — propagated on both paths (B.1 fix)
 		}
 		if routeErr, failed := failedMap[r.DeploymentID]; failed {
 			result.Status = "failed"
 			result.Error = routeErr
+			apiStep = newSyncStep("api_synced", "failed", routeErr)
 		} else if syncErr != nil && len(failedMap) == 0 {
 			result.Status = "failed"
 			result.Error = syncErr.Error()
+			apiStep = newSyncStep("api_synced", "failed", syncErr.Error())
 		} else {
 			result.Status = "applied"
 		}
+		result.Steps = []SyncStep{agentStep, adapterStep, apiStep}
 		results = append(results, result)
 	}
 

--- a/stoa-go/internal/connect/sync_route_test.go
+++ b/stoa-go/internal/connect/sync_route_test.go
@@ -113,8 +113,14 @@ func TestRouteSyncerPerRouteFailure(t *testing.T) {
 	if results[0].Status != "applied" {
 		t.Errorf("dep-1 should be applied, got %q", results[0].Status)
 	}
+	if got := results[0].Steps[2]; got.Name != "api_synced" || got.Status != "success" || got.Detail != "" {
+		t.Errorf("dep-1 should carry successful api_synced step, got %+v", got)
+	}
 	if results[1].Status != "failed" || results[1].Error != "route conflict" {
 		t.Errorf("dep-2 should be failed with 'route conflict', got status=%q err=%q", results[1].Status, results[1].Error)
+	}
+	if got := results[1].Steps[2]; got.Name != "api_synced" || got.Status != "failed" || got.Detail != "route conflict" {
+		t.Errorf("dep-2 should carry failed api_synced step, got %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make stoa-connect route sync steps per-route, so successful routes no longer carry a failed api_synced step from another failed route in the same batch
- make control-plane route-sync-ack fail closed when status=applied contradicts failed sync steps, while preserving already-synced generations on bad re-acks
- add migration 103 to repair existing false-green GatewayDeployment rows and update the runtime reconciliation contract

## Validation
- go test ./... (stoa-go)
- python3 -m pytest tests/test_gateway_internal.py::TestRouteSyncAck tests/test_regression_route_sync_ack_stability.py tests/test_regression_cab_1977_alembic_heads.py -q (control-plane-api)
- python3 -m ruff check src/routers/gateway_internal.py tests/test_gateway_internal.py tests/test_regression_route_sync_ack_stability.py alembic/versions/103_route_sync_ack_consistency.py