### PR TITLE
fix: adopt catalog git identity collisions

### DIFF
--- a/control-plane-api/src/services/catalog_reconciler/projection.py
+++ b/control-plane-api/src/services/catalog_reconciler/projection.py
@@ -16,6 +16,10 @@ Contract:
 * ``metadata`` is projected from ``api.yaml`` because Console fields such as
   ``backend_url`` and ``display_name`` are read from that JSONB column.
 * The projection NEVER touches ``id`` (PK UUID) on UPDATE.
+* The projection may canonicalize ``api_id`` from a legacy UUID to the Git
+  slug when the active row is uniquely identified by ``(tenant, api_name,
+  version)``. This makes Git the identity source of truth without losing DB
+  references that point at the row PK.
 * The projection rejects ``id != name`` content (§6.10) and UUID-shaped names.
 """
 
@@ -24,7 +28,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from sqlalchemy import select, update
+from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.catalog import APICatalog
@@ -217,6 +221,57 @@ def row_matches_projection(
     )
 
 
+async def _canonicalize_soft_api_references(
+    db_session: AsyncSession,
+    *,
+    tenant_id: str,
+    old_api_id: str,
+    new_api_id: str,
+    api_name: str,
+) -> None:
+    """Move known soft string references when adopting a legacy catalog row.
+
+    Runtime deployment/policy rows use ``api_catalog.id`` and are preserved
+    naturally when the catalog row is updated in place. Older lifecycle tables
+    still keep a soft ``tenant_id + api_id`` reference, so canonicalizing only
+    ``api_catalog.api_id`` would detach history from the Git identity.
+    """
+    if old_api_id == new_api_id:
+        return
+
+    params = {
+        "tenant_id": tenant_id,
+        "old_api_id": old_api_id,
+        "new_api_id": new_api_id,
+        "api_name": api_name,
+    }
+    statements = (
+        "UPDATE deployments SET api_id = :new_api_id, api_name = :api_name "
+        "WHERE tenant_id = :tenant_id AND api_id = :old_api_id",
+        "UPDATE promotions SET api_id = :new_api_id "
+        "WHERE tenant_id = :tenant_id AND api_id = :old_api_id "
+        "AND NOT (status IN ('pending', 'promoting') AND EXISTS ("
+        "SELECT 1 FROM promotions dst "
+        "WHERE dst.api_id = :new_api_id "
+        "AND dst.target_environment = promotions.target_environment "
+        "AND dst.status IN ('pending', 'promoting')"
+        "))",
+        "UPDATE subscriptions SET api_id = :new_api_id, api_name = :api_name "
+        "WHERE tenant_id = :tenant_id AND api_id = :old_api_id",
+        "UPDATE credential_mappings SET api_id = :new_api_id "
+        "WHERE tenant_id = :tenant_id AND api_id = :old_api_id "
+        "AND NOT EXISTS ("
+        "SELECT 1 FROM credential_mappings dst "
+        "WHERE dst.consumer_id = credential_mappings.consumer_id "
+        "AND dst.api_id = :new_api_id"
+        ")",
+        "UPDATE pipeline_traces SET api_id = :new_api_id, api_name = :api_name "
+        "WHERE tenant_id = :tenant_id AND api_id = :old_api_id",
+    )
+    for statement in statements:
+        await db_session.execute(text(statement), params)
+
+
 async def project_to_api_catalog(
     db_session: AsyncSession,
     projection: ApiCatalogProjection,
@@ -261,6 +316,17 @@ async def project_to_api_catalog(
     existing = result.scalar_one_or_none()
 
     if existing is None:
+        identity_collision_stmt = (
+            select(APICatalog)
+            .where(APICatalog.tenant_id == projection.tenant_id)
+            .where(APICatalog.api_name == projection.api_name)
+            .where(APICatalog.version == projection.version)
+            .where(APICatalog.deleted_at.is_(None))
+        )
+        result = await db_session.execute(identity_collision_stmt)
+        existing = result.scalar_one_or_none()
+
+    if existing is None:
         new_row = APICatalog(
             tenant_id=projection.tenant_id,
             api_id=projection.api_id,
@@ -280,10 +346,21 @@ async def project_to_api_catalog(
         await db_session.flush()
         return
 
+    old_api_id = str(existing.api_id)
+    if old_api_id != projection.api_id:
+        await _canonicalize_soft_api_references(
+            db_session,
+            tenant_id=projection.tenant_id,
+            old_api_id=old_api_id,
+            new_api_id=projection.api_id,
+            api_name=projection.api_name,
+        )
+
     update_stmt = (
         update(APICatalog)
         .where(APICatalog.id == existing.id)
         .values(
+            api_id=projection.api_id,
             api_name=projection.api_name,
             version=projection.version,
             status=projection.status,

--- a/control-plane-api/tests/services/catalog_reconciler/test_projection_db.py
+++ b/control-plane-api/tests/services/catalog_reconciler/test_projection_db.py
@@ -14,6 +14,7 @@ import pytest
 from sqlalchemy import select
 
 from src.models.catalog import APICatalog
+from src.models.deployment import Deployment
 from src.services.catalog_reconciler.projection import (
     ApiCatalogProjection,
     project_to_api_catalog,
@@ -128,6 +129,69 @@ async def test_update_preserves_target_gateways(integration_db) -> None:
     assert row.openapi_spec == {"openapi": "3.0.0", "info": {"title": "Pet"}}
     assert row.api_metadata["display_name"] == "petstore"
     assert row.api_metadata["backend_url"] == "http://example.invalid"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_update_adopts_legacy_uuid_identity_collision(integration_db) -> None:
+    """A canonical Git row adopts a unique legacy UUID row by name/version.
+
+    Prod observed this as ``UNIQUE (tenant_id, api_name, version)`` failures:
+    the canonical ``tenants/{tenant}/apis/{name}/api.yaml`` file existed, but
+    the DB row still used a UUID ``api_id`` from the pre-GitOps writer. The
+    reconciler must update that row in place so Git becomes the identity truth
+    and PK-based references survive.
+    """
+    existing = APICatalog(
+        tenant_id="demo-gitops",
+        api_id="4d678b27-6691-43c9-9d23-c51c02176049",
+        api_name="petstore",
+        version="1.0.0",
+        status="draft",
+        tags=[],
+        portal_published=False,
+        audience="public",
+        api_metadata={"display_name": "Legacy Petstore", "backend_url": "http://legacy"},
+        openapi_spec={"openapi": "3.0.0", "info": {"title": "Legacy Petstore"}},
+        target_gateways=["webmethods-prod"],
+        git_path="tenants/demo-gitops/apis/4d678b27-6691-43c9-9d23-c51c02176049",
+    )
+    integration_db.add(existing)
+    integration_db.add(
+        Deployment(
+            tenant_id="demo-gitops",
+            api_id="4d678b27-6691-43c9-9d23-c51c02176049",
+            api_name="Legacy Petstore",
+            environment="dev",
+            version="1.0.0",
+            status="pending",
+            deployed_by="test",
+        )
+    )
+    await integration_db.flush()
+    original_id = existing.id
+
+    proj = _projection(api_id="petstore", git_commit_sha="c" * 40, catalog_content_hash="d" * 64)
+    await project_to_api_catalog(integration_db, proj)
+
+    result = await integration_db.execute(
+        select(APICatalog).where(APICatalog.tenant_id == "demo-gitops", APICatalog.api_id == "petstore")
+    )
+    row = result.scalar_one()
+    assert row.id == original_id
+    assert row.api_id == "petstore"
+    assert row.api_name == "petstore"
+    assert row.git_path == "tenants/demo-gitops/apis/petstore/api.yaml"
+    assert row.git_commit_sha == "c" * 40
+    assert row.catalog_content_hash == "d" * 64
+    assert row.target_gateways == ["webmethods-prod"]
+    assert row.openapi_spec == {"openapi": "3.0.0", "info": {"title": "Legacy Petstore"}}
+
+    deployment_result = await integration_db.execute(
+        select(Deployment).where(Deployment.tenant_id == "demo-gitops", Deployment.api_id == "petstore")
+    )
+    deployment = deployment_result.scalar_one()
+    assert deployment.api_name == "petstore"
 
 
 @pytest.mark.integration

--- a/control-plane-api/tests/services/catalog_reconciler/test_worker_loop.py
+++ b/control-plane-api/tests/services/catalog_reconciler/test_worker_loop.py
@@ -24,6 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from structlog.testing import capture_logs
 
 from src.models.catalog import APICatalog
+from src.models.deployment import Deployment
 from src.services.catalog.write_api_yaml import render_api_yaml
 from src.services.catalog_reconciler.worker import CatalogReconcilerWorker
 from src.services.gitops_writer.advisory_lock import advisory_lock_key
@@ -314,6 +315,64 @@ class TestProjectionDriftRepair:
         assert row.git_path == path  # canonical path preserved
         assert row.git_commit_sha != "cafe" * 10  # Git's actual SHA replaced the drift
         assert row.catalog_content_hash != "cafe" * 16
+
+
+class TestIdentityCollisionAdoption:
+    async def test_iteration_adopts_uuid_api_id_row_by_name_version(self, session_factory) -> None:
+        tenant = f"{_TEST_TENANT_PREFIX}identity-adopt"
+        legacy_api_id = "4d678b27-6691-43c9-9d23-c51c02176049"
+        path = f"tenants/{tenant}/apis/petstore/api.yaml"
+        fake_git = InMemoryCatalogGitClient()
+        fake_git.seed(path, _render_yaml(tenant_id=tenant, api_name="petstore"))
+
+        async with session_factory() as session:
+            session.add(
+                APICatalog(
+                    tenant_id=tenant,
+                    api_id=legacy_api_id,
+                    api_name="petstore",
+                    version="1.0.0",
+                    status="draft",
+                    tags=[],
+                    portal_published=False,
+                    audience="public",
+                    api_metadata={},
+                    git_path=f"tenants/{tenant}/apis/{legacy_api_id}",
+                    git_commit_sha="dead" * 10,
+                )
+            )
+            session.add(
+                Deployment(
+                    tenant_id=tenant,
+                    api_id=legacy_api_id,
+                    api_name="Legacy Petstore",
+                    environment="dev",
+                    version="1.0.0",
+                    status="pending",
+                    deployed_by="test",
+                )
+            )
+            await session.commit()
+
+        worker = _new_worker(session_factory, fake_git)
+        await worker._reconcile_iteration()
+
+        row = await _select_row(session_factory, tenant, "petstore")
+        assert row is not None
+        assert row.git_path == path
+        assert row.git_commit_sha is not None
+        assert row.catalog_content_hash is not None
+
+        old_row = await _select_row(session_factory, tenant, legacy_api_id)
+        assert old_row is None
+
+        async with session_factory() as session:
+            deployment = (
+                await session.execute(
+                    select(Deployment).where(Deployment.tenant_id == tenant, Deployment.api_id == "petstore")
+                )
+            ).scalar_one()
+            assert deployment.api_name == "petstore"
 
 
 class TestNonCanonicalPaths:

--- a/specs/api-creation-gitops-rewrite.md
+++ b/specs/api-creation-gitops-rewrite.md
@@ -107,8 +107,16 @@ Doctrine résultante :
 
 **Cycle migration legacy** :
 - Migration destructive des 7 rows catégorie B (UUID drifté) du tenant `demo`
-- Migration légale d'un `api_id` UUID vers slug (impacte FKs subscriptions/deployments/keys)
+- Migration de masse d'un `api_id` UUID vers slug sans fichier Git canonique
 - Migration globale legacy → GitOps de tenants existants
+
+Exception in-scope après audit prod du 2026-05-02 : si le reconciler lit un
+fichier Git canonique `tenants/{tenant}/apis/{slug}/api.yaml`, qu'aucune row
+active `(tenant, api_id=slug)` n'existe, et qu'une seule row active
+`(tenant, api_name=slug, version)` existe, cette row peut être adoptée en place.
+Le PK `api_catalog.id` est conservé et les références souples connues
+(`deployments`, `promotions`, `subscriptions`, `credential_mappings`,
+`pipeline_traces`) sont déplacées dans la même transaction.
 
 **Cycle promotion / multi-env** :
 - Promotion dev/staging/prod
@@ -503,7 +511,7 @@ deployments:
 |---|---|---|
 | `id` (PK) | non écrite par GitOps | gen_random_uuid() pour un nouveau INSERT, préservé pour un UPDATE |
 | `tenant_id` | tenant du `git_path` | |
-| `api_id` | YAML `.id` (= slug) | **jamais UUID** |
+| `api_id` | YAML `.id` (= slug) | **jamais UUID**; peut remplacer un ancien UUID en adoption contrôlée par `(tenant, api_name, version)` |
 | `api_name` | YAML `.name` | |
 | `version` | YAML `.version` | |
 | `status` | YAML `.status` | |
@@ -569,14 +577,22 @@ api_id = UUID string  OU  git_path UUID-shaped
 fichier Git réel = sous le slug
 ```
 
-**Action** : **détection seulement, aucune réparation automatique**.
+**Action par défaut** : **détection seulement, aucune réparation automatique**.
 
 Justification : `subscriptions.api_id`, `deployments.api_id`, gateway routes, API keys référencent potentiellement le UUID. La migration relève d'un cycle séparé qui devra identifier toutes les FK et choisir une stratégie.
+
+**Exception reconciler 2026-05-02** : lorsque le fichier Git canonique existe et
+que la DB n'a pas de row `(tenant, api_id=slug)` mais a une unique row active
+`(tenant, api_name=slug, version)`, le reconciler adopte cette row en place :
+`api_catalog.id` reste stable, `api_id/git_path/git_commit_sha/catalog_content_hash`
+deviennent canoniques, et les références souples connues sont mises à jour dans
+la même transaction. Ce cas évite les `UNIQUE (tenant_id, api_name, version)` en
+prod sans créer une seconde API.
 
 Comportement reconciler :
 - `update_status(drift_detected, "uuid hard drift")`
 - `last_error` documente : `api_id={UUID}, real_git_name={slug}`
-- **aucune mutation `api_catalog`, aucune écriture Git**
+- hors exception ci-dessus : **aucune mutation `api_catalog`, aucune écriture Git**
 
 #### Catégorie C — Orphelin DB (1 API `demo` : banking-services-v1-2)
 


### PR DESCRIPTION
## Summary
- adopt a unique legacy api_catalog row by (tenant, api_name, version) when Git has the canonical slug path but api_id is still a UUID
- canonicalize known soft api_id references in the same transaction so history follows the Git identity
- document the 2026-05-02 prod exception and add regression coverage

## Tests
- ruff check control-plane-api/src/services/catalog_reconciler/projection.py control-plane-api/tests/services/catalog_reconciler/test_projection_db.py control-plane-api/tests/services/catalog_reconciler/test_worker_loop.py
- pytest control-plane-api/tests/services/catalog_reconciler/test_projection.py control-plane-api/tests/services/catalog_reconciler/test_projection_db.py control-plane-api/tests/services/catalog_reconciler/test_worker_loop.py (DB integration tests skipped locally: DATABASE_URL not set)