### PR TITLE
feat(api): observability audit fixtures gated by profile (phase 2)

### DIFF
--- a/control-plane-api/scripts/seeder/observability_fixtures/__init__.py
+++ b/control-plane-api/scripts/seeder/observability_fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Synthetic observability fixtures for non-production seed profiles."""

--- a/control-plane-api/scripts/seeder/observability_fixtures/audit_events.py
+++ b/control-plane-api/scripts/seeder/observability_fixtures/audit_events.py
@@ -1,0 +1,218 @@
+"""Seed synthetic audit-log events for dev and demo staging only."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import NAMESPACE_URL, uuid5
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from scripts.seeder.models import StepResult
+
+FIXTURE_BATCH = "observability-data-visibility-2026-05-09"
+TARGET_TENANT_ID = "demo"
+TARGET_EVENT_COUNT = 100
+OPT_IN_ENV = "STOA_OBSERVABILITY_AUDIT_FIXTURES"
+FIXTURE_PROFILE_ENV = "STOA_OBSERVABILITY_AUDIT_FIXTURE_PROFILE"
+_PROD_VALUES = {"prod", "production"}
+_TRUTHY_VALUES = {"1", "true", "yes", "on", "enabled"}
+_VALID_FIXTURE_PROFILES = {"dev", "staging-demo", "staging-prodlike", "prod"}
+
+SYNTHETIC_DETAILS = {
+    "synthetic": True,
+    "source": "seed",
+    "fixture_batch": FIXTURE_BATCH,
+}
+
+_ACTIONS = [
+    ("create", "POST", "api", 201),
+    ("update", "PATCH", "api", 200),
+    ("delete", "DELETE", "subscription", 204),
+    ("login", "POST", "session", 200),
+    ("logout", "POST", "session", 204),
+    ("access_denied", "GET", "gateway", 403),
+    ("config_change", "PATCH", "policy", 200),
+    ("export", "GET", "audit", 200),
+    ("deploy", "POST", "deployment", 202),
+    ("chat_tool_call", "POST", "mcp_tool", 200),
+]
+
+_OUTCOMES = ["success", "failure", "denied", "error"]
+
+_ACTORS = [
+    ("demo-admin", "admin@demo.gostoa.dev", "user"),
+    ("demo-devops", "devops@demo.gostoa.dev", "user"),
+    ("demo-viewer", "viewer@demo.gostoa.dev", "user"),
+    ("api-key-demo", None, "api_key"),
+    ("system-seed", None, "system"),
+]
+
+
+def _env_value(name: str) -> str:
+    return os.environ.get(name, "").strip().lower()
+
+
+def _prod_environment_enabled() -> bool:
+    return _env_value("ENVIRONMENT") in _PROD_VALUES or _env_value("STOA_ENVIRONMENT") in _PROD_VALUES
+
+
+def _truthy_env(name: str) -> bool:
+    return _env_value(name) in _TRUTHY_VALUES
+
+
+def _fixture_profile(seed_profile: str) -> str:
+    explicit = _env_value(FIXTURE_PROFILE_ENV)
+    if explicit:
+        profile = explicit
+    elif seed_profile == "staging":
+        profile = "staging-prodlike"
+    else:
+        profile = seed_profile
+
+    if profile not in _VALID_FIXTURE_PROFILES:
+        valid = ", ".join(sorted(_VALID_FIXTURE_PROFILES))
+        raise ValueError(f"{FIXTURE_PROFILE_ENV}={profile!r} is invalid. Valid: {valid}")
+    return profile
+
+
+def _fixtures_enabled(seed_profile: str) -> bool:
+    if _prod_environment_enabled():
+        raise RuntimeError("Synthetic audit fixtures are forbidden when ENVIRONMENT is production/prod")
+
+    profile = _fixture_profile(seed_profile)
+    if profile == "prod":
+        raise RuntimeError("Synthetic audit fixtures are forbidden in prod profile")
+    if profile == "dev":
+        return True
+    if profile == "staging-demo":
+        return _truthy_env(OPT_IN_ENV)
+    if profile == "staging-prodlike":
+        return False
+    return False
+
+
+def _event_id(index: int) -> str:
+    return str(uuid5(NAMESPACE_URL, f"stoa:{FIXTURE_BATCH}:{TARGET_TENANT_ID}:{index}"))
+
+
+def _event_payload(index: int, now: datetime) -> dict[str, Any]:
+    action, method, resource_type, status_code = _ACTIONS[index % len(_ACTIONS)]
+    outcome = _OUTCOMES[(index // len(_ACTIONS)) % len(_OUTCOMES)]
+    actor_id, actor_email, actor_type = _ACTORS[index % len(_ACTORS)]
+    resource_id = f"{resource_type}-{index % 25:02d}"
+    created_at = now - timedelta(days=index % 30, minutes=(index * 17) % 1440)
+
+    return {
+        "id": _event_id(index),
+        "tenant_id": TARGET_TENANT_ID,
+        "actor_id": actor_id,
+        "actor_email": actor_email,
+        "actor_type": actor_type,
+        "action": action,
+        "method": method,
+        "path": f"/v1/{resource_type}s/{resource_id}",
+        "resource_type": resource_type,
+        "resource_id": resource_id,
+        "resource_name": f"Demo {resource_type} {index % 25:02d}",
+        "outcome": outcome,
+        "status_code": status_code if outcome == "success" else _failure_status(outcome),
+        "client_ip": f"10.42.{index % 10}.{20 + index % 200}",
+        "user_agent": "stoa-seeder/observability-fixtures",
+        "correlation_id": str(uuid5(NAMESPACE_URL, f"stoa:{FIXTURE_BATCH}:correlation:{index}")),
+        "details": json.dumps(SYNTHETIC_DETAILS, sort_keys=True),
+        "duration_ms": 25 + (index * 13) % 750,
+        "created_at": created_at,
+    }
+
+
+def _failure_status(outcome: str) -> int:
+    if outcome == "denied":
+        return 403
+    if outcome == "error":
+        return 500
+    return 400
+
+
+async def seed(session: AsyncSession, profile: str, *, dry_run: bool = False) -> StepResult:
+    """Seed synthetic audit events for the configured non-production profile."""
+    result = StepResult(name="observability_fixtures")
+    if not _fixtures_enabled(profile):
+        return result
+
+    now = datetime.now(UTC)
+    for index in range(TARGET_EVENT_COUNT):
+        payload = _event_payload(index, now)
+        existing = await session.execute(
+            text("SELECT COUNT(*) FROM audit_events WHERE id = :id"),
+            {"id": payload["id"]},
+        )
+        if existing.scalar_one() > 0:
+            result.skipped += 1
+            continue
+
+        if dry_run:
+            print(f"  [DRY-RUN] Would create synthetic audit_event: {payload['id']}")
+            result.created += 1
+            continue
+
+        await session.execute(
+            text("""
+                INSERT INTO audit_events (
+                    id, tenant_id, actor_id, actor_email, actor_type,
+                    action, method, path, resource_type, resource_id, resource_name,
+                    outcome, status_code, client_ip, user_agent, correlation_id,
+                    details, duration_ms, created_at
+                ) VALUES (
+                    :id, :tenant_id, :actor_id, :actor_email, :actor_type,
+                    :action, :method, :path, :resource_type, :resource_id, :resource_name,
+                    :outcome, :status_code, :client_ip, :user_agent, :correlation_id,
+                    CAST(:details AS jsonb), :duration_ms, :created_at
+                )
+            """),
+            payload,
+        )
+        result.created += 1
+
+    return result
+
+
+async def check(session: AsyncSession, profile: str) -> list[str]:
+    """Check whether the expected synthetic audit fixture batch exists."""
+    if not _fixtures_enabled(profile):
+        return []
+
+    row = await session.execute(
+        text("""
+            SELECT COUNT(*) FROM audit_events
+            WHERE tenant_id = :tenant_id
+              AND details->>'synthetic' = 'true'
+              AND details->>'source' = 'seed'
+              AND details->>'fixture_batch' = :fixture_batch
+        """),
+        {"tenant_id": TARGET_TENANT_ID, "fixture_batch": FIXTURE_BATCH},
+    )
+    if row.scalar_one() < TARGET_EVENT_COUNT:
+        return [f"audit_events:{TARGET_TENANT_ID}:{FIXTURE_BATCH} (incomplete)"]
+    return []
+
+
+async def reset(session: AsyncSession, profile: str) -> int:
+    """Delete only the synthetic audit fixture batch."""
+    if not _fixtures_enabled(profile):
+        return 0
+
+    result = await session.execute(
+        text("""
+            DELETE FROM audit_events
+            WHERE tenant_id = :tenant_id
+              AND details->>'synthetic' = 'true'
+              AND details->>'source' = 'seed'
+              AND details->>'fixture_batch' = :fixture_batch
+        """),
+        {"tenant_id": TARGET_TENANT_ID, "fixture_batch": FIXTURE_BATCH},
+    )
+    return getattr(result, "rowcount", 0) or 0

--- a/control-plane-api/scripts/seeder/profiles/dev.py
+++ b/control-plane-api/scripts/seeder/profiles/dev.py
@@ -10,4 +10,9 @@ STEPS: list[StepDefinition] = [
     StepDefinition(name="consumers", deps=["tenants", "plans"]),
     StepDefinition(name="mcp_servers", deps=["tenants"]),
     StepDefinition(name="security_posture", deps=["tenants"]),
+    StepDefinition(
+        name="observability_fixtures",
+        deps=["tenants"],
+        seed_fn="scripts.seeder.observability_fixtures.audit_events",
+    ),
 ]

--- a/control-plane-api/scripts/seeder/profiles/staging.py
+++ b/control-plane-api/scripts/seeder/profiles/staging.py
@@ -10,4 +10,9 @@ STEPS: list[StepDefinition] = [
     StepDefinition(name="consumers", deps=["tenants", "plans"]),
     StepDefinition(name="mcp_servers", deps=["tenants"]),
     StepDefinition(name="security_posture", deps=["tenants"]),
+    StepDefinition(
+        name="observability_fixtures",
+        deps=["tenants"],
+        seed_fn="scripts.seeder.observability_fixtures.audit_events",
+    ),
 ]

--- a/control-plane-api/scripts/seeder/runner.py
+++ b/control-plane-api/scripts/seeder/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+import os
 from typing import TYPE_CHECKING
 
 from scripts.seeder.models import SeederResult, StepDefinition, StepResult
@@ -24,6 +25,12 @@ VALID_STEPS = (
     "mcp_servers",
     "prospects",
     "security_posture",
+    "observability_fixtures",
+)
+
+_OBSERVABILITY_FIXTURE_ENVS = (
+    "STOA_OBSERVABILITY_AUDIT_FIXTURES",
+    "STOA_OBSERVABILITY_AUDIT_FIXTURE_PROFILE",
 )
 
 
@@ -33,8 +40,14 @@ def _load_profile(profile: str) -> list[StepDefinition]:
     return mod.STEPS
 
 
-def _load_step_module(step_name: str):
-    """Load the step module (scripts.seeder.steps.<name>)."""
+def _load_step_module(step_def: StepDefinition):
+    """Load the module that implements a seeder step."""
+    module_path = step_def.seed_fn or f"scripts.seeder.steps.{step_def.name}"
+    return importlib.import_module(module_path)
+
+
+def _load_dependency_module(step_name: str):
+    """Load a core dependency step module."""
     return importlib.import_module(f"scripts.seeder.steps.{step_name}")
 
 
@@ -71,6 +84,9 @@ class SeederRunner:
 
         if step is not None and step not in VALID_STEPS:
             raise ValueError(f"Unknown step: {step}. Valid: {', '.join(VALID_STEPS)}")
+
+        if profile == "prod" and (step == "observability_fixtures" or _observability_fixtures_requested()):
+            raise ValueError("Synthetic audit fixtures are forbidden in prod profile")
 
         self.session = session
         self.profile = profile
@@ -111,7 +127,7 @@ class SeederRunner:
                     result.error = dep_error
                     return result
 
-            step_mod = _load_step_module(step_def.name)
+            step_mod = _load_step_module(step_def)
             try:
                 step_result = await step_mod.seed(self.session, self.profile, dry_run=self.dry_run)
                 result.steps.append(step_result)
@@ -135,7 +151,7 @@ class SeederRunner:
     async def _run_check(self, result: SeederResult) -> SeederResult:
         """Run check mode — verify expected data exists."""
         for step_def in self._steps:
-            step_mod = _load_step_module(step_def.name)
+            step_mod = _load_step_module(step_def)
             missing = await step_mod.check(self.session, self.profile)
             result.missing.extend(missing)
 
@@ -153,7 +169,7 @@ class SeederRunner:
         for step_def in reversed(self._steps):
             if self.step_filter and step_def.name != self.step_filter:
                 continue
-            step_mod = _load_step_module(step_def.name)
+            step_mod = _load_step_module(step_def)
             deleted = await step_mod.reset(self.session, self.profile)
             if deleted > 0:
                 print(f"  [RESET] {step_def.name}: deleted {deleted} rows")
@@ -163,7 +179,7 @@ class SeederRunner:
     async def _check_deps(self, step_def: StepDefinition) -> str | None:
         """Check that dependencies exist when running a single step."""
         for dep_name in step_def.deps:
-            dep_mod = _load_step_module(dep_name)
+            dep_mod = _load_dependency_module(dep_name)
             missing = await dep_mod.check(self.session, self.profile)
             if missing:
                 return f"Missing dependency: {dep_name} ({', '.join(missing)})"
@@ -178,3 +194,10 @@ def _log_step(step_result: StepResult) -> None:
         f"skipped {step_result.skipped} / "
         f"failed {step_result.failed}"
     )
+
+
+def _observability_fixtures_requested() -> bool:
+    """Return true when an operator explicitly requested audit fixtures."""
+    opt_in = os.environ.get(_OBSERVABILITY_FIXTURE_ENVS[0], "").strip().lower()
+    fixture_profile = os.environ.get(_OBSERVABILITY_FIXTURE_ENVS[1], "").strip()
+    return opt_in in {"1", "true", "yes", "on", "enabled"} or bool(fixture_profile)

--- a/control-plane-api/src/routers/audit.py
+++ b/control-plane-api/src/routers/audit.py
@@ -60,6 +60,7 @@ class AuditEntry(BaseModel):
     user_agent: str | None
     details: dict[str, Any] | None
     request_id: str | None
+    is_synthetic: bool = False
 
 
 class AuditListResponse(BaseModel):
@@ -135,6 +136,17 @@ class PiiErasureResponse(BaseModel):
     pg_records_affected: int
     os_records_deleted: int
     pseudo_id: str
+
+
+def _is_synthetic_details(details: dict[str, Any] | None) -> bool:
+    """Return true for audit fixture rows marked in details JSONB."""
+    if not isinstance(details, dict):
+        return False
+    return (
+        details.get("synthetic") is True
+        and details.get("source") == "seed"
+        and details.get("fixture_batch") == "observability-data-visibility-2026-05-09"
+    )
 
 
 # =============================================================================
@@ -645,6 +657,7 @@ async def export_audit_csv(
             "Status",
             "Client IP",
             "Request ID",
+            "Is Synthetic",
         ]
     )
 
@@ -662,6 +675,7 @@ async def export_audit_csv(
                 entry.get("status"),
                 entry.get("client_ip"),
                 entry.get("request_id"),
+                entry.get("is_synthetic", False),
             ]
         )
 
@@ -721,7 +735,7 @@ async def export_audit_json(
         "tenant_id": tenant_id,
         "exported_at": datetime.now(UTC).isoformat(),
         "total_entries": len(rows),
-        "entries": rows,
+        "entries": [{**row, "is_synthetic": row.get("is_synthetic", False)} for row in rows],
     }
 
     json_content = json.dumps(export_data, indent=2, default=str)
@@ -1020,6 +1034,7 @@ async def _pg_event_to_entry(event: Any) -> AuditEntry:
         user_agent=event.user_agent,
         details=event.details,
         request_id=event.correlation_id,
+        is_synthetic=_is_synthetic_details(event.details),
     )
 
 
@@ -1041,6 +1056,7 @@ def _pg_event_to_dict(event: Any) -> dict[str, Any]:
         "path": event.path,
         "status_code": event.status_code,
         "duration_ms": event.duration_ms,
+        "is_synthetic": _is_synthetic_details(event.details),
     }
 
 
@@ -1149,6 +1165,7 @@ async def _query_opensearch_audit(
                 user_agent=actor_src.get("user_agent"),
                 details=src.get("details"),
                 request_id=src.get("correlation_id"),
+                is_synthetic=_is_synthetic_details(src.get("details")),
             )
         )
 

--- a/control-plane-api/tests/test_audit_router.py
+++ b/control-plane-api/tests/test_audit_router.py
@@ -14,9 +14,8 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from fastapi.testclient import TestClient
-
 import pytest
+from fastapi.testclient import TestClient
 
 import src.routers.audit as audit_router
 from src.auth.dependencies import User, get_current_user
@@ -126,6 +125,42 @@ class TestListAuditEntries:
             resp = client.get(f"/v1/audit/{DEMO_TENANT}")
 
         assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_pg_audit_event_exposes_computed_is_synthetic() -> None:
+    event = SimpleNamespace(
+        id="evt-synthetic",
+        created_at=datetime(2026, 5, 9, tzinfo=UTC),
+        tenant_id=DEMO_TENANT,
+        actor_id="system-seed",
+        actor_email=None,
+        action="export",
+        resource_type="audit",
+        resource_id="audit-1",
+        outcome="success",
+        client_ip=None,
+        user_agent=None,
+        details={
+            "synthetic": True,
+            "source": "seed",
+            "fixture_batch": "observability-data-visibility-2026-05-09",
+        },
+        correlation_id="req-synthetic",
+        method="GET",
+        path="/v1/audits/audit-1",
+        status_code=200,
+        duration_ms=42,
+    )
+
+    with patch(
+        "src.routers.audit.resolve_actor",
+        AsyncMock(return_value=SimpleNamespace(user_email=None, user_display_name=None, resolved=False)),
+    ):
+        entry = await audit_router._pg_event_to_entry(event)
+
+    assert entry.is_synthetic is True
+    assert audit_router._pg_event_to_dict(event)["is_synthetic"] is True
 
 
 class TestAuditStatsEndpoint:

--- a/control-plane-api/tests/test_observability_audit_fixtures.py
+++ b/control-plane-api/tests/test_observability_audit_fixtures.py
@@ -1,0 +1,128 @@
+"""Tests for synthetic audit-log fixtures."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from scripts.seeder.observability_fixtures import audit_events
+from scripts.seeder.runner import SeederRunner
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _mock_session(existing_count: int = 0) -> AsyncMock:
+    session = AsyncMock(spec=AsyncSession)
+    result = MagicMock()
+    result.scalar_one.return_value = existing_count
+    result.rowcount = 0
+    session.execute = AsyncMock(return_value=result)
+    return session
+
+
+def _clear_fixture_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "ENVIRONMENT",
+        "STOA_ENVIRONMENT",
+        audit_events.OPT_IN_ENV,
+        audit_events.FIXTURE_PROFILE_ENV,
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _insert_calls(session: AsyncMock) -> list:
+    return [
+        call
+        for call in session.execute.await_args_list
+        if call.args and "INSERT INTO audit_events" in str(call.args[0])
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dev_profile_seeds_target_volume_with_locked_markers(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_fixture_env(monkeypatch)
+    session = _mock_session()
+
+    result = await audit_events.seed(session, "dev")
+
+    assert result.name == "observability_fixtures"
+    assert result.created == audit_events.TARGET_EVENT_COUNT
+    inserts = _insert_calls(session)
+    assert len(inserts) == audit_events.TARGET_EVENT_COUNT
+    for call in inserts:
+        details = json.loads(call.args[1]["details"])
+        assert details == audit_events.SYNTHETIC_DETAILS
+
+
+@pytest.mark.asyncio
+async def test_production_environment_refuses_synthetic_audit_fixtures(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_fixture_env(monkeypatch)
+    monkeypatch.setenv("ENVIRONMENT", "production")
+
+    with pytest.raises(RuntimeError, match="forbidden"):
+        await audit_events.seed(_mock_session(), "dev")
+
+
+@pytest.mark.asyncio
+async def test_prod_profile_refuses_synthetic_audit_fixtures(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_fixture_env(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="prod profile"):
+        await audit_events.seed(_mock_session(), "prod")
+
+
+def test_runner_refuses_prod_fixture_step(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_fixture_env(monkeypatch)
+
+    with pytest.raises(ValueError, match="forbidden in prod profile"):
+        SeederRunner(session=_mock_session(), profile="prod", step="observability_fixtures")
+
+
+def test_runner_refuses_prod_fixture_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_fixture_env(monkeypatch)
+    monkeypatch.setenv(audit_events.OPT_IN_ENV, "true")
+
+    with pytest.raises(ValueError, match="forbidden in prod profile"):
+        SeederRunner(session=_mock_session(), profile="prod")
+
+
+def test_runner_does_not_treat_false_prod_opt_in_as_requested(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_fixture_env(monkeypatch)
+    monkeypatch.setenv(audit_events.OPT_IN_ENV, "false")
+
+    runner = SeederRunner(session=_mock_session(), profile="prod")
+
+    assert runner.profile == "prod"
+
+
+@pytest.mark.asyncio
+async def test_staging_demo_requires_explicit_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_fixture_env(monkeypatch)
+    monkeypatch.setenv(audit_events.FIXTURE_PROFILE_ENV, "staging-demo")
+    session = _mock_session()
+
+    result = await audit_events.seed(session, "staging")
+
+    assert result.created == 0
+    session.execute.assert_not_awaited()
+
+    monkeypatch.setenv(audit_events.OPT_IN_ENV, "true")
+    enabled_session = _mock_session()
+
+    enabled_result = await audit_events.seed(enabled_session, "staging")
+
+    assert enabled_result.created == audit_events.TARGET_EVENT_COUNT
+    assert len(_insert_calls(enabled_session)) == audit_events.TARGET_EVENT_COUNT
+
+
+@pytest.mark.asyncio
+async def test_staging_prodlike_does_not_seed_even_with_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_fixture_env(monkeypatch)
+    monkeypatch.setenv(audit_events.FIXTURE_PROFILE_ENV, "staging-prodlike")
+    monkeypatch.setenv(audit_events.OPT_IN_ENV, "true")
+    session = _mock_session()
+
+    result = await audit_events.seed(session, "staging")
+
+    assert result.created == 0
+    session.execute.assert_not_awaited()

--- a/control-plane-ui/src/pages/AuditLog.test.tsx
+++ b/control-plane-ui/src/pages/AuditLog.test.tsx
@@ -390,6 +390,52 @@ describe('AuditLog', () => {
     });
   });
 
+  it('shows a visible badge for synthetic audit events', async () => {
+    vi.useRealTimers();
+    mockGet.mockImplementation((url: unknown) => {
+      if (String(url) === '/v1/audit/gregarious-games') {
+        return Promise.resolve({
+          data: {
+            entries: [
+              {
+                id: 'evt-synthetic',
+                timestamp: '2026-05-09T10:00:00Z',
+                user_id: 'system-seed',
+                user_email: null,
+                action: 'export',
+                resource_type: 'audit',
+                resource_id: 'audit-1',
+                resource_name: 'audit-one',
+                status: 'success',
+                details: {
+                  synthetic: true,
+                  source: 'seed',
+                  fixture_batch: 'observability-data-visibility-2026-05-09',
+                },
+                is_synthetic: true,
+                client_ip: null,
+                user_agent: null,
+                request_id: 'req-synthetic',
+                tenant_id: 'gregarious-games',
+              },
+            ],
+            total: 1,
+            page: 1,
+            page_size: 20,
+            has_more: false,
+          },
+        });
+      }
+      return defaultAuditMock(url);
+    });
+
+    render(<AuditLog />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('audit-synthetic-badge')).toHaveTextContent('synthetic');
+    });
+  });
+
   it('shows the last successful refresh timestamp', async () => {
     vi.useRealTimers();
     render(<AuditLog />);

--- a/control-plane-ui/src/pages/AuditLog.tsx
+++ b/control-plane-ui/src/pages/AuditLog.tsx
@@ -52,6 +52,7 @@ interface AuditEntry {
   resource_name?: string;
   status: AuditStatus;
   details: Record<string, unknown> | null;
+  is_synthetic?: boolean;
   client_ip: string | null;
   user_agent: string | null;
   request_id: string | null;
@@ -627,6 +628,15 @@ export function AuditLog() {
                                   <span className="text-neutral-700 dark:text-neutral-300 capitalize">
                                     {entry.action.replace(/_/g, ' ')}
                                   </span>
+                                  {entry.is_synthetic && (
+                                    <span
+                                      data-testid="audit-synthetic-badge"
+                                      title="Synthetic seed event"
+                                      className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium uppercase text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
+                                    >
+                                      synthetic
+                                    </span>
+                                  )}
                                 </div>
                               </td>
                               <td className="px-4 py-3">


### PR DESCRIPTION
## Scope

Implements Phase 2 audit-log synthetic fixtures from the observability data visibility plan.

- plan_ref: docs/plans/2026-05-09-observability-data-visibility.md
- phase: 2
- plan decision: docs/decisions/2026-05-09-observability-data-visibility.md
- seed-vs-runtime contract: docs/decisions/2026-05-09-seed-vs-runtime-contract.md
- this PR does not validate the audit pipeline end-to-end

## What changed

- Adds `control-plane-api/scripts/seeder/observability_fixtures/audit_events.py` at the locked Phase 1 path.
- Seeds deterministic synthetic audit events for `demo` in `dev` by default.
- Keeps `staging-prodlike` disabled and requires explicit `staging-demo` opt-in.
- Fails closed for prod profile / prod environment instead of falling back silently.
- Exposes computed `is_synthetic` in the audit API and CSV/JSON exports.
- Shows a visible `synthetic` badge in `/audit-log`.

## Validation

- `python3 -m pytest tests/test_observability_audit_fixtures.py tests/test_audit_router.py -q` -> 51 passed
- `npm run test -- AuditLog.test.tsx --run` -> 24 passed
- `python3 -m ruff check ...` -> passed
- `npx prettier --check src/pages/AuditLog.tsx src/pages/AuditLog.test.tsx` -> passed
- `npx eslint src/pages/AuditLog.tsx src/pages/AuditLog.test.tsx --max-warnings 110` -> passed
- `git diff --check origin/main..HEAD` -> passed

## Anti-goals checked

- No Alembic migration.
- No synthetic traffic.
- No Phase 5 probe or pipeline validation.
- No by_actor / by_resource decision.
- No `metadata.synthetic` wording.
