### PR TITLE
feat(api): add gateway overview read model

### DIFF
--- a/control-plane-api/src/routers/gateway_instances.py
+++ b/control-plane-api/src/routers/gateway_instances.py
@@ -20,8 +20,10 @@ from src.schemas.gateway import (
     PaginatedGatewayInstances,
 )
 from src.schemas.gateway_import import ImportPreviewResponse, ImportResultResponse
+from src.schemas.gateway_overview import GatewayOverviewResponse
 from src.services.gateway_import_service import GatewayImportService
 from src.services.gateway_instance_service import GatewayInstanceService
+from src.services.gateway_overview_service import GatewayOverviewService
 
 logger = logging.getLogger(__name__)
 
@@ -155,6 +157,17 @@ async def get_gateway(
     if not instance:
         raise HTTPException(status_code=404, detail="Gateway instance not found")
     return instance
+
+
+@router.get("/{gateway_id}/overview", response_model=GatewayOverviewResponse)
+async def get_gateway_overview(
+    gateway_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(require_role(["cpi-admin", "tenant-admin"])),
+):
+    """Get the read-only Control Plane overview for a gateway detail page."""
+    svc = GatewayOverviewService(db)
+    return await svc.get_overview(gateway_id, user)
 
 
 @router.get("/{gateway_id}/tools")

--- a/control-plane-api/src/schemas/gateway_overview.py
+++ b/control-plane-api/src/schemas/gateway_overview.py
@@ -1,0 +1,227 @@
+"""Schemas for the Gateway Detail overview read-model."""
+
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class GatewayOverviewSyncStatus(StrEnum):
+    """Gateway overview sync status."""
+
+    IN_SYNC = "in_sync"
+    PENDING = "pending"
+    DRIFT = "drift"
+    FAILED = "failed"
+    UNKNOWN = "unknown"
+
+
+class GatewayOverviewRuntimeStatus(StrEnum):
+    """Gateway overview runtime status."""
+
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    STALE = "stale"
+    OFFLINE = "offline"
+    UNKNOWN = "unknown"
+
+
+class GatewayOverviewMetricsStatus(StrEnum):
+    """Gateway overview metrics status."""
+
+    AVAILABLE = "available"
+    PARTIAL = "partial"
+    UNAVAILABLE = "unavailable"
+
+
+class GatewayOverviewDataQualitySeverity(StrEnum):
+    """Data-quality warning severity."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+class GatewayOverviewRuntimeFreshness(StrEnum):
+    """Freshness of runtime data."""
+
+    FRESH = "fresh"
+    STALE = "stale"
+    MISSING = "missing"
+
+
+class GatewayOverviewWarning(BaseModel):
+    """Stable data-quality warning returned by the overview endpoint."""
+
+    code: str
+    severity: GatewayOverviewDataQualitySeverity
+    message: str
+
+
+class GatewayOverviewGateway(BaseModel):
+    """Basic gateway identity for the overview page."""
+
+    id: UUID
+    name: str
+    display_name: str
+    gateway_type: str
+    environment: str
+    status: str
+    mode: str | None = None
+    version: str | None = None
+
+
+class GatewayOverviewVisibility(BaseModel):
+    """RBAC visibility metadata for the response."""
+
+    rbac_scope: str
+    tenant_id: str | None = None
+    filtered: bool
+
+
+class GatewayOverviewSource(BaseModel):
+    """Top-level source metadata for the overview read-model."""
+
+    control_plane_revision: str | None = None
+    last_loaded_at: datetime | None = None
+
+
+class GatewayOverviewApiSource(BaseModel):
+    """Per-API source metadata."""
+
+    git_path: str | None = None
+    git_commit_sha: str | None = None
+    spec_hash: str | None = None
+
+
+class GatewayOverviewRoutePreview(BaseModel):
+    """Compact route preview row for the UI."""
+
+    method: str
+    path: str
+    backend: str | None = None
+
+
+class GatewayOverviewApi(BaseModel):
+    """API deployment as interpreted for the Gateway Detail page."""
+
+    tenant_id: str
+    api_id: str
+    api_catalog_id: UUID
+    name: str
+    version: str
+    source: GatewayOverviewApiSource
+    routes_count: int
+    routes_preview: list[GatewayOverviewRoutePreview] = Field(default_factory=list)
+    backend: str | None = None
+    policies_count: int
+    sync_status: GatewayOverviewSyncStatus
+    last_sync_at: datetime | None = None
+    last_error: str | None = None
+
+
+class GatewayOverviewPolicyTarget(BaseModel):
+    """Effective policy target."""
+
+    type: str
+    id: str | None = None
+    name: str | None = None
+
+
+class GatewayOverviewPolicyBindingSource(BaseModel):
+    """Source binding used to resolve an effective policy."""
+
+    id: UUID
+    scope: str
+    target_id: str | None = None
+
+
+class GatewayOverviewPolicy(BaseModel):
+    """Effective enabled policy visible on a gateway."""
+
+    id: UUID
+    name: str
+    type: str
+    scope: str
+    target: GatewayOverviewPolicyTarget
+    enabled: bool
+    priority: int
+    summary: str
+    sync_status: GatewayOverviewSyncStatus
+    source_binding: GatewayOverviewPolicyBindingSource
+
+
+class GatewayOverviewResolvedConfig(BaseModel):
+    """Expected Control Plane configuration, without runtime data."""
+
+    apis: list[GatewayOverviewApi] = Field(default_factory=list)
+    policies: list[GatewayOverviewPolicy] = Field(default_factory=list)
+
+
+class GatewayOverviewSync(BaseModel):
+    """Gateway reconciliation state, without runtime metrics."""
+
+    desired_generation: int | None = None
+    applied_generation: int | None = None
+    status: GatewayOverviewSyncStatus
+    drift: bool
+    last_reconciled_at: datetime | None = None
+    last_error: str | None = None
+    steps: list[dict] = Field(default_factory=list)
+
+
+class GatewayOverviewRuntime(BaseModel):
+    """Observed dataplane runtime state."""
+
+    status: GatewayOverviewRuntimeStatus
+    last_heartbeat_at: datetime | None = None
+    heartbeat_age_seconds: int | None = None
+    version: str | None = None
+    mode: str | None = None
+    uptime_seconds: int | None = None
+    reported_routes_count: int | None = None
+    reported_policies_count: int | None = None
+    mcp_tools_count: int | None = None
+    requests_total: int | None = None
+    error_rate: float | None = None
+    memory_usage_bytes: int | None = None
+
+
+class GatewayOverviewDataQuality(BaseModel):
+    """Freshness and partial-data metadata."""
+
+    runtime_freshness: GatewayOverviewRuntimeFreshness
+    heartbeat_stale_after_seconds: int
+    metrics_status: GatewayOverviewMetricsStatus
+    metrics_window_seconds: int | None = None
+    warnings: list[GatewayOverviewWarning] = Field(default_factory=list)
+
+
+class GatewayOverviewSummary(BaseModel):
+    """Top-level values used by Gateway Detail summary cards."""
+
+    sync_status: GatewayOverviewSyncStatus
+    runtime_status: GatewayOverviewRuntimeStatus
+    metrics_status: GatewayOverviewMetricsStatus
+    apis_count: int
+    expected_routes_count: int
+    reported_routes_count: int | None = None
+    effective_policies_count: int
+    reported_policies_count: int | None = None
+    failed_policies_count: int
+
+
+class GatewayOverviewResponse(BaseModel):
+    """Gateway Detail overview read-model."""
+
+    schema_version: str = "1.0"
+    generated_at: datetime
+    gateway: GatewayOverviewGateway
+    visibility: GatewayOverviewVisibility
+    source: GatewayOverviewSource
+    summary: GatewayOverviewSummary
+    resolved_config: GatewayOverviewResolvedConfig
+    sync: GatewayOverviewSync
+    runtime: GatewayOverviewRuntime
+    data_quality: GatewayOverviewDataQuality

--- a/control-plane-api/src/services/gateway_overview_service.py
+++ b/control-plane-api/src/services/gateway_overview_service.py
@@ -1,0 +1,785 @@
+"""Gateway Detail overview read-model service."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config import settings
+from src.models.catalog import APICatalog
+from src.models.gateway_deployment import DeploymentSyncStatus, GatewayDeployment, PolicySyncStatus
+from src.models.gateway_instance import GatewayInstance
+from src.models.gateway_policy import GatewayPolicy, GatewayPolicyBinding
+from src.repositories.gateway_instance import GatewayInstanceRepository
+from src.schemas.gateway_overview import (
+    GatewayOverviewApi,
+    GatewayOverviewApiSource,
+    GatewayOverviewDataQuality,
+    GatewayOverviewDataQualitySeverity,
+    GatewayOverviewGateway,
+    GatewayOverviewMetricsStatus,
+    GatewayOverviewPolicy,
+    GatewayOverviewPolicyBindingSource,
+    GatewayOverviewPolicyTarget,
+    GatewayOverviewResolvedConfig,
+    GatewayOverviewResponse,
+    GatewayOverviewRoutePreview,
+    GatewayOverviewRuntime,
+    GatewayOverviewRuntimeFreshness,
+    GatewayOverviewRuntimeStatus,
+    GatewayOverviewSource,
+    GatewayOverviewSummary,
+    GatewayOverviewSync,
+    GatewayOverviewSyncStatus,
+    GatewayOverviewVisibility,
+    GatewayOverviewWarning,
+)
+
+SENSITIVE_KEY_PARTS = (
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "api-key",
+    "apikey",
+    "token",
+    "secret",
+    "password",
+    "credential",
+    "private_key",
+    "client_secret",
+    "bearer",
+    "jwt",
+)
+
+HTTP_METHODS = {"get", "post", "put", "patch", "delete", "head", "options", "trace"}
+
+
+class GatewayOverviewService:
+    """Builds a safe Control Plane overview for a gateway."""
+
+    def __init__(
+        self,
+        db: AsyncSession,
+        now_fn: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.db = db
+        self.now_fn = now_fn or (lambda: datetime.now(UTC))
+
+    async def get_overview(self, gateway_id: UUID, user: Any) -> GatewayOverviewResponse:
+        """Return an interpreted Gateway Detail overview."""
+        now = _ensure_aware(self.now_fn())
+        gateway = await self._load_gateway(gateway_id)
+        if gateway is None:
+            raise HTTPException(status_code=404, detail="Gateway instance not found")
+
+        tenant_filter = self._tenant_filter(user)
+        if not self._can_view_gateway(gateway, tenant_filter):
+            raise HTTPException(status_code=403, detail="Access denied to this gateway")
+
+        api_rows = await self._load_api_rows(gateway.id, tenant_filter)
+        deployments = [row[0] for row in api_rows]
+        catalog_by_id = {row[1].id: row[1] for row in api_rows}
+        tenant_ids = {row[1].tenant_id for row in api_rows if row[1].tenant_id}
+        if tenant_filter:
+            tenant_ids = {tenant_filter}
+        elif getattr(gateway, "tenant_id", None):
+            tenant_ids.add(gateway.tenant_id)
+
+        policy_rows = await self._load_policy_rows(
+            gateway_id=gateway.id,
+            catalog_ids=list(catalog_by_id),
+            tenant_ids=list(tenant_ids),
+            tenant_filter=tenant_filter,
+        )
+
+        deployment_by_api = {dep.api_catalog_id: dep for dep in deployments}
+        policy_context = self._build_policy_context(policy_rows, gateway, catalog_by_id, deployment_by_api)
+        apis = [
+            self._build_api_overview(dep, catalog, policy_context.api_policy_counts.get(catalog.id, 0))
+            for dep, catalog in api_rows
+        ]
+        policies = [
+            self._build_policy_overview(policy, binding, gateway, catalog_by_id, policy_context.policy_statuses)
+            for policy, binding in policy_context.effective_rows
+        ]
+
+        sync = self._build_sync(deployments)
+        runtime, data_quality = self._build_runtime(gateway, now)
+        summary = GatewayOverviewSummary(
+            sync_status=sync.status,
+            runtime_status=runtime.status,
+            metrics_status=data_quality.metrics_status,
+            apis_count=len(apis),
+            expected_routes_count=sum(api.routes_count for api in apis),
+            reported_routes_count=runtime.reported_routes_count,
+            effective_policies_count=len(policies),
+            reported_policies_count=runtime.reported_policies_count,
+            failed_policies_count=sum(1 for policy in policies if policy.sync_status == GatewayOverviewSyncStatus.FAILED),
+        )
+
+        return GatewayOverviewResponse(
+            generated_at=now,
+            gateway=GatewayOverviewGateway(
+                id=gateway.id,
+                name=gateway.name,
+                display_name=gateway.display_name,
+                gateway_type=_enum_value(gateway.gateway_type),
+                environment=gateway.environment,
+                status=_enum_value(gateway.status),
+                mode=gateway.mode,
+                version=gateway.version,
+            ),
+            visibility=GatewayOverviewVisibility(
+                rbac_scope="tenant" if tenant_filter else "admin",
+                tenant_id=tenant_filter,
+                filtered=tenant_filter is not None,
+            ),
+            source=self._build_source(api_rows),
+            summary=summary,
+            resolved_config=GatewayOverviewResolvedConfig(apis=apis, policies=policies),
+            sync=sync,
+            runtime=runtime,
+            data_quality=data_quality,
+        )
+
+    async def _load_gateway(self, gateway_id: UUID) -> GatewayInstance | None:
+        repo = GatewayInstanceRepository(self.db)
+        return await repo.get_by_id(gateway_id)
+
+    async def _load_api_rows(
+        self,
+        gateway_id: UUID,
+        tenant_filter: str | None,
+    ) -> list[tuple[GatewayDeployment, APICatalog]]:
+        query = (
+            select(GatewayDeployment, APICatalog)
+            .join(APICatalog, GatewayDeployment.api_catalog_id == APICatalog.id)
+            .where(
+                GatewayDeployment.gateway_instance_id == gateway_id,
+                APICatalog.deleted_at.is_(None),
+            )
+            .order_by(APICatalog.tenant_id, APICatalog.api_name, APICatalog.version)
+        )
+        if tenant_filter:
+            query = query.where(APICatalog.tenant_id == tenant_filter)
+        result = await self.db.execute(query)
+        return [(row[0], row[1]) for row in result.all()]
+
+    async def _load_policy_rows(
+        self,
+        gateway_id: UUID,
+        catalog_ids: list[UUID],
+        tenant_ids: list[str],
+        tenant_filter: str | None,
+    ) -> list[tuple[GatewayPolicy, GatewayPolicyBinding]]:
+        conditions = [
+            and_(
+                GatewayPolicyBinding.gateway_instance_id == gateway_id,
+                GatewayPolicyBinding.api_catalog_id.is_(None),
+            )
+        ]
+        if catalog_ids:
+            conditions.append(GatewayPolicyBinding.api_catalog_id.in_(catalog_ids))
+        if tenant_ids:
+            conditions.append(
+                and_(
+                    GatewayPolicyBinding.tenant_id.in_(tenant_ids),
+                    GatewayPolicyBinding.api_catalog_id.is_(None),
+                    GatewayPolicyBinding.gateway_instance_id.is_(None),
+                )
+            )
+
+        query = (
+            select(GatewayPolicy, GatewayPolicyBinding)
+            .join(GatewayPolicyBinding, GatewayPolicy.id == GatewayPolicyBinding.policy_id)
+            .where(
+                GatewayPolicy.enabled.is_(True),
+                GatewayPolicyBinding.enabled.is_(True),
+                or_(*conditions),
+            )
+            .order_by(GatewayPolicy.priority, GatewayPolicy.name, GatewayPolicyBinding.created_at)
+        )
+        if tenant_filter:
+            query = query.where(or_(GatewayPolicy.tenant_id == tenant_filter, GatewayPolicy.tenant_id.is_(None)))
+
+        result = await self.db.execute(query)
+        return [(row[0], row[1]) for row in result.all()]
+
+    def _tenant_filter(self, user: Any) -> str | None:
+        roles = getattr(user, "roles", []) or []
+        if "cpi-admin" in roles:
+            return None
+        tenant_id = getattr(user, "tenant_id", None)
+        if not tenant_id:
+            raise HTTPException(status_code=403, detail="Tenant-scoped user has no tenant")
+        return tenant_id
+
+    def _can_view_gateway(self, gateway: GatewayInstance, tenant_filter: str | None) -> bool:
+        if tenant_filter is None:
+            return True
+
+        gateway_tenant = getattr(gateway, "tenant_id", None)
+        if gateway_tenant and gateway_tenant != tenant_filter:
+            return False
+
+        visibility = getattr(gateway, "visibility", None)
+        if visibility is None:
+            return True
+        if not isinstance(visibility, dict):
+            return False
+        tenant_ids = visibility.get("tenant_ids") or []
+        return tenant_filter in tenant_ids
+
+    def _build_source(self, api_rows: list[tuple[GatewayDeployment, APICatalog]]) -> GatewayOverviewSource:
+        commits = {catalog.git_commit_sha for _, catalog in api_rows if catalog.git_commit_sha}
+        loaded = [_coerce_datetime(getattr(catalog, "synced_at", None)) for _, catalog in api_rows]
+        loaded = [dt for dt in loaded if dt is not None]
+        return GatewayOverviewSource(
+            control_plane_revision=next(iter(commits)) if len(commits) == 1 else None,
+            last_loaded_at=max(loaded) if loaded else None,
+        )
+
+    def _build_api_overview(
+        self,
+        deployment: GatewayDeployment,
+        catalog: APICatalog,
+        policies_count: int,
+    ) -> GatewayOverviewApi:
+        desired_state = deployment.desired_state or {}
+        backend = _safe_url(
+            desired_state.get("backend_url")
+            or _dict_get(catalog.api_metadata, "backend_url")
+            or _dict_get(catalog.api_metadata, "url")
+        )
+        routes_count, routes_preview = self._route_preview(deployment, catalog, backend)
+        return GatewayOverviewApi(
+            tenant_id=catalog.tenant_id,
+            api_id=catalog.api_id,
+            api_catalog_id=catalog.id,
+            name=catalog.api_name,
+            version=catalog.version,
+            source=GatewayOverviewApiSource(
+                git_path=catalog.git_path,
+                git_commit_sha=catalog.git_commit_sha,
+                spec_hash=desired_state.get("spec_hash"),
+            ),
+            routes_count=routes_count,
+            routes_preview=routes_preview,
+            backend=backend,
+            policies_count=policies_count,
+            sync_status=self._deployment_sync_status(deployment),
+            last_sync_at=_coerce_datetime(deployment.last_sync_success),
+            last_error=deployment.sync_error or deployment.policy_sync_error,
+        )
+
+    def _route_preview(
+        self,
+        deployment: GatewayDeployment,
+        catalog: APICatalog,
+        backend: str | None,
+    ) -> tuple[int, list[GatewayOverviewRoutePreview]]:
+        desired_state = deployment.desired_state or {}
+        spec = desired_state.get("openapi_spec") or catalog.openapi_spec or {}
+        routes: list[GatewayOverviewRoutePreview] = []
+        routes_count = 0
+
+        paths = spec.get("paths") if isinstance(spec, dict) else None
+        if isinstance(paths, dict):
+            for path, path_item in sorted(paths.items()):
+                if not isinstance(path_item, dict):
+                    continue
+                for method in sorted(path_item):
+                    if method.lower() not in HTTP_METHODS:
+                        continue
+                    routes_count += 1
+                    if len(routes) < 3:
+                        routes.append(
+                            GatewayOverviewRoutePreview(
+                                method=method.upper(),
+                                path=str(path),
+                                backend=backend,
+                            )
+                        )
+
+        if routes_count > 0:
+            return routes_count, routes
+
+        methods = desired_state.get("methods") if isinstance(desired_state.get("methods"), list) else ["ANY"]
+        api_name = desired_state.get("api_name") or catalog.api_name
+        route_path = desired_state.get("path") or desired_state.get("base_path") or f"/apis/{catalog.tenant_id}/{api_name}"
+        return 1, [
+            GatewayOverviewRoutePreview(
+                method=str(methods[0]).upper(),
+                path=str(route_path),
+                backend=backend,
+            )
+        ]
+
+    def _build_policy_context(
+        self,
+        policy_rows: list[tuple[GatewayPolicy, GatewayPolicyBinding]],
+        gateway: GatewayInstance,
+        catalog_by_id: dict[UUID, APICatalog],
+        deployment_by_api: dict[UUID, GatewayDeployment],
+    ) -> _PolicyContext:
+        # A policy may match through multiple bindings. Keep one effective row,
+        # preferring the most specific binding, then priority order from SQL.
+        by_policy: dict[UUID, tuple[GatewayPolicy, GatewayPolicyBinding]] = {}
+        for policy, binding in policy_rows:
+            if not bool(policy.enabled) or not bool(binding.enabled):
+                continue
+            existing = by_policy.get(policy.id)
+            if existing is None or _binding_specificity(binding) > _binding_specificity(existing[1]):
+                by_policy[policy.id] = (policy, binding)
+
+        effective_rows = sorted(
+            by_policy.values(),
+            key=lambda row: (row[0].priority, row[0].name),
+        )
+        api_policy_counts: dict[UUID, int] = defaultdict(int)
+        policy_statuses: dict[UUID, GatewayOverviewSyncStatus] = {}
+
+        for policy, binding in effective_rows:
+            binding_scope = _binding_scope(binding)
+            target_api_ids = _binding_api_ids(binding, catalog_by_id)
+            if binding_scope == "api" and binding.api_catalog_id:
+                api_policy_counts[binding.api_catalog_id] += 1
+            elif binding_scope == "gateway":
+                for api_id in catalog_by_id:
+                    api_policy_counts[api_id] += 1
+            elif binding_scope == "tenant":
+                for api_id, catalog in catalog_by_id.items():
+                    if catalog.tenant_id == binding.tenant_id:
+                        api_policy_counts[api_id] += 1
+
+            policy_statuses[policy.id] = self._aggregate_policy_sync_status(
+                [deployment_by_api[api_id] for api_id in target_api_ids if api_id in deployment_by_api]
+            )
+
+        return _PolicyContext(
+            effective_rows=effective_rows,
+            api_policy_counts=api_policy_counts,
+            policy_statuses=policy_statuses,
+        )
+
+    def _aggregate_policy_sync_status(
+        self,
+        deployments: list[GatewayDeployment],
+    ) -> GatewayOverviewSyncStatus:
+        if not deployments:
+            return GatewayOverviewSyncStatus.UNKNOWN
+        statuses = [self._deployment_sync_status(dep) for dep in deployments]
+        if GatewayOverviewSyncStatus.FAILED in statuses:
+            return GatewayOverviewSyncStatus.FAILED
+        if GatewayOverviewSyncStatus.DRIFT in statuses:
+            return GatewayOverviewSyncStatus.DRIFT
+        if GatewayOverviewSyncStatus.PENDING in statuses:
+            return GatewayOverviewSyncStatus.PENDING
+        if all(status == GatewayOverviewSyncStatus.IN_SYNC for status in statuses):
+            return GatewayOverviewSyncStatus.IN_SYNC
+        return GatewayOverviewSyncStatus.UNKNOWN
+
+    def _build_policy_overview(
+        self,
+        policy: GatewayPolicy,
+        binding: GatewayPolicyBinding,
+        gateway: GatewayInstance,
+        catalog_by_id: dict[UUID, APICatalog],
+        policy_statuses: dict[UUID, GatewayOverviewSyncStatus],
+    ) -> GatewayOverviewPolicy:
+        scope = _binding_scope(binding)
+        target = _policy_target(scope, binding, gateway, catalog_by_id)
+        return GatewayOverviewPolicy(
+            id=policy.id,
+            name=policy.name,
+            type=_enum_value(policy.policy_type),
+            scope=scope,
+            target=target,
+            enabled=bool(policy.enabled),
+            priority=policy.priority,
+            summary=_policy_summary(_enum_value(policy.policy_type), policy.config or {}),
+            sync_status=policy_statuses.get(policy.id, GatewayOverviewSyncStatus.UNKNOWN),
+            source_binding=GatewayOverviewPolicyBindingSource(
+                id=binding.id,
+                scope=scope,
+                target_id=target.id,
+            ),
+        )
+
+    def _build_sync(self, deployments: list[GatewayDeployment]) -> GatewayOverviewSync:
+        status = self._overall_sync_status(deployments)
+        desired_generations = [_int_or_none(getattr(dep, "desired_generation", None)) for dep in deployments]
+        applied_generations = [_int_or_none(getattr(dep, "synced_generation", None)) for dep in deployments]
+        desired_generations = [value for value in desired_generations if value is not None]
+        applied_generations = [value for value in applied_generations if value is not None]
+        reconciled_times = [
+            _coerce_datetime(dep.last_sync_success) or _coerce_datetime(dep.actual_at) or _coerce_datetime(dep.last_sync_attempt)
+            for dep in deployments
+        ]
+        reconciled_times = [dt for dt in reconciled_times if dt is not None]
+        steps = []
+        for dep in deployments:
+            for step in dep.sync_steps or []:
+                item = dict(step)
+                item.setdefault("deployment_id", str(dep.id))
+                item.setdefault("api_catalog_id", str(dep.api_catalog_id))
+                steps.append(item)
+
+        return GatewayOverviewSync(
+            desired_generation=max(desired_generations) if desired_generations else None,
+            applied_generation=min(applied_generations) if applied_generations else None,
+            status=status,
+            drift=status == GatewayOverviewSyncStatus.DRIFT,
+            last_reconciled_at=max(reconciled_times) if reconciled_times else None,
+            last_error=next((dep.sync_error or dep.policy_sync_error for dep in deployments if dep.sync_error or dep.policy_sync_error), None),
+            steps=steps,
+        )
+
+    def _overall_sync_status(self, deployments: list[GatewayDeployment]) -> GatewayOverviewSyncStatus:
+        if not deployments:
+            return GatewayOverviewSyncStatus.IN_SYNC
+        statuses = [self._deployment_sync_status(dep) for dep in deployments]
+        if GatewayOverviewSyncStatus.FAILED in statuses:
+            return GatewayOverviewSyncStatus.FAILED
+        if GatewayOverviewSyncStatus.DRIFT in statuses:
+            return GatewayOverviewSyncStatus.DRIFT
+        if GatewayOverviewSyncStatus.PENDING in statuses:
+            return GatewayOverviewSyncStatus.PENDING
+        if all(status == GatewayOverviewSyncStatus.IN_SYNC for status in statuses):
+            return GatewayOverviewSyncStatus.IN_SYNC
+        return GatewayOverviewSyncStatus.UNKNOWN
+
+    def _deployment_sync_status(self, deployment: GatewayDeployment) -> GatewayOverviewSyncStatus:
+        sync_status = _enum_value(deployment.sync_status)
+        policy_status = _enum_value(getattr(deployment, "policy_sync_status", None))
+        if sync_status == DeploymentSyncStatus.ERROR.value or policy_status in {
+            PolicySyncStatus.ERROR.value,
+            PolicySyncStatus.PARTIAL.value,
+        }:
+            return GatewayOverviewSyncStatus.FAILED
+        if sync_status == DeploymentSyncStatus.DRIFTED.value:
+            return GatewayOverviewSyncStatus.DRIFT
+        if sync_status in {
+            DeploymentSyncStatus.PENDING.value,
+            DeploymentSyncStatus.SYNCING.value,
+            DeploymentSyncStatus.DELETING.value,
+        }:
+            return GatewayOverviewSyncStatus.PENDING
+
+        desired_generation = _int_or_none(getattr(deployment, "desired_generation", None))
+        synced_generation = _int_or_none(getattr(deployment, "synced_generation", None))
+        if desired_generation is not None and synced_generation is not None and desired_generation != synced_generation:
+            return GatewayOverviewSyncStatus.PENDING
+        if sync_status == DeploymentSyncStatus.SYNCED.value:
+            return GatewayOverviewSyncStatus.IN_SYNC
+        return GatewayOverviewSyncStatus.UNKNOWN
+
+    def _build_runtime(
+        self,
+        gateway: GatewayInstance,
+        now: datetime,
+    ) -> tuple[GatewayOverviewRuntime, GatewayOverviewDataQuality]:
+        health_details = gateway.health_details if isinstance(gateway.health_details, dict) else {}
+        heartbeat_at = _coerce_datetime(health_details.get("last_heartbeat")) or _coerce_datetime(gateway.last_health_check)
+        heartbeat_age = int((now - heartbeat_at).total_seconds()) if heartbeat_at else None
+        stale_after = settings.GATEWAY_HEARTBEAT_TIMEOUT_SECONDS
+        freshness = GatewayOverviewRuntimeFreshness.MISSING
+        warnings: list[GatewayOverviewWarning] = []
+
+        if heartbeat_at is None:
+            runtime_status = GatewayOverviewRuntimeStatus.OFFLINE
+            warnings.append(
+                GatewayOverviewWarning(
+                    code="runtime_heartbeat_missing",
+                    severity=GatewayOverviewDataQualitySeverity.WARNING,
+                    message="No heartbeat has been reported by this gateway",
+                )
+            )
+        elif heartbeat_age is not None and heartbeat_age > stale_after:
+            freshness = GatewayOverviewRuntimeFreshness.STALE
+            runtime_status = GatewayOverviewRuntimeStatus.STALE
+            warnings.append(
+                GatewayOverviewWarning(
+                    code="runtime_heartbeat_stale",
+                    severity=GatewayOverviewDataQualitySeverity.WARNING,
+                    message="Gateway heartbeat data is stale",
+                )
+            )
+        else:
+            freshness = GatewayOverviewRuntimeFreshness.FRESH
+            runtime_status = _runtime_status_from_gateway(gateway.status)
+
+        runtime = GatewayOverviewRuntime(
+            status=runtime_status,
+            last_heartbeat_at=heartbeat_at,
+            heartbeat_age_seconds=heartbeat_age,
+            version=gateway.version,
+            mode=gateway.mode,
+            uptime_seconds=_int_or_none(health_details.get("uptime_seconds")),
+            reported_routes_count=_int_or_none(health_details.get("routes_count")),
+            reported_policies_count=_int_or_none(health_details.get("policies_count")),
+            mcp_tools_count=_int_or_none(
+                health_details.get("mcp_tools_count", health_details.get("discovered_apis_count"))
+            ),
+            requests_total=_int_or_none(health_details.get("requests_total")),
+            error_rate=_float_or_none(health_details.get("error_rate")),
+            memory_usage_bytes=_int_or_none(
+                health_details.get("memory_usage_bytes", health_details.get("memory_rss_bytes"))
+            ),
+        )
+
+        metrics_status = _metrics_status(runtime)
+        if metrics_status == GatewayOverviewMetricsStatus.UNAVAILABLE:
+            warnings.append(
+                GatewayOverviewWarning(
+                    code="runtime_metrics_unavailable",
+                    severity=GatewayOverviewDataQualitySeverity.WARNING,
+                    message="Runtime metrics are not available for this gateway",
+                )
+            )
+        elif metrics_status == GatewayOverviewMetricsStatus.PARTIAL:
+            warnings.append(
+                GatewayOverviewWarning(
+                    code="runtime_metrics_partial",
+                    severity=GatewayOverviewDataQualitySeverity.INFO,
+                    message="Some runtime metrics are not available for this gateway",
+                )
+            )
+
+        data_quality = GatewayOverviewDataQuality(
+            runtime_freshness=freshness,
+            heartbeat_stale_after_seconds=stale_after,
+            metrics_status=metrics_status,
+            metrics_window_seconds=_int_or_none(health_details.get("metrics_window_seconds")) or 300,
+            warnings=warnings,
+        )
+        return runtime, data_quality
+
+
+class _PolicyContext:
+    def __init__(
+        self,
+        effective_rows: list[tuple[GatewayPolicy, GatewayPolicyBinding]],
+        api_policy_counts: dict[UUID, int],
+        policy_statuses: dict[UUID, GatewayOverviewSyncStatus],
+    ) -> None:
+        self.effective_rows = effective_rows
+        self.api_policy_counts = api_policy_counts
+        self.policy_statuses = policy_statuses
+
+
+def _enum_value(value: Any) -> str:
+    if isinstance(value, Enum):
+        return str(value.value)
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _ensure_aware(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _coerce_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _ensure_aware(value)
+    if isinstance(value, str):
+        try:
+            return _ensure_aware(datetime.fromisoformat(value.replace("Z", "+00:00")))
+        except ValueError:
+            return None
+    return None
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _dict_get(value: Any, key: str) -> Any:
+    if isinstance(value, dict):
+        return value.get(key)
+    return None
+
+
+def _safe_url(value: Any) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    parts = urlsplit(value)
+    if not parts.scheme or not parts.netloc:
+        return _redact_string(value)
+
+    hostname = parts.hostname or ""
+    netloc = hostname
+    if parts.port:
+        netloc = f"{netloc}:{parts.port}"
+    query = urlencode(
+        [
+            (key, "[REDACTED]" if _is_sensitive_key(key) else val)
+            for key, val in parse_qsl(parts.query, keep_blank_values=True)
+        ]
+    )
+    return urlunsplit((parts.scheme, netloc, parts.path, query, ""))
+
+
+def _is_sensitive_key(key: str) -> bool:
+    lower = key.lower().replace("_", "-")
+    return any(part in lower for part in SENSITIVE_KEY_PARTS)
+
+
+def _redact_string(value: str) -> str:
+    lower = value.lower()
+    if any(part in lower for part in SENSITIVE_KEY_PARTS):
+        return "[REDACTED]"
+    return value
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: "[REDACTED]" if _is_sensitive_key(str(key)) else _redact(val)
+            for key, val in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    if isinstance(value, str):
+        return _redact_string(value)
+    return value
+
+
+def _policy_summary(policy_type: str, config: dict) -> str:
+    safe = _redact(config or {})
+    if policy_type == "rate_limit":
+        limit = (
+            safe.get("requests_per_minute")
+            or safe.get("requests_per_min")
+            or safe.get("rpm")
+            or safe.get("limit")
+        )
+        if limit is not None:
+            return f"Rate limit: {limit} req/min per consumer"
+        return "Rate limit configured"
+    if policy_type == "jwt_validation":
+        return "JWT policy configured"
+    if policy_type == "cors":
+        origins = _count_values(safe.get("origins") or safe.get("allow_origins"))
+        methods = safe.get("methods") or safe.get("allow_methods") or []
+        methods_text = "/".join(str(method).upper() for method in methods[:3]) if isinstance(methods, list) else "configured"
+        if origins is not None:
+            return f"CORS: {origins} origins, {methods_text}"
+        return "CORS policy configured"
+    if policy_type == "ip_filter":
+        cidrs = _count_values(safe.get("allowlist") or safe.get("allowed_cidrs") or safe.get("cidrs"))
+        if cidrs is not None:
+            return f"IP filter: {cidrs} CIDRs allowed"
+        return "IP filter configured"
+    if policy_type == "logging":
+        return "Logging policy configured"
+    if policy_type == "caching":
+        return "Caching policy configured"
+    if policy_type == "transform":
+        return "Transform policy configured"
+    return "Policy configured"
+
+
+def _count_values(value: Any) -> int | None:
+    if isinstance(value, list):
+        return len(value)
+    if isinstance(value, str) and value:
+        return 1
+    return None
+
+
+def _binding_scope(binding: GatewayPolicyBinding) -> str:
+    if binding.api_catalog_id is not None:
+        return "api"
+    if binding.gateway_instance_id is not None:
+        return "gateway"
+    return "tenant"
+
+
+def _binding_specificity(binding: GatewayPolicyBinding) -> int:
+    scope = _binding_scope(binding)
+    return {"tenant": 1, "gateway": 2, "api": 3}.get(scope, 0)
+
+
+def _binding_api_ids(
+    binding: GatewayPolicyBinding,
+    catalog_by_id: dict[UUID, APICatalog],
+) -> list[UUID]:
+    scope = _binding_scope(binding)
+    if scope == "api" and binding.api_catalog_id in catalog_by_id:
+        return [binding.api_catalog_id]
+    if scope == "gateway":
+        return list(catalog_by_id)
+    return [
+        api_id
+        for api_id, catalog in catalog_by_id.items()
+        if catalog.tenant_id == binding.tenant_id
+    ]
+
+
+def _policy_target(
+    scope: str,
+    binding: GatewayPolicyBinding,
+    gateway: GatewayInstance,
+    catalog_by_id: dict[UUID, APICatalog],
+) -> GatewayOverviewPolicyTarget:
+    if scope == "api" and binding.api_catalog_id in catalog_by_id:
+        catalog = catalog_by_id[binding.api_catalog_id]
+        return GatewayOverviewPolicyTarget(type="api", id=str(catalog.id), name=catalog.api_name)
+    if scope == "gateway":
+        return GatewayOverviewPolicyTarget(type="gateway", id=str(gateway.id), name=gateway.name)
+    return GatewayOverviewPolicyTarget(type="tenant", id=binding.tenant_id, name=binding.tenant_id)
+
+
+def _runtime_status_from_gateway(status: Any) -> GatewayOverviewRuntimeStatus:
+    value = _enum_value(status)
+    if value == "online":
+        return GatewayOverviewRuntimeStatus.HEALTHY
+    if value == "degraded":
+        return GatewayOverviewRuntimeStatus.DEGRADED
+    if value == "offline":
+        return GatewayOverviewRuntimeStatus.OFFLINE
+    return GatewayOverviewRuntimeStatus.UNKNOWN
+
+
+def _metrics_status(runtime: GatewayOverviewRuntime) -> GatewayOverviewMetricsStatus:
+    values: Iterable[Any] = (
+        runtime.requests_total,
+        runtime.error_rate,
+        runtime.memory_usage_bytes,
+    )
+    available = [value is not None for value in values]
+    if not any(available):
+        return GatewayOverviewMetricsStatus.UNAVAILABLE
+    if all(available):
+        return GatewayOverviewMetricsStatus.AVAILABLE
+    return GatewayOverviewMetricsStatus.PARTIAL

--- a/control-plane-api/tests/test_gateway_overview_service.py
+++ b/control-plane-api/tests/test_gateway_overview_service.py
@@ -1,0 +1,423 @@
+"""Tests for Gateway Overview read-model."""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.models.gateway_deployment import DeploymentSyncStatus, PolicySyncStatus
+from src.models.gateway_instance import GatewayInstanceStatus, GatewayType
+from src.models.gateway_policy import PolicyType
+from src.schemas.gateway_overview import (
+    GatewayOverviewMetricsStatus,
+    GatewayOverviewRuntimeFreshness,
+    GatewayOverviewRuntimeStatus,
+    GatewayOverviewSyncStatus,
+)
+from src.services.gateway_overview_service import GatewayOverviewService
+
+NOW = datetime(2026, 5, 4, 10, 22, 18, tzinfo=UTC)
+
+
+def _user(roles=None, tenant_id=None):
+    return SimpleNamespace(roles=roles or ["cpi-admin"], tenant_id=tenant_id)
+
+
+def _gateway(**overrides):
+    defaults = {
+        "id": uuid4(),
+        "name": "stoa-gateway-dev-edge-mcp-dev",
+        "display_name": "STOA Gateway Dev",
+        "gateway_type": GatewayType.STOA_EDGE_MCP,
+        "environment": "dev",
+        "tenant_id": None,
+        "status": GatewayInstanceStatus.ONLINE,
+        "mode": "edge-mcp",
+        "version": "0.9.21",
+        "visibility": None,
+        "last_health_check": NOW - timedelta(seconds=18),
+        "health_details": {
+            "last_heartbeat": (NOW - timedelta(seconds=18)).isoformat(),
+            "uptime_seconds": 3600,
+            "routes_count": 2,
+            "policies_count": 1,
+            "discovered_apis_count": 5,
+            "requests_total": 100,
+            "error_rate": 0.01,
+        },
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _catalog(**overrides):
+    defaults = {
+        "id": uuid4(),
+        "tenant_id": "acme",
+        "api_id": "users-api",
+        "api_name": "Users API",
+        "version": "1.4.2",
+        "git_path": "tenants/acme/apis/users-api",
+        "git_commit_sha": "abc123",
+        "synced_at": NOW - timedelta(minutes=2),
+        "api_metadata": {"backend_url": "https://users.internal"},
+        "openapi_spec": {
+            "paths": {
+                "/v1/users": {"get": {}, "post": {}},
+            }
+        },
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _deployment(catalog_id, gateway_id, **overrides):
+    defaults = {
+        "id": uuid4(),
+        "api_catalog_id": catalog_id,
+        "gateway_instance_id": gateway_id,
+        "desired_state": {
+            "spec_hash": "sha256:users",
+            "api_name": "Users API",
+            "backend_url": "https://users.internal",
+            "methods": ["GET", "POST"],
+        },
+        "actual_state": None,
+        "actual_at": NOW - timedelta(minutes=1),
+        "sync_status": DeploymentSyncStatus.SYNCED,
+        "policy_sync_status": PolicySyncStatus.SYNCED,
+        "policy_sync_error": None,
+        "last_sync_success": NOW - timedelta(minutes=1),
+        "last_sync_attempt": NOW - timedelta(minutes=1),
+        "sync_error": None,
+        "sync_steps": [],
+        "desired_generation": 3,
+        "synced_generation": 3,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _policy(**overrides):
+    defaults = {
+        "id": uuid4(),
+        "name": "default-rate-limit",
+        "policy_type": PolicyType.RATE_LIMIT,
+        "tenant_id": None,
+        "enabled": True,
+        "priority": 100,
+        "config": {"requests_per_minute": 1000},
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _binding(**overrides):
+    defaults = {
+        "id": uuid4(),
+        "policy_id": uuid4(),
+        "api_catalog_id": None,
+        "gateway_instance_id": None,
+        "tenant_id": None,
+        "enabled": True,
+        "created_at": NOW,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _svc(mock_db_session, gateway, api_rows=None, policy_rows=None):
+    svc = GatewayOverviewService(mock_db_session, now_fn=lambda: NOW)
+    svc._load_gateway = AsyncMock(return_value=gateway)
+    svc._load_api_rows = AsyncMock(return_value=api_rows or [])
+    svc._load_policy_rows = AsyncMock(return_value=policy_rows or [])
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_gateway_without_apis(mock_db_session):
+    svc = _svc(mock_db_session, _gateway(), api_rows=[], policy_rows=[])
+
+    overview = await svc.get_overview(uuid4(), _user())
+
+    assert overview.summary.apis_count == 0
+    assert overview.summary.expected_routes_count == 0
+    assert overview.sync.status == GatewayOverviewSyncStatus.IN_SYNC
+
+
+@pytest.mark.asyncio
+async def test_gateway_with_multiple_apis(mock_db_session):
+    gw = _gateway()
+    cat1 = _catalog()
+    cat2 = _catalog(
+        id=uuid4(),
+        tenant_id="beta",
+        api_id="orders-api",
+        api_name="Orders API",
+        openapi_spec={"paths": {"/v1/orders": {"get": {}}}},
+    )
+    dep1 = _deployment(cat1.id, gw.id)
+    dep2 = _deployment(cat2.id, gw.id)
+    svc = _svc(mock_db_session, gw, api_rows=[(dep1, cat1), (dep2, cat2)])
+
+    overview = await svc.get_overview(gw.id, _user())
+
+    assert overview.summary.apis_count == 2
+    assert overview.summary.expected_routes_count == 3
+    assert [api.name for api in overview.resolved_config.apis] == ["Users API", "Orders API"]
+
+
+@pytest.mark.asyncio
+async def test_tenant_admin_gets_filtered_visibility(mock_db_session):
+    gw = _gateway()
+    cat = _catalog(tenant_id="acme")
+    dep = _deployment(cat.id, gw.id)
+    svc = _svc(mock_db_session, gw, api_rows=[(dep, cat)])
+
+    overview = await svc.get_overview(gw.id, _user(["tenant-admin"], tenant_id="acme"))
+
+    assert overview.visibility.rbac_scope == "tenant"
+    assert overview.visibility.tenant_id == "acme"
+    assert overview.visibility.filtered is True
+    svc._load_api_rows.assert_awaited_once_with(gw.id, "acme")
+
+
+@pytest.mark.asyncio
+async def test_tenant_level_policy_is_applicable(mock_db_session):
+    gw = _gateway()
+    cat = _catalog()
+    dep = _deployment(cat.id, gw.id)
+    pol = _policy()
+    bind = _binding(policy_id=pol.id, tenant_id="acme")
+    svc = _svc(mock_db_session, gw, api_rows=[(dep, cat)], policy_rows=[(pol, bind)])
+
+    overview = await svc.get_overview(gw.id, _user())
+
+    assert overview.summary.effective_policies_count == 1
+    assert overview.resolved_config.apis[0].policies_count == 1
+    assert overview.resolved_config.policies[0].source_binding.scope == "tenant"
+
+
+@pytest.mark.asyncio
+async def test_api_level_policy_priority_is_preserved(mock_db_session):
+    gw = _gateway()
+    cat = _catalog()
+    dep = _deployment(cat.id, gw.id)
+    gateway_policy = _policy(name="gateway-policy", priority=100)
+    api_policy = _policy(name="api-policy", priority=10)
+    rows = [
+        (gateway_policy, _binding(policy_id=gateway_policy.id, gateway_instance_id=gw.id)),
+        (api_policy, _binding(policy_id=api_policy.id, api_catalog_id=cat.id, gateway_instance_id=gw.id)),
+    ]
+    svc = _svc(mock_db_session, gw, api_rows=[(dep, cat)], policy_rows=rows)
+
+    overview = await svc.get_overview(gw.id, _user())
+
+    assert [policy.name for policy in overview.resolved_config.policies] == ["api-policy", "gateway-policy"]
+    assert overview.resolved_config.apis[0].policies_count == 2
+
+
+@pytest.mark.asyncio
+async def test_disabled_policy_is_excluded(mock_db_session):
+    gw = _gateway()
+    cat = _catalog()
+    dep = _deployment(cat.id, gw.id)
+    disabled = _policy(enabled=False)
+    bind = _binding(policy_id=disabled.id, gateway_instance_id=gw.id)
+    svc = _svc(mock_db_session, gw, api_rows=[(dep, cat)], policy_rows=[(disabled, bind)])
+
+    overview = await svc.get_overview(gw.id, _user())
+
+    assert overview.summary.effective_policies_count == 0
+    assert overview.resolved_config.policies == []
+
+
+@pytest.mark.asyncio
+async def test_failed_policy_sync_is_reported(mock_db_session):
+    gw = _gateway()
+    cat = _catalog()
+    dep = _deployment(
+        cat.id,
+        gw.id,
+        policy_sync_status=PolicySyncStatus.ERROR,
+        policy_sync_error="policy apply failed",
+    )
+    pol = _policy()
+    bind = _binding(policy_id=pol.id, gateway_instance_id=gw.id)
+    svc = _svc(mock_db_session, gw, api_rows=[(dep, cat)], policy_rows=[(pol, bind)])
+
+    overview = await svc.get_overview(gw.id, _user())
+
+    assert overview.summary.failed_policies_count == 1
+    assert overview.resolved_config.policies[0].sync_status == GatewayOverviewSyncStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_fresh_heartbeat(mock_db_session):
+    svc = _svc(mock_db_session, _gateway())
+
+    overview = await svc.get_overview(uuid4(), _user())
+
+    assert overview.runtime.status == GatewayOverviewRuntimeStatus.HEALTHY
+    assert overview.runtime.heartbeat_age_seconds == 18
+    assert overview.data_quality.runtime_freshness == GatewayOverviewRuntimeFreshness.FRESH
+
+
+@pytest.mark.asyncio
+async def test_stale_heartbeat(mock_db_session):
+    old = NOW - timedelta(seconds=120)
+    gw = _gateway(last_health_check=old, health_details={"last_heartbeat": old.isoformat()})
+    svc = _svc(mock_db_session, gw)
+
+    overview = await svc.get_overview(gw.id, _user())
+
+    assert overview.runtime.status == GatewayOverviewRuntimeStatus.STALE
+    assert overview.data_quality.runtime_freshness == GatewayOverviewRuntimeFreshness.STALE
+    assert overview.data_quality.warnings[0].code == "runtime_heartbeat_stale"
+
+
+@pytest.mark.asyncio
+async def test_runtime_absent_uses_null_not_zero(mock_db_session):
+    gw = _gateway(
+        status=GatewayInstanceStatus.OFFLINE,
+        last_health_check=None,
+        health_details=None,
+    )
+    svc = _svc(mock_db_session, gw)
+
+    overview = await svc.get_overview(gw.id, _user())
+
+    assert overview.runtime.status == GatewayOverviewRuntimeStatus.OFFLINE
+    assert overview.runtime.reported_routes_count is None
+    assert overview.summary.reported_routes_count is None
+    assert overview.data_quality.runtime_freshness == GatewayOverviewRuntimeFreshness.MISSING
+
+
+@pytest.mark.asyncio
+async def test_metrics_partial(mock_db_session):
+    gw = _gateway(health_details={"last_heartbeat": (NOW - timedelta(seconds=10)).isoformat(), "requests_total": 42})
+    svc = _svc(mock_db_session, gw)
+
+    overview = await svc.get_overview(gw.id, _user())
+
+    assert overview.summary.metrics_status == GatewayOverviewMetricsStatus.PARTIAL
+    assert any(w.code == "runtime_metrics_partial" for w in overview.data_quality.warnings)
+
+
+@pytest.mark.asyncio
+async def test_redacts_sensitive_values(mock_db_session):
+    gw = _gateway()
+    cat = _catalog(api_metadata={"backend_url": "https://user:pass@users.internal/v1?token=abc"})
+    dep = _deployment(
+        cat.id,
+        gw.id,
+        desired_state={
+            "spec_hash": "sha256:redacted",
+            "backend_url": "https://user:pass@users.internal/v1?token=abc",
+        },
+    )
+    pol = _policy(
+        policy_type=PolicyType.JWT_VALIDATION,
+        config={"client_secret": "super-secret", "authorization": "Bearer abc"},
+    )
+    bind = _binding(policy_id=pol.id, gateway_instance_id=gw.id)
+    svc = _svc(mock_db_session, gw, api_rows=[(dep, cat)], policy_rows=[(pol, bind)])
+
+    overview = await svc.get_overview(gw.id, _user())
+    rendered = overview.model_dump_json()
+
+    assert "super-secret" not in rendered
+    assert "Bearer abc" not in rendered
+    assert "user:pass" not in rendered
+    assert "token=abc" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_drift_desired_vs_actual(mock_db_session):
+    gw = _gateway()
+    cat = _catalog()
+    dep = _deployment(
+        cat.id,
+        gw.id,
+        sync_status=DeploymentSyncStatus.DRIFTED,
+        desired_generation=4,
+        synced_generation=3,
+    )
+    svc = _svc(mock_db_session, gw, api_rows=[(dep, cat)])
+
+    overview = await svc.get_overview(gw.id, _user())
+
+    assert overview.summary.sync_status == GatewayOverviewSyncStatus.DRIFT
+    assert overview.sync.drift is True
+
+
+def test_gateway_overview_router(app_with_cpi_admin):
+    overview = {
+        "schema_version": "1.0",
+        "generated_at": NOW.isoformat(),
+        "gateway": {
+            "id": str(uuid4()),
+            "name": "gw",
+            "display_name": "Gateway",
+            "gateway_type": "stoa_edge_mcp",
+            "environment": "dev",
+            "status": "online",
+            "mode": "edge-mcp",
+            "version": "0.9.21",
+        },
+        "visibility": {"rbac_scope": "admin", "tenant_id": None, "filtered": False},
+        "source": {"control_plane_revision": None, "last_loaded_at": None},
+        "summary": {
+            "sync_status": "in_sync",
+            "runtime_status": "healthy",
+            "metrics_status": "partial",
+            "apis_count": 0,
+            "expected_routes_count": 0,
+            "reported_routes_count": None,
+            "effective_policies_count": 0,
+            "reported_policies_count": None,
+            "failed_policies_count": 0,
+        },
+        "resolved_config": {"apis": [], "policies": []},
+        "sync": {
+            "desired_generation": None,
+            "applied_generation": None,
+            "status": "in_sync",
+            "drift": False,
+            "last_reconciled_at": None,
+            "last_error": None,
+            "steps": [],
+        },
+        "runtime": {
+            "status": "healthy",
+            "last_heartbeat_at": None,
+            "heartbeat_age_seconds": None,
+            "version": "0.9.21",
+            "mode": "edge-mcp",
+            "uptime_seconds": None,
+            "reported_routes_count": None,
+            "reported_policies_count": None,
+            "mcp_tools_count": None,
+            "requests_total": None,
+            "error_rate": None,
+            "memory_usage_bytes": None,
+        },
+        "data_quality": {
+            "runtime_freshness": "missing",
+            "heartbeat_stale_after_seconds": 90,
+            "metrics_status": "partial",
+            "metrics_window_seconds": 300,
+            "warnings": [],
+        },
+    }
+
+    with patch("src.routers.gateway_instances.GatewayOverviewService") as MockService:
+        MockService.return_value.get_overview = AsyncMock(return_value=overview)
+        with TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/admin/gateways/{uuid4()}/overview")
+
+    assert resp.status_code == 200
+    assert resp.json()["schema_version"] == "1.0"


### PR DESCRIPTION
## Summary

Adds the backend read-model for Gateway Detail:

- `GET /v1/admin/gateways/{id}/overview`
- separates `resolved_config`, `sync`, `runtime`, and `data_quality`
- includes typed status enums, `null` vs `0` runtime semantics, RBAC visibility metadata, effective enabled policies, expected/reported counters, and safe policy/backend redaction

This is PR1 backend only. GatewayDetail UI consumption stays out of scope for PR2.

## Validation

- `pytest control-plane-api/tests/test_gateway_instances_router.py control-plane-api/tests/test_gateway_overview_service.py -q` -> `85 passed`
- `ruff check control-plane-api/src/schemas/gateway_overview.py control-plane-api/src/services/gateway_overview_service.py control-plane-api/src/routers/gateway_instances.py control-plane-api/tests/test_gateway_overview_service.py`
- `git diff --cached --check`

## Out of scope

- GatewayDetail UI tabs/cards
- Runtime mutation or policy editing
- Grafana/logs integration
- CPU/RAM observability improvements
