### PR TITLE
[codex] Complete replayed promotions already synced

### DIFF
--- a/control-plane-api/src/services/api_lifecycle/service.py
+++ b/control-plane-api/src/services/api_lifecycle/service.py
@@ -664,7 +664,10 @@ class ApiLifecycleService:
 
         promotion.target_deployment_id = target_deployment.id
         promotion.target_gateway_ids = [str(target_gateway.id)]
-        if promotion.status == PromotionStatus.PENDING.value:
+        if _deployment_synced_to_desired_generation(target_deployment):
+            promotion.status = PromotionStatus.PROMOTED.value
+            promotion.completed_at = promotion.completed_at or datetime.now(UTC)
+        elif promotion.status == PromotionStatus.PENDING.value:
             promotion.status = PromotionStatus.PROMOTING.value
         saved_promotion = await self.repository.save_promotion(promotion)
 
@@ -1245,6 +1248,15 @@ def _normalize_deployment_environment(value: str) -> str:
 
 def _wire_value(value: object) -> str:
     return str(getattr(value, "value", value))
+
+
+def _deployment_synced_to_desired_generation(deployment: GatewayDeployment) -> bool:
+    return (
+        _wire_value(deployment.sync_status) == DeploymentSyncStatus.SYNCED.value
+        and deployment.desired_generation is not None
+        and deployment.synced_generation is not None
+        and deployment.synced_generation >= deployment.desired_generation
+    )
 
 
 def _promotion_result(promotion_action: str, deployment_action: str) -> str:

--- a/control-plane-api/tests/test_regression_cab_1917_api_creation.py
+++ b/control-plane-api/tests/test_regression_cab_1917_api_creation.py
@@ -99,6 +99,47 @@ class TestRegression_AutoDeployOnPromotion:
             mock_orch.auto_deploy_on_promotion.assert_not_called()
 
 
+class TestRegression_PromotionReplayCompletion:
+    """CAB-1917: replayed lifecycle promotions must not stay promoting forever."""
+
+    @pytest.mark.asyncio
+    async def test_replayed_promoting_deployment_completes_when_already_synced(self):
+        from datetime import UTC, datetime
+
+        from src.models.gateway_deployment import DeploymentSyncStatus
+        from src.models.promotion import PromotionStatus
+        from tests.test_api_lifecycle_promotion import (
+            _actor,
+            _api,
+            _deploy_sync_publish_source,
+            _gateway,
+            _promote_command,
+            _service,
+        )
+
+        api = _api()
+        dev_gateway = _gateway(environment="dev")
+        staging_gateway = _gateway(environment="staging")
+        service, repository, audit, _ = _service(api=api, gateways=[dev_gateway, staging_gateway])
+        await _deploy_sync_publish_source(service, repository)
+
+        first = await service.promote_to_environment(_promote_command(), _actor())
+        target_deployment = repository.deployments[(api.id, staging_gateway.id)]
+        target_deployment.sync_status = DeploymentSyncStatus.SYNCED
+        target_deployment.synced_generation = target_deployment.desired_generation
+        target_deployment.last_sync_success = datetime.now(UTC)
+
+        second = await service.promote_to_environment(_promote_command(), _actor())
+
+        stored_promotion = repository.promotions[first.promotion_id]
+        assert second.result == "unchanged"
+        assert second.promotion_id == first.promotion_id
+        assert second.promotion_status == PromotionStatus.PROMOTED.value
+        assert stored_promotion.target_deployment_id == target_deployment.id
+        assert stored_promotion.completed_at is not None
+        assert audit.events[-1]["details"]["promotion_status"] == PromotionStatus.PROMOTED.value
+
+
 # ---------------------------------------------------------------------------
 # 3. list_apis error handling
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Complete lifecycle promotions immediately when the target GatewayDeployment is already synced to its desired generation.
- Preserve the existing idempotent promotion path without duplicating promotions or deployments.
- Add a regression test for the replayed `promoting` state where no new gateway ack will arrive.

## Root Cause

A repeated lifecycle promotion could return `unchanged` after its target deployment had already reached the desired generation. Because no new route-sync ack is emitted for an unchanged deployment, the promotion could remain in `promoting` indefinitely.

## Validation

- `pytest tests/test_api_lifecycle_promotion.py tests/test_api_lifecycle_promotion_router.py tests/test_regression_cab_1917_api_creation.py -q`
- `ruff check src/services/api_lifecycle/service.py tests/test_api_lifecycle_promotion.py`
