### PR TITLE
fix(gateway): decouple native runtime tools from API discovery

### DIFF
--- a/control-plane-api/src/routers/gateway_internal.py
+++ b/control-plane-api/src/routers/gateway_internal.py
@@ -53,12 +53,17 @@ _UI_ENDPOINT_KEYS = {"ui_url", "uiUrl", "console_url", "consoleUrl", "web_ui_url
 _TARGET_ENDPOINT_KEYS = {"target_gateway_url", "targetGatewayUrl", "target_url", "targetUrl"}
 
 
-def _is_edge_mcp_instance(instance: GatewayInstance) -> bool:
-    """Return true for the native STOA edge MCP gateway mode."""
+def _reports_runtime_tools_in_discovered_apis(instance: GatewayInstance) -> bool:
+    """Return true when the legacy heartbeat field carries runtime tools, not API discovery."""
     gateway_type = (
         instance.gateway_type.value if hasattr(instance.gateway_type, "value") else str(instance.gateway_type)
     )
-    return instance.mode == "edge-mcp" or gateway_type == GatewayType.STOA_EDGE_MCP.value
+    return (instance.mode or "").lower() in {"edge-mcp", "sidecar", "proxy", "shadow"} or gateway_type in {
+        GatewayType.STOA_EDGE_MCP.value,
+        GatewayType.STOA_SIDECAR.value,
+        GatewayType.STOA_PROXY.value,
+        GatewayType.STOA_SHADOW.value,
+    }
 
 
 # --- Route Reload Endpoint (CAB-1828) ---
@@ -675,8 +680,8 @@ async def gateway_heartbeat(
 
     # Store metrics in health_details.
     # CAB-1916: heartbeat stores counts only; `discovered_apis` remains
-    # reserved for the discovery array. Native edge-mcp heartbeats report
-    # MCP tool registry size in the legacy `discovered_apis` payload field,
+    # reserved for the discovery array. Native STOA runtime heartbeats report
+    # tool registry size in the legacy `discovered_apis` payload field,
     # so keep it under `mcp_tools_count` and do not inflate API discovery.
     existing_health = instance.health_details or {}
     heartbeat_details = {
@@ -688,7 +693,7 @@ async def gateway_heartbeat(
         "requests_total": payload.requests_total,
         "error_rate": payload.error_rate,
     }
-    if _is_edge_mcp_instance(instance):
+    if _reports_runtime_tools_in_discovered_apis(instance):
         heartbeat_details["mcp_tools_count"] = payload.discovered_apis
         discovered_apis = existing_health.get("discovered_apis")
         heartbeat_details["discovered_apis_count"] = len(discovered_apis) if isinstance(discovered_apis, list) else 0

--- a/control-plane-api/tests/test_regression_health_normalization.py
+++ b/control-plane-api/tests/test_regression_health_normalization.py
@@ -111,6 +111,70 @@ class TestRegressionCAB1916HeartbeatDiscoveryRace:
         assert gw.health_details["discovered_apis_count"] == 0
         assert "discovered_apis" not in gw.health_details
 
+    def test_sidecar_heartbeat_stores_tools_count_not_api_discovery_count(self, client):
+        """Sidecar heartbeat also reports runtime tools in the legacy field."""
+        from src.models.gateway_instance import GatewayType
+
+        gw = _make_gateway_instance(
+            gateway_type=GatewayType.STOA_SIDECAR,
+            mode="sidecar",
+            health_details={"discovered_apis_count": 15},
+        )
+
+        with (
+            patch("src.routers.gateway_internal.settings") as mock_settings,
+            patch("src.routers.gateway_internal.GatewayInstanceRepository") as MockRepo,
+        ):
+            mock_settings.gateway_api_keys_list = [VALID_KEY]
+            mock_repo = MockRepo.return_value
+            mock_repo.get_by_id = AsyncMock(return_value=gw)
+            mock_repo.update = AsyncMock(return_value=gw)
+
+            client.post(
+                f"/v1/internal/gateways/{gw.id}/heartbeat",
+                json={"uptime_seconds": 60, "routes_count": 2, "discovered_apis": 15},
+                headers={GW_KEY_HEADER: VALID_KEY},
+            )
+
+        assert gw.health_details["mcp_tools_count"] == 15
+        assert gw.health_details["discovered_apis_count"] == 0
+        assert "discovered_apis" not in gw.health_details
+
+    def test_sidecar_heartbeat_preserves_discovery_array_count(self, client):
+        """Runtime tool heartbeat must not replace a real discovery report."""
+        from src.models.gateway_instance import GatewayType
+
+        gw = _make_gateway_instance(
+            gateway_type=GatewayType.STOA_SIDECAR,
+            mode="sidecar",
+            health_details={
+                "discovered_apis_count": 2,
+                "discovered_apis": [
+                    {"name": "manual-test-1777312098", "is_active": True},
+                    {"name": "fapi-banking", "is_active": True},
+                ],
+            },
+        )
+
+        with (
+            patch("src.routers.gateway_internal.settings") as mock_settings,
+            patch("src.routers.gateway_internal.GatewayInstanceRepository") as MockRepo,
+        ):
+            mock_settings.gateway_api_keys_list = [VALID_KEY]
+            mock_repo = MockRepo.return_value
+            mock_repo.get_by_id = AsyncMock(return_value=gw)
+            mock_repo.update = AsyncMock(return_value=gw)
+
+            client.post(
+                f"/v1/internal/gateways/{gw.id}/heartbeat",
+                json={"uptime_seconds": 60, "routes_count": 2, "discovered_apis": 15},
+                headers={GW_KEY_HEADER: VALID_KEY},
+            )
+
+        assert gw.health_details["mcp_tools_count"] == 15
+        assert gw.health_details["discovered_apis_count"] == 2
+        assert len(gw.health_details["discovered_apis"]) == 2
+
     def test_heartbeat_after_discovery_preserves_api_array(self, client):
         """Heartbeat after discovery must not overwrite the `discovered_apis` array.
 

--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.test.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.test.tsx
@@ -131,6 +131,8 @@ describe('GatewayDetail', () => {
     vi.clearAllMocks();
     vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
     // Reset gateway to enabled state
+    mockGateway.name = 'stoa-gateway-edge-mcp-dev';
+    mockGateway.display_name = 'STOA Edge MCP Gateway';
     mockGateway.enabled = true;
     mockGateway.visibility = null;
     mockGateway.public_url = 'https://mcp.gostoa.dev';
@@ -142,6 +144,7 @@ describe('GatewayDetail', () => {
     mockGateway.topology = null;
     mockGateway.mode = 'edge-mcp';
     mockGateway.gateway_type = 'stoa_edge_mcp';
+    mockGateway.health_details.discovered_apis_count = 3;
   });
 
   it('renders gateway display name', async () => {
@@ -244,7 +247,22 @@ describe('GatewayDetail', () => {
     expect(screen.getByText('1.0%')).toBeInTheDocument(); // error rate
   });
 
-  it('keeps Discovered APIs label for non edge-mcp gateways', async () => {
+  it('uses deployed APIs label for native sidecar gateways', async () => {
+    mockGateway.mode = 'sidecar';
+    mockGateway.gateway_type = 'stoa_sidecar';
+    mockGateway.display_name = 'STOA Gateway (sidecar)';
+    mockGateway.health_details.discovered_apis_count = 15;
+
+    renderGatewayDetail();
+    await screen.findByText('STOA Gateway (sidecar)');
+
+    const deployedMetric = screen.getByText('Deployed APIs').closest('div');
+    expect(deployedMetric).not.toBeNull();
+    expect(within(deployedMetric!).getByText('1')).toBeInTheDocument();
+    expect(screen.queryByText('Discovered APIs')).not.toBeInTheDocument();
+  });
+
+  it('keeps Discovered APIs label for connect gateways', async () => {
     mockGateway.mode = 'connect';
     mockGateway.gateway_type = 'webmethods';
     renderGatewayDetail();

--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
@@ -44,6 +44,21 @@ const STATUS_CONFIG: Record<string, { color: string; icon: typeof CheckCircle2 }
   maintenance: { color: 'text-blue-600 bg-blue-50', icon: Clock },
 };
 
+const NATIVE_STOA_RUNTIME_MODES = new Set(['edge-mcp', 'sidecar', 'proxy', 'shadow']);
+const NATIVE_STOA_GATEWAY_TYPES = new Set([
+  'stoa_edge_mcp',
+  'stoa_sidecar',
+  'stoa_proxy',
+  'stoa_shadow',
+]);
+
+function reportsRuntimeTools(gateway: GatewayInstance): boolean {
+  return (
+    NATIVE_STOA_RUNTIME_MODES.has(gateway.mode ?? '') ||
+    NATIVE_STOA_GATEWAY_TYPES.has(gateway.gateway_type ?? '')
+  );
+}
+
 function formatUptime(seconds: number): string {
   const days = Math.floor(seconds / 86400);
   const hours = Math.floor((seconds % 86400) / 3600);
@@ -134,10 +149,10 @@ export function GatewayDetail() {
   const StatusIcon = statusCfg.icon;
   const deployments = deploymentsData?.items || [];
   const discoveredApis = toolsData || [];
-  const isEdgeMcp = gateway.mode === 'edge-mcp' || gateway.gateway_type === 'stoa_edge_mcp';
+  const usesDeploymentMetric = reportsRuntimeTools(gateway);
   const syncedDeployments = deployments.filter((deployment) => deployment.sync_status === 'synced');
-  const discoveryMetricLabel = isEdgeMcp ? 'Deployed APIs' : 'Discovered APIs';
-  const discoveryMetricValue = isEdgeMcp
+  const discoveryMetricLabel = usesDeploymentMetric ? 'Deployed APIs' : 'Discovered APIs';
+  const discoveryMetricValue = usesDeploymentMetric
     ? deploymentsData
       ? String(syncedDeployments.length)
       : '-'


### PR DESCRIPTION
## Summary\n- treat native STOA runtime heartbeats (edge MCP, sidecar, proxy, shadow) as reporting runtime tool count in the legacy discovered_apis field\n- keep true API discovery counts reserved for discovery reports / connect gateways\n- show Deployed APIs from synced deployments for native STOA gateway detail pages, including sidecar\n\n## Verification\n- python3 -m pytest tests/test_regression_health_normalization.py tests/test_gateway_internal.py -q\n- python3 -m ruff check src/routers/gateway_internal.py tests/test_regression_health_normalization.py\n- npm test -- --run src/pages/Gateways/GatewayDetail.test.tsx\n- npm run lint -- src/pages/Gateways/GatewayDetail.tsx src/pages/Gateways/GatewayDetail.test.tsx\n- npm run build