### PR TITLE
fix(ci): align e2e-cross-validation secrets with actual GH names

### DIFF
--- a/.github/workflows/e2e-cross-validation.yml
+++ b/.github/workflows/e2e-cross-validation.yml
@@ -50,21 +50,24 @@ jobs:
       - name: Run auth setup
         working-directory: e2e
         env:
-          STOA_CONSOLE_URL: ${{ secrets.STOA_CONSOLE_URL }}
-          STOA_PORTAL_URL: ${{ secrets.STOA_PORTAL_URL }}
-          STOA_API_URL: ${{ secrets.STOA_API_URL }}
-          KEYCLOAK_URL: ${{ secrets.KEYCLOAK_URL }}
+          STOA_CONSOLE_URL: ${{ secrets.E2E_CONSOLE_URL }}
+          STOA_PORTAL_URL: ${{ secrets.E2E_PORTAL_URL }}
+          STOA_API_URL: ${{ secrets.E2E_GATEWAY_URL }}
+          KEYCLOAK_URL: ${{ secrets.E2E_KEYCLOAK_URL }}
+          PARZIVAL_USER: ${{ secrets.PARZIVAL_USER }}
           PARZIVAL_PASSWORD: ${{ secrets.PARZIVAL_PASSWORD }}
+          ANORAK_USER: ${{ secrets.ANORAK_USER }}
           ANORAK_PASSWORD: ${{ secrets.ANORAK_PASSWORD }}
         run: npx playwright test --project=auth-setup
 
       - name: Run cross-validation tests
         working-directory: e2e
         env:
-          STOA_CONSOLE_URL: ${{ secrets.STOA_CONSOLE_URL }}
-          STOA_PORTAL_URL: ${{ secrets.STOA_PORTAL_URL }}
-          STOA_API_URL: ${{ secrets.STOA_API_URL }}
-          STOA_AUTH_URL: ${{ secrets.KEYCLOAK_URL }}
+          STOA_CONSOLE_URL: ${{ secrets.E2E_CONSOLE_URL }}
+          STOA_PORTAL_URL: ${{ secrets.E2E_PORTAL_URL }}
+          STOA_API_URL: ${{ secrets.E2E_GATEWAY_URL }}
+          STOA_AUTH_URL: ${{ secrets.E2E_KEYCLOAK_URL }}
+          ANORAK_USER: ${{ secrets.ANORAK_USER }}
           ANORAK_PASSWORD: ${{ secrets.ANORAK_PASSWORD }}
         run: >
           npx playwright test


### PR DESCRIPTION
## Summary

- Workflow `e2e-cross-validation.yml` referenced 4 non-existent secrets (`STOA_CONSOLE_URL`, `STOA_PORTAL_URL`, `STOA_API_URL`, `KEYCLOAK_URL`); aligned to the real names (`E2E_*`).
- Added `PARZIVAL_USER` / `ANORAK_USER` env vars so `e2e/fixtures/personas.ts` uses the real KC usernames (`parzival`, `anorak`) instead of the hardcoded fallback `parzival@high-five.io` / `anorak@gostoa.dev` which no KC user has.
- Persona passwords were re-synced this session: KC reset → Infisical `/e2e-personas` → GH repo secrets.

## Why it matters

Job `Cross-Validation (Seeded Data)` has been failing since 2026-04-05, masked by `continue-on-error: true`. Captured failure (run 25273308849) shows the Keycloak page with `Invalid credentials. Please try again.` while username field is filled with `parzival@high-five.io` — that user doesn't exist in prod KC (real email is `parzival@test.gostoa.dev`).

## Test plan

- [ ] Merge → `workflow_dispatch` trigger on main
- [ ] `Cross-Validation (Seeded Data)` job result = `success` (not just workflow-level success masked by `continue-on-error`)
- [ ] Subsequent daily cron run also green

## Follow-ups (not in this PR)

- `personas.ts` hardcoded fallback emails (`@high-five.io`, `@gostoa.dev`, `@ioi.corp`...) should align with KC reality (`@test.gostoa.dev`)
- `docs/SECRETS-ROTATION.md:84` references non-existent Vault path `k8s/e2e-personas` (real is Infisical `/e2e-personas`)
- Vault `shared/demo-credentials/anorak_password` is a 4-char placeholder, should be removed or synced
- Decide if `continue-on-error: true` on this job should be removed once stable (currently masks regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)