### PR TITLE
fix(gateways): isolate webMethods staging target

### DIFF
--- a/control-plane-api/alembic/versions/105_fix_webmethods_staging_target_urls.py
+++ b/control-plane-api/alembic/versions/105_fix_webmethods_staging_target_urls.py
@@ -1,0 +1,91 @@
+"""fix webMethods staging target urls
+
+Revision ID: 105_fix_webmethods_staging_target_urls
+Revises: 104_gateway_external_urls
+Create Date: 2026-05-02
+
+Staging webMethods has two external surfaces:
+
+* ``staging-wm.gostoa.dev`` reaches the third-party webMethods gateway.
+* ``staging-wm-k3s.gostoa.dev`` reaches the STOA remote-link runtime.
+
+The target gateway URL must identify the third-party gateway, otherwise a
+rebuild can make staging Link/Connect point back to the K3s STOA link.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "105_fix_webmethods_staging_target_urls"
+down_revision: str | tuple[str, ...] | None = "104_gateway_external_urls"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_WEBMETHODS_STAGING_URL_FIXES = (
+    (
+        "connect-webmethods-staging",
+        "staging",
+        "https://staging-wm.gostoa.dev",
+        "https://staging-wm.gostoa.dev",
+    ),
+    (
+        "connect-webmethods-staging-connect-staging",
+        "staging",
+        "https://staging-wm.gostoa.dev",
+        "https://staging-wm.gostoa.dev",
+    ),
+    (
+        "stoa-link-wm-staging",
+        "staging",
+        "https://staging-wm-k3s.gostoa.dev",
+        "https://staging-wm.gostoa.dev",
+    ),
+    (
+        "stoa-link-wm-staging-sidecar-staging",
+        "staging",
+        "https://staging-wm-k3s.gostoa.dev",
+        "https://staging-wm.gostoa.dev",
+    ),
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for name, environment, public_url, target_gateway_url in _WEBMETHODS_STAGING_URL_FIXES:
+        conn.execute(
+            sa.text("""
+                UPDATE gateway_instances
+                SET
+                  public_url = :public_url,
+                  target_gateway_url = :target_gateway_url,
+                  endpoints = jsonb_strip_nulls(
+                    (
+                      COALESCE(endpoints, '{}'::jsonb)
+                      - 'publicUrl' - 'public' - 'runtime_url' - 'runtimeUrl'
+                      - 'external_url' - 'externalUrl'
+                      - 'targetGatewayUrl' - 'target_url' - 'targetUrl'
+                    )
+                    || jsonb_build_object(
+                      'public_url', :public_url,
+                      'target_gateway_url', :target_gateway_url
+                    )
+                  ),
+                  updated_at = NOW()
+                WHERE name = :name
+                  AND environment = :environment
+                  AND deleted_at IS NULL
+            """),
+            {
+                "name": name,
+                "environment": environment,
+                "public_url": public_url,
+                "target_gateway_url": target_gateway_url,
+            },
+        )
+
+
+def downgrade() -> None:
+    # Data repair only. Previous values were inconsistent across rebuild paths.
+    pass

--- a/control-plane-api/tests/test_regression_cab_2240_webmethods_staging_targets.py
+++ b/control-plane-api/tests/test_regression_cab_2240_webmethods_staging_targets.py
@@ -1,0 +1,84 @@
+"""Regression coverage for staging webMethods target URL isolation."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAGING_OVERLAY = REPO_ROOT / "k8s" / "gateways" / "overlays" / "staging"
+MIGRATION = (
+    REPO_ROOT
+    / "control-plane-api"
+    / "alembic"
+    / "versions"
+    / "105_fix_webmethods_staging_target_urls.py"
+)
+
+
+def _load_yaml(path: Path) -> list[dict]:
+    with path.open(encoding="utf-8") as handle:
+        return [doc for doc in yaml.safe_load_all(handle) if isinstance(doc, dict)]
+
+
+def _env_map_from_stoa_link_patch() -> dict[str, str]:
+    kustomization = _load_yaml(STAGING_OVERLAY / "kustomization.yaml")[0]
+    link_patch = next(
+        patch
+        for patch in kustomization["patches"]
+        if patch["target"]["kind"] == "Deployment" and patch["target"]["name"] == "stoa-link-wm"
+    )
+    deployment = yaml.safe_load(link_patch["patch"])
+    env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
+    return {item["name"]: item["value"] for item in env}
+
+
+def test_regression_cab_2240_staging_link_targets_real_webmethods_gateway() -> None:
+    env = _env_map_from_stoa_link_patch()
+
+    assert env["STOA_GATEWAY_PUBLIC_URL"] == "https://staging-wm-k3s.gostoa.dev"
+    assert env["STOA_TARGET_GATEWAY_URL"] == "https://staging-wm.gostoa.dev"
+
+
+def test_regression_cab_2240_gateway_instances_keep_runtime_and_target_urls_separate() -> None:
+    instances = {doc["metadata"]["name"]: doc for doc in _load_yaml(STAGING_OVERLAY / "gateway-instances.yaml")}
+
+    connect_endpoints = instances["connect-webmethods-staging"]["spec"]["endpoints"]
+    assert connect_endpoints["publicUrl"] == "https://staging-wm.gostoa.dev"
+    assert connect_endpoints["targetGatewayUrl"] == "https://staging-wm.gostoa.dev"
+
+    link_endpoints = instances["stoa-link-wm-staging"]["spec"]["endpoints"]
+    assert link_endpoints["publicUrl"] == "https://staging-wm-k3s.gostoa.dev"
+    assert link_endpoints["targetGatewayUrl"] == "https://staging-wm.gostoa.dev"
+
+
+def test_regression_cab_2240_migration_repairs_all_staging_webmethods_rows() -> None:
+    spec = importlib.util.spec_from_file_location("migration_105", MIGRATION)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    fixes = {
+        name: (public_url, target_gateway_url)
+        for name, _environment, public_url, target_gateway_url in module._WEBMETHODS_STAGING_URL_FIXES
+    }
+
+    assert fixes["connect-webmethods-staging"] == (
+        "https://staging-wm.gostoa.dev",
+        "https://staging-wm.gostoa.dev",
+    )
+    assert fixes["connect-webmethods-staging-connect-staging"] == (
+        "https://staging-wm.gostoa.dev",
+        "https://staging-wm.gostoa.dev",
+    )
+    assert fixes["stoa-link-wm-staging"] == (
+        "https://staging-wm-k3s.gostoa.dev",
+        "https://staging-wm.gostoa.dev",
+    )
+    assert fixes["stoa-link-wm-staging-sidecar-staging"] == (
+        "https://staging-wm-k3s.gostoa.dev",
+        "https://staging-wm.gostoa.dev",
+    )

--- a/k8s/gateways/overlays/staging/gateway-instances.yaml
+++ b/k8s/gateways/overlays/staging/gateway-instances.yaml
@@ -16,8 +16,8 @@ spec:
   targetGatewayType: webmethods
   topology: remote-agent
   endpoints:
-    publicUrl: https://staging-wm-k3s.gostoa.dev
-    targetGatewayUrl: https://staging-wm-k3s.gostoa.dev
+    publicUrl: https://staging-wm.gostoa.dev
+    targetGatewayUrl: https://staging-wm.gostoa.dev
     adminUrl: http://connect-webmethods-staging:8090
     healthUrl: http://connect-webmethods-staging:8090/health
   capabilities:
@@ -76,7 +76,7 @@ spec:
   topology: remote-agent
   endpoints:
     publicUrl: https://staging-wm-k3s.gostoa.dev
-    targetGatewayUrl: https://staging-wm-k3s.gostoa.dev
+    targetGatewayUrl: https://staging-wm.gostoa.dev
     adminUrl: http://stoa-link-wm-staging:8080
     healthUrl: http://stoa-link-wm-staging:8080/health
   capabilities:

--- a/k8s/gateways/overlays/staging/kustomization.yaml
+++ b/k8s/gateways/overlays/staging/kustomization.yaml
@@ -68,7 +68,7 @@ patches:
                   - name: STOA_GATEWAY_PUBLIC_URL
                     value: "https://staging-wm-k3s.gostoa.dev"
                   - name: STOA_TARGET_GATEWAY_URL
-                    value: "https://staging-wm-k3s.gostoa.dev"
+                    value: "https://staging-wm.gostoa.dev"
                   - name: STOA_DEPLOYMENT_MODE
                     value: "connect"
                   - name: STOA_TARGET_GATEWAY_TYPE


### PR DESCRIPTION
## Summary
- point staging WebMethods Link runtime at the STOA K3s URL while keeping its target gateway on the real staging WebMethods URL
- align the staging GatewayInstance manifest for both Connect and Link
- add an Alembic repair so rebuilds do not restore staging target URLs to the K3s link host

## Live verification
- Applied the K3s Link runtime fix for dev and staging.
- Verified dev/staging Link deployments are rolled out and pods are Running.
- Verified /health returns 200 for direct WebMethods and STOA Link URLs.

## Tests
- kubectl kustomize k8s/gateways/overlays/dev
- kubectl kustomize k8s/gateways/overlays/staging
- python3 -m py_compile control-plane-api/alembic/versions/105_fix_webmethods_staging_target_urls.py
- pytest tests/test_regression_cab_1977_alembic_heads.py tests/test_regression_cab_1953_webmethods_nonprod_urls.py tests/test_regression_gateway_url_contract.py -q