### PR TITLE
fix(ui): show sidecar deployment mode in gateway detail

### DIFF
--- a/control-plane-ui/src/__tests__/regression/CAB-2173-sidecar-mode-display.test.ts
+++ b/control-plane-ui/src/__tests__/regression/CAB-2173-sidecar-mode-display.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { deploymentModeValue } from '../../pages/Gateways/gatewayDisplay';
+import type { GatewayInstance } from '../../types';
+
+describe('regression/CAB-2173 sidecar mode display', () => {
+  it('shows native STOA sidecar runtime mode instead of remote-agent topology mode', () => {
+    const gateway = {
+      gateway_type: 'stoa_sidecar',
+      mode: 'sidecar',
+      deployment_mode: 'connect',
+    } as GatewayInstance;
+
+    expect(deploymentModeValue(gateway)).toBe('sidecar');
+  });
+});

--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.test.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.test.tsx
@@ -235,6 +235,38 @@ describe('GatewayDetail', () => {
     );
   });
 
+  it('renders STOA sidecar runtime mode instead of remote-agent deployment mode', async () => {
+    const { apiService } = await import('../../services/api');
+    vi.mocked(apiService.getGatewayInstance).mockResolvedValueOnce({
+      ...mockGateway,
+      id: 'gw-sidecar',
+      name: 'stoa-link-wm-dev-sidecar-dev',
+      display_name: 'STOA Gateway (sidecar)',
+      gateway_type: 'stoa_sidecar',
+      base_url: 'https://dev-wm-k3s.gostoa.dev',
+      public_url: 'https://dev-wm-k3s.gostoa.dev',
+      target_gateway_url: 'https://dev-wm.gostoa.dev',
+      ui_url: 'https://dev-wm.gostoa.dev/apigatewayui/',
+      endpoints: {
+        public_url: 'https://dev-wm-k3s.gostoa.dev',
+        target_gateway_url: 'https://dev-wm.gostoa.dev',
+        ui_url: 'https://dev-wm.gostoa.dev/apigatewayui/',
+      },
+      mode: 'sidecar',
+      deployment_mode: 'connect',
+      target_gateway_type: 'webmethods',
+      topology: 'remote-agent',
+      tags: ['mode:sidecar', 'auto-registered'],
+    });
+
+    renderGatewayDetail('gw-sidecar');
+    await screen.findByText('STOA Gateway (sidecar)');
+
+    expect(screen.getByText('Deployment Mode')).toBeInTheDocument();
+    expect(screen.getByText('sidecar')).toBeInTheDocument();
+    expect(screen.queryByText('connect')).not.toBeInTheDocument();
+  });
+
   it('renders health metrics', async () => {
     renderGatewayDetail();
     await screen.findByText('STOA Edge MCP Gateway');

--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
@@ -25,7 +25,7 @@ import {
   ShieldAlert,
 } from 'lucide-react';
 import type { GatewayInstance } from '../../types';
-import { deploymentLabel, gatewayUrls, topologyLabel } from './gatewayDisplay';
+import { deploymentLabel, deploymentModeValue, gatewayUrls, topologyLabel } from './gatewayDisplay';
 
 interface DiscoveredAPI {
   name: string;
@@ -159,6 +159,7 @@ export function GatewayDetail() {
     : String(hd.discovered_apis_count ?? '-');
   const urls = gatewayUrls(gateway);
   const modeLabel = deploymentLabel(gateway);
+  const configDeploymentMode = deploymentModeValue(gateway);
   const topologyText = topologyLabel(gateway);
   const hasVisibilityRestriction =
     gateway.visibility && Array.isArray(gateway.visibility.tenant_ids);
@@ -279,8 +280,8 @@ export function GatewayDetail() {
           {gateway.target_gateway_type && (
             <ConfigItem label="Target Type" value={gateway.target_gateway_type} />
           )}
-          {gateway.deployment_mode && (
-            <ConfigItem label="Deployment Mode" value={gateway.deployment_mode} />
+          {configDeploymentMode && (
+            <ConfigItem label="Deployment Mode" value={configDeploymentMode} />
           )}
           {gateway.topology && <ConfigItem label="Topology" value={gateway.topology} />}
           {gateway.version && <ConfigItem label="Version" value={gateway.version} />}

--- a/control-plane-ui/src/pages/Gateways/gatewayDisplay.ts
+++ b/control-plane-ui/src/pages/Gateways/gatewayDisplay.ts
@@ -152,6 +152,13 @@ export function deploymentLabel(gw: GatewayInstance): string | null {
   return gw.mode ? (MODE_LABELS[gw.mode] ?? gw.mode) : null;
 }
 
+export function deploymentModeValue(gw: GatewayInstance): string | null {
+  if (gw.mode === 'sidecar' || gw.gateway_type === 'stoa_sidecar') return 'sidecar';
+  if (gw.mode === 'edge-mcp' || gw.gateway_type === 'stoa_edge_mcp') return 'edge';
+  if (gw.mode === 'connect') return 'connect';
+  return gw.deployment_mode ?? null;
+}
+
 export function targetLabel(gw: GatewayInstance, fallback: string): string {
   if (gw.target_gateway_type) {
     return TARGET_LABELS[gw.target_gateway_type] ?? gw.target_gateway_type;


### PR DESCRIPTION
## Summary\n- display STOA sidecar runtime mode as sidecar in Gateway Detail instead of the internal remote-agent deployment_mode=connect\n- keep topology badges/rows available for Link K8s / remote-agent classification\n- add regression coverage for the prod sidecar shape\n\n## Tests\n- npm test -- --run src/pages/Gateways/GatewayDetail.test.tsx\n- npm run lint -- src/pages/Gateways/GatewayDetail.tsx src/pages/Gateways/GatewayDetail.test.tsx src/pages/Gateways/gatewayDisplay.ts\n- npm run build