### PR TITLE
feat(ui): add gateway overview tabs

### DIFF
--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.test.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createAuthMock } from '../../test/helpers';
@@ -11,7 +11,7 @@ import type { PersonaRole } from '../../test/helpers';
 // Mocks
 // ---------------------------------------------------------------------------
 
-const { mockGateway, mockDeployments, mockTools } = vi.hoisted(() => ({
+const { mockGateway, mockDeployments, mockTools, mockOverview } = vi.hoisted(() => ({
   mockGateway: {
     id: 'gw-1',
     name: 'stoa-gateway-edge-mcp-dev',
@@ -74,6 +74,147 @@ const { mockGateway, mockDeployments, mockTools } = vi.hoisted(() => ({
     { name: 'payment_charge', description: 'Process a payment charge' },
     { name: 'crm_contacts', description: 'List CRM contacts' },
   ],
+  mockOverview: {
+    schema_version: '1.0',
+    generated_at: '2026-05-06T06:00:00Z',
+    gateway: {
+      id: 'gw-1',
+      name: 'stoa-gateway-edge-mcp-dev',
+      display_name: 'STOA Edge MCP Gateway',
+      gateway_type: 'stoa_edge_mcp',
+      environment: 'dev',
+      status: 'online',
+      mode: 'edge-mcp',
+      version: '0.9.1',
+    },
+    visibility: {
+      rbac_scope: 'admin',
+      tenant_id: null,
+      filtered: false,
+    },
+    source: {
+      control_plane_revision: 'abc123',
+      last_loaded_at: '2026-05-06T05:58:00Z',
+    },
+    summary: {
+      sync_status: 'in_sync',
+      runtime_status: 'healthy',
+      metrics_status: 'partial',
+      apis_count: 2,
+      expected_routes_count: 5,
+      reported_routes_count: 5,
+      effective_policies_count: 2,
+      reported_policies_count: 2,
+      failed_policies_count: 0,
+    },
+    resolved_config: {
+      apis: [
+        {
+          tenant_id: 'tenant-a',
+          api_id: 'payments-api',
+          api_catalog_id: 'catalog-payments',
+          name: 'Payments API',
+          version: '1.0.0',
+          source: {
+            git_path: 'apis/payments/openapi.yaml',
+            git_commit_sha: 'abc123',
+            spec_hash: 'sha256:payments',
+          },
+          routes_count: 2,
+          routes_preview: [
+            { method: 'GET', path: '/v1/payments', backend: 'https://payments.internal' },
+            { method: 'POST', path: '/v1/payments', backend: 'https://payments.internal' },
+          ],
+          backend: 'https://payments.internal',
+          policies_count: 1,
+          sync_status: 'in_sync',
+          last_sync_at: '2026-05-06T05:59:00Z',
+          last_error: null,
+        },
+        {
+          tenant_id: 'tenant-a',
+          api_id: 'users-api',
+          api_catalog_id: 'catalog-users',
+          name: 'Users API',
+          version: '2.1.0',
+          source: {
+            git_path: 'apis/users/openapi.yaml',
+            git_commit_sha: 'abc123',
+            spec_hash: 'sha256:users',
+          },
+          routes_count: 3,
+          routes_preview: [{ method: 'GET', path: '/v1/users', backend: 'https://users.internal' }],
+          backend: 'https://users.internal',
+          policies_count: 1,
+          sync_status: 'pending',
+          last_sync_at: null,
+          last_error: null,
+        },
+      ],
+      policies: [
+        {
+          id: 'policy-1',
+          name: 'default-rate-limit',
+          type: 'rate_limit',
+          scope: 'gateway',
+          target: { type: 'gateway', id: 'gw-1', name: 'STOA Edge MCP Gateway' },
+          enabled: true,
+          priority: 100,
+          summary: 'Rate limit: 1000 req/min per consumer',
+          sync_status: 'in_sync',
+          source_binding: { id: 'binding-1', scope: 'gateway', target_id: 'gw-1' },
+        },
+        {
+          id: 'policy-2',
+          name: 'jwt-auth',
+          type: 'jwt_validation',
+          scope: 'api',
+          target: { type: 'api', id: 'catalog-users', name: 'Users API' },
+          enabled: true,
+          priority: 10,
+          summary: 'JWT policy configured',
+          sync_status: 'pending',
+          source_binding: { id: 'binding-2', scope: 'api', target_id: 'catalog-users' },
+        },
+      ],
+    },
+    sync: {
+      desired_generation: 42,
+      applied_generation: 42,
+      status: 'in_sync',
+      drift: false,
+      last_reconciled_at: '2026-05-06T05:59:00Z',
+      last_error: null,
+      steps: [],
+    },
+    runtime: {
+      status: 'healthy',
+      last_heartbeat_at: '2026-05-06T05:59:42Z',
+      heartbeat_age_seconds: 18,
+      version: '0.9.1',
+      mode: 'edge-mcp',
+      uptime_seconds: 7200,
+      reported_routes_count: 5,
+      reported_policies_count: 2,
+      mcp_tools_count: 3,
+      requests_total: 129,
+      error_rate: 0.01,
+      memory_usage_bytes: 268435456,
+    },
+    data_quality: {
+      runtime_freshness: 'fresh',
+      heartbeat_stale_after_seconds: 90,
+      metrics_status: 'partial',
+      metrics_window_seconds: 300,
+      warnings: [
+        {
+          code: 'runtime_metrics_partial',
+          severity: 'info',
+          message: 'Some runtime metrics are not available for this gateway',
+        },
+      ],
+    },
+  },
 }));
 
 const mockConfirm = vi.fn().mockResolvedValue(true);
@@ -83,6 +224,7 @@ vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
 vi.mock('../../services/api', () => ({
   apiService: {
     getGatewayInstance: vi.fn().mockResolvedValue(mockGateway),
+    getGatewayOverview: vi.fn().mockResolvedValue(mockOverview),
     getGatewayDeployments: vi.fn().mockResolvedValue(mockDeployments),
     getGatewayTools: vi.fn().mockResolvedValue(mockTools),
     updateGatewayInstance: vi.fn().mockResolvedValue(mockGateway),
@@ -120,6 +262,10 @@ function renderGatewayDetail(id = 'gw-1') {
       </MemoryRouter>
     </QueryClientProvider>
   );
+}
+
+function cloneOverview() {
+  return structuredClone(mockOverview);
 }
 
 // ---------------------------------------------------------------------------
@@ -267,16 +413,25 @@ describe('GatewayDetail', () => {
     expect(screen.queryByText('connect')).not.toBeInTheDocument();
   });
 
-  it('renders health metrics', async () => {
+  it('loads the gateway overview read-model', async () => {
+    const { apiService } = await import('../../services/api');
     renderGatewayDetail();
     await screen.findByText('STOA Edge MCP Gateway');
-    expect(screen.getByText('2h 0m')).toBeInTheDocument(); // 7200s
-    expect(screen.getByText('5')).toBeInTheDocument(); // routes
-    const deployedMetric = screen.getByText('Deployed APIs').closest('div');
-    expect(deployedMetric).not.toBeNull();
-    expect(within(deployedMetric!).getByText('1')).toBeInTheDocument(); // synced deployments
-    expect(screen.queryByText('Discovered APIs')).not.toBeInTheDocument();
-    expect(screen.getByText('1.0%')).toBeInTheDocument(); // error rate
+    expect(apiService.getGatewayOverview).toHaveBeenCalledWith('gw-1');
+  });
+
+  it('renders overview summary cards', async () => {
+    renderGatewayDetail();
+    await screen.findByText('STOA Edge MCP Gateway');
+    expect(screen.getByText('42 desired / 42 applied')).toBeInTheDocument();
+    expect(screen.getByText('Heartbeat 18s ago')).toBeInTheDocument();
+    expect(screen.getByText('2 deployed')).toBeInTheDocument();
+    expect(screen.getByText('Routes 5 expected / 5 reported')).toBeInTheDocument();
+    expect(screen.getByText('2 effective')).toBeInTheDocument();
+    expect(screen.getByText('0 failed')).toBeInTheDocument();
+    expect(
+      screen.getByText('Some runtime metrics are not available for this gateway')
+    ).toBeInTheDocument();
   });
 
   it('uses deployed APIs label for native sidecar gateways', async () => {
@@ -288,33 +443,72 @@ describe('GatewayDetail', () => {
     renderGatewayDetail();
     await screen.findByText('STOA Gateway (sidecar)');
 
-    const deployedMetric = screen.getByText('Deployed APIs').closest('div');
-    expect(deployedMetric).not.toBeNull();
-    expect(within(deployedMetric!).getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2 deployed')).toBeInTheDocument();
     expect(screen.queryByText('Discovered APIs')).not.toBeInTheDocument();
   });
 
-  it('keeps Discovered APIs label for connect gateways', async () => {
+  it('keeps the legacy Discovered APIs metric when overview is unavailable', async () => {
+    const { apiService } = await import('../../services/api');
+    vi.mocked(apiService.getGatewayOverview).mockRejectedValueOnce(
+      new Error('overview unavailable')
+    );
     mockGateway.mode = 'connect';
     mockGateway.gateway_type = 'webmethods';
     renderGatewayDetail();
     await screen.findByText('STOA Edge MCP Gateway');
+    expect(
+      screen.getByText('Gateway overview unavailable. Showing legacy gateway data.')
+    ).toBeInTheDocument();
     expect(screen.getByText('Discovered APIs')).toBeInTheDocument();
   });
 
-  it('renders deployed APIs table', async () => {
+  it('renders overview APIs table with API detail links', async () => {
     renderGatewayDetail();
     await screen.findByText('STOA Edge MCP Gateway');
-    expect(screen.getByText('Payments API')).toBeInTheDocument();
+    const paymentsLink = screen.getByText('Payments API').closest('a');
+    expect(paymentsLink).toHaveAttribute('href', '/apis/tenant-a/payments-api');
     expect(screen.getByText('Users API')).toBeInTheDocument();
-    expect(screen.getByText('2 APIs')).toBeInTheDocument();
+    expect(screen.getAllByText('/v1/payments').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('/v1/users')).toBeInTheDocument();
+    expect(screen.getByText('https://payments.internal')).toBeInTheDocument();
   });
 
-  it('renders sync status badges', async () => {
+  it('renders overview sync status badges', async () => {
     renderGatewayDetail();
     await screen.findByText('STOA Edge MCP Gateway');
-    expect(screen.getByText('synced')).toBeInTheDocument();
+    expect(screen.getAllByText('in sync').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('pending')).toBeInTheDocument();
+  });
+
+  it('renders policies tab with safe summaries', async () => {
+    renderGatewayDetail();
+    await screen.findByText('STOA Edge MCP Gateway');
+    fireEvent.click(screen.getByRole('button', { name: /Policies/ }));
+    expect(screen.getByText('default-rate-limit')).toBeInTheDocument();
+    expect(screen.getByText('Rate limit: 1000 req/min per consumer')).toBeInTheDocument();
+    expect(screen.getByText('jwt-auth')).toBeInTheDocument();
+    expect(screen.getByText('JWT policy configured')).toBeInTheDocument();
+  });
+
+  it('renders runtime tab with observed runtime and sync details', async () => {
+    renderGatewayDetail();
+    await screen.findByText('STOA Edge MCP Gateway');
+    fireEvent.click(screen.getByRole('button', { name: /Runtime/ }));
+    expect(screen.getByText('2h 0m')).toBeInTheDocument();
+    expect(screen.getByText('1.0%')).toBeInTheDocument();
+    expect(screen.getByText('256.0 MB')).toBeInTheDocument();
+    expect(screen.getByText('129')).toBeInTheDocument();
+    expect(screen.getByText('partial / 300s')).toBeInTheDocument();
+    expect(screen.getByText('5 expected / 5 reported')).toBeInTheDocument();
+  });
+
+  it('renders RBAC filtered overview notice', async () => {
+    const { apiService } = await import('../../services/api');
+    const overview = cloneOverview();
+    overview.visibility = { rbac_scope: 'tenant', tenant_id: 'tenant-a', filtered: true };
+    vi.mocked(apiService.getGatewayOverview).mockResolvedValueOnce(overview);
+    renderGatewayDetail();
+    expect(await screen.findByText('Vue filtrée selon vos permissions.')).toBeInTheDocument();
   });
 
   it('renders capabilities', async () => {
@@ -349,6 +543,15 @@ describe('GatewayDetail', () => {
 
   it('renders empty state when no deployments and no tools', async () => {
     const { apiService } = await import('../../services/api');
+    const overview = cloneOverview();
+    overview.summary.apis_count = 0;
+    overview.summary.expected_routes_count = 0;
+    overview.summary.reported_routes_count = 0;
+    overview.summary.effective_policies_count = 0;
+    overview.summary.reported_policies_count = 0;
+    overview.resolved_config.apis = [];
+    overview.resolved_config.policies = [];
+    vi.mocked(apiService.getGatewayOverview).mockResolvedValueOnce(overview);
     vi.mocked(apiService.getGatewayTools).mockResolvedValueOnce([]);
     vi.mocked(apiService.getGatewayDeployments).mockResolvedValueOnce({
       items: [],
@@ -356,8 +559,10 @@ describe('GatewayDetail', () => {
     });
     renderGatewayDetail();
     await screen.findByText('STOA Edge MCP Gateway');
+    expect(screen.getByText('No APIs are deployed on this gateway.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Policies/ }));
     expect(
-      screen.getByText('No APIs deployed and no MCP tools registered on this gateway')
+      screen.getByText('No effective policies are applied to this gateway.')
     ).toBeInTheDocument();
   });
 
@@ -365,7 +570,8 @@ describe('GatewayDetail', () => {
     renderGatewayDetail();
     expect(await screen.findByText('weather_forecast')).toBeInTheDocument();
     expect(screen.getByText('Payments API')).toBeInTheDocument();
-    expect(screen.getByText('API Deployments')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /APIs/ })).toBeInTheDocument();
+    expect(screen.queryByText('API Deployments')).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /MCP Tools/ })).toBeInTheDocument();
   });
 
@@ -441,7 +647,7 @@ describe('GatewayDetail', () => {
     mockGateway.visibility = { tenant_ids: ['tenant-a', 'tenant-b'] } as any;
     renderGatewayDetail();
     await screen.findByText('STOA Edge MCP Gateway');
-    expect(screen.getByText('tenant-a')).toBeInTheDocument();
+    expect(screen.getAllByText('tenant-a').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('tenant-b')).toBeInTheDocument();
   });
 
@@ -464,6 +670,10 @@ describe('GatewayDetail', () => {
   });
 
   it('renders force sync buttons for deployments', async () => {
+    const { apiService } = await import('../../services/api');
+    vi.mocked(apiService.getGatewayOverview).mockRejectedValueOnce(
+      new Error('overview unavailable')
+    );
     renderGatewayDetail();
     await screen.findByText('STOA Edge MCP Gateway');
     const syncButtons = screen.getAllByText('Sync');
@@ -472,6 +682,9 @@ describe('GatewayDetail', () => {
 
   it('calls forceSyncDeployment on sync click', async () => {
     const { apiService } = await import('../../services/api');
+    vi.mocked(apiService.getGatewayOverview).mockRejectedValueOnce(
+      new Error('overview unavailable')
+    );
     renderGatewayDetail();
     await screen.findByText('STOA Edge MCP Gateway');
     const syncButtons = screen.getAllByText('Sync');

--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
@@ -1,4 +1,5 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useState, type ReactNode } from 'react';
+import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiService } from '../../services/api';
 import { useAuth } from '../../contexts/AuthContext';
@@ -12,6 +13,11 @@ import {
   Zap,
   Globe,
   Activity,
+  Layers,
+  Shield,
+  Route,
+  Gauge,
+  FileText,
   GitBranch,
   Clock,
   CheckCircle2,
@@ -24,7 +30,7 @@ import {
   EyeOff,
   ShieldAlert,
 } from 'lucide-react';
-import type { GatewayInstance } from '../../types';
+import type { GatewayInstance, GatewayOverviewResponse } from '../../types';
 import { deploymentLabel, deploymentModeValue, gatewayUrls, topologyLabel } from './gatewayDisplay';
 
 interface DiscoveredAPI {
@@ -43,6 +49,8 @@ const STATUS_CONFIG: Record<string, { color: string; icon: typeof CheckCircle2 }
   degraded: { color: 'text-amber-600 bg-amber-50', icon: AlertTriangle },
   maintenance: { color: 'text-blue-600 bg-blue-50', icon: Clock },
 };
+
+type OverviewTab = 'apis' | 'policies' | 'runtime';
 
 const NATIVE_STOA_RUNTIME_MODES = new Set(['edge-mcp', 'sidecar', 'proxy', 'shadow']);
 const NATIVE_STOA_GATEWAY_TYPES = new Set([
@@ -75,6 +83,7 @@ export function GatewayDetail() {
   const toast = useToastActions();
   const queryClient = useQueryClient();
   const [confirm, ConfirmDialog] = useConfirm();
+  const [overviewTab, setOverviewTab] = useState<OverviewTab>('apis');
 
   const canWrite = hasPermission('admin:servers');
 
@@ -82,6 +91,17 @@ export function GatewayDetail() {
     queryKey: ['gateway', id],
     queryFn: () => apiService.getGatewayInstance(id!),
     enabled: isReady && !!id,
+  });
+
+  const {
+    data: overview,
+    isLoading: overviewLoading,
+    isError: overviewError,
+  } = useQuery<GatewayOverviewResponse>({
+    queryKey: ['gateway-overview', id],
+    queryFn: () => apiService.getGatewayOverview(id!),
+    enabled: isReady && !!id,
+    retry: false,
   });
 
   const { data: deploymentsData } = useQuery({
@@ -105,6 +125,7 @@ export function GatewayDetail() {
     mutationFn: async (enabled: boolean) => apiService.updateGatewayInstance(id!, { enabled }),
     onSuccess: (_data, enabled) => {
       queryClient.invalidateQueries({ queryKey: ['gateway', id] });
+      queryClient.invalidateQueries({ queryKey: ['gateway-overview', id] });
       queryClient.invalidateQueries({ queryKey: ['gateways'] });
       toast.success(enabled ? 'Gateway enabled' : 'Gateway disabled');
     },
@@ -115,6 +136,7 @@ export function GatewayDetail() {
     mutationFn: () => apiService.checkGatewayHealth(id!),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['gateway', id] });
+      queryClient.invalidateQueries({ queryKey: ['gateway-overview', id] });
       toast.success('Health check completed');
     },
     onError: () => toast.error('Health check failed'),
@@ -163,6 +185,9 @@ export function GatewayDetail() {
   const topologyText = topologyLabel(gateway);
   const hasVisibilityRestriction =
     gateway.visibility && Array.isArray(gateway.visibility.tenant_ids);
+  const hasOverview = Boolean(overview);
+  const showLegacyGatewayData = !overviewLoading && !hasOverview;
+  const overviewWarnings = overview?.data_quality.warnings ?? [];
 
   return (
     <div className="p-6 max-w-5xl mx-auto space-y-6">
@@ -264,6 +289,76 @@ export function GatewayDetail() {
         </div>
       )}
 
+      {overviewLoading && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">
+          <CardSkeleton className="h-24" />
+          <CardSkeleton className="h-24" />
+          <CardSkeleton className="h-24" />
+          <CardSkeleton className="h-24" />
+        </div>
+      )}
+
+      {overview && (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">
+            <OverviewSummaryCard
+              icon={<GitBranch className="h-4 w-4" />}
+              label="Config"
+              value={formatStatusLabel(overview.summary.sync_status)}
+              detail={`${formatNullableNumber(overview.sync.desired_generation)} desired / ${formatNullableNumber(overview.sync.applied_generation)} applied`}
+              status={overview.summary.sync_status}
+            />
+            <OverviewSummaryCard
+              icon={<Activity className="h-4 w-4" />}
+              label="Runtime"
+              value={formatStatusLabel(overview.summary.runtime_status)}
+              detail={`Heartbeat ${formatAge(overview.runtime.heartbeat_age_seconds)}`}
+              status={overview.summary.runtime_status}
+            />
+            <OverviewSummaryCard
+              icon={<Layers className="h-4 w-4" />}
+              label="APIs"
+              value={`${overview.summary.apis_count} deployed`}
+              detail={`Routes ${overview.summary.expected_routes_count} expected / ${formatNullableNumber(overview.summary.reported_routes_count)} reported`}
+            />
+            <OverviewSummaryCard
+              icon={<Shield className="h-4 w-4" />}
+              label="Policies"
+              value={`${overview.summary.effective_policies_count} effective`}
+              detail={`${overview.summary.failed_policies_count} failed`}
+              status={overview.summary.failed_policies_count > 0 ? 'failed' : 'in_sync'}
+            />
+          </div>
+
+          {(overview.visibility.filtered || overviewWarnings.length > 0) && (
+            <div className="space-y-2">
+              {overview.visibility.filtered && (
+                <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                  <EyeOff className="h-4 w-4" />
+                  Vue filtrée selon vos permissions.
+                </div>
+              )}
+              {overviewWarnings.map((warning) => (
+                <div
+                  key={warning.code}
+                  className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700"
+                >
+                  <AlertTriangle className="h-4 w-4 text-amber-500" />
+                  {warning.message}
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {overviewError && (
+        <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          <AlertTriangle className="h-4 w-4" />
+          Gateway overview unavailable. Showing legacy gateway data.
+        </div>
+      )}
+
       {/* Configuration */}
       <section className="bg-white rounded-xl border border-gray-200 p-6">
         <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
@@ -330,29 +425,65 @@ export function GatewayDetail() {
         </div>
       </section>
 
+      {overview && (
+        <section className="bg-white rounded-xl border border-gray-200">
+          <div className="border-b border-gray-100 px-4 pt-4">
+            <div className="flex flex-wrap gap-1">
+              <OverviewTabButton
+                active={overviewTab === 'apis'}
+                icon={<Layers className="h-4 w-4" />}
+                label="APIs"
+                onClick={() => setOverviewTab('apis')}
+              />
+              <OverviewTabButton
+                active={overviewTab === 'policies'}
+                icon={<Shield className="h-4 w-4" />}
+                label="Policies"
+                onClick={() => setOverviewTab('policies')}
+              />
+              <OverviewTabButton
+                active={overviewTab === 'runtime'}
+                icon={<Gauge className="h-4 w-4" />}
+                label="Runtime"
+                onClick={() => setOverviewTab('runtime')}
+              />
+            </div>
+          </div>
+          <div className="p-4">
+            {overviewTab === 'apis' && <GatewayOverviewApis overview={overview} />}
+            {overviewTab === 'policies' && <GatewayOverviewPolicies overview={overview} />}
+            {overviewTab === 'runtime' && <GatewayOverviewRuntime overview={overview} />}
+          </div>
+        </section>
+      )}
+
       {/* Health & Metrics */}
-      <section className="bg-white rounded-xl border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-          <Activity className="h-5 w-5 text-gray-400" />
-          Health &amp; Metrics
-        </h2>
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-          <MetricCard
-            label="Uptime"
-            value={hd.uptime_seconds ? formatUptime(hd.uptime_seconds as number) : '-'}
-          />
-          <MetricCard label="Routes" value={String(hd.routes_count ?? '-')} />
-          <MetricCard label={discoveryMetricLabel} value={discoveryMetricValue} />
-          <MetricCard
-            label="Error Rate"
-            value={hd.error_rate != null ? `${((hd.error_rate as number) * 100).toFixed(1)}%` : '-'}
-            alert={(hd.error_rate as number) > 0.05}
-          />
-        </div>
-      </section>
+      {showLegacyGatewayData && (
+        <section className="bg-white rounded-xl border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+            <Activity className="h-5 w-5 text-gray-400" />
+            Health &amp; Metrics
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <MetricCard
+              label="Uptime"
+              value={hd.uptime_seconds ? formatUptime(hd.uptime_seconds as number) : '-'}
+            />
+            <MetricCard label="Routes" value={String(hd.routes_count ?? '-')} />
+            <MetricCard label={discoveryMetricLabel} value={discoveryMetricValue} />
+            <MetricCard
+              label="Error Rate"
+              value={
+                hd.error_rate != null ? `${((hd.error_rate as number) * 100).toFixed(1)}%` : '-'
+              }
+              alert={(hd.error_rate as number) > 0.05}
+            />
+          </div>
+        </section>
+      )}
 
       {/* API Deployments */}
-      {deployments.length > 0 && (
+      {showLegacyGatewayData && deployments.length > 0 && (
         <section className="bg-white rounded-xl border border-gray-200 p-6">
           <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
             <Zap className="h-5 w-5 text-gray-400" />
@@ -437,7 +568,7 @@ export function GatewayDetail() {
       )}
 
       {/* Empty state: no deployments and no discovered APIs */}
-      {deployments.length === 0 && discoveredApis.length === 0 && (
+      {showLegacyGatewayData && deployments.length === 0 && discoveredApis.length === 0 && (
         <section className="bg-white rounded-xl border border-gray-200 p-6">
           <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
             <Zap className="h-5 w-5 text-gray-400" />
@@ -462,6 +593,7 @@ function ForceSyncButton({ deploymentId }: { deploymentId: string }) {
     mutationFn: () => apiService.forceSyncDeployment(deploymentId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['gateway-deployments'] });
+      queryClient.invalidateQueries({ queryKey: ['gateway-overview'] });
       toast.success('Sync triggered');
     },
     onError: () => toast.error('Sync failed'),
@@ -476,6 +608,293 @@ function ForceSyncButton({ deploymentId }: { deploymentId: string }) {
       <RefreshCw className={`h-3 w-3 ${syncMutation.isPending ? 'animate-spin' : ''}`} />
       Sync
     </button>
+  );
+}
+
+function OverviewTabButton({
+  active,
+  icon,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center gap-2 border-b-2 px-3 py-2 text-sm font-medium transition-colors ${
+        active
+          ? 'border-indigo-600 text-indigo-700'
+          : 'border-transparent text-gray-500 hover:text-gray-800'
+      }`}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function OverviewSummaryCard({
+  icon,
+  label,
+  value,
+  detail,
+  status,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  detail: string;
+  status?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm font-medium text-gray-500">
+          <span className="text-gray-400">{icon}</span>
+          {label}
+        </div>
+        {status && <StatusDot status={status} />}
+      </div>
+      <div className="mt-3 text-xl font-semibold text-gray-900">{value}</div>
+      <div className="mt-1 text-sm text-gray-500">{detail}</div>
+    </div>
+  );
+}
+
+function GatewayOverviewApis({ overview }: { overview: GatewayOverviewResponse }) {
+  const apis = overview.resolved_config.apis;
+  if (apis.length === 0) {
+    return (
+      <div className="py-10 text-center text-sm text-gray-400">
+        No APIs are deployed on this gateway.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-100 text-left text-gray-500">
+            <th className="pb-2 font-medium">API</th>
+            <th className="pb-2 font-medium">Tenant</th>
+            <th className="pb-2 font-medium">Version</th>
+            <th className="pb-2 font-medium">Routes</th>
+            <th className="pb-2 font-medium">Backend</th>
+            <th className="pb-2 font-medium">Policies</th>
+            <th className="pb-2 font-medium">Sync</th>
+            <th className="pb-2 font-medium">Last sync</th>
+          </tr>
+        </thead>
+        <tbody>
+          {apis.map((api) => (
+            <tr
+              key={api.api_catalog_id}
+              className="border-b border-gray-50 align-top hover:bg-gray-50"
+            >
+              <td className="py-3 pr-4">
+                <Link
+                  to={`/apis/${encodeURIComponent(api.tenant_id)}/${encodeURIComponent(api.api_id)}`}
+                  className="inline-flex items-center gap-1 font-medium text-indigo-700 hover:text-indigo-900"
+                >
+                  {api.name}
+                  <ExternalLink className="h-3 w-3" />
+                </Link>
+                <div className="mt-1 font-mono text-xs text-gray-400">{api.api_id}</div>
+              </td>
+              <td className="py-3 pr-4 font-mono text-xs text-gray-500">{api.tenant_id}</td>
+              <td className="py-3 pr-4 text-gray-600">{api.version}</td>
+              <td className="py-3 pr-4">
+                <div className="font-medium text-gray-900">{api.routes_count}</div>
+                <div className="mt-1 space-y-1">
+                  {api.routes_preview.map((route) => (
+                    <div
+                      key={`${route.method}-${route.path}`}
+                      className="whitespace-nowrap font-mono text-xs text-gray-500"
+                    >
+                      <span className="mr-2 rounded bg-gray-100 px-1.5 py-0.5 text-[11px] font-semibold text-gray-700">
+                        {route.method}
+                      </span>
+                      {route.path}
+                    </div>
+                  ))}
+                  {api.routes_count > api.routes_preview.length && (
+                    <div className="text-xs text-gray-400">
+                      + {api.routes_count - api.routes_preview.length} routes
+                    </div>
+                  )}
+                </div>
+              </td>
+              <td className="max-w-xs py-3 pr-4">
+                {api.backend ? (
+                  <span
+                    className="block truncate font-mono text-xs text-gray-600"
+                    title={api.backend}
+                  >
+                    {api.backend}
+                  </span>
+                ) : (
+                  <span className="text-gray-400">-</span>
+                )}
+              </td>
+              <td className="py-3 pr-4 text-gray-600">{api.policies_count}</td>
+              <td className="py-3 pr-4">
+                <SyncBadge status={api.sync_status} />
+                {api.last_error && (
+                  <div
+                    className="mt-1 max-w-xs truncate text-xs text-red-600"
+                    title={api.last_error}
+                  >
+                    {api.last_error}
+                  </div>
+                )}
+              </td>
+              <td className="py-3 pr-4 text-xs text-gray-500">
+                {formatDateTime(api.last_sync_at)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function GatewayOverviewPolicies({ overview }: { overview: GatewayOverviewResponse }) {
+  const policies = overview.resolved_config.policies;
+  if (policies.length === 0) {
+    return (
+      <div className="py-10 text-center text-sm text-gray-400">
+        No effective policies are applied to this gateway.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-100 text-left text-gray-500">
+            <th className="pb-2 font-medium">Name</th>
+            <th className="pb-2 font-medium">Type</th>
+            <th className="pb-2 font-medium">Scope</th>
+            <th className="pb-2 font-medium">Target</th>
+            <th className="pb-2 font-medium">Priority</th>
+            <th className="pb-2 font-medium">Status</th>
+            <th className="pb-2 font-medium">Summary</th>
+          </tr>
+        </thead>
+        <tbody>
+          {policies.map((policy) => (
+            <tr key={policy.id} className="border-b border-gray-50 align-top hover:bg-gray-50">
+              <td className="py-3 pr-4 font-medium text-gray-900">{policy.name}</td>
+              <td className="py-3 pr-4 font-mono text-xs text-gray-600">{policy.type}</td>
+              <td className="py-3 pr-4">
+                <span className="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700">
+                  {policy.scope}
+                </span>
+              </td>
+              <td className="py-3 pr-4">
+                <div className="text-gray-700">{policy.target.name || policy.target.id || '-'}</div>
+                <div className="font-mono text-xs text-gray-400">{policy.target.type}</div>
+              </td>
+              <td className="py-3 pr-4 text-gray-600">{policy.priority}</td>
+              <td className="py-3 pr-4">
+                <SyncBadge status={policy.sync_status} />
+              </td>
+              <td className="max-w-md py-3 pr-4 text-gray-600">{policy.summary}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function GatewayOverviewRuntime({ overview }: { overview: GatewayOverviewResponse }) {
+  const runtime = overview.runtime;
+  const sync = overview.sync;
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <div>
+        <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold text-gray-900">
+          <Activity className="h-4 w-4 text-gray-400" />
+          Runtime
+        </h3>
+        <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <RuntimeItem label="Status" value={formatStatusLabel(runtime.status)} />
+          <RuntimeItem label="Heartbeat" value={formatAge(runtime.heartbeat_age_seconds)} />
+          <RuntimeItem label="Version" value={runtime.version || '-'} />
+          <RuntimeItem label="Mode" value={runtime.mode || '-'} />
+          <RuntimeItem
+            label="Uptime"
+            value={runtime.uptime_seconds != null ? formatUptime(runtime.uptime_seconds) : '-'}
+          />
+          <RuntimeItem label="MCP tools" value={formatNullableNumber(runtime.mcp_tools_count)} />
+          <RuntimeItem label="Requests" value={formatNullableNumber(runtime.requests_total)} />
+          <RuntimeItem label="Error rate" value={formatPercent(runtime.error_rate)} />
+          <RuntimeItem label="Memory" value={formatBytes(runtime.memory_usage_bytes)} />
+          <RuntimeItem
+            label="Metrics"
+            value={`${formatStatusLabel(overview.summary.metrics_status)} / ${overview.data_quality.metrics_window_seconds ?? '-'}s`}
+          />
+        </dl>
+      </div>
+
+      <div>
+        <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold text-gray-900">
+          <Route className="h-4 w-4 text-gray-400" />
+          Sync / drift
+        </h3>
+        <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <RuntimeItem label="Sync status" value={formatStatusLabel(sync.status)} />
+          <RuntimeItem
+            label="Generation"
+            value={`${formatNullableNumber(sync.desired_generation)} desired / ${formatNullableNumber(sync.applied_generation)} applied`}
+          />
+          <RuntimeItem
+            label="Routes"
+            value={`${overview.summary.expected_routes_count} expected / ${formatNullableNumber(overview.summary.reported_routes_count)} reported`}
+          />
+          <RuntimeItem
+            label="Policies"
+            value={`${overview.summary.effective_policies_count} expected / ${formatNullableNumber(overview.summary.reported_policies_count)} reported`}
+          />
+          <RuntimeItem label="Last reconciled" value={formatDateTime(sync.last_reconciled_at)} />
+          <RuntimeItem label="Last error" value={sync.last_error || '-'} />
+        </dl>
+        {sync.steps.length > 0 && (
+          <div className="mt-4 rounded-lg border border-gray-100">
+            <div className="border-b border-gray-100 px-3 py-2 text-xs font-medium text-gray-500">
+              Sync steps
+            </div>
+            <div className="max-h-48 overflow-auto p-3">
+              <pre className="text-xs text-gray-600">{JSON.stringify(sync.steps, null, 2)}</pre>
+            </div>
+          </div>
+        )}
+        {overview.source.control_plane_revision && (
+          <div className="mt-4 flex items-center gap-2 text-xs text-gray-500">
+            <FileText className="h-3.5 w-3.5" />
+            Revision {overview.source.control_plane_revision}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RuntimeItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-gray-100 p-3">
+      <dt className="text-xs font-medium text-gray-500">{label}</dt>
+      <dd className="mt-1 break-words text-sm font-medium text-gray-900">{value}</dd>
+    </div>
   );
 }
 
@@ -513,19 +932,89 @@ function MetricCard({ label, value, alert }: { label: string; value: string; ale
   );
 }
 
+function StatusDot({ status }: { status: string }) {
+  const color =
+    {
+      in_sync: 'bg-green-500',
+      healthy: 'bg-green-500',
+      available: 'bg-green-500',
+      pending: 'bg-amber-500',
+      stale: 'bg-amber-500',
+      partial: 'bg-amber-500',
+      drift: 'bg-orange-500',
+      degraded: 'bg-orange-500',
+      failed: 'bg-red-500',
+      offline: 'bg-red-500',
+      unavailable: 'bg-red-500',
+    }[status] ?? 'bg-gray-400';
+
+  return <span className={`h-2.5 w-2.5 rounded-full ${color}`} aria-hidden="true" />;
+}
+
 function SyncBadge({ status }: { status: string }) {
   const colors: Record<string, string> = {
+    in_sync: 'bg-green-50 text-green-700',
     synced: 'bg-green-50 text-green-700',
     pending: 'bg-amber-50 text-amber-700',
     syncing: 'bg-blue-50 text-blue-700',
+    failed: 'bg-red-50 text-red-700',
     error: 'bg-red-50 text-red-700',
+    drift: 'bg-orange-50 text-orange-700',
     drifted: 'bg-orange-50 text-orange-700',
+    unknown: 'bg-gray-50 text-gray-700',
   };
   return (
     <span
       className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${colors[status] || 'bg-gray-50 text-gray-700'}`}
     >
-      {status}
+      {formatStatusLabel(status)}
     </span>
   );
+}
+
+function formatStatusLabel(status: string): string {
+  return status.replace(/_/g, ' ');
+}
+
+function formatNullableNumber(value: number | null | undefined): string {
+  return value == null ? '-' : String(value);
+}
+
+function formatAge(seconds: number | null | undefined): string {
+  if (seconds == null) return '-';
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function formatDateTime(value: string | null | undefined): string {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '-';
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatPercent(value: number | null | undefined): string {
+  if (value == null) return '-';
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatBytes(value: number | null | undefined): string {
+  if (value == null) return '-';
+  if (value < 1024) return `${value} B`;
+  const units = ['KB', 'MB', 'GB'];
+  let amount = value / 1024;
+  for (const unit of units) {
+    if (amount < 1024) return `${amount.toFixed(1)} ${unit}`;
+    amount /= 1024;
+  }
+  return `${amount.toFixed(1)} TB`;
 }

--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -63,6 +63,7 @@ import type {
   GatewayInstanceMetrics,
   GatewayInstanceUpdate,
   GatewayModeStats,
+  GatewayOverviewResponse,
   GatewayPolicy,
   PaginatedGatewayDeployments,
   PaginatedGatewayInstances,
@@ -732,6 +733,10 @@ class ApiService {
 
   async getGatewayInstance(id: string): Promise<GatewayInstance> {
     return gatewaysClient.getInstance(id);
+  }
+
+  async getGatewayOverview(id: string): Promise<GatewayOverviewResponse> {
+    return gatewaysClient.getOverview(id);
   }
 
   async getGatewayTools(id: string): Promise<Schemas['ListToolsResponse']['tools']> {

--- a/control-plane-ui/src/services/api/gateways.ts
+++ b/control-plane-ui/src/services/api/gateways.ts
@@ -9,6 +9,7 @@ import type {
   GatewayInstanceMetrics,
   GatewayInstanceUpdate,
   GatewayModeStats,
+  GatewayOverviewResponse,
   GatewayPolicy,
   PaginatedGatewayInstances,
 } from '../../types';
@@ -36,6 +37,11 @@ export const gatewaysClient = {
 
   async getInstance(id: string): Promise<GatewayInstance> {
     const { data } = await httpClient.get(path('v1', 'admin', 'gateways', id));
+    return data;
+  },
+
+  async getOverview(id: string): Promise<GatewayOverviewResponse> {
+    const { data } = await httpClient.get(path('v1', 'admin', 'gateways', id, 'overview'));
     return data;
   },
 

--- a/control-plane-ui/src/test/services/api/ui2-s2d-clients.test.ts
+++ b/control-plane-ui/src/test/services/api/ui2-s2d-clients.test.ts
@@ -218,6 +218,7 @@ describe('UI-2 S2d domain clients', () => {
   it('covers gatewaysClient request delegation', async () => {
     const gatewayList = { items: [{ id: 'gw-1' }], total: 1, page: 1, page_size: 20 };
     const gateway = { id: 'gw-1', mode: 'edge-mcp' };
+    const overview = { schema_version: '1.0', gateway: { id: 'gw-1' } };
     const tools = [{ id: 'tool-1' }];
     const modeStats = { modes: [{ mode: 'edge-mcp', total: 1 }], total_gateways: 1 };
     const metrics = { requests_total: 42 };
@@ -230,6 +231,7 @@ describe('UI-2 S2d domain clients', () => {
     mockHttpClient.get
       .mockResolvedValueOnce({ data: gatewayList })
       .mockResolvedValueOnce({ data: gateway })
+      .mockResolvedValueOnce({ data: overview })
       .mockResolvedValueOnce({ data: tools })
       .mockResolvedValueOnce({ data: modeStats })
       .mockResolvedValueOnce({ data: metrics })
@@ -262,6 +264,7 @@ describe('UI-2 S2d domain clients', () => {
       })
     ).resolves.toBe(gatewayList);
     await expect(gatewaysClient.getInstance('gw-1')).resolves.toBe(gateway);
+    await expect(gatewaysClient.getOverview('gw-1')).resolves.toBe(overview);
     await expect(gatewaysClient.listTools('gw-1')).resolves.toBe(tools);
     await expect(
       gatewaysClient.createInstance({
@@ -317,7 +320,8 @@ describe('UI-2 S2d domain clients', () => {
       },
     });
     expect(mockHttpClient.get).toHaveBeenNthCalledWith(2, '/v1/admin/gateways/gw-1');
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(3, '/v1/admin/gateways/gw-1/tools');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(3, '/v1/admin/gateways/gw-1/overview');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(4, '/v1/admin/gateways/gw-1/tools');
     expect(mockHttpClient.post).toHaveBeenNthCalledWith(1, '/v1/admin/gateways', {
       name: 'Gateway 1',
     });
@@ -327,16 +331,16 @@ describe('UI-2 S2d domain clients', () => {
     expect(mockHttpClient.delete).toHaveBeenNthCalledWith(1, '/v1/admin/gateways/gw-1');
     expect(mockHttpClient.post).toHaveBeenNthCalledWith(2, '/v1/admin/gateways/gw-1/restore');
     expect(mockHttpClient.post).toHaveBeenNthCalledWith(3, '/v1/admin/gateways/gw-1/health');
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(4, '/v1/admin/gateways/modes/stats');
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(5, '/v1/admin/gateways/metrics');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(5, '/v1/admin/gateways/modes/stats');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(6, '/v1/admin/gateways/metrics');
     expect(mockHttpClient.get).toHaveBeenNthCalledWith(
-      6,
+      7,
       '/v1/admin/gateways/metrics/guardrails/events',
       { params: { limit: 15 } }
     );
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(7, '/v1/admin/gateways/health-summary');
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(8, '/v1/admin/gateways/gw-1/metrics');
-    expect(mockHttpClient.get).toHaveBeenNthCalledWith(9, '/v1/admin/policies', {
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(8, '/v1/admin/gateways/health-summary');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(9, '/v1/admin/gateways/gw-1/metrics');
+    expect(mockHttpClient.get).toHaveBeenNthCalledWith(10, '/v1/admin/policies', {
       params: { tenant_id: 'tenant-1', environment: 'prod' },
     });
     expect(mockHttpClient.post).toHaveBeenNthCalledWith(4, '/v1/admin/policies', {

--- a/control-plane-ui/src/types/index.ts
+++ b/control-plane-ui/src/types/index.ts
@@ -1123,6 +1123,142 @@ export interface PaginatedGatewayInstances {
   page_size: number;
 }
 
+export type GatewayOverviewSyncStatus = 'in_sync' | 'pending' | 'drift' | 'failed' | 'unknown';
+
+export type GatewayOverviewRuntimeStatus = 'healthy' | 'degraded' | 'stale' | 'offline' | 'unknown';
+
+export type GatewayOverviewMetricsStatus = 'available' | 'partial' | 'unavailable';
+export type GatewayOverviewRuntimeFreshness = 'fresh' | 'stale' | 'missing';
+export type GatewayOverviewDataQualitySeverity = 'info' | 'warning' | 'error';
+
+export interface GatewayOverviewWarning {
+  code: string;
+  severity: GatewayOverviewDataQualitySeverity;
+  message: string;
+}
+
+export interface GatewayOverviewApiSource {
+  git_path?: string | null;
+  git_commit_sha?: string | null;
+  spec_hash?: string | null;
+}
+
+export interface GatewayOverviewRoutePreview {
+  method: string;
+  path: string;
+  backend?: string | null;
+}
+
+export interface GatewayOverviewApi {
+  tenant_id: string;
+  api_id: string;
+  api_catalog_id: string;
+  name: string;
+  version: string;
+  source: GatewayOverviewApiSource;
+  routes_count: number;
+  routes_preview: GatewayOverviewRoutePreview[];
+  backend?: string | null;
+  policies_count: number;
+  sync_status: GatewayOverviewSyncStatus;
+  last_sync_at?: string | null;
+  last_error?: string | null;
+}
+
+export interface GatewayOverviewPolicyTarget {
+  type: string;
+  id?: string | null;
+  name?: string | null;
+}
+
+export interface GatewayOverviewPolicyBindingSource {
+  id: string;
+  scope: string;
+  target_id?: string | null;
+}
+
+export interface GatewayOverviewPolicy {
+  id: string;
+  name: string;
+  type: string;
+  scope: string;
+  target: GatewayOverviewPolicyTarget;
+  enabled: boolean;
+  priority: number;
+  summary: string;
+  sync_status: GatewayOverviewSyncStatus;
+  source_binding: GatewayOverviewPolicyBindingSource;
+}
+
+export interface GatewayOverviewResponse {
+  schema_version: string;
+  generated_at: string;
+  gateway: {
+    id: string;
+    name: string;
+    display_name: string;
+    gateway_type: string;
+    environment: string;
+    status: string;
+    mode?: string | null;
+    version?: string | null;
+  };
+  visibility: {
+    rbac_scope: string;
+    tenant_id?: string | null;
+    filtered: boolean;
+  };
+  source: {
+    control_plane_revision?: string | null;
+    last_loaded_at?: string | null;
+  };
+  summary: {
+    sync_status: GatewayOverviewSyncStatus;
+    runtime_status: GatewayOverviewRuntimeStatus;
+    metrics_status: GatewayOverviewMetricsStatus;
+    apis_count: number;
+    expected_routes_count: number;
+    reported_routes_count?: number | null;
+    effective_policies_count: number;
+    reported_policies_count?: number | null;
+    failed_policies_count: number;
+  };
+  resolved_config: {
+    apis: GatewayOverviewApi[];
+    policies: GatewayOverviewPolicy[];
+  };
+  sync: {
+    desired_generation?: number | null;
+    applied_generation?: number | null;
+    status: GatewayOverviewSyncStatus;
+    drift: boolean;
+    last_reconciled_at?: string | null;
+    last_error?: string | null;
+    steps: Record<string, unknown>[];
+  };
+  runtime: {
+    status: GatewayOverviewRuntimeStatus;
+    last_heartbeat_at?: string | null;
+    heartbeat_age_seconds?: number | null;
+    version?: string | null;
+    mode?: string | null;
+    uptime_seconds?: number | null;
+    reported_routes_count?: number | null;
+    reported_policies_count?: number | null;
+    mcp_tools_count?: number | null;
+    requests_total?: number | null;
+    error_rate?: number | null;
+    memory_usage_bytes?: number | null;
+  };
+  data_quality: {
+    runtime_freshness: GatewayOverviewRuntimeFreshness;
+    heartbeat_stale_after_seconds: number;
+    metrics_status: GatewayOverviewMetricsStatus;
+    metrics_window_seconds?: number | null;
+    warnings: GatewayOverviewWarning[];
+  };
+}
+
 export interface SyncStep {
   name: string;
   status: 'running' | 'success' | 'failed' | 'skipped';


### PR DESCRIPTION
## Summary
- consume `GET /v1/admin/gateways/{id}/overview` from the console API client
- add Gateway Detail overview summary cards plus APIs / Policies / Runtime tabs
- keep legacy deployments/health fallback when the overview endpoint is unavailable

## Validation
- npm --prefix control-plane-ui test -- GatewayDetail.test.tsx
- npm --prefix control-plane-ui test -- src/test/services/api/ui2-s2d-clients.test.ts
- npm --prefix control-plane-ui run build
- npm --prefix control-plane-ui run lint (51 pre-existing warnings, 0 errors)
- git diff --check