### PR TITLE
test(api)+docs(api): migrate snapshot tests + .env.example cleanup (cab-2199 3-d)

### DIFF
--- a/control-plane-api/.env.example
+++ b/control-plane-api/.env.example
@@ -45,6 +45,8 @@ KEYCLOAK_CLIENT_SECRET=
 # Settings post-consolidation). Distinct from `OPENSEARCH_URL` below — that
 # one is the docs/embedding-search endpoint and can target a different
 # OpenSearch cluster in prod. See control-plane-api/CLAUDE.md note #2.
+# Default in Settings: https://opensearch.gostoa.dev (prod-shaped).
+# Local-dev override example (uncomment + adjust):
 # OPENSEARCH_HOST=https://localhost:9200
 # OPENSEARCH_USER=admin
 # OPENSEARCH_PASSWORD=

--- a/control-plane-api/tests/test_config_opensearch_consolidation.py
+++ b/control-plane-api/tests/test_config_opensearch_consolidation.py
@@ -120,18 +120,36 @@ def test_model_dump_excludes_flat_opensearch_fields():
     assert sub["password"].get_secret_value() == "leaky-test-value"
 
 
-def test_get_settings_returns_consolidated_submodel():
+def test_get_settings_returns_consolidated_submodel(monkeypatch):
     """``opensearch.opensearch_integration.get_settings()`` is a back-compat
-    accessor that now returns the consolidated ``Settings.opensearch_audit``
-    sub-model. Legacy importers ``from ...opensearch_integration import
-    get_settings`` keep working without code change."""
-    from src.opensearch.opensearch_integration import get_settings
+    accessor that returns the consolidated ``Settings.opensearch_audit``
+    sub-model. Legacy importers
+    ``from ...opensearch_integration import get_settings`` keep working
+    without code change.
 
-    s = get_settings()
-    # Must be the OpenSearchAuditConfig type, not the legacy OpenSearchSettings
+    Phase 3-D BH-INFRA1a-008 — the test now patches the module-level
+    ``settings`` singleton with a fresh ``Settings()`` instantiated under
+    the fixture's controlled env so the assertions actually exercise the
+    Phase 2 consolidation contract under known config (rather than
+    asserting only the type of the boot-time singleton).
+    """
+    import src.opensearch.opensearch_integration as opensearch_integration
+
+    monkeypatch.setenv("OPENSEARCH_HOST", "https://controlled.example.io")
+    monkeypatch.setenv("AUDIT_BUFFER_SIZE", "42")
+    fresh = Settings()
+    monkeypatch.setattr(opensearch_integration, "settings", fresh)
+
+    s = opensearch_integration.get_settings()
+
+    # Must be the OpenSearchAuditConfig type, not the legacy OpenSearchSettings.
     assert isinstance(s, OpenSearchAuditConfig)
-    # Same field shape as before, post-rename: host/user/password/etc.
+    # Field shape preserved (consumer contract).
     assert hasattr(s, "host")
     assert hasattr(s, "user")
     assert hasattr(s, "password")
     assert hasattr(s, "audit_enabled")
+    # Behaviour under controlled env: flat-env hydration reflected in the
+    # sub-model returned by get_settings().
+    assert s.host == "https://controlled.example.io"
+    assert s.audit_buffer_size == 42

--- a/control-plane-api/tests/test_snapshot_config.py
+++ b/control-plane-api/tests/test_snapshot_config.py
@@ -25,13 +25,20 @@ class TestSnapshotSettingsDefaults:
         assert settings.async_capture is True
 
     def test_custom_env(self):
+        """Phase 3-D — uses canonical STOA_API_SNAPSHOT_* prefix.
+
+        Migrated from legacy STOA_SNAPSHOTS_* per CAB-2199 plan §2.6.d.
+        Closes BH-INFRA1a-010 — pre-Phase-3-D this test passed only via
+        the AliasChoices alias path, leaving the canonical prefix
+        unexercised by the bulk of the snapshot test suite.
+        """
         env = {
-            "STOA_SNAPSHOTS_ENABLED": "false",
-            "STOA_SNAPSHOTS_CAPTURE_ON_4XX": "true",
-            "STOA_SNAPSHOTS_RETENTION_DAYS": "7",
-            "STOA_SNAPSHOTS_STORAGE_TYPE": "s3",
-            "STOA_SNAPSHOTS_STORAGE_USE_SSL": "true",
-            "STOA_SNAPSHOTS_MAX_BODY_SIZE": "50000",
+            "STOA_API_SNAPSHOT_ENABLED": "false",
+            "STOA_API_SNAPSHOT_CAPTURE_ON_4XX": "true",
+            "STOA_API_SNAPSHOT_RETENTION_DAYS": "7",
+            "STOA_API_SNAPSHOT_STORAGE_TYPE": "s3",
+            "STOA_API_SNAPSHOT_STORAGE_USE_SSL": "true",
+            "STOA_API_SNAPSHOT_MAX_BODY_SIZE": "50000",
         }
         with patch.dict("os.environ", env, clear=True):
             settings = SnapshotSettings()
@@ -41,6 +48,18 @@ class TestSnapshotSettingsDefaults:
         assert settings.storage_type == "s3"
         assert settings.storage_use_ssl is True
         assert settings.max_body_size == 50000
+
+    def test_legacy_prefix_still_works_via_alias(self):
+        """Phase 3-D — keep ONE regression test on the legacy prefix so
+        the AliasChoices surface stays exercised until CAB-2203 sunset."""
+        env = {
+            "STOA_SNAPSHOTS_ENABLED": "false",
+            "STOA_SNAPSHOTS_RETENTION_DAYS": "14",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            settings = SnapshotSettings()
+        assert settings.enabled is False
+        assert settings.retention_days == 14
 
 
 class TestExcludePaths:

--- a/control-plane-api/tests/test_snapshot_storage_ops.py
+++ b/control-plane-api/tests/test_snapshot_storage_ops.py
@@ -10,14 +10,18 @@ from src.features.error_snapshots.storage import SnapshotStorage
 
 
 def _make_settings(**overrides):
-    """Create SnapshotSettings with test defaults."""
+    """Create SnapshotSettings with test defaults.
+
+    Phase 3-D — migrated from legacy STOA_SNAPSHOTS_* to canonical
+    STOA_API_SNAPSHOT_* per CAB-2199 plan §2.6.d (closes BH-INFRA1a-010).
+    """
     defaults = {
-        "STOA_SNAPSHOTS_STORAGE_BUCKET": "test-bucket",
-        "STOA_SNAPSHOTS_STORAGE_ACCESS_KEY": "test-key",
-        "STOA_SNAPSHOTS_STORAGE_SECRET_KEY": "test-secret",
-        "STOA_SNAPSHOTS_STORAGE_ENDPOINT": "localhost:9000",
-        "STOA_SNAPSHOTS_STORAGE_REGION": "us-east-1",
-        "STOA_SNAPSHOTS_RETENTION_DAYS": "30",
+        "STOA_API_SNAPSHOT_STORAGE_BUCKET": "test-bucket",
+        "STOA_API_SNAPSHOT_STORAGE_ACCESS_KEY": "test-key",
+        "STOA_API_SNAPSHOT_STORAGE_SECRET_KEY": "test-secret",
+        "STOA_API_SNAPSHOT_STORAGE_ENDPOINT": "localhost:9000",
+        "STOA_API_SNAPSHOT_STORAGE_REGION": "us-east-1",
+        "STOA_API_SNAPSHOT_RETENTION_DAYS": "30",
     }
     defaults.update(overrides)
     with patch.dict("os.environ", defaults, clear=False):
@@ -294,7 +298,7 @@ class TestSnapshotSettings:
         assert settings.storage_url == "http://localhost:9000"
 
     def test_storage_url_https(self):
-        settings = _make_settings(STOA_SNAPSHOTS_STORAGE_USE_SSL="true")
+        settings = _make_settings(STOA_API_SNAPSHOT_STORAGE_USE_SSL="true")
         assert settings.storage_url.startswith("https://")
 
     def test_exclude_paths_list(self):
@@ -316,8 +320,8 @@ class TestSnapshotSettings:
 
     def test_masking_config_with_extras(self):
         settings = _make_settings(
-            STOA_SNAPSHOTS_MASKING_EXTRA_HEADERS='["X-Custom"]',
-            STOA_SNAPSHOTS_MASKING_EXTRA_BODY_PATHS='["$.secret"]',
+            STOA_API_SNAPSHOT_MASKING_EXTRA_HEADERS='["X-Custom"]',
+            STOA_API_SNAPSHOT_MASKING_EXTRA_BODY_PATHS='["$.secret"]',
         )
         config = settings.masking_config
         assert "X-Custom" in config.headers
@@ -337,3 +341,16 @@ class TestSnapshotSettings:
     def test_parse_exclude_paths_string_input(self):
         result = SnapshotSettings.parse_exclude_paths('["/health"]')
         assert result == '["/health"]'
+
+    def test_legacy_prefix_still_works_via_alias(self):
+        """Phase 3-D — keep ONE regression test on the legacy prefix so
+        the AliasChoices surface stays exercised until CAB-2203 sunset.
+        """
+        env = {
+            "STOA_SNAPSHOTS_STORAGE_BUCKET": "legacy-bucket",
+            "STOA_SNAPSHOTS_STORAGE_USE_SSL": "true",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            settings = SnapshotSettings()
+        assert settings.storage_bucket == "legacy-bucket"
+        assert settings.storage_use_ssl is True


### PR DESCRIPTION
## Summary

**Phase 3-D** of CAB-2199 INFRA-1a Bug Hunt remediation. Closes 3
findings from `docs/infra/INFRA-1a-BUG-HUNT.md` (Family E, audit PR
#2633). Pure test/doc cleanup — no production code change.

This PR ships three independent small patches that share the same
disposition class (FIX-NOW Phase 3-D) and the same blast radius (none):
test migration to the canonical prefix, a singleton-bypass test
correctness fix, and a `.env.example` doc-drift fix that the original
S4 commit promised but never landed.

## Findings closed

- **BH-INFRA1a-008 (P3)** — `test_get_settings_returns_consolidated_submodel`
  asserted only `isinstance(s, OpenSearchAuditConfig)` against the
  boot-time module-level `settings` singleton; the test fixture's
  `monkeypatch.delenv` calls had no effect on the singleton, so the
  test passed trivially without exercising the consolidation under
  controlled env. Fixed by `monkeypatch.setattr` the module-level
  singleton with a fresh `Settings()` built under known env vars.
- **BH-INFRA1a-010 (P2)** — `test_snapshot_config.py` and
  `test_snapshot_storage_ops.py` were never migrated to
  `STOA_API_SNAPSHOT_*` per plan §2.6.d. The 36 existing tests passed
  via the `AliasChoices` alias path — the canonical prefix had no
  test exercise outside the 15 alias-targeted tests in
  `test_snapshot_config_alias.py`. Migrated 15 hits across both files
  to the canonical prefix; added one
  `test_legacy_prefix_still_works_via_alias` regression test per file
  to keep the alias surface pinned until the CAB-2203 sunset.
- **BH-INFRA1a-015 (P3)** — `.env.example` documented
  `OPENSEARCH_HOST=https://localhost:9200` while the Settings default
  is `https://opensearch.gostoa.dev`. Plan §4 BH-3 entry claimed
  *"Fixed inline by S4"* — the fix never shipped. Comment now states
  the Settings default explicitly and marks the localhost line as a
  local-dev override example.

## Tests

| Change | File | Purpose |
|---|---|---|
| `_make_settings` helper migrated to `STOA_API_SNAPSHOT_*` | `tests/test_snapshot_storage_ops.py` | Canonical prefix exercised by 25 storage-ops tests |
| `test_storage_url_https`, `test_masking_config_with_extras` migrated | same | inline override calls |
| `+test_legacy_prefix_still_works_via_alias` | same | alias surface pin (1 test) |
| `test_custom_env` migrated to `STOA_API_SNAPSHOT_*` | `tests/test_snapshot_config.py` | Canonical prefix exercised by 11 config tests |
| `+test_legacy_prefix_still_works_via_alias` | same | alias surface pin (1 test) |
| `test_get_settings_returns_consolidated_submodel` rewritten | `tests/test_config_opensearch_consolidation.py` | Patches module singleton with fresh Settings() under controlled env; asserts host + audit_buffer_size reflect env vars |

## Test plan

- [x] Targeted: 59/59 affected tests pass.
- [x] Combined config + snapshot suite: 122/122 tests pass.
- [x] BH-008 reproducer closed: test now exercises behaviour, not type.
- [x] BH-010 reproducer closed: `grep -c STOA_API_SNAPSHOT_` on
  the two migrated files now returns 15 (was 0).
- [x] BH-015 reproducer closed: `.env.example` now distinguishes the
  Settings default from the local-dev override hint.
- [ ] CI pipeline green.

## Diff

`+81/−25` across 4 files (3 test files + `.env.example`). Well under
the 300 LOC micro-PR budget.

## Phase 3 status

- **3-A** #2634 ✅ merged — Family A + Family D
- **3-B** #2635 ✅ merged — Family C
- **3-C** #2679 🟡 pending merge — Family B
- **3-D** this PR — Family E (last one in the Phase 3 batch)

After 3-C and 3-D merge, the only remaining audit finding is
**BH-INFRA1a-013** (Gitleaks `_Pwd` workaround) which is handed off to
INFRA-1c per the audit report.

## Refs

- Audit report PR: #2633 (Family E section)
- Audit doc: `docs/infra/INFRA-1a-BUG-HUNT.md`
- Linear: [CAB-2199](https://linear.app/hlfh-workspace/issue/CAB-2199)

🤖 Generated with [Claude Code](https://claude.com/claude-code)