### PR TITLE
fix(ui): reduce gateway metrics warning noise

### DIFF
--- a/control-plane-ui/src/__tests__/regression/gateway-overview-warning-noise.test.ts
+++ b/control-plane-ui/src/__tests__/regression/gateway-overview-warning-noise.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { filterProminentOverviewWarnings } from '../../pages/Gateways/gatewayOverviewWarnings';
+
+describe('regression/gateway-overview-warning-noise', () => {
+  it('keeps informational runtime metrics warnings out of prominent gateway alerts', () => {
+    expect(
+      filterProminentOverviewWarnings([
+        {
+          code: 'runtime_metrics_partial',
+          severity: 'info',
+          message: 'Some runtime metrics are not available for this gateway',
+        },
+        {
+          code: 'runtime_heartbeat_stale',
+          severity: 'warning',
+          message: 'Gateway heartbeat is stale',
+        },
+      ])
+    ).toEqual([
+      {
+        code: 'runtime_heartbeat_stale',
+        severity: 'warning',
+        message: 'Gateway heartbeat is stale',
+      },
+    ]);
+  });
+});

--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.test.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.test.tsx
@@ -430,8 +430,8 @@ describe('GatewayDetail', () => {
     expect(screen.getByText('2 effective')).toBeInTheDocument();
     expect(screen.getByText('0 failed')).toBeInTheDocument();
     expect(
-      screen.getByText('Some runtime metrics are not available for this gateway')
-    ).toBeInTheDocument();
+      screen.queryByText('Some runtime metrics are not available for this gateway')
+    ).not.toBeInTheDocument();
   });
 
   it('uses deployed APIs label for native sidecar gateways', async () => {
@@ -500,6 +500,10 @@ describe('GatewayDetail', () => {
     expect(screen.getByText('129')).toBeInTheDocument();
     expect(screen.getByText('partial / 300s')).toBeInTheDocument();
     expect(screen.getByText('5 expected / 5 reported')).toBeInTheDocument();
+    expect(screen.getByText('Data quality')).toBeInTheDocument();
+    expect(
+      screen.getByText('Some runtime metrics are not available for this gateway')
+    ).toBeInTheDocument();
   });
 
   it('renders RBAC filtered overview notice', async () => {

--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
@@ -188,6 +188,9 @@ export function GatewayDetail() {
   const hasOverview = Boolean(overview);
   const showLegacyGatewayData = !overviewLoading && !hasOverview;
   const overviewWarnings = overview?.data_quality.warnings ?? [];
+  const prominentOverviewWarnings = overviewWarnings.filter(
+    (warning) => warning.severity !== 'info'
+  );
 
   return (
     <div className="p-6 max-w-5xl mx-auto space-y-6">
@@ -330,7 +333,7 @@ export function GatewayDetail() {
             />
           </div>
 
-          {(overview.visibility.filtered || overviewWarnings.length > 0) && (
+          {(overview.visibility.filtered || prominentOverviewWarnings.length > 0) && (
             <div className="space-y-2">
               {overview.visibility.filtered && (
                 <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
@@ -338,7 +341,7 @@ export function GatewayDetail() {
                   Vue filtrée selon vos permissions.
                 </div>
               )}
-              {overviewWarnings.map((warning) => (
+              {prominentOverviewWarnings.map((warning) => (
                 <div
                   key={warning.code}
                   className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700"
@@ -882,6 +885,23 @@ function GatewayOverviewRuntime({ overview }: { overview: GatewayOverviewRespons
           <div className="mt-4 flex items-center gap-2 text-xs text-gray-500">
             <FileText className="h-3.5 w-3.5" />
             Revision {overview.source.control_plane_revision}
+          </div>
+        )}
+        {overview.data_quality.warnings.length > 0 && (
+          <div className="mt-4 rounded-lg border border-gray-100">
+            <div className="border-b border-gray-100 px-3 py-2 text-xs font-medium text-gray-500">
+              Data quality
+            </div>
+            <div className="space-y-2 p-3">
+              {overview.data_quality.warnings.map((warning) => (
+                <div key={warning.code} className="text-xs text-gray-600">
+                  <span className="font-medium text-gray-800">
+                    {formatStatusLabel(warning.severity)}:
+                  </span>{' '}
+                  {warning.message}
+                </div>
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
+++ b/control-plane-ui/src/pages/Gateways/GatewayDetail.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { useToastActions } from '@stoa/shared/components/Toast';
 import { useConfirm } from '@stoa/shared/components/ConfirmDialog';
 import { CardSkeleton } from '@stoa/shared/components/Skeleton';
+import { filterProminentOverviewWarnings } from './gatewayOverviewWarnings';
 import {
   ArrowLeft,
   ExternalLink,
@@ -188,9 +189,7 @@ export function GatewayDetail() {
   const hasOverview = Boolean(overview);
   const showLegacyGatewayData = !overviewLoading && !hasOverview;
   const overviewWarnings = overview?.data_quality.warnings ?? [];
-  const prominentOverviewWarnings = overviewWarnings.filter(
-    (warning) => warning.severity !== 'info'
-  );
+  const prominentOverviewWarnings = filterProminentOverviewWarnings(overviewWarnings);
 
   return (
     <div className="p-6 max-w-5xl mx-auto space-y-6">

--- a/control-plane-ui/src/pages/Gateways/gatewayOverviewWarnings.ts
+++ b/control-plane-ui/src/pages/Gateways/gatewayOverviewWarnings.ts
@@ -1,0 +1,7 @@
+import type { GatewayOverviewResponse } from '../../types';
+
+export function filterProminentOverviewWarnings(
+  warnings: GatewayOverviewResponse['data_quality']['warnings']
+) {
+  return warnings.filter((warning) => warning.severity !== 'info');
+}


### PR DESCRIPTION
## Summary
- hide info-level gateway overview data-quality messages from the top Gateway Detail alert area
- keep those info messages available inside the Runtime tab under Data quality

## Validation
- npm --prefix control-plane-ui test -- GatewayDetail.test.tsx
- npm --prefix control-plane-ui run build
- npm --prefix control-plane-ui run lint (51 pre-existing warnings, 0 errors)
- git diff --check