### PR TITLE
feat(api): audit log /stats /actions + actor resolution + demo fallback gate

### DIFF
--- a/control-plane-api/openapi-snapshot.json
+++ b/control-plane-api/openapi-snapshot.json
@@ -2370,6 +2370,17 @@
             ],
             "title": "User Email"
           },
+          "user_display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Display Name"
+          },
           "user_id": {
             "anyOf": [
               {
@@ -2380,6 +2391,11 @@
               }
             ],
             "title": "User Id"
+          },
+          "user_resolved": {
+            "default": false,
+            "title": "User Resolved",
+            "type": "boolean"
           }
         },
         "required": [
@@ -29884,9 +29900,31 @@
             "title": "Page Size",
             "type": "integer"
           },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
           "total": {
             "title": "Total",
             "type": "integer"
+          },
+          "warning": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warning"
           }
         },
         "required": [

--- a/control-plane-api/requirements.txt
+++ b/control-plane-api/requirements.txt
@@ -15,6 +15,7 @@ PyGithub>=2.9.1
 pyyaml==6.0.3
 sse-starlette==3.4.1
 aiocache==0.12.3
+cachetools>=5.3.0
 prometheus-client==0.25.0
 structlog==25.5.0
 # Database

--- a/control-plane-api/src/config.py
+++ b/control-plane-api/src/config.py
@@ -203,6 +203,17 @@ class Settings(BaseSettings):
     # startup in production and still requires X-Demo-Mode: true per request.
     STOA_DISABLE_AUTH: bool = False
 
+    # Audit log demo fallback is dev/test-only by default. Production must fail
+    # closed unless operators explicitly opt in for a controlled diagnostic.
+    STOA_AUDIT_DEMO_FALLBACK: bool | None = None
+
+    @property
+    def audit_demo_fallback_enabled(self) -> bool:
+        """Whether audit API demo rows may be returned when real backends fail."""
+        if self.STOA_AUDIT_DEMO_FALLBACK is not None:
+            return self.STOA_AUDIT_DEMO_FALLBACK
+        return self.ENVIRONMENT in {"dev", "test"}
+
     @property
     def keycloak_internal_url(self) -> str:
         """Return internal URL for backend-to-KC calls, falling back to public URL."""

--- a/control-plane-api/src/main.py
+++ b/control-plane-api/src/main.py
@@ -201,6 +201,12 @@ async def lifespan(app: FastAPI):
         version=settings.VERSION,
         environment=settings.ENVIRONMENT,
     )
+    if not settings.audit_demo_fallback_enabled:
+        logger.info(
+            "Audit demo fallback disabled",
+            environment=settings.ENVIRONMENT,
+            configured_value=settings.STOA_AUDIT_DEMO_FALLBACK,
+        )
 
     # Initialize services
     try:

--- a/control-plane-api/src/routers/audit.py
+++ b/control-plane-api/src/routers/audit.py
@@ -27,9 +27,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import User, get_current_user, require_tenant_access
 from ..auth.rbac import require_role
+from ..config import settings
 from ..database import get_db
 from ..opensearch.opensearch_integration import OpenSearchService
-from ..services.audit_service import AuditService
+from ..services.audit_service import AuditService, resolve_actor
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,8 @@ class AuditEntry(BaseModel):
     tenant_id: str
     user_id: str | None
     user_email: str | None
+    user_display_name: str | None = None
+    user_resolved: bool = False
     action: str
     resource_type: str
     resource_id: str | None
@@ -67,6 +70,40 @@ class AuditListResponse(BaseModel):
     page: int
     page_size: int
     has_more: bool
+    source: str | None = None
+    warning: str | None = None
+
+
+class AuditStatsResponse(BaseModel):
+    """Response for audit statistics endpoint."""
+
+    total_events: int
+    success_count: int
+    failed_count: int
+    unique_actors: int
+    by_action: dict[str, int]
+    by_status: dict[str, int]
+    window_start: datetime
+    window_end: datetime
+    source: str | None = None
+    warning: str | None = None
+
+
+class AuditActionCount(BaseModel):
+    """Distinct audit action count."""
+
+    action: str
+    count: int
+
+
+class AuditActionsResponse(BaseModel):
+    """Response for audit action filter endpoint."""
+
+    actions: list[AuditActionCount]
+    window_start: datetime
+    window_end: datetime
+    source: str | None = None
+    warning: str | None = None
 
 
 class SecurityEvent(BaseModel):
@@ -187,6 +224,173 @@ def _init_demo_data():
         )
 
 
+DEMO_SOURCE = "demo"
+DEMO_WARNING = "Audit backend unavailable"
+
+
+def _audit_demo_fallback_enabled() -> bool:
+    return bool(settings.audit_demo_fallback_enabled)
+
+
+def _empty_audit_list_response(page: int, page_size: int) -> AuditListResponse:
+    return AuditListResponse(entries=[], total=0, page=page, page_size=page_size, has_more=False)
+
+
+def _stats_window(
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+) -> tuple[datetime, datetime]:
+    window_end = end_date or datetime.now(UTC)
+    window_start = start_date or (window_end - timedelta(days=30))
+    return window_start, window_end
+
+
+def _filter_demo_audit_entries(
+    tenant_id: str,
+    *,
+    action: str | None = None,
+    status: str | None = None,
+    resource_type: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    search: str | None = None,
+) -> list[dict[str, Any]]:
+    entries = [e for e in _demo_audit_entries if e["tenant_id"] == tenant_id]
+
+    if action:
+        entries = [e for e in entries if e["action"] == action]
+    if status:
+        entries = [e for e in entries if e["status"] == status]
+    if resource_type:
+        entries = [e for e in entries if e["resource_type"] == resource_type]
+    if start_date:
+        entries = [e for e in entries if datetime.fromisoformat(e["timestamp"]) >= start_date]
+    if end_date:
+        entries = [e for e in entries if datetime.fromisoformat(e["timestamp"]) <= end_date]
+    if search:
+        needle = search.lower()
+        entries = [
+            e
+            for e in entries
+            if any(
+                needle in str(e.get(field) or "").lower()
+                for field in ("action", "resource_type", "resource_id", "user_id", "user_email", "request_id")
+            )
+        ]
+
+    return entries
+
+
+def _demo_audit_list_response(
+    tenant_id: str,
+    *,
+    page: int,
+    page_size: int,
+    action: str | None = None,
+    status: str | None = None,
+    resource_type: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    search: str | None = None,
+) -> AuditListResponse:
+    _init_demo_data()
+    entries = _filter_demo_audit_entries(
+        tenant_id,
+        action=action,
+        status=status,
+        resource_type=resource_type,
+        start_date=start_date,
+        end_date=end_date,
+        search=search,
+    )
+
+    total = len(entries)
+    start_idx = (page - 1) * page_size
+    end_idx = start_idx + page_size
+    page_entries = entries[start_idx:end_idx]
+
+    return AuditListResponse(
+        entries=[AuditEntry(**e) for e in page_entries],
+        total=total,
+        page=page,
+        page_size=page_size,
+        has_more=end_idx < total,
+        source=DEMO_SOURCE,
+        warning=DEMO_WARNING,
+    )
+
+
+def _demo_audit_stats_response(
+    tenant_id: str,
+    *,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    action: str | None = None,
+    status: str | None = None,
+    resource_type: str | None = None,
+    search: str | None = None,
+) -> AuditStatsResponse:
+    window_start, window_end = _stats_window(start_date=start_date, end_date=end_date)
+    _init_demo_data()
+    entries = _filter_demo_audit_entries(
+        tenant_id,
+        action=action,
+        status=status,
+        resource_type=resource_type,
+        start_date=window_start,
+        end_date=window_end,
+        search=search,
+    )
+
+    by_action: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    actor_ids: set[str] = set()
+    for entry in entries:
+        by_action[entry["action"]] = by_action.get(entry["action"], 0) + 1
+        by_status[entry["status"]] = by_status.get(entry["status"], 0) + 1
+        if entry.get("user_id"):
+            actor_ids.add(entry["user_id"])
+
+    by_action = dict(sorted(by_action.items(), key=lambda item: (-item[1], item[0]))[:20])
+    by_status = dict(sorted(by_status.items(), key=lambda item: (-item[1], item[0])))
+    success_count = by_status.get("success", 0)
+
+    return AuditStatsResponse(
+        total_events=len(entries),
+        success_count=success_count,
+        failed_count=len(entries) - success_count,
+        unique_actors=len(actor_ids),
+        by_action=by_action,
+        by_status=by_status,
+        window_start=window_start,
+        window_end=window_end,
+        source=DEMO_SOURCE,
+        warning=DEMO_WARNING,
+    )
+
+
+def _demo_audit_actions_response(tenant_id: str) -> AuditActionsResponse:
+    window_start, window_end = _stats_window()
+    _init_demo_data()
+    entries = _filter_demo_audit_entries(tenant_id, start_date=window_start, end_date=window_end)
+
+    by_action: dict[str, int] = {}
+    for entry in entries:
+        by_action[entry["action"]] = by_action.get(entry["action"], 0) + 1
+
+    actions = [
+        AuditActionCount(action=action, count=count)
+        for action, count in sorted(by_action.items(), key=lambda item: (-item[1], item[0]))[:100]
+    ]
+    return AuditActionsResponse(
+        actions=actions,
+        window_start=window_start,
+        window_end=window_end,
+        source=DEMO_SOURCE,
+        warning=DEMO_WARNING,
+    )
+
+
 # =============================================================================
 # Endpoints
 # =============================================================================
@@ -200,6 +404,7 @@ async def list_audit_entries(
     page_size: int = Query(default=50, ge=1, le=500, description="Results per page"),
     action: str | None = Query(default=None, description="Filter by action"),
     status: str | None = Query(default=None, description="Filter by status"),
+    resource_type: str | None = Query(default=None, description="Filter by resource type"),
     start_date: datetime | None = Query(default=None, description="Start date (ISO 8601)"),
     end_date: datetime | None = Query(default=None, description="End date (ISO 8601)"),
     search: str | None = Query(default=None, description="Search in path/resource"),
@@ -221,18 +426,18 @@ async def list_audit_entries(
             page_size=page_size,
             action=action,
             outcome=status,
+            resource_type=resource_type,
             start_date=start_date,
             end_date=end_date,
             search=search,
         )
-        if total > 0 or page > 1:
-            return AuditListResponse(
-                entries=[_pg_event_to_entry(e) for e in events],
-                total=total,
-                page=page,
-                page_size=page_size,
-                has_more=(page * page_size) < total,
-            )
+        return AuditListResponse(
+            entries=[await _pg_event_to_entry(e) for e in events],
+            total=total,
+            page=page,
+            page_size=page_size,
+            has_more=(page * page_size) < total,
+        )
     except Exception as e:
         logger.warning(f"PostgreSQL audit query failed: {e}")
 
@@ -247,40 +452,141 @@ async def list_audit_entries(
                 page_size,
                 action=action,
                 status=status,
+                resource_type=resource_type,
                 start_date=start_date,
                 end_date=end_date,
+                search=search,
             )
             if result is not None:
                 return result
         except Exception as e:
-            logger.warning(f"OpenSearch query failed, falling back to demo data: {e}")
+            logger.warning(f"OpenSearch query failed: {e}")
 
-    # 3. Fallback to demo data
-    _init_demo_data()
+    # 3. Fallback to demo data only when explicitly enabled.
+    if not _audit_demo_fallback_enabled():
+        return _empty_audit_list_response(page, page_size)
 
-    entries = [e for e in _demo_audit_entries if e["tenant_id"] == tenant_id]
-
-    if action:
-        entries = [e for e in entries if e["action"] == action]
-    if status:
-        entries = [e for e in entries if e["status"] == status]
-    if start_date:
-        entries = [e for e in entries if datetime.fromisoformat(e["timestamp"]) >= start_date]
-    if end_date:
-        entries = [e for e in entries if datetime.fromisoformat(e["timestamp"]) <= end_date]
-
-    total = len(entries)
-    start_idx = (page - 1) * page_size
-    end_idx = start_idx + page_size
-    page_entries = entries[start_idx:end_idx]
-
-    return AuditListResponse(
-        entries=[AuditEntry(**e) for e in page_entries],
-        total=total,
+    return _demo_audit_list_response(
+        tenant_id,
         page=page,
         page_size=page_size,
-        has_more=end_idx < total,
+        action=action,
+        status=status,
+        resource_type=resource_type,
+        start_date=start_date,
+        end_date=end_date,
+        search=search,
     )
+
+
+@router.get("/{tenant_id}/stats", response_model=AuditStatsResponse)
+@require_tenant_access
+async def get_audit_stats(
+    tenant_id: str,
+    start_date: datetime | None = Query(default=None, description="Start date (ISO 8601)"),
+    end_date: datetime | None = Query(default=None, description="End date (ISO 8601)"),
+    action: str | None = Query(default=None, description="Filter by action"),
+    status: str | None = Query(default=None, description="Filter by status"),
+    resource_type: str | None = Query(default=None, description="Filter by resource type"),
+    search: str | None = Query(default=None, description="Search in path/resource"),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> AuditStatsResponse:
+    """
+    Return filtered audit aggregates for a tenant.
+
+    Data sources: PostgreSQL (primary) -> OpenSearch -> explicit demo fallback.
+    """
+    try:
+        audit_svc = AuditService(db)
+        stats = await audit_svc.get_stats(
+            tenant_id,
+            start_date=start_date,
+            end_date=end_date,
+            action=action,
+            outcome=status,
+            resource_type=resource_type,
+            search=search,
+        )
+        return AuditStatsResponse(**stats)
+    except Exception as e:
+        logger.warning(f"PostgreSQL audit stats query failed: {e}")
+
+    service = OpenSearchService.get_instance()
+    if service.client:
+        try:
+            result = await _query_opensearch_audit_stats(
+                service.client,
+                tenant_id,
+                start_date=start_date,
+                end_date=end_date,
+                action=action,
+                status=status,
+                resource_type=resource_type,
+                search=search,
+            )
+            if result is not None:
+                return result
+        except Exception as e:
+            logger.warning(f"OpenSearch audit stats query failed: {e}")
+
+    if not _audit_demo_fallback_enabled():
+        window_start, window_end = _stats_window(start_date=start_date, end_date=end_date)
+        return AuditStatsResponse(
+            total_events=0,
+            success_count=0,
+            failed_count=0,
+            unique_actors=0,
+            by_action={},
+            by_status={},
+            window_start=window_start,
+            window_end=window_end,
+        )
+
+    return _demo_audit_stats_response(
+        tenant_id,
+        start_date=start_date,
+        end_date=end_date,
+        action=action,
+        status=status,
+        resource_type=resource_type,
+        search=search,
+    )
+
+
+@router.get("/{tenant_id}/actions", response_model=AuditActionsResponse)
+@require_tenant_access
+async def get_audit_actions(
+    tenant_id: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> AuditActionsResponse:
+    """
+    Return the top 100 distinct actions for a tenant over the last 30 days.
+
+    Data sources: PostgreSQL (primary) -> OpenSearch -> explicit demo fallback.
+    """
+    try:
+        audit_svc = AuditService(db)
+        actions_result = await audit_svc.get_actions(tenant_id)
+        return AuditActionsResponse(**actions_result)
+    except Exception as e:
+        logger.warning(f"PostgreSQL audit actions query failed: {e}")
+
+    service = OpenSearchService.get_instance()
+    if service.client:
+        try:
+            os_result = await _query_opensearch_audit_actions(service.client, tenant_id)
+            if os_result is not None:
+                return os_result
+        except Exception as e:
+            logger.warning(f"OpenSearch audit actions query failed: {e}")
+
+    if not _audit_demo_fallback_enabled():
+        window_start, window_end = _stats_window()
+        return AuditActionsResponse(actions=[], window_start=window_start, window_end=window_end)
+
+    return _demo_audit_actions_response(tenant_id)
 
 
 @router.get("/{tenant_id}/export/csv")
@@ -313,8 +619,8 @@ async def export_audit_csv(
     except Exception as e:
         logger.warning(f"PostgreSQL export failed: {e}")
 
-    # Fallback to demo data
-    if not rows:
+    # Fallback to demo data only when explicitly enabled.
+    if not rows and _audit_demo_fallback_enabled():
         _init_demo_data()
         rows = [e for e in _demo_audit_entries if e["tenant_id"] == tenant_id]
         if start_date:
@@ -402,8 +708,8 @@ async def export_audit_json(
     except Exception as e:
         logger.warning(f"PostgreSQL export failed: {e}")
 
-    # Fallback to demo data
-    if not rows:
+    # Fallback to demo data only when explicitly enabled.
+    if not rows and _audit_demo_fallback_enabled():
         _init_demo_data()
         rows = [e for e in _demo_audit_entries if e["tenant_id"] == tenant_id]
         if start_date:
@@ -465,7 +771,10 @@ async def get_security_events(
         except Exception as e:
             logger.warning(f"OpenSearch security query failed, falling back to demo: {e}")
 
-    # Fallback to demo data
+    # Fallback to demo data only when explicitly enabled.
+    if not _audit_demo_fallback_enabled():
+        return SecurityEventsResponse(events=[], total=0, summary={})
+
     _init_demo_data()
 
     events = [e for e in _demo_security_events if e["tenant_id"] == tenant_id]
@@ -644,7 +953,18 @@ async def get_global_audit_summary(
     except Exception as e:
         logger.warning(f"PostgreSQL summary failed: {e}")
 
-    # Fallback to demo data
+    # Fallback to demo data only when explicitly enabled.
+    if not _audit_demo_fallback_enabled():
+        return {
+            "total_audit_entries": 0,
+            "total_security_events": 0,
+            "entries_by_tenant": {},
+            "entries_by_action": {},
+            "security_by_severity": {"info": 0, "warning": 0, "critical": 0},
+            "generated_at": datetime.now(UTC).isoformat(),
+            "source": "none",
+        }
+
     _init_demo_data()
 
     total_entries = len(_demo_audit_entries)
@@ -681,14 +1001,17 @@ async def get_global_audit_summary(
 # =============================================================================
 
 
-def _pg_event_to_entry(event: Any) -> AuditEntry:
+async def _pg_event_to_entry(event: Any) -> AuditEntry:
     """Convert a PostgreSQL AuditEvent model to the router AuditEntry schema."""
+    actor = await resolve_actor(event.actor_id, event.actor_email)
     return AuditEntry(
         id=event.id,
         timestamp=event.created_at,
         tenant_id=event.tenant_id,
         user_id=event.actor_id,
-        user_email=event.actor_email,
+        user_email=event.actor_email or actor.user_email,
+        user_display_name=actor.user_display_name,
+        user_resolved=actor.resolved,
         action=event.action,
         resource_type=event.resource_type,
         resource_id=event.resource_id,
@@ -726,6 +1049,49 @@ def _pg_event_to_dict(event: Any) -> dict[str, Any]:
 # =============================================================================
 
 
+def _opensearch_audit_must(
+    tenant_id: str,
+    *,
+    action: str | None = None,
+    status: str | None = None,
+    resource_type: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    search: str | None = None,
+) -> list[dict[str, Any]]:
+    must: list[dict[str, Any]] = [{"term": {"tenant_id.keyword": tenant_id}}]
+    if action:
+        must.append({"term": {"action.keyword": action}})
+    if status:
+        must.append({"term": {"outcome.keyword": status}})
+    if resource_type:
+        must.append({"term": {"resource.type.keyword": resource_type}})
+    if start_date or end_date:
+        ts_range: dict[str, str] = {}
+        if start_date:
+            ts_range["gte"] = start_date.isoformat()
+        if end_date:
+            ts_range["lte"] = end_date.isoformat()
+        must.append({"range": {"@timestamp": ts_range}})
+    if search:
+        must.append(
+            {
+                "multi_match": {
+                    "query": search,
+                    "fields": [
+                        "path",
+                        "action",
+                        "resource.type",
+                        "resource.id",
+                        "actor.email",
+                        "correlation_id",
+                    ],
+                }
+            }
+        )
+    return must
+
+
 async def _query_opensearch_audit(
     client: Any,
     tenant_id: str,
@@ -734,22 +1100,21 @@ async def _query_opensearch_audit(
     *,
     action: str | None = None,
     status: str | None = None,
+    resource_type: str | None = None,
     start_date: datetime | None = None,
     end_date: datetime | None = None,
+    search: str | None = None,
 ) -> AuditListResponse | None:
-    """Query audit* index in OpenSearch. Returns None if no index exists."""
-    must = [{"term": {"tenant_id.keyword": tenant_id}}]
-    if action:
-        must.append({"match": {"action": action}})
-    if status:
-        must.append({"term": {"outcome.keyword": status}})
-    if start_date or end_date:
-        ts_range: dict[str, str] = {}
-        if start_date:
-            ts_range["gte"] = start_date.isoformat()
-        if end_date:
-            ts_range["lte"] = end_date.isoformat()
-        must.append({"range": {"@timestamp": ts_range}})
+    """Query audit* index in OpenSearch."""
+    must = _opensearch_audit_must(
+        tenant_id,
+        action=action,
+        status=status,
+        resource_type=resource_type,
+        start_date=start_date,
+        end_date=end_date,
+        search=search,
+    )
 
     body = {
         "query": {"bool": {"must": must}},
@@ -761,25 +1126,27 @@ async def _query_opensearch_audit(
     resp = await client.search(index="audit*", body=body)
     hits = resp.get("hits", {})
     total = hits.get("total", {}).get("value", 0)
-    if total == 0 and page == 1:
-        return None  # No data — fall back to demo
 
     entries = []
     for hit in hits.get("hits", []):
         src = hit["_source"]
+        actor_src = src.get("actor", {})
+        actor = await resolve_actor(actor_src.get("id"), actor_src.get("email"))
         entries.append(
             AuditEntry(
                 id=src.get("event_id", hit["_id"]),
                 timestamp=src.get("@timestamp", datetime.now(UTC).isoformat()),
-                tenant_id=src.get("actor", {}).get("tenant_id", tenant_id),
-                user_id=src.get("actor", {}).get("id"),
-                user_email=src.get("actor", {}).get("email"),
+                tenant_id=src.get("tenant_id") or actor_src.get("tenant_id", tenant_id),
+                user_id=actor_src.get("id"),
+                user_email=actor_src.get("email") or actor.user_email,
+                user_display_name=actor.user_display_name,
+                user_resolved=actor.resolved,
                 action=src.get("action", "unknown"),
                 resource_type=src.get("resource", {}).get("type", "unknown"),
                 resource_id=src.get("resource", {}).get("id"),
                 status=src.get("outcome", "unknown"),
-                client_ip=src.get("actor", {}).get("ip_address"),
-                user_agent=src.get("actor", {}).get("user_agent"),
+                client_ip=actor_src.get("ip_address"),
+                user_agent=actor_src.get("user_agent"),
                 details=src.get("details"),
                 request_id=src.get("correlation_id"),
             )
@@ -791,6 +1158,85 @@ async def _query_opensearch_audit(
         page=page,
         page_size=page_size,
         has_more=(page * page_size) < total,
+    )
+
+
+async def _query_opensearch_audit_stats(
+    client: Any,
+    tenant_id: str,
+    *,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    action: str | None = None,
+    status: str | None = None,
+    resource_type: str | None = None,
+    search: str | None = None,
+) -> AuditStatsResponse | None:
+    """Query audit aggregates from OpenSearch."""
+    window_start, window_end = _stats_window(start_date=start_date, end_date=end_date)
+    must = _opensearch_audit_must(
+        tenant_id,
+        action=action,
+        status=status,
+        resource_type=resource_type,
+        start_date=window_start,
+        end_date=window_end,
+        search=search,
+    )
+
+    body = {
+        "query": {"bool": {"must": must}},
+        "size": 0,
+        "aggs": {
+            "by_action": {"terms": {"field": "action.keyword", "size": 20, "order": {"_count": "desc"}}},
+            "by_status": {"terms": {"field": "outcome.keyword", "size": 20, "order": {"_count": "desc"}}},
+            "unique_actors": {"cardinality": {"field": "actor.id.keyword"}},
+            "success_count": {"filter": {"term": {"outcome.keyword": "success"}}},
+        },
+    }
+    resp = await client.search(index="audit*", body=body)
+    hits = resp.get("hits", {})
+    total_events = int(hits.get("total", {}).get("value", 0) or 0)
+    aggs = resp.get("aggregations", {})
+    by_action = {
+        bucket["key"]: int(bucket["doc_count"])
+        for bucket in aggs.get("by_action", {}).get("buckets", [])
+    }
+    by_status = {
+        bucket["key"]: int(bucket["doc_count"])
+        for bucket in aggs.get("by_status", {}).get("buckets", [])
+    }
+    success_count = int(aggs.get("success_count", {}).get("doc_count", 0) or 0)
+
+    return AuditStatsResponse(
+        total_events=total_events,
+        success_count=success_count,
+        failed_count=total_events - success_count,
+        unique_actors=int(aggs.get("unique_actors", {}).get("value", 0) or 0),
+        by_action=by_action,
+        by_status=by_status,
+        window_start=window_start,
+        window_end=window_end,
+    )
+
+
+async def _query_opensearch_audit_actions(client: Any, tenant_id: str) -> AuditActionsResponse | None:
+    """Query top distinct audit actions from OpenSearch over the last 30 days."""
+    window_start, window_end = _stats_window()
+    must = _opensearch_audit_must(tenant_id, start_date=window_start, end_date=window_end)
+    body = {
+        "query": {"bool": {"must": must}},
+        "size": 0,
+        "aggs": {
+            "actions": {"terms": {"field": "action.keyword", "size": 100, "order": {"_count": "desc"}}},
+        },
+    }
+    resp = await client.search(index="audit*", body=body)
+    buckets = resp.get("aggregations", {}).get("actions", {}).get("buckets", [])
+    return AuditActionsResponse(
+        actions=[AuditActionCount(action=bucket["key"], count=int(bucket["doc_count"])) for bucket in buckets],
+        window_start=window_start,
+        window_end=window_end,
     )
 
 

--- a/control-plane-api/src/services/audit_service.py
+++ b/control-plane-api/src/services/audit_service.py
@@ -8,15 +8,99 @@ Provides:
 """
 
 import logging
-from datetime import UTC, datetime
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
 from uuid import uuid4
 
-from sqlalchemy import func, select, update
+from cachetools import TTLCache  # type: ignore[import-untyped]
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.audit_event import AuditEvent
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolvedActor:
+    """Resolved actor identity returned to audit API callers."""
+
+    user_id: str | None
+    user_email: str | None
+    user_display_name: str | None
+    resolved: bool
+
+
+_ACTOR_CACHE: TTLCache[tuple[str | None, str | None], ResolvedActor] = TTLCache(maxsize=2000, ttl=300)
+
+
+def _keycloak_display_name(user: dict[str, Any]) -> str | None:
+    first_name = str(user.get("firstName") or "").strip()
+    last_name = str(user.get("lastName") or "").strip()
+    full_name = " ".join(part for part in (first_name, last_name) if part)
+    if full_name:
+        return full_name
+    username = str(user.get("username") or "").strip()
+    if username:
+        return username
+    email = user.get("email")
+    return str(email) if email else None
+
+
+async def resolve_actor(user_id: str | None, user_email: str | None) -> ResolvedActor:
+    """Resolve an audit actor via Keycloak without ever breaking audit reads."""
+    cache_key = (user_id, user_email)
+    cached = cast(ResolvedActor | None, _ACTOR_CACHE.get(cache_key))
+    if cached is not None:
+        return cached
+
+    if not user_id:
+        unresolved = ResolvedActor(
+            user_id=user_id,
+            user_email=user_email,
+            user_display_name=None,
+            resolved=False,
+        )
+        _ACTOR_CACHE[cache_key] = unresolved
+        return unresolved
+
+    try:
+        from src.services.keycloak_service import keycloak_service
+
+        if getattr(keycloak_service, "_admin", None) is None:
+            await keycloak_service.connect()
+
+        user = await keycloak_service.get_user(user_id)
+        if not user:
+            unresolved = ResolvedActor(
+                user_id=user_id,
+                user_email=None,
+                user_display_name=None,
+                resolved=False,
+            )
+            _ACTOR_CACHE[cache_key] = unresolved
+            return unresolved
+
+        email = user.get("email")
+        resolved = ResolvedActor(
+            user_id=user_id,
+            user_email=str(email) if email else user_email,
+            user_display_name=_keycloak_display_name(user),
+            resolved=True,
+        )
+        _ACTOR_CACHE[cache_key] = resolved
+        return resolved
+    except Exception as exc:
+        logger.debug("Failed to resolve audit actor %s: %s", user_id, exc)
+        unresolved = ResolvedActor(
+            user_id=user_id,
+            user_email=None,
+            user_display_name=None,
+            resolved=False,
+        )
+        _ACTOR_CACHE[cache_key] = unresolved
+        return unresolved
 
 
 class AuditService:
@@ -82,6 +166,46 @@ class AuditService:
 
     # ============ Read ============
 
+    def _filters(
+        self,
+        tenant_id: str,
+        *,
+        action: str | None = None,
+        outcome: str | None = None,
+        resource_type: str | None = None,
+        actor_id: str | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        search: str | None = None,
+    ) -> list[Any]:
+        conditions: list[Any] = [AuditEvent.tenant_id == tenant_id]
+
+        if action:
+            conditions.append(AuditEvent.action == action)
+        if outcome:
+            conditions.append(AuditEvent.outcome == outcome)
+        if resource_type:
+            conditions.append(AuditEvent.resource_type == resource_type)
+        if actor_id:
+            conditions.append(AuditEvent.actor_id == actor_id)
+        if start_date:
+            conditions.append(AuditEvent.created_at >= start_date)
+        if end_date:
+            conditions.append(AuditEvent.created_at <= end_date)
+        if search:
+            like_pattern = f"%{search}%"
+            conditions.append(
+                or_(
+                    AuditEvent.path.ilike(like_pattern),
+                    AuditEvent.resource_type.ilike(like_pattern),
+                    AuditEvent.resource_id.ilike(like_pattern),
+                    AuditEvent.resource_name.ilike(like_pattern),
+                    AuditEvent.action.ilike(like_pattern),
+                )
+            )
+
+        return conditions
+
     async def list_events(
         self,
         tenant_id: str,
@@ -97,32 +221,18 @@ class AuditService:
         search: str | None = None,
     ) -> tuple[list[AuditEvent], int]:
         """Query audit events with filters. Returns (events, total_count)."""
-        query = select(AuditEvent).where(AuditEvent.tenant_id == tenant_id)
-        count_query = select(func.count(AuditEvent.id)).where(AuditEvent.tenant_id == tenant_id)
-
-        if action:
-            query = query.where(AuditEvent.action == action)
-            count_query = count_query.where(AuditEvent.action == action)
-        if outcome:
-            query = query.where(AuditEvent.outcome == outcome)
-            count_query = count_query.where(AuditEvent.outcome == outcome)
-        if resource_type:
-            query = query.where(AuditEvent.resource_type == resource_type)
-            count_query = count_query.where(AuditEvent.resource_type == resource_type)
-        if actor_id:
-            query = query.where(AuditEvent.actor_id == actor_id)
-            count_query = count_query.where(AuditEvent.actor_id == actor_id)
-        if start_date:
-            query = query.where(AuditEvent.created_at >= start_date)
-            count_query = count_query.where(AuditEvent.created_at >= start_date)
-        if end_date:
-            query = query.where(AuditEvent.created_at <= end_date)
-            count_query = count_query.where(AuditEvent.created_at <= end_date)
-        if search:
-            like_pattern = f"%{search}%"
-            search_filter = AuditEvent.path.ilike(like_pattern) | AuditEvent.resource_type.ilike(like_pattern)
-            query = query.where(search_filter)
-            count_query = count_query.where(search_filter)
+        filters = self._filters(
+            tenant_id,
+            action=action,
+            outcome=outcome,
+            resource_type=resource_type,
+            actor_id=actor_id,
+            start_date=start_date,
+            end_date=end_date,
+            search=search,
+        )
+        query = select(AuditEvent).where(*filters)
+        count_query = select(func.count(AuditEvent.id)).where(*filters)
 
         # Count
         total_result = await self.db.execute(count_query)
@@ -134,6 +244,91 @@ class AuditService:
         events = list(result.scalars().all())
 
         return events, total
+
+    async def get_stats(
+        self,
+        tenant_id: str,
+        *,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        action: str | None = None,
+        outcome: str | None = None,
+        resource_type: str | None = None,
+        search: str | None = None,
+    ) -> dict[str, Any]:
+        """Return filtered audit aggregates for one tenant."""
+        window_end = end_date or datetime.now(UTC)
+        window_start = start_date or (window_end - timedelta(days=30))
+        filters = self._filters(
+            tenant_id,
+            action=action,
+            outcome=outcome,
+            resource_type=resource_type,
+            start_date=window_start,
+            end_date=window_end,
+            search=search,
+        )
+
+        total_result = await self.db.execute(select(func.count(AuditEvent.id)).where(*filters))
+        total_events = int(total_result.scalar() or 0)
+
+        success_result = await self.db.execute(
+            select(func.count(AuditEvent.id)).where(*filters, AuditEvent.outcome == "success")
+        )
+        success_count = int(success_result.scalar() or 0)
+
+        unique_result = await self.db.execute(select(func.count(func.distinct(AuditEvent.actor_id))).where(*filters))
+        unique_actors = int(unique_result.scalar() or 0)
+
+        action_count = func.count(AuditEvent.id)
+        action_result = await self.db.execute(
+            select(AuditEvent.action, action_count.label("cnt"))
+            .where(*filters)
+            .group_by(AuditEvent.action)
+            .order_by(action_count.desc(), AuditEvent.action.asc())
+            .limit(20)
+        )
+        by_action = {row.action: int(row.cnt) for row in action_result}
+
+        status_count = func.count(AuditEvent.id)
+        status_result = await self.db.execute(
+            select(AuditEvent.outcome, status_count.label("cnt"))
+            .where(*filters)
+            .group_by(AuditEvent.outcome)
+            .order_by(status_count.desc(), AuditEvent.outcome.asc())
+        )
+        by_status = {row.outcome: int(row.cnt) for row in status_result}
+
+        return {
+            "total_events": total_events,
+            "success_count": success_count,
+            "failed_count": total_events - success_count,
+            "unique_actors": unique_actors,
+            "by_action": by_action,
+            "by_status": by_status,
+            "window_start": window_start,
+            "window_end": window_end,
+        }
+
+    async def get_actions(self, tenant_id: str) -> dict[str, Any]:
+        """Return top distinct audit actions for one tenant over the last 30 days."""
+        window_end = datetime.now(UTC)
+        window_start = window_end - timedelta(days=30)
+        filters = self._filters(tenant_id, start_date=window_start, end_date=window_end)
+        action_count = func.count(AuditEvent.id)
+        result = await self.db.execute(
+            select(AuditEvent.action, action_count.label("cnt"))
+            .where(*filters)
+            .group_by(AuditEvent.action)
+            .order_by(action_count.desc(), AuditEvent.action.asc())
+            .limit(100)
+        )
+
+        return {
+            "actions": [{"action": row.action, "count": int(row.cnt)} for row in result],
+            "window_start": window_start,
+            "window_end": window_end,
+        }
 
     async def get_event(self, event_id: str) -> AuditEvent | None:
         """Get a single audit event by ID."""
@@ -216,7 +411,7 @@ class AuditService:
 
         stmt = delete(AuditEvent).where(AuditEvent.tenant_id == tenant_id).where(AuditEvent.created_at < before_date)
         result = await self.db.execute(stmt)
-        count = result.rowcount
+        count = int(getattr(result, "rowcount", 0) or 0)
         logger.info(f"Purged {count} audit events for tenant {tenant_id} before {before_date}")
         return count
 
@@ -257,7 +452,7 @@ class AuditService:
             stmt = stmt.where(AuditEvent.tenant_id == tenant_id)
 
         result = await self.db.execute(stmt)
-        count = result.rowcount
+        count = int(getattr(result, "rowcount", 0) or 0)
 
         logger.info(
             f"GDPR erasure: pseudonymized {count} audit records for user {user_id}"

--- a/control-plane-api/tests/test_audit_router.py
+++ b/control-plane-api/tests/test_audit_router.py
@@ -10,16 +10,20 @@ Strategy:
 """
 
 import json as _json
-from unittest.mock import MagicMock, patch
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
 import pytest
 
+import src.routers.audit as audit_router
 from src.auth.dependencies import User, get_current_user
 from src.database import get_db
 
 OS_SVC_PATH = "src.routers.audit.OpenSearchService"
+AUDIT_SERVICE_PATH = "src.routers.audit.AuditService"
 DEMO_TENANT = "oasis"
 
 
@@ -122,6 +126,348 @@ class TestListAuditEntries:
             resp = client.get(f"/v1/audit/{DEMO_TENANT}")
 
         assert resp.status_code == 403
+
+
+class TestAuditStatsEndpoint:
+    """Tests for GET /v1/audit/{tenant_id}/stats."""
+
+    def test_stats_endpoint_returns_aggregates(self, app_with_cpi_admin):
+        window_end = datetime(2026, 5, 8, 12, 0, tzinfo=UTC)
+        service = MagicMock()
+        service.get_stats = AsyncMock(
+            return_value={
+                "total_events": 4,
+                "success_count": 3,
+                "failed_count": 1,
+                "unique_actors": 2,
+                "by_action": {"export": 2, "deploy": 1, "update": 1},
+                "by_status": {"success": 3, "failure": 1},
+                "window_start": window_end - timedelta(days=30),
+                "window_end": window_end,
+            }
+        )
+
+        with patch(AUDIT_SERVICE_PATH, return_value=service), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/stats")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_events"] == 4
+        assert data["success_count"] == 3
+        assert data["failed_count"] == 1
+        assert data["unique_actors"] == 2
+        assert data["by_action"] == {"export": 2, "deploy": 1, "update": 1}
+        assert data["by_status"] == {"success": 3, "failure": 1}
+
+    def test_stats_endpoint_filters_by_window(self, app_with_cpi_admin):
+        service = MagicMock()
+        service.get_stats = AsyncMock(
+            return_value={
+                "total_events": 1,
+                "success_count": 1,
+                "failed_count": 0,
+                "unique_actors": 1,
+                "by_action": {"export": 1},
+                "by_status": {"success": 1},
+                "window_start": datetime(2026, 5, 1, tzinfo=UTC),
+                "window_end": datetime(2026, 5, 8, tzinfo=UTC),
+            }
+        )
+
+        with patch(AUDIT_SERVICE_PATH, return_value=service), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(
+                f"/v1/audit/{DEMO_TENANT}/stats"
+                "?start_date=2026-05-01T00:00:00Z&end_date=2026-05-08T00:00:00Z"
+            )
+
+        assert resp.status_code == 200
+        kwargs = service.get_stats.await_args.kwargs
+        assert kwargs["start_date"] == datetime(2026, 5, 1, tzinfo=UTC)
+        assert kwargs["end_date"] == datetime(2026, 5, 8, tzinfo=UTC)
+
+    def test_stats_endpoint_filters_by_action(self, app_with_cpi_admin):
+        service = MagicMock()
+        service.get_stats = AsyncMock(
+            return_value={
+                "total_events": 2,
+                "success_count": 2,
+                "failed_count": 0,
+                "unique_actors": 1,
+                "by_action": {"export": 2},
+                "by_status": {"success": 2},
+                "window_start": datetime(2026, 5, 1, tzinfo=UTC),
+                "window_end": datetime(2026, 5, 8, tzinfo=UTC),
+            }
+        )
+
+        with patch(AUDIT_SERVICE_PATH, return_value=service), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/stats?action=export")
+
+        assert resp.status_code == 200
+        assert service.get_stats.await_args.kwargs["action"] == "export"
+        assert resp.json()["by_action"] == {"export": 2}
+
+
+class TestAuditActionsEndpoint:
+    """Tests for GET /v1/audit/{tenant_id}/actions."""
+
+    def test_actions_endpoint_returns_distinct_top_100(self, app_with_cpi_admin):
+        window_end = datetime(2026, 5, 8, 12, 0, tzinfo=UTC)
+        actions = [{"action": f"action_{idx}", "count": 100 - idx} for idx in range(100)]
+        service = MagicMock()
+        service.get_actions = AsyncMock(
+            return_value={
+                "actions": actions,
+                "window_start": window_end - timedelta(days=30),
+                "window_end": window_end,
+            }
+        )
+
+        with patch(AUDIT_SERVICE_PATH, return_value=service), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/actions")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["actions"]) == 100
+        assert data["actions"][0] == {"action": "action_0", "count": 100}
+
+    def test_actions_endpoint_orders_by_count_desc(self, app_with_cpi_admin):
+        window_end = datetime(2026, 5, 8, 12, 0, tzinfo=UTC)
+        service = MagicMock()
+        service.get_actions = AsyncMock(
+            return_value={
+                "actions": [
+                    {"action": "export", "count": 5},
+                    {"action": "deploy", "count": 3},
+                    {"action": "update", "count": 1},
+                ],
+                "window_start": window_end - timedelta(days=30),
+                "window_end": window_end,
+            }
+        )
+
+        with patch(AUDIT_SERVICE_PATH, return_value=service), TestClient(app_with_cpi_admin) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/actions")
+
+        assert resp.status_code == 200
+        counts = [item["count"] for item in resp.json()["actions"]]
+        assert counts == [5, 3, 1]
+
+
+class TestAuditDemoFallbackGate:
+    """Tests for STOA_AUDIT_DEMO_FALLBACK gating."""
+
+    def test_demo_fallback_disabled_when_env_false(self, app_with_cpi_admin, monkeypatch):
+        service = MagicMock()
+        service.list_events = AsyncMock(side_effect=RuntimeError("pg down"))
+        monkeypatch.setattr("src.routers.audit.settings.STOA_AUDIT_DEMO_FALLBACK", False)
+
+        mock_os = _make_os_mock()
+        with patch(AUDIT_SERVICE_PATH, return_value=service), patch(OS_SVC_PATH, mock_os), TestClient(
+            app_with_cpi_admin
+        ) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["entries"] == []
+        assert data["total"] == 0
+        assert data.get("source") is None
+        assert data.get("warning") is None
+
+    def test_demo_fallback_enabled_when_env_true_emits_source_demo(self, app_with_cpi_admin, monkeypatch):
+        service = MagicMock()
+        service.list_events = AsyncMock(side_effect=RuntimeError("pg down"))
+        monkeypatch.setattr("src.routers.audit.settings.STOA_AUDIT_DEMO_FALLBACK", True)
+
+        mock_os = _make_os_mock()
+        with patch(AUDIT_SERVICE_PATH, return_value=service), patch(OS_SVC_PATH, mock_os), TestClient(
+            app_with_cpi_admin
+        ) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["source"] == "demo"
+        assert data["warning"] == "Audit backend unavailable"
+        assert data["total"] >= 1
+
+    def test_stats_demo_fallback_enabled_emits_source_demo(self, app_with_cpi_admin, monkeypatch):
+        service = MagicMock()
+        service.get_stats = AsyncMock(side_effect=RuntimeError("pg down"))
+        monkeypatch.setattr("src.routers.audit.settings.STOA_AUDIT_DEMO_FALLBACK", True)
+
+        mock_os = _make_os_mock()
+        with patch(AUDIT_SERVICE_PATH, return_value=service), patch(OS_SVC_PATH, mock_os), TestClient(
+            app_with_cpi_admin
+        ) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/stats?action=api_call")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["source"] == "demo"
+        assert data["warning"] == "Audit backend unavailable"
+        assert data["by_action"] == {"api_call": data["total_events"]}
+
+    def test_actions_demo_fallback_disabled_returns_empty(self, app_with_cpi_admin, monkeypatch):
+        service = MagicMock()
+        service.get_actions = AsyncMock(side_effect=RuntimeError("pg down"))
+        monkeypatch.setattr("src.routers.audit.settings.STOA_AUDIT_DEMO_FALLBACK", False)
+
+        mock_os = _make_os_mock()
+        with patch(AUDIT_SERVICE_PATH, return_value=service), patch(OS_SVC_PATH, mock_os), TestClient(
+            app_with_cpi_admin
+        ) as client:
+            resp = client.get(f"/v1/audit/{DEMO_TENANT}/actions")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["actions"] == []
+        assert data.get("source") is None
+        assert data.get("warning") is None
+
+
+class TestAuditDemoHelpers:
+    """Direct coverage for explicit demo fallback helpers."""
+
+    def test_demo_stats_helper_filters_and_emits_warning(self):
+        result = audit_router._demo_audit_stats_response(
+            DEMO_TENANT,
+            action="api_call",
+            resource_type="tool",
+            search="oasis",
+        )
+
+        assert result.source == "demo"
+        assert result.warning == "Audit backend unavailable"
+        assert result.total_events >= 1
+        assert set(result.by_action) == {"api_call"}
+        assert result.by_status["success"] >= 1
+
+    def test_demo_actions_helper_orders_actions(self):
+        result = audit_router._demo_audit_actions_response(DEMO_TENANT)
+
+        assert result.source == "demo"
+        assert result.warning == "Audit backend unavailable"
+        assert result.actions
+        assert result.actions[0].count >= result.actions[-1].count
+
+
+class TestAuditOpenSearchHelpers:
+    """Direct coverage for OpenSearch audit fallback helpers."""
+
+    @pytest.mark.asyncio
+    async def test_query_opensearch_audit_maps_entries_and_actor_resolution(self):
+        client = MagicMock()
+        client.search = AsyncMock(
+            return_value={
+                "hits": {
+                    "total": {"value": 1},
+                    "hits": [
+                        {
+                            "_id": "os-1",
+                            "_source": {
+                                "@timestamp": "2026-05-08T12:00:00+00:00",
+                                "event_id": "event-1",
+                                "tenant_id": DEMO_TENANT,
+                                "actor": {
+                                    "id": "user-123",
+                                    "email": None,
+                                    "ip_address": "192.0.2.10",
+                                    "user_agent": "pytest",
+                                },
+                                "action": "export",
+                                "resource": {"type": "report", "id": "rpt-1"},
+                                "outcome": "success",
+                                "details": {"source": "opensearch"},
+                                "correlation_id": "req-1",
+                            },
+                        }
+                    ],
+                }
+            }
+        )
+        actor = SimpleNamespace(user_email="alice@example.com", user_display_name="Alice Nguyen", resolved=True)
+
+        with patch("src.routers.audit.resolve_actor", AsyncMock(return_value=actor)):
+            result = await audit_router._query_opensearch_audit(
+                client,
+                DEMO_TENANT,
+                1,
+                50,
+                action="export",
+                status="success",
+                resource_type="report",
+                start_date=datetime(2026, 5, 1, tzinfo=UTC),
+                end_date=datetime(2026, 5, 8, tzinfo=UTC),
+                search="report",
+            )
+
+        assert result is not None
+        assert result.total == 1
+        assert result.entries[0].user_email == "alice@example.com"
+        assert result.entries[0].user_display_name == "Alice Nguyen"
+        assert result.entries[0].user_resolved is True
+        body = client.search.await_args.kwargs["body"]
+        must = body["query"]["bool"]["must"]
+        assert {"term": {"action.keyword": "export"}} in must
+        assert {"term": {"outcome.keyword": "success"}} in must
+        assert {"term": {"resource.type.keyword": "report"}} in must
+        assert any("multi_match" in item for item in must)
+
+    @pytest.mark.asyncio
+    async def test_query_opensearch_audit_stats_returns_aggregates(self):
+        client = MagicMock()
+        client.search = AsyncMock(
+            return_value={
+                "hits": {"total": {"value": 3}},
+                "aggregations": {
+                    "by_action": {"buckets": [{"key": "export", "doc_count": 2}, {"key": "deploy", "doc_count": 1}]},
+                    "by_status": {"buckets": [{"key": "success", "doc_count": 2}, {"key": "failure", "doc_count": 1}]},
+                    "unique_actors": {"value": 2},
+                    "success_count": {"doc_count": 2},
+                },
+            }
+        )
+
+        result = await audit_router._query_opensearch_audit_stats(
+            client,
+            DEMO_TENANT,
+            action="export",
+            status="success",
+            resource_type="report",
+            search="report",
+        )
+
+        assert result is not None
+        assert result.total_events == 3
+        assert result.success_count == 2
+        assert result.failed_count == 1
+        assert result.unique_actors == 2
+        assert result.by_action == {"export": 2, "deploy": 1}
+        assert result.by_status == {"success": 2, "failure": 1}
+
+    @pytest.mark.asyncio
+    async def test_query_opensearch_audit_actions_returns_top_actions(self):
+        client = MagicMock()
+        client.search = AsyncMock(
+            return_value={
+                "aggregations": {
+                    "actions": {
+                        "buckets": [
+                            {"key": "export", "doc_count": 5},
+                            {"key": "deploy", "doc_count": 2},
+                        ]
+                    }
+                }
+            }
+        )
+
+        result = await audit_router._query_opensearch_audit_actions(client, DEMO_TENANT)
+
+        assert result is not None
+        assert [item.action for item in result.actions] == ["export", "deploy"]
+        assert [item.count for item in result.actions] == [5, 2]
 
 
 class TestExportAuditCsv:

--- a/control-plane-api/tests/test_audit_service.py
+++ b/control-plane-api/tests/test_audit_service.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.models.audit_event import AuditEvent
-from src.services.audit_service import AuditService
+from src.services.audit_service import _ACTOR_CACHE, AuditService, resolve_actor
 
 
 @pytest.fixture
@@ -27,6 +27,13 @@ def mock_session():
 def audit_service(mock_session):
     """Create AuditService with mock session."""
     return AuditService(mock_session)
+
+
+@pytest.fixture(autouse=True)
+def clear_actor_cache():
+    _ACTOR_CACHE.clear()
+    yield
+    _ACTOR_CACHE.clear()
 
 
 class TestRecordEvent:
@@ -147,6 +154,62 @@ class TestListEvents:
 
         assert total == 100
         assert len(events) == 10
+
+
+class TestResolveActor:
+    """Tests for audit actor resolution."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_actor_caches_keycloak_lookup(self):
+        keycloak = MagicMock()
+        keycloak._admin = object()
+        keycloak.get_user = AsyncMock(
+            return_value={
+                "id": "user-123",
+                "email": "alice@example.com",
+                "firstName": "Alice",
+                "lastName": "Nguyen",
+                "username": "alice",
+            }
+        )
+
+        with patch("src.services.keycloak_service.keycloak_service", keycloak):
+            first = await resolve_actor("user-123", None)
+            second = await resolve_actor("user-123", None)
+
+        assert first == second
+        assert first.resolved is True
+        assert first.user_email == "alice@example.com"
+        assert first.user_display_name == "Alice Nguyen"
+        keycloak.get_user.assert_awaited_once_with("user-123")
+
+    @pytest.mark.asyncio
+    async def test_resolve_actor_returns_unresolved_when_keycloak_down(self):
+        keycloak = MagicMock()
+        keycloak._admin = object()
+        keycloak.get_user = AsyncMock(side_effect=RuntimeError("keycloak down"))
+
+        with patch("src.services.keycloak_service.keycloak_service", keycloak):
+            actor = await resolve_actor("user-123", "alice@example.com")
+
+        assert actor.user_id == "user-123"
+        assert actor.user_email is None
+        assert actor.user_display_name is None
+        assert actor.resolved is False
+
+    @pytest.mark.asyncio
+    async def test_resolve_actor_does_not_raise_on_missing_user(self):
+        keycloak = MagicMock()
+        keycloak._admin = object()
+        keycloak.get_user = AsyncMock(return_value=None)
+
+        with patch("src.services.keycloak_service.keycloak_service", keycloak):
+            actor = await resolve_actor("missing-user", "missing@example.com")
+
+        assert actor.user_id == "missing-user"
+        assert actor.user_email is None
+        assert actor.user_display_name is None
+        assert actor.resolved is False
 
 
 class TestGetEvent:

--- a/control-plane-api/tests/test_regression_cab_2736_audit_demo_fallback.py
+++ b/control-plane-api/tests/test_regression_cab_2736_audit_demo_fallback.py
@@ -1,0 +1,37 @@
+"""Regression guard for audit demo fallback fail-closed defaults."""
+
+from src.config import Settings
+
+
+def test_regression_cab_2736_audit_demo_fallback_defaults_false_in_production():
+    settings = Settings(
+        ENVIRONMENT="production",
+        GIT_PROVIDER="gitlab",
+        GITLAB_TOKEN="test-token",
+        GITLAB_PROJECT_ID="1",
+    )
+
+    assert settings.audit_demo_fallback_enabled is False
+
+
+def test_regression_cab_2736_audit_demo_fallback_defaults_true_in_test():
+    settings = Settings(
+        ENVIRONMENT="test",
+        GIT_PROVIDER="gitlab",
+        GITLAB_TOKEN="test-token",
+        GITLAB_PROJECT_ID="1",
+    )
+
+    assert settings.audit_demo_fallback_enabled is True
+
+
+def test_regression_cab_2736_audit_demo_fallback_explicit_env_wins():
+    settings = Settings(
+        ENVIRONMENT="test",
+        STOA_AUDIT_DEMO_FALLBACK=False,
+        GIT_PROVIDER="gitlab",
+        GITLAB_TOKEN="test-token",
+        GITLAB_PROJECT_ID="1",
+    )
+
+    assert settings.audit_demo_fallback_enabled is False


### PR DESCRIPTION
## Summary
- Add backend-only `GET /v1/audit/{tenant_id}/stats` and `GET /v1/audit/{tenant_id}/actions` per Annex A.
- Add cached Keycloak actor resolution for audit list entries with fail-open unresolved metadata.
- Add `STOA_AUDIT_DEMO_FALLBACK` fail-closed production gate and explicit `source=demo` / `warning` metadata when demo fallback is used.

## References
- Plan: `docs/plans/2026-05-07-observability-data-integrity.md`
- Annex A: Audit Log API contract (PR-1B) in the plan above
- PR-1A6 unblock evidence: `docs/audits/2026-05-09-audit-consumer-verification/post-activation.md`

## Non-goals
- No AuditLog UI / frontend work.
- No Kafka consumer change.
- No sidebar/nav, Live Calls, or Guardrails touch.
- No stoa-infra change.

PR-1B2 (UI consumption) lands separately and depends on this PR merging.

## Test plan
- `python3 -m pytest tests/test_audit_router.py tests/test_audit_service.py tests/test_regression_cab_2736_audit_demo_fallback.py -q`
- `python3 -m pytest tests/test_audit_router.py tests/test_audit_service.py --cov=src.routers.audit --cov=src.services.audit_service --cov-fail-under=70 -q`
- `python3 -m pytest tests/test_openapi_contract.py::TestOpenAPIContract::test_openapi_schema_properties_match_snapshot -q`
- `ruff check src/`
- `mypy --follow-imports=skip src/routers/audit.py src/services/audit_service.py`
- `git diff --check`

Note: the exact repo mypy command `mypy src/routers/audit.py src/services/audit_service.py` still follows imports and reports the existing cp-api mypy baseline outside these touched files; the touched files pass in follow-imports-skip mode.