### PR TITLE
fix(observability): wire sidecar and stoa-connect telemetry

### DIFF
--- a/charts/stoa-platform/templates/stoa-sidecar-deployment.yaml
+++ b/charts/stoa-platform/templates/stoa-sidecar-deployment.yaml
@@ -143,6 +143,10 @@ spec:
               value: {{ .Values.stoaSidecar.logLevel | default "info" | quote }}
             - name: STOA_LOG_FORMAT
               value: {{ .Values.stoaSidecar.logFormat | default "json" | quote }}
+            {{- if .Values.stoaSidecar.otelEndpoint }}
+            - name: STOA_OTEL_ENDPOINT
+              value: {{ .Values.stoaSidecar.otelEndpoint | quote }}
+            {{- end }}
 
             {{- with .Values.stoaSidecar.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/stoa-platform/templates/stoa-sidecar-servicemonitor.yaml
+++ b/charts/stoa-platform/templates/stoa-sidecar-servicemonitor.yaml
@@ -48,7 +48,7 @@ spec:
       scrapeTimeout: {{ .Values.stoaSidecar.serviceMonitor.scrapeTimeout | default "10s" }}
       metricRelabelings:
         - targetLabel: cluster
-          replacement: {{ .Values.stoaSidecar.clusterName | default "default" }}
+          replacement: {{ .Values.stoaSidecar.serviceMonitor.clusterName | default "default" }}
         - targetLabel: environment
           replacement: {{ .Values.stoaSidecar.environment | default "dev" }}
         - targetLabel: deployment_mode

--- a/charts/stoa-platform/templates/stoa-sidecar-servicemonitor.yaml
+++ b/charts/stoa-platform/templates/stoa-sidecar-servicemonitor.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.stoaSidecar.enabled (default false .Values.stoaSidecar.serviceMonitor.enabled) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.stoaSidecar.targetGateway | default "third-party" }}-stoa-sidecar
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: stoa-sidecar
+    app.kubernetes.io/component: sidecar
+    stoa.io/observability-target: stoa-sidecar
+    stoa.io/target-gateway: {{ .Values.stoaSidecar.targetGateway | default "generic" }}
+    {{- include "stoa-platform.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8081
+      targetPort: authz
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: stoa-sidecar
+    stoa.io/target-gateway: {{ .Values.stoaSidecar.targetGateway | default "generic" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.stoaSidecar.targetGateway | default "third-party" }}-stoa-sidecar
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: stoa-sidecar
+    app.kubernetes.io/component: sidecar
+    stoa.io/observability-target: stoa-sidecar
+    stoa.io/target-gateway: {{ .Values.stoaSidecar.targetGateway | default "generic" }}
+    {{- include "stoa-platform.labels" . | nindent 4 }}
+    prometheus: kube-prometheus-stack
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: stoa-sidecar
+      stoa.io/observability-target: stoa-sidecar
+      stoa.io/target-gateway: {{ .Values.stoaSidecar.targetGateway | default "generic" }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.stoaSidecar.serviceMonitor.interval | default "15s" }}
+      scrapeTimeout: {{ .Values.stoaSidecar.serviceMonitor.scrapeTimeout | default "10s" }}
+      metricRelabelings:
+        - targetLabel: cluster
+          replacement: {{ .Values.stoaSidecar.clusterName | default "default" }}
+        - targetLabel: environment
+          replacement: {{ .Values.stoaSidecar.environment | default "dev" }}
+        - targetLabel: deployment_mode
+          replacement: sidecar
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/stoa-platform/values.yaml
+++ b/charts/stoa-platform/values.yaml
@@ -233,6 +233,17 @@ stoaSidecar:
   logLevel: info
   logFormat: json
 
+  # OpenTelemetry Collector endpoint (Grafana Alloy in stoa-monitoring namespace)
+  # Set to enable distributed tracing export via OTLP gRPC.
+  otelEndpoint: 'http://stoa-alloy-otlp.stoa-monitoring:4317'
+
+  # ServiceMonitor for explicit sidecar metrics scraping.
+  serviceMonitor:
+    enabled: true
+    interval: 15s
+    scrapeTimeout: 10s
+  clusterName: default
+
   # Service configuration
   service:
     type: ClusterIP

--- a/charts/stoa-platform/values.yaml
+++ b/charts/stoa-platform/values.yaml
@@ -242,7 +242,7 @@ stoaSidecar:
     enabled: true
     interval: 15s
     scrapeTimeout: 10s
-  clusterName: default
+    clusterName: default
 
   # Service configuration
   service:

--- a/deploy/docker-compose/config/prometheus/prometheus.yml
+++ b/deploy/docker-compose/config/prometheus/prometheus.yml
@@ -48,9 +48,9 @@ scrape_configs:
     scrape_interval: 10s
 
   # -------------------------------------------------------------------------
-  # STOA Gateway — Connect Mode
+  # STOA Gateway — Rust connect-mode simulation
   # -------------------------------------------------------------------------
-  - job_name: 'stoa-connect'
+  - job_name: 'stoa-gateway-connect-mode'
     static_configs:
       - targets: ['stoa-gateway-connect:8083']
         labels:

--- a/deploy/docker-compose/docker-compose.webmethods.yml
+++ b/deploy/docker-compose/docker-compose.webmethods.yml
@@ -54,6 +54,7 @@ services:
       STOA_INSTANCE_NAME: "stoa-connect-wm-local"
       STOA_ENVIRONMENT: "dev"
       STOA_GATEWAY_MODE: "connect"
+      STOA_LOG_FORMAT: "json"
       # Target gateway (webMethods)
       STOA_GATEWAY_ADMIN_URL: http://apigateway:5555
       STOA_GATEWAY_TYPE: webmethods

--- a/docs/observability/sidecar-connect-wiring.md
+++ b/docs/observability/sidecar-connect-wiring.md
@@ -1,0 +1,37 @@
+# Sidecar and stoa-connect Observability Wiring
+
+This records the narrow PR4 wiring for the Kubernetes sidecar and the Go
+`stoa-connect` agent. It does not redesign the global pipeline.
+
+## Component Matrix
+
+| Component | Metrics | Traces | Logs | Notes |
+| --- | --- | --- | --- | --- |
+| Rust gateway sidecar mode | `*-stoa-sidecar` ServiceMonitor | `STOA_OTEL_ENDPOINT` -> Alloy OTLP | JSON gateway logs | Real same-pod sidecar. |
+| Go stoa-connect | `/metrics` on the agent port | `OTEL_EXPORTER_OTLP_ENDPOINT` when set | JSON stdout logs | Separate from Rust connect-mode. |
+| Rust connect-mode simulation | `stoa-gateway-connect-mode` Compose job | `STOA_OTEL_ENDPOINT` | JSON gateway logs | Compose-only simulation. |
+
+## Kubernetes Sidecar
+
+When `stoaSidecar.enabled=true`, the chart renders a third-party gateway plus
+the Rust `stoa-sidecar` container. PR4 adds a dedicated `*-stoa-sidecar` service
+and ServiceMonitor for `/metrics` on port `8081`.
+
+The ServiceMonitor adds only bounded operational labels: `cluster`,
+`environment`, and `deployment_mode=sidecar`. It does not add `tenant_id`,
+`consumer_id`, `trace_id`, `span_id`, request IDs, raw paths, or payload-derived
+values as Prometheus labels.
+
+The sidecar receives `STOA_OTEL_ENDPOINT` from `stoaSidecar.otelEndpoint`, which
+defaults to Alloy.
+
+## Go stoa-connect
+
+The Go agent exposes `/metrics` on `STOA_CONNECT_PORT` (default `8090`). Metrics
+stay agent-level and do not carry trace IDs, span IDs, request IDs, or consumer
+IDs as labels.
+
+`stoa-connect` logs JSON with `service.name`, `service.version`,
+`service.instance.id`, `environment`, `tenant_id`, `trace_id`, and `span_id`.
+The webhook endpoint is wrapped with OTel HTTP instrumentation so request logs
+can include active span context when tracing is configured or propagated.

--- a/stoa-go/cmd/stoa-connect/main.go
+++ b/stoa-go/cmd/stoa-connect/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stoa-platform/stoa-go/internal/connect/adapters"
 	"github.com/stoa-platform/stoa-go/internal/connect/telemetry"
 	"github.com/stoa-platform/stoa-go/pkg/config"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // Version and Commit are set via ldflags at build time.
@@ -26,6 +27,9 @@ var (
 )
 
 func main() {
+	agentCfg := connect.ConfigFromEnv(Version)
+	logger := telemetry.ConfigureStructuredLogging(telemetry.LogConfigFromEnv(Version, agentCfg.InstanceName, agentCfg.Environment))
+
 	cfg, err := config.Load()
 	if err != nil {
 		log.Printf("warning: could not load config: %v", err)
@@ -42,7 +46,6 @@ func main() {
 	}
 
 	// Set up CP registration agent
-	agentCfg := connect.ConfigFromEnv(Version)
 	agent := connect.New(agentCfg)
 
 	// Initialize OpenTelemetry (no-op if OTEL_EXPORTER_OTLP_ENDPOINT is not set)
@@ -135,14 +138,15 @@ func main() {
 			http.Error(w, "invalid payload", http.StatusBadRequest)
 			return
 		}
-		log.Printf("received %d telemetry events via webhook", len(events))
+		logger.Info(r.Context(), "received telemetry events via webhook", "accepted", len(events))
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprintf(w, `{"accepted":%d}`, len(events))
 	})
 
+	handler := otelhttp.NewHandler(mux, "stoa-connect.http")
 	srv := &http.Server{
 		Addr:              ":" + port,
-		Handler:           mux,
+		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 

--- a/stoa-go/internal/connect/telemetry/logging.go
+++ b/stoa-go/internal/connect/telemetry/logging.go
@@ -1,0 +1,116 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+type LogConfig struct {
+	ServiceName  string
+	Version      string
+	InstanceName string
+	Environment  string
+	TenantID     string
+	Writer       io.Writer
+	Now          func() time.Time
+}
+
+type StructuredLogger struct {
+	cfg LogConfig
+	mu  sync.Mutex
+}
+
+func LogConfigFromEnv(version, instanceName, environment string) LogConfig {
+	return LogConfig{
+		ServiceName:  "stoa-connect",
+		Version:      version,
+		InstanceName: instanceName,
+		Environment:  environment,
+		TenantID:     os.Getenv("STOA_TENANT_ID"),
+	}
+}
+
+func NewStructuredLogger(cfg LogConfig) *StructuredLogger {
+	if cfg.ServiceName == "" {
+		cfg.ServiceName = "stoa-connect"
+	}
+	if cfg.Writer == nil {
+		cfg.Writer = os.Stdout
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &StructuredLogger{cfg: cfg}
+}
+
+func ConfigureStructuredLogging(cfg LogConfig) *StructuredLogger {
+	logger := NewStructuredLogger(cfg)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	log.SetOutput(logger)
+	return logger
+}
+
+func (l *StructuredLogger) Write(p []byte) (int, error) {
+	for _, line := range strings.Split(strings.TrimRight(string(p), "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if err := l.emit(context.Background(), inferLevel(line), line, nil); err != nil {
+			return 0, err
+		}
+	}
+	return len(p), nil
+}
+
+func (l *StructuredLogger) Info(ctx context.Context, message string, fields ...any) {
+	_ = l.emit(ctx, "info", message, fields)
+}
+
+func (l *StructuredLogger) emit(ctx context.Context, level, message string, fields []any) error {
+	entry := map[string]any{
+		"timestamp":           l.cfg.Now().UTC().Format(time.RFC3339Nano),
+		"level":               level,
+		"message":             message,
+		"service.name":        l.cfg.ServiceName,
+		"service.version":     l.cfg.Version,
+		"service.instance.id": l.cfg.InstanceName,
+		"environment":         l.cfg.Environment,
+		"tenant_id":           l.cfg.TenantID,
+		"trace_id":            "-",
+		"span_id":             "-",
+	}
+	if spanCtx := trace.SpanContextFromContext(ctx); spanCtx.IsValid() {
+		entry["trace_id"] = spanCtx.TraceID().String()
+		entry["span_id"] = spanCtx.SpanID().String()
+	}
+	for i := 0; i+1 < len(fields); i += 2 {
+		if key, ok := fields[i].(string); ok && key != "" {
+			entry[key] = fields[i+1]
+		}
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return json.NewEncoder(l.cfg.Writer).Encode(entry)
+}
+
+func inferLevel(message string) string {
+	lower := strings.ToLower(message)
+	switch {
+	case strings.HasPrefix(lower, "warning"):
+		return "warn"
+	case strings.Contains(lower, "error"), strings.Contains(lower, "failed"), strings.HasPrefix(lower, "listen:"), strings.HasPrefix(lower, "shutdown:"):
+		return "error"
+	default:
+		return "info"
+	}
+}

--- a/stoa-go/internal/connect/telemetry/logging_test.go
+++ b/stoa-go/internal/connect/telemetry/logging_test.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func TestStructuredLoggerWritesContractFields(t *testing.T) {
+func TestRegressionStoaConnectStructuredLoggerWritesContractFields(t *testing.T) {
 	var buf bytes.Buffer
 	logger := NewStructuredLogger(LogConfig{
 		ServiceName:  "stoa-connect",

--- a/stoa-go/internal/connect/telemetry/logging_test.go
+++ b/stoa-go/internal/connect/telemetry/logging_test.go
@@ -1,0 +1,61 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestStructuredLoggerWritesContractFields(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewStructuredLogger(LogConfig{
+		ServiceName:  "stoa-connect",
+		Version:      "1.2.3",
+		InstanceName: "wm-local",
+		Environment:  "dev",
+		TenantID:     "tenant-a",
+		Writer:       &buf,
+		Now:          func() time.Time { return time.Unix(1700000000, 0) },
+	})
+
+	traceID, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	spanID, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID,
+		SpanID:  spanID,
+	}))
+
+	logger.Info(ctx, "received telemetry events via webhook", "accepted", 3)
+	entry := decodeLogEntry(t, buf.Bytes())
+
+	want := map[string]any{
+		"level":               "info",
+		"message":             "received telemetry events via webhook",
+		"service.name":        "stoa-connect",
+		"service.version":     "1.2.3",
+		"service.instance.id": "wm-local",
+		"environment":         "dev",
+		"tenant_id":           "tenant-a",
+		"trace_id":            traceID.String(),
+		"span_id":             spanID.String(),
+		"accepted":            float64(3),
+	}
+	for key, value := range want {
+		if entry[key] != value {
+			t.Fatalf("expected %s=%v, got %v", key, value, entry[key])
+		}
+	}
+}
+
+func decodeLogEntry(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var entry map[string]any
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("decode log entry: %v; data=%s", err, string(data))
+	}
+	return entry
+}


### PR DESCRIPTION
## Summary

Wires sidecar and Go stoa-connect telemetry according to the accepted observability contract.

Changes include:
- add sidecar OTLP endpoint wiring through `stoaSidecar.otelEndpoint`
- add a dedicated sidecar metrics Service and ServiceMonitor for `/metrics` on `8081`
- keep sidecar Prometheus relabels bounded to `cluster`, `environment`, and `deployment_mode`
- read the sidecar cluster relabel from `stoaSidecar.serviceMonitor.clusterName`
- add JSON stdout logs for Go `stoa-connect` with service and correlation fields
- wrap the `stoa-connect` webhook handler with OTel HTTP instrumentation
- rename the Compose Prometheus job for Rust connect-mode to avoid confusing it with Go `stoa-connect`
- document the sidecar/connect wiring split

## Non-goals

This PR does not:
- redesign Console Observability
- rationalize OpenSearch
- remove Fluent Bit, Data Prepper, or Alloy
- rework the global Loki/Tempo/OTel pipeline
- change sampling policy
- change tenant authorization
- make another gateway cardinality pass

## Validation

- `go test ./...` in `stoa-go`
- `go test ./internal/connect/telemetry` after the Regression Guard naming fix
- `helm lint charts/stoa-platform`
- `helm template stoa-sidecar charts/stoa-platform --set stoaGateway.enabled=false --set stoaSidecar.enabled=true --set stoaSidecar.mainGateway.enabled=true`
- `helm template stoa-sidecar charts/stoa-platform --set stoaGateway.enabled=false --set stoaSidecar.enabled=true --set stoaSidecar.mainGateway.enabled=true --set stoaSidecar.serviceMonitor.clusterName=prod-eu-1 | rg -n "targetLabel: cluster|replacement: prod-eu-1|deployment_mode|stoa-sidecar"`
- `python3 -m pytest tests/test_regression_observability_promql_compat.py -q`
- `git diff --check`
- hidden/bidi Unicode scan across all files changed by `origin/main...HEAD` clean

## Branch hygiene

- Branch created from `origin/main` at `b08e05036`
- Commits:
  - `f66c69c42 fix(observability): wire sidecar and stoa-connect telemetry`
  - `6a48d449f test(observability): mark stoa-connect logger regression`
  - `703337ec1 fix(observability): use sidecar ServiceMonitor cluster value`
- Original repo local `memory.md` remains outside this PR
- Expected merge mode: squash