### PR TITLE
feat(ui): audit log stats + actions + actor + backoff + export + i18n

### DIFF
--- a/control-plane-ui/src/pages/AuditLog.test.tsx
+++ b/control-plane-ui/src/pages/AuditLog.test.tsx
@@ -222,6 +222,47 @@ describe('AuditLog', () => {
     expect(screen.getAllByText('Last 30 days')).toHaveLength(4);
   });
 
+  it('shows backend warning when audit responses come from demo fallback', async () => {
+    vi.useRealTimers();
+    mockGet.mockImplementation((url: unknown) => {
+      const path = String(url);
+      if (path.endsWith('/stats')) {
+        return Promise.resolve({
+          data: {
+            ...emptyStatsResponse,
+            source: 'demo',
+            warning: 'Audit backend unavailable',
+          },
+        });
+      }
+      if (path.endsWith('/actions')) {
+        return Promise.resolve({
+          data: {
+            ...emptyActionsResponse,
+            source: 'demo',
+            warning: 'Audit backend unavailable',
+          },
+        });
+      }
+      return Promise.resolve({
+        data: {
+          ...emptyListResponse,
+          source: 'demo',
+          warning: 'Audit backend unavailable',
+        },
+      });
+    });
+
+    render(<AuditLog />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('audit-backend-warning')).toHaveTextContent(
+        'Audit backend unavailable'
+      );
+      expect(screen.getByText('Source: demo')).toBeInTheDocument();
+    });
+  });
+
   it('actions endpoint populates filter dynamically by count', async () => {
     vi.useRealTimers();
     mockGet.mockImplementation((url: unknown) => {

--- a/control-plane-ui/src/pages/AuditLog.test.tsx
+++ b/control-plane-ui/src/pages/AuditLog.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
+import i18n from 'i18next';
 import { createAuthMock } from '../test/helpers';
 import { useAuth } from '../contexts/AuthContext';
 import type { PersonaRole } from '../test/helpers';
@@ -21,17 +22,56 @@ vi.mock('../services/api', () => ({
   },
 }));
 
+const statsWindow = {
+  window_start: '2026-05-01T00:00:00Z',
+  window_end: '2026-05-08T00:00:00Z',
+};
+
+const emptyListResponse = {
+  entries: [],
+  total: 0,
+  page: 1,
+  page_size: 20,
+  has_more: false,
+};
+
+const emptyStatsResponse = {
+  total_events: 0,
+  success_count: 0,
+  failed_count: 0,
+  unique_actors: 0,
+  by_action: {},
+  by_status: {},
+  ...statsWindow,
+};
+
+const emptyActionsResponse = {
+  actions: [],
+  ...statsWindow,
+};
+
+function defaultAuditMock(url: unknown) {
+  const path = String(url);
+  if (path.endsWith('/stats')) {
+    return Promise.resolve({ data: emptyStatsResponse });
+  }
+  if (path.endsWith('/actions')) {
+    return Promise.resolve({ data: emptyActionsResponse });
+  }
+  if (path.includes('/export/')) {
+    return Promise.resolve({ data: 'timestamp,action\n' });
+  }
+  return Promise.resolve({ data: emptyListResponse });
+}
+
 describe('AuditLog', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    await i18n.changeLanguage('en');
     localStorage.clear();
     vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
-    mockGet.mockImplementation(() =>
-      Promise.resolve({
-        data: { entries: [], total: 0, page: 1, page_size: 20, has_more: false },
-      })
-    );
+    mockGet.mockImplementation(defaultAuditMock);
   });
 
   afterEach(() => {
@@ -76,6 +116,16 @@ describe('AuditLog', () => {
       const params = (dateFilteredCall?.[1] as { params?: Record<string, unknown> })?.params;
       expect(params).not.toHaveProperty('date_from');
       expect(params).not.toHaveProperty('date_to');
+
+      const statsCall = mockGet.mock.calls.find(([url, options]) => {
+        const params = (options as { params?: Record<string, unknown> } | undefined)?.params;
+        return (
+          url === '/v1/audit/gregarious-games/stats' &&
+          params?.start_date === '2026-05-01' &&
+          params?.end_date === '2026-05-07'
+        );
+      });
+      expect(statsCall).toBeTruthy();
     });
   });
 
@@ -98,9 +148,7 @@ describe('AuditLog', () => {
       if (typeof url === 'string' && url.endsWith('/export/csv')) {
         return Promise.resolve({ data: 'timestamp,action\n' });
       }
-      return Promise.resolve({
-        data: { entries: [], total: 0, page: 1, page_size: 20, has_more: false },
-      });
+      return defaultAuditMock(url);
     });
 
     try {
@@ -116,7 +164,7 @@ describe('AuditLog', () => {
 
       fireEvent.change(dateInputs[0], { target: { value: '2026-05-01' } });
       fireEvent.change(dateInputs[1], { target: { value: '2026-05-07' } });
-      fireEvent.click(screen.getByRole('button', { name: /export/i }));
+      fireEvent.click(screen.getByRole('button', { name: /export csv/i }));
 
       await waitFor(() => {
         const exportCall = mockGet.mock.calls.find(([url]) => String(url).endsWith('/export/csv'));
@@ -141,6 +189,335 @@ describe('AuditLog', () => {
       });
       anchorClickSpy.mockRestore();
     }
+  });
+
+  it('stats endpoint populates KPIs and removes page-only subtitles', async () => {
+    vi.useRealTimers();
+    mockGet.mockImplementation((url: unknown) => {
+      if (String(url).endsWith('/stats')) {
+        return Promise.resolve({
+          data: {
+            total_events: 128,
+            success_count: 97,
+            failed_count: 11,
+            unique_actors: 23,
+            by_action: { deploy: 44, create: 30 },
+            by_status: { success: 97, failure: 11 },
+            ...statsWindow,
+          },
+        });
+      }
+      return defaultAuditMock(url);
+    });
+
+    render(<AuditLog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('128')).toBeInTheDocument();
+      expect(screen.getByText('97')).toBeInTheDocument();
+      expect(screen.getByText('11')).toBeInTheDocument();
+      expect(screen.getByText('23')).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/On this page/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText('Last 30 days')).toHaveLength(4);
+  });
+
+  it('actions endpoint populates filter dynamically by count', async () => {
+    vi.useRealTimers();
+    mockGet.mockImplementation((url: unknown) => {
+      if (String(url).endsWith('/actions')) {
+        return Promise.resolve({
+          data: {
+            actions: [
+              { action: 'create', count: 3 },
+              { action: 'export', count: 9 },
+              { action: 'deploy', count: 6 },
+            ],
+            ...statsWindow,
+          },
+        });
+      }
+      return defaultAuditMock(url);
+    });
+
+    render(<AuditLog />);
+    await waitFor(() => {
+      expect(screen.getByText(/Total Events/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    const [actionSelect] = document.querySelectorAll<HTMLSelectElement>('select');
+    expect(actionSelect).toBeTruthy();
+    expect(Array.from(actionSelect.options).map((option) => option.textContent)).toEqual([
+      'All actions',
+      'Export (9)',
+      'Deploy (6)',
+      'Create (3)',
+    ]);
+
+    fireEvent.change(actionSelect, { target: { value: 'export' } });
+
+    await waitFor(() => {
+      const filteredCall = mockGet.mock.calls.find(([url, options]) => {
+        const params = (options as { params?: Record<string, unknown> } | undefined)?.params;
+        return url === '/v1/audit/gregarious-games' && params?.action === 'export';
+      });
+      expect(filteredCall).toBeTruthy();
+    });
+  });
+
+  it('actor display shows email, display name, then unresolved badge', async () => {
+    vi.useRealTimers();
+    mockGet.mockImplementation((url: unknown) => {
+      if (String(url) === '/v1/audit/gregarious-games') {
+        return Promise.resolve({
+          data: {
+            entries: [
+              {
+                id: 'evt-email',
+                timestamp: '2026-04-04T10:00:00Z',
+                user_id: 'user-1',
+                user_email: 'alice@acme.com',
+                user_display_name: 'Alice Display',
+                user_resolved: true,
+                action: 'create',
+                resource_type: 'api',
+                resource_id: 'api-1',
+                resource_name: 'api-one',
+                status: 'success',
+                details: null,
+                client_ip: null,
+                user_agent: null,
+                request_id: null,
+                tenant_id: 'acme',
+              },
+              {
+                id: 'evt-display',
+                timestamp: '2026-04-04T10:01:00Z',
+                user_id: 'user-2',
+                user_email: null,
+                user_display_name: 'Bob Resolved',
+                user_resolved: true,
+                action: 'update',
+                resource_type: 'api',
+                resource_id: 'api-2',
+                resource_name: 'api-two',
+                status: 'success',
+                details: null,
+                client_ip: null,
+                user_agent: null,
+                request_id: null,
+                tenant_id: 'acme',
+              },
+              {
+                id: 'evt-unresolved',
+                timestamp: '2026-04-04T10:02:00Z',
+                user_id: 'svc-agent-001',
+                user_email: null,
+                user_display_name: null,
+                user_resolved: false,
+                action: 'deploy',
+                resource_type: 'deployment',
+                resource_id: 'dep-1',
+                resource_name: null,
+                status: 'failure',
+                details: null,
+                client_ip: null,
+                user_agent: null,
+                request_id: null,
+                tenant_id: 'acme',
+              },
+            ],
+            total: 3,
+            page: 1,
+            page_size: 20,
+            has_more: false,
+          },
+        });
+      }
+      return defaultAuditMock(url);
+    });
+
+    render(<AuditLog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('alice@acme.com')).toBeInTheDocument();
+      expect(screen.queryByText('Alice Display')).not.toBeInTheDocument();
+      expect(screen.getByText('Bob Resolved')).toBeInTheDocument();
+      expect(screen.getByText('svc-agent-001')).toBeInTheDocument();
+      expect(screen.getByTestId('actor-unresolved-badge')).toHaveTextContent('unresolved');
+    });
+  });
+
+  it('shows the last successful refresh timestamp', async () => {
+    vi.useRealTimers();
+    render(<AuditLog />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('audit-refresh-status')).toHaveTextContent(
+        /Last refreshed (just now|\d+ min ago)/
+      );
+    });
+  });
+
+  it('backs off on consecutive failures and resets after success', async () => {
+    let listAttempts = 0;
+    mockGet.mockImplementation((url: unknown) => {
+      const path = String(url);
+      if (path === '/v1/audit/gregarious-games') {
+        listAttempts += 1;
+        if (listAttempts <= 2) {
+          return Promise.reject({ response: { data: { detail: 'backend unavailable' } } });
+        }
+        return Promise.resolve({ data: emptyListResponse });
+      }
+      return defaultAuditMock(url);
+    });
+
+    render(<AuditLog />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText(/retrying in 60s/i)).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(screen.getByText(/retrying in 120s/i)).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(120_000);
+      await Promise.resolve();
+    });
+    expect(screen.queryByText(/Refresh failed/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('audit-refresh-status')).toHaveTextContent(/Last refreshed/);
+
+    const attemptsAfterReset = listAttempts;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(29_000);
+    });
+    expect(listAttempts).toBe(attemptsAfterReset);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(listAttempts).toBe(attemptsAfterReset + 1);
+  });
+
+  it('split-button exports call csv and json endpoints', async () => {
+    vi.useRealTimers();
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const anchorClickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:audit-log'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    mockGet.mockImplementation((url: unknown) => {
+      if (String(url).includes('/export/csv')) {
+        return Promise.resolve({ data: 'timestamp,action\n' });
+      }
+      if (String(url).includes('/export/json')) {
+        return Promise.resolve({ data: [{ action: 'deploy' }] });
+      }
+      return defaultAuditMock(url);
+    });
+
+    try {
+      render(<AuditLog />);
+      await waitFor(() => {
+        expect(screen.getByText(/Total Events/i)).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /export csv/i }));
+      await waitFor(() => {
+        expect(mockGet.mock.calls.some(([url]) => String(url).endsWith('/export/csv'))).toBe(true);
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /export options/i }));
+      fireEvent.click(screen.getByRole('button', { name: /export json/i }));
+      await waitFor(() => {
+        expect(mockGet.mock.calls.some(([url]) => String(url).endsWith('/export/json'))).toBe(true);
+      });
+    } finally {
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        value: originalCreateObjectURL,
+      });
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        value: originalRevokeObjectURL,
+      });
+      anchorClickSpy.mockRestore();
+    }
+  });
+
+  it('locale switcher language changes timestamp formatting', async () => {
+    vi.useRealTimers();
+    const timestamp = '2026-05-04T13:05:06Z';
+    const formatOptions = {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    } as const;
+    mockGet.mockImplementation((url: unknown) => {
+      if (String(url) === '/v1/audit/gregarious-games') {
+        return Promise.resolve({
+          data: {
+            entries: [
+              {
+                id: 'evt-locale',
+                timestamp,
+                user_id: 'user-123',
+                user_email: 'alice@acme.com',
+                action: 'create',
+                resource_type: 'api',
+                resource_id: 'api-456',
+                resource_name: 'my-api',
+                status: 'success',
+                details: null,
+                client_ip: null,
+                user_agent: null,
+                request_id: null,
+                tenant_id: 'acme',
+              },
+            ],
+            total: 1,
+            page: 1,
+            page_size: 20,
+            has_more: false,
+          },
+        });
+      }
+      return defaultAuditMock(url);
+    });
+
+    render(<AuditLog />);
+
+    const expectedEnglish = new Date(timestamp).toLocaleString('en', formatOptions);
+    await waitFor(() => {
+      expect(screen.getByText(expectedEnglish)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      await i18n.changeLanguage('fr');
+    });
+
+    const expectedFrench = new Date(timestamp).toLocaleString('fr', formatOptions);
+    await waitFor(() => {
+      expect(screen.getByText(expectedFrench)).toBeInTheDocument();
+    });
   });
 
   it('clears polling interval on unmount and does not update state after unmount', async () => {
@@ -178,11 +555,14 @@ describe('AuditLog', () => {
   describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(
     '%s persona',
     (role) => {
-      it('renders the page', () => {
+      it('renders the page', async () => {
         vi.useRealTimers();
         vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
         render(<AuditLog />);
         expect(screen.getByText('Audit Log')).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.getByText(/Total Events/i)).toBeInTheDocument();
+        });
       });
     }
   );
@@ -196,7 +576,7 @@ describe('AuditLog', () => {
         vi.mocked(useAuth).mockReturnValue(createAuthMock(role));
         render(<AuditLog />);
         await waitFor(() => {
-          expect(screen.getByText('Export')).toBeInTheDocument();
+          expect(screen.getByText('Export CSV')).toBeInTheDocument();
         });
       }
     );
@@ -208,7 +588,7 @@ describe('AuditLog', () => {
       await waitFor(() => {
         expect(screen.getByText(/Total Events/i)).toBeInTheDocument();
       });
-      expect(screen.queryByText('Export')).not.toBeInTheDocument();
+      expect(screen.queryByText('Export CSV')).not.toBeInTheDocument();
     });
   });
 

--- a/control-plane-ui/src/pages/AuditLog.tsx
+++ b/control-plane-ui/src/pages/AuditLog.tsx
@@ -14,6 +14,7 @@ import {
   ChevronDown,
   ChevronRight,
 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { apiService } from '../services/api';
 import { CardSkeleton } from '@stoa/shared/components/Skeleton';
@@ -21,8 +22,10 @@ import { StatCard } from '@stoa/shared/components/StatCard';
 import { EmptyState } from '@stoa/shared/components/EmptyState';
 
 const AUTO_REFRESH_INTERVAL = 30_000;
+const MAX_REFRESH_INTERVAL = 300_000;
 const ACTIVE_TENANT_KEY = 'stoa-active-tenant';
 const PAGE_SIZE = 20;
+const LEGACY_ACTION_OPTIONS = ['create', 'update', 'delete', 'deploy', 'login', 'access_denied'];
 
 type AuditAction =
   | 'create'
@@ -41,6 +44,8 @@ interface AuditEntry {
   timestamp: string;
   user_id: string | null;
   user_email: string | null;
+  user_display_name?: string | null;
+  user_resolved?: boolean;
   action: AuditAction;
   resource_type: string;
   resource_id: string | null;
@@ -59,6 +64,28 @@ interface AuditFilters {
   start_date?: string;
   end_date?: string;
   search?: string;
+}
+
+interface AuditStatsResponse {
+  total_events: number;
+  success_count: number;
+  failed_count: number;
+  unique_actors: number;
+  by_action: Record<string, number>;
+  by_status: Record<string, number>;
+  window_start: string;
+  window_end: string;
+}
+
+interface AuditActionCount {
+  action: string;
+  count: number;
+}
+
+interface AuditActionsResponse {
+  actions: AuditActionCount[];
+  window_start: string;
+  window_end: string;
 }
 
 const ACTION_ICONS: Record<string, typeof User> = {
@@ -87,9 +114,9 @@ const STATUS_STYLES: Record<string, { bg: string; text: string }> = {
   },
 };
 
-function formatTimestamp(ts: string): string {
+function formatTimestamp(ts: string, locale: string): string {
   const d = new Date(ts);
-  return d.toLocaleString('fr-FR', {
+  return d.toLocaleString(locale, {
     day: '2-digit',
     month: '2-digit',
     year: 'numeric',
@@ -99,10 +126,54 @@ function formatTimestamp(ts: string): string {
   });
 }
 
+function buildAuditParams(filters: AuditFilters, page?: number): Record<string, string | number> {
+  const params: Record<string, string | number> = {};
+  if (page !== undefined) {
+    params.page = page;
+    params.page_size = PAGE_SIZE;
+  }
+  if (filters.action) params.action = filters.action;
+  if (filters.status) params.status = filters.status;
+  if (filters.start_date) params.start_date = filters.start_date;
+  if (filters.end_date) params.end_date = filters.end_date;
+  if (filters.search) params.search = filters.search;
+  return params;
+}
+
+function formatActionLabel(action: string): string {
+  return action
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatWindowSubtitle(filters: AuditFilters, stats: AuditStatsResponse | null): string {
+  if (filters.start_date || filters.end_date) {
+    const start = filters.start_date || stats?.window_start?.slice(0, 10) || '...';
+    const end = filters.end_date || stats?.window_end?.slice(0, 10) || '...';
+    return `Window: ${start} → ${end}`;
+  }
+  return 'Last 30 days';
+}
+
+function formatRelativeTime(value: Date, now = new Date()): string {
+  const elapsedSeconds = Math.max(0, Math.floor((now.getTime() - value.getTime()) / 1000));
+  if (elapsedSeconds < 60) return 'just now';
+  const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+  if (elapsedMinutes < 60) {
+    return `${elapsedMinutes} min ago`;
+  }
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  return `${elapsedHours} hr ago`;
+}
+
 export function AuditLog() {
   const { user, isReady, hasRole } = useAuth();
+  const { i18n } = useTranslation();
+  const locale = i18n.language || i18n.resolvedLanguage || navigator.language || 'en';
   const [entries, setEntries] = useState<AuditEntry[]>([]);
   const [total, setTotal] = useState(0);
+  const [stats, setStats] = useState<AuditStatsResponse | null>(null);
+  const [actions, setActions] = useState<AuditActionCount[]>([]);
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -110,6 +181,9 @@ export function AuditLog() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [showFilters, setShowFilters] = useState(false);
   const [exporting, setExporting] = useState(false);
+  const [showExportMenu, setShowExportMenu] = useState(false);
+  const [lastSuccessAt, setLastSuccessAt] = useState<Date | null>(null);
+  const [currentInterval, setCurrentInterval] = useState(AUTO_REFRESH_INTERVAL);
 
   const canExport = hasRole('cpi-admin') || hasRole('tenant-admin');
   const tenantId = localStorage.getItem(ACTIVE_TENANT_KEY) || user?.tenant_id || 'default';
@@ -118,63 +192,75 @@ export function AuditLog() {
 
   const loadData = useCallback(async () => {
     try {
-      const params: Record<string, any> = {
-        page,
-        page_size: PAGE_SIZE,
-      };
-      if (filters.action) params.action = filters.action;
-      if (filters.status) params.status = filters.status;
-      if (filters.start_date) params.start_date = filters.start_date;
-      if (filters.end_date) params.end_date = filters.end_date;
-      if (filters.search) params.search = filters.search;
-
-      const { data } = await apiService.get<{
-        entries: AuditEntry[];
-        total: number;
-        page: number;
-        page_size: number;
-        has_more: boolean;
-      }>(`/v1/audit/${tenantId}`, { params });
+      const listParams = buildAuditParams(filters, page);
+      const statsParams = buildAuditParams(filters);
+      const [{ data }, statsResponse] = await Promise.all([
+        apiService.get<{
+          entries: AuditEntry[];
+          total: number;
+          page: number;
+          page_size: number;
+          has_more: boolean;
+        }>(`/v1/audit/${tenantId}`, { params: listParams }),
+        apiService.get<AuditStatsResponse>(`/v1/audit/${tenantId}/stats`, {
+          params: statsParams,
+        }),
+      ]);
 
       if (!mountedRef.current) return;
       setEntries(data.entries || []);
       setTotal(data.total || 0);
+      setStats(statsResponse.data || null);
       setError(null);
+      setLastSuccessAt(new Date());
+      setCurrentInterval(AUTO_REFRESH_INTERVAL);
     } catch (err: unknown) {
       if (!mountedRef.current) return;
       const axiosErr = err as { response?: { data?: { detail?: string } } };
       setError(axiosErr.response?.data?.detail || 'Failed to load audit log');
       setEntries([]);
       setTotal(0);
+      setStats(null);
+      setCurrentInterval((interval) => Math.min(interval * 2, MAX_REFRESH_INTERVAL));
     } finally {
       if (mountedRef.current) setLoading(false);
     }
   }, [tenantId, page, filters]);
 
+  const loadActions = useCallback(async () => {
+    try {
+      const { data } = await apiService.get<AuditActionsResponse>(`/v1/audit/${tenantId}/actions`);
+      if (!mountedRef.current) return;
+      const sortedActions = [...(data.actions || [])].sort((a, b) => b.count - a.count).slice(0, 100);
+      setActions(sortedActions);
+    } catch {
+      if (mountedRef.current) setActions([]);
+    }
+  }, [tenantId]);
+
   useEffect(() => {
     mountedRef.current = true;
-    if (isReady) loadData();
+    if (isReady) {
+      loadData();
+      loadActions();
+    }
     return () => {
       mountedRef.current = false;
     };
-  }, [isReady, loadData]);
+  }, [isReady, loadData, loadActions]);
 
   useEffect(() => {
     if (!isReady) return;
-    const interval = setInterval(loadData, AUTO_REFRESH_INTERVAL);
+    const interval = setInterval(loadData, currentInterval);
     return () => clearInterval(interval);
-  }, [isReady, loadData]);
+  }, [isReady, loadData, currentInterval]);
 
   const handleExport = async (format: 'csv' | 'json') => {
     setExporting(true);
+    setShowExportMenu(false);
     try {
       const { data } = await apiService.get<string>(`/v1/audit/${tenantId}/export/${format}`, {
-        params: {
-          ...(filters.action && { action: filters.action }),
-          ...(filters.status && { status: filters.status }),
-          ...(filters.start_date && { start_date: filters.start_date }),
-          ...(filters.end_date && { end_date: filters.end_date }),
-        },
+        params: buildAuditParams(filters),
       });
       const blob = new Blob([typeof data === 'string' ? data : JSON.stringify(data, null, 2)], {
         type: format === 'csv' ? 'text/csv' : 'application/json',
@@ -194,9 +280,15 @@ export function AuditLog() {
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
-  const successCount = entries.filter((e) => e.status === 'success').length;
-  const failureCount = entries.filter((e) => e.status === 'failure').length;
-  const uniqueActors = new Set(entries.map((e) => e.user_email || e.user_id)).size;
+  const successCount = stats?.success_count ?? entries.filter((e) => e.status === 'success').length;
+  const failureCount = stats?.failed_count ?? entries.filter((e) => e.status === 'failure').length;
+  const uniqueActors =
+    stats?.unique_actors ?? new Set(entries.map((e) => e.user_email || e.user_id).filter(Boolean)).size;
+  const totalEvents = stats?.total_events ?? total;
+  const statWindowSubtitle = formatWindowSubtitle(filters, stats);
+  const actionOptions =
+    actions.length > 0 ? actions : LEGACY_ACTION_OPTIONS.map((action) => ({ action, count: 0 }));
+  const retrySeconds = Math.ceil(currentInterval / 1000);
 
   return (
     <div className="space-y-6">
@@ -213,15 +305,46 @@ export function AuditLog() {
         </div>
         <div className="flex items-center gap-2">
           {canExport && (
-            <div className="relative">
+            <div className="relative flex" data-testid="audit-export-split">
               <button
                 onClick={() => handleExport('csv')}
                 disabled={exporting}
-                className="flex items-center gap-2 border border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-3 py-2 rounded-lg text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700 disabled:opacity-50"
+                className="flex items-center gap-2 border border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-3 py-2 rounded-l-lg text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700 disabled:opacity-50"
               >
                 <Download className="h-4 w-4" />
-                Export
+                Export CSV
               </button>
+              <button
+                type="button"
+                aria-label="Export options"
+                aria-expanded={showExportMenu}
+                onClick={() => setShowExportMenu((open) => !open)}
+                disabled={exporting}
+                className="border-y border-r border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 px-2 py-2 rounded-r-lg text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700 disabled:opacity-50"
+              >
+                <ChevronDown className="h-4 w-4" />
+              </button>
+              {showExportMenu && (
+                <div
+                  data-testid="audit-export-menu"
+                  className="absolute right-0 top-full z-20 mt-1 w-36 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 shadow-lg"
+                >
+                  <button
+                    type="button"
+                    onClick={() => handleExport('csv')}
+                    className="block w-full px-3 py-2 text-left text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700"
+                  >
+                    Export CSV
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleExport('json')}
+                    className="block w-full px-3 py-2 text-left text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700"
+                  >
+                    Export JSON
+                  </button>
+                </div>
+              )}
             </div>
           )}
           <button
@@ -234,10 +357,17 @@ export function AuditLog() {
         </div>
       </div>
 
+      <div className="text-xs text-neutral-500 dark:text-neutral-400" data-testid="audit-refresh-status">
+        {lastSuccessAt ? `Last refreshed ${formatRelativeTime(lastSuccessAt)}` : 'Last refreshed pending'}
+      </div>
+
       {/* Error banner */}
       {error && (
         <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 px-4 py-3 rounded-lg flex items-center justify-between">
-          <span className="text-sm">{error}</span>
+          <div className="text-sm">
+            <div className="font-medium">Refresh failed — retrying in {retrySeconds}s</div>
+            <div>{error}</div>
+          </div>
           <button
             onClick={() => setError(null)}
             className="text-red-500 hover:text-red-700 dark:hover:text-red-300"
@@ -262,31 +392,31 @@ export function AuditLog() {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <StatCard
               label="Total Events"
-              value={total.toLocaleString()}
+              value={totalEvents.toLocaleString()}
               icon={ClipboardList}
               colorClass="text-blue-600"
-              subtitle="All audit entries"
+              subtitle={statWindowSubtitle}
             />
             <StatCard
               label="Successful"
               value={successCount}
               icon={Settings}
               colorClass="text-green-600"
-              subtitle="On this page"
+              subtitle={statWindowSubtitle}
             />
             <StatCard
               label="Failed"
               value={failureCount}
               icon={AlertTriangle}
               colorClass={failureCount > 0 ? 'text-red-600' : 'text-green-600'}
-              subtitle="On this page"
+              subtitle={statWindowSubtitle}
             />
             <StatCard
               label="Unique Actors"
               value={uniqueActors}
               icon={User}
               colorClass="text-blue-600"
-              subtitle="On this page"
+              subtitle={statWindowSubtitle}
             />
           </div>
 
@@ -333,13 +463,13 @@ export function AuditLog() {
                   }}
                   className="text-sm border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg px-3 py-2"
                 >
-                  <option value="">All Actions</option>
-                  <option value="create">Create</option>
-                  <option value="update">Update</option>
-                  <option value="delete">Delete</option>
-                  <option value="deploy">Deploy</option>
-                  <option value="login">Login</option>
-                  <option value="access_denied">Access Denied</option>
+                  <option value="">All actions</option>
+                  {actionOptions.map(({ action, count }) => (
+                    <option key={action} value={action}>
+                      {formatActionLabel(action)}
+                      {count > 0 ? ` (${count})` : ''}
+                    </option>
+                  ))}
                 </select>
                 <select
                   value={filters.status || ''}
@@ -422,14 +552,34 @@ export function AuditLog() {
                                 )}
                               </td>
                               <td className="px-4 py-3 text-xs text-neutral-600 dark:text-neutral-400 whitespace-nowrap">
-                                {formatTimestamp(entry.timestamp)}
+                                {formatTimestamp(entry.timestamp, locale)}
                               </td>
                               <td className="px-4 py-3">
                                 <div className="flex items-center gap-2">
                                   <User className="h-3.5 w-3.5 text-neutral-400" />
-                                  <span className="text-neutral-900 dark:text-white">
-                                    {entry.user_email || entry.user_id || 'system'}
-                                  </span>
+                                  {entry.user_email ? (
+                                    <span className="text-neutral-900 dark:text-white">
+                                      {entry.user_email}
+                                    </span>
+                                  ) : entry.user_display_name ? (
+                                    <span className="text-neutral-900 dark:text-white">
+                                      {entry.user_display_name}
+                                    </span>
+                                  ) : entry.user_id ? (
+                                    <>
+                                      <span className="text-neutral-900 dark:text-white">
+                                        {entry.user_id}
+                                      </span>
+                                      <span
+                                        data-testid="actor-unresolved-badge"
+                                        className="rounded bg-neutral-100 px-1.5 py-0.5 text-[10px] font-medium text-neutral-500 dark:bg-neutral-700 dark:text-neutral-300"
+                                      >
+                                        unresolved
+                                      </span>
+                                    </>
+                                  ) : (
+                                    <span className="text-neutral-900 dark:text-white">system</span>
+                                  )}
                                 </div>
                               </td>
                               <td className="px-4 py-3">

--- a/control-plane-ui/src/pages/AuditLog.tsx
+++ b/control-plane-ui/src/pages/AuditLog.tsx
@@ -141,9 +141,7 @@ function buildAuditParams(filters: AuditFilters, page?: number): Record<string, 
 }
 
 function formatActionLabel(action: string): string {
-  return action
-    .replace(/_/g, ' ')
-    .replace(/\b\w/g, (char) => char.toUpperCase());
+  return action.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
 function formatWindowSubtitle(filters: AuditFilters, stats: AuditStatsResponse | null): string {
@@ -231,7 +229,9 @@ export function AuditLog() {
     try {
       const { data } = await apiService.get<AuditActionsResponse>(`/v1/audit/${tenantId}/actions`);
       if (!mountedRef.current) return;
-      const sortedActions = [...(data.actions || [])].sort((a, b) => b.count - a.count).slice(0, 100);
+      const sortedActions = [...(data.actions || [])]
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 100);
       setActions(sortedActions);
     } catch {
       if (mountedRef.current) setActions([]);
@@ -283,7 +283,8 @@ export function AuditLog() {
   const successCount = stats?.success_count ?? entries.filter((e) => e.status === 'success').length;
   const failureCount = stats?.failed_count ?? entries.filter((e) => e.status === 'failure').length;
   const uniqueActors =
-    stats?.unique_actors ?? new Set(entries.map((e) => e.user_email || e.user_id).filter(Boolean)).size;
+    stats?.unique_actors ??
+    new Set(entries.map((e) => e.user_email || e.user_id).filter(Boolean)).size;
   const totalEvents = stats?.total_events ?? total;
   const statWindowSubtitle = formatWindowSubtitle(filters, stats);
   const actionOptions =
@@ -357,8 +358,13 @@ export function AuditLog() {
         </div>
       </div>
 
-      <div className="text-xs text-neutral-500 dark:text-neutral-400" data-testid="audit-refresh-status">
-        {lastSuccessAt ? `Last refreshed ${formatRelativeTime(lastSuccessAt)}` : 'Last refreshed pending'}
+      <div
+        className="text-xs text-neutral-500 dark:text-neutral-400"
+        data-testid="audit-refresh-status"
+      >
+        {lastSuccessAt
+          ? `Last refreshed ${formatRelativeTime(lastSuccessAt)}`
+          : 'Last refreshed pending'}
       </div>
 
       {/* Error banner */}

--- a/control-plane-ui/src/pages/AuditLog.tsx
+++ b/control-plane-ui/src/pages/AuditLog.tsx
@@ -66,7 +66,20 @@ interface AuditFilters {
   search?: string;
 }
 
-interface AuditStatsResponse {
+interface AuditBackendMetadata {
+  source?: string | null;
+  warning?: string | null;
+}
+
+interface AuditListResponse extends AuditBackendMetadata {
+  entries: AuditEntry[];
+  total: number;
+  page: number;
+  page_size: number;
+  has_more: boolean;
+}
+
+interface AuditStatsResponse extends AuditBackendMetadata {
   total_events: number;
   success_count: number;
   failed_count: number;
@@ -82,7 +95,7 @@ interface AuditActionCount {
   count: number;
 }
 
-interface AuditActionsResponse {
+interface AuditActionsResponse extends AuditBackendMetadata {
   actions: AuditActionCount[];
   window_start: string;
   window_end: string;
@@ -164,6 +177,10 @@ function formatRelativeTime(value: Date, now = new Date()): string {
   return `${elapsedHours} hr ago`;
 }
 
+function extractAuditNotice(...responses: AuditBackendMetadata[]): AuditBackendMetadata | null {
+  return responses.find((response) => response.source || response.warning) || null;
+}
+
 export function AuditLog() {
   const { user, isReady, hasRole } = useAuth();
   const { i18n } = useTranslation();
@@ -172,6 +189,10 @@ export function AuditLog() {
   const [total, setTotal] = useState(0);
   const [stats, setStats] = useState<AuditStatsResponse | null>(null);
   const [actions, setActions] = useState<AuditActionCount[]>([]);
+  const [dataBackendNotice, setDataBackendNotice] = useState<AuditBackendMetadata | null>(null);
+  const [actionsBackendNotice, setActionsBackendNotice] = useState<AuditBackendMetadata | null>(
+    null
+  );
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -193,13 +214,7 @@ export function AuditLog() {
       const listParams = buildAuditParams(filters, page);
       const statsParams = buildAuditParams(filters);
       const [{ data }, statsResponse] = await Promise.all([
-        apiService.get<{
-          entries: AuditEntry[];
-          total: number;
-          page: number;
-          page_size: number;
-          has_more: boolean;
-        }>(`/v1/audit/${tenantId}`, { params: listParams }),
+        apiService.get<AuditListResponse>(`/v1/audit/${tenantId}`, { params: listParams }),
         apiService.get<AuditStatsResponse>(`/v1/audit/${tenantId}/stats`, {
           params: statsParams,
         }),
@@ -209,6 +224,7 @@ export function AuditLog() {
       setEntries(data.entries || []);
       setTotal(data.total || 0);
       setStats(statsResponse.data || null);
+      setDataBackendNotice(extractAuditNotice(data, statsResponse.data));
       setError(null);
       setLastSuccessAt(new Date());
       setCurrentInterval(AUTO_REFRESH_INTERVAL);
@@ -219,6 +235,7 @@ export function AuditLog() {
       setEntries([]);
       setTotal(0);
       setStats(null);
+      setDataBackendNotice(null);
       setCurrentInterval((interval) => Math.min(interval * 2, MAX_REFRESH_INTERVAL));
     } finally {
       if (mountedRef.current) setLoading(false);
@@ -233,8 +250,12 @@ export function AuditLog() {
         .sort((a, b) => b.count - a.count)
         .slice(0, 100);
       setActions(sortedActions);
+      setActionsBackendNotice(extractAuditNotice(data));
     } catch {
-      if (mountedRef.current) setActions([]);
+      if (mountedRef.current) {
+        setActions([]);
+        setActionsBackendNotice(null);
+      }
     }
   }, [tenantId]);
 
@@ -290,6 +311,8 @@ export function AuditLog() {
   const actionOptions =
     actions.length > 0 ? actions : LEGACY_ACTION_OPTIONS.map((action) => ({ action, count: 0 }));
   const retrySeconds = Math.ceil(currentInterval / 1000);
+  const backendNotice = dataBackendNotice || actionsBackendNotice;
+  const backendWarning = backendNotice?.warning || 'Audit backend unavailable';
 
   return (
     <div className="space-y-6">
@@ -380,6 +403,16 @@ export function AuditLog() {
           >
             &times;
           </button>
+        </div>
+      )}
+
+      {backendNotice && (
+        <div
+          data-testid="audit-backend-warning"
+          className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-300"
+        >
+          <div className="font-medium">{backendWarning}</div>
+          {backendNotice.source && <div className="mt-1">Source: {backendNotice.source}</div>}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Consume `/v1/audit/{tenant_id}/stats` for AuditLog KPI totals over the filtered window.
- Consume `/v1/audit/{tenant_id}/actions` for the dynamic action filter with legacy fallback.
- Add actor display fallback, last-successful refresh state, exponential retry backoff, CSV/JSON split export, and i18n-aware timestamp formatting.

## References
- Plan: `docs/plans/2026-05-07-observability-data-integrity.md`
- Annex A consumed from the plan contract.
- Depends on PR-1B1: #2737, merge commit `bd408bbb49e07545d3158ab2aa86b96400564d40`.
- PR-1A6 unblock evidence: `docs/audits/2026-05-09-audit-consumer-verification/post-activation.md`.

## Explicit non-goals
- No backend changes.
- No Kafka consumer changes.
- No nav, Live Calls, or Guardrails changes.
- No stoa-infra changes.

## Test plan
- `npm run test -- --run src/pages/AuditLog.test.tsx`
- `npm run test -- --run`
- `npm run lint`
- `npm run build`
- `git diff --check`

Note: PR-1B2 (UI consumption) lands separately and depends on PR-1B1 merging.