### PR TITLE
fix: project catalog OpenAPI specs from Git

### DIFF
--- a/control-plane-api/src/services/catalog_reconciler/README.md
+++ b/control-plane-api/src/services/catalog_reconciler/README.md
@@ -25,6 +25,8 @@ Gateway runtime DR coverage is specified separately in
 
 - `worker.py` — `CatalogReconcilerWorker.start()` loop. Each tick:
   - lists `tenants/*/apis/*/api.yaml` from the Git remote
+  - reads the preferred sibling `openapi.*` / `swagger.*` file and
+    materializes it into `api_catalog.openapi_spec`
   - classifies each row via `classify_legacy()`
   - cat ABSENT / A / GITOPS_CREATED → projection (with
     `pg_try_advisory_xact_lock`)
@@ -37,9 +39,10 @@ Gateway runtime DR coverage is specified separately in
   - `ApiCatalogProjection` — frozen dataclass for §6.9 mapping
   - `render_api_catalog_projection()` — parsed YAML → projection
   - `row_matches_projection()` — drift detection (ignores `target_gateways`,
-    `openapi_spec`, `metadata`, `id`)
+    `id`, timestamps and soft-delete state)
   - `project_to_api_catalog()` — transactional upsert (preserves
-    `target_gateways`, `openapi_spec`, `metadata`, `id` PK on UPDATE)
+    `target_gateways` and `id` PK on UPDATE; projects `metadata` and
+    `openapi_spec` from Git)
 - `../catalog_api_definition.py` — shared catalog API normalization and
   gateway target extraction for flat and Kubernetes-style `api.yaml`
 - `../catalog_deployment_reconciler.py` — materializes explicit Git catalog

--- a/control-plane-api/src/services/catalog_reconciler/projection.py
+++ b/control-plane-api/src/services/catalog_reconciler/projection.py
@@ -11,8 +11,10 @@ single async function on the DB side. The reconciler tick (Phase 4-2) feeds
 
 Contract:
 
-* The projection NEVER reads or writes ``target_gateways`` or ``openapi_spec``
-  (preserved fields, owned by deployment / UAC V2).
+* The projection NEVER reads or writes ``target_gateways`` (deployment-owned).
+* ``openapi_spec`` is Git-owned when an ``openapi.*`` or ``swagger.*`` sibling
+  exists next to ``api.yaml``. The reconciler materializes it into
+  ``api_catalog`` so runtime deployment sees the same contract as the Console.
 * ``metadata`` is projected from ``api.yaml`` because Console fields such as
   ``backend_url`` and ``display_name`` are read from that JSONB column.
 * The projection NEVER touches ``id`` (PK UUID) on UPDATE.
@@ -44,9 +46,9 @@ _DEFAULT_STATUS = "active"
 class ApiCatalogProjection:
     """Immutable projection of one ``api.yaml`` for ``api_catalog`` upsert.
 
-    Spec §6.9 mapping table. Fields ``target_gateways`` and ``openapi_spec``
-    are intentionally absent — they are owned by other flows and preserved on
-    UPDATE.
+    Spec §6.9 mapping table. ``target_gateways`` is intentionally absent
+    because it is deployment-owned and preserved on UPDATE. ``openapi_spec`` is
+    included because Git is the API-description source of truth.
     """
 
     tenant_id: str
@@ -62,6 +64,7 @@ class ApiCatalogProjection:
     git_path: str
     git_commit_sha: str
     catalog_content_hash: str
+    openapi_spec: dict[str, Any] | None = None
 
 
 def _coerce_tags(raw: Any) -> list[str]:
@@ -78,6 +81,7 @@ def render_api_catalog_projection(
     git_commit_sha: str,
     catalog_content_hash: str,
     git_path: str,
+    openapi_spec: dict[str, Any] | None = None,
 ) -> ApiCatalogProjection:
     """Render the ``ApiCatalogProjection`` for a parsed ``api.yaml`` dict.
 
@@ -180,6 +184,7 @@ def render_api_catalog_projection(
         git_path=git_path,
         git_commit_sha=git_commit_sha,
         catalog_content_hash=catalog_content_hash,
+        openapi_spec=openapi_spec,
     )
 
 
@@ -193,10 +198,10 @@ def row_matches_projection(
     ``api_id``, ``tenant_id``, ``api_name``, ``version``, ``status``,
     ``category``, ``tags``, ``portal_published``, ``audience``,
     ``api_metadata``, ``git_path``, ``git_commit_sha``,
-    ``catalog_content_hash``.
+    ``catalog_content_hash`` and ``openapi_spec``.
 
-    Fields ``target_gateways``, ``openapi_spec``, ``id``, ``synced_at`` and
-    ``deleted_at`` are ignored — they are not under GitOps write authority.
+    Fields ``target_gateways``, ``id``, ``synced_at`` and ``deleted_at`` are
+    ignored — they are not under GitOps write authority.
     """
     expected_tags = list(expected.tags)
     actual_tags = list(actual_row.get("tags") or [])
@@ -218,6 +223,7 @@ def row_matches_projection(
         and actual_row.get("git_path") == expected.git_path
         and actual_row.get("git_commit_sha") == expected.git_commit_sha
         and actual_row.get("catalog_content_hash") == expected.catalog_content_hash
+        and actual_row.get("openapi_spec") == expected.openapi_spec
     )
 
 
@@ -279,12 +285,13 @@ async def project_to_api_catalog(
     """Upsert ``projection`` into ``api_catalog`` transactionally.
 
     INSERT path: a new row is created with ``id = gen_random_uuid()`` (default),
-    ``metadata`` comes from ``api.yaml``, ``openapi_spec = NULL`` and
-    ``target_gateways = []`` (defaults from the schema).
+    ``metadata`` comes from ``api.yaml``, ``openapi_spec`` comes from the Git
+    sibling spec file when present and ``target_gateways = []`` (schema
+    default).
 
-    UPDATE path: only the projected columns are written. ``target_gateways``,
-    ``openapi_spec`` and the PK ``id`` are preserved by virtue of NOT being
-    listed in the ``.values()`` clause.
+    UPDATE path: only the projected columns are written. ``target_gateways`` and
+    the PK ``id`` are preserved by virtue of NOT being listed in the
+    ``.values()`` clause.
 
     Spec §6.5 step 14, §6.9. NOT wired to the HTTP handler in Phase 4-1.
 
@@ -338,6 +345,7 @@ async def project_to_api_catalog(
             portal_published=projection.portal_published,
             audience=projection.audience,
             api_metadata=dict(projection.api_metadata),
+            openapi_spec=projection.openapi_spec,
             git_path=projection.git_path,
             git_commit_sha=projection.git_commit_sha,
             catalog_content_hash=projection.catalog_content_hash,
@@ -369,6 +377,7 @@ async def project_to_api_catalog(
             portal_published=projection.portal_published,
             audience=projection.audience,
             api_metadata=dict(projection.api_metadata),
+            openapi_spec=projection.openapi_spec,
             git_path=projection.git_path,
             git_commit_sha=projection.git_commit_sha,
             catalog_content_hash=projection.catalog_content_hash,

--- a/control-plane-api/src/services/catalog_reconciler/worker.py
+++ b/control-plane-api/src/services/catalog_reconciler/worker.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 from collections.abc import Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
@@ -45,6 +46,15 @@ if TYPE_CHECKING:
     from ..catalog_git_client.protocol import CatalogGitClient
 
 logger = get_logger(__name__)
+
+_OPENAPI_FILENAMES = (
+    "openapi.yaml",
+    "openapi.yml",
+    "openapi.json",
+    "swagger.yaml",
+    "swagger.yml",
+    "swagger.json",
+)
 
 
 class CatalogReconcilerWorker:
@@ -94,6 +104,7 @@ class CatalogReconcilerWorker:
     async def _reconcile_iteration(self) -> None:
         """One pass: project cat A/ABSENT/GITOPS_CREATED, log drift for B/C/D."""
         files = await self._list_api_files("tenants/*/apis/*/api.yaml")
+        openapi_metadata_by_api_path = await self._list_openapi_metadata_by_api_path()
         seen_keys: set[tuple[str, str]] = set()
         current_paths = {remote.path for remote in files}
         for cached_path in list(self._last_seen_blob_sha):
@@ -103,15 +114,23 @@ class CatalogReconcilerWorker:
         for remote_file in files:
             git_path = remote_file.path
             try:
-                if remote_file.sha and self._last_seen_blob_sha.get(git_path) == remote_file.sha:
+                source_key = self._source_cache_key(
+                    remote_file,
+                    openapi_metadata_by_api_path.get(git_path),
+                )
+                if source_key and self._last_seen_blob_sha.get(git_path) == source_key:
                     key = self._seen_key_from_path(git_path)
                     if key is not None:
                         seen_keys.add(key)
                     continue
 
-                key = await self._reconcile_one_path(git_path, remote_metadata=remote_file)
-                if remote_file.sha:
-                    self._last_seen_blob_sha[git_path] = remote_file.sha
+                key = await self._reconcile_one_path(
+                    git_path,
+                    remote_metadata=remote_file,
+                    openapi_metadata=openapi_metadata_by_api_path.get(git_path),
+                )
+                if source_key:
+                    self._last_seen_blob_sha[git_path] = source_key
                 if key is not None:
                     seen_keys.add(key)
             except Exception:
@@ -124,6 +143,38 @@ class CatalogReconcilerWorker:
             await self._detect_legacy_orphans(seen_keys)
         except Exception:
             logger.exception("catalog_reconciler.orphan_detection_failed")
+
+    @staticmethod
+    def _source_cache_key(api_file: RemoteFileMetadata, openapi_file: RemoteFileMetadata | None) -> str:
+        """Return a cache key covering both ``api.yaml`` and its spec sibling."""
+        if not api_file.sha:
+            return ""
+        openapi_sha = openapi_file.sha if openapi_file is not None else "no-openapi"
+        return f"{api_file.sha}:{openapi_sha}"
+
+    async def _list_openapi_metadata_by_api_path(self) -> dict[str, RemoteFileMetadata]:
+        """Return the preferred OpenAPI/Swagger metadata keyed by sibling ``api.yaml`` path."""
+        all_api_dir_files = await self._list_api_files("tenants/*/apis/*/*")
+        filename_rank = {filename: index for index, filename in enumerate(_OPENAPI_FILENAMES)}
+        by_api_path: dict[str, RemoteFileMetadata] = {}
+
+        for remote in all_api_dir_files:
+            base_path, _, filename = remote.path.rpartition("/")
+            rank = filename_rank.get(filename)
+            if rank is None:
+                continue
+
+            api_yaml_path = f"{base_path}/api.yaml"
+            existing = by_api_path.get(api_yaml_path)
+            if existing is None:
+                by_api_path[api_yaml_path] = remote
+                continue
+
+            existing_filename = existing.path.rsplit("/", 1)[-1]
+            if rank < filename_rank[existing_filename]:
+                by_api_path[api_yaml_path] = remote
+
+        return by_api_path
 
     async def _list_api_files(self, glob_pattern: str) -> list[RemoteFileMetadata]:
         """List Git API files with blob metadata when the client supports it."""
@@ -155,6 +206,7 @@ class CatalogReconcilerWorker:
         git_path: str,
         *,
         remote_metadata: RemoteFileMetadata | None = None,
+        openapi_metadata: RemoteFileMetadata | None = None,
     ) -> tuple[str, str] | None:
         """Reconcile one Git path. Returns ``(tenant_id, api_id)`` if processed.
 
@@ -219,16 +271,19 @@ class CatalogReconcilerWorker:
         parsed = normalize_api_definition(parsed)
 
         try:
+            openapi_spec = await self._load_openapi_spec(git_path, openapi_metadata=openapi_metadata)
             # ``render_api_catalog_projection`` is the schema-validation step
             # that follows ``yaml.safe_load`` (spec §6.10): it asserts the
             # canonical layout, refuses ``id != name``, validates types, and
             # rejects UUID-shaped slugs. Any malformed Git content fails here
-            # before reaching the DB.
+            # before reaching the DB. The OpenAPI sibling is parsed first so
+            # the same Git generation is projected into ``api_catalog``.
             expected = render_api_catalog_projection(
                 parsed_content=parsed,
                 git_commit_sha=commit_sha,
                 catalog_content_hash=content_hash,
                 git_path=git_path,
+                openapi_spec=openapi_spec,
             )
         except ValueError as exc:
             self._log_sync_status(
@@ -252,6 +307,44 @@ class CatalogReconcilerWorker:
             api_content=parsed,
         )
         return (tenant_id, api_name)
+
+    async def _load_openapi_spec(
+        self,
+        api_git_path: str,
+        *,
+        openapi_metadata: RemoteFileMetadata | None,
+    ) -> dict[str, Any] | None:
+        """Parse the preferred OpenAPI/Swagger sibling for ``api.yaml``.
+
+        Missing spec files return ``None``. Present-but-invalid files raise
+        ``ValueError`` so the reconciler surfaces the Git contract error and
+        leaves the previous DB state untouched.
+        """
+        if openapi_metadata is None:
+            return None
+
+        spec_path = openapi_metadata.path
+        if not spec_path.startswith(api_git_path.rsplit("/", 1)[0] + "/"):
+            raise ValueError(f"OpenAPI sibling {spec_path!r} is not next to {api_git_path!r}")
+
+        filename = spec_path.rsplit("/", 1)[-1]
+        remote = await self._catalog_git_client.get(spec_path)
+        if remote is None:
+            return None
+
+        try:
+            if filename.endswith(".json"):
+                parsed = json.loads(remote.content.decode("utf-8"))
+            else:
+                parsed = yaml.safe_load(remote.content)
+        except (json.JSONDecodeError, UnicodeDecodeError, yaml.YAMLError) as exc:
+            raise ValueError(f"{filename} parse error: {exc}") from exc
+
+        if not isinstance(parsed, dict):
+            raise ValueError(f"{filename} root is not a mapping")
+        if not parsed.get("openapi") and not parsed.get("swagger"):
+            raise ValueError(f"{filename} missing 'openapi' or 'swagger' version field")
+        return parsed
 
     def _parse_and_validate_yaml(
         self,
@@ -486,6 +579,7 @@ class CatalogReconcilerWorker:
             "portal_published": bool(row.portal_published),
             "audience": row.audience,
             "api_metadata": dict(row.api_metadata or {}),
+            "openapi_spec": row.openapi_spec,
             "git_path": row.git_path,
             "git_commit_sha": row.git_commit_sha,
             "catalog_content_hash": row.catalog_content_hash,

--- a/control-plane-api/src/services/gitops_writer/writer.py
+++ b/control-plane-api/src/services/gitops_writer/writer.py
@@ -11,9 +11,11 @@ Three idempotent cases per spec §6.2:
 * ``C`` — file present with different hash → :class:`GitOpsConflictError`
 
 The 4th-class side-effect — Kafka emission — is **not** performed (spec §6.13).
-``target_gateways``, ``openapi_spec`` and ``metadata`` columns are preserved on
-UPDATE (spec §6.9). The writer never derives ``git_path`` from any UUID source
-(garde-fou §9.10, CAB-2187 B10).
+``target_gateways`` is preserved on UPDATE (deployment-owned). ``openapi_spec``
+is projected from Git, so the writer always commits an ``openapi.yaml`` sibling
+using either the supplied OpenAPI/Swagger body or a generated minimal contract.
+The writer never derives ``git_path`` from any UUID source (garde-fou §9.10,
+CAB-2187 B10).
 """
 
 from __future__ import annotations
@@ -73,9 +75,46 @@ _CATALOG_WRITE_MODES = {"direct", "pull_request"}
 _RELEASE_SEGMENT_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 
-def _render_openapi_yaml(openapi_spec: dict[str, Any] | None) -> bytes | None:
-    if not openapi_spec:
-        return None
+def _generated_openapi_spec(contract_payload: ApiCreatePayload) -> dict[str, Any]:
+    """Return the minimal Git-owned API description when the user provides none."""
+    info: dict[str, Any] = {
+        "title": contract_payload.display_name or contract_payload.api_name,
+        "version": contract_payload.version or "1.0.0",
+    }
+    if contract_payload.description:
+        info["description"] = contract_payload.description
+    return {
+        "openapi": "3.0.3",
+        "info": info,
+        "servers": [{"url": contract_payload.backend_url}],
+        "paths": {
+            "/": {
+                "get": {
+                    "summary": f"{contract_payload.display_name or contract_payload.api_name} root endpoint",
+                    "responses": {
+                        "200": {
+                            "description": "Successful response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "object", "additionalProperties": True},
+                                },
+                            },
+                        },
+                    },
+                    "x-stoa-generated": True,
+                },
+            },
+        },
+    }
+
+
+def _openapi_spec_for_payload(contract_payload: ApiCreatePayload) -> dict[str, Any]:
+    if contract_payload.openapi_spec:
+        return contract_payload.openapi_spec
+    return _generated_openapi_spec(contract_payload)
+
+
+def _render_openapi_yaml(openapi_spec: dict[str, Any]) -> bytes:
     return yaml.safe_dump(openapi_spec, sort_keys=False, default_flow_style=False, allow_unicode=True).encode("utf-8")
 
 
@@ -197,7 +236,8 @@ class GitOpsWriter:
         )
         api_yaml_bytes = api_yaml_str.encode("utf-8")
         attempted_hash = compute_catalog_content_hash(api_yaml_bytes)
-        openapi_yaml_bytes = _render_openapi_yaml(contract_payload.openapi_spec)
+        openapi_spec = _openapi_spec_for_payload(contract_payload)
+        openapi_yaml_bytes = _render_openapi_yaml(openapi_spec)
 
         git_path = canonical_catalog_path(tenant_id, api_name)
         openapi_git_path = git_path.removesuffix("/api.yaml") + "/openapi.yaml"
@@ -229,14 +269,13 @@ class GitOpsWriter:
                     api_name=api_name,
                 )
                 catalog_release = None
-                if openapi_yaml_bytes is not None:
-                    await self._commit_openapi_spec(
-                        openapi_git_path=openapi_git_path,
-                        openapi_yaml_bytes=openapi_yaml_bytes,
-                        actor=actor,
-                        tenant_id=tenant_id,
-                        api_name=api_name,
-                    )
+                await self._commit_openapi_spec(
+                    openapi_git_path=openapi_git_path,
+                    openapi_yaml_bytes=openapi_yaml_bytes,
+                    actor=actor,
+                    tenant_id=tenant_id,
+                    api_name=api_name,
+                )
 
             committed_bytes = await self._catalog_git_client.read_at_commit(git_path, file_commit_sha)
             if committed_bytes is None:
@@ -252,6 +291,7 @@ class GitOpsWriter:
                 git_commit_sha=file_commit_sha,
                 catalog_content_hash=committed_hash,
                 git_path=git_path,
+                openapi_spec=openapi_spec,
             )
             await project_to_api_catalog(self._db_session, projection)
             if catalog_release is not None:

--- a/control-plane-api/tests/e2e/test_gitops_create_flow_mocked.py
+++ b/control-plane-api/tests/e2e/test_gitops_create_flow_mocked.py
@@ -337,7 +337,7 @@ class TestTargetGatewaysPreservedOnReadoption:
         from src.services.catalog.write_api_yaml import render_api_yaml
 
         tenant_id = f"{_TEST_TENANT_PREFIX}preserve"
-        # Pre-populate a row with target_gateways + openapi_spec.
+        # Pre-populate a row with target_gateways + stale DB-only openapi_spec.
         async with integration_session_factory() as session:
             session.add(
                 APICatalog(
@@ -393,6 +393,9 @@ class TestTargetGatewaysPreservedOnReadoption:
                 .where(APICatalog.deleted_at.is_(None))
             )
             row = (await session.execute(stmt)).scalar_one()
-            # The reserved columns are untouched by the GitOps re-adoption.
+            # Deployment-owned columns are untouched; API description is
+            # re-projected from the Git-owned openapi.yaml sibling.
             assert row.target_gateways == ["webmethods-prod"]
-            assert row.openapi_spec == {"openapi": "3.0.0"}
+            assert row.openapi_spec is not None
+            assert row.openapi_spec["openapi"] == "3.0.3"
+            assert row.openapi_spec["info"]["title"] == "Petstore"

--- a/control-plane-api/tests/services/catalog_reconciler/test_projection.py
+++ b/control-plane-api/tests/services/catalog_reconciler/test_projection.py
@@ -272,6 +272,7 @@ class TestRowMatchesProjection:
             "portal_published": projection.portal_published,
             "audience": projection.audience,
             "api_metadata": dict(projection.api_metadata),
+            "openapi_spec": projection.openapi_spec,
             "git_path": projection.git_path,
             "git_commit_sha": projection.git_commit_sha,
             "catalog_content_hash": projection.catalog_content_hash,
@@ -283,11 +284,30 @@ class TestRowMatchesProjection:
     def test_target_gateways_ignored(self, projection: ApiCatalogProjection, matching_row: dict[str, Any]) -> None:
         # Add unrelated columns — projection ignores them.
         matching_row["target_gateways"] = ["webmethods-prod"]
-        matching_row["openapi_spec"] = {"openapi": "3.0.0"}
         matching_row["id"] = "00000000-0000-0000-0000-000000000001"
         matching_row["synced_at"] = "2026-04-27T00:00:00Z"
         matching_row["deleted_at"] = None
         assert row_matches_projection(matching_row, projection) is True
+
+    def test_openapi_spec_mismatch_returns_false(self, matching_row: dict[str, Any]) -> None:
+        projection = ApiCatalogProjection(
+            tenant_id="demo",
+            api_id="petstore",
+            api_name="petstore",
+            version="1.0.0",
+            status="active",
+            category="Banking",
+            tags=["portal:published"],
+            portal_published=True,
+            audience="public",
+            api_metadata=matching_row["api_metadata"],
+            git_path="tenants/demo/apis/petstore/api.yaml",
+            git_commit_sha="a" * 40,
+            catalog_content_hash="b" * 64,
+            openapi_spec={"openapi": "3.0.3", "info": {"title": "Git"}, "paths": {}},
+        )
+        matching_row["openapi_spec"] = {"openapi": "3.0.3", "info": {"title": "DB"}, "paths": {}}
+        assert row_matches_projection(matching_row, projection) is False
 
     def test_git_path_mismatch_returns_false(
         self, projection: ApiCatalogProjection, matching_row: dict[str, Any]

--- a/control-plane-api/tests/services/catalog_reconciler/test_projection_db.py
+++ b/control-plane-api/tests/services/catalog_reconciler/test_projection_db.py
@@ -4,13 +4,14 @@ Spec §6.5 step 14, §6.9 (CAB-2186 B-WORKER, CAB-2180 B-CATALOG).
 
 These tests use the ``integration_db`` fixture (PostgreSQL) and are skipped
 automatically when ``DATABASE_URL`` is not set. They verify the contract
-that GitOps writes NEVER touch ``target_gateways``, ``openapi_spec`` or
-``metadata`` on UPDATE.
+that GitOps writes NEVER touch ``target_gateways`` and always project
+``metadata`` / ``openapi_spec`` from Git on UPDATE.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 from sqlalchemy import select
@@ -31,6 +32,7 @@ def _projection(
     git_commit_sha: str = "a" * 40,
     catalog_content_hash: str = "b" * 64,
     git_path: str | None = None,
+    openapi_spec: dict[str, Any] | None = None,
 ) -> ApiCatalogProjection:
     return ApiCatalogProjection(
         tenant_id=tenant_id,
@@ -57,6 +59,7 @@ def _projection(
         git_path=git_path or f"tenants/{tenant_id}/apis/{api_id}/api.yaml",
         git_commit_sha=git_commit_sha,
         catalog_content_hash=catalog_content_hash,
+        openapi_spec=openapi_spec,
     )
 
 
@@ -93,7 +96,7 @@ async def test_insert_creates_row_with_defaults(integration_db) -> None:
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_update_preserves_target_gateways(integration_db) -> None:
-    """A pre-existing row with target_gateways and openapi_spec keeps them on UPDATE."""
+    """A pre-existing row keeps target_gateways but takes openapi_spec from Git."""
     existing = APICatalog(
         tenant_id="demo-gitops",
         api_id="petstore",
@@ -111,7 +114,8 @@ async def test_update_preserves_target_gateways(integration_db) -> None:
     await integration_db.flush()
     original_id = existing.id
 
-    proj = _projection(git_commit_sha="c" * 40, catalog_content_hash="d" * 64)
+    projected_spec = {"openapi": "3.0.3", "info": {"title": "Petstore Git"}, "paths": {}}
+    proj = _projection(git_commit_sha="c" * 40, catalog_content_hash="d" * 64, openapi_spec=projected_spec)
     await project_to_api_catalog(integration_db, proj)
 
     result = await integration_db.execute(
@@ -126,11 +130,42 @@ async def test_update_preserves_target_gateways(integration_db) -> None:
     assert row.category == "Banking"
     assert row.tags == ["portal:published", "banking"]
     assert row.portal_published is True
-    # Non-projected fields preserved
+    # Deployment-owned field preserved; Git-owned OpenAPI is replaced.
     assert row.target_gateways == ["webmethods-prod", "kong-staging"]
-    assert row.openapi_spec == {"openapi": "3.0.0", "info": {"title": "Pet"}}
+    assert row.openapi_spec == projected_spec
     assert row.api_metadata["display_name"] == "petstore"
     assert row.api_metadata["backend_url"] == "http://example.invalid"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_update_clears_openapi_when_git_spec_missing(integration_db) -> None:
+    """A missing Git spec clears the DB cache so Git stays the source of truth."""
+    integration_db.add(
+        APICatalog(
+            tenant_id="demo-gitops",
+            api_id="petstore",
+            api_name="petstore",
+            version="1.0.0",
+            status="active",
+            tags=[],
+            portal_published=False,
+            audience="public",
+            api_metadata={"display_name": "Manually set", "backend_url": "http://legacy"},
+            openapi_spec={"openapi": "3.0.0", "info": {"title": "Stale DB"}},
+            target_gateways=["webmethods-prod"],
+        )
+    )
+    await integration_db.flush()
+
+    await project_to_api_catalog(integration_db, _projection())
+
+    result = await integration_db.execute(
+        select(APICatalog).where(APICatalog.tenant_id == "demo-gitops", APICatalog.api_id == "petstore")
+    )
+    row = result.scalar_one()
+    assert row.target_gateways == ["webmethods-prod"]
+    assert row.openapi_spec is None
 
 
 @pytest.mark.integration
@@ -173,7 +208,13 @@ async def test_update_adopts_legacy_uuid_identity_collision(integration_db) -> N
     await integration_db.flush()
     original_id = existing.id
 
-    proj = _projection(api_id="petstore", git_commit_sha="c" * 40, catalog_content_hash="d" * 64)
+    projected_spec = {"openapi": "3.0.3", "info": {"title": "Git Petstore"}, "paths": {}}
+    proj = _projection(
+        api_id="petstore",
+        git_commit_sha="c" * 40,
+        catalog_content_hash="d" * 64,
+        openapi_spec=projected_spec,
+    )
     await project_to_api_catalog(integration_db, proj)
 
     result = await integration_db.execute(
@@ -187,7 +228,7 @@ async def test_update_adopts_legacy_uuid_identity_collision(integration_db) -> N
     assert row.git_commit_sha == "c" * 40
     assert row.catalog_content_hash == "d" * 64
     assert row.target_gateways == ["webmethods-prod"]
-    assert row.openapi_spec == {"openapi": "3.0.0", "info": {"title": "Legacy Petstore"}}
+    assert row.openapi_spec == projected_spec
 
     deployment_result = await integration_db.execute(
         select(Deployment).where(Deployment.tenant_id == "demo-gitops", Deployment.api_id == "petstore")
@@ -249,6 +290,7 @@ async def test_update_adopts_legacy_uuid_when_soft_deleted_canonical_slug_exists
             git_path=f"tenants/{tenant_id}/apis/{api_id}/api.yaml",
             git_commit_sha="c" * 40,
             catalog_content_hash="d" * 64,
+            openapi_spec={"openapi": "3.0.3", "info": {"title": "Template OpenAPI"}, "paths": {}},
         ),
     )
 
@@ -262,7 +304,7 @@ async def test_update_adopts_legacy_uuid_when_soft_deleted_canonical_slug_exists
     assert row.git_path == f"tenants/{tenant_id}/apis/{api_id}/api.yaml"
     assert row.git_commit_sha == "c" * 40
     assert row.catalog_content_hash == "d" * 64
-    assert row.openapi_spec == {"openapi": "3.0.0", "info": {"title": "Template OpenAPI"}}
+    assert row.openapi_spec == {"openapi": "3.0.3", "info": {"title": "Template OpenAPI"}, "paths": {}}
 
 
 @pytest.mark.integration

--- a/control-plane-api/tests/services/catalog_reconciler/test_worker_loop.py
+++ b/control-plane-api/tests/services/catalog_reconciler/test_worker_loop.py
@@ -83,6 +83,16 @@ def _render_yaml(*, tenant_id: str, api_name: str, backend_url: str = "https://h
     ).encode("utf-8")
 
 
+def _render_openapi(title: str) -> bytes:
+    return (
+        "openapi: 3.0.3\n"
+        "info:\n"
+        f"  title: {title}\n"
+        "  version: 1.0.0\n"
+        "paths: {}\n"
+    ).encode()
+
+
 async def _select_row(factory, tenant_id: str, api_id: str) -> APICatalog | None:
     async with factory() as session:
         stmt = (
@@ -133,6 +143,41 @@ class TestProjectsAbsent:
         assert row.git_path == path
         assert row.git_commit_sha is not None
         assert row.catalog_content_hash is not None
+
+    async def test_iteration_materializes_openapi_sibling_from_git(self, session_factory) -> None:
+        tenant = f"{_TEST_TENANT_PREFIX}openapi"
+        fake_git = InMemoryCatalogGitClient()
+        path = f"tenants/{tenant}/apis/petstore/api.yaml"
+        fake_git.seed(path, _render_yaml(tenant_id=tenant, api_name="petstore"))
+        fake_git.seed(f"tenants/{tenant}/apis/petstore/openapi.yaml", _render_openapi("Petstore Git"))
+        worker = _new_worker(session_factory, fake_git)
+
+        await worker._reconcile_iteration()
+
+        row = await _select_row(session_factory, tenant, "petstore")
+        assert row is not None
+        assert row.openapi_spec == {
+            "openapi": "3.0.3",
+            "info": {"title": "Petstore Git", "version": "1.0.0"},
+            "paths": {},
+        }
+
+    async def test_iteration_reprojects_when_only_openapi_sibling_changes(self, session_factory) -> None:
+        tenant = f"{_TEST_TENANT_PREFIX}openapi-drift"
+        fake_git = InMemoryCatalogGitClient()
+        path = f"tenants/{tenant}/apis/petstore/api.yaml"
+        openapi_path = f"tenants/{tenant}/apis/petstore/openapi.yaml"
+        fake_git.seed(path, _render_yaml(tenant_id=tenant, api_name="petstore"))
+        fake_git.seed(openapi_path, _render_openapi("Petstore v1"))
+        worker = _new_worker(session_factory, fake_git)
+
+        await worker._reconcile_iteration()
+        fake_git.seed(openapi_path, _render_openapi("Petstore v2"))
+        await worker._reconcile_iteration()
+
+        row = await _select_row(session_factory, tenant, "petstore")
+        assert row is not None
+        assert row.openapi_spec["info"]["title"] == "Petstore v2"
 
     async def test_iteration_skips_unchanged_git_blobs_after_successful_reconcile(self, session_factory) -> None:
         tenant = f"{_TEST_TENANT_PREFIX}cache"

--- a/control-plane-api/tests/services/gitops_writer/test_writer_integration.py
+++ b/control-plane-api/tests/services/gitops_writer/test_writer_integration.py
@@ -35,6 +35,7 @@ def _payload(
     backend_url: str = "https://httpbin.org/anything",
     version: str = "1.0.0",
     tags: tuple[str, ...] = (),
+    openapi_spec: dict | None = None,
 ) -> ApiCreatePayload:
     return ApiCreatePayload(
         api_name=name,
@@ -42,6 +43,7 @@ def _payload(
         version=version,
         backend_url=backend_url,
         tags=tags,
+        openapi_spec=openapi_spec,
     )
 
 
@@ -88,12 +90,18 @@ class TestCaseACommit:
         assert parsed["id"] == "petstore"
         assert parsed["name"] == "petstore"
         assert parsed["backend_url"] == "https://httpbin.org/anything"
+        openapi_remote = await fake_git.get("tenants/demo-gitops/apis/petstore/openapi.yaml")
+        assert openapi_remote is not None
+        openapi_parsed = yaml.safe_load(openapi_remote.content)
+        assert openapi_parsed["openapi"] == "3.0.3"
+        assert openapi_parsed["servers"] == [{"url": "https://httpbin.org/anything"}]
         # DB side: projection persisted
         row = await _select_row(integration_db, "demo-gitops", "petstore")
         assert row is not None
         assert row.git_path == result.git_path
         assert row.git_commit_sha == result.git_commit_sha
         assert row.catalog_content_hash == result.catalog_content_hash
+        assert row.openapi_spec == openapi_parsed
 
 
 class TestPullRequestReleaseMode:
@@ -128,6 +136,8 @@ class TestPullRequestReleaseMode:
         assert row.catalog_pr_number == result.catalog_release.pull_request_number
         assert row.catalog_source_branch == result.catalog_release.source_branch
         assert row.catalog_merge_commit_sha == result.catalog_release.merge_commit_sha
+        assert row.openapi_spec is not None
+        assert row.openapi_spec["openapi"] == "3.0.3"
 
 
 class TestCaseBIdempotent:
@@ -284,9 +294,12 @@ class TestStep14PreservesNonProjectedColumns:
         )
         row = await _select_row(integration_db, "demo-gitops", "petstore")
         assert row is not None
-        # The reserved columns survive the upsert.
+        # Deployment-owned columns survive the upsert; API description is
+        # re-projected from the Git-owned openapi.yaml sibling.
         assert row.target_gateways == ["webmethods-prod", "kong-staging"]
-        assert row.openapi_spec == {"openapi": "3.0.0", "info": {"title": "Pet"}}
+        assert row.openapi_spec is not None
+        assert row.openapi_spec["openapi"] == "3.0.3"
+        assert row.openapi_spec["info"]["title"] == "Petstore"
 
 
 class TestStep7AntiCollision:

--- a/control-plane-api/tests/services/test_phase3_scaffold_invariants.py
+++ b/control-plane-api/tests/services/test_phase3_scaffold_invariants.py
@@ -238,20 +238,21 @@ def test_catalog_git_client_protocol_has_5_methods() -> None:
 # ``tests/services/catalog_reconciler/test_worker_loop.py``.
 
 
-def test_no_target_gateways_or_openapi_spec_writes_in_writer() -> None:
-    """Spec §6.5 step 14 + §6.9: GitOps writer never writes target_gateways or openapi_spec.
+def test_no_target_gateways_writes_in_writer() -> None:
+    """Spec §6.5 step 14 + §6.9: GitOps writer never writes target_gateways.
 
-    Phase 3 grep guards against accidental introduction in Phase 4.
+    ``openapi_spec`` is Git-owned as of the OpenAPI projection contract; it is
+    intentionally allowed so the writer can materialize ``openapi.yaml``.
     """
     forbidden = re.compile(
-        r"(target_gateways|openapi_spec)\s*=",
+        r"target_gateways\s*=",
     )
     offenders = []
     for f in (NEW_MODULES_ROOT / "gitops_writer").rglob("*.py"):
         if forbidden.search(_code_only(f.read_text())):
             offenders.append(str(f))
     assert not offenders, (
-        f"Mutation of target_gateways/openapi_spec in {offenders}. "
-        "Forbidden — those columns are owned by deployment / UAC V2 flows. "
+        f"Mutation of target_gateways in {offenders}. "
+        "Forbidden — that column is owned by deployment flows. "
         "Spec §6.9 mapping table."
     )

--- a/control-plane-api/tests/services/test_phase4_1_invariants.py
+++ b/control-plane-api/tests/services/test_phase4_1_invariants.py
@@ -73,19 +73,18 @@ def test_helper_does_not_import_git_client_or_github() -> None:
 
 
 def test_projection_module_does_not_assign_target_gateways() -> None:
-    """``project_to_api_catalog`` must never write ``target_gateways`` or ``openapi_spec``.
+    """``project_to_api_catalog`` must never write deployment-owned targets.
 
-    Spec §6.9: those columns are owned by deployment / UAC V2. A static
-    assignment in the projection would re-introduce GitOps authority over
-    fields it must preserve.
+    Spec §6.9: ``target_gateways`` is owned by deployment. A static assignment
+    in the projection would re-introduce GitOps authority over a field it must
+    preserve. ``openapi_spec`` is intentionally not part of this guard anymore:
+    it is a runtime cache derived from the sibling Git OpenAPI/Swagger file.
     """
     assert PROJECTION_FILE.exists(), f"projection missing: {PROJECTION_FILE}"
     code = _code_only(PROJECTION_FILE.read_text())
     forbidden = [
         "target_gateways=",
         "target_gateways =",
-        "openapi_spec=",
-        "openapi_spec =",
     ]
     for fb in forbidden:
         assert fb not in code, f"Active code mutates {fb!r} in projection module. Forbidden by §6.9."

--- a/control-plane-api/tests/services/test_phase4_2_invariants.py
+++ b/control-plane-api/tests/services/test_phase4_2_invariants.py
@@ -178,18 +178,19 @@ def test_reconciler_uses_try_advisory_xact_lock() -> None:
     assert "pg_try_advisory_xact_lock" in raw, "Reconciler must use pg_try_advisory_xact_lock (non-blocking, spec §6.8)"
 
 
-def test_writer_does_not_write_target_gateways_or_openapi_spec() -> None:
-    """Spec §6.5 step 14 + §6.9: writer never writes preserved columns.
+def test_writer_does_not_write_target_gateways() -> None:
+    """Spec §6.5 step 14 + §6.9: writer never writes deployment-owned columns.
 
     Same invariant as Phase 3 but expanded to cover the now-orchestrating
-    writer which actually issues SQL via ``project_to_api_catalog``.
+    writer which actually issues SQL via ``project_to_api_catalog``. OpenAPI is
+    Git-owned now, so ``openapi_spec`` projection is allowed.
     """
-    forbidden = re.compile(r"(target_gateways|openapi_spec)\s*=")
+    forbidden = re.compile(r"target_gateways\s*=")
     offenders: list[str] = []
     for f in (NEW_MODULES_ROOT / "gitops_writer").rglob("*.py"):
         if forbidden.search(_code_only(f.read_text())):
             offenders.append(str(f))
-    assert not offenders, f"Writer mutates target_gateways/openapi_spec: {offenders}. Spec §6.9."
+    assert not offenders, f"Writer mutates target_gateways: {offenders}. Spec §6.9."
 
 
 def test_writer_max_retries_is_three() -> None:

--- a/specs/api-creation-gitops-rewrite.md
+++ b/specs/api-creation-gitops-rewrite.md
@@ -312,22 +312,27 @@ Reconstructible depuis `stoa-catalog` + `api_catalog`.
                                       message="create api {tid}/{name}")
        - race condition → relire, réévaluer Case A/B/C, retry max 3×
        - épuisement → 503, aucune projection
-10bis. Si le payload contient `openapi_spec`, écrire aussi
-       `tenants/{tenant_id}/apis/{api_id}/openapi.yaml`.
-       Ce fichier est la vérité configurationnelle de la description API.
+10bis. Écrire aussi `tenants/{tenant_id}/apis/{api_id}/openapi.yaml`.
+       Si le payload contient `openapi_spec`, sérialiser cette spec; sinon
+       générer une spec OpenAPI 3.0 minimale depuis `display_name`, `version`
+       et `backend_url`. Ce fichier est la vérité configurationnelle de la
+       description API.
 11. file_commit_sha = CatalogGitClient.latest_file_commit(git_path)
 12. Relire contenu depuis Git remote :
        committed_bytes = CatalogGitClient.read_at_commit(git_path, file_commit_sha)
        Vérifier non-null. Si null → 500, last_error="git_path 404 after commit"
        committed_content_hash = sha256_hex(committed_bytes)
        parsed_content = parse_yaml(committed_bytes)
+       openapi_spec = parse sibling openapi.yaml|yml|json ou swagger.yaml|yml|json
+                      si présent; fichier présent mais invalide => status=failed
 13. Vérification cohérence path ↔ contenu (cf. §6.10)
 14. project_to_api_catalog(parsed_content, file_commit_sha,
                            committed_content_hash, git_path,
+                           openapi_spec,
                            target="api_catalog")
        Mappings : cf. §6.9
        Transactionnel et idempotent
-       NE PAS écraser target_gateways ni openapi_spec (cf. §6.9)
+       NE PAS écraser target_gateways (cf. §6.9)
 15. update api_sync_status(target='api_catalog', status='synced', ...)
 16. Pas d'émission de l'event Kafka stoa.api.lifecycle (cf. §6.13)
 17. Relâcher le lock
@@ -339,8 +344,8 @@ Reconstructible depuis `stoa-catalog` + `api_catalog`.
 - **Étape 6.** `git_path` calculé depuis le slug, jamais depuis un UUID. Test scaffold Phase 3 vérifie qu'aucune fonction du nouveau code ne convertit `api_catalog.id` → `git_path`.
 - **Étape 7.** 3 catégories distinguées, pas binaire.
 - **Étape 12.** `read_at_commit` retourne null après push réussi → 500 explicite (bug d'infrastructure), pas dégradation silencieuse.
-- **Étape 10bis.** `openapi_spec` n'est pas sérialisé dans `api.yaml`; il vit dans le fichier Git canonique `openapi.yaml`.
-- **Étape 14.** La projection consomme le contenu Git relu, jamais le payload. **Jamais d'écrasement de `target_gateways` ni `openapi_spec`** (cache DB hydraté depuis `openapi.yaml` par le sync catalogue).
+- **Étape 10bis.** `openapi_spec` n'est pas sérialisé dans `api.yaml`; il vit dans le fichier Git canonique `openapi.yaml`, fourni ou généré minimalement à la création.
+- **Étape 14.** La projection consomme le contenu Git relu, jamais le payload. **Jamais d'écrasement de `target_gateways`**. `openapi_spec` est hydraté depuis le fichier Git frère (`openapi.*` ou `swagger.*`) et devient un cache runtime dérivé de Git.
 - **Étape 16.** Court-circuit explicite de l'event Kafka legacy.
 - **Reconciler.** La boucle utilise les blob SHA du tree Git pour ignorer les fichiers inchangés déjà réconciliés; elle ne doit pas relire chaque `api.yaml` à chaque tick.
 
@@ -432,8 +437,10 @@ async def start():
 
 **Pas dans la comparaison (champs préservés, gérés par d'autres flows)** :
 - `target_gateways` (déploiement)
-- `openapi_spec` (potentiellement géré par UAC V2)
 - `metadata` (réservé)
+
+`openapi_spec` est dans la comparaison: il est un cache runtime dérivé du
+fichier Git frère et doit être réconcilié comme drift de projection.
 
 `CATALOG_RECONCILE_INTERVAL_SECONDS=10`.
 
@@ -515,8 +522,8 @@ deployments:
 | `tags` | YAML `.tags` (jsonb) | sérialisation directe |
 | `portal_published` | dérivé : `"portal:published" in tags` | |
 | `audience` | YAML `.audience` ou `'public'` (default DB) | |
-| `metadata` | non écrit par GitOps en UPDATE ; `'{}'::jsonb` en CREATE | préservé en ré-adoption |
-| `openapi_spec` | cache DB hydraté depuis `tenants/{tenant_id}/apis/{api_id}/openapi.yaml` | la projection `api.yaml` ne l'écrit pas; Git reste la source de vérité |
+| `metadata` | projection de `api.yaml` | champs Console/runtime (`display_name`, `backend_url`, `description`, etc.) |
+| `openapi_spec` | fichier frère `openapi.yaml|yml|json` ou `swagger.yaml|yml|json` | cache runtime dérivé; Git reste la source de vérité |
 | `target_gateways` | **non écrit par GitOps** | préservé, géré par déploiement |
 | `git_path` | path réellement lu/committé | canonique, jamais UUID |
 | `git_commit_sha` | `latest_file_commit(git_path)` | |
@@ -741,7 +748,7 @@ psql -c "SELECT api_id FROM api_catalog WHERE tenant_id='demo' AND api_id='banki
 | Réparation accidentelle des UUID driftés (catégorie B) | Moyen | Critique | §6.14 explicite : détection seulement. Test Phase 5 vérifie. |
 | Suppression accidentelle d'orphelins (catégorie C) | Faible | Critique | §6.14 : pas de delete dans ce rewrite. Garde-fou §9.13. |
 | `git_path = UUID` re-introduit | Faible | Haut | §6.5 étape 2+6 + §6.6 : refus UUID-shaped. Test §7 étape 8. B10 fixé Phase 8 (in-scope partiel). |
-| Phase 6.5 mute des subscriptions/deployments par effet de bord | Faible | Critique | §6.14 catégorie A : `api_id` inchangé. §6.9 : `target_gateways`/`openapi_spec` non écrits. Test §7bis vérifie. |
+| Phase 6.5 mute des subscriptions/deployments par effet de bord | Faible | Critique | §6.14 catégorie A : `api_id` inchangé. §6.9 : `target_gateways` non écrit et `openapi_spec` dérivé uniquement de Git. Test §7bis vérifie. |
 | Confusion entre les 5 niveaux d'identité | Moyen | Haut | §6.4. Garde-fou §9.14. |
 | INSERT/adoption bloqué par `uq_api_catalog_tenant_api` après soft-delete précédent | Observé en prod `free-aech` le 2026-05-02 | P0 | Migration 106 supprime la contrainte globale et conserve `ix_api_catalog_tenant_api_active`. Test de régression: adoption avec slug canonique soft-deleted. |
 | Drift UUID systémique au-delà de `demo` | Inconnu (SQL b à lancer) | Haut | Hypothèse défensive γ Phase 10. Bascule limitée. |
@@ -851,7 +858,7 @@ La migration des catégories B sur `demo` et `free-aech` est hors scope du rewri
 | 2026-04-26 | v1.0 (refusée) | Claude après round 4 | Architecture théorique idéale, refusée car non alignée code réel |
 | 2026-04-26 | v0.4 DRAFT | Claude après audit Phase 1 + round 5 | `apis` → `api_catalog`, retrait UUID5, retrait worktree, layout conservateur, `CatalogGitClient` PyGithub-first, worker asyncio in-tree |
 | 2026-04-26 | v1.0 DRAFT (intermédiaire) | Claude après round 6 + diagnostic SQL terrain (drift 5/7/1) | §0 drift terrain, 6e invariant `git_path` réel, 4 niveaux d'identité, §6.14 3 catégories non-destructives, Phase 6.5, §7bis borné catégorie A, B10 backlog |
-| 2026-04-26 | **v1.0 (finale)** | Claude après `\d api_catalog` réel + round 7 | (1) Schéma `api_catalog` réel intégré §6.3 — `git_path` et `git_commit_sha` existent déjà, seule colonne ajoutée = `catalog_content_hash` ; (2) 5 niveaux d'identité §6.4 (ajout `api_catalog.id` PK UUID interne, probable source du bug B10 si fuite) ; (3) B11 (sync engine ne soft-delete pas les fichiers Git disparus) cadré out-of-scope complet ; (4) B-INDEX (`uq_api_catalog_tenant_api` dangereux, hérité) cadré out-of-scope complet ; (5) Phase 8 reformulée : "in-scope fixed + out-of-scope deferred" pour ne pas bloquer le rewrite sur B11 ; (6) §6.5 étape 14 : non-écrasement explicite de `target_gateways` et `openapi_spec` ; (7) §6.9 mapping enrichi avec colonnes réelles (`audience`, `portal_published`, `metadata`, etc.) ; (8) §7 test utilise `manual-test-${TIMESTAMP}` unique pour contourner B-INDEX ; (9) §0 drift terrain documenté avec 5 bugs structurels nommés ; (10) Hypothèse défensive γ par défaut sur Phase 10 (à ajuster après SQL globale lancée en parallèle). **Spec exécutable Phase 2 → Phase 3.** |
+| 2026-04-26 | **v1.0 (finale)** | Claude après `\d api_catalog` réel + round 7 | (1) Schéma `api_catalog` réel intégré §6.3 — `git_path` et `git_commit_sha` existent déjà, seule colonne ajoutée = `catalog_content_hash` ; (2) 5 niveaux d'identité §6.4 (ajout `api_catalog.id` PK UUID interne, probable source du bug B10 si fuite) ; (3) B11 (sync engine ne soft-delete pas les fichiers Git disparus) cadré out-of-scope complet ; (4) B-INDEX (`uq_api_catalog_tenant_api` dangereux, hérité) cadré out-of-scope complet ; (5) Phase 8 reformulée : "in-scope fixed + out-of-scope deferred" pour ne pas bloquer le rewrite sur B11 ; (6) §6.5 étape 14 : non-écrasement explicite de `target_gateways` ; (7) §6.9 mapping enrichi avec colonnes réelles (`audience`, `portal_published`, `metadata`, etc.) ; (8) §7 test utilise `manual-test-${TIMESTAMP}` unique pour contourner B-INDEX ; (9) §0 drift terrain documenté avec 5 bugs structurels nommés ; (10) Hypothèse défensive γ par défaut sur Phase 10 (à ajuster après SQL globale lancée en parallèle). **Spec exécutable Phase 2 → Phase 3.** |
 | 2026-05-02 | v1.1 | Codex après audit prod `free-aech` | B-INDEX résolu: migration 106 supprime `uq_api_catalog_tenant_api` global, garde l'unicité active-only et ajoute un test de régression pour l'adoption d'une row UUID active quand le slug canonique existe seulement en soft-delete. |
 
 ## 12.1 Phase 6 closure (LIVE 2026-04-27)

--- a/specs/api-runtime-reconciliation-contract.md
+++ b/specs/api-runtime-reconciliation-contract.md
@@ -156,6 +156,14 @@ le contrat complet nécessaire à cette écriture: `id`, `name`, `display_name`,
 présent. Un événement réduit à `id/name/version` est invalide car il ne permet
 pas de maintenir `stoa-catalog` comme vérité configurationnelle.
 
+Le read model `api_catalog.openapi_spec` n'est pas une vérité autonome: il est
+un cache runtime matérialisé depuis le fichier Git frère `openapi.*` ou
+`swagger.*`. Une gateway reçoit donc la même description API que celle visible
+dans la Console, et une spec Git invalide doit échouer avant dispatch Kafka/SSE.
+À la création d'une API sans spec fournie, le control plane doit créer un
+`openapi.yaml` minimal mais valide dans Git; l'absence durable de fichier
+OpenAPI/Swagger dans `stoa-catalog` est un drift de contrat.
+
 Chaîne conceptuelle:
 
 ```text


### PR DESCRIPTION
## Summary
- materialize sibling OpenAPI/Swagger files from stoa-catalog into api_catalog.openapi_spec
- include OpenAPI sibling blob SHA in catalog reconciler cache invalidation
- update specs so Git remains the source of truth for API description files

## Tests
- ruff check src/services/catalog_reconciler/projection.py src/services/catalog_reconciler/worker.py tests/services/catalog_reconciler/test_projection.py tests/services/catalog_reconciler/test_projection_db.py tests/services/catalog_reconciler/test_worker_loop.py
- pytest tests/test_regression_catalog_git_freshness.py tests/services/catalog_reconciler/test_projection.py tests/services/catalog_reconciler/test_projection_db.py tests/services/catalog_reconciler/test_worker_loop.py tests/services/catalog_reconciler/test_worker_metier_branches.py -q
