### PR TITLE
fix(api): preserve deployment status during gateway outages

### DIFF
--- a/control-plane-api/src/routers/gateway_internal.py
+++ b/control-plane-api/src/routers/gateway_internal.py
@@ -816,6 +816,31 @@ class RouteSyncAckPayload(BaseModel):
     sync_timestamp: str = Field(..., description="ISO timestamp of sync completion")
 
 
+def _is_gateway_connectivity_error(error: str | None) -> bool:
+    """Return True when a sync failure is gateway reachability, not route drift."""
+    if not error:
+        return False
+    normalized = error.casefold()
+    return any(
+        marker in normalized
+        for marker in (
+            "connection reset",
+            "connection refused",
+            "connect: connection",
+            "clientconnectordnserror",
+            "context deadline exceeded",
+            "did not acknowledge",
+            "eof",
+            "gateway unreachable",
+            "i/o timeout",
+            "no route to host",
+            "temporarily unavailable",
+            "timed out",
+            "timeout",
+        )
+    )
+
+
 @router.post("/{gateway_id}/route-sync-ack", status_code=200)
 async def route_sync_ack(
     gateway_id: UUID,
@@ -909,11 +934,14 @@ async def route_sync_ack(
         desired_generation = deployment.desired_generation if isinstance(deployment.desired_generation, int) else 1
         synced_generation = deployment.synced_generation if isinstance(deployment.synced_generation, int) else 0
 
+        is_failed_connectivity_observation = effective_status == "failed" and _is_gateway_connectivity_error(
+            step_error or effective_error
+        )
         if (
             effective_status == "failed"
             and deployment.sync_status == DeploymentSyncStatus.SYNCED
             and deployment.last_sync_success is not None
-            and synced_generation >= desired_generation
+            and (synced_generation >= desired_generation or is_failed_connectivity_observation)
         ):
             logger.info(
                 "route-sync-ack: preserving synced deployment %s after failed re-ack for generation %s",

--- a/control-plane-api/tests/test_regression_route_sync_ack_stability.py
+++ b/control-plane-api/tests/test_regression_route_sync_ack_stability.py
@@ -73,6 +73,71 @@ def test_regression_route_sync_ack_failed_does_not_downgrade_stable_synced_deplo
         mock_deploy_repo.update.assert_awaited_once()
 
 
+def test_regression_route_sync_ack_connectivity_failure_preserves_forced_resync(client):
+    """A gateway outage during force-sync is health, not proof the deployed API vanished."""
+    last_success = datetime.now(UTC)
+    successful_steps = [
+        {"name": "event_emitted", "status": "success", "detail": "deployment dispatched to agent"},
+        {"name": "agent_received", "status": "success"},
+        {"name": "adapter_connected", "status": "success"},
+        {"name": "api_synced", "status": "success"},
+    ]
+    outage_steps = [
+        {"name": "agent_received", "status": "success"},
+        {"name": "adapter_connected", "status": "success"},
+        {
+            "name": "api_synced",
+            "status": "failed",
+            "detail": 'list existing apis: Get "http://localhost:5555/rest/apigateway/apis": EOF',
+        },
+    ]
+    dep = _make_deployment(
+        sync_status=DeploymentSyncStatus.SYNCED,
+        last_sync_success=last_success,
+        sync_error=None,
+        sync_steps=successful_steps,
+        sync_attempts=0,
+    )
+    dep.desired_generation = 9
+    dep.synced_generation = 2
+    dep.attempted_generation = 8
+
+    with (
+        patch("src.routers.gateway_internal.settings") as mock_settings,
+        patch("src.routers.gateway_internal.GatewayDeploymentRepository") as MockDeployRepo,
+    ):
+        mock_settings.gateway_api_keys_list = [VALID_KEY]
+        mock_deploy_repo = MockDeployRepo.return_value
+        mock_deploy_repo.get_by_id = AsyncMock(return_value=dep)
+        mock_deploy_repo.update = AsyncMock()
+
+        resp = client.post(
+            f"/v1/internal/gateways/{dep.gateway_instance_id}/route-sync-ack",
+            json={
+                "synced_routes": [
+                    {
+                        "deployment_id": str(dep.id),
+                        "status": "failed",
+                        "error": 'list existing apis: Get "http://localhost:5555/rest/apigateway/apis": EOF',
+                        "steps": outage_steps,
+                        "generation": 9,
+                    },
+                ],
+                "sync_timestamp": "2026-05-02T13:02:15Z",
+            },
+            headers={GW_KEY_HEADER: VALID_KEY},
+        )
+
+        assert resp.status_code == 200
+        assert dep.sync_status == DeploymentSyncStatus.SYNCED
+        assert dep.last_sync_success == last_success
+        assert dep.sync_error is None
+        assert dep.sync_steps == successful_steps
+        assert dep.synced_generation == 2
+        assert dep.attempted_generation == 9
+        mock_deploy_repo.update.assert_awaited_once()
+
+
 def test_regression_route_sync_ack_contradictory_applied_reack_preserves_stable_synced_deployment(client):
     """A bad applied ack trace must not overwrite an already stable synced route."""
     last_success = datetime.now(UTC)


### PR DESCRIPTION
## Summary
- keep already-synced gateway deployments green when a route-sync ack reports gateway connectivity failures
- classify EOF, connection reset, timeout, and unreachable errors as gateway health observations instead of runtime undeploy proof
- add regression coverage for forced re-sync during a webMethods outage

## Validation
- ruff check src/routers/gateway_internal.py tests/test_regression_route_sync_ack_stability.py
- pytest tests/test_regression_route_sync_ack_stability.py -q