### PR TITLE
feat(ui): guardrails runtime truth UI per PR-3A contract

### DIFF
--- a/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.test.tsx
+++ b/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.test.tsx
@@ -1,22 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { createAuthMock, renderWithProviders } from '../../test/helpers';
 import { useAuth } from '../../contexts/AuthContext';
 import type { PersonaRole } from '../../test/helpers';
+import type { AggregatedMetrics, GuardrailsConfigResponse } from '../../types';
 
 vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
 
-const mockGetGatewayAggregatedMetrics = vi.fn().mockResolvedValue({
-  guardrails: { pii_detections: 5, injection_blocks: 2, content_filters: 0, prompt_guard_flags: 1 },
-  rate_limiting: { enforcements: 12 },
-});
-
-const mockGetGuardrailsEvents = vi.fn().mockResolvedValue({ events: [] });
+const mockGetGatewayAggregatedMetrics = vi.fn();
+const mockGetGuardrailsConfig = vi.fn();
+const mockGetGuardrailsEvents = vi.fn();
 
 vi.mock('../../services/api', () => ({
   apiService: {
     getGatewayAggregatedMetrics: (...args: unknown[]) => mockGetGatewayAggregatedMetrics(...args),
+    getGuardrailsConfig: (...args: unknown[]) => mockGetGuardrailsConfig(...args),
     getGuardrailsEvents: (...args: unknown[]) => mockGetGuardrailsEvents(...args),
     setAuthToken: vi.fn(),
     clearAuthToken: vi.fn(),
@@ -29,6 +28,54 @@ vi.mock('@stoa/shared/components/Toast', () => ({
 
 import { GuardrailsDashboard } from './GuardrailsDashboard';
 
+const enabledConfig: GuardrailsConfigResponse = {
+  pii_enabled: true,
+  injection_detection_enabled: true,
+  prompt_guard_enabled: true,
+  content_filter_enabled: true,
+  rate_limit_enabled: true,
+  opa_policy_enabled: true,
+  source: 'env',
+  updated_at: new Date(Date.now() - 30_000).toISOString(),
+};
+
+function metrics(
+  guardrails: Partial<NonNullable<AggregatedMetrics['guardrails']>> = {}
+): AggregatedMetrics {
+  return {
+    health: {
+      total_gateways: 1,
+      online: 1,
+      offline: 0,
+      degraded: 0,
+      maintenance: 0,
+      health_percentage: 100,
+    },
+    sync: {
+      total_deployments: 1,
+      synced: 1,
+      pending: 0,
+      syncing: 0,
+      drifted: 0,
+      error: 0,
+      deleting: 0,
+      sync_percentage: 100,
+    },
+    overall_status: 'healthy',
+    guardrails: {
+      pii_detections: 5,
+      injection_blocks: 2,
+      prompt_guard_blocks: 1,
+      content_filter_blocks: 0,
+      rate_limit_blocks: 0,
+      last_sample_at: new Date(Date.now() - 15_000).toISOString(),
+      metrics_age_seconds: 15,
+      source_healthy: true,
+      ...guardrails,
+    },
+  };
+}
+
 function LocationProbe() {
   const location = useLocation();
   return <div data-testid="location">{location.pathname}</div>;
@@ -37,40 +84,227 @@ function LocationProbe() {
 describe('GuardrailsDashboard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetGatewayAggregatedMetrics.mockResolvedValue({
-      guardrails: {
-        pii_detections: 5,
-        injection_blocks: 2,
-        content_filters: 0,
-        prompt_guard_flags: 1,
-      },
-      rate_limiting: { enforcements: 12 },
-    });
-    mockGetGuardrailsEvents.mockResolvedValue({ events: [] });
+    mockGetGuardrailsConfig.mockResolvedValue(enabledConfig);
+    mockGetGatewayAggregatedMetrics.mockResolvedValue(metrics());
+    mockGetGuardrailsEvents.mockResolvedValue({ events: [], total: 0 });
     vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
   });
 
-  it('renders the heading', async () => {
+  it('renders the AR-1 heading and subtitle', async () => {
     renderWithProviders(<GuardrailsDashboard />);
     expect(
       await screen.findByRole('heading', { name: /Security & Guardrails/i })
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Runtime events — guardrail decisions, PII/prompt/content/rate-limit monitoring'
+      )
+    ).toBeInTheDocument();
   });
 
-  it('renders guardrail cards', async () => {
+  it('config panel renders enabled and disabled state from /guardrails/config', async () => {
+    mockGetGuardrailsConfig.mockResolvedValue({
+      ...enabledConfig,
+      injection_detection_enabled: false,
+      opa_policy_enabled: false,
+    });
+
     renderWithProviders(<GuardrailsDashboard />);
-    // Cards render titles that also appear in config section — use getAllByText
-    const piiElements = await screen.findAllByText('PII Detection');
-    expect(piiElements.length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText(/Injection/i).length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText(/Prompt Guard/i).length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText('Rate Limit')).toBeInTheDocument();
+
+    expect(await screen.findByText('Guardrail Configuration')).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('config-pii-detection')).getByText('Enabled')
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('config-injection-detection')).getByText('Disabled')
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('config-opa-policy')).getByText('Disabled')
+    ).toBeInTheDocument();
   });
 
-  it('does not render Rate Limit as a misleading all-filter button', async () => {
+  it('card state is disabled when config is false', async () => {
+    mockGetGuardrailsConfig.mockResolvedValue({ ...enabledConfig, pii_enabled: false });
+
     renderWithProviders(<GuardrailsDashboard />);
-    const rateLimit = await screen.findByText('Rate Limit');
-    expect(rateLimit.closest('button')).toBeNull();
+
+    expect(
+      await within(screen.getByTestId('guardrail-card-pii-detection')).findByText('Disabled')
+    ).toBeInTheDocument();
+  });
+
+  it('card state renders enabled zero with a healthy source', async () => {
+    mockGetGatewayAggregatedMetrics.mockResolvedValue(metrics({ pii_detections: 0 }));
+
+    renderWithProviders(<GuardrailsDashboard />);
+
+    await waitFor(() => {
+      expect(
+        within(screen.getByTestId('guardrail-card-pii-detection')).getByText(
+          /0 events · last sample/
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('card state renders enabled N with a healthy source', async () => {
+    mockGetGatewayAggregatedMetrics.mockResolvedValue(metrics({ injection_blocks: 7 }));
+
+    renderWithProviders(<GuardrailsDashboard />);
+
+    expect(await screen.findByText(/7 events · last sample/)).toBeInTheDocument();
+  });
+
+  it('card state renders no sample when last_sample_at is null', async () => {
+    mockGetGatewayAggregatedMetrics.mockResolvedValue(
+      metrics({
+        pii_detections: null,
+        injection_blocks: null,
+        prompt_guard_blocks: null,
+        content_filter_blocks: null,
+        rate_limit_blocks: null,
+        last_sample_at: null,
+        metrics_age_seconds: null,
+      })
+    );
+
+    renderWithProviders(<GuardrailsDashboard />);
+
+    expect(
+      await within(screen.getByTestId('guardrail-card-pii-detection')).findByText(
+        'No metrics sample'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('current prod fail-closed config can show config unavailable while metrics show no sample', async () => {
+    mockGetGuardrailsConfig.mockRejectedValue(new Error('guardrails env missing'));
+    mockGetGatewayAggregatedMetrics.mockResolvedValue(
+      metrics({
+        pii_detections: null,
+        injection_blocks: null,
+        prompt_guard_blocks: null,
+        content_filter_blocks: null,
+        rate_limit_blocks: null,
+        last_sample_at: null,
+        metrics_age_seconds: null,
+      })
+    );
+
+    renderWithProviders(<GuardrailsDashboard />);
+
+    expect(await screen.findAllByText('Metrics unavailable')).not.toHaveLength(0);
+    expect(
+      await within(screen.getByTestId('guardrail-card-pii-detection')).findByText(
+        'No metrics sample'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('card state renders stale when metrics age is above 60 seconds', async () => {
+    mockGetGatewayAggregatedMetrics.mockResolvedValue(
+      metrics({
+        metrics_age_seconds: 61,
+        last_sample_at: new Date(Date.now() - 61_000).toISOString(),
+      })
+    );
+
+    renderWithProviders(<GuardrailsDashboard />);
+
+    expect(
+      await within(screen.getByTestId('guardrail-card-pii-detection')).findByText('Stale metrics')
+    ).toBeInTheDocument();
+  });
+
+  it('card state renders metrics unavailable when source is unhealthy', async () => {
+    mockGetGatewayAggregatedMetrics.mockResolvedValue(metrics({ source_healthy: false }));
+
+    renderWithProviders(<GuardrailsDashboard />);
+
+    expect(
+      await within(screen.getByTestId('guardrail-card-pii-detection')).findByText(
+        'Metrics unavailable'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('card state renders metrics unavailable on metrics HTTP error', async () => {
+    mockGetGatewayAggregatedMetrics.mockRejectedValue(new Error('metrics 503'));
+
+    renderWithProviders(<GuardrailsDashboard />);
+
+    expect(
+      await within(screen.getByTestId('guardrail-card-pii-detection')).findByText(
+        'Metrics unavailable'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('time range selector propagates to metrics and events fetch', async () => {
+    renderWithProviders(<GuardrailsDashboard />);
+
+    await waitFor(() => {
+      expect(mockGetGatewayAggregatedMetrics).toHaveBeenCalledWith('1h');
+      expect(mockGetGuardrailsEvents).toHaveBeenCalledWith(50, '1h');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '6h' }));
+
+    await waitFor(() => {
+      expect(mockGetGatewayAggregatedMetrics).toHaveBeenCalledWith('6h');
+      expect(mockGetGuardrailsEvents).toHaveBeenCalledWith(50, '6h');
+    });
+  });
+
+  it('time range selector does not refetch config', async () => {
+    renderWithProviders(<GuardrailsDashboard />);
+
+    await waitFor(() => expect(mockGetGuardrailsConfig).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: '24h' }));
+
+    await waitFor(() => expect(mockGetGatewayAggregatedMetrics).toHaveBeenCalledWith('24h'));
+    expect(mockGetGuardrailsConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('rate limit card does not use a synthetic all filter', async () => {
+    renderWithProviders(<GuardrailsDashboard />);
+
+    await waitFor(() => {
+      expect(
+        within(screen.getByTestId('guardrail-card-rate-limit')).getByText(/0 events · last sample/)
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(await screen.findByTestId('guardrail-card-rate-limit'));
+
+    expect(await screen.findByText(/— Rate Limit/)).toBeInTheDocument();
+    expect(screen.queryByText(/— All/)).not.toBeInTheDocument();
+  });
+
+  it('rate limit card filters to rate-limit or shows explicit empty state', async () => {
+    mockGetGuardrailsEvents.mockResolvedValue({
+      events: [
+        {
+          timestamp: '2026-05-07T10:00:00Z',
+          trace_id: 'trace-pii',
+          span_id: 'span-pii',
+          tool: 'payment-api',
+          action: 'pii-redacted',
+          reason: 'Sensitive payload redacted',
+        },
+      ],
+      total: 1,
+    });
+
+    renderWithProviders(<GuardrailsDashboard />);
+
+    await waitFor(() => {
+      expect(
+        within(screen.getByTestId('guardrail-card-rate-limit')).getByText(/0 events · last sample/)
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(await screen.findByTestId('guardrail-card-rate-limit'));
+
+    expect(await screen.findByText('No rate-limit events')).toBeInTheDocument();
   });
 
   it('routes guardrail event traces through the canonical Live Calls detail path', async () => {
@@ -85,6 +319,7 @@ describe('GuardrailsDashboard', () => {
           reason: 'Sensitive payload redacted',
         },
       ],
+      total: 1,
     });
 
     render(
@@ -108,24 +343,12 @@ describe('GuardrailsDashboard', () => {
     });
   });
 
-  it('renders configuration section', async () => {
-    renderWithProviders(<GuardrailsDashboard />);
-    expect(await screen.findByText('Guardrail Configuration')).toBeInTheDocument();
-  });
-
   it('P1-1: metrics render when events endpoint fails (allSettled)', async () => {
-    // Regression: Promise.all would have discarded the fulfilled metrics
-    // slice the moment the auxiliary events endpoint threw. allSettled
-    // preserves metrics + error is not set for a partial failure.
     mockGetGuardrailsEvents.mockRejectedValue(new Error('Events endpoint 500'));
+
     renderWithProviders(<GuardrailsDashboard />);
-    expect(
-      await screen.findByRole('heading', { name: /Security & Guardrails/i })
-    ).toBeInTheDocument();
-    // Metric cards still render with non-zero PII detection value from the
-    // fulfilled metrics slice.
-    const pii = await screen.findAllByText('PII Detection');
-    expect(pii.length).toBeGreaterThanOrEqual(1);
+
+    expect(await screen.findByText(/5 events · last sample/)).toBeInTheDocument();
   });
 
   describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(

--- a/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.tsx
+++ b/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.tsx
@@ -4,6 +4,8 @@ import { useAuth } from '../../contexts/AuthContext';
 import { apiService } from '../../services/api';
 import { SubNav } from '../../components/SubNav';
 import { observabilityTabs } from '../../components/subNavGroups';
+import { TimeRangeSelector } from '@stoa/shared/components/TimeRangeSelector';
+import type { TimeRange } from '@stoa/shared/components/TimeRangeSelector';
 import {
   RefreshCw,
   ShieldAlert,
@@ -13,35 +15,34 @@ import {
   Zap,
   AlertTriangle,
   ExternalLink,
+  Scale,
 } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type {
+  AggregatedMetrics,
+  GatewayGuardrailsEvent,
+  GuardrailsConfigResponse,
+  GuardrailsMetricField,
+  GuardrailsTimeRange,
+} from '../../types';
+import { guardrailCardState, type GuardrailCardUIState } from './guardrailCardState';
 
-interface GuardrailStats {
-  pii_detections: number;
-  injection_blocks: number;
-  content_filters: number;
-  prompt_guard_flags: number;
-  rate_limit_enforcements: number;
-  by_tool: Record<string, number>;
-  by_category: Record<string, number>;
-}
+type FilterType = 'all' | 'pii' | 'injection' | 'content' | 'prompt' | 'rate-limit';
 
-interface GuardrailEvent {
-  timestamp: string;
-  trace_id: string;
-  span_id: string;
-  tool: string;
-  action: string;
-  reason: string;
-}
-
-type FilterType = 'all' | 'pii' | 'injection' | 'content' | 'prompt';
+const GUARDRAILS_TIME_RANGES: GuardrailsTimeRange[] = ['1h', '6h', '24h', '7d'];
 
 const ACTION_TO_FILTER: Record<string, FilterType> = {
   'pii-redacted': 'pii',
   'pii-blocked': 'pii',
   blocked: 'injection',
+  'injection-blocked': 'injection',
   'content-flagged': 'content',
+  'content-filter': 'content',
   'prompt-guard': 'prompt',
+  'prompt-guard-blocked': 'prompt',
+  'rate-limit': 'rate-limit',
+  'rate-limited': 'rate-limit',
+  rate_limit: 'rate-limit',
 };
 
 const FILTER_LABELS: Record<FilterType, string> = {
@@ -50,6 +51,7 @@ const FILTER_LABELS: Record<FilterType, string> = {
   injection: 'Injection',
   content: 'Content',
   prompt: 'Prompt',
+  'rate-limit': 'Rate Limit',
 };
 
 const ACTION_BADGE: Record<string, { label: string; className: string }> = {
@@ -69,7 +71,102 @@ const ACTION_BADGE: Record<string, { label: string; className: string }> = {
     label: 'Prompt guard',
     className: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
   },
+  'rate-limit': {
+    label: 'Rate limit',
+    className: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+  },
 };
+
+type ConfigField = keyof Pick<
+  GuardrailsConfigResponse,
+  | 'pii_enabled'
+  | 'injection_detection_enabled'
+  | 'prompt_guard_enabled'
+  | 'content_filter_enabled'
+  | 'rate_limit_enabled'
+  | 'opa_policy_enabled'
+>;
+
+interface MetricCardConfig {
+  kind: 'metric';
+  icon: LucideIcon;
+  title: string;
+  metricField: GuardrailsMetricField;
+  description: string;
+  color: string;
+  filter: Exclude<FilterType, 'all'>;
+}
+
+interface ConfigCardConfig {
+  kind: 'config';
+  icon: LucideIcon;
+  title: string;
+  configField: ConfigField;
+  description: string;
+  color: string;
+}
+
+type GuardrailCardConfig = MetricCardConfig | ConfigCardConfig;
+
+const GUARDRAIL_CARDS: GuardrailCardConfig[] = [
+  {
+    kind: 'metric',
+    icon: Fingerprint,
+    title: 'PII Detection',
+    metricField: 'pii_detections',
+    description: 'Sensitive data detection and redaction outcomes',
+    color: 'text-purple-600 bg-purple-50 dark:bg-purple-900/20',
+    filter: 'pii',
+  },
+  {
+    kind: 'metric',
+    icon: Bug,
+    title: 'Injection Blocks',
+    metricField: 'injection_blocks',
+    description: 'Prompt and request injection attempts blocked',
+    color: 'text-red-600 bg-red-50 dark:bg-red-900/20',
+    filter: 'injection',
+  },
+  {
+    kind: 'metric',
+    icon: MessageSquareWarning,
+    title: 'Prompt Guard',
+    metricField: 'prompt_guard_blocks',
+    description: 'LLM prompt guard enforcement outcomes',
+    color: 'text-amber-600 bg-amber-50 dark:bg-amber-900/20',
+    filter: 'prompt',
+  },
+  {
+    kind: 'metric',
+    icon: ShieldAlert,
+    title: 'Content Filter',
+    metricField: 'content_filter_blocks',
+    description: 'Content and payload policy filter blocks',
+    color: 'text-blue-600 bg-blue-50 dark:bg-blue-900/20',
+    filter: 'content',
+  },
+  {
+    kind: 'metric',
+    icon: Zap,
+    title: 'Rate Limit',
+    metricField: 'rate_limit_blocks',
+    description: 'Requests throttled by rate-limit protection',
+    color: 'text-orange-600 bg-orange-50 dark:bg-orange-900/20',
+    filter: 'rate-limit',
+  },
+  {
+    kind: 'config',
+    icon: Scale,
+    title: 'OPA Policy',
+    configField: 'opa_policy_enabled',
+    description: 'Policy evaluation enablement from runtime config',
+    color: 'text-emerald-600 bg-emerald-50 dark:bg-emerald-900/20',
+  },
+];
+
+function isGuardrailsTimeRange(range: TimeRange): range is GuardrailsTimeRange {
+  return GUARDRAILS_TIME_RANGES.includes(range as GuardrailsTimeRange);
+}
 
 function formatTimestamp(iso: string): string {
   try {
@@ -80,192 +177,251 @@ function formatTimestamp(iso: string): string {
   }
 }
 
+function formatRelativeSample(iso: string): string {
+  const timestampMs = new Date(iso).getTime();
+  if (Number.isNaN(timestampMs)) return iso;
+
+  const ageSeconds = Math.max(0, Math.floor((Date.now() - timestampMs) / 1000));
+  if (ageSeconds < 60) return `${ageSeconds}s ago`;
+
+  const ageMinutes = Math.floor(ageSeconds / 60);
+  if (ageMinutes < 60) return `${ageMinutes} min ago`;
+
+  const ageHours = Math.floor(ageMinutes / 60);
+  if (ageHours < 24) return `${ageHours}h ago`;
+
+  const ageDays = Math.floor(ageHours / 24);
+  return `${ageDays}d ago`;
+}
+
+function isContractMetrics(metrics: AggregatedMetrics): boolean {
+  const guardrails = metrics.guardrails;
+  if (!guardrails) return false;
+
+  return (
+    typeof guardrails.source_healthy === 'boolean' &&
+    'last_sample_at' in guardrails &&
+    'metrics_age_seconds' in guardrails
+  );
+}
+
+function cardStateText(state: GuardrailCardUIState): string {
+  switch (state.kind) {
+    case 'metrics-unavailable':
+      return 'Metrics unavailable';
+    case 'disabled':
+      return 'Disabled';
+    case 'no-sample':
+      return 'No metrics sample';
+    case 'stale':
+      return 'Stale metrics';
+    case 'healthy':
+      return `${state.count} events · last sample ${formatRelativeSample(state.lastSampleAt ?? '')}`;
+  }
+}
+
+function configStatusText(
+  config: GuardrailsConfigResponse | null,
+  field: ConfigField,
+  loading: boolean,
+  unavailable: boolean
+): string {
+  if (loading) return 'Loading';
+  if (unavailable || !config) return 'Metrics unavailable';
+  return config[field] ? 'Enabled' : 'Disabled';
+}
+
+function cardTestId(title: string): string {
+  return `guardrail-card-${title.toLowerCase().replace(/\s+/g, '-')}`;
+}
+
 export function GuardrailsDashboard() {
   const { isReady } = useAuth();
   const navigate = useNavigate();
-  const [stats, setStats] = useState<GuardrailStats | null>(null);
-  const [events, setEvents] = useState<GuardrailEvent[]>([]);
+  const [config, setConfig] = useState<GuardrailsConfigResponse | null>(null);
+  const [metrics, setMetrics] = useState<AggregatedMetrics | null>(null);
+  const [events, setEvents] = useState<GatewayGuardrailsEvent[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [configLoading, setConfigLoading] = useState(true);
+  const [configUnavailable, setConfigUnavailable] = useState(false);
+  const [metricsUnavailable, setMetricsUnavailable] = useState(false);
   const [activeFilter, setActiveFilter] = useState<FilterType>('all');
+  const [timeRange, setTimeRange] = useState<GuardrailsTimeRange>('1h');
 
-  const loadData = useCallback(async () => {
+  const loadConfig = useCallback(async () => {
+    setConfigLoading(true);
+    try {
+      const nextConfig = await apiService.getGuardrailsConfig();
+      setConfig(nextConfig);
+      setConfigUnavailable(false);
+    } catch (reason) {
+      console.error('Failed to load guardrails config:', reason);
+      setConfig(null);
+      setConfigUnavailable(true);
+    } finally {
+      setConfigLoading(false);
+    }
+  }, []);
+
+  const loadRuntimeData = useCallback(async () => {
     setLoading(true);
-    // P1-1: allSettled — each endpoint independent, partial failure leaves
-    // the other slice's prior state intact.
     const [metricsResult, eventsResult] = await Promise.allSettled([
-      apiService.getGatewayAggregatedMetrics(),
-      apiService.getGuardrailsEvents(50),
+      apiService.getGatewayAggregatedMetrics(timeRange),
+      apiService.getGuardrailsEvents(50, timeRange),
     ]);
 
-    if (metricsResult.status === 'fulfilled') {
-      const metrics = metricsResult.value;
-      setStats({
-        pii_detections: metrics?.guardrails?.pii_detections || 0,
-        injection_blocks: metrics?.guardrails?.injection_blocks || 0,
-        content_filters: metrics?.guardrails?.content_filters || 0,
-        prompt_guard_flags: metrics?.guardrails?.prompt_guard_flags || 0,
-        rate_limit_enforcements: metrics?.rate_limiting?.enforcements || 0,
-        by_tool: metrics?.guardrails?.by_tool || {},
-        by_category: metrics?.guardrails?.by_category || {},
-      });
+    if (metricsResult.status === 'fulfilled' && isContractMetrics(metricsResult.value)) {
+      setMetrics(metricsResult.value);
+      setMetricsUnavailable(false);
     } else {
-      console.error('Failed to load gateway aggregated metrics:', metricsResult.reason);
+      const reason =
+        metricsResult.status === 'rejected'
+          ? metricsResult.reason
+          : 'Guardrails metrics response missing freshness fields';
+      console.error('Failed to load gateway aggregated metrics:', reason);
+      setMetrics(null);
+      setMetricsUnavailable(true);
     }
+
     if (eventsResult.status === 'fulfilled') {
-      setEvents(eventsResult.value?.events || []);
+      setEvents(eventsResult.value?.events ?? []);
     } else {
       console.error('Failed to load guardrails events:', eventsResult.reason);
     }
 
-    if (metricsResult.status === 'rejected' && eventsResult.status === 'rejected') {
-      const reason = metricsResult.reason;
-      const message = reason instanceof Error ? reason.message : 'Failed to load guardrail metrics';
-      setError(message);
-    } else {
-      setError(null);
-    }
     setLoading(false);
-  }, []);
+  }, [timeRange]);
 
   useEffect(() => {
-    if (isReady) loadData();
-  }, [isReady, loadData]);
+    if (isReady) loadConfig();
+  }, [isReady, loadConfig]);
+
+  useEffect(() => {
+    if (isReady) loadRuntimeData();
+  }, [isReady, loadRuntimeData]);
 
   useEffect(() => {
     if (!isReady) return;
-    const interval = setInterval(loadData, 30_000);
+    const interval = setInterval(loadRuntimeData, 30_000);
     return () => clearInterval(interval);
-  }, [isReady, loadData]);
+  }, [isReady, loadRuntimeData]);
+
+  const handleRefresh = () => {
+    void Promise.all([loadConfig(), loadRuntimeData()]);
+  };
 
   const filteredEvents =
     activeFilter === 'all'
       ? events
-      : events.filter((e) => ACTION_TO_FILTER[e.action] === activeFilter);
+      : events.filter((event) => ACTION_TO_FILTER[event.action] === activeFilter);
 
-  const guardrailCards: {
-    icon: typeof Fingerprint;
-    title: string;
-    value: number;
-    description: string;
-    color: string;
-    filter?: FilterType;
-  }[] = [
-    {
-      icon: Fingerprint,
-      title: 'PII Detection',
-      value: stats?.pii_detections ?? 0,
-      description: 'SSN, credit card, phone, email patterns blocked',
-      color: 'text-purple-600 bg-purple-50 dark:bg-purple-900/20',
-      filter: 'pii',
-    },
-    {
-      icon: Bug,
-      title: 'Injection Blocks',
-      value: stats?.injection_blocks ?? 0,
-      description: 'SQL, XPath, command injection attempts blocked',
-      color: 'text-red-600 bg-red-50 dark:bg-red-900/20',
-      filter: 'injection',
-    },
-    {
-      icon: MessageSquareWarning,
-      title: 'Prompt Guard',
-      value: stats?.prompt_guard_flags ?? 0,
-      description: 'LLM prompt injection attempts flagged',
-      color: 'text-amber-600 bg-amber-50 dark:bg-amber-900/20',
-      filter: 'prompt',
-    },
-    {
-      icon: ShieldAlert,
-      title: 'Content Filters',
-      value: stats?.content_filters ?? 0,
-      description: 'MIME type and body size violations',
-      color: 'text-blue-600 bg-blue-50 dark:bg-blue-900/20',
-      filter: 'content',
-    },
-    {
-      icon: Zap,
-      title: 'Rate Limit',
-      value: stats?.rate_limit_enforcements ?? 0,
-      description: 'Requests throttled by token bucket',
-      color: 'text-orange-600 bg-orange-50 dark:bg-orange-900/20',
-    },
-  ];
+  const emptyEventsText =
+    activeFilter === 'rate-limit'
+      ? 'No rate-limit events'
+      : events.length === 0
+        ? `No guardrail events in the selected ${timeRange} window`
+        : `No ${FILTER_LABELS[activeFilter].toLowerCase()} events found`;
 
   return (
     <div className="space-y-6">
       <SubNav tabs={observabilityTabs} />
 
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div>
           <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">
             Security & Guardrails
           </h1>
           <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
-            Audit, policy decisions, PII protection, prompt guard, and rate limiting events
+            Runtime events — guardrail decisions, PII/prompt/content/rate-limit monitoring
           </p>
         </div>
-        <button
-          onClick={loadData}
-          disabled={loading}
-          className="flex items-center gap-2 px-3 py-2 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-800"
-        >
-          <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
-          Refresh
-        </button>
+        <div className="flex items-center gap-3">
+          <TimeRangeSelector
+            value={timeRange}
+            ranges={GUARDRAILS_TIME_RANGES}
+            onChange={(range) => {
+              if (isGuardrailsTimeRange(range)) setTimeRange(range);
+            }}
+          />
+          <button
+            onClick={handleRefresh}
+            disabled={loading || configLoading}
+            className="flex items-center gap-2 px-3 py-2 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-800 disabled:opacity-60"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading || configLoading ? 'animate-spin' : ''}`} />
+            Refresh
+          </button>
+        </div>
       </div>
 
-      {error && (
+      {(configUnavailable || metricsUnavailable) && (
         <div className="rounded-lg bg-red-50 dark:bg-red-900/20 p-4 text-red-700 dark:text-red-400">
           <AlertTriangle className="inline h-4 w-4 mr-2" />
-          {error}
+          Metrics unavailable
         </div>
       )}
 
-      {/* Guardrail Cards — click filters the events table below */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {guardrailCards.map((card) => {
-          const isFilterable = Boolean(card.filter);
-          const isActive = isFilterable && activeFilter === card.filter;
+        {GUARDRAIL_CARDS.map((card) => {
+          const Icon = card.icon;
+          const state =
+            card.kind === 'metric'
+              ? guardrailCardState(config, metrics, card.metricField, { metricsUnavailable })
+              : null;
+          const statusText =
+            card.kind === 'metric'
+              ? cardStateText(state as GuardrailCardUIState)
+              : configStatusText(config, card.configField, configLoading, configUnavailable);
+          const isDisabled =
+            statusText === 'Disabled' ||
+            statusText === 'Metrics unavailable' ||
+            statusText === 'No metrics sample';
+          const isFilterable =
+            card.kind === 'metric' &&
+            !isDisabled &&
+            state?.kind !== 'stale' &&
+            Boolean(card.filter);
+          const isActive = card.kind === 'metric' && activeFilter === card.filter;
           const className = `rounded-lg border p-5 text-left transition-all ${card.color} ${
             isActive
               ? 'ring-2 ring-current border-current'
               : 'border-neutral-200 dark:border-neutral-700'
           } ${
-            isFilterable && card.value > 0
+            isFilterable
               ? 'cursor-pointer hover:ring-2 hover:ring-offset-1 hover:ring-current'
               : 'cursor-default'
-          } ${card.value === 0 ? 'opacity-60' : ''}`;
+          } ${isDisabled ? 'opacity-75' : ''}`;
           const content = (
             <>
               <div className="flex items-center gap-2 mb-3">
-                <card.icon className="h-5 w-5" />
+                <Icon className="h-5 w-5" />
                 <span className="text-sm font-semibold">{card.title}</span>
               </div>
-              {loading ? (
-                <div className="h-8 w-16 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
+              {loading && card.kind === 'metric' && !metrics && !metricsUnavailable ? (
+                <div className="h-6 w-32 bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse" />
               ) : (
-                <p className="text-3xl font-bold">{card.value}</p>
+                <p className="text-sm font-semibold">{statusText}</p>
               )}
               <p className="text-xs mt-2 opacity-75">{card.description}</p>
             </>
           );
 
-          if (!card.filter) {
+          if (!isFilterable || card.kind !== 'metric') {
             return (
-              <div key={card.title} className={className}>
+              <div key={card.title} className={className} data-testid={cardTestId(card.title)}>
                 {content}
               </div>
             );
           }
 
-          const filter = card.filter;
-
           return (
             <button
               key={card.title}
-              onClick={() => setActiveFilter((prev) => (prev === filter ? 'all' : filter))}
+              onClick={() =>
+                setActiveFilter((prev) => (prev === card.filter ? 'all' : card.filter))
+              }
               className={className}
+              data-testid={cardTestId(card.title)}
             >
               {content}
             </button>
@@ -273,7 +429,6 @@ export function GuardrailsDashboard() {
         })}
       </div>
 
-      {/* Recent Events — each row links to trace detail */}
       <div className="bg-white dark:bg-neutral-900 rounded-lg border border-neutral-200 dark:border-neutral-700">
         <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-700 flex items-center justify-between">
           <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
@@ -293,15 +448,11 @@ export function GuardrailsDashboard() {
           <span className="text-xs text-neutral-400">{filteredEvents.length} events</span>
         </div>
         {filteredEvents.length === 0 ? (
-          <div className="p-8 text-center text-neutral-400 text-sm">
-            {events.length === 0
-              ? 'No guardrail events in the last hour'
-              : `No ${FILTER_LABELS[activeFilter].toLowerCase()} events found`}
-          </div>
+          <div className="p-8 text-center text-neutral-400 text-sm">{emptyEventsText}</div>
         ) : (
           <div className="divide-y divide-neutral-100 dark:divide-neutral-800">
             {filteredEvents.map((event) => {
-              const badge = ACTION_BADGE[event.action] || {
+              const badge = ACTION_BADGE[event.action] ?? {
                 label: event.action,
                 className:
                   'bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300',
@@ -336,32 +487,94 @@ export function GuardrailsDashboard() {
         )}
       </div>
 
-      {/* Feature Status */}
       <div className="bg-white dark:bg-neutral-900 rounded-lg border border-neutral-200 dark:border-neutral-700">
         <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-700">
           <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
             Guardrail Configuration
           </h2>
+          {config && !configUnavailable && (
+            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
+              Source: {config.source} · Updated {formatRelativeSample(config.updated_at)}
+            </p>
+          )}
         </div>
         <div className="p-4 space-y-3">
-          <ConfigRow label="PII Detection" envVar="GUARDRAILS_PII_ENABLED" />
-          <ConfigRow label="Injection Protection" envVar="GUARDRAILS_INJECTION_ENABLED" />
-          <ConfigRow label="Content Filter" envVar="GUARDRAILS_CONTENT_FILTER_ENABLED" />
-          <ConfigRow label="Prompt Guard" envVar="PROMPT_GUARD_ENABLED" />
-          <ConfigRow label="OPA Policy Engine" envVar="POLICY_ENABLED" />
+          <ConfigRow
+            label="PII Detection"
+            status={configStatusText(config, 'pii_enabled', configLoading, configUnavailable)}
+            testId="config-pii-detection"
+          />
+          <ConfigRow
+            label="Injection Detection"
+            status={configStatusText(
+              config,
+              'injection_detection_enabled',
+              configLoading,
+              configUnavailable
+            )}
+            testId="config-injection-detection"
+          />
+          <ConfigRow
+            label="Prompt Guard"
+            status={configStatusText(
+              config,
+              'prompt_guard_enabled',
+              configLoading,
+              configUnavailable
+            )}
+            testId="config-prompt-guard"
+          />
+          <ConfigRow
+            label="Content Filter"
+            status={configStatusText(
+              config,
+              'content_filter_enabled',
+              configLoading,
+              configUnavailable
+            )}
+            testId="config-content-filter"
+          />
+          <ConfigRow
+            label="Rate Limit"
+            status={configStatusText(
+              config,
+              'rate_limit_enabled',
+              configLoading,
+              configUnavailable
+            )}
+            testId="config-rate-limit"
+          />
+          <ConfigRow
+            label="OPA Policy"
+            status={configStatusText(
+              config,
+              'opa_policy_enabled',
+              configLoading,
+              configUnavailable
+            )}
+            testId="config-opa-policy"
+          />
         </div>
       </div>
     </div>
   );
 }
 
-function ConfigRow({ label, envVar }: { label: string; envVar: string }) {
+function ConfigRow({ label, status, testId }: { label: string; status: string; testId: string }) {
+  const statusClass =
+    status === 'Enabled'
+      ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+      : status === 'Disabled'
+        ? 'bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400'
+        : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400';
+
   return (
-    <div className="flex items-center justify-between py-2 border-b border-neutral-100 dark:border-neutral-800 last:border-0">
+    <div
+      className="flex items-center justify-between py-2 border-b border-neutral-100 dark:border-neutral-800 last:border-0"
+      data-testid={testId}
+    >
       <span className="text-sm text-neutral-700 dark:text-neutral-300">{label}</span>
-      <code className="text-xs text-neutral-500 dark:text-neutral-400 bg-neutral-100 dark:bg-neutral-800 px-2 py-1 rounded">
-        {envVar}
-      </code>
+      <span className={`text-xs font-medium px-2 py-1 rounded-full ${statusClass}`}>{status}</span>
     </div>
   );
 }

--- a/control-plane-ui/src/pages/GatewayGuardrails/guardrailCardState.test.ts
+++ b/control-plane-ui/src/pages/GatewayGuardrails/guardrailCardState.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import type { AggregatedMetrics, GuardrailsConfigResponse } from '../../types';
+import { guardrailCardState } from './guardrailCardState';
+
+const config: GuardrailsConfigResponse = {
+  pii_enabled: true,
+  injection_detection_enabled: true,
+  prompt_guard_enabled: true,
+  content_filter_enabled: true,
+  rate_limit_enabled: true,
+  opa_policy_enabled: true,
+  source: 'env',
+  updated_at: '2026-05-09T06:00:00Z',
+};
+
+function metrics(
+  guardrails: Partial<NonNullable<AggregatedMetrics['guardrails']>> = {}
+): AggregatedMetrics {
+  return {
+    health: {
+      total_gateways: 1,
+      online: 1,
+      offline: 0,
+      degraded: 0,
+      maintenance: 0,
+      health_percentage: 100,
+    },
+    sync: {
+      total_deployments: 1,
+      synced: 1,
+      pending: 0,
+      syncing: 0,
+      drifted: 0,
+      error: 0,
+      deleting: 0,
+      sync_percentage: 100,
+    },
+    overall_status: 'healthy',
+    guardrails: {
+      pii_detections: 0,
+      injection_blocks: 2,
+      prompt_guard_blocks: 3,
+      content_filter_blocks: 4,
+      rate_limit_blocks: 5,
+      last_sample_at: '2026-05-09T06:00:00Z',
+      metrics_age_seconds: 15,
+      source_healthy: true,
+      ...guardrails,
+    },
+  };
+}
+
+describe('guardrailCardState', () => {
+  it.each([
+    {
+      name: 'metrics transport error wins',
+      cfg: { ...config, pii_enabled: false },
+      value: metrics({ source_healthy: true }),
+      options: { metricsUnavailable: true },
+      expected: 'metrics-unavailable',
+    },
+    {
+      name: 'missing metrics block is unavailable',
+      cfg: config,
+      value: { ...metrics(), guardrails: undefined },
+      options: {},
+      expected: 'metrics-unavailable',
+    },
+    {
+      name: 'disabled config wins over healthy count',
+      cfg: { ...config, pii_enabled: false },
+      value: metrics({ pii_detections: 9 }),
+      options: {},
+      expected: 'disabled',
+    },
+    {
+      name: 'source unhealthy is unavailable',
+      cfg: config,
+      value: metrics({ source_healthy: false }),
+      options: {},
+      expected: 'metrics-unavailable',
+    },
+    {
+      name: 'null sample timestamp is no sample',
+      cfg: config,
+      value: metrics({ last_sample_at: null, metrics_age_seconds: null }),
+      options: {},
+      expected: 'no-sample',
+    },
+    {
+      name: 'null count is no sample',
+      cfg: config,
+      value: metrics({ pii_detections: null }),
+      options: {},
+      expected: 'no-sample',
+    },
+    {
+      name: 'undefined count is no sample',
+      cfg: config,
+      value: metrics({ pii_detections: undefined }),
+      options: {},
+      expected: 'no-sample',
+    },
+    {
+      name: 'non-null timestamp with null age is invalid',
+      cfg: config,
+      value: metrics({ last_sample_at: '2026-05-09T06:00:00Z', metrics_age_seconds: null }),
+      options: {},
+      expected: 'metrics-unavailable',
+    },
+    {
+      name: 'exactly 60 seconds is still fresh',
+      cfg: config,
+      value: metrics({ pii_detections: 0, metrics_age_seconds: 60 }),
+      options: {},
+      expected: 'healthy',
+    },
+    {
+      name: 'above 60 seconds is stale',
+      cfg: config,
+      value: metrics({ pii_detections: 0, metrics_age_seconds: 61 }),
+      options: {},
+      expected: 'stale',
+    },
+    {
+      name: 'healthy zero preserves zero',
+      cfg: config,
+      value: metrics({ pii_detections: 0 }),
+      options: {},
+      expected: 'healthy',
+      expectedCount: 0,
+    },
+    {
+      name: 'healthy N preserves count',
+      cfg: config,
+      value: metrics({ pii_detections: 42 }),
+      options: {},
+      expected: 'healthy',
+      expectedCount: 42,
+    },
+    {
+      name: 'rate limit maps to rate_limit_enabled',
+      cfg: { ...config, rate_limit_enabled: false },
+      value: metrics({ rate_limit_blocks: 4 }),
+      field: 'rate_limit_blocks' as const,
+      options: {},
+      expected: 'disabled',
+    },
+  ])('$name', ({ cfg, value, field = 'pii_detections', options, expected, expectedCount }) => {
+    const state = guardrailCardState(cfg, value, field, options);
+
+    expect(state.kind).toBe(expected);
+    if (expectedCount !== undefined) {
+      expect(state.count).toBe(expectedCount);
+    }
+  });
+});

--- a/control-plane-ui/src/pages/GatewayGuardrails/guardrailCardState.ts
+++ b/control-plane-ui/src/pages/GatewayGuardrails/guardrailCardState.ts
@@ -1,0 +1,70 @@
+import type {
+  AggregatedMetrics,
+  GuardrailsConfigResponse,
+  GuardrailsMetricField,
+} from '../../types';
+
+export type GuardrailCardStateKind =
+  | 'metrics-unavailable'
+  | 'disabled'
+  | 'no-sample'
+  | 'stale'
+  | 'healthy';
+
+export interface GuardrailCardUIState {
+  kind: GuardrailCardStateKind;
+  count: number | null;
+  lastSampleAt: string | null;
+}
+
+export interface GuardrailCardStateOptions {
+  metricsUnavailable?: boolean;
+}
+
+const METRIC_TO_CONFIG_FIELD: Record<GuardrailsMetricField, keyof GuardrailsConfigResponse> = {
+  pii_detections: 'pii_enabled',
+  injection_blocks: 'injection_detection_enabled',
+  prompt_guard_blocks: 'prompt_guard_enabled',
+  content_filter_blocks: 'content_filter_enabled',
+  rate_limit_blocks: 'rate_limit_enabled',
+};
+
+export function guardrailCardState(
+  config: GuardrailsConfigResponse | null,
+  metrics: AggregatedMetrics | null,
+  fieldName: GuardrailsMetricField,
+  options: GuardrailCardStateOptions = {}
+): GuardrailCardUIState {
+  if (options.metricsUnavailable || !metrics?.guardrails) {
+    return unavailableState();
+  }
+
+  const configField = METRIC_TO_CONFIG_FIELD[fieldName];
+  if (config && config[configField] === false) {
+    return { kind: 'disabled', count: null, lastSampleAt: null };
+  }
+
+  const guardrails = metrics.guardrails;
+  if (guardrails.source_healthy !== true) {
+    return unavailableState();
+  }
+
+  const count = guardrails[fieldName];
+  if (guardrails.last_sample_at === null || count === null || count === undefined) {
+    return { kind: 'no-sample', count: null, lastSampleAt: null };
+  }
+
+  if (guardrails.metrics_age_seconds === null || guardrails.metrics_age_seconds === undefined) {
+    return unavailableState();
+  }
+
+  if (guardrails.metrics_age_seconds > 60) {
+    return { kind: 'stale', count, lastSampleAt: guardrails.last_sample_at };
+  }
+
+  return { kind: 'healthy', count, lastSampleAt: guardrails.last_sample_at };
+}
+
+function unavailableState(): GuardrailCardUIState {
+  return { kind: 'metrics-unavailable', count: null, lastSampleAt: null };
+}

--- a/control-plane-ui/src/services/api.ts
+++ b/control-plane-ui/src/services/api.ts
@@ -54,6 +54,8 @@ import type {
   TenantToolPermission,
   TenantToolPermissionListResponse,
   AggregatedMetrics,
+  GuardrailsConfigResponse,
+  GuardrailsTimeRange,
   DeploymentStatusSummary,
   GatewayDeployment,
   GatewayGuardrailsResponse,
@@ -875,12 +877,19 @@ class ApiService {
   // Gateway Observability
   // =========================================================================
 
-  async getGatewayAggregatedMetrics(): Promise<AggregatedMetrics> {
-    return gatewaysClient.getAggregatedMetrics();
+  async getGatewayAggregatedMetrics(range?: GuardrailsTimeRange): Promise<AggregatedMetrics> {
+    return gatewaysClient.getAggregatedMetrics(range);
   }
 
-  async getGuardrailsEvents(limit = 20): Promise<GatewayGuardrailsResponse> {
-    return gatewaysClient.getGuardrailsEvents(limit);
+  async getGuardrailsConfig(): Promise<GuardrailsConfigResponse> {
+    return gatewaysClient.getGuardrailsConfig();
+  }
+
+  async getGuardrailsEvents(
+    limit = 20,
+    range?: GuardrailsTimeRange
+  ): Promise<GatewayGuardrailsResponse> {
+    return gatewaysClient.getGuardrailsEvents(limit, range);
   }
 
   async getGatewayHealthSummary(): Promise<GatewayHealthSummary> {

--- a/control-plane-ui/src/services/api/gateways.ts
+++ b/control-plane-ui/src/services/api/gateways.ts
@@ -2,6 +2,8 @@ import type { Schemas } from '@stoa/shared/api-types';
 import { httpClient, path } from '../http';
 import type {
   AggregatedMetrics,
+  GuardrailsConfigResponse,
+  GuardrailsTimeRange,
   GatewayGuardrailsResponse,
   GatewayHealthSummary,
   GatewayInstance,
@@ -80,15 +82,25 @@ export const gatewaysClient = {
   },
 
   // Observability
-  async getAggregatedMetrics(): Promise<AggregatedMetrics> {
-    const { data } = await httpClient.get('/v1/admin/gateways/metrics');
+  async getAggregatedMetrics(range?: GuardrailsTimeRange): Promise<AggregatedMetrics> {
+    const { data } = range
+      ? await httpClient.get('/v1/admin/gateways/metrics', { params: { range } })
+      : await httpClient.get('/v1/admin/gateways/metrics');
     return data;
   },
 
-  async getGuardrailsEvents(limit = 20): Promise<GatewayGuardrailsResponse> {
+  async getGuardrailsConfig(): Promise<GuardrailsConfigResponse> {
+    const { data } = await httpClient.get('/v1/admin/gateways/guardrails/config');
+    return data;
+  },
+
+  async getGuardrailsEvents(
+    limit = 20,
+    range?: GuardrailsTimeRange
+  ): Promise<GatewayGuardrailsResponse> {
     // P1-11 residu: use axios params option rather than inline template string.
     const { data } = await httpClient.get('/v1/admin/gateways/metrics/guardrails/events', {
-      params: { limit },
+      params: range ? { limit, range } : { limit },
     });
     return data;
   },

--- a/control-plane-ui/src/types/index.ts
+++ b/control-plane-ui/src/types/index.ts
@@ -1393,24 +1393,44 @@ export interface AggregatedMetrics {
     sync_percentage: number;
   };
   overall_status: string;
-  // Guardrails slice is emitted by the metrics endpoint when runtime security
-  // features are enabled. Backend does not expose a canonical schema — consumer
-  // (`GuardrailsDashboard`) expects this shape (CAB-2164).
-  guardrails?: {
-    pii_detections?: number;
-    injection_blocks?: number;
-    content_filters?: number;
-    prompt_guard_flags?: number;
-    by_tool?: Record<string, number>;
-    by_category?: Record<string, number>;
-  };
-  rate_limiting?: {
-    enforcements?: number;
-  };
-  // TODO(WAVE-2): promote guardrails/rate_limiting to Schemas when backend
-  // publishes their shape (see BACKEND-GAPS-CAB-2159.md §BUG-6/BUG-9).
+  // Guardrails slice follows the validated PR-3A runtime truth contract:
+  // docs/plans/2026-05-10-guardrails-runtime-truth-contract.md
+  guardrails?: GuardrailsMetricsBlock;
   [key: string]: unknown;
 }
+
+export type GuardrailsConfigSource = 'env' | 'runtime' | 'config-service';
+
+export type GuardrailsTimeRange = '1h' | '6h' | '24h' | '7d';
+
+export interface GuardrailsConfigResponse {
+  pii_enabled: boolean;
+  injection_detection_enabled: boolean;
+  prompt_guard_enabled: boolean;
+  content_filter_enabled: boolean;
+  rate_limit_enabled: boolean;
+  opa_policy_enabled: boolean;
+  source: GuardrailsConfigSource;
+  updated_at: string;
+}
+
+export interface GuardrailsMetricsBlock {
+  pii_detections: number | null;
+  injection_blocks: number | null;
+  prompt_guard_blocks: number | null;
+  content_filter_blocks: number | null;
+  rate_limit_blocks: number | null;
+  last_sample_at: string | null;
+  metrics_age_seconds: number | null;
+  source_healthy: boolean;
+}
+
+export type GuardrailsMetricField =
+  | 'pii_detections'
+  | 'injection_blocks'
+  | 'prompt_guard_blocks'
+  | 'content_filter_blocks'
+  | 'rate_limit_blocks';
 
 // CAB-2164 local wrapper: guardrails event stream consumed by
 // `GuardrailsDashboard.tsx`. Backend does not publish a canonical schema —


### PR DESCRIPTION
## Summary

- Consume `GET /v1/admin/gateways/guardrails/config` to drive Guardrails card/config enablement without frontend defaults.
- Consume the PR-3A guardrails metrics contract from `/v1/admin/gateways/metrics?range=...`, preserving `null` vs `0` and freshness fields end-to-end.
- Add a pure `guardrailCardState(...)` precedence helper for disabled, no-sample, stale, unavailable, and healthy numeric states.
- Add the 1h / 6h / 24h / 7d time range selector and pass it to metrics and guardrails events fetches without refetching config.
- Keep Rate Limit under Security & Guardrails per AR-2, filtering to `rate-limit` with an explicit `No rate-limit events` empty state.

## References

- Plan: `docs/plans/2026-05-07-observability-data-integrity.md`
- Contract: `docs/plans/2026-05-10-guardrails-runtime-truth-contract.md`
- PR-3B1 merge SHA: `ae52ff9c` (#2742)

## Explicit Non-Goals

- No backend changes.
- No Kafka consumer changes.
- No navigation/sidebar changes.
- No AuditLog changes.
- No Live Calls changes.
- No Security Posture changes.
- No OPA runtime counter or real heatmap implementation.

## Test Plan

- `npm run test -- --run src/pages/GatewayGuardrails/`
- `npm run test -- --run src/test/services/api/ui2-s2d-clients.test.ts src/pages/GatewayGuardrails/`
- `npm run test -- --run`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `git diff --check`

Browser smoke screenshot was not captured in this local run.
