### PR TITLE
fix: reconcile prod promotion migrations

### DIFF
--- a/control-plane-api/alembic/versions/106_drop_api_catalog_full_unique.py
+++ b/control-plane-api/alembic/versions/106_drop_api_catalog_full_unique.py
@@ -1,7 +1,7 @@
 """drop obsolete api_catalog full unique constraint
 
 Revision ID: 106_drop_api_catalog_full_unique
-Revises: 105_fix_webmethods_staging_target_urls
+Revises: 106_gateway_aware_promotions
 Create Date: 2026-05-02
 
 Migration 084 introduced the active-row-only uniqueness contract:
@@ -22,7 +22,7 @@ from collections.abc import Sequence
 from alembic import op
 
 revision: str = "106_drop_api_catalog_full_unique"
-down_revision: str | tuple[str, ...] | None = "105_fix_webmethods_staging_target_urls"
+down_revision: str | tuple[str, ...] | None = "106_gateway_aware_promotions"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/control-plane-api/alembic/versions/106_gateway_aware_promotions.py
+++ b/control-plane-api/alembic/versions/106_gateway_aware_promotions.py
@@ -1,0 +1,31 @@
+"""gateway-aware promotions
+
+Revision ID: 106_gateway_aware_promotions
+Revises: 105_fix_webmethods_staging_target_urls
+Create Date: 2026-05-02
+
+Promotion requests now carry explicit target gateway IDs. The column stays
+nullable so historical promotion rows remain readable.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "106_gateway_aware_promotions"
+down_revision: str | tuple[str, ...] | None = "105_fix_webmethods_staging_target_urls"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "promotions",
+        sa.Column("target_gateway_ids", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("promotions", "target_gateway_ids")

--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -19094,6 +19094,12 @@
             "title": "Message",
             "type": "string"
           },
+          "source_deployment_id": {
+            "description": "Synced source GatewayDeployment UUID to promote",
+            "format": "uuid",
+            "title": "Source Deployment Id",
+            "type": "string"
+          },
           "source_environment": {
             "description": "Source environment (dev, staging)",
             "title": "Source Environment",
@@ -19103,9 +19109,21 @@
             "description": "Target environment (staging, production)",
             "title": "Target Environment",
             "type": "string"
+          },
+          "target_gateway_ids": {
+            "description": "Explicit target gateway UUIDs receiving the promoted API",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Target Gateway Ids",
+            "type": "array"
           }
         },
         "required": [
+          "source_deployment_id",
+          "target_gateway_ids",
           "source_environment",
           "target_environment",
           "message"
@@ -19298,6 +19316,21 @@
           "target_environment": {
             "title": "Target Environment",
             "type": "string"
+          },
+          "target_gateway_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Gateway Ids"
           },
           "tenant_id": {
             "title": "Tenant Id",

--- a/control-plane-api/src/consumers/promotion_deploy_consumer.py
+++ b/control-plane-api/src/consumers/promotion_deploy_consumer.py
@@ -100,6 +100,13 @@ class PromotionDeployConsumer:
                 return  # Not our event
 
             payload = data.get("payload", {})
+            if payload.get("gateway_deployments_created"):
+                logger.info(
+                    "Skipping legacy promotion auto-deploy for promotion=%s; gateway deployments already created",
+                    payload.get("promotion_id"),
+                )
+                return
+
             api_id = payload.get("api_id")
             target_env = payload.get("target_environment")
             approved_by = payload.get("approved_by", "system")

--- a/control-plane-api/src/models/promotion.py
+++ b/control-plane-api/src/models/promotion.py
@@ -1,4 +1,5 @@
 """Promotion SQLAlchemy model for GitOps promotion flow (CAB-1706)"""
+
 import enum
 import uuid
 from datetime import datetime
@@ -35,10 +36,7 @@ def validate_promotion_chain(source: str, target: str) -> None:
         raise ValueError(f"Cannot promote to the same environment: {source}")
     if (source, target) not in VALID_PROMOTION_CHAINS:
         allowed = ", ".join(f"{s}→{t}" for s, t in sorted(VALID_PROMOTION_CHAINS))
-        raise ValueError(
-            f"Invalid promotion chain: {source}→{target}. "
-            f"Allowed chains: {allowed}"
-        )
+        raise ValueError(f"Invalid promotion chain: {source}→{target}. " f"Allowed chains: {allowed}")
 
 
 class Promotion(Base):
@@ -53,17 +51,14 @@ class Promotion(Base):
     target_environment = Column(String(50), nullable=False)
     source_deployment_id = Column(UUID(as_uuid=True), nullable=True)
     target_deployment_id = Column(UUID(as_uuid=True), nullable=True)
-    status = Column(
-        String(50), nullable=False, default=PromotionStatus.PENDING.value
-    )
+    target_gateway_ids = Column(JSONB, nullable=True)
+    status = Column(String(50), nullable=False, default=PromotionStatus.PENDING.value)
     spec_diff = Column(JSONB, nullable=True)
     message = Column(Text, nullable=False)
     requested_by = Column(String(255), nullable=False)
     approved_by = Column(String(255), nullable=True)
     completed_at = Column(DateTime, nullable=True)
-    created_at = Column(
-        DateTime, nullable=False, default=datetime.utcnow
-    )
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     updated_at = Column(
         DateTime,
         nullable=False,
@@ -90,8 +85,4 @@ class Promotion(Base):
     )
 
     def __repr__(self) -> str:
-        return (
-            f"<Promotion {self.id} "
-            f"{self.source_environment}→{self.target_environment} "
-            f"status={self.status}>"
-        )
+        return f"<Promotion {self.id} " f"{self.source_environment}→{self.target_environment} " f"status={self.status}>"

--- a/control-plane-api/src/routers/promotions.py
+++ b/control-plane-api/src/routers/promotions.py
@@ -38,6 +38,8 @@ async def create_promotion(
         promotion = await service.create_promotion(
             tenant_id=tenant_id,
             api_id=api_id,
+            source_deployment_id=request.source_deployment_id,
+            target_gateway_ids=request.target_gateway_ids,
             source_environment=request.source_environment,
             target_environment=request.target_environment,
             message=request.message,

--- a/control-plane-api/src/schemas/promotion.py
+++ b/control-plane-api/src/schemas/promotion.py
@@ -16,15 +16,14 @@ class PromotionStatusEnum(StrEnum):
 
 
 class PromotionCreate(BaseModel):
-    source_environment: str = Field(
-        ..., description="Source environment (dev, staging)"
+    source_deployment_id: UUID = Field(..., description="Synced source GatewayDeployment UUID to promote")
+    target_gateway_ids: list[UUID] = Field(
+        ..., min_length=1, description="Explicit target gateway UUIDs receiving the promoted API"
     )
-    target_environment: str = Field(
-        ..., description="Target environment (staging, production)"
-    )
+    source_environment: str = Field(..., description="Source environment (dev, staging)")
+    target_environment: str = Field(..., description="Target environment (staging, production)")
     message: str = Field(
-        ..., min_length=1, max_length=1000,
-        description="Mandatory audit trail message explaining the promotion reason"
+        ..., min_length=1, max_length=1000, description="Mandatory audit trail message explaining the promotion reason"
     )
 
 
@@ -38,6 +37,7 @@ class PromotionResponse(BaseModel):
     target_environment: str
     source_deployment_id: UUID | None = None
     target_deployment_id: UUID | None = None
+    target_gateway_ids: list[UUID] | None = None
     status: str
     spec_diff: dict | None = None
     message: str
@@ -57,8 +57,7 @@ class PromotionListResponse(BaseModel):
 
 class PromotionRollbackRequest(BaseModel):
     message: str = Field(
-        ..., min_length=1, max_length=1000,
-        description="Mandatory audit trail message explaining the rollback reason"
+        ..., min_length=1, max_length=1000, description="Mandatory audit trail message explaining the rollback reason"
     )
 
 

--- a/control-plane-api/src/services/deployment_orchestration_service.py
+++ b/control-plane-api/src/services/deployment_orchestration_service.py
@@ -423,8 +423,9 @@ class DeploymentOrchestrationService:
         target_environment: str,
         approved_by: str,
         promotion_id: UUID | None = None,
+        gateway_ids: list[UUID] | None = None,
     ) -> list:
-        """Triggered by promotion event — auto-deploy to assigned gateways."""
+        """Triggered by promotion event — auto-deploy to explicit or assigned gateways."""
         # Resolve the catalog entry
         try:
             api_catalog = await self._resolve_api_catalog(tenant_id, api_id)
@@ -436,16 +437,18 @@ class DeploymentOrchestrationService:
             )
             return []
 
-        # Get auto-deploy assignments
         target_environment = normalize_deployment_environment(target_environment) or target_environment
-        assignments = await self.assignment_repo.list_auto_deploy(api_catalog.id, target_environment)
-        if not assignments:
-            raise ValueError(
-                f"Promotion to {target_environment} cannot be marked deployed: no auto-deploy gateway "
-                f"assignments exist for API '{api_catalog.api_name}'. Configure at least one target gateway."
-            )
+        if gateway_ids is None:
+            assignments = await self.assignment_repo.list_auto_deploy(api_catalog.id, target_environment)
+            if not assignments:
+                raise ValueError(
+                    f"Promotion to {target_environment} cannot be marked deployed: no auto-deploy gateway "
+                    f"assignments exist for API '{api_catalog.api_name}'. Configure at least one target gateway."
+                )
+            gateway_ids = [a.gateway_id for a in assignments]
+        else:
+            await self._validate_gateways_for_env(gateway_ids, target_environment)
 
-        gateway_ids = [a.gateway_id for a in assignments]
         preflight = await self._preflight_gateway_ids(api_catalog, gateway_ids)
         failed = [result for result in preflight if not result.deployable]
         if failed:

--- a/control-plane-api/src/services/promotion_service.py
+++ b/control-plane-api/src/services/promotion_service.py
@@ -4,15 +4,20 @@ import logging
 from datetime import datetime
 from uuid import UUID
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import settings
+from ..models.catalog import APICatalog
 from ..models.gateway_deployment import DeploymentSyncStatus
+from ..models.gateway_instance import GatewayInstance
 from ..models.promotion import Promotion, PromotionStatus, validate_promotion_chain
 from ..notifications.promotion_notifier import notify_promotion_event
 from ..repositories.deployment import DeploymentRepository
 from ..repositories.gateway_deployment import GatewayDeploymentRepository
 from ..repositories.promotion import PromotionRepository
+from ..services.environment_aliases import deployment_environment_matches
+from ..services.gateway_topology import normalize_gateway_topology
 from ..services.kafka_service import Topics, kafka_service
 
 logger = logging.getLogger(__name__)
@@ -29,6 +34,8 @@ class PromotionService:
         self,
         tenant_id: str,
         api_id: str,
+        source_deployment_id: UUID,
+        target_gateway_ids: list[UUID],
         source_environment: str,
         target_environment: str,
         message: str,
@@ -38,18 +45,29 @@ class PromotionService:
         """Create a new promotion request after validating the chain."""
         validate_promotion_chain(source_environment, target_environment)
 
-        active = await self.repo.get_active_for_target(api_id, target_environment)
+        api_catalog = await self._validate_gateway_aware_request(
+            tenant_id=tenant_id,
+            api_id=api_id,
+            source_deployment_id=source_deployment_id,
+            target_gateway_ids=target_gateway_ids,
+            source_environment=source_environment,
+            target_environment=target_environment,
+        )
+
+        active = await self.repo.get_active_for_target(api_catalog.api_id, target_environment)
         if active:
             raise ValueError(
-                f"Active promotion already exists for {api_id} → {target_environment} "
+                f"Active promotion already exists for {api_catalog.api_id} → {target_environment} "
                 f"(id={active.id}, status={active.status})"
             )
 
         promotion = Promotion(
             tenant_id=tenant_id,
-            api_id=api_id,
+            api_id=api_catalog.api_id,
             source_environment=source_environment,
             target_environment=target_environment,
+            source_deployment_id=source_deployment_id,
+            target_gateway_ids=[str(gateway_id) for gateway_id in target_gateway_ids],
             status=PromotionStatus.PENDING.value,
             message=message,
             requested_by=requested_by,
@@ -60,7 +78,7 @@ class PromotionService:
             "Promotion created: %s → %s for api=%s tenant=%s",
             source_environment,
             target_environment,
-            api_id,
+            api_catalog.api_id,
             tenant_id,
         )
 
@@ -71,9 +89,11 @@ class PromotionService:
             resource_id=str(promotion.id),
             user_id=user_id,
             details={
-                "api_id": api_id,
+                "api_id": api_catalog.api_id,
                 "source_environment": source_environment,
                 "target_environment": target_environment,
+                "source_deployment_id": str(source_deployment_id),
+                "target_gateway_ids": [str(gateway_id) for gateway_id in target_gateway_ids],
             },
         )
 
@@ -81,7 +101,7 @@ class PromotionService:
             "promotion.pending_approval",
             {
                 "tenant_id": tenant_id,
-                "api_id": api_id,
+                "api_id": api_catalog.api_id,
                 "source_environment": source_environment,
                 "target_environment": target_environment,
                 "requested_by": requested_by,
@@ -91,6 +111,148 @@ class PromotionService:
         )
 
         return promotion
+
+    async def _validate_gateway_aware_request(
+        self,
+        *,
+        tenant_id: str,
+        api_id: str,
+        source_deployment_id: UUID,
+        target_gateway_ids: list[UUID],
+        source_environment: str,
+        target_environment: str,
+    ) -> APICatalog:
+        """Validate that a promotion maps one synced source lane to equivalent target lanes."""
+        if not target_gateway_ids:
+            raise ValueError("Promotion requires at least one target gateway")
+
+        source_deployment = await self.gw_deploy_repo.get_by_id(source_deployment_id)
+        if not source_deployment:
+            raise ValueError(f"Source gateway deployment {source_deployment_id} not found")
+
+        result = await self.db.execute(
+            select(APICatalog).where(
+                APICatalog.id == source_deployment.api_catalog_id,
+                APICatalog.deleted_at.is_(None),
+            )
+        )
+        api_catalog = result.scalar_one_or_none()
+        if not api_catalog:
+            raise ValueError("Source gateway deployment API catalog entry not found")
+        if api_catalog.tenant_id != tenant_id:
+            raise ValueError("Source gateway deployment belongs to another tenant")
+        if api_id not in {api_catalog.api_id, api_catalog.api_name, str(api_catalog.id)}:
+            raise ValueError(f"Source gateway deployment belongs to API '{api_catalog.api_id}', not '{api_id}'")
+
+        source_gateway = await self._get_gateway_or_raise(source_deployment.gateway_instance_id)
+        self._validate_gateway_tenant(source_gateway, tenant_id)
+        if not deployment_environment_matches(source_gateway.environment, source_environment):
+            raise ValueError(
+                f"Source gateway '{source_gateway.name}' is in environment "
+                f"'{source_gateway.environment}', not '{source_environment}'"
+            )
+
+        if self._wire_value(source_deployment.sync_status) != DeploymentSyncStatus.SYNCED.value:
+            raise ValueError(
+                f"Source deployment {source_deployment_id} is '{self._wire_value(source_deployment.sync_status)}'. "
+                "Only synced gateway deployments can be promoted."
+            )
+
+        target_gateways = []
+        for target_gateway_id in target_gateway_ids:
+            gateway = await self._get_gateway_or_raise(target_gateway_id)
+            self._validate_gateway_tenant(gateway, tenant_id)
+            if getattr(gateway, "deleted_at", None):
+                raise ValueError(f"Target gateway '{gateway.name}' has been deleted")
+            if getattr(gateway, "enabled", True) is False:
+                raise ValueError(f"Target gateway '{gateway.name}' is disabled")
+            if not deployment_environment_matches(gateway.environment, target_environment):
+                raise ValueError(
+                    f"Target gateway '{gateway.name}' is in environment '{gateway.environment}', "
+                    f"not '{target_environment}'"
+                )
+            target_gateways.append(gateway)
+
+        source_family = self._target_gateway_type_value(source_gateway)
+        source_topology = self._topology_value(source_gateway)
+        for gateway in target_gateways:
+            target_family = self._target_gateway_type_value(gateway)
+            if target_family != source_family:
+                raise ValueError(
+                    f"Target gateway '{gateway.name}' is '{target_family}', but the source gateway "
+                    f"'{source_gateway.name}' is '{source_family}'. Select an equivalent target gateway."
+                )
+            target_topology = self._topology_value(gateway)
+            if source_topology and target_topology and target_topology != source_topology:
+                raise ValueError(
+                    f"Target gateway '{gateway.name}' topology is '{target_topology}', but the source gateway "
+                    f"'{source_gateway.name}' topology is '{source_topology}'."
+                )
+
+        from ..services.deployment_orchestration_service import DeploymentOrchestrationService
+
+        orchestration_svc = DeploymentOrchestrationService(self.db)
+        preflight = await orchestration_svc.preflight_api_to_gateways(api_catalog.id, target_gateway_ids)
+        failed = [result for result in preflight if not result.deployable]
+        if failed:
+            raise ValueError(orchestration_svc._format_preflight_failure(failed))
+
+        return api_catalog
+
+    async def _get_gateway_or_raise(self, gateway_id: UUID) -> GatewayInstance:
+        result = await self.db.execute(select(GatewayInstance).where(GatewayInstance.id == gateway_id))
+        gateway = result.scalar_one_or_none()
+        if not gateway:
+            raise ValueError(f"Gateway {gateway_id} not found")
+        return gateway
+
+    @staticmethod
+    def _validate_gateway_tenant(gateway: GatewayInstance, tenant_id: str) -> None:
+        gateway_tenant = getattr(gateway, "tenant_id", None)
+        if gateway_tenant and gateway_tenant != tenant_id:
+            raise ValueError(f"Gateway '{gateway.name}' belongs to another tenant")
+
+    @staticmethod
+    def _wire_value(value) -> str:
+        return str(getattr(value, "value", value))
+
+    @staticmethod
+    def _target_gateway_type_value(gateway: GatewayInstance) -> str:
+        return normalize_gateway_topology(
+            gateway_type=gateway.gateway_type,
+            mode=gateway.mode,
+            source=gateway.source,
+            deployment_mode=gateway.deployment_mode,
+            target_gateway_type=gateway.target_gateway_type,
+            topology=gateway.topology,
+            health_details=gateway.health_details,
+            endpoints=gateway.endpoints,
+            base_url=gateway.base_url,
+            public_url=gateway.public_url,
+            ui_url=gateway.ui_url,
+            target_gateway_url=gateway.target_gateway_url,
+            tags=gateway.tags,
+            name=gateway.name,
+        ).target_gateway_type
+
+    @staticmethod
+    def _topology_value(gateway: GatewayInstance) -> str:
+        return normalize_gateway_topology(
+            gateway_type=gateway.gateway_type,
+            mode=gateway.mode,
+            source=gateway.source,
+            deployment_mode=gateway.deployment_mode,
+            target_gateway_type=gateway.target_gateway_type,
+            topology=gateway.topology,
+            health_details=gateway.health_details,
+            endpoints=gateway.endpoints,
+            base_url=gateway.base_url,
+            public_url=gateway.public_url,
+            ui_url=gateway.ui_url,
+            target_gateway_url=gateway.target_gateway_url,
+            tags=gateway.tags,
+            name=gateway.name,
+        ).topology
 
     async def get_promotion(self, tenant_id: str, promotion_id: UUID) -> Promotion | None:
         return await self.repo.get_by_id_and_tenant(promotion_id, tenant_id)
@@ -136,31 +298,40 @@ class PromotionService:
                 "A different team member must approve production deployments."
             )
 
+        target_gateway_ids = self._parse_target_gateway_ids(promotion.target_gateway_ids)
+        if not target_gateway_ids:
+            raise ValueError(
+                "Cannot approve promotion without explicit target gateways. " "Create a new gateway-aware promotion."
+            )
+
+        # Trigger deployment before the state transition so no promotion can
+        # enter PROMOTING without at least one linked GatewayDeployment.
+        from ..services.deployment_orchestration_service import DeploymentOrchestrationService
+
+        orchestration_svc = DeploymentOrchestrationService(self.db)
+        deployments = await orchestration_svc.auto_deploy_on_promotion(
+            api_id=promotion.api_id,
+            tenant_id=tenant_id,
+            target_environment=promotion.target_environment,
+            approved_by=approved_by,
+            promotion_id=promotion.id,
+            gateway_ids=target_gateway_ids,
+        )
+        if not deployments:
+            raise ValueError(
+                "Promotion approval did not create any gateway deployment. " "Check the selected target gateways."
+            )
+
         promotion.status = PromotionStatus.PROMOTING.value
         promotion.approved_by = approved_by
         promotion = await self.repo.update(promotion)
 
-        logger.info("Promotion %s approved by %s", promotion_id, approved_by)
-
-        # Trigger auto-deploy to assigned gateways (CAB-1917)
-        from ..services.deployment_orchestration_service import DeploymentOrchestrationService
-
-        orchestration_svc = DeploymentOrchestrationService(self.db)
-        try:
-            deployments = await orchestration_svc.auto_deploy_on_promotion(
-                api_id=promotion.api_id,
-                tenant_id=tenant_id,
-                target_environment=promotion.target_environment,
-                approved_by=approved_by,
-            )
-            if deployments:
-                logger.info(
-                    "Auto-deploy triggered for promotion %s: %d deployments",
-                    promotion_id,
-                    len(deployments),
-                )
-        except Exception as e:
-            logger.error("Auto-deploy failed for promotion %s: %s", promotion_id, e)
+        logger.info(
+            "Promotion %s approved by %s; %d gateway deployments linked",
+            promotion_id,
+            approved_by,
+            len(deployments),
+        )
 
         await kafka_service.publish(
             topic=Topics.DEPLOY_REQUESTS,
@@ -172,6 +343,9 @@ class PromotionService:
                 "source_environment": promotion.source_environment,
                 "target_environment": promotion.target_environment,
                 "approved_by": approved_by,
+                "target_gateway_ids": [str(gateway_id) for gateway_id in target_gateway_ids],
+                "gateway_deployment_ids": [str(getattr(deployment, "id", deployment)) for deployment in deployments],
+                "gateway_deployments_created": True,
             },
             user_id=user_id,
         )
@@ -188,6 +362,17 @@ class PromotionService:
 
         return promotion
 
+    @staticmethod
+    def _parse_target_gateway_ids(raw_ids: object) -> list[UUID]:
+        if not raw_ids:
+            return []
+        if not isinstance(raw_ids, list):
+            raise ValueError("Promotion target gateways must be a list")
+        try:
+            return [value if isinstance(value, UUID) else UUID(str(value)) for value in raw_ids]
+        except ValueError as exc:
+            raise ValueError("Promotion contains an invalid target gateway ID") from exc
+
     async def complete_promotion(
         self,
         promotion_id: UUID,
@@ -203,6 +388,20 @@ class PromotionService:
                 f"Cannot complete promotion in status '{promotion.status}' "
                 f"(expected '{PromotionStatus.PROMOTING.value}')"
             )
+
+        if target_deployment_id is None:
+            linked_deployments = await self.gw_deploy_repo.list_by_promotion(promotion_id)
+            if not linked_deployments:
+                raise ValueError("Cannot complete promotion without linked gateway deployments")
+            not_synced = [
+                dep
+                for dep in linked_deployments
+                if self._wire_value(dep.sync_status) != DeploymentSyncStatus.SYNCED.value
+            ]
+            if not_synced:
+                raise ValueError("Cannot complete promotion until all linked gateway deployments are synced")
+            if len(linked_deployments) == 1:
+                target_deployment_id = linked_deployments[0].id
 
         promotion.status = PromotionStatus.PROMOTED.value
         promotion.target_deployment_id = target_deployment_id
@@ -238,10 +437,7 @@ class PromotionService:
             return  # No deployments linked — nothing to do
 
         statuses = [d.sync_status for d in deployments]
-        pending_or_syncing = [
-            s for s in statuses
-            if s in (DeploymentSyncStatus.PENDING, DeploymentSyncStatus.SYNCING)
-        ]
+        pending_or_syncing = [s for s in statuses if s in (DeploymentSyncStatus.PENDING, DeploymentSyncStatus.SYNCING)]
 
         if pending_or_syncing:
             return  # Still waiting for some gateways

--- a/control-plane-api/tests/test_deployment_orchestration_service.py
+++ b/control-plane-api/tests/test_deployment_orchestration_service.py
@@ -166,6 +166,19 @@ class TestDeploymentOrchestrationService:
             assert len(result) == 1
 
     @pytest.mark.asyncio
+    async def test_validate_gateways_accepts_prod_alias_for_production(self):
+        """prod gateway rows satisfy production deployment requests."""
+        from src.services.deployment_orchestration_service import DeploymentOrchestrationService
+
+        gateway = self._make_gateway(environment="prod")
+        db = AsyncMock()
+        svc = DeploymentOrchestrationService(db)
+
+        with patch.object(svc, "_get_gateway_or_raise", new_callable=AsyncMock) as mock_gateway:
+            mock_gateway.return_value = gateway
+            await svc._validate_gateways_for_env([gateway.id], "production")
+
+    @pytest.mark.asyncio
     async def test_deploy_uses_assignments_when_no_gateway_ids(self):
         """When gateway_ids is None, should use auto-deploy assignments."""
         from src.services.deployment_orchestration_service import DeploymentOrchestrationService
@@ -284,6 +297,45 @@ class TestDeploymentOrchestrationService:
             )
 
             assert len(result) == 1
+            mock_preflight.assert_awaited_once_with(catalog, [gw_id])
+            mock_deploy.assert_called_once_with(catalog.id, [gw_id])
+
+    @pytest.mark.asyncio
+    async def test_auto_deploy_on_promotion_uses_explicit_gateway_ids(self):
+        """gateway-aware promotions bypass assignments and deploy to selected targets."""
+        from src.services.deployment_orchestration_service import DeploymentOrchestrationService
+
+        catalog = self._make_catalog()
+        gw_id = uuid4()
+        deployments = [MagicMock(id=uuid4())]
+
+        db = AsyncMock()
+        svc = DeploymentOrchestrationService(db)
+
+        with (
+            patch.object(svc.assignment_repo, "list_auto_deploy", new_callable=AsyncMock) as mock_assign,
+            patch.object(svc, "_validate_gateways_for_env", new_callable=AsyncMock) as mock_validate,
+            patch.object(svc, "_preflight_gateway_ids", new_callable=AsyncMock) as mock_preflight,
+            patch.object(svc.deploy_svc, "deploy_api", new_callable=AsyncMock) as mock_deploy,
+        ):
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = catalog
+            db.execute.return_value = mock_result
+
+            mock_preflight.return_value = [MagicMock(deployable=True)]
+            mock_deploy.return_value = deployments
+
+            result = await svc.auto_deploy_on_promotion(
+                api_id="payments-v2",
+                tenant_id="acme",
+                target_environment="staging",
+                approved_by="admin",
+                gateway_ids=[gw_id],
+            )
+
+            assert len(result) == 1
+            mock_assign.assert_not_awaited()
+            mock_validate.assert_awaited_once_with([gw_id], "staging")
             mock_preflight.assert_awaited_once_with(catalog, [gw_id])
             mock_deploy.assert_called_once_with(catalog.id, [gw_id])
 

--- a/control-plane-api/tests/test_integration_promotion_chain.py
+++ b/control-plane-api/tests/test_integration_promotion_chain.py
@@ -149,15 +149,21 @@ class TestPromotionChainIntegration:
         gw = _make_gateway()
         assignment = _make_assignment(api.id, gw.id)
         promo = _make_promotion(api_id=str(api.id))
+        source_deployment_id = uuid4()
+        promo.source_deployment_id = source_deployment_id
+        promo.target_gateway_ids = [str(gw.id)]
 
         # --- Step 1: Create promotion ---
         promo_svc = PromotionService(mock_db)
+        promo_svc._validate_gateway_aware_request = AsyncMock(return_value=api)
         promo_svc.repo.get_active_for_target = AsyncMock(return_value=None)
         promo_svc.repo.create = AsyncMock(return_value=promo)
 
         created = await promo_svc.create_promotion(
             tenant_id="acme",
             api_id=str(api.id),
+            source_deployment_id=source_deployment_id,
+            target_gateway_ids=[gw.id],
             source_environment="dev",
             target_environment="staging",
             message="QA release",
@@ -170,12 +176,17 @@ class TestPromotionChainIntegration:
         promo_svc.repo.get_by_id_and_tenant = AsyncMock(return_value=promo)
         promo_svc.repo.update = AsyncMock(side_effect=lambda p: p)
 
-        approved = await promo_svc.approve_promotion(
-            tenant_id="acme",
-            promotion_id=promo.id,
-            approved_by="user-approver",
-            user_id="uid-2",
-        )
+        with patch(
+            "src.services.deployment_orchestration_service.DeploymentOrchestrationService.auto_deploy_on_promotion",
+            new_callable=AsyncMock,
+        ) as mock_approve_deploy:
+            mock_approve_deploy.return_value = [MagicMock()]
+            approved = await promo_svc.approve_promotion(
+                tenant_id="acme",
+                promotion_id=promo.id,
+                approved_by="user-approver",
+                user_id="uid-2",
+            )
         assert approved.status == PromotionStatus.PROMOTING.value
         assert approved.approved_by == "user-approver"
 
@@ -232,15 +243,21 @@ class TestPromotionChainIntegration:
         assignment1 = _make_assignment(api.id, gw1.id)
         assignment2 = _make_assignment(api.id, gw2.id)
         promo = _make_promotion(api_id=str(api.id))
+        source_deployment_id = uuid4()
+        promo.source_deployment_id = source_deployment_id
+        promo.target_gateway_ids = [str(gw1.id), str(gw2.id)]
 
         # Create + approve promotion
         promo_svc = PromotionService(mock_db)
+        promo_svc._validate_gateway_aware_request = AsyncMock(return_value=api)
         promo_svc.repo.get_active_for_target = AsyncMock(return_value=None)
         promo_svc.repo.create = AsyncMock(return_value=promo)
 
         await promo_svc.create_promotion(
             tenant_id="acme",
             api_id=str(api.id),
+            source_deployment_id=source_deployment_id,
+            target_gateway_ids=[gw1.id, gw2.id],
             source_environment="dev",
             target_environment="staging",
             message="QA release",
@@ -251,12 +268,17 @@ class TestPromotionChainIntegration:
         promo_svc.repo.get_by_id_and_tenant = AsyncMock(return_value=promo)
         promo_svc.repo.update = AsyncMock(side_effect=lambda p: p)
 
-        await promo_svc.approve_promotion(
-            tenant_id="acme",
-            promotion_id=promo.id,
-            approved_by="user-approver",
-            user_id="uid-2",
-        )
+        with patch(
+            "src.services.deployment_orchestration_service.DeploymentOrchestrationService.auto_deploy_on_promotion",
+            new_callable=AsyncMock,
+        ) as mock_approve_deploy:
+            mock_approve_deploy.return_value = [MagicMock()]
+            await promo_svc.approve_promotion(
+                tenant_id="acme",
+                promotion_id=promo.id,
+                approved_by="user-approver",
+                user_id="uid-2",
+            )
         assert promo.status == PromotionStatus.PROMOTING.value
 
         # auto_deploy → 2 deployments PENDING

--- a/control-plane-api/tests/test_promotion_api.py
+++ b/control-plane-api/tests/test_promotion_api.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -29,6 +29,11 @@ class TestPromotionServiceCreate:
     @patch("src.services.promotion_service.kafka_service")
     async def test_create_valid(self, mock_kafka, service):
         mock_kafka.emit_audit_event = AsyncMock()
+        source_deployment_id = uuid.uuid4()
+        target_gateway_id = uuid.uuid4()
+        api_catalog = MagicMock()
+        api_catalog.api_id = "api-1"
+        service._validate_gateway_aware_request = AsyncMock(return_value=api_catalog)
         service.repo.get_active_for_target = AsyncMock(return_value=None)
         created = Promotion()
         created.id = uuid.uuid4()
@@ -44,6 +49,8 @@ class TestPromotionServiceCreate:
         result = await service.create_promotion(
             tenant_id="acme",
             api_id="api-1",
+            source_deployment_id=source_deployment_id,
+            target_gateway_ids=[target_gateway_id],
             source_environment="dev",
             target_environment="staging",
             message="QA release",
@@ -61,6 +68,8 @@ class TestPromotionServiceCreate:
             await service.create_promotion(
                 tenant_id="acme",
                 api_id="api-1",
+                source_deployment_id=uuid.uuid4(),
+                target_gateway_ids=[uuid.uuid4()],
                 source_environment="dev",
                 target_environment="production",
                 message="Skip staging",
@@ -70,15 +79,20 @@ class TestPromotionServiceCreate:
 
     @pytest.mark.asyncio
     async def test_create_active_conflict(self, service):
+        api_catalog = MagicMock()
+        api_catalog.api_id = "api-1"
         existing = Promotion()
         existing.id = uuid.uuid4()
         existing.status = PromotionStatus.PENDING.value
+        service._validate_gateway_aware_request = AsyncMock(return_value=api_catalog)
         service.repo.get_active_for_target = AsyncMock(return_value=existing)
 
         with pytest.raises(ValueError, match="Active promotion already exists"):
             await service.create_promotion(
                 tenant_id="acme",
                 api_id="api-1",
+                source_deployment_id=uuid.uuid4(),
+                target_gateway_ids=[uuid.uuid4()],
                 source_environment="dev",
                 target_environment="staging",
                 message="Duplicate",
@@ -98,8 +112,10 @@ class TestPromotionServiceApprove:
 
     @pytest.mark.asyncio
     @patch("src.services.promotion_service.kafka_service")
-    async def test_approve_pending(self, mock_kafka, service):
+    @patch("src.services.deployment_orchestration_service.DeploymentOrchestrationService.auto_deploy_on_promotion")
+    async def test_approve_pending(self, mock_auto_deploy, mock_kafka, service):
         mock_kafka.publish = AsyncMock()
+        mock_auto_deploy.return_value = [MagicMock()]
         promo = Promotion()
         promo.id = uuid.uuid4()
         promo.tenant_id = "acme"
@@ -107,6 +123,7 @@ class TestPromotionServiceApprove:
         promo.source_environment = "dev"
         promo.target_environment = "staging"
         promo.status = PromotionStatus.PENDING.value
+        promo.target_gateway_ids = [str(uuid.uuid4())]
         service.repo.get_by_id_and_tenant = AsyncMock(return_value=promo)
         service.repo.update = AsyncMock(return_value=promo)
 
@@ -119,7 +136,31 @@ class TestPromotionServiceApprove:
 
         assert result.status == PromotionStatus.PROMOTING.value
         assert result.approved_by == "admin"
+        mock_auto_deploy.assert_awaited_once()
         mock_kafka.publish.assert_awaited_once()
+        published_payload = mock_kafka.publish.await_args.kwargs["payload"]
+        assert published_payload["gateway_deployments_created"] is True
+        assert published_payload["target_gateway_ids"] == promo.target_gateway_ids
+
+    @pytest.mark.asyncio
+    async def test_approve_without_target_gateways_rejected(self, service):
+        promo = Promotion()
+        promo.id = uuid.uuid4()
+        promo.tenant_id = "acme"
+        promo.api_id = "api-1"
+        promo.source_environment = "dev"
+        promo.target_environment = "staging"
+        promo.status = PromotionStatus.PENDING.value
+        promo.target_gateway_ids = None
+        service.repo.get_by_id_and_tenant = AsyncMock(return_value=promo)
+
+        with pytest.raises(ValueError, match="explicit target gateways"):
+            await service.approve_promotion(
+                tenant_id="acme",
+                promotion_id=promo.id,
+                approved_by="admin",
+                user_id="uid-2",
+            )
 
     @pytest.mark.asyncio
     async def test_approve_not_found(self, service):
@@ -234,6 +275,17 @@ class TestPromotionServiceComplete:
         assert result.spec_diff == {"changed": ["version"]}
 
     @pytest.mark.asyncio
+    async def test_complete_requires_linked_deployments(self, service):
+        promo = Promotion()
+        promo.id = uuid.uuid4()
+        promo.status = PromotionStatus.PROMOTING.value
+        service.repo.get_by_id = AsyncMock(return_value=promo)
+        service.gw_deploy_repo.list_by_promotion = AsyncMock(return_value=[])
+
+        with pytest.raises(ValueError, match="linked gateway deployments"):
+            await service.complete_promotion(promotion_id=promo.id)
+
+    @pytest.mark.asyncio
     async def test_fail_promotion(self, service):
         promo = Promotion()
         promo.id = uuid.uuid4()
@@ -319,9 +371,11 @@ class TestPromotionSelfApproveGuard:
 
     @pytest.mark.asyncio
     @patch("src.services.promotion_service.kafka_service")
-    async def test_self_approve_allowed_for_staging(self, mock_kafka, service):
+    @patch("src.services.deployment_orchestration_service.DeploymentOrchestrationService.auto_deploy_on_promotion")
+    async def test_self_approve_allowed_for_staging(self, mock_auto_deploy, mock_kafka, service):
         """2-eyes principle: requester can self-approve dev→staging promotions."""
         mock_kafka.publish = AsyncMock()
+        mock_auto_deploy.return_value = [MagicMock()]
         promo = Promotion()
         promo.id = uuid.uuid4()
         promo.tenant_id = "acme"
@@ -330,6 +384,7 @@ class TestPromotionSelfApproveGuard:
         promo.target_environment = "staging"
         promo.status = PromotionStatus.PENDING.value
         promo.requested_by = "alice@acme.com"
+        promo.target_gateway_ids = [str(uuid.uuid4())]
         service.repo.get_by_id_and_tenant = AsyncMock(return_value=promo)
         service.repo.update = AsyncMock(return_value=promo)
 
@@ -345,9 +400,11 @@ class TestPromotionSelfApproveGuard:
 
     @pytest.mark.asyncio
     @patch("src.services.promotion_service.kafka_service")
-    async def test_different_user_can_approve(self, mock_kafka, service):
+    @patch("src.services.deployment_orchestration_service.DeploymentOrchestrationService.auto_deploy_on_promotion")
+    async def test_different_user_can_approve(self, mock_auto_deploy, mock_kafka, service):
         """A different user can approve the promotion."""
         mock_kafka.publish = AsyncMock()
+        mock_auto_deploy.return_value = [MagicMock()]
         promo = Promotion()
         promo.id = uuid.uuid4()
         promo.tenant_id = "acme"
@@ -356,6 +413,7 @@ class TestPromotionSelfApproveGuard:
         promo.target_environment = "staging"
         promo.status = PromotionStatus.PENDING.value
         promo.requested_by = "alice@acme.com"
+        promo.target_gateway_ids = [str(uuid.uuid4())]
         service.repo.get_by_id_and_tenant = AsyncMock(return_value=promo)
         service.repo.update = AsyncMock(return_value=promo)
 
@@ -537,6 +595,11 @@ class TestPromotionServiceNotifications:
     async def test_create_sends_slack_notification(self, mock_kafka, mock_notify, service):
         mock_kafka.emit_audit_event = AsyncMock()
         mock_notify.return_value = None
+        source_deployment_id = uuid.uuid4()
+        target_gateway_id = uuid.uuid4()
+        api_catalog = MagicMock()
+        api_catalog.api_id = "api-1"
+        service._validate_gateway_aware_request = AsyncMock(return_value=api_catalog)
         service.repo.get_active_for_target = AsyncMock(return_value=None)
         created = Promotion()
         created.id = uuid.uuid4()
@@ -552,6 +615,8 @@ class TestPromotionServiceNotifications:
         await service.create_promotion(
             tenant_id="acme",
             api_id="api-1",
+            source_deployment_id=source_deployment_id,
+            target_gateway_ids=[target_gateway_id],
             source_environment="dev",
             target_environment="staging",
             message="QA release",
@@ -570,9 +635,11 @@ class TestPromotionServiceNotifications:
     @pytest.mark.asyncio
     @patch("src.services.promotion_service.notify_promotion_event")
     @patch("src.services.promotion_service.kafka_service")
-    async def test_approve_sends_slack_notification(self, mock_kafka, mock_notify, service):
+    @patch("src.services.deployment_orchestration_service.DeploymentOrchestrationService.auto_deploy_on_promotion")
+    async def test_approve_sends_slack_notification(self, mock_auto_deploy, mock_kafka, mock_notify, service):
         mock_kafka.publish = AsyncMock()
         mock_notify.return_value = None
+        mock_auto_deploy.return_value = [MagicMock()]
         promo = Promotion()
         promo.id = uuid.uuid4()
         promo.tenant_id = "acme"
@@ -581,6 +648,7 @@ class TestPromotionServiceNotifications:
         promo.target_environment = "staging"
         promo.status = PromotionStatus.PENDING.value
         promo.requested_by = "torpedo"
+        promo.target_gateway_ids = [str(uuid.uuid4())]
         service.repo.get_by_id_and_tenant = AsyncMock(return_value=promo)
         service.repo.update = AsyncMock(return_value=promo)
 

--- a/control-plane-api/tests/test_promotion_deploy_consumer.py
+++ b/control-plane-api/tests/test_promotion_deploy_consumer.py
@@ -1,0 +1,27 @@
+"""Tests for the promotion deploy Kafka consumer."""
+
+from unittest.mock import MagicMock
+
+from src.consumers.promotion_deploy_consumer import PromotionDeployConsumer
+
+
+def test_gateway_aware_promotion_event_does_not_trigger_legacy_auto_deploy():
+    consumer = PromotionDeployConsumer()
+    consumer._auto_deploy = MagicMock()
+    consumer._loop = MagicMock()
+    message = MagicMock()
+    message.value = {
+        "event_type": "promotion-approved",
+        "tenant_id": "acme",
+        "payload": {
+            "promotion_id": "16d9e16d-d97d-4661-9eb2-b0c2dbda0821",
+            "api_id": "payments",
+            "target_environment": "staging",
+            "approved_by": "admin",
+            "gateway_deployments_created": True,
+        },
+    }
+
+    consumer._handle_message(message)
+
+    consumer._auto_deploy.assert_not_called()

--- a/control-plane-api/tests/test_regression_cab_1917_api_creation.py
+++ b/control-plane-api/tests/test_regression_cab_1917_api_creation.py
@@ -61,6 +61,8 @@ class TestRegression_AutoDeployOnPromotion:
         mock_promotion.target_environment = "staging"
         mock_promotion.api_id = "api-123"
         mock_promotion.source_environment = "dev"
+        target_gateway_id = uuid4()
+        mock_promotion.target_gateway_ids = [str(target_gateway_id)]
 
         svc.repo = MagicMock()
         svc.repo.get_by_id_and_tenant = AsyncMock(return_value=mock_promotion)
@@ -74,7 +76,7 @@ class TestRegression_AutoDeployOnPromotion:
             patch(
                 "src.services.deployment_orchestration_service.DeploymentOrchestrationService",
                 return_value=mock_orch,
-            ) as mock_orch_cls,
+            ),
             patch("src.services.promotion_service.notify_promotion_event", new_callable=AsyncMock),
         ):
             mock_kafka.publish = AsyncMock()
@@ -99,6 +101,8 @@ class TestRegression_AutoDeployOnPromotion:
                 tenant_id="acme",
                 target_environment="staging",
                 approved_by="admin",
+                promotion_id=mock_promotion.id,
+                gateway_ids=[target_gateway_id],
             )
 
 

--- a/control-plane-ui/src/pages/Promotions.test.tsx
+++ b/control-plane-ui/src/pages/Promotions.test.tsx
@@ -3,7 +3,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Promotions } from './Promotions';
 import { createAuthMock, renderWithProviders, type PersonaRole } from '../test/helpers';
-import type { Promotion, Tenant, API } from '../types';
+import type { Promotion, Tenant, API, GatewayDeployment, GatewayInstance } from '../types';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -34,6 +34,8 @@ vi.mock('../services/api', () => ({
     completePromotion: vi.fn(),
     rollbackPromotion: vi.fn(),
     getPromotionDiff: vi.fn(),
+    getGatewayInstances: vi.fn(),
+    getGatewayDeployments: vi.fn(),
   },
 }));
 
@@ -73,6 +75,7 @@ const mockPromotion: Promotion = {
   target_environment: 'staging',
   source_deployment_id: 'deploy-1',
   target_deployment_id: null,
+  target_gateway_ids: ['gw-staging'],
   status: 'pending',
   spec_diff: null,
   message: 'Ready for staging validation',
@@ -82,6 +85,81 @@ const mockPromotion: Promotion = {
   created_at: '2026-03-08T10:00:00Z',
   updated_at: '2026-03-08T10:00:00Z',
 };
+
+const mockGateways: GatewayInstance[] = [
+  {
+    id: 'gw-dev',
+    name: 'stoa-gateway-dev',
+    display_name: 'STOA Gateway Dev',
+    gateway_type: 'stoa_edge_mcp',
+    environment: 'dev',
+    tenant_id: 'tenant-1',
+    base_url: 'https://dev.example.com',
+    auth_config: {},
+    capabilities: [],
+    status: 'online',
+    health_details: null,
+    last_health_check: null,
+    source: 'self_register',
+    protected: false,
+    enabled: true,
+    tags: [],
+    version: null,
+    endpoints: {},
+    target_gateway_type: 'stoa',
+    topology: 'native-edge',
+    deployment_mode: 'edge',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'gw-staging',
+    name: 'stoa-gateway-staging',
+    display_name: 'STOA Gateway Staging',
+    gateway_type: 'stoa_edge_mcp',
+    environment: 'staging',
+    tenant_id: 'tenant-1',
+    base_url: 'https://staging.example.com',
+    auth_config: {},
+    capabilities: [],
+    status: 'online',
+    health_details: null,
+    last_health_check: null,
+    source: 'self_register',
+    protected: false,
+    enabled: true,
+    tags: [],
+    version: null,
+    endpoints: {},
+    target_gateway_type: 'stoa',
+    topology: 'native-edge',
+    deployment_mode: 'edge',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+const mockSourceDeployments: GatewayDeployment[] = [
+  {
+    id: 'deploy-1',
+    api_catalog_id: 'catalog-1',
+    gateway_instance_id: 'gw-dev',
+    desired_state: {
+      api_id: 'api-1',
+      api_name: 'orders-api',
+      api_catalog_id: 'catalog-1',
+    },
+    desired_at: '2026-03-08T09:00:00Z',
+    sync_status: 'synced',
+    sync_attempts: 0,
+    created_at: '2026-03-08T09:00:00Z',
+    updated_at: '2026-03-08T09:00:00Z',
+    gateway_name: 'stoa-gateway-dev',
+    gateway_display_name: 'STOA Gateway Dev',
+    gateway_type: 'stoa_edge_mcp',
+    gateway_environment: 'dev',
+  },
+];
 
 // ── Setup ─────────────────────────────────────────────────────────────────────
 
@@ -93,6 +171,18 @@ function setupMocks(role: PersonaRole = 'cpi-admin') {
   vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
   vi.mocked(apiService.getTenants).mockResolvedValue(mockTenants);
   vi.mocked(apiService.getApis).mockResolvedValue(mockApis);
+  vi.mocked(apiService.getGatewayInstances).mockResolvedValue({
+    items: mockGateways,
+    total: mockGateways.length,
+    page: 1,
+    page_size: 100,
+  });
+  vi.mocked(apiService.getGatewayDeployments).mockResolvedValue({
+    items: mockSourceDeployments,
+    total: mockSourceDeployments.length,
+    page: 1,
+    page_size: 100,
+  });
   vi.mocked(apiService.listPromotions).mockResolvedValue({
     items: [mockPromotion],
     total: 1,
@@ -233,8 +323,8 @@ describe('Promotions', () => {
     });
   });
 
-  describe('Mark Deployed', () => {
-    it('shows Mark Deployed button for promoting promotions', async () => {
+  describe('Verify Complete', () => {
+    it('shows Verify Complete button for promoting promotions', async () => {
       const promotingPromotion: Promotion = {
         ...mockPromotion,
         status: 'promoting',
@@ -250,11 +340,11 @@ describe('Promotions', () => {
       renderWithProviders(<Promotions />);
 
       await waitFor(() => {
-        expect(screen.getByText('Mark Deployed')).toBeInTheDocument();
+        expect(screen.getByText('Verify Complete')).toBeInTheDocument();
       });
     });
 
-    it('calls completePromotion when Mark Deployed is clicked', async () => {
+    it('calls completePromotion when Verify Complete is clicked', async () => {
       const promotingPromotion: Promotion = {
         ...mockPromotion,
         status: 'promoting',
@@ -273,17 +363,17 @@ describe('Promotions', () => {
       const user = userEvent.setup();
 
       await waitFor(() => {
-        expect(screen.getByText('Mark Deployed')).toBeInTheDocument();
+        expect(screen.getByText('Verify Complete')).toBeInTheDocument();
       });
 
-      await user.click(screen.getByText('Mark Deployed'));
+      await user.click(screen.getByText('Verify Complete'));
 
       await waitFor(() => {
         expect(apiService.completePromotion).toHaveBeenCalledWith('tenant-1', 'promo-1');
       });
     });
 
-    it('hides Mark Deployed for viewers', async () => {
+    it('hides Verify Complete for viewers', async () => {
       const promotingPromotion: Promotion = {
         ...mockPromotion,
         status: 'promoting',
@@ -301,7 +391,7 @@ describe('Promotions', () => {
       await waitFor(() => {
         expect(screen.getByText('Promoting')).toBeInTheDocument();
       });
-      expect(screen.queryByText('Mark Deployed')).not.toBeInTheDocument();
+      expect(screen.queryByText('Verify Complete')).not.toBeInTheDocument();
     });
   });
 
@@ -344,6 +434,48 @@ describe('Promotions', () => {
       // Dialog has a heading "Create Promotion" and a submit button with same text
       expect(screen.getByRole('heading', { name: 'Create Promotion' })).toBeInTheDocument();
       expect(screen.getByText('Promotion Path')).toBeInTheDocument();
+    });
+
+    it('creates a gateway-aware promotion with source deployment and target gateways', async () => {
+      setupMocks('cpi-admin');
+      vi.mocked(apiService.createPromotion).mockResolvedValue(mockPromotion);
+      renderWithProviders(<Promotions />);
+
+      const user = userEvent.setup();
+
+      await waitFor(() => {
+        expect(screen.getByText('New Promotion')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('New Promotion'));
+      await user.selectOptions(screen.getByTestId('promotion-api-select'), 'api-1');
+
+      await waitFor(() => {
+        expect(apiService.getGatewayDeployments).toHaveBeenCalledWith({
+          environment: 'dev',
+          page_size: 100,
+        });
+      });
+
+      await user.selectOptions(screen.getByTestId('source-deployment-select'), 'deploy-1');
+
+      await waitFor(() => {
+        expect(screen.getByText('STOA Gateway Staging')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByLabelText(/STOA Gateway Staging/));
+      await user.type(screen.getByPlaceholderText(/Why are you promoting/), 'Ready for staging');
+      await user.click(screen.getByRole('button', { name: /Create Promotion/ }));
+
+      await waitFor(() => {
+        expect(apiService.createPromotion).toHaveBeenCalledWith('tenant-1', 'api-1', {
+          source_deployment_id: 'deploy-1',
+          target_gateway_ids: ['gw-staging'],
+          source_environment: 'dev',
+          target_environment: 'staging',
+          message: 'Ready for staging',
+        });
+      });
     });
   });
 

--- a/control-plane-ui/src/pages/Promotions.tsx
+++ b/control-plane-ui/src/pages/Promotions.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { apiService } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
 import { useToastActions } from '@stoa/shared/components/Toast';
@@ -6,8 +6,16 @@ import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
 import { EmptyState } from '@stoa/shared/components/EmptyState';
 import { TableSkeleton } from '@stoa/shared/components/Skeleton';
 import { Button } from '@stoa/shared/components/Button';
-import type { Promotion, PromotionStatus, Tenant, API } from '../types';
+import type {
+  Promotion,
+  PromotionStatus,
+  Tenant,
+  API,
+  GatewayDeployment,
+  GatewayInstance,
+} from '../types';
 import type { Schemas } from '@stoa/shared/api-types';
+import { normalizeEnvironment } from '@stoa/shared/constants/environments';
 import {
   ArrowRight,
   CheckCircle2,
@@ -88,6 +96,26 @@ const VALID_CHAINS: [string, string][] = [
   ['dev', 'staging'],
   ['staging', 'production'],
 ];
+
+function sameEnvironment(left?: string, right?: string): boolean {
+  if (!left || !right) return false;
+  return normalizeEnvironment(left) === normalizeEnvironment(right);
+}
+
+function gatewayFamily(gateway?: GatewayInstance | null): string {
+  return String(gateway?.target_gateway_type || gateway?.gateway_type || '').toLowerCase();
+}
+
+function gatewayTopology(gateway?: GatewayInstance | null): string {
+  return String(gateway?.topology || '').toLowerCase();
+}
+
+function deploymentMatchesApi(deployment: GatewayDeployment, apiId: string): boolean {
+  const desired = deployment.desired_state || {};
+  return [deployment.api_catalog_id, desired.api_catalog_id, desired.api_id, desired.api_name].some(
+    (value) => String(value || '') === apiId
+  );
+}
 
 // =============================================================================
 // PROMOTION PIPELINE INDICATOR
@@ -196,24 +224,133 @@ function CreatePromotionDialog({ tenantId, apis, onClose, onCreated }: CreatePro
   const [selectedApi, setSelectedApi] = useState('');
   const [source, setSource] = useState('dev');
   const [target, setTarget] = useState('staging');
+  const [gateways, setGateways] = useState<GatewayInstance[]>([]);
+  const [sourceDeployments, setSourceDeployments] = useState<GatewayDeployment[]>([]);
+  const [selectedSourceDeploymentId, setSelectedSourceDeploymentId] = useState('');
+  const [selectedTargetGatewayIds, setSelectedTargetGatewayIds] = useState<string[]>([]);
   const [message, setMessage] = useState('');
+  const [loadingTargets, setLoadingTargets] = useState(true);
+  const [loadingSourceDeployments, setLoadingSourceDeployments] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const isValidChain = VALID_CHAINS.some(([s, t]) => s === source && t === target);
 
   useEffect(() => {
+    let cancelled = false;
+    async function loadGateways() {
+      try {
+        setLoadingTargets(true);
+        const result = await apiService.getGatewayInstances({ page_size: 100 });
+        if (!cancelled) setGateways(result.items);
+      } catch (err: unknown) {
+        if (!cancelled) setError(extractErrorMessage(err));
+      } finally {
+        if (!cancelled) setLoadingTargets(false);
+      }
+    }
+    loadGateways();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
     if (source === 'dev') setTarget('staging');
     else if (source === 'staging') setTarget('production');
   }, [source]);
 
+  useEffect(() => {
+    setSelectedSourceDeploymentId('');
+    setSelectedTargetGatewayIds([]);
+    if (!selectedApi) {
+      setSourceDeployments([]);
+      return;
+    }
+
+    let cancelled = false;
+    async function loadSourceDeployments() {
+      try {
+        setLoadingSourceDeployments(true);
+        const result = await apiService.getGatewayDeployments({
+          environment: source,
+          page_size: 100,
+        });
+        if (!cancelled) setSourceDeployments(result.items);
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setSourceDeployments([]);
+          setError(extractErrorMessage(err));
+        }
+      } finally {
+        if (!cancelled) setLoadingSourceDeployments(false);
+      }
+    }
+
+    loadSourceDeployments();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedApi, source]);
+
+  const matchingSourceDeployments = useMemo(
+    () =>
+      sourceDeployments.filter(
+        (deployment) =>
+          deployment.sync_status === 'synced' &&
+          sameEnvironment(deployment.gateway_environment, source) &&
+          deploymentMatchesApi(deployment, selectedApi)
+      ),
+    [sourceDeployments, selectedApi, source]
+  );
+
+  const selectedSourceDeployment = useMemo(
+    () =>
+      matchingSourceDeployments.find((deployment) => deployment.id === selectedSourceDeploymentId),
+    [matchingSourceDeployments, selectedSourceDeploymentId]
+  );
+
+  const selectedSourceGateway = useMemo(
+    () => gateways.find((gateway) => gateway.id === selectedSourceDeployment?.gateway_instance_id),
+    [gateways, selectedSourceDeployment]
+  );
+
+  const targetGatewayCandidates = useMemo(() => {
+    if (!selectedSourceGateway) return [];
+    const sourceFamily = gatewayFamily(selectedSourceGateway);
+    const sourceTopology = gatewayTopology(selectedSourceGateway);
+    return gateways.filter((gateway) => {
+      if (gateway.id === selectedSourceGateway.id) return false;
+      if (gateway.enabled === false) return false;
+      if (!sameEnvironment(gateway.environment, target)) return false;
+      if (gatewayFamily(gateway) !== sourceFamily) return false;
+      const targetTopology = gatewayTopology(gateway);
+      return !sourceTopology || !targetTopology || targetTopology === sourceTopology;
+    });
+  }, [gateways, selectedSourceGateway, target]);
+
+  useEffect(() => {
+    setSelectedTargetGatewayIds((current) =>
+      current.filter((id) => targetGatewayCandidates.some((gateway) => gateway.id === id))
+    );
+  }, [targetGatewayCandidates]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!selectedApi || !message.trim()) return;
+    if (
+      !selectedApi ||
+      !selectedSourceDeploymentId ||
+      selectedTargetGatewayIds.length === 0 ||
+      !message.trim()
+    ) {
+      return;
+    }
     try {
       setSubmitting(true);
       setError(null);
       await apiService.createPromotion(tenantId, selectedApi, {
+        source_deployment_id: selectedSourceDeploymentId,
+        target_gateway_ids: selectedTargetGatewayIds,
         source_environment: source,
         target_environment: target,
         message: message.trim(),
@@ -235,7 +372,7 @@ function CreatePromotionDialog({ tenantId, apis, onClose, onCreated }: CreatePro
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-lg mx-4">
+      <div className="bg-white dark:bg-neutral-800 rounded-lg shadow-xl w-full max-w-2xl mx-4 max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between border-b border-neutral-200 dark:border-neutral-700 px-6 py-4">
           <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
             Create Promotion
@@ -266,6 +403,7 @@ function CreatePromotionDialog({ tenantId, apis, onClose, onCreated }: CreatePro
               onChange={(e) => setSelectedApi(e.target.value)}
               className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white text-sm"
               required
+              data-testid="promotion-api-select"
             >
               <option value="">Select an API...</option>
               {apis.map((api) => (
@@ -307,6 +445,106 @@ function CreatePromotionDialog({ tenantId, apis, onClose, onCreated }: CreatePro
             )}
           </div>
 
+          {/* Source deployment */}
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+              Source Deployment
+            </label>
+            <select
+              value={selectedSourceDeploymentId}
+              onChange={(e) => {
+                setSelectedSourceDeploymentId(e.target.value);
+                setSelectedTargetGatewayIds([]);
+              }}
+              className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white text-sm"
+              disabled={!selectedApi || loadingSourceDeployments}
+              required
+              data-testid="source-deployment-select"
+            >
+              <option value="">
+                {loadingSourceDeployments
+                  ? 'Loading synced deployments...'
+                  : 'Select a synced source deployment...'}
+              </option>
+              {matchingSourceDeployments.map((deployment) => (
+                <option key={deployment.id} value={deployment.id}>
+                  {deployment.gateway_display_name ||
+                    deployment.gateway_name ||
+                    deployment.gateway_instance_id}{' '}
+                  · {deployment.gateway_type || 'gateway'} · {deployment.id.slice(0, 8)}
+                </option>
+              ))}
+            </select>
+            {selectedApi && !loadingSourceDeployments && matchingSourceDeployments.length === 0 && (
+              <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+                No synced {source} gateway deployment exists for this API.
+              </p>
+            )}
+          </div>
+
+          {/* Target gateways */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                Target Gateways
+              </label>
+              {selectedSourceGateway && (
+                <span className="text-xs text-neutral-500 dark:text-neutral-400">
+                  {gatewayFamily(selectedSourceGateway)}
+                  {gatewayTopology(selectedSourceGateway)
+                    ? ` · ${gatewayTopology(selectedSourceGateway)}`
+                    : ''}
+                </span>
+              )}
+            </div>
+            <div
+              className="border border-neutral-200 dark:border-neutral-700 rounded-lg divide-y divide-neutral-200 dark:divide-neutral-700 overflow-hidden"
+              data-testid="target-gateway-list"
+            >
+              {loadingTargets ? (
+                <div className="px-3 py-3 text-sm text-neutral-500 dark:text-neutral-400">
+                  Loading gateways...
+                </div>
+              ) : !selectedSourceDeploymentId ? (
+                <div className="px-3 py-3 text-sm text-neutral-500 dark:text-neutral-400">
+                  Select a source deployment first.
+                </div>
+              ) : targetGatewayCandidates.length === 0 ? (
+                <div className="px-3 py-3 text-sm text-amber-600 dark:text-amber-400">
+                  No compatible {target} gateway found for the selected source gateway.
+                </div>
+              ) : (
+                targetGatewayCandidates.map((gateway) => (
+                  <label
+                    key={gateway.id}
+                    className="flex items-center gap-3 px-3 py-2 text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedTargetGatewayIds.includes(gateway.id)}
+                      onChange={(e) => {
+                        setSelectedTargetGatewayIds((current) =>
+                          e.target.checked
+                            ? [...current, gateway.id]
+                            : current.filter((id) => id !== gateway.id)
+                        );
+                      }}
+                      className="h-4 w-4 rounded border-neutral-300 text-blue-600 focus:ring-blue-500"
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block font-medium text-neutral-900 dark:text-white truncate">
+                        {gateway.display_name || gateway.name}
+                      </span>
+                      <span className="block text-xs text-neutral-500 dark:text-neutral-400 truncate">
+                        {gateway.name} · {gateway.environment}
+                      </span>
+                    </span>
+                  </label>
+                ))
+              )}
+            </div>
+          </div>
+
           {/* Message */}
           <div>
             <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
@@ -331,7 +569,14 @@ function CreatePromotionDialog({ tenantId, apis, onClose, onCreated }: CreatePro
             </Button>
             <Button
               type="submit"
-              disabled={submitting || !selectedApi || !message.trim() || !isValidChain}
+              disabled={
+                submitting ||
+                !selectedApi ||
+                !selectedSourceDeploymentId ||
+                selectedTargetGatewayIds.length === 0 ||
+                !message.trim() ||
+                !isValidChain
+              }
             >
               {submitting ? (
                 <>
@@ -426,16 +671,16 @@ function PromotionRow({
 
   const handleComplete = async () => {
     const ok = await confirm({
-      title: 'Mark as Deployed',
-      message: `Confirm that ${promotion.source_environment} → ${promotion.target_environment} deployment is complete?`,
-      confirmLabel: 'Mark Deployed',
+      title: 'Verify Promotion Completion',
+      message: `Complete this promotion only if all linked gateway deployments are synced for ${promotion.source_environment} → ${promotion.target_environment}.`,
+      confirmLabel: 'Verify Complete',
       variant: 'default',
     });
     if (!ok) return;
     try {
       setActionLoading(true);
       await apiService.completePromotion(tenantId, promotion.id);
-      toast.success('Promotion completed', 'Marked as deployed');
+      toast.success('Promotion completed', 'All linked deployments are synced');
       onRefresh();
     } catch (err: unknown) {
       toast.error('Complete failed', extractErrorMessage(err));
@@ -511,6 +756,11 @@ function PromotionRow({
           >
             {promotion.target_environment.toUpperCase()}
           </span>
+          {promotion.target_gateway_ids?.length ? (
+            <span className="text-xs text-neutral-500 dark:text-neutral-400">
+              {promotion.target_gateway_ids.length} gw
+            </span>
+          ) : null}
         </div>
 
         {/* Status */}
@@ -569,7 +819,7 @@ function PromotionRow({
               className="flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
             >
               <CheckCircle2 className="h-3.5 w-3.5" />
-              Mark Deployed
+              Verify Complete
             </button>
           )}
           {canRollback && (

--- a/control-plane-ui/src/types/index.ts
+++ b/control-plane-ui/src/types/index.ts
@@ -1776,6 +1776,7 @@ export interface Promotion {
   target_environment: string;
   source_deployment_id: string | null;
   target_deployment_id: string | null;
+  target_gateway_ids: string[] | null;
   status: PromotionStatus;
   spec_diff: Record<string, unknown> | null;
   message: string;

--- a/shared/api-types/generated.ts
+++ b/shared/api-types/generated.ts
@@ -17667,6 +17667,12 @@ export interface components {
              */
             message: string;
             /**
+             * Source Deployment Id
+             * Format: uuid
+             * @description Synced source GatewayDeployment UUID to promote
+             */
+            source_deployment_id: string;
+            /**
              * Source Environment
              * @description Source environment (dev, staging)
              */
@@ -17676,6 +17682,11 @@ export interface components {
              * @description Target environment (staging, production)
              */
             target_environment: string;
+            /**
+             * Target Gateway Ids
+             * @description Explicit target gateway UUIDs receiving the promoted API
+             */
+            target_gateway_ids: string[];
         };
         /** PromotionDiffResponse */
         PromotionDiffResponse: {
@@ -17754,6 +17765,8 @@ export interface components {
             target_deployment_id?: string | null;
             /** Target Environment */
             target_environment: string;
+            /** Target Gateway Ids */
+            target_gateway_ids?: string[] | null;
             /** Tenant Id */
             tenant_id: string;
             /**


### PR DESCRIPTION
## Summary\n- bring the gateway-aware promotion migration/code that prod is already running back into main\n- chain the catalog soft-delete migration after the prod alembic revision so Argo migrations can advance cleanly\n- prevent gateway-aware promotion approval events from being consumed by the legacy auto-deploy consumer a second time\n\n## Validation\n- cd control-plane-api && alembic heads\n- cd control-plane-api && ruff check alembic/versions/106_gateway_aware_promotions.py alembic/versions/106_drop_api_catalog_full_unique.py src/models/promotion.py src/routers/promotions.py src/schemas/promotion.py src/services/deployment_orchestration_service.py src/services/promotion_service.py src/consumers/promotion_deploy_consumer.py tests/test_deployment_orchestration_service.py tests/test_integration_promotion_chain.py tests/test_promotion_api.py tests/test_promotion_deploy_consumer.py tests/test_regression_cab_1917_api_creation.py\n- cd control-plane-api && pytest tests/test_promotion_api.py tests/test_promotion_deploy_consumer.py tests/test_deployment_orchestration_service.py tests/test_integration_promotion_chain.py tests/test_regression_cab_1917_api_creation.py tests/services/catalog_reconciler/test_projection.py tests/services/catalog_reconciler/test_projection_db.py tests/services/catalog_reconciler/test_worker_loop.py -q\n- cd control-plane-ui && npx vitest run src/pages/Promotions.test.tsx\n- cd control-plane-ui && npm run build\n- cd control-plane-ui && npm run lint\n\n## Prod context\nProd DB is currently at alembic revision 106_gateway_aware_promotions, but main lacked that revision. The previous promotion attempt built successfully but Argo PreSync migrations could not locate the revision and kept prod on the older image.