### PR TITLE
Fix deployment diagnostics and STOA gateway route acks

### DIFF
--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -12793,6 +12793,11 @@
             "title": "Deployment Id",
             "type": "string"
           },
+          "gateway_instance_id": {
+            "default": "",
+            "title": "Gateway Instance Id",
+            "type": "string"
+          },
           "generation": {
             "default": 1,
             "title": "Generation",

--- a/control-plane-api/src/routers/gateway_internal.py
+++ b/control-plane-api/src/routers/gateway_internal.py
@@ -107,6 +107,7 @@ class GatewayRouteItem(BaseModel):
     id: str
     api_id: str = ""
     deployment_id: str = ""
+    gateway_instance_id: str = ""
     name: str
     tenant_id: str
     path_prefix: str
@@ -161,7 +162,12 @@ async def list_gateway_routes(
         tenant_id = ds.get("tenant_id", "")
         route = map_api_spec_to_stoa(ds, tenant_id)
         if route.get("backend_url"):  # Skip routes without a backend
-            item = GatewayRouteItem(**route, deployment_id=str(dep.id), generation=dep.desired_generation or 1)
+            item = GatewayRouteItem(
+                **route,
+                deployment_id=str(dep.id),
+                gateway_instance_id=str(dep.gateway_instance_id),
+                generation=dep.desired_generation or 1,
+            )
             routes.append(item)
 
     return routes

--- a/control-plane-api/src/schemas/api_lifecycle.py
+++ b/control-plane-api/src/schemas/api_lifecycle.py
@@ -68,6 +68,14 @@ class ApiLifecycleSpecResponse(BaseModel):
     fallback_reason: str | None = None
 
 
+class ApiLifecycleSyncStepResponse(BaseModel):
+    name: str
+    status: str
+    detail: str | None = None
+    started_at: str | None = None
+    completed_at: str | None = None
+
+
 class ApiLifecycleGatewayDeploymentResponse(BaseModel):
     id: UUID
     environment: str
@@ -80,7 +88,11 @@ class ApiLifecycleGatewayDeploymentResponse(BaseModel):
     gateway_resource_id: str | None = None
     public_url: str | None = None
     sync_error: str | None = None
+    last_sync_attempt: datetime | None = None
     last_sync_success: datetime | None = None
+    policy_sync_status: str | None = None
+    policy_sync_error: str | None = None
+    sync_steps: list[ApiLifecycleSyncStepResponse] = Field(default_factory=list)
 
 
 class ApiLifecyclePromotionResponse(BaseModel):

--- a/control-plane-api/src/services/api_lifecycle/ports.py
+++ b/control-plane-api/src/services/api_lifecycle/ports.py
@@ -185,6 +185,15 @@ class ApiSpecState:
 
 
 @dataclass(frozen=True)
+class GatewayDeploymentSyncStep:
+    name: str
+    status: str
+    detail: str | None = None
+    started_at: str | None = None
+    completed_at: str | None = None
+
+
+@dataclass(frozen=True)
 class GatewayDeploymentState:
     id: UUID
     environment: str
@@ -197,7 +206,11 @@ class GatewayDeploymentState:
     gateway_resource_id: str | None = None
     public_url: str | None = None
     sync_error: str | None = None
+    last_sync_attempt: datetime | None = None
     last_sync_success: datetime | None = None
+    policy_sync_status: str | None = None
+    policy_sync_error: str | None = None
+    sync_steps: list[GatewayDeploymentSyncStep] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -246,7 +259,11 @@ class GatewayDeploymentSnapshot:
     gateway_resource_id: str | None = None
     public_url: str | None = None
     sync_error: str | None = None
+    last_sync_attempt: datetime | None = None
     last_sync_success: datetime | None = None
+    policy_sync_status: str | None = None
+    policy_sync_error: str | None = None
+    sync_steps: list[GatewayDeploymentSyncStep] = field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/control-plane-api/src/services/api_lifecycle/repository.py
+++ b/control-plane-api/src/services/api_lifecycle/repository.py
@@ -13,7 +13,7 @@ from src.models.gateway_instance import GatewayInstance
 from src.models.promotion import Promotion, PromotionStatus
 from src.services.catalog_api_definition import environment_matches
 
-from .ports import GatewayDeploymentSnapshot, GatewayTarget, PromotionSnapshot
+from .ports import GatewayDeploymentSnapshot, GatewayDeploymentSyncStep, GatewayTarget, PromotionSnapshot
 
 
 class SqlAlchemyApiLifecycleRepository:
@@ -79,7 +79,11 @@ class SqlAlchemyApiLifecycleRepository:
                     gateway_resource_id=deployment.gateway_resource_id,
                     public_url=gateway.public_url,
                     sync_error=deployment.sync_error,
+                    last_sync_attempt=deployment.last_sync_attempt,
                     last_sync_success=deployment.last_sync_success,
+                    policy_sync_status=str(deployment.policy_sync_status) if deployment.policy_sync_status else None,
+                    policy_sync_error=deployment.policy_sync_error,
+                    sync_steps=_sync_steps_from_model(deployment.sync_steps),
                 )
             )
         return deployments
@@ -243,3 +247,30 @@ def _gateway_target_from_model(gateway: GatewayInstance) -> GatewayTarget:
         enabled=bool(gateway.enabled),
         public_url=gateway.public_url,
     )
+
+
+def _sync_steps_from_model(raw_steps: object) -> list[GatewayDeploymentSyncStep]:
+    if not isinstance(raw_steps, list):
+        return []
+
+    steps: list[GatewayDeploymentSyncStep] = []
+    for raw_step in raw_steps:
+        if not isinstance(raw_step, dict):
+            continue
+        name = raw_step.get("name")
+        status = raw_step.get("status")
+        if not isinstance(name, str) or not isinstance(status, str):
+            continue
+        detail = raw_step.get("detail")
+        started_at = raw_step.get("started_at")
+        completed_at = raw_step.get("completed_at")
+        steps.append(
+            GatewayDeploymentSyncStep(
+                name=name,
+                status=status,
+                detail=detail if isinstance(detail, str) else None,
+                started_at=started_at if isinstance(started_at, str) else None,
+                completed_at=completed_at if isinstance(completed_at, str) else None,
+            )
+        )
+    return steps

--- a/control-plane-api/src/services/api_lifecycle/service.py
+++ b/control-plane-api/src/services/api_lifecycle/service.py
@@ -734,7 +734,11 @@ class ApiLifecycleService:
                 gateway_resource_id=item.gateway_resource_id,
                 public_url=item.public_url,
                 sync_error=item.sync_error,
+                last_sync_attempt=item.last_sync_attempt,
                 last_sync_success=item.last_sync_success,
+                policy_sync_status=item.policy_sync_status,
+                policy_sync_error=item.policy_sync_error,
+                sync_steps=item.sync_steps,
             )
             for item in deployments
         ]

--- a/control-plane-api/tests/test_api_lifecycle_deploy.py
+++ b/control-plane-api/tests/test_api_lifecycle_deploy.py
@@ -10,7 +10,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from src.models.catalog import APICatalog
-from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment
+from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment, PolicySyncStatus
 from src.services.api_lifecycle.errors import (
     ApiLifecycleGatewayAmbiguousError,
     ApiLifecycleGatewayNotFoundError,
@@ -20,6 +20,7 @@ from src.services.api_lifecycle.errors import (
 from src.services.api_lifecycle.ports import (
     DeployApiCommand,
     GatewayDeploymentSnapshot,
+    GatewayDeploymentSyncStep,
     GatewayTarget,
     LifecycleActor,
     PromotionSnapshot,
@@ -79,7 +80,20 @@ class InMemoryApiLifecycleRepository:
                     gateway_resource_id=deployment.gateway_resource_id,
                     public_url=gateway.public_url,
                     sync_error=deployment.sync_error,
+                    last_sync_attempt=deployment.last_sync_attempt,
                     last_sync_success=deployment.last_sync_success,
+                    policy_sync_status=str(deployment.policy_sync_status) if deployment.policy_sync_status else None,
+                    policy_sync_error=deployment.policy_sync_error,
+                    sync_steps=[
+                        GatewayDeploymentSyncStep(
+                            name=step["name"],
+                            status=step["status"],
+                            detail=step.get("detail"),
+                            started_at=step.get("started_at"),
+                            completed_at=step.get("completed_at"),
+                        )
+                        for step in deployment.sync_steps or []
+                    ],
                 )
             )
         return snapshots
@@ -252,6 +266,39 @@ async def test_get_lifecycle_after_deploy_returns_gateway_deployment() -> None:
     assert len(state.deployments) == 1
     assert state.deployments[0].environment == "dev"
     assert state.deployments[0].sync_status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_get_lifecycle_exposes_gateway_deployment_diagnostics() -> None:
+    service, repository, _ = _service(api=_api(), gateways=[_gateway()])
+    await service.deploy_to_environment(_deploy_command(), _actor())
+    deployment = next(iter(repository.deployments.values()))
+    attempted_at = datetime.now(UTC)
+    deployment.sync_status = DeploymentSyncStatus.ERROR
+    deployment.sync_error = "webmethods verifyAndActivate failed: activation failed (500)"
+    deployment.last_sync_attempt = attempted_at
+    deployment.policy_sync_status = PolicySyncStatus.ERROR
+    deployment.policy_sync_error = "webmethods API not found: default-rate-limit"
+    deployment.sync_steps = [
+        {"name": "agent_received", "status": "success", "detail": "sync request received"},
+        {
+            "name": "api_synced",
+            "status": "failed",
+            "detail": "webmethods verifyAndActivate failed: activation failed (500)",
+        },
+    ]
+
+    state = await service.get_lifecycle_state("acme", "payments-api")
+    diagnostic = state.deployments[0]
+
+    assert diagnostic.sync_status == "error"
+    assert diagnostic.sync_error == "webmethods verifyAndActivate failed: activation failed (500)"
+    assert diagnostic.last_sync_attempt == attempted_at
+    assert diagnostic.policy_sync_status == "error"
+    assert diagnostic.policy_sync_error == "webmethods API not found: default-rate-limit"
+    assert diagnostic.sync_steps[-1].name == "api_synced"
+    assert diagnostic.sync_steps[-1].status == "failed"
+    assert diagnostic.sync_steps[-1].detail == "webmethods verifyAndActivate failed: activation failed (500)"
 
 
 @pytest.mark.asyncio

--- a/control-plane-api/tests/test_api_lifecycle_promotion.py
+++ b/control-plane-api/tests/test_api_lifecycle_promotion.py
@@ -88,6 +88,7 @@ class InMemoryApiLifecycleRepository:
                     gateway_resource_id=deployment.gateway_resource_id,
                     public_url=gateway.public_url,
                     sync_error=deployment.sync_error,
+                    last_sync_attempt=deployment.last_sync_attempt,
                     last_sync_success=deployment.last_sync_success,
                 )
             )

--- a/control-plane-api/tests/test_api_lifecycle_publish.py
+++ b/control-plane-api/tests/test_api_lifecycle_publish.py
@@ -87,6 +87,7 @@ class InMemoryApiLifecycleRepository:
                     gateway_resource_id=deployment.gateway_resource_id,
                     public_url=gateway.public_url,
                     sync_error=deployment.sync_error,
+                    last_sync_attempt=deployment.last_sync_attempt,
                     last_sync_success=deployment.last_sync_success,
                 )
             )

--- a/control-plane-api/tests/test_gateway_internal_router.py
+++ b/control-plane-api/tests/test_gateway_internal_router.py
@@ -659,6 +659,7 @@ def _make_deployment(desired_state: dict):
     """Build a minimal mock GatewayDeployment."""
     m = MagicMock()
     m.id = uuid4()
+    m.gateway_instance_id = uuid4()
     m.desired_generation = 1
     m.desired_state = desired_state
     return m
@@ -695,6 +696,9 @@ class TestListGatewayRoutes:
         assert len(routes) == 1
         assert routes[0]["api_id"] == "petstore"
         assert routes[0]["name"] == "petstore"
+        assert routes[0]["deployment_id"] == str(dep.id)
+        assert routes[0]["gateway_instance_id"] == str(dep.gateway_instance_id)
+        assert routes[0]["generation"] == 1
         assert routes[0]["spec_hash"] == "abc123"
         assert routes[0]["openapi_spec"] is None
 

--- a/control-plane-ui/src/pages/ApiLifecyclePanel.test.tsx
+++ b/control-plane-ui/src/pages/ApiLifecyclePanel.test.tsx
@@ -123,6 +123,51 @@ describe('ApiLifecyclePanel', () => {
     );
   });
 
+  it('renders gateway deployment diagnostics without truncating the runtime error', async () => {
+    const webmethodsError =
+      'webmethods verifyAndActivate failed: API created but activation failed on webMethods: stoa-demo-api2 (def76d06-20dd-442e-a7b4-fc11ecbaddbf): webmethods api activate failed (500)';
+    vi.mocked(apiService.getApiLifecycleState).mockResolvedValue({
+      ...baseLifecycleState,
+      catalog_status: 'ready',
+      lifecycle_phase: 'failed',
+      deployments: [
+        {
+          id: 'deployment-1',
+          environment: 'dev',
+          gateway_instance_id: 'gateway-1',
+          gateway_name: 'connect-webmethods-dev-connect-dev',
+          gateway_type: 'webmethods',
+          sync_status: 'error',
+          desired_generation: 5,
+          synced_generation: 0,
+          gateway_resource_id: 'def76d06-20dd-442e-a7b4-fc11ecbaddbf',
+          public_url: 'https://vps-wm.gostoa.dev',
+          sync_error: webmethodsError,
+          last_sync_attempt: '2026-05-04T07:53:20Z',
+          last_sync_success: null,
+          policy_sync_status: 'error',
+          policy_sync_error: 'webmethods API not found: default-rate-limit-demo-gitops',
+          sync_steps: [
+            { name: 'agent_received', status: 'success', detail: 'sync request received' },
+            { name: 'api_synced', status: 'failed', detail: webmethodsError },
+          ],
+        },
+      ],
+    });
+
+    renderPanel();
+
+    expect(await screen.findByTestId('api-lifecycle-deployment-error')).toHaveTextContent(
+      webmethodsError
+    );
+    expect(screen.getByText('synced 0 / desired 5')).toBeInTheDocument();
+    expect(screen.getByTestId('api-lifecycle-deployment-policy-error')).toHaveTextContent(
+      'default-rate-limit-demo-gitops'
+    );
+    expect(screen.getByTestId('api-lifecycle-deployment-step')).toHaveTextContent('api_synced');
+    expect(screen.getByTestId('api-lifecycle-deployment-step')).toHaveTextContent(webmethodsError);
+  });
+
   it('sends publication and promotion requests through lifecycle actions', async () => {
     const readyState = { ...baseLifecycleState, catalog_status: 'ready', lifecycle_phase: 'ready' };
     vi.mocked(apiService.getApiLifecycleState).mockResolvedValue(readyState);

--- a/control-plane-ui/src/pages/ApiLifecyclePanel.tsx
+++ b/control-plane-ui/src/pages/ApiLifecyclePanel.tsx
@@ -2,7 +2,11 @@ import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AlertCircle, ArrowUpRight, CheckCircle2, RefreshCw, Rocket, Send } from 'lucide-react';
-import { apiService, type ApiLifecycleState } from '../services/api';
+import {
+  apiService,
+  type ApiLifecycleGatewayDeployment,
+  type ApiLifecycleState,
+} from '../services/api';
 
 interface ApiLifecyclePanelProps {
   tenantId: string;
@@ -50,6 +54,13 @@ function statusBadgeClass(status: string): string {
     return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300';
   }
   return 'bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300';
+}
+
+function formatTimestamp(value?: string | null): string | null {
+  if (!value) return null;
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) return value;
+  return timestamp.toLocaleString();
 }
 
 function CompactStatus({ label, value }: { label: string; value: string | boolean | null }) {
@@ -442,16 +453,7 @@ function LifecycleSummary({ lifecycle }: { lifecycle: ApiLifecycleState }) {
       )}
 
       <div className="grid gap-4 lg:grid-cols-3">
-        <SummaryList
-          title="Deployments"
-          empty="No gateway deployment"
-          items={lifecycle.deployments.map((deployment) => ({
-            id: deployment.id,
-            title: `${deployment.environment} / ${deployment.gateway_name}`,
-            status: deployment.sync_status,
-            detail: deployment.sync_error || deployment.gateway_instance_id,
-          }))}
-        />
+        <DeploymentSummary deployments={lifecycle.deployments} />
         <SummaryList
           title="Portal publications"
           empty="Not published"
@@ -473,6 +475,143 @@ function LifecycleSummary({ lifecycle }: { lifecycle: ApiLifecycleState }) {
           }))}
         />
       </div>
+    </div>
+  );
+}
+
+function DeploymentSummary({ deployments }: { deployments: ApiLifecycleGatewayDeployment[] }) {
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold text-neutral-900 dark:text-white">Deployments</h3>
+      {deployments.length === 0 ? (
+        <p className="rounded border border-dashed border-neutral-300 p-3 text-sm text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">
+          No gateway deployment
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {deployments.map((deployment) => {
+            const failedSteps = (deployment.sync_steps || []).filter(
+              (step) => step.status.toLowerCase() === 'failed'
+            );
+            const lastAttempt = formatTimestamp(deployment.last_sync_attempt);
+            const lastSuccess = formatTimestamp(deployment.last_sync_success);
+
+            return (
+              <div
+                data-testid="api-lifecycle-deployments-item"
+                key={deployment.id}
+                className="rounded border border-neutral-200 p-3 dark:border-neutral-700"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="min-w-0 text-sm font-medium text-neutral-900 dark:text-white">
+                    {deployment.environment} / {deployment.gateway_name}
+                  </span>
+                  <span
+                    className={`shrink-0 rounded px-2 py-1 text-xs ${statusBadgeClass(
+                      deployment.sync_status
+                    )}`}
+                  >
+                    {deployment.sync_status}
+                  </span>
+                </div>
+
+                <dl className="mt-2 grid gap-2 text-xs text-neutral-500 dark:text-neutral-400">
+                  <div>
+                    <dt className="font-medium text-neutral-700 dark:text-neutral-300">
+                      Gateway instance
+                    </dt>
+                    <dd className="break-all font-mono">{deployment.gateway_instance_id}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-neutral-700 dark:text-neutral-300">
+                      Generation
+                    </dt>
+                    <dd>
+                      synced {deployment.synced_generation} / desired{' '}
+                      {deployment.desired_generation}
+                    </dd>
+                  </div>
+                  {(lastAttempt || lastSuccess) && (
+                    <div>
+                      <dt className="font-medium text-neutral-700 dark:text-neutral-300">
+                        Sync timestamps
+                      </dt>
+                      <dd>
+                        {lastAttempt ? `last attempt: ${lastAttempt}` : null}
+                        {lastAttempt && lastSuccess ? ' · ' : null}
+                        {lastSuccess ? `last success: ${lastSuccess}` : null}
+                      </dd>
+                    </div>
+                  )}
+                  {deployment.public_url && (
+                    <div>
+                      <dt className="font-medium text-neutral-700 dark:text-neutral-300">
+                        Public URL
+                      </dt>
+                      <dd className="break-all font-mono">{deployment.public_url}</dd>
+                    </div>
+                  )}
+                </dl>
+
+                {deployment.sync_error && (
+                  <div
+                    data-testid="api-lifecycle-deployment-error"
+                    className="mt-3 rounded border border-red-200 bg-red-50 p-3 text-xs text-red-800 dark:border-red-900/60 dark:bg-red-900/20 dark:text-red-200"
+                  >
+                    <div className="mb-1 font-semibold">Gateway deployment error</div>
+                    <p className="whitespace-pre-wrap break-words font-mono">
+                      {deployment.sync_error}
+                    </p>
+                  </div>
+                )}
+
+                {deployment.policy_sync_error && (
+                  <div
+                    data-testid="api-lifecycle-deployment-policy-error"
+                    className="mt-3 rounded border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-200"
+                  >
+                    <div className="mb-1 font-semibold">
+                      Policy sync {deployment.policy_sync_status || 'error'}
+                    </div>
+                    <p className="whitespace-pre-wrap break-words font-mono">
+                      {deployment.policy_sync_error}
+                    </p>
+                  </div>
+                )}
+
+                {failedSteps.length > 0 && (
+                  <div className="mt-3 space-y-2" data-testid="api-lifecycle-deployment-steps">
+                    <div className="text-xs font-semibold text-neutral-700 dark:text-neutral-300">
+                      Failed sync steps
+                    </div>
+                    {failedSteps.map((step) => (
+                      <div
+                        data-testid="api-lifecycle-deployment-step"
+                        key={`${deployment.id}:${step.name}`}
+                        className="rounded bg-neutral-50 p-2 text-xs dark:bg-neutral-800"
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="font-medium text-neutral-900 dark:text-white">
+                            {step.name}
+                          </span>
+                          <span className={`rounded px-2 py-0.5 ${statusBadgeClass(step.status)}`}>
+                            {step.status}
+                          </span>
+                        </div>
+                        {step.detail && (
+                          <p className="mt-1 whitespace-pre-wrap break-words font-mono text-neutral-600 dark:text-neutral-300">
+                            {step.detail}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -184,6 +184,7 @@ export type {
 } from './api/monitoring';
 export type {
   ApiLifecycleCreateDraftRequest,
+  ApiLifecycleGatewayDeployment,
   ApiLifecycleState,
   ApiLifecycleValidateDraftRequest,
   ApiLifecycleValidateDraftResponse,

--- a/control-plane-ui/src/services/api/apiLifecycle.ts
+++ b/control-plane-ui/src/services/api/apiLifecycle.ts
@@ -37,6 +37,14 @@ export interface ApiLifecycleSpecState {
   fallback_reason?: string | null;
 }
 
+export interface ApiLifecycleSyncStep {
+  name: string;
+  status: string;
+  detail?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+}
+
 export interface ApiLifecycleGatewayDeployment {
   id: string;
   environment: string;
@@ -49,7 +57,11 @@ export interface ApiLifecycleGatewayDeployment {
   gateway_resource_id?: string | null;
   public_url?: string | null;
   sync_error?: string | null;
+  last_sync_attempt?: string | null;
   last_sync_success?: string | null;
+  policy_sync_status?: string | null;
+  policy_sync_error?: string | null;
+  sync_steps?: ApiLifecycleSyncStep[];
 }
 
 export interface ApiLifecyclePromotion {

--- a/shared/api-types/generated.ts
+++ b/shared/api-types/generated.ts
@@ -14867,6 +14867,11 @@ export interface components {
              */
             deployment_id: string;
             /**
+             * Gateway Instance Id
+             * @default
+             */
+            gateway_instance_id: string;
+            /**
              * Generation
              * @default 1
              */

--- a/stoa-gateway/src/handlers/admin/reload.rs
+++ b/stoa-gateway/src/handlers/admin/reload.rs
@@ -7,6 +7,9 @@
 //! message plus the id.
 
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use thiserror::Error;
 use tracing::{error, warn};
 use uuid::Uuid;
@@ -25,6 +28,10 @@ pub enum ReloadError {
     CpStatus(u16),
     #[error("Failed to parse control plane response")]
     ParseFailed(#[source] reqwest::Error),
+    #[error("Route reload ack request to control plane failed")]
+    AckUnreachable(#[source] reqwest::Error),
+    #[error("Control plane route reload ack returned non-success status {0}")]
+    AckStatus(u16),
 }
 
 impl ReloadError {
@@ -32,9 +39,11 @@ impl ReloadError {
     fn http_status(&self) -> StatusCode {
         match self {
             Self::NotConfigured => StatusCode::SERVICE_UNAVAILABLE,
-            Self::CpUnreachable(_) | Self::CpStatus(_) | Self::ParseFailed(_) => {
-                StatusCode::BAD_GATEWAY
-            }
+            Self::CpUnreachable(_)
+            | Self::CpStatus(_)
+            | Self::ParseFailed(_)
+            | Self::AckUnreachable(_)
+            | Self::AckStatus(_) => StatusCode::BAD_GATEWAY,
         }
     }
 
@@ -45,8 +54,44 @@ impl ReloadError {
             Self::CpUnreachable(_) => "Route reload failed: control plane unreachable",
             Self::CpStatus(_) => "Route reload failed: control plane returned an error",
             Self::ParseFailed(_) => "Route reload failed: control plane response malformed",
+            Self::AckUnreachable(_) => "Route reload failed: control plane ack unreachable",
+            Self::AckStatus(_) => "Route reload failed: control plane rejected route ack",
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct ControlPlaneRoute {
+    #[serde(flatten)]
+    route: crate::routes::ApiRoute,
+    #[serde(default)]
+    deployment_id: String,
+    #[serde(default)]
+    gateway_instance_id: String,
+    #[serde(default)]
+    generation: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct RouteSyncAckPayload {
+    synced_routes: Vec<RouteSyncAckResult>,
+    sync_timestamp: String,
+}
+
+#[derive(Debug, Serialize)]
+struct RouteSyncAckResult {
+    deployment_id: String,
+    status: &'static str,
+    error: Option<String>,
+    steps: Vec<RouteSyncAckStep>,
+    generation: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct RouteSyncAckStep {
+    name: &'static str,
+    status: &'static str,
+    detail: &'static str,
 }
 
 /// Trigger a route table reload from the Control Plane.
@@ -128,11 +173,79 @@ pub async fn reload_routes_from_cp(state: &AppState) -> Result<usize, ReloadErro
         return Err(ReloadError::CpStatus(response.status().as_u16()));
     }
 
-    let routes: Vec<crate::routes::ApiRoute> =
+    let control_plane_routes: Vec<ControlPlaneRoute> =
         response.json().await.map_err(ReloadError::ParseFailed)?;
 
+    let acks = build_route_sync_acks(&control_plane_routes);
+    let routes = control_plane_routes
+        .into_iter()
+        .map(|item| item.route)
+        .collect();
     let count = state.route_registry.swap_all(routes);
+    send_route_sync_acks(state, cp_url, acks).await?;
     Ok(count)
+}
+
+fn build_route_sync_acks(routes: &[ControlPlaneRoute]) -> HashMap<String, Vec<RouteSyncAckResult>> {
+    let mut acks: HashMap<String, Vec<RouteSyncAckResult>> = HashMap::new();
+    for route in routes {
+        if route.deployment_id.is_empty() || route.gateway_instance_id.is_empty() {
+            continue;
+        }
+        acks.entry(route.gateway_instance_id.clone())
+            .or_default()
+            .push(RouteSyncAckResult {
+                deployment_id: route.deployment_id.clone(),
+                status: "applied",
+                error: None,
+                steps: vec![
+                    RouteSyncAckStep {
+                        name: "gateway_routes_fetched",
+                        status: "success",
+                        detail: "route loaded from control plane",
+                    },
+                    RouteSyncAckStep {
+                        name: "gateway_routes_applied",
+                        status: "success",
+                        detail: "route table swapped in stoa-gateway",
+                    },
+                ],
+                generation: route.generation,
+            });
+    }
+    acks
+}
+
+async fn send_route_sync_acks(
+    state: &AppState,
+    cp_url: &str,
+    acks: HashMap<String, Vec<RouteSyncAckResult>>,
+) -> Result<(), ReloadError> {
+    if acks.is_empty() {
+        return Ok(());
+    }
+
+    for (gateway_id, synced_routes) in acks {
+        let url = format!(
+            "{}/v1/internal/gateways/{}/route-sync-ack",
+            cp_url.trim_end_matches('/'),
+            gateway_id
+        );
+        let payload = RouteSyncAckPayload {
+            synced_routes,
+            sync_timestamp: Utc::now().to_rfc3339(),
+        };
+        let mut request = state.http_client.post(&url).json(&payload);
+        if let Some(ref token) = state.config.control_plane_api_key {
+            request = request.header("X-Gateway-Key", token.as_str());
+        }
+        let response = request.send().await.map_err(ReloadError::AckUnreachable)?;
+        if !response.status().is_success() {
+            return Err(ReloadError::AckStatus(response.status().as_u16()));
+        }
+    }
+
+    Ok(())
 }
 
 fn current_gateway_name(config: &crate::config::Config) -> Option<String> {
@@ -160,6 +273,8 @@ fn derive_gateway_name(hostname: &str, mode: &str, environment: &str) -> String 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{body_string_contains, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn regression_route_reload_gateway_name_matches_control_plane_registration() {
@@ -189,12 +304,114 @@ mod tests {
         assert!(!err.client_message().contains("418"));
     }
 
+    #[tokio::test]
+    async fn reload_routes_posts_route_sync_ack_for_loaded_deployments() {
+        let mock_server = MockServer::start().await;
+        let deployment_id = Uuid::new_v4();
+        let gateway_id = Uuid::new_v4();
+
+        Mock::given(method("GET"))
+            .and(path("/v1/internal/gateways/routes"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": "route-1",
+                    "api_id": "payments-api",
+                    "deployment_id": deployment_id.to_string(),
+                    "gateway_instance_id": gateway_id.to_string(),
+                    "generation": 7,
+                    "name": "Payments API",
+                    "tenant_id": "acme",
+                    "path_prefix": "/apis/acme/payments",
+                    "backend_url": "https://backend.test",
+                    "methods": ["GET"],
+                    "spec_hash": "abc123",
+                    "activated": true
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path(format!(
+                "/v1/internal/gateways/{gateway_id}/route-sync-ack"
+            )))
+            .and(header("X-Gateway-Key", "test-key"))
+            .and(body_string_contains(deployment_id.to_string()))
+            .and(body_string_contains("\"status\":\"applied\""))
+            .and(body_string_contains("\"generation\":7"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "processed": 1,
+                "not_found": 0
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = crate::config::Config {
+            control_plane_url: Some(mock_server.uri()),
+            control_plane_api_key: Some("test-key".to_string()),
+            ..crate::config::Config::default()
+        };
+        let state = AppState::new(config);
+
+        let count = reload_routes_from_cp(&state)
+            .await
+            .expect("reload succeeds");
+
+        assert_eq!(count, 1);
+        assert_eq!(state.route_registry.count(), 1);
+    }
+
+    #[tokio::test]
+    async fn reload_routes_keeps_routes_without_deployment_metadata_but_skips_ack() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/internal/gateways/routes"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": "legacy-route",
+                    "name": "Legacy API",
+                    "tenant_id": "acme",
+                    "path_prefix": "/legacy",
+                    "backend_url": "https://legacy.test",
+                    "methods": ["GET"],
+                    "spec_hash": "abc123",
+                    "activated": true
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/internal/gateways/ignored/route-sync-ack"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let config = crate::config::Config {
+            control_plane_url: Some(mock_server.uri()),
+            control_plane_api_key: Some("test-key".to_string()),
+            ..crate::config::Config::default()
+        };
+        let state = AppState::new(config);
+
+        let count = reload_routes_from_cp(&state)
+            .await
+            .expect("reload succeeds");
+
+        assert_eq!(count, 1);
+        assert_eq!(state.route_registry.count(), 1);
+    }
+
     #[test]
     fn regression_reload_client_messages_are_static_and_non_leaky() {
         // None of the generic messages should reveal reqwest/serde/DNS internals.
         for msg in [
             ReloadError::NotConfigured.client_message(),
             ReloadError::CpStatus(500).client_message(),
+            ReloadError::AckStatus(500).client_message(),
         ] {
             for needle in ["reqwest", "connection refused", "dns", "expected field"] {
                 assert!(


### PR DESCRIPTION
## Summary

- Surface GatewayDeployment sync diagnostics in lifecycle state and Console API detail panel.
- Show full gateway errors, failed sync steps, policy sync errors, generation lag, and timestamps instead of truncating runtime failures.
- Include gateway_instance_id in control-plane route reload payloads.
- Make stoa-gateway route hot-reload post route-sync-ack with deployment_id and generation after applying routes, so GatewayDeployment can move from pending to synced.

## Validation

Backend:
- ruff check targeted lifecycle/gateway files: OK
- ruff format --check targeted lifecycle/gateway files: OK
- pytest tests/test_api_lifecycle*.py tests/test_gateway_internal_router.py -q: 122 passed, 1 skipped

UI:
- npm run format:check targeted files: OK
- npm run test -- ApiLifecyclePanel --run: 5 passed
- npm run build: OK
- npm run lint: OK, 51 existing warnings

Gateway:
- cargo fmt --check: OK
- cargo test reload_routes --quiet: 2 passed
- cargo clippy --all-targets -- -D warnings: OK

## Prod context

Observed prod issue had two separate causes:
- webMethods created the API but failed verifyAndActivate; the UI now shows the exact sync_error and failed step from GatewayDeployment.
- STOA gateway hot-reload loaded routes but did not ack GatewayDeployment generations; the Rust gateway now sends route-sync-ack after route table swap.