### PR TITLE
fix(ui): consolidate Live Calls trace details

### DIFF
--- a/control-plane-ui/src/App.tsx
+++ b/control-plane-ui/src/App.tsx
@@ -194,6 +194,11 @@ const CallFlowDashboard = lazy(() =>
 const TraceDetail = lazy(() =>
   import('./pages/CallFlow').then((m) => ({ default: m.TraceDetail }))
 );
+const LegacyCallFlowTraceRedirect = lazy(() =>
+  import('./pages/CallFlow/LegacyCallFlowTraceRedirect').then((m) => ({
+    default: m.LegacyCallFlowTraceRedirect,
+  }))
+);
 
 // CAB-1487: LLM Cost Dashboard
 const LLMCostDashboard = lazy(() =>
@@ -395,7 +400,7 @@ function ProtectedRoutes() {
                   path="/call-flow"
                   element={<Navigate to="/observability/live-calls" replace />}
                 />
-                <Route path="/call-flow/trace/:traceId" element={<TraceDetail />} />
+                <Route path="/call-flow/trace/:traceId" element={<LegacyCallFlowTraceRedirect />} />
                 <Route path="/llm-cost" element={<LLMCostDashboard />} />
                 <Route path="/webhooks" element={<Webhooks />} />
                 <Route path="/credential-mappings" element={<CredentialMappings />} />

--- a/control-plane-ui/src/__tests__/regression/live-calls-consolidation.test.tsx
+++ b/control-plane-ui/src/__tests__/regression/live-calls-consolidation.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * Regression: legacy call-flow deep links must land in the Live Calls model.
+ */
+import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { LegacyCallFlowTraceRedirect } from '../../pages/CallFlow/LegacyCallFlowTraceRedirect';
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+describe('regression/live-calls-consolidation', () => {
+  it('redirects legacy call-flow trace links to Live Calls trace details', async () => {
+    render(
+      <MemoryRouter initialEntries={['/call-flow/trace/abc123']}>
+        <Routes>
+          <Route path="/call-flow/trace/:traceId" element={<LegacyCallFlowTraceRedirect />} />
+          <Route path="/observability/live-calls/trace/:traceId" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent(
+        '/observability/live-calls/trace/abc123'
+      );
+    });
+  });
+});

--- a/control-plane-ui/src/__tests__/spec/cab-2004.test.tsx
+++ b/control-plane-ui/src/__tests__/spec/cab-2004.test.tsx
@@ -156,6 +156,34 @@ describe('spec/CAB-2004: LogExplorer', () => {
       });
     });
 
+    it('encodes trace IDs when navigating to Live Calls trace detail', async () => {
+      mockApiSuccess({
+        ...mockLogsResponse,
+        logs: [
+          {
+            ...mockLogsResponse.logs[0],
+            message: 'route sensitive trace',
+            trace_id: 'abc/123?x=1',
+          },
+        ],
+      });
+      await renderLogExplorer();
+
+      await waitFor(() => {
+        expect(screen.getByText('route sensitive trace')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('route sensitive trace'));
+
+      await waitFor(() => {
+        const traceLink = screen.getByText('abc/123?x=1');
+        fireEvent.click(traceLink);
+        expect(mockNavigate).toHaveBeenCalledWith(
+          '/observability/live-calls/trace/abc%2F123%3Fx%3D1'
+        );
+      });
+    });
+
     it('initializes log search from Live Calls trace links', async () => {
       mockApiSuccess();
       await renderLogExplorer(['/logs?service=gateway&trace_id=abc123']);

--- a/control-plane-ui/src/__tests__/spec/cab-2004.test.tsx
+++ b/control-plane-ui/src/__tests__/spec/cab-2004.test.tsx
@@ -80,10 +80,10 @@ function mockApiError(status: number) {
   mockGet.mockRejectedValue({ response: { status } });
 }
 
-async function renderLogExplorer() {
+async function renderLogExplorer(initialEntries: string[] = ['/logs']) {
   const { LogExplorer } = await import('../../pages/RequestExplorer/LogExplorer');
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <LogExplorer />
     </MemoryRouter>
   );
@@ -154,6 +154,24 @@ describe('spec/CAB-2004: LogExplorer', () => {
         fireEvent.click(traceLink);
         expect(mockNavigate).toHaveBeenCalledWith('/observability/live-calls/trace/abc123');
       });
+    });
+
+    it('initializes log search from Live Calls trace links', async () => {
+      mockApiSuccess();
+      await renderLogExplorer(['/logs?service=gateway&trace_id=abc123']);
+
+      await waitFor(() => {
+        expect(mockGet).toHaveBeenCalledWith(
+          '/v1/admin/logs',
+          expect.objectContaining({
+            params: expect.objectContaining({
+              service: 'gateway',
+              search: 'abc123',
+            }),
+          })
+        );
+      });
+      expect(screen.getByDisplayValue('abc123')).toBeInTheDocument();
     });
   });
 

--- a/control-plane-ui/src/hooks/useBreadcrumbs.test.ts
+++ b/control-plane-ui/src/hooks/useBreadcrumbs.test.ts
@@ -72,6 +72,25 @@ describe('useBreadcrumbs', () => {
     ]);
   });
 
+  it('uses the Live Calls product breadcrumb for trace details', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/observability/live-calls/trace/trace-test0001',
+      search: '',
+      hash: '',
+      state: null,
+      key: '',
+    });
+    mockUseParams.mockReturnValue({ traceId: 'trace-test0001' });
+
+    const { result } = renderHook(() => useBreadcrumbs());
+    expect(result.current).toEqual([
+      { label: 'Dashboard', href: '/' },
+      { label: 'Observability', href: '/observability' },
+      { label: 'Live Calls', href: '/observability/live-calls' },
+      { label: 'Trace trace-test0001' },
+    ]);
+  });
+
   it('formats unknown segments as title case', () => {
     mockUseLocation.mockReturnValue({
       pathname: '/some-unknown-page',

--- a/control-plane-ui/src/hooks/useBreadcrumbs.ts
+++ b/control-plane-ui/src/hooks/useBreadcrumbs.ts
@@ -73,6 +73,14 @@ const routeLabels: Record<string, string> = {
 /**
  * Hook to generate breadcrumbs from the current route
  */
+function safeDecodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
 export function useBreadcrumbs(): BreadcrumbItem[] {
   const location = useLocation();
   const params = useParams();
@@ -86,6 +94,20 @@ export function useBreadcrumbs(): BreadcrumbItem[] {
     // If we're on the dashboard, don't add more
     if (pathSegments.length === 0) {
       return [{ label: 'Dashboard' }]; // No href = current page
+    }
+
+    if (
+      pathSegments[0] === 'observability' &&
+      pathSegments[1] === 'live-calls' &&
+      pathSegments[2] === 'trace'
+    ) {
+      const traceId = safeDecodeSegment(pathSegments[3] || '');
+      return [
+        { label: 'Dashboard', href: '/' },
+        { label: 'Observability', href: '/observability' },
+        { label: 'Live Calls', href: '/observability/live-calls' },
+        { label: traceId ? `Trace ${traceId}` : 'Trace' },
+      ];
     }
 
     // Build breadcrumbs from path segments

--- a/control-plane-ui/src/pages/CallFlow/LegacyCallFlowTraceRedirect.tsx
+++ b/control-plane-ui/src/pages/CallFlow/LegacyCallFlowTraceRedirect.tsx
@@ -1,0 +1,13 @@
+import { Navigate, useParams } from 'react-router-dom';
+
+export function LegacyCallFlowTraceRedirect() {
+  const { traceId } = useParams<{ traceId?: string }>();
+
+  if (!traceId) {
+    return <Navigate to="/observability/live-calls" replace />;
+  }
+
+  return <Navigate to={`/observability/live-calls/trace/${encodeURIComponent(traceId)}`} replace />;
+}
+
+export default LegacyCallFlowTraceRedirect;

--- a/control-plane-ui/src/pages/CallFlow/TraceDetail.test.tsx
+++ b/control-plane-ui/src/pages/CallFlow/TraceDetail.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { TraceDetail } from './TraceDetail';
 
 const mockGetTransactionDetail = vi.fn();
@@ -11,12 +11,18 @@ vi.mock('../../services/api', () => ({
   },
 }));
 
+function LogsProbe() {
+  const location = useLocation();
+  return <div data-testid="logs-search">{location.search}</div>;
+}
+
 function renderWithRoute(traceId: string) {
   return render(
     <MemoryRouter initialEntries={[`/observability/live-calls/trace/${traceId}`]}>
       <Routes>
         <Route path="/observability/live-calls/trace/:traceId" element={<TraceDetail />} />
         <Route path="/observability/live-calls" element={<div>Live Calls</div>} />
+        <Route path="/logs" element={<LogsProbe />} />
         <Route path="/call-flow/trace/:traceId" element={<TraceDetail />} />
       </Routes>
     </MemoryRouter>
@@ -45,7 +51,7 @@ const MOCK_DETAIL = {
       start_offset_ms: 0,
       duration_ms: 5,
       status: 'success',
-      metadata: {},
+      metadata: { span_id: 'span-test0001' },
     },
     {
       name: 'auth_validation',
@@ -72,6 +78,7 @@ const MOCK_DETAIL = {
   response_headers: {
     'Content-Type': 'application/json',
     'X-STOA-Duration-Ms': '45',
+    'X-STOA-Version': '0.9.23',
   },
   error_message: null,
 };
@@ -132,6 +139,40 @@ describe('TraceDetail', () => {
       expect(screen.getByText('Auth')).toBeInTheDocument();
       expect(screen.getByText('Upstream')).toBeInTheDocument();
       expect(screen.getByText('Retries')).toBeInTheDocument();
+    });
+
+    it('surfaces canonical trace context fields', async () => {
+      renderWithRoute('test-trace-001');
+      await waitFor(() => {
+        expect(screen.getByText('Trace Context')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('trace_id')).toBeInTheDocument();
+      expect(screen.getAllByText('trace-test0001').length).toBeGreaterThan(0);
+      expect(screen.getByText('span_id')).toBeInTheDocument();
+      expect(screen.getByText('span-test0001')).toBeInTheDocument();
+      expect(screen.getByText('tenant_id')).toBeInTheDocument();
+      expect(screen.getByText('service.name')).toBeInTheDocument();
+      expect(screen.getByText('service.version')).toBeInTheDocument();
+      expect(screen.getByText('0.9.23')).toBeInTheDocument();
+      expect(screen.getByText('http_route')).toBeInTheDocument();
+      expect(screen.getByText('status_class')).toBeInTheDocument();
+      expect(screen.getByText('2xx')).toBeInTheDocument();
+    });
+
+    it('links to the existing logs route with trace search parameters', async () => {
+      renderWithRoute('test-trace-001');
+      await waitFor(() => {
+        expect(screen.getByText('Trace Context')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /view logs for trace/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('logs-search')).toHaveTextContent(
+          '?service=gateway&trace_id=trace-test0001'
+        );
+      });
     });
   });
 

--- a/control-plane-ui/src/pages/CallFlow/TraceDetail.test.tsx
+++ b/control-plane-ui/src/pages/CallFlow/TraceDetail.test.tsx
@@ -51,7 +51,7 @@ const MOCK_DETAIL = {
       start_offset_ms: 0,
       duration_ms: 5,
       status: 'success',
-      metadata: { span_id: 'span-test0001' },
+      metadata: { span_id: 'span-test0001', route: '/v4/latest/{base}' },
     },
     {
       name: 'auth_validation',
@@ -156,6 +156,7 @@ describe('TraceDetail', () => {
       expect(screen.getByText('service.version')).toBeInTheDocument();
       expect(screen.getByText('0.9.23')).toBeInTheDocument();
       expect(screen.getByText('http_route')).toBeInTheDocument();
+      expect(screen.getByText('/v4/latest/{base}')).toBeInTheDocument();
       expect(screen.getByText('status_class')).toBeInTheDocument();
       expect(screen.getByText('2xx')).toBeInTheDocument();
     });

--- a/control-plane-ui/src/pages/CallFlow/TraceDetail.tsx
+++ b/control-plane-ui/src/pages/CallFlow/TraceDetail.tsx
@@ -440,6 +440,7 @@ function TraceContextGrid({
       'resource.attributes.service.version',
     ]);
   const spanId = firstMetadataValue(detail.spans, ['span_id', 'span.id', 'spanId']);
+  const httpRoute = firstMetadataValue(detail.spans, ['http.route', 'http_route', 'route']);
 
   const fields = [
     { label: 'trace_id', value: detail.trace_id },
@@ -447,7 +448,7 @@ function TraceContextGrid({
     { label: 'tenant_id', value: detail.tenant_id ?? undefined },
     { label: 'service.name', value: serviceName },
     { label: 'service.version', value: serviceVersion },
-    { label: 'http_route', value: detail.path },
+    { label: httpRoute ? 'http_route' : 'http.path', value: httpRoute || detail.path },
     { label: 'status_code', value: String(detail.status_code) },
     { label: 'status_class', value: statusClass(detail.status_code) },
     { label: 'latency', value: fmtDuration(detail.total_duration_ms) },

--- a/control-plane-ui/src/pages/CallFlow/TraceDetail.tsx
+++ b/control-plane-ui/src/pages/CallFlow/TraceDetail.tsx
@@ -12,9 +12,12 @@ import {
   Cpu,
   Network,
   Lock,
+  ScrollText,
 } from 'lucide-react';
 import { StatCard } from '@stoa/shared/components/StatCard';
 import { CardSkeleton } from '@stoa/shared/components/Skeleton';
+import { SubNav } from '../../components/SubNav';
+import { observabilityTabs } from '../../components/subNavGroups';
 
 // ─── Types ───
 // Canonical: `Schemas['TransactionDetailWithDemoResponse']` from the backend
@@ -100,6 +103,31 @@ function statusConfig(code: number): {
     text: 'text-green-700 dark:text-green-400',
     icon: CheckCircle,
   };
+}
+
+function statusClass(code: number): string {
+  if (code >= 100 && code < 600) {
+    return `${Math.floor(code / 100)}xx`;
+  }
+  return 'unknown';
+}
+
+function headerValue(headers: Record<string, string>, name: string): string | undefined {
+  const entry = Object.entries(headers).find(([key]) => key.toLowerCase() === name.toLowerCase());
+  return entry?.[1];
+}
+
+function firstMetadataValue(spans: TransactionSpan[], keys: string[]): string | undefined {
+  for (const span of spans) {
+    if (!span.metadata) continue;
+    for (const key of keys) {
+      const value = span.metadata[key];
+      if (value !== undefined && value !== null && value !== '') {
+        return String(value);
+      }
+    }
+  }
+  return undefined;
 }
 
 // ─── Fetch (authenticated via apiService) ───
@@ -395,6 +423,57 @@ function KernelMetricsGrid({ spans }: { spans: TransactionSpan[] }) {
   );
 }
 
+function TraceContextGrid({
+  detail,
+  responseHeaders,
+}: {
+  detail: TransactionDetail;
+  responseHeaders: Record<string, string>;
+}) {
+  const serviceName = detail.spans.find((span) => span.service)?.service;
+  const serviceVersion =
+    headerValue(responseHeaders, 'x-stoa-version') ||
+    firstMetadataValue(detail.spans, [
+      'service.version',
+      'service_version',
+      'resource.service.version',
+      'resource.attributes.service.version',
+    ]);
+  const spanId = firstMetadataValue(detail.spans, ['span_id', 'span.id', 'spanId']);
+
+  const fields = [
+    { label: 'trace_id', value: detail.trace_id },
+    { label: 'span_id', value: spanId },
+    { label: 'tenant_id', value: detail.tenant_id ?? undefined },
+    { label: 'service.name', value: serviceName },
+    { label: 'service.version', value: serviceVersion },
+    { label: 'http_route', value: detail.path },
+    { label: 'status_code', value: String(detail.status_code) },
+    { label: 'status_class', value: statusClass(detail.status_code) },
+    { label: 'latency', value: fmtDuration(detail.total_duration_ms) },
+  ].filter((field) => field.value && field.value !== '-');
+
+  return (
+    <div className="bg-white dark:bg-neutral-800 rounded-lg shadow p-4">
+      <h2 className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase mb-4">
+        Trace Context
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-3">
+        {fields.map((field) => (
+          <div key={field.label} className="min-w-0">
+            <div className="text-[10px] uppercase text-neutral-400 dark:text-neutral-500 mb-1">
+              {field.label}
+            </div>
+            <div className="font-mono text-xs text-neutral-700 dark:text-neutral-300 truncate">
+              {field.value}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 // ─── Main Component ───
 
 export function TraceDetail() {
@@ -462,9 +541,12 @@ export function TraceDetail() {
 
   const sc = statusConfig(detail.status_code);
   const StatusIcon = sc.icon;
+  const logsPath = `/logs?service=gateway&trace_id=${encodeURIComponent(detail.trace_id)}`;
 
   return (
     <div className="space-y-6">
+      <SubNav tabs={observabilityTabs} />
+
       {/* ─── Breadcrumb + Banner ─── */}
       <div>
         <button
@@ -501,6 +583,18 @@ export function TraceDetail() {
           </span>
         </div>
       </div>
+
+      <div className="flex items-center justify-end">
+        <button
+          onClick={() => navigate(logsPath)}
+          className="inline-flex items-center gap-2 border border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-3 py-2 rounded-lg text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700"
+        >
+          <ScrollText className="h-4 w-4" />
+          View logs for trace
+        </button>
+      </div>
+
+      <TraceContextGrid detail={detail} responseHeaders={responseHeaders} />
 
       {/* ─── 6 Summary Cards ─── */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">

--- a/control-plane-ui/src/pages/RequestExplorer/LogExplorer.tsx
+++ b/control-plane-ui/src/pages/RequestExplorer/LogExplorer.tsx
@@ -177,6 +177,8 @@ export function LogExplorer() {
     );
   }
 
+  const selectedTraceId = selectedLog?.trace_id;
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -390,21 +392,23 @@ export function LogExplorer() {
               <DetailRow label="Tenant ID" value={selectedLog.tenant_id} />
 
               {/* Trace ID with navigation link */}
-              {selectedLog.trace_id && selectedLog.trace_id !== '-' ? (
+              {selectedTraceId && selectedTraceId !== '-' ? (
                 <div className="flex items-center justify-between py-1">
                   <span className="text-neutral-500 dark:text-neutral-400">Trace ID</span>
                   <button
                     onClick={() =>
-                      navigate(`/observability/live-calls/trace/${selectedLog.trace_id}`)
+                      navigate(
+                        `/observability/live-calls/trace/${encodeURIComponent(selectedTraceId)}`
+                      )
                     }
                     className="text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1 text-xs font-mono"
                   >
-                    {selectedLog.trace_id}
+                    {selectedTraceId}
                     <ChevronRight className="h-3 w-3" />
                   </button>
                 </div>
               ) : (
-                <DetailRow label="Trace ID" value={selectedLog.trace_id} />
+                <DetailRow label="Trace ID" value={selectedTraceId} />
               )}
             </div>
           </div>

--- a/control-plane-ui/src/pages/RequestExplorer/LogExplorer.tsx
+++ b/control-plane-ui/src/pages/RequestExplorer/LogExplorer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { AlertTriangle, ChevronRight, RefreshCw, Search, X } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { SubNav } from '../../components/SubNav';
@@ -57,6 +57,11 @@ const TIME_RANGE_OPTIONS = [
   { value: '24h', label: '24h', hours: 24 },
 ];
 
+function normalizeServiceFilter(value: string | null): string {
+  if (!value) return 'all';
+  return SERVICE_OPTIONS.some((option) => option.value === value) ? value : 'all';
+}
+
 const LEVEL_COLORS: Record<string, string> = {
   error: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
   warning: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
@@ -72,7 +77,9 @@ const SERVICE_COLORS: Record<string, string> = {
 
 export function LogExplorer() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { hasRole } = useAuth();
+  const initialTraceSearch = searchParams.get('trace_id') || searchParams.get('search') || '';
 
   const [logs, setLogs] = useState<AdminLogEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -80,9 +87,9 @@ export function LogExplorer() {
   const [queryTimeMs, setQueryTimeMs] = useState<number>(0);
 
   // Filters
-  const [service, setService] = useState('all');
+  const [service, setService] = useState(normalizeServiceFilter(searchParams.get('service')));
   const [level, setLevel] = useState('');
-  const [search, setSearch] = useState('');
+  const [search, setSearch] = useState(initialTraceSearch);
   const [timeRange, setTimeRange] = useState('1h');
   const [refreshInterval, setRefreshInterval] = useState(0);
 
@@ -90,6 +97,17 @@ export function LogExplorer() {
   const [selectedLog, setSelectedLog] = useState<AdminLogEntry | null>(null);
 
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    const nextSearch = searchParams.get('trace_id') || searchParams.get('search');
+    if (nextSearch != null) {
+      setSearch(nextSearch);
+    }
+    const nextService = searchParams.get('service');
+    if (nextService != null) {
+      setService(normalizeServiceFilter(nextService));
+    }
+  }, [searchParams]);
 
   const fetchLogs = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary

Consolidates Live Calls as the Console product surface for trace-level observability.

Changes include:
- redirect legacy `/call-flow/trace/:traceId` deep links to `/observability/live-calls/trace/:traceId`
- render trace details inside the Observability sub-navigation context
- add a Trace Context panel with canonical fields when available (`trace_id`, `span_id`, `tenant_id`, `service.name`, `service.version`, `http_route`, `status_code`, `status_class`, `latency`)
- add a token-free link from trace details to the existing logs explorer using `trace_id` as the search input
- initialize LogExplorer filters from `/logs?service=gateway&trace_id=...`
- add regression coverage for Live Calls deep-link consolidation and trace/log navigation

## Non-goals

This PR does not:
- rewire OTel, Loki, Tempo, Prometheus, OpenSearch, Fluent Bit, Data Prepper, or Alloy
- add a new trace/log backend API
- change gateway metric cardinality
- change sidecar or stoa-connect telemetry wiring
- change sampling policy
- change tenant authorization semantics
- reintroduce Grafana JWT/token or frontend `tenant_id` URL parameters

## Validation

- `npm test -- --run src/pages/CallFlow/TraceDetail.test.tsx src/hooks/useBreadcrumbs.test.ts src/__tests__/spec/cab-2004.test.tsx src/__tests__/regression/live-calls-consolidation.test.tsx`
- `npx prettier --check src/App.tsx src/pages/CallFlow/TraceDetail.tsx src/pages/CallFlow/TraceDetail.test.tsx src/pages/CallFlow/LegacyCallFlowTraceRedirect.tsx src/pages/RequestExplorer/LogExplorer.tsx src/hooks/useBreadcrumbs.ts src/hooks/useBreadcrumbs.test.ts src/__tests__/spec/cab-2004.test.tsx src/__tests__/regression/live-calls-consolidation.test.tsx`
- `npx eslint src/App.tsx src/pages/CallFlow/TraceDetail.tsx src/pages/CallFlow/TraceDetail.test.tsx src/pages/CallFlow/LegacyCallFlowTraceRedirect.tsx src/pages/RequestExplorer/LogExplorer.tsx src/hooks/useBreadcrumbs.ts src/hooks/useBreadcrumbs.test.ts src/__tests__/spec/cab-2004.test.tsx src/__tests__/regression/live-calls-consolidation.test.tsx --max-warnings 0`
- `npm run build`
- `git diff --check`
- hidden/bidi Unicode scan clean

Notes:
- `npm ci` emitted Node engine warnings because the local runtime is Node v23.6.1 while several packages declare Node 20/22/24-compatible engines.
- `npm run build` required `npm ci` in `shared/` for the sibling workspace dependencies.
- Existing LogExplorer spec tests still emit React `act(...)` warnings, but all targeted tests pass.
