### PR TITLE
feat(api): guardrails /config endpoint + metrics freshness

### DIFF
--- a/control-plane-api/src/routers/gateway_observability.py
+++ b/control-plane-api/src/routers/gateway_observability.py
@@ -8,9 +8,13 @@ Phase 2 (CAB-1635): per-tenant filtering, adapter operation metrics, health hist
 """
 
 import logging
+import os
+from datetime import UTC, datetime
+from typing import Literal, cast
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.auth.rbac import require_role
@@ -24,16 +28,85 @@ router = APIRouter(
     tags=["Gateway Observability"],
 )
 
+GuardrailsConfigSource = Literal["env", "runtime", "config-service"]
+TimeRange = Literal["1h", "6h", "24h", "7d"]
+
+
+class GuardrailsConfigResponse(BaseModel):
+    """Effective guardrails runtime/config state per PR-3A contract."""
+
+    pii_enabled: bool
+    injection_detection_enabled: bool
+    prompt_guard_enabled: bool
+    content_filter_enabled: bool
+    rate_limit_enabled: bool
+    opa_policy_enabled: bool
+    source: GuardrailsConfigSource
+    updated_at: datetime
+
 
 def _tenant_filter(user) -> str | None:
     """Return tenant_id for filtering: None for cpi-admin (sees all), user's tenant otherwise."""
     if "cpi-admin" in user.roles:
         return None
-    return user.tenant_id
+    return cast(str | None, user.tenant_id)
+
+
+def _read_bool_env(name: str) -> bool:
+    """Read a required boolean env value without guessing absent runtime state."""
+    raw = os.environ.get(name)
+    if raw is None:
+        raise HTTPException(status_code=503, detail=f"Guardrails config env missing: {name}")
+
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on", "enabled"}:
+        return True
+    if normalized in {"0", "false", "no", "off", "disabled"}:
+        return False
+
+    raise HTTPException(status_code=503, detail=f"Guardrails config env invalid: {name}")
+
+
+def _read_rate_limit_enabled() -> bool:
+    """Read rate-limit enablement from explicit bool or numeric gateway default."""
+    if os.environ.get("STOA_RATE_LIMIT_ENABLED") is not None:
+        return _read_bool_env("STOA_RATE_LIMIT_ENABLED")
+
+    raw = os.environ.get("STOA_RATE_LIMIT_DEFAULT")
+    if raw is None:
+        raise HTTPException(status_code=503, detail="Guardrails config env missing: STOA_RATE_LIMIT_DEFAULT")
+
+    try:
+        return int(raw.strip()) > 0
+    except ValueError:
+        raise HTTPException(status_code=503, detail="Guardrails config env invalid: STOA_RATE_LIMIT_DEFAULT")
+
+
+def _guardrails_config_from_env() -> GuardrailsConfigResponse:
+    """Build the config response from gateway/control-plane visible env."""
+    return GuardrailsConfigResponse(
+        pii_enabled=_read_bool_env("STOA_GUARDRAILS_PII_ENABLED"),
+        injection_detection_enabled=_read_bool_env("STOA_GUARDRAILS_INJECTION_ENABLED"),
+        prompt_guard_enabled=_read_bool_env("STOA_PROMPT_GUARD_ENABLED"),
+        content_filter_enabled=_read_bool_env("STOA_GUARDRAILS_CONTENT_FILTER_ENABLED"),
+        rate_limit_enabled=_read_rate_limit_enabled(),
+        opa_policy_enabled=_read_bool_env("STOA_POLICY_ENABLED"),
+        source="env",
+        updated_at=datetime.now(UTC),
+    )
+
+
+@router.get("/guardrails/config", response_model=GuardrailsConfigResponse)
+async def get_guardrails_config(
+    user=Depends(require_role(["cpi-admin", "tenant-admin"])),
+) -> GuardrailsConfigResponse:
+    """Effective Guardrails config state for /observability/security."""
+    return _guardrails_config_from_env()
 
 
 @router.get("/metrics")
 async def get_aggregated_metrics(
+    time_range: TimeRange = Query("1h", alias="range"),
     db: AsyncSession = Depends(get_db),
     user=Depends(require_role(["cpi-admin", "tenant-admin"])),
 ):
@@ -42,13 +115,14 @@ async def get_aggregated_metrics(
     cpi-admin sees all gateways; tenant-admin sees only own tenant's gateways.
     """
     svc = GatewayMetricsService(db)
-    return await svc.get_aggregated_metrics(tenant_id=_tenant_filter(user))
+    return await svc.get_aggregated_metrics(tenant_id=_tenant_filter(user), time_range=time_range)
 
 
 @router.get("/metrics/guardrails/events")
 async def get_guardrails_events(
     limit: int = 50,
-    time_range_minutes: int = 60,
+    time_range: TimeRange = Query("1h", alias="range"),
+    time_range_minutes: int | None = None,
     user=Depends(require_role(["cpi-admin", "tenant-admin"])),
 ):
     """Recent guardrails events (blocked, redacted, flagged) from OpenSearch spans.
@@ -62,10 +136,11 @@ async def get_guardrails_events(
         return {"events": [], "total": 0}
 
     tenant_id = _tenant_filter(user)
+    range_minutes = {"1h": 60, "6h": 360, "24h": 1440, "7d": 10080}[time_range]
 
     try:
         filters: list[dict] = [
-            {"range": {"startTime": {"gte": f"now-{time_range_minutes}m"}}},
+            {"range": {"startTime": {"gte": f"now-{time_range_minutes if time_range_minutes is not None else range_minutes}m"}}},
             {"term": {"name": "policy.guardrails"}},
             {"exists": {"field": "span.attributes.guardrails@action"}},
         ]
@@ -136,7 +211,7 @@ async def get_adapter_operation_metrics(
     Returns per-gateway-type: total_ops, success_rate, avg_latency_ms.
     cpi-admin only (process-wide metrics, not tenant-scoped).
     """
-    svc = GatewayMetricsService(db=None)  # type: ignore[arg-type]
+    svc = GatewayMetricsService(db=None)
     return svc.get_adapter_operation_metrics()
 
 

--- a/control-plane-api/src/services/gateway_metrics_service.py
+++ b/control-plane-api/src/services/gateway_metrics_service.py
@@ -4,6 +4,8 @@ Phase 2 (CAB-1635): per-tenant filtering, adapter operation metrics, health hist
 """
 
 import logging
+from datetime import UTC, datetime
+from typing import Any, Literal
 from uuid import UUID
 
 from sqlalchemy import func, select
@@ -18,6 +20,21 @@ from src.models.gateway_instance import GatewayInstance, GatewayInstanceStatus
 from src.services.prometheus_client import prometheus_client
 
 logger = logging.getLogger(__name__)
+
+TimeRange = Literal["1h", "6h", "24h", "7d"]
+
+_GUARDRAILS_TOTAL_QUERIES: dict[str, str] = {
+    "pii_detections": "sum(increase(stoa_guardrails_pii_detected_total[{range}]))",
+    "injection_blocks": "sum(increase(stoa_guardrails_injection_blocked_total[{range}]))",
+    "content_filter_blocks": "sum(increase(stoa_guardrails_content_filtered_total[{range}]))",
+    "prompt_guard_blocks": "sum(increase(stoa_prompt_guard_detected_total[{range}]))",
+}
+
+_RATE_LIMIT_BLOCK_QUERIES: tuple[str, ...] = (
+    "sum(increase(stoa_rate_limit_hits_total[{range}]))",
+    "sum(increase(stoa_api_proxy_rate_limited_total[{range}]))",
+    "sum(increase(stoa_ws_proxy_rate_limited_total[{range}]))",
+)
 
 
 class GatewayMetricsService:
@@ -138,38 +155,119 @@ class GatewayMetricsService:
             "recent_errors": recent_errors,
         }
 
-    async def _fetch_guardrails_metrics(self) -> dict:
-        """Fetch guardrails counters + per-tool breakdown from Prometheus."""
-        guardrails: dict = {
-            "pii_detections": 0,
-            "injection_blocks": 0,
-            "content_filters": 0,
-            "prompt_guard_flags": 0,
+    @staticmethod
+    def _empty_guardrails_metrics(source_healthy: bool) -> dict[str, Any]:
+        return {
+            "pii_detections": None,
+            "injection_blocks": None,
+            "prompt_guard_blocks": None,
+            "content_filter_blocks": None,
+            "rate_limit_blocks": None,
+            "last_sample_at": None,
+            "metrics_age_seconds": None,
+            "source_healthy": source_healthy,
+            # Compatibility fields for the current UI until PR-3B2 consumes the contract names.
+            "content_filters": None,
+            "prompt_guard_flags": None,
+            "rate_limit_enforcements": None,
             "by_tool": {},
             "by_category": {},
         }
+
+    @staticmethod
+    def _extract_prometheus_scalar(result: dict[str, Any] | None) -> tuple[int | None, datetime | None, bool]:
+        """Return scalar value, sample timestamp, and whether the result was interpretable."""
+        if result is None:
+            return None, None, False
+
+        values = result.get("result")
+        if not isinstance(values, list):
+            return None, None, False
+        if not values:
+            return None, None, True
+
+        raw_value = values[0].get("value")
+        if not isinstance(raw_value, list) or len(raw_value) < 2:
+            return None, None, False
+
+        try:
+            sample_at = datetime.fromtimestamp(float(raw_value[0]), UTC)
+            numeric = float(raw_value[1])
+        except (TypeError, ValueError, OSError):
+            return None, None, False
+
+        if numeric != numeric or numeric in {float("inf"), float("-inf")}:
+            return None, None, False
+
+        return int(numeric), sample_at, True
+
+    @staticmethod
+    def _metrics_age_seconds(last_sample_at: datetime | None) -> int | None:
+        if last_sample_at is None:
+            return None
+        return max(0, int(datetime.now(UTC).timestamp() - last_sample_at.timestamp()))
+
+    async def _fetch_guardrails_metrics(self, time_range: TimeRange = "1h") -> dict[str, Any]:
+        """Fetch guardrails counters + freshness from Prometheus."""
+        guardrails = self._empty_guardrails_metrics(source_healthy=False)
         if not prometheus_client.is_enabled:
             return guardrails
 
-        # Totals
-        totals = {
-            "pii_detections": "sum(stoa_guardrails_pii_detected_total) or vector(0)",
-            "injection_blocks": "sum(stoa_guardrails_injection_blocked_total) or vector(0)",
-            "content_filters": "sum(stoa_guardrails_content_filtered_total) or vector(0)",
-            "prompt_guard_flags": "sum(stoa_prompt_guard_detected_total) or vector(0)",
-        }
-        for key, promql in totals.items():
+        guardrails = self._empty_guardrails_metrics(source_healthy=True)
+        source_healthy = True
+        newest_sample_at: datetime | None = None
+
+        for key, promql_template in _GUARDRAILS_TOTAL_QUERIES.items():
             try:
-                result = await prometheus_client.query(promql)
-                if result and result.get("result"):
-                    val = result["result"][0].get("value", [None, "0"])
-                    guardrails[key] = int(float(val[1]))
+                result = await prometheus_client.query(promql_template.format(range=time_range))
             except Exception:
                 logger.debug("Failed to fetch guardrails metric %s", key)
+                source_healthy = False
+                continue
+
+            value, sample_at, interpretable = self._extract_prometheus_scalar(result)
+            if not interpretable:
+                source_healthy = False
+                continue
+            guardrails[key] = value
+            if sample_at and (newest_sample_at is None or sample_at > newest_sample_at):
+                newest_sample_at = sample_at
+
+        rate_limit_values: list[int] = []
+        for promql_template in _RATE_LIMIT_BLOCK_QUERIES:
+            try:
+                result = await prometheus_client.query(promql_template.format(range=time_range))
+            except Exception:
+                logger.debug("Failed to fetch rate-limit guardrails metric")
+                source_healthy = False
+                continue
+
+            value, sample_at, interpretable = self._extract_prometheus_scalar(result)
+            if not interpretable:
+                source_healthy = False
+                continue
+            if value is not None:
+                rate_limit_values.append(value)
+            if sample_at and (newest_sample_at is None or sample_at > newest_sample_at):
+                newest_sample_at = sample_at
+
+        if rate_limit_values:
+            guardrails["rate_limit_blocks"] = sum(rate_limit_values)
+
+        guardrails["last_sample_at"] = newest_sample_at.isoformat() if newest_sample_at else None
+        guardrails["metrics_age_seconds"] = self._metrics_age_seconds(newest_sample_at)
+        guardrails["source_healthy"] = source_healthy
+
+        # Compatibility aliases for the current UI. PR-3B2 consumes the canonical names.
+        guardrails["content_filters"] = guardrails["content_filter_blocks"]
+        guardrails["prompt_guard_flags"] = guardrails["prompt_guard_blocks"]
+        guardrails["rate_limit_enforcements"] = guardrails["rate_limit_blocks"]
 
         # Breakdown by tool (injection)
         try:
-            result = await prometheus_client.query("sum by (tool) (stoa_guardrails_injection_blocked_total)")
+            result = await prometheus_client.query(
+                f"sum by (tool) (increase(stoa_guardrails_injection_blocked_total[{time_range}]))"
+            )
             if result and result.get("result"):
                 for item in result["result"]:
                     tool = item.get("metric", {}).get("tool", "unknown")
@@ -180,7 +278,9 @@ class GatewayMetricsService:
 
         # Breakdown by category (content filter)
         try:
-            result = await prometheus_client.query("sum by (category) (stoa_guardrails_content_filtered_total)")
+            result = await prometheus_client.query(
+                f"sum by (category) (increase(stoa_guardrails_content_filtered_total[{time_range}]))"
+            )
             if result and result.get("result"):
                 for item in result["result"]:
                     cat = item.get("metric", {}).get("category", "unknown")
@@ -191,7 +291,9 @@ class GatewayMetricsService:
 
         # Breakdown by tool (PII — via recent rate to identify which tools leak PII)
         try:
-            result = await prometheus_client.query("sum by (tool) (stoa_guardrails_pii_detected_total)")
+            result = await prometheus_client.query(
+                f"sum by (tool) (increase(stoa_guardrails_pii_detected_total[{time_range}]))"
+            )
             if result and result.get("result"):
                 for item in result["result"]:
                     tool = item.get("metric", {}).get("tool", "unknown")
@@ -203,11 +305,11 @@ class GatewayMetricsService:
 
         return guardrails
 
-    async def get_aggregated_metrics(self, tenant_id: str | None = None) -> dict:
+    async def get_aggregated_metrics(self, tenant_id: str | None = None, time_range: TimeRange = "1h") -> dict:
         """Combined health + sync summaries + guardrails + overall_status."""
         health = await self.get_health_summary(tenant_id=tenant_id)
         sync = await self.get_sync_status_summary(tenant_id=tenant_id)
-        guardrails = await self._fetch_guardrails_metrics()
+        guardrails = await self._fetch_guardrails_metrics(time_range=time_range)
 
         # Determine overall status
         total_gateways = health.get("total_gateways", 0)

--- a/control-plane-api/tests/test_gateway_observability_router.py
+++ b/control-plane-api/tests/test_gateway_observability_router.py
@@ -8,15 +8,116 @@ Endpoints:
 RBAC: require_role(["cpi-admin", "tenant-admin"])
 """
 
+from typing import get_args
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 from fastapi import Depends
 from fastapi.testclient import TestClient
+import pytest
+
+
+_GUARDRAILS_ENV = {
+    "STOA_GUARDRAILS_PII_ENABLED": "true",
+    "STOA_GUARDRAILS_INJECTION_ENABLED": "false",
+    "STOA_PROMPT_GUARD_ENABLED": "true",
+    "STOA_GUARDRAILS_CONTENT_FILTER_ENABLED": "false",
+    "STOA_RATE_LIMIT_DEFAULT": "1000",
+    "STOA_POLICY_ENABLED": "true",
+}
 
 
 class TestGatewayObservabilityRouter:
     """Test suite for Gateway Observability endpoints."""
+
+    # ============== GET /guardrails/config ==============
+
+    def test_guardrails_config_endpoint_returns_documented_shape(self, app_with_cpi_admin, mock_db_session):
+        """GET /guardrails/config returns the PR-3A documented shape."""
+        with patch.dict("os.environ", _GUARDRAILS_ENV, clear=False):
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/admin/gateways/guardrails/config")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert set(data) == {
+            "pii_enabled",
+            "injection_detection_enabled",
+            "prompt_guard_enabled",
+            "content_filter_enabled",
+            "rate_limit_enabled",
+            "opa_policy_enabled",
+            "source",
+            "updated_at",
+        }
+        assert data["source"] == "env"
+        assert isinstance(data["updated_at"], str)
+
+    def test_guardrails_config_booleans_never_null(self, app_with_cpi_admin, mock_db_session):
+        """All six guardrails config fields are non-null booleans."""
+        with patch.dict("os.environ", _GUARDRAILS_ENV, clear=False):
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/admin/gateways/guardrails/config")
+
+        assert response.status_code == 200
+        data = response.json()
+        for field in (
+            "pii_enabled",
+            "injection_detection_enabled",
+            "prompt_guard_enabled",
+            "content_filter_enabled",
+            "rate_limit_enabled",
+            "opa_policy_enabled",
+        ):
+            assert isinstance(data[field], bool)
+
+    def test_guardrails_config_source_enum(self, app_with_cpi_admin, mock_db_session):
+        """The response model source enum is exactly the PR-3A contract set."""
+        from src.routers.gateway_observability import GuardrailsConfigResponse
+
+        source_values = set(get_args(GuardrailsConfigResponse.model_fields["source"].annotation))
+        assert source_values == {"env", "runtime", "config-service"}
+
+        with patch.dict("os.environ", _GUARDRAILS_ENV, clear=False):
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/admin/gateways/guardrails/config")
+
+        assert response.status_code == 200
+        assert response.json()["source"] in source_values
+
+    def test_guardrails_config_missing_env_fails_closed(self, app_with_cpi_admin, mock_db_session):
+        """Missing effective env state fails instead of returning guessed booleans."""
+        env = dict(_GUARDRAILS_ENV)
+        env.pop("STOA_GUARDRAILS_PII_ENABLED")
+
+        with patch.dict("os.environ", env, clear=True):
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/admin/gateways/guardrails/config")
+
+        assert response.status_code == 503
+        assert "STOA_GUARDRAILS_PII_ENABLED" in response.json()["detail"]
+
+    def test_guardrails_config_invalid_env_fails_closed(self, app_with_cpi_admin, mock_db_session):
+        """Invalid effective env state fails instead of returning guessed booleans."""
+        env = dict(_GUARDRAILS_ENV, STOA_GUARDRAILS_PII_ENABLED="maybe")
+
+        with patch.dict("os.environ", env, clear=True):
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/admin/gateways/guardrails/config")
+
+        assert response.status_code == 503
+        assert "invalid" in response.json()["detail"]
+
+    def test_guardrails_config_explicit_rate_limit_bool(self, app_with_cpi_admin, mock_db_session):
+        """Explicit STOA_RATE_LIMIT_ENABLED is honored over numeric default."""
+        env = dict(_GUARDRAILS_ENV, STOA_RATE_LIMIT_ENABLED="false")
+
+        with patch.dict("os.environ", env, clear=True):
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/admin/gateways/guardrails/config")
+
+        assert response.status_code == 200
+        assert response.json()["rate_limit_enabled"] is False
 
     # ============== GET /metrics ==============
 
@@ -75,6 +176,163 @@ class TestGatewayObservabilityRouter:
 
         assert response.status_code == 403
         app.dependency_overrides.clear()
+
+    def test_guardrails_metrics_preserves_null_vs_zero(self, app_with_cpi_admin, mock_db_session):
+        """Guardrails metrics preserve unknown null separately from healthy zero."""
+        mock_metrics = {
+            "health": {"total_gateways": 0},
+            "sync": {"error": 0, "drifted": 0},
+            "guardrails": {
+                "pii_detections": None,
+                "injection_blocks": 0,
+                "prompt_guard_blocks": None,
+                "content_filter_blocks": 0,
+                "rate_limit_blocks": None,
+                "last_sample_at": "2026-05-10T00:00:00+00:00",
+                "metrics_age_seconds": 12,
+                "source_healthy": True,
+            },
+            "overall_status": "unknown",
+        }
+
+        with patch("src.routers.gateway_observability.GatewayMetricsService") as MockSvc:
+            MockSvc.return_value.get_aggregated_metrics = AsyncMock(return_value=mock_metrics)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/admin/gateways/metrics")
+
+        assert response.status_code == 200
+        guardrails = response.json()["guardrails"]
+        assert guardrails["pii_detections"] is None
+        assert guardrails["injection_blocks"] == 0
+        assert guardrails["content_filter_blocks"] == 0
+        assert guardrails["rate_limit_blocks"] is None
+
+    def test_guardrails_metrics_includes_freshness_fields(self, app_with_cpi_admin, mock_db_session):
+        """Guardrails metrics include freshness fields required by PR-3A."""
+        mock_metrics = {
+            "health": {"total_gateways": 0},
+            "sync": {"error": 0, "drifted": 0},
+            "guardrails": {
+                "pii_detections": 1,
+                "injection_blocks": 0,
+                "prompt_guard_blocks": 0,
+                "content_filter_blocks": 0,
+                "rate_limit_blocks": 0,
+                "last_sample_at": "2026-05-10T00:00:00+00:00",
+                "metrics_age_seconds": 12,
+                "source_healthy": True,
+            },
+            "overall_status": "unknown",
+        }
+
+        with patch("src.routers.gateway_observability.GatewayMetricsService") as MockSvc:
+            MockSvc.return_value.get_aggregated_metrics = AsyncMock(return_value=mock_metrics)
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/admin/gateways/metrics")
+
+        assert response.status_code == 200
+        guardrails = response.json()["guardrails"]
+        assert "last_sample_at" in guardrails
+        assert "metrics_age_seconds" in guardrails
+        assert "source_healthy" in guardrails
+
+    @pytest.mark.asyncio
+    async def test_guardrails_metrics_source_healthy_false_on_query_failure(self, mock_db_session):
+        """Prometheus query failure sets source_healthy=false instead of fake zeroes."""
+        from src.services.gateway_metrics_service import GatewayMetricsService
+
+        svc = GatewayMetricsService(mock_db_session)
+
+        with patch("src.services.gateway_metrics_service.prometheus_client") as mock_prometheus:
+            mock_prometheus.is_enabled = True
+            mock_prometheus.query = AsyncMock(return_value=None)
+
+            result = await svc._fetch_guardrails_metrics(time_range="1h")
+
+        assert result["source_healthy"] is False
+        assert result["pii_detections"] is None
+        assert result["last_sample_at"] is None
+        assert result["metrics_age_seconds"] is None
+
+    def test_guardrails_metrics_range_filter(self, app_with_cpi_admin, mock_db_session):
+        """GET /metrics accepts Live Calls-aligned range and passes it to the service."""
+        mock_metrics = {
+            "health": {"total_gateways": 0},
+            "sync": {"error": 0, "drifted": 0},
+            "guardrails": {},
+            "overall_status": "unknown",
+        }
+
+        with patch("src.routers.gateway_observability.GatewayMetricsService") as MockSvc:
+            get_aggregated_metrics = AsyncMock(return_value=mock_metrics)
+            MockSvc.return_value.get_aggregated_metrics = get_aggregated_metrics
+
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/admin/gateways/metrics?range=6h")
+
+        assert response.status_code == 200
+        get_aggregated_metrics.assert_awaited_once_with(tenant_id=None, time_range="6h")
+
+    # ============== GET /metrics/guardrails/events ==============
+
+    def test_guardrails_events_accepts_range_filter(self, app_with_tenant_admin, mock_db_session):
+        """Guardrails events accepts Live Calls-aligned range and maps it to OpenSearch."""
+        mock_client = MagicMock()
+        mock_client.search = AsyncMock(
+            return_value={
+                "hits": {
+                    "hits": [
+                        {
+                            "_source": {
+                                "startTime": "2026-05-10T00:00:00Z",
+                                "traceId": "trace-1",
+                                "spanId": "span-1",
+                                "span.attributes.guardrails@tool": "tool-a",
+                                "span.attributes.guardrails@action": "blocked",
+                                "span.attributes.guardrails@reason": "injection",
+                            }
+                        }
+                    ]
+                }
+            }
+        )
+
+        with patch("src.opensearch.opensearch_integration.get_opensearch_client", AsyncMock(return_value=mock_client)):
+            with TestClient(app_with_tenant_admin) as client:
+                response = client.get("/v1/admin/gateways/metrics/guardrails/events?range=6h&limit=5")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["events"][0]["trace_id"] == "trace-1"
+
+        body = mock_client.search.await_args.kwargs["body"]
+        assert body["size"] == 5
+        assert {"range": {"startTime": {"gte": "now-360m"}}} in body["query"]["bool"]["filter"]
+        assert {"term": {"resource.attributes.tenant@id": "acme"}} in body["query"]["bool"]["filter"]
+
+    def test_guardrails_events_no_client_returns_empty(self, app_with_cpi_admin, mock_db_session):
+        """Missing OpenSearch client returns explicit empty events payload."""
+        with patch("src.opensearch.opensearch_integration.get_opensearch_client", AsyncMock(return_value=None)):
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/admin/gateways/metrics/guardrails/events")
+
+        assert response.status_code == 200
+        assert response.json() == {"events": [], "total": 0}
+
+    def test_guardrails_events_query_failure_returns_empty(self, app_with_cpi_admin, mock_db_session):
+        """OpenSearch query failure degrades to empty events payload."""
+        mock_client = MagicMock()
+        mock_client.search = AsyncMock(side_effect=RuntimeError("opensearch down"))
+
+        with patch("src.opensearch.opensearch_integration.get_opensearch_client", AsyncMock(return_value=mock_client)):
+            with TestClient(app_with_cpi_admin) as client:
+                response = client.get("/v1/admin/gateways/metrics/guardrails/events")
+
+        assert response.status_code == 200
+        assert response.json() == {"events": [], "total": 0}
 
     # ============== GET /health-summary ==============
 

--- a/control-plane-api/tests/test_regression_cab_xxxx_guardrails_runtime_truth.py
+++ b/control-plane-api/tests/test_regression_cab_xxxx_guardrails_runtime_truth.py
@@ -1,0 +1,51 @@
+"""Regression guard for PR-3B1 guardrails runtime truth.
+
+The backend must preserve unknown ``null`` separately from a healthy numeric
+``0`` so the frontend can distinguish no sample from enabled+zero events.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.services.gateway_metrics_service import GatewayMetricsService
+
+
+def _result(value: int) -> dict:
+    return {"result": [{"value": [1_777_777_777.0, str(value)]}]}
+
+
+def _empty_result() -> dict:
+    return {"result": []}
+
+
+@pytest.mark.asyncio
+async def test_guardrails_runtime_truth_distinguishes_healthy_zero_from_unknown_null():
+    svc = GatewayMetricsService(AsyncMock())
+    pii_query = "sum(increase(stoa_guardrails_pii_detected_total[1h]))"
+
+    async def healthy_zero_query(promql: str) -> dict:
+        if promql == pii_query:
+            return _result(0)
+        return _empty_result()
+
+    async def unknown_query(promql: str) -> dict:
+        return _empty_result()
+
+    with patch("src.services.gateway_metrics_service.prometheus_client") as mock_prometheus:
+        mock_prometheus.is_enabled = True
+        mock_prometheus.query = AsyncMock(side_effect=healthy_zero_query)
+        zero = await svc._fetch_guardrails_metrics(time_range="1h")
+
+    with patch("src.services.gateway_metrics_service.prometheus_client") as mock_prometheus:
+        mock_prometheus.is_enabled = True
+        mock_prometheus.query = AsyncMock(side_effect=unknown_query)
+        unknown = await svc._fetch_guardrails_metrics(time_range="1h")
+
+    assert zero["source_healthy"] is True
+    assert unknown["source_healthy"] is True
+    assert zero["pii_detections"] == 0
+    assert unknown["pii_detections"] is None
+    assert zero["last_sample_at"] is not None
+    assert unknown["last_sample_at"] is None
+    assert all("opa" not in key for key in zero)


### PR DESCRIPTION
## Summary
- Add `GET /v1/admin/gateways/guardrails/config` per the PR-3A contract.
- Extend gateway metrics guardrails payload with freshness fields and null-preserving counters.
- Add `range=1h|6h|24h|7d` support for metrics and guardrails events.

## References
- Plan: `docs/plans/2026-05-07-observability-data-integrity.md`
- Contract: `docs/plans/2026-05-10-guardrails-runtime-truth-contract.md`

## Explicit non-goals
- No UI/frontend changes.
- No Kafka consumer changes.
- No nav/sidebar changes.
- No stoa-infra changes.
- No OPA runtime counter; `opa_policy_enabled` remains config-only.
- No AuditLog or Live Calls changes.

## Test plan
- `python3 -m pytest tests/test_gateway_observability_router.py -q`
- `python3 -m pytest tests/test_gateway_metrics_service.py tests/test_regression_cab_xxxx_guardrails_runtime_truth.py -q`
- `python3 -m pytest tests/test_gateway_observability_router.py tests/test_regression_cab_xxxx_guardrails_runtime_truth.py --cov=src.routers.gateway_observability -q`
- `ruff check src/`
- `mypy --follow-imports=skip src/routers/gateway_observability.py`
- `git diff --check`

Note: `python3 -m pytest --cov=src/routers/gateway_observability.py -q` was started exactly as requested, but it expands to the whole control-plane-api suite in this repo and was stopped after passing the touched router/service tests; the targeted pytest-cov module form above reached 89.52% coverage.

PR-3B2 (UI consumption) lands separately and depends on this PR merging + deploying.