### PR TITLE
fix(api): block webMethods-incompatible OpenAPI schemas

### DIFF
--- a/control-plane-api/src/routers/apis.py
+++ b/control-plane-api/src/routers/apis.py
@@ -220,9 +220,7 @@ def _generated_openapi_fallback(api: APICatalog) -> dict[str, Any]:
                         "200": {
                             "description": "Successful response",
                             "content": {
-                                "application/json": {
-                                    "schema": {"type": "object", "additionalProperties": True}
-                                }
+                                "application/json": {"schema": {"type": "object"}}
                             },
                         }
                     },

--- a/control-plane-api/src/services/deployment_orchestration_service.py
+++ b/control-plane-api/src/services/deployment_orchestration_service.py
@@ -726,6 +726,50 @@ class DeploymentOrchestrationService:
                         )
                     )
 
+        errors.extend(
+            DeploymentOrchestrationService._validate_no_boolean_additional_properties(
+                openapi_spec,
+                error=error,
+            )
+        )
+        return errors
+
+    @staticmethod
+    def _validate_no_boolean_additional_properties(
+        value,
+        *,
+        error,
+        path: str = "openapi_spec",
+    ) -> list[DeploymentPreflightError]:
+        errors: list[DeploymentPreflightError] = []
+        if isinstance(value, dict):
+            for key, child in value.items():
+                child_path = f"{path}.{key}"
+                if key == "additionalProperties" and isinstance(child, bool):
+                    errors.append(
+                        error(
+                            "openapi_schema_boolean_additional_properties",
+                            "webMethods rejects boolean additionalProperties; omit it or use an explicit schema object",
+                            child_path,
+                        )
+                    )
+                    continue
+                errors.extend(
+                    DeploymentOrchestrationService._validate_no_boolean_additional_properties(
+                        child,
+                        error=error,
+                        path=child_path,
+                    )
+                )
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                errors.extend(
+                    DeploymentOrchestrationService._validate_no_boolean_additional_properties(
+                        child,
+                        error=error,
+                        path=f"{path}.{index}",
+                    )
+                )
         return errors
 
     async def _has_active_promotion(self, api_id: str, tenant_id: str, target_environment: str) -> bool:

--- a/control-plane-api/src/services/gitops_writer/writer.py
+++ b/control-plane-api/src/services/gitops_writer/writer.py
@@ -96,7 +96,7 @@ def _generated_openapi_spec(contract_payload: ApiCreatePayload) -> dict[str, Any
                             "description": "Successful response",
                             "content": {
                                 "application/json": {
-                                    "schema": {"type": "object", "additionalProperties": True},
+                                    "schema": {"type": "object"},
                                 },
                             },
                         },

--- a/control-plane-api/tests/services/gitops_writer/test_writer_unit.py
+++ b/control-plane-api/tests/services/gitops_writer/test_writer_unit.py
@@ -8,14 +8,28 @@ without ``DATABASE_URL``). Spec §6.5 + §6.8.
 
 from __future__ import annotations
 
+from src.services.gitops_writer.models import ApiCreatePayload
 from src.services.gitops_writer.writer import (
     _ACTOR_MAX_LEN,
     _MAX_RACE_RETRIES,
     _catalog_release_branch_name,
     _catalog_release_id,
     _catalog_release_tag_name,
+    _generated_openapi_spec,
     _sanitize_actor,
 )
+
+
+def _contains_boolean_additional_properties(value) -> bool:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key == "additionalProperties" and isinstance(child, bool):
+                return True
+            if _contains_boolean_additional_properties(child):
+                return True
+    if isinstance(value, list):
+        return any(_contains_boolean_additional_properties(child) for child in value)
+    return False
 
 
 class TestSanitizeActor:
@@ -48,6 +62,21 @@ class TestRetryConstant:
     def test_max_retries_is_three(self) -> None:
         # Spec §6.5 step 10: exactly 3 attempts before raising 503.
         assert _MAX_RACE_RETRIES == 3
+
+
+class TestGeneratedOpenApiSpec:
+    def test_generated_spec_is_webmethods_compatible(self) -> None:
+        spec = _generated_openapi_spec(
+            ApiCreatePayload(
+                api_name="demo-petstore",
+                display_name="Demo Petstore",
+                version="1.0.0",
+                backend_url="https://petstore.example.invalid",
+            )
+        )
+
+        assert spec["openapi"] == "3.0.3"
+        assert _contains_boolean_additional_properties(spec) is False
 
 
 class TestCatalogReleaseNaming:

--- a/control-plane-api/tests/test_apis_openapi.py
+++ b/control-plane-api/tests/test_apis_openapi.py
@@ -7,6 +7,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from src.models.catalog import APICatalog
 
 
+def _contains_boolean_additional_properties(value) -> bool:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key == "additionalProperties" and isinstance(child, bool):
+                return True
+            if _contains_boolean_additional_properties(child):
+                return True
+    if isinstance(value, list):
+        return any(_contains_boolean_additional_properties(child) for child in value)
+    return False
+
+
 def _catalog_api(*, openapi_spec: dict | None = None) -> APICatalog:
     return APICatalog(
         tenant_id="acme",
@@ -101,3 +113,4 @@ def test_get_openapi_returns_marked_generated_fallback(client_as_tenant_admin):
     assert data["format"] == "openapi"
     assert data["spec"]["info"]["title"] == "Payment API"
     assert "/" in data["spec"]["paths"]
+    assert _contains_boolean_additional_properties(data["spec"]) is False

--- a/control-plane-api/tests/test_regression_deployment_preflight.py
+++ b/control-plane-api/tests/test_regression_deployment_preflight.py
@@ -147,3 +147,48 @@ async def test_regression_admin_preflight_reports_targeted_error_for_explicit_ga
     assert results[0].gateway_name == "connect-webmethods-dev"
     assert results[0].target_gateway_type == "webmethods"
     assert results[0].errors[0].code == "openapi_operation_responses_missing"
+
+
+@pytest.mark.asyncio
+async def test_regression_webmethods_preflight_blocks_boolean_additional_properties():
+    from src.services.deployment_orchestration_service import DeploymentOrchestrationService
+
+    catalog = _catalog(
+        {
+            "openapi": "3.0.3",
+            "info": {"title": "Manual Test", "version": "1.0.0"},
+            "paths": {
+                "/": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "description": "ok",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"type": "object", "additionalProperties": True}
+                                    }
+                                },
+                            }
+                        }
+                    }
+                }
+            },
+        }
+    )
+    gateway = _webmethods_gateway()
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_result(catalog), _result(gateway), _result(gateway)])
+    svc = DeploymentOrchestrationService(db)
+
+    results = await svc.preflight_deploy_api_to_env(
+        tenant_id="demo",
+        api_identifier=str(catalog.id),
+        environment="dev",
+        gateway_ids=[gateway.id],
+    )
+
+    assert len(results) == 1
+    assert results[0].deployable is False
+    assert results[0].errors[0].code == "openapi_schema_boolean_additional_properties"
+    assert results[0].errors[0].path.endswith(".schema.additionalProperties")

--- a/specs/api-creation-gitops-rewrite.md
+++ b/specs/api-creation-gitops-rewrite.md
@@ -315,8 +315,9 @@ Reconstructible depuis `stoa-catalog` + `api_catalog`.
 10bis. Écrire aussi `tenants/{tenant_id}/apis/{api_id}/openapi.yaml`.
        Si le payload contient `openapi_spec`, sérialiser cette spec; sinon
        générer une spec OpenAPI 3.0 minimale depuis `display_name`, `version`
-       et `backend_url`. Ce fichier est la vérité configurationnelle de la
-       description API.
+       et `backend_url`. La spec générée doit rester compatible avec le
+       preflight webMethods, notamment sans `additionalProperties` booléen.
+       Ce fichier est la vérité configurationnelle de la description API.
 11. file_commit_sha = CatalogGitClient.latest_file_commit(git_path)
 12. Relire contenu depuis Git remote :
        committed_bytes = CatalogGitClient.read_at_commit(git_path, file_commit_sha)

--- a/specs/api-runtime-reconciliation-contract.md
+++ b/specs/api-runtime-reconciliation-contract.md
@@ -561,7 +561,10 @@ Pour `target_gateway_type=webmethods`, le preflight minimal est strict:
 - `openapi` ou `swagger` doit être présent;
 - `info.title` et `info.version` doivent être présents;
 - `paths` doit contenir au moins une route;
-- chaque opération HTTP déclarée doit contenir un objet `responses` non vide.
+- chaque opération HTTP déclarée doit contenir un objet `responses` non vide;
+- aucun schéma ne doit utiliser `additionalProperties` booléen (`true` ou
+  `false`), car webMethods le rejette; omettre le champ ou utiliser un schéma
+  objet explicite.
 
 Une spec OpenAPI générique peut donc être valide pour STOA mais non déployable
 vers webMethods. Dans ce cas le statut utilisateur est `invalid_desired_state`
@@ -767,11 +770,13 @@ des modes gateway acquittés.
 
 Déployer une API vers `target_gateway_type=webmethods` avec une spec OpenAPI
 syntaxiquement parseable mais incomplète pour WebMethods, par exemple une
-opération sans `responses`.
+opération sans `responses` ou un schéma contenant
+`additionalProperties: true`.
 
 PASS si:
 - `POST /deploy/validate` retourne `deployable=false` pour la gateway
-  webMethods avec `code=openapi_operation_responses_missing`;
+  webMethods avec `code=openapi_operation_responses_missing` ou
+  `code=openapi_schema_boolean_additional_properties`;
 - `POST /deploy` retourne une erreur 400 actionnable avant `event_emitted`;
 - aucun `GatewayDeployment` n'est créé et aucun event Kafka/SSE n'est émis.
 


### PR DESCRIPTION
## Summary
- remove boolean additionalProperties from STOA-generated OpenAPI fallbacks
- add webMethods preflight rejection for boolean additionalProperties before GatewayDeployment/event dispatch
- align runtime reconciliation specs with the new contract

## Validation
- ruff check src/services/gitops_writer/writer.py src/routers/apis.py src/services/deployment_orchestration_service.py tests/services/gitops_writer/test_writer_unit.py tests/test_apis_openapi.py tests/test_regression_deployment_preflight.py
- pytest tests/services/gitops_writer/test_writer_unit.py tests/test_apis_openapi.py tests/test_regression_deployment_preflight.py -q
- pytest tests/e2e/test_gitops_create_flow_mocked.py tests/services/gitops_writer/test_writer_integration.py -q (2 passed, 17 skipped locally without DATABASE_URL)