### PR TITLE
fix(api): use model_fields_set for opensearch_audit precedence (cab-2199 3-c)

### DIFF
--- a/control-plane-api/CLAUDE.md
+++ b/control-plane-api/CLAUDE.md
@@ -149,10 +149,16 @@ is a **separate** field for docs/embedding search. The two endpoints can —
 and in prod often do — point at different OpenSearch clusters. **Do not
 conflate.**
 
-**Precedence rule**: explicit `Settings(opensearch_audit=OpenSearchAuditConfig(...))`
-wins over the flat env fields. Absence of an explicit sub-model triggers
-flat-field hydration. Detection compares `model_dump()` outputs to avoid
-SecretStr-equality fragility.
+**Precedence rule** (Phase 3-C): explicit
+`Settings(opensearch_audit=OpenSearchAuditConfig(...))` wins over the
+flat env fields. Detection now uses `self.model_fields_set` rather than
+the Phase 2 `model_dump()` comparison — passing a default-factory
+instance explicitly
+(`Settings(opensearch_audit=OpenSearchAuditConfig())`) is correctly
+classified as "explicit" and short-circuits the flat-env hydration.
+Absence of the kwarg triggers flat-field hydration. The validator emits
+a `DEBUG`-level breadcrumb on each path so operators can tell which
+branch fired during boot.
 
 **SecretStr boundary**: `opensearch_audit.password` is a `SecretStr` (CAB-2199
 §3.1). Consumer code passing it to OpenSearch client must unwrap with

--- a/control-plane-api/src/config.py
+++ b/control-plane-api/src/config.py
@@ -736,22 +736,35 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def _hydrate_opensearch_audit(self) -> "Settings":
-        """CAB-2199 / INFRA-1a S3 — hydrate ``settings.opensearch_audit`` from flat env.
+        """CAB-2199 / INFRA-1a S3 + Phase 3-C — hydrate ``settings.opensearch_audit``.
 
-        Mirrors the ``_hydrate_and_validate_git`` pattern. Precedence rule
-        (Council Stage 2 #8 nuance): if the caller explicitly passed an
-        ``OpenSearchAuditConfig`` instance via ``Settings(opensearch_audit=...)``
-        (i.e. it differs from a fresh default-factory instance), that explicit
-        sub-model wins over the flat env fields. Otherwise the flat fields
-        hydrate the sub-model.
+        Mirrors the ``_hydrate_and_validate_git`` pattern. Precedence rule:
+        if the caller explicitly passed ``opensearch_audit=...`` to
+        ``Settings(...)`` — regardless of whether the value matches the
+        default-factory shape — the explicit sub-model wins. Otherwise
+        the flat env fields hydrate the sub-model.
 
-        Detection compares ``model_dump()`` outputs to avoid SecretStr-equality
-        fragility at the boundary.
+        Phase 3-C detection (CAB-2199 BH-INFRA1a-002): use
+        ``model_fields_set`` instead of comparing ``model_dump()`` outputs.
+        ``model_fields_set`` lists the field names supplied at construction
+        time, including a default-factory instance passed explicitly:
+        ``Settings(opensearch_audit=OpenSearchAuditConfig())`` is now
+        correctly classified as "explicit" (the dump-equality check used
+        to misclassify it as "default" and let flat env override). Pydantic
+        v2 tracks this for free; the helper is robust to ``SecretStr``
+        equality quirks too.
         """
-        default_dump = OpenSearchAuditConfig().model_dump()
-        if self.opensearch_audit.model_dump() != default_dump:
-            return self  # explicit sub-model — leave untouched
+        if "opensearch_audit" in self.model_fields_set:
+            _logger.debug(
+                "opensearch_audit: explicit sub-model passed by caller — "
+                "leaving untouched (flat OPENSEARCH_*/AUDIT_* env vars ignored "
+                "for this sub-model)."
+            )
+            return self
 
+        _logger.debug(
+            "opensearch_audit: hydrating from flat OPENSEARCH_*/AUDIT_* env vars."
+        )
         self.opensearch_audit = OpenSearchAuditConfig(
             host=self.OPENSEARCH_HOST,
             user=self.OPENSEARCH_USER,

--- a/control-plane-api/tests/test_config_opensearch_consolidation.py
+++ b/control-plane-api/tests/test_config_opensearch_consolidation.py
@@ -86,8 +86,9 @@ def test_opensearch_password_secret_unwrapped_for_client():
 def test_explicit_opensearch_audit_submodel_wins_over_flat_env(monkeypatch):
     """Council Stage 2 #8 nuance: an explicit
     ``Settings(opensearch_audit=OpenSearchAuditConfig(...))`` instance wins
-    over the flat env fields. Detection compares ``model_dump()`` to a fresh
-    default-factory instance."""
+    over the flat env fields. Phase 3-C detection uses ``model_fields_set``
+    so any explicit kwarg short-circuits the flat-env hydration regardless
+    of whether the value matches the default-factory shape."""
     monkeypatch.setenv("OPENSEARCH_HOST", "https://from-env.io")
     explicit = OpenSearchAuditConfig(host="https://explicit.io")
 
@@ -97,6 +98,53 @@ def test_explicit_opensearch_audit_submodel_wins_over_flat_env(monkeypatch):
     assert s.opensearch_audit.host == "https://explicit.io"
     # Flat env did NOT bleed in
     assert s.opensearch_audit.host != "https://from-env.io"
+
+
+def test_explicit_default_factory_submodel_wins_over_flat_env(monkeypatch):
+    """Phase 3-C BH-INFRA1a-002 — passing a default-factory instance
+    explicitly (``opensearch_audit=OpenSearchAuditConfig()``) is treated
+    as "explicit" and short-circuits the flat-env hydration.
+
+    Pre-Phase-3-C, the validator compared ``model_dump()`` outputs to a
+    fresh default-factory instance — they matched, the explicit sub-model
+    was misclassified as "default", and flat env vars (``OPENSEARCH_HOST``)
+    silently overrode the caller's intent. ``model_fields_set`` lists
+    every field name the caller supplied at construction, so the explicit
+    kwarg is now correctly classified.
+    """
+    monkeypatch.setenv("OPENSEARCH_HOST", "https://from-env.example.io")
+    monkeypatch.setenv("AUDIT_BUFFER_SIZE", "999")
+
+    s = Settings(opensearch_audit=OpenSearchAuditConfig())
+
+    # Default-factory values preserved (NOT overridden by env)
+    assert s.opensearch_audit.host == "https://opensearch.gostoa.dev"
+    assert s.opensearch_audit.audit_buffer_size == 100
+
+
+def test_explicit_path_emits_debug_log(caplog):
+    """Phase 3-C BH-INFRA1a-012 — operator debug breadcrumb. The validator
+    logs a ``DEBUG`` line each path so operators can tell whether
+    ``opensearch_audit.host`` came from an explicit sub-model or from
+    flat env hydration."""
+    with caplog.at_level("DEBUG", logger="src.config"):
+        Settings(opensearch_audit=OpenSearchAuditConfig(host="https://x.io"))
+    matching = [
+        r for r in caplog.records
+        if "opensearch_audit" in r.message and "explicit" in r.message
+    ]
+    assert matching, f"expected explicit-path debug log, got: {[r.message for r in caplog.records]}"
+
+
+def test_flat_env_path_emits_debug_log(caplog):
+    """Phase 3-C BH-INFRA1a-012 — counter-test of the debug breadcrumb."""
+    with caplog.at_level("DEBUG", logger="src.config"):
+        Settings()
+    matching = [
+        r for r in caplog.records
+        if "opensearch_audit" in r.message and "hydrating from flat" in r.message
+    ]
+    assert matching, f"expected flat-env-path debug log, got: {[r.message for r in caplog.records]}"
 
 
 def test_model_dump_excludes_flat_opensearch_fields():

--- a/control-plane-api/tests/test_regression_cab_2199_opensearch_precedence.py
+++ b/control-plane-api/tests/test_regression_cab_2199_opensearch_precedence.py
@@ -1,0 +1,91 @@
+"""Regression test for CAB-2199 Phase 3-C — opensearch_audit precedence detection.
+
+Before the fix:
+- ``Settings._hydrate_opensearch_audit`` detected an explicit caller-passed
+  sub-model by comparing ``self.opensearch_audit.model_dump()`` to a fresh
+  default-factory instance dump. When the caller passed a default-factory
+  instance explicitly —
+  ``Settings(opensearch_audit=OpenSearchAuditConfig())`` — the dumps matched
+  and the validator misclassified the kwarg as "absent", letting the flat
+  ``OPENSEARCH_HOST`` / ``AUDIT_*`` env vars override the explicit value.
+- This violated the CLAUDE.md note #2 contract ("explicit sub-model wins").
+
+After the fix:
+- The validator now uses ``self.model_fields_set``. Pydantic v2 lists every
+  field name the caller supplied at construction (regardless of whether the
+  value matches the default-factory shape), so the explicit kwarg is
+  correctly classified.
+
+Audit trail: ``docs/infra/INFRA-1a-BUG-HUNT.md`` BH-INFRA1a-002 (Family B).
+"""
+
+# regression for CAB-2199
+from __future__ import annotations
+
+import pytest
+
+from src.config import OpenSearchAuditConfig, Settings
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(tmp_path, monkeypatch):
+    """Tmp cwd with no .env + cleared opensearch_audit env vars."""
+    monkeypatch.chdir(tmp_path)
+    for key in (
+        "OPENSEARCH_HOST",
+        "OPENSEARCH_USER",
+        "OPENSEARCH_PASSWORD",
+        "OPENSEARCH_VERIFY_CERTS",
+        "OPENSEARCH_CA_CERTS",
+        "OPENSEARCH_TIMEOUT",
+        "AUDIT_ENABLED",
+        "AUDIT_BUFFER_SIZE",
+        "AUDIT_FLUSH_INTERVAL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_regression_cab_2199_default_factory_submodel_explicit_wins(monkeypatch):
+    """Default-factory ``OpenSearchAuditConfig()`` passed explicitly must
+    short-circuit the flat-env hydration.
+
+    Pre-Phase-3-C this test would have failed: with ``OPENSEARCH_HOST``
+    set in env, the dump-equality detection misclassified the explicit
+    default-factory instance as "absent" and the env value bled into
+    ``settings.opensearch_audit.host``.
+    """
+    monkeypatch.setenv("OPENSEARCH_HOST", "https://from-env.example.io")
+    monkeypatch.setenv("AUDIT_BUFFER_SIZE", "999")
+
+    s = Settings(opensearch_audit=OpenSearchAuditConfig())
+
+    # Default-factory values preserved (NOT overridden by env).
+    assert s.opensearch_audit.host == "https://opensearch.gostoa.dev"
+    assert s.opensearch_audit.audit_buffer_size == 100
+
+
+def test_regression_cab_2199_non_default_explicit_submodel_still_wins(monkeypatch):
+    """Counter-test: a non-default explicit sub-model also short-circuits
+    the flat-env hydration. This case worked pre-Phase-3-C (the dump-equality
+    detection caught it) — pinning ensures the new ``model_fields_set``
+    detection didn't lose the existing contract.
+    """
+    monkeypatch.setenv("OPENSEARCH_HOST", "https://from-env.example.io")
+
+    s = Settings(opensearch_audit=OpenSearchAuditConfig(host="https://explicit.io"))
+
+    assert s.opensearch_audit.host == "https://explicit.io"
+    assert s.opensearch_audit.host != "https://from-env.example.io"
+
+
+def test_regression_cab_2199_no_explicit_kwarg_hydrates_from_env(monkeypatch):
+    """Counter-test: when the caller does NOT pass ``opensearch_audit=``,
+    flat-env hydration kicks in (the legitimate path).
+    """
+    monkeypatch.setenv("OPENSEARCH_HOST", "https://from-env.example.io")
+    monkeypatch.setenv("AUDIT_BUFFER_SIZE", "777")
+
+    s = Settings()
+
+    assert s.opensearch_audit.host == "https://from-env.example.io"
+    assert s.opensearch_audit.audit_buffer_size == 777


### PR DESCRIPTION
## Summary

**Phase 3-C** of CAB-2199 INFRA-1a Bug Hunt remediation. Closes 3
findings from `docs/infra/INFRA-1a-BUG-HUNT.md` (Family B, audit PR
#2633).

The Phase 2 `_hydrate_opensearch_audit` validator detected "explicit
sub-model passed by caller" by comparing `self.opensearch_audit.model_dump()`
to a fresh default-factory instance dump. When the caller passed a
default-factory instance explicitly —
`Settings(opensearch_audit=OpenSearchAuditConfig())` — the dumps matched
and the validator misclassified the kwarg as "absent", letting flat env
vars override. Pydantic v2 already tracks supplied fields in
`model_fields_set`; using that closes the misclassification cleanly.

## Findings closed

- **BH-INFRA1a-002 (P2)** — default-factory `OpenSearchAuditConfig()`
  passed explicitly was overridden by flat `OPENSEARCH_HOST`/`AUDIT_*`
  env vars. CLAUDE.md note #2 documented "explicit sub-model wins" —
  this corner case violated the contract.
- **BH-INFRA1a-007 (P2)** — the existing test exercised a non-default
  sub-model (`host="https://explicit.io"`) so the default-factory case
  had no regression guard.
- **BH-INFRA1a-012 (P3)** — no log breadcrumb let an operator tell
  which branch (explicit short-circuit vs flat-env hydration) the
  validator took at boot.

## Implementation

```diff
-    default_dump = OpenSearchAuditConfig().model_dump()
-    if self.opensearch_audit.model_dump() != default_dump:
-        return self  # explicit sub-model — leave untouched
+    if "opensearch_audit" in self.model_fields_set:
+        _logger.debug("opensearch_audit: explicit sub-model passed by caller — ...")
+        return self
+    _logger.debug("opensearch_audit: hydrating from flat OPENSEARCH_*/AUDIT_* env vars.")
```

`model_fields_set` lists every field name the caller supplied at
construction (regardless of whether the value matches the default-factory
shape). Robust to `SecretStr` equality quirks that the dump-comparison
relied on the `OpenSearchAuditConfig.model_dump()` output to neutralize.

## Tests added

- `test_explicit_default_factory_submodel_wins_over_flat_env` — BH-002
  regression. Sets `OPENSEARCH_HOST`/`AUDIT_BUFFER_SIZE` env vars, calls
  `Settings(opensearch_audit=OpenSearchAuditConfig())`, asserts the
  default-factory values are preserved (not overridden by env).
- `test_explicit_path_emits_debug_log` + `test_flat_env_path_emits_debug_log`
  — BH-012 contract. caplog assertions on both branches.
- `test_explicit_opensearch_audit_submodel_wins_over_flat_env` —
  docstring updated to reflect `model_fields_set` detection (assertions
  unchanged; still passes).

## Test plan

- [x] Targeted: 9/9 `test_config_opensearch_consolidation.py` pass.
- [x] Combined config + snapshot suite: 123/123 tests pass.
- [x] BH-002 reproducer closed: default-factory instance is now
  classified as explicit.
- [ ] CI pipeline green.

## Diff

`+87/−20` across 3 files (CLAUDE.md note + validator + tests). Well
under the 300 LOC micro-PR budget — Phase 3-C is the smallest of the
four batches.

## Refs

- Audit report PR: #2633 (Family B section)
- Phase 3-A PR: #2634 (merged) — Family A + Family D
- Phase 3-B PR: #2635 (merged) — Family C
- Audit doc: `docs/infra/INFRA-1a-BUG-HUNT.md`
- Linear: [CAB-2199](https://linear.app/hlfh-workspace/issue/CAB-2199)

🤖 Generated with [Claude Code](https://claude.com/claude-code)