### PR TITLE
fix(gateways): canonicalize webMethods UI URLs

### DIFF
--- a/control-plane-api/tests/test_regression_cab_2240_webmethods_staging_targets.py
+++ b/control-plane-api/tests/test_regression_cab_2240_webmethods_staging_targets.py
@@ -43,7 +43,7 @@ def test_regression_cab_2240_staging_link_targets_real_webmethods_gateway() -> N
 
     assert env["STOA_GATEWAY_PUBLIC_URL"] == "https://staging-wm-k3s.gostoa.dev"
     assert env["STOA_TARGET_GATEWAY_URL"] == "https://staging-wm.gostoa.dev"
-    assert env["STOA_GATEWAY_UI_URL"] == "https://staging-wm-ui.gostoa.dev"
+    assert env["STOA_GATEWAY_UI_URL"] == "https://staging-wm-ui.gostoa.dev/apigatewayui/"
 
 
 def test_regression_cab_2240_link_registration_urls_are_explicit_for_all_envs() -> None:
@@ -51,17 +51,17 @@ def test_regression_cab_2240_link_registration_urls_are_explicit_for_all_envs() 
         DEV_OVERLAY: {
             "STOA_GATEWAY_PUBLIC_URL": "https://dev-wm-k3s.gostoa.dev",
             "STOA_TARGET_GATEWAY_URL": "https://dev-wm.gostoa.dev",
-            "STOA_GATEWAY_UI_URL": "https://dev-wm-ui.gostoa.dev",
+            "STOA_GATEWAY_UI_URL": "https://dev-wm-ui.gostoa.dev/apigatewayui/",
         },
         STAGING_OVERLAY: {
             "STOA_GATEWAY_PUBLIC_URL": "https://staging-wm-k3s.gostoa.dev",
             "STOA_TARGET_GATEWAY_URL": "https://staging-wm.gostoa.dev",
-            "STOA_GATEWAY_UI_URL": "https://staging-wm-ui.gostoa.dev",
+            "STOA_GATEWAY_UI_URL": "https://staging-wm-ui.gostoa.dev/apigatewayui/",
         },
         PROD_OVERLAY: {
             "STOA_GATEWAY_PUBLIC_URL": "https://vps-wm-link.gostoa.dev",
             "STOA_TARGET_GATEWAY_URL": "https://vps-wm.gostoa.dev",
-            "STOA_GATEWAY_UI_URL": "https://vps-wm-ui.gostoa.dev",
+            "STOA_GATEWAY_UI_URL": "https://vps-wm-ui.gostoa.dev/apigatewayui/",
         },
     }
 
@@ -77,12 +77,12 @@ def test_regression_cab_2240_gateway_instances_keep_runtime_and_target_urls_sepa
     connect_endpoints = instances["connect-webmethods-staging"]["spec"]["endpoints"]
     assert connect_endpoints["publicUrl"] == "https://staging-wm.gostoa.dev"
     assert connect_endpoints["targetGatewayUrl"] == "https://staging-wm.gostoa.dev"
-    assert connect_endpoints["uiUrl"] == "https://staging-wm-ui.gostoa.dev"
+    assert connect_endpoints["uiUrl"] == "https://staging-wm-ui.gostoa.dev/apigatewayui/"
 
     link_endpoints = instances["stoa-link-wm-staging"]["spec"]["endpoints"]
     assert link_endpoints["publicUrl"] == "https://staging-wm-k3s.gostoa.dev"
     assert link_endpoints["targetGatewayUrl"] == "https://staging-wm.gostoa.dev"
-    assert link_endpoints["uiUrl"] == "https://staging-wm-ui.gostoa.dev"
+    assert link_endpoints["uiUrl"] == "https://staging-wm-ui.gostoa.dev/apigatewayui/"
 
 
 def test_regression_cab_2240_gateway_instances_expose_webmethods_ui_urls_for_all_envs() -> None:
@@ -92,42 +92,42 @@ def test_regression_cab_2240_gateway_instances_expose_webmethods_ui_urls_for_all
             "connect-webmethods-dev",
             "https://dev-wm.gostoa.dev",
             "https://dev-wm.gostoa.dev",
-            "https://dev-wm-ui.gostoa.dev",
+            "https://dev-wm-ui.gostoa.dev/apigatewayui/",
         ),
         (
             DEV_OVERLAY,
             "stoa-link-wm-dev",
             "https://dev-wm-k3s.gostoa.dev",
             "https://dev-wm.gostoa.dev",
-            "https://dev-wm-ui.gostoa.dev",
+            "https://dev-wm-ui.gostoa.dev/apigatewayui/",
         ),
         (
             STAGING_OVERLAY,
             "connect-webmethods-staging",
             "https://staging-wm.gostoa.dev",
             "https://staging-wm.gostoa.dev",
-            "https://staging-wm-ui.gostoa.dev",
+            "https://staging-wm-ui.gostoa.dev/apigatewayui/",
         ),
         (
             STAGING_OVERLAY,
             "stoa-link-wm-staging",
             "https://staging-wm-k3s.gostoa.dev",
             "https://staging-wm.gostoa.dev",
-            "https://staging-wm-ui.gostoa.dev",
+            "https://staging-wm-ui.gostoa.dev/apigatewayui/",
         ),
         (
             PROD_OVERLAY,
             "connect-webmethods-prod",
             "https://vps-wm.gostoa.dev",
             "https://vps-wm.gostoa.dev",
-            "https://vps-wm-ui.gostoa.dev",
+            "https://vps-wm-ui.gostoa.dev/apigatewayui/",
         ),
         (
             PROD_OVERLAY,
             "vps-wm-link-prod",
             "https://vps-wm-link.gostoa.dev",
             "https://vps-wm.gostoa.dev",
-            "https://vps-wm-ui.gostoa.dev",
+            "https://vps-wm-ui.gostoa.dev/apigatewayui/",
         ),
     )
 

--- a/k8s/gateways/base/stoa-link-wm/deployment.yaml
+++ b/k8s/gateways/base/stoa-link-wm/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: ghcr-creds
       containers:
         - name: stoa-gateway
-          image: ghcr.io/stoa-platform/stoa-gateway:dev-d8b67cad540eba4d4337847eeddbc0161c6f32b0
+          image: ghcr.io/stoa-platform/stoa-gateway:dev-9511b0a53bb99dca36911be1534936296596b6bb
           ports:
             - containerPort: 8080
               name: http

--- a/k8s/gateways/overlays/dev/gateway-instances.yaml
+++ b/k8s/gateways/overlays/dev/gateway-instances.yaml
@@ -18,7 +18,7 @@ spec:
   endpoints:
     publicUrl: https://dev-wm.gostoa.dev
     targetGatewayUrl: https://dev-wm.gostoa.dev
-    uiUrl: https://dev-wm-ui.gostoa.dev
+    uiUrl: https://dev-wm-ui.gostoa.dev/apigatewayui/
     adminUrl: http://connect-webmethods-dev:8090
     healthUrl: http://connect-webmethods-dev:8090/health
   capabilities:
@@ -49,7 +49,7 @@ spec:
   endpoints:
     publicUrl: https://dev-wm-k3s.gostoa.dev
     targetGatewayUrl: https://dev-wm.gostoa.dev
-    uiUrl: https://dev-wm-ui.gostoa.dev
+    uiUrl: https://dev-wm-ui.gostoa.dev/apigatewayui/
     adminUrl: http://stoa-link-wm-dev:8080
     healthUrl: http://stoa-link-wm-dev:8080/health
   capabilities:

--- a/k8s/gateways/overlays/dev/kustomization.yaml
+++ b/k8s/gateways/overlays/dev/kustomization.yaml
@@ -70,7 +70,7 @@ patches:
                   - name: STOA_TARGET_GATEWAY_URL
                     value: "https://dev-wm.gostoa.dev"
                   - name: STOA_GATEWAY_UI_URL
-                    value: "https://dev-wm-ui.gostoa.dev"
+                    value: "https://dev-wm-ui.gostoa.dev/apigatewayui/"
                   - name: STOA_DEPLOYMENT_MODE
                     value: "connect"
                   - name: STOA_TARGET_GATEWAY_TYPE

--- a/k8s/gateways/overlays/production/gateway-instances.yaml
+++ b/k8s/gateways/overlays/production/gateway-instances.yaml
@@ -76,7 +76,7 @@ spec:
   endpoints:
     publicUrl: https://vps-wm.gostoa.dev
     targetGatewayUrl: https://vps-wm.gostoa.dev
-    uiUrl: https://vps-wm-ui.gostoa.dev
+    uiUrl: https://vps-wm-ui.gostoa.dev/apigatewayui/
     adminUrl: http://connect-webmethods-prod:8090
     healthUrl: http://connect-webmethods-prod:8090/health
   capabilities:
@@ -223,7 +223,7 @@ spec:
   endpoints:
     publicUrl: https://vps-wm-link.gostoa.dev
     targetGatewayUrl: https://vps-wm.gostoa.dev
-    uiUrl: https://vps-wm-ui.gostoa.dev
+    uiUrl: https://vps-wm-ui.gostoa.dev/apigatewayui/
     adminUrl: http://vps-wm-link-prod:9200
     healthUrl: http://vps-wm-link-prod:9200/health
   capabilities:

--- a/k8s/gateways/overlays/production/kustomization.yaml
+++ b/k8s/gateways/overlays/production/kustomization.yaml
@@ -64,7 +64,7 @@ patches:
                   - name: STOA_TARGET_GATEWAY_URL
                     value: "https://vps-wm.gostoa.dev"
                   - name: STOA_GATEWAY_UI_URL
-                    value: "https://vps-wm-ui.gostoa.dev"
+                    value: "https://vps-wm-ui.gostoa.dev/apigatewayui/"
                   - name: STOA_DEPLOYMENT_MODE
                     value: "connect"
                   - name: STOA_TARGET_GATEWAY_TYPE

--- a/k8s/gateways/overlays/staging/gateway-instances.yaml
+++ b/k8s/gateways/overlays/staging/gateway-instances.yaml
@@ -18,7 +18,7 @@ spec:
   endpoints:
     publicUrl: https://staging-wm.gostoa.dev
     targetGatewayUrl: https://staging-wm.gostoa.dev
-    uiUrl: https://staging-wm-ui.gostoa.dev
+    uiUrl: https://staging-wm-ui.gostoa.dev/apigatewayui/
     adminUrl: http://connect-webmethods-staging:8090
     healthUrl: http://connect-webmethods-staging:8090/health
   capabilities:
@@ -78,7 +78,7 @@ spec:
   endpoints:
     publicUrl: https://staging-wm-k3s.gostoa.dev
     targetGatewayUrl: https://staging-wm.gostoa.dev
-    uiUrl: https://staging-wm-ui.gostoa.dev
+    uiUrl: https://staging-wm-ui.gostoa.dev/apigatewayui/
     adminUrl: http://stoa-link-wm-staging:8080
     healthUrl: http://stoa-link-wm-staging:8080/health
   capabilities:

--- a/k8s/gateways/overlays/staging/kustomization.yaml
+++ b/k8s/gateways/overlays/staging/kustomization.yaml
@@ -70,7 +70,7 @@ patches:
                   - name: STOA_TARGET_GATEWAY_URL
                     value: "https://staging-wm.gostoa.dev"
                   - name: STOA_GATEWAY_UI_URL
-                    value: "https://staging-wm-ui.gostoa.dev"
+                    value: "https://staging-wm-ui.gostoa.dev/apigatewayui/"
                   - name: STOA_DEPLOYMENT_MODE
                     value: "connect"
                   - name: STOA_TARGET_GATEWAY_TYPE


### PR DESCRIPTION
## Summary
- pin the K3s webMethods Link sidecar to the STOA Gateway image that sends ui_url during registration
- canonicalize webMethods UI URLs to the dedicated UI host plus /apigatewayui/ across dev, staging, and prod manifests
- update CAB-2240 regression coverage for the canonical UI URL contract

## Verification
- pytest control-plane-api/tests/test_regression_cab_2240_webmethods_staging_targets.py -q
- kubectl kustomize k8s/gateways/overlays/dev
- kubectl kustomize k8s/gateways/overlays/staging
- kubectl kustomize k8s/gateways/overlays/production
- git diff --check