### PR TITLE
[codex] clarify gateway URL surfaces

### DIFF
--- a/charts/stoa-platform/crds/gatewayinstances.gostoa.dev.yaml
+++ b/charts/stoa-platform/crds/gatewayinstances.gostoa.dev.yaml
@@ -80,7 +80,13 @@ spec:
                   properties:
                     publicUrl:
                       type: string
-                      description: User or tenant reachable runtime URL
+                      description: User or tenant reachable runtime URL for this STOA runtime
+                    targetGatewayUrl:
+                      type: string
+                      description: Third-party gateway admin/runtime URL controlled by STOA Link or STOA Connect
+                    uiUrl:
+                      type: string
+                      description: Third-party gateway web UI URL; never use the STOA Link runtime URL here
                     internalUrl:
                       type: string
                       description: Cluster/service URL for in-cluster calls

--- a/control-plane-api/tests/test_regression_cab_2240_webmethods_staging_targets.py
+++ b/control-plane-api/tests/test_regression_cab_2240_webmethods_staging_targets.py
@@ -11,6 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DEV_OVERLAY = REPO_ROOT / "k8s" / "gateways" / "overlays" / "dev"
 STAGING_OVERLAY = REPO_ROOT / "k8s" / "gateways" / "overlays" / "staging"
 PROD_OVERLAY = REPO_ROOT / "k8s" / "gateways" / "overlays" / "production"
+GATEWAY_INSTANCE_CRD = REPO_ROOT / "charts" / "stoa-platform" / "crds" / "gatewayinstances.gostoa.dev.yaml"
 MIGRATION = (
     REPO_ROOT
     / "control-plane-api"
@@ -136,6 +137,16 @@ def test_regression_cab_2240_gateway_instances_expose_webmethods_ui_urls_for_all
         assert endpoints["publicUrl"] == public_url
         assert endpoints["targetGatewayUrl"] == target_gateway_url
         assert endpoints["uiUrl"] == ui_url
+
+
+def test_regression_cab_2240_crd_declares_gateway_url_contract() -> None:
+    crd = _load_yaml(GATEWAY_INSTANCE_CRD)[0]
+    schema = crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"]
+    endpoints = schema["properties"]["spec"]["properties"]["endpoints"]["properties"]
+
+    assert endpoints["publicUrl"]["description"].startswith("User or tenant reachable runtime URL")
+    assert "Third-party gateway" in endpoints["targetGatewayUrl"]["description"]
+    assert "never use the STOA Link runtime URL" in endpoints["uiUrl"]["description"]
 
 
 def test_regression_cab_2240_migration_repairs_all_staging_webmethods_rows() -> None:

--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.test.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.test.tsx
@@ -22,6 +22,10 @@ const { mockGateway, mockDeployments, mockTools } = vi.hoisted(() => ({
     public_url: 'https://mcp.gostoa.dev',
     target_gateway_url: null,
     ui_url: null,
+    endpoints: null,
+    deployment_mode: null,
+    target_gateway_type: null,
+    topology: null,
     auth_config: {},
     status: 'online',
     enabled: true,
@@ -129,6 +133,14 @@ describe('GatewayDetail', () => {
     // Reset gateway to enabled state
     mockGateway.enabled = true;
     mockGateway.visibility = null;
+    mockGateway.public_url = 'https://mcp.gostoa.dev';
+    mockGateway.target_gateway_url = null;
+    mockGateway.ui_url = null;
+    mockGateway.endpoints = null;
+    mockGateway.deployment_mode = null;
+    mockGateway.target_gateway_type = null;
+    mockGateway.topology = null;
+    mockGateway.mode = 'edge-mcp';
   });
 
   it('renders gateway display name', async () => {
@@ -167,6 +179,56 @@ describe('GatewayDetail', () => {
     await screen.findByText('STOA Edge MCP Gateway');
     const openBtn = screen.getByText('Open Gateway');
     expect(openBtn.closest('a')).toHaveAttribute('href', 'https://mcp.gostoa.dev');
+  });
+
+  it('renders endpoint-map URLs for a remote WebMethods link', async () => {
+    const { apiService } = await import('../../services/api');
+    vi.mocked(apiService.getGatewayInstance).mockResolvedValueOnce({
+      ...mockGateway,
+      id: 'gw-link',
+      name: 'stoa-link-wm-staging',
+      display_name: 'STOA Link webMethods Staging',
+      gateway_type: 'stoa',
+      base_url: 'http://stoa-link-wm-staging:8080',
+      public_url: null,
+      target_gateway_url: null,
+      ui_url: null,
+      endpoints: {
+        publicUrl: 'https://staging-wm-k3s.gostoa.dev',
+        targetGatewayUrl: 'https://staging-wm.gostoa.dev',
+        uiUrl: 'https://staging-wm-ui.gostoa.dev',
+      },
+      mode: 'sidecar',
+      deployment_mode: 'connect',
+      target_gateway_type: 'webmethods',
+      topology: 'remote-agent',
+      tags: ['remote-agent', 'webmethods', 'not-a-k8s-sidecar'],
+    });
+
+    renderGatewayDetail('gw-link');
+    await screen.findByText('STOA Link webMethods Staging');
+
+    expect(screen.getByText('Link K8s')).toBeInTheDocument();
+    expect(screen.getByText('Remote link')).toBeInTheDocument();
+    expect(screen.getByText('STOA Runtime')).toBeInTheDocument();
+    expect(screen.getByText('Target Gateway')).toBeInTheDocument();
+    expect(screen.getByText('Third-party UI')).toBeInTheDocument();
+    expect(screen.getByText('Open Gateway').closest('a')).toHaveAttribute(
+      'href',
+      'https://staging-wm-k3s.gostoa.dev'
+    );
+    expect(screen.getByText('https://staging-wm-k3s.gostoa.dev').closest('a')).toHaveAttribute(
+      'href',
+      'https://staging-wm-k3s.gostoa.dev'
+    );
+    expect(screen.getByText('https://staging-wm.gostoa.dev').closest('a')).toHaveAttribute(
+      'href',
+      'https://staging-wm.gostoa.dev'
+    );
+    expect(screen.getByText('https://staging-wm-ui.gostoa.dev').closest('a')).toHaveAttribute(
+      'href',
+      'https://staging-wm-ui.gostoa.dev'
+    );
   });
 
   it('renders health metrics', async () => {

--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
@@ -25,6 +25,7 @@ import {
   ShieldAlert,
 } from 'lucide-react';
 import type { GatewayInstance } from '../../types';
+import { deploymentLabel, gatewayUrls, topologyLabel } from './gatewayDisplay';
 
 interface DiscoveredAPI {
   name: string;
@@ -35,26 +36,6 @@ interface DiscoveredAPI {
   annotations?: Record<string, unknown> | null;
   [key: string]: unknown;
 }
-
-const MODE_LABELS: Record<string, string> = {
-  'edge-mcp': 'Edge MCP',
-  sidecar: 'Runtime Sidecar',
-  proxy: 'Proxy',
-  shadow: 'Shadow',
-  connect: 'Connect',
-};
-
-const DEPLOYMENT_LABELS: Record<string, string> = {
-  edge: 'Edge',
-  connect: 'Connect',
-  sidecar: 'Sidecar',
-};
-
-const TOPOLOGY_LABELS: Record<string, string> = {
-  'native-edge': 'Native edge',
-  'remote-agent': 'Remote agent',
-  'same-pod': 'Same pod',
-};
 
 const STATUS_CONFIG: Record<string, { color: string; icon: typeof CheckCircle2 }> = {
   online: { color: 'text-green-600 bg-green-50', icon: CheckCircle2 },
@@ -153,14 +134,9 @@ export function GatewayDetail() {
   const StatusIcon = statusCfg.icon;
   const deployments = deploymentsData?.items || [];
   const discoveredApis = toolsData || [];
-  const modeLabel = gateway.deployment_mode
-    ? DEPLOYMENT_LABELS[gateway.deployment_mode] || gateway.deployment_mode
-    : gateway.mode
-      ? MODE_LABELS[gateway.mode] || gateway.mode
-      : null;
-  const topologyLabel = gateway.topology
-    ? TOPOLOGY_LABELS[gateway.topology] || gateway.topology
-    : null;
+  const urls = gatewayUrls(gateway);
+  const modeLabel = deploymentLabel(gateway);
+  const topologyText = topologyLabel(gateway);
   const hasVisibilityRestriction =
     gateway.visibility && Array.isArray(gateway.visibility.tenant_ids);
 
@@ -194,9 +170,9 @@ export function GatewayDetail() {
                 {modeLabel}
               </span>
             )}
-            {topologyLabel && (
+            {topologyText && (
               <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-slate-50 text-slate-700">
-                {topologyLabel}
+                {topologyText}
               </span>
             )}
             {gateway.source === 'argocd' && (
@@ -235,9 +211,9 @@ export function GatewayDetail() {
               </button>
             </>
           )}
-          {gateway.public_url && (
+          {urls.publicUrl && (
             <a
-              href={gateway.public_url}
+              href={urls.publicUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
@@ -271,14 +247,10 @@ export function GatewayDetail() {
           Configuration
         </h2>
         <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4">
-          <ConfigItem label="Admin URL" value={gateway.base_url} isLink />
-          {gateway.public_url && (
-            <ConfigItem label="Public URL" value={gateway.public_url} isLink />
-          )}
-          {gateway.target_gateway_url && (
-            <ConfigItem label="Target Gateway" value={gateway.target_gateway_url} isLink />
-          )}
-          {gateway.ui_url && <ConfigItem label="Gateway UI" value={gateway.ui_url} isLink />}
+          <ConfigItem label="Admin URL" value={urls.baseUrl ?? '--'} isLink={!!urls.baseUrl} />
+          {urls.publicUrl && <ConfigItem label="STOA Runtime" value={urls.publicUrl} isLink />}
+          {urls.targetUrl && <ConfigItem label="Target Gateway" value={urls.targetUrl} isLink />}
+          {urls.uiUrl && <ConfigItem label="Third-party UI" value={urls.uiUrl} isLink />}
           <ConfigItem label="Environment" value={gateway.environment} />
           <ConfigItem label="Type" value={gateway.gateway_type} />
           {gateway.target_gateway_type && (

--- a/control-plane-ui/src/pages/Gateways/GatewayList.test.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayList.test.tsx
@@ -255,7 +255,7 @@ describe('GatewayList', () => {
       'href',
       'https://wm-runtime.gostoa.dev'
     );
-    expect(screen.getByRole('link', { name: /^ui/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /third-party ui/i })).toHaveAttribute(
       'href',
       'https://wm-ui.gostoa.dev'
     );
@@ -263,6 +263,8 @@ describe('GatewayList', () => {
       'href',
       'https://vps-wm.gostoa.dev'
     );
+    expect(screen.getByText('Connect VPS')).toBeInTheDocument();
+    expect(screen.getByText('Remote link')).toBeInTheDocument();
   });
 
   it('renders status dot with title for live gateway', async () => {

--- a/control-plane-ui/src/pages/Gateways/GatewayList.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayList.tsx
@@ -11,15 +11,11 @@ import { EmptyState } from '@stoa/shared/components/EmptyState';
 import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 import {
   RefreshCw,
-  Activity,
   Server,
   ChevronRight,
   ExternalLink,
   Trash2,
   HeartPulse,
-  Shield,
-  Globe,
-  Zap,
   RotateCcw,
   Lock,
   Eye,
@@ -27,9 +23,19 @@ import {
   GitBranch,
 } from 'lucide-react';
 import { Button } from '@stoa/shared/components/Button';
-import type { GatewayInstance, GatewayInstanceStatus, GatewayMode } from '../../types';
+import type { GatewayInstance, GatewayInstanceStatus } from '../../types';
 import { SubNav } from '../../components/SubNav';
 import { gatewayTabs } from '../../components/subNavGroups';
+import {
+  TYPE_DISPLAY,
+  deploymentLabel,
+  displayUrl,
+  externalUrl,
+  gatewayExternalLinks,
+  gatewayUrls,
+  targetLabel,
+  topologyLabel,
+} from './gatewayDisplay';
 
 // ---------------------------------------------------------------------------
 // Constants — colors from shared constants (green=dev, amber=staging, red=prod)
@@ -92,49 +98,6 @@ const STATUS_CONFIG: Record<GatewayInstanceStatus, { dot: string; label: string;
     },
   };
 
-const TYPE_DISPLAY: Record<string, { label: string; icon: typeof Server }> = {
-  stoa: { label: 'STOA', icon: Zap },
-  stoa_edge_mcp: { label: 'STOA Edge MCP', icon: Zap },
-  stoa_sidecar: { label: 'STOA Link', icon: Shield },
-  stoa_proxy: { label: 'STOA Proxy', icon: Globe },
-  stoa_shadow: { label: 'STOA Shadow', icon: Activity },
-  webmethods: { label: 'webMethods', icon: Server },
-  kong: { label: 'Kong', icon: Server },
-  apigee: { label: 'Apigee', icon: Server },
-  aws_apigateway: { label: 'AWS API GW', icon: Server },
-  azure_apim: { label: 'Azure APIM', icon: Server },
-  gravitee: { label: 'Gravitee', icon: Server },
-  stoa_connect: { label: 'STOA Connect', icon: GitBranch },
-};
-
-const MODE_LABELS: Record<GatewayMode, string> = {
-  'edge-mcp': 'Edge MCP',
-  sidecar: 'Runtime Sidecar',
-  proxy: 'Proxy',
-  shadow: 'Shadow',
-  connect: 'Connect',
-};
-
-const DEPLOYMENT_LABELS: Record<string, string> = {
-  edge: 'Edge',
-  connect: 'Connect',
-  sidecar: 'Sidecar',
-};
-
-const TOPOLOGY_LABELS: Record<string, string> = {
-  'native-edge': 'Native edge',
-  'remote-agent': 'Remote agent',
-  'same-pod': 'Same pod',
-};
-
-const TARGET_LABELS: Record<string, string> = {
-  stoa: 'STOA',
-  kong: 'Kong',
-  webmethods: 'webMethods',
-  gravitee: 'Gravitee',
-  agentgateway: 'Agent Gateway',
-};
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -150,24 +113,6 @@ function isLive(gw: GatewayInstance): boolean {
 
 function isStoa(type: string): boolean {
   return type.startsWith('stoa');
-}
-
-function deploymentLabel(gw: GatewayInstance): string | null {
-  if (gw.deployment_mode) return DEPLOYMENT_LABELS[gw.deployment_mode] ?? gw.deployment_mode;
-  if (gw.mode) return MODE_LABELS[gw.mode] ?? gw.mode;
-  return null;
-}
-
-function targetLabel(gw: GatewayInstance, fallback: string): string {
-  if (gw.target_gateway_type) {
-    return TARGET_LABELS[gw.target_gateway_type] ?? gw.target_gateway_type;
-  }
-  return fallback;
-}
-
-function topologyLabel(gw: GatewayInstance): string | null {
-  if (!gw.topology) return null;
-  return TOPOLOGY_LABELS[gw.topology] ?? gw.topology;
 }
 
 function formatUptime(seconds: number): string {
@@ -186,95 +131,6 @@ function timeAgo(dateStr: string): string {
   const hrs = Math.floor(mins / 60);
   if (hrs < 24) return `${hrs}h ago`;
   return `${Math.floor(hrs / 24)}d ago`;
-}
-
-const ENDPOINT_ALIASES: Record<string, string[]> = {
-  public_url: ['public_url', 'publicUrl', 'public', 'runtime_url', 'runtimeUrl', 'external_url'],
-  ui_url: ['ui_url', 'uiUrl', 'console_url', 'consoleUrl', 'web_ui_url', 'webUiUrl'],
-  target_gateway_url: ['target_gateway_url', 'targetGatewayUrl', 'target_url', 'targetUrl'],
-  admin_url: ['admin_url', 'adminUrl', 'admin', 'base_url', 'baseUrl'],
-  internal_url: ['internal_url', 'internalUrl', 'internal'],
-};
-
-type GatewayUrls = {
-  publicUrl: string | null;
-  uiUrl: string | null;
-  targetUrl: string | null;
-  baseUrl: string | null;
-  primaryUrl: string | null;
-};
-
-function cleanUrl(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
-  const trimmed = value.trim();
-  return trimmed ? trimmed : null;
-}
-
-function endpointValue(gw: GatewayInstance, canonicalKey: string): string | null {
-  const endpoints = gw.endpoints ?? {};
-  for (const key of ENDPOINT_ALIASES[canonicalKey] ?? [canonicalKey]) {
-    const value = cleanUrl(endpoints[key]);
-    if (value) return value;
-  }
-  return null;
-}
-
-function isInternalUrl(value: string): boolean {
-  if (!/^https?:\/\//i.test(value)) return true;
-  try {
-    const host = new URL(value).hostname.toLowerCase();
-    return (
-      host === 'localhost' ||
-      host === '127.0.0.1' ||
-      host === '0.0.0.0' ||
-      host.endsWith('.svc') ||
-      host.includes('.svc.cluster.local') ||
-      host.endsWith('.cluster.local')
-    );
-  } catch {
-    return true;
-  }
-}
-
-function externalUrl(value: unknown): string | null {
-  const url = cleanUrl(value);
-  return url && !isInternalUrl(url) ? url : null;
-}
-
-function displayUrl(value: string | null): string {
-  return value?.replace(/^https?:\/\//, '') ?? '--';
-}
-
-function gatewayUrls(gw: GatewayInstance): GatewayUrls {
-  const publicUrl = externalUrl(gw.public_url) ?? externalUrl(endpointValue(gw, 'public_url'));
-  const uiUrl = externalUrl(gw.ui_url) ?? externalUrl(endpointValue(gw, 'ui_url'));
-  const targetUrl =
-    externalUrl(gw.target_gateway_url) ?? externalUrl(endpointValue(gw, 'target_gateway_url'));
-  const baseUrl = cleanUrl(gw.base_url) ?? endpointValue(gw, 'admin_url');
-  const externalBaseUrl = baseUrl ? externalUrl(baseUrl) : null;
-
-  return {
-    publicUrl,
-    uiUrl,
-    targetUrl,
-    baseUrl,
-    primaryUrl: publicUrl ?? targetUrl ?? uiUrl ?? externalBaseUrl ?? baseUrl,
-  };
-}
-
-function gatewayExternalLinks(
-  urls: GatewayUrls
-): { label: string; href: string; icon: typeof Zap }[] {
-  const seen = new Set<string>();
-  return [
-    { label: 'Runtime', href: urls.publicUrl, icon: Zap },
-    { label: 'UI', href: urls.uiUrl, icon: Globe },
-    { label: 'Target', href: urls.targetUrl, icon: Server },
-  ].flatMap((link) => {
-    if (!link.href || seen.has(link.href)) return [];
-    seen.add(link.href);
-    return [{ ...link, href: link.href }];
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -1078,12 +934,14 @@ function GatewayDetailPanel({
               <DetailRow label="Environment" value={gw.environment} />
               <DetailRow label="Base URL" value={<UrlValue url={urls.baseUrl} />} />
               {urls.publicUrl && (
-                <DetailRow label="Runtime URL" value={<UrlValue url={urls.publicUrl} />} />
+                <DetailRow label="STOA Runtime" value={<UrlValue url={urls.publicUrl} />} />
               )}
               {urls.targetUrl && (
                 <DetailRow label="Target Gateway" value={<UrlValue url={urls.targetUrl} />} />
               )}
-              {urls.uiUrl && <DetailRow label="Gateway UI" value={<UrlValue url={urls.uiUrl} />} />}
+              {urls.uiUrl && (
+                <DetailRow label="Third-party UI" value={<UrlValue url={urls.uiUrl} />} />
+              )}
               {gw.source && (
                 <DetailRow
                   label="Source"

--- a/control-plane-ui/src/pages/Gateways/__snapshots__/GatewayList.test.tsx.snap
+++ b/control-plane-ui/src/pages/Gateways/__snapshots__/GatewayList.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`GatewayList > snapshot: cpi-admin persona > matches structural snapshot
     },
     {
       "href": "https://wm-ui.gostoa.dev",
-      "text": "UI",
+      "text": "Third-party UI",
     },
     {
       "href": "https://vps-wm.gostoa.dev",
@@ -93,7 +93,7 @@ exports[`GatewayList > snapshot: devops persona > matches structural snapshot 1`
     },
     {
       "href": "https://wm-ui.gostoa.dev",
-      "text": "UI",
+      "text": "Third-party UI",
     },
     {
       "href": "https://vps-wm.gostoa.dev",
@@ -144,7 +144,7 @@ exports[`GatewayList > snapshot: tenant-admin persona > matches structural snaps
     },
     {
       "href": "https://wm-ui.gostoa.dev",
-      "text": "UI",
+      "text": "Third-party UI",
     },
     {
       "href": "https://vps-wm.gostoa.dev",
@@ -195,7 +195,7 @@ exports[`GatewayList > snapshot: viewer persona > matches structural snapshot 1`
     },
     {
       "href": "https://wm-ui.gostoa.dev",
-      "text": "UI",
+      "text": "Third-party UI",
     },
     {
       "href": "https://vps-wm.gostoa.dev",

--- a/control-plane-ui/src/pages/Gateways/gatewayDisplay.ts
+++ b/control-plane-ui/src/pages/Gateways/gatewayDisplay.ts
@@ -1,0 +1,178 @@
+import { Activity, GitBranch, Globe, Server, Shield, Zap, type LucideIcon } from 'lucide-react';
+import type { GatewayInstance, GatewayMode } from '../../types';
+
+export const TYPE_DISPLAY: Record<string, { label: string; icon: LucideIcon }> = {
+  stoa: { label: 'STOA', icon: Zap },
+  stoa_edge_mcp: { label: 'STOA Edge MCP', icon: Zap },
+  stoa_sidecar: { label: 'STOA Link', icon: Shield },
+  stoa_proxy: { label: 'STOA Proxy', icon: Globe },
+  stoa_shadow: { label: 'STOA Shadow', icon: Activity },
+  webmethods: { label: 'webMethods', icon: Server },
+  kong: { label: 'Kong', icon: Server },
+  apigee: { label: 'Apigee', icon: Server },
+  aws_apigateway: { label: 'AWS API GW', icon: Server },
+  azure_apim: { label: 'Azure APIM', icon: Server },
+  gravitee: { label: 'Gravitee', icon: Server },
+  stoa_connect: { label: 'STOA Connect', icon: GitBranch },
+};
+
+export const MODE_LABELS: Record<GatewayMode, string> = {
+  'edge-mcp': 'Edge MCP',
+  sidecar: 'STOA Link',
+  proxy: 'Proxy',
+  shadow: 'Shadow',
+  connect: 'Connect',
+};
+
+const TARGET_LABELS: Record<string, string> = {
+  stoa: 'STOA',
+  kong: 'Kong',
+  webmethods: 'webMethods',
+  gravitee: 'Gravitee',
+  agentgateway: 'Agent Gateway',
+};
+
+const TOPOLOGY_LABELS: Record<string, string> = {
+  'native-edge': 'Native edge',
+  'remote-agent': 'Remote link',
+  'same-pod': 'Same-pod sidecar',
+};
+
+const ENDPOINT_ALIASES: Record<string, string[]> = {
+  public_url: ['public_url', 'publicUrl', 'public', 'runtime_url', 'runtimeUrl', 'external_url'],
+  ui_url: ['ui_url', 'uiUrl', 'console_url', 'consoleUrl', 'web_ui_url', 'webUiUrl'],
+  target_gateway_url: ['target_gateway_url', 'targetGatewayUrl', 'target_url', 'targetUrl'],
+  admin_url: ['admin_url', 'adminUrl', 'admin', 'base_url', 'baseUrl'],
+  internal_url: ['internal_url', 'internalUrl', 'internal'],
+};
+
+export type GatewayUrls = {
+  publicUrl: string | null;
+  uiUrl: string | null;
+  targetUrl: string | null;
+  baseUrl: string | null;
+  primaryUrl: string | null;
+};
+
+export type GatewayExternalLink = {
+  label: string;
+  href: string;
+  icon: LucideIcon;
+};
+
+function cleanUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function endpointValue(gw: GatewayInstance, canonicalKey: string): string | null {
+  const endpoints = gw.endpoints ?? {};
+  for (const key of ENDPOINT_ALIASES[canonicalKey] ?? [canonicalKey]) {
+    const value = cleanUrl(endpoints[key]);
+    if (value) return value;
+  }
+  return null;
+}
+
+function isInternalUrl(value: string): boolean {
+  if (!/^https?:\/\//i.test(value)) return true;
+  try {
+    const host = new URL(value).hostname.toLowerCase();
+    return (
+      host === 'localhost' ||
+      host === '127.0.0.1' ||
+      host === '0.0.0.0' ||
+      host.endsWith('.svc') ||
+      host.includes('.svc.cluster.local') ||
+      host.endsWith('.cluster.local')
+    );
+  } catch {
+    return true;
+  }
+}
+
+export function externalUrl(value: unknown): string | null {
+  const url = cleanUrl(value);
+  return url && !isInternalUrl(url) ? url : null;
+}
+
+function hostname(value: string | null): string {
+  if (!value) return '';
+  try {
+    return new URL(value).hostname.toLowerCase();
+  } catch {
+    return value.toLowerCase();
+  }
+}
+
+export function displayUrl(value: string | null): string {
+  return value?.replace(/^https?:\/\//, '') ?? '--';
+}
+
+export function gatewayUrls(gw: GatewayInstance): GatewayUrls {
+  const publicUrl = externalUrl(gw.public_url) ?? externalUrl(endpointValue(gw, 'public_url'));
+  const uiUrl = externalUrl(gw.ui_url) ?? externalUrl(endpointValue(gw, 'ui_url'));
+  const targetUrl =
+    externalUrl(gw.target_gateway_url) ?? externalUrl(endpointValue(gw, 'target_gateway_url'));
+  const baseUrl = cleanUrl(gw.base_url) ?? endpointValue(gw, 'admin_url');
+  const externalBaseUrl = baseUrl ? externalUrl(baseUrl) : null;
+
+  return {
+    publicUrl,
+    uiUrl,
+    targetUrl,
+    baseUrl,
+    primaryUrl: publicUrl ?? targetUrl ?? uiUrl ?? externalBaseUrl ?? baseUrl,
+  };
+}
+
+function isLinkRuntime(gw: GatewayInstance, urls: GatewayUrls): boolean {
+  return (
+    gw.mode === 'sidecar' ||
+    gw.gateway_type === 'stoa_sidecar' ||
+    hostname(urls.publicUrl).includes('-link.') ||
+    (gw.tags ?? []).includes('remote-agent')
+  );
+}
+
+export function deploymentLabel(gw: GatewayInstance): string | null {
+  const urls = gatewayUrls(gw);
+  if (gw.deployment_mode === 'edge') return 'Edge';
+  if (gw.deployment_mode === 'sidecar') return 'Sidecar';
+  if (gw.deployment_mode === 'connect') {
+    if (isLinkRuntime(gw, urls)) {
+      const publicHost = hostname(urls.publicUrl);
+      if (publicHost.includes('-k3s.')) return 'Link K8s';
+      if (publicHost.includes('-link.')) return 'Link VPS';
+      return 'STOA Link';
+    }
+    return 'Connect VPS';
+  }
+  return gw.mode ? (MODE_LABELS[gw.mode] ?? gw.mode) : null;
+}
+
+export function targetLabel(gw: GatewayInstance, fallback: string): string {
+  if (gw.target_gateway_type) {
+    return TARGET_LABELS[gw.target_gateway_type] ?? gw.target_gateway_type;
+  }
+  return fallback;
+}
+
+export function topologyLabel(gw: GatewayInstance): string | null {
+  if (!gw.topology) return null;
+  return TOPOLOGY_LABELS[gw.topology] ?? gw.topology;
+}
+
+export function gatewayExternalLinks(urls: GatewayUrls): GatewayExternalLink[] {
+  const seen = new Set<string>();
+  return [
+    { label: 'Runtime', href: urls.publicUrl, icon: Zap },
+    { label: 'Third-party UI', href: urls.uiUrl, icon: Globe },
+    { label: 'Target', href: urls.targetUrl, icon: Server },
+  ].flatMap((link) => {
+    if (!link.href || seen.has(link.href)) return [];
+    seen.add(link.href);
+    return [{ ...link, href: link.href }];
+  });
+}

--- a/docs/runbooks/gateway-url-contract.md
+++ b/docs/runbooks/gateway-url-contract.md
@@ -1,0 +1,53 @@
+# Gateway URL Contract
+
+This runbook fixes the naming contract used by Console, GatewayInstance CRDs,
+and WebMethods operations.
+
+## URL Fields
+
+| Field | Meaning | WebMethods examples |
+|---|---|---|
+| `base_url` / `adminUrl` | Internal admin endpoint used by the Control Plane or reconciler. May be cluster-local or container-local. | `http://stoa-link-wm-staging:8080` |
+| `public_url` / `publicUrl` | Public runtime URL for this STOA or third-party runtime instance. | `https://staging-wm-k3s.gostoa.dev`, `https://vps-wm-link.gostoa.dev` |
+| `target_gateway_url` / `targetGatewayUrl` | Third-party gateway target controlled by STOA Link or STOA Connect. | `https://staging-wm.gostoa.dev` |
+| `ui_url` / `uiUrl` | Third-party gateway web UI. This is never a STOA Link runtime URL. | `https://staging-wm-ui.gostoa.dev` |
+
+## WebMethods Surface Matrix
+
+| Environment | Surface | `publicUrl` | `targetGatewayUrl` | `uiUrl` |
+|---|---|---|---|---|
+| dev | Connect VPS | `https://dev-wm.gostoa.dev` | `https://dev-wm.gostoa.dev` | `https://dev-wm-ui.gostoa.dev` |
+| dev | Link K8s | `https://dev-wm-k3s.gostoa.dev` | `https://dev-wm.gostoa.dev` | `https://dev-wm-ui.gostoa.dev` |
+| staging | Connect VPS | `https://staging-wm.gostoa.dev` | `https://staging-wm.gostoa.dev` | `https://staging-wm-ui.gostoa.dev` |
+| staging | Link K8s | `https://staging-wm-k3s.gostoa.dev` | `https://staging-wm.gostoa.dev` | `https://staging-wm-ui.gostoa.dev` |
+| prod | Connect VPS | `https://vps-wm.gostoa.dev` | `https://vps-wm.gostoa.dev` | `https://vps-wm-ui.gostoa.dev` |
+| prod | Link VPS | `https://vps-wm-link.gostoa.dev` | `https://vps-wm.gostoa.dev` | `https://vps-wm-ui.gostoa.dev` |
+
+## Invalid States
+
+- A non-prod WebMethods `uiUrl` must not point to `https://vps-wm-ui.gostoa.dev`.
+- A WebMethods `uiUrl` must not point to a STOA Link runtime such as `*-wm-k3s.gostoa.dev`
+  or `vps-wm-link.gostoa.dev`.
+- A WebMethods Link runtime has `publicUrl != targetGatewayUrl`.
+- A WebMethods Connect registration has `publicUrl == targetGatewayUrl`.
+
+## Operational Checks
+
+For WebMethods, smoke the public target and UI separately:
+
+```bash
+curl -fsS https://dev-wm.gostoa.dev/health
+curl -fsSI https://dev-wm-ui.gostoa.dev/
+curl -fsS https://dev-wm-k3s.gostoa.dev/health
+
+curl -fsS https://staging-wm.gostoa.dev/health
+curl -fsSI https://staging-wm-ui.gostoa.dev/
+curl -fsS https://staging-wm-k3s.gostoa.dev/health
+
+curl -fsS https://vps-wm.gostoa.dev/health
+curl -fsSI https://vps-wm-ui.gostoa.dev/
+curl -fsS https://vps-wm-link.gostoa.dev/health
+```
+
+If the Link runtime is healthy but `targetGatewayUrl` or `uiUrl` returns 5xx,
+debug the WebMethods VPS or its Caddy upstream before changing Console URL data.


### PR DESCRIPTION
## Summary

- Centralize gateway URL display logic for Console gateway list/detail views.
- Distinguish STOA runtime, target gateway, and third-party UI URLs for Connect VPS and STOA Link runtimes.
- Document the WebMethods URL contract and enforce it in CRD/regression coverage.

## Why

WebMethods gateway entries were ambiguous across dev, staging, and prod: STOA Connect on VPS and STOA Link runtimes could show the same UI/admin labels even though their public runtime, target gateway, and third-party UI surfaces are different. This PR makes that contract explicit in UI, CRD schema docs, and tests.

## Validation

- `pytest control-plane-api/tests/test_regression_cab_2240_webmethods_staging_targets.py -q` -> 6 passed
- `npm --prefix control-plane-ui test -- src/pages/Gateways/GatewayList.test.tsx src/pages/Gateways/GatewayDetail.test.tsx` -> 54 passed
- `git diff --check` -> passed

## Known local build blocker

`npm --prefix control-plane-ui run build` still fails in this isolated worktree before these gateway changes with shared React/lucide type resolution errors and `ErrorBoundary` JSX typing errors, e.g. `src/App.tsx(489,6)` and many `../shared/components/*` missing React/lucide declaration errors. The touched gateway files passed targeted tests.
