### PR TITLE
chore(ui): observability quick wins

### DIFF
--- a/control-plane-ui/src/pages/AuditLog.test.tsx
+++ b/control-plane-ui/src/pages/AuditLog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 import { createAuthMock } from '../test/helpers';
 import { useAuth } from '../contexts/AuthContext';
 import type { PersonaRole } from '../test/helpers';
@@ -25,6 +25,7 @@ describe('AuditLog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    localStorage.clear();
     vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
     mockGet.mockImplementation(() =>
       Promise.resolve({
@@ -44,6 +45,102 @@ describe('AuditLog', () => {
     await waitFor(() => {
       expect(screen.getByText(/Total Events/i)).toBeInTheDocument();
     });
+  });
+
+  it('sends start_date and end_date params when date filters are set', async () => {
+    vi.useRealTimers();
+    render(<AuditLog />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Total Events/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    const dateInputs = document.querySelectorAll<HTMLInputElement>('input[type="date"]');
+    expect(dateInputs).toHaveLength(2);
+
+    fireEvent.change(dateInputs[0], { target: { value: '2026-05-01' } });
+    fireEvent.change(dateInputs[1], { target: { value: '2026-05-07' } });
+
+    await waitFor(() => {
+      const dateFilteredCall = mockGet.mock.calls.find(([url, options]) => {
+        const params = (options as { params?: Record<string, unknown> } | undefined)?.params;
+        return (
+          url === '/v1/audit/gregarious-games' &&
+          params?.start_date === '2026-05-01' &&
+          params?.end_date === '2026-05-07'
+        );
+      });
+      expect(dateFilteredCall).toBeTruthy();
+
+      const params = (dateFilteredCall?.[1] as { params?: Record<string, unknown> })?.params;
+      expect(params).not.toHaveProperty('date_from');
+      expect(params).not.toHaveProperty('date_to');
+    });
+  });
+
+  it('exports with start_date and end_date params when date filters are set', async () => {
+    vi.useRealTimers();
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const anchorClickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:audit-log'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    mockGet.mockImplementation((url: unknown) => {
+      if (typeof url === 'string' && url.endsWith('/export/csv')) {
+        return Promise.resolve({ data: 'timestamp,action\n' });
+      }
+      return Promise.resolve({
+        data: { entries: [], total: 0, page: 1, page_size: 20, has_more: false },
+      });
+    });
+
+    try {
+      render(<AuditLog />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Total Events/i)).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+      const dateInputs = document.querySelectorAll<HTMLInputElement>('input[type="date"]');
+      expect(dateInputs).toHaveLength(2);
+
+      fireEvent.change(dateInputs[0], { target: { value: '2026-05-01' } });
+      fireEvent.change(dateInputs[1], { target: { value: '2026-05-07' } });
+      fireEvent.click(screen.getByRole('button', { name: /export/i }));
+
+      await waitFor(() => {
+        const exportCall = mockGet.mock.calls.find(([url]) => String(url).endsWith('/export/csv'));
+        expect(exportCall).toBeTruthy();
+
+        const params = (exportCall?.[1] as { params?: Record<string, unknown> })?.params;
+        expect(params).toMatchObject({
+          start_date: '2026-05-01',
+          end_date: '2026-05-07',
+        });
+        expect(params).not.toHaveProperty('date_from');
+        expect(params).not.toHaveProperty('date_to');
+      });
+    } finally {
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        value: originalCreateObjectURL,
+      });
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        value: originalRevokeObjectURL,
+      });
+      anchorClickSpy.mockRestore();
+    }
   });
 
   it('clears polling interval on unmount and does not update state after unmount', async () => {

--- a/control-plane-ui/src/pages/AuditLog.tsx
+++ b/control-plane-ui/src/pages/AuditLog.tsx
@@ -124,8 +124,8 @@ export function AuditLog() {
       };
       if (filters.action) params.action = filters.action;
       if (filters.status) params.status = filters.status;
-      if (filters.start_date) params.date_from = filters.start_date;
-      if (filters.end_date) params.date_to = filters.end_date;
+      if (filters.start_date) params.start_date = filters.start_date;
+      if (filters.end_date) params.end_date = filters.end_date;
       if (filters.search) params.search = filters.search;
 
       const { data } = await apiService.get<{
@@ -172,8 +172,8 @@ export function AuditLog() {
         params: {
           ...(filters.action && { action: filters.action }),
           ...(filters.status && { status: filters.status }),
-          ...(filters.start_date && { date_from: filters.start_date }),
-          ...(filters.end_date && { date_to: filters.end_date }),
+          ...(filters.start_date && { start_date: filters.start_date }),
+          ...(filters.end_date && { end_date: filters.end_date }),
         },
       });
       const blob = new Blob([typeof data === 'string' ? data : JSON.stringify(data, null, 2)], {
@@ -358,7 +358,7 @@ export function AuditLog() {
                   type="date"
                   value={filters.start_date || ''}
                   onChange={(e) => {
-                    setFilters((f) => ({ ...f, date_from: e.target.value || undefined }));
+                    setFilters((f) => ({ ...f, start_date: e.target.value || undefined }));
                     setPage(1);
                   }}
                   className="text-sm border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg px-3 py-2"
@@ -368,7 +368,7 @@ export function AuditLog() {
                   type="date"
                   value={filters.end_date || ''}
                   onChange={(e) => {
-                    setFilters((f) => ({ ...f, date_to: e.target.value || undefined }));
+                    setFilters((f) => ({ ...f, end_date: e.target.value || undefined }));
                     setPage(1);
                   }}
                   className="text-sm border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg px-3 py-2"

--- a/control-plane-ui/src/pages/CallFlow/CallFlowDashboard.test.tsx
+++ b/control-plane-ui/src/pages/CallFlow/CallFlowDashboard.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/helpers';
+import { CallFlowDashboard } from './CallFlowDashboard';
+
+const prometheusMocks = vi.hoisted(() => ({
+  refetch: vi.fn(),
+}));
+
+vi.mock('../../hooks/usePrometheus', () => ({
+  usePrometheusQuery: vi.fn(() => ({
+    data: null,
+    loading: false,
+    error: null,
+    refetch: prometheusMocks.refetch,
+  })),
+  usePrometheusRange: vi.fn(() => ({
+    data: [],
+    loading: false,
+    error: null,
+    refetch: prometheusMocks.refetch,
+  })),
+  scalarValue: vi.fn(() => null),
+  groupByLabel: vi.fn(() => ({})),
+}));
+
+vi.mock('../../services/api', () => ({
+  apiService: {
+    getTransactions: vi.fn().mockResolvedValue({ transactions: [] }),
+  },
+}));
+
+describe('CallFlowDashboard', () => {
+  it('renders the Live Calls product heading', async () => {
+    renderWithProviders(<CallFlowDashboard />, { route: '/observability/live-calls' });
+
+    expect(await screen.findByRole('heading', { name: 'Live Calls' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Call Flow' })).not.toBeInTheDocument();
+  });
+});

--- a/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.test.tsx
+++ b/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { createAuthMock, renderWithProviders } from '../../test/helpers';
 import { useAuth } from '../../contexts/AuthContext';
 import type { PersonaRole } from '../../test/helpers';
@@ -28,6 +29,11 @@ vi.mock('@stoa/shared/components/Toast', () => ({
 
 import { GuardrailsDashboard } from './GuardrailsDashboard';
 
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
 describe('GuardrailsDashboard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -40,6 +46,7 @@ describe('GuardrailsDashboard', () => {
       },
       rate_limiting: { enforcements: 12 },
     });
+    mockGetGuardrailsEvents.mockResolvedValue({ events: [] });
     vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
   });
 
@@ -58,6 +65,47 @@ describe('GuardrailsDashboard', () => {
     expect(screen.getAllByText(/Injection/i).length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText(/Prompt Guard/i).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('Rate Limit')).toBeInTheDocument();
+  });
+
+  it('does not render Rate Limit as a misleading all-filter button', async () => {
+    renderWithProviders(<GuardrailsDashboard />);
+    const rateLimit = await screen.findByText('Rate Limit');
+    expect(rateLimit.closest('button')).toBeNull();
+  });
+
+  it('routes guardrail event traces through the canonical Live Calls detail path', async () => {
+    mockGetGuardrailsEvents.mockResolvedValue({
+      events: [
+        {
+          timestamp: '2026-05-07T10:00:00Z',
+          trace_id: 'trace-123',
+          span_id: 'span-123',
+          tool: 'payment-api',
+          action: 'pii-redacted',
+          reason: 'Sensitive payload redacted',
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/observability/security']}>
+        <Routes>
+          <Route path="/observability/security" element={<GuardrailsDashboard />} />
+          <Route path="/observability/live-calls/trace/:traceId" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const toolCell = await screen.findByText('payment-api');
+    const eventRow = toolCell.closest('button');
+    expect(eventRow).not.toBeNull();
+    fireEvent.click(eventRow as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent(
+        '/observability/live-calls/trace/trace-123'
+      );
+    });
   });
 
   it('renders configuration section', async () => {

--- a/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.tsx
+++ b/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.tsx
@@ -149,7 +149,7 @@ export function GuardrailsDashboard() {
     value: number;
     description: string;
     color: string;
-    filter: FilterType;
+    filter?: FilterType;
   }[] = [
     {
       icon: Fingerprint,
@@ -189,7 +189,6 @@ export function GuardrailsDashboard() {
       value: stats?.rate_limit_enforcements ?? 0,
       description: 'Requests throttled by token bucket',
       color: 'text-orange-600 bg-orange-50 dark:bg-orange-900/20',
-      filter: 'all',
     },
   ];
 
@@ -225,28 +224,53 @@ export function GuardrailsDashboard() {
 
       {/* Guardrail Cards — click filters the events table below */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {guardrailCards.map((card) => (
-          <button
-            key={card.title}
-            onClick={() => setActiveFilter((prev) => (prev === card.filter ? 'all' : card.filter))}
-            className={`rounded-lg border p-5 text-left transition-all ${card.color} ${
-              activeFilter === card.filter
-                ? 'ring-2 ring-current border-current'
-                : 'border-neutral-200 dark:border-neutral-700'
-            } ${card.value > 0 ? 'cursor-pointer hover:ring-2 hover:ring-offset-1 hover:ring-current' : 'opacity-60'}`}
-          >
-            <div className="flex items-center gap-2 mb-3">
-              <card.icon className="h-5 w-5" />
-              <span className="text-sm font-semibold">{card.title}</span>
-            </div>
-            {loading ? (
-              <div className="h-8 w-16 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
-            ) : (
-              <p className="text-3xl font-bold">{card.value}</p>
-            )}
-            <p className="text-xs mt-2 opacity-75">{card.description}</p>
-          </button>
-        ))}
+        {guardrailCards.map((card) => {
+          const isFilterable = Boolean(card.filter);
+          const isActive = isFilterable && activeFilter === card.filter;
+          const className = `rounded-lg border p-5 text-left transition-all ${card.color} ${
+            isActive
+              ? 'ring-2 ring-current border-current'
+              : 'border-neutral-200 dark:border-neutral-700'
+          } ${
+            isFilterable && card.value > 0
+              ? 'cursor-pointer hover:ring-2 hover:ring-offset-1 hover:ring-current'
+              : 'cursor-default'
+          } ${card.value === 0 ? 'opacity-60' : ''}`;
+          const content = (
+            <>
+              <div className="flex items-center gap-2 mb-3">
+                <card.icon className="h-5 w-5" />
+                <span className="text-sm font-semibold">{card.title}</span>
+              </div>
+              {loading ? (
+                <div className="h-8 w-16 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
+              ) : (
+                <p className="text-3xl font-bold">{card.value}</p>
+              )}
+              <p className="text-xs mt-2 opacity-75">{card.description}</p>
+            </>
+          );
+
+          if (!card.filter) {
+            return (
+              <div key={card.title} className={className}>
+                {content}
+              </div>
+            );
+          }
+
+          const filter = card.filter;
+
+          return (
+            <button
+              key={card.title}
+              onClick={() => setActiveFilter((prev) => (prev === filter ? 'all' : filter))}
+              className={className}
+            >
+              {content}
+            </button>
+          );
+        })}
       </div>
 
       {/* Recent Events — each row links to trace detail */}


### PR DESCRIPTION
## Summary
Small preflight cleanup before the Observability Data Integrity remediation work.
Fixes:
- L7: Live Calls page title still said “Call Flow”
- S1: Security page title still said “Gateway Guardrails”
- S7: Guardrail event trace navigation used legacy `/call-flow/trace/...`
- S6: Rate Limit card click was a no-op through `filter: 'all'`
- A4: Audit Log date filters sent `date_from/date_to` while API expects `start_date/end_date`

## Non-goals
- No Prometheus query changes
- No audit ingestion changes
- No new audit stats/actions endpoints
- No heatmap changes
- No sidebar IA cleanup

## Tests
- [x] npm run lint
- [x] npm run test -- --run
- [x] AuditLog date params regression
- [x] Observability title regression if supported by existing test setup
- [x] Rate Limit card regression
