### PR TITLE
fix(observability): add gateway trace log correlation

### DIFF
--- a/docs/observability/gateway-trace-log-correlation.md
+++ b/docs/observability/gateway-trace-log-correlation.md
@@ -1,0 +1,29 @@
+# Gateway Trace/Log Correlation
+
+This document records the narrow PR3 implementation of the observability
+contract for gateway access logs. It does not rewire telemetry pipelines.
+
+## Scope
+
+Gateway structured access logs MUST expose the correlation fields needed to
+navigate between live traces and logs:
+
+| Log field | Source | Fallback | Notes |
+| --- | --- | --- | --- |
+| `trace_id` | Current OTel span context captured by `http_metrics_middleware` | `x-stoa-trace-id`, then `-` | Allows log-to-trace correlation in Loki/Tempo. |
+| `span_id` | Current OTel span context captured by `http_metrics_middleware` | `-` | Represents the local gateway span, not an incoming parent span. |
+| `tenant_id` | Gateway request extensions | empty string | Present when auth/tenant context is known. |
+| `consumer_id` | Gateway request extensions | empty string | Logs only; still forbidden as a Prometheus label. |
+| `service.name` | Static gateway service identity | none | `stoa-gateway`. |
+| `service.version` | Cargo package version | none | Matches the gateway build version. |
+
+## Non-goals
+
+This change does not:
+
+- add trace or span IDs to Prometheus labels;
+- change Prometheus metrics or cardinality;
+- redesign Console Observability;
+- rewire Loki, Tempo, OpenSearch, Fluent Bit, Data Prepper, or Alloy;
+- change tenant authorization or server-side tenant filtering;
+- change OTel sampling behavior.

--- a/stoa-gateway/src/access_log.rs
+++ b/stoa-gateway/src/access_log.rs
@@ -164,7 +164,7 @@ mod tests {
     use tower::ServiceExt;
 
     #[test]
-    fn test_resolve_trace_id_prefers_response_extension() {
+    fn regression_access_log_prefers_captured_trace_id_extension() {
         let mut response = Response::new(Body::empty());
         response.extensions_mut().insert(CapturedTraceId(
             "abc123def456abc123def456abc123de".to_string(),
@@ -181,7 +181,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_trace_id_falls_back_to_header() {
+    fn regression_access_log_trace_id_falls_back_to_x_stoa_trace_id_header() {
         let mut response = Response::new(Body::empty());
         response.headers_mut().insert(
             "x-stoa-trace-id",
@@ -195,7 +195,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_span_id_from_response_extension() {
+    fn regression_access_log_resolves_span_id_from_response_extension() {
         let mut response = Response::new(Body::empty());
         response
             .extensions_mut()

--- a/stoa-gateway/src/access_log.rs
+++ b/stoa-gateway/src/access_log.rs
@@ -21,6 +21,13 @@ use crate::diagnostics::latency::{new_shared_tracker, to_server_timing, Stage};
 #[derive(Clone, Debug)]
 pub struct CapturedTraceId(pub String);
 
+/// Span ID captured inside the OTel span by `http_metrics_middleware`.
+///
+/// Injected into response extensions with `CapturedTraceId` so access logs can
+/// correlate directly to the Tempo span that handled the request.
+#[derive(Clone, Debug)]
+pub struct CapturedSpanId(pub String);
+
 /// Paths to skip from access logging (noisy health/metrics endpoints).
 const SKIP_PATHS: &[&str] = &[
     "/health",
@@ -29,6 +36,32 @@ const SKIP_PATHS: &[&str] = &[
     "/ready",
     "/metrics",
 ];
+
+const SERVICE_NAME: &str = "stoa-gateway";
+const SERVICE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn resolve_trace_id(response: &Response) -> String {
+    response
+        .extensions()
+        .get::<CapturedTraceId>()
+        .map(|t| t.0.clone())
+        .or_else(|| {
+            response
+                .headers()
+                .get("x-stoa-trace-id")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn resolve_span_id(response: &Response) -> String {
+    response
+        .extensions()
+        .get::<CapturedSpanId>()
+        .map(|s| s.0.clone())
+        .unwrap_or_else(|| "-".to_string())
+}
 
 /// Access log middleware — emits structured JSON for each request.
 ///
@@ -92,18 +125,8 @@ pub async fn access_log_middleware(mut request: Request, next: Next) -> Response
     //
     // Reading from request extensions before next.run() doesn't work: trace_context_middleware
     // (inner layer) hasn't set RequestTraceContext yet when access_log (outer layer) starts.
-    let trace_id = response
-        .extensions()
-        .get::<CapturedTraceId>()
-        .map(|t| t.0.clone())
-        .or_else(|| {
-            response
-                .headers()
-                .get("x-stoa-trace-id")
-                .and_then(|v| v.to_str().ok())
-                .map(str::to_owned)
-        })
-        .unwrap_or_else(|| "-".to_string());
+    let trace_id = resolve_trace_id(&response);
+    let span_id = resolve_span_id(&response);
 
     tracing::info!(
         target: "access_log",
@@ -115,6 +138,9 @@ pub async fn access_log_middleware(mut request: Request, next: Next) -> Response
         consumer_id = %consumer_id,
         user_agent = %user_agent,
         trace_id = %trace_id,
+        span_id = %span_id,
+        "service.name" = %SERVICE_NAME,
+        "service.version" = %SERVICE_VERSION,
         log_type = "access_log",
         server_timing = %server_timing,
         "request completed"
@@ -136,6 +162,55 @@ mod tests {
     use super::*;
     use axum::{body::Body, http::StatusCode, routing::get, Router};
     use tower::ServiceExt;
+
+    #[test]
+    fn test_resolve_trace_id_prefers_response_extension() {
+        let mut response = Response::new(Body::empty());
+        response.extensions_mut().insert(CapturedTraceId(
+            "abc123def456abc123def456abc123de".to_string(),
+        ));
+        response.headers_mut().insert(
+            "x-stoa-trace-id",
+            axum::http::HeaderValue::from_static("4bf92f3577b34da6a3ce929d0e0e4736"),
+        );
+
+        assert_eq!(
+            resolve_trace_id(&response),
+            "abc123def456abc123def456abc123de"
+        );
+    }
+
+    #[test]
+    fn test_resolve_trace_id_falls_back_to_header() {
+        let mut response = Response::new(Body::empty());
+        response.headers_mut().insert(
+            "x-stoa-trace-id",
+            axum::http::HeaderValue::from_static("4bf92f3577b34da6a3ce929d0e0e4736"),
+        );
+
+        assert_eq!(
+            resolve_trace_id(&response),
+            "4bf92f3577b34da6a3ce929d0e0e4736"
+        );
+    }
+
+    #[test]
+    fn test_resolve_span_id_from_response_extension() {
+        let mut response = Response::new(Body::empty());
+        response
+            .extensions_mut()
+            .insert(CapturedSpanId("00f067aa0ba902b7".to_string()));
+
+        assert_eq!(resolve_span_id(&response), "00f067aa0ba902b7");
+    }
+
+    #[test]
+    fn test_resolve_correlation_ids_fallback_to_dash() {
+        let response = Response::new(Body::empty());
+
+        assert_eq!(resolve_trace_id(&response), "-");
+        assert_eq!(resolve_span_id(&response), "-");
+    }
 
     #[tokio::test]
     async fn test_access_log_skips_health() {
@@ -180,6 +255,9 @@ mod tests {
             response.extensions_mut().insert(CapturedTraceId(
                 "abc123def456abc123def456abc123de".to_string(),
             ));
+            response
+                .extensions_mut()
+                .insert(CapturedSpanId("00f067aa0ba902b7".to_string()));
             response
         }
 

--- a/stoa-gateway/src/access_log.rs
+++ b/stoa-gateway/src/access_log.rs
@@ -44,12 +44,15 @@ fn resolve_trace_id(response: &Response) -> String {
     response
         .extensions()
         .get::<CapturedTraceId>()
-        .map(|t| t.0.clone())
+        .map(|t| t.0.as_str())
+        .filter(|trace_id| !trace_id.is_empty() && *trace_id != "-")
+        .map(str::to_owned)
         .or_else(|| {
             response
                 .headers()
                 .get("x-stoa-trace-id")
                 .and_then(|v| v.to_str().ok())
+                .filter(|trace_id| !trace_id.is_empty() && *trace_id != "-")
                 .map(str::to_owned)
         })
         .unwrap_or_else(|| "-".to_string())
@@ -183,6 +186,23 @@ mod tests {
     #[test]
     fn regression_access_log_trace_id_falls_back_to_x_stoa_trace_id_header() {
         let mut response = Response::new(Body::empty());
+        response.headers_mut().insert(
+            "x-stoa-trace-id",
+            axum::http::HeaderValue::from_static("4bf92f3577b34da6a3ce929d0e0e4736"),
+        );
+
+        assert_eq!(
+            resolve_trace_id(&response),
+            "4bf92f3577b34da6a3ce929d0e0e4736"
+        );
+    }
+
+    #[test]
+    fn regression_access_log_ignores_dash_captured_trace_id_and_falls_back_to_header() {
+        let mut response = Response::new(Body::empty());
+        response
+            .extensions_mut()
+            .insert(CapturedTraceId("-".to_string()));
         response.headers_mut().insert(
             "x-stoa-trace-id",
             axum::http::HeaderValue::from_static("4bf92f3577b34da6a3ce929d0e0e4736"),

--- a/stoa-gateway/src/lib.rs
+++ b/stoa-gateway/src/lib.rs
@@ -607,7 +607,7 @@ async fn http_metrics_middleware(
                 .map(|s| s.to_string())
         })
         .unwrap_or_else(|| remote_ip.clone());
-    let (response, captured_trace_id) = if tracing_enabled {
+    let (response, captured_trace_id, captured_span_id) = if tracing_enabled {
         let deployment_mode = state.config.gateway_mode.to_string();
         let request_span = tracing::span!(
             tracing::Level::INFO,
@@ -630,11 +630,11 @@ async fn http_metrics_middleware(
         request_span.record("process.rss_bytes", crate::memory::read_rss_bytes());
         request_span.record("process.fd_count", crate::memory::read_fd_count());
         request_span.record("process.thread_count", crate::memory::read_thread_count());
-        // CAB-1866: capture trace_id inside the span so access_log_middleware can read it.
+        // CAB-1866/PR3: capture trace/span IDs inside the span so access_log_middleware can read them.
         // access_log is an outer layer — by the time it sees the response, this span has
         // already closed and tracing::Span::current() returns Span::none().
         // Status code + OTel status are recorded inside the span before it closes.
-        let (resp, trace_id) = async {
+        let (resp, trace_id, span_id) = async {
             let r = next.run(request).await;
             let status = r.status().as_u16();
             let current = tracing::Span::current();
@@ -646,19 +646,23 @@ async fn http_metrics_middleware(
                 current.record("otel.status_code", "OK");
             }
             let tid = crate::telemetry::extract_trace_id();
-            (r, tid)
+            let sid = crate::telemetry::extract_span_id();
+            (r, tid, sid)
         }
         .instrument(request_span)
         .await;
-        (resp, trace_id)
+        (resp, trace_id, span_id)
     } else {
         let resp = next.run(request).await;
-        (resp, "-".to_string())
+        (resp, "-".to_string(), "-".to_string())
     };
     let mut response = response;
     response
         .extensions_mut()
         .insert(crate::access_log::CapturedTraceId(captured_trace_id));
+    response
+        .extensions_mut()
+        .insert(crate::access_log::CapturedSpanId(captured_span_id));
 
     let duration = start.elapsed().as_secs_f64();
     let status = response.status().as_u16();

--- a/stoa-gateway/src/telemetry/mod.rs
+++ b/stoa-gateway/src/telemetry/mod.rs
@@ -167,6 +167,24 @@ pub fn extract_trace_id() -> String {
     "-".to_string()
 }
 
+/// Extract the current OTel span_id as hex string (for access logs).
+///
+/// Returns `"-"` when OTel is inactive.
+pub fn extract_span_id() -> String {
+    if is_otel_active() {
+        use opentelemetry::trace::TraceContextExt;
+        use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+        let cx = tracing::Span::current().context();
+        let span_ref = cx.span();
+        let span_id = span_ref.span_context().span_id();
+        if span_id != opentelemetry::trace::SpanId::INVALID {
+            return format!("{span_id}");
+        }
+    }
+    "-".to_string()
+}
+
 /// Shutdown OpenTelemetry (flush pending spans)
 pub fn shutdown_telemetry() {
     if is_otel_active() {
@@ -239,5 +257,14 @@ mod tests {
         let trace_id = extract_trace_id();
         // Either "-" (inactive) or a valid hex trace ID
         assert!(!trace_id.is_empty());
+    }
+
+    #[test]
+    fn test_extract_span_id_when_inactive() {
+        // When OTel is not initialized, should return "-"
+        // (OnceLock may or may not be set depending on test order)
+        let span_id = extract_span_id();
+        // Either "-" (inactive) or a valid hex span ID
+        assert!(!span_id.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Adds gateway trace/log correlation fields according to the accepted observability contract.

Changes include:
- capture the current OTel `trace_id` and `span_id` inside the gateway HTTP span before it closes
- expose `trace_id`, `span_id`, `service.name`, and `service.version` on structured `access_log` events
- keep `tenant_id` and `consumer_id` as log-only context when available
- document the gateway correlation contract implemented by this PR
- add focused regression tests for correlation ID resolution and fallback behavior

## Non-goals

This PR does not:
- add trace or span IDs to Prometheus labels
- change Prometheus metrics or cardinality
- redesign Console Observability
- rewire Loki, Tempo, OpenSearch, Fluent Bit, Data Prepper, or Alloy
- change sidecar or stoa-connect telemetry wiring
- change tenant authorization behavior
- change OTel sampling policy

## Validation

- `cargo fmt --check` passes in `stoa-gateway/`
- `cargo test access_log` passes
- `cargo test telemetry` passes
- `cargo test` passes in `stoa-gateway/`
- `cargo clippy --all-targets -- -D warnings` passes in `stoa-gateway/`
- `python3 -m pytest tests/test_regression_observability_promql_compat.py -q` passes in `control-plane-api/`
- `git diff --cached --check` passed before commit

## Follow-up

Next observability PR remains PR4: sidecar + stoa-connect pipeline wiring.
