### PR TITLE
fix(test): replace audit consumer reload test with static check

### DIFF
--- a/control-plane-api/tests/test_regression_kafka_boot.py
+++ b/control-plane-api/tests/test_regression_kafka_boot.py
@@ -56,36 +56,36 @@ def test_per_consumer_flags_respect_master_gate() -> None:
         ), f"{flag} must AND with KAFKA_CONSUMERS_ENABLED so the master gate turns it off."
 
 
-def test_audit_trail_consumer_safe_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Regression: ENABLE_AUDIT_TRAIL_CONSUMER must default to False even when
-    the master gate is on. The consumer is opt-in per environment to give
-    rollouts an explicit gate after PR-1A4 lands the Kafka -> PG sink.
+def test_audit_trail_consumer_safe_by_default() -> None:
+    """Regression: src/main.py must default ENABLE_AUDIT_TRAIL_CONSUMER to "false"
+    so the audit Kafka -> PG consumer is opt-in per environment.
+
+    Static check on the source: importlib.reload(main) caused CI hangs because
+    conftest.py mocks several services in src.main via patch.object(...).start(),
+    and reloading drops those patches; subsequent lifespan tests then attempted
+    real Kafka connections. This static check covers the same intent without
+    touching module state.
     """
-    monkeypatch.setenv("STOA_ENABLE_KAFKA_CONSUMERS", "true")
-    monkeypatch.delenv("ENABLE_AUDIT_TRAIL_CONSUMER", raising=False)
+    import re
+    from pathlib import Path
 
-    import importlib
-
-    from src import main
-
-    importlib.reload(main)
-    try:
-        assert main.KAFKA_CONSUMERS_ENABLED is True
-        assert main.ENABLE_AUDIT_TRAIL_CONSUMER is False, (
-            "ENABLE_AUDIT_TRAIL_CONSUMER must default to False — environments must opt in explicitly. "
-            "See docs/plans/2026-05-08-audit-consumer-ingestion-contract.md."
-        )
-
-        monkeypatch.setenv("ENABLE_AUDIT_TRAIL_CONSUMER", "true")
-        importlib.reload(main)
-        assert main.ENABLE_AUDIT_TRAIL_CONSUMER is True, (
-            "ENABLE_AUDIT_TRAIL_CONSUMER=true with master gate on must enable the consumer."
-        )
-    finally:
-        # Restore module state so subsequent tests see the conftest.py defaults.
-        monkeypatch.delenv("ENABLE_AUDIT_TRAIL_CONSUMER", raising=False)
-        monkeypatch.setenv("STOA_ENABLE_KAFKA_CONSUMERS", "false")
-        importlib.reload(main)
+    main_py = (Path(__file__).resolve().parent.parent / "src" / "main.py").read_text()
+    pattern = re.compile(
+        r"ENABLE_AUDIT_TRAIL_CONSUMER\s*=\s*\(\s*"
+        r"KAFKA_CONSUMERS_ENABLED\s+and\s+"
+        r'os\.getenv\(\s*"ENABLE_AUDIT_TRAIL_CONSUMER"\s*,\s*"(?P<default>[^"]+)"\s*\)'
+        r"\s*\.\s*lower\(\)\s*==\s*\"true\"\s*\)",
+    )
+    match = pattern.search(main_py)
+    assert match is not None, (
+        "ENABLE_AUDIT_TRAIL_CONSUMER expression in src/main.py does not match the expected shape. "
+        "Update this regression if the formula changed, but keep the safe default invariant."
+    )
+    assert match.group("default") == "false", (
+        f'src/main.py defaults ENABLE_AUDIT_TRAIL_CONSUMER to "{match.group("default")}". '
+        'It must default to "false" — environments opt in explicitly via stoa-infra Helm values. '
+        "See docs/plans/2026-05-08-audit-consumer-ingestion-contract.md."
+    )
 
 
 def test_app_lifespan_emits_no_kafka_errors(caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## Summary

Fix CI hang introduced by #2730. The regression test added there used \`importlib.reload(main)\` mid-test, which broke conftest.py's \`patch.object(_main_module, ...).start()\` chain. The next test in the same file then attempted a real Kafka connect inside \`TestClient(app)\` lifespan and hung the runner.

## Symptom

- Run [25516466204](https://github.com/stoa-platform/stoa/actions/runs/25516466204) (#2730 push to main): in_progress for 6+ hours on "Run tests" step before being cancelled.
- Retry via workflow_dispatch [25539592858](https://github.com/stoa-platform/stoa/actions/runs/25539592858): same hang at the same step.
- Net effect: no post-#2730 image was pushed to ghcr → no auto-bump in stoa-infra → ArgoCD still serves the unsafe #2726 image. Prod is currently protected only by the env override from stoa-infra#73.

## Fix

Replace the reload-based check with a **static regex check** on \`src/main.py\` source. Same invariant (\`default == "false"\`), no module state mutation, no conftest interaction.

\`\`\`python
match = re.search(
    r'ENABLE_AUDIT_TRAIL_CONSUMER\s*=\s*\(\s*KAFKA_CONSUMERS_ENABLED\s+and\s+'
    r'os\.getenv\(\s*"ENABLE_AUDIT_TRAIL_CONSUMER"\s*,\s*"(?P<default>[^"]+)"\s*\)'
    r'\s*\.\s*lower\(\)\s*==\s*"true"\s*\)',
    main_py
)
assert match.group("default") == "false"
\`\`\`

## Coverage trade-off

- **Lost**: dynamic verification that runtime env values (\`STOA_ENABLE_KAFKA_CONSUMERS=true\` + \`ENABLE_AUDIT_TRAIL_CONSUMER=true\`) yield the correct flag. The existing \`test_per_consumer_flags_respect_master_gate\` still covers the master-gate=OFF half.
- **Gained**: a static invariant that the source default is "false". Cheaper, deterministic, no CI hang risk.

## Validation

- [x] \`pytest tests/test_regression_kafka_boot.py\` — 4 passed in 0.19s (vs 4.5s with reload).
- [x] No module state mutation (conftest patches preserved).
- [x] Brittle to formatting changes — regex matches the current shape; if the formula is refactored, the regex must be updated, but the safe-default invariant remains testable.

## Cross-refs

- [stoa#2726](https://github.com/stoa-platform/stoa/pull/2726) — PR-1A4 audit consumer.
- [stoa#2730](https://github.com/stoa-platform/stoa/pull/2730) — added the hanging test.
- [stoa-infra#73](https://github.com/PotoMitan/stoa-infra/pull/73) — env override safety in prod.