### PR TITLE
fix(gateway): decouple edge MCP tools from API discovery

### DIFF
--- a/control-plane-api/src/routers/gateway_internal.py
+++ b/control-plane-api/src/routers/gateway_internal.py
@@ -53,6 +53,14 @@ _UI_ENDPOINT_KEYS = {"ui_url", "uiUrl", "console_url", "consoleUrl", "web_ui_url
 _TARGET_ENDPOINT_KEYS = {"target_gateway_url", "targetGatewayUrl", "target_url", "targetUrl"}
 
 
+def _is_edge_mcp_instance(instance: GatewayInstance) -> bool:
+    """Return true for the native STOA edge MCP gateway mode."""
+    gateway_type = (
+        instance.gateway_type.value if hasattr(instance.gateway_type, "value") else str(instance.gateway_type)
+    )
+    return instance.mode == "edge-mcp" or gateway_type == GatewayType.STOA_EDGE_MCP.value
+
+
 # --- Route Reload Endpoint (CAB-1828) ---
 
 
@@ -666,18 +674,28 @@ async def gateway_heartbeat(
     instance.status = GatewayInstanceStatus.ONLINE
 
     # Store metrics in health_details.
-    # CAB-1916: heartbeat stores `discovered_apis_count` (int), never
-    # `discovered_apis` — that key is reserved for the discovery array.
-    instance.health_details = {
-        **(instance.health_details or {}),
+    # CAB-1916: heartbeat stores counts only; `discovered_apis` remains
+    # reserved for the discovery array. Native edge-mcp heartbeats report
+    # MCP tool registry size in the legacy `discovered_apis` payload field,
+    # so keep it under `mcp_tools_count` and do not inflate API discovery.
+    existing_health = instance.health_details or {}
+    heartbeat_details = {
+        **existing_health,
         "last_heartbeat": now.isoformat(),
         "uptime_seconds": payload.uptime_seconds,
         "routes_count": payload.routes_count,
         "policies_count": payload.policies_count,
-        "discovered_apis_count": payload.discovered_apis,
         "requests_total": payload.requests_total,
         "error_rate": payload.error_rate,
     }
+    if _is_edge_mcp_instance(instance):
+        heartbeat_details["mcp_tools_count"] = payload.discovered_apis
+        discovered_apis = existing_health.get("discovered_apis")
+        heartbeat_details["discovered_apis_count"] = len(discovered_apis) if isinstance(discovered_apis, list) else 0
+    else:
+        heartbeat_details["discovered_apis_count"] = payload.discovered_apis
+
+    instance.health_details = heartbeat_details
 
     await repo.update(instance)
     await db.commit()

--- a/control-plane-api/tests/test_regression_health_normalization.py
+++ b/control-plane-api/tests/test_regression_health_normalization.py
@@ -52,7 +52,7 @@ class TestRegressionCAB1916HeartbeatDiscoveryRace:
     """CAB-1916: heartbeat must not overwrite discovery's `discovered_apis` array."""
 
     def test_heartbeat_stores_discovered_apis_count_not_discovered_apis(self, client):
-        """Heartbeat must store `discovered_apis_count` (int), never `discovered_apis`.
+        """Non-edge heartbeat must store `discovered_apis_count` (int), never `discovered_apis`.
 
         Before the fix, heartbeat stored `discovered_apis: 5` (int) which
         would overwrite the discovery array `discovered_apis: [{...}]`.
@@ -81,6 +81,35 @@ class TestRegressionCAB1916HeartbeatDiscoveryRace:
         assert "discovered_apis" not in gw.health_details or isinstance(
             gw.health_details.get("discovered_apis"), list
         )
+
+    def test_edge_mcp_heartbeat_stores_tools_count_not_api_discovery_count(self, client):
+        """Edge MCP heartbeat reports MCP tools, not discovered/deployed APIs."""
+        from src.models.gateway_instance import GatewayType
+
+        gw = _make_gateway_instance(
+            gateway_type=GatewayType.STOA_EDGE_MCP,
+            mode="edge-mcp",
+            health_details={"discovered_apis_count": 51},
+        )
+
+        with (
+            patch("src.routers.gateway_internal.settings") as mock_settings,
+            patch("src.routers.gateway_internal.GatewayInstanceRepository") as MockRepo,
+        ):
+            mock_settings.gateway_api_keys_list = [VALID_KEY]
+            mock_repo = MockRepo.return_value
+            mock_repo.get_by_id = AsyncMock(return_value=gw)
+            mock_repo.update = AsyncMock(return_value=gw)
+
+            client.post(
+                f"/v1/internal/gateways/{gw.id}/heartbeat",
+                json={"uptime_seconds": 60, "discovered_apis": 51},
+                headers={GW_KEY_HEADER: VALID_KEY},
+            )
+
+        assert gw.health_details["mcp_tools_count"] == 51
+        assert gw.health_details["discovered_apis_count"] == 0
+        assert "discovered_apis" not in gw.health_details
 
     def test_heartbeat_after_discovery_preserves_api_array(self, client):
         """Heartbeat after discovery must not overwrite the `discovered_apis` array.

--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.test.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createAuthMock } from '../../test/helpers';
@@ -237,8 +237,9 @@ describe('GatewayDetail', () => {
     await screen.findByText('STOA Edge MCP Gateway');
     expect(screen.getByText('2h 0m')).toBeInTheDocument(); // 7200s
     expect(screen.getByText('5')).toBeInTheDocument(); // routes
-    expect(screen.getByText('3')).toBeInTheDocument(); // MCP tools
-    expect(screen.getByText('MCP Tools')).toBeInTheDocument();
+    const deployedMetric = screen.getByText('Deployed APIs').closest('div');
+    expect(deployedMetric).not.toBeNull();
+    expect(within(deployedMetric!).getByText('1')).toBeInTheDocument(); // synced deployments
     expect(screen.queryByText('Discovered APIs')).not.toBeInTheDocument();
     expect(screen.getByText('1.0%')).toBeInTheDocument(); // error rate
   });
@@ -249,7 +250,6 @@ describe('GatewayDetail', () => {
     renderGatewayDetail();
     await screen.findByText('STOA Edge MCP Gateway');
     expect(screen.getByText('Discovered APIs')).toBeInTheDocument();
-    expect(screen.queryByText('MCP Tools')).not.toBeInTheDocument();
   });
 
   it('renders deployed APIs table', async () => {
@@ -315,7 +315,7 @@ describe('GatewayDetail', () => {
     renderGatewayDetail();
     expect(await screen.findByText('weather_forecast')).toBeInTheDocument();
     expect(screen.getByText('Payments API')).toBeInTheDocument();
-    expect(screen.getByText('APIs Deployed')).toBeInTheDocument();
+    expect(screen.getByText('API Deployments')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /MCP Tools/ })).toBeInTheDocument();
   });
 

--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
@@ -135,7 +135,13 @@ export function GatewayDetail() {
   const deployments = deploymentsData?.items || [];
   const discoveredApis = toolsData || [];
   const isEdgeMcp = gateway.mode === 'edge-mcp' || gateway.gateway_type === 'stoa_edge_mcp';
-  const discoveryMetricLabel = isEdgeMcp ? 'MCP Tools' : 'Discovered APIs';
+  const syncedDeployments = deployments.filter((deployment) => deployment.sync_status === 'synced');
+  const discoveryMetricLabel = isEdgeMcp ? 'Deployed APIs' : 'Discovered APIs';
+  const discoveryMetricValue = isEdgeMcp
+    ? deploymentsData
+      ? String(syncedDeployments.length)
+      : '-'
+    : String(hd.discovered_apis_count ?? '-');
   const urls = gatewayUrls(gateway);
   const modeLabel = deploymentLabel(gateway);
   const topologyText = topologyLabel(gateway);
@@ -320,10 +326,7 @@ export function GatewayDetail() {
             value={hd.uptime_seconds ? formatUptime(hd.uptime_seconds as number) : '-'}
           />
           <MetricCard label="Routes" value={String(hd.routes_count ?? '-')} />
-          <MetricCard
-            label={discoveryMetricLabel}
-            value={String(hd.discovered_apis_count ?? '-')}
-          />
+          <MetricCard label={discoveryMetricLabel} value={discoveryMetricValue} />
           <MetricCard
             label="Error Rate"
             value={hd.error_rate != null ? `${((hd.error_rate as number) * 100).toFixed(1)}%` : '-'}
@@ -332,12 +335,12 @@ export function GatewayDetail() {
         </div>
       </section>
 
-      {/* APIs Deployed */}
+      {/* API Deployments */}
       {deployments.length > 0 && (
         <section className="bg-white rounded-xl border border-gray-200 p-6">
           <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
             <Zap className="h-5 w-5 text-gray-400" />
-            APIs Deployed
+            API Deployments
             <span className="ml-auto text-sm font-normal text-gray-400">
               {deployments.length} API{deployments.length !== 1 ? 's' : ''}
             </span>


### PR DESCRIPTION
## What changed

- Store edge MCP heartbeat tool counts as `mcp_tools_count` instead of `discovered_apis_count`.
- Reset edge MCP `discovered_apis_count` to the actual discovery array length, or `0` when no discovery snapshot exists.
- Show `Deployed APIs` on the gateway detail metric for edge MCP, based on synced gateway deployments.
- Rename the deployment table section to `API Deployments` so failed/pending desired deployments are not presented as live deployed APIs.

## Root cause

The Rust edge MCP gateway still sends its MCP tool registry size in the legacy heartbeat field named `discovered_apis`. The control-plane stored that value as `health_details.discovered_apis_count`, so the Console displayed MCP tools as discovered/deployed APIs. For the reported gateway, that made `Routes=0` appear beside `Discovered APIs=51`.

## Validation

- `python3 -m pytest tests/test_regression_health_normalization.py tests/test_gateway_internal.py -q`
- `npm test -- --run src/pages/Gateways/GatewayDetail.test.tsx`
- `python3 -m ruff check src/routers/gateway_internal.py tests/test_regression_health_normalization.py`
- `npm run lint -- src/pages/Gateways/GatewayDetail.tsx src/pages/Gateways/GatewayDetail.test.tsx`
- `npm run build`
