### PR TITLE
fix(ui): remove Grafana URL token embedding

### DIFF
--- a/control-plane-ui/src/__tests__/regression/grafana-url-token.test.tsx
+++ b/control-plane-ui/src/__tests__/regression/grafana-url-token.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuth } from '../../contexts/AuthContext';
+import { GrafanaEmbed } from '../../pages/GrafanaEmbed';
+import { createAuthMock } from '../../test/helpers';
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../../config', () => ({
+  config: {
+    services: {
+      grafana: {
+        url: '/grafana/',
+      },
+    },
+  },
+}));
+
+const mockSearchParams = new URLSearchParams();
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [mockSearchParams],
+}));
+
+vi.mock('../../utils/navigation', () => ({
+  isAllowedEmbedUrl: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../../hooks/useServiceHealth', () => ({
+  useServiceHealth: () => ({ status: 'available', retry: vi.fn() }),
+}));
+
+describe('regression/observability-grafana-token-url', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+    vi.spyOn(window, 'open').mockImplementation(() => null);
+    mockSearchParams.delete('url');
+  });
+
+  it('does not expose the Keycloak JWT in Grafana iframe or external URLs', () => {
+    mockSearchParams.set('url', 'https://grafana.gostoa.dev/d/stoa-gateway-overview');
+
+    render(<GrafanaEmbed />);
+
+    const iframe = screen.getByTitle('STOA Observability - Grafana');
+    const iframeSrc = iframe.getAttribute('src') ?? '';
+
+    expect(iframeSrc).toContain('https://grafana.gostoa.dev/d/stoa-gateway-overview');
+    expect(iframeSrc).not.toContain('mock-jwt-token-for-grafana');
+    expect(iframeSrc).not.toContain('auth_token=');
+    expect(iframeSrc).not.toContain('var-tenant_id=');
+
+    fireEvent.click(screen.getByTitle('Open in new tab'));
+
+    const openedUrl = vi.mocked(window.open).mock.calls.at(-1)?.[0] as string;
+    expect(openedUrl).not.toContain('mock-jwt-token-for-grafana');
+    expect(openedUrl).not.toContain('auth_token=');
+    expect(openedUrl).not.toContain('var-tenant_id=');
+  });
+});

--- a/control-plane-ui/src/contexts/AuthContext.tsx
+++ b/control-plane-ui/src/contexts/AuthContext.tsx
@@ -25,12 +25,11 @@ interface AuthContextType {
    * in the allowlist below. Adding new consumers requires a security review
    * (track token leak surface).
    *
-   * Known consumers (2026-04-24):
-   * - src/pages/GrafanaEmbed.tsx (Grafana iframe auth injection)
+   * Known consumers (2026-05-06):
+   * - none
    *
-   * P2-4 (WONT-FIX, documented): the long-term fix is a backend-signed URL
-   * flow (tracked separately); until then keep the surface minimal and
-   * document every new reader.
+   * Grafana expert mode MUST use backend/proxy/session authorization rather
+   * than URL token injection.
    */
   accessToken: string | null;
   login: () => void;

--- a/control-plane-ui/src/pages/GrafanaEmbed.test.tsx
+++ b/control-plane-ui/src/pages/GrafanaEmbed.test.tsx
@@ -42,16 +42,17 @@ describe('GrafanaEmbed', () => {
 
   it('renders title heading', () => {
     render(<GrafanaEmbed />);
-    expect(screen.getByRole('heading', { name: 'STOA Observability' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Grafana Expert' })).toBeInTheDocument();
   });
 
-  it('renders iframe with auth_token in src', () => {
+  it('renders iframe without auth_token in src', () => {
     render(<GrafanaEmbed />);
     const iframe = screen.getByTitle('STOA Observability - Grafana');
     expect(iframe).toBeInTheDocument();
     const src = iframe.getAttribute('src')!;
     expect(src).toContain('/grafana/');
-    expect(src).toContain('auth_token=mock-jwt-token-for-grafana');
+    expect(src).not.toContain('auth_token=');
+    expect(src).not.toContain('var-tenant_id=');
   });
 
   it('shows loading state initially', () => {
@@ -85,12 +86,17 @@ describe('GrafanaEmbed', () => {
     expect(rootDiv.className).not.toContain('fixed');
   });
 
-  it('open in new tab calls window.open with auth_token', () => {
+  it('open in new tab does not include auth_token', () => {
     render(<GrafanaEmbed />);
     const openButton = screen.getByTitle('Open in new tab');
     fireEvent.click(openButton);
     expect(window.open).toHaveBeenCalledWith(
       expect.stringContaining('/grafana/'),
+      '_blank',
+      'noopener,noreferrer'
+    );
+    expect(window.open).not.toHaveBeenCalledWith(
+      expect.stringContaining('auth_token='),
       '_blank',
       'noopener,noreferrer'
     );
@@ -114,31 +120,32 @@ describe('GrafanaEmbed', () => {
     expect(iframe).toHaveAttribute('referrerPolicy', 'no-referrer-when-downgrade');
   });
 
-  it('uses deep-link URL from search params with auth_token appended', () => {
+  it('uses deep-link URL from search params without token query params', () => {
     mockSearchParams.set('url', 'https://grafana.gostoa.dev/d/custom-dashboard');
     render(<GrafanaEmbed />);
     const iframe = screen.getByTitle('STOA Observability - Grafana');
     const src = iframe.getAttribute('src')!;
     expect(src).toContain('https://grafana.gostoa.dev/d/custom-dashboard');
-    expect(src).toContain('auth_token=mock-jwt-token-for-grafana');
+    expect(src).not.toContain('auth_token=');
+    expect(src).not.toContain('var-tenant_id=');
   });
 
-  // CAB-2032: tenant-admin iframe URL includes var-tenant_id
-  it('tenant-admin iframe includes var-tenant_id', () => {
+  it('regression does not put Keycloak tokens in Grafana iframe or new-tab URLs', () => {
+    render(<GrafanaEmbed />);
+    const iframe = screen.getByTitle('STOA Observability - Grafana');
+    expect(iframe.getAttribute('src')).not.toContain('mock-jwt-token-for-grafana');
+
+    fireEvent.click(screen.getByTitle('Open in new tab'));
+    const openedUrl = vi.mocked(window.open).mock.calls.at(-1)?.[0] as string;
+    expect(openedUrl).not.toContain('mock-jwt-token-for-grafana');
+    expect(openedUrl).not.toContain('auth_token=');
+  });
+
+  it('denies tenant-admin access to expert mode', () => {
     vi.mocked(useAuth).mockReturnValue(createAuthMock('tenant-admin'));
     render(<GrafanaEmbed />);
-    const iframe = screen.getByTitle('STOA Observability - Grafana');
-    const src = iframe.getAttribute('src')!;
-    expect(src).toContain('var-tenant_id=oasis-gunters');
-  });
-
-  // CAB-2032: cpi-admin iframe does NOT include var-tenant_id (sees all)
-  it('cpi-admin iframe does not include var-tenant_id', () => {
-    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
-    render(<GrafanaEmbed />);
-    const iframe = screen.getByTitle('STOA Observability - Grafana');
-    const src = iframe.getAttribute('src')!;
-    expect(src).not.toContain('var-tenant_id');
+    expect(screen.getByRole('heading', { name: 'Grafana Expert Mode' })).toBeInTheDocument();
+    expect(screen.queryByTitle('STOA Observability - Grafana')).not.toBeInTheDocument();
   });
 
   // 4-persona coverage
@@ -148,7 +155,11 @@ describe('GrafanaEmbed', () => {
       it('renders the page', () => {
         vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
         render(<GrafanaEmbed />);
-        expect(screen.getByRole('heading', { name: 'STOA Observability' })).toBeInTheDocument();
+        if (role === 'cpi-admin' || role === 'devops') {
+          expect(screen.getByRole('heading', { name: 'Grafana Expert' })).toBeInTheDocument();
+        } else {
+          expect(screen.getByRole('heading', { name: 'Grafana Expert Mode' })).toBeInTheDocument();
+        }
       });
     }
   );

--- a/control-plane-ui/src/pages/GrafanaEmbed.tsx
+++ b/control-plane-ui/src/pages/GrafanaEmbed.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { config } from '../config';
 import { isAllowedEmbedUrl } from '../utils/navigation';
-import { ExternalLink, RefreshCw, Maximize2, Minimize2, Gauge } from 'lucide-react';
+import { ExternalLink, RefreshCw, Maximize2, Minimize2, Gauge, Shield } from 'lucide-react';
 import { useServiceHealth } from '../hooks/useServiceHealth';
 import { ServiceUnavailable } from '../components/ServiceUnavailable';
 import { useAuth } from '../contexts/AuthContext';
@@ -19,7 +19,7 @@ export function GrafanaEmbed() {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [key, setKey] = useState(0);
-  const { accessToken, user } = useAuth();
+  const { hasRole } = useAuth();
 
   const targetUrl = searchParams.get('url');
   const baseIframeUrl =
@@ -28,20 +28,11 @@ export function GrafanaEmbed() {
   const isPrometheus = baseIframeUrl.includes('prometheus');
   const serviceLabel = isPrometheus ? 'Prometheus' : 'Grafana';
 
-  // Append Keycloak JWT for Grafana [auth.jwt] url_login (not for Prometheus)
-  // CAB-2032: Inject tenant_id as Grafana variable to scope dashboards
+  // Grafana is expert/operator mode. Do not append JWTs or tenant variables to
+  // URLs; auth and tenant scoping must be handled by the backend/proxy/session.
   const iframeUrl = useMemo(() => {
-    if (!accessToken || isPrometheus) return baseIframeUrl;
-    const params = new URLSearchParams();
-    params.set('auth_token', accessToken);
-    // Scope dashboards by tenant (cpi-admin sees all — no filter)
-    const isCpiAdmin = user?.roles?.includes('cpi-admin');
-    if (user?.tenant_id && !isCpiAdmin) {
-      params.set('var-tenant_id', user.tenant_id);
-    }
-    const separator = baseIframeUrl.includes('?') ? '&' : '?';
-    return `${baseIframeUrl}${separator}${params.toString()}`;
-  }, [baseIframeUrl, accessToken, isPrometheus, user]);
+    return baseIframeUrl;
+  }, [baseIframeUrl]);
 
   const { status: serviceStatus, retry: retryHealth } = useServiceHealth(baseIframeUrl);
 
@@ -57,6 +48,25 @@ export function GrafanaEmbed() {
   const handleOpenExternal = () => {
     window.open(iframeUrl, '_blank', 'noopener,noreferrer');
   };
+
+  const canAccessExpertMode = hasRole('cpi-admin') || hasRole('devops');
+
+  if (!canAccessExpertMode) {
+    return (
+      <div className="flex min-h-[360px] items-center justify-center">
+        <div className="max-w-md rounded-lg border border-neutral-200 bg-white p-6 text-center shadow dark:border-neutral-700 dark:bg-neutral-900">
+          <Shield className="mx-auto mb-3 h-8 w-8 text-neutral-400" />
+          <h1 className="text-xl font-semibold text-neutral-900 dark:text-white">
+            Grafana Expert Mode
+          </h1>
+          <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
+            Grafana access is limited to platform operators. Use the product observability views for
+            tenant-scoped health, calls, and guardrail events.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   if (serviceStatus === 'unavailable') {
     return (
@@ -80,11 +90,9 @@ export function GrafanaEmbed() {
         className={`flex items-center justify-between ${isFullscreen ? 'p-4 border-b border-neutral-200 dark:border-neutral-700' : ''}`}
       >
         <div>
-          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
-            STOA Observability
-          </h1>
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Grafana Expert</h1>
           <p className="text-neutral-500 dark:text-neutral-400 mt-1">
-            Platform metrics, dashboards, and monitoring
+            Operator dashboards for deep debugging
           </p>
         </div>
         <div className="flex items-center gap-2">

--- a/control-plane-ui/src/utils/navigation.test.ts
+++ b/control-plane-ui/src/utils/navigation.test.ts
@@ -8,7 +8,7 @@ describe('observabilityPath', () => {
 
   it('returns path with encoded target URL', () => {
     expect(observabilityPath('https://grafana.gostoa.dev/d/abc')).toBe(
-      '/observability?url=https%3A%2F%2Fgrafana.gostoa.dev%2Fd%2Fabc'
+      '/observability/grafana?url=https%3A%2F%2Fgrafana.gostoa.dev%2Fd%2Fabc'
     );
   });
 });

--- a/control-plane-ui/src/utils/navigation.test.ts
+++ b/control-plane-ui/src/utils/navigation.test.ts
@@ -42,8 +42,17 @@ describe('isAllowedEmbedUrl', () => {
     expect(isAllowedEmbedUrl('https://evil.com/steal')).toBe(false);
   });
 
-  it('allows relative paths', () => {
-    expect(isAllowedEmbedUrl('/d/dashboard')).toBe(true);
+  it('allows known relative observability embed paths', () => {
+    expect(isAllowedEmbedUrl('/grafana/d/stoa-gateway-overview')).toBe(true);
+    expect(isAllowedEmbedUrl('/prometheus/graph')).toBe(true);
+  });
+
+  it('rejects protocol-relative embed URLs', () => {
+    expect(isAllowedEmbedUrl('//evil.example/d/stoa')).toBe(false);
+  });
+
+  it('rejects unknown relative embed paths', () => {
+    expect(isAllowedEmbedUrl('/not-grafana/dashboard')).toBe(false);
   });
 
   it('rejects non-relative invalid URLs', () => {

--- a/control-plane-ui/src/utils/navigation.ts
+++ b/control-plane-ui/src/utils/navigation.ts
@@ -3,10 +3,10 @@
  * Converts external links into internal iframe routes with deep-link support.
  */
 
-/** Build a path to the Observability iframe, optionally with a target URL. */
+/** Build a path to the product Observability page, or Grafana expert mode with a target URL. */
 export function observabilityPath(targetUrl?: string): string {
   if (!targetUrl) return '/observability';
-  return `/observability?url=${encodeURIComponent(targetUrl)}`;
+  return `/observability/grafana?url=${encodeURIComponent(targetUrl)}`;
 }
 
 /** Build a path to the Logs iframe, optionally with a target URL. */

--- a/control-plane-ui/src/utils/navigation.ts
+++ b/control-plane-ui/src/utils/navigation.ts
@@ -18,6 +18,9 @@ export function logsPath(targetUrl?: string): string {
 /** Allowed hostnames for embedded iframe URLs. */
 const ALLOWED_HOSTS = ['grafana.gostoa.dev', 'prometheus.gostoa.dev', 'localhost'];
 
+/** Allowed same-origin paths for observability embeds. */
+const ALLOWED_RELATIVE_PREFIXES = ['/grafana/', '/prometheus/'];
+
 /** Validate that a URL is safe to embed in an iframe (no open redirect). */
 export function isAllowedEmbedUrl(url: string): boolean {
   try {
@@ -26,7 +29,6 @@ export function isAllowedEmbedUrl(url: string): boolean {
       (host) => parsed.hostname === host || parsed.hostname.endsWith(`.${host}`)
     );
   } catch {
-    // Relative URL or invalid — allow relative paths
-    return url.startsWith('/');
+    return ALLOWED_RELATIVE_PREFIXES.some((prefix) => url.startsWith(prefix));
   }
 }

--- a/docs/observability/telemetry-contract.md
+++ b/docs/observability/telemetry-contract.md
@@ -207,7 +207,7 @@ It is not yet the full migration plan.
 | `tool`, `tool_id`, `tool_name` mismatch | canonical `tool_name` | API readers support current names, then migrate to canonical projection. | platform/gateway | TBD |
 | `mcp_request_duration_seconds` queries | emitted STOA MCP duration metric or recording rule | Add alias or update reader after metric audit. | platform | TBD |
 | OpenSearch `resource.attributes.tenant@id` filters | canonical tenant filter | Do not assume tenant is a resource attribute unless the collector sets it. | platform | TBD |
-| Grafana URL token authentication | backend-mediated session/proxy | Replace in Console productization PR. | console/platform | TBD |
+| Grafana URL token authentication | backend-mediated session/proxy | Console expert route MUST NOT append JWTs to URLs; backend/proxy/session authorization remains the target. | console/platform | backend session/proxy TBD |
 
 ## 9. Tenant-Safety Requirements
 


### PR DESCRIPTION
## Summary

Starts Console Observability productization with the highest-risk compatibility item from the accepted telemetry contract: Grafana URL token authentication.

Changes include:
- stop appending Keycloak JWTs to Grafana iframe and external URLs
- stop appending frontend `var-tenant_id` dashboard filters to Grafana URLs
- limit Grafana expert mode to operator/admin personas (`cpi-admin`, `devops`)
- route dashboard deep links through `/observability/grafana?url=...` instead of overloading `/observability`
- update the telemetry contract row for Grafana URL token authentication
- add/update regression coverage proving Grafana URLs do not contain tokens

## Non-goals

This PR does not:
- complete the full three-view Console observability consolidation
- redesign Gateway Health, Live Calls, or Security & Guardrails
- rewire OTel/Loki/Tempo/OpenSearch pipelines
- change gateway Prometheus cardinality
- change sidecar or stoa-connect telemetry wiring
- change sampling policy
- change tenant authorization semantics outside Grafana expert access gating

## Validation

- `npm ci` in `control-plane-ui`
- `npm ci` in `shared`
- `npm test -- --run src/pages/GrafanaEmbed.test.tsx src/utils/navigation.test.ts`
- `npx prettier --check src/pages/GrafanaEmbed.tsx src/pages/GrafanaEmbed.test.tsx src/utils/navigation.ts src/utils/navigation.test.ts src/contexts/AuthContext.tsx`
- `npx eslint src/pages/GrafanaEmbed.tsx src/pages/GrafanaEmbed.test.tsx src/utils/navigation.ts src/utils/navigation.test.ts --max-warnings 0`
- `npm run build`
- `git diff --check`
- hidden/bidi Unicode scan across changed files

Note: targeted lint including `AuthContext.tsx` still reports pre-existing warnings unrelated to this change (`no-explicit-any`, `react-refresh/only-export-components`), so the strict lint command was scoped to modified executable/test files.

## Follow-up

Next Console Observability slice should consolidate navigation/product views around:
- Gateway Health
- Live Calls
- Security & Guardrails

Grafana remains expert/operator mode only.
