### PR TITLE
fix(ui): honest wording for guardrails empty state (phase 3)

### DIFF
--- a/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.test.tsx
+++ b/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.test.tsx
@@ -172,7 +172,7 @@ describe('GuardrailsDashboard', () => {
 
     expect(
       await within(screen.getByTestId('guardrail-card-pii-detection')).findByText(
-        'No metrics sample'
+        'No guardrail trip samples in window'
       )
     ).toBeInTheDocument();
   });
@@ -196,7 +196,7 @@ describe('GuardrailsDashboard', () => {
     expect(await screen.findAllByText('Metrics unavailable')).not.toHaveLength(0);
     expect(
       await within(screen.getByTestId('guardrail-card-pii-detection')).findByText(
-        'No metrics sample'
+        'No guardrail trip samples in window'
       )
     ).toBeInTheDocument();
   });

--- a/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.tsx
+++ b/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.tsx
@@ -212,7 +212,7 @@ function cardStateText(state: GuardrailCardUIState): string {
     case 'disabled':
       return 'Disabled';
     case 'no-sample':
-      return 'No metrics sample';
+      return 'No guardrail trip samples in window';
     case 'stale':
       return 'Stale metrics';
     case 'healthy':
@@ -375,7 +375,7 @@ export function GuardrailsDashboard() {
           const isDisabled =
             statusText === 'Disabled' ||
             statusText === 'Metrics unavailable' ||
-            statusText === 'No metrics sample';
+            statusText === 'No guardrail trip samples in window';
           const isFilterable =
             card.kind === 'metric' &&
             !isDisabled &&


### PR DESCRIPTION
## Summary

- Replaces guardrails card empty-state copy from `No metrics sample` to `No guardrail trip samples in window`.
- Updates the Guardrails Dashboard regression assertions for the new wording.
- Keeps the change UI-only: no backend contract changes and no new metric registration.

## Plan Traceability

- plan_ref: docs/plans/2026-05-09-observability-data-visibility.md
- phase: 3
- plan decision: docs/decisions/2026-05-09-observability-data-visibility.md
- this PR does not introduce new metrics; the zero-vs-absent semantic split is deferred to Phase 6.

## Validation

- `npm run test -- src/pages/GatewayGuardrails/GuardrailsDashboard.test.tsx src/__tests__/regression/observability-titles.test.tsx` — 23 passed
- `npm run test` — 171 files passed, 2,338 tests passed, 11 skipped
- `npm run format:check`
- `npm run lint` — 0 errors, 49 warnings under the 110-warning gate
- `git diff --check`

## Scope Guardrails

- No files under `control-plane-api/`, `stoa-gateway/`, `charts/`, or `alembic/` changed.
- No changes to `routers/gateway_observability.py`.
- No new Prometheus metric or gateway counter.
- No attempt to distinguish zero trips from absent series.
