### PR TITLE
feat(api,infra): audit consumer implementation

### DIFF
--- a/control-plane-api/k8s/deployment.yaml
+++ b/control-plane-api/k8s/deployment.yaml
@@ -37,6 +37,10 @@ spec:
           env:
             - name: LOG_TRACE_EXPORT_ENDPOINT
               value: "http://stoa-alloy-otlp.stoa-monitoring:4317"
+            - name: ENABLE_AUDIT_TRAIL_CONSUMER
+              value: "true"
+            - name: AUDIT_TRAIL_DLQ_TOPIC
+              value: "stoa.audit.trail.dlq"
             # Shared internal keys (CAB-1863)
             - name: CHAT_GATEWAY_API_KEY
               valueFrom:

--- a/control-plane-api/src/main.py
+++ b/control-plane-api/src/main.py
@@ -137,6 +137,7 @@ from .services import (
 )
 from .services.gateway_service import gateway_service
 from .tracing_config import configure_tracing, shutdown_tracing
+from .workers.audit_trail_consumer import audit_trail_consumer
 from .workers.billing_metering_consumer import billing_metering_consumer
 from .workers.chat_metering_consumer import chat_metering_consumer
 from .workers.error_snapshot_consumer import error_snapshot_consumer
@@ -179,6 +180,9 @@ ENABLE_CHAT_METERING_CONSUMER = (
 )
 ENABLE_BILLING_METERING_CONSUMER = (
     KAFKA_CONSUMERS_ENABLED and os.getenv("ENABLE_BILLING_METERING_CONSUMER", "true").lower() == "true"
+)
+ENABLE_AUDIT_TRAIL_CONSUMER = (
+    KAFKA_CONSUMERS_ENABLED and os.getenv("ENABLE_AUDIT_TRAIL_CONSUMER", "true").lower() == "true"
 )
 ENABLE_TELEMETRY_WORKER = os.getenv("ENABLE_TELEMETRY_WORKER", "true").lower() == "true"
 ENABLE_GATEWAY_RECONCILER = os.getenv("ENABLE_GATEWAY_RECONCILER", "true").lower() == "true"
@@ -318,6 +322,15 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.warning("Failed to start billing metering consumer", error=str(e))
 
+    # Start audit trail PostgreSQL sink consumer (PR-1A4)
+    audit_trail_consumer_task = None
+    if ENABLE_AUDIT_TRAIL_CONSUMER:
+        try:
+            audit_trail_consumer_task = asyncio.create_task(audit_trail_consumer.start())
+            logger.info("Audit trail consumer started")
+        except Exception as e:
+            logger.warning("Failed to start audit trail consumer", error=str(e))
+
     # Start Git sync worker (CAB-2012 — async Git commits on API CRUD)
     git_sync_task = None
     if ENABLE_GIT_SYNC_WORKER and settings.GIT_SYNC_ON_WRITE:
@@ -426,6 +439,13 @@ async def lifespan(app: FastAPI):
         billing_metering_task.cancel()
         with suppress(asyncio.CancelledError):
             await billing_metering_task
+
+    # Stop audit trail PostgreSQL sink consumer (PR-1A4)
+    if ENABLE_AUDIT_TRAIL_CONSUMER and audit_trail_consumer_task:
+        await audit_trail_consumer.stop()
+        audit_trail_consumer_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await audit_trail_consumer_task
 
     # Stop git sync worker (CAB-2012)
     if ENABLE_GIT_SYNC_WORKER and git_sync_task:

--- a/control-plane-api/src/workers/audit_trail_consumer.py
+++ b/control-plane-api/src/workers/audit_trail_consumer.py
@@ -1,0 +1,410 @@
+"""Audit trail Kafka consumer that persists audit envelopes to PostgreSQL."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from kafka import KafkaConsumer, KafkaProducer
+from kafka.errors import KafkaError
+from prometheus_client import Counter, Gauge, Histogram
+from pydantic import BaseModel, Field, ValidationError, field_validator
+from sqlalchemy.exc import IntegrityError
+
+from ..config import settings
+from ..core.pii.masker import MaskingContext, get_masker
+from ..database import _get_session_factory
+from ..models.audit_event import AuditEvent
+from ..services.kafka_service import EVENT_VERSION, Topics
+
+logger = logging.getLogger(__name__)
+
+COMPONENT = "audit-trail-consumer"
+TOPIC = Topics.AUDIT_LOG
+GROUP_ID = "audit-trail-pg-consumer"
+DEFAULT_DLQ_TOPIC = "stoa.audit.trail.dlq"
+VALID_OUTCOMES = {"success", "failure", "denied", "error"}
+PROCESSING_TIMEOUT_SECONDS = 30
+
+MESSAGES_TOTAL = Counter(
+    "stoa_audit_consumer_messages_total",
+    "Audit trail Kafka messages processed by result.",
+    ["result"],
+)
+PROCESSING_SECONDS = Histogram(
+    "stoa_audit_consumer_processing_seconds",
+    "Audit trail Kafka message processing latency.",
+)
+DB_ERRORS_TOTAL = Counter(
+    "stoa_audit_consumer_db_errors_total",
+    "Audit trail PostgreSQL persistence failures.",
+)
+DLQ_TOTAL = Counter(
+    "stoa_audit_consumer_dlq_total",
+    "Audit trail Kafka messages published to the DLQ.",
+    ["error_type"],
+)
+DUPLICATE_TOTAL = Counter(
+    "stoa_audit_consumer_duplicate_total",
+    "Audit trail duplicate event ids skipped.",
+)
+LAST_SUCCESS_TIMESTAMP = Gauge(
+    "stoa_audit_consumer_last_success_timestamp_seconds",
+    "Unix timestamp of the latest successful audit trail sink operation.",
+)
+
+
+class AuditPayload(BaseModel):
+    """Compatible payload fields published by KafkaService.emit_audit_event."""
+
+    action: str
+    resource_type: str
+    resource_id: str | None = None
+    details: dict[str, Any] | None = Field(default_factory=dict)
+    method: str | None = None
+    path: str | None = None
+    resource_name: str | None = None
+    outcome: str = "success"
+    status_code: int | None = None
+    actor_email: str | None = None
+    actor_type: str | None = None
+    correlation_id: str | None = None
+    client_ip: str | None = None
+    user_agent: str | None = None
+    diff: dict[str, Any] | None = None
+    duration_ms: int | None = None
+
+    @field_validator("action", "resource_type")
+    @classmethod
+    def _required_text(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("field must be non-empty")
+        return value
+
+    @field_validator("outcome")
+    @classmethod
+    def _valid_outcome(cls, value: str) -> str:
+        if value not in VALID_OUTCOMES:
+            raise ValueError("outcome must be one of success, failure, denied, error")
+        return value
+
+    @field_validator("details")
+    @classmethod
+    def _details_must_be_object(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        if value is not None and not isinstance(value, dict):
+            raise ValueError("details must be an object")
+        return value
+
+
+class AuditTrailEnvelope(BaseModel):
+    """Canonical audit event envelope from `stoa.audit.trail`."""
+
+    id: str
+    type: str
+    source: str
+    tenant_id: str
+    timestamp: datetime
+    version: str
+    user_id: str | None = None
+    payload: AuditPayload
+
+    @field_validator("id")
+    @classmethod
+    def _id_must_be_uuid(cls, value: str) -> str:
+        uuid.UUID(value)
+        return value
+
+    @field_validator("type")
+    @classmethod
+    def _type_must_be_audit(cls, value: str) -> str:
+        if value != "audit":
+            raise ValueError('type must equal "audit"')
+        return value
+
+    @field_validator("source")
+    @classmethod
+    def _source_must_be_non_empty(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("source must be non-empty")
+        return value
+
+    @field_validator("tenant_id")
+    @classmethod
+    def _tenant_must_be_known(cls, value: str) -> str:
+        if not value or not value.strip() or value.strip().lower() == "unknown":
+            raise ValueError("tenant_id must be non-empty and known")
+        return value
+
+    @field_validator("timestamp")
+    @classmethod
+    def _timestamp_must_be_aware(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("timestamp must be timezone-aware")
+        return value.astimezone(UTC)
+
+    @field_validator("version")
+    @classmethod
+    def _version_must_match(cls, value: str) -> str:
+        if value != EVENT_VERSION:
+            raise ValueError(f"version must equal {EVENT_VERSION}")
+        return value
+
+
+class AuditTrailConsumer:
+    """Threaded Kafka consumer with manual commit after PG or DLQ success."""
+
+    def __init__(self) -> None:
+        self._consumer: KafkaConsumer | None = None
+        self._producer: KafkaProducer | None = None
+        self._running = False
+        self._thread: threading.Thread | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._db_backoff_seconds = 1.0
+        self.dlq_topic = os.getenv("AUDIT_TRAIL_DLQ_TOPIC", DEFAULT_DLQ_TOPIC)
+
+    async def start(self) -> None:
+        """Start consuming audit trail events in a daemon thread."""
+        self._loop = asyncio.get_running_loop()
+        self._running = True
+        self._thread = threading.Thread(target=self._consume_thread, daemon=True, name=COMPONENT)
+        self._thread.start()
+        logger.info("Audit trail consumer started", extra={"component": COMPONENT, "topic": TOPIC})
+
+    async def stop(self) -> None:
+        """Stop the consumer and close Kafka clients."""
+        self._running = False
+        if self._consumer:
+            self._consumer.close()
+        if self._producer:
+            self._producer.close()
+        logger.info("Audit trail consumer stopped", extra={"component": COMPONENT})
+
+    def _consume_thread(self) -> None:
+        try:
+            self._consumer = self._create_consumer()
+            if self._consumer is None:
+                return
+            while self._running:
+                for _tp, records in self._consumer.poll(timeout_ms=1000).items():
+                    for message in records:
+                        if not self._running:
+                            break
+                        processed = self._process_message_sync(message)
+                        while self._running and not processed:
+                            processed = self._process_message_sync(message)
+                        if processed:
+                            self._consumer.commit()
+        except Exception:
+            if self._running:
+                logger.error("Audit trail consumer thread failed", exc_info=True, extra={"component": COMPONENT})
+        finally:
+            if self._consumer:
+                self._consumer.close()
+
+    def _create_consumer(self) -> KafkaConsumer | None:
+        try:
+            return KafkaConsumer(TOPIC, **self._kafka_config(group_id=GROUP_ID, enable_auto_commit=False))
+        except KafkaError:
+            logger.error("Failed to create audit trail consumer", exc_info=True, extra={"component": COMPONENT})
+            return None
+
+    def _create_producer(self) -> KafkaProducer:
+        return KafkaProducer(
+            **self._kafka_base_config(),
+            value_serializer=lambda value: json.dumps(value).encode("utf-8"),
+        )
+
+    def _kafka_config(self, *, group_id: str | None, enable_auto_commit: bool | None) -> dict[str, Any]:
+        config = {
+            **self._kafka_base_config(),
+            "auto_offset_reset": "earliest",
+            "value_deserializer": self._decode_value,
+        }
+        if group_id is not None:
+            config["group_id"] = group_id
+        if enable_auto_commit is not None:
+            config["enable_auto_commit"] = enable_auto_commit
+        return config
+
+    def _kafka_base_config(self) -> dict[str, Any]:
+        config: dict[str, Any] = {
+            "bootstrap_servers": settings.KAFKA_BOOTSTRAP_SERVERS.split(","),
+        }
+        if settings.KAFKA_SECURITY_PROTOCOL != "PLAINTEXT":
+            config["security_protocol"] = settings.KAFKA_SECURITY_PROTOCOL
+        if settings.KAFKA_SASL_MECHANISM:
+            config["sasl_mechanism"] = settings.KAFKA_SASL_MECHANISM
+            config["sasl_plain_username"] = settings.KAFKA_SASL_USERNAME
+            config["sasl_plain_password"] = settings.KAFKA_SASL_PASSWORD
+        return config
+
+    @staticmethod
+    def _decode_value(message: bytes) -> Any:
+        try:
+            return json.loads(message.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return message.decode("utf-8", errors="replace")
+
+    def _process_message_sync(self, message: Any) -> bool:
+        if self._loop is None:
+            logger.error("No event loop available for audit consumer", extra={"component": COMPONENT})
+            return False
+        future = asyncio.run_coroutine_threadsafe(self._handle_message(message), self._loop)
+        return bool(future.result(timeout=PROCESSING_TIMEOUT_SECONDS))
+
+    async def _handle_message(self, message: Any) -> bool:
+        started = time.monotonic()
+        try:
+            envelope = AuditTrailEnvelope.model_validate(message.value)
+            event = self._to_audit_event(envelope, message)
+            result = await self._persist_event(event)
+            self._record_success(result)
+            self._log_message(message, envelope, result=result)
+            return True
+        except (ValidationError, ValueError) as exc:
+            ok = await self._publish_dlq(message, "validation_error", str(exc))
+            result = "invalid" if ok else "dlq_error"
+            MESSAGES_TOTAL.labels(result=result).inc()
+            if not ok:
+                await self._sleep_before_retry()
+            self._log_message(message, None, result=result, error_type="validation_error")
+            return ok
+        except Exception as exc:
+            DB_ERRORS_TOTAL.inc()
+            MESSAGES_TOTAL.labels(result="db_error").inc()
+            await self._sleep_before_retry()
+            self._log_message(message, None, result="db_error", error_type=type(exc).__name__)
+            return False
+        finally:
+            PROCESSING_SECONDS.observe(time.monotonic() - started)
+
+    def _to_audit_event(self, envelope: AuditTrailEnvelope, message: Any) -> AuditEvent:
+        payload = envelope.payload
+        method = payload.method or "KAFKA"
+        path = payload.path or f"/events/kafka/{TOPIC}/{payload.resource_type}/{payload.action}"
+        if len(method) > 10:
+            raise ValueError("method must fit audit_events.method")
+        if len(path) > 1024:
+            raise ValueError("path must fit audit_events.path")
+
+        raw_details = payload.details or {}
+        correlation_id = payload.correlation_id or raw_details.get("correlation_id")
+        details = get_masker().mask_dict(
+            raw_details,
+            context=MaskingContext(tenant_id=envelope.tenant_id, user_id=envelope.user_id, source=COMPONENT),
+        )
+        details["_kafka"] = {
+            "topic": getattr(message, "topic", TOPIC),
+            "partition": getattr(message, "partition", None),
+            "offset": getattr(message, "offset", None),
+            "producer_event_id": envelope.id,
+            "producer_source": envelope.source,
+            "producer_version": envelope.version,
+        }
+
+        return AuditEvent(
+            id=envelope.id,
+            tenant_id=envelope.tenant_id,
+            actor_id=envelope.user_id,
+            actor_email=payload.actor_email,
+            actor_type=payload.actor_type or ("user" if envelope.user_id else "system"),
+            action=payload.action,
+            method=method,
+            path=path,
+            resource_type=payload.resource_type,
+            resource_id=payload.resource_id,
+            resource_name=payload.resource_name,
+            outcome=payload.outcome,
+            status_code=payload.status_code,
+            client_ip=payload.client_ip,
+            user_agent=payload.user_agent,
+            correlation_id=correlation_id,
+            details=details,
+            diff=payload.diff,
+            duration_ms=payload.duration_ms,
+            created_at=envelope.timestamp,
+        )
+
+    async def _persist_event(self, event: AuditEvent) -> str:
+        factory = _get_session_factory()
+        async with factory() as session:
+            existing = await session.get(AuditEvent, event.id)
+            if existing is not None:
+                await session.rollback()
+                return "duplicate"
+            try:
+                session.add(event)
+                await session.commit()
+                return "inserted"
+            except IntegrityError:
+                await session.rollback()
+                return "duplicate"
+            except Exception:
+                await session.rollback()
+                raise
+
+    async def _publish_dlq(self, message: Any, error_type: str, error_message: str) -> bool:
+        dlq_message = {
+            "source_topic": getattr(message, "topic", TOPIC),
+            "source_partition": getattr(message, "partition", None),
+            "source_offset": getattr(message, "offset", None),
+            "error_type": error_type,
+            "error_message": error_message,
+            "received_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "raw_event": message.value,
+        }
+        try:
+            if self._producer is None:
+                self._producer = self._create_producer()
+            self._producer.send(self.dlq_topic, value=dlq_message).get(timeout=10)
+            DLQ_TOTAL.labels(error_type=error_type).inc()
+            return True
+        except Exception:
+            logger.error("Failed to publish audit event to DLQ", exc_info=True, extra={"component": COMPONENT})
+            return False
+
+    async def _sleep_before_retry(self) -> None:
+        delay = self._db_backoff_seconds
+        self._db_backoff_seconds = min(self._db_backoff_seconds * 2, 60)
+        await asyncio.sleep(delay)
+
+    def _record_success(self, result: str) -> None:
+        self._db_backoff_seconds = 1.0
+        MESSAGES_TOTAL.labels(result=result).inc()
+        if result == "duplicate":
+            DUPLICATE_TOTAL.inc()
+        LAST_SUCCESS_TIMESTAMP.set(time.time())
+
+    def _log_message(
+        self,
+        message: Any,
+        envelope: AuditTrailEnvelope | None,
+        *,
+        result: str,
+        error_type: str | None = None,
+    ) -> None:
+        logger.info(
+            "Audit trail message processed",
+            extra={
+                "component": COMPONENT,
+                "topic": getattr(message, "topic", TOPIC),
+                "partition": getattr(message, "partition", None),
+                "offset": getattr(message, "offset", None),
+                "event_id": envelope.id if envelope else None,
+                "tenant_id": envelope.tenant_id if envelope else None,
+                "action": envelope.payload.action if envelope else None,
+                "resource_type": envelope.payload.resource_type if envelope else None,
+                "result": result,
+                "error_type": error_type,
+            },
+        )
+
+
+audit_trail_consumer = AuditTrailConsumer()

--- a/control-plane-api/tests/test_audit_trail_consumer.py
+++ b/control-plane-api/tests/test_audit_trail_consumer.py
@@ -1,0 +1,233 @@
+"""Tests for audit trail Kafka -> PostgreSQL consumer."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.models.audit_event import AuditEvent
+from src.workers.audit_trail_consumer import (
+    DEFAULT_DLQ_TOPIC,
+    GROUP_ID,
+    TOPIC,
+    AuditTrailConsumer,
+    AuditTrailEnvelope,
+)
+
+EVENT_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _event(**overrides):
+    data = {
+        "id": EVENT_ID,
+        "type": "audit",
+        "source": "control-plane-api",
+        "tenant_id": "acme",
+        "timestamp": datetime(2026, 5, 8, 12, 0, tzinfo=UTC).isoformat().replace("+00:00", "Z"),
+        "version": "1.0",
+        "user_id": "user-1",
+        "payload": {
+            "action": "api.created",
+            "resource_type": "api",
+            "resource_id": "api-1",
+            "details": {"correlation_id": "550e8400-e29b-41d4-a716-446655440001"},
+        },
+    }
+    data.update(overrides)
+    return data
+
+
+def _message(value):
+    return SimpleNamespace(value=value, topic=TOPIC, partition=2, offset=42)
+
+
+class _SessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+def _session_factory(session):
+    return MagicMock(return_value=_SessionContext(session))
+
+
+def test_current_envelope_maps_to_audit_event_with_kafka_metadata():
+    consumer = AuditTrailConsumer()
+    envelope = AuditTrailEnvelope.model_validate(_event())
+
+    with patch("src.workers.audit_trail_consumer.get_masker") as get_masker:
+        get_masker.return_value.mask_dict.return_value = {"correlation_id": "cid"}
+        event = consumer._to_audit_event(envelope, _message(_event()))
+
+    assert event.id == EVENT_ID
+    assert event.tenant_id == "acme"
+    assert event.actor_id == "user-1"
+    assert event.actor_type == "user"
+    assert event.method == "KAFKA"
+    assert event.path == "/events/kafka/stoa.audit.trail/api/api.created"
+    assert event.correlation_id == "550e8400-e29b-41d4-a716-446655440001"
+    assert event.created_at == datetime(2026, 5, 8, 12, 0, tzinfo=UTC)
+    assert event.details["_kafka"] == {
+        "topic": TOPIC,
+        "partition": 2,
+        "offset": 42,
+        "producer_event_id": EVENT_ID,
+        "producer_source": "control-plane-api",
+        "producer_version": "1.0",
+    }
+
+
+@pytest.mark.asyncio
+async def test_persist_event_inserts_once_and_commits():
+    consumer = AuditTrailConsumer()
+    event = AuditEvent(id=EVENT_ID, tenant_id="acme", action="create", method="KAFKA", path="/p", resource_type="api")
+    session = MagicMock()
+    session.get = AsyncMock(return_value=None)
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+
+    with patch("src.workers.audit_trail_consumer._get_session_factory", return_value=_session_factory(session)):
+        assert await consumer._persist_event(event) == "inserted"
+
+    session.add.assert_called_once_with(event)
+    session.commit.assert_awaited_once()
+    session.rollback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_event_id_is_successful_noop():
+    consumer = AuditTrailConsumer()
+    event = AuditEvent(id=EVENT_ID, tenant_id="acme", action="create", method="KAFKA", path="/p", resource_type="api")
+    session = MagicMock()
+    session.get = AsyncMock(return_value=event)
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+
+    with patch("src.workers.audit_trail_consumer._get_session_factory", return_value=_session_factory(session)):
+        assert await consumer._persist_event(event) == "duplicate"
+
+    session.add.assert_not_called()
+    session.commit.assert_not_awaited()
+    session.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_invalid_tenant_goes_to_dlq_and_allows_offset_commit():
+    consumer = AuditTrailConsumer()
+    message = _message(_event(tenant_id="unknown"))
+
+    with patch.object(consumer, "_publish_dlq", new=AsyncMock(return_value=True)) as dlq:
+        assert await consumer._handle_message(message) is True
+
+    dlq.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_invalid_outcome_goes_to_dlq_and_dlq_failure_blocks_commit():
+    consumer = AuditTrailConsumer()
+    event = _event()
+    event["payload"]["outcome"] = "maybe"
+    message = _message(event)
+
+    with (
+        patch.object(consumer, "_publish_dlq", new=AsyncMock(return_value=False)) as dlq,
+        patch.object(consumer, "_sleep_before_retry", new=AsyncMock()) as backoff,
+    ):
+        assert await consumer._handle_message(message) is False
+
+    dlq.assert_awaited_once()
+    backoff.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_db_error_rolls_back_and_does_not_allow_offset_commit():
+    consumer = AuditTrailConsumer()
+    message = _message(_event())
+
+    with (
+        patch.object(consumer, "_persist_event", new=AsyncMock(side_effect=RuntimeError("db down"))),
+        patch.object(consumer, "_sleep_before_retry", new=AsyncMock()) as backoff,
+    ):
+        assert await consumer._handle_message(message) is False
+
+    backoff.assert_awaited_once()
+
+
+def test_consumer_retries_and_commits_offsets_only_after_successful_processing():
+    consumer = AuditTrailConsumer()
+    consumer._running = True
+    kafka = MagicMock()
+    kafka.poll.return_value = {object(): [_message(_event())]}
+    outcomes = [False, True]
+
+    def process(_message):
+        result = outcomes.pop(0)
+        if result:
+            consumer._running = False
+        return result
+
+    with (
+        patch.object(consumer, "_create_consumer", return_value=kafka),
+        patch.object(consumer, "_process_message_sync", side_effect=process) as process_message,
+    ):
+        consumer._consume_thread()
+
+    assert process_message.call_count == 2
+    kafka.commit.assert_called_once()
+
+
+def test_consumer_does_not_commit_after_failed_processing():
+    consumer = AuditTrailConsumer()
+    consumer._running = True
+    kafka = MagicMock()
+    kafka.poll.return_value = {object(): [_message(_event())]}
+
+    def process(_message):
+        consumer._running = False
+        return False
+
+    with (
+        patch.object(consumer, "_create_consumer", return_value=kafka),
+        patch.object(consumer, "_process_message_sync", side_effect=process),
+    ):
+        consumer._consume_thread()
+
+    kafka.commit.assert_not_called()
+
+
+def test_create_consumer_uses_contract_topic_group_and_manual_commit():
+    consumer = AuditTrailConsumer()
+    mock_kafka = MagicMock()
+
+    with (
+        patch("src.workers.audit_trail_consumer.KafkaConsumer", return_value=mock_kafka) as kafka_consumer,
+        patch("src.workers.audit_trail_consumer.settings") as mock_settings,
+    ):
+        mock_settings.KAFKA_BOOTSTRAP_SERVERS = "broker1:9092,broker2:9092"
+        mock_settings.KAFKA_SECURITY_PROTOCOL = "PLAINTEXT"
+        mock_settings.KAFKA_SASL_MECHANISM = ""
+        assert consumer._create_consumer() is mock_kafka
+
+    kafka_consumer.assert_called_once()
+    args, kwargs = kafka_consumer.call_args
+    assert args == (TOPIC,)
+    assert kwargs["group_id"] == GROUP_ID
+    assert kwargs["auto_offset_reset"] == "earliest"
+    assert kwargs["enable_auto_commit"] is False
+    assert kwargs["bootstrap_servers"] == ["broker1:9092", "broker2:9092"]
+
+
+def test_invalid_json_is_decoded_as_dlq_eligible_string():
+    assert AuditTrailConsumer._decode_value(b"not-json") == "not-json"
+
+
+def test_default_dlq_topic():
+    assert AuditTrailConsumer().dlq_topic == DEFAULT_DLQ_TOPIC

--- a/control-plane-api/tests/test_regression_kafka_boot.py
+++ b/control-plane-api/tests/test_regression_kafka_boot.py
@@ -47,6 +47,7 @@ def test_per_consumer_flags_respect_master_gate() -> None:
         "ENABLE_SYNC_ENGINE",
         "ENABLE_CHAT_METERING_CONSUMER",
         "ENABLE_BILLING_METERING_CONSUMER",
+        "ENABLE_AUDIT_TRAIL_CONSUMER",
         "ENABLE_GIT_SYNC_WORKER",
     )
     for flag in kafka_backed_flags:

--- a/docs/plans/2026-05-08-audit-consumer-ingestion-contract.md
+++ b/docs/plans/2026-05-08-audit-consumer-ingestion-contract.md
@@ -1,0 +1,289 @@
+---
+id: plan-2026-05-08-audit-consumer-ingestion-contract
+validation_status: draft
+source_evidence:
+  - docs/audits/2026-05-08-audit-ingestion/findings.md
+  - docs/audits/2026-05-08-audit-consumer-restore/scoping.md
+---
+
+# Mini-spec — Audit consumer ingestion contract
+## Context
+
+PR-1A proved that OVH prod has Kafka topics `stoa.audit.trail` and `audit-log`, but no consumer group subscribed to either. PostgreSQL `audit_events` exists, but the newest observed row was `2026-05-03 20:04:46+00`, with `0` rows in the last 24h.
+
+PR-1A2 proved that the repo contains audit Kafka producers and reusable consumer patterns, but no audit consumer implementation and no deployment manifest to restore. This document defines the missing ingestion contract before any code PR.
+
+This mini-spec is draft until explicitly validated. Do not implement the consumer while `validation_status != validated`.
+## Problem
+
+Kafka-only audit emitters publish compliance-relevant events that are not persisted to PostgreSQL `audit_events`, which is the primary source for `/v1/audit/{tenant_id}` and `/audit-log`.
+
+The implementation PR must not invent topic name, payload shape, consumer group, idempotency, retry/DLQ behavior, PostgreSQL semantics, observability, or deployment shape.
+## Non-goals
+- No Audit Log `/stats` or `/actions` endpoint.
+- No actor display, actor resolution, UI refresh/backoff, export, locale, or filter work.
+- No `audit_events` schema migration.
+- No replacement of existing direct `AuditService.record_event(...)` paths.
+- No OpenSearch audit rewrite.
+- No deletion, migration, or aliasing of `audit-log` or `stoa.audit.events`.
+- No backfill outside retained Kafka messages.
+## Canonical producer topic
+
+Canonical source topic:
+
+```text
+stoa.audit.trail
+```
+
+Evidence: `Topics.AUDIT_LOG = "stoa.audit.trail"` and `KafkaService.emit_audit_event(...)` publishes there. PR-1A also verified the topic exists in prod.
+
+Topic contract:
+
+| Topic | Status |
+|---|---|
+| `stoa.audit.trail` | Canonical source for this consumer |
+| `audit-log` | Runtime topic exists, but no repo producer/consumer found; do not consume first |
+| `stoa.audit.events` | Legacy/documented constant; do not consume first |
+## Event payload schema
+
+The first implementation must support the current `KafkaService._create_event(...)` envelope. Producer changes are not required.
+
+```json
+{
+  "id": "uuid-string",
+  "type": "audit",
+  "source": "control-plane-api",
+  "tenant_id": "tenant-id",
+  "timestamp": "2026-05-08T12:34:56.000000Z",
+  "version": "1.0",
+  "user_id": "actor-id-or-null",
+  "payload": {
+    "action": "api.created",
+    "resource_type": "api",
+    "resource_id": "resource-id-or-null",
+    "details": {}
+  }
+}
+```
+
+Required fields:
+
+| Field | Rule |
+|---|---|
+| `id` | UUID string; maps to `audit_events.id` |
+| `type` | Must equal `audit` |
+| `source` | Non-empty; expected `control-plane-api` |
+| `tenant_id` | Non-empty; must not be `unknown` |
+| `timestamp` | ISO-8601 UTC; maps to `created_at` |
+| `version` | Must equal `1.0` |
+| `payload.action` | Maps to `action` |
+| `payload.resource_type` | Maps to `resource_type` |
+
+Optional compatible fields: `payload.resource_id`, `payload.details`, `payload.method`, `payload.path`, `payload.resource_name`, `payload.outcome`, `payload.status_code`, `payload.actor_email`, `payload.actor_type`, `payload.correlation_id`, `payload.client_ip`, `payload.user_agent`, `payload.diff`, `payload.duration_ms`.
+
+Defaults are allowed only as specified in "PostgreSQL sink contract". Missing required fields go to DLQ.
+## Consumer group
+
+Durable consumer group:
+
+```text
+audit-trail-pg-consumer
+```
+
+Rules:
+- Consume only `stoa.audit.trail`.
+- Use `auto_offset_reset=earliest` for first deployment because the group is new.
+- Disable auto-commit.
+- Commit offsets only after PostgreSQL commit, duplicate skip, or successful DLQ publish.
+- Do not commit offsets after PostgreSQL outage or DLQ publish failure.
+## Idempotency and deduplication
+
+Idempotency key:
+
+```text
+Kafka envelope id -> audit_events.id
+```
+
+Behavior:
+- Successful insert: commit DB transaction, then commit Kafka offset.
+- Duplicate `audit_events.id`: treat as success, do not mutate the existing row, then commit offset.
+- Invalid UUID `id`: send to DLQ.
+- Valid events must not use topic/partition/offset as primary id.
+- Add Kafka trace metadata under `details._kafka`: `topic`, `partition`, `offset`, `producer_event_id`, `producer_source`, `producer_version`.
+## PostgreSQL sink contract
+
+Sink table: `public.audit_events`. Writes are append-only inserts through `AuditEvent` or a repository wrapper; no update/delete.
+
+Field mapping:
+
+| Column | Mapping |
+|---|---|
+| `id` | envelope `id` |
+| `tenant_id` | envelope `tenant_id` |
+| `actor_id` | envelope `user_id` |
+| `actor_email` | `payload.actor_email` else `NULL` |
+| `actor_type` | `payload.actor_type`, else `user` if `user_id`, else `system` |
+| `action` | `payload.action` |
+| `method` | `payload.method` else `KAFKA` |
+| `path` | `payload.path` else `/events/kafka/stoa.audit.trail/{resource_type}/{action}` |
+| `resource_type` | `payload.resource_type` |
+| `resource_id` | `payload.resource_id` |
+| `resource_name` | `payload.resource_name` else `NULL` |
+| `outcome` | `payload.outcome` else `success` |
+| `status_code` | `payload.status_code` else `NULL` |
+| `client_ip` | `payload.client_ip` else `NULL` |
+| `user_agent` | `payload.user_agent` else `NULL` |
+| `correlation_id` | `payload.correlation_id`, else `payload.details.correlation_id`, else `NULL` |
+| `details` | sanitized `payload.details` plus `details._kafka` |
+| `diff` | `payload.diff` else `NULL` |
+| `duration_ms` | `payload.duration_ms` else `NULL` |
+| `created_at` | envelope `timestamp` |
+
+Validation before insert:
+- Non-null: `tenant_id`, `action`, `resource_type`, `method`, `path`, `outcome`, `created_at`.
+- `method` must fit 10 chars; `path` must fit 1024 chars.
+- `outcome` must be one of `success`, `failure`, `denied`, `error`.
+- Kafka offset is committed only after the DB transaction commits.
+## Error handling, retries, and DLQ
+
+DLQ topic:
+
+```text
+stoa.audit.trail.dlq
+```
+
+DLQ message shape:
+
+```json
+{
+  "source_topic": "stoa.audit.trail",
+  "source_partition": 0,
+  "source_offset": 123,
+  "error_type": "validation_error",
+  "error_message": "reason",
+  "received_at": "2026-05-08T12:35:10Z",
+  "raw_event": {}
+}
+```
+
+Rules:
+- Validation errors go to DLQ once; commit source offset only after DLQ publish succeeds.
+- Duplicate primary key is a successful no-op.
+- PostgreSQL transient errors roll back, do not commit offset, and retry with exponential backoff capped at 60s.
+- PostgreSQL schema/programming errors roll back and do not commit offset; do not DLQ unless the mapper classifies the message as invalid.
+- DLQ publish failure means source offset is not committed.
+- Auto-commit is forbidden.
+
+Validation errors include missing required fields, `type != "audit"`, unsupported `version`, invalid UUID/timestamp, empty or `unknown` tenant, missing `payload.action` or `payload.resource_type`, invalid `outcome`, and non-object `payload.details`.
+## Ordering guarantees
+
+The consumer guarantees Kafka partition order only. There is no global ordering across partitions. `created_at` comes from the producer envelope timestamp, not ingestion time. Backfill can insert older rows after newer rows already exist; readers must continue ordering by `created_at DESC`.
+## Tenant isolation and security
+- Reject empty or `unknown` `tenant_id`.
+- Never infer tenant from resource id, actor id, namespace, or environment.
+- Never log full raw payloads at info/warn level.
+- Treat DLQ as sensitive internal data because it can include raw events.
+- Preserve producer-side masking; run the existing PII/secret masker before writing `details` or prove equivalent sanitization in tests.
+- Do not resolve `actor_email` through Keycloak in this consumer.
+## Observability
+
+Structured logs must include: `component="audit-trail-consumer"`, topic, partition, offset, event_id, tenant_id, action, resource_type, result, and error_type when applicable.
+
+Required metrics:
+
+```text
+stoa_audit_consumer_messages_total{result}
+stoa_audit_consumer_processing_seconds_bucket
+stoa_audit_consumer_db_errors_total
+stoa_audit_consumer_dlq_total{error_type}
+stoa_audit_consumer_duplicate_total
+stoa_audit_consumer_last_success_timestamp_seconds
+```
+
+Allowed `result` labels: `inserted`, `duplicate`, `invalid`, `dlq`, `db_error`, `dlq_error`.
+
+Alert intent:
+- consumer group absent in prod after rollout;
+- last success older than 15 minutes while source lag is greater than 0;
+- DLQ count increases for 5 consecutive minutes.
+## Deployment shape
+
+First implementation runs as an in-process Control Plane API background consumer, matching current Kafka-backed consumers.
+
+Required shape:
+- New module: `control-plane-api/src/workers/audit_trail_consumer.py`.
+- Singleton: `audit_trail_consumer`.
+- Startup integration in `control-plane-api/src/main.py`.
+- Master gate: `STOA_ENABLE_KAFKA_CONSUMERS`.
+- Per-consumer gate: `ENABLE_AUDIT_TRAIL_CONSUMER`, default `true`.
+- Topic: `stoa.audit.trail`.
+- Group: `audit-trail-pg-consumer`.
+- DLQ env override: `AUDIT_TRAIL_DLQ_TOPIC`, default `stoa.audit.trail.dlq`.
+
+Do not add a separate Kubernetes Deployment in the first implementation. Split later only if operational coupling or review size requires it.
+## Backfill policy
+- First deployment backfills retained `stoa.audit.trail` messages via `auto_offset_reset=earliest`.
+- Do not manually seek offsets in code.
+- Do not backfill from PostgreSQL, OpenSearch, logs, `audit-log`, or `stoa.audit.events`.
+- Do not attempt to recover messages older than Kafka retention.
+- Verify backfill with aggregate counts and non-PII samples.
+## Rollout plan
+1. Add unit tests for schema validation and PostgreSQL mapping.
+2. Implement manual-commit consumer and idempotent insert.
+3. Add startup gates and extend Kafka boot regression coverage.
+4. Run tests with Kafka mocked; no broker required in unit tests.
+5. Deploy to dev with `ENABLE_AUDIT_TRAIL_CONSUMER=true`.
+6. Produce one controlled audit event through an existing `emit_audit_event(...)` path.
+7. Verify `audit_events.details._kafka.producer_event_id`.
+8. Verify group `audit-trail-pg-consumer` exists and lag is acceptable.
+9. Promote to prod only after dev verification.
+10. In prod, verify at least one non-chat audit row appears in `/v1/audit/{tenant_id}` after a manual API mutation.
+## Verification plan
+
+Required implementation tests:
+- Valid current envelope inserts an `AuditEvent`.
+- Missing or `unknown` tenant goes to DLQ.
+- Invalid `outcome` goes to DLQ.
+- Duplicate `event.id` is a successful no-op.
+- PostgreSQL transient error rolls back and does not commit offset.
+- DLQ publish failure does not commit offset.
+- `STOA_ENABLE_KAFKA_CONSUMERS=false` disables startup.
+- `ENABLE_AUDIT_TRAIL_CONSUMER=false` disables startup.
+- `git diff --check`.
+
+Runtime verification:
+
+```bash
+rpk group describe audit-trail-pg-consumer
+rpk topic consume stoa.audit.trail.dlq --num 1 --offset end
+```
+
+PostgreSQL aggregate check:
+
+```sql
+SELECT action, resource_type, COUNT(*)
+FROM audit_events
+WHERE created_at > NOW() - INTERVAL '1 hour'
+GROUP BY action, resource_type
+ORDER BY COUNT(*) DESC;
+```
+
+API signal: `GET /v1/audit/{tenant_id}` returns at least one non-`chat_*` row after a controlled Kafka-backed mutation.
+## Acceptance criteria
+- Implementation consumes only `stoa.audit.trail`.
+- Consumer group is exactly `audit-trail-pg-consumer`.
+- Consumer uses manual offset commits.
+- Valid current envelopes insert into `audit_events`.
+- `event.id` is the idempotency key.
+- Duplicate messages do not create or mutate rows.
+- Invalid messages go to `stoa.audit.trail.dlq`.
+- PostgreSQL outages do not commit source offsets.
+- Both startup gates disable the consumer.
+- `/v1/audit/{tenant_id}` shows at least one non-`chat_*` event after a controlled Kafka-backed audit mutation.
+- PR-1B remains blocked until that production signal is observed.
+## Open questions
+1. Should `audit-log` be deleted, aliased, or retained as unmanaged legacy after the consumer is live?
+2. Should `Topics.AUDIT_EVENTS = "stoa.audit.events"` be deprecated or migrated later?
+3. Should this consumer move to a dedicated Kubernetes Deployment after initial restore?
+4. Should future producers add `method`, `path`, `actor_email`, and `correlation_id` to all audit events?
+5. What exact broker retention should `stoa.audit.trail.dlq` use? Minimum recommended retention is 30 days.

--- a/docs/plans/2026-05-08-audit-consumer-ingestion-contract.md
+++ b/docs/plans/2026-05-08-audit-consumer-ingestion-contract.md
@@ -1,6 +1,6 @@
 ---
 id: plan-2026-05-08-audit-consumer-ingestion-contract
-validation_status: draft
+validation_status: validated           # 2026-05-08 — accepted by product owner; PR-1A4 unblocked
 source_evidence:
   - docs/audits/2026-05-08-audit-ingestion/findings.md
   - docs/audits/2026-05-08-audit-consumer-restore/scoping.md


### PR DESCRIPTION
## Summary
Implements PR-1A4: the missing Kafka consumer for the validated audit ingestion contract.

- consumes only `stoa.audit.trail`
- uses consumer group `audit-trail-pg-consumer`
- persists valid envelopes into `audit_events` with `event.id -> audit_events.id`
- disables Kafka auto-commit and commits offsets only after PG persistence, duplicate skip, or successful DLQ publish
- sends validation failures to `stoa.audit.trail.dlq`
- wires the in-process worker through `ENABLE_AUDIT_TRAIL_CONSUMER`

## Contract Alignment
Source of truth: `docs/plans/2026-05-08-audit-consumer-ingestion-contract.md`.

This PR follows the validated contract names:
- module: `control-plane-api/src/workers/audit_trail_consumer.py`
- gate: `ENABLE_AUDIT_TRAIL_CONSUMER`
- DLQ override: `AUDIT_TRAIL_DLQ_TOPIC`

## Deployment Model
In-process Control Plane API background worker, matching the mini-spec first implementation shape. No standalone Kubernetes Deployment added.

`control-plane-api/k8s/deployment.yaml` explicitly enables the worker and declares the DLQ topic for the Control Plane deployment.

## Backfill Strategy
Uses `auto_offset_reset=earliest` for the new consumer group. No manual seek, no historical PG/OpenSearch/log backfill, and no consumption from `audit-log` or `stoa.audit.events`.

## Non-goals
- No `/v1/audit/{tenant_id}/stats`
- No `/v1/audit/{tenant_id}/actions`
- No `AuditLog.tsx`
- No actor resolution
- No demo fallback changes
- No producer emit-site changes
- No schema redesign

## Tests
- [x] `python3 -m pytest tests/test_audit_trail_consumer.py tests/test_regression_kafka_boot.py -q`
- [x] `python3 -m ruff check src/main.py src/workers/audit_trail_consumer.py tests/test_audit_trail_consumer.py tests/test_regression_kafka_boot.py`
- [x] `python3 -m black --check src/main.py src/workers/audit_trail_consumer.py tests/test_audit_trail_consumer.py tests/test_regression_kafka_boot.py`
- [x] `git diff --check`
- [x] `kubectl apply --dry-run=client --validate=false -f control-plane-api/k8s/deployment.yaml`

## Rollback
Revert commit `1ea90a52f`. That removes the worker, startup gate wiring, manifest envs, and regression tests.

## Remaining Risk
PR-1B stays blocked until runtime verification shows at least one non-`chat_*` audit event visible through `/v1/audit/{tenant_id}` after deployment.
