### PR TITLE
Lifecycle API: add canonical backend flow and minimal Console controls

### DIFF
--- a/control-plane-api/src/consumers/promotion_deploy_consumer.py
+++ b/control-plane-api/src/consumers/promotion_deploy_consumer.py
@@ -1,8 +1,8 @@
-"""Kafka consumer for auto-deploy on promotion (CAB-1888).
+"""Kafka consumer for legacy promotion-approved events (CAB-1888).
 
 Listens to deploy-requests topic for promotion-approved events.
-When a promotion is approved and the target environment has auto-deploy
-assignments, triggers deployment to those gateways.
+Promotion deployments are now executed by ApiLifecycleService; repeated legacy
+events are intentionally ignored to prevent double deployment.
 
 Topic:   stoa.deploy.requests
 Group:   promotion-deploy-consumer
@@ -18,8 +18,6 @@ from kafka import KafkaConsumer
 from kafka.errors import KafkaError
 
 from ..config import settings
-from ..database import _get_session_factory
-from ..services.deployment_orchestration_service import DeploymentOrchestrationService
 from ..services.kafka_service import Topics
 
 logger = logging.getLogger(__name__)
@@ -28,7 +26,7 @@ GROUP_ID = "promotion-deploy-consumer"
 
 
 class PromotionDeployConsumer:
-    """Consumes promotion-approved events and triggers auto-deploy.
+    """Consumes promotion-approved events without executing deployment.
 
     Uses kafka-python in a background thread (same pattern as DeploymentConsumer).
     """
@@ -63,12 +61,14 @@ class PromotionDeployConsumer:
                 "value_deserializer": lambda m: json.loads(m.decode("utf-8")),
             }
             if hasattr(settings, "KAFKA_SASL_USERNAME") and settings.KAFKA_SASL_USERNAME:
-                kafka_config.update({
-                    "security_protocol": "SASL_PLAINTEXT",
-                    "sasl_mechanism": "SCRAM-SHA-256",
-                    "sasl_plain_username": settings.KAFKA_SASL_USERNAME,
-                    "sasl_plain_password": settings.KAFKA_SASL_PASSWORD,
-                })
+                kafka_config.update(
+                    {
+                        "security_protocol": "SASL_PLAINTEXT",
+                        "sasl_mechanism": "SCRAM-SHA-256",
+                        "sasl_plain_username": settings.KAFKA_SASL_USERNAME,
+                        "sasl_plain_password": settings.KAFKA_SASL_PASSWORD,
+                    }
+                )
 
             self._consumer = KafkaConsumer(Topics.DEPLOY_REQUESTS, **kafka_config)
             logger.info("PromotionDeployConsumer Kafka consumer connected")
@@ -119,7 +119,9 @@ class PromotionDeployConsumer:
 
             logger.info(
                 "Received promotion-approved: api=%s env=%s approved_by=%s",
-                api_id, target_env, approved_by,
+                api_id,
+                target_env,
+                approved_by,
             )
 
             if self._loop:
@@ -133,28 +135,28 @@ class PromotionDeployConsumer:
             logger.error("Failed to handle promotion-approved event: %s", e, exc_info=True)
 
     async def _auto_deploy(
-        self, api_id: str, tenant_id: str, target_env: str, approved_by: str,
+        self,
+        api_id: str,
+        tenant_id: str,
+        target_env: str,
+        approved_by: str,
         promotion_id: str | None = None,
     ) -> None:
-        """Execute auto-deploy in an async context with its own DB session."""
-        from uuid import UUID as _UUID
+        """Ignore legacy promotion-approved events.
 
-        promo_uuid = _UUID(promotion_id) if promotion_id else None
-        async with _get_session_factory()() as session:
-            svc = DeploymentOrchestrationService(session)
-            deployments = await svc.auto_deploy_on_promotion(
-                api_id=api_id,
-                tenant_id=tenant_id,
-                target_environment=target_env,
-                approved_by=approved_by,
-                promotion_id=promo_uuid,
-            )
-            if deployments:
-                await session.commit()
-                logger.info(
-                    "Auto-deployed api=%s to %d gateways in %s",
-                    api_id, len(deployments), target_env,
-                )
+        Promotion deployment execution is now owned by ApiLifecycleService. This
+        consumer stays subscribed for backward compatibility but must not create
+        or reset GatewayDeployment rows.
+        """
+        logger.info(
+            "Ignoring promotion-approved event for api=%s tenant=%s env=%s promotion=%s approved_by=%s; "
+            "deployment execution is owned by ApiLifecycleService",
+            api_id,
+            tenant_id,
+            target_env,
+            promotion_id,
+            approved_by,
+        )
 
     @staticmethod
     def _deploy_callback(future) -> None:

--- a/control-plane-api/src/main.py
+++ b/control-plane-api/src/main.py
@@ -39,6 +39,7 @@ from .routers import (
     admin_logs,
     admin_prospects,
     api_gateway_assignments,
+    api_lifecycle,
     apis,
     applications,
     argocd_admin,
@@ -758,6 +759,9 @@ app.add_middleware(AuditMiddleware)
 
 # Routers
 app.include_router(tenants.router)
+# Canonical API lifecycle routes must be registered before apis.router because
+# both share /v1/tenants/{tenant_id}/apis/{api_id}.
+app.include_router(api_lifecycle.router)
 # api_gateway_assignments MUST be before apis — both share /v1/tenants/{tenant_id}/apis/{api_id}
 # prefix, and FastAPI resolves in registration order. Without this, /deploy and
 # /deployable-environments are swallowed by the apis router's /{api_id} catch-all.

--- a/control-plane-api/src/models/promotion.py
+++ b/control-plane-api/src/models/promotion.py
@@ -36,7 +36,7 @@ def validate_promotion_chain(source: str, target: str) -> None:
         raise ValueError(f"Cannot promote to the same environment: {source}")
     if (source, target) not in VALID_PROMOTION_CHAINS:
         allowed = ", ".join(f"{s}→{t}" for s, t in sorted(VALID_PROMOTION_CHAINS))
-        raise ValueError(f"Invalid promotion chain: {source}→{target}. " f"Allowed chains: {allowed}")
+        raise ValueError(f"Invalid promotion chain: {source}→{target}. Allowed chains: {allowed}")
 
 
 class Promotion(Base):
@@ -85,4 +85,4 @@ class Promotion(Base):
     )
 
     def __repr__(self) -> str:
-        return f"<Promotion {self.id} " f"{self.source_environment}→{self.target_environment} " f"status={self.status}>"
+        return f"<Promotion {self.id} {self.source_environment}→{self.target_environment} status={self.status}>"

--- a/control-plane-api/src/routers/api_lifecycle.py
+++ b/control-plane-api/src/routers/api_lifecycle.py
@@ -1,0 +1,338 @@
+"""Canonical API lifecycle router."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.auth import (
+    Permission,
+    User,
+    get_current_user,
+    require_permission,
+    require_tenant_access,
+    require_writable_environment,
+)
+from src.database import get_db
+from src.schemas.api_lifecycle import (
+    ApiLifecycleCreateDraftRequest,
+    ApiLifecycleDeployRequest,
+    ApiLifecycleDeployResponse,
+    ApiLifecyclePromoteRequest,
+    ApiLifecyclePromotionRequestResponse,
+    ApiLifecyclePublishRequest,
+    ApiLifecyclePublishResponse,
+    ApiLifecycleStateResponse,
+    ApiLifecycleValidateDraftRequest,
+    ApiLifecycleValidateDraftResponse,
+)
+from src.services.api_lifecycle import (
+    ApiLifecycleService,
+    SqlAlchemyApiLifecycleRepository,
+    SqlAlchemyLifecycleAuditSink,
+)
+from src.services.api_lifecycle.errors import (
+    ApiLifecycleConflictError,
+    ApiLifecycleGatewayAmbiguousError,
+    ApiLifecycleGatewayNotFoundError,
+    ApiLifecycleNotFoundError,
+    ApiLifecycleSpecValidationError,
+    ApiLifecycleTransitionError,
+    ApiLifecycleValidationError,
+)
+from src.services.api_lifecycle.ports import (
+    CreateApiDraftCommand,
+    DeployApiCommand,
+    LifecycleActor,
+    PromoteApiCommand,
+    PublishApiCommand,
+    ValidateApiDraftCommand,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/tenants/{tenant_id}/apis", tags=["API Lifecycle"])
+
+
+def _build_service(db: AsyncSession) -> ApiLifecycleService:
+    return ApiLifecycleService(
+        repository=SqlAlchemyApiLifecycleRepository(db),
+        audit_sink=SqlAlchemyLifecycleAuditSink(db),
+    )
+
+
+def _actor_from_user(user: User) -> LifecycleActor:
+    return LifecycleActor(
+        actor_id=getattr(user, "id", None),
+        email=getattr(user, "email", None),
+        username=getattr(user, "username", None),
+    )
+
+
+def _response_from_state(state) -> ApiLifecycleStateResponse:
+    return ApiLifecycleStateResponse.model_validate(asdict(state))
+
+
+def _response_from_validation(outcome) -> ApiLifecycleValidateDraftResponse:
+    payload = asdict(outcome)
+    payload["lifecycle"] = payload.pop("lifecycle_state")
+    return ApiLifecycleValidateDraftResponse.model_validate(payload)
+
+
+def _response_from_deployment(outcome) -> ApiLifecycleDeployResponse:
+    payload = asdict(outcome)
+    payload["lifecycle"] = payload.pop("lifecycle_state")
+    return ApiLifecycleDeployResponse.model_validate(payload)
+
+
+def _response_from_publication(outcome) -> ApiLifecyclePublishResponse:
+    payload = asdict(outcome)
+    payload["lifecycle"] = payload.pop("lifecycle_state")
+    return ApiLifecyclePublishResponse.model_validate(payload)
+
+
+def _response_from_promotion(outcome) -> ApiLifecyclePromotionRequestResponse:
+    payload = asdict(outcome)
+    payload["lifecycle"] = payload.pop("lifecycle_state")
+    return ApiLifecyclePromotionRequestResponse.model_validate(payload)
+
+
+@router.post(
+    "/lifecycle/drafts",
+    response_model=ApiLifecycleStateResponse,
+    status_code=201,
+    dependencies=[Depends(require_writable_environment)],
+)
+@require_permission(Permission.APIS_CREATE)
+@require_tenant_access
+async def create_api_draft(
+    tenant_id: str,
+    request: ApiLifecycleCreateDraftRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create an API draft through the canonical lifecycle service."""
+    service = _build_service(db)
+    try:
+        state = await service.create_draft(
+            CreateApiDraftCommand(
+                tenant_id=tenant_id,
+                name=request.name,
+                display_name=request.display_name,
+                version=request.version,
+                description=request.description,
+                backend_url=request.backend_url,
+                openapi_spec=request.openapi_spec,
+                spec_reference=request.spec_reference,
+                tags=tuple(request.tags),
+                owner_team=request.owner_team,
+            ),
+            actor=_actor_from_user(user),
+        )
+        await db.commit()
+        return _response_from_state(state)
+    except ApiLifecycleValidationError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ApiLifecycleConflictError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception as exc:
+        await db.rollback()
+        logger.exception("Failed to create API lifecycle draft for tenant=%s", tenant_id)
+        raise HTTPException(status_code=500, detail="Failed to create API draft") from exc
+
+
+@router.post("/{api_id}/lifecycle/validate", response_model=ApiLifecycleValidateDraftResponse)
+@require_permission(Permission.APIS_UPDATE)
+@require_tenant_access
+async def validate_api_draft(
+    tenant_id: str,
+    api_id: str,
+    request: ApiLifecycleValidateDraftRequest | None = None,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Validate a draft API and transition its catalog status to ready."""
+    service = _build_service(db)
+    try:
+        outcome = await service.validate_draft(
+            ValidateApiDraftCommand(
+                tenant_id=tenant_id,
+                api_id=api_id,
+                reason=request.reason if request else None,
+            ),
+            actor=_actor_from_user(user),
+        )
+        await db.commit()
+        return _response_from_validation(outcome)
+    except ApiLifecycleNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ApiLifecycleTransitionError as exc:
+        await db.commit()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ApiLifecycleSpecValidationError as exc:
+        await db.commit()
+        raise HTTPException(status_code=422, detail={"code": exc.code, "message": str(exc)}) from exc
+    except Exception as exc:
+        await db.rollback()
+        logger.exception("Failed to validate API lifecycle draft for tenant=%s api_id=%s", tenant_id, api_id)
+        raise HTTPException(status_code=500, detail="Failed to validate API draft") from exc
+
+
+@router.post("/{api_id}/lifecycle/deployments", response_model=ApiLifecycleDeployResponse)
+@require_permission(Permission.APIS_DEPLOY)
+@require_tenant_access
+async def deploy_api_to_lifecycle_gateway(
+    tenant_id: str,
+    api_id: str,
+    request: ApiLifecycleDeployRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Request a runtime deployment by creating/updating GatewayDeployment."""
+    service = _build_service(db)
+    try:
+        outcome = await service.deploy_to_environment(
+            DeployApiCommand(
+                tenant_id=tenant_id,
+                api_id=api_id,
+                environment=request.environment,
+                gateway_instance_id=request.gateway_instance_id,
+                force=request.force,
+            ),
+            actor=_actor_from_user(user),
+        )
+        await db.commit()
+        return _response_from_deployment(outcome)
+    except (ApiLifecycleNotFoundError, ApiLifecycleGatewayNotFoundError) as exc:
+        await db.commit()
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ApiLifecycleTransitionError as exc:
+        await db.commit()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ApiLifecycleGatewayAmbiguousError as exc:
+        await db.commit()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ApiLifecycleValidationError as exc:
+        await db.commit()
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:
+        await db.rollback()
+        logger.exception("Failed to deploy API lifecycle target for tenant=%s api_id=%s", tenant_id, api_id)
+        raise HTTPException(status_code=500, detail="Failed to request API deployment") from exc
+
+
+@router.post("/{api_id}/lifecycle/publications", response_model=ApiLifecyclePublishResponse)
+@require_permission(Permission.APIS_UPDATE)
+@require_tenant_access
+async def publish_api_to_lifecycle_portal(
+    tenant_id: str,
+    api_id: str,
+    request: ApiLifecyclePublishRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Publish a synced GatewayDeployment to the STOA portal catalog."""
+    service = _build_service(db)
+    try:
+        outcome = await service.publish_to_portal(
+            PublishApiCommand(
+                tenant_id=tenant_id,
+                api_id=api_id,
+                environment=request.environment,
+                gateway_instance_id=request.gateway_instance_id,
+                force=request.force,
+            ),
+            actor=_actor_from_user(user),
+        )
+        await db.commit()
+        return _response_from_publication(outcome)
+    except (ApiLifecycleNotFoundError, ApiLifecycleGatewayNotFoundError) as exc:
+        await db.commit()
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ApiLifecycleTransitionError as exc:
+        await db.commit()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ApiLifecycleGatewayAmbiguousError as exc:
+        await db.commit()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ApiLifecycleSpecValidationError as exc:
+        await db.commit()
+        raise HTTPException(status_code=422, detail={"code": exc.code, "message": str(exc)}) from exc
+    except ApiLifecycleValidationError as exc:
+        await db.commit()
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:
+        await db.rollback()
+        logger.exception("Failed to publish API lifecycle target for tenant=%s api_id=%s", tenant_id, api_id)
+        raise HTTPException(status_code=500, detail="Failed to publish API") from exc
+
+
+@router.post("/{api_id}/lifecycle/promotions", response_model=ApiLifecyclePromotionRequestResponse)
+@require_permission(Permission.APIS_DEPLOY)
+@require_tenant_access
+async def promote_api_through_lifecycle(
+    tenant_id: str,
+    api_id: str,
+    request: ApiLifecyclePromoteRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Request a controlled cross-environment API promotion."""
+    service = _build_service(db)
+    try:
+        outcome = await service.promote_to_environment(
+            PromoteApiCommand(
+                tenant_id=tenant_id,
+                api_id=api_id,
+                source_environment=request.source_environment,
+                target_environment=request.target_environment,
+                source_gateway_instance_id=request.source_gateway_instance_id,
+                target_gateway_instance_id=request.target_gateway_instance_id,
+                force=request.force,
+            ),
+            actor=_actor_from_user(user),
+        )
+        await db.commit()
+        return _response_from_promotion(outcome)
+    except (ApiLifecycleNotFoundError, ApiLifecycleGatewayNotFoundError) as exc:
+        await db.commit()
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ApiLifecycleTransitionError as exc:
+        await db.commit()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ApiLifecycleGatewayAmbiguousError as exc:
+        await db.commit()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ApiLifecycleValidationError as exc:
+        await db.commit()
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:
+        await db.rollback()
+        logger.exception("Failed to promote API lifecycle target for tenant=%s api_id=%s", tenant_id, api_id)
+        raise HTTPException(status_code=500, detail="Failed to promote API") from exc
+
+
+@router.get("/{api_id}/lifecycle", response_model=ApiLifecycleStateResponse)
+@require_permission(Permission.APIS_READ)
+@require_tenant_access
+async def get_api_lifecycle_state(
+    tenant_id: str,
+    api_id: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get the aggregate lifecycle state calculated from catalog, gateway, and promotion state."""
+    service = _build_service(db)
+    try:
+        state = await service.get_lifecycle_state(tenant_id, api_id)
+        return _response_from_state(state)
+    except ApiLifecycleNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Failed to load API lifecycle state for tenant=%s api_id=%s", tenant_id, api_id)
+        raise HTTPException(status_code=500, detail="Failed to retrieve API lifecycle state") from exc

--- a/control-plane-api/src/routers/apis.py
+++ b/control-plane-api/src/routers/apis.py
@@ -26,6 +26,7 @@ from ..repositories.catalog import CatalogRepository
 from ..repositories.tenant import TenantRepository
 from ..schemas.pagination import PaginatedResponse
 from ..services import git_service
+from ..services.api_lifecycle.portal_tags import find_legacy_portal_publication_tags
 from ..services.catalog_git_client.github_contents import GitHubContentsCatalogClient
 from ..services.gitops_writer import (
     ApiCreatePayload,
@@ -96,7 +97,7 @@ class APIResponse(BaseModel):
     deployed_dev: bool = False
     deployed_staging: bool = False
     tags: list[str] = []
-    portal_promoted: bool = False  # True if API has portal:published tag
+    portal_promoted: bool = False  # True when lifecycle publication set portal_published
     audience: AudienceLiteral = "public"
     catalog_release_id: str | None = None
     catalog_release_tag: str | None = None
@@ -233,12 +234,23 @@ def _generated_openapi_fallback(api: APICatalog) -> dict[str, Any]:
     return spec
 
 
+def _reject_implicit_portal_publication_tags(tags: list[str] | None) -> None:
+    forbidden = find_legacy_portal_publication_tags(tags)
+    if forbidden:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Portal publication must use POST "
+                "/v1/tenants/{tenant_id}/apis/{api_id}/lifecycle/publications, not tags: " + ", ".join(forbidden)
+            ),
+        )
+
+
 def _api_from_catalog(api: APICatalog) -> APIResponse:
     """Convert APICatalog DB model to APIResponse."""
     metadata = api.api_metadata or {}
     tags = api.tags or []
-    promotion_tags = {"portal:published", "promoted:portal", "portal-promoted"}
-    portal_promoted = any(tag.lower() in promotion_tags for tag in tags)
+    portal_promoted = bool(api.portal_published)
     deployments = metadata.get("deployments", {})
     # CAB-2159 BUG-4 — audience column has a non-null default in the DB; coerce
     # any unexpected stored value back into the Literal set so Pydantic validation
@@ -434,6 +446,8 @@ async def create_api(
     ``False`` and the eligible-tenant list is empty by default — production
     behaviour is unchanged until Phase 6 strangler.
     """
+    _reject_implicit_portal_publication_tags(api.tags)
+
     if is_gitops_create_eligible(
         enabled=settings.GITOPS_CREATE_API_ENABLED,
         tenant_id=tenant_id,
@@ -475,8 +489,6 @@ async def _create_api_legacy(
         _validate_openapi_spec(api.openapi_spec)
 
     tags = api.tags or []
-    promotion_tags = {"portal:published", "promoted:portal", "portal-promoted"}
-    portal_promoted = any(tag.lower() in promotion_tags for tag in tags)
 
     # Generate URL-safe slug from name (CAB-1938)
     api_id = _slugify(api.name)
@@ -502,7 +514,7 @@ async def _create_api_legacy(
             version=api.version,
             status="draft",
             tags=tags,
-            portal_published=portal_promoted,
+            portal_published=False,
             api_metadata=api_metadata,
             openapi_spec=openapi_spec,
             synced_at=datetime.now(UTC),
@@ -550,7 +562,7 @@ async def _create_api_legacy(
             deployed_dev=False,
             deployed_staging=False,
             tags=tags,
-            portal_promoted=portal_promoted,
+            portal_promoted=False,
         )
 
     except Exception as e:
@@ -667,6 +679,8 @@ async def update_api(
 
         if not updates:
             return _api_from_catalog(current)
+        if "tags" in updates:
+            _reject_implicit_portal_publication_tags(updates["tags"])
 
         # Apply updates to model fields
         metadata = dict(current.api_metadata or {})
@@ -683,8 +697,6 @@ async def update_api(
         if "tags" in updates:
             current.tags = updates["tags"]
             metadata["tags"] = updates["tags"]
-            promotion_tags = {"portal:published", "promoted:portal", "portal-promoted"}
-            current.portal_published = any(tag.lower() in promotion_tags for tag in updates["tags"])
         if "openapi_spec" in updates:
             current.openapi_spec = _parse_openapi_spec(updates["openapi_spec"])
 

--- a/control-plane-api/src/routers/catalog_admin.py
+++ b/control-plane-api/src/routers/catalog_admin.py
@@ -23,7 +23,8 @@ from ..schemas.catalog import (
     SyncStatusResponse,
     SyncTriggerResponse,
 )
-from ..services.catalog_sync_service import CatalogSyncService
+from ..services.api_lifecycle.portal_tags import strip_legacy_portal_publication_tags
+from ..services.catalog_sync_service import CatalogSyncService, metadata_update_preserving_lifecycle
 from ..services.git_provider import GitProvider, get_git_provider
 
 logger = logging.getLogger(__name__)
@@ -361,9 +362,16 @@ async def seed_catalog_directly(
 
     for api_entry in data.apis:
         api_id = _slugify(api_entry.name)
-        tags = api_entry.tags
-        promotion_tags = {"portal:published", "promoted:portal", "portal-promoted"}
-        portal_published = any(tag.lower() in promotion_tags for tag in tags)
+        tags, ignored_portal_tags = strip_legacy_portal_publication_tags(api_entry.tags)
+        if ignored_portal_tags:
+            logger.warning(
+                "catalog_admin.portal_publication_tags_ignored",
+                extra={
+                    "tenant_id": data.tenant_id,
+                    "api_id": api_id,
+                    "ignored_tags": ignored_portal_tags,
+                },
+            )
 
         # Build metadata dict (same shape as GitLab api.yaml)
         api_metadata = {
@@ -396,7 +404,7 @@ async def seed_catalog_directly(
                     status="active",
                     category=api_entry.category,
                     tags=tags,
-                    portal_published=portal_published,
+                    portal_published=False,
                     api_metadata=api_metadata,
                     openapi_spec=openapi_spec,
                     git_path=None,
@@ -413,8 +421,7 @@ async def seed_catalog_directly(
                         "status": "active",
                         "category": api_entry.category,
                         "tags": tags,
-                        "portal_published": portal_published,
-                        "metadata": api_metadata,
+                        APICatalog.api_metadata: metadata_update_preserving_lifecycle(api_metadata),
                         "openapi_spec": openapi_spec,
                         "synced_at": datetime.now(UTC),
                         "deleted_at": None,
@@ -431,7 +438,7 @@ async def seed_catalog_directly(
 
     await db.commit()
 
-    logger.info(f"Catalog seed by {user.username}: {seeded} seeded, {failed} failed " f"(tenant: {data.tenant_id})")
+    logger.info(f"Catalog seed by {user.username}: {seeded} seeded, {failed} failed (tenant: {data.tenant_id})")
 
     return CatalogSeedResponse(seeded=seeded, failed=failed, results=results)
 

--- a/control-plane-api/src/routers/deployments.py
+++ b/control-plane-api/src/routers/deployments.py
@@ -20,7 +20,7 @@ from ..schemas.deployment import (
     EnvironmentStatusResponse,
     RollbackCreate,
 )
-from ..services.deployment_service import DeploymentService
+from ..services.deployment_service import DeploymentService, LifecycleDeploymentPathError
 from ..services.git_provider import GitProvider, get_git_provider, git_provider_factory
 
 logger = logging.getLogger(__name__)
@@ -119,16 +119,19 @@ async def create_deployment(
         logger.warning("Failed to lookup API in git for %s/%s: %s", tenant_id, lookup_key, e)
 
     service = DeploymentService(db)
-    deployment = await service.create_deployment(
-        tenant_id=tenant_id,
-        api_id=request.api_id,
-        api_name=api_name,
-        environment=request.environment.value,
-        version=version,
-        deployed_by=user.username,
-        user_id=user.id,
-        gateway_id=request.gateway_id,
-    )
+    try:
+        deployment = await service.create_deployment(
+            tenant_id=tenant_id,
+            api_id=request.api_id,
+            api_name=api_name,
+            environment=request.environment.value,
+            version=version,
+            deployed_by=user.username,
+            user_id=user.id,
+            gateway_id=request.gateway_id,
+        )
+    except LifecycleDeploymentPathError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     await db.commit()
 
     if _demo_mode_enabled(http_request) and request.gateway_id:
@@ -175,6 +178,8 @@ async def rollback_deployment(
             deployed_by=user.username,
             user_id=user.id,
         )
+    except LifecycleDeploymentPathError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     await db.commit()
@@ -202,6 +207,8 @@ async def update_deployment_status(
             commit_sha=request.commit_sha,
             metadata=request.metadata,
         )
+    except LifecycleDeploymentPathError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     await db.commit()

--- a/control-plane-api/src/schemas/api_lifecycle.py
+++ b/control-plane-api/src/schemas/api_lifecycle.py
@@ -1,0 +1,183 @@
+"""Schemas for the canonical API lifecycle endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ApiLifecycleCreateDraftRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    display_name: str = Field(..., min_length=1, max_length=255)
+    version: str = Field(default="1.0.0", min_length=1, max_length=50)
+    description: str = ""
+    backend_url: str = Field(..., min_length=1, max_length=500)
+    openapi_spec: str | dict[str, Any] | None = None
+    spec_reference: str | None = Field(default=None, max_length=500)
+    tags: list[str] = Field(default_factory=list)
+    owner_team: str | None = Field(default=None, max_length=255)
+
+
+class ApiLifecycleValidateDraftRequest(BaseModel):
+    reason: str | None = Field(default=None, max_length=1000)
+
+
+class ApiLifecycleDeployRequest(BaseModel):
+    environment: str = Field(..., min_length=1, max_length=50)
+    gateway_instance_id: UUID | None = None
+    force: bool = False
+
+
+class ApiLifecyclePublishRequest(BaseModel):
+    environment: str = Field(..., min_length=1, max_length=50)
+    gateway_instance_id: UUID | None = None
+    force: bool = False
+
+
+class ApiLifecyclePromoteRequest(BaseModel):
+    source_environment: str = Field(..., min_length=1, max_length=50)
+    target_environment: str = Field(..., min_length=1, max_length=50)
+    source_gateway_instance_id: UUID | None = None
+    target_gateway_instance_id: UUID | None = None
+    force: bool = False
+
+
+class ApiLifecycleValidationResultResponse(BaseModel):
+    valid: bool
+    code: str
+    message: str
+    spec_source: str
+    spec_format: str | None = None
+    spec_version: str | None = None
+    title: str | None = None
+    version: str | None = None
+    path_count: int = 0
+    operation_count: int = 0
+    validated_at: datetime | None = None
+
+
+class ApiLifecycleSpecResponse(BaseModel):
+    source: str
+    has_openapi_spec: bool
+    git_path: str | None = None
+    git_commit_sha: str | None = None
+    reference: str | None = None
+    fallback_reason: str | None = None
+
+
+class ApiLifecycleGatewayDeploymentResponse(BaseModel):
+    id: UUID
+    environment: str
+    gateway_instance_id: UUID
+    gateway_name: str
+    gateway_type: str
+    sync_status: str
+    desired_generation: int
+    synced_generation: int
+    gateway_resource_id: str | None = None
+    public_url: str | None = None
+    sync_error: str | None = None
+    last_sync_success: datetime | None = None
+
+
+class ApiLifecyclePromotionResponse(BaseModel):
+    id: UUID
+    source_environment: str
+    target_environment: str
+    status: str
+    message: str
+    requested_by: str
+    approved_by: str | None = None
+    completed_at: datetime | None = None
+
+
+class ApiLifecyclePortalPublicationResponse(BaseModel):
+    environment: str
+    gateway_instance_id: UUID
+    deployment_id: UUID
+    publication_status: str
+    result: str
+    spec_hash: str
+    published_at: datetime
+
+
+class ApiLifecyclePortalResponse(BaseModel):
+    published: bool
+    status: str
+    publications: list[ApiLifecyclePortalPublicationResponse] = Field(default_factory=list)
+    last_result: str | None = None
+    last_environment: str | None = None
+    last_gateway_instance_id: UUID | None = None
+    last_deployment_id: UUID | None = None
+    last_published_at: datetime | None = None
+
+
+class ApiLifecycleStateResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    catalog_id: UUID
+    tenant_id: str
+    api_id: str
+    api_name: str
+    display_name: str
+    version: str
+    description: str
+    backend_url: str
+    catalog_status: str
+    lifecycle_phase: str
+    portal_published: bool
+    tags: list[str]
+    spec: ApiLifecycleSpecResponse
+    deployments: list[ApiLifecycleGatewayDeploymentResponse]
+    promotions: list[ApiLifecyclePromotionResponse]
+    last_error: str | None = None
+    portal: ApiLifecyclePortalResponse
+
+
+class ApiLifecycleValidateDraftResponse(BaseModel):
+    tenant_id: str
+    api_id: str
+    status: str
+    validation: ApiLifecycleValidationResultResponse
+    lifecycle: ApiLifecycleStateResponse
+
+
+class ApiLifecycleDeployResponse(BaseModel):
+    tenant_id: str
+    api_id: str
+    environment: str
+    gateway_instance_id: UUID
+    deployment_id: UUID
+    deployment_status: str
+    action: str
+    lifecycle: ApiLifecycleStateResponse
+
+
+class ApiLifecyclePublishResponse(BaseModel):
+    tenant_id: str
+    api_id: str
+    environment: str
+    gateway_instance_id: UUID
+    deployment_id: UUID
+    publication_status: str
+    portal_published: bool
+    result: str
+    lifecycle: ApiLifecycleStateResponse
+
+
+class ApiLifecyclePromotionRequestResponse(BaseModel):
+    tenant_id: str
+    api_id: str
+    promotion_id: UUID
+    source_environment: str
+    target_environment: str
+    source_gateway_instance_id: UUID
+    target_gateway_instance_id: UUID
+    target_deployment_id: UUID
+    promotion_status: str
+    deployment_status: str
+    result: str
+    lifecycle: ApiLifecycleStateResponse

--- a/control-plane-api/src/services/api_lifecycle/__init__.py
+++ b/control-plane-api/src/services/api_lifecycle/__init__.py
@@ -1,0 +1,13 @@
+"""API lifecycle domain service."""
+
+from .audit import SqlAlchemyLifecycleAuditSink
+from .portal import CatalogPortalPublisher
+from .repository import SqlAlchemyApiLifecycleRepository
+from .service import ApiLifecycleService
+
+__all__ = [
+    "ApiLifecycleService",
+    "CatalogPortalPublisher",
+    "SqlAlchemyApiLifecycleRepository",
+    "SqlAlchemyLifecycleAuditSink",
+]

--- a/control-plane-api/src/services/api_lifecycle/audit.py
+++ b/control-plane-api/src/services/api_lifecycle/audit.py
@@ -1,0 +1,51 @@
+"""Audit adapter for API lifecycle transitions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.audit_event import AuditEvent
+
+from .ports import LifecycleActor
+
+
+class SqlAlchemyLifecycleAuditSink:
+    """Writes lifecycle transitions to the existing immutable audit table."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def record_transition(
+        self,
+        *,
+        tenant_id: str,
+        actor: LifecycleActor,
+        action: str,
+        resource_id: str,
+        resource_name: str,
+        details: dict[str, Any],
+        outcome: str = "success",
+        status_code: int = 200,
+        method: str = "POST",
+        path: str | None = None,
+    ) -> None:
+        self.session.add(
+            AuditEvent(
+                tenant_id=tenant_id,
+                actor_id=actor.actor_id,
+                actor_email=actor.email,
+                actor_type=actor.actor_type,
+                action=action,
+                method=method,
+                path=path or f"/v1/tenants/{tenant_id}/apis/lifecycle/drafts",
+                resource_type="api",
+                resource_id=resource_id,
+                resource_name=resource_name,
+                outcome=outcome,
+                status_code=status_code,
+                details=details,
+            )
+        )
+        await self.session.flush()

--- a/control-plane-api/src/services/api_lifecycle/errors.py
+++ b/control-plane-api/src/services/api_lifecycle/errors.py
@@ -1,0 +1,37 @@
+"""Errors raised by the API lifecycle domain service."""
+
+
+class ApiLifecycleError(Exception):
+    """Base error for lifecycle operations."""
+
+
+class ApiLifecycleValidationError(ApiLifecycleError):
+    """Input or transition is invalid for the requested lifecycle operation."""
+
+
+class ApiLifecycleSpecValidationError(ApiLifecycleValidationError):
+    """OpenAPI contract validation failed."""
+
+    def __init__(self, code: str, message: str):
+        self.code = code
+        super().__init__(message)
+
+
+class ApiLifecycleTransitionError(ApiLifecycleError):
+    """Requested lifecycle transition is not allowed."""
+
+
+class ApiLifecycleGatewayNotFoundError(ApiLifecycleError):
+    """Requested gateway target does not exist or is not visible to the tenant."""
+
+
+class ApiLifecycleGatewayAmbiguousError(ApiLifecycleError):
+    """More than one gateway target matches the requested deployment."""
+
+
+class ApiLifecycleConflictError(ApiLifecycleError):
+    """Requested operation conflicts with an existing lifecycle resource."""
+
+
+class ApiLifecycleNotFoundError(ApiLifecycleError):
+    """Requested lifecycle resource does not exist."""

--- a/control-plane-api/src/services/api_lifecycle/openapi.py
+++ b/control-plane-api/src/services/api_lifecycle/openapi.py
@@ -1,0 +1,133 @@
+"""OpenAPI helpers used by the API lifecycle service."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+
+from .errors import ApiLifecycleSpecValidationError, ApiLifecycleValidationError
+
+HTTP_METHODS = frozenset({"get", "put", "post", "delete", "options", "head", "patch", "trace"})
+
+
+@dataclass(frozen=True)
+class OpenApiValidationResult:
+    valid: bool
+    code: str
+    message: str
+    spec_format: str
+    spec_version: str
+    title: str
+    version: str
+    path_count: int
+    operation_count: int
+
+
+def parse_openapi_contract(spec: str | dict[str, Any] | None) -> dict[str, Any] | None:
+    """Parse an inline OpenAPI/Swagger document without changing catalog state."""
+    if spec is None:
+        return None
+    if isinstance(spec, dict):
+        parsed = spec
+    elif isinstance(spec, str):
+        if not spec.strip():
+            return None
+        try:
+            parsed = json.loads(spec) if spec.lstrip().startswith("{") else yaml.safe_load(spec)
+        except (json.JSONDecodeError, yaml.YAMLError) as exc:
+            raise ApiLifecycleValidationError(f"Invalid OpenAPI spec: unable to parse: {exc}") from exc
+    else:
+        raise ApiLifecycleValidationError("Invalid OpenAPI spec: expected a JSON/YAML string or object")
+
+    if not isinstance(parsed, dict):
+        raise ApiLifecycleValidationError("Invalid OpenAPI spec: must be a JSON/YAML object")
+
+    return parsed
+
+
+def validate_openapi_contract(spec: str | dict[str, Any] | None) -> OpenApiValidationResult:
+    """Validate the minimum OpenAPI/Swagger structure needed before deployment."""
+    try:
+        parsed = parse_openapi_contract(spec)
+    except ApiLifecycleValidationError as exc:
+        _invalid("openapi_spec_invalid", str(exc))
+    if parsed is None:
+        _invalid("openapi_spec_missing", "OpenAPI spec is required")
+
+    spec_format, spec_version = _validate_spec_version(parsed)
+    info = parsed.get("info")
+    if not isinstance(info, dict):
+        _invalid("openapi_info_missing", "OpenAPI spec must include an info object")
+
+    title = info.get("title")
+    if not isinstance(title, str) or not title.strip():
+        _invalid("openapi_info_title_missing", "OpenAPI info.title is required")
+
+    api_version = info.get("version")
+    if not isinstance(api_version, str) or not api_version.strip():
+        _invalid("openapi_info_version_missing", "OpenAPI info.version is required")
+
+    paths = parsed.get("paths")
+    if not isinstance(paths, dict):
+        _invalid("openapi_paths_missing", "OpenAPI spec must include a paths object")
+    if not paths:
+        _invalid("openapi_paths_empty", "OpenAPI spec must include at least one path")
+
+    operation_count = _validate_paths(paths)
+    return OpenApiValidationResult(
+        valid=True,
+        code="validated",
+        message="OpenAPI contract validated",
+        spec_format=spec_format,
+        spec_version=spec_version,
+        title=title.strip(),
+        version=api_version.strip(),
+        path_count=len(paths),
+        operation_count=operation_count,
+    )
+
+
+def _validate_spec_version(spec: dict[str, Any]) -> tuple[str, str]:
+    openapi_version = spec.get("openapi")
+    swagger_version = spec.get("swagger")
+    if openapi_version:
+        version = str(openapi_version)
+        if not version.startswith("3"):
+            _invalid("openapi_version_unsupported", f"Unsupported OpenAPI version: {version}. Supported: 3.x")
+        return "openapi", version
+    if swagger_version:
+        version = str(swagger_version)
+        if not version.startswith("2"):
+            _invalid("swagger_version_unsupported", f"Unsupported Swagger version: {version}. Supported: 2.0")
+        return "swagger", version
+    _invalid("openapi_version_missing", "OpenAPI spec must declare 'openapi' or 'swagger'")
+
+
+def _validate_paths(paths: dict[str, Any]) -> int:
+    operation_count = 0
+    for path, path_item in paths.items():
+        if not isinstance(path, str) or not path.startswith("/"):
+            _invalid("openapi_path_invalid", "OpenAPI path keys must start with '/'")
+        if not isinstance(path_item, dict):
+            _invalid("openapi_path_item_invalid", f"OpenAPI path item must be an object: {path}")
+
+        for method, operation in path_item.items():
+            if method.lower() not in HTTP_METHODS:
+                continue
+            operation_count += 1
+            if not isinstance(operation, dict):
+                _invalid("openapi_operation_invalid", f"OpenAPI operation must be an object: {path} {method}")
+            responses = operation.get("responses")
+            if not isinstance(responses, dict) or not responses:
+                _invalid(
+                    "openapi_operation_responses_missing",
+                    f"OpenAPI operation must declare a non-empty responses object: {path} {method}",
+                )
+    return operation_count
+
+
+def _invalid(code: str, message: str) -> None:
+    raise ApiLifecycleSpecValidationError(code, message)

--- a/control-plane-api/src/services/api_lifecycle/portal.py
+++ b/control-plane-api/src/services/api_lifecycle/portal.py
@@ -1,0 +1,46 @@
+"""Portal publication adapter for API lifecycle operations."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from src.models.catalog import APICatalog
+
+from .ports import PortalPublicationState
+
+
+class CatalogPortalPublisher:
+    """Publishes an API to the STOA Portal by updating the catalog visibility state."""
+
+    async def publish(
+        self,
+        *,
+        api: APICatalog,
+        publication: PortalPublicationState,
+    ) -> APICatalog:
+        metadata = deepcopy(api.api_metadata or {}) if isinstance(api.api_metadata, dict) else {}
+        lifecycle = dict(metadata.get("lifecycle") or {})
+        publications = dict(lifecycle.get("portal_publications") or {})
+        key = _publication_key(publication.environment, publication.gateway_instance_id)
+        publication_payload = {
+            "environment": publication.environment,
+            "gateway_instance_id": str(publication.gateway_instance_id),
+            "deployment_id": str(publication.deployment_id),
+            "publication_status": publication.publication_status,
+            "result": publication.result,
+            "spec_hash": publication.spec_hash,
+            "published_at": publication.published_at.isoformat(),
+            "source": "api_lifecycle",
+        }
+        publications[key] = publication_payload
+        lifecycle["portal_publications"] = publications
+        lifecycle["portal_last_publication"] = publication_payload
+        metadata["lifecycle"] = lifecycle
+
+        api.api_metadata = metadata
+        api.portal_published = True
+        return api
+
+
+def _publication_key(environment: str, gateway_instance_id) -> str:
+    return f"{environment}:{gateway_instance_id}"

--- a/control-plane-api/src/services/api_lifecycle/portal_tags.py
+++ b/control-plane-api/src/services/api_lifecycle/portal_tags.py
@@ -1,0 +1,37 @@
+"""Portal publication tag policy.
+
+Legacy catalog imports used free-form tags to publish APIs to the portal. The
+canonical lifecycle now owns publication, so these tags are either rejected on
+HTTP write paths or stripped from catalog imports.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+LEGACY_PORTAL_PUBLICATION_TAGS = frozenset({"portal:published", "promoted:portal", "portal-promoted"})
+
+
+def find_legacy_portal_publication_tags(tags: Iterable[object] | None) -> list[str]:
+    """Return legacy portal publication tags found in ``tags``."""
+    found: list[str] = []
+    for tag in tags or []:
+        normalized = str(tag).strip()
+        if normalized.lower() in LEGACY_PORTAL_PUBLICATION_TAGS:
+            found.append(normalized)
+    return found
+
+
+def strip_legacy_portal_publication_tags(tags: Iterable[object] | None) -> tuple[list[str], list[str]]:
+    """Return ``(clean_tags, stripped_tags)`` without legacy portal markers."""
+    clean: list[str] = []
+    stripped: list[str] = []
+    for tag in tags or []:
+        normalized = str(tag).strip()
+        if not normalized:
+            continue
+        if normalized.lower() in LEGACY_PORTAL_PUBLICATION_TAGS:
+            stripped.append(normalized)
+            continue
+        clean.append(normalized)
+    return clean, stripped

--- a/control-plane-api/src/services/api_lifecycle/ports.py
+++ b/control-plane-api/src/services/api_lifecycle/ports.py
@@ -1,0 +1,357 @@
+"""Ports and DTOs for the API lifecycle service.
+
+The lifecycle core depends on these protocols, not directly on SQLAlchemy,
+gateway clients, portal clients, or audit storage.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Protocol
+from uuid import UUID
+
+from src.models.catalog import APICatalog
+from src.models.gateway_deployment import GatewayDeployment
+from src.models.promotion import Promotion
+
+
+@dataclass(frozen=True)
+class LifecycleActor:
+    actor_id: str | None
+    email: str | None
+    username: str | None
+    actor_type: str = "user"
+
+
+@dataclass(frozen=True)
+class CreateApiDraftCommand:
+    tenant_id: str
+    name: str
+    display_name: str
+    version: str
+    description: str
+    backend_url: str
+    openapi_spec: str | dict[str, Any] | None = None
+    spec_reference: str | None = None
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    owner_team: str | None = None
+
+
+@dataclass(frozen=True)
+class ValidateApiDraftCommand:
+    tenant_id: str
+    api_id: str
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class DeployApiCommand:
+    tenant_id: str
+    api_id: str
+    environment: str
+    gateway_instance_id: UUID | None = None
+    force: bool = False
+
+
+@dataclass(frozen=True)
+class PublishApiCommand:
+    tenant_id: str
+    api_id: str
+    environment: str
+    gateway_instance_id: UUID | None = None
+    force: bool = False
+
+
+@dataclass(frozen=True)
+class PromoteApiCommand:
+    tenant_id: str
+    api_id: str
+    source_environment: str
+    target_environment: str
+    source_gateway_instance_id: UUID | None = None
+    target_gateway_instance_id: UUID | None = None
+    force: bool = False
+
+
+@dataclass(frozen=True)
+class DraftValidationResult:
+    valid: bool
+    code: str
+    message: str
+    spec_source: str
+    spec_format: str | None = None
+    spec_version: str | None = None
+    title: str | None = None
+    version: str | None = None
+    path_count: int = 0
+    operation_count: int = 0
+    validated_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class ApiDraftValidationOutcome:
+    tenant_id: str
+    api_id: str
+    status: str
+    validation: DraftValidationResult
+    lifecycle_state: ApiLifecycleState
+
+
+@dataclass(frozen=True)
+class GatewayTarget:
+    id: UUID
+    name: str
+    display_name: str
+    gateway_type: str
+    environment: str
+    tenant_id: str | None
+    enabled: bool
+    public_url: str | None = None
+
+
+@dataclass(frozen=True)
+class ApiDeploymentRequestOutcome:
+    tenant_id: str
+    api_id: str
+    environment: str
+    gateway_instance_id: UUID
+    deployment_id: UUID
+    deployment_status: str
+    action: str
+    lifecycle_state: ApiLifecycleState
+
+
+@dataclass(frozen=True)
+class PortalPublicationState:
+    environment: str
+    gateway_instance_id: UUID
+    deployment_id: UUID
+    publication_status: str
+    result: str
+    spec_hash: str
+    published_at: datetime
+
+
+@dataclass(frozen=True)
+class PortalLifecycleState:
+    published: bool = False
+    status: str = "not_published"
+    publications: list[PortalPublicationState] = field(default_factory=list)
+    last_result: str | None = None
+    last_environment: str | None = None
+    last_gateway_instance_id: UUID | None = None
+    last_deployment_id: UUID | None = None
+    last_published_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class ApiPortalPublicationOutcome:
+    tenant_id: str
+    api_id: str
+    environment: str
+    gateway_instance_id: UUID
+    deployment_id: UUID
+    publication_status: str
+    portal_published: bool
+    result: str
+    lifecycle_state: ApiLifecycleState
+
+
+@dataclass(frozen=True)
+class ApiPromotionRequestOutcome:
+    tenant_id: str
+    api_id: str
+    promotion_id: UUID
+    source_environment: str
+    target_environment: str
+    source_gateway_instance_id: UUID
+    target_gateway_instance_id: UUID
+    target_deployment_id: UUID
+    promotion_status: str
+    deployment_status: str
+    result: str
+    lifecycle_state: ApiLifecycleState
+
+
+@dataclass(frozen=True)
+class ApiSpecState:
+    source: str
+    has_openapi_spec: bool
+    git_path: str | None = None
+    git_commit_sha: str | None = None
+    reference: str | None = None
+    fallback_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class GatewayDeploymentState:
+    id: UUID
+    environment: str
+    gateway_instance_id: UUID
+    gateway_name: str
+    gateway_type: str
+    sync_status: str
+    desired_generation: int
+    synced_generation: int
+    gateway_resource_id: str | None = None
+    public_url: str | None = None
+    sync_error: str | None = None
+    last_sync_success: datetime | None = None
+
+
+@dataclass(frozen=True)
+class PromotionState:
+    id: UUID
+    source_environment: str
+    target_environment: str
+    status: str
+    message: str
+    requested_by: str
+    approved_by: str | None = None
+    completed_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class ApiLifecycleState:
+    catalog_id: UUID
+    tenant_id: str
+    api_id: str
+    api_name: str
+    display_name: str
+    version: str
+    description: str
+    backend_url: str
+    catalog_status: str
+    lifecycle_phase: str
+    portal_published: bool
+    tags: list[str]
+    spec: ApiSpecState
+    deployments: list[GatewayDeploymentState]
+    promotions: list[PromotionState]
+    last_error: str | None = None
+    portal: PortalLifecycleState = field(default_factory=PortalLifecycleState)
+
+
+@dataclass(frozen=True)
+class GatewayDeploymentSnapshot:
+    id: UUID
+    environment: str
+    gateway_instance_id: UUID
+    gateway_name: str
+    gateway_type: str
+    sync_status: str
+    desired_generation: int
+    synced_generation: int
+    gateway_resource_id: str | None = None
+    public_url: str | None = None
+    sync_error: str | None = None
+    last_sync_success: datetime | None = None
+
+
+@dataclass(frozen=True)
+class PromotionSnapshot:
+    id: UUID
+    source_environment: str
+    target_environment: str
+    status: str
+    message: str
+    requested_by: str
+    approved_by: str | None = None
+    completed_at: datetime | None = None
+
+
+class ApiLifecycleRepository(Protocol):
+    async def get_api_by_id(self, tenant_id: str, api_id: str) -> APICatalog | None:
+        """Return an active API catalog row."""
+
+    async def get_api_by_name_version(self, tenant_id: str, api_name: str, version: str) -> APICatalog | None:
+        """Return an active API catalog row by name and version."""
+
+    async def create_api_catalog(self, api: APICatalog) -> APICatalog:
+        """Persist a new API catalog row."""
+
+    async def save_api_catalog(self, api: APICatalog) -> APICatalog:
+        """Persist changes to an existing API catalog row."""
+
+    async def list_gateway_deployments(self, api_catalog_id: UUID) -> list[GatewayDeploymentSnapshot]:
+        """Return runtime deployment state for an API catalog row."""
+
+    async def get_gateway_target(self, tenant_id: str, gateway_instance_id: UUID) -> GatewayTarget | None:
+        """Return one visible gateway target for a tenant."""
+
+    async def list_gateway_targets(self, tenant_id: str, environment: str) -> list[GatewayTarget]:
+        """Return visible gateway targets for a tenant and environment."""
+
+    async def get_gateway_deployment(self, api_catalog_id: UUID, gateway_instance_id: UUID) -> GatewayDeployment | None:
+        """Return the runtime deployment row for one API/gateway target."""
+
+    async def create_gateway_deployment(self, deployment: GatewayDeployment) -> GatewayDeployment:
+        """Create a runtime deployment row."""
+
+    async def save_gateway_deployment(self, deployment: GatewayDeployment) -> GatewayDeployment:
+        """Persist changes to a runtime deployment row."""
+
+    async def list_promotions(self, tenant_id: str, api_id: str) -> list[PromotionSnapshot]:
+        """Return promotion state for an API."""
+
+    async def get_active_promotion(
+        self,
+        tenant_id: str,
+        api_id: str,
+        source_environment: str,
+        target_environment: str,
+    ) -> Promotion | None:
+        """Return one active promotion for a source/target lane."""
+
+    async def get_latest_promoted_promotion(
+        self,
+        tenant_id: str,
+        api_id: str,
+        source_environment: str,
+        target_environment: str,
+    ) -> Promotion | None:
+        """Return the most recent completed promotion for a source/target lane."""
+
+    async def get_active_promotion_for_target_deployment(
+        self,
+        tenant_id: str,
+        api_id: str,
+        target_environment: str,
+        target_deployment_id: UUID,
+    ) -> Promotion | None:
+        """Return the active promotion that owns a target GatewayDeployment."""
+
+    async def create_promotion(self, promotion: Promotion) -> Promotion:
+        """Create a promotion row."""
+
+    async def save_promotion(self, promotion: Promotion) -> Promotion:
+        """Persist promotion changes."""
+
+
+class LifecycleAuditSink(Protocol):
+    async def record_transition(
+        self,
+        *,
+        tenant_id: str,
+        actor: LifecycleActor,
+        action: str,
+        resource_id: str,
+        resource_name: str,
+        details: dict[str, Any],
+        outcome: str = "success",
+        status_code: int = 200,
+        method: str = "POST",
+        path: str | None = None,
+    ) -> None:
+        """Persist a lifecycle transition audit event."""
+
+
+class PortalPublisherPort(Protocol):
+    async def publish(
+        self,
+        *,
+        api: APICatalog,
+        publication: PortalPublicationState,
+    ) -> APICatalog:
+        """Persist the portal publication state for one API."""

--- a/control-plane-api/src/services/api_lifecycle/repository.py
+++ b/control-plane-api/src/services/api_lifecycle/repository.py
@@ -1,0 +1,245 @@
+"""SQLAlchemy persistence adapter for API lifecycle operations."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.catalog import APICatalog
+from src.models.gateway_deployment import GatewayDeployment
+from src.models.gateway_instance import GatewayInstance
+from src.models.promotion import Promotion, PromotionStatus
+from src.services.catalog_api_definition import environment_matches
+
+from .ports import GatewayDeploymentSnapshot, GatewayTarget, PromotionSnapshot
+
+
+class SqlAlchemyApiLifecycleRepository:
+    """Persistence adapter backed by the existing control-plane models."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_api_by_id(self, tenant_id: str, api_id: str) -> APICatalog | None:
+        stmt = select(APICatalog).where(
+            APICatalog.tenant_id == tenant_id,
+            APICatalog.api_id == api_id,
+            APICatalog.deleted_at.is_(None),
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_api_by_name_version(self, tenant_id: str, api_name: str, version: str) -> APICatalog | None:
+        stmt = select(APICatalog).where(
+            APICatalog.tenant_id == tenant_id,
+            APICatalog.api_name == api_name,
+            APICatalog.version == version,
+            APICatalog.deleted_at.is_(None),
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def create_api_catalog(self, api: APICatalog) -> APICatalog:
+        self.session.add(api)
+        await self.session.flush()
+        await self.session.refresh(api)
+        return api
+
+    async def save_api_catalog(self, api: APICatalog) -> APICatalog:
+        self.session.add(api)
+        await self.session.flush()
+        await self.session.refresh(api)
+        return api
+
+    async def list_gateway_deployments(self, api_catalog_id: UUID) -> list[GatewayDeploymentSnapshot]:
+        stmt = (
+            select(GatewayDeployment, GatewayInstance)
+            .join(GatewayInstance, GatewayDeployment.gateway_instance_id == GatewayInstance.id)
+            .where(
+                GatewayDeployment.api_catalog_id == api_catalog_id,
+                GatewayInstance.deleted_at.is_(None),
+            )
+            .order_by(GatewayInstance.environment, GatewayInstance.name)
+        )
+        result = await self.session.execute(stmt)
+        deployments: list[GatewayDeploymentSnapshot] = []
+        for deployment, gateway in result.all():
+            deployments.append(
+                GatewayDeploymentSnapshot(
+                    id=deployment.id,
+                    environment=gateway.environment,
+                    gateway_instance_id=gateway.id,
+                    gateway_name=gateway.name,
+                    gateway_type=str(gateway.gateway_type),
+                    sync_status=str(deployment.sync_status),
+                    desired_generation=deployment.desired_generation,
+                    synced_generation=deployment.synced_generation,
+                    gateway_resource_id=deployment.gateway_resource_id,
+                    public_url=gateway.public_url,
+                    sync_error=deployment.sync_error,
+                    last_sync_success=deployment.last_sync_success,
+                )
+            )
+        return deployments
+
+    async def get_gateway_target(self, tenant_id: str, gateway_instance_id: UUID) -> GatewayTarget | None:
+        stmt = select(GatewayInstance).where(
+            GatewayInstance.id == gateway_instance_id,
+            GatewayInstance.deleted_at.is_(None),
+        )
+        result = await self.session.execute(stmt)
+        gateway = result.scalar_one_or_none()
+        if not gateway:
+            return None
+        if gateway.tenant_id not in (None, tenant_id):
+            return None
+        return _gateway_target_from_model(gateway)
+
+    async def list_gateway_targets(self, tenant_id: str, environment: str) -> list[GatewayTarget]:
+        stmt = select(GatewayInstance).where(
+            GatewayInstance.deleted_at.is_(None),
+            GatewayInstance.enabled.is_(True),
+        )
+        result = await self.session.execute(stmt)
+        gateways = [
+            gateway
+            for gateway in result.scalars().all()
+            if gateway.tenant_id in (None, tenant_id) and environment_matches(gateway.environment, environment)
+        ]
+        return [_gateway_target_from_model(gateway) for gateway in gateways]
+
+    async def get_gateway_deployment(self, api_catalog_id: UUID, gateway_instance_id: UUID) -> GatewayDeployment | None:
+        stmt = select(GatewayDeployment).where(
+            GatewayDeployment.api_catalog_id == api_catalog_id,
+            GatewayDeployment.gateway_instance_id == gateway_instance_id,
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def create_gateway_deployment(self, deployment: GatewayDeployment) -> GatewayDeployment:
+        self.session.add(deployment)
+        await self.session.flush()
+        await self.session.refresh(deployment)
+        return deployment
+
+    async def save_gateway_deployment(self, deployment: GatewayDeployment) -> GatewayDeployment:
+        self.session.add(deployment)
+        await self.session.flush()
+        await self.session.refresh(deployment)
+        return deployment
+
+    async def list_promotions(self, tenant_id: str, api_id: str) -> list[PromotionSnapshot]:
+        stmt = (
+            select(Promotion)
+            .where(
+                Promotion.tenant_id == tenant_id,
+                Promotion.api_id == api_id,
+            )
+            .order_by(Promotion.created_at.desc())
+        )
+        result = await self.session.execute(stmt)
+        return [
+            PromotionSnapshot(
+                id=promotion.id,
+                source_environment=promotion.source_environment,
+                target_environment=promotion.target_environment,
+                status=str(promotion.status),
+                message=promotion.message,
+                requested_by=promotion.requested_by,
+                approved_by=promotion.approved_by,
+                completed_at=promotion.completed_at,
+            )
+            for promotion in result.scalars().all()
+        ]
+
+    async def get_active_promotion(
+        self,
+        tenant_id: str,
+        api_id: str,
+        source_environment: str,
+        target_environment: str,
+    ) -> Promotion | None:
+        stmt = (
+            select(Promotion)
+            .where(
+                Promotion.tenant_id == tenant_id,
+                Promotion.api_id == api_id,
+                Promotion.source_environment == source_environment,
+                Promotion.target_environment == target_environment,
+                Promotion.status.in_([PromotionStatus.PENDING.value, PromotionStatus.PROMOTING.value]),
+            )
+            .limit(1)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_latest_promoted_promotion(
+        self,
+        tenant_id: str,
+        api_id: str,
+        source_environment: str,
+        target_environment: str,
+    ) -> Promotion | None:
+        stmt = (
+            select(Promotion)
+            .where(
+                Promotion.tenant_id == tenant_id,
+                Promotion.api_id == api_id,
+                Promotion.source_environment == source_environment,
+                Promotion.target_environment == target_environment,
+                Promotion.status == PromotionStatus.PROMOTED.value,
+            )
+            .order_by(Promotion.completed_at.desc())
+            .limit(1)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_active_promotion_for_target_deployment(
+        self,
+        tenant_id: str,
+        api_id: str,
+        target_environment: str,
+        target_deployment_id: UUID,
+    ) -> Promotion | None:
+        stmt = (
+            select(Promotion)
+            .where(
+                Promotion.tenant_id == tenant_id,
+                Promotion.api_id == api_id,
+                Promotion.target_environment == target_environment,
+                Promotion.target_deployment_id == target_deployment_id,
+                Promotion.status.in_([PromotionStatus.PENDING.value, PromotionStatus.PROMOTING.value]),
+            )
+            .limit(1)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def create_promotion(self, promotion: Promotion) -> Promotion:
+        self.session.add(promotion)
+        await self.session.flush()
+        await self.session.refresh(promotion)
+        return promotion
+
+    async def save_promotion(self, promotion: Promotion) -> Promotion:
+        self.session.add(promotion)
+        await self.session.flush()
+        await self.session.refresh(promotion)
+        return promotion
+
+
+def _gateway_target_from_model(gateway: GatewayInstance) -> GatewayTarget:
+    gateway_type = getattr(gateway.gateway_type, "value", gateway.gateway_type)
+    return GatewayTarget(
+        id=gateway.id,
+        name=gateway.name,
+        display_name=gateway.display_name,
+        gateway_type=str(gateway_type),
+        environment=gateway.environment,
+        tenant_id=gateway.tenant_id,
+        enabled=bool(gateway.enabled),
+        public_url=gateway.public_url,
+    )

--- a/control-plane-api/src/services/api_lifecycle/service.py
+++ b/control-plane-api/src/services/api_lifecycle/service.py
@@ -1,0 +1,1392 @@
+"""Canonical API lifecycle service."""
+
+from __future__ import annotations
+
+import json
+import re
+from copy import deepcopy
+from datetime import UTC, datetime
+from hashlib import sha256
+from uuid import UUID, uuid4
+
+from src.models.catalog import APICatalog
+from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment
+from src.models.promotion import Promotion, PromotionStatus, validate_promotion_chain
+from src.services.catalog_api_definition import environment_matches, normalize_environment
+from src.services.gateway_deployment_service import GatewayDeploymentService
+
+from .errors import (
+    ApiLifecycleConflictError,
+    ApiLifecycleGatewayAmbiguousError,
+    ApiLifecycleGatewayNotFoundError,
+    ApiLifecycleNotFoundError,
+    ApiLifecycleSpecValidationError,
+    ApiLifecycleTransitionError,
+    ApiLifecycleValidationError,
+)
+from .openapi import parse_openapi_contract, validate_openapi_contract
+from .portal import CatalogPortalPublisher
+from .portal_tags import find_legacy_portal_publication_tags
+from .ports import (
+    ApiDeploymentRequestOutcome,
+    ApiDraftValidationOutcome,
+    ApiLifecycleRepository,
+    ApiLifecycleState,
+    ApiPortalPublicationOutcome,
+    ApiPromotionRequestOutcome,
+    ApiSpecState,
+    CreateApiDraftCommand,
+    DeployApiCommand,
+    DraftValidationResult,
+    GatewayDeploymentState,
+    GatewayTarget,
+    LifecycleActor,
+    LifecycleAuditSink,
+    PortalLifecycleState,
+    PortalPublicationState,
+    PortalPublisherPort,
+    PromoteApiCommand,
+    PromotionState,
+    PublishApiCommand,
+    ValidateApiDraftCommand,
+)
+
+
+class ApiLifecycleService:
+    """Coordinates the lifecycle of one catalog API across STOA control-plane state."""
+
+    def __init__(
+        self,
+        repository: ApiLifecycleRepository,
+        audit_sink: LifecycleAuditSink,
+        portal_publisher: PortalPublisherPort | None = None,
+    ):
+        self.repository = repository
+        self.audit_sink = audit_sink
+        self.portal_publisher = portal_publisher or CatalogPortalPublisher()
+
+    async def create_draft(self, command: CreateApiDraftCommand, actor: LifecycleActor) -> ApiLifecycleState:
+        """Create a catalog draft without deploying or publishing it."""
+        normalized = self._normalize_create_command(command)
+        forbidden_tags = find_legacy_portal_publication_tags(normalized.tags)
+        if forbidden_tags:
+            raise ApiLifecycleValidationError(
+                "Portal publication must use the lifecycle publish action, not catalog tags: "
+                + ", ".join(forbidden_tags)
+            )
+
+        existing = await self.repository.get_api_by_name_version(
+            normalized.tenant_id,
+            normalized.name,
+            normalized.version,
+        )
+        if existing:
+            raise ApiLifecycleConflictError(
+                f"API '{normalized.name}' version '{normalized.version}' already exists in this tenant"
+            )
+
+        api_id = _slugify(normalized.name)
+        existing_api_id = await self.repository.get_api_by_id(normalized.tenant_id, api_id)
+        if existing_api_id:
+            raise ApiLifecycleConflictError(f"API id '{api_id}' already exists in this tenant")
+
+        parsed_spec = parse_openapi_contract(normalized.openapi_spec)
+        if not parsed_spec and not normalized.spec_reference:
+            raise ApiLifecycleValidationError("API OpenAPI spec or spec_reference is required")
+
+        catalog_metadata = {
+            "name": normalized.name,
+            "display_name": normalized.display_name,
+            "version": normalized.version,
+            "description": normalized.description,
+            "backend_url": normalized.backend_url,
+            "tags": list(normalized.tags),
+            "owner_team": normalized.owner_team,
+            "status": "draft",
+            "lifecycle": {
+                "catalog_status": "draft",
+                "spec_source": "inline" if parsed_spec else "reference" if normalized.spec_reference else "missing",
+                "spec_reference": normalized.spec_reference,
+            },
+        }
+
+        api = APICatalog(
+            id=uuid4(),
+            tenant_id=normalized.tenant_id,
+            api_id=api_id,
+            api_name=normalized.name,
+            version=normalized.version,
+            status="draft",
+            tags=list(normalized.tags),
+            portal_published=False,
+            api_metadata=catalog_metadata,
+            openapi_spec=parsed_spec,
+            synced_at=datetime.now(UTC),
+        )
+
+        created = await self.repository.create_api_catalog(api)
+        await self.audit_sink.record_transition(
+            tenant_id=created.tenant_id,
+            actor=actor,
+            action="api_lifecycle.create_draft",
+            resource_id=created.api_id,
+            resource_name=created.api_name,
+            details={
+                "api_id": created.api_id,
+                "api_name": created.api_name,
+                "version": created.version,
+                "catalog_status": created.status,
+                "spec_source": catalog_metadata["lifecycle"]["spec_source"],
+                "portal_published": created.portal_published,
+            },
+            outcome="success",
+            status_code=201,
+            path=f"/v1/tenants/{created.tenant_id}/apis/lifecycle/drafts",
+        )
+        return await self._state_from_catalog(created)
+
+    async def validate_draft(
+        self,
+        command: ValidateApiDraftCommand,
+        actor: LifecycleActor,
+    ) -> ApiDraftValidationOutcome:
+        """Validate a catalog draft and mark it ready for deployment."""
+        api = await self.repository.get_api_by_id(command.tenant_id, command.api_id)
+        if not api:
+            raise ApiLifecycleNotFoundError(f"API '{command.api_id}' was not found")
+
+        if api.status == "archived":
+            await self._audit_validation_failure(
+                api,
+                actor,
+                code="transition_archived",
+                message="Archived APIs cannot be validated",
+                status_code=409,
+            )
+            raise ApiLifecycleTransitionError("Archived APIs cannot be validated")
+        if api.status not in {"draft", "ready"}:
+            await self._audit_validation_failure(
+                api,
+                actor,
+                code="transition_invalid",
+                message=f"API status '{api.status}' cannot be validated",
+                status_code=409,
+            )
+            raise ApiLifecycleTransitionError(f"API status '{api.status}' cannot be validated")
+
+        spec_source = _spec_state(api).source
+        if not api.openapi_spec:
+            reference = _spec_state(api).reference
+            if reference:
+                message = f"Spec reference cannot be resolved yet: {reference}"
+                await self._audit_validation_failure(
+                    api,
+                    actor,
+                    code="spec_reference_unresolved",
+                    message=message,
+                    status_code=422,
+                )
+                raise ApiLifecycleSpecValidationError("spec_reference_unresolved", message)
+
+        try:
+            openapi_result = validate_openapi_contract(api.openapi_spec)
+        except ApiLifecycleSpecValidationError as exc:
+            await self._audit_validation_failure(
+                api,
+                actor,
+                code=exc.code,
+                message=str(exc),
+                status_code=422,
+            )
+            raise
+
+        validated_at = datetime.now(UTC)
+        validation_hash = _spec_fingerprint(api.openapi_spec)
+        metadata = _metadata_copy(api)
+        lifecycle = dict(metadata.get("lifecycle") or {})
+        previous_hash = lifecycle.get("validation_spec_hash")
+        if api.status == "ready" and previous_hash and previous_hash != validation_hash:
+            await self._audit_validation_failure(
+                api,
+                actor,
+                code="ready_spec_changed",
+                message="Ready API spec changed; return the API to draft before validating again",
+                status_code=409,
+            )
+            raise ApiLifecycleTransitionError("Ready API spec changed; return the API to draft before validating again")
+
+        lifecycle.update(
+            {
+                "catalog_status": "ready",
+                "validated_at": validated_at.isoformat(),
+                "validation_spec_hash": validation_hash,
+                "validation_result": {
+                    "valid": True,
+                    "code": openapi_result.code,
+                    "message": openapi_result.message,
+                    "spec_source": spec_source,
+                    "spec_format": openapi_result.spec_format,
+                    "spec_version": openapi_result.spec_version,
+                    "title": openapi_result.title,
+                    "version": openapi_result.version,
+                    "path_count": openapi_result.path_count,
+                    "operation_count": openapi_result.operation_count,
+                },
+            }
+        )
+        metadata["status"] = "ready"
+        metadata["lifecycle"] = lifecycle
+
+        api.status = "ready"
+        api.api_metadata = metadata
+        saved = await self.repository.save_api_catalog(api)
+        validation = DraftValidationResult(
+            valid=True,
+            code=openapi_result.code,
+            message=openapi_result.message,
+            spec_source=spec_source,
+            spec_format=openapi_result.spec_format,
+            spec_version=openapi_result.spec_version,
+            title=openapi_result.title,
+            version=openapi_result.version,
+            path_count=openapi_result.path_count,
+            operation_count=openapi_result.operation_count,
+            validated_at=validated_at,
+        )
+        await self.audit_sink.record_transition(
+            tenant_id=saved.tenant_id,
+            actor=actor,
+            action="api_lifecycle.validate_draft",
+            resource_id=saved.api_id,
+            resource_name=saved.api_name,
+            details={
+                "api_id": saved.api_id,
+                "api_name": saved.api_name,
+                "version": saved.version,
+                "catalog_status": saved.status,
+                "validation": {
+                    "code": validation.code,
+                    "spec_source": validation.spec_source,
+                    "spec_format": validation.spec_format,
+                    "spec_version": validation.spec_version,
+                    "path_count": validation.path_count,
+                    "operation_count": validation.operation_count,
+                },
+                "reason": command.reason,
+            },
+            outcome="success",
+            status_code=200,
+            path=f"/v1/tenants/{saved.tenant_id}/apis/{saved.api_id}/lifecycle/validate",
+        )
+        return ApiDraftValidationOutcome(
+            tenant_id=saved.tenant_id,
+            api_id=saved.api_id,
+            status=saved.status,
+            validation=validation,
+            lifecycle_state=await self._state_from_catalog(saved),
+        )
+
+    async def deploy_to_environment(
+        self,
+        command: DeployApiCommand,
+        actor: LifecycleActor,
+    ) -> ApiDeploymentRequestOutcome:
+        """Request runtime deployment by materializing a GatewayDeployment row."""
+        environment = _normalize_deployment_environment(command.environment)
+        api = await self.repository.get_api_by_id(command.tenant_id, command.api_id)
+        if not api:
+            raise ApiLifecycleNotFoundError(f"API '{command.api_id}' was not found")
+
+        if api.status != "ready":
+            await self._audit_deploy_failure(
+                api,
+                actor,
+                environment=environment,
+                code="transition_invalid",
+                message=f"API status '{api.status}' cannot be deployed; validate the draft first",
+                status_code=409,
+            )
+            raise ApiLifecycleTransitionError(f"API status '{api.status}' cannot be deployed; validate the draft first")
+
+        try:
+            gateway = await self._resolve_gateway_target(command.tenant_id, environment, command.gateway_instance_id)
+        except (
+            ApiLifecycleGatewayNotFoundError,
+            ApiLifecycleGatewayAmbiguousError,
+            ApiLifecycleValidationError,
+        ) as exc:
+            failure_status = 404 if isinstance(exc, ApiLifecycleGatewayNotFoundError) else 409
+            if isinstance(exc, ApiLifecycleValidationError):
+                failure_status = 422
+            await self._audit_deploy_failure(
+                api,
+                actor,
+                environment=environment,
+                code=exc.__class__.__name__,
+                message=str(exc),
+                status_code=failure_status,
+            )
+            raise
+        desired_state = {
+            **GatewayDeploymentService.build_desired_state(api),
+            "target_environment": environment,
+            "target_gateway_name": gateway.name,
+            "target_source": "api_lifecycle",
+        }
+        deployment, action = await self._upsert_gateway_deployment(api, gateway, desired_state, command.force)
+        audit_action = "api_lifecycle.deploy_idempotent" if action == "unchanged" else "api_lifecycle.deploy_requested"
+        await self.audit_sink.record_transition(
+            tenant_id=api.tenant_id,
+            actor=actor,
+            action=audit_action,
+            resource_id=api.api_id,
+            resource_name=api.api_name,
+            details={
+                "api_id": api.api_id,
+                "api_name": api.api_name,
+                "version": api.version,
+                "catalog_status": api.status,
+                "environment": environment,
+                "gateway_instance_id": str(gateway.id),
+                "gateway_name": gateway.name,
+                "deployment_id": str(deployment.id),
+                "deployment_status": _wire_value(deployment.sync_status),
+                "action": action,
+            },
+            outcome="success",
+            status_code=200,
+            path=f"/v1/tenants/{api.tenant_id}/apis/{api.api_id}/lifecycle/deployments",
+        )
+        return ApiDeploymentRequestOutcome(
+            tenant_id=api.tenant_id,
+            api_id=api.api_id,
+            environment=environment,
+            gateway_instance_id=gateway.id,
+            deployment_id=deployment.id,
+            deployment_status=_wire_value(deployment.sync_status),
+            action=action,
+            lifecycle_state=await self._state_from_catalog(api),
+        )
+
+    async def publish_to_portal(
+        self,
+        command: PublishApiCommand,
+        actor: LifecycleActor,
+    ) -> ApiPortalPublicationOutcome:
+        """Publish a synced API deployment to the portal catalog."""
+        environment = _normalize_deployment_environment(command.environment)
+        api = await self.repository.get_api_by_id(command.tenant_id, command.api_id)
+        if not api:
+            raise ApiLifecycleNotFoundError(f"API '{command.api_id}' was not found")
+
+        if api.status != "ready":
+            await self._audit_publish_failure(
+                api,
+                actor,
+                environment=environment,
+                code="transition_invalid",
+                message=f"API status '{api.status}' cannot be published; validate the draft first",
+                status_code=409,
+            )
+            raise ApiLifecycleTransitionError(
+                f"API status '{api.status}' cannot be published; validate the draft first"
+            )
+
+        gateway = await self._resolve_publish_gateway(
+            command.tenant_id, environment, command.gateway_instance_id, api, actor
+        )
+        deployment = await self.repository.get_gateway_deployment(api.id, gateway.id)
+        if not deployment:
+            await self._audit_publish_failure(
+                api,
+                actor,
+                environment=environment,
+                code="deployment_not_found",
+                message=f"No GatewayDeployment found for gateway '{gateway.name}'",
+                status_code=404,
+                gateway_instance_id=gateway.id,
+            )
+            raise ApiLifecycleNotFoundError(f"No GatewayDeployment found for gateway '{gateway.name}'")
+        if _wire_value(deployment.sync_status) != DeploymentSyncStatus.SYNCED.value:
+            await self._audit_publish_failure(
+                api,
+                actor,
+                environment=environment,
+                code="deployment_not_synced",
+                message=f"Deployment '{deployment.id}' is '{_wire_value(deployment.sync_status)}', not 'synced'",
+                status_code=409,
+                gateway_instance_id=gateway.id,
+                deployment_id=deployment.id,
+            )
+            raise ApiLifecycleTransitionError(
+                f"Deployment '{deployment.id}' is '{_wire_value(deployment.sync_status)}', not 'synced'"
+            )
+
+        validation_result = await self._validate_publishable_spec(api, actor, environment, gateway.id, deployment.id)
+        spec_hash = _spec_fingerprint(api.openapi_spec)
+        previous = _portal_publication_record(api, environment, gateway.id)
+        if (
+            previous
+            and api.portal_published
+            and previous.get("spec_hash") == spec_hash
+            and previous.get("deployment_id") == str(deployment.id)
+            and not command.force
+        ):
+            await self._complete_promotion_for_publication(
+                api=api,
+                actor=actor,
+                environment=environment,
+                gateway_instance_id=gateway.id,
+                deployment_id=deployment.id,
+            )
+            await self.audit_sink.record_transition(
+                tenant_id=api.tenant_id,
+                actor=actor,
+                action="api_lifecycle.publish_idempotent",
+                resource_id=api.api_id,
+                resource_name=api.api_name,
+                details={
+                    "api_id": api.api_id,
+                    "api_name": api.api_name,
+                    "environment": environment,
+                    "gateway_instance_id": str(gateway.id),
+                    "deployment_id": str(deployment.id),
+                    "result": "unchanged",
+                },
+                outcome="success",
+                status_code=200,
+                path=f"/v1/tenants/{api.tenant_id}/apis/{api.api_id}/lifecycle/publications",
+            )
+            return ApiPortalPublicationOutcome(
+                tenant_id=api.tenant_id,
+                api_id=api.api_id,
+                environment=environment,
+                gateway_instance_id=gateway.id,
+                deployment_id=deployment.id,
+                publication_status="published",
+                portal_published=True,
+                result="unchanged",
+                lifecycle_state=await self._state_from_catalog(api),
+            )
+
+        result = "republished" if previous else "published"
+        published_at = datetime.now(UTC)
+        publication = PortalPublicationState(
+            environment=environment,
+            gateway_instance_id=gateway.id,
+            deployment_id=deployment.id,
+            publication_status="published",
+            result=result,
+            spec_hash=spec_hash,
+            published_at=published_at,
+        )
+        published_api = await self.portal_publisher.publish(api=api, publication=publication)
+        saved = await self.repository.save_api_catalog(published_api)
+        await self.audit_sink.record_transition(
+            tenant_id=saved.tenant_id,
+            actor=actor,
+            action="api_lifecycle.publish_requested",
+            resource_id=saved.api_id,
+            resource_name=saved.api_name,
+            details={
+                "api_id": saved.api_id,
+                "api_name": saved.api_name,
+                "version": saved.version,
+                "catalog_status": saved.status,
+                "environment": environment,
+                "gateway_instance_id": str(gateway.id),
+                "gateway_name": gateway.name,
+                "deployment_id": str(deployment.id),
+                "deployment_status": _wire_value(deployment.sync_status),
+                "publication_status": "published",
+                "result": result,
+                "spec": {
+                    "code": validation_result.code,
+                    "spec_format": validation_result.spec_format,
+                    "spec_version": validation_result.spec_version,
+                },
+            },
+            outcome="success",
+            status_code=200,
+            path=f"/v1/tenants/{saved.tenant_id}/apis/{saved.api_id}/lifecycle/publications",
+        )
+        await self._complete_promotion_for_publication(
+            api=saved,
+            actor=actor,
+            environment=environment,
+            gateway_instance_id=gateway.id,
+            deployment_id=deployment.id,
+        )
+        return ApiPortalPublicationOutcome(
+            tenant_id=saved.tenant_id,
+            api_id=saved.api_id,
+            environment=environment,
+            gateway_instance_id=gateway.id,
+            deployment_id=deployment.id,
+            publication_status="published",
+            portal_published=saved.portal_published,
+            result=result,
+            lifecycle_state=await self._state_from_catalog(saved),
+        )
+
+    async def promote_to_environment(
+        self,
+        command: PromoteApiCommand,
+        actor: LifecycleActor,
+    ) -> ApiPromotionRequestOutcome:
+        """Promote a published source deployment by requesting a target GatewayDeployment."""
+        source_environment = _normalize_deployment_environment(command.source_environment)
+        target_environment = _normalize_deployment_environment(command.target_environment)
+        try:
+            validate_promotion_chain(source_environment, target_environment)
+        except ValueError as exc:
+            raise ApiLifecycleValidationError(str(exc)) from exc
+
+        api = await self.repository.get_api_by_id(command.tenant_id, command.api_id)
+        if not api:
+            raise ApiLifecycleNotFoundError(f"API '{command.api_id}' was not found")
+
+        if api.status != "ready":
+            await self._audit_promotion_failure(
+                api,
+                actor,
+                source_environment=source_environment,
+                target_environment=target_environment,
+                code="transition_invalid",
+                message=f"API status '{api.status}' cannot be promoted; validate the draft first",
+                status_code=409,
+            )
+            raise ApiLifecycleTransitionError(f"API status '{api.status}' cannot be promoted; validate the draft first")
+
+        source_gateway = await self._resolve_promotion_gateway(
+            command.tenant_id,
+            source_environment,
+            command.source_gateway_instance_id,
+            api,
+            actor,
+            target_environment=target_environment,
+            gateway_role="source",
+        )
+        target_gateway = await self._resolve_promotion_gateway(
+            command.tenant_id,
+            target_environment,
+            command.target_gateway_instance_id,
+            api,
+            actor,
+            source_environment=source_environment,
+            gateway_role="target",
+        )
+
+        source_deployment = await self.repository.get_gateway_deployment(api.id, source_gateway.id)
+        if not source_deployment:
+            await self._audit_promotion_failure(
+                api,
+                actor,
+                source_environment=source_environment,
+                target_environment=target_environment,
+                code="source_deployment_not_found",
+                message=f"No source GatewayDeployment found for gateway '{source_gateway.name}'",
+                status_code=404,
+                source_gateway_instance_id=source_gateway.id,
+                target_gateway_instance_id=target_gateway.id,
+            )
+            raise ApiLifecycleNotFoundError(f"No source GatewayDeployment found for gateway '{source_gateway.name}'")
+        if _wire_value(source_deployment.sync_status) != DeploymentSyncStatus.SYNCED.value:
+            await self._audit_promotion_failure(
+                api,
+                actor,
+                source_environment=source_environment,
+                target_environment=target_environment,
+                code="source_deployment_not_synced",
+                message=(
+                    f"Source deployment '{source_deployment.id}' is "
+                    f"'{_wire_value(source_deployment.sync_status)}', not 'synced'"
+                ),
+                status_code=409,
+                source_gateway_instance_id=source_gateway.id,
+                target_gateway_instance_id=target_gateway.id,
+                source_deployment_id=source_deployment.id,
+            )
+            raise ApiLifecycleTransitionError(
+                f"Source deployment '{source_deployment.id}' is "
+                f"'{_wire_value(source_deployment.sync_status)}', not 'synced'"
+            )
+
+        source_publication = _portal_publication_record(api, source_environment, source_gateway.id)
+        if (
+            not api.portal_published
+            or not source_publication
+            or source_publication.get("deployment_id") != str(source_deployment.id)
+        ):
+            await self._audit_promotion_failure(
+                api,
+                actor,
+                source_environment=source_environment,
+                target_environment=target_environment,
+                code="source_publication_missing",
+                message=f"Source environment '{source_environment}' is not published through lifecycle",
+                status_code=409,
+                source_gateway_instance_id=source_gateway.id,
+                target_gateway_instance_id=target_gateway.id,
+                source_deployment_id=source_deployment.id,
+            )
+            raise ApiLifecycleTransitionError(
+                f"Source environment '{source_environment}' is not published through lifecycle"
+            )
+
+        promotion, promotion_action = await self._upsert_promotion(
+            api=api,
+            actor=actor,
+            source_environment=source_environment,
+            target_environment=target_environment,
+            source_deployment=source_deployment,
+            target_gateway=target_gateway,
+            force=command.force,
+        )
+
+        desired_state = {
+            **GatewayDeploymentService.build_desired_state(api),
+            "target_environment": target_environment,
+            "target_gateway_name": target_gateway.name,
+            "target_source": "api_lifecycle_promotion",
+            "promotion_id": str(promotion.id),
+            "source_environment": source_environment,
+            "source_gateway_instance_id": str(source_gateway.id),
+            "source_deployment_id": str(source_deployment.id),
+        }
+        target_deployment, deployment_action = await self._upsert_gateway_deployment(
+            api,
+            target_gateway,
+            desired_state,
+            command.force,
+            promotion_id=promotion.id,
+        )
+
+        promotion.target_deployment_id = target_deployment.id
+        promotion.target_gateway_ids = [str(target_gateway.id)]
+        if promotion.status == PromotionStatus.PENDING.value:
+            promotion.status = PromotionStatus.PROMOTING.value
+        saved_promotion = await self.repository.save_promotion(promotion)
+
+        result = _promotion_result(promotion_action, deployment_action)
+        audit_action = (
+            "api_lifecycle.promotion_idempotent" if result == "unchanged" else "api_lifecycle.promotion_requested"
+        )
+        await self.audit_sink.record_transition(
+            tenant_id=api.tenant_id,
+            actor=actor,
+            action=audit_action,
+            resource_id=api.api_id,
+            resource_name=api.api_name,
+            details={
+                "api_id": api.api_id,
+                "api_name": api.api_name,
+                "promotion_id": str(saved_promotion.id),
+                "source_environment": source_environment,
+                "target_environment": target_environment,
+                "source_gateway_instance_id": str(source_gateway.id),
+                "target_gateway_instance_id": str(target_gateway.id),
+                "source_deployment_id": str(source_deployment.id),
+                "target_deployment_id": str(target_deployment.id),
+                "promotion_status": saved_promotion.status,
+                "deployment_status": _wire_value(target_deployment.sync_status),
+                "result": result,
+            },
+            outcome="success",
+            status_code=200,
+            path=f"/v1/tenants/{api.tenant_id}/apis/{api.api_id}/lifecycle/promotions",
+        )
+        return ApiPromotionRequestOutcome(
+            tenant_id=api.tenant_id,
+            api_id=api.api_id,
+            promotion_id=saved_promotion.id,
+            source_environment=source_environment,
+            target_environment=target_environment,
+            source_gateway_instance_id=source_gateway.id,
+            target_gateway_instance_id=target_gateway.id,
+            target_deployment_id=target_deployment.id,
+            promotion_status=saved_promotion.status,
+            deployment_status=_wire_value(target_deployment.sync_status),
+            result=result,
+            lifecycle_state=await self._state_from_catalog(api),
+        )
+
+    async def get_lifecycle_state(self, tenant_id: str, api_id: str) -> ApiLifecycleState:
+        """Return the aggregate lifecycle state calculated from canonical models."""
+        api = await self.repository.get_api_by_id(tenant_id, api_id)
+        if not api:
+            raise ApiLifecycleNotFoundError(f"API '{api_id}' was not found")
+        return await self._state_from_catalog(api)
+
+    async def _state_from_catalog(self, api: APICatalog) -> ApiLifecycleState:
+        deployments = await self.repository.list_gateway_deployments(api.id)
+        promotions = await self.repository.list_promotions(api.tenant_id, api.api_id)
+        deployment_states = [
+            GatewayDeploymentState(
+                id=item.id,
+                environment=item.environment,
+                gateway_instance_id=item.gateway_instance_id,
+                gateway_name=item.gateway_name,
+                gateway_type=item.gateway_type,
+                sync_status=item.sync_status,
+                desired_generation=item.desired_generation,
+                synced_generation=item.synced_generation,
+                gateway_resource_id=item.gateway_resource_id,
+                public_url=item.public_url,
+                sync_error=item.sync_error,
+                last_sync_success=item.last_sync_success,
+            )
+            for item in deployments
+        ]
+        promotion_states = [
+            PromotionState(
+                id=item.id,
+                source_environment=item.source_environment,
+                target_environment=item.target_environment,
+                status=item.status,
+                message=item.message,
+                requested_by=item.requested_by,
+                approved_by=item.approved_by,
+                completed_at=item.completed_at,
+            )
+            for item in promotions
+        ]
+
+        return ApiLifecycleState(
+            catalog_id=api.id,
+            tenant_id=api.tenant_id,
+            api_id=api.api_id,
+            api_name=api.api_name,
+            display_name=str(_metadata(api).get("display_name") or api.api_name),
+            version=api.version,
+            description=str(_metadata(api).get("description") or ""),
+            backend_url=str(_metadata(api).get("backend_url") or ""),
+            catalog_status=api.status,
+            lifecycle_phase=_calculate_lifecycle_phase(
+                api.status, api.portal_published, deployment_states, promotion_states
+            ),
+            portal_published=api.portal_published,
+            tags=list(api.tags or []),
+            spec=_spec_state(api),
+            deployments=deployment_states,
+            promotions=promotion_states,
+            last_error=_last_error(api.status, deployment_states, promotion_states),
+            portal=_portal_state(api),
+        )
+
+    @staticmethod
+    def _normalize_create_command(command: CreateApiDraftCommand) -> CreateApiDraftCommand:
+        name = command.name.strip()
+        display_name = command.display_name.strip()
+        version = command.version.strip() or "1.0.0"
+        backend_url = command.backend_url.strip()
+        if not name:
+            raise ApiLifecycleValidationError("API name is required")
+        if not display_name:
+            raise ApiLifecycleValidationError("API display_name is required")
+        if not backend_url:
+            raise ApiLifecycleValidationError("API backend_url is required")
+
+        return CreateApiDraftCommand(
+            tenant_id=command.tenant_id,
+            name=name,
+            display_name=display_name,
+            version=version,
+            description=command.description.strip(),
+            backend_url=backend_url,
+            openapi_spec=command.openapi_spec,
+            spec_reference=command.spec_reference.strip() if command.spec_reference else None,
+            tags=tuple(tag.strip() for tag in command.tags if tag and tag.strip()),
+            owner_team=command.owner_team.strip() if command.owner_team else None,
+        )
+
+    async def _resolve_gateway_target(
+        self,
+        tenant_id: str,
+        environment: str,
+        gateway_instance_id,
+    ) -> GatewayTarget:
+        if gateway_instance_id:
+            gateway = await self.repository.get_gateway_target(tenant_id, gateway_instance_id)
+            if not gateway:
+                raise ApiLifecycleGatewayNotFoundError(f"Gateway '{gateway_instance_id}' was not found")
+            if not gateway.enabled:
+                raise ApiLifecycleGatewayNotFoundError(f"Gateway '{gateway.name}' is disabled")
+            if not environment_matches(gateway.environment, environment):
+                raise ApiLifecycleValidationError(
+                    f"Gateway '{gateway.name}' is in environment '{gateway.environment}', not '{environment}'"
+                )
+            return gateway
+
+        gateways = await self.repository.list_gateway_targets(tenant_id, environment)
+        if not gateways:
+            raise ApiLifecycleGatewayNotFoundError(f"No gateway target found for environment '{environment}'")
+        if len(gateways) > 1:
+            gateway_names = ", ".join(gateway.name for gateway in gateways)
+            raise ApiLifecycleGatewayAmbiguousError(
+                f"Multiple gateway targets found for environment '{environment}': {gateway_names}. "
+                "Provide gateway_instance_id explicitly."
+            )
+        return gateways[0]
+
+    async def _upsert_gateway_deployment(
+        self,
+        api: APICatalog,
+        gateway: GatewayTarget,
+        desired_state: dict,
+        force: bool,
+        promotion_id: UUID | None = None,
+    ) -> tuple[GatewayDeployment, str]:
+        now = datetime.now(UTC)
+        existing = await self.repository.get_gateway_deployment(api.id, gateway.id)
+        if existing:
+            if promotion_id and existing.promotion_id != promotion_id:
+                existing.promotion_id = promotion_id
+                if existing.desired_state == desired_state and not force:
+                    saved = await self.repository.save_gateway_deployment(existing)
+                    return saved, "unchanged"
+            if existing.desired_state == desired_state and not force:
+                return existing, "unchanged"
+
+            existing.desired_state = desired_state
+            existing.promotion_id = promotion_id or existing.promotion_id
+            existing.desired_at = now
+            existing.sync_status = DeploymentSyncStatus.PENDING
+            existing.sync_error = None
+            existing.sync_attempts = 0
+            existing.desired_generation = (existing.desired_generation or 0) + 1
+            saved = await self.repository.save_gateway_deployment(existing)
+            return saved, "updated"
+
+        deployment = GatewayDeployment(
+            id=uuid4(),
+            api_catalog_id=api.id,
+            gateway_instance_id=gateway.id,
+            desired_state=desired_state,
+            desired_at=now,
+            desired_generation=1,
+            synced_generation=0,
+            attempted_generation=0,
+            sync_status=DeploymentSyncStatus.PENDING,
+            sync_attempts=0,
+            promotion_id=promotion_id,
+        )
+        created = await self.repository.create_gateway_deployment(deployment)
+        return created, "created"
+
+    async def _resolve_promotion_gateway(
+        self,
+        tenant_id: str,
+        environment: str,
+        gateway_instance_id,
+        api: APICatalog,
+        actor: LifecycleActor,
+        *,
+        gateway_role: str,
+        source_environment: str | None = None,
+        target_environment: str | None = None,
+    ) -> GatewayTarget:
+        try:
+            return await self._resolve_gateway_target(tenant_id, environment, gateway_instance_id)
+        except (
+            ApiLifecycleGatewayNotFoundError,
+            ApiLifecycleGatewayAmbiguousError,
+            ApiLifecycleValidationError,
+        ) as exc:
+            failure_status = 404 if isinstance(exc, ApiLifecycleGatewayNotFoundError) else 409
+            if isinstance(exc, ApiLifecycleValidationError):
+                failure_status = 422
+            await self._audit_promotion_failure(
+                api,
+                actor,
+                source_environment=source_environment or environment,
+                target_environment=target_environment or environment,
+                code=f"{gateway_role}_gateway_{exc.__class__.__name__}",
+                message=str(exc),
+                status_code=failure_status,
+            )
+            raise
+
+    async def _upsert_promotion(
+        self,
+        *,
+        api: APICatalog,
+        actor: LifecycleActor,
+        source_environment: str,
+        target_environment: str,
+        source_deployment: GatewayDeployment,
+        target_gateway: GatewayTarget,
+        force: bool,
+    ) -> tuple[Promotion, str]:
+        active = await self.repository.get_active_promotion(
+            api.tenant_id,
+            api.api_id,
+            source_environment,
+            target_environment,
+        )
+        if active and not force:
+            return active, "unchanged"
+
+        if not force:
+            promoted = await self.repository.get_latest_promoted_promotion(
+                api.tenant_id,
+                api.api_id,
+                source_environment,
+                target_environment,
+            )
+            if promoted:
+                return promoted, "unchanged"
+
+        promotion = active if active and force else None
+        if promotion:
+            promotion.status = PromotionStatus.PROMOTING.value
+            promotion.source_deployment_id = source_deployment.id
+            promotion.target_gateway_ids = [str(target_gateway.id)]
+            promotion.completed_at = None
+            saved = await self.repository.save_promotion(promotion)
+            return saved, "updated"
+
+        requested_by = actor.email or actor.username or actor.actor_id or "system"
+        promotion = Promotion(
+            id=uuid4(),
+            tenant_id=api.tenant_id,
+            api_id=api.api_id,
+            source_environment=source_environment,
+            target_environment=target_environment,
+            source_deployment_id=source_deployment.id,
+            target_gateway_ids=[str(target_gateway.id)],
+            status=PromotionStatus.PROMOTING.value,
+            message=f"Lifecycle promotion {source_environment}->{target_environment}",
+            requested_by=requested_by,
+            approved_by=requested_by,
+        )
+        created = await self.repository.create_promotion(promotion)
+        return created, "created"
+
+    async def _complete_promotion_for_publication(
+        self,
+        *,
+        api: APICatalog,
+        actor: LifecycleActor,
+        environment: str,
+        gateway_instance_id: UUID,
+        deployment_id: UUID,
+    ) -> None:
+        promotion = await self.repository.get_active_promotion_for_target_deployment(
+            api.tenant_id,
+            api.api_id,
+            environment,
+            deployment_id,
+        )
+        if not promotion:
+            return
+
+        promotion.status = PromotionStatus.PROMOTED.value
+        promotion.target_deployment_id = deployment_id
+        promotion.completed_at = datetime.now(UTC)
+        saved = await self.repository.save_promotion(promotion)
+        await self.audit_sink.record_transition(
+            tenant_id=api.tenant_id,
+            actor=actor,
+            action="api_lifecycle.promotion_completed",
+            resource_id=api.api_id,
+            resource_name=api.api_name,
+            details={
+                "api_id": api.api_id,
+                "api_name": api.api_name,
+                "promotion_id": str(saved.id),
+                "source_environment": saved.source_environment,
+                "target_environment": saved.target_environment,
+                "target_gateway_instance_id": str(gateway_instance_id),
+                "target_deployment_id": str(deployment_id),
+                "promotion_status": saved.status,
+                "result": "promoted",
+            },
+            outcome="success",
+            status_code=200,
+            path=f"/v1/tenants/{api.tenant_id}/apis/{api.api_id}/lifecycle/promotions",
+        )
+
+    async def _audit_validation_failure(
+        self,
+        api: APICatalog,
+        actor: LifecycleActor,
+        *,
+        code: str,
+        message: str,
+        status_code: int,
+    ) -> None:
+        await self.audit_sink.record_transition(
+            tenant_id=api.tenant_id,
+            actor=actor,
+            action="api_lifecycle.validate_draft_failed",
+            resource_id=api.api_id,
+            resource_name=api.api_name,
+            details={
+                "api_id": api.api_id,
+                "api_name": api.api_name,
+                "version": api.version,
+                "catalog_status": api.status,
+                "validation": {
+                    "valid": False,
+                    "code": code,
+                    "message": message,
+                },
+            },
+            outcome="failure",
+            status_code=status_code,
+            path=f"/v1/tenants/{api.tenant_id}/apis/{api.api_id}/lifecycle/validate",
+        )
+
+    async def _audit_deploy_failure(
+        self,
+        api: APICatalog,
+        actor: LifecycleActor,
+        *,
+        environment: str,
+        code: str,
+        message: str,
+        status_code: int,
+    ) -> None:
+        await self.audit_sink.record_transition(
+            tenant_id=api.tenant_id,
+            actor=actor,
+            action="api_lifecycle.deploy_failed",
+            resource_id=api.api_id,
+            resource_name=api.api_name,
+            details={
+                "api_id": api.api_id,
+                "api_name": api.api_name,
+                "version": api.version,
+                "catalog_status": api.status,
+                "environment": environment,
+                "deployment": {
+                    "valid": False,
+                    "code": code,
+                    "message": message,
+                },
+            },
+            outcome="failure",
+            status_code=status_code,
+            path=f"/v1/tenants/{api.tenant_id}/apis/{api.api_id}/lifecycle/deployments",
+        )
+
+    async def _resolve_publish_gateway(
+        self,
+        tenant_id: str,
+        environment: str,
+        gateway_instance_id,
+        api: APICatalog,
+        actor: LifecycleActor,
+    ) -> GatewayTarget:
+        try:
+            return await self._resolve_gateway_target(tenant_id, environment, gateway_instance_id)
+        except (
+            ApiLifecycleGatewayNotFoundError,
+            ApiLifecycleGatewayAmbiguousError,
+            ApiLifecycleValidationError,
+        ) as exc:
+            failure_status = 404 if isinstance(exc, ApiLifecycleGatewayNotFoundError) else 409
+            if isinstance(exc, ApiLifecycleValidationError):
+                failure_status = 422
+            await self._audit_publish_failure(
+                api,
+                actor,
+                environment=environment,
+                code=exc.__class__.__name__,
+                message=str(exc),
+                status_code=failure_status,
+            )
+            raise
+
+    async def _validate_publishable_spec(
+        self,
+        api: APICatalog,
+        actor: LifecycleActor,
+        environment: str,
+        gateway_instance_id,
+        deployment_id,
+    ):
+        if not api.openapi_spec:
+            reference = _spec_state(api).reference
+            if reference:
+                code = "spec_reference_unresolved"
+                message = f"Spec reference cannot be resolved for publication: {reference}"
+            else:
+                code = "openapi_spec_missing"
+                message = "OpenAPI spec is required for portal publication"
+            await self._audit_publish_failure(
+                api,
+                actor,
+                environment=environment,
+                code=code,
+                message=message,
+                status_code=422,
+                gateway_instance_id=gateway_instance_id,
+                deployment_id=deployment_id,
+            )
+            raise ApiLifecycleSpecValidationError(code, message)
+
+        try:
+            return validate_openapi_contract(api.openapi_spec)
+        except ApiLifecycleSpecValidationError as exc:
+            await self._audit_publish_failure(
+                api,
+                actor,
+                environment=environment,
+                code=exc.code,
+                message=str(exc),
+                status_code=422,
+                gateway_instance_id=gateway_instance_id,
+                deployment_id=deployment_id,
+            )
+            raise
+
+    async def _audit_publish_failure(
+        self,
+        api: APICatalog,
+        actor: LifecycleActor,
+        *,
+        environment: str,
+        code: str,
+        message: str,
+        status_code: int,
+        gateway_instance_id=None,
+        deployment_id=None,
+    ) -> None:
+        await self.audit_sink.record_transition(
+            tenant_id=api.tenant_id,
+            actor=actor,
+            action="api_lifecycle.publish_failed",
+            resource_id=api.api_id,
+            resource_name=api.api_name,
+            details={
+                "api_id": api.api_id,
+                "api_name": api.api_name,
+                "version": api.version,
+                "catalog_status": api.status,
+                "environment": environment,
+                "gateway_instance_id": str(gateway_instance_id) if gateway_instance_id else None,
+                "deployment_id": str(deployment_id) if deployment_id else None,
+                "publication": {
+                    "valid": False,
+                    "code": code,
+                    "message": message,
+                },
+            },
+            outcome="failure",
+            status_code=status_code,
+            path=f"/v1/tenants/{api.tenant_id}/apis/{api.api_id}/lifecycle/publications",
+        )
+
+    async def _audit_promotion_failure(
+        self,
+        api: APICatalog,
+        actor: LifecycleActor,
+        *,
+        source_environment: str,
+        target_environment: str,
+        code: str,
+        message: str,
+        status_code: int,
+        source_gateway_instance_id=None,
+        target_gateway_instance_id=None,
+        source_deployment_id=None,
+        target_deployment_id=None,
+        promotion_id=None,
+    ) -> None:
+        await self.audit_sink.record_transition(
+            tenant_id=api.tenant_id,
+            actor=actor,
+            action="api_lifecycle.promotion_failed",
+            resource_id=api.api_id,
+            resource_name=api.api_name,
+            details={
+                "api_id": api.api_id,
+                "api_name": api.api_name,
+                "version": api.version,
+                "catalog_status": api.status,
+                "promotion_id": str(promotion_id) if promotion_id else None,
+                "source_environment": source_environment,
+                "target_environment": target_environment,
+                "source_gateway_instance_id": (str(source_gateway_instance_id) if source_gateway_instance_id else None),
+                "target_gateway_instance_id": (str(target_gateway_instance_id) if target_gateway_instance_id else None),
+                "source_deployment_id": str(source_deployment_id) if source_deployment_id else None,
+                "target_deployment_id": str(target_deployment_id) if target_deployment_id else None,
+                "promotion": {
+                    "valid": False,
+                    "code": code,
+                    "message": message,
+                },
+            },
+            outcome="failure",
+            status_code=status_code,
+            path=f"/v1/tenants/{api.tenant_id}/apis/{api.api_id}/lifecycle/promotions",
+        )
+
+
+def _slugify(value: str) -> str:
+    value = value.lower().strip()
+    value = re.sub(r"[^a-z0-9\s-]", "", value)
+    value = re.sub(r"[\s-]+", "-", value).strip("-")
+    return value or "api"
+
+
+def _normalize_deployment_environment(value: str) -> str:
+    environment = normalize_environment(value)
+    if environment not in {"dev", "staging", "production"}:
+        raise ApiLifecycleValidationError(f"Invalid deployment environment: {value}")
+    return environment
+
+
+def _wire_value(value: object) -> str:
+    return str(getattr(value, "value", value))
+
+
+def _promotion_result(promotion_action: str, deployment_action: str) -> str:
+    if promotion_action == "unchanged" and deployment_action == "unchanged":
+        return "unchanged"
+    if "created" in {promotion_action, deployment_action}:
+        return "requested"
+    return "updated"
+
+
+def _metadata(api: APICatalog) -> dict:
+    return api.api_metadata if isinstance(api.api_metadata, dict) else {}
+
+
+def _metadata_copy(api: APICatalog) -> dict:
+    return deepcopy(_metadata(api))
+
+
+def _spec_fingerprint(spec: object) -> str:
+    canonical = json.dumps(spec, sort_keys=True, separators=(",", ":"), default=str)
+    return sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _spec_state(api: APICatalog) -> ApiSpecState:
+    metadata = _metadata(api)
+    lifecycle = metadata.get("lifecycle") if isinstance(metadata.get("lifecycle"), dict) else {}
+    source = lifecycle.get("spec_source")
+    reference = lifecycle.get("spec_reference")
+    if api.openapi_spec:
+        source = "git" if api.git_path or api.git_commit_sha else source or "inline"
+    elif reference:
+        source = source or "reference"
+    else:
+        source = source or "missing"
+
+    return ApiSpecState(
+        source=source,
+        has_openapi_spec=bool(api.openapi_spec),
+        git_path=api.git_path,
+        git_commit_sha=api.git_commit_sha,
+        reference=reference,
+        fallback_reason=lifecycle.get("fallback_reason"),
+    )
+
+
+def _portal_state(api: APICatalog) -> PortalLifecycleState:
+    records = _portal_publication_records(api)
+    publications: list[PortalPublicationState] = []
+    for record in records:
+        try:
+            publications.append(
+                PortalPublicationState(
+                    environment=str(record["environment"]),
+                    gateway_instance_id=record["gateway_instance_id"],
+                    deployment_id=record["deployment_id"],
+                    publication_status=str(record["publication_status"]),
+                    result=str(record["result"]),
+                    spec_hash=str(record["spec_hash"]),
+                    published_at=record["published_at"],
+                )
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+
+    publications.sort(key=lambda item: item.published_at, reverse=True)
+    last = publications[0] if publications else None
+    return PortalLifecycleState(
+        published=bool(api.portal_published),
+        status="published" if api.portal_published else "not_published",
+        publications=publications,
+        last_result=last.result if last else None,
+        last_environment=last.environment if last else None,
+        last_gateway_instance_id=last.gateway_instance_id if last else None,
+        last_deployment_id=last.deployment_id if last else None,
+        last_published_at=last.published_at if last else None,
+    )
+
+
+def _portal_publication_record(api: APICatalog, environment: str, gateway_instance_id) -> dict | None:
+    metadata = _metadata(api)
+    lifecycle = metadata.get("lifecycle") if isinstance(metadata.get("lifecycle"), dict) else {}
+    publications = (
+        lifecycle.get("portal_publications") if isinstance(lifecycle.get("portal_publications"), dict) else {}
+    )
+    key = f"{environment}:{gateway_instance_id}"
+    record = publications.get(key)
+    return record if isinstance(record, dict) else None
+
+
+def _portal_publication_records(api: APICatalog) -> list[dict]:
+    metadata = _metadata(api)
+    lifecycle = metadata.get("lifecycle") if isinstance(metadata.get("lifecycle"), dict) else {}
+    publications = (
+        lifecycle.get("portal_publications") if isinstance(lifecycle.get("portal_publications"), dict) else {}
+    )
+    records: list[dict] = []
+    for raw in publications.values():
+        if not isinstance(raw, dict):
+            continue
+        parsed = dict(raw)
+        try:
+            from uuid import UUID
+
+            parsed["gateway_instance_id"] = UUID(str(parsed["gateway_instance_id"]))
+            parsed["deployment_id"] = UUID(str(parsed["deployment_id"]))
+            parsed["published_at"] = datetime.fromisoformat(str(parsed["published_at"]))
+        except (KeyError, TypeError, ValueError):
+            continue
+        records.append(parsed)
+    return records
+
+
+def _calculate_lifecycle_phase(
+    catalog_status: str,
+    portal_published: bool,
+    deployments: list[GatewayDeploymentState],
+    promotions: list[PromotionState],
+) -> str:
+    if catalog_status in {"archived", "failed"}:
+        return catalog_status
+    if any(deployment.sync_status == "error" for deployment in deployments):
+        return "failed"
+    if any(promotion.status == "failed" for promotion in promotions):
+        return "failed"
+    if any(promotion.status in {"pending", "promoting"} for promotion in promotions):
+        return "promoting"
+    if any(promotion.status == "promoted" for promotion in promotions):
+        return "promoted"
+    if portal_published:
+        return "published"
+    if any(deployment.sync_status == "synced" for deployment in deployments):
+        return "deployed"
+    return catalog_status
+
+
+def _last_error(
+    catalog_status: str,
+    deployments: list[GatewayDeploymentState],
+    promotions: list[PromotionState],
+) -> str | None:
+    if catalog_status == "failed":
+        return "catalog validation failed"
+    for deployment in deployments:
+        if deployment.sync_status == "error" and deployment.sync_error:
+            return deployment.sync_error
+    for promotion in promotions:
+        if promotion.status == "failed":
+            return promotion.message
+    return None

--- a/control-plane-api/src/services/catalog_reconciler/projection.py
+++ b/control-plane-api/src/services/catalog_reconciler/projection.py
@@ -15,8 +15,11 @@ Contract:
 * ``openapi_spec`` is Git-owned when an ``openapi.*`` or ``swagger.*`` sibling
   exists next to ``api.yaml``. The reconciler materializes it into
   ``api_catalog`` so runtime deployment sees the same contract as the Console.
+* Existing portal publication state is preserved and never derived from Git
+  tags. The lifecycle publication endpoint owns that state.
 * ``metadata`` is projected from ``api.yaml`` because Console fields such as
-  ``backend_url`` and ``display_name`` are read from that JSONB column.
+  ``backend_url`` and ``display_name`` are read from that JSONB column. The
+  lifecycle-owned ``metadata.lifecycle`` subtree is preserved on UPDATE.
 * The projection NEVER touches ``id`` (PK UUID) on UPDATE.
 * The projection may canonicalize ``api_id`` from a legacy UUID to the Git
   slug when the active row is uniquely identified by ``(tenant, api_name,
@@ -34,10 +37,10 @@ from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.catalog import APICatalog
+from src.services.api_lifecycle.portal_tags import strip_legacy_portal_publication_tags
 from src.services.catalog_api_definition import normalize_api_definition
 from src.services.gitops_writer.paths import is_uuid_shaped, parse_canonical_path
 
-_PORTAL_PUBLISHED_TAG = "portal:published"
 _DEFAULT_AUDIENCE = "public"
 _DEFAULT_STATUS = "active"
 
@@ -49,6 +52,8 @@ class ApiCatalogProjection:
     Spec §6.9 mapping table. ``target_gateways`` is intentionally absent
     because it is deployment-owned and preserved on UPDATE. ``openapi_spec`` is
     included because Git is the API-description source of truth.
+    ``portal_published`` is false on INSERT and preserved on UPDATE; Git tags
+    never publish an API.
     """
 
     tenant_id: str
@@ -128,8 +133,8 @@ def render_api_catalog_projection(
     if category is not None and not isinstance(category, str):
         raise ValueError("api.yaml 'category' must be a string when present")
 
-    tags = _coerce_tags(parsed_content.get("tags"))
-    portal_published = _PORTAL_PUBLISHED_TAG in tags
+    tags, _ignored_portal_tags = strip_legacy_portal_publication_tags(_coerce_tags(parsed_content.get("tags")))
+    portal_published = False
 
     audience = parsed_content.get("audience", _DEFAULT_AUDIENCE)
     if not isinstance(audience, str) or not audience:
@@ -196,12 +201,14 @@ def row_matches_projection(
 
     Compares only the projected fields (spec §6.6 + §6.9):
     ``api_id``, ``tenant_id``, ``api_name``, ``version``, ``status``,
-    ``category``, ``tags``, ``portal_published``, ``audience``,
-    ``api_metadata``, ``git_path``, ``git_commit_sha``,
-    ``catalog_content_hash`` and ``openapi_spec``.
+    ``category``, ``tags``, ``audience``, ``api_metadata``, ``git_path``,
+    ``git_commit_sha``, ``catalog_content_hash`` and ``openapi_spec``.
 
     Fields ``target_gateways``, ``id``, ``synced_at`` and ``deleted_at`` are
-    ignored — they are not under GitOps write authority.
+    ignored — they are not under GitOps write authority. ``portal_published`` is
+    also ignored because lifecycle publication owns it. The lifecycle-owned
+    ``api_metadata.lifecycle`` subtree is ignored because GitOps projections
+    preserve it on UPDATE.
     """
     expected_tags = list(expected.tags)
     actual_tags = list(actual_row.get("tags") or [])
@@ -217,9 +224,8 @@ def row_matches_projection(
         and actual_row.get("status") == expected.status
         and actual_row.get("category") == expected.category
         and actual_tags == expected_tags
-        and bool(actual_row.get("portal_published")) == expected.portal_published
         and actual_row.get("audience") == expected.audience
-        and actual_metadata == expected.api_metadata
+        and _without_lifecycle_metadata(actual_metadata) == _without_lifecycle_metadata(expected.api_metadata)
         and actual_row.get("git_path") == expected.git_path
         and actual_row.get("git_commit_sha") == expected.git_commit_sha
         and actual_row.get("catalog_content_hash") == expected.catalog_content_hash
@@ -286,12 +292,14 @@ async def project_to_api_catalog(
 
     INSERT path: a new row is created with ``id = gen_random_uuid()`` (default),
     ``metadata`` comes from ``api.yaml``, ``openapi_spec`` comes from the Git
-    sibling spec file when present and ``target_gateways = []`` (schema
-    default).
+    sibling spec file when present, ``portal_published = false`` and
+    ``target_gateways = []`` (schema default).
 
     UPDATE path: only the projected columns are written. ``target_gateways`` and
     the PK ``id`` are preserved by virtue of NOT being listed in the
-    ``.values()`` clause.
+    ``.values()`` clause. ``portal_published`` is likewise preserved. The
+    lifecycle-owned ``metadata.lifecycle`` subtree is merged back into the
+    projected metadata before the update is flushed.
 
     Spec §6.5 step 14, §6.9. NOT wired to the HTTP handler in Phase 4-1.
 
@@ -342,7 +350,7 @@ async def project_to_api_catalog(
             status=projection.status,
             category=projection.category,
             tags=list(projection.tags),
-            portal_published=projection.portal_published,
+            portal_published=False,
             audience=projection.audience,
             api_metadata=dict(projection.api_metadata),
             openapi_spec=projection.openapi_spec,
@@ -364,6 +372,7 @@ async def project_to_api_catalog(
             api_name=projection.api_name,
         )
 
+    metadata = _metadata_preserving_lifecycle(projection.api_metadata, existing.api_metadata)
     update_stmt = (
         update(APICatalog)
         .where(APICatalog.id == existing.id)
@@ -374,9 +383,8 @@ async def project_to_api_catalog(
             status=projection.status,
             category=projection.category,
             tags=list(projection.tags),
-            portal_published=projection.portal_published,
             audience=projection.audience,
-            api_metadata=dict(projection.api_metadata),
+            api_metadata=metadata,
             openapi_spec=projection.openapi_spec,
             git_path=projection.git_path,
             git_commit_sha=projection.git_commit_sha,
@@ -385,6 +393,21 @@ async def project_to_api_catalog(
     )
     await db_session.execute(update_stmt)
     await db_session.flush()
+
+
+def _metadata_preserving_lifecycle(projected: dict[str, Any], existing: Any) -> dict[str, Any]:
+    metadata = dict(projected)
+    if isinstance(existing, dict) and isinstance(existing.get("lifecycle"), dict):
+        metadata["lifecycle"] = dict(existing["lifecycle"])
+    return metadata
+
+
+def _without_lifecycle_metadata(metadata: Any) -> Any:
+    if not isinstance(metadata, dict):
+        return metadata
+    metadata = dict(metadata)
+    metadata.pop("lifecycle", None)
+    return metadata
 
 
 __all__ = [

--- a/control-plane-api/src/services/catalog_sync_service.py
+++ b/control-plane-api/src/services/catalog_sync_service.py
@@ -4,8 +4,8 @@ import logging
 import time
 from datetime import UTC, datetime
 
-from sqlalchemy import select, update
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy import cast, func, select, update
+from sqlalchemy.dialects.postgresql import JSONB, insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
@@ -18,6 +18,7 @@ from src.models.mcp_subscription import (
     MCPServerTool,
 )
 from src.models.tenant import Tenant, TenantProvisioningStatus, TenantStatus
+from src.services.api_lifecycle.portal_tags import strip_legacy_portal_publication_tags
 from src.services.catalog_api_definition import (
     extract_target_gateway_names,
     normalize_api_definition,
@@ -36,6 +37,20 @@ def resolve_api_config(base: dict, override: dict | None) -> dict:
     if not override:
         return {**base}
     return {**base, **override}
+
+
+def metadata_update_preserving_lifecycle(projected_metadata: dict):
+    """Return a JSONB update expression that preserves lifecycle-owned metadata.
+
+    Catalog sync owns the Git-projected metadata fields, but lifecycle
+    publication state is runtime-owned and stored under
+    ``metadata.lifecycle``. On conflict updates must not drop that subtree.
+    """
+    return func.jsonb_strip_nulls(
+        cast(projected_metadata, JSONB).op("||")(
+            func.jsonb_build_object("lifecycle", APICatalog.api_metadata["lifecycle"])
+        )
+    )
 
 
 class CatalogSyncService:
@@ -277,9 +292,17 @@ class CatalogSyncService:
         api = normalize_api_definition(resolve_api_config(api, override))
 
         git_path = f"tenants/{tenant_id}/apis/{api_id}"
-        tags = api.get("tags", [])
-        promotion_tags = {"portal:published", "promoted:portal", "portal-promoted"}
-        portal_published = any(tag.lower() in promotion_tags for tag in tags)
+        tags, ignored_portal_tags = strip_legacy_portal_publication_tags(api.get("tags", []))
+        if ignored_portal_tags:
+            logger.warning(
+                "catalog_sync.portal_publication_tags_ignored",
+                extra={
+                    "tenant_id": tenant_id,
+                    "api_id": api_id,
+                    "ignored_tags": ignored_portal_tags,
+                },
+            )
+        api = {**api, "tags": tags}
 
         # Extract explicit target gateways from api.yaml. Environment-only
         # deployments (e.g. deployments.dev=true) are not enough to identify a
@@ -296,7 +319,7 @@ class CatalogSyncService:
                 status=api.get("status", "active"),
                 category=api.get("category"),
                 tags=tags,
-                portal_published=portal_published,
+                portal_published=False,
                 api_metadata=api,
                 openapi_spec=openapi_spec,
                 git_path=git_path,
@@ -314,8 +337,7 @@ class CatalogSyncService:
                     APICatalog.status: api.get("status", "active"),
                     APICatalog.category: api.get("category"),
                     APICatalog.tags: tags,
-                    APICatalog.portal_published: portal_published,
-                    APICatalog.api_metadata: api,
+                    APICatalog.api_metadata: metadata_update_preserving_lifecycle(api),
                     APICatalog.openapi_spec: openapi_spec,
                     APICatalog.git_commit_sha: commit_sha,
                     APICatalog.target_gateways: target_gateways,

--- a/control-plane-api/src/services/deployment_orchestration_service.py
+++ b/control-plane-api/src/services/deployment_orchestration_service.py
@@ -31,6 +31,7 @@ from ..services.gateway_topology import normalize_gateway_topology
 logger = logging.getLogger(__name__)
 
 HTTP_METHODS = {"get", "post", "put", "patch", "delete", "head", "options", "trace"}
+LIFECYCLE_DEPLOYMENT_ENDPOINT = "POST /v1/tenants/{tenant_id}/apis/{api_id}/lifecycle/deployments"
 
 
 @dataclass(frozen=True)
@@ -167,8 +168,7 @@ class DeploymentOrchestrationService:
             return entry
 
         raise ValueError(
-            f"API '{api_identifier}' not found for tenant '{tenant_id}'. "
-            f"Ensure the API exists in the Git repository."
+            f"API '{api_identifier}' not found for tenant '{tenant_id}'. Ensure the API exists in the Git repository."
         )
 
     async def _sync_api_from_git(self, tenant_id: str, api_id: str) -> APICatalog | None:
@@ -256,6 +256,10 @@ class DeploymentOrchestrationService:
 
         # 1. Resolve API to catalog entry (sync from Git if needed)
         api_catalog = await self._resolve_api_catalog(tenant_id, api_identifier)
+        if _is_lifecycle_managed_catalog(api_catalog):
+            raise ValueError(
+                f"API '{api_catalog.api_id}' is lifecycle-managed. Use {LIFECYCLE_DEPLOYMENT_ENDPOINT} instead."
+            )
 
         # 2. Validate promotion prerequisite (staging/prod only — dev is no-ceremony)
         if environment != "dev":
@@ -436,8 +440,16 @@ class DeploymentOrchestrationService:
                 tenant_id,
             )
             return []
-
         target_environment = normalize_deployment_environment(target_environment) or target_environment
+        if _is_lifecycle_managed_catalog(api_catalog):
+            logger.info(
+                "Auto-deploy skipped for lifecycle-managed api=%s tenant=%s env=%s",
+                api_catalog.api_id,
+                tenant_id,
+                target_environment,
+            )
+            return []
+
         if gateway_ids is None:
             assignments = await self.assignment_repo.list_auto_deploy(api_catalog.id, target_environment)
             if not assignments:
@@ -807,3 +819,8 @@ class DeploymentOrchestrationService:
                     f"Gateway '{gateway.name}' is in environment '{gateway.environment}', "
                     f"not '{environment}'. Select gateways matching the target environment."
                 )
+
+
+def _is_lifecycle_managed_catalog(api_catalog: object) -> bool:
+    metadata = getattr(api_catalog, "api_metadata", None)
+    return isinstance(metadata, dict) and isinstance(metadata.get("lifecycle"), dict)

--- a/control-plane-api/src/services/deployment_service.py
+++ b/control-plane-api/src/services/deployment_service.py
@@ -1,7 +1,9 @@
 """Deployment service — business logic for deployment lifecycle (CAB-1353, CAB-1410)"""
 
 import logging
+from contextlib import suppress
 from datetime import datetime
+from inspect import isawaitable
 from uuid import UUID
 
 from sqlalchemy import or_, select
@@ -27,6 +29,12 @@ from src.services.kafka_service import Topics, kafka_service
 
 logger = logging.getLogger(__name__)
 
+LIFECYCLE_DEPLOYMENT_ENDPOINT = "POST /v1/tenants/{tenant_id}/apis/{api_id}/lifecycle/deployments"
+
+
+class LifecycleDeploymentPathError(ValueError):
+    """Raised when the legacy Deployment path is used for a lifecycle-managed API."""
+
 
 class DeploymentService:
     def __init__(self, db: AsyncSession):
@@ -45,6 +53,12 @@ class DeploymentService:
         user_id: str,
         gateway_id: str | None = None,
     ) -> Deployment:
+        await self._raise_if_lifecycle_managed_api(
+            tenant_id=tenant_id,
+            api_id=api_id,
+            api_name=api_name,
+            action="create legacy deployment",
+        )
         deployment = Deployment(
             tenant_id=tenant_id,
             api_id=api_id,
@@ -151,6 +165,12 @@ class DeploymentService:
         original = await self.repo.get_by_id_and_tenant(deployment_id, tenant_id)
         if not original:
             raise ValueError(f"Deployment {deployment_id} not found")
+        await self._raise_if_lifecycle_managed_api(
+            tenant_id=tenant_id,
+            api_id=original.api_id,
+            api_name=original.api_name,
+            action="rollback legacy deployment",
+        )
         if not target_version:
             prev = await self.repo.get_latest_success(tenant_id, original.api_id, original.environment)
             target_version = prev.version if prev else "previous"
@@ -201,6 +221,12 @@ class DeploymentService:
         deployment = await self.repo.get_by_id_and_tenant(deployment_id, tenant_id)
         if not deployment:
             raise ValueError(f"Deployment {deployment_id} not found")
+        await self._raise_if_lifecycle_managed_api(
+            tenant_id=tenant_id,
+            api_id=deployment.api_id,
+            api_name=deployment.api_name,
+            action="update legacy deployment status",
+        )
         deployment.status = status
         deployment.updated_at = datetime.utcnow()
         if error_message is not None:
@@ -336,3 +362,48 @@ class DeploymentService:
             after_seq=after_seq,
             limit=limit,
         )
+
+    async def _raise_if_lifecycle_managed_api(
+        self,
+        *,
+        tenant_id: str,
+        api_id: str,
+        api_name: str | None = None,
+        action: str,
+    ) -> None:
+        api = await self._find_lifecycle_catalog_entry(tenant_id=tenant_id, api_id=api_id, api_name=api_name)
+        if not api:
+            return
+        raise LifecycleDeploymentPathError(
+            f"Cannot {action} for lifecycle-managed API '{api.api_id}'. Use {LIFECYCLE_DEPLOYMENT_ENDPOINT} instead."
+        )
+
+    async def _find_lifecycle_catalog_entry(
+        self,
+        *,
+        tenant_id: str,
+        api_id: str,
+        api_name: str | None = None,
+    ) -> APICatalog | None:
+        matches = [APICatalog.api_id == api_id, APICatalog.api_name == api_id]
+        if api_name:
+            matches.extend([APICatalog.api_id == api_name, APICatalog.api_name == api_name])
+        with suppress(ValueError):
+            matches.append(APICatalog.id == UUID(str(api_id)))
+
+        result = await self.db.execute(
+            select(APICatalog).where(
+                APICatalog.tenant_id == tenant_id,
+                APICatalog.deleted_at.is_(None),
+                or_(*matches),
+            )
+        )
+        api = result.scalar_one_or_none()
+        if isawaitable(api):
+            api = await api
+        return api if _is_lifecycle_managed_catalog(api) else None
+
+
+def _is_lifecycle_managed_catalog(api: object) -> bool:
+    metadata = getattr(api, "api_metadata", None)
+    return isinstance(metadata, dict) and isinstance(metadata.get("lifecycle"), dict)

--- a/control-plane-api/src/services/gateway_deployment_service.py
+++ b/control-plane-api/src/services/gateway_deployment_service.py
@@ -23,6 +23,8 @@ from src.services.sync_step_tracker import SyncStepTracker
 
 logger = logging.getLogger(__name__)
 
+LIFECYCLE_DEPLOYMENT_ENDPOINT = "POST /v1/tenants/{tenant_id}/apis/{api_id}/lifecycle/deployments"
+
 
 class GatewayDeploymentService:
     """Business logic for deploying APIs to gateways."""
@@ -131,6 +133,10 @@ class GatewayDeploymentService:
         api_catalog = result.scalar_one_or_none()
         if not api_catalog:
             raise ValueError("API catalog entry not found")
+        if _is_lifecycle_managed_catalog(api_catalog):
+            raise PermissionError(
+                f"API '{api_catalog.api_id}' is lifecycle-managed. Use {LIFECYCLE_DEPLOYMENT_ENDPOINT} instead."
+            )
 
         now = datetime.now(UTC)
         deployments: list[GatewayDeployment] = []
@@ -140,7 +146,7 @@ class GatewayDeploymentService:
             if not gateway:
                 raise ValueError(f"Gateway instance {gw_id} not found")
             if not gateway.enabled:
-                raise PermissionError(f"Gateway '{gateway.name}' is disabled. " f"Enable it before deploying.")
+                raise PermissionError(f"Gateway '{gateway.name}' is disabled. Enable it before deploying.")
             if self._requires_git_backed_desired_state(gateway) and not getattr(api_catalog, "git_commit_sha", None):
                 raise PermissionError(
                     "Production deployment requires a Git-backed UAC/catalog desired state "
@@ -151,6 +157,9 @@ class GatewayDeploymentService:
             desired_state = self.build_desired_state_for_gateway(api_catalog, gateway, target_source="direct")
 
             if existing:
+                if existing.desired_state == desired_state:
+                    deployments.append(existing)
+                    continue
                 existing.desired_state = desired_state
                 existing.desired_at = now
                 existing.sync_status = DeploymentSyncStatus.PENDING
@@ -204,6 +213,7 @@ class GatewayDeploymentService:
         deployment = await self.deploy_repo.get_by_id(deployment_id)
         if not deployment:
             raise ValueError("Deployment not found")
+        await self._raise_if_lifecycle_managed_deployment(deployment)
 
         if deployment.gateway_resource_id:
             deployment.sync_status = DeploymentSyncStatus.DELETING
@@ -217,6 +227,7 @@ class GatewayDeploymentService:
         deployment = await self.deploy_repo.get_by_id(deployment_id)
         if not deployment:
             raise ValueError("Deployment not found")
+        await self._raise_if_lifecycle_managed_deployment(deployment)
 
         deployment.sync_status = DeploymentSyncStatus.PENDING
         deployment.sync_error = None
@@ -273,3 +284,17 @@ class GatewayDeploymentService:
                 )
             except Exception as e:
                 logger.warning("Failed to emit SSE event for deployment %s: %s", dep.id, e)
+
+    async def _raise_if_lifecycle_managed_deployment(self, deployment: GatewayDeployment) -> None:
+        result = await self.db.execute(select(APICatalog).where(APICatalog.id == deployment.api_catalog_id))
+        api_catalog = result.scalar_one_or_none()
+        if _is_lifecycle_managed_catalog(api_catalog):
+            raise ValueError(
+                f"GatewayDeployment '{deployment.id}' belongs to lifecycle-managed API "
+                f"'{api_catalog.api_id}'. Use lifecycle operations instead."
+            )
+
+
+def _is_lifecycle_managed_catalog(api_catalog: object) -> bool:
+    metadata = getattr(api_catalog, "api_metadata", None)
+    return isinstance(metadata, dict) and isinstance(metadata.get("lifecycle"), dict)

--- a/control-plane-api/src/services/promotion_service.py
+++ b/control-plane-api/src/services/promotion_service.py
@@ -9,16 +9,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import settings
 from ..models.catalog import APICatalog
-from ..models.gateway_deployment import DeploymentSyncStatus
+from ..models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment
 from ..models.gateway_instance import GatewayInstance
 from ..models.promotion import Promotion, PromotionStatus, validate_promotion_chain
 from ..notifications.promotion_notifier import notify_promotion_event
-from ..repositories.deployment import DeploymentRepository
 from ..repositories.gateway_deployment import GatewayDeploymentRepository
 from ..repositories.promotion import PromotionRepository
 from ..services.environment_aliases import deployment_environment_matches
 from ..services.gateway_topology import normalize_gateway_topology
-from ..services.kafka_service import Topics, kafka_service
+from ..services.kafka_service import kafka_service
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +26,6 @@ class PromotionService:
     def __init__(self, db: AsyncSession):
         self.db = db
         self.repo = PromotionRepository(db)
-        self.deployment_repo = DeploymentRepository(db)
         self.gw_deploy_repo = GatewayDeploymentRepository(db)
 
     async def create_promotion(
@@ -288,8 +286,7 @@ class PromotionService:
             raise ValueError(f"Promotion {promotion_id} not found")
         if promotion.status != PromotionStatus.PENDING.value:
             raise ValueError(
-                f"Cannot approve promotion in status '{promotion.status}' "
-                f"(expected '{PromotionStatus.PENDING.value}')"
+                f"Cannot approve promotion in status '{promotion.status}' (expected '{PromotionStatus.PENDING.value}')"
             )
         # 4-eyes principle: self-approval blocked for production promotions
         if promotion.requested_by == approved_by and promotion.target_environment == "production":
@@ -301,25 +298,7 @@ class PromotionService:
         target_gateway_ids = self._parse_target_gateway_ids(promotion.target_gateway_ids)
         if not target_gateway_ids:
             raise ValueError(
-                "Cannot approve promotion without explicit target gateways. " "Create a new gateway-aware promotion."
-            )
-
-        # Trigger deployment before the state transition so no promotion can
-        # enter PROMOTING without at least one linked GatewayDeployment.
-        from ..services.deployment_orchestration_service import DeploymentOrchestrationService
-
-        orchestration_svc = DeploymentOrchestrationService(self.db)
-        deployments = await orchestration_svc.auto_deploy_on_promotion(
-            api_id=promotion.api_id,
-            tenant_id=tenant_id,
-            target_environment=promotion.target_environment,
-            approved_by=approved_by,
-            promotion_id=promotion.id,
-            gateway_ids=target_gateway_ids,
-        )
-        if not deployments:
-            raise ValueError(
-                "Promotion approval did not create any gateway deployment. " "Check the selected target gateways."
+                "Cannot approve promotion without explicit target gateways. Create a new gateway-aware promotion."
             )
 
         promotion.status = PromotionStatus.PROMOTING.value
@@ -327,27 +306,9 @@ class PromotionService:
         promotion = await self.repo.update(promotion)
 
         logger.info(
-            "Promotion %s approved by %s; %d gateway deployments linked",
+            "Promotion %s approved by %s; deployment execution is owned by ApiLifecycleService",
             promotion_id,
             approved_by,
-            len(deployments),
-        )
-
-        await kafka_service.publish(
-            topic=Topics.DEPLOY_REQUESTS,
-            event_type="promotion-approved",
-            tenant_id=tenant_id,
-            payload={
-                "promotion_id": str(promotion.id),
-                "api_id": promotion.api_id,
-                "source_environment": promotion.source_environment,
-                "target_environment": promotion.target_environment,
-                "approved_by": approved_by,
-                "target_gateway_ids": [str(gateway_id) for gateway_id in target_gateway_ids],
-                "gateway_deployment_ids": [str(getattr(deployment, "id", deployment)) for deployment in deployments],
-                "gateway_deployments_created": True,
-            },
-            user_id=user_id,
         )
 
         await notify_promotion_event(
@@ -538,17 +499,42 @@ class PromotionService:
         }
 
     async def _get_deployment_spec(self, tenant_id: str, api_id: str, environment: str) -> dict | None:
-        """Fetch the latest successful deployment spec for an environment."""
-        deployment = await self.deployment_repo.get_latest_success(
-            tenant_id=tenant_id, api_id=api_id, environment=environment
+        """Fetch the latest synced GatewayDeployment snapshot for an environment."""
+        result = await self.db.execute(
+            select(GatewayDeployment, GatewayInstance, APICatalog)
+            .join(APICatalog, GatewayDeployment.api_catalog_id == APICatalog.id)
+            .join(GatewayInstance, GatewayDeployment.gateway_instance_id == GatewayInstance.id)
+            .where(
+                APICatalog.tenant_id == tenant_id,
+                APICatalog.api_id == api_id,
+                APICatalog.deleted_at.is_(None),
+                GatewayInstance.deleted_at.is_(None),
+            )
         )
-        if not deployment:
+        candidates = [
+            (deployment, gateway, catalog)
+            for deployment, gateway, catalog in result.all()
+            if deployment_environment_matches(gateway.environment, environment)
+            and self._wire_value(deployment.sync_status) == DeploymentSyncStatus.SYNCED.value
+        ]
+        if not candidates:
             return None
+        deployment, gateway, catalog = max(
+            candidates,
+            key=lambda item: item[0].last_sync_success or item[0].desired_at or item[0].created_at,
+        )
+        desired_state = deployment.desired_state if isinstance(deployment.desired_state, dict) else {}
         return {
             "deployment_id": str(deployment.id),
-            "version": deployment.version,
-            "spec_hash": deployment.spec_hash,
-            "commit_sha": deployment.commit_sha,
-            "deployed_by": deployment.deployed_by,
-            "completed_at": deployment.completed_at.isoformat() if deployment.completed_at else None,
+            "gateway_instance_id": str(gateway.id),
+            "gateway_name": gateway.name,
+            "environment": gateway.environment,
+            "api_catalog_id": str(catalog.id),
+            "version": catalog.version,
+            "spec_hash": desired_state.get("spec_hash") or desired_state.get("openapi_spec_hash"),
+            "desired_generation": deployment.desired_generation,
+            "synced_generation": deployment.synced_generation,
+            "sync_status": self._wire_value(deployment.sync_status),
+            "gateway_resource_id": deployment.gateway_resource_id,
+            "last_sync_success": (deployment.last_sync_success.isoformat() if deployment.last_sync_success else None),
         }

--- a/control-plane-api/tests/services/catalog_reconciler/test_projection.py
+++ b/control-plane-api/tests/services/catalog_reconciler/test_projection.py
@@ -83,15 +83,17 @@ class TestRenderApiCatalogProjection:
         assert proj.git_commit_sha == "a" * 40
         assert proj.catalog_content_hash == "b" * 64
 
-    def test_portal_published_tag_promoted(self) -> None:
+    @pytest.mark.parametrize("portal_tag", ["portal:published", "promoted:portal", "portal-promoted"])
+    def test_portal_publication_tags_are_stripped_and_do_not_publish(self, portal_tag: str) -> None:
         proj = render_api_catalog_projection(
-            parsed_content=_minimal_yaml(tags=["portal:published", "banking"]),
+            parsed_content=_minimal_yaml(tags=[portal_tag, "banking"]),
             git_commit_sha="a" * 40,
             catalog_content_hash="b" * 64,
             git_path="tenants/demo/apis/petstore/api.yaml",
         )
-        assert proj.portal_published is True
-        assert proj.tags == ["portal:published", "banking"]
+        assert proj.portal_published is False
+        assert proj.tags == ["banking"]
+        assert proj.api_metadata["tags"] == ["banking"]
 
     def test_portal_not_published_when_tag_absent(self) -> None:
         proj = render_api_catalog_projection(
@@ -240,8 +242,8 @@ class TestRowMatchesProjection:
             version="1.0.0",
             status="active",
             category="Banking",
-            tags=["portal:published"],
-            portal_published=True,
+            tags=["banking"],
+            portal_published=False,
             audience="public",
             api_metadata={
                 "name": "petstore",
@@ -251,7 +253,7 @@ class TestRowMatchesProjection:
                 "backend_url": "http://example.invalid",
                 "status": "active",
                 "deployments": {"dev": True, "staging": False},
-                "tags": ["portal:published"],
+                "tags": ["banking"],
                 "audience": "public",
             },
             git_path="tenants/demo/apis/petstore/api.yaml",
@@ -321,6 +323,22 @@ class TestRowMatchesProjection:
         matching_row["api_metadata"] = {**projection.api_metadata, "backend_url": "https://other.example"}
         assert row_matches_projection(matching_row, projection) is False
 
+    def test_lifecycle_metadata_is_ignored_by_gitops_projection(
+        self, projection: ApiCatalogProjection, matching_row: dict[str, Any]
+    ) -> None:
+        matching_row["api_metadata"] = {
+            **projection.api_metadata,
+            "lifecycle": {
+                "portal_publications": {
+                    "dev:00000000-0000-4000-8000-000000000001": {
+                        "publication_status": "published",
+                        "source": "api_lifecycle",
+                    }
+                }
+            },
+        }
+        assert row_matches_projection(matching_row, projection) is True
+
     def test_catalog_content_hash_mismatch_returns_false(
         self, projection: ApiCatalogProjection, matching_row: dict[str, Any]
     ) -> None:
@@ -329,8 +347,8 @@ class TestRowMatchesProjection:
 
     def test_tags_order_matters(self, projection: ApiCatalogProjection, matching_row: dict[str, Any]) -> None:
         # Add a second tag in projection
-        proj = ApiCatalogProjection(**{**projection.__dict__, "tags": ["portal:published", "banking"]})
-        matching_row["tags"] = ["banking", "portal:published"]
+        proj = ApiCatalogProjection(**{**projection.__dict__, "tags": ["banking", "regulated"]})
+        matching_row["tags"] = ["regulated", "banking"]
         assert row_matches_projection(matching_row, proj) is False
 
     def test_status_mismatch_returns_false(
@@ -339,11 +357,11 @@ class TestRowMatchesProjection:
         matching_row["status"] = "draft"
         assert row_matches_projection(matching_row, projection) is False
 
-    def test_portal_published_mismatch_returns_false(
+    def test_portal_published_is_ignored_by_gitops_projection(
         self, projection: ApiCatalogProjection, matching_row: dict[str, Any]
     ) -> None:
-        matching_row["portal_published"] = False
-        assert row_matches_projection(matching_row, projection) is False
+        matching_row["portal_published"] = True
+        assert row_matches_projection(matching_row, projection) is True
 
     def test_missing_field_returns_false(self, projection: ApiCatalogProjection, matching_row: dict[str, Any]) -> None:
         del matching_row["catalog_content_hash"]

--- a/control-plane-api/tests/services/catalog_reconciler/test_projection_db.py
+++ b/control-plane-api/tests/services/catalog_reconciler/test_projection_db.py
@@ -5,7 +5,8 @@ Spec §6.5 step 14, §6.9 (CAB-2186 B-WORKER, CAB-2180 B-CATALOG).
 These tests use the ``integration_db`` fixture (PostgreSQL) and are skipped
 automatically when ``DATABASE_URL`` is not set. They verify the contract
 that GitOps writes NEVER touch ``target_gateways`` and always project
-``metadata`` / ``openapi_spec`` from Git on UPDATE.
+``metadata`` / ``openapi_spec`` from Git on UPDATE while preserving
+``portal_published`` and lifecycle metadata.
 """
 
 from __future__ import annotations
@@ -41,8 +42,8 @@ def _projection(
         version=version,
         status="active",
         category="Banking",
-        tags=["portal:published", "banking"],
-        portal_published=True,
+        tags=["banking"],
+        portal_published=False,
         audience="public",
         api_metadata={
             "name": api_id,
@@ -52,7 +53,7 @@ def _projection(
             "backend_url": "http://example.invalid",
             "status": "active",
             "deployments": {"dev": True, "staging": False},
-            "tags": ["portal:published", "banking"],
+            "tags": ["banking"],
             "category": "Banking",
             "audience": "public",
         },
@@ -82,8 +83,8 @@ async def test_insert_creates_row_with_defaults(integration_db) -> None:
     assert row.version == "1.0.0"
     assert row.status == "active"
     assert row.category == "Banking"
-    assert row.tags == ["portal:published", "banking"]
-    assert row.portal_published is True
+    assert row.tags == ["banking"]
+    assert row.portal_published is False
     assert row.audience == "public"
     assert row.git_path == "tenants/demo-gitops/apis/petstore/api.yaml"
     assert row.git_commit_sha == "a" * 40
@@ -95,18 +96,30 @@ async def test_insert_creates_row_with_defaults(integration_db) -> None:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_update_preserves_target_gateways(integration_db) -> None:
-    """A pre-existing row keeps target_gateways but takes openapi_spec from Git."""
+async def test_update_preserves_runtime_and_portal_fields(integration_db) -> None:
+    """A pre-existing row keeps lifecycle-owned fields on UPDATE."""
     existing = APICatalog(
         tenant_id="demo-gitops",
         api_id="petstore",
         api_name="petstore",
         version="1.0.0",
         status="active",
-        tags=[],
-        portal_published=False,
+        tags=["old"],
+        portal_published=True,
         audience="public",
-        api_metadata={"display_name": "Manually set", "backend_url": "http://legacy"},
+        api_metadata={
+            "display_name": "Manually set",
+            "backend_url": "http://legacy",
+            "lifecycle": {
+                "catalog_status": "ready",
+                "portal_publications": {
+                    "dev:00000000-0000-4000-8000-000000000001": {
+                        "publication_status": "published",
+                        "source": "api_lifecycle",
+                    }
+                },
+            },
+        },
         openapi_spec={"openapi": "3.0.0", "info": {"title": "Pet"}},
         target_gateways=["webmethods-prod", "kong-staging"],
     )
@@ -128,13 +141,18 @@ async def test_update_preserves_target_gateways(integration_db) -> None:
     assert row.git_commit_sha == "c" * 40
     assert row.catalog_content_hash == "d" * 64
     assert row.category == "Banking"
-    assert row.tags == ["portal:published", "banking"]
+    assert row.tags == ["banking"]
     assert row.portal_published is True
     # Deployment-owned field preserved; Git-owned OpenAPI is replaced.
     assert row.target_gateways == ["webmethods-prod", "kong-staging"]
     assert row.openapi_spec == projected_spec
     assert row.api_metadata["display_name"] == "petstore"
     assert row.api_metadata["backend_url"] == "http://example.invalid"
+    assert row.api_metadata["lifecycle"]["catalog_status"] == "ready"
+    assert (
+        row.api_metadata["lifecycle"]["portal_publications"]["dev:00000000-0000-4000-8000-000000000001"]["source"]
+        == "api_lifecycle"
+    )
 
 
 @pytest.mark.integration

--- a/control-plane-api/tests/test_api_lifecycle_deploy.py
+++ b/control-plane-api/tests/test_api_lifecycle_deploy.py
@@ -1,0 +1,349 @@
+"""Deployment tests for the canonical API lifecycle service, Slice 3."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.models.catalog import APICatalog
+from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment
+from src.services.api_lifecycle.errors import (
+    ApiLifecycleGatewayAmbiguousError,
+    ApiLifecycleGatewayNotFoundError,
+    ApiLifecycleNotFoundError,
+    ApiLifecycleTransitionError,
+)
+from src.services.api_lifecycle.ports import (
+    DeployApiCommand,
+    GatewayDeploymentSnapshot,
+    GatewayTarget,
+    LifecycleActor,
+    PromotionSnapshot,
+)
+from src.services.api_lifecycle.service import ApiLifecycleService
+
+OPENAPI_SPEC: dict[str, Any] = {
+    "openapi": "3.0.3",
+    "info": {"title": "Payments API", "version": "1.0.0"},
+    "paths": {"/payments": {"get": {"responses": {"200": {"description": "ok"}}}}},
+}
+
+
+@dataclass
+class InMemoryApiLifecycleRepository:
+    apis: dict[tuple[str, str], APICatalog] = field(default_factory=dict)
+    gateways: dict[UUID, GatewayTarget] = field(default_factory=dict)
+    deployments: dict[tuple[UUID, UUID], GatewayDeployment] = field(default_factory=dict)
+
+    async def get_api_by_id(self, tenant_id: str, api_id: str) -> APICatalog | None:
+        return self.apis.get((tenant_id, api_id))
+
+    async def get_api_by_name_version(self, tenant_id: str, api_name: str, version: str) -> APICatalog | None:
+        return next(
+            (
+                row
+                for (row_tenant_id, _), row in self.apis.items()
+                if row_tenant_id == tenant_id and row.api_name == api_name and row.version == version
+            ),
+            None,
+        )
+
+    async def create_api_catalog(self, api: APICatalog) -> APICatalog:
+        self.apis[(api.tenant_id, api.api_id)] = api
+        return api
+
+    async def save_api_catalog(self, api: APICatalog) -> APICatalog:
+        self.apis[(api.tenant_id, api.api_id)] = api
+        return api
+
+    async def list_gateway_deployments(self, api_catalog_id: UUID) -> list[GatewayDeploymentSnapshot]:
+        snapshots: list[GatewayDeploymentSnapshot] = []
+        for (row_api_catalog_id, gateway_id), deployment in self.deployments.items():
+            if row_api_catalog_id != api_catalog_id:
+                continue
+            gateway = self.gateways[gateway_id]
+            snapshots.append(
+                GatewayDeploymentSnapshot(
+                    id=deployment.id,
+                    environment=gateway.environment,
+                    gateway_instance_id=gateway.id,
+                    gateway_name=gateway.name,
+                    gateway_type=gateway.gateway_type,
+                    sync_status=str(deployment.sync_status),
+                    desired_generation=deployment.desired_generation,
+                    synced_generation=deployment.synced_generation,
+                    gateway_resource_id=deployment.gateway_resource_id,
+                    public_url=gateway.public_url,
+                    sync_error=deployment.sync_error,
+                    last_sync_success=deployment.last_sync_success,
+                )
+            )
+        return snapshots
+
+    async def get_gateway_target(self, tenant_id: str, gateway_instance_id: UUID) -> GatewayTarget | None:
+        gateway = self.gateways.get(gateway_instance_id)
+        if not gateway or gateway.tenant_id not in (None, tenant_id):
+            return None
+        return gateway
+
+    async def list_gateway_targets(self, tenant_id: str, environment: str) -> list[GatewayTarget]:
+        return [
+            gateway
+            for gateway in self.gateways.values()
+            if gateway.enabled and gateway.environment == environment and gateway.tenant_id in (None, tenant_id)
+        ]
+
+    async def get_gateway_deployment(self, api_catalog_id: UUID, gateway_instance_id: UUID) -> GatewayDeployment | None:
+        return self.deployments.get((api_catalog_id, gateway_instance_id))
+
+    async def create_gateway_deployment(self, deployment: GatewayDeployment) -> GatewayDeployment:
+        self.deployments[(deployment.api_catalog_id, deployment.gateway_instance_id)] = deployment
+        return deployment
+
+    async def save_gateway_deployment(self, deployment: GatewayDeployment) -> GatewayDeployment:
+        self.deployments[(deployment.api_catalog_id, deployment.gateway_instance_id)] = deployment
+        return deployment
+
+    async def list_promotions(self, tenant_id: str, api_id: str) -> list[PromotionSnapshot]:
+        return []
+
+
+@dataclass
+class InMemoryAuditSink:
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    async def record_transition(
+        self,
+        *,
+        tenant_id: str,
+        actor: LifecycleActor,
+        action: str,
+        resource_id: str,
+        resource_name: str,
+        details: dict[str, Any],
+        outcome: str = "success",
+        status_code: int = 200,
+        method: str = "POST",
+        path: str | None = None,
+    ) -> None:
+        self.events.append(
+            {
+                "tenant_id": tenant_id,
+                "actor": actor,
+                "action": action,
+                "resource_id": resource_id,
+                "resource_name": resource_name,
+                "details": details,
+                "outcome": outcome,
+                "status_code": status_code,
+                "method": method,
+                "path": path,
+            }
+        )
+
+
+def _actor() -> LifecycleActor:
+    return LifecycleActor(actor_id="user-1", email="owner@acme.test", username="owner")
+
+
+def _api(status: str = "ready", tenant_id: str = "acme", api_id: str = "payments-api") -> APICatalog:
+    return APICatalog(
+        id=uuid4(),
+        tenant_id=tenant_id,
+        api_id=api_id,
+        api_name="Payments API",
+        version="1.0.0",
+        status=status,
+        tags=[],
+        portal_published=False,
+        api_metadata={
+            "display_name": "Payments API",
+            "description": "Payment operations",
+            "backend_url": "https://payments.internal",
+            "status": status,
+            "lifecycle": {"catalog_status": status, "spec_source": "inline"},
+        },
+        openapi_spec=OPENAPI_SPEC,
+    )
+
+
+def _gateway(
+    *,
+    gateway_id: UUID | None = None,
+    tenant_id: str | None = None,
+    environment: str = "dev",
+    name: str = "stoa-dev",
+) -> GatewayTarget:
+    return GatewayTarget(
+        id=gateway_id or uuid4(),
+        name=name,
+        display_name=name,
+        gateway_type="stoa",
+        environment=environment,
+        tenant_id=tenant_id,
+        enabled=True,
+        public_url="https://gateway.dev.example",
+    )
+
+
+def _service(
+    *,
+    api: APICatalog | None = None,
+    gateways: list[GatewayTarget] | None = None,
+) -> tuple[ApiLifecycleService, InMemoryApiLifecycleRepository, InMemoryAuditSink]:
+    repository = InMemoryApiLifecycleRepository()
+    if api:
+        repository.apis[(api.tenant_id, api.api_id)] = api
+    for gateway in gateways or []:
+        repository.gateways[gateway.id] = gateway
+    audit = InMemoryAuditSink()
+    return ApiLifecycleService(repository=repository, audit_sink=audit), repository, audit
+
+
+def _deploy_command(**overrides) -> DeployApiCommand:
+    values = {
+        "tenant_id": "acme",
+        "api_id": "payments-api",
+        "environment": "dev",
+        "gateway_instance_id": None,
+        "force": False,
+    }
+    values.update(overrides)
+    return DeployApiCommand(**values)
+
+
+@pytest.mark.asyncio
+async def test_ready_api_with_unique_dev_gateway_creates_gateway_deployment() -> None:
+    service, repository, _ = _service(api=_api(), gateways=[_gateway()])
+
+    outcome = await service.deploy_to_environment(_deploy_command(), _actor())
+
+    assert outcome.action == "created"
+    assert outcome.deployment_status == "pending"
+    assert len(repository.deployments) == 1
+    deployment = next(iter(repository.deployments.values()))
+    assert deployment.sync_status == DeploymentSyncStatus.PENDING
+    assert deployment.desired_state["api_id"] == "payments-api"
+    assert deployment.desired_state["target_environment"] == "dev"
+
+
+@pytest.mark.asyncio
+async def test_deploy_keeps_catalog_status_ready() -> None:
+    api = _api()
+    service, repository, _ = _service(api=api, gateways=[_gateway()])
+
+    await service.deploy_to_environment(_deploy_command(), _actor())
+
+    assert repository.apis[("acme", "payments-api")].status == "ready"
+
+
+@pytest.mark.asyncio
+async def test_get_lifecycle_after_deploy_returns_gateway_deployment() -> None:
+    service, _, _ = _service(api=_api(), gateways=[_gateway()])
+    await service.deploy_to_environment(_deploy_command(), _actor())
+
+    state = await service.get_lifecycle_state("acme", "payments-api")
+
+    assert state.catalog_status == "ready"
+    assert len(state.deployments) == 1
+    assert state.deployments[0].environment == "dev"
+    assert state.deployments[0].sync_status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_draft_api_cannot_be_deployed() -> None:
+    service, _, audit = _service(api=_api(status="draft"), gateways=[_gateway()])
+
+    with pytest.raises(ApiLifecycleTransitionError, match="cannot be deployed"):
+        await service.deploy_to_environment(_deploy_command(), _actor())
+
+    assert audit.events[-1]["action"] == "api_lifecycle.deploy_failed"
+
+
+@pytest.mark.asyncio
+async def test_archived_api_cannot_be_deployed() -> None:
+    service, _, _ = _service(api=_api(status="archived"), gateways=[_gateway()])
+
+    with pytest.raises(ApiLifecycleTransitionError, match="cannot be deployed"):
+        await service.deploy_to_environment(_deploy_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_missing_api_returns_not_found() -> None:
+    service, _, _ = _service(gateways=[_gateway()])
+
+    with pytest.raises(ApiLifecycleNotFoundError):
+        await service.deploy_to_environment(_deploy_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_other_tenant_api_cannot_be_deployed() -> None:
+    service, repository, _ = _service(api=_api(tenant_id="other"), gateways=[_gateway()])
+
+    with pytest.raises(ApiLifecycleNotFoundError):
+        await service.deploy_to_environment(_deploy_command(), _actor())
+
+    assert repository.apis[("other", "payments-api")].status == "ready"
+    assert repository.deployments == {}
+
+
+@pytest.mark.asyncio
+async def test_explicit_missing_gateway_returns_clear_error() -> None:
+    service, _, _ = _service(api=_api())
+
+    with pytest.raises(ApiLifecycleGatewayNotFoundError, match="Gateway"):
+        await service.deploy_to_environment(_deploy_command(gateway_instance_id=uuid4()), _actor())
+
+
+@pytest.mark.asyncio
+async def test_multiple_gateways_without_gateway_id_is_ambiguous() -> None:
+    service, _, _ = _service(api=_api(), gateways=[_gateway(name="dev-a"), _gateway(name="dev-b")])
+
+    with pytest.raises(ApiLifecycleGatewayAmbiguousError, match="Multiple gateway targets"):
+        await service.deploy_to_environment(_deploy_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_identical_pending_deployment_is_idempotent_without_duplicate() -> None:
+    service, repository, audit = _service(api=_api(), gateways=[_gateway()])
+    first = await service.deploy_to_environment(_deploy_command(), _actor())
+
+    second = await service.deploy_to_environment(_deploy_command(), _actor())
+
+    assert first.action == "created"
+    assert second.action == "unchanged"
+    assert second.deployment_status == "pending"
+    assert len(repository.deployments) == 1
+    assert audit.events[-1]["action"] == "api_lifecycle.deploy_idempotent"
+
+
+@pytest.mark.asyncio
+async def test_identical_synced_deployment_is_idempotent_and_stays_synced() -> None:
+    service, repository, _ = _service(api=_api(), gateways=[_gateway()])
+    first = await service.deploy_to_environment(_deploy_command(), _actor())
+    deployment = next(iter(repository.deployments.values()))
+    deployment.sync_status = DeploymentSyncStatus.SYNCED
+    deployment.synced_generation = deployment.desired_generation
+    deployment.last_sync_success = datetime.now(UTC)
+
+    second = await service.deploy_to_environment(_deploy_command(), _actor())
+
+    assert first.deployment_status == "pending"
+    assert second.action == "unchanged"
+    assert second.deployment_id == deployment.id
+    assert next(iter(repository.deployments.values())).sync_status == DeploymentSyncStatus.SYNCED
+
+
+@pytest.mark.asyncio
+async def test_success_audit_event_is_written() -> None:
+    service, _, audit = _service(api=_api(), gateways=[_gateway()])
+
+    outcome = await service.deploy_to_environment(_deploy_command(), _actor())
+
+    assert audit.events[-1]["action"] == "api_lifecycle.deploy_requested"
+    assert audit.events[-1]["details"]["deployment_id"] == str(outcome.deployment_id)
+    assert audit.events[-1]["details"]["action"] == "created"

--- a/control-plane-api/tests/test_api_lifecycle_deploy_router.py
+++ b/control-plane-api/tests/test_api_lifecycle_deploy_router.py
@@ -1,0 +1,136 @@
+"""Router tests for API lifecycle deployment requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+from src.services.api_lifecycle.errors import (
+    ApiLifecycleGatewayAmbiguousError,
+    ApiLifecycleGatewayNotFoundError,
+    ApiLifecycleTransitionError,
+    ApiLifecycleValidationError,
+)
+from src.services.api_lifecycle.ports import (
+    ApiDeploymentRequestOutcome,
+    ApiLifecycleState,
+    ApiSpecState,
+)
+
+
+@dataclass
+class FakeDeployService:
+    outcome: ApiDeploymentRequestOutcome | None = None
+    exc: Exception | None = None
+
+    async def deploy_to_environment(self, command, actor):
+        if self.exc:
+            raise self.exc
+        return self.outcome
+
+
+def _lifecycle_state() -> ApiLifecycleState:
+    return ApiLifecycleState(
+        catalog_id=uuid4(),
+        tenant_id="acme",
+        api_id="payments-api",
+        api_name="Payments API",
+        display_name="Payments API",
+        version="1.0.0",
+        description="Payment operations",
+        backend_url="https://payments.internal",
+        catalog_status="ready",
+        lifecycle_phase="ready",
+        portal_published=False,
+        tags=[],
+        spec=ApiSpecState(source="inline", has_openapi_spec=True),
+        deployments=[],
+        promotions=[],
+    )
+
+
+def _outcome() -> ApiDeploymentRequestOutcome:
+    return ApiDeploymentRequestOutcome(
+        tenant_id="acme",
+        api_id="payments-api",
+        environment="dev",
+        gateway_instance_id=uuid4(),
+        deployment_id=uuid4(),
+        deployment_status="pending",
+        action="created",
+        lifecycle_state=_lifecycle_state(),
+    )
+
+
+def _patch_service(monkeypatch, service: FakeDeployService) -> None:
+    import src.routers.api_lifecycle as router_module
+
+    def build_service(_db):
+        return service
+
+    monkeypatch.setattr(router_module, "_build_service", build_service)
+
+
+def test_deploy_lifecycle_endpoint_returns_deployment_response(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(monkeypatch, FakeDeployService(outcome=_outcome()))
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/deployments",
+        json={"environment": "dev"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["api_id"] == "payments-api"
+    assert data["environment"] == "dev"
+    assert data["deployment_status"] == "pending"
+    assert data["action"] == "created"
+    assert data["lifecycle"]["catalog_status"] == "ready"
+
+
+def test_deploy_lifecycle_endpoint_maps_transition_error_to_409(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(
+        monkeypatch, FakeDeployService(exc=ApiLifecycleTransitionError("API status 'draft' cannot be deployed"))
+    )
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/deployments",
+        json={"environment": "dev"},
+    )
+
+    assert response.status_code == 409
+
+
+def test_deploy_lifecycle_endpoint_maps_missing_gateway_to_404(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(monkeypatch, FakeDeployService(exc=ApiLifecycleGatewayNotFoundError("Gateway not found")))
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/deployments",
+        json={"environment": "dev", "gateway_instance_id": str(uuid4())},
+    )
+
+    assert response.status_code == 404
+
+
+def test_deploy_lifecycle_endpoint_maps_ambiguous_gateway_to_409(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(monkeypatch, FakeDeployService(exc=ApiLifecycleGatewayAmbiguousError("Multiple gateway targets")))
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/deployments",
+        json={"environment": "dev"},
+    )
+
+    assert response.status_code == 409
+
+
+def test_deploy_lifecycle_endpoint_maps_invalid_environment_to_422(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(
+        monkeypatch, FakeDeployService(exc=ApiLifecycleValidationError("Invalid deployment environment: qa"))
+    )
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/deployments",
+        json={"environment": "qa"},
+    )
+
+    assert response.status_code == 422

--- a/control-plane-api/tests/test_api_lifecycle_promotion.py
+++ b/control-plane-api/tests/test_api_lifecycle_promotion.py
@@ -1,0 +1,535 @@
+"""Promotion tests for the canonical API lifecycle service, Slice 5."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.models.catalog import APICatalog
+from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment
+from src.models.promotion import Promotion, PromotionStatus
+from src.services.api_lifecycle.errors import (
+    ApiLifecycleGatewayAmbiguousError,
+    ApiLifecycleGatewayNotFoundError,
+    ApiLifecycleNotFoundError,
+    ApiLifecycleTransitionError,
+    ApiLifecycleValidationError,
+)
+from src.services.api_lifecycle.portal import CatalogPortalPublisher
+from src.services.api_lifecycle.ports import (
+    CreateApiDraftCommand,
+    DeployApiCommand,
+    GatewayDeploymentSnapshot,
+    GatewayTarget,
+    LifecycleActor,
+    PortalPublicationState,
+    PromoteApiCommand,
+    PromotionSnapshot,
+    PublishApiCommand,
+    ValidateApiDraftCommand,
+)
+from src.services.api_lifecycle.service import ApiLifecycleService
+
+OPENAPI_SPEC: dict[str, Any] = {
+    "openapi": "3.0.3",
+    "info": {"title": "Payments API", "version": "1.0.0"},
+    "paths": {"/payments": {"get": {"responses": {"200": {"description": "ok"}}}}},
+}
+
+
+@dataclass
+class InMemoryApiLifecycleRepository:
+    apis: dict[tuple[str, str], APICatalog] = field(default_factory=dict)
+    gateways: dict[UUID, GatewayTarget] = field(default_factory=dict)
+    deployments: dict[tuple[UUID, UUID], GatewayDeployment] = field(default_factory=dict)
+    promotions: dict[UUID, Promotion] = field(default_factory=dict)
+
+    async def get_api_by_id(self, tenant_id: str, api_id: str) -> APICatalog | None:
+        return self.apis.get((tenant_id, api_id))
+
+    async def get_api_by_name_version(self, tenant_id: str, api_name: str, version: str) -> APICatalog | None:
+        return next(
+            (
+                row
+                for (row_tenant_id, _), row in self.apis.items()
+                if row_tenant_id == tenant_id and row.api_name == api_name and row.version == version
+            ),
+            None,
+        )
+
+    async def create_api_catalog(self, api: APICatalog) -> APICatalog:
+        self.apis[(api.tenant_id, api.api_id)] = api
+        return api
+
+    async def save_api_catalog(self, api: APICatalog) -> APICatalog:
+        self.apis[(api.tenant_id, api.api_id)] = api
+        return api
+
+    async def list_gateway_deployments(self, api_catalog_id: UUID) -> list[GatewayDeploymentSnapshot]:
+        snapshots: list[GatewayDeploymentSnapshot] = []
+        for (row_api_catalog_id, gateway_id), deployment in self.deployments.items():
+            if row_api_catalog_id != api_catalog_id:
+                continue
+            gateway = self.gateways[gateway_id]
+            snapshots.append(
+                GatewayDeploymentSnapshot(
+                    id=deployment.id,
+                    environment=gateway.environment,
+                    gateway_instance_id=gateway.id,
+                    gateway_name=gateway.name,
+                    gateway_type=gateway.gateway_type,
+                    sync_status=str(deployment.sync_status),
+                    desired_generation=deployment.desired_generation,
+                    synced_generation=deployment.synced_generation,
+                    gateway_resource_id=deployment.gateway_resource_id,
+                    public_url=gateway.public_url,
+                    sync_error=deployment.sync_error,
+                    last_sync_success=deployment.last_sync_success,
+                )
+            )
+        return snapshots
+
+    async def get_gateway_target(self, tenant_id: str, gateway_instance_id: UUID) -> GatewayTarget | None:
+        gateway = self.gateways.get(gateway_instance_id)
+        if not gateway or gateway.tenant_id not in (None, tenant_id):
+            return None
+        return gateway
+
+    async def list_gateway_targets(self, tenant_id: str, environment: str) -> list[GatewayTarget]:
+        return [
+            gateway
+            for gateway in self.gateways.values()
+            if gateway.enabled and gateway.environment == environment and gateway.tenant_id in (None, tenant_id)
+        ]
+
+    async def get_gateway_deployment(self, api_catalog_id: UUID, gateway_instance_id: UUID) -> GatewayDeployment | None:
+        return self.deployments.get((api_catalog_id, gateway_instance_id))
+
+    async def create_gateway_deployment(self, deployment: GatewayDeployment) -> GatewayDeployment:
+        self.deployments[(deployment.api_catalog_id, deployment.gateway_instance_id)] = deployment
+        return deployment
+
+    async def save_gateway_deployment(self, deployment: GatewayDeployment) -> GatewayDeployment:
+        self.deployments[(deployment.api_catalog_id, deployment.gateway_instance_id)] = deployment
+        return deployment
+
+    async def list_promotions(self, tenant_id: str, api_id: str) -> list[PromotionSnapshot]:
+        return [
+            PromotionSnapshot(
+                id=promotion.id,
+                source_environment=promotion.source_environment,
+                target_environment=promotion.target_environment,
+                status=promotion.status,
+                message=promotion.message,
+                requested_by=promotion.requested_by,
+                approved_by=promotion.approved_by,
+                completed_at=promotion.completed_at,
+            )
+            for promotion in self.promotions.values()
+            if promotion.tenant_id == tenant_id and promotion.api_id == api_id
+        ]
+
+    async def get_active_promotion(
+        self,
+        tenant_id: str,
+        api_id: str,
+        source_environment: str,
+        target_environment: str,
+    ) -> Promotion | None:
+        return next(
+            (
+                promotion
+                for promotion in self.promotions.values()
+                if promotion.tenant_id == tenant_id
+                and promotion.api_id == api_id
+                and promotion.source_environment == source_environment
+                and promotion.target_environment == target_environment
+                and promotion.status in {PromotionStatus.PENDING.value, PromotionStatus.PROMOTING.value}
+            ),
+            None,
+        )
+
+    async def get_latest_promoted_promotion(
+        self,
+        tenant_id: str,
+        api_id: str,
+        source_environment: str,
+        target_environment: str,
+    ) -> Promotion | None:
+        promoted = [
+            promotion
+            for promotion in self.promotions.values()
+            if promotion.tenant_id == tenant_id
+            and promotion.api_id == api_id
+            and promotion.source_environment == source_environment
+            and promotion.target_environment == target_environment
+            and promotion.status == PromotionStatus.PROMOTED.value
+        ]
+        return promoted[-1] if promoted else None
+
+    async def get_active_promotion_for_target_deployment(
+        self,
+        tenant_id: str,
+        api_id: str,
+        target_environment: str,
+        target_deployment_id: UUID,
+    ) -> Promotion | None:
+        return next(
+            (
+                promotion
+                for promotion in self.promotions.values()
+                if promotion.tenant_id == tenant_id
+                and promotion.api_id == api_id
+                and promotion.target_environment == target_environment
+                and promotion.target_deployment_id == target_deployment_id
+                and promotion.status in {PromotionStatus.PENDING.value, PromotionStatus.PROMOTING.value}
+            ),
+            None,
+        )
+
+    async def create_promotion(self, promotion: Promotion) -> Promotion:
+        self.promotions[promotion.id] = promotion
+        return promotion
+
+    async def save_promotion(self, promotion: Promotion) -> Promotion:
+        self.promotions[promotion.id] = promotion
+        return promotion
+
+
+@dataclass
+class InMemoryAuditSink:
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    async def record_transition(
+        self,
+        *,
+        tenant_id: str,
+        actor: LifecycleActor,
+        action: str,
+        resource_id: str,
+        resource_name: str,
+        details: dict[str, Any],
+        outcome: str = "success",
+        status_code: int = 200,
+        method: str = "POST",
+        path: str | None = None,
+    ) -> None:
+        self.events.append(
+            {
+                "tenant_id": tenant_id,
+                "actor": actor,
+                "action": action,
+                "resource_id": resource_id,
+                "resource_name": resource_name,
+                "details": details,
+                "outcome": outcome,
+                "status_code": status_code,
+                "method": method,
+                "path": path,
+            }
+        )
+
+
+@dataclass
+class FakePortalPublisher:
+    calls: list[PortalPublicationState] = field(default_factory=list)
+    adapter: CatalogPortalPublisher = field(default_factory=CatalogPortalPublisher)
+
+    async def publish(self, *, api: APICatalog, publication: PortalPublicationState) -> APICatalog:
+        self.calls.append(publication)
+        return await self.adapter.publish(api=api, publication=publication)
+
+
+def _actor() -> LifecycleActor:
+    return LifecycleActor(actor_id="user-1", email="owner@acme.test", username="owner")
+
+
+def _api(status: str = "ready", tenant_id: str = "acme", api_id: str = "payments-api") -> APICatalog:
+    return APICatalog(
+        id=uuid4(),
+        tenant_id=tenant_id,
+        api_id=api_id,
+        api_name="Payments API",
+        version="1.0.0",
+        status=status,
+        tags=[],
+        portal_published=False,
+        api_metadata={
+            "display_name": "Payments API",
+            "description": "Payment operations",
+            "backend_url": "https://payments.internal",
+            "status": status,
+            "lifecycle": {"catalog_status": status, "spec_source": "inline"},
+        },
+        openapi_spec=OPENAPI_SPEC,
+    )
+
+
+def _gateway(
+    *,
+    gateway_id: UUID | None = None,
+    tenant_id: str | None = None,
+    environment: str = "dev",
+    name: str = "stoa-dev",
+) -> GatewayTarget:
+    return GatewayTarget(
+        id=gateway_id or uuid4(),
+        name=name,
+        display_name=name,
+        gateway_type="stoa",
+        environment=environment,
+        tenant_id=tenant_id,
+        enabled=True,
+        public_url=f"https://gateway.{environment}.example",
+    )
+
+
+def _service(
+    *,
+    api: APICatalog | None = None,
+    gateways: list[GatewayTarget] | None = None,
+) -> tuple[ApiLifecycleService, InMemoryApiLifecycleRepository, InMemoryAuditSink, FakePortalPublisher]:
+    repository = InMemoryApiLifecycleRepository()
+    if api:
+        repository.apis[(api.tenant_id, api.api_id)] = api
+    for gateway in gateways or []:
+        repository.gateways[gateway.id] = gateway
+    audit = InMemoryAuditSink()
+    portal = FakePortalPublisher()
+    return (
+        ApiLifecycleService(repository=repository, audit_sink=audit, portal_publisher=portal),
+        repository,
+        audit,
+        portal,
+    )
+
+
+def _promote_command(**overrides) -> PromoteApiCommand:
+    values = {
+        "tenant_id": "acme",
+        "api_id": "payments-api",
+        "source_environment": "dev",
+        "target_environment": "staging",
+        "source_gateway_instance_id": None,
+        "target_gateway_instance_id": None,
+        "force": False,
+    }
+    values.update(overrides)
+    return PromoteApiCommand(**values)
+
+
+async def _deploy_sync_publish_source(
+    service: ApiLifecycleService,
+    repository: InMemoryApiLifecycleRepository,
+    api_id: str = "payments-api",
+) -> GatewayDeployment:
+    await service.deploy_to_environment(
+        DeployApiCommand(tenant_id="acme", api_id=api_id, environment="dev"),
+        _actor(),
+    )
+    source_deployment = next(
+        deployment
+        for (api_catalog_id, gateway_id), deployment in repository.deployments.items()
+        if repository.gateways[gateway_id].environment == "dev"
+    )
+    source_deployment.sync_status = DeploymentSyncStatus.SYNCED
+    source_deployment.synced_generation = source_deployment.desired_generation
+    source_deployment.last_sync_success = datetime.now(UTC)
+    await service.publish_to_portal(PublishApiCommand(tenant_id="acme", api_id=api_id, environment="dev"), _actor())
+    return source_deployment
+
+
+@pytest.mark.asyncio
+async def test_e2e_promote_dev_to_staging_then_publish_target_completes_promotion() -> None:
+    dev_gateway = _gateway(environment="dev", name="stoa-dev")
+    staging_gateway = _gateway(environment="staging", name="stoa-staging")
+    service, repository, _, _ = _service(gateways=[dev_gateway, staging_gateway])
+
+    draft = await service.create_draft(
+        CreateApiDraftCommand(
+            tenant_id="acme",
+            name="Payments API",
+            display_name="Payments API",
+            version="1.0.0",
+            description="Payment operations",
+            backend_url="https://payments.internal",
+            openapi_spec=OPENAPI_SPEC,
+        ),
+        _actor(),
+    )
+    await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id=draft.api_id), _actor())
+    await _deploy_sync_publish_source(service, repository, draft.api_id)
+
+    promotion = await service.promote_to_environment(_promote_command(api_id=draft.api_id), _actor())
+
+    target_deployment = repository.deployments[(draft.catalog_id, staging_gateway.id)]
+    assert promotion.result == "requested"
+    assert promotion.promotion_status == PromotionStatus.PROMOTING.value
+    assert promotion.target_deployment_id == target_deployment.id
+    assert target_deployment.sync_status == DeploymentSyncStatus.PENDING
+    assert target_deployment.promotion_id == promotion.promotion_id
+    assert repository.apis[("acme", draft.api_id)].status == "ready"
+
+    target_deployment.sync_status = DeploymentSyncStatus.SYNCED
+    target_deployment.synced_generation = target_deployment.desired_generation
+    target_deployment.last_sync_success = datetime.now(UTC)
+    await service.publish_to_portal(
+        PublishApiCommand(tenant_id="acme", api_id=draft.api_id, environment="staging"),
+        _actor(),
+    )
+    state = await service.get_lifecycle_state("acme", draft.api_id)
+
+    assert {deployment.environment for deployment in state.deployments} == {"dev", "staging"}
+    assert state.portal.last_environment == "staging"
+    assert state.promotions[0].status == PromotionStatus.PROMOTED.value
+    assert state.lifecycle_phase == "promoted"
+
+
+@pytest.mark.asyncio
+async def test_promote_draft_api_is_refused() -> None:
+    service, _, _, _ = _service(api=_api(status="draft"), gateways=[_gateway(), _gateway(environment="staging")])
+
+    with pytest.raises(ApiLifecycleTransitionError, match="cannot be promoted"):
+        await service.promote_to_environment(_promote_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_promote_archived_api_is_refused() -> None:
+    service, _, _, _ = _service(api=_api(status="archived"), gateways=[_gateway(), _gateway(environment="staging")])
+
+    with pytest.raises(ApiLifecycleTransitionError, match="cannot be promoted"):
+        await service.promote_to_environment(_promote_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_missing_api_returns_not_found() -> None:
+    service, _, _, _ = _service(gateways=[_gateway(), _gateway(environment="staging")])
+
+    with pytest.raises(ApiLifecycleNotFoundError):
+        await service.promote_to_environment(_promote_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_other_tenant_api_cannot_be_promoted() -> None:
+    service, repository, _, _ = _service(
+        api=_api(tenant_id="other"), gateways=[_gateway(), _gateway(environment="staging")]
+    )
+
+    with pytest.raises(ApiLifecycleNotFoundError):
+        await service.promote_to_environment(_promote_command(), _actor())
+
+    assert repository.promotions == {}
+
+
+@pytest.mark.asyncio
+async def test_missing_source_gateway_returns_clear_error() -> None:
+    service, _, _, _ = _service(api=_api(), gateways=[_gateway(environment="staging")])
+
+    with pytest.raises(ApiLifecycleGatewayNotFoundError, match="No gateway target"):
+        await service.promote_to_environment(_promote_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_missing_target_gateway_returns_clear_error() -> None:
+    dev_gateway = _gateway(environment="dev")
+    service, repository, _, _ = _service(api=_api(), gateways=[dev_gateway])
+    await _deploy_sync_publish_source(service, repository)
+
+    with pytest.raises(ApiLifecycleGatewayNotFoundError, match="No gateway target"):
+        await service.promote_to_environment(_promote_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_target_gateway_is_refused_without_explicit_id() -> None:
+    dev_gateway = _gateway(environment="dev")
+    service, repository, _, _ = _service(
+        api=_api(),
+        gateways=[
+            dev_gateway,
+            _gateway(environment="staging", name="staging-a"),
+            _gateway(environment="staging", name="staging-b"),
+        ],
+    )
+    await _deploy_sync_publish_source(service, repository)
+
+    with pytest.raises(ApiLifecycleGatewayAmbiguousError, match="Multiple gateway targets"):
+        await service.promote_to_environment(_promote_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_missing_source_deployment_is_refused() -> None:
+    service, _, _, _ = _service(api=_api(), gateways=[_gateway(), _gateway(environment="staging")])
+
+    with pytest.raises(ApiLifecycleNotFoundError, match="No source GatewayDeployment"):
+        await service.promote_to_environment(_promote_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_unsynced_source_deployment_is_refused() -> None:
+    service, _, _, _ = _service(api=_api(), gateways=[_gateway(), _gateway(environment="staging")])
+    await service.deploy_to_environment(
+        DeployApiCommand(tenant_id="acme", api_id="payments-api", environment="dev"), _actor()
+    )
+
+    with pytest.raises(ApiLifecycleTransitionError, match="not 'synced'"):
+        await service.promote_to_environment(_promote_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_unpublished_source_is_refused() -> None:
+    service, repository, _, _ = _service(api=_api(), gateways=[_gateway(), _gateway(environment="staging")])
+    await service.deploy_to_environment(
+        DeployApiCommand(tenant_id="acme", api_id="payments-api", environment="dev"), _actor()
+    )
+    deployment = next(iter(repository.deployments.values()))
+    deployment.sync_status = DeploymentSyncStatus.SYNCED
+    deployment.synced_generation = deployment.desired_generation
+
+    with pytest.raises(ApiLifecycleTransitionError, match="not published"):
+        await service.promote_to_environment(_promote_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_invalid_promotion_chain_is_refused() -> None:
+    service, _, _, _ = _service(api=_api(), gateways=[_gateway(), _gateway(environment="staging")])
+
+    with pytest.raises(ApiLifecycleValidationError, match="Invalid promotion chain"):
+        await service.promote_to_environment(
+            _promote_command(source_environment="dev", target_environment="production"),
+            _actor(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_repeated_promotion_is_idempotent_without_duplicate_promotion_or_deployment() -> None:
+    dev_gateway = _gateway(environment="dev")
+    staging_gateway = _gateway(environment="staging")
+    service, repository, audit, _ = _service(api=_api(), gateways=[dev_gateway, staging_gateway])
+    await _deploy_sync_publish_source(service, repository)
+
+    first = await service.promote_to_environment(_promote_command(), _actor())
+    second = await service.promote_to_environment(_promote_command(), _actor())
+
+    assert first.result == "requested"
+    assert second.result == "unchanged"
+    assert len(repository.promotions) == 1
+    assert len([gateway for (_api_id, gateway) in repository.deployments if gateway == staging_gateway.id]) == 1
+    assert audit.events[-1]["action"] == "api_lifecycle.promotion_idempotent"
+
+
+@pytest.mark.asyncio
+async def test_get_lifecycle_exposes_promotion_and_target_deployment() -> None:
+    service, repository, _, _ = _service(api=_api(), gateways=[_gateway(), _gateway(environment="staging")])
+    await _deploy_sync_publish_source(service, repository)
+    await service.promote_to_environment(_promote_command(), _actor())
+
+    state = await service.get_lifecycle_state("acme", "payments-api")
+
+    assert state.catalog_status == "ready"
+    assert len(state.deployments) == 2
+    assert state.promotions[0].status == PromotionStatus.PROMOTING.value
+    assert state.lifecycle_phase == "promoting"

--- a/control-plane-api/tests/test_api_lifecycle_promotion_router.py
+++ b/control-plane-api/tests/test_api_lifecycle_promotion_router.py
@@ -1,0 +1,150 @@
+"""Router tests for API lifecycle promotion requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+from src.services.api_lifecycle.errors import (
+    ApiLifecycleGatewayAmbiguousError,
+    ApiLifecycleGatewayNotFoundError,
+    ApiLifecycleNotFoundError,
+    ApiLifecycleTransitionError,
+    ApiLifecycleValidationError,
+)
+from src.services.api_lifecycle.ports import (
+    ApiLifecycleState,
+    ApiPromotionRequestOutcome,
+    ApiSpecState,
+)
+
+
+@dataclass
+class FakePromoteService:
+    outcome: ApiPromotionRequestOutcome | None = None
+    exc: Exception | None = None
+
+    async def promote_to_environment(self, command, actor):
+        if self.exc:
+            raise self.exc
+        return self.outcome
+
+
+def _lifecycle_state() -> ApiLifecycleState:
+    return ApiLifecycleState(
+        catalog_id=uuid4(),
+        tenant_id="acme",
+        api_id="payments-api",
+        api_name="Payments API",
+        display_name="Payments API",
+        version="1.0.0",
+        description="Payment operations",
+        backend_url="https://payments.internal",
+        catalog_status="ready",
+        lifecycle_phase="promoting",
+        portal_published=True,
+        tags=[],
+        spec=ApiSpecState(source="inline", has_openapi_spec=True),
+        deployments=[],
+        promotions=[],
+    )
+
+
+def _outcome() -> ApiPromotionRequestOutcome:
+    return ApiPromotionRequestOutcome(
+        tenant_id="acme",
+        api_id="payments-api",
+        promotion_id=uuid4(),
+        source_environment="dev",
+        target_environment="staging",
+        source_gateway_instance_id=uuid4(),
+        target_gateway_instance_id=uuid4(),
+        target_deployment_id=uuid4(),
+        promotion_status="promoting",
+        deployment_status="pending",
+        result="requested",
+        lifecycle_state=_lifecycle_state(),
+    )
+
+
+def _patch_service(monkeypatch, service: FakePromoteService) -> None:
+    import src.routers.api_lifecycle as router_module
+
+    def build_service(_db):
+        return service
+
+    monkeypatch.setattr(router_module, "_build_service", build_service)
+
+
+def test_promote_lifecycle_endpoint_returns_promotion_response(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(monkeypatch, FakePromoteService(outcome=_outcome()))
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/promotions",
+        json={"source_environment": "dev", "target_environment": "staging"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["api_id"] == "payments-api"
+    assert data["source_environment"] == "dev"
+    assert data["target_environment"] == "staging"
+    assert data["promotion_status"] == "promoting"
+    assert data["deployment_status"] == "pending"
+    assert data["result"] == "requested"
+    assert data["lifecycle"]["catalog_status"] == "ready"
+
+
+def test_promote_lifecycle_endpoint_maps_transition_error_to_409(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(monkeypatch, FakePromoteService(exc=ApiLifecycleTransitionError("source is not synced")))
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/promotions",
+        json={"source_environment": "dev", "target_environment": "staging"},
+    )
+
+    assert response.status_code == 409
+
+
+def test_promote_lifecycle_endpoint_maps_missing_api_to_404(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(monkeypatch, FakePromoteService(exc=ApiLifecycleNotFoundError("API not found")))
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/promotions",
+        json={"source_environment": "dev", "target_environment": "staging"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_promote_lifecycle_endpoint_maps_missing_gateway_to_404(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(monkeypatch, FakePromoteService(exc=ApiLifecycleGatewayNotFoundError("Gateway not found")))
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/promotions",
+        json={"source_environment": "dev", "target_environment": "staging"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_promote_lifecycle_endpoint_maps_ambiguous_gateway_to_409(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(monkeypatch, FakePromoteService(exc=ApiLifecycleGatewayAmbiguousError("Multiple gateway targets")))
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/promotions",
+        json={"source_environment": "dev", "target_environment": "staging"},
+    )
+
+    assert response.status_code == 409
+
+
+def test_promote_lifecycle_endpoint_maps_invalid_chain_to_422(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(monkeypatch, FakePromoteService(exc=ApiLifecycleValidationError("Invalid promotion chain")))
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/promotions",
+        json={"source_environment": "dev", "target_environment": "production"},
+    )
+
+    assert response.status_code == 422

--- a/control-plane-api/tests/test_api_lifecycle_publish.py
+++ b/control-plane-api/tests/test_api_lifecycle_publish.py
@@ -1,0 +1,581 @@
+"""Portal publication tests for the canonical API lifecycle service, Slice 4."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.models.catalog import APICatalog
+from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment
+from src.models.promotion import Promotion, PromotionStatus
+from src.services.api_lifecycle.errors import (
+    ApiLifecycleGatewayAmbiguousError,
+    ApiLifecycleGatewayNotFoundError,
+    ApiLifecycleNotFoundError,
+    ApiLifecycleSpecValidationError,
+    ApiLifecycleTransitionError,
+)
+from src.services.api_lifecycle.portal import CatalogPortalPublisher
+from src.services.api_lifecycle.ports import (
+    CreateApiDraftCommand,
+    DeployApiCommand,
+    GatewayDeploymentSnapshot,
+    GatewayTarget,
+    LifecycleActor,
+    PortalPublicationState,
+    PromotionSnapshot,
+    PublishApiCommand,
+    ValidateApiDraftCommand,
+)
+from src.services.api_lifecycle.service import ApiLifecycleService
+
+OPENAPI_SPEC: dict[str, Any] = {
+    "openapi": "3.0.3",
+    "info": {"title": "Payments API", "version": "1.0.0"},
+    "paths": {"/payments": {"get": {"responses": {"200": {"description": "ok"}}}}},
+}
+
+
+@dataclass
+class InMemoryApiLifecycleRepository:
+    apis: dict[tuple[str, str], APICatalog] = field(default_factory=dict)
+    gateways: dict[UUID, GatewayTarget] = field(default_factory=dict)
+    deployments: dict[tuple[UUID, UUID], GatewayDeployment] = field(default_factory=dict)
+    promotions: dict[UUID, Promotion] = field(default_factory=dict)
+
+    async def get_api_by_id(self, tenant_id: str, api_id: str) -> APICatalog | None:
+        return self.apis.get((tenant_id, api_id))
+
+    async def get_api_by_name_version(self, tenant_id: str, api_name: str, version: str) -> APICatalog | None:
+        return next(
+            (
+                row
+                for (row_tenant_id, _), row in self.apis.items()
+                if row_tenant_id == tenant_id and row.api_name == api_name and row.version == version
+            ),
+            None,
+        )
+
+    async def create_api_catalog(self, api: APICatalog) -> APICatalog:
+        self.apis[(api.tenant_id, api.api_id)] = api
+        return api
+
+    async def save_api_catalog(self, api: APICatalog) -> APICatalog:
+        self.apis[(api.tenant_id, api.api_id)] = api
+        return api
+
+    async def list_gateway_deployments(self, api_catalog_id: UUID) -> list[GatewayDeploymentSnapshot]:
+        snapshots: list[GatewayDeploymentSnapshot] = []
+        for (row_api_catalog_id, gateway_id), deployment in self.deployments.items():
+            if row_api_catalog_id != api_catalog_id:
+                continue
+            gateway = self.gateways[gateway_id]
+            snapshots.append(
+                GatewayDeploymentSnapshot(
+                    id=deployment.id,
+                    environment=gateway.environment,
+                    gateway_instance_id=gateway.id,
+                    gateway_name=gateway.name,
+                    gateway_type=gateway.gateway_type,
+                    sync_status=str(deployment.sync_status),
+                    desired_generation=deployment.desired_generation,
+                    synced_generation=deployment.synced_generation,
+                    gateway_resource_id=deployment.gateway_resource_id,
+                    public_url=gateway.public_url,
+                    sync_error=deployment.sync_error,
+                    last_sync_success=deployment.last_sync_success,
+                )
+            )
+        return snapshots
+
+    async def get_gateway_target(self, tenant_id: str, gateway_instance_id: UUID) -> GatewayTarget | None:
+        gateway = self.gateways.get(gateway_instance_id)
+        if not gateway or gateway.tenant_id not in (None, tenant_id):
+            return None
+        return gateway
+
+    async def list_gateway_targets(self, tenant_id: str, environment: str) -> list[GatewayTarget]:
+        return [
+            gateway
+            for gateway in self.gateways.values()
+            if gateway.enabled and gateway.environment == environment and gateway.tenant_id in (None, tenant_id)
+        ]
+
+    async def get_gateway_deployment(self, api_catalog_id: UUID, gateway_instance_id: UUID) -> GatewayDeployment | None:
+        return self.deployments.get((api_catalog_id, gateway_instance_id))
+
+    async def create_gateway_deployment(self, deployment: GatewayDeployment) -> GatewayDeployment:
+        self.deployments[(deployment.api_catalog_id, deployment.gateway_instance_id)] = deployment
+        return deployment
+
+    async def save_gateway_deployment(self, deployment: GatewayDeployment) -> GatewayDeployment:
+        self.deployments[(deployment.api_catalog_id, deployment.gateway_instance_id)] = deployment
+        return deployment
+
+    async def list_promotions(self, tenant_id: str, api_id: str) -> list[PromotionSnapshot]:
+        return [
+            PromotionSnapshot(
+                id=promotion.id,
+                source_environment=promotion.source_environment,
+                target_environment=promotion.target_environment,
+                status=promotion.status,
+                message=promotion.message,
+                requested_by=promotion.requested_by,
+                approved_by=promotion.approved_by,
+                completed_at=promotion.completed_at,
+            )
+            for promotion in self.promotions.values()
+            if promotion.tenant_id == tenant_id and promotion.api_id == api_id
+        ]
+
+    async def get_active_promotion(
+        self,
+        tenant_id: str,
+        api_id: str,
+        source_environment: str,
+        target_environment: str,
+    ) -> Promotion | None:
+        return next(
+            (
+                promotion
+                for promotion in self.promotions.values()
+                if promotion.tenant_id == tenant_id
+                and promotion.api_id == api_id
+                and promotion.source_environment == source_environment
+                and promotion.target_environment == target_environment
+                and promotion.status in {PromotionStatus.PENDING.value, PromotionStatus.PROMOTING.value}
+            ),
+            None,
+        )
+
+    async def get_latest_promoted_promotion(
+        self,
+        tenant_id: str,
+        api_id: str,
+        source_environment: str,
+        target_environment: str,
+    ) -> Promotion | None:
+        promoted = [
+            promotion
+            for promotion in self.promotions.values()
+            if promotion.tenant_id == tenant_id
+            and promotion.api_id == api_id
+            and promotion.source_environment == source_environment
+            and promotion.target_environment == target_environment
+            and promotion.status == PromotionStatus.PROMOTED.value
+        ]
+        return promoted[-1] if promoted else None
+
+    async def get_active_promotion_for_target_deployment(
+        self,
+        tenant_id: str,
+        api_id: str,
+        target_environment: str,
+        target_deployment_id: UUID,
+    ) -> Promotion | None:
+        return next(
+            (
+                promotion
+                for promotion in self.promotions.values()
+                if promotion.tenant_id == tenant_id
+                and promotion.api_id == api_id
+                and promotion.target_environment == target_environment
+                and promotion.target_deployment_id == target_deployment_id
+                and promotion.status in {PromotionStatus.PENDING.value, PromotionStatus.PROMOTING.value}
+            ),
+            None,
+        )
+
+    async def create_promotion(self, promotion: Promotion) -> Promotion:
+        self.promotions[promotion.id] = promotion
+        return promotion
+
+    async def save_promotion(self, promotion: Promotion) -> Promotion:
+        self.promotions[promotion.id] = promotion
+        return promotion
+
+
+@dataclass
+class InMemoryAuditSink:
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    async def record_transition(
+        self,
+        *,
+        tenant_id: str,
+        actor: LifecycleActor,
+        action: str,
+        resource_id: str,
+        resource_name: str,
+        details: dict[str, Any],
+        outcome: str = "success",
+        status_code: int = 200,
+        method: str = "POST",
+        path: str | None = None,
+    ) -> None:
+        self.events.append(
+            {
+                "tenant_id": tenant_id,
+                "actor": actor,
+                "action": action,
+                "resource_id": resource_id,
+                "resource_name": resource_name,
+                "details": details,
+                "outcome": outcome,
+                "status_code": status_code,
+                "method": method,
+                "path": path,
+            }
+        )
+
+
+@dataclass
+class FakePortalPublisher:
+    calls: list[PortalPublicationState] = field(default_factory=list)
+    adapter: CatalogPortalPublisher = field(default_factory=CatalogPortalPublisher)
+
+    async def publish(self, *, api: APICatalog, publication: PortalPublicationState) -> APICatalog:
+        self.calls.append(publication)
+        return await self.adapter.publish(api=api, publication=publication)
+
+
+def _actor() -> LifecycleActor:
+    return LifecycleActor(actor_id="user-1", email="owner@acme.test", username="owner")
+
+
+def _api(
+    status: str = "ready",
+    tenant_id: str = "acme",
+    api_id: str = "payments-api",
+    openapi_spec: dict[str, Any] | None = OPENAPI_SPEC,
+    spec_reference: str | None = None,
+) -> APICatalog:
+    return APICatalog(
+        id=uuid4(),
+        tenant_id=tenant_id,
+        api_id=api_id,
+        api_name="Payments API",
+        version="1.0.0",
+        status=status,
+        tags=[],
+        portal_published=False,
+        api_metadata={
+            "display_name": "Payments API",
+            "description": "Payment operations",
+            "backend_url": "https://payments.internal",
+            "status": status,
+            "lifecycle": {
+                "catalog_status": status,
+                "spec_source": "reference" if spec_reference else "inline",
+                "spec_reference": spec_reference,
+            },
+        },
+        openapi_spec=openapi_spec,
+    )
+
+
+def _gateway(
+    *,
+    gateway_id: UUID | None = None,
+    tenant_id: str | None = None,
+    environment: str = "dev",
+    name: str = "stoa-dev",
+) -> GatewayTarget:
+    return GatewayTarget(
+        id=gateway_id or uuid4(),
+        name=name,
+        display_name=name,
+        gateway_type="stoa",
+        environment=environment,
+        tenant_id=tenant_id,
+        enabled=True,
+        public_url="https://gateway.dev.example",
+    )
+
+
+def _deployment(
+    api: APICatalog,
+    gateway: GatewayTarget,
+    status: DeploymentSyncStatus = DeploymentSyncStatus.SYNCED,
+) -> GatewayDeployment:
+    return GatewayDeployment(
+        id=uuid4(),
+        api_catalog_id=api.id,
+        gateway_instance_id=gateway.id,
+        desired_state={"api_id": api.api_id, "spec_hash": "abc123"},
+        desired_at=datetime.now(UTC),
+        desired_generation=1,
+        synced_generation=1 if status == DeploymentSyncStatus.SYNCED else 0,
+        attempted_generation=1,
+        sync_status=status,
+        sync_attempts=1,
+        last_sync_success=datetime.now(UTC) if status == DeploymentSyncStatus.SYNCED else None,
+    )
+
+
+def _service(
+    *,
+    api: APICatalog | None = None,
+    gateways: list[GatewayTarget] | None = None,
+    deployments: list[GatewayDeployment] | None = None,
+) -> tuple[ApiLifecycleService, InMemoryApiLifecycleRepository, InMemoryAuditSink, FakePortalPublisher]:
+    repository = InMemoryApiLifecycleRepository()
+    if api:
+        repository.apis[(api.tenant_id, api.api_id)] = api
+    for gateway in gateways or []:
+        repository.gateways[gateway.id] = gateway
+    for deployment in deployments or []:
+        repository.deployments[(deployment.api_catalog_id, deployment.gateway_instance_id)] = deployment
+    audit = InMemoryAuditSink()
+    portal = FakePortalPublisher()
+    return (
+        ApiLifecycleService(repository=repository, audit_sink=audit, portal_publisher=portal),
+        repository,
+        audit,
+        portal,
+    )
+
+
+def _publish_command(**overrides) -> PublishApiCommand:
+    values = {
+        "tenant_id": "acme",
+        "api_id": "payments-api",
+        "environment": "dev",
+        "gateway_instance_id": None,
+        "force": False,
+    }
+    values.update(overrides)
+    return PublishApiCommand(**values)
+
+
+@pytest.mark.asyncio
+async def test_ready_api_with_synced_deployment_publishes_to_portal() -> None:
+    api = _api()
+    gateway = _gateway()
+    service, repository, _, portal = _service(api=api, gateways=[gateway], deployments=[_deployment(api, gateway)])
+
+    outcome = await service.publish_to_portal(_publish_command(), _actor())
+
+    assert outcome.result == "published"
+    assert outcome.publication_status == "published"
+    assert outcome.portal_published is True
+    assert repository.apis[("acme", "payments-api")].portal_published is True
+    assert len(portal.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_keeps_catalog_status_ready() -> None:
+    api = _api()
+    gateway = _gateway()
+    service, repository, _, _ = _service(api=api, gateways=[gateway], deployments=[_deployment(api, gateway)])
+
+    await service.publish_to_portal(_publish_command(), _actor())
+
+    assert repository.apis[("acme", "payments-api")].status == "ready"
+
+
+@pytest.mark.asyncio
+async def test_get_lifecycle_after_publish_returns_portal_state() -> None:
+    api = _api()
+    gateway = _gateway()
+    service, _, _, _ = _service(api=api, gateways=[gateway], deployments=[_deployment(api, gateway)])
+    await service.publish_to_portal(_publish_command(), _actor())
+
+    state = await service.get_lifecycle_state("acme", "payments-api")
+
+    assert state.catalog_status == "ready"
+    assert state.portal_published is True
+    assert state.portal.published is True
+    assert state.portal.status == "published"
+    assert state.portal.last_environment == "dev"
+    assert state.portal.publications[0].gateway_instance_id == gateway.id
+
+
+@pytest.mark.asyncio
+async def test_repeated_publish_same_context_is_idempotent_without_duplicate() -> None:
+    api = _api()
+    gateway = _gateway()
+    service, repository, audit, portal = _service(api=api, gateways=[gateway], deployments=[_deployment(api, gateway)])
+
+    first = await service.publish_to_portal(_publish_command(), _actor())
+    second = await service.publish_to_portal(_publish_command(), _actor())
+
+    publications = repository.apis[("acme", "payments-api")].api_metadata["lifecycle"]["portal_publications"]
+    assert first.result == "published"
+    assert second.result == "unchanged"
+    assert len(publications) == 1
+    assert len(portal.calls) == 1
+    assert audit.events[-1]["action"] == "api_lifecycle.publish_idempotent"
+
+
+@pytest.mark.asyncio
+async def test_force_republishes_same_context_without_duplicate() -> None:
+    api = _api()
+    gateway = _gateway()
+    service, repository, _, portal = _service(api=api, gateways=[gateway], deployments=[_deployment(api, gateway)])
+
+    await service.publish_to_portal(_publish_command(), _actor())
+    second = await service.publish_to_portal(_publish_command(force=True), _actor())
+
+    publications = repository.apis[("acme", "payments-api")].api_metadata["lifecycle"]["portal_publications"]
+    assert second.result == "republished"
+    assert len(publications) == 1
+    assert len(portal.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_pending_deployment_cannot_be_published() -> None:
+    api = _api()
+    gateway = _gateway()
+    service, _, audit, _ = _service(
+        api=api,
+        gateways=[gateway],
+        deployments=[_deployment(api, gateway, DeploymentSyncStatus.PENDING)],
+    )
+
+    with pytest.raises(ApiLifecycleTransitionError, match="not 'synced'"):
+        await service.publish_to_portal(_publish_command(), _actor())
+
+    assert audit.events[-1]["action"] == "api_lifecycle.publish_failed"
+    assert audit.events[-1]["details"]["publication"]["code"] == "deployment_not_synced"
+
+
+@pytest.mark.asyncio
+async def test_missing_deployment_cannot_be_published() -> None:
+    service, _, _, _ = _service(api=_api(), gateways=[_gateway()])
+
+    with pytest.raises(ApiLifecycleNotFoundError, match="No GatewayDeployment"):
+        await service.publish_to_portal(_publish_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_draft_api_cannot_be_published() -> None:
+    api = _api(status="draft")
+    gateway = _gateway()
+    service, _, _, _ = _service(api=api, gateways=[gateway], deployments=[_deployment(api, gateway)])
+
+    with pytest.raises(ApiLifecycleTransitionError, match="cannot be published"):
+        await service.publish_to_portal(_publish_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_archived_api_cannot_be_published() -> None:
+    api = _api(status="archived")
+    gateway = _gateway()
+    service, _, _, _ = _service(api=api, gateways=[gateway], deployments=[_deployment(api, gateway)])
+
+    with pytest.raises(ApiLifecycleTransitionError, match="cannot be published"):
+        await service.publish_to_portal(_publish_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_missing_api_returns_not_found() -> None:
+    service, _, _, _ = _service(gateways=[_gateway()])
+
+    with pytest.raises(ApiLifecycleNotFoundError):
+        await service.publish_to_portal(_publish_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_other_tenant_api_cannot_be_published() -> None:
+    api = _api(tenant_id="other")
+    gateway = _gateway()
+    service, repository, _, portal = _service(api=api, gateways=[gateway], deployments=[_deployment(api, gateway)])
+
+    with pytest.raises(ApiLifecycleNotFoundError):
+        await service.publish_to_portal(_publish_command(), _actor())
+
+    assert repository.apis[("other", "payments-api")].portal_published is False
+    assert portal.calls == []
+
+
+@pytest.mark.asyncio
+async def test_explicit_missing_gateway_returns_clear_error() -> None:
+    service, _, _, _ = _service(api=_api())
+
+    with pytest.raises(ApiLifecycleGatewayNotFoundError, match="Gateway"):
+        await service.publish_to_portal(_publish_command(gateway_instance_id=uuid4()), _actor())
+
+
+@pytest.mark.asyncio
+async def test_multiple_gateways_without_gateway_id_is_ambiguous() -> None:
+    service, _, _, _ = _service(api=_api(), gateways=[_gateway(name="dev-a"), _gateway(name="dev-b")])
+
+    with pytest.raises(ApiLifecycleGatewayAmbiguousError, match="Multiple gateway targets"):
+        await service.publish_to_portal(_publish_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_spec_reference_without_resolved_spec_is_refused() -> None:
+    api = _api(openapi_spec=None, spec_reference="git://catalog/apis/payments/openapi.yaml")
+    gateway = _gateway()
+    service, _, audit, _ = _service(api=api, gateways=[gateway], deployments=[_deployment(api, gateway)])
+
+    with pytest.raises(ApiLifecycleSpecValidationError) as exc:
+        await service.publish_to_portal(_publish_command(), _actor())
+
+    assert exc.value.code == "spec_reference_unresolved"
+    assert audit.events[-1]["details"]["publication"]["code"] == "spec_reference_unresolved"
+
+
+@pytest.mark.asyncio
+async def test_success_audit_event_is_written() -> None:
+    api = _api()
+    gateway = _gateway()
+    service, _, audit, _ = _service(api=api, gateways=[gateway], deployments=[_deployment(api, gateway)])
+
+    outcome = await service.publish_to_portal(_publish_command(), _actor())
+
+    assert audit.events[-1]["action"] == "api_lifecycle.publish_requested"
+    assert audit.events[-1]["details"]["deployment_id"] == str(outcome.deployment_id)
+    assert audit.events[-1]["details"]["result"] == "published"
+
+
+@pytest.mark.asyncio
+async def test_e2e_create_validate_deploy_sync_publish_get_lifecycle() -> None:
+    gateway = _gateway()
+    service, repository, _, _ = _service(gateways=[gateway])
+
+    draft = await service.create_draft(
+        CreateApiDraftCommand(
+            tenant_id="acme",
+            name="Payments API",
+            display_name="Payments API",
+            version="1.0.0",
+            description="Payment operations",
+            backend_url="https://payments.internal",
+            openapi_spec=OPENAPI_SPEC,
+        ),
+        _actor(),
+    )
+    validation = await service.validate_draft(
+        ValidateApiDraftCommand(tenant_id="acme", api_id=draft.api_id),
+        _actor(),
+    )
+    deployment_outcome = await service.deploy_to_environment(
+        DeployApiCommand(
+            tenant_id="acme",
+            api_id=draft.api_id,
+            environment="dev",
+        ),
+        _actor(),
+    )
+    deployment = next(iter(repository.deployments.values()))
+    deployment.sync_status = DeploymentSyncStatus.SYNCED
+    deployment.synced_generation = deployment.desired_generation
+    deployment.last_sync_success = datetime.now(UTC)
+
+    publication = await service.publish_to_portal(_publish_command(api_id=draft.api_id), _actor())
+    state = await service.get_lifecycle_state("acme", draft.api_id)
+
+    assert validation.status == "ready"
+    assert deployment_outcome.deployment_status == "pending"
+    assert publication.result == "published"
+    assert state.catalog_status == "ready"
+    assert state.deployments[0].sync_status == "synced"
+    assert state.portal.published is True
+    assert state.promotions == []

--- a/control-plane-api/tests/test_api_lifecycle_publish_db.py
+++ b/control-plane-api/tests/test_api_lifecycle_publish_db.py
@@ -1,0 +1,164 @@
+"""DB persistence checks for lifecycle portal publication."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import delete, select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from src.database import Base
+from src.models.catalog import APICatalog
+from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment
+from src.models.gateway_instance import GatewayInstance, GatewayType
+from src.models.promotion import Promotion  # noqa: F401 - registers FK target for create_all
+from src.services.api_lifecycle.ports import LifecycleActor, PublishApiCommand
+from src.services.api_lifecycle.repository import SqlAlchemyApiLifecycleRepository
+from src.services.api_lifecycle.service import ApiLifecycleService
+
+OPENAPI_SPEC: dict[str, Any] = {
+    "openapi": "3.0.3",
+    "info": {"title": "Payments API", "version": "1.0.0"},
+    "paths": {"/payments": {"get": {"responses": {"200": {"description": "ok"}}}}},
+}
+
+
+@dataclass
+class InMemoryAuditSink:
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    async def record_transition(
+        self,
+        *,
+        tenant_id: str,
+        actor: LifecycleActor,
+        action: str,
+        resource_id: str,
+        resource_name: str,
+        details: dict[str, Any],
+        outcome: str = "success",
+        status_code: int = 200,
+        method: str = "POST",
+        path: str | None = None,
+    ) -> None:
+        self.events.append(
+            {
+                "tenant_id": tenant_id,
+                "actor": actor,
+                "action": action,
+                "resource_id": resource_id,
+                "resource_name": resource_name,
+                "details": details,
+                "outcome": outcome,
+                "status_code": status_code,
+                "method": method,
+                "path": path,
+            }
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_publication_metadata_persists_after_commit_and_reload() -> None:
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        pytest.skip("DATABASE_URL not set")
+
+    engine = create_async_engine(database_url, echo=False)
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE SCHEMA IF NOT EXISTS stoa"))
+        await conn.run_sync(Base.metadata.create_all)
+
+    tenant_id = f"slice45-{uuid4().hex}"
+    api_id = "payments-api"
+    gateway_name = f"slice45-dev-{uuid4().hex}"
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with session_factory() as session:
+        api: APICatalog | None = None
+        try:
+            api = APICatalog(
+                tenant_id=tenant_id,
+                api_id=api_id,
+                api_name="Payments API",
+                version="1.0.0",
+                status="ready",
+                tags=[],
+                portal_published=False,
+                api_metadata={
+                    "display_name": "Payments API",
+                    "description": "Payment operations",
+                    "backend_url": "https://payments.internal",
+                    "lifecycle": {"catalog_status": "ready", "spec_source": "inline"},
+                },
+                openapi_spec=OPENAPI_SPEC,
+            )
+            gateway = GatewayInstance(
+                name=gateway_name,
+                display_name="Slice45 Dev",
+                gateway_type=GatewayType.STOA,
+                environment="dev",
+                tenant_id=tenant_id,
+                base_url="https://gateway.dev.example/admin",
+                public_url="https://gateway.dev.example",
+                enabled=True,
+            )
+            session.add_all([api, gateway])
+            await session.flush()
+
+            deployment = GatewayDeployment(
+                api_catalog_id=api.id,
+                gateway_instance_id=gateway.id,
+                desired_state={"api_id": api.api_id},
+                desired_at=datetime.now(UTC),
+                desired_generation=1,
+                synced_generation=1,
+                attempted_generation=1,
+                sync_status=DeploymentSyncStatus.SYNCED,
+                sync_attempts=1,
+                last_sync_success=datetime.now(UTC),
+            )
+            session.add(deployment)
+            await session.commit()
+            gateway_id = gateway.id
+            deployment_id = deployment.id
+
+            service = ApiLifecycleService(
+                repository=SqlAlchemyApiLifecycleRepository(session),
+                audit_sink=InMemoryAuditSink(),
+            )
+            outcome = await service.publish_to_portal(
+                PublishApiCommand(
+                    tenant_id=tenant_id,
+                    api_id=api_id,
+                    environment="dev",
+                    gateway_instance_id=gateway.id,
+                ),
+                LifecycleActor(actor_id="user-1", email="owner@acme.test", username="owner"),
+            )
+            await session.commit()
+
+            session.expire_all()
+            result = await session.execute(
+                select(APICatalog).where(APICatalog.tenant_id == tenant_id, APICatalog.api_id == api_id)
+            )
+            reloaded = result.scalar_one()
+            publication = reloaded.api_metadata["lifecycle"]["portal_publications"][f"dev:{gateway_id}"]
+            assert outcome.result == "published"
+            assert reloaded.portal_published is True
+            assert publication["deployment_id"] == str(deployment_id)
+            assert publication["publication_status"] == "published"
+            assert publication["source"] == "api_lifecycle"
+        finally:
+            if api is not None and api.id is not None:
+                await session.execute(delete(GatewayDeployment).where(GatewayDeployment.api_catalog_id == api.id))
+            await session.execute(delete(GatewayInstance).where(GatewayInstance.name == gateway_name))
+            await session.execute(delete(APICatalog).where(APICatalog.tenant_id == tenant_id))
+            await session.commit()
+
+    await engine.dispose()

--- a/control-plane-api/tests/test_api_lifecycle_publish_router.py
+++ b/control-plane-api/tests/test_api_lifecycle_publish_router.py
@@ -1,0 +1,166 @@
+"""Router tests for API lifecycle portal publication requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+from src.services.api_lifecycle.errors import (
+    ApiLifecycleGatewayAmbiguousError,
+    ApiLifecycleGatewayNotFoundError,
+    ApiLifecycleNotFoundError,
+    ApiLifecycleSpecValidationError,
+    ApiLifecycleTransitionError,
+    ApiLifecycleValidationError,
+)
+from src.services.api_lifecycle.ports import (
+    ApiLifecycleState,
+    ApiPortalPublicationOutcome,
+    ApiSpecState,
+)
+
+
+@dataclass
+class FakePublishService:
+    outcome: ApiPortalPublicationOutcome | None = None
+    exc: Exception | None = None
+
+    async def publish_to_portal(self, command, actor):
+        if self.exc:
+            raise self.exc
+        return self.outcome
+
+
+def _lifecycle_state() -> ApiLifecycleState:
+    return ApiLifecycleState(
+        catalog_id=uuid4(),
+        tenant_id="acme",
+        api_id="payments-api",
+        api_name="Payments API",
+        display_name="Payments API",
+        version="1.0.0",
+        description="Payment operations",
+        backend_url="https://payments.internal",
+        catalog_status="ready",
+        lifecycle_phase="published",
+        portal_published=True,
+        tags=[],
+        spec=ApiSpecState(source="inline", has_openapi_spec=True),
+        deployments=[],
+        promotions=[],
+    )
+
+
+def _outcome() -> ApiPortalPublicationOutcome:
+    return ApiPortalPublicationOutcome(
+        tenant_id="acme",
+        api_id="payments-api",
+        environment="dev",
+        gateway_instance_id=uuid4(),
+        deployment_id=uuid4(),
+        publication_status="published",
+        portal_published=True,
+        result="published",
+        lifecycle_state=_lifecycle_state(),
+    )
+
+
+def _patch_service(monkeypatch, service: FakePublishService) -> None:
+    import src.routers.api_lifecycle as router_module
+
+    def build_service(_db):
+        return service
+
+    monkeypatch.setattr(router_module, "_build_service", build_service)
+
+
+def test_publish_lifecycle_endpoint_returns_publication_response(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(monkeypatch, FakePublishService(outcome=_outcome()))
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/publications",
+        json={"environment": "dev"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["api_id"] == "payments-api"
+    assert data["environment"] == "dev"
+    assert data["publication_status"] == "published"
+    assert data["portal_published"] is True
+    assert data["result"] == "published"
+    assert data["lifecycle"]["catalog_status"] == "ready"
+
+
+def test_publish_lifecycle_endpoint_maps_transition_error_to_409(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(
+        monkeypatch, FakePublishService(exc=ApiLifecycleTransitionError("Deployment is 'pending', not 'synced'"))
+    )
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/publications",
+        json={"environment": "dev"},
+    )
+
+    assert response.status_code == 409
+
+
+def test_publish_lifecycle_endpoint_maps_missing_api_to_404(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(monkeypatch, FakePublishService(exc=ApiLifecycleNotFoundError("API not found")))
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/publications",
+        json={"environment": "dev"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_publish_lifecycle_endpoint_maps_missing_gateway_to_404(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(monkeypatch, FakePublishService(exc=ApiLifecycleGatewayNotFoundError("Gateway not found")))
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/publications",
+        json={"environment": "dev", "gateway_instance_id": str(uuid4())},
+    )
+
+    assert response.status_code == 404
+
+
+def test_publish_lifecycle_endpoint_maps_ambiguous_gateway_to_409(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(monkeypatch, FakePublishService(exc=ApiLifecycleGatewayAmbiguousError("Multiple gateway targets")))
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/publications",
+        json={"environment": "dev"},
+    )
+
+    assert response.status_code == 409
+
+
+def test_publish_lifecycle_endpoint_maps_invalid_spec_to_422(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(
+        monkeypatch,
+        FakePublishService(exc=ApiLifecycleSpecValidationError("openapi_spec_missing", "OpenAPI spec is required")),
+    )
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/publications",
+        json={"environment": "dev"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "openapi_spec_missing"
+
+
+def test_publish_lifecycle_endpoint_maps_invalid_environment_to_422(client_as_tenant_admin, monkeypatch) -> None:
+    _patch_service(
+        monkeypatch, FakePublishService(exc=ApiLifecycleValidationError("Invalid deployment environment: qa"))
+    )
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/payments-api/lifecycle/publications",
+        json={"environment": "qa"},
+    )
+
+    assert response.status_code == 422

--- a/control-plane-api/tests/test_api_lifecycle_router.py
+++ b/control-plane-api/tests/test_api_lifecycle_router.py
@@ -1,0 +1,177 @@
+"""Router tests for the canonical API lifecycle endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from src.models.catalog import APICatalog
+
+
+def _scalar_result(value):
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
+def _rows_result(rows):
+    result = MagicMock()
+    result.all.return_value = rows
+    return result
+
+
+def _scalars_result(rows):
+    result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = rows
+    result.scalars.return_value = scalars
+    return result
+
+
+def test_create_draft_endpoint_returns_lifecycle_state(client_as_tenant_admin, mock_db_session) -> None:
+    mock_db_session.execute.side_effect = [
+        _scalar_result(None),
+        _scalar_result(None),
+        _rows_result([]),
+        _scalars_result([]),
+    ]
+
+    response = client_as_tenant_admin.post(
+        "/v1/tenants/acme/apis/lifecycle/drafts",
+        json={
+            "name": "Payments API",
+            "display_name": "Payments API",
+            "version": "1.0.0",
+            "description": "Payment operations",
+            "backend_url": "https://payments.internal",
+            "openapi_spec": {
+                "openapi": "3.0.3",
+                "info": {"title": "Payments API", "version": "1.0.0"},
+                "paths": {},
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["api_id"] == "payments-api"
+    assert data["catalog_status"] == "draft"
+    assert data["lifecycle_phase"] == "draft"
+    assert data["portal_published"] is False
+    assert data["spec"]["source"] == "inline"
+    assert data["deployments"] == []
+    assert data["promotions"] == []
+    mock_db_session.commit.assert_awaited_once()
+
+
+def test_get_lifecycle_state_endpoint_is_registered_before_api_catch_all(
+    client_as_tenant_admin,
+    mock_db_session,
+) -> None:
+    catalog = APICatalog(
+        id=uuid4(),
+        tenant_id="acme",
+        api_id="payments-api",
+        api_name="Payments API",
+        version="1.0.0",
+        status="draft",
+        tags=[],
+        portal_published=False,
+        api_metadata={
+            "display_name": "Payments API",
+            "description": "Payment operations",
+            "backend_url": "https://payments.internal",
+            "lifecycle": {"spec_source": "inline"},
+        },
+        openapi_spec={
+            "openapi": "3.0.3",
+            "info": {"title": "Payments API", "version": "1.0.0"},
+            "paths": {},
+        },
+    )
+    mock_db_session.execute.side_effect = [
+        _scalar_result(catalog),
+        _rows_result([]),
+        _scalars_result([]),
+    ]
+
+    response = client_as_tenant_admin.get("/v1/tenants/acme/apis/payments-api/lifecycle")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["api_id"] == "payments-api"
+    assert data["catalog_status"] == "draft"
+    assert data["lifecycle_phase"] == "draft"
+
+
+def test_validate_draft_endpoint_returns_ready_state(client_as_tenant_admin, mock_db_session) -> None:
+    catalog = APICatalog(
+        id=uuid4(),
+        tenant_id="acme",
+        api_id="payments-api",
+        api_name="Payments API",
+        version="1.0.0",
+        status="draft",
+        tags=[],
+        portal_published=False,
+        api_metadata={
+            "display_name": "Payments API",
+            "description": "Payment operations",
+            "backend_url": "https://payments.internal",
+            "lifecycle": {"spec_source": "inline"},
+        },
+        openapi_spec={
+            "openapi": "3.0.3",
+            "info": {"title": "Payments API", "version": "1.0.0"},
+            "paths": {"/payments": {"get": {"responses": {"200": {"description": "ok"}}}}},
+        },
+    )
+    mock_db_session.execute.side_effect = [
+        _scalar_result(catalog),
+        _rows_result([]),
+        _scalars_result([]),
+    ]
+
+    response = client_as_tenant_admin.post("/v1/tenants/acme/apis/payments-api/lifecycle/validate")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["api_id"] == "payments-api"
+    assert data["status"] == "ready"
+    assert data["validation"]["valid"] is True
+    assert data["validation"]["spec_format"] == "openapi"
+    assert data["lifecycle"]["catalog_status"] == "ready"
+    assert data["lifecycle"]["deployments"] == []
+    mock_db_session.commit.assert_awaited_once()
+
+
+def test_validate_draft_endpoint_returns_422_for_invalid_spec(client_as_tenant_admin, mock_db_session) -> None:
+    catalog = APICatalog(
+        id=uuid4(),
+        tenant_id="acme",
+        api_id="payments-api",
+        api_name="Payments API",
+        version="1.0.0",
+        status="draft",
+        tags=[],
+        portal_published=False,
+        api_metadata={
+            "display_name": "Payments API",
+            "description": "Payment operations",
+            "backend_url": "https://payments.internal",
+            "lifecycle": {"spec_source": "inline"},
+        },
+        openapi_spec={
+            "openapi": "3.0.3",
+            "info": {"title": "Payments API", "version": "1.0.0"},
+            "paths": {"/payments": {"get": {"operationId": "listPayments"}}},
+        },
+    )
+    mock_db_session.execute.side_effect = [_scalar_result(catalog)]
+
+    response = client_as_tenant_admin.post("/v1/tenants/acme/apis/payments-api/lifecycle/validate")
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "openapi_operation_responses_missing"
+    assert catalog.status == "draft"
+    mock_db_session.commit.assert_awaited_once()

--- a/control-plane-api/tests/test_api_lifecycle_service.py
+++ b/control-plane-api/tests/test_api_lifecycle_service.py
@@ -1,0 +1,459 @@
+"""Tests for the canonical API lifecycle service, Slice 1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.models.catalog import APICatalog
+from src.services.api_lifecycle.errors import (
+    ApiLifecycleConflictError,
+    ApiLifecycleNotFoundError,
+    ApiLifecycleSpecValidationError,
+    ApiLifecycleTransitionError,
+    ApiLifecycleValidationError,
+)
+from src.services.api_lifecycle.ports import (
+    CreateApiDraftCommand,
+    GatewayDeploymentSnapshot,
+    LifecycleActor,
+    PromotionSnapshot,
+    ValidateApiDraftCommand,
+)
+from src.services.api_lifecycle.service import ApiLifecycleService
+
+OPENAPI_SPEC: dict[str, Any] = {
+    "openapi": "3.0.3",
+    "info": {"title": "Payments API", "version": "1.0.0"},
+    "paths": {"/payments": {"get": {"responses": {"200": {"description": "ok"}}}}},
+}
+
+SWAGGER_SPEC: dict[str, Any] = {
+    "swagger": "2.0",
+    "info": {"title": "Pets API", "version": "1.0.0"},
+    "paths": {"/pets": {"get": {"responses": {"200": {"description": "ok"}}}}},
+}
+
+
+@dataclass
+class InMemoryApiLifecycleRepository:
+    rows: dict[tuple[str, str], APICatalog] = field(default_factory=dict)
+
+    async def get_api_by_id(self, tenant_id: str, api_id: str) -> APICatalog | None:
+        return self.rows.get((tenant_id, api_id))
+
+    async def get_api_by_name_version(self, tenant_id: str, api_name: str, version: str) -> APICatalog | None:
+        return next(
+            (
+                row
+                for (row_tenant_id, _), row in self.rows.items()
+                if row_tenant_id == tenant_id and row.api_name == api_name and row.version == version
+            ),
+            None,
+        )
+
+    async def create_api_catalog(self, api: APICatalog) -> APICatalog:
+        self.rows[(api.tenant_id, api.api_id)] = api
+        return api
+
+    async def save_api_catalog(self, api: APICatalog) -> APICatalog:
+        self.rows[(api.tenant_id, api.api_id)] = api
+        return api
+
+    async def list_gateway_deployments(self, api_catalog_id: UUID) -> list[GatewayDeploymentSnapshot]:
+        return []
+
+    async def list_promotions(self, tenant_id: str, api_id: str) -> list[PromotionSnapshot]:
+        return []
+
+
+@dataclass
+class InMemoryAuditSink:
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    async def record_transition(
+        self,
+        *,
+        tenant_id: str,
+        actor: LifecycleActor,
+        action: str,
+        resource_id: str,
+        resource_name: str,
+        details: dict[str, Any],
+        outcome: str = "success",
+        status_code: int = 200,
+        method: str = "POST",
+        path: str | None = None,
+    ) -> None:
+        self.events.append(
+            {
+                "tenant_id": tenant_id,
+                "actor": actor,
+                "action": action,
+                "resource_id": resource_id,
+                "resource_name": resource_name,
+                "details": details,
+                "outcome": outcome,
+                "status_code": status_code,
+                "method": method,
+                "path": path,
+            }
+        )
+
+
+def _service() -> tuple[ApiLifecycleService, InMemoryApiLifecycleRepository, InMemoryAuditSink]:
+    repository = InMemoryApiLifecycleRepository()
+    audit = InMemoryAuditSink()
+    return ApiLifecycleService(repository=repository, audit_sink=audit), repository, audit
+
+
+def _command(**overrides) -> CreateApiDraftCommand:
+    values = {
+        "tenant_id": "acme",
+        "name": "Payments API",
+        "display_name": "Payments API",
+        "version": "1.0.0",
+        "description": "Payment operations",
+        "backend_url": "https://payments.internal",
+        "openapi_spec": OPENAPI_SPEC,
+        "tags": ("finance",),
+        "owner_team": "payments",
+    }
+    values.update(overrides)
+    return CreateApiDraftCommand(**values)
+
+
+def _actor() -> LifecycleActor:
+    return LifecycleActor(actor_id="user-1", email="owner@acme.test", username="owner")
+
+
+def _direct_catalog(
+    *,
+    tenant_id: str = "acme",
+    api_id: str = "payments-api",
+    status: str = "draft",
+    spec: Any = OPENAPI_SPEC,
+    spec_reference: str | None = None,
+) -> APICatalog:
+    return APICatalog(
+        id=uuid4(),
+        tenant_id=tenant_id,
+        api_id=api_id,
+        api_name="Payments API",
+        version="1.0.0",
+        status=status,
+        tags=[],
+        portal_published=False,
+        api_metadata={
+            "display_name": "Payments API",
+            "description": "Payment operations",
+            "backend_url": "https://payments.internal",
+            "status": status,
+            "lifecycle": {
+                "catalog_status": status,
+                "spec_source": "inline" if spec else "reference",
+                "spec_reference": spec_reference,
+            },
+        },
+        openapi_spec=spec,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_draft_persists_catalog_spec_and_audit_event() -> None:
+    service, repository, audit = _service()
+
+    state = await service.create_draft(_command(), _actor())
+
+    assert state.api_id == "payments-api"
+    assert state.catalog_status == "draft"
+    assert state.lifecycle_phase == "draft"
+    assert state.portal_published is False
+    assert state.deployments == []
+    assert state.promotions == []
+    assert state.spec.source == "inline"
+    assert state.spec.has_openapi_spec is True
+
+    stored = repository.rows[("acme", "payments-api")]
+    assert stored.status == "draft"
+    assert stored.portal_published is False
+    assert stored.openapi_spec == OPENAPI_SPEC
+    assert stored.api_metadata["lifecycle"]["spec_source"] == "inline"
+
+    assert audit.events == [
+        {
+            "tenant_id": "acme",
+            "actor": _actor(),
+            "action": "api_lifecycle.create_draft",
+            "resource_id": "payments-api",
+            "resource_name": "Payments API",
+            "details": {
+                "api_id": "payments-api",
+                "api_name": "Payments API",
+                "version": "1.0.0",
+                "catalog_status": "draft",
+                "spec_source": "inline",
+                "portal_published": False,
+            },
+            "outcome": "success",
+            "status_code": 201,
+            "method": "POST",
+            "path": "/v1/tenants/acme/apis/lifecycle/drafts",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_lifecycle_state_returns_aggregate_draft_state() -> None:
+    service, _, _ = _service()
+    await service.create_draft(_command(), _actor())
+
+    state = await service.get_lifecycle_state("acme", "payments-api")
+
+    assert state.catalog_status == "draft"
+    assert state.lifecycle_phase == "draft"
+    assert state.spec.source == "inline"
+    assert state.deployments == []
+    assert state.promotions == []
+    assert state.last_error is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("portal_tag", ["portal:published", "promoted:portal", "portal-promoted"])
+async def test_create_draft_rejects_implicit_portal_publication_tag(portal_tag: str) -> None:
+    service, repository, _ = _service()
+
+    with pytest.raises(ApiLifecycleValidationError, match="Portal publication must use"):
+        await service.create_draft(_command(tags=(portal_tag,)), _actor())
+
+    assert repository.rows == {}
+
+
+@pytest.mark.asyncio
+async def test_create_draft_requires_spec_or_reference() -> None:
+    service, repository, _ = _service()
+
+    with pytest.raises(ApiLifecycleValidationError, match="OpenAPI spec or spec_reference is required"):
+        await service.create_draft(_command(openapi_spec=None, spec_reference=None), _actor())
+
+    assert repository.rows == {}
+
+
+@pytest.mark.asyncio
+async def test_create_draft_rejects_duplicate_name_version() -> None:
+    service, _, _ = _service()
+    await service.create_draft(_command(), _actor())
+
+    with pytest.raises(ApiLifecycleConflictError, match="already exists"):
+        await service.create_draft(_command(), _actor())
+
+
+@pytest.mark.asyncio
+async def test_validate_draft_openapi3_transitions_to_ready_and_audits_success() -> None:
+    service, repository, audit = _service()
+    await service.create_draft(_command(openapi_spec=OPENAPI_SPEC), _actor())
+
+    outcome = await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="payments-api"), _actor())
+
+    assert outcome.status == "ready"
+    assert outcome.validation.valid is True
+    assert outcome.validation.spec_format == "openapi"
+    assert outcome.validation.spec_version == "3.0.3"
+    assert outcome.validation.path_count == 1
+    assert outcome.lifecycle_state.catalog_status == "ready"
+    assert outcome.lifecycle_state.lifecycle_phase == "ready"
+    stored = repository.rows[("acme", "payments-api")]
+    assert stored.status == "ready"
+    assert stored.api_metadata["lifecycle"]["validation_spec_hash"]
+    assert audit.events[-1]["action"] == "api_lifecycle.validate_draft"
+    assert audit.events[-1]["outcome"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_validate_draft_swagger2_transitions_to_ready() -> None:
+    service, _, _ = _service()
+    await service.create_draft(_command(name="Pets API", display_name="Pets API", openapi_spec=SWAGGER_SPEC), _actor())
+
+    outcome = await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="pets-api"), _actor())
+
+    assert outcome.status == "ready"
+    assert outcome.validation.spec_format == "swagger"
+    assert outcome.validation.spec_version == "2.0"
+
+
+@pytest.mark.asyncio
+async def test_validate_invalid_spec_is_refused_and_status_stays_draft() -> None:
+    service, repository, _ = _service()
+    repository.rows[("acme", "payments-api")] = _direct_catalog(spec=["not-an-object"])
+
+    with pytest.raises(ApiLifecycleSpecValidationError) as exc:
+        await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="payments-api"), _actor())
+
+    assert exc.value.code == "openapi_spec_invalid"
+    assert repository.rows[("acme", "payments-api")].status == "draft"
+
+
+@pytest.mark.asyncio
+async def test_validate_spec_without_paths_is_refused() -> None:
+    service, repository, _ = _service()
+    await service.create_draft(
+        _command(openapi_spec={"openapi": "3.0.3", "info": {"title": "API", "version": "1"}}), _actor()
+    )
+
+    with pytest.raises(ApiLifecycleSpecValidationError) as exc:
+        await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="payments-api"), _actor())
+
+    assert exc.value.code == "openapi_paths_missing"
+    assert repository.rows[("acme", "payments-api")].status == "draft"
+
+
+@pytest.mark.asyncio
+async def test_validate_spec_without_info_title_is_refused() -> None:
+    service, repository, _ = _service()
+    await service.create_draft(
+        _command(
+            openapi_spec={
+                "openapi": "3.0.3",
+                "info": {"version": "1"},
+                "paths": {"/payments": {"get": {"responses": {"200": {"description": "ok"}}}}},
+            }
+        ),
+        _actor(),
+    )
+
+    with pytest.raises(ApiLifecycleSpecValidationError) as exc:
+        await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="payments-api"), _actor())
+
+    assert exc.value.code == "openapi_info_title_missing"
+    assert repository.rows[("acme", "payments-api")].status == "draft"
+
+
+@pytest.mark.asyncio
+async def test_validate_spec_without_info_version_is_refused() -> None:
+    service, repository, _ = _service()
+    await service.create_draft(
+        _command(
+            openapi_spec={
+                "openapi": "3.0.3",
+                "info": {"title": "API"},
+                "paths": {"/payments": {"get": {"responses": {"200": {"description": "ok"}}}}},
+            }
+        ),
+        _actor(),
+    )
+
+    with pytest.raises(ApiLifecycleSpecValidationError) as exc:
+        await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="payments-api"), _actor())
+
+    assert exc.value.code == "openapi_info_version_missing"
+    assert repository.rows[("acme", "payments-api")].status == "draft"
+
+
+@pytest.mark.asyncio
+async def test_validate_spec_with_empty_paths_is_refused() -> None:
+    service, repository, _ = _service()
+    await service.create_draft(
+        _command(openapi_spec={"openapi": "3.0.3", "info": {"title": "API", "version": "1"}, "paths": {}}),
+        _actor(),
+    )
+
+    with pytest.raises(ApiLifecycleSpecValidationError) as exc:
+        await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="payments-api"), _actor())
+
+    assert exc.value.code == "openapi_paths_empty"
+    assert repository.rows[("acme", "payments-api")].status == "draft"
+
+
+@pytest.mark.asyncio
+async def test_validate_operation_without_responses_is_refused() -> None:
+    service, repository, _ = _service()
+    await service.create_draft(
+        _command(
+            openapi_spec={
+                "openapi": "3.0.3",
+                "info": {"title": "API", "version": "1"},
+                "paths": {"/payments": {"get": {"operationId": "listPayments"}}},
+            }
+        ),
+        _actor(),
+    )
+
+    with pytest.raises(ApiLifecycleSpecValidationError) as exc:
+        await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="payments-api"), _actor())
+
+    assert exc.value.code == "openapi_operation_responses_missing"
+    assert repository.rows[("acme", "payments-api")].status == "draft"
+
+
+@pytest.mark.asyncio
+async def test_validate_missing_api_returns_not_found() -> None:
+    service, _, _ = _service()
+
+    with pytest.raises(ApiLifecycleNotFoundError, match="was not found"):
+        await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="missing-api"), _actor())
+
+
+@pytest.mark.asyncio
+async def test_validate_other_tenant_api_returns_not_found_without_mutating() -> None:
+    service, repository, _ = _service()
+    repository.rows[("other", "payments-api")] = _direct_catalog(tenant_id="other")
+
+    with pytest.raises(ApiLifecycleNotFoundError):
+        await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="payments-api"), _actor())
+
+    assert repository.rows[("other", "payments-api")].status == "draft"
+
+
+@pytest.mark.asyncio
+async def test_validate_ready_api_is_idempotent_when_spec_unchanged() -> None:
+    service, repository, _ = _service()
+    await service.create_draft(_command(), _actor())
+    first = await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="payments-api"), _actor())
+
+    second = await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="payments-api"), _actor())
+
+    assert first.status == "ready"
+    assert second.status == "ready"
+    assert repository.rows[("acme", "payments-api")].status == "ready"
+
+
+@pytest.mark.asyncio
+async def test_validate_archived_api_is_refused() -> None:
+    service, repository, audit = _service()
+    repository.rows[("acme", "payments-api")] = _direct_catalog(status="archived")
+
+    with pytest.raises(ApiLifecycleTransitionError, match="Archived APIs cannot be validated"):
+        await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="payments-api"), _actor())
+
+    assert repository.rows[("acme", "payments-api")].status == "archived"
+    assert audit.events[-1]["action"] == "api_lifecycle.validate_draft_failed"
+    assert audit.events[-1]["outcome"] == "failure"
+
+
+@pytest.mark.asyncio
+async def test_validate_spec_reference_without_resolver_is_refused() -> None:
+    service, repository, _ = _service()
+    await service.create_draft(_command(openapi_spec=None, spec_reference="apis/payments/openapi.yaml"), _actor())
+
+    with pytest.raises(ApiLifecycleSpecValidationError) as exc:
+        await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="payments-api"), _actor())
+
+    assert exc.value.code == "spec_reference_unresolved"
+    assert repository.rows[("acme", "payments-api")].status == "draft"
+
+
+@pytest.mark.asyncio
+async def test_get_lifecycle_after_validation_returns_ready_without_gateway_state() -> None:
+    service, _, _ = _service()
+    await service.create_draft(_command(), _actor())
+    await service.validate_draft(ValidateApiDraftCommand(tenant_id="acme", api_id="payments-api"), _actor())
+
+    state = await service.get_lifecycle_state("acme", "payments-api")
+
+    assert state.catalog_status == "ready"
+    assert state.lifecycle_phase == "ready"
+    assert state.deployments == []
+    assert state.promotions == []

--- a/control-plane-api/tests/test_apis_router.py
+++ b/control-plane-api/tests/test_apis_router.py
@@ -4,6 +4,8 @@ import uuid
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from src.models.catalog import APICatalog
 
 KAFKA_PATH = "src.routers.apis.kafka_service"
@@ -207,7 +209,10 @@ paths:
         app_with_tenant_admin.dependency_overrides.pop(get_db, None)
         assert resp.status_code == 409
 
-    def test_portal_promoted_tag(self, app_with_tenant_admin, client_as_tenant_admin):
+    @pytest.mark.parametrize("portal_tag", ["portal:published", "promoted:portal", "portal-promoted"])
+    def test_create_rejects_implicit_portal_publication_tag(
+        self, app_with_tenant_admin, client_as_tenant_admin, portal_tag
+    ):
         with patch(CATALOG_REPO_PATH), patch(KAFKA_PATH) as mock_kafka:
             mock_kafka.emit_api_created = AsyncMock(return_value="evt-1")
             mock_kafka.emit_audit_event = AsyncMock(return_value="evt-2")
@@ -217,12 +222,13 @@ paths:
                     "name": "portal-api",
                     "display_name": "Portal API",
                     "backend_url": "https://api.example.com",
-                    "tags": ["portal:published", "v1"],
+                    "tags": [portal_tag, "v1"],
                 },
             )
 
-        body = resp.json()
-        assert body["portal_promoted"] is True
+        assert resp.status_code == 422
+        assert "lifecycle/publications" in resp.json()["detail"]
+        mock_kafka.emit_api_created.assert_not_called()
 
 
 class TestUpdateAPI:
@@ -251,6 +257,26 @@ class TestUpdateAPI:
 
         assert resp.status_code == 404
 
+    @pytest.mark.parametrize("portal_tag", ["portal:published", "promoted:portal", "portal-promoted"])
+    def test_update_rejects_implicit_portal_publication_tag(
+        self, app_with_tenant_admin, client_as_tenant_admin, portal_tag
+    ):
+        mock_api = _mock_catalog_api()
+        with patch(CATALOG_REPO_PATH) as MockRepo:
+            MockRepo.return_value.get_api_by_id = AsyncMock(return_value=mock_api)
+            with patch(KAFKA_PATH) as mock_kafka:
+                mock_kafka.emit_api_updated = AsyncMock(return_value="evt-1")
+                mock_kafka.emit_audit_event = AsyncMock(return_value="evt-2")
+                resp = client_as_tenant_admin.put(
+                    "/v1/tenants/acme/apis/weather-api",
+                    json={"tags": [portal_tag, "v1"]},
+                )
+
+        assert resp.status_code == 422
+        assert "lifecycle/publications" in resp.json()["detail"]
+        assert mock_api.portal_published is False
+        mock_kafka.emit_api_updated.assert_not_called()
+
 
 class TestDeleteAPI:
     def test_delete_success(self, app_with_tenant_admin, client_as_tenant_admin):
@@ -274,17 +300,17 @@ class TestDeleteAPI:
 
 
 class TestApiFromCatalog:
-    def test_portal_promoted_detection(self):
+    def test_portal_promoted_detection_uses_catalog_field(self):
         from src.routers.apis import _api_from_catalog
 
-        api = _mock_catalog_api(tags=["portal:published", "v1"])
+        api = _mock_catalog_api(tags=["v1"], portal_published=True)
         result = _api_from_catalog(api)
         assert result.portal_promoted is True
 
-    def test_no_portal_tag(self):
+    def test_portal_tag_alone_does_not_mark_portal_promoted(self):
         from src.routers.apis import _api_from_catalog
 
-        api = _mock_catalog_api(tags=["v1"])
+        api = _mock_catalog_api(tags=["portal:published", "v1"], portal_published=False)
         result = _api_from_catalog(api)
         assert result.portal_promoted is False
 

--- a/control-plane-api/tests/test_catalog_admin_router.py
+++ b/control-plane-api/tests/test_catalog_admin_router.py
@@ -11,7 +11,9 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.dialects import postgresql
 
 SYNC_SVC_PATH = "src.routers.catalog_admin.CatalogSyncService"
 CATALOG_REPO_PATH = "src.routers.catalog_admin.CatalogRepository"
@@ -155,7 +157,6 @@ class TestTriggerMcpServersSync:
         assert resp.status_code == 403
 
 
-
 class TestTriggerTenantSync:
     """Tests for POST /v1/admin/catalog/sync/tenant/{tenant_id}."""
 
@@ -197,7 +198,6 @@ class TestTriggerTenantSync:
             resp = client.post("/v1/admin/catalog/sync/tenant/acme")
 
         assert resp.status_code == 403
-
 
 
 class TestGetSyncStatus:
@@ -553,7 +553,8 @@ class TestSeedCatalog:
         assert data["seeded"] == 2
         assert data["failed"] == 1
 
-    def test_seed_catalog_portal_published_tags(self, app_with_cpi_admin, mock_db_session):
+    @pytest.mark.parametrize("portal_tag", ["portal:published", "promoted:portal", "portal-promoted"])
+    def test_seed_catalog_portal_publication_tags_are_stripped(self, app_with_cpi_admin, mock_db_session, portal_tag):
         mock_db_session.execute = AsyncMock(return_value=MagicMock())
         mock_db_session.commit = AsyncMock()
 
@@ -564,7 +565,7 @@ class TestSeedCatalog:
                     "name": "promoted-api",
                     "display_name": "Promoted",
                     "version": "1.0.0",
-                    "tags": ["portal:published", "v2"],
+                    "tags": [portal_tag, "v2"],
                 }
             ],
         }
@@ -574,6 +575,16 @@ class TestSeedCatalog:
 
         assert resp.status_code == 200
         assert resp.json()["seeded"] == 1
+        stmt = mock_db_session.execute.await_args.args[0]
+        compiled = stmt.compile(dialect=postgresql.dialect())
+        params = compiled.params
+        assert params["tags"] == ["v2"]
+        assert params["metadata"]["tags"] == ["v2"]
+        assert params["portal_published"] is False
+        update_clause = str(compiled).split("DO UPDATE SET", maxsplit=1)[1]
+        assert "portal_published =" not in update_clause
+        assert "jsonb_strip_nulls" in update_clause
+        assert "jsonb_build_object" in update_clause
 
     def test_seed_catalog_403_viewer(self, app_with_no_tenant_user, mock_db_session):
         with TestClient(app_with_no_tenant_user) as client:

--- a/control-plane-api/tests/test_catalog_sync_service.py
+++ b/control-plane-api/tests/test_catalog_sync_service.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy.dialects import postgresql
 
 from src.models.catalog import CatalogSyncStatus, SyncStatus, SyncType
 from src.models.gateway_deployment import DeploymentSyncStatus
@@ -519,8 +520,9 @@ class TestUpsertApi:
 
         db.execute.assert_awaited_once()
 
-    async def test_portal_published_detection(self):
-        """Tags matching portal promotion markers set portal_published=True."""
+    @pytest.mark.parametrize("portal_tag", ["portal:published", "promoted:portal", "portal-promoted"])
+    async def test_portal_publication_tags_are_stripped_without_publishing(self, portal_tag):
+        """Catalog sync does not publish APIs from legacy portal tags."""
         db = _make_db()
         git = _make_git()
         svc = CatalogSyncService(db, git)
@@ -533,17 +535,19 @@ class TestUpsertApi:
 
         db.execute = capture_execute
 
-        # Use "portal:published" tag
-        api = {"name": "Published API", "tags": ["portal:published", "internal"]}
+        api = {"name": "Published API", "tags": [portal_tag, "internal"]}
         await svc._upsert_api("acme", "pub-api", api, None, "sha")
 
-        # Verify db.execute was called with the INSERT statement
         assert "stmt" in captured_stmt
-        # The _upsert_api method builds the stmt with portal_published=True
-        # for tags containing "portal:published". We verify the method completed
-        # without error, which means the statement was built correctly.
-        # Direct value inspection requires SQLAlchemy compilation internals
-        # that vary across versions, so we verify via integration instead.
+        compiled = captured_stmt["stmt"].compile(dialect=postgresql.dialect())
+        params = compiled.params
+        assert params["tags"] == ["internal"]
+        assert params["metadata"]["tags"] == ["internal"]
+        assert params["portal_published"] is False
+        update_clause = str(compiled).split("DO UPDATE SET", maxsplit=1)[1]
+        assert "portal_published =" not in update_clause
+        assert "jsonb_strip_nulls" in update_clause
+        assert "jsonb_build_object" in update_clause
 
     async def test_target_gateways_extraction(self):
         """gateways: block in api.yaml populates target_gateways list."""

--- a/control-plane-api/tests/test_deployment_consumer.py
+++ b/control-plane-api/tests/test_deployment_consumer.py
@@ -82,13 +82,13 @@ class TestHandleMessage:
             ),
             patch("asyncio.run_coroutine_threadsafe") as mock_rcts,
         ):
-                mock_future = MagicMock()
-                mock_rcts.return_value = mock_future
+            mock_future = MagicMock()
+            mock_rcts.return_value = mock_future
 
-                consumer._handle(message)
+            consumer._handle(message)
 
-                mock_rcts.assert_called_once()
-                mock_future.result.assert_called_once_with(timeout=10)
+            mock_rcts.assert_called_once()
+            mock_future.result.assert_called_once_with(timeout=10)
 
         loop.close()
 

--- a/control-plane-api/tests/test_deployment_logs.py
+++ b/control-plane-api/tests/test_deployment_logs.py
@@ -257,7 +257,9 @@ class TestDeploymentLogsRouter:
         log1.id = uuid4()
         log1.created_at = "2026-02-23T10:00:00"
 
-        with (patch("src.routers.deployments.DeploymentService") as MockSvc,):
+        with (
+            patch("src.routers.deployments.DeploymentService") as MockSvc,
+        ):
             instance = MockSvc.return_value
             instance.get_deployment = AsyncMock(return_value=mock_deployment)
             instance.get_logs = AsyncMock(return_value=[log1])

--- a/control-plane-api/tests/test_deployment_notifier.py
+++ b/control-plane-api/tests/test_deployment_notifier.py
@@ -7,7 +7,6 @@ import pytest
 from src.notifications import templates
 from src.notifications.deployment_notifier import notify_deployment_event
 
-
 # ---------------------------------------------------------------------------
 # templates.py unit tests
 # ---------------------------------------------------------------------------

--- a/control-plane-api/tests/test_deployment_orchestration_service.py
+++ b/control-plane-api/tests/test_deployment_orchestration_service.py
@@ -110,6 +110,32 @@ class TestDeploymentOrchestrationService:
             mock_deploy.assert_called_once_with(catalog.id, [gw.id])
 
     @pytest.mark.asyncio
+    async def test_deploy_to_env_rejects_lifecycle_managed_api(self):
+        """Deprecated deploy path must not mutate lifecycle-managed APIs."""
+        from src.services.deployment_orchestration_service import DeploymentOrchestrationService
+
+        catalog = self._make_catalog(api_metadata={"lifecycle": {"catalog_status": "ready"}})
+
+        db = AsyncMock()
+        svc = DeploymentOrchestrationService(db)
+
+        with patch.object(svc.deploy_svc, "deploy_api", new_callable=AsyncMock) as mock_deploy:
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = catalog
+            db.execute.return_value = mock_result
+
+            with pytest.raises(ValueError, match="lifecycle/deployments"):
+                await svc.deploy_api_to_env(
+                    tenant_id="acme",
+                    api_identifier=str(catalog.id),
+                    environment="dev",
+                    gateway_ids=[uuid4()],
+                    deployed_by="admin",
+                )
+
+            mock_deploy.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_deploy_to_staging_requires_promotion(self):
         """Staging deployment should fail without an active promotion."""
         from src.services.deployment_orchestration_service import DeploymentOrchestrationService
@@ -301,6 +327,35 @@ class TestDeploymentOrchestrationService:
             mock_deploy.assert_called_once_with(catalog.id, [gw_id])
 
     @pytest.mark.asyncio
+    async def test_auto_deploy_on_promotion_skips_lifecycle_managed_api(self):
+        """Legacy promotion auto-deploy must not mutate lifecycle-managed APIs."""
+        from src.services.deployment_orchestration_service import DeploymentOrchestrationService
+
+        catalog = self._make_catalog(api_metadata={"lifecycle": {"catalog_status": "ready"}})
+
+        db = AsyncMock()
+        svc = DeploymentOrchestrationService(db)
+
+        with (
+            patch.object(svc.assignment_repo, "list_auto_deploy", new_callable=AsyncMock) as mock_assign,
+            patch.object(svc.deploy_svc, "deploy_api", new_callable=AsyncMock) as mock_deploy,
+        ):
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = catalog
+            db.execute.return_value = mock_result
+
+            result = await svc.auto_deploy_on_promotion(
+                api_id="payments-v2",
+                tenant_id="acme",
+                target_environment="staging",
+                approved_by="admin",
+            )
+
+            assert result == []
+            mock_assign.assert_not_awaited()
+            mock_deploy.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_auto_deploy_on_promotion_uses_explicit_gateway_ids(self):
         """gateway-aware promotions bypass assignments and deploy to selected targets."""
         from src.services.deployment_orchestration_service import DeploymentOrchestrationService
@@ -425,7 +480,9 @@ class TestDeploymentOrchestrationService:
         db = AsyncMock()
         svc = DeploymentOrchestrationService(db)
 
-        with (patch.object(svc, "_get_latest_promotion", new_callable=AsyncMock) as mock_promo,):
+        with (
+            patch.object(svc, "_get_latest_promotion", new_callable=AsyncMock) as mock_promo,
+        ):
             mock_result = MagicMock()
             mock_result.scalar_one_or_none.return_value = catalog
             db.execute.return_value = mock_result
@@ -483,6 +540,6 @@ class TestRegressionCab1889:
             mock_git.get_head_commit_sha.assert_awaited_once_with()
             # _project must never be touched — if it is, this attribute access would work on MagicMock
             # so we assert that only the interface methods were called.
-            assert not any(
-                "_project" in str(call) for call in mock_git.mock_calls
-            ), f"_project leaked into calls: {mock_git.mock_calls}"
+            assert not any("_project" in str(call) for call in mock_git.mock_calls), (
+                f"_project leaked into calls: {mock_git.mock_calls}"
+            )

--- a/control-plane-api/tests/test_deployment_producer.py
+++ b/control-plane-api/tests/test_deployment_producer.py
@@ -1,4 +1,5 @@
 """Tests for deployment lifecycle event producer (CAB-1410)."""
+
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 

--- a/control-plane-api/tests/test_deployment_service.py
+++ b/control-plane-api/tests/test_deployment_service.py
@@ -1,13 +1,15 @@
 """Tests for DeploymentService (CAB-1291)"""
 
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.models.catalog import APICatalog
 from src.models.deployment import Deployment, DeploymentStatus
-from src.services.deployment_service import DeploymentService
+from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment
+from src.services.deployment_service import DeploymentService, LifecycleDeploymentPathError
 
 
 def _make_deployment(**overrides) -> Deployment:
@@ -22,8 +24,8 @@ def _make_deployment(**overrides) -> Deployment:
         "status": DeploymentStatus.PENDING.value,
         "deployed_by": "alice",
         "attempt_count": 0,
-        "created_at": datetime(2026, 2, 1),
-        "updated_at": datetime(2026, 2, 1),
+        "created_at": datetime(2026, 2, 1, tzinfo=UTC),
+        "updated_at": datetime(2026, 2, 1, tzinfo=UTC),
     }
     defaults.update(overrides)
     deployment = MagicMock(spec=Deployment)
@@ -88,7 +90,7 @@ class TestCreateDeployment:
             patch("src.services.deployment_service.kafka_service", _mock_kafka()),
             patch("src.services.webhook_service.emit_deployment_started", new_callable=AsyncMock),
         ):
-            result = await service.create_deployment(
+            await service.create_deployment(
                 tenant_id="acme",
                 api_id="api-1",
                 api_name="Test",
@@ -102,6 +104,31 @@ class TestCreateDeployment:
         # Verify the Deployment object passed to repo.create has gateway_id
         call_args = service.repo.create.call_args[0][0]
         assert call_args.gateway_id == "gw-1"
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_managed_api_is_rejected_before_legacy_create(self, service, mock_db):
+        api = APICatalog(
+            tenant_id="acme",
+            api_id="payments-api",
+            api_name="Payments API",
+            version="1.0.0",
+            status="ready",
+            api_metadata={"lifecycle": {"catalog_status": "ready"}},
+        )
+        mock_db.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=api))
+
+        with pytest.raises(LifecycleDeploymentPathError, match="lifecycle/deployments"):
+            await service.create_deployment(
+                tenant_id="acme",
+                api_id="payments-api",
+                api_name="Payments API",
+                environment="dev",
+                version="1.0.0",
+                deployed_by="alice",
+                user_id="user-1",
+            )
+
+        service.repo.create.assert_not_called()
 
 
 class TestRollbackDeployment:
@@ -134,7 +161,7 @@ class TestRollbackDeployment:
         service.repo.create.return_value = _make_deployment(version="2.0.0")
 
         with patch("src.services.deployment_service.kafka_service", _mock_kafka()):
-            result = await service.rollback_deployment(
+            await service.rollback_deployment(
                 tenant_id="acme",
                 deployment_id=original.id,
                 target_version=None,
@@ -154,7 +181,7 @@ class TestRollbackDeployment:
         service.repo.create.return_value = _make_deployment(version="previous")
 
         with patch("src.services.deployment_service.kafka_service", _mock_kafka()):
-            result = await service.rollback_deployment(
+            await service.rollback_deployment(
                 tenant_id="acme",
                 deployment_id=original.id,
                 target_version=None,
@@ -187,7 +214,7 @@ class TestUpdateStatus:
         service.repo.update.return_value = deployment
 
         with patch("src.services.webhook_service.emit_deployment_succeeded", new_callable=AsyncMock) as mock_webhook:
-            result = await service.update_status(
+            await service.update_status(
                 tenant_id="acme",
                 deployment_id=deployment.id,
                 status=DeploymentStatus.SUCCESS.value,
@@ -204,7 +231,7 @@ class TestUpdateStatus:
         service.repo.update.return_value = deployment
 
         with patch("src.services.webhook_service.emit_deployment_failed", new_callable=AsyncMock) as mock_webhook:
-            result = await service.update_status(
+            await service.update_status(
                 tenant_id="acme",
                 deployment_id=deployment.id,
                 status=DeploymentStatus.FAILED.value,
@@ -223,7 +250,7 @@ class TestUpdateStatus:
         service.repo.update.return_value = deployment
 
         with patch("src.services.webhook_service.emit_deployment_rolled_back", new_callable=AsyncMock) as mock_webhook:
-            result = await service.update_status(
+            await service.update_status(
                 tenant_id="acme",
                 deployment_id=deployment.id,
                 status=DeploymentStatus.ROLLED_BACK.value,
@@ -281,7 +308,7 @@ class TestListAndGet:
         deployments = [_make_deployment(), _make_deployment()]
         service.repo.list_by_tenant.return_value = (deployments, 2)
 
-        result, total = await service.list_deployments("acme")
+        _result, total = await service.list_deployments("acme")
 
         assert total == 2
         service.repo.list_by_tenant.assert_called_once_with(
@@ -353,7 +380,7 @@ class TestEnvironmentStatus:
         ]
         service.repo.get_environment_summary.return_value = deps
 
-        result, healthy = await service.get_environment_status("acme", "staging")
+        _result, healthy = await service.get_environment_status("acme", "staging")
 
         assert healthy is False
 
@@ -363,3 +390,71 @@ class TestEnvironmentStatus:
         result, healthy = await service.get_environment_status("acme", "dev")
         assert healthy is True
         assert result == []
+
+
+class TestGatewayDeploymentServiceHardening:
+    @pytest.mark.asyncio
+    async def test_deploy_api_rejects_lifecycle_managed_catalog(self, mock_db):
+        from src.services.gateway_deployment_service import GatewayDeploymentService
+
+        api = APICatalog(
+            id=uuid.uuid4(),
+            tenant_id="acme",
+            api_id="payments-api",
+            api_name="Payments API",
+            version="1.0.0",
+            status="ready",
+            api_metadata={"lifecycle": {"catalog_status": "ready"}},
+        )
+        mock_db.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=api))
+        svc = GatewayDeploymentService(mock_db)
+        svc.gw_repo.get_by_id = AsyncMock()
+        svc.deploy_repo.create = AsyncMock()
+
+        with pytest.raises(PermissionError, match="lifecycle/deployments"):
+            await svc.deploy_api(api.id, [uuid.uuid4()], emit_sync_requests=False)
+
+        svc.gw_repo.get_by_id.assert_not_awaited()
+        svc.deploy_repo.create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unchanged_synced_gateway_deployment_is_not_reset_to_pending(self, mock_db):
+        from src.services.gateway_deployment_service import GatewayDeploymentService
+
+        api = APICatalog(
+            id=uuid.uuid4(),
+            tenant_id="acme",
+            api_id="legacy-api",
+            api_name="Legacy API",
+            version="1.0.0",
+            status="active",
+            api_metadata={},
+            openapi_spec={"openapi": "3.0.3", "info": {"title": "Legacy", "version": "1"}, "paths": {}},
+        )
+        gateway_id = uuid.uuid4()
+        gateway = MagicMock(id=gateway_id, enabled=True, name="stoa-dev", environment="dev")
+        svc = GatewayDeploymentService(mock_db)
+        desired_state = svc.build_desired_state_for_gateway(api, gateway, target_source="direct")
+        deployment = GatewayDeployment(
+            id=uuid.uuid4(),
+            api_catalog_id=api.id,
+            gateway_instance_id=gateway_id,
+            desired_state=desired_state,
+            desired_at=datetime.now(UTC),
+            desired_generation=3,
+            synced_generation=3,
+            attempted_generation=3,
+            sync_status=DeploymentSyncStatus.SYNCED,
+            sync_attempts=1,
+        )
+        mock_db.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=api))
+        svc.gw_repo.get_by_id = AsyncMock(return_value=gateway)
+        svc.deploy_repo.get_by_api_and_gateway = AsyncMock(return_value=deployment)
+        svc.deploy_repo.update = AsyncMock(return_value=deployment)
+        svc._emit_sse_events = AsyncMock()
+
+        result = await svc.deploy_api(api.id, [gateway_id], emit_sync_requests=False)
+
+        assert result == [deployment]
+        assert deployment.sync_status == DeploymentSyncStatus.SYNCED
+        assert deployment.desired_generation == 3

--- a/control-plane-api/tests/test_deployments.py
+++ b/control-plane-api/tests/test_deployments.py
@@ -164,6 +164,33 @@ class TestCreateDeployment:
             )
         assert resp.status_code == 201
 
+    @pytest.mark.asyncio
+    async def test_lifecycle_managed_api_is_rejected(self, app_with_tenant_admin, client_as_tenant_admin):
+        from src.services.deployment_service import LifecycleDeploymentPathError
+        from src.services.git_provider import get_git_provider
+
+        mock_git = _make_mock_git(
+            get_api=AsyncMock(return_value=None),
+            update_api=AsyncMock(return_value=None),
+        )
+        app_with_tenant_admin.dependency_overrides[get_git_provider] = lambda: mock_git
+        with patch(SERVICE_PATH) as MockSvc:
+            MockSvc.return_value.create_deployment = AsyncMock(
+                side_effect=LifecycleDeploymentPathError(
+                    "Cannot create legacy deployment for lifecycle-managed API 'payments-api'. "
+                    "Use POST /v1/tenants/{tenant_id}/apis/{api_id}/lifecycle/deployments instead."
+                )
+            )
+            resp = client_as_tenant_admin.post(
+                "/v1/tenants/acme/deployments",
+                json={"api_id": "payments-api", "environment": "dev"},
+            )
+
+        app_with_tenant_admin.dependency_overrides.pop(get_git_provider, None)
+
+        assert resp.status_code == 409
+        assert "lifecycle/deployments" in resp.json()["detail"]
+
 
 class TestRollbackDeployment:
     @pytest.mark.asyncio
@@ -197,6 +224,25 @@ class TestRollbackDeployment:
                 json={},
             )
         assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_managed_api_is_rejected(self, client_as_tenant_admin):
+        from src.services.deployment_service import LifecycleDeploymentPathError
+
+        with patch(SERVICE_PATH) as MockSvc:
+            MockSvc.return_value.rollback_deployment = AsyncMock(
+                side_effect=LifecycleDeploymentPathError(
+                    "Cannot rollback legacy deployment for lifecycle-managed API 'payments-api'. "
+                    "Use POST /v1/tenants/{tenant_id}/apis/{api_id}/lifecycle/deployments instead."
+                )
+            )
+            resp = client_as_tenant_admin.post(
+                f"/v1/tenants/acme/deployments/{uuid4()}/rollback",
+                json={},
+            )
+
+        assert resp.status_code == 409
+        assert "lifecycle/deployments" in resp.json()["detail"]
 
 
 class TestUpdateStatus:
@@ -242,6 +288,25 @@ class TestUpdateStatus:
                 json={"status": "success"},
             )
         assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_managed_api_is_rejected(self, client_as_tenant_admin):
+        from src.services.deployment_service import LifecycleDeploymentPathError
+
+        with patch(SERVICE_PATH) as MockSvc:
+            MockSvc.return_value.update_status = AsyncMock(
+                side_effect=LifecycleDeploymentPathError(
+                    "Cannot update legacy deployment status for lifecycle-managed API 'payments-api'. "
+                    "Use POST /v1/tenants/{tenant_id}/apis/{api_id}/lifecycle/deployments instead."
+                )
+            )
+            resp = client_as_tenant_admin.patch(
+                f"/v1/tenants/acme/deployments/{uuid4()}/status",
+                json={"status": "success"},
+            )
+
+        assert resp.status_code == 409
+        assert "lifecycle/deployments" in resp.json()["detail"]
 
 
 class TestDeploymentLogs:
@@ -327,6 +392,41 @@ class TestDeploymentServiceCreate:
             mock_kafka.publish.assert_called_once()
             mock_kafka.emit_audit_event.assert_called_once()
             mock_emit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_lifecycle_managed_api_before_legacy_deployment(self):
+        from src.models.catalog import APICatalog
+        from src.services.deployment_service import DeploymentService, LifecycleDeploymentPathError
+
+        mock_db = AsyncMock()
+        api = APICatalog(
+            tenant_id="acme",
+            api_id="payments-api",
+            api_name="Payments API",
+            version="1.0.0",
+            status="ready",
+            api_metadata={"lifecycle": {"catalog_status": "ready"}},
+        )
+        mock_db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=api)))
+        with (
+            patch("src.services.deployment_service.DeploymentRepository") as MockRepo,
+            patch("src.services.deployment_service.DeploymentLogRepository"),
+        ):
+            MockRepo.return_value.create = AsyncMock()
+            svc = DeploymentService(mock_db)
+
+            with pytest.raises(LifecycleDeploymentPathError, match="lifecycle/deployments"):
+                await svc.create_deployment(
+                    "acme",
+                    "payments-api",
+                    "Payments API",
+                    "dev",
+                    "1.0.0",
+                    "admin",
+                    "user-123",
+                )
+
+            MockRepo.return_value.create.assert_not_awaited()
 
 
 class TestDeploymentServiceUpdateStatus:

--- a/control-plane-api/tests/test_deployments_router.py
+++ b/control-plane-api/tests/test_deployments_router.py
@@ -171,7 +171,7 @@ class TestListDeployments:
             TestClient(app_with_tenant_admin) as client,
         ):
             resp = client.get(
-                "/v1/tenants/acme/deployments" "?api_id=api-1&environment=staging&status=pending&page=2&page_size=10"
+                "/v1/tenants/acme/deployments?api_id=api-1&environment=staging&status=pending&page=2&page_size=10"
             )
 
         assert resp.status_code == 200

--- a/control-plane-api/tests/test_promotion_api.py
+++ b/control-plane-api/tests/test_promotion_api.py
@@ -6,7 +6,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.models.deployment import Deployment
+from src.models.catalog import APICatalog
+from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment
+from src.models.gateway_instance import GatewayInstance
 from src.models.promotion import Promotion, PromotionStatus
 from src.notifications.templates import format_message
 from src.services.promotion_service import PromotionService
@@ -136,11 +138,8 @@ class TestPromotionServiceApprove:
 
         assert result.status == PromotionStatus.PROMOTING.value
         assert result.approved_by == "admin"
-        mock_auto_deploy.assert_awaited_once()
-        mock_kafka.publish.assert_awaited_once()
-        published_payload = mock_kafka.publish.await_args.kwargs["payload"]
-        assert published_payload["gateway_deployments_created"] is True
-        assert published_payload["target_gateway_ids"] == promo.target_gateway_ids
+        mock_auto_deploy.assert_not_awaited()
+        mock_kafka.publish.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_approve_without_target_gateways_rejected(self, service):
@@ -317,7 +316,7 @@ class TestPromotionServiceDiff:
         promo.target_environment = "staging"
         promo.spec_diff = {"changed_fields": ["version"]}
         service.repo.get_by_id_and_tenant = AsyncMock(return_value=promo)
-        service.deployment_repo.get_latest_success = AsyncMock(return_value=None)
+        service.db.execute = AsyncMock(return_value=MagicMock(all=MagicMock(return_value=[])))
 
         result = await service.get_diff("acme", promo.id)
 
@@ -448,31 +447,50 @@ class TestPromotionComputedDiff:
         promo.spec_diff = {"changed_fields": ["version"]}
         service.repo.get_by_id_and_tenant = AsyncMock(return_value=promo)
 
-        source_deploy = Deployment()
+        source_deploy = GatewayDeployment()
         source_deploy.id = uuid.uuid4()
-        source_deploy.version = "2.0.0"
-        source_deploy.spec_hash = "abc123"
-        source_deploy.commit_sha = "def456"
-        source_deploy.deployed_by = "alice"
-        source_deploy.completed_at = datetime(2026, 3, 8, 10, 0, 0, tzinfo=UTC)
+        source_deploy.desired_state = {"spec_hash": "abc123"}
+        source_deploy.desired_generation = 2
+        source_deploy.synced_generation = 2
+        source_deploy.sync_status = DeploymentSyncStatus.SYNCED
+        source_deploy.last_sync_success = datetime(2026, 3, 8, 10, 0, 0, tzinfo=UTC)
 
-        target_deploy = Deployment()
+        target_deploy = GatewayDeployment()
         target_deploy.id = uuid.uuid4()
-        target_deploy.version = "1.0.0"
-        target_deploy.spec_hash = "xyz789"
-        target_deploy.commit_sha = "uvw012"
-        target_deploy.deployed_by = "bob"
-        target_deploy.completed_at = datetime(2026, 3, 7, 10, 0, 0, tzinfo=UTC)
+        target_deploy.desired_state = {"spec_hash": "xyz789"}
+        target_deploy.desired_generation = 1
+        target_deploy.synced_generation = 1
+        target_deploy.sync_status = DeploymentSyncStatus.SYNCED
+        target_deploy.last_sync_success = datetime(2026, 3, 7, 10, 0, 0, tzinfo=UTC)
 
-        env_map = {"dev": source_deploy, "staging": target_deploy}
-        service.deployment_repo.get_latest_success = AsyncMock(
-            side_effect=lambda **kwargs: env_map.get(kwargs.get("environment"))
+        source_gateway = GatewayInstance()
+        source_gateway.id = uuid.uuid4()
+        source_gateway.name = "stoa-dev"
+        source_gateway.environment = "dev"
+        source_gateway.deleted_at = None
+        target_gateway = GatewayInstance()
+        target_gateway.id = uuid.uuid4()
+        target_gateway.name = "stoa-staging"
+        target_gateway.environment = "staging"
+        target_gateway.deleted_at = None
+        catalog = APICatalog()
+        catalog.id = uuid.uuid4()
+        catalog.version = "2.0.0"
+        service.db.execute = AsyncMock(
+            return_value=MagicMock(
+                all=MagicMock(
+                    return_value=[
+                        (source_deploy, source_gateway, catalog),
+                        (target_deploy, target_gateway, catalog),
+                    ]
+                )
+            )
         )
 
         result = await service.get_diff("acme", promo.id)
 
-        assert result["source_spec"]["version"] == "2.0.0"
-        assert result["target_spec"]["version"] == "1.0.0"
+        assert result["source_spec"]["spec_hash"] == "abc123"
+        assert result["target_spec"]["spec_hash"] == "xyz789"
         assert result["diff_summary"] == {"changed_fields": ["version"]}
 
     @pytest.mark.asyncio
@@ -486,17 +504,24 @@ class TestPromotionComputedDiff:
         promo.spec_diff = None
         service.repo.get_by_id_and_tenant = AsyncMock(return_value=promo)
 
-        source_deploy = Deployment()
+        source_deploy = GatewayDeployment()
         source_deploy.id = uuid.uuid4()
-        source_deploy.version = "1.0.0"
-        source_deploy.spec_hash = "abc123"
-        source_deploy.commit_sha = "def456"
-        source_deploy.deployed_by = "alice"
-        source_deploy.completed_at = datetime(2026, 3, 8, 10, 0, 0, tzinfo=UTC)
+        source_deploy.desired_state = {"spec_hash": "abc123"}
+        source_deploy.desired_generation = 1
+        source_deploy.synced_generation = 1
+        source_deploy.sync_status = DeploymentSyncStatus.SYNCED
+        source_deploy.last_sync_success = datetime(2026, 3, 8, 10, 0, 0, tzinfo=UTC)
 
-        env_map = {"dev": source_deploy}
-        service.deployment_repo.get_latest_success = AsyncMock(
-            side_effect=lambda **kwargs: env_map.get(kwargs.get("environment"))
+        source_gateway = GatewayInstance()
+        source_gateway.id = uuid.uuid4()
+        source_gateway.name = "stoa-dev"
+        source_gateway.environment = "dev"
+        source_gateway.deleted_at = None
+        catalog = APICatalog()
+        catalog.id = uuid.uuid4()
+        catalog.version = "1.0.0"
+        service.db.execute = AsyncMock(
+            return_value=MagicMock(all=MagicMock(return_value=[(source_deploy, source_gateway, catalog)]))
         )
 
         result = await service.get_diff("acme", promo.id)

--- a/control-plane-api/tests/test_promotion_deploy_consumer.py
+++ b/control-plane-api/tests/test_promotion_deploy_consumer.py
@@ -1,6 +1,11 @@
-"""Tests for the promotion deploy Kafka consumer."""
+"""Regression tests for the legacy promotion deploy consumer."""
 
+from __future__ import annotations
+
+import uuid
 from unittest.mock import MagicMock
+
+import pytest
 
 from src.consumers.promotion_deploy_consumer import PromotionDeployConsumer
 
@@ -25,3 +30,24 @@ def test_gateway_aware_promotion_event_does_not_trigger_legacy_auto_deploy():
     consumer._handle_message(message)
 
     consumer._auto_deploy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_repeated_promotion_approved_event_is_ignored_without_auto_deploy(monkeypatch) -> None:
+    import src.consumers.promotion_deploy_consumer as consumer_module
+
+    def fail_if_legacy_orchestrator_is_loaded(*_args, **_kwargs):
+        raise AssertionError("legacy deployment orchestrator must not be used")
+
+    monkeypatch.setattr(
+        consumer_module,
+        "DeploymentOrchestrationService",
+        fail_if_legacy_orchestrator_is_loaded,
+        raising=False,
+    )
+
+    consumer = PromotionDeployConsumer()
+    promotion_id = str(uuid.uuid4())
+
+    await consumer._auto_deploy("payments-api", "acme", "staging", "admin", promotion_id)
+    await consumer._auto_deploy("payments-api", "acme", "staging", "admin", promotion_id)

--- a/control-plane-api/tests/test_regression_cab_1917_api_creation.py
+++ b/control-plane-api/tests/test_regression_cab_1917_api_creation.py
@@ -3,7 +3,7 @@ Regression tests for CAB-1917 — Fix API creation and deployment pipeline.
 
 Covers:
 1. Legacy deployment endpoint returns deprecation headers
-2. auto_deploy_on_promotion() is called on promotion approval
+2. promotion approval no longer auto-deploys directly
 3. list_apis returns 503 on errors (not empty list)
 4. OpenAPI spec validation rejects invalid specs
 """
@@ -37,15 +37,15 @@ class TestRegression_LegacyDeployDeprecation:
 
 
 # ---------------------------------------------------------------------------
-# 2. auto_deploy_on_promotion wired to approval flow
+# 2. approval flow does not double-trigger deployment
 # ---------------------------------------------------------------------------
 
 
 class TestRegression_AutoDeployOnPromotion:
-    """CAB-1917: approve_promotion() must trigger auto_deploy_on_promotion()."""
+    """CAB-1917: approve_promotion() must not bypass ApiLifecycleService."""
 
     @pytest.mark.asyncio
-    async def test_approve_calls_auto_deploy(self):
+    async def test_approve_does_not_call_auto_deploy(self):
         from uuid import uuid4
 
         from src.services.promotion_service import PromotionService
@@ -96,14 +96,7 @@ class TestRegression_AutoDeployOnPromotion:
                     user_id="user-1",
                 )
 
-            mock_orch.auto_deploy_on_promotion.assert_called_once_with(
-                api_id="api-123",
-                tenant_id="acme",
-                target_environment="staging",
-                approved_by="admin",
-                promotion_id=mock_promotion.id,
-                gateway_ids=[target_gateway_id],
-            )
+            mock_orch.auto_deploy_on_promotion.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/control-plane-ui/src/pages/APIDetail.test.tsx
+++ b/control-plane-ui/src/pages/APIDetail.test.tsx
@@ -55,6 +55,12 @@ vi.mock('../services/api', () => ({
     createDeployment: vi.fn(),
     listDeployments: vi.fn(),
     listPromotions: vi.fn(),
+    getGatewayDeployments: vi.fn(),
+    getApiLifecycleState: vi.fn(),
+    validateLifecycleDraft: vi.fn(),
+    deployLifecycleApi: vi.fn(),
+    publishLifecycleApi: vi.fn(),
+    promoteLifecycleApi: vi.fn(),
   },
 }));
 
@@ -114,6 +120,38 @@ const baseApi = mockAPI({
   portal_promoted: false,
 });
 
+const baseLifecycleState = {
+  catalog_id: 'api-1',
+  tenant_id: 'oasis-gunters',
+  api_id: 'api-1',
+  api_name: 'payment-api',
+  display_name: 'Payment API',
+  version: '2.0.0',
+  description: 'Handles all payment processing',
+  backend_url: 'https://payments.example.com',
+  catalog_status: 'ready',
+  lifecycle_phase: 'ready',
+  portal_published: false,
+  tags: ['payments'],
+  spec: {
+    source: 'inline',
+    has_openapi_spec: true,
+  },
+  deployments: [],
+  promotions: [],
+  last_error: null,
+  portal: {
+    published: false,
+    status: 'not_published',
+    publications: [],
+    last_result: null,
+    last_environment: null,
+    last_gateway_instance_id: null,
+    last_deployment_id: null,
+    last_published_at: null,
+  },
+};
+
 // ── Setup helpers ─────────────────────────────────────────────────────────────
 
 function setupMocks(role: PersonaRole = 'cpi-admin') {
@@ -152,6 +190,13 @@ function setupMocks(role: PersonaRole = 'cpi-admin') {
     page: 1,
     page_size: 20,
   });
+  vi.mocked(apiService.getGatewayDeployments).mockResolvedValue({
+    items: [],
+    total: 0,
+    page: 1,
+    page_size: 100,
+  });
+  vi.mocked(apiService.getApiLifecycleState).mockResolvedValue(baseLifecycleState);
 }
 
 function renderAPIDetail() {
@@ -341,16 +386,16 @@ describe('APIDetail', () => {
 
   describe('RBAC — action buttons', () => {
     describe('cpi-admin', () => {
-      it('shows portal toggle button', async () => {
+      it('shows the lifecycle panel', async () => {
         setupMocks('cpi-admin');
         renderAPIDetail();
 
         await waitFor(() => {
-          expect(screen.getByText(/Portal:/)).toBeInTheDocument();
+          expect(screen.getByTestId('api-lifecycle-panel')).toBeInTheDocument();
         });
       });
 
-      it('shows Deploy DEV button when not deployed to dev', async () => {
+      it('does not show legacy Deploy DEV button when not deployed to dev', async () => {
         setupMocks('cpi-admin');
         vi.mocked(apiService.getApi).mockResolvedValue({
           ...baseApi,
@@ -360,17 +405,19 @@ describe('APIDetail', () => {
         renderAPIDetail();
 
         await waitFor(() => {
-          expect(screen.getByText('Deploy DEV')).toBeInTheDocument();
+          expect(screen.getByTestId('api-lifecycle-deploy')).toBeInTheDocument();
         });
+        expect(screen.queryByText('Deploy DEV')).not.toBeInTheDocument();
       });
 
-      it('shows Deploy STG button when deployed to dev but not staging', async () => {
+      it('does not show legacy Deploy STG button when deployed to dev but not staging', async () => {
         setupMocks('cpi-admin');
         renderAPIDetail(); // baseApi has deployed_dev=true, deployed_staging=false
 
         await waitFor(() => {
-          expect(screen.getByText('Deploy STG')).toBeInTheDocument();
+          expect(screen.getByTestId('api-lifecycle-deploy')).toBeInTheDocument();
         });
+        expect(screen.queryByText('Deploy STG')).not.toBeInTheDocument();
       });
 
       it('shows edit button', async () => {
@@ -401,21 +448,22 @@ describe('APIDetail', () => {
     });
 
     describe('tenant-admin', () => {
-      it('shows portal toggle button', async () => {
+      it('shows lifecycle publish action instead of portal tag toggle', async () => {
         setupMocks('tenant-admin');
         renderAPIDetail();
 
         await waitFor(() => {
-          expect(screen.getByText(/Portal:/)).toBeInTheDocument();
+          expect(screen.getByTestId('api-lifecycle-publish')).toBeInTheDocument();
         });
+        expect(screen.queryByText(/Portal:/)).not.toBeInTheDocument();
       });
 
-      it('shows deploy button (has apis:deploy permission)', async () => {
+      it('shows lifecycle deploy action (has apis:deploy permission)', async () => {
         setupMocks('tenant-admin');
         renderAPIDetail();
 
         await waitFor(() => {
-          expect(screen.getByText('Deploy STG')).toBeInTheDocument();
+          expect(screen.getByTestId('api-lifecycle-deploy')).toBeInTheDocument();
         });
       });
     });
@@ -429,21 +477,20 @@ describe('APIDetail', () => {
         // (canRemove = apis:delete && canDelete)
       });
 
-      it('shows Deploy STG button (has apis:deploy)', async () => {
+      it('shows lifecycle deploy action (has apis:deploy)', async () => {
         renderAPIDetail();
 
         await waitFor(() => {
-          expect(screen.getByText('Deploy STG')).toBeInTheDocument();
+          expect(screen.getByTestId('api-lifecycle-deploy')).toBeInTheDocument();
         });
       });
 
-      it('does NOT show portal toggle (no apis:update... wait devops has apis:update)', async () => {
+      it('shows lifecycle publish action through apis:update permission', async () => {
         // devops permissions include 'apis:update' so canManage=true in full mode
-        // This confirms devops CAN see portal toggle
         renderAPIDetail();
 
         await waitFor(() => {
-          expect(screen.getByText(/Portal:/)).toBeInTheDocument();
+          expect(screen.getByTestId('api-lifecycle-publish')).toBeInTheDocument();
         });
       });
 
@@ -461,7 +508,7 @@ describe('APIDetail', () => {
         // The Trash2 delete button is gated on canRemove = hasPermission('apis:delete') && canDelete
         // Since apis:delete is absent for devops, the delete button should not render
         // There's no text label on the delete button (icon only), so we check the total
-        // action-area buttons: only portal toggle, deploy STG, and edit (pencil) should be present
+        // action-area buttons include lifecycle buttons and edit, but not the delete action.
         const buttons = screen.getAllByRole('button');
         const buttonTexts = buttons.map((b) => b.textContent?.trim());
         // Must NOT have an empty button that comes after the edit button (Trash2 renders after Pencil)
@@ -565,8 +612,8 @@ describe('APIDetail', () => {
 
   // ── Portal toggle ────────────────────────────────────────────────────────
 
-  describe('Portal toggle', () => {
-    it('shows "Portal: Private" when portal_promoted is false', async () => {
+  describe('Portal publication', () => {
+    it('does not expose the legacy portal tag toggle when portal_promoted is false', async () => {
       setupMocks('cpi-admin');
       vi.mocked(apiService.getApi).mockResolvedValue({
         ...baseApi,
@@ -575,20 +622,31 @@ describe('APIDetail', () => {
       renderAPIDetail();
 
       await waitFor(() => {
-        expect(screen.getByText(/Portal: Private/)).toBeInTheDocument();
+        expect(screen.getByTestId('api-lifecycle-publish')).toBeInTheDocument();
       });
+      expect(screen.queryByText(/Portal: Private/)).not.toBeInTheDocument();
     });
 
-    it('shows "Portal: Published" when portal_promoted is true', async () => {
+    it('still shows portal state in lifecycle summary when published', async () => {
       setupMocks('cpi-admin');
       vi.mocked(apiService.getApi).mockResolvedValue({
         ...baseApi,
         portal_promoted: true,
       });
+      vi.mocked(apiService.getApiLifecycleState).mockResolvedValue({
+        ...baseLifecycleState,
+        portal_published: true,
+        lifecycle_phase: 'published',
+        portal: {
+          ...baseLifecycleState.portal,
+          published: true,
+          status: 'published',
+        },
+      });
       renderAPIDetail();
 
       await waitFor(() => {
-        expect(screen.getByText(/Portal: Published/)).toBeInTheDocument();
+        expect(screen.getByTestId('api-lifecycle-portal')).toHaveTextContent('published');
       });
     });
   });

--- a/control-plane-ui/src/pages/APIDetail.tsx
+++ b/control-plane-ui/src/pages/APIDetail.tsx
@@ -15,8 +15,6 @@ import {
   GitCommit,
   Rocket,
   ArrowUpRight,
-  Globe,
-  GlobeLock,
   Pencil,
   Trash2,
   ExternalLink,
@@ -34,7 +32,7 @@ import { Button } from '@stoa/shared/components/Button';
 import { EnvironmentPipeline } from '../components/EnvironmentPipeline';
 import type { API, GatewayDeployment } from '../types';
 import type { Schemas } from '@stoa/shared/api-types';
-import { DeployAPIDialog } from './GatewayDeployments/DeployAPIDialog';
+import { ApiLifecyclePanel } from './ApiLifecyclePanel';
 
 type TabId = 'overview' | 'spec' | 'versions' | 'deployments' | 'promotions';
 
@@ -50,7 +48,6 @@ export function APIDetail() {
   const { hasPermission } = useAuth();
   const { canEdit, canDelete, canDeploy } = useEnvironmentMode();
   const toast = useToastActions();
-  const queryClient = useQueryClient();
   const [confirm, ConfirmDialog] = useConfirm();
   const [activeTab, setActiveTab] = useState<TabId>('overview');
 
@@ -75,46 +72,6 @@ export function APIDetail() {
     enabled: !!tenantId && !!apiId && activeTab === 'versions',
   });
 
-  // Portal toggle mutation
-  const portalToggle = useMutation({
-    mutationFn: async (promoted: boolean) => {
-      if (!api) return;
-      const currentTags = api.tags || [];
-      const newTags = promoted
-        ? [...currentTags.filter((t) => t !== 'portal:published'), 'portal:published']
-        : currentTags.filter((t) => t !== 'portal:published');
-      await apiService.updateApi(tenantId!, apiId!, { tags: newTags });
-      // Trigger catalog sync so the Portal DB picks up the change
-      await apiService.triggerCatalogSync(tenantId!).catch(() => {
-        /* sync is best-effort — tag update already succeeded */
-      });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['api', tenantId, apiId] });
-      toast.success(api?.portal_promoted ? 'Removed from portal' : 'Published to portal');
-    },
-    onError: () => toast.error('Failed to update portal status'),
-  });
-
-  // Deploy mutation
-  const deployMutation = useMutation({
-    mutationFn: async (environment: 'dev' | 'staging') => {
-      await apiService.createDeployment(tenantId!, {
-        api_id: apiId!,
-        api_name: api?.name || apiId!,
-        environment,
-        version: api?.version || '1.0.0',
-      });
-      // Sync catalog so deployment flags are reflected in Portal
-      await apiService.triggerCatalogSync(tenantId!).catch(() => {});
-    },
-    onSuccess: (_data, environment) => {
-      queryClient.invalidateQueries({ queryKey: ['api', tenantId, apiId] });
-      toast.success(`Deployment to ${environment} initiated`);
-    },
-    onError: () => toast.error('Deployment failed'),
-  });
-
   // Delete mutation
   const deleteMutation = useMutation({
     mutationFn: () => apiService.deleteApi(tenantId!, apiId!),
@@ -133,15 +90,6 @@ export function APIDetail() {
       variant: 'danger',
     });
     if (confirmed) deleteMutation.mutate();
-  };
-
-  const handleDeploy = async (env: 'dev' | 'staging') => {
-    const confirmed = await confirm({
-      title: `Deploy to ${env.toUpperCase()}`,
-      message: `Deploy "${api?.display_name}" v${api?.version} to ${env}?`,
-      confirmLabel: 'Deploy',
-    });
-    if (confirmed) deployMutation.mutate(env);
   };
 
   const tabs: { id: TabId; label: string; icon: React.ReactNode }[] = [
@@ -227,54 +175,6 @@ export function APIDetail() {
 
           {/* Actions */}
           <div className="flex items-center gap-2 flex-shrink-0">
-            {/* Portal toggle */}
-            {canManage && (
-              <Button
-                variant={api.portal_promoted ? 'secondary' : 'ghost'}
-                size="sm"
-                onClick={() => portalToggle.mutate(!api.portal_promoted)}
-                disabled={portalToggle.isPending}
-              >
-                {api.portal_promoted ? (
-                  <>
-                    <Globe className="h-4 w-4 mr-1" />
-                    Portal: Published
-                  </>
-                ) : (
-                  <>
-                    <GlobeLock className="h-4 w-4 mr-1" />
-                    Portal: Private
-                  </>
-                )}
-              </Button>
-            )}
-
-            {/* Deploy buttons */}
-            {canDeploy && (
-              <>
-                {!api.deployed_dev && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleDeploy('dev')}
-                    disabled={deployMutation.isPending}
-                  >
-                    Deploy DEV
-                  </Button>
-                )}
-                {api.deployed_dev && !api.deployed_staging && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleDeploy('staging')}
-                    disabled={deployMutation.isPending}
-                  >
-                    Deploy STG
-                  </Button>
-                )}
-              </>
-            )}
-
             {canManage && (
               <Button variant="ghost" size="sm" onClick={() => navigate(`/apis?edit=${api.id}`)}>
                 <Pencil className="h-4 w-4" />
@@ -296,6 +196,13 @@ export function APIDetail() {
           />
         </div>
       </div>
+
+      <ApiLifecyclePanel
+        tenantId={tenantId!}
+        apiId={apiId!}
+        canManage={canManage}
+        canDeploy={canDeploy}
+      />
 
       {/* Tabs */}
       <div className="border-b border-neutral-200 dark:border-neutral-700">
@@ -322,7 +229,7 @@ export function APIDetail() {
         {activeTab === 'overview' && <OverviewTab api={api} />}
         {activeTab === 'spec' && <SpecTab api={api} />}
         {activeTab === 'versions' && <VersionsTab versions={versions} loading={versionsLoading} />}
-        {activeTab === 'deployments' && <DeploymentsTab api={api} tenantId={tenantId!} />}
+        {activeTab === 'deployments' && <DeploymentsTab api={api} />}
         {activeTab === 'promotions' && <PromotionsTab api={api} tenantId={tenantId!} />}
       </div>
     </div>
@@ -526,10 +433,9 @@ function VersionsTab({
   );
 }
 
-function DeploymentsTab({ api, tenantId }: { api: API; tenantId: string }) {
+function DeploymentsTab({ api }: { api: API }) {
   const toast = useToastActions();
   const queryClient = useQueryClient();
-  const [showDeployDialog, setShowDeployDialog] = useState(false);
 
   // Query gateway deployments for this specific API
   const { data, isLoading } = useQuery({
@@ -572,19 +478,13 @@ function DeploymentsTab({ api, tenantId }: { api: API; tenantId: string }) {
         <p className="text-sm text-neutral-500 dark:text-neutral-400">
           {deployments.length} gateway deployment{deployments.length !== 1 ? 's' : ''}
         </p>
-        <button
-          onClick={() => setShowDeployDialog(true)}
-          className="bg-blue-600 text-white px-3 py-1.5 rounded-lg text-sm hover:bg-blue-700"
-        >
-          + Deploy
-        </button>
       </div>
 
       {deployments.length === 0 ? (
         <div className="text-center py-12 text-neutral-500 dark:text-neutral-400">
           <Rocket className="h-12 w-12 mx-auto mb-4 text-neutral-300 dark:text-neutral-600" />
           <p className="text-sm">No gateway deployments yet for this API.</p>
-          <p className="text-xs mt-1">Click + Deploy to deploy to gateways.</p>
+          <p className="text-xs mt-1">Use the lifecycle panel to request a deployment.</p>
         </div>
       ) : (
         <div className="space-y-2">
@@ -638,17 +538,9 @@ function DeploymentsTab({ api, tenantId }: { api: API; tenantId: string }) {
         </div>
       )}
 
-      {showDeployDialog && (
-        <DeployAPIDialog
-          onClose={() => setShowDeployDialog(false)}
-          onDeployed={() => {
-            setShowDeployDialog(false);
-            queryClient.invalidateQueries({ queryKey: ['gateway-deployments', api.id] });
-            toast.success('Deployment initiated');
-          }}
-          preselectedApiKey={`${tenantId}:${api.name || api.id}`}
-        />
-      )}
+      <p className="text-xs text-neutral-500 dark:text-neutral-400">
+        Runtime writes for lifecycle APIs are controlled by the lifecycle panel.
+      </p>
     </div>
   );
 }

--- a/control-plane-ui/src/pages/APIs.test.tsx
+++ b/control-plane-ui/src/pages/APIs.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createAuthMock } from '../test/helpers';
@@ -100,6 +101,7 @@ vi.mock('../services/api', () => ({
       },
     ]),
     createApi: vi.fn(),
+    createLifecycleDraft: vi.fn(),
     updateApi: vi.fn(),
     deleteApi: vi.fn(),
     deployApi: vi.fn(),
@@ -159,6 +161,8 @@ vi.mock('../hooks/useEnvironmentMode', () => ({
 }));
 
 import { APIs } from './APIs';
+
+const { apiService } = await import('../services/api');
 
 const READ_ONLY_MODE = {
   canCreate: false,
@@ -264,23 +268,118 @@ describe('APIs', () => {
     expect(screen.queryByText('Delete')).not.toBeInTheDocument();
   });
 
-  it('links writable users to the deployment workflow', async () => {
+  it('links writable users to the lifecycle detail', async () => {
     renderAPIs();
     await screen.findByText('Payment API');
-    const deploymentLinks = screen.getAllByRole('link', { name: 'Open Deployments' });
-    expect(deploymentLinks[0]).toHaveAttribute(
-      'href',
-      '/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters'
-    );
+    const lifecycleLinks = screen.getAllByRole('link', { name: 'Open Lifecycle' });
+    expect(lifecycleLinks[0]).toHaveAttribute('href', '/apis/oasis-gunters/payment-api');
   });
 
-  it('hides deployment workflow links in read-only mode', async () => {
+  it('creates lifecycle drafts through the canonical endpoint', async () => {
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('tenant-admin'));
+    vi.mocked(apiService.createLifecycleDraft).mockResolvedValue({
+      catalog_id: 'api-new',
+      tenant_id: 'oasis-gunters',
+      api_id: 'payments-api',
+      api_name: 'payments-api',
+      display_name: 'Payments API',
+      version: '1.0.0',
+      description: 'Payments',
+      backend_url: 'https://payments.internal',
+      catalog_status: 'draft',
+      lifecycle_phase: 'draft',
+      portal_published: false,
+      tags: [],
+      spec: { source: 'inline', has_openapi_spec: true },
+      deployments: [],
+      promotions: [],
+      last_error: null,
+      portal: {
+        published: false,
+        status: 'not_published',
+        publications: [],
+        last_result: null,
+        last_environment: null,
+        last_gateway_instance_id: null,
+        last_deployment_id: null,
+        last_published_at: null,
+      },
+    });
+
+    renderAPIs();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByRole('button', { name: 'Create API' }));
+    await user.type(screen.getByTestId('api-form-name'), 'payments-api');
+    await user.type(screen.getByTestId('api-form-display-name'), 'Payments API');
+    await user.type(screen.getByTestId('api-form-description'), 'Payments');
+    await user.type(screen.getByTestId('api-form-backend-url'), 'https://payments.internal');
+    fireEvent.change(screen.getByTestId('api-form-openapi-spec'), {
+      target: {
+        value: JSON.stringify({
+          openapi: '3.0.3',
+          info: { title: 'Payments API', version: '1.0.0' },
+          paths: { '/payments': { get: { responses: { '200': { description: 'ok' } } } } },
+        }),
+      },
+    });
+    await user.click(screen.getByRole('button', { name: 'Create lifecycle draft' }));
+
+    await waitFor(() => {
+      expect(apiService.createLifecycleDraft).toHaveBeenCalledWith(
+        'oasis-gunters',
+        expect.objectContaining({
+          name: 'payments-api',
+          display_name: 'Payments API',
+          backend_url: 'https://payments.internal',
+          tags: [],
+          spec_reference: null,
+        })
+      );
+    });
+  });
+
+  it('does not expose legacy deployment workflow links in read-only mode', async () => {
     mockUseEnvironmentMode.mockReturnValue(READ_ONLY_MODE);
     renderAPIs();
     await screen.findByText('Payment API');
     expect(screen.queryByText('Deploy DEV')).not.toBeInTheDocument();
     expect(screen.queryByText('Deploy STG')).not.toBeInTheDocument();
     expect(screen.queryByText('Open Deployments')).not.toBeInTheDocument();
+  });
+
+  it('removes legacy portal tags before legacy create/update submits', async () => {
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('tenant-admin'));
+    renderAPIs();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByRole('button', { name: 'Create API' }));
+    await user.click(screen.getByRole('button', { name: 'Manual Entry' }));
+    await user.type(screen.getByTestId('api-form-name'), 'manual-api');
+    await user.type(screen.getByTestId('api-form-display-name'), 'Manual API');
+    await user.type(screen.getByTestId('api-form-backend-url'), 'https://manual.internal');
+    const submitButtons = screen.getAllByRole('button', { name: 'Create API' });
+    await user.click(submitButtons[submitButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(apiService.createApi).toHaveBeenCalledWith(
+        'oasis-gunters',
+        expect.objectContaining({
+          tags: [],
+          portal_promoted: false,
+        })
+      );
+    });
+  });
+
+  it('keeps existing deployment route href out of the API list', async () => {
+    renderAPIs();
+    await screen.findByText('Payment API');
+    const links = screen.getAllByRole('link', { name: 'Open Lifecycle' });
+    expect(links[0]).not.toHaveAttribute(
+      'href',
+      '/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters'
+    );
   });
 
   // 4-persona coverage

--- a/control-plane-ui/src/pages/APIs.tsx
+++ b/control-plane-ui/src/pages/APIs.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { apiService } from '../services/api';
+import { apiService, type ApiLifecycleCreateDraftRequest } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
 import { useEnvironment } from '../contexts/EnvironmentContext';
 import { useEnvironmentMode } from '../hooks/useEnvironmentMode';
@@ -29,12 +29,30 @@ const statusColors: Record<string, string> = {
 };
 
 const ALL_TENANTS = '__all__';
+const LEGACY_PORTAL_TAGS = new Set(['portal:published', 'promoted:portal', 'portal-promoted']);
+
+function sanitizedApiTags(tags: string[] | undefined): string[] {
+  return (tags || []).filter((tag) => !LEGACY_PORTAL_TAGS.has(tag));
+}
+
+function parseSpecDocument(content: string): Record<string, unknown> {
+  let spec: unknown;
+  try {
+    spec = JSON.parse(content);
+  } catch {
+    spec = yaml.load(content);
+  }
+  if (!spec || typeof spec !== 'object' || Array.isArray(spec)) {
+    throw new Error('OpenAPI/Swagger spec must be a JSON or YAML object');
+  }
+  return spec as Record<string, unknown>;
+}
 
 export function APIs() {
   const { isReady, hasRole } = useAuth();
   const isAdmin = hasRole('cpi-admin');
   const { activeEnvironment } = useEnvironment();
-  const { canCreate, canEdit, canDelete, canDeploy, isReadOnly } = useEnvironmentMode();
+  const { canCreate, canEdit, canDelete, isReadOnly } = useEnvironmentMode();
   const isMobile = useMediaQuery('(max-width: 767px)');
   const toast = useToastActions();
   const queryClient = useQueryClient();
@@ -135,52 +153,28 @@ export function APIs() {
     queryClient.invalidateQueries({ queryKey: ['apis', selectedTenant, activeEnvironment] });
   }, [queryClient, selectedTenant, activeEnvironment]);
 
-  const getDeploymentWorkflowHref = useCallback(
+  const getApiDetailHref = useCallback(
     (api: { id: string; name: string; tenant_id?: string }) => {
-      const params = new URLSearchParams({
-        api_id: api.id,
-        api_name: api.name,
-        environment: activeEnvironment,
-        open_deploy: 'true',
-      });
       const tenantId = api.tenant_id || (selectedTenant !== ALL_TENANTS ? selectedTenant : '');
-      if (tenantId) {
-        params.set('tenant_id', tenantId);
-      }
-      return `/api-deployments?${params.toString()}`;
+      return tenantId ? `/apis/${tenantId}/${api.name}` : `/apis/${api.id}`;
     },
-    [activeEnvironment, selectedTenant]
+    [selectedTenant]
   );
 
   // Memoized handlers to prevent unnecessary re-renders
   const handleCreate = useCallback(
-    async (api: APICreate, openDeploymentWorkflow: boolean) => {
+    async (api: APICreate, _openDeploymentWorkflow: boolean) => {
       try {
         const wasFirstApi = isFirstApi;
-        const created = await apiService.createApi(selectedTenant, api);
+        await apiService.createApi(selectedTenant, api);
 
         setShowCreateModal(false);
         invalidateApis();
 
-        if (openDeploymentWorkflow) {
-          navigate(
-            getDeploymentWorkflowHref({
-              id: created.id,
-              name: api.name,
-              tenant_id: selectedTenant !== ALL_TENANTS ? selectedTenant : undefined,
-            })
-          );
-        }
-
         // Celebrate first API creation
         if (wasFirstApi) {
           celebrate();
-          toast.success(
-            'Welcome!',
-            openDeploymentWorkflow
-              ? 'You created your first API. Complete deployment from the Deployments page.'
-              : 'You created your first API. Explore the Deployments page next.'
-          );
+          toast.success('Welcome!', 'You created your first API. Open its lifecycle to continue.');
         } else {
           toast.success('API created', `${api.display_name || api.name} has been created`);
         }
@@ -188,15 +182,26 @@ export function APIs() {
         toast.error('Creation failed', err.message || 'Failed to create API');
       }
     },
-    [
-      selectedTenant,
-      isFirstApi,
-      celebrate,
-      toast,
-      invalidateApis,
-      navigate,
-      getDeploymentWorkflowHref,
-    ]
+    [selectedTenant, isFirstApi, celebrate, toast, invalidateApis]
+  );
+
+  const handleCreateLifecycleDraft = useCallback(
+    async (draft: ApiLifecycleCreateDraftRequest) => {
+      try {
+        if (selectedTenant === ALL_TENANTS) {
+          throw new Error('Select a concrete tenant before creating a lifecycle draft');
+        }
+        const state = await apiService.createLifecycleDraft(selectedTenant, draft);
+        setShowCreateModal(false);
+        invalidateApis();
+        toast.success('Lifecycle draft created', `${state.display_name} is ready for validation`);
+        navigate(`/apis/${state.tenant_id}/${state.api_id}`);
+      } catch (err: any) {
+        toast.error('Draft creation failed', err.message || 'Failed to create lifecycle draft');
+        throw err;
+      }
+    },
+    [selectedTenant, invalidateApis, toast, navigate]
   );
 
   const handleUpdate = useCallback(
@@ -429,7 +434,7 @@ export function APIs() {
                   >
                     {api.status}
                   </span>
-                  {(api.portal_promoted || api.tags?.includes('portal:published')) && (
+                  {api.portal_promoted && (
                     <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
                       Portal
                     </span>
@@ -447,14 +452,12 @@ export function APIs() {
                 </div>
 
                 <div className="flex flex-wrap gap-3 pt-1">
-                  {canDeploy && (
-                    <a
-                      href={getDeploymentWorkflowHref(api)}
-                      className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300 text-sm py-1"
-                    >
-                      Open Deployments
-                    </a>
-                  )}
+                  <a
+                    href={getApiDetailHref(api)}
+                    className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300 text-sm py-1"
+                  >
+                    Open Lifecycle
+                  </a>
                   {canEdit && (
                     <button
                       onClick={() => setEditingApi(api)}
@@ -538,7 +541,7 @@ export function APIs() {
                       </span>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm">
-                      {api.portal_promoted || api.tags?.includes('portal:published') ? (
+                      {api.portal_promoted ? (
                         <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
                           <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
                             <path
@@ -574,15 +577,13 @@ export function APIs() {
                       onClick={(e) => e.stopPropagation()}
                     >
                       <div className="flex gap-2">
-                        {canDeploy && (
-                          <a
-                            href={getDeploymentWorkflowHref(api)}
-                            className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300"
-                            title="Open deployment workflow"
-                          >
-                            Open Deployments
-                          </a>
-                        )}
+                        <a
+                          href={getApiDetailHref(api)}
+                          className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300"
+                          title="Open lifecycle"
+                        >
+                          Open Lifecycle
+                        </a>
                         {canEdit && (
                           <button
                             onClick={() => setEditingApi(api)}
@@ -646,6 +647,7 @@ export function APIs() {
         <APIFormModal
           onClose={() => setShowCreateModal(false)}
           onSubmit={handleCreate}
+          onLifecycleSubmit={handleCreateLifecycleDraft}
           title="Create New API"
         />
       )}
@@ -671,16 +673,24 @@ interface APIFormModalProps {
   api?: API;
   onClose: () => void;
   onSubmit: (data: APICreate, openDeploymentWorkflow: boolean) => Promise<void>;
+  onLifecycleSubmit?: (data: ApiLifecycleCreateDraftRequest) => Promise<void>;
   title: string;
   isEdit?: boolean;
 }
 
-type CreateMode = 'manual' | 'openapi';
+type CreateMode = 'lifecycle' | 'manual' | 'openapi';
 
-function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalProps) {
-  const [mode, setMode] = useState<CreateMode>('manual');
-  const [openDeploymentWorkflow, setOpenDeploymentWorkflow] = useState(!isEdit);
+function APIFormModal({
+  api,
+  onClose,
+  onSubmit,
+  onLifecycleSubmit,
+  title,
+  isEdit,
+}: APIFormModalProps) {
+  const [mode, setMode] = useState<CreateMode>(isEdit ? 'manual' : 'lifecycle');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [specReference, setSpecReference] = useState('');
   const [formData, setFormData] = useState<APICreate>({
     name: api?.name || '',
     display_name: api?.display_name || '',
@@ -692,7 +702,7 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
         ? JSON.stringify(api.openapi_spec, null, 2)
         : (api?.openapi_spec as string) || '',
     tags: api?.tags || [],
-    portal_promoted: api?.portal_promoted || api?.tags?.includes('portal:published') || false,
+    portal_promoted: api?.portal_promoted || false,
   });
   const [parseError, setParseError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -712,14 +722,7 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
   const parseOpenApiSpec = (content: string, _filename?: string) => {
     try {
       setParseError(null);
-      let spec: any;
-
-      // Try to parse as JSON first, then YAML
-      try {
-        spec = JSON.parse(content);
-      } catch {
-        spec = yaml.load(content);
-      }
+      const spec: any = parseSpecDocument(content);
 
       if (!spec) {
         throw new Error('Could not parse OpenAPI/Swagger specification');
@@ -763,6 +766,8 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
         description,
         backend_url: backendUrl,
         openapi_spec: content,
+        tags: sanitizedApiTags(formData.tags),
+        portal_promoted: false,
       });
     } catch (err: any) {
       setParseError(err.message || 'Failed to parse OpenAPI specification');
@@ -773,20 +778,58 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
     e.preventDefault();
     if (isSubmitting) return;
 
-    // Build tags array based on portal_promoted flag
-    const tags = [...(formData.tags || [])].filter((tag) => tag !== 'portal:published');
-    if (formData.portal_promoted) {
-      tags.push('portal:published');
+    const tags = sanitizedApiTags(formData.tags);
+
+    if (mode === 'lifecycle' && !isEdit && onLifecycleSubmit) {
+      setParseError(null);
+      let openapiSpec: Record<string, unknown> | undefined;
+      const specContent = formData.openapi_spec?.trim();
+      if (specContent) {
+        try {
+          openapiSpec = parseSpecDocument(specContent);
+        } catch (err: any) {
+          setParseError(err.message || 'Failed to parse OpenAPI specification');
+          return;
+        }
+      }
+
+      const reference = specReference.trim();
+      if (!openapiSpec && !reference) {
+        setParseError(
+          'Lifecycle drafts require an inline OpenAPI/Swagger spec or a spec reference'
+        );
+        return;
+      }
+
+      const draft: ApiLifecycleCreateDraftRequest = {
+        name: formData.name,
+        display_name: formData.display_name,
+        version: formData.version,
+        description: formData.description,
+        backend_url: formData.backend_url,
+        openapi_spec: openapiSpec,
+        spec_reference: reference || null,
+        tags,
+      };
+
+      setIsSubmitting(true);
+      try {
+        await onLifecycleSubmit(draft);
+      } finally {
+        setIsSubmitting(false);
+      }
+      return;
     }
 
     const submitData: APICreate = {
       ...formData,
       tags,
+      portal_promoted: false,
     };
 
     setIsSubmitting(true);
     try {
-      await onSubmit(submitData, openDeploymentWorkflow);
+      await onSubmit(submitData, false);
     } finally {
       setIsSubmitting(false);
     }
@@ -816,6 +859,17 @@ function APIFormModal({ api, onClose, onSubmit, title, isEdit }: APIFormModalPro
         {!isEdit && (
           <div className="px-6 pt-4">
             <div className="flex rounded-lg bg-neutral-100 dark:bg-neutral-700 p-1">
+              <button
+                type="button"
+                onClick={() => setMode('lifecycle')}
+                className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors ${
+                  mode === 'lifecycle'
+                    ? 'bg-white dark:bg-neutral-600 text-neutral-900 dark:text-white shadow'
+                    : 'text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300'
+                }`}
+              >
+                Lifecycle Draft
+              </button>
               <button
                 type="button"
                 onClick={() => setMode('manual')}
@@ -938,6 +992,7 @@ paths:
                     Name (slug)
                   </label>
                   <input
+                    data-testid="api-form-name"
                     type="text"
                     value={formData.name}
                     onChange={(e) =>
@@ -971,6 +1026,7 @@ paths:
                   Display Name
                 </label>
                 <input
+                  data-testid="api-form-display-name"
                   type="text"
                   value={formData.display_name}
                   onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
@@ -985,6 +1041,7 @@ paths:
                   Description
                 </label>
                 <textarea
+                  data-testid="api-form-description"
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                   className="w-full border border-neutral-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
@@ -1007,6 +1064,7 @@ paths:
                 Backend URL
               </label>
               <input
+                data-testid="api-form-backend-url"
                 type="url"
                 value={formData.backend_url}
                 onChange={(e) => setFormData({ ...formData, backend_url: e.target.value })}
@@ -1020,95 +1078,69 @@ paths:
             </div>
           </Collapsible>
 
-          {/* OpenAPI Spec for manual mode */}
-          {mode === 'manual' && (
+          {/* OpenAPI Spec for manual/lifecycle modes */}
+          {(mode === 'manual' || mode === 'lifecycle') && (
             <Collapsible
-              title="OpenAPI Specification"
+              title={mode === 'lifecycle' ? 'Lifecycle Contract' : 'OpenAPI Specification'}
               icon={<Code2 className="h-4 w-4" />}
-              badge="Optional"
-              defaultExpanded={false}
+              badge={mode === 'lifecycle' ? 'Required' : 'Optional'}
+              defaultExpanded={mode === 'lifecycle'}
               variant="bordered"
             >
-              <div>
+              <div className="space-y-3">
                 <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                   OpenAPI Spec
                 </label>
                 <textarea
+                  data-testid="api-form-openapi-spec"
                   value={formData.openapi_spec}
                   onChange={(e) => setFormData({ ...formData, openapi_spec: e.target.value })}
                   className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"
                   rows={6}
                   placeholder="Paste OpenAPI/Swagger spec here (YAML or JSON)..."
                 />
-                <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-                  Adding an OpenAPI spec enables API documentation and validation
+                {mode === 'lifecycle' && (
+                  <label className="block text-sm">
+                    <span className="mb-1 block font-medium text-neutral-700 dark:text-neutral-300">
+                      Spec reference
+                    </span>
+                    <input
+                      data-testid="lifecycle-spec-reference"
+                      type="text"
+                      value={specReference}
+                      onChange={(e) => setSpecReference(e.target.value)}
+                      className="w-full border border-neutral-300 dark:border-neutral-600 rounded-lg px-3 py-2 bg-white dark:bg-neutral-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      placeholder="optional Git/catalog reference"
+                    />
+                  </label>
+                )}
+                <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                  {mode === 'lifecycle'
+                    ? 'Validation uses this persisted contract. A reference-only draft may fail validation until the backend can resolve it.'
+                    : 'Adding an OpenAPI spec enables API documentation and validation.'}
                 </p>
+                {parseError && mode === 'lifecycle' && (
+                  <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 px-4 py-3 rounded-lg text-sm">
+                    {parseError}
+                  </div>
+                )}
               </div>
             </Collapsible>
           )}
 
-          {/* Portal & Deployment Settings */}
-          <Collapsible
-            title="Portal & Deployment"
-            icon={<Settings className="h-4 w-4" />}
-            defaultExpanded={!isEdit}
-            variant="bordered"
-          >
-            <div className="space-y-4">
-              {/* Portal Promotion Toggle */}
-              <div className="flex items-start gap-3">
-                <div className="flex items-center h-5">
-                  <input
-                    type="checkbox"
-                    id="portalPromoted"
-                    checked={formData.portal_promoted}
-                    onChange={(e) =>
-                      setFormData({ ...formData, portal_promoted: e.target.checked })
-                    }
-                    className="w-4 h-4 text-blue-600 border-neutral-300 rounded focus:ring-blue-500"
-                  />
-                </div>
-                <div className="flex-1">
-                  <label
-                    htmlFor="portalPromoted"
-                    className="text-sm font-medium text-neutral-700 dark:text-neutral-300"
-                  >
-                    Promote to Developer Portal
-                  </label>
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-                    When enabled, this API will be visible in the Developer Portal for consumers to
-                    discover and subscribe.
-                  </p>
-                </div>
-              </div>
-
-              {/* Deployment workflow shortcut */}
-              {!isEdit && (
-                <div className="flex items-start gap-3 pt-3 border-t dark:border-neutral-700">
-                  <div className="flex items-center h-5">
-                    <input
-                      type="checkbox"
-                      id="openDeploymentWorkflow"
-                      checked={openDeploymentWorkflow}
-                      onChange={(e) => setOpenDeploymentWorkflow(e.target.checked)}
-                      className="w-4 h-4 text-blue-600 border-neutral-300 rounded focus:ring-blue-500"
-                    />
-                  </div>
-                  <div className="flex-1">
-                    <label
-                      htmlFor="openDeploymentWorkflow"
-                      className="text-sm font-medium text-neutral-700 dark:text-neutral-300"
-                    >
-                      Open deployment workflow after creation
-                    </label>
-                    <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-                      Choose the target environment and gateway from the dedicated Deployments page.
-                    </p>
-                  </div>
-                </div>
-              )}
-            </div>
-          </Collapsible>
+          {!isEdit && mode !== 'lifecycle' && (
+            <Collapsible
+              title="Lifecycle"
+              icon={<Settings className="h-4 w-4" />}
+              defaultExpanded={false}
+              variant="bordered"
+            >
+              <p className="text-sm text-neutral-600 dark:text-neutral-400">
+                Portal publication and gateway deployment are controlled from the API lifecycle
+                panel after creation.
+              </p>
+            </Collapsible>
+          )}
 
           <div className="flex justify-end gap-3 pt-4 border-t dark:border-neutral-700 mt-6">
             <Button variant="secondary" type="button" onClick={onClose}>
@@ -1117,8 +1149,8 @@ paths:
             <Button type="submit" loading={isSubmitting}>
               {isEdit
                 ? 'Update API'
-                : openDeploymentWorkflow
-                  ? 'Create & Open Deployments'
+                : mode === 'lifecycle'
+                  ? 'Create lifecycle draft'
                   : 'Create API'}
             </Button>
           </div>

--- a/control-plane-ui/src/pages/ApiLifecyclePanel.test.tsx
+++ b/control-plane-ui/src/pages/ApiLifecyclePanel.test.tsx
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../test/helpers';
+import { ApiLifecyclePanel } from './ApiLifecyclePanel';
+
+vi.mock('../services/api', () => ({
+  apiService: {
+    getApiLifecycleState: vi.fn(),
+    validateLifecycleDraft: vi.fn(),
+    deployLifecycleApi: vi.fn(),
+    publishLifecycleApi: vi.fn(),
+    promoteLifecycleApi: vi.fn(),
+  },
+}));
+
+const { apiService } = await import('../services/api');
+
+const baseLifecycleState = {
+  catalog_id: 'api-1',
+  tenant_id: 'tenant-1',
+  api_id: 'payments-api',
+  api_name: 'payments-api',
+  display_name: 'Payments API',
+  version: '1.0.0',
+  description: 'Payments',
+  backend_url: 'https://payments.internal',
+  catalog_status: 'draft',
+  lifecycle_phase: 'draft',
+  portal_published: false,
+  tags: [],
+  spec: {
+    source: 'inline',
+    has_openapi_spec: true,
+  },
+  deployments: [],
+  promotions: [],
+  last_error: null,
+  portal: {
+    published: false,
+    status: 'not_published',
+    publications: [],
+    last_result: null,
+    last_environment: null,
+    last_gateway_instance_id: null,
+    last_deployment_id: null,
+    last_published_at: null,
+  },
+};
+
+function renderPanel(canManage = true, canDeploy = true) {
+  return renderWithProviders(
+    <ApiLifecyclePanel
+      tenantId="tenant-1"
+      apiId="payments-api"
+      canManage={canManage}
+      canDeploy={canDeploy}
+    />
+  );
+}
+
+describe('ApiLifecyclePanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(apiService.getApiLifecycleState).mockResolvedValue(baseLifecycleState);
+  });
+
+  it('renders draft lifecycle state', async () => {
+    renderPanel();
+
+    expect(await screen.findByTestId('api-lifecycle-panel')).toBeInTheDocument();
+    expect(await screen.findByText('No gateway deployment')).toBeInTheDocument();
+    expect(screen.getByTestId('api-lifecycle-catalog-status')).toHaveTextContent('draft');
+  });
+
+  it('validates a draft and refreshes state', async () => {
+    const readyState = { ...baseLifecycleState, catalog_status: 'ready', lifecycle_phase: 'ready' };
+    vi.mocked(apiService.validateLifecycleDraft).mockResolvedValue({
+      tenant_id: 'tenant-1',
+      api_id: 'payments-api',
+      status: 'ready',
+      validation: {
+        valid: true,
+        code: 'validated',
+        message: 'OpenAPI spec is valid',
+        spec_source: 'inline',
+        path_count: 1,
+        operation_count: 1,
+      },
+      lifecycle: readyState,
+    });
+    vi.mocked(apiService.getApiLifecycleState).mockResolvedValueOnce(baseLifecycleState);
+    vi.mocked(apiService.getApiLifecycleState).mockResolvedValueOnce(readyState);
+
+    renderPanel();
+
+    await userEvent.click(await screen.findByTestId('api-lifecycle-validate'));
+
+    await waitFor(() => {
+      expect(apiService.validateLifecycleDraft).toHaveBeenCalledWith('tenant-1', 'payments-api');
+    });
+    expect(await screen.findByTestId('api-lifecycle-action-message')).toHaveTextContent(
+      'validated'
+    );
+  });
+
+  it('shows backend deployment errors clearly', async () => {
+    vi.mocked(apiService.getApiLifecycleState).mockResolvedValue({
+      ...baseLifecycleState,
+      catalog_status: 'ready',
+      lifecycle_phase: 'ready',
+    });
+    vi.mocked(apiService.deployLifecycleApi).mockRejectedValue({
+      response: { data: { detail: 'gateway target is ambiguous' } },
+    });
+
+    renderPanel();
+
+    await userEvent.click(await screen.findByTestId('api-lifecycle-deploy'));
+
+    expect(await screen.findByTestId('api-lifecycle-action-error')).toHaveTextContent(
+      'gateway target is ambiguous'
+    );
+  });
+
+  it('sends publication and promotion requests through lifecycle actions', async () => {
+    const readyState = { ...baseLifecycleState, catalog_status: 'ready', lifecycle_phase: 'ready' };
+    vi.mocked(apiService.getApiLifecycleState).mockResolvedValue(readyState);
+    vi.mocked(apiService.publishLifecycleApi).mockResolvedValue({
+      tenant_id: 'tenant-1',
+      api_id: 'payments-api',
+      environment: 'dev',
+      gateway_instance_id: 'gw-1',
+      deployment_id: 'dep-1',
+      publication_status: 'published',
+      portal_published: true,
+      result: 'published',
+      lifecycle: readyState,
+    });
+    vi.mocked(apiService.promoteLifecycleApi).mockResolvedValue({
+      tenant_id: 'tenant-1',
+      api_id: 'payments-api',
+      promotion_id: 'promo-1',
+      source_environment: 'dev',
+      target_environment: 'staging',
+      source_gateway_instance_id: 'gw-1',
+      target_gateway_instance_id: 'gw-2',
+      target_deployment_id: 'dep-2',
+      promotion_status: 'promoting',
+      deployment_status: 'pending',
+      result: 'requested',
+      lifecycle: readyState,
+    });
+
+    renderPanel();
+
+    await userEvent.click(await screen.findByTestId('api-lifecycle-publish'));
+    await waitFor(() => {
+      expect(apiService.publishLifecycleApi).toHaveBeenCalledWith('tenant-1', 'payments-api', {
+        environment: 'dev',
+        gateway_instance_id: null,
+        force: false,
+      });
+    });
+
+    await userEvent.click(screen.getByTestId('api-lifecycle-promote'));
+    await waitFor(() => {
+      expect(apiService.promoteLifecycleApi).toHaveBeenCalledWith('tenant-1', 'payments-api', {
+        source_environment: 'dev',
+        target_environment: 'staging',
+        source_gateway_instance_id: null,
+        target_gateway_instance_id: null,
+        force: false,
+      });
+    });
+  });
+});

--- a/control-plane-ui/src/pages/ApiLifecyclePanel.tsx
+++ b/control-plane-ui/src/pages/ApiLifecyclePanel.tsx
@@ -1,0 +1,523 @@
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { AlertCircle, ArrowUpRight, CheckCircle2, RefreshCw, Rocket, Send } from 'lucide-react';
+import { apiService, type ApiLifecycleState } from '../services/api';
+
+interface ApiLifecyclePanelProps {
+  tenantId: string;
+  apiId: string;
+  canManage: boolean;
+  canDeploy: boolean;
+}
+
+interface BackendErrorShape {
+  response?: {
+    data?: {
+      detail?: unknown;
+    };
+  };
+  message?: string;
+}
+
+function backendErrorMessage(error: unknown): string {
+  const candidate = error as BackendErrorShape;
+  const detail = candidate.response?.data?.detail;
+  if (typeof detail === 'string') return detail;
+  if (detail && typeof detail === 'object') {
+    const message = (detail as { message?: unknown }).message;
+    const code = (detail as { code?: unknown }).code;
+    if (typeof message === 'string' && typeof code === 'string') return `${code}: ${message}`;
+    if (typeof message === 'string') return message;
+    try {
+      return JSON.stringify(detail);
+    } catch {
+      return 'Backend returned a lifecycle error';
+    }
+  }
+  return candidate.message || 'Lifecycle action failed';
+}
+
+function statusBadgeClass(status: string): string {
+  const normalized = status.toLowerCase();
+  if (['ready', 'synced', 'published', 'promoted'].includes(normalized)) {
+    return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300';
+  }
+  if (['draft', 'pending', 'promoting', 'syncing'].includes(normalized)) {
+    return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300';
+  }
+  if (['failed', 'error', 'drifted'].includes(normalized)) {
+    return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300';
+  }
+  return 'bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300';
+}
+
+function CompactStatus({ label, value }: { label: string; value: string | boolean | null }) {
+  const rendered = value == null ? 'none' : String(value);
+  return (
+    <div data-testid={`api-lifecycle-${label.toLowerCase().replace(/\s+/g, '-')}`}>
+      <dt className="text-xs font-medium uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+        {label}
+      </dt>
+      <dd className="mt-1">
+        <span className={`inline-flex rounded px-2 py-1 text-xs ${statusBadgeClass(rendered)}`}>
+          {rendered}
+        </span>
+      </dd>
+    </div>
+  );
+}
+
+function ActionInput({
+  label,
+  value,
+  onChange,
+  placeholder,
+  testId,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  testId: string;
+}) {
+  return (
+    <label className="block text-sm">
+      <span className="mb-1 block font-medium text-neutral-700 dark:text-neutral-300">{label}</span>
+      <input
+        data-testid={testId}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className="w-full rounded border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white"
+      />
+    </label>
+  );
+}
+
+function ForceToggle({
+  checked,
+  onChange,
+  testId,
+}: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  testId: string;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300">
+      <input
+        data-testid={testId}
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        className="h-4 w-4 rounded border-neutral-300 text-blue-600 focus:ring-blue-500"
+      />
+      Force
+    </label>
+  );
+}
+
+function ActionButton({
+  children,
+  disabled,
+  onClick,
+  testId,
+}: {
+  children: ReactNode;
+  disabled?: boolean;
+  onClick: () => void;
+  testId: string;
+}) {
+  return (
+    <button
+      data-testid={testId}
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className="inline-flex items-center justify-center gap-2 rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-neutral-300 disabled:text-neutral-600 dark:disabled:bg-neutral-700 dark:disabled:text-neutral-400"
+    >
+      {children}
+    </button>
+  );
+}
+
+export function ApiLifecyclePanel({
+  tenantId,
+  apiId,
+  canManage,
+  canDeploy,
+}: ApiLifecyclePanelProps) {
+  const queryClient = useQueryClient();
+  const [deployEnvironment, setDeployEnvironment] = useState('dev');
+  const [deployGatewayId, setDeployGatewayId] = useState('');
+  const [deployForce, setDeployForce] = useState(false);
+  const [publishEnvironment, setPublishEnvironment] = useState('dev');
+  const [publishGatewayId, setPublishGatewayId] = useState('');
+  const [publishForce, setPublishForce] = useState(false);
+  const [sourceEnvironment, setSourceEnvironment] = useState('dev');
+  const [targetEnvironment, setTargetEnvironment] = useState('staging');
+  const [sourceGatewayId, setSourceGatewayId] = useState('');
+  const [targetGatewayId, setTargetGatewayId] = useState('');
+  const [promotionForce, setPromotionForce] = useState(false);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const lifecycleQuery = useQuery({
+    queryKey: ['api-lifecycle', tenantId, apiId],
+    queryFn: () => apiService.getApiLifecycleState(tenantId, apiId),
+    enabled: Boolean(tenantId && apiId),
+    retry: false,
+  });
+
+  const refreshLifecycle = async () => {
+    await lifecycleQuery.refetch();
+    await queryClient.invalidateQueries({ queryKey: ['api', tenantId, apiId] });
+  };
+
+  const handleMutationError = (error: unknown) => {
+    setActionMessage(null);
+    setActionError(backendErrorMessage(error));
+  };
+
+  const validateMutation = useMutation({
+    mutationFn: () => apiService.validateLifecycleDraft(tenantId, apiId),
+    onSuccess: async (response) => {
+      setActionError(null);
+      setActionMessage(`Validation ${response.validation.code}: ${response.validation.message}`);
+      await refreshLifecycle();
+    },
+    onError: handleMutationError,
+  });
+
+  const deployMutation = useMutation({
+    mutationFn: () =>
+      apiService.deployLifecycleApi(tenantId, apiId, {
+        environment: deployEnvironment,
+        gateway_instance_id: deployGatewayId.trim() || null,
+        force: deployForce,
+      }),
+    onSuccess: async (response) => {
+      setActionError(null);
+      setActionMessage(`Deployment ${response.action}: ${response.deployment_status}`);
+      await refreshLifecycle();
+    },
+    onError: handleMutationError,
+  });
+
+  const publishMutation = useMutation({
+    mutationFn: () =>
+      apiService.publishLifecycleApi(tenantId, apiId, {
+        environment: publishEnvironment,
+        gateway_instance_id: publishGatewayId.trim() || null,
+        force: publishForce,
+      }),
+    onSuccess: async (response) => {
+      setActionError(null);
+      setActionMessage(`Portal publication ${response.result}: ${response.publication_status}`);
+      await refreshLifecycle();
+    },
+    onError: handleMutationError,
+  });
+
+  const promoteMutation = useMutation({
+    mutationFn: () =>
+      apiService.promoteLifecycleApi(tenantId, apiId, {
+        source_environment: sourceEnvironment,
+        target_environment: targetEnvironment,
+        source_gateway_instance_id: sourceGatewayId.trim() || null,
+        target_gateway_instance_id: targetGatewayId.trim() || null,
+        force: promotionForce,
+      }),
+    onSuccess: async (response) => {
+      setActionError(null);
+      setActionMessage(`Promotion ${response.result}: ${response.promotion_status}`);
+      await refreshLifecycle();
+    },
+    onError: handleMutationError,
+  });
+
+  const lifecycle = lifecycleQuery.data;
+  const isReady = lifecycle?.catalog_status === 'ready';
+  const canValidateCatalog =
+    canManage && (lifecycle?.catalog_status === 'draft' || lifecycle?.catalog_status === 'ready');
+  const actionsDisabled = !lifecycle || lifecycleQuery.isLoading;
+
+  return (
+    <section
+      data-testid="api-lifecycle-panel"
+      className="space-y-5 rounded-lg border border-neutral-200 bg-white p-5 dark:border-neutral-700 dark:bg-neutral-900"
+    >
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">API lifecycle</h2>
+          <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+            Canonical draft, validation, runtime deployment, portal publication, and promotion.
+          </p>
+        </div>
+        <button
+          data-testid="api-lifecycle-refresh"
+          type="button"
+          onClick={() => void refreshLifecycle()}
+          disabled={lifecycleQuery.isFetching}
+          className="inline-flex items-center gap-2 rounded border border-neutral-300 px-3 py-2 text-sm text-neutral-700 hover:bg-neutral-50 disabled:opacity-60 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+        >
+          <RefreshCw className={`h-4 w-4 ${lifecycleQuery.isFetching ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      {lifecycleQuery.isError && (
+        <div
+          data-testid="api-lifecycle-unavailable"
+          className="flex items-start gap-2 rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-200"
+        >
+          <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <span>{backendErrorMessage(lifecycleQuery.error)}</span>
+        </div>
+      )}
+
+      {lifecycle && <LifecycleSummary lifecycle={lifecycle} />}
+
+      {actionError && (
+        <div
+          data-testid="api-lifecycle-action-error"
+          className="flex items-start gap-2 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-900/20 dark:text-red-200"
+        >
+          <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <span>{actionError}</span>
+        </div>
+      )}
+
+      {actionMessage && (
+        <div
+          data-testid="api-lifecycle-action-message"
+          className="flex items-start gap-2 rounded border border-green-200 bg-green-50 p-3 text-sm text-green-700 dark:border-green-900/60 dark:bg-green-900/20 dark:text-green-200"
+        >
+          <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <span>{actionMessage}</span>
+        </div>
+      )}
+
+      <div className="grid gap-4 xl:grid-cols-4">
+        <div className="space-y-3 rounded border border-neutral-200 p-4 dark:border-neutral-700">
+          <h3 className="text-sm font-semibold text-neutral-900 dark:text-white">Validate</h3>
+          <p className="text-xs text-neutral-500 dark:text-neutral-400">
+            Validates the stored OpenAPI/Swagger contract and sets catalog readiness.
+          </p>
+          <ActionButton
+            testId="api-lifecycle-validate"
+            disabled={actionsDisabled || !canValidateCatalog || validateMutation.isPending}
+            onClick={() => validateMutation.mutate()}
+          >
+            <CheckCircle2 className="h-4 w-4" />
+            {lifecycle?.catalog_status === 'ready' ? 'Revalidate' : 'Validate draft'}
+          </ActionButton>
+        </div>
+
+        <div className="space-y-3 rounded border border-neutral-200 p-4 dark:border-neutral-700">
+          <h3 className="text-sm font-semibold text-neutral-900 dark:text-white">Deploy</h3>
+          <ActionInput
+            testId="api-lifecycle-deploy-environment"
+            label="Environment"
+            value={deployEnvironment}
+            onChange={setDeployEnvironment}
+          />
+          <ActionInput
+            testId="api-lifecycle-deploy-gateway"
+            label="Gateway instance ID"
+            value={deployGatewayId}
+            onChange={setDeployGatewayId}
+            placeholder="optional"
+          />
+          <ForceToggle
+            testId="api-lifecycle-deploy-force"
+            checked={deployForce}
+            onChange={setDeployForce}
+          />
+          <ActionButton
+            testId="api-lifecycle-deploy"
+            disabled={actionsDisabled || !canDeploy || !isReady || deployMutation.isPending}
+            onClick={() => deployMutation.mutate()}
+          >
+            <Rocket className="h-4 w-4" />
+            Deploy
+          </ActionButton>
+        </div>
+
+        <div className="space-y-3 rounded border border-neutral-200 p-4 dark:border-neutral-700">
+          <h3 className="text-sm font-semibold text-neutral-900 dark:text-white">Publish</h3>
+          <ActionInput
+            testId="api-lifecycle-publish-environment"
+            label="Environment"
+            value={publishEnvironment}
+            onChange={setPublishEnvironment}
+          />
+          <ActionInput
+            testId="api-lifecycle-publish-gateway"
+            label="Gateway instance ID"
+            value={publishGatewayId}
+            onChange={setPublishGatewayId}
+            placeholder="optional"
+          />
+          <ForceToggle
+            testId="api-lifecycle-publish-force"
+            checked={publishForce}
+            onChange={setPublishForce}
+          />
+          <ActionButton
+            testId="api-lifecycle-publish"
+            disabled={actionsDisabled || !canManage || !isReady || publishMutation.isPending}
+            onClick={() => publishMutation.mutate()}
+          >
+            <Send className="h-4 w-4" />
+            Publish
+          </ActionButton>
+        </div>
+
+        <div className="space-y-3 rounded border border-neutral-200 p-4 dark:border-neutral-700">
+          <h3 className="text-sm font-semibold text-neutral-900 dark:text-white">Promote</h3>
+          <div className="grid grid-cols-2 gap-2">
+            <ActionInput
+              testId="api-lifecycle-promote-source-env"
+              label="Source"
+              value={sourceEnvironment}
+              onChange={setSourceEnvironment}
+            />
+            <ActionInput
+              testId="api-lifecycle-promote-target-env"
+              label="Target"
+              value={targetEnvironment}
+              onChange={setTargetEnvironment}
+            />
+          </div>
+          <ActionInput
+            testId="api-lifecycle-promote-source-gateway"
+            label="Source gateway ID"
+            value={sourceGatewayId}
+            onChange={setSourceGatewayId}
+            placeholder="optional"
+          />
+          <ActionInput
+            testId="api-lifecycle-promote-target-gateway"
+            label="Target gateway ID"
+            value={targetGatewayId}
+            onChange={setTargetGatewayId}
+            placeholder="optional"
+          />
+          <ForceToggle
+            testId="api-lifecycle-promote-force"
+            checked={promotionForce}
+            onChange={setPromotionForce}
+          />
+          <ActionButton
+            testId="api-lifecycle-promote"
+            disabled={actionsDisabled || !canDeploy || !isReady || promoteMutation.isPending}
+            onClick={() => promoteMutation.mutate()}
+          >
+            <ArrowUpRight className="h-4 w-4" />
+            Promote
+          </ActionButton>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function LifecycleSummary({ lifecycle }: { lifecycle: ApiLifecycleState }) {
+  return (
+    <div className="space-y-4">
+      <dl className="grid grid-cols-2 gap-4 md:grid-cols-5">
+        <CompactStatus label="Catalog status" value={lifecycle.catalog_status} />
+        <CompactStatus label="Lifecycle phase" value={lifecycle.lifecycle_phase} />
+        <CompactStatus label="Portal" value={lifecycle.portal.status} />
+        <CompactStatus label="Spec source" value={lifecycle.spec.source} />
+        <CompactStatus label="Spec present" value={lifecycle.spec.has_openapi_spec} />
+      </dl>
+
+      {lifecycle.last_error && (
+        <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-900/20 dark:text-red-200">
+          {lifecycle.last_error}
+        </div>
+      )}
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <SummaryList
+          title="Deployments"
+          empty="No gateway deployment"
+          items={lifecycle.deployments.map((deployment) => ({
+            id: deployment.id,
+            title: `${deployment.environment} / ${deployment.gateway_name}`,
+            status: deployment.sync_status,
+            detail: deployment.sync_error || deployment.gateway_instance_id,
+          }))}
+        />
+        <SummaryList
+          title="Portal publications"
+          empty="Not published"
+          items={lifecycle.portal.publications.map((publication) => ({
+            id: `${publication.environment}:${publication.gateway_instance_id}`,
+            title: `${publication.environment} / ${publication.publication_status}`,
+            status: publication.result,
+            detail: publication.deployment_id,
+          }))}
+        />
+        <SummaryList
+          title="Promotions"
+          empty="No promotion"
+          items={lifecycle.promotions.map((promotion) => ({
+            id: promotion.id,
+            title: `${promotion.source_environment} to ${promotion.target_environment}`,
+            status: promotion.status,
+            detail: promotion.message,
+          }))}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SummaryList({
+  title,
+  empty,
+  items,
+}: {
+  title: string;
+  empty: string;
+  items: { id: string; title: string; status: string; detail?: string | null }[];
+}) {
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold text-neutral-900 dark:text-white">{title}</h3>
+      {items.length === 0 ? (
+        <p className="rounded border border-dashed border-neutral-300 p-3 text-sm text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">
+          {empty}
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {items.map((item) => (
+            <div
+              data-testid={`api-lifecycle-${title.toLowerCase().replace(/\s+/g, '-')}-item`}
+              key={item.id}
+              className="rounded border border-neutral-200 p-3 dark:border-neutral-700"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm font-medium text-neutral-900 dark:text-white">
+                  {item.title}
+                </span>
+                <span className={`rounded px-2 py-1 text-xs ${statusBadgeClass(item.status)}`}>
+                  {item.status}
+                </span>
+              </div>
+              {item.detail && (
+                <p className="mt-1 truncate font-mono text-xs text-neutral-500 dark:text-neutral-400">
+                  {item.detail}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/control-plane-ui/src/pages/__snapshots__/APIs.test.tsx.snap
+++ b/control-plane-ui/src/pages/__snapshots__/APIs.test.tsx.snap
@@ -12,12 +12,12 @@ exports[`APIs > snapshot: cpi-admin persona > matches structural snapshot 1`] = 
   "headings": [],
   "links": [
     {
-      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
-      "text": "Open Deployments",
+      "href": "/apis/oasis-gunters/payment-api",
+      "text": "Open Lifecycle",
     },
     {
-      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
-      "text": "Open Deployments",
+      "href": "/apis/oasis-gunters/user-api",
+      "text": "Open Lifecycle",
     },
   ],
 }
@@ -35,12 +35,12 @@ exports[`APIs > snapshot: devops persona > matches structural snapshot 1`] = `
   "headings": [],
   "links": [
     {
-      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
-      "text": "Open Deployments",
+      "href": "/apis/oasis-gunters/payment-api",
+      "text": "Open Lifecycle",
     },
     {
-      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
-      "text": "Open Deployments",
+      "href": "/apis/oasis-gunters/user-api",
+      "text": "Open Lifecycle",
     },
   ],
 }
@@ -58,12 +58,12 @@ exports[`APIs > snapshot: tenant-admin persona > matches structural snapshot 1`]
   "headings": [],
   "links": [
     {
-      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
-      "text": "Open Deployments",
+      "href": "/apis/oasis-gunters/payment-api",
+      "text": "Open Lifecycle",
     },
     {
-      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
-      "text": "Open Deployments",
+      "href": "/apis/oasis-gunters/user-api",
+      "text": "Open Lifecycle",
     },
   ],
 }
@@ -81,12 +81,12 @@ exports[`APIs > snapshot: viewer persona > matches structural snapshot 1`] = `
   "headings": [],
   "links": [
     {
-      "href": "/api-deployments?api_id=api-1&api_name=payment-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
-      "text": "Open Deployments",
+      "href": "/apis/oasis-gunters/payment-api",
+      "text": "Open Lifecycle",
     },
     {
-      "href": "/api-deployments?api_id=api-2&api_name=user-api&environment=dev&open_deploy=true&tenant_id=oasis-gunters",
-      "text": "Open Deployments",
+      "href": "/apis/oasis-gunters/user-api",
+      "text": "Open Lifecycle",
     },
   ],
 }

--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -98,6 +98,7 @@ import { platformClient } from './api/platform';
 import { chatClient } from './api/chat';
 import { llmClient } from './api/llm';
 import { monitoringClient } from './api/monitoring';
+import { apiLifecycleClient } from './api/apiLifecycle';
 
 // Imports internes des types co-localisés (nécessaires pour les signatures de
 // la classe ApiService ci-dessous). Ré-exports publics : voir en bas de fichier.
@@ -129,6 +130,18 @@ import type {
   MonitoringTransactionDetail,
   MonitoringStats,
 } from './api/monitoring';
+import type {
+  ApiLifecycleCreateDraftRequest,
+  ApiLifecycleState,
+  ApiLifecycleValidateDraftRequest,
+  ApiLifecycleValidateDraftResponse,
+  ApiLifecycleDeploymentRequest,
+  ApiLifecycleDeployResponse,
+  ApiLifecyclePublicationRequest,
+  ApiLifecyclePublishResponse,
+  ApiLifecyclePromotionRequest,
+  ApiLifecyclePromotionResponse,
+} from './api/apiLifecycle';
 
 // ── Type re-exports (historiquement inline en bas de api.ts) ─────────────────
 // Ces types sont désormais co-localisés avec leur client de domaine.
@@ -169,6 +182,18 @@ export type {
   MonitoringTransactionDetail,
   MonitoringStats,
 } from './api/monitoring';
+export type {
+  ApiLifecycleCreateDraftRequest,
+  ApiLifecycleState,
+  ApiLifecycleValidateDraftRequest,
+  ApiLifecycleValidateDraftResponse,
+  ApiLifecycleDeploymentRequest,
+  ApiLifecycleDeployResponse,
+  ApiLifecyclePublicationRequest,
+  ApiLifecyclePublishResponse,
+  ApiLifecyclePromotionRequest,
+  ApiLifecyclePromotionResponse,
+} from './api/apiLifecycle';
 
 // =============================================================================
 // Façade ApiService — agrège le core transport (services/http) et tous les
@@ -313,6 +338,50 @@ class ApiService {
 
   async triggerCatalogSync(tenantId: string): Promise<void> {
     return apisClient.triggerCatalogSync(tenantId);
+  }
+
+  // Canonical API lifecycle
+  async createLifecycleDraft(
+    tenantId: string,
+    request: ApiLifecycleCreateDraftRequest
+  ): Promise<ApiLifecycleState> {
+    return apiLifecycleClient.createDraft(tenantId, request);
+  }
+
+  async getApiLifecycleState(tenantId: string, apiId: string): Promise<ApiLifecycleState> {
+    return apiLifecycleClient.getState(tenantId, apiId);
+  }
+
+  async validateLifecycleDraft(
+    tenantId: string,
+    apiId: string,
+    request: ApiLifecycleValidateDraftRequest = {}
+  ): Promise<ApiLifecycleValidateDraftResponse> {
+    return apiLifecycleClient.validateDraft(tenantId, apiId, request);
+  }
+
+  async deployLifecycleApi(
+    tenantId: string,
+    apiId: string,
+    request: ApiLifecycleDeploymentRequest
+  ): Promise<ApiLifecycleDeployResponse> {
+    return apiLifecycleClient.deploy(tenantId, apiId, request);
+  }
+
+  async publishLifecycleApi(
+    tenantId: string,
+    apiId: string,
+    request: ApiLifecyclePublicationRequest
+  ): Promise<ApiLifecyclePublishResponse> {
+    return apiLifecycleClient.publish(tenantId, apiId, request);
+  }
+
+  async promoteLifecycleApi(
+    tenantId: string,
+    apiId: string,
+    request: ApiLifecyclePromotionRequest
+  ): Promise<ApiLifecyclePromotionResponse> {
+    return apiLifecycleClient.promote(tenantId, apiId, request);
   }
 
   // Applications

--- a/control-plane-ui/src/services/api/apiLifecycle.test.ts
+++ b/control-plane-ui/src/services/api/apiLifecycle.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockHttpClient } = vi.hoisted(() => ({
+  mockHttpClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+vi.mock('../http', async () => {
+  const actual = await vi.importActual<typeof import('../http')>('../http');
+  return { ...actual, httpClient: mockHttpClient };
+});
+
+import { apiLifecycleClient } from './apiLifecycle';
+
+describe('apiLifecycleClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHttpClient.get.mockResolvedValue({ data: {} });
+    mockHttpClient.post.mockResolvedValue({ data: {} });
+  });
+
+  it('creates lifecycle drafts through the canonical endpoint', async () => {
+    const request = {
+      name: 'payments-api',
+      display_name: 'Payments API',
+      version: '1.0.0',
+      description: 'Payments',
+      backend_url: 'https://payments.internal',
+      openapi_spec: { openapi: '3.0.3', info: { title: 'Payments API', version: '1.0.0' } },
+      tags: ['payments'],
+    };
+
+    await apiLifecycleClient.createDraft('tenant-1', request);
+
+    expect(mockHttpClient.post).toHaveBeenCalledWith(
+      '/v1/tenants/tenant-1/apis/lifecycle/drafts',
+      request
+    );
+  });
+
+  it('loads aggregate lifecycle state', async () => {
+    await apiLifecycleClient.getState('tenant-1', 'payments-api');
+
+    expect(mockHttpClient.get).toHaveBeenCalledWith(
+      '/v1/tenants/tenant-1/apis/payments-api/lifecycle'
+    );
+  });
+
+  it('posts validation, deployment, publication, and promotion actions', async () => {
+    await apiLifecycleClient.validateDraft('tenant-1', 'payments-api', { reason: 'manual' });
+    await apiLifecycleClient.deploy('tenant-1', 'payments-api', {
+      environment: 'dev',
+      gateway_instance_id: 'gw-1',
+      force: false,
+    });
+    await apiLifecycleClient.publish('tenant-1', 'payments-api', {
+      environment: 'dev',
+      gateway_instance_id: 'gw-1',
+      force: false,
+    });
+    await apiLifecycleClient.promote('tenant-1', 'payments-api', {
+      source_environment: 'dev',
+      target_environment: 'staging',
+      target_gateway_instance_id: 'gw-2',
+      force: false,
+    });
+
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      1,
+      '/v1/tenants/tenant-1/apis/payments-api/lifecycle/validate',
+      { reason: 'manual' }
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      2,
+      '/v1/tenants/tenant-1/apis/payments-api/lifecycle/deployments',
+      { environment: 'dev', gateway_instance_id: 'gw-1', force: false }
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      3,
+      '/v1/tenants/tenant-1/apis/payments-api/lifecycle/publications',
+      { environment: 'dev', gateway_instance_id: 'gw-1', force: false }
+    );
+    expect(mockHttpClient.post).toHaveBeenNthCalledWith(
+      4,
+      '/v1/tenants/tenant-1/apis/payments-api/lifecycle/promotions',
+      {
+        source_environment: 'dev',
+        target_environment: 'staging',
+        target_gateway_instance_id: 'gw-2',
+        force: false,
+      }
+    );
+  });
+});

--- a/control-plane-ui/src/services/api/apiLifecycle.ts
+++ b/control-plane-ui/src/services/api/apiLifecycle.ts
@@ -1,0 +1,243 @@
+import { httpClient, path } from '../http';
+
+export type ApiLifecycleSpecDocument = Record<string, unknown>;
+
+export interface ApiLifecycleCreateDraftRequest {
+  name: string;
+  display_name: string;
+  version: string;
+  description?: string;
+  backend_url: string;
+  openapi_spec?: string | ApiLifecycleSpecDocument | null;
+  spec_reference?: string | null;
+  tags?: string[];
+  owner_team?: string | null;
+}
+
+export interface ApiLifecycleValidationResult {
+  valid: boolean;
+  code: string;
+  message: string;
+  spec_source: string;
+  spec_format?: string | null;
+  spec_version?: string | null;
+  title?: string | null;
+  version?: string | null;
+  path_count: number;
+  operation_count: number;
+  validated_at?: string | null;
+}
+
+export interface ApiLifecycleSpecState {
+  source: string;
+  has_openapi_spec: boolean;
+  git_path?: string | null;
+  git_commit_sha?: string | null;
+  reference?: string | null;
+  fallback_reason?: string | null;
+}
+
+export interface ApiLifecycleGatewayDeployment {
+  id: string;
+  environment: string;
+  gateway_instance_id: string;
+  gateway_name: string;
+  gateway_type: string;
+  sync_status: string;
+  desired_generation: number;
+  synced_generation: number;
+  gateway_resource_id?: string | null;
+  public_url?: string | null;
+  sync_error?: string | null;
+  last_sync_success?: string | null;
+}
+
+export interface ApiLifecyclePromotion {
+  id: string;
+  source_environment: string;
+  target_environment: string;
+  status: string;
+  message: string;
+  requested_by: string;
+  approved_by?: string | null;
+  completed_at?: string | null;
+}
+
+export interface ApiLifecyclePortalPublication {
+  environment: string;
+  gateway_instance_id: string;
+  deployment_id: string;
+  publication_status: string;
+  result: string;
+  spec_hash: string;
+  published_at: string;
+}
+
+export interface ApiLifecyclePortalState {
+  published: boolean;
+  status: string;
+  publications: ApiLifecyclePortalPublication[];
+  last_result?: string | null;
+  last_environment?: string | null;
+  last_gateway_instance_id?: string | null;
+  last_deployment_id?: string | null;
+  last_published_at?: string | null;
+}
+
+export interface ApiLifecycleState {
+  catalog_id: string;
+  tenant_id: string;
+  api_id: string;
+  api_name: string;
+  display_name: string;
+  version: string;
+  description: string;
+  backend_url: string;
+  catalog_status: string;
+  lifecycle_phase: string;
+  portal_published: boolean;
+  tags: string[];
+  spec: ApiLifecycleSpecState;
+  deployments: ApiLifecycleGatewayDeployment[];
+  promotions: ApiLifecyclePromotion[];
+  last_error?: string | null;
+  portal: ApiLifecyclePortalState;
+}
+
+export interface ApiLifecycleValidateDraftRequest {
+  reason?: string | null;
+}
+
+export interface ApiLifecycleValidateDraftResponse {
+  tenant_id: string;
+  api_id: string;
+  status: string;
+  validation: ApiLifecycleValidationResult;
+  lifecycle: ApiLifecycleState;
+}
+
+export interface ApiLifecycleDeploymentRequest {
+  environment: string;
+  gateway_instance_id?: string | null;
+  force?: boolean;
+}
+
+export interface ApiLifecycleDeployResponse {
+  tenant_id: string;
+  api_id: string;
+  environment: string;
+  gateway_instance_id: string;
+  deployment_id: string;
+  deployment_status: string;
+  action: string;
+  lifecycle: ApiLifecycleState;
+}
+
+export interface ApiLifecyclePublicationRequest {
+  environment: string;
+  gateway_instance_id?: string | null;
+  force?: boolean;
+}
+
+export interface ApiLifecyclePublishResponse {
+  tenant_id: string;
+  api_id: string;
+  environment: string;
+  gateway_instance_id: string;
+  deployment_id: string;
+  publication_status: string;
+  portal_published: boolean;
+  result: string;
+  lifecycle: ApiLifecycleState;
+}
+
+export interface ApiLifecyclePromotionRequest {
+  source_environment: string;
+  target_environment: string;
+  source_gateway_instance_id?: string | null;
+  target_gateway_instance_id?: string | null;
+  force?: boolean;
+}
+
+export interface ApiLifecyclePromotionResponse {
+  tenant_id: string;
+  api_id: string;
+  promotion_id: string;
+  source_environment: string;
+  target_environment: string;
+  source_gateway_instance_id: string;
+  target_gateway_instance_id: string;
+  target_deployment_id: string;
+  promotion_status: string;
+  deployment_status: string;
+  result: string;
+  lifecycle: ApiLifecycleState;
+}
+
+export const apiLifecycleClient = {
+  async createDraft(
+    tenantId: string,
+    request: ApiLifecycleCreateDraftRequest
+  ): Promise<ApiLifecycleState> {
+    const { data } = await httpClient.post(
+      path('v1', 'tenants', tenantId, 'apis', 'lifecycle', 'drafts'),
+      request
+    );
+    return data;
+  },
+
+  async getState(tenantId: string, apiId: string): Promise<ApiLifecycleState> {
+    const { data } = await httpClient.get(
+      path('v1', 'tenants', tenantId, 'apis', apiId, 'lifecycle')
+    );
+    return data;
+  },
+
+  async validateDraft(
+    tenantId: string,
+    apiId: string,
+    request: ApiLifecycleValidateDraftRequest = {}
+  ): Promise<ApiLifecycleValidateDraftResponse> {
+    const { data } = await httpClient.post(
+      path('v1', 'tenants', tenantId, 'apis', apiId, 'lifecycle', 'validate'),
+      request
+    );
+    return data;
+  },
+
+  async deploy(
+    tenantId: string,
+    apiId: string,
+    request: ApiLifecycleDeploymentRequest
+  ): Promise<ApiLifecycleDeployResponse> {
+    const { data } = await httpClient.post(
+      path('v1', 'tenants', tenantId, 'apis', apiId, 'lifecycle', 'deployments'),
+      request
+    );
+    return data;
+  },
+
+  async publish(
+    tenantId: string,
+    apiId: string,
+    request: ApiLifecyclePublicationRequest
+  ): Promise<ApiLifecyclePublishResponse> {
+    const { data } = await httpClient.post(
+      path('v1', 'tenants', tenantId, 'apis', apiId, 'lifecycle', 'publications'),
+      request
+    );
+    return data;
+  },
+
+  async promote(
+    tenantId: string,
+    apiId: string,
+    request: ApiLifecyclePromotionRequest
+  ): Promise<ApiLifecyclePromotionResponse> {
+    const { data } = await httpClient.post(
+      path('v1', 'tenants', tenantId, 'apis', apiId, 'lifecycle', 'promotions'),
+      request
+    );
+    return data;
+  },
+};

--- a/docs/api-lifecycle.md
+++ b/docs/api-lifecycle.md
@@ -1,0 +1,455 @@
+# API Lifecycle
+
+This document describes the canonical lifecycle path implemented in the
+control-plane API. Draft, validation, gateway deployment, portal publication,
+and environment promotion are all orchestrated through `ApiLifecycleService`.
+
+## Canonical Models
+
+- `APICatalog`: API identity, catalog metadata, catalog status, and OpenAPI
+  contract cache.
+- `GatewayDeployment`: runtime gateway desired/actual state per gateway.
+- `Promotion`: explicit transition between environments.
+- `AuditEvent`: immutable lifecycle transition trace.
+
+`APICatalog.status` is only the catalog state. Runtime deployment, portal
+publication, and promotion state are aggregated by the lifecycle endpoint from
+their own canonical models.
+
+## States
+
+Implemented:
+
+- `draft`: catalog entry exists, may contain an inline OpenAPI spec or a spec
+  reference, and has not been validated for deployment.
+- `ready`: draft validation succeeded. This is only a catalog readiness state;
+  it does not mean deployed, published, or promoted.
+- `deployed`: aggregate lifecycle phase when at least one `GatewayDeployment`
+  is synced. The catalog status remains `ready`.
+- `published`: aggregate lifecycle phase when a synced gateway deployment has
+  been explicitly published to the portal.
+- `promoting`: an environment promotion is pending or running.
+- `promoted`: promotion has completed.
+- `failed`: catalog validation, gateway sync, portal publication, or promotion
+  failed with an explicit error.
+- `archived`: catalog entry is no longer active.
+
+## Endpoints
+
+### Create Draft
+
+`POST /v1/tenants/{tenant_id}/apis/lifecycle/drafts`
+
+Creates an `APICatalog` row with `status=draft`, `portal_published=false`, and
+an audit event `api_lifecycle.create_draft`. The request must provide either an
+inline OpenAPI/Swagger document or a `spec_reference`.
+
+Minimal body:
+
+```json
+{
+  "name": "Payments API",
+  "display_name": "Payments API",
+  "version": "1.0.0",
+  "description": "Payment operations",
+  "backend_url": "https://payments.internal",
+  "openapi_spec": {
+    "openapi": "3.0.3",
+    "info": {"title": "Payments API", "version": "1.0.0"},
+    "paths": {
+      "/payments": {
+        "get": {"responses": {"200": {"description": "ok"}}}
+      }
+    }
+  }
+}
+```
+
+Portal publication tags such as `portal:published` are rejected on this path.
+Publication must go through the lifecycle publish action.
+
+### Get Lifecycle State
+
+`GET /v1/tenants/{tenant_id}/apis/{api_id}/lifecycle`
+
+Returns the aggregate lifecycle state calculated from `APICatalog`,
+`GatewayDeployment`, and `Promotion`. A newly created draft has empty
+`deployments` and `promotions` arrays.
+
+### Validate Draft
+
+`POST /v1/tenants/{tenant_id}/apis/{api_id}/lifecycle/validate`
+
+Validates the persisted OpenAPI/Swagger contract and transitions the catalog
+state from `draft` to `ready`. A `ready` API can be revalidated idempotently
+when the spec has not changed. `archived` APIs and other non-draft/non-ready
+catalog states are refused with a transition error.
+
+Minimal validation rules:
+
+- OpenAPI 3.x via `openapi` is supported.
+- Swagger 2.0 via `swagger` is supported.
+- The spec must be a JSON/YAML object.
+- `info.title` is required.
+- `info.version` is required.
+- `paths` is required and cannot be empty.
+- Every path key must start with `/`.
+- Every HTTP operation must declare a non-empty `responses` object.
+
+If the draft only contains `spec_reference`, validation currently returns
+`spec_reference_unresolved` and keeps `APICatalog.status=draft`. No existing
+control-plane service resolves arbitrary lifecycle spec references reliably yet.
+
+Successful response shape:
+
+```json
+{
+  "tenant_id": "acme",
+  "api_id": "payments-api",
+  "status": "ready",
+  "validation": {
+    "valid": true,
+    "code": "validated",
+    "spec_source": "inline",
+    "spec_format": "openapi",
+    "spec_version": "3.0.3",
+    "path_count": 1,
+    "operation_count": 1
+  },
+  "lifecycle": {
+    "catalog_status": "ready",
+    "lifecycle_phase": "ready",
+    "deployments": [],
+    "promotions": []
+  }
+}
+```
+
+### Request Gateway Deployment
+
+`POST /v1/tenants/{tenant_id}/apis/{api_id}/lifecycle/deployments`
+
+Creates or updates a `GatewayDeployment` desired state for a target gateway.
+This endpoint does not call a gateway directly and does not publish to the
+portal. The `SyncEngine` is responsible for reconciling `pending` deployments
+against the actual gateway.
+
+Request body:
+
+```json
+{
+  "environment": "dev",
+  "gateway_instance_id": "optional-uuid",
+  "force": false
+}
+```
+
+Gateway resolution:
+
+- If `gateway_instance_id` is provided, it must be visible to the tenant and
+  match the requested environment.
+- If it is omitted, exactly one enabled gateway visible to the tenant must
+  exist for the environment.
+- If no gateway matches, the request returns a clear not-found error.
+- If more than one gateway matches, the request is ambiguous and must include
+  `gateway_instance_id`.
+
+Idempotence:
+
+- Same API, same environment, same gateway, same desired state returns the
+  existing `GatewayDeployment`.
+- Existing `pending` or `syncing` rows are not duplicated.
+- Existing `synced` rows are not reset to `pending` when the desired state is
+  unchanged.
+- A changed desired state updates the row, increments `desired_generation`, and
+  sets `sync_status=pending`.
+
+Successful response shape:
+
+```json
+{
+  "tenant_id": "acme",
+  "api_id": "payments-api",
+  "environment": "dev",
+  "gateway_instance_id": "00000000-0000-4000-8000-000000000001",
+  "deployment_id": "00000000-0000-4000-8000-000000000002",
+  "deployment_status": "pending",
+  "action": "created",
+  "lifecycle": {
+    "catalog_status": "ready",
+    "deployments": [
+      {
+        "environment": "dev",
+        "gateway_name": "stoa-dev",
+        "sync_status": "pending"
+      }
+    ],
+    "promotions": []
+  }
+}
+```
+
+### Publish To Portal
+
+`POST /v1/tenants/{tenant_id}/apis/{api_id}/lifecycle/publications`
+
+Publishes a synced `GatewayDeployment` to the STOA portal. In the current portal
+architecture, the portal catalog reads `APICatalog.portal_published`, so the
+lifecycle adapter updates that field and records the target publication context
+under `api_metadata.lifecycle.portal_publications`. This is the only active HTTP
+path that may publish an API to the portal.
+
+Request body:
+
+```json
+{
+  "environment": "dev",
+  "gateway_instance_id": "optional-uuid",
+  "force": false
+}
+```
+
+Rules:
+
+- The API catalog status must be `ready`.
+- A matching `GatewayDeployment` must already exist.
+- The matching deployment must be `synced`.
+- Gateway resolution follows the same tenant/environment rules as deployment.
+- Publication never creates a deployment and never mutates
+  `APICatalog.status`.
+- `APICatalog.openapi_spec` must be present and valid. A `spec_reference`
+  without a resolved spec is refused with `spec_reference_unresolved`.
+- Repeating the same publication with the same deployment and spec hash returns
+  `result=unchanged`.
+- `force=true` reruns the controlled publication adapter and records
+  `result=republished` without creating duplicate publication records.
+
+Successful response shape:
+
+```json
+{
+  "tenant_id": "acme",
+  "api_id": "payments-api",
+  "environment": "dev",
+  "gateway_instance_id": "00000000-0000-4000-8000-000000000001",
+  "deployment_id": "00000000-0000-4000-8000-000000000002",
+  "publication_status": "published",
+  "portal_published": true,
+  "result": "published",
+  "lifecycle": {
+    "catalog_status": "ready",
+    "lifecycle_phase": "published",
+    "portal": {
+      "published": true,
+      "status": "published",
+      "last_environment": "dev"
+    },
+    "promotions": []
+  }
+}
+```
+
+Legacy API create/update endpoints reject `portal:published`,
+`promoted:portal`, and `portal-promoted` tags with `422`. Tags are no longer a
+publication mechanism; publication must use the lifecycle endpoint above.
+Catalog sync, GitOps projection, and admin seed paths strip those legacy tags
+from imported tags and insert new catalog rows with `portal_published=false`.
+On update they preserve existing portal publication state instead of deriving
+it from Git. They also preserve the lifecycle-owned
+`api_metadata.lifecycle` subtree, including `portal_publications`, while
+refreshing Git-projected metadata fields.
+
+### Promote To Environment
+
+`POST /v1/tenants/{tenant_id}/apis/{api_id}/lifecycle/promotions`
+
+Promotes an API from a published, synced source environment to the next allowed
+environment and requests the target `GatewayDeployment`. This endpoint owns the
+promotion execution path. Legacy promotion approval no longer deploys directly
+and no longer emits a `promotion-approved` deploy command; the legacy consumer
+ignores repeated `promotion-approved` events to avoid double deployment.
+
+Request body:
+
+```json
+{
+  "source_environment": "dev",
+  "target_environment": "staging",
+  "source_gateway_instance_id": "optional-uuid",
+  "target_gateway_instance_id": "optional-uuid",
+  "force": false
+}
+```
+
+Rules:
+
+- The API catalog status must be `ready`.
+- The source and target environments must be different and follow the allowed
+  chain: `dev -> staging` or `staging -> production`.
+- The source gateway deployment must exist and be `synced`.
+- The source deployment must have been published through the lifecycle
+  publication endpoint.
+- The target gateway is resolved with the same tenant/environment rules as
+  deployment and publication.
+- Promotion creates or reuses one `Promotion` row and creates or reuses one
+  target `GatewayDeployment`.
+- Promotion never creates a legacy `Deployment` and never mutates
+  `APICatalog.status`.
+- Repeating the same promotion returns `result=unchanged` and does not create a
+  second `Promotion` or target `GatewayDeployment`.
+- The promotion remains `promoting` until the target deployment is synced and
+  the target environment is published through the controlled publication
+  endpoint. That target publication marks the promotion `promoted`.
+
+Successful response shape:
+
+```json
+{
+  "tenant_id": "acme",
+  "api_id": "payments-api",
+  "promotion_id": "00000000-0000-4000-8000-000000000003",
+  "source_environment": "dev",
+  "target_environment": "staging",
+  "source_gateway_instance_id": "00000000-0000-4000-8000-000000000001",
+  "target_gateway_instance_id": "00000000-0000-4000-8000-000000000004",
+  "target_deployment_id": "00000000-0000-4000-8000-000000000005",
+  "promotion_status": "promoting",
+  "deployment_status": "pending",
+  "result": "requested",
+  "lifecycle": {
+    "catalog_status": "ready",
+    "lifecycle_phase": "promoting"
+  }
+}
+```
+
+## Legacy Deployment Hardening
+
+The lifecycle path is the only write path for lifecycle-managed APIs. A catalog
+row is lifecycle-managed when `api_metadata.lifecycle` is present. For those
+APIs:
+
+- legacy `POST /v1/tenants/{tenant_id}/deployments` returns `409` and points to
+  `POST /v1/tenants/{tenant_id}/apis/{api_id}/lifecycle/deployments`.
+- legacy deployment rollback and status writes return `409`.
+- `DeploymentService` refuses to create, rollback, or update legacy
+  `Deployment` rows.
+- `GatewayDeploymentService.deploy_api()` refuses direct/admin deploys and does
+  not reset an unchanged existing `GatewayDeployment` to `pending`.
+- `GatewayDeploymentService.undeploy()` and `force_sync()` refuse lifecycle
+  deployments.
+- `DeploymentOrchestrationService.deploy_api_to_env()` refuses lifecycle APIs,
+  and promotion auto-deploy skips lifecycle-managed APIs.
+
+Read-only legacy deployment queries may still return historical `Deployment`
+records. They are not the runtime source of truth for lifecycle APIs.
+`GatewayDeployment` remains the runtime source of truth.
+
+## DB Persistence Checks
+
+The JSONB persistence checks are integration tests and require a real
+PostgreSQL database URL. Without `DATABASE_URL`, they skip automatically.
+
+Run them with:
+
+```bash
+cd /Users/torpedo/hlfh-repos/stoa/control-plane-api
+DATABASE_URL=<postgresql+asyncpg-url> pytest \
+  tests/test_api_lifecycle_publish_db.py \
+  tests/services/catalog_reconciler/test_projection_db.py \
+  -q
+```
+
+These tests verify that controlled portal publication survives commit/reload
+and that GitOps/catalog projection updates preserve lifecycle-owned metadata.
+
+## Console UI
+
+The Console exposes a minimal lifecycle flow on the existing API surfaces:
+
+- `APIs` creates new lifecycle drafts through
+  `POST /v1/tenants/{tenant_id}/apis/lifecycle/drafts`.
+- API detail loads `GET /v1/tenants/{tenant_id}/apis/{api_id}/lifecycle`.
+- The API detail lifecycle panel can validate, deploy, publish, and promote
+  through the canonical lifecycle endpoints.
+- After every lifecycle action the panel refreshes aggregate state from the
+  backend instead of assuming an optimistic status.
+- Gateway IDs remain optional in the UI. If the backend reports no gateway or
+  ambiguous gateway selection, the backend error is shown directly.
+- Legacy portal publication tags are stripped from UI create/update payloads.
+  The detail page no longer exposes a portal tag toggle.
+- The API list links to the API detail lifecycle panel instead of opening the
+  legacy deployment workflow for this flow.
+
+The Console keeps local TypeScript lifecycle types in
+`control-plane-ui/src/services/api/apiLifecycle.ts`. Shared generated API types
+are not regenerated for this UI slice.
+
+## Slice 1 Scenario
+
+1. Create draft through `POST /lifecycle/drafts`.
+2. Store the parsed inline OpenAPI/Swagger object in `APICatalog.openapi_spec`,
+   or store a required spec reference in catalog metadata.
+3. Read state through `GET /{api_id}/lifecycle`.
+4. Confirm `catalog_status=draft`, `lifecycle_phase=draft`, and no gateway or
+   portal side effect.
+
+## Slice 2 Scenario
+
+1. Create draft through `POST /lifecycle/drafts` with a valid inline OpenAPI 3.x
+   or Swagger 2.0 document.
+2. Validate through `POST /{api_id}/lifecycle/validate`.
+3. Confirm `status=ready`, `validation.valid=true`, and
+   `lifecycle.catalog_status=ready`.
+4. Confirm `deployments` remains empty; no gateway runtime state is invented in
+   this slice.
+
+## Slice 3 Scenario
+
+1. Create draft through `POST /lifecycle/drafts`.
+2. Validate through `POST /{api_id}/lifecycle/validate`.
+3. Deploy through `POST /{api_id}/lifecycle/deployments` with
+   `environment=dev`.
+4. Confirm `APICatalog.status` remains `ready`.
+5. Confirm `GET /{api_id}/lifecycle` contains a `GatewayDeployment` entry and
+   still has no portal publication or promotion state.
+
+## Slice 4 Scenario
+
+1. Create draft through `POST /lifecycle/drafts`.
+2. Validate through `POST /{api_id}/lifecycle/validate`.
+3. Deploy through `POST /{api_id}/lifecycle/deployments`.
+4. Let the sync engine, or a test fake, mark the `GatewayDeployment` as
+   `synced`.
+5. Publish through `POST /{api_id}/lifecycle/publications`.
+6. Confirm `APICatalog.status=ready`, `portal.published=true`, the deployment
+   remains `synced`, and `promotions=[]`.
+
+## Slice 5 Scenario
+
+1. Create draft through `POST /lifecycle/drafts`.
+2. Validate through `POST /{api_id}/lifecycle/validate`.
+3. Deploy dev through `POST /{api_id}/lifecycle/deployments`.
+4. Let the sync engine, or a test fake, mark the dev `GatewayDeployment` as
+   `synced`.
+5. Publish dev through `POST /{api_id}/lifecycle/publications`.
+6. Promote dev to staging through `POST /{api_id}/lifecycle/promotions`.
+7. Confirm the promotion is `promoting` and a staging `GatewayDeployment` was
+   requested with `sync_status=pending`.
+8. Let the sync engine, or a test fake, mark the staging deployment as
+   `synced`.
+9. Publish staging through `POST /{api_id}/lifecycle/publications`.
+10. Confirm `APICatalog.status=ready`, source and target deployments are
+    visible, target portal publication is visible, and the promotion is
+    `promoted`.
+
+## Slice 6 Scenario
+
+1. Run the full lifecycle scenario from Slice 5.
+2. Attempt legacy `POST /v1/tenants/{tenant_id}/deployments` for the same API.
+3. Confirm the response is `409` and no legacy `Deployment` row is created.
+4. Attempt direct `GatewayDeploymentService.deploy_api()` for the same API.
+5. Confirm the operation is rejected before creating or mutating runtime state.
+6. Repeat a lifecycle deployment with unchanged desired state.
+7. Confirm an existing `synced` `GatewayDeployment` is returned unchanged and
+   is not reset to `pending`.


### PR DESCRIPTION
## Summary

This PR introduces the canonical STOA API lifecycle flow across the control plane backend and a minimal Console UI.

It adds support for:

- creating lifecycle-managed API drafts;
- validating OpenAPI/Swagger specs;
- deploying through GatewayDeployment as the runtime source of truth;
- publishing through a controlled lifecycle action;
- promoting APIs across environments without double deployment;
- exposing lifecycle state through dedicated endpoints;
- using the Console to drive the lifecycle flow.

## Backend

- Adds ApiLifecycleService and lifecycle routes.
- Keeps APICatalog.status catalog-only: draft, ready, archived, etc.
- Uses GatewayDeployment as the runtime deployment source of truth.
- Adds OpenAPI/Swagger structural validation.
- Adds controlled portal publication.
- Persists portal lifecycle metadata under api_metadata.lifecycle.portal_publications.
- Adds lifecycle promotion orchestration.
- Prevents promotion double-trigger by neutralizing the old approve + event consumer path.
- Hardens legacy /deployments writes for lifecycle-managed APIs.
- Blocks legacy portal publication tags such as portal:published, promoted:portal and portal-promoted.
- Preserves lifecycle metadata through catalog sync, GitOps projection and admin catalog updates.

## UI

- Adds a minimal lifecycle panel in the Console.
- Creates API drafts through the lifecycle flow by default.
- Adds validate, deploy, publish and promote actions.
- Removes dangerous legacy shortcuts from the API detail flow.
- Displays backend lifecycle errors instead of silently falling back.

## Validation

- Backend Ruff: OK.
- Full backend CI-like pytest: 7117 passed, 3 skipped, 97 deselected.
- Coverage: 76.55%.
- PostgreSQL real DB lifecycle tests: 9 passed.
- UI lint: OK with existing non-blocking warnings.
- UI format: OK.
- UI test coverage: 2265 passed, 11 skipped.
- UI build: OK.

## Notes

- openapi-snapshot.json and shared/api-types/generated.ts are intentionally excluded together.
- Infra, k8s, charts, deploy, .claude and memory.md are excluded from this PR.

## Checklist

- [x] Lifecycle backend implemented.
- [x] GatewayDeployment used as runtime source of truth.
- [x] APICatalog.status kept catalog-only.
- [x] Legacy deployment write path neutralized for lifecycle-managed APIs.
- [x] Portal publication controlled through lifecycle endpoint only.
- [x] Promotion double-trigger removed.
- [x] PostgreSQL JSONB persistence verified.
- [x] Minimal Console lifecycle UI added.
- [x] Backend targeted and CI-like tests passed.
- [x] UI lint, tests and build passed.
- [x] Scope extracted into clean worktree.
- [x] Infra/generated/hors-scope files excluded.
