### PR TITLE
chore(ui): observability nav IA cleanup

### DIFF
--- a/control-plane-ui/src/__tests__/regression/observability-titles.test.tsx
+++ b/control-plane-ui/src/__tests__/regression/observability-titles.test.tsx
@@ -1,0 +1,184 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import i18n from 'i18next';
+import type { ReactElement } from 'react';
+import { createAuthMock, renderWithProviders } from '../../test/helpers';
+import { useAuth } from '../../contexts/AuthContext';
+import { useBreadcrumbs } from '../../hooks/useBreadcrumbs';
+import { AuditLog } from '../../pages/AuditLog';
+import { CallFlowDashboard } from '../../pages/CallFlow/CallFlowDashboard';
+import { GuardrailsDashboard } from '../../pages/GatewayGuardrails/GuardrailsDashboard';
+
+const mocks = vi.hoisted(() => ({
+  getTransactions: vi.fn(),
+  getGatewayAggregatedMetrics: vi.fn(),
+  getGuardrailsConfig: vi.fn(),
+  getGuardrailsEvents: vi.fn(),
+  get: vi.fn(),
+  refetch: vi.fn(),
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../../hooks/usePrometheus', () => ({
+  usePrometheusQuery: vi.fn(() => ({
+    data: null,
+    loading: false,
+    error: null,
+    refetch: mocks.refetch,
+  })),
+  usePrometheusRange: vi.fn(() => ({
+    data: [],
+    loading: false,
+    error: null,
+    refetch: mocks.refetch,
+  })),
+  scalarValue: vi.fn(() => null),
+  groupByLabel: vi.fn(() => ({})),
+}));
+
+vi.mock('../../services/api', () => ({
+  apiService: {
+    getTransactions: mocks.getTransactions,
+    getGatewayAggregatedMetrics: mocks.getGatewayAggregatedMetrics,
+    getGuardrailsConfig: mocks.getGuardrailsConfig,
+    getGuardrailsEvents: mocks.getGuardrailsEvents,
+    get: mocks.get,
+  },
+}));
+
+function BreadcrumbLastLabel() {
+  const breadcrumbs = useBreadcrumbs();
+  return <span data-testid="breadcrumb-last">{breadcrumbs.at(-1)?.label}</span>;
+}
+
+function renderAuditedPage(route: string, page: ReactElement) {
+  return renderWithProviders(
+    <>
+      <BreadcrumbLastLabel />
+      {page}
+    </>,
+    { route }
+  );
+}
+
+const guardrailsConfig = {
+  pii_enabled: true,
+  injection_detection_enabled: true,
+  prompt_guard_enabled: true,
+  content_filter_enabled: true,
+  rate_limit_enabled: true,
+  opa_policy_enabled: true,
+  source: 'env',
+  updated_at: '2026-05-09T00:00:00.000Z',
+};
+
+const guardrailsMetrics = {
+  health: {
+    total_gateways: 1,
+    online: 1,
+    offline: 0,
+    degraded: 0,
+    maintenance: 0,
+    health_percentage: 100,
+  },
+  sync: {
+    total_deployments: 1,
+    synced: 1,
+    pending: 0,
+    syncing: 0,
+    drifted: 0,
+    error: 0,
+    deleting: 0,
+    sync_percentage: 100,
+  },
+  overall_status: 'healthy',
+  guardrails: {
+    pii_detections: 0,
+    injection_blocks: 0,
+    prompt_guard_blocks: 0,
+    content_filter_blocks: 0,
+    rate_limit_blocks: 0,
+    last_sample_at: '2026-05-09T00:00:00.000Z',
+    metrics_age_seconds: 10,
+    source_healthy: true,
+  },
+};
+
+const auditStatsWindow = {
+  window_start: '2026-05-09T00:00:00.000Z',
+  window_end: '2026-05-09T01:00:00.000Z',
+};
+
+function mockAuditResponse(url: unknown) {
+  const path = String(url);
+
+  if (path.endsWith('/stats')) {
+    return Promise.resolve({
+      data: {
+        total_events: 0,
+        success_count: 0,
+        failed_count: 0,
+        unique_actors: 0,
+        by_action: {},
+        by_status: {},
+        ...auditStatsWindow,
+      },
+    });
+  }
+
+  if (path.endsWith('/actions')) {
+    return Promise.resolve({ data: { actions: [], ...auditStatsWindow } });
+  }
+
+  return Promise.resolve({
+    data: {
+      entries: [],
+      total: 0,
+      page: 1,
+      page_size: 20,
+      has_more: false,
+    },
+  });
+}
+
+describe('regression/observability-titles', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    await i18n.changeLanguage('en');
+
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+    mocks.getTransactions.mockResolvedValue({ transactions: [] });
+    mocks.getGuardrailsConfig.mockResolvedValue(guardrailsConfig);
+    mocks.getGatewayAggregatedMetrics.mockResolvedValue(guardrailsMetrics);
+    mocks.getGuardrailsEvents.mockResolvedValue({ events: [], total: 0 });
+    mocks.get.mockImplementation(mockAuditResponse);
+  });
+
+  it.each([
+    {
+      route: '/observability/live-calls',
+      heading: 'Live Calls',
+      page: <CallFlowDashboard />,
+    },
+    {
+      route: '/audit-log',
+      heading: 'Audit Log',
+      page: <AuditLog />,
+    },
+    {
+      route: '/observability/security',
+      heading: 'Security & Guardrails',
+      page: <GuardrailsDashboard />,
+    },
+  ])('keeps $route h1 aligned with its breadcrumb label', async ({ route, heading, page }) => {
+    renderAuditedPage(route, page);
+
+    const h1 = await screen.findByRole('heading', { level: 1, name: heading });
+    expect(screen.getByTestId('breadcrumb-last')).toHaveTextContent(heading);
+    expect(h1).toHaveTextContent(screen.getByTestId('breadcrumb-last').textContent ?? '');
+  });
+});

--- a/control-plane-ui/src/__tests__/regression/sidebar-no-legacy-redirects.test.tsx
+++ b/control-plane-ui/src/__tests__/regression/sidebar-no-legacy-redirects.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { within } from '@testing-library/react';
+import { createAuthMock, renderWithProviders } from '../../test/helpers';
+import { useAuth } from '../../contexts/AuthContext';
+import { Layout } from '../../components/Layout';
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../../contexts/EnvironmentContext', () => ({
+  useEnvironment: () => ({
+    activeEnvironment: 'dev',
+    activeConfig: { name: 'dev', label: 'Development', mode: 'full', color: 'green' },
+    environments: [{ name: 'dev', label: 'Development', mode: 'full', color: 'green' }],
+    switchEnvironment: vi.fn(),
+  }),
+}));
+
+vi.mock('../../services/api', () => ({
+  apiService: {
+    getTenants: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('../../hooks/useApiConnectivity', () => ({
+  useApiConnectivity: () => ({ isConnected: true, isChecking: false }),
+}));
+
+vi.mock('@stoa/shared/components/Breadcrumb', () => ({
+  Breadcrumb: () => <nav data-testid="breadcrumb" />,
+}));
+
+vi.mock('@stoa/shared/components/CommandPalette', () => ({
+  useCommandPalette: () => ({ setOpen: vi.fn(), setItems: vi.fn() }),
+}));
+
+vi.mock('@stoa/shared/components/EnvironmentChrome', () => ({
+  EnvironmentChrome: () => null,
+}));
+
+vi.mock('@stoa/shared/components/ThemeToggle', () => ({
+  ThemeToggle: () => <button type="button" data-testid="theme-toggle" />,
+}));
+
+vi.mock('@stoa/shared/contexts', () => ({
+  useTheme: () => ({ resolvedTheme: 'light', toggleTheme: vi.fn() }),
+}));
+
+vi.mock('@stoa/shared/hooks', () => ({
+  useSequenceShortcuts: vi.fn(),
+}));
+
+describe('regression/sidebar-no-legacy-redirects', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+  });
+
+  it('does not advertise legacy gateway redirect routes in the active sidebar', () => {
+    const { container } = renderWithProviders(
+      <Layout>
+        <div>Console content</div>
+      </Layout>,
+      { route: '/observability/security' }
+    );
+
+    const sidebar = container.querySelector('nav');
+    expect(sidebar).not.toBeNull();
+
+    const hrefs = within(sidebar as HTMLElement)
+      .getAllByRole('link')
+      .map((link) => link.getAttribute('href') ?? link.getAttribute('to') ?? '');
+
+    expect(
+      hrefs.filter(
+        (href) => href.startsWith('/gateway-security') || href.startsWith('/gateway-guardrails')
+      )
+    ).toEqual([]);
+  });
+});

--- a/control-plane-ui/src/components/Layout.tsx
+++ b/control-plane-ui/src/components/Layout.tsx
@@ -210,18 +210,6 @@ const navigationSections: NavSection[] = [
         permission: 'tenants:read',
       },
       {
-        name: 'nav.security',
-        href: '/gateway-security',
-        icon: Shield,
-        permission: 'tenants:read',
-      },
-      {
-        name: 'nav.guardrails',
-        href: '/gateway-guardrails',
-        icon: Shield,
-        permission: 'tenants:read',
-      },
-      {
         name: 'nav.backendHealth',
         href: '/proxy-owner',
         icon: Activity,

--- a/control-plane-ui/src/components/subNavGroups.ts
+++ b/control-plane-ui/src/components/subNavGroups.ts
@@ -52,6 +52,7 @@ export const gatewayTabs: SubNavTab[] = [
   { label: 'Config Sync', href: '/drift', icon: GitCompareArrows },
 ];
 
+// AR-1: static security posture remains under Governance; runtime guardrail events stay here.
 export const observabilityTabs: SubNavTab[] = [
   { label: 'Gateway Health', href: '/observability', icon: Gauge },
   { label: 'Live Calls', href: '/observability/live-calls', icon: Activity },

--- a/control-plane-ui/src/pages/SecurityPosture/SecurityPostureDashboard.test.tsx
+++ b/control-plane-ui/src/pages/SecurityPosture/SecurityPostureDashboard.test.tsx
@@ -180,7 +180,7 @@ describe('SecurityPostureDashboard', () => {
   it('renders the subtitle', () => {
     render(<SecurityPostureDashboard />);
     expect(
-      screen.getByText('Continuous security monitoring and compliance scoring')
+      screen.getByText('Compliance findings, security score, configuration assessment')
     ).toBeInTheDocument();
   });
 

--- a/control-plane-ui/src/pages/SecurityPosture/SecurityPostureDashboard.tsx
+++ b/control-plane-ui/src/pages/SecurityPosture/SecurityPostureDashboard.tsx
@@ -345,7 +345,7 @@ export function SecurityPostureDashboard() {
         <div>
           <h1 className="text-2xl font-bold text-neutral-900 dark:text-white">Security Posture</h1>
           <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
-            Continuous security monitoring and compliance scoring
+            Compliance findings, security score, configuration assessment
           </p>
         </div>
         <div className="flex items-center gap-2">

--- a/memory.md
+++ b/memory.md
@@ -1,6 +1,6 @@
 # STOA Memory
 
-> Dernière MAJ: 2026-05-07. Archive complète (cycles passés, DONE, etc.) → `memory-archive.md`.
+> Dernière MAJ: 2026-05-09. Archive complète (cycles passés, DONE, etc.) → `memory-archive.md`.
 
 ## Session Notes — 2026-05-07
 
@@ -9,6 +9,10 @@
 - PR-1A5 Audit consumer runtime verification evidence produced on branch `docs/audit-consumer-runtime-verification` in worktree `/Users/torpedo/hlfh-repos/stoa-audit-consumer-runtime-verification`. Output file: `docs/audits/2026-05-09-audit-consumer-verification/findings.md`. OVH prod was verified with `KUBECONFIG=/Users/torpedo/.kube/config-stoa-ovh`; deployed image was `ghcr.io/stoa-platform/control-plane-api:dev-6400f51a51b32e4f3fb9d2b8010a90dc9d2ae8cc` (#2726). A non-chat `GET /v1/tenants/demo/export` event at `2026-05-07T19:24:38Z` produced Kafka event `b9ca45fb-67b3-4823-98af-c198c3d68871`, advanced `audit-trail-pg-consumer` offset `30018→30019` with lag `0`, persisted to `audit_events`, and was visible via `/v1/audit/demo`. Caveat: during collection the deployment rolled to revision 515 with `ENABLE_AUDIT_TRAIL_CONSUMER=false`; current group state is `Empty`/`MEMBERS=0`, so #2726 persistence is proven when enabled but continuous prod ingestion is currently disabled.
 
 - PR-2 Live Calls http_route migration implemented on branch `fix/live-calls-http-route-metric-integrity` in worktree `/Users/torpedo/hlfh-repos/stoa-live-calls-pr2`. Scope stayed frontend-only: Live Calls PromQL request queries now share `MODE_FILTER`, route-level panels group by `http_route`, `groupByLabel` uses explicit `(unlabelled)` fallback, Top Routes filters unusable route labels and renders a route-label unavailable state, synthetic heatmap generation was removed in favor of an explicit not-wired state, Active Modes counts jobs, scope-mismatch banner added, and traces empty-state now distinguishes Prometheus metrics from Tempo/OpenSearch traces. No AuditLog, Guardrails, backend, gateway Rust, Tempo/Loki/OpenSearch, sidebar/nav, or real heatmap implementation changes. Validation passed: `npm run test -- --run` (2302 passed, 11 skipped), targeted CallFlow/usePrometheus regressions (54 passed), `npm run lint` (50 pre-existing warnings, 0 errors), `npm run format:check`, `npm run build` after `shared/npm ci`, `git diff --check`, and static scan confirmed no Live Calls `sum by (path)`, `count by (path)`, `metric.path`, old `unknown` fallback, or synthetic heatmap hash block remains.
+
+## Session Notes — 2026-05-09
+
+- PR-4 observability nav IA cleanup on `chore/observability-nav-ia-cleanup`: removed advertised legacy Gateway sidebar links to `/gateway-security` and `/gateway-guardrails` while preserving `App.tsx` deep-link redirects to `/observability/security`; aligned Security Posture subtitle with validated AR-1 wording and added sidebar/title regression coverage. Frontend validation passed (`lint`, `format:check`, regression vitest, full vitest, build, `git diff --check`).
 
 ## Session Notes — 2026-05-04
 


### PR DESCRIPTION
## Summary

- Removes the legacy redirected Gateway sidebar entries for `/gateway-security` and `/gateway-guardrails` while keeping both deep-link redirects in `control-plane-ui/src/App.tsx`.
- Keeps AR-1 separation intact: Security Posture remains Governance/static posture, while Security & Guardrails remains Observability/runtime guardrail events.
- Adds regression coverage for sidebar legacy href removal and h1-to-breadcrumb alignment on `/observability/live-calls`, `/audit-log`, and `/observability/security`.

## Plan / AR-1

Plan: `docs/plans/2026-05-07-observability-data-integrity.md`.

AR-1 is validated: clarify, no fusion. Security Posture stays under Governance for static posture, findings, score, and configuration assessment. Security & Guardrails stays under Observability for runtime guardrail events.

## Evidence References

- PR-2 runtime evidence (#2740) confirms `/observability/live-calls` h1/subtitle behavior.
- PR-3 runtime evidence (#2744) confirms `/observability/security` h1/subtitle behavior.

## Explicit Non-Goals

- No backend changes.
- No API contract changes.
- No AuditLog, Live Calls, or Guardrails Dashboard logic changes.
- No infra changes.
- No removal of legacy redirect routes from `App.tsx`.

## Test Plan

- `npm run lint`
- `npm run format:check`
- `npm run test -- --run src/__tests__/regression/`
- `npm run test -- --run`
- `npm run build`
- `git diff --check`
