### PR TITLE
fix(ui): align live calls metrics on http_route

### DIFF
--- a/control-plane-ui/src/__tests__/regression/live-calls-metric-integrity.test.tsx
+++ b/control-plane-ui/src/__tests__/regression/live-calls-metric-integrity.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Regression: Live Calls must use current Prometheus route labels.
+ *
+ * PR-2 evidence showed current stoa_http_* series expose http_route, not path.
+ * The dashboard must not collapse route panels into fabricated "unknown" rows.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/helpers';
+import { usePrometheusQuery, usePrometheusRange } from '../../hooks/usePrometheus';
+import { apiService } from '../../services/api';
+import { CallFlowDashboard } from '../../pages/CallFlow/CallFlowDashboard';
+import {
+  buildLiveCallsQueries,
+  HEATMAP_UNAVAILABLE_MESSAGE,
+  METRICS_TRACES_SPLIT_MESSAGE,
+  MODE_FILTER,
+  ROUTE_LABEL,
+} from '../../pages/CallFlow/metrics';
+
+const mocks = vi.hoisted(() => ({
+  getTransactions: vi.fn(),
+  refetch: vi.fn(),
+}));
+
+vi.mock('../../hooks/usePrometheus', async () => {
+  const actual = await vi.importActual<typeof import('../../hooks/usePrometheus')>(
+    '../../hooks/usePrometheus'
+  );
+  return {
+    ...actual,
+    usePrometheusQuery: vi.fn(),
+    usePrometheusRange: vi.fn(),
+  };
+});
+
+vi.mock('../../services/api', () => ({
+  apiService: {
+    getTransactions: mocks.getTransactions,
+  },
+}));
+
+function vector(value: number, metric: Record<string, string> = {}) {
+  return [{ metric, value: [123, String(value)] as [number, string] }];
+}
+
+function mockLiveCallsMetrics(totalRequests = 42) {
+  vi.mocked(usePrometheusQuery).mockImplementation((query: string) => {
+    if (query.startsWith('sum(increase(stoa_http_requests_total') && !query.includes('status=')) {
+      return { data: vector(totalRequests), loading: false, error: null, refetch: mocks.refetch };
+    }
+    if (query.includes('status=~')) {
+      return { data: vector(0), loading: false, error: null, refetch: mocks.refetch };
+    }
+    if (query.startsWith('histogram_quantile')) {
+      return { data: vector(0.05), loading: false, error: null, refetch: mocks.refetch };
+    }
+    if (query.startsWith('count(count by (job)')) {
+      return { data: vector(1), loading: false, error: null, refetch: mocks.refetch };
+    }
+    return { data: [], loading: false, error: null, refetch: mocks.refetch };
+  });
+
+  vi.mocked(usePrometheusRange).mockReturnValue({
+    data: [],
+    loading: false,
+    error: null,
+    refetch: mocks.refetch,
+  });
+  vi.mocked(apiService.getTransactions).mockResolvedValue({ transactions: [] });
+}
+
+describe('regression/live-calls-metric-integrity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLiveCallsMetrics();
+  });
+
+  it('builds route-level PromQL with http_route and the shared mode scope', () => {
+    const queries = buildLiveCallsQueries('1h');
+    const queryText = Object.values(queries).join('\n');
+
+    expect(queries.topRoutesP95).toContain(`sum by (le, ${ROUTE_LABEL})`);
+    expect(queries.topRoutesCalls).toContain(`sum by (${ROUTE_LABEL})`);
+    expect(queries.activeModes).toContain('count by (job)');
+    expect(queries.activeModes).not.toContain('path');
+    expect(queryText).toContain(MODE_FILTER);
+    expect(queryText).not.toMatch(/sum by \(path\)|count by \(path\)|metric\.path/);
+  });
+
+  it('shows a scope mismatch banner when total requests exist but mode breakdowns are empty', async () => {
+    renderWithProviders(<CallFlowDashboard />, { route: '/observability/live-calls' });
+
+    expect(
+      await screen.findByText(
+        /Total requests are available, but no Gateway\/Link\/Connect breakdown traffic was found/
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('clarifies metrics and traces are separate pipelines when requests exist but traces are empty', async () => {
+    renderWithProviders(<CallFlowDashboard />, { route: '/observability/live-calls' });
+
+    expect(await screen.findByText(METRICS_TRACES_SPLIT_MESSAGE)).toBeInTheDocument();
+  });
+
+  it('renders the heatmap unavailable state instead of synthetic cells', async () => {
+    renderWithProviders(<CallFlowDashboard />, { route: '/observability/live-calls' });
+
+    expect(await screen.findByText(HEATMAP_UNAVAILABLE_MESSAGE)).toBeInTheDocument();
+  });
+});

--- a/control-plane-ui/src/hooks/usePrometheus.test.ts
+++ b/control-plane-ui/src/hooks/usePrometheus.test.ts
@@ -221,13 +221,13 @@ describe('groupByLabel', () => {
     });
   });
 
-  it('uses "unknown" for missing label', () => {
+  it('uses "(unlabelled)" for missing label', () => {
     const results = [
       { metric: {}, value: [123, '7'] as [number, string] },
       { metric: { status: '500' }, value: [123, '3'] as [number, string] },
     ];
     expect(groupByLabel(results, 'status')).toEqual({
-      unknown: 7,
+      '(unlabelled)': 7,
       '500': 3,
     });
   });
@@ -281,9 +281,9 @@ describe('groupByLabel', () => {
       { metric: { tag: '' }, value: [123, '10'] as [number, string] },
       { metric: { tag: 'prod' }, value: [123, '20'] as [number, string] },
     ];
-    // Empty string is treated as "unknown" by the groupByLabel function
+    // Empty string is treated as an explicit unlabelled data state.
     expect(groupByLabel(results, 'tag')).toEqual({
-      unknown: 10,
+      '(unlabelled)': 10,
       prod: 20,
     });
   });

--- a/control-plane-ui/src/hooks/usePrometheus.ts
+++ b/control-plane-ui/src/hooks/usePrometheus.ts
@@ -6,6 +6,7 @@ import { httpClient } from '../services/http';
 // httpClient baseURL is https://api.gostoa.dev, so the path is /v1/... — no /api prefix.
 const PROMETHEUS_BASE = '/v1/metrics';
 const PROMETHEUS_TIMEOUT_MS = 10_000;
+const UNLABELLED_LABEL = '(unlabelled)';
 
 interface PrometheusResult {
   metric: Record<string, string>;
@@ -155,7 +156,8 @@ export function groupByLabel(
   if (!results) return {};
   const groups: Record<string, number> = {};
   for (const r of results) {
-    const key = r.metric[label] || 'unknown';
+    const raw = r.metric[label];
+    const key = raw && raw.trim() ? raw : UNLABELLED_LABEL;
     groups[key] = (groups[key] || 0) + parseFloat(r.value?.[1] || '0');
   }
   return groups;

--- a/control-plane-ui/src/pages/CallFlow/CallFlowDashboard.tsx
+++ b/control-plane-ui/src/pages/CallFlow/CallFlowDashboard.tsx
@@ -24,6 +24,7 @@ import { TrafficHeatmap } from './components/TrafficHeatmap';
 import { LiveTraces } from './components/LiveTraces';
 import type { TraceEntry } from './components/LiveTraces';
 import { AutoRefreshToggle } from './components/AutoRefreshToggle';
+import { buildLiveCallsQueries, METRICS_TRACES_SPLIT_MESSAGE, ROUTE_LABEL } from './metrics';
 
 const DEFAULT_REFRESH = 15;
 
@@ -51,6 +52,10 @@ function latencyColorClass(ms: number | null): string | undefined {
   if (ms < 300) return 'text-green-600';
   if (ms < 500) return 'text-yellow-600';
   return 'text-red-600';
+}
+
+function seriesHasTraffic(data: { value: number }[] | null | undefined): boolean {
+  return data?.some((point) => point.value > 0) ?? false;
 }
 
 // ─── Live Traces: fetch from monitoring API (authenticated) ───
@@ -137,46 +142,32 @@ export function CallFlowDashboard() {
 
   const refreshMs = autoRefresh > 0 ? autoRefresh * 1000 : 0;
   const rangeCfg = RANGE_CONFIG[timeRange];
+  const queries = useMemo(() => buildLiveCallsQueries(timeRange), [timeRange]);
 
   // ─── KPI Queries ───
 
-  const totalRequests = usePrometheusQuery(
-    `sum(increase(stoa_http_requests_total[${timeRange}]))`,
-    refreshMs || 15_000
-  );
-  const totalErrors = usePrometheusQuery(
-    `sum(increase(stoa_http_requests_total{status=~"5.."}[${timeRange}]))`,
-    refreshMs || 15_000
-  );
-  const p50Latency = usePrometheusQuery(
-    `histogram_quantile(0.50, sum(rate(stoa_http_request_duration_seconds_bucket[5m])) by (le))`,
-    refreshMs || 15_000
-  );
-  const p99Latency = usePrometheusQuery(
-    `histogram_quantile(0.99, sum(rate(stoa_http_request_duration_seconds_bucket[5m])) by (le))`,
-    refreshMs || 15_000
-  );
-  const activeModes = usePrometheusQuery(
-    `count(count by (path) (stoa_http_requests_total))`,
-    refreshMs || 15_000
-  );
+  const totalRequests = usePrometheusQuery(queries.totalRequests, refreshMs || 15_000);
+  const totalErrors = usePrometheusQuery(queries.totalErrors, refreshMs || 15_000);
+  const p50Latency = usePrometheusQuery(queries.p50Latency, refreshMs || 15_000);
+  const p99Latency = usePrometheusQuery(queries.p99Latency, refreshMs || 15_000);
+  const activeModes = usePrometheusQuery(queries.activeModes, refreshMs || 15_000);
 
   // ─── Throughput (per-mode range queries for stacked area) ───
 
   const edgeMcpTrend = usePrometheusRange(
-    `sum(rate(stoa_http_requests_total{job="stoa-gateway"}[5m]))`,
+    queries.edgeMcpTrend,
     rangeCfg.seconds,
     rangeCfg.step,
     refreshMs || 15_000
   );
   const sidecarTrend = usePrometheusRange(
-    `sum(rate(stoa_http_requests_total{job="stoa-link"}[5m]))`,
+    queries.sidecarTrend,
     rangeCfg.seconds,
     rangeCfg.step,
     refreshMs || 15_000
   );
   const connectTrend = usePrometheusRange(
-    `sum(rate(stoa_http_requests_total{job="stoa-connect"}[5m]))`,
+    queries.connectTrend,
     rangeCfg.seconds,
     rangeCfg.step,
     refreshMs || 15_000
@@ -184,28 +175,16 @@ export function CallFlowDashboard() {
 
   // ─── Latency histogram buckets ───
 
-  const latencyBuckets = usePrometheusQuery(
-    `sum(increase(stoa_http_request_duration_seconds_bucket[${timeRange}])) by (le)`,
-    refreshMs || 15_000
-  );
+  const latencyBuckets = usePrometheusQuery(queries.latencyBuckets, refreshMs || 15_000);
 
   // ─── Error breakdown by status code ───
 
-  const errorsByStatus = usePrometheusQuery(
-    `sum by (status) (increase(stoa_http_requests_total{status=~"4..|5.."}[${timeRange}]))`,
-    refreshMs || 15_000
-  );
+  const errorsByStatus = usePrometheusQuery(queries.errorsByStatus, refreshMs || 15_000);
 
   // ─── Top routes by P95 latency ───
 
-  const topRoutesP95 = usePrometheusQuery(
-    `topk(8, histogram_quantile(0.95, sum by (le, path) (rate(stoa_http_request_duration_seconds_bucket[5m]))))`,
-    refreshMs || 15_000
-  );
-  const topRoutesCalls = usePrometheusQuery(
-    `sum by (path) (increase(stoa_http_requests_total[${timeRange}]))`,
-    refreshMs || 15_000
-  );
+  const topRoutesP95 = usePrometheusQuery(queries.topRoutesP95, refreshMs || 15_000);
+  const topRoutesCalls = usePrometheusQuery(queries.topRoutesCalls, refreshMs || 15_000);
 
   // ─── Fallback queries (when service graph is not available) ───
 
@@ -271,6 +250,16 @@ export function CallFlowDashboard() {
 
   const prometheusAvailable = !totalRequests.error && !fallbackRequests.error;
   const loading = totalRequests.loading && fallbackRequests.loading;
+  const modeBreakdownLoading = edgeMcpTrend.loading || sidecarTrend.loading || connectTrend.loading;
+  const modeBreakdownHasTraffic =
+    seriesHasTraffic(edgeMcpTrend.data) ||
+    seriesHasTraffic(sidecarTrend.data) ||
+    seriesHasTraffic(connectTrend.data);
+  const showScopeMismatch =
+    useServiceGraph &&
+    !modeBreakdownLoading &&
+    (totalRequestsVal ?? 0) > 0 &&
+    !modeBreakdownHasTraffic;
 
   // ─── Client-side trace filters (from chart clicks) ───
 
@@ -321,8 +310,8 @@ export function CallFlowDashboard() {
   // ─── Parse top routes ───
 
   const topRoutes = useMemo(() => {
-    const p95Map = groupByLabel(topRoutesP95.data, 'path');
-    const callsMap = groupByLabel(topRoutesCalls.data, 'path');
+    const p95Map = groupByLabel(topRoutesP95.data, ROUTE_LABEL);
+    const callsMap = groupByLabel(topRoutesCalls.data, ROUTE_LABEL);
     return Object.entries(p95Map)
       .map(([route, p95Secs]) => ({
         route,
@@ -335,32 +324,10 @@ export function CallFlowDashboard() {
   }, [topRoutesP95.data, topRoutesCalls.data]);
 
   // ─── Parse traffic heatmap ───
-  // heatmapData is a range query with `sum by (client)` — we get one series per client
-  // For now, we use demo data since the range query returns aggregated series
+  // TODO: implement real heatmap with Prometheus query_range grouped by http_route (separate ticket).
   const heatmapCells = useMemo(() => {
-    // Derive heatmap from topRoutes calls — distribute proportionally across hours
-    // Business hours (8-20) get ~80% of traffic, off-hours get ~20%
-    const routes = topRoutes.slice(0, 6).map((r) => r.route);
-    if (routes.length === 0) return { cells: [], routes: [] };
-
-    // Simple hash for deterministic distribution per route+hour
-    const hash = (s: string, n: number) => {
-      let h = 0;
-      for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
-      return Math.abs((h * (n + 1) * 2654435761) % 100) / 100;
-    };
-
-    const cells = topRoutes.slice(0, 6).flatMap((r) =>
-      Array.from({ length: 24 }, (_, h) => {
-        const businessHour = h >= 8 && h <= 20;
-        const baseFraction = businessHour ? 0.06 : 0.015; // ~78% in business hours
-        const jitter = hash(r.route, h) * 0.04; // ±4% variation
-        const value = Math.round(r.calls * (baseFraction + jitter));
-        return { hour: h, route: r.route, value };
-      })
-    );
-    return { cells, routes };
-  }, [topRoutes]);
+    return { cells: [], routes: [] };
+  }, []);
 
   // ─── Throughput series for stacked area ───
 
@@ -382,9 +349,7 @@ export function CallFlowDashboard() {
   // ─── Sparkline data for KPI cards ───
 
   const requestsTrend = usePrometheusRange(
-    useServiceGraph
-      ? `sum(rate(traces_service_graph_request_total{server="stoa-gateway"}[5m]))`
-      : `sum(rate(stoa_mcp_tools_calls_total[5m]))`,
+    useServiceGraph ? queries.requestsTrend : `sum(rate(stoa_mcp_tools_calls_total[5m]))`,
     rangeCfg.seconds,
     rangeCfg.step,
     refreshMs || 15_000
@@ -410,7 +375,7 @@ export function CallFlowDashboard() {
     fallbackErrors.refetch();
     fallbackTrend.refetch();
     requestsTrend.refetch();
-    fetchTransactions(50, serviceType, timeRange, statusFilter).then(setTraces);
+    fetchTransactions(50, serviceType, timeRange, statusFilter, routeFilter).then(setTraces);
   }, [
     totalRequests,
     totalErrors,
@@ -431,8 +396,16 @@ export function CallFlowDashboard() {
     requestsTrend,
     serviceType,
     statusFilter,
+    routeFilter,
     timeRange,
   ]);
+
+  const liveTracesEmptyMessage =
+    activeFilterCount > 0
+      ? 'No trace spans found for this filter — metrics (Prometheus) and traces (OpenSearch) may not cover the same time window'
+      : (totalRequestsVal ?? 0) > 0
+        ? METRICS_TRACES_SPLIT_MESSAGE
+        : 'No traces yet — ensure gateway routes are configured and the observability pipeline (Alloy, Tempo, OpenSearch) is active';
 
   return (
     <div className="space-y-6">
@@ -478,7 +451,7 @@ export function CallFlowDashboard() {
         <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 px-4 py-3 rounded-lg flex items-center gap-2">
           <AlertTriangle className="h-4 w-4 text-yellow-600" />
           <span className="text-sm text-yellow-700 dark:text-yellow-400">
-            Prometheus is not reachable. Call flow data requires Tempo service graph metrics.
+            Prometheus is not reachable. Live Calls request metrics require Prometheus.
           </span>
         </div>
       )}
@@ -487,8 +460,18 @@ export function CallFlowDashboard() {
         <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 px-4 py-3 rounded-lg flex items-center gap-2">
           <Network className="h-4 w-4 text-blue-600" />
           <span className="text-sm text-blue-700 dark:text-blue-400">
-            Tempo service graph metrics not yet available — showing gateway tool call metrics as
-            fallback. Service graph populates automatically when traces flow through Tempo.
+            Gateway HTTP request metrics are not available — showing gateway tool call metrics as
+            fallback. Request metrics populate when gateway Prometheus scraping is active.
+          </span>
+        </div>
+      )}
+
+      {showScopeMismatch && (
+        <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 px-4 py-3 rounded-lg flex items-center gap-2">
+          <AlertTriangle className="h-4 w-4 text-yellow-600" />
+          <span className="text-sm text-yellow-700 dark:text-yellow-400">
+            Total requests are available, but no Gateway/Link/Connect breakdown traffic was found
+            for the selected window. Some scraped series may not match the expected job scope.
           </span>
         </div>
       )}
@@ -590,7 +573,7 @@ export function CallFlowDashboard() {
               value={activeModesVal !== null ? Math.round(activeModesVal).toString() : '--'}
               icon={Network}
               colorClass="text-blue-600"
-              subtitle="Deployment modes"
+              subtitle="Gateway / Link / Connect jobs reporting traffic"
             />
           </div>
 
@@ -685,11 +668,7 @@ export function CallFlowDashboard() {
             <LiveTraces
               traces={filteredTraces}
               onSelectTrace={(id) => navigate(`/observability/live-calls/trace/${id}`)}
-              emptyMessage={
-                activeFilterCount > 0
-                  ? 'No trace spans found for this filter — metrics (Prometheus) and traces (OpenSearch) may not cover the same time window'
-                  : 'No traces yet — ensure gateway routes are configured and the observability pipeline (Alloy, Tempo, OpenSearch) is active'
-              }
+              emptyMessage={liveTracesEmptyMessage}
             />
           </ChartCard>
 

--- a/control-plane-ui/src/pages/CallFlow/components/TopRoutes.test.tsx
+++ b/control-plane-ui/src/pages/CallFlow/components/TopRoutes.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TopRoutes } from './TopRoutes';
+import { filterRenderableRoutes, ROUTE_LABELS_UNAVAILABLE_MESSAGE } from '../metrics';
+
+describe('TopRoutes', () => {
+  it('filters unlabelled and unknown route labels before rendering route rows', () => {
+    expect(
+      filterRenderableRoutes([
+        { route: '(unlabelled)', p95Ms: 100, calls: 10 },
+        { route: 'unknown', p95Ms: 80, calls: 8 },
+        { route: '/mcp', p95Ms: 40, calls: 4 },
+      ])
+    ).toEqual([{ route: '/mcp', p95Ms: 40, calls: 4 }]);
+  });
+
+  it('renders an explicit unavailable state when every route label is unusable', () => {
+    render(
+      <TopRoutes
+        routes={[
+          { route: '(unlabelled)', p95Ms: 100, calls: 10 },
+          { route: 'unknown', p95Ms: 80, calls: 8 },
+        ]}
+      />
+    );
+
+    expect(screen.getByText(ROUTE_LABELS_UNAVAILABLE_MESSAGE)).toBeInTheDocument();
+  });
+});

--- a/control-plane-ui/src/pages/CallFlow/components/TopRoutes.tsx
+++ b/control-plane-ui/src/pages/CallFlow/components/TopRoutes.tsx
@@ -14,8 +14,9 @@ import {
   CHART_GRID_STYLE,
   ChartEmptyState,
 } from '@stoa/shared/components/ChartCard';
+import { filterRenderableRoutes, ROUTE_LABELS_UNAVAILABLE_MESSAGE } from '../metrics';
 
-interface RouteLatency {
+export interface RouteLatency {
   route: string;
   p95Ms: number;
   calls: number;
@@ -35,10 +36,14 @@ function latencyColor(ms: number): string {
 }
 
 export function TopRoutes({ routes, activeRoute, onRouteClick }: TopRoutesProps) {
-  const data = routes.slice(0, 8);
+  const data = filterRenderableRoutes(routes).slice(0, 8);
 
   if (data.length === 0) {
-    return <ChartEmptyState message="No route data available" />;
+    return (
+      <ChartEmptyState
+        message={routes.length > 0 ? ROUTE_LABELS_UNAVAILABLE_MESSAGE : 'No route data available'}
+      />
+    );
   }
 
   return (

--- a/control-plane-ui/src/pages/CallFlow/components/TrafficHeatmap.test.tsx
+++ b/control-plane-ui/src/pages/CallFlow/components/TrafficHeatmap.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TrafficHeatmap } from './TrafficHeatmap';
+import { HEATMAP_UNAVAILABLE_MESSAGE } from '../metrics';
+
+describe('TrafficHeatmap', () => {
+  it('renders the real-heatmap-not-wired state when no range-query heatmap data exists', () => {
+    render(<TrafficHeatmap cells={[]} routes={[]} />);
+
+    expect(screen.getByText(HEATMAP_UNAVAILABLE_MESSAGE)).toBeInTheDocument();
+  });
+});

--- a/control-plane-ui/src/pages/CallFlow/components/TrafficHeatmap.tsx
+++ b/control-plane-ui/src/pages/CallFlow/components/TrafficHeatmap.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { ChartEmptyState } from '@stoa/shared/components/ChartCard';
+import { HEATMAP_UNAVAILABLE_MESSAGE } from '../metrics';
 
 interface HeatmapCell {
   hour: number;
@@ -37,7 +38,7 @@ export function TrafficHeatmap({ cells, routes, activeRoute, onCellClick }: Traf
   const [tooltip, setTooltip] = useState<TooltipState | null>(null);
 
   if (cells.length === 0 || routes.length === 0) {
-    return <ChartEmptyState message="No traffic heatmap data" height={200} />;
+    return <ChartEmptyState message={HEATMAP_UNAVAILABLE_MESSAGE} height={200} />;
   }
 
   const max = Math.max(...cells.map((c) => c.value), 1);

--- a/control-plane-ui/src/pages/CallFlow/metrics.ts
+++ b/control-plane-ui/src/pages/CallFlow/metrics.ts
@@ -1,0 +1,59 @@
+import type { TimeRange } from '@stoa/shared/components/TimeRangeSelector';
+
+export const MODE_FILTER = 'job=~"stoa-gateway|stoa-link|stoa-connect"';
+export const ROUTE_LABEL = 'http_route';
+export const UNLABELLED_ROUTE = '(unlabelled)';
+
+export const ROUTE_LABELS_UNAVAILABLE_MESSAGE =
+  'Route labels unavailable. Metrics currently do not expose a usable `http_route` label for route-level panels. Check Prometheus scrape config and gateway instrumentation.';
+
+export const HEATMAP_UNAVAILABLE_MESSAGE =
+  'Traffic heatmap unavailable. A real range-query heatmap is not wired yet for the selected time range.';
+
+export const METRICS_TRACES_SPLIT_MESSAGE =
+  'Request metrics are available, but no traces were found for this time range. Metrics source: Prometheus. Trace source: Tempo/OpenSearch pipeline.';
+
+interface LiveCallsQueries {
+  totalRequests: string;
+  totalErrors: string;
+  p50Latency: string;
+  p99Latency: string;
+  activeModes: string;
+  edgeMcpTrend: string;
+  sidecarTrend: string;
+  connectTrend: string;
+  latencyBuckets: string;
+  errorsByStatus: string;
+  topRoutesP95: string;
+  topRoutesCalls: string;
+  requestsTrend: string;
+}
+
+const ROUTE_LABEL_FILTER = `${ROUTE_LABEL}!="", ${ROUTE_LABEL}!="unknown", ${ROUTE_LABEL}!="${UNLABELLED_ROUTE}"`;
+
+export function buildLiveCallsQueries(timeRange: TimeRange): LiveCallsQueries {
+  return {
+    totalRequests: `sum(increase(stoa_http_requests_total{${MODE_FILTER}}[${timeRange}]))`,
+    totalErrors: `sum(increase(stoa_http_requests_total{${MODE_FILTER}, status=~"5.."}[${timeRange}]))`,
+    p50Latency: `histogram_quantile(0.50, sum(rate(stoa_http_request_duration_seconds_bucket{${MODE_FILTER}}[5m])) by (le))`,
+    p99Latency: `histogram_quantile(0.99, sum(rate(stoa_http_request_duration_seconds_bucket{${MODE_FILTER}}[5m])) by (le))`,
+    activeModes: `count(count by (job) (stoa_http_requests_total{${MODE_FILTER}}))`,
+    edgeMcpTrend: `sum(rate(stoa_http_requests_total{${MODE_FILTER}, job="stoa-gateway"}[5m]))`,
+    sidecarTrend: `sum(rate(stoa_http_requests_total{${MODE_FILTER}, job="stoa-link"}[5m]))`,
+    connectTrend: `sum(rate(stoa_http_requests_total{${MODE_FILTER}, job="stoa-connect"}[5m]))`,
+    latencyBuckets: `sum(increase(stoa_http_request_duration_seconds_bucket{${MODE_FILTER}}[${timeRange}])) by (le)`,
+    errorsByStatus: `sum by (status) (increase(stoa_http_requests_total{${MODE_FILTER}, status=~"4..|5.."}[${timeRange}]))`,
+    topRoutesP95: `topk(8, histogram_quantile(0.95, sum by (le, ${ROUTE_LABEL}) (rate(stoa_http_request_duration_seconds_bucket{${MODE_FILTER}, ${ROUTE_LABEL_FILTER}}[5m]))))`,
+    topRoutesCalls: `sum by (${ROUTE_LABEL}) (increase(stoa_http_requests_total{${MODE_FILTER}, ${ROUTE_LABEL_FILTER}}[${timeRange}]))`,
+    requestsTrend: `sum(rate(stoa_http_requests_total{${MODE_FILTER}}[5m]))`,
+  };
+}
+
+export function isRenderableRouteLabel(route: string): boolean {
+  const normalized = route.trim().toLowerCase();
+  return normalized !== '' && normalized !== 'unknown' && normalized !== UNLABELLED_ROUTE;
+}
+
+export function filterRenderableRoutes<T extends { route: string }>(routes: T[]): T[] {
+  return routes.filter((route) => isRenderableRouteLabel(route.route));
+}

--- a/memory.md
+++ b/memory.md
@@ -1,6 +1,10 @@
 # STOA Memory
 
-> Dernière MAJ: 2026-05-04. Archive complète (cycles passés, DONE, etc.) → `memory-archive.md`.
+> Dernière MAJ: 2026-05-07. Archive complète (cycles passés, DONE, etc.) → `memory-archive.md`.
+
+## Session Notes — 2026-05-07
+
+- PR-2 Live Calls http_route migration implemented on branch `fix/live-calls-http-route-metric-integrity` in worktree `/Users/torpedo/hlfh-repos/stoa-live-calls-pr2`. Scope stayed frontend-only: Live Calls PromQL request queries now share `MODE_FILTER`, route-level panels group by `http_route`, `groupByLabel` uses explicit `(unlabelled)` fallback, Top Routes filters unusable route labels and renders a route-label unavailable state, synthetic heatmap generation was removed in favor of an explicit not-wired state, Active Modes counts jobs, scope-mismatch banner added, and traces empty-state now distinguishes Prometheus metrics from Tempo/OpenSearch traces. No AuditLog, Guardrails, backend, gateway Rust, Tempo/Loki/OpenSearch, sidebar/nav, or real heatmap implementation changes. Validation passed: `npm run test -- --run` (2302 passed, 11 skipped), targeted CallFlow/usePrometheus regressions (54 passed), `npm run lint` (50 pre-existing warnings, 0 errors), `npm run format:check`, `npm run build` after `shared/npm ci`, `git diff --check`, and static scan confirmed no Live Calls `sum by (path)`, `count by (path)`, `metric.path`, old `unknown` fallback, or synthetic heatmap hash block remains.
 
 ## Session Notes — 2026-05-04
 


### PR DESCRIPTION
## Summary
Fixes Live Calls metric integrity based on the PR-2 step 0 PromQL evidence.

Evidence:
- current `stoa_http_requests_total` series expose `http_route` on 306/306 series
- `path` is absent on 0/306 series

Changes:
- align Live Calls metric scope across KPI and breakdowns
- use `http_route` for route-level panels
- remove synthetic heatmap
- add explicit route-label unavailable state
- add scope-mismatch banner
- clarify Prometheus metrics vs traces empty state

## Non-goals
- no real heatmap implementation
- no Tempo/OpenSearch rewiring
- no AuditLog changes
- no Guardrails changes
- no sidebar cleanup

## Tests
- [x] npm run lint
- [x] npm run test -- --run
- [x] npm run test -- --run src/pages/CallFlow src/__tests__/regression/live-calls-metric-integrity.test.tsx src/hooks/usePrometheus.test.ts
- [x] npm run format:check
- [x] npm run build
- [x] route-level queries use `http_route`
- [x] unlabelled routes do not render as normal rows
- [x] synthetic heatmap removed
- [x] scope mismatch banner
- [x] traces split-brain empty state
