### PR TITLE
docs(guardrails): define runtime truth contract

### DIFF
--- a/docs/plans/2026-05-07-observability-data-integrity.md
+++ b/docs/plans/2026-05-07-observability-data-integrity.md
@@ -40,7 +40,7 @@ Restaurer la cohérence et la véracité des trois pages observability (`/observ
 | 7 | PR-1A6 | Activation A1b + post-activation evidence amend | MEGA-A | P0 | PR-1A5 reviewed + operator go | ⏳ stoa-infra #75 merged/activated; post-activation evidence amend pending |
 | 8 | PR-1B | Audit Log API + UI | MEGA-A | P0 | PR-1A6 PASS | blocked — post-activation evidence amend required |
 | 9 | PR-2 | Live Calls metric integrity | MEGA-B | P0 | PR-0 merged | ✅ #2727 merged |
-| 10 | PR-3 | Security & Guardrails runtime truth | MEGA-B | P1 | Annex B locked | blocked |
+| 10 | PR-3 | Security & Guardrails runtime truth | MEGA-B | P1 | PR-3A runtime-truth contract merged | blocked — contract drafted in `docs/plans/2026-05-10-guardrails-runtime-truth-contract.md` |
 | 11 | PR-4 | Navigation IA cleanup | MEGA-B | P2 | PR-3 merged | blocked |
 
 **Total estimated**: ~62 pts (MEGA-A grew to ~32pt/7 phases, MEGA-B 21pt/3 phases, PR-0 1pt).
@@ -178,7 +178,7 @@ Codex peut implémenter directement à partir de ce plan pour les PRs où la sur
 | PR-1A | No | Investigation-only, evidence pack format défini par checklist. |
 | PR-1B | **Yes** | New API endpoints + actor resolution + demo fallback semantics. Voir Annex A. |
 | PR-2 | Partial | PromQL evidence pack (PR-2 step 0) + data integrity rules dans le prompt. Pas de nouveau endpoint. |
-| PR-3 | **Yes** | New `/guardrails/config` endpoint + null/zero/stale/disabled/error semantics. Voir Annex B. |
+| PR-3 | **Yes** | New `/guardrails/config` endpoint + null/zero/stale/disabled/error semantics. Voir Annex B + `docs/plans/2026-05-10-guardrails-runtime-truth-contract.md`. |
 | PR-4 | Partial | Wording IA dépend de AR-1; pas de nouvelle surface API. |
 
 Une mini-spec doit fixer: shape request/response, sémantique d'état (null vs 0 vs disabled vs stale vs error), fallback behavior, acceptance criteria, tests obligatoires. Pas plus.
@@ -923,6 +923,7 @@ Changes:
 **MEGA**: B — Phase 2
 **Estimated**: 8 pts, ~250 LOC
 **Risk**: medium (depends on AR-1, AR-2)
+**Contract**: PR-3 implementation must follow `docs/plans/2026-05-10-guardrails-runtime-truth-contract.md`, which elaborates Annex B and preserves AR-1/AR-2.
 
 ## Goal
 
@@ -942,7 +943,7 @@ S2, S3, S4, S5 (couper le sous-titre), S8 (après AR-1), S9 (sidebar — délég
 ```
 You are working on STOA control-plane-api and control-plane-ui.
 
-PRECONDITION: read docs/plans/2026-05-07-observability-data-integrity.md (section 'Arbitrages requis'). If AR-1 (Security Posture vs Security & Guardrails) is not yet decided, STOP and request decision before proceeding.
+PRECONDITION: read docs/plans/2026-05-07-observability-data-integrity.md (section 'Arbitrages requis') and docs/plans/2026-05-10-guardrails-runtime-truth-contract.md. If AR-1 (Security Posture vs Security & Guardrails) is not yet decided, or if the PR-3A contract is missing/not validated, STOP and request decision before proceeding.
 
 Goal: make /observability/security display real runtime state.
 
@@ -1607,6 +1608,8 @@ Côté UI, exponential backoff sur erreur:
 # Annex B — Mini-spec: Guardrails runtime state contract (PR-3)
 
 **Lock this annex before PR-3 starts**. Bug racine actuel: `metrics?.guardrails?.pii_detections || 0` masque `null` en `0`. Cette annexe fixe les sémantiques pour empêcher la régression.
+
+**PR-3A implementation contract**: `docs/plans/2026-05-10-guardrails-runtime-truth-contract.md` elaborates this annex for implementation. It does not change the validated AR-1/AR-2 decisions above.
 
 ## Endpoints
 

--- a/docs/plans/2026-05-10-guardrails-runtime-truth-contract.md
+++ b/docs/plans/2026-05-10-guardrails-runtime-truth-contract.md
@@ -1,0 +1,239 @@
+---
+id: plan-2026-05-10-guardrails-runtime-truth-contract
+validation_status: validated
+plan_ref: docs/plans/2026-05-07-observability-data-integrity.md
+source_evidence:
+  - docs/audits/2026-05-07-observability/AUDIT.md
+---
+
+# PR-3A — Guardrails Runtime Truth Contract
+## Context
+
+This mini-spec locks the runtime truth contract for `/observability/security` before PR-3 implementation. It elaborates Annex B in `docs/plans/2026-05-07-observability-data-integrity.md` without changing AR-1 or AR-2.
+
+Root bug: the current UI can collapse unknown guardrail metrics into `0`, which makes disabled, enabled-with-zero-events, stale, and broken data sources look identical.
+## Scope
+
+In scope:
+- `GET /v1/admin/gateways/guardrails/config`.
+- Guardrails metrics shape under `GET /v1/admin/gateways/metrics`.
+- Freshness, `null` vs `0`, disabled vs enabled+0, stale vs error semantics.
+- Time range behavior for metrics and guardrails events.
+- Rate Limit ownership per AR-2.
+- Security Posture vs Security & Guardrails wording per AR-1.
+
+Out of scope:
+- Code implementation.
+- Security Posture backend changes.
+- Navigation/sidebar cleanup beyond the AR-1 wording contract.
+- Moving Rate Limit into Live Calls.
+- New OPA policy event ingestion.
+## Canonical product decisions
+
+AR-1 is already validated in the canonical plan: do not merge Security Posture and Security & Guardrails. Use distinct scopes and wording:
+
+| Route | Title | Subtitle |
+|---|---|---|
+| `/observability/security` | Security & Guardrails | Runtime events — guardrail decisions, PII/prompt/content/rate-limit monitoring |
+| `/security-posture` | Security Posture | Compliance findings, security score, configuration assessment |
+
+AR-2 is already validated in the canonical plan: Rate Limit belongs to Security & Guardrails because rate limiting is a protection outcome, not a traffic-volume signal. Live Calls may expose traffic, latency, and errors, but does not own rate-limit guardrail truth.
+## Endpoint: `GET /v1/admin/gateways/guardrails/config`
+
+Returns the effective guardrail enablement state used by the running gateway/control-plane integration.
+
+```json
+{
+  "pii_enabled": true,
+  "injection_detection_enabled": true,
+  "prompt_guard_enabled": true,
+  "content_filter_enabled": true,
+  "rate_limit_enabled": true,
+  "opa_policy_enabled": true,
+  "source": "env",
+  "updated_at": "2026-05-10T00:00:00Z"
+}
+```
+
+Field rules:
+
+| Field | Type | Semantics |
+|---|---|---|
+| `pii_enabled` | boolean | Effective PII detection runtime/config state. |
+| `injection_detection_enabled` | boolean | Effective prompt injection detection runtime/config state. |
+| `prompt_guard_enabled` | boolean | Effective prompt guard runtime/config state. |
+| `content_filter_enabled` | boolean | Effective content filtering runtime/config state. |
+| `rate_limit_enabled` | boolean | Effective rate-limit protection runtime/config state. |
+| `opa_policy_enabled` | boolean | Effective OPA policy evaluation runtime/config state. |
+| `source` | `"env" \| "runtime" \| "config-service"` | Authority used for the values in this response. |
+| `updated_at` | ISO-8601 UTC string | Time at which the backend last evaluated or refreshed this config state. |
+
+`source` values:
+- `env`: values are derived from environment/config values visible to the control plane or gateway process.
+- `runtime`: values are derived from a live gateway runtime/admin endpoint.
+- `config-service`: values are derived from a config service that is authoritative for the gateway.
+
+Config booleans are not UI preferences. They are the backend's best statement of the effective runtime state. The response must not use `null` for config booleans; if the backend cannot determine the state, the request should fail instead of returning guessed booleans.
+## Guardrails metrics response
+
+`GET /v1/admin/gateways/metrics?range=<range>` must include the guardrails object below. The object may be returned by the existing metrics endpoint or by a compatible sibling endpoint, but `/observability/security` consumes these exact field names.
+
+```json
+{
+  "guardrails": {
+    "pii_detections": 0,
+    "injection_blocks": 0,
+    "prompt_guard_blocks": 0,
+    "content_filter_blocks": 0,
+    "rate_limit_blocks": 0,
+    "last_sample_at": "2026-05-10T00:00:00Z",
+    "metrics_age_seconds": 12,
+    "source_healthy": true
+  }
+}
+```
+
+Type contract:
+
+```ts
+{
+  guardrails: {
+    pii_detections: number | null,
+    injection_blocks: number | null,
+    prompt_guard_blocks: number | null,
+    content_filter_blocks: number | null,
+    rate_limit_blocks: number | null,
+    last_sample_at: string | null,
+    metrics_age_seconds: number | null,
+    source_healthy: boolean
+  }
+}
+```
+
+Metric-to-config mapping:
+
+| Metric field | Config owner |
+|---|---|
+| `pii_detections` | `pii_enabled` |
+| `injection_blocks` | `injection_detection_enabled` |
+| `prompt_guard_blocks` | `prompt_guard_enabled` |
+| `content_filter_blocks` | `content_filter_enabled` |
+| `rate_limit_blocks` | `rate_limit_enabled` |
+
+`opa_policy_enabled` is config-only in this contract. Adding OPA runtime counters later is a contract change and must not be hidden inside an existing metric.
+## Freshness semantics
+
+Freshness describes the metrics source, not the guardrail config source.
+
+| Field | Rule |
+|---|---|
+| `last_sample_at` | ISO-8601 UTC timestamp of the newest metrics sample used for the guardrails values. `null` means no usable sample was returned. |
+| `metrics_age_seconds` | Backend-computed age of `last_sample_at` at response time. `null` iff `last_sample_at` is `null`. |
+| `source_healthy` | `true` when the metrics query succeeded and the response was interpretable. `false` when the metrics backend/query failed or returned an invalid response. |
+
+Stale threshold: metrics are stale when `source_healthy=true`, `last_sample_at` is not `null`, and `metrics_age_seconds > 60`.
+
+Precedence:
+1. Backend transport error or invalid response: UI renders "Metrics unavailable".
+2. Feature disabled by config: UI renders "Disabled".
+3. `source_healthy=false`: UI renders "Metrics unavailable".
+4. `last_sample_at=null` or the card's count is `null`: UI renders "No metrics sample".
+5. `metrics_age_seconds > 60`: UI renders "Stale metrics".
+6. Healthy numeric value: UI renders the count and latest sample context.
+## `null` vs `0` semantics
+
+`0` means the metrics source was healthy and the backend can prove that zero matching events occurred for the selected time range.
+
+`null` means unknown, unavailable, not sampled, or not safely distinguishable from absent instrumentation. The backend must preserve `null`; the frontend must not coerce it to `0`.
+
+Forbidden UI pattern:
+
+```ts
+metrics?.guardrails?.pii_detections || 0
+```
+
+Required UI pattern:
+
+```ts
+const count = metrics?.guardrails?.pii_detections;
+if (count === null || count === undefined) {
+  return "No metrics sample";
+}
+return `${count} events`;
+```
+## Disabled vs enabled+0
+
+Disabled state comes from `GET /v1/admin/gateways/guardrails/config`. A disabled feature is rendered as disabled even if the metrics payload contains `0` or `null` for the corresponding counter.
+
+Enabled+0 means the feature is enabled, the metrics source is healthy and fresh, and the corresponding count is exactly `0`.
+
+Required UI state rules:
+
+| State | Required rendering |
+|---|---|
+| enabled + healthy + `0` | "0 events · last sample ..." |
+| disabled | "Disabled" |
+| `null` sample | "No metrics sample" |
+| stale | "Stale metrics" |
+| backend error | "Metrics unavailable" |
+
+The UI may include icons, colors, or relative timestamps, but the visible semantic text above must be present.
+## Stale vs error
+
+Stale is a successful read of old metrics. Error is a failed read.
+
+| Condition | Meaning | UI |
+|---|---|---|
+| HTTP request fails, times out, or response is invalid | Metrics backend unavailable or contract broken | "Metrics unavailable" |
+| `source_healthy=false` | Metrics backend/query failed behind a successful API response | "Metrics unavailable" |
+| `source_healthy=true`, `last_sample_at=null` | Query worked but no sample exists | "No metrics sample" |
+| `source_healthy=true`, `last_sample_at!=null`, `metrics_age_seconds > 60` | Source is reachable but sample is too old | "Stale metrics" |
+
+The UI must not render stale as an error, and must not render an error as stale.
+## Time range behavior
+
+Supported ranges are aligned with Live Calls:
+
+```text
+1h / 6h / 24h / 7d
+```
+
+Rules:
+- The selected range is passed to `GET /v1/admin/gateways/metrics`.
+- The selected range is passed to `GET /v1/admin/gateways/metrics/guardrails/events` if the events endpoint supports range filtering; if not, PR-3 must add or document equivalent behavior before showing a range selector for events.
+- Counts reflect the selected range only.
+- `last_sample_at` and `metrics_age_seconds` describe the newest metrics sample used, not the range start or end.
+- `GET /v1/admin/gateways/guardrails/config` is not range-dependent and must not be refetched solely because the time range changed.
+- Empty query results are `0` only when the metrics source is healthy and the backend can prove no events occurred in the selected range. Otherwise they remain `null`.
+## Rate Limit ownership per AR-2
+
+Rate Limit stays in Security & Guardrails.
+
+Implementation constraints for PR-3:
+- The Rate Limit card is backed by `rate_limit_enabled` and `rate_limit_blocks`.
+- If clickable, it must filter to `rate-limit` events.
+- If no reliable rate-limit event stream exists, the card must be non-clickable or show an explicit empty state such as "No rate-limit events".
+- It must never route through a synthetic `all` filter that silently changes semantics.
+## Acceptance criteria
+
+- [ ] `GET /v1/admin/gateways/guardrails/config` returns the documented shape and real effective booleans.
+- [ ] Guardrails metrics expose `last_sample_at`, `metrics_age_seconds`, and `source_healthy`.
+- [ ] `null` is preserved and is never collapsed into `0`.
+- [ ] UI distinguishes disabled, enabled+0, no sample, stale, and error.
+- [ ] Time range selection affects guardrails metrics and events consistently.
+- [ ] Rate Limit remains in Security & Guardrails per AR-2.
+- [ ] `/observability/security` and `/security-posture` use the AR-1 wording exactly.
+## Required tests for PR-3 implementation
+
+Backend:
+- Config endpoint returns the exact response shape.
+- Metrics endpoint preserves `null` vs `0`.
+- Metrics endpoint includes freshness fields.
+- Source failure returns `source_healthy=false` or an API error, never fake zeroes.
+
+Frontend:
+- Config panel renders enabled/disabled states from `/guardrails/config`.
+- Cards render enabled+0, enabled+N, disabled, no-sample, stale, and error states.
+- Time range selector propagates to metrics and guardrails events fetches.
+- Rate Limit does not use a synthetic `all` filter.
+- Page title/subtitle match AR-1 wording.


### PR DESCRIPTION
## Summary

PR-3A — Guardrails runtime truth mini-spec (docs-only).

Defines the contract for `/observability/security` before the PR-3B implementation:
- `GET /v1/admin/gateways/guardrails/config` shape
- metrics freshness semantics
- null vs 0 vs disabled vs stale vs error UI rendering rules
- time range behavior aligned with Live Calls
- Rate Limit ownership per AR-2 (stays in Security & Guardrails)
- Security Posture vs Security & Guardrails wording per AR-1 (clarify, no fusion)

Contract file: `docs/plans/2026-05-10-guardrails-runtime-truth-contract.md`.
Plan canon updated with PR-3A pointer; AR-1 / AR-2 decisions unchanged.

## Non-goals

- No code changes.
- No PR-3B implementation in this PR.
- No backend / UI / infra changes.

## Validation

- [x] `git diff --check` clean
- [x] Docs-only diff (plan canon pointer + new mini-spec file)

## Cross-refs

- Plan canon: [docs/plans/2026-05-07-observability-data-integrity.md](https://github.com/stoa-platform/stoa/blob/main/docs/plans/2026-05-07-observability-data-integrity.md)
- AR-1 / AR-2 decisions inline in plan canon, validated 2026-05-07.