### PR TITLE
fix(gateway): keep scoped discovery counts authoritative

### DIFF
--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.test.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.test.tsx
@@ -141,6 +141,7 @@ describe('GatewayDetail', () => {
     mockGateway.target_gateway_type = null;
     mockGateway.topology = null;
     mockGateway.mode = 'edge-mcp';
+    mockGateway.gateway_type = 'stoa_edge_mcp';
   });
 
   it('renders gateway display name', async () => {
@@ -236,8 +237,19 @@ describe('GatewayDetail', () => {
     await screen.findByText('STOA Edge MCP Gateway');
     expect(screen.getByText('2h 0m')).toBeInTheDocument(); // 7200s
     expect(screen.getByText('5')).toBeInTheDocument(); // routes
-    expect(screen.getByText('3')).toBeInTheDocument(); // discovered APIs
+    expect(screen.getByText('3')).toBeInTheDocument(); // MCP tools
+    expect(screen.getByText('MCP Tools')).toBeInTheDocument();
+    expect(screen.queryByText('Discovered APIs')).not.toBeInTheDocument();
     expect(screen.getByText('1.0%')).toBeInTheDocument(); // error rate
+  });
+
+  it('keeps Discovered APIs label for non edge-mcp gateways', async () => {
+    mockGateway.mode = 'connect';
+    mockGateway.gateway_type = 'webmethods';
+    renderGatewayDetail();
+    await screen.findByText('STOA Edge MCP Gateway');
+    expect(screen.getByText('Discovered APIs')).toBeInTheDocument();
+    expect(screen.queryByText('MCP Tools')).not.toBeInTheDocument();
   });
 
   it('renders deployed APIs table', async () => {
@@ -282,7 +294,7 @@ describe('GatewayDetail', () => {
     expect(screen.getByText('payment_charge')).toBeInTheDocument();
     expect(screen.getByText('crm_contacts')).toBeInTheDocument();
     expect(screen.getByText('Get weather forecast for a location')).toBeInTheDocument();
-    expect(screen.getByText('MCP Tools')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /MCP Tools/ })).toBeInTheDocument();
   });
 
   it('renders empty state when no deployments and no tools', async () => {
@@ -304,7 +316,7 @@ describe('GatewayDetail', () => {
     expect(await screen.findByText('weather_forecast')).toBeInTheDocument();
     expect(screen.getByText('Payments API')).toBeInTheDocument();
     expect(screen.getByText('APIs Deployed')).toBeInTheDocument();
-    expect(screen.getByText('MCP Tools')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /MCP Tools/ })).toBeInTheDocument();
   });
 
   // --- Enabled/Disabled ---

--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
@@ -134,6 +134,8 @@ export function GatewayDetail() {
   const StatusIcon = statusCfg.icon;
   const deployments = deploymentsData?.items || [];
   const discoveredApis = toolsData || [];
+  const isEdgeMcp = gateway.mode === 'edge-mcp' || gateway.gateway_type === 'stoa_edge_mcp';
+  const discoveryMetricLabel = isEdgeMcp ? 'MCP Tools' : 'Discovered APIs';
   const urls = gatewayUrls(gateway);
   const modeLabel = deploymentLabel(gateway);
   const topologyText = topologyLabel(gateway);
@@ -318,7 +320,10 @@ export function GatewayDetail() {
             value={hd.uptime_seconds ? formatUptime(hd.uptime_seconds as number) : '-'}
           />
           <MetricCard label="Routes" value={String(hd.routes_count ?? '-')} />
-          <MetricCard label="Discovered APIs" value={String(hd.discovered_apis_count ?? '-')} />
+          <MetricCard
+            label={discoveryMetricLabel}
+            value={String(hd.discovered_apis_count ?? '-')}
+          />
           <MetricCard
             label="Error Rate"
             value={hd.error_rate != null ? `${((hd.error_rate as number) * 100).toFixed(1)}%` : '-'}

--- a/memory.md
+++ b/memory.md
@@ -1,6 +1,10 @@
 # STOA Memory
 
-> Dernière MAJ: 2026-04-25. Archive complète (cycles passés, DONE, etc.) → `memory-archive.md`.
+> Dernière MAJ: 2026-05-04. Archive complète (cycles passés, DONE, etc.) → `memory-archive.md`.
+
+## Session Notes — 2026-05-04
+
+- Hotfix gateway discovery count: `stoa-gateway` no longer falls back to the global API catalog when scoped `gateway_id` discovery returns empty, and skips catalog discovery until auto-registration has a gateway ID. Console labels the edge-MCP heartbeat count as "MCP Tools" instead of "Discovered APIs" because it comes from `tool_registry`. This prevents gateway details from implying global tools/APIs (e.g. 51) are deployed APIs when routes are zero. Regression coverage added for coarse/per-operation discovery and the UI label.
 
 ## ✅ FREEZE LEVÉ (2026-04-19)
 

--- a/stoa-gateway/src/main.rs
+++ b/stoa-gateway/src/main.rs
@@ -302,36 +302,44 @@ async fn register_tools(state: &AppState, registrar: Option<std::sync::Arc<Gatew
         let cp_url = state.control_plane.base_url().to_string();
         let http_client = stoa_gateway::mcp::tools::native_tool::create_http_client();
 
-        // Read gateway_id if registration has completed (may be None at startup)
-        let gw_id = match &registrar {
+        let expansion_mode = state.config.tool_expansion_mode;
+        let gw_id = match registrar.as_ref() {
             Some(r) => r.gateway_id().await,
             None => None,
         };
 
-        let expansion_mode = state.config.tool_expansion_mode;
-        let discovery = match expansion_mode {
-            stoa_gateway::config::ExpansionMode::Coarse => {
-                api_bridge::discover_api_tools(&state.tool_registry, &cp_url, &http_client, gw_id)
+        if registrar.is_some() && gw_id.is_none() {
+            info!("Skipping API catalog discovery until gateway registration completes");
+        } else {
+            let discovery = match expansion_mode {
+                stoa_gateway::config::ExpansionMode::Coarse => {
+                    api_bridge::discover_api_tools(
+                        &state.tool_registry,
+                        &cp_url,
+                        &http_client,
+                        gw_id,
+                    )
                     .await
-            }
-            stoa_gateway::config::ExpansionMode::PerOp => {
-                api_bridge::discover_expanded_api_tools(
-                    &state.tool_registry,
-                    &cp_url,
-                    &http_client,
-                    gw_id,
-                )
-                .await
-            }
-        };
-        match discovery {
-            Ok(count) => {
-                if count > 0 {
-                    info!(count, mode = ?expansion_mode, "API catalog tools registered");
                 }
-            }
-            Err(e) => {
-                warn!(error = %e, mode = ?expansion_mode, "API catalog discovery failed (will retry in background)");
+                stoa_gateway::config::ExpansionMode::PerOp => {
+                    api_bridge::discover_expanded_api_tools(
+                        &state.tool_registry,
+                        &cp_url,
+                        &http_client,
+                        gw_id,
+                    )
+                    .await
+                }
+            };
+            match discovery {
+                Ok(count) => {
+                    if count > 0 {
+                        info!(count, mode = ?expansion_mode, "API catalog tools registered");
+                    }
+                }
+                Err(e) => {
+                    warn!(error = %e, mode = ?expansion_mode, "API catalog discovery failed (will retry in background)");
+                }
             }
         }
 

--- a/stoa-gateway/src/mcp/tools/api_bridge.rs
+++ b/stoa-gateway/src/mcp/tools/api_bridge.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 use uuid::Uuid;
 
 use super::dynamic_tool::DynamicTool;
@@ -79,8 +79,7 @@ struct ExpandedToolsResponse {
 /// to its backend_url. Tools are named after the API slug (e.g. "payments").
 ///
 /// When `gateway_id` is provided, only APIs assigned to this gateway are returned.
-/// If the filtered query returns 0 APIs, falls back to unfiltered (backward compat
-/// for gateways without assignments configured yet — CAB-1940 adjustment #1).
+/// An empty scoped result is authoritative: the gateway has no assigned APIs.
 ///
 /// Returns the number of API tools registered.
 pub async fn discover_api_tools(
@@ -90,19 +89,6 @@ pub async fn discover_api_tools(
     gateway_id: Option<Uuid>,
 ) -> Result<usize, String> {
     let catalog = fetch_catalog(cp_base_url, client, gateway_id).await?;
-
-    // CAB-1940 fallback: if gateway_id filter returned 0 APIs, retry unfiltered.
-    // This handles gateways that have no api_gateway_assignments rows yet.
-    let catalog = match gateway_id {
-        Some(gw_id) if catalog.apis.is_empty() => {
-            warn!(
-                gateway_id = %gw_id,
-                "No APIs found for gateway — falling back to unfiltered catalog"
-            );
-            fetch_catalog(cp_base_url, client, None).await?
-        }
-        _ => catalog,
-    };
 
     let mut count = 0;
     for api in &catalog.apis {
@@ -188,8 +174,8 @@ pub async fn discover_api_tools(
 /// with its pre-built input schema and path pattern; `DynamicTool` handles
 /// path-param substitution + query/body routing at invocation time.
 ///
-/// Falls back silently to zero tools on transport errors — the background
-/// refresh task retries, consistent with `discover_api_tools`.
+/// Returns transport and parse errors to the caller; the background refresh
+/// task retries while keeping the existing registry state.
 pub async fn discover_expanded_api_tools(
     registry: &ToolRegistry,
     cp_base_url: &str,
@@ -197,17 +183,6 @@ pub async fn discover_expanded_api_tools(
     gateway_id: Option<Uuid>,
 ) -> Result<usize, String> {
     let catalog = fetch_expanded_catalog(cp_base_url, client, gateway_id).await?;
-
-    let catalog = match gateway_id {
-        Some(gw_id) if catalog.tools.is_empty() => {
-            warn!(
-                gateway_id = %gw_id,
-                "No expanded tools found for gateway — falling back to unfiltered catalog"
-            );
-            fetch_expanded_catalog(cp_base_url, client, None).await?
-        }
-        _ => catalog,
-    };
 
     let mut count = 0;
     for tool in catalog.tools {
@@ -349,7 +324,13 @@ pub fn start_api_tool_refresh_task(
             tokio::time::sleep(API_TOOL_REFRESH_INTERVAL).await;
 
             let gw_id = match &registrar {
-                Some(r) => r.gateway_id().await,
+                Some(r) => match r.gateway_id().await {
+                    Some(id) => Some(id),
+                    None => {
+                        debug!("Skipping API tool refresh until gateway registration completes");
+                        continue;
+                    }
+                },
                 None => None,
             };
 
@@ -610,9 +591,11 @@ mod tests {
         assert!(registry.get("scoped").is_some());
     }
 
-    /// CAB-1940 Phase 3: fallback to unfiltered when gateway_id filter returns 0 APIs.
+    /// Regression: a scoped empty catalog means this gateway has no assigned APIs.
+    /// It must not fall back to the global catalog, otherwise Console shows
+    /// unrelated APIs as discovered for gateways with zero deployments.
     #[tokio::test]
-    async fn regression_cab_1940_fallback_to_unfiltered_on_empty() {
+    async fn regression_cab_1940_scoped_empty_does_not_fallback() {
         let gw_id = Uuid::new_v4();
         let mock = MockServer::start().await;
 
@@ -621,15 +604,7 @@ mod tests {
             .and(path("/v1/internal/catalog/apis"))
             .and(query_param("gateway_id", gw_id.to_string()))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"apis": []})))
-            .mount(&mock)
-            .await;
-
-        // Unfiltered request returns APIs
-        Mock::given(method("GET"))
-            .and(path("/v1/internal/catalog/apis"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "apis": [{"id": "fallback", "name": "Fallback API", "backend_url": "http://b:80"}]
-            })))
+            .expect(1)
             .mount(&mock)
             .await;
 
@@ -639,8 +614,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(count, 1, "Should fallback to unfiltered catalog");
-        assert!(registry.get("fallback").is_some());
+        assert_eq!(count, 0, "Scoped empty catalog must remain empty");
+        assert_eq!(registry.count(), 0);
     }
 
     /// CAB-1940 Phase 3: no fallback when gateway_id is None (unfiltered is the only call).
@@ -753,7 +728,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cab_2113_gateway_id_scope_and_fallback() {
+    async fn cab_2113_gateway_id_scope_empty_does_not_fallback() {
         let gw_id = Uuid::new_v4();
         let mock = MockServer::start().await;
 
@@ -764,15 +739,7 @@ mod tests {
             .respond_with(
                 ResponseTemplate::new(200).set_body_json(serde_json::json!({"tools": []})),
             )
-            .mount(&mock)
-            .await;
-
-        // Unfiltered fallback: returns tools
-        Mock::given(method("GET"))
-            .and(path("/v1/internal/catalog/apis/expanded"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "tools": [expanded_tool_json("demo:bank:op", "http://bank:8080", "GET", None)]
-            })))
+            .expect(1)
             .mount(&mock)
             .await;
 
@@ -782,10 +749,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(
-            count, 1,
-            "must fallback to unfiltered catalog when scoped is empty"
-        );
+        assert_eq!(count, 0, "Scoped empty expanded catalog must remain empty");
+        assert_eq!(registry.count(), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What
- Keep gateway-scoped API discovery authoritative when the Control Plane returns an empty scoped catalog.
- Skip API catalog discovery until auto-registration has assigned a gateway ID.
- Label edge-MCP heartbeat discovery counts as MCP Tools in Console instead of Discovered APIs.

## Why
A gateway with zero deployed routes could show the global API/tool catalog count (for example 51) because the Rust gateway fell back to unfiltered discovery when `gateway_id` returned an empty result. That made the Console imply APIs were deployed when they were not.

## Validation
- `cargo test` in `stoa-gateway`
- `npm test -- src/pages/Gateways/GatewayDetail.test.tsx` in `control-plane-ui`
- `cargo fmt --check`
- Prettier check for changed GatewayDetail files
- `git diff --check`