### PR TITLE
fix(console): surface lifecycle runtime status

### DIFF
--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -560,6 +560,13 @@
             "title": "Portal Promoted",
             "type": "boolean"
           },
+          "runtime_deployments": {
+            "items": {
+              "$ref": "#/components/schemas/APIRuntimeDeploymentSummary"
+            },
+            "title": "Runtime Deployments",
+            "type": "array"
+          },
           "status": {
             "default": "draft",
             "title": "Status",
@@ -604,6 +611,79 @@
           "backend_url"
         ],
         "title": "APIResponse",
+        "type": "object"
+      },
+      "APIRuntimeDeploymentSummary": {
+        "properties": {
+          "drifted_count": {
+            "default": 0,
+            "title": "Drifted Count",
+            "type": "integer"
+          },
+          "environment": {
+            "title": "Environment",
+            "type": "string"
+          },
+          "error_count": {
+            "default": 0,
+            "title": "Error Count",
+            "type": "integer"
+          },
+          "gateway_count": {
+            "default": 0,
+            "title": "Gateway Count",
+            "type": "integer"
+          },
+          "gateway_names": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Gateway Names",
+            "type": "array"
+          },
+          "last_sync_success": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Success"
+          },
+          "latest_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Error"
+          },
+          "pending_count": {
+            "default": 0,
+            "title": "Pending Count",
+            "type": "integer"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "synced_count": {
+            "default": 0,
+            "title": "Synced Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "environment",
+          "status"
+        ],
+        "title": "APIRuntimeDeploymentSummary",
         "type": "object"
       },
       "APIUpdate": {
@@ -1073,6 +1153,13 @@
             "title": "Name",
             "type": "string"
           },
+          "runtime_deployments": {
+            "items": {
+              "$ref": "#/components/schemas/AdminAPIRuntimeDeploymentSummary"
+            },
+            "title": "Runtime Deployments",
+            "type": "array"
+          },
           "status": {
             "default": "draft",
             "title": "Status",
@@ -1104,6 +1191,79 @@
           "description"
         ],
         "title": "AdminAPIResponse",
+        "type": "object"
+      },
+      "AdminAPIRuntimeDeploymentSummary": {
+        "properties": {
+          "drifted_count": {
+            "default": 0,
+            "title": "Drifted Count",
+            "type": "integer"
+          },
+          "environment": {
+            "title": "Environment",
+            "type": "string"
+          },
+          "error_count": {
+            "default": 0,
+            "title": "Error Count",
+            "type": "integer"
+          },
+          "gateway_count": {
+            "default": 0,
+            "title": "Gateway Count",
+            "type": "integer"
+          },
+          "gateway_names": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Gateway Names",
+            "type": "array"
+          },
+          "last_sync_success": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Success"
+          },
+          "latest_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Error"
+          },
+          "pending_count": {
+            "default": 0,
+            "title": "Pending Count",
+            "type": "integer"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "synced_count": {
+            "default": 0,
+            "title": "Synced Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "environment",
+          "status"
+        ],
+        "title": "AdminAPIRuntimeDeploymentSummary",
         "type": "object"
       },
       "AdminApplicationResponse": {

--- a/control-plane-api/src/routers/apis.py
+++ b/control-plane-api/src/routers/apis.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -27,6 +27,7 @@ from ..repositories.tenant import TenantRepository
 from ..schemas.pagination import PaginatedResponse
 from ..services import git_service
 from ..services.api_lifecycle.portal_tags import find_legacy_portal_publication_tags
+from ..services.api_runtime_summary import load_api_runtime_deployment_summaries
 from ..services.catalog_git_client.github_contents import GitHubContentsCatalogClient
 from ..services.gitops_writer import (
     ApiCreatePayload,
@@ -85,6 +86,19 @@ class APIUpdate(BaseModel):
     tags: list[str] | None = None  # Tags for categorization and portal promotion
 
 
+class APIRuntimeDeploymentSummary(BaseModel):
+    environment: str
+    status: str
+    gateway_count: int = 0
+    synced_count: int = 0
+    error_count: int = 0
+    pending_count: int = 0
+    drifted_count: int = 0
+    latest_error: str | None = None
+    last_sync_success: datetime | None = None
+    gateway_names: list[str] = Field(default_factory=list)
+
+
 class APIResponse(BaseModel):
     id: str
     tenant_id: str
@@ -111,6 +125,7 @@ class APIResponse(BaseModel):
     # separately (migration scope).
     created_at: datetime | None = None
     updated_at: datetime | None = None
+    runtime_deployments: list[APIRuntimeDeploymentSummary] = Field(default_factory=list)
 
 
 class APIOpenAPISpecResponse(BaseModel):
@@ -220,9 +235,7 @@ def _generated_openapi_fallback(api: APICatalog) -> dict[str, Any]:
                     "responses": {
                         "200": {
                             "description": "Successful response",
-                            "content": {
-                                "application/json": {"schema": {"type": "object"}}
-                            },
+                            "content": {"application/json": {"schema": {"type": "object"}}},
                         }
                     },
                 }
@@ -246,7 +259,10 @@ def _reject_implicit_portal_publication_tags(tags: list[str] | None) -> None:
         )
 
 
-def _api_from_catalog(api: APICatalog) -> APIResponse:
+def _api_from_catalog(
+    api: APICatalog,
+    runtime_deployments: list[dict[str, Any]] | None = None,
+) -> APIResponse:
     """Convert APICatalog DB model to APIResponse."""
     metadata = api.api_metadata or {}
     tags = api.tags or []
@@ -266,6 +282,17 @@ def _api_from_catalog(api: APICatalog) -> APIResponse:
     if not isinstance(catalog_pr_number, int):
         catalog_pr_number = None
 
+    runtime_items = [APIRuntimeDeploymentSummary.model_validate(item) for item in runtime_deployments or []]
+
+    def _is_runtime_synced(environment: str) -> bool | None:
+        matching = [item for item in runtime_items if item.environment == environment]
+        if not matching:
+            return None
+        return any(item.status == "synced" for item in matching)
+
+    deployed_dev = _is_runtime_synced("dev")
+    deployed_staging = _is_runtime_synced("staging")
+
     return APIResponse(
         id=api.api_id,
         tenant_id=api.tenant_id,
@@ -275,8 +302,8 @@ def _api_from_catalog(api: APICatalog) -> APIResponse:
         description=metadata.get("description", ""),
         backend_url=metadata.get("backend_url", ""),
         status=api.status or "draft",
-        deployed_dev=deployments.get("dev", False),
-        deployed_staging=deployments.get("staging", False),
+        deployed_dev=deployed_dev if deployed_dev is not None else deployments.get("dev", False),
+        deployed_staging=deployed_staging if deployed_staging is not None else deployments.get("staging", False),
         tags=tags,
         portal_promoted=portal_promoted,
         audience=audience,
@@ -288,7 +315,25 @@ def _api_from_catalog(api: APICatalog) -> APIResponse:
         catalog_merge_commit_sha=_optional_str_attr("catalog_merge_commit_sha"),
         created_at=api.synced_at,
         updated_at=api.synced_at,
+        runtime_deployments=runtime_items,
     )
+
+
+def _api_matches_environment(api: APIResponse, environment: str) -> bool:
+    """Filter by runtime deployment summary first, then legacy catalog metadata."""
+
+    if api.runtime_deployments:
+        if environment == "prod":
+            return any(item.environment in {"prod", "production"} for item in api.runtime_deployments)
+        return any(item.environment == environment for item in api.runtime_deployments)
+
+    if environment == "dev":
+        return api.deployed_dev or (not api.deployed_dev and not api.deployed_staging)
+    if environment == "staging":
+        return api.deployed_staging
+    if environment == "prod":
+        return api.deployed_dev and api.deployed_staging
+    return False
 
 
 @router.get("", response_model=PaginatedResponse[APIResponse])
@@ -313,17 +358,16 @@ async def list_apis(
             page=page,
             page_size=page_size,
         )
-        all_items = [_api_from_catalog(api) for api in apis]
+        runtime_summaries = await load_api_runtime_deployment_summaries(db, [api.id for api in apis])
+        all_items = [_api_from_catalog(api, runtime_summaries.get(api.id)) for api in apis]
         # Filter by environment if specified (post-filter since catalog doesn't support this natively)
         if environment:
             if environment == "dev":
-                all_items = [
-                    api for api in all_items if api.deployed_dev or (not api.deployed_dev and not api.deployed_staging)
-                ]
+                all_items = [api for api in all_items if _api_matches_environment(api, "dev")]
             elif environment == "staging":
-                all_items = [api for api in all_items if api.deployed_staging]
+                all_items = [api for api in all_items if _api_matches_environment(api, "staging")]
             elif environment == "prod":
-                all_items = [api for api in all_items if api.deployed_dev and api.deployed_staging]
+                all_items = [api for api in all_items if _api_matches_environment(api, "prod")]
             total = len(all_items)
         return PaginatedResponse(items=all_items, total=total, page=page, page_size=page_size)
     except Exception as e:
@@ -348,7 +392,8 @@ async def get_api(
         api = await repo.get_api_by_id(tenant_id, api_id)
         if not api:
             raise HTTPException(status_code=404, detail="API not found")
-        return _api_from_catalog(api)
+        runtime_summaries = await load_api_runtime_deployment_summaries(db, [api.id])
+        return _api_from_catalog(api, runtime_summaries.get(api.id))
     except HTTPException:
         raise
     except Exception as e:

--- a/control-plane-api/src/routers/catalog_admin.py
+++ b/control-plane-api/src/routers/catalog_admin.py
@@ -9,7 +9,7 @@ import logging
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -24,6 +24,7 @@ from ..schemas.catalog import (
     SyncTriggerResponse,
 )
 from ..services.api_lifecycle.portal_tags import strip_legacy_portal_publication_tags
+from ..services.api_runtime_summary import load_api_runtime_deployment_summaries
 from ..services.catalog_sync_service import CatalogSyncService, metadata_update_preserving_lifecycle
 from ..services.git_provider import GitProvider, get_git_provider
 
@@ -513,6 +514,19 @@ async def update_api_audience(
 # ============================================================================
 
 
+class AdminAPIRuntimeDeploymentSummary(BaseModel):
+    environment: str
+    status: str
+    gateway_count: int = 0
+    synced_count: int = 0
+    error_count: int = 0
+    pending_count: int = 0
+    drifted_count: int = 0
+    latest_error: str | None = None
+    last_sync_success: datetime | None = None
+    gateway_names: list[str] = Field(default_factory=list)
+
+
 class AdminAPIResponse(BaseModel):
     """API response for cross-tenant admin listing."""
 
@@ -524,6 +538,7 @@ class AdminAPIResponse(BaseModel):
     description: str
     status: str = "draft"
     tags: list[str] = []
+    runtime_deployments: list[AdminAPIRuntimeDeploymentSummary] = Field(default_factory=list)
 
 
 class AdminAPIPaginatedResponse(BaseModel):
@@ -554,6 +569,7 @@ async def list_all_apis(
         page=page,
         page_size=page_size,
     )
+    runtime_summaries = await load_api_runtime_deployment_summaries(db, [api.id for api in apis])
     items = [
         AdminAPIResponse(
             id=api.api_id,
@@ -564,6 +580,7 @@ async def list_all_apis(
             description=(api.api_metadata or {}).get("description", ""),
             status=api.status or "draft",
             tags=api.tags or [],
+            runtime_deployments=runtime_summaries.get(api.id, []),
         )
         for api in apis
     ]

--- a/control-plane-api/src/schemas/api_lifecycle.py
+++ b/control-plane-api/src/schemas/api_lifecycle.py
@@ -104,6 +104,9 @@ class ApiLifecyclePromotionResponse(BaseModel):
     requested_by: str
     approved_by: str | None = None
     completed_at: datetime | None = None
+    source_deployment_id: UUID | None = None
+    target_deployment_id: UUID | None = None
+    target_gateway_ids: list[UUID] = Field(default_factory=list)
 
 
 class ApiLifecyclePortalPublicationResponse(BaseModel):

--- a/control-plane-api/src/services/api_lifecycle/ports.py
+++ b/control-plane-api/src/services/api_lifecycle/ports.py
@@ -223,6 +223,9 @@ class PromotionState:
     requested_by: str
     approved_by: str | None = None
     completed_at: datetime | None = None
+    source_deployment_id: UUID | None = None
+    target_deployment_id: UUID | None = None
+    target_gateway_ids: list[UUID] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -276,6 +279,9 @@ class PromotionSnapshot:
     requested_by: str
     approved_by: str | None = None
     completed_at: datetime | None = None
+    source_deployment_id: UUID | None = None
+    target_deployment_id: UUID | None = None
+    target_gateway_ids: list[UUID] = field(default_factory=list)
 
 
 class ApiLifecycleRepository(Protocol):

--- a/control-plane-api/src/services/api_lifecycle/repository.py
+++ b/control-plane-api/src/services/api_lifecycle/repository.py
@@ -154,6 +154,9 @@ class SqlAlchemyApiLifecycleRepository:
                 requested_by=promotion.requested_by,
                 approved_by=promotion.approved_by,
                 completed_at=promotion.completed_at,
+                source_deployment_id=promotion.source_deployment_id,
+                target_deployment_id=promotion.target_deployment_id,
+                target_gateway_ids=_uuid_list_from_json(promotion.target_gateway_ids),
             )
             for promotion in result.scalars().all()
         ]
@@ -274,3 +277,15 @@ def _sync_steps_from_model(raw_steps: object) -> list[GatewayDeploymentSyncStep]
             )
         )
     return steps
+
+
+def _uuid_list_from_json(raw_value: object) -> list[UUID]:
+    if not isinstance(raw_value, list):
+        return []
+    values: list[UUID] = []
+    for item in raw_value:
+        try:
+            values.append(item if isinstance(item, UUID) else UUID(str(item)))
+        except (TypeError, ValueError):
+            continue
+    return values

--- a/control-plane-api/src/services/api_lifecycle/service.py
+++ b/control-plane-api/src/services/api_lifecycle/service.py
@@ -755,6 +755,9 @@ class ApiLifecycleService:
                 requested_by=item.requested_by,
                 approved_by=item.approved_by,
                 completed_at=item.completed_at,
+                source_deployment_id=item.source_deployment_id,
+                target_deployment_id=item.target_deployment_id,
+                target_gateway_ids=item.target_gateway_ids,
             )
             for item in promotions
         ]

--- a/control-plane-api/src/services/api_runtime_summary.py
+++ b/control-plane-api/src/services/api_runtime_summary.py
@@ -1,0 +1,104 @@
+"""Runtime deployment summaries for API catalog list views."""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.gateway_deployment import GatewayDeployment
+from src.models.gateway_instance import GatewayInstance
+
+logger = logging.getLogger(__name__)
+
+_STATUS_PRIORITY = {
+    "error": 60,
+    "drifted": 50,
+    "syncing": 40,
+    "pending": 30,
+    "deleting": 20,
+    "synced": 10,
+}
+
+
+async def load_api_runtime_deployment_summaries(
+    session: AsyncSession,
+    catalog_ids: list[UUID],
+) -> dict[UUID, list[dict[str, Any]]]:
+    """Return per-environment GatewayDeployment summaries keyed by APICatalog.id.
+
+    The API catalog list remains usable if the enrichment query fails; the
+    detail lifecycle endpoint remains the authoritative place for exact rows.
+    """
+
+    if not catalog_ids:
+        return {}
+
+    try:
+        stmt = (
+            select(GatewayDeployment, GatewayInstance)
+            .join(GatewayInstance, GatewayDeployment.gateway_instance_id == GatewayInstance.id)
+            .where(
+                GatewayDeployment.api_catalog_id.in_(catalog_ids),
+                GatewayInstance.deleted_at.is_(None),
+            )
+            .order_by(GatewayInstance.environment, GatewayInstance.name)
+        )
+        result = await session.execute(stmt)
+    except Exception as exc:  # pragma: no cover - defensive enrichment fallback
+        logger.warning("Failed to load API runtime deployment summaries: %s", exc)
+        return {}
+
+    grouped: dict[tuple[UUID, str], list[tuple[GatewayDeployment, GatewayInstance]]] = defaultdict(list)
+    for deployment, gateway in result.all():
+        grouped[(deployment.api_catalog_id, gateway.environment)].append((deployment, gateway))
+
+    summaries: dict[UUID, list[dict[str, Any]]] = defaultdict(list)
+    for (catalog_id, environment), rows in grouped.items():
+        statuses = [_status_value(deployment.sync_status) for deployment, _gateway in rows]
+        aggregate_status = max(statuses, key=lambda status: _STATUS_PRIORITY.get(status, 0))
+        latest_error = _latest_error(rows)
+        latest_success = _latest_sync_success(rows)
+        summaries[catalog_id].append(
+            {
+                "environment": environment,
+                "status": aggregate_status,
+                "gateway_count": len(rows),
+                "synced_count": sum(1 for status in statuses if status == "synced"),
+                "error_count": sum(1 for status in statuses if status == "error"),
+                "pending_count": sum(1 for status in statuses if status in {"pending", "syncing"}),
+                "drifted_count": sum(1 for status in statuses if status == "drifted"),
+                "latest_error": latest_error,
+                "last_sync_success": latest_success,
+                "gateway_names": [gateway.name for _deployment, gateway in rows],
+            }
+        )
+
+    return dict(summaries)
+
+
+def _status_value(value: object) -> str:
+    raw_value = getattr(value, "value", value)
+    return str(raw_value)
+
+
+def _latest_error(rows: list[tuple[GatewayDeployment, GatewayInstance]]) -> str | None:
+    errored = [
+        deployment
+        for deployment, _gateway in rows
+        if deployment.sync_error or _status_value(deployment.sync_status) in {"error", "drifted"}
+    ]
+    if not errored:
+        return None
+    errored.sort(key=lambda deployment: deployment.last_sync_attempt or deployment.updated_at, reverse=True)
+    return errored[0].sync_error
+
+
+def _latest_sync_success(rows: list[tuple[GatewayDeployment, GatewayInstance]]) -> datetime | None:
+    successes = [deployment.last_sync_success for deployment, _gateway in rows if deployment.last_sync_success]
+    return max(successes) if successes else None

--- a/control-plane-api/tests/test_apis_router.py
+++ b/control-plane-api/tests/test_apis_router.py
@@ -327,6 +327,48 @@ class TestApiFromCatalog:
         assert result.deployed_dev is True
         assert result.deployed_staging is True
 
+    def test_runtime_deployment_summary_overrides_legacy_metadata(self):
+        from src.routers.apis import _api_from_catalog
+
+        api = _mock_catalog_api(
+            api_metadata={
+                **_mock_catalog_api().api_metadata,
+                "deployments": {"dev": False, "staging": False},
+            }
+        )
+        result = _api_from_catalog(
+            api,
+            [
+                {
+                    "environment": "dev",
+                    "status": "synced",
+                    "gateway_count": 1,
+                    "synced_count": 1,
+                    "error_count": 0,
+                    "pending_count": 0,
+                    "drifted_count": 0,
+                    "latest_error": None,
+                    "gateway_names": ["stoa-dev"],
+                },
+                {
+                    "environment": "staging",
+                    "status": "error",
+                    "gateway_count": 1,
+                    "synced_count": 0,
+                    "error_count": 1,
+                    "pending_count": 0,
+                    "drifted_count": 0,
+                    "latest_error": "activation failed",
+                    "gateway_names": ["webmethods-staging"],
+                },
+            ],
+        )
+
+        assert result.deployed_dev is True
+        assert result.deployed_staging is False
+        assert result.runtime_deployments[0].status == "synced"
+        assert result.runtime_deployments[1].latest_error == "activation failed"
+
     def test_catalog_release_metadata_exposed(self):
         from src.routers.apis import _api_from_catalog
 

--- a/control-plane-api/tests/test_regression_lifecycle_runtime_status.py
+++ b/control-plane-api/tests/test_regression_lifecycle_runtime_status.py
@@ -1,0 +1,58 @@
+"""Regression tests for lifecycle runtime status projections."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from src.models.catalog import APICatalog
+from src.routers.apis import _api_from_catalog
+
+
+def test_regression_api_list_uses_gateway_deployment_runtime_status():
+    """The API list must expose GatewayDeployment runtime state, not stale metadata."""
+
+    catalog_api = MagicMock(spec=APICatalog)
+    catalog_api.id = uuid4()
+    catalog_api.tenant_id = "acme"
+    catalog_api.api_id = "banking-demo"
+    catalog_api.api_name = "Banking Demo"
+    catalog_api.version = "1.0.0"
+    catalog_api.status = "ready"
+    catalog_api.tags = []
+    catalog_api.portal_published = False
+    catalog_api.openapi_spec = {"openapi": "3.0.0", "info": {"title": "Banking Demo", "version": "1.0.0"}, "paths": {}}
+    catalog_api.synced_at = datetime.now(UTC)
+    catalog_api.deleted_at = None
+    catalog_api.api_metadata = {
+        "name": "banking-demo",
+        "display_name": "Banking Demo",
+        "version": "1.0.0",
+        "status": "ready",
+        "deployments": {"dev": False, "staging": False},
+        "tags": [],
+    }
+
+    api_response = _api_from_catalog(
+        catalog_api,
+        [
+            {
+                "environment": "dev",
+                "status": "synced",
+                "gateway_count": 1,
+                "synced_count": 1,
+                "error_count": 0,
+                "pending_count": 0,
+                "drifted_count": 0,
+                "latest_error": None,
+                "last_sync_success": None,
+                "gateway_names": ["stoa-dev"],
+            }
+        ],
+    )
+
+    assert api_response.deployed_dev is True
+    assert api_response.deployed_staging is False
+    assert api_response.runtime_deployments[0].environment == "dev"
+    assert api_response.runtime_deployments[0].status == "synced"

--- a/control-plane-ui/src/pages/APIDetail.test.tsx
+++ b/control-plane-ui/src/pages/APIDetail.test.tsx
@@ -343,7 +343,8 @@ describe('APIDetail', () => {
       await user.click(screen.getByText('Spec'));
 
       await waitFor(() => {
-        expect(screen.getByText('Git source')).toBeInTheDocument();
+        expect(screen.getByText('Git authoritative')).toBeInTheDocument();
+        expect(screen.getByText('Authoritative')).toBeInTheDocument();
         expect(screen.getByText(/"openapi": "3.0.3"/)).toBeInTheDocument();
       });
       expect(apiService.getApiOpenApiSpec).toHaveBeenCalledWith('oasis-gunters', 'payment-api');
@@ -378,7 +379,85 @@ describe('APIDetail', () => {
 
       await waitFor(() => {
         expect(screen.getByText('No promotions yet for this API.')).toBeInTheDocument();
+        expect(screen.getByText(/Use the lifecycle panel to promote/)).toBeInTheDocument();
       });
+    });
+
+    it('shows deployments from the aggregate lifecycle state', async () => {
+      setupMocks();
+      vi.mocked(apiService.getApiLifecycleState).mockResolvedValue({
+        ...baseLifecycleState,
+        deployments: [
+          {
+            id: 'deployment-1',
+            environment: 'dev',
+            gateway_instance_id: 'gateway-1',
+            gateway_name: 'stoa-dev',
+            gateway_type: 'stoa',
+            sync_status: 'error',
+            desired_generation: 3,
+            synced_generation: 2,
+            gateway_resource_id: null,
+            public_url: null,
+            sync_error: 'webMethods activation failed',
+            last_sync_attempt: '2026-05-04T10:00:00Z',
+            last_sync_success: null,
+            policy_sync_status: null,
+            policy_sync_error: null,
+            sync_steps: [
+              {
+                name: 'api_activate',
+                status: 'failed',
+                detail: 'activate failed',
+              },
+            ],
+          },
+        ],
+      });
+      renderAPIDetail();
+      const user = userEvent.setup();
+
+      await user.click(await screen.findByText('Deployments'));
+
+      await waitFor(() => {
+        expect(screen.getAllByText('dev / stoa-dev').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('webMethods activation failed').length).toBeGreaterThan(0);
+        expect(screen.getByText(/api_activate: activate failed/)).toBeInTheDocument();
+      });
+      expect(apiService.getGatewayDeployments).not.toHaveBeenCalled();
+    });
+
+    it('shows promotions from the aggregate lifecycle state', async () => {
+      setupMocks();
+      vi.mocked(apiService.getApiLifecycleState).mockResolvedValue({
+        ...baseLifecycleState,
+        promotions: [
+          {
+            id: 'promotion-1',
+            source_environment: 'dev',
+            target_environment: 'staging',
+            status: 'promoting',
+            message: 'Waiting for target deployment sync',
+            requested_by: 'ops@example.com',
+            approved_by: null,
+            completed_at: null,
+            source_deployment_id: 'source-deployment',
+            target_deployment_id: 'target-deployment',
+            target_gateway_ids: ['target-gateway'],
+          },
+        ],
+      });
+      renderAPIDetail();
+      const user = userEvent.setup();
+
+      await user.click(await screen.findByText('Promotions'));
+
+      await waitFor(() => {
+        expect(screen.getByText('dev → staging')).toBeInTheDocument();
+        expect(screen.getAllByText('Waiting for target deployment sync').length).toBeGreaterThan(0);
+        expect(screen.getByText('target target-deployment')).toBeInTheDocument();
+      });
+      expect(apiService.listPromotions).not.toHaveBeenCalled();
     });
   });
 

--- a/control-plane-ui/src/pages/APIDetail.tsx
+++ b/control-plane-ui/src/pages/APIDetail.tsx
@@ -7,7 +7,7 @@
 
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import {
   ArrowLeft,
   Info,
@@ -30,8 +30,9 @@ import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
 import { CardSkeleton } from '@stoa/shared/components/Skeleton';
 import { Button } from '@stoa/shared/components/Button';
 import { EnvironmentPipeline } from '../components/EnvironmentPipeline';
-import type { API, GatewayDeployment } from '../types';
+import type { API } from '../types';
 import type { Schemas } from '@stoa/shared/api-types';
+import type { ApiLifecycleState } from '../services/api/apiLifecycle';
 import { ApiLifecyclePanel } from './ApiLifecyclePanel';
 
 type TabId = 'overview' | 'spec' | 'versions' | 'deployments' | 'promotions';
@@ -62,6 +63,12 @@ export function APIDetail() {
   } = useQuery({
     queryKey: ['api', tenantId, apiId],
     queryFn: () => apiService.getApi(tenantId!, apiId!),
+    enabled: !!tenantId && !!apiId,
+  });
+
+  const { data: lifecycle, isLoading: lifecycleLoading } = useQuery({
+    queryKey: ['api-lifecycle', tenantId, apiId],
+    queryFn: () => apiService.getApiLifecycleState(tenantId!, apiId!),
     enabled: !!tenantId && !!apiId,
   });
 
@@ -191,8 +198,8 @@ export function APIDetail() {
         {/* Environment Pipeline */}
         <div className="mt-4 pt-4 border-t border-neutral-100 dark:border-neutral-800">
           <EnvironmentPipeline
-            deployed_dev={api.deployed_dev}
-            deployed_staging={api.deployed_staging}
+            deployed_dev={isEnvironmentSynced(lifecycle, 'dev') ?? api.deployed_dev}
+            deployed_staging={isEnvironmentSynced(lifecycle, 'staging') ?? api.deployed_staging}
           />
         </div>
       </div>
@@ -229,11 +236,27 @@ export function APIDetail() {
         {activeTab === 'overview' && <OverviewTab api={api} />}
         {activeTab === 'spec' && <SpecTab api={api} />}
         {activeTab === 'versions' && <VersionsTab versions={versions} loading={versionsLoading} />}
-        {activeTab === 'deployments' && <DeploymentsTab api={api} />}
-        {activeTab === 'promotions' && <PromotionsTab api={api} tenantId={tenantId!} />}
+        {activeTab === 'deployments' && (
+          <DeploymentsTab lifecycle={lifecycle} loading={lifecycleLoading} />
+        )}
+        {activeTab === 'promotions' && (
+          <PromotionsTab lifecycle={lifecycle} loading={lifecycleLoading} />
+        )}
       </div>
     </div>
   );
+}
+
+function isEnvironmentSynced(
+  lifecycle: ApiLifecycleState | undefined,
+  environment: string
+): boolean | null {
+  if (!lifecycle) return null;
+  const deployments = lifecycle.deployments.filter(
+    (deployment) => deployment.environment === environment
+  );
+  if (deployments.length === 0) return null;
+  return deployments.some((deployment) => deployment.sync_status === 'synced');
 }
 
 // --- Tab Components ---
@@ -311,17 +334,21 @@ function SpecTab({ api }: { api: API }) {
   }
 
   const sourceLabel =
-    data.source === 'git'
-      ? 'Git source'
-      : data.source === 'db_cache'
-        ? 'DB cache'
-        : 'Generated fallback';
+    data.source === 'git' && data.is_authoritative
+      ? 'Git authoritative'
+      : data.source === 'git'
+        ? 'Git source'
+        : data.source === 'db_cache'
+          ? 'DB cache'
+          : 'Generated fallback';
   const sourceClass =
-    data.source === 'git'
+    data.source === 'git' && data.is_authoritative
       ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
-      : data.source === 'db_cache'
+      : data.source === 'git'
         ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400'
-        : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
+        : data.source === 'db_cache'
+          ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400'
+          : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
   const prettySpec = JSON.stringify(data.spec, null, 2);
 
   const copySpec = async () => {
@@ -338,6 +365,12 @@ function SpecTab({ api }: { api: API }) {
             <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${sourceClass}`}>
               {sourceLabel}
             </span>
+            {data.is_authoritative && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-50 text-green-700 ring-1 ring-green-200 dark:bg-green-900/20 dark:text-green-300 dark:ring-green-800">
+                <Check className="h-3 w-3" />
+                Authoritative
+              </span>
+            )}
             <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
               {data.format}
             </span>
@@ -433,34 +466,18 @@ function VersionsTab({
   );
 }
 
-function DeploymentsTab({ api }: { api: API }) {
-  const toast = useToastActions();
-  const queryClient = useQueryClient();
-
-  // Query gateway deployments for this specific API
-  const { data, isLoading } = useQuery({
-    queryKey: ['gateway-deployments', api.id],
-    queryFn: () => apiService.getGatewayDeployments({ page_size: 100 }),
-    enabled: !!api.id,
-  });
-
-  const forceSyncMutation = useMutation({
-    mutationFn: (deploymentId: string) => apiService.forceSyncDeployment(deploymentId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['gateway-deployments', api.id] });
-      toast.success('Re-sync triggered');
-    },
-    onError: () => toast.error('Failed to trigger re-sync'),
-  });
-
-  if (isLoading) {
+function DeploymentsTab({
+  lifecycle,
+  loading,
+}: {
+  lifecycle: ApiLifecycleState | undefined;
+  loading: boolean;
+}) {
+  if (loading) {
     return <CardSkeleton className="h-32" />;
   }
 
-  // Filter deployments to this API by matching api_catalog_id
-  const deployments = (data?.items || []).filter(
-    (d: GatewayDeployment) => d.api_catalog_id === api.id
-  );
+  const deployments = lifecycle?.deployments || [];
 
   const syncStatusBadge: Record<string, string> = {
     pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
@@ -473,10 +490,9 @@ function DeploymentsTab({ api }: { api: API }) {
 
   return (
     <div className="space-y-4">
-      {/* Header with deploy button */}
       <div className="flex items-center justify-between">
         <p className="text-sm text-neutral-500 dark:text-neutral-400">
-          {deployments.length} gateway deployment{deployments.length !== 1 ? 's' : ''}
+          {deployments.length} lifecycle gateway deployment{deployments.length !== 1 ? 's' : ''}
         </p>
       </div>
 
@@ -491,48 +507,67 @@ function DeploymentsTab({ api }: { api: API }) {
           {deployments.map((d) => (
             <div
               key={d.id}
-              className="flex items-center justify-between p-3 rounded-lg border border-neutral-100 dark:border-neutral-800"
+              className="p-3 rounded-lg border border-neutral-100 dark:border-neutral-800"
             >
-              <div className="flex items-center gap-3">
-                <span className="text-sm font-medium text-neutral-900 dark:text-white">
-                  {d.gateway_name || d.gateway_instance_id?.slice(0, 8)}
-                </span>
-                <span className="text-xs font-semibold uppercase px-2 py-0.5 rounded bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400">
-                  {d.gateway_environment || '—'}
-                </span>
-                <span
-                  className={`text-xs px-2 py-0.5 rounded ${syncStatusBadge[d.sync_status] || ''}`}
-                >
-                  {d.sync_status}
-                </span>
-              </div>
-              <div className="flex items-center gap-2">
-                {d.sync_status === 'drifted' && (
-                  <button
-                    onClick={() => forceSyncMutation.mutate(d.id)}
-                    disabled={forceSyncMutation.isPending}
-                    className="text-xs text-orange-600 dark:text-orange-400 hover:underline"
-                  >
-                    Re-deploy
-                  </button>
-                )}
-                {d.sync_status === 'error' && (
-                  <button
-                    onClick={() => forceSyncMutation.mutate(d.id)}
-                    disabled={forceSyncMutation.isPending}
-                    className="text-xs text-red-600 dark:text-red-400 hover:underline"
-                  >
-                    Retry
-                  </button>
-                )}
+              <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium text-neutral-900 dark:text-white">
+                      {d.environment} / {d.gateway_name || d.gateway_instance_id.slice(0, 8)}
+                    </span>
+                    <span
+                      className={`text-xs px-2 py-0.5 rounded ${syncStatusBadge[d.sync_status] || ''}`}
+                    >
+                      {d.sync_status}
+                    </span>
+                  </div>
+                  <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-neutral-500 dark:text-neutral-400">
+                    <span>gateway {d.gateway_instance_id}</span>
+                    <span>
+                      generation {d.synced_generation}/{d.desired_generation}
+                    </span>
+                    {d.gateway_resource_id && <span>resource {d.gateway_resource_id}</span>}
+                  </div>
+                </div>
                 <span className="text-xs text-neutral-400 dark:text-neutral-500">
                   {d.last_sync_success
                     ? new Date(d.last_sync_success).toLocaleString()
-                    : d.created_at
-                      ? new Date(d.created_at).toLocaleString()
+                    : d.last_sync_attempt
+                      ? new Date(d.last_sync_attempt).toLocaleString()
                       : '—'}
                 </span>
               </div>
+              {(d.sync_error || d.policy_sync_error) && (
+                <div className="mt-3 space-y-2">
+                  {d.sync_error && (
+                    <p className="rounded border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900/60 dark:bg-red-900/20 dark:text-red-200">
+                      {d.sync_error}
+                    </p>
+                  )}
+                  {d.policy_sync_error && (
+                    <p className="rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-200">
+                      {d.policy_sync_error}
+                    </p>
+                  )}
+                </div>
+              )}
+              {d.sync_steps?.some((step) => step.status.toLowerCase() === 'failed') && (
+                <div className="mt-3 space-y-1 text-xs">
+                  <p className="font-medium text-neutral-700 dark:text-neutral-300">
+                    Failed sync steps
+                  </p>
+                  {d.sync_steps
+                    .filter((step) => step.status.toLowerCase() === 'failed')
+                    .map((step) => (
+                      <p
+                        key={`${d.id}:${step.name}`}
+                        className="rounded bg-neutral-50 p-2 font-mono text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+                      >
+                        {step.name}: {step.detail || step.status}
+                      </p>
+                    ))}
+                </div>
+              )}
             </div>
           ))}
         </div>
@@ -545,20 +580,18 @@ function DeploymentsTab({ api }: { api: API }) {
   );
 }
 
-function PromotionsTab({ api, tenantId }: { api: API; tenantId: string }) {
-  const { data, isLoading } = useQuery({
-    queryKey: ['promotions', tenantId],
-    queryFn: () => apiService.listPromotions(tenantId, { page: 1, page_size: 20 }),
-    enabled: !!tenantId,
-  });
-
-  if (isLoading) {
+function PromotionsTab({
+  lifecycle,
+  loading,
+}: {
+  lifecycle: ApiLifecycleState | undefined;
+  loading: boolean;
+}) {
+  if (loading) {
     return <CardSkeleton className="h-32" />;
   }
 
-  const promotions = (data?.items || []).filter(
-    (p: { api_id?: string }) => p.api_id === api.id || p.api_id === api.name
-  );
+  const promotions = lifecycle?.promotions || [];
 
   if (promotions.length === 0) {
     return (
@@ -566,7 +599,7 @@ function PromotionsTab({ api, tenantId }: { api: API; tenantId: string }) {
         <ArrowUpRight className="h-12 w-12 mx-auto mb-4 text-neutral-300 dark:text-neutral-600" />
         <p className="text-sm">No promotions yet for this API.</p>
         <p className="text-xs mt-1">
-          Use the Promotions page to promote this API between environments.
+          Use the lifecycle panel to promote this API between environments.
         </p>
       </div>
     );
@@ -582,34 +615,39 @@ function PromotionsTab({ api, tenantId }: { api: API; tenantId: string }) {
 
   return (
     <div className="space-y-2">
-      {promotions.map(
-        (p: {
-          id: string;
-          source_environment: string;
-          target_environment: string;
-          status: string;
-          created_at: string;
-          requested_by?: string;
-        }) => (
-          <div
-            key={p.id}
-            className="flex items-center justify-between p-3 rounded-lg border border-neutral-100 dark:border-neutral-800"
-          >
-            <div className="flex items-center gap-3">
-              <span className="text-xs font-mono text-neutral-600 dark:text-neutral-400">
-                {p.source_environment} → {p.target_environment}
-              </span>
-              <span className={`text-xs px-2 py-0.5 rounded ${statusBadge[p.status] || ''}`}>
-                {p.status}
-              </span>
+      {promotions.map((p) => (
+        <div
+          key={p.id}
+          className="p-3 rounded-lg border border-neutral-100 dark:border-neutral-800"
+        >
+          <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+            <div className="min-w-0">
+              <div className="flex items-center gap-3">
+                <span className="text-xs font-mono text-neutral-600 dark:text-neutral-400">
+                  {p.source_environment} → {p.target_environment}
+                </span>
+                <span className={`text-xs px-2 py-0.5 rounded ${statusBadge[p.status] || ''}`}>
+                  {p.status}
+                </span>
+              </div>
+              <p className="mt-1 text-sm text-neutral-700 dark:text-neutral-300">{p.message}</p>
+              <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-neutral-500 dark:text-neutral-400">
+                {p.source_deployment_id && <span>source {p.source_deployment_id}</span>}
+                {p.target_deployment_id && <span>target {p.target_deployment_id}</span>}
+                {p.target_gateway_ids && p.target_gateway_ids.length > 0 && (
+                  <span>target gateways {p.target_gateway_ids.join(', ')}</span>
+                )}
+              </div>
             </div>
-            <div className="flex items-center gap-3 text-xs text-neutral-400 dark:text-neutral-500">
+            <div className="text-xs text-neutral-400 dark:text-neutral-500">
               {p.requested_by && <span>{p.requested_by}</span>}
-              <span>{new Date(p.created_at).toLocaleString()}</span>
+              {p.completed_at && (
+                <span> · completed {new Date(p.completed_at).toLocaleString()}</span>
+              )}
             </div>
           </div>
-        )
-      )}
+        </div>
+      ))}
     </div>
   );
 }

--- a/control-plane-ui/src/pages/APIs.test.tsx
+++ b/control-plane-ui/src/pages/APIs.test.tsx
@@ -52,6 +52,30 @@ vi.mock('../services/api', () => ({
         status: 'published',
         deployed_dev: true,
         deployed_staging: false,
+        runtime_deployments: [
+          {
+            environment: 'dev',
+            status: 'synced',
+            gateway_count: 1,
+            synced_count: 1,
+            error_count: 0,
+            pending_count: 0,
+            drifted_count: 0,
+            latest_error: null,
+            gateway_names: ['stoa-dev'],
+          },
+          {
+            environment: 'staging',
+            status: 'error',
+            gateway_count: 1,
+            synced_count: 0,
+            error_count: 1,
+            pending_count: 0,
+            drifted_count: 0,
+            latest_error: 'activation failed',
+            gateway_names: ['webmethods-staging'],
+          },
+        ],
         tags: ['payments'],
         created_at: '2024-01-01T00:00:00Z',
         updated_at: '2024-01-15T00:00:00Z',
@@ -84,6 +108,30 @@ vi.mock('../services/api', () => ({
         status: 'published',
         deployed_dev: true,
         deployed_staging: false,
+        runtime_deployments: [
+          {
+            environment: 'dev',
+            status: 'synced',
+            gateway_count: 1,
+            synced_count: 1,
+            error_count: 0,
+            pending_count: 0,
+            drifted_count: 0,
+            latest_error: null,
+            gateway_names: ['stoa-dev'],
+          },
+          {
+            environment: 'staging',
+            status: 'error',
+            gateway_count: 1,
+            synced_count: 0,
+            error_count: 1,
+            pending_count: 0,
+            drifted_count: 0,
+            latest_error: 'activation failed',
+            gateway_names: ['webmethods-staging'],
+          },
+        ],
         tags: ['payments'],
       },
       {
@@ -239,6 +287,13 @@ describe('APIs', () => {
     renderAPIs();
     expect(await screen.findByText('published')).toBeInTheDocument();
     expect(screen.getByText('draft')).toBeInTheDocument();
+  });
+
+  it('renders runtime deployment statuses from GatewayDeployment summaries', async () => {
+    renderAPIs();
+    expect(await screen.findByText('DEV synced')).toBeInTheDocument();
+    expect(screen.getByText('STAGING error')).toBeInTheDocument();
+    expect(screen.getByTitle(/activation failed/)).toBeInTheDocument();
   });
 
   it('renders API backend URLs', async () => {

--- a/control-plane-ui/src/pages/APIs.tsx
+++ b/control-plane-ui/src/pages/APIs.tsx
@@ -31,8 +31,73 @@ const statusColors: Record<string, string> = {
 const ALL_TENANTS = '__all__';
 const LEGACY_PORTAL_TAGS = new Set(['portal:published', 'promoted:portal', 'portal-promoted']);
 
+const runtimeStatusColors: Record<string, string> = {
+  synced: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+  syncing: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  drifted: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300',
+  error: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+  none: 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400',
+};
+
 function sanitizedApiTags(tags: string[] | undefined): string[] {
   return (tags || []).filter((tag) => !LEGACY_PORTAL_TAGS.has(tag));
+}
+
+function RuntimeDeploymentBadges({ api }: { api: API }) {
+  const summaries =
+    api.runtime_deployments && api.runtime_deployments.length > 0
+      ? api.runtime_deployments
+      : [
+          {
+            environment: 'dev',
+            status: api.deployed_dev ? 'synced' : 'none',
+            gateway_count: api.deployed_dev ? 1 : 0,
+            synced_count: api.deployed_dev ? 1 : 0,
+            error_count: 0,
+            pending_count: 0,
+            drifted_count: 0,
+            latest_error: null,
+            gateway_names: [],
+          },
+          {
+            environment: 'staging',
+            status: api.deployed_staging ? 'synced' : 'none',
+            gateway_count: api.deployed_staging ? 1 : 0,
+            synced_count: api.deployed_staging ? 1 : 0,
+            error_count: 0,
+            pending_count: 0,
+            drifted_count: 0,
+            latest_error: null,
+            gateway_names: [],
+          },
+        ];
+
+  return (
+    <div className="flex flex-wrap gap-1.5" data-testid="api-runtime-deployments">
+      {summaries.map((summary) => {
+        const title = [
+          `${summary.environment}: ${summary.status}`,
+          summary.gateway_count ? `${summary.gateway_count} gateway target(s)` : null,
+          summary.gateway_names?.length ? summary.gateway_names.join(', ') : null,
+          summary.latest_error ? `Error: ${summary.latest_error}` : null,
+        ]
+          .filter(Boolean)
+          .join(' · ');
+        return (
+          <span
+            key={`${summary.environment}:${summary.status}:${summary.gateway_names?.join(',') || ''}`}
+            title={title}
+            className={`px-2 py-1 rounded text-xs font-medium ${
+              runtimeStatusColors[summary.status] || runtimeStatusColors.none
+            }`}
+          >
+            {summary.environment.toUpperCase()} {summary.status}
+          </span>
+        );
+      })}
+    </div>
+  );
 }
 
 function parseSpecDocument(content: string): Record<string, unknown> {
@@ -439,16 +504,7 @@ export function APIs() {
                       Portal
                     </span>
                   )}
-                  <span
-                    className={`px-2 py-1 rounded text-xs ${api.deployed_dev ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}
-                  >
-                    DEV
-                  </span>
-                  <span
-                    className={`px-2 py-1 rounded text-xs ${api.deployed_staging ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}
-                  >
-                    STG
-                  </span>
+                  <RuntimeDeploymentBadges api={api} />
                 </div>
 
                 <div className="flex flex-wrap gap-3 pt-1">
@@ -559,18 +615,7 @@ export function APIs() {
                       )}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm">
-                      <div className="flex gap-2">
-                        <span
-                          className={`px-2 py-1 rounded text-xs ${api.deployed_dev ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}
-                        >
-                          DEV
-                        </span>
-                        <span
-                          className={`px-2 py-1 rounded text-xs ${api.deployed_staging ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}
-                        >
-                          STG
-                        </span>
-                      </div>
+                      <RuntimeDeploymentBadges api={api} />
                     </td>
                     <td
                       className="px-6 py-4 whitespace-nowrap text-sm"

--- a/control-plane-ui/src/pages/ApiLifecyclePanel.test.tsx
+++ b/control-plane-ui/src/pages/ApiLifecyclePanel.test.tsx
@@ -73,6 +73,24 @@ describe('ApiLifecyclePanel', () => {
     expect(screen.getByTestId('api-lifecycle-catalog-status')).toHaveTextContent('draft');
   });
 
+  it('highlights Git authoritative spec state without rendering raw booleans', async () => {
+    vi.mocked(apiService.getApiLifecycleState).mockResolvedValue({
+      ...baseLifecycleState,
+      spec: {
+        source: 'git',
+        has_openapi_spec: true,
+        git_path: 'tenants/tenant-1/apis/payments-api/openapi.yaml',
+        git_commit_sha: 'abc123',
+      },
+    });
+
+    renderPanel();
+
+    expect(await screen.findByText('Git authoritative')).toBeInTheDocument();
+    expect(screen.getByText('OpenAPI present')).toBeInTheDocument();
+    expect(screen.queryByTestId('api-lifecycle-spec-present')).not.toBeInTheDocument();
+  });
+
   it('validates a draft and refreshes state', async () => {
     const readyState = { ...baseLifecycleState, catalog_status: 'ready', lifecycle_phase: 'ready' };
     vi.mocked(apiService.validateLifecycleDraft).mockResolvedValue({

--- a/control-plane-ui/src/pages/ApiLifecyclePanel.tsx
+++ b/control-plane-ui/src/pages/ApiLifecyclePanel.tsx
@@ -438,13 +438,12 @@ export function ApiLifecyclePanel({
 function LifecycleSummary({ lifecycle }: { lifecycle: ApiLifecycleState }) {
   return (
     <div className="space-y-4">
-      <dl className="grid grid-cols-2 gap-4 md:grid-cols-5">
+      <dl className="grid grid-cols-2 gap-4 md:grid-cols-4">
         <CompactStatus label="Catalog status" value={lifecycle.catalog_status} />
         <CompactStatus label="Lifecycle phase" value={lifecycle.lifecycle_phase} />
         <CompactStatus label="Portal" value={lifecycle.portal.status} />
-        <CompactStatus label="Spec source" value={lifecycle.spec.source} />
-        <CompactStatus label="Spec present" value={lifecycle.spec.has_openapi_spec} />
       </dl>
+      <SpecStateSummary lifecycle={lifecycle} />
 
       {lifecycle.last_error && (
         <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-900/20 dark:text-red-200">
@@ -465,7 +464,7 @@ function LifecycleSummary({ lifecycle }: { lifecycle: ApiLifecycleState }) {
           }))}
         />
         <SummaryList
-          title="Promotions"
+          title="Promotion summary"
           empty="No promotion"
           items={lifecycle.promotions.map((promotion) => ({
             id: promotion.id,
@@ -479,10 +478,58 @@ function LifecycleSummary({ lifecycle }: { lifecycle: ApiLifecycleState }) {
   );
 }
 
+function SpecStateSummary({ lifecycle }: { lifecycle: ApiLifecycleState }) {
+  const isGitAuthoritative = lifecycle.spec.source === 'git' && lifecycle.spec.has_openapi_spec;
+  const sourceClass = isGitAuthoritative
+    ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+    : lifecycle.spec.source === 'generated_fallback'
+      ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
+      : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300';
+  const sourceLabel = isGitAuthoritative
+    ? 'Git authoritative'
+    : lifecycle.spec.source === 'generated_fallback'
+      ? 'Generated fallback'
+      : lifecycle.spec.source;
+
+  return (
+    <div className="rounded border border-neutral-200 p-3 text-sm dark:border-neutral-700">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${sourceClass}`}>
+          {sourceLabel}
+        </span>
+        {lifecycle.spec.has_openapi_spec ? (
+          <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 ring-1 ring-green-200 dark:bg-green-900/20 dark:text-green-300 dark:ring-green-800">
+            <CheckCircle2 className="h-3 w-3" />
+            OpenAPI present
+          </span>
+        ) : (
+          <span className="rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700 ring-1 ring-red-200 dark:bg-red-900/20 dark:text-red-300 dark:ring-red-800">
+            OpenAPI missing
+          </span>
+        )}
+      </div>
+      <div className="mt-2 space-y-1 text-xs text-neutral-500 dark:text-neutral-400">
+        {lifecycle.spec.git_path && (
+          <p className="break-all font-mono">{lifecycle.spec.git_path}</p>
+        )}
+        {lifecycle.spec.git_commit_sha && (
+          <p className="break-all font-mono">{lifecycle.spec.git_commit_sha}</p>
+        )}
+        {lifecycle.spec.reference && (
+          <p className="break-all">reference: {lifecycle.spec.reference}</p>
+        )}
+        {lifecycle.spec.fallback_reason && (
+          <p className="text-red-700 dark:text-red-300">{lifecycle.spec.fallback_reason}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function DeploymentSummary({ deployments }: { deployments: ApiLifecycleGatewayDeployment[] }) {
   return (
     <div className="space-y-2">
-      <h3 className="text-sm font-semibold text-neutral-900 dark:text-white">Deployments</h3>
+      <h3 className="text-sm font-semibold text-neutral-900 dark:text-white">Deployment summary</h3>
       {deployments.length === 0 ? (
         <p className="rounded border border-dashed border-neutral-300 p-3 text-sm text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">
           No gateway deployment

--- a/control-plane-ui/src/services/api/apiLifecycle.ts
+++ b/control-plane-ui/src/services/api/apiLifecycle.ts
@@ -73,6 +73,9 @@ export interface ApiLifecyclePromotion {
   requested_by: string;
   approved_by?: string | null;
   completed_at?: string | null;
+  source_deployment_id?: string | null;
+  target_deployment_id?: string | null;
+  target_gateway_ids?: string[];
 }
 
 export interface ApiLifecyclePortalPublication {

--- a/control-plane-ui/src/types/index.ts
+++ b/control-plane-ui/src/types/index.ts
@@ -56,7 +56,21 @@ export type API = Schemas['APIResponse'] & {
   catalog_pr_number?: number | null;
   catalog_source_branch?: string | null;
   catalog_merge_commit_sha?: string | null;
+  runtime_deployments?: APIRuntimeDeploymentSummary[];
 };
+
+export interface APIRuntimeDeploymentSummary {
+  environment: string;
+  status: string;
+  gateway_count: number;
+  synced_count: number;
+  error_count: number;
+  pending_count: number;
+  drifted_count: number;
+  latest_error?: string | null;
+  last_sync_success?: string | null;
+  gateway_names?: string[];
+}
 
 export interface APIOpenAPISpec {
   spec: Record<string, unknown>;

--- a/shared/api-types/generated.ts
+++ b/shared/api-types/generated.ts
@@ -9504,6 +9504,8 @@ export interface components {
              * @default false
              */
             portal_promoted: boolean;
+            /** Runtime Deployments */
+            runtime_deployments?: components["schemas"]["APIRuntimeDeploymentSummary"][];
             /**
              * Status
              * @default draft
@@ -9520,6 +9522,44 @@ export interface components {
             updated_at?: string | null;
             /** Version */
             version: string;
+        };
+        /** APIRuntimeDeploymentSummary */
+        APIRuntimeDeploymentSummary: {
+            /**
+             * Drifted Count
+             * @default 0
+             */
+            drifted_count: number;
+            /** Environment */
+            environment: string;
+            /**
+             * Error Count
+             * @default 0
+             */
+            error_count: number;
+            /**
+             * Gateway Count
+             * @default 0
+             */
+            gateway_count: number;
+            /** Gateway Names */
+            gateway_names?: string[];
+            /** Last Sync Success */
+            last_sync_success?: string | null;
+            /** Latest Error */
+            latest_error?: string | null;
+            /**
+             * Pending Count
+             * @default 0
+             */
+            pending_count: number;
+            /** Status */
+            status: string;
+            /**
+             * Synced Count
+             * @default 0
+             */
+            synced_count: number;
         };
         /** APIUpdate */
         APIUpdate: {
@@ -9718,6 +9758,8 @@ export interface components {
             id: string;
             /** Name */
             name: string;
+            /** Runtime Deployments */
+            runtime_deployments?: components["schemas"]["AdminAPIRuntimeDeploymentSummary"][];
             /**
              * Status
              * @default draft
@@ -9732,6 +9774,44 @@ export interface components {
             tenant_id: string;
             /** Version */
             version: string;
+        };
+        /** AdminAPIRuntimeDeploymentSummary */
+        AdminAPIRuntimeDeploymentSummary: {
+            /**
+             * Drifted Count
+             * @default 0
+             */
+            drifted_count: number;
+            /** Environment */
+            environment: string;
+            /**
+             * Error Count
+             * @default 0
+             */
+            error_count: number;
+            /**
+             * Gateway Count
+             * @default 0
+             */
+            gateway_count: number;
+            /** Gateway Names */
+            gateway_names?: string[];
+            /** Last Sync Success */
+            last_sync_success?: string | null;
+            /** Latest Error */
+            latest_error?: string | null;
+            /**
+             * Pending Count
+             * @default 0
+             */
+            pending_count: number;
+            /** Status */
+            status: string;
+            /**
+             * Synced Count
+             * @default 0
+             */
+            synced_count: number;
         };
         /**
          * AdminApplicationResponse


### PR DESCRIPTION
## Summary

- add runtime GatewayDeployment summaries to tenant/admin API list responses
- render deployment status chips on `/apis` from runtime state instead of legacy booleans
- render API detail deployments/promotions from lifecycle state and highlight Git-authoritative specs without showing raw booleans

## Validation

- `control-plane-api`: targeted Ruff check/format passed
- `control-plane-api`: `pytest tests/test_apis_router.py tests/test_api_lifecycle_router.py -q` => 29 passed
- `control-plane-ui`: `npm run lint` => 0 errors, 51 existing warnings
- `control-plane-ui`: `npm run build` => OK
- `control-plane-ui`: targeted Vitest for API lifecycle pages => 74 passed
- `git diff --check HEAD~1..HEAD` => OK

## Scope

- excludes infra, k8s, charts, deploy, generated shared types, and local memory notes
