### PR TITLE
fix(audit): default audit trail consumer off

### DIFF
--- a/control-plane-api/k8s/deployment.yaml
+++ b/control-plane-api/k8s/deployment.yaml
@@ -37,8 +37,11 @@ spec:
           env:
             - name: LOG_TRACE_EXPORT_ENDPOINT
               value: "http://stoa-alloy-otlp.stoa-monitoring:4317"
+            # Safe-by-default: audit trail consumer is OFF in the base manifest.
+            # Per-environment activation goes through stoa-infra Helm chart values
+            # (staging=true after smoke test; prod=true only after PR-1A5 PASS verdict).
             - name: ENABLE_AUDIT_TRAIL_CONSUMER
-              value: "true"
+              value: "false"
             - name: AUDIT_TRAIL_DLQ_TOPIC
               value: "stoa.audit.trail.dlq"
             # Shared internal keys (CAB-1863)

--- a/control-plane-api/src/main.py
+++ b/control-plane-api/src/main.py
@@ -182,7 +182,7 @@ ENABLE_BILLING_METERING_CONSUMER = (
     KAFKA_CONSUMERS_ENABLED and os.getenv("ENABLE_BILLING_METERING_CONSUMER", "true").lower() == "true"
 )
 ENABLE_AUDIT_TRAIL_CONSUMER = (
-    KAFKA_CONSUMERS_ENABLED and os.getenv("ENABLE_AUDIT_TRAIL_CONSUMER", "true").lower() == "true"
+    KAFKA_CONSUMERS_ENABLED and os.getenv("ENABLE_AUDIT_TRAIL_CONSUMER", "false").lower() == "true"
 )
 ENABLE_TELEMETRY_WORKER = os.getenv("ENABLE_TELEMETRY_WORKER", "true").lower() == "true"
 ENABLE_GATEWAY_RECONCILER = os.getenv("ENABLE_GATEWAY_RECONCILER", "true").lower() == "true"

--- a/control-plane-api/tests/test_regression_kafka_boot.py
+++ b/control-plane-api/tests/test_regression_kafka_boot.py
@@ -56,6 +56,38 @@ def test_per_consumer_flags_respect_master_gate() -> None:
         ), f"{flag} must AND with KAFKA_CONSUMERS_ENABLED so the master gate turns it off."
 
 
+def test_audit_trail_consumer_safe_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: ENABLE_AUDIT_TRAIL_CONSUMER must default to False even when
+    the master gate is on. The consumer is opt-in per environment to give
+    rollouts an explicit gate after PR-1A4 lands the Kafka -> PG sink.
+    """
+    monkeypatch.setenv("STOA_ENABLE_KAFKA_CONSUMERS", "true")
+    monkeypatch.delenv("ENABLE_AUDIT_TRAIL_CONSUMER", raising=False)
+
+    import importlib
+
+    from src import main
+
+    importlib.reload(main)
+    try:
+        assert main.KAFKA_CONSUMERS_ENABLED is True
+        assert main.ENABLE_AUDIT_TRAIL_CONSUMER is False, (
+            "ENABLE_AUDIT_TRAIL_CONSUMER must default to False — environments must opt in explicitly. "
+            "See docs/plans/2026-05-08-audit-consumer-ingestion-contract.md."
+        )
+
+        monkeypatch.setenv("ENABLE_AUDIT_TRAIL_CONSUMER", "true")
+        importlib.reload(main)
+        assert main.ENABLE_AUDIT_TRAIL_CONSUMER is True, (
+            "ENABLE_AUDIT_TRAIL_CONSUMER=true with master gate on must enable the consumer."
+        )
+    finally:
+        # Restore module state so subsequent tests see the conftest.py defaults.
+        monkeypatch.delenv("ENABLE_AUDIT_TRAIL_CONSUMER", raising=False)
+        monkeypatch.setenv("STOA_ENABLE_KAFKA_CONSUMERS", "false")
+        importlib.reload(main)
+
+
 def test_app_lifespan_emits_no_kafka_errors(caplog: pytest.LogCaptureFixture) -> None:
     """Running the full lifespan must not surface any Kafka broker lookup."""
     from src.main import app


### PR DESCRIPTION
## Summary

Corrective patch to **#2726** (audit trail consumer implementation) — make the new consumer **safe-by-default**.

## Why

#2726 merged with three "true" defaults stacking up:

- **Python** (`src/main.py:184-186`): `os.getenv("ENABLE_AUDIT_TRAIL_CONSUMER", "true")`
- **k8s/deployment.yaml**: explicit `ENABLE_AUDIT_TRAIL_CONSUMER=true`
- **Prod cluster**: `STOA_ENABLE_KAFKA_CONSUMERS=true` (already on)

Combined, any next cp-api rollout would have started consuming `stoa.audit.trail` and writing `audit_events` without explicit operator opt-in. That contradicts the rollout runbook agreed in conversation: **deploy disabled first → smoke in staging → activate prod only after PR-1A5 PASS**.

This is **not a functional regression** — it is a **rollout safety choice** for a first Kafka → PostgreSQL ingestion path.

## Changes

| File | Change |
|---|---|
| `control-plane-api/src/main.py` | env var fallback `"true"` → `"false"`. Requires explicit `ENABLE_AUDIT_TRAIL_CONSUMER=true` alongside master gate to start. |
| `control-plane-api/k8s/deployment.yaml` | base manifest sets `ENABLE_AUDIT_TRAIL_CONSUMER=false` with comment pointing to stoa-infra Helm chart for per-env activation. |
| `control-plane-api/tests/test_regression_kafka_boot.py` | new regression `test_audit_trail_consumer_safe_by_default` proving the safe default + the explicit-opt-in path. |

## What this does NOT do

- Does not change topic, group, DLQ, offset semantics, payload schema, idempotency.
- Does not modify AuditLog UI/API.
- Does not implement PR-1B.
- Does not touch stoa-infra (per-environment activation is a separate PR there).

## Mini-spec compliance

The PR-1A3 mini-spec (`docs/plans/2026-05-08-audit-consumer-ingestion-contract.md`, section "Deployment shape") states default `ENABLE_AUDIT_TRAIL_CONSUMER=true`. This patch keeps the env var name and the per-env override mechanism — only the conservative default is flipped. The mini-spec's intent (env var as the activation switch) is preserved; we just chose a safer base.

## Validation

- [x] `python3 -m pytest tests/test_audit_trail_consumer.py -q` → 11 passed
- [x] `python3 -m pytest tests/test_regression_kafka_boot.py -q` → 4 passed
- [x] `ruff check src/main.py tests/test_regression_kafka_boot.py` → clean
- [x] `kubectl apply --dry-run=client -f control-plane-api/k8s/deployment.yaml` → ok
- [x] No DLQ/group/topic/offset/schema change → contract compliance unchanged

## Rollout sequence (post-merge)

1. Merge this PR.
2. Open stoa-infra PR adding `ENABLE_AUDIT_TRAIL_CONSUMER=true` to staging chart values, **leaving prod=false**.
3. Bump cp-api image tag in stoa-infra to point at the post-#2726 + post-this-PR build.
4. Deploy staging. Verify boot logs (`stoa-control-plane-api` pod, `Audit trail consumer started` for staging only).
5. Produce a non-chat audit event in staging (e.g. tenant create).
6. Verify Kafka consumer group `audit-trail-pg-consumer`, PG `audit_events` row, `/v1/audit/{tenant_id}` API.
7. Land that as PR-1A5 evidence pack.
8. Only after PR-1A5 PASS, open stoa-infra PR flipping prod to `=true`.
9. PR-1B unblocks.