### PR TITLE
feat(api): control-plane audit pipeline probe (phase 5A)

### DIFF
--- a/control-plane-api/scripts/probes/audit_pipeline_probe.py
+++ b/control-plane-api/scripts/probes/audit_pipeline_probe.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Phase 5A probe: control-plane audit action -> Kafka -> PG -> audit API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+from typing import Any
+
+import httpx
+import psycopg2
+from kafka import KafkaConsumer, TopicPartition
+from psycopg2.extras import Json, RealDictCursor
+
+TENANT_ID = "audit-probe"
+TOPIC = "stoa.audit.trail"
+API_PREFIX = "audit-pipeline-probe"
+TRUTHY = {"1", "true", "yes", "y", "on", "operator-approved"}
+
+
+def args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the Phase 5A audit pipeline probe.")
+    parser.add_argument("--api-url", default=os.getenv("STOA_CONTROL_PLANE_API_URL", "http://localhost:8000"))
+    parser.add_argument("--api-token", default=os.getenv("STOA_API_TOKEN") or os.getenv("CONTROL_PLANE_API_TOKEN"))
+    parser.add_argument(
+        "--database-url", default=os.getenv("DATABASE_URL", "postgresql://stoa:stoa@localhost:5432/stoa")
+    )
+    parser.add_argument(
+        "--kafka-bootstrap-servers",
+        default=os.getenv("KAFKA_BOOTSTRAP_SERVERS", "redpanda.stoa-system.svc.cluster.local:9092"),
+    )
+    parser.add_argument("--environment", default=os.getenv("ENVIRONMENT", "dev"))
+    parser.add_argument("--timeout-seconds", type=int, default=60)
+    return parser.parse_args(argv)
+
+
+def gate(env: str) -> None:
+    if env.strip().lower() in {"prod", "production"} and os.getenv("OPERATOR_OPT_IN", "").lower() not in TRUTHY:
+        raise RuntimeError("Refusing production run without OPERATOR_OPT_IN=true.")
+
+
+def pg_url(url: str) -> str:
+    return (
+        "postgresql://" + url.removeprefix("postgresql+asyncpg://") if url.startswith("postgresql+asyncpg://") else url
+    )
+
+
+def new_probe() -> dict[str, str]:
+    suffix = uuid.uuid4().hex[:12]
+    api_id = f"{API_PREFIX}-{suffix}"
+    return {"probe_id": f"probe-{suffix}", "api_id": api_id, "api_version": f"probe-{suffix}"}
+
+
+def db_cleanup(conn: Any, probe: dict[str, str], *, tenant_created: bool = False) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            DELETE FROM audit_events
+            WHERE tenant_id=%s
+              AND (id=%s OR (resource_type='api' AND resource_id=%s)
+                   OR details->>'name'=%s OR details->>'version'=%s)
+            """,
+            (TENANT_ID, probe.get("event_id"), probe["api_id"], probe["api_id"], probe["api_version"]),
+        )
+        cur.execute("DELETE FROM api_catalog WHERE tenant_id=%s AND api_id=%s", (TENANT_ID, probe["api_id"]))
+        if tenant_created:
+            cur.execute("DELETE FROM tenants WHERE id=%s", (TENANT_ID,))
+    conn.commit()
+
+
+def db_prepare(conn: Any) -> bool:
+    with conn.cursor() as cur:
+        cur.execute("SELECT id FROM tenants WHERE id=%s", (TENANT_ID,))
+        if cur.fetchone():
+            return False
+        cur.execute(
+            """
+            INSERT INTO tenants (id, name, description, status, settings, provisioning_status)
+            VALUES (%s, %s, %s, 'active', %s, 'ready')
+            """,
+            (
+                TENANT_ID,
+                "Audit Probe",
+                "Dedicated tenant for Phase 5A audit pipeline probes.",
+                Json({"max_apis": 100, "max_applications": 100, "source": "audit_pipeline_probe"}),
+            ),
+        )
+    conn.commit()
+    return True
+
+
+def kafka_consumer(bootstrap: str, timeout: int) -> KafkaConsumer:
+    consumer = KafkaConsumer(
+        bootstrap_servers=[s.strip() for s in bootstrap.split(",") if s.strip()],
+        enable_auto_commit=False,
+        value_deserializer=lambda raw: json.loads(raw.decode("utf-8")),
+    )
+    deadline = time.monotonic() + timeout
+    partitions: set[int] | None = None
+    while time.monotonic() < deadline and not partitions:
+        partitions = consumer.partitions_for_topic(TOPIC)
+        time.sleep(0.5)
+    if not partitions:
+        raise RuntimeError(f"Kafka topic {TOPIC} is not available.")
+    tps = [TopicPartition(TOPIC, p) for p in sorted(partitions)]
+    consumer.assign(tps)
+    consumer.seek_to_end(*tps)
+    return consumer
+
+
+def emit_action(cfg: argparse.Namespace, probe: dict[str, str]) -> None:
+    if not cfg.api_token:
+        raise RuntimeError("Missing STOA_API_TOKEN or CONTROL_PLANE_API_TOKEN.")
+    headers = {
+        "Authorization": f"Bearer {cfg.api_token}",
+        "X-Probe-Id": probe["probe_id"],
+        "User-Agent": "stoa-audit-pipeline-probe/phase-5a",
+    }
+    payload = {
+        "name": probe["api_id"],
+        "display_name": f"Audit Pipeline Probe {probe['probe_id']}",
+        "version": probe["api_version"],
+        "backend_url": "https://audit-probe.invalid",
+    }
+    with httpx.Client(timeout=cfg.timeout_seconds) as client:
+        resp = client.post(f"{cfg.api_url.rstrip('/')}/v1/tenants/{TENANT_ID}/apis", headers=headers, json=payload)
+    if resp.status_code < 200 or resp.status_code >= 300:
+        raise RuntimeError(f"API create returned HTTP {resp.status_code}: {resp.text[:300]}")
+    data = resp.json()
+    if data.get("id") != probe["api_id"] or data.get("tenant_id") != TENANT_ID:
+        raise RuntimeError(f"Unexpected API create response: {data}")
+
+
+def match_event(event: Any, probe: dict[str, str]) -> bool:
+    payload = event.get("payload") if isinstance(event, dict) else None
+    details = payload.get("details") if isinstance(payload, dict) else None
+    return (
+        isinstance(details, dict)
+        and event.get("type") == "audit"
+        and event.get("tenant_id") == TENANT_ID
+        and payload.get("action") == "create"
+        and payload.get("resource_type") == "api"
+        and payload.get("resource_id") == probe["api_id"]
+        and details.get("name") == probe["api_id"]
+        and details.get("version") == probe["api_version"]
+    )
+
+
+def wait_kafka(consumer: KafkaConsumer, probe: dict[str, str], timeout: int) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        for records in consumer.poll(timeout_ms=1000).values():
+            for msg in records:
+                if match_event(msg.value, probe):
+                    probe.update(
+                        {"event_id": msg.value["id"], "kafka_partition": msg.partition, "kafka_offset": msg.offset}
+                    )
+                    return
+    raise RuntimeError(f"No matching audit envelope observed on {TOPIC}.")
+
+
+def wait_pg(conn: Any, probe: dict[str, str], timeout: int) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id FROM audit_events
+                WHERE tenant_id=%s AND (id=%s OR (resource_type='api' AND resource_id=%s AND details->>'version'=%s))
+                LIMIT 1
+                """,
+                (TENANT_ID, probe.get("event_id"), probe["api_id"], probe["api_version"]),
+            )
+            if row := cur.fetchone():
+                probe["event_id"] = row["id"]
+                return
+        time.sleep(1)
+    raise RuntimeError("No matching audit_events row observed before timeout.")
+
+
+def wait_api(cfg: argparse.Namespace, probe: dict[str, str]) -> None:
+    headers = {"Authorization": f"Bearer {cfg.api_token}", "X-Probe-Id": probe["probe_id"]}
+    with httpx.Client(timeout=cfg.timeout_seconds) as client:
+        resp = client.get(
+            f"{cfg.api_url.rstrip('/')}/v1/audit/{TENANT_ID}",
+            headers=headers,
+            params={"search": probe["api_id"], "page_size": 10},
+        )
+    if resp.status_code < 200 or resp.status_code >= 300:
+        raise RuntimeError(f"Audit API returned HTTP {resp.status_code}: {resp.text[:300]}")
+    if not any(
+        e.get("id") == probe.get("event_id") and e.get("resource_id") == probe["api_id"]
+        for e in resp.json().get("entries", [])
+    ):
+        raise RuntimeError("Audit API did not return the persisted probe event.")
+
+
+def run(cfg: argparse.Namespace) -> int:
+    gate(cfg.environment)
+    probe = new_probe()
+    hops = {
+        name: {"status": "fail", "detail": "not run"}
+        for name in ("audit_emit", "kafka_consumed", "pg_persisted", "api_visible")
+    }
+    conn = psycopg2.connect(pg_url(cfg.database_url), cursor_factory=RealDictCursor)
+    consumer: KafkaConsumer | None = None
+    tenant_created = False
+    try:
+        db_cleanup(conn, probe)
+        tenant_created = db_prepare(conn)
+        consumer = kafka_consumer(cfg.kafka_bootstrap_servers, cfg.timeout_seconds)
+        for name, fn in (
+            ("audit_emit", lambda: emit_action(cfg, probe)),
+            ("kafka_consumed", lambda: wait_kafka(consumer, probe, cfg.timeout_seconds)),
+            ("pg_persisted", lambda: wait_pg(conn, probe, cfg.timeout_seconds)),
+            ("api_visible", lambda: wait_api(cfg, probe)),
+        ):
+            try:
+                fn()
+                hops[name] = {"status": "pass", "detail": "ok"}
+            except Exception as exc:
+                hops[name] = {"status": "fail", "detail": str(exc)}
+                break
+    finally:
+        cleanup = "pass"
+        try:
+            db_cleanup(conn, probe, tenant_created=tenant_created)
+        except Exception as exc:
+            cleanup = f"fail: {exc}"
+        conn.close()
+        if consumer:
+            consumer.close()
+    summary = {
+        "probe": "control-plane-audit-pipeline",
+        "phase": "5A",
+        "tenant_id": TENANT_ID,
+        "topic": TOPIC,
+        **probe,
+        "hops": hops,
+        "cleanup": cleanup,
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if all(h["status"] == "pass" for h in hops.values()) and cleanup == "pass" else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        return run(args(argv or sys.argv[1:]))
+    except Exception as exc:
+        print(json.dumps({"probe": "control-plane-audit-pipeline", "phase": "5A", "error": str(exc)}), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/observability/audit-pipeline-probe.md
+++ b/docs/observability/audit-pipeline-probe.md
@@ -1,0 +1,40 @@
+# Control-plane audit pipeline probe
+
+Plan: `docs/plans/2026-05-09-observability-data-visibility.md`; phase: 5A. Decisions:
+`docs/decisions/2026-05-09-observability-data-visibility.md`,
+`docs/decisions/2026-05-09-seed-vs-runtime-contract.md`,
+`docs/audits/2026-05-09-observability-data-visibility/probe-trace-walk.md`.
+
+Implementation shape: Option A, `control-plane-api/scripts/probes/audit_pipeline_probe.py`.
+The probe validates only:
+
+```text
+control-plane action -> Kafka audit topic -> audit_trail_consumer -> audit_events -> /v1/audit/{tenant}
+```
+
+It creates one API under fixed tenant `audit-probe`, sends `X-Probe-Id`, observes
+the matching envelope on `stoa.audit.trail` (`Topics.AUDIT_LOG`), waits for
+`audit_events`, then checks `/v1/audit/audit-probe`.
+
+Required binary hops:
+
+- `audit_emit`: `POST /v1/tenants/audit-probe/apis` returns the expected API.
+- `kafka_consumed`: the probe consumes the matching `audit` envelope from Kafka.
+- `pg_persisted`: a matching row appears after `audit_trail_consumer` runs.
+- `api_visible`: `/v1/audit/audit-probe?search=<api_id>` returns the event.
+
+This PR validates the control-plane audit path only; gateway telemetry traces are
+Phase 5B and gated by Phase 0 verdict. It does not prove gateway runtime
+telemetry, Prometheus metrics, Tempo/OpenSearch traces, Phase 2 fixtures, or
+end-to-end trace visibility.
+
+- Fixed tenant `audit-probe`; never `demo`, `free-aech`, or customer tenants.
+- Probe API rows and matching audit rows are deleted at the end.
+- If `audit-probe` is absent, a minimal tenant row is created and cleaned up.
+- Phase 2 fixture markers are untouched: no `details.synthetic=true`, no `fixture_batch`.
+- `ENVIRONMENT=production` refuses unless `OPERATOR_OPT_IN` is `1`, `true`, `yes`, `y`, `on`, or `operator-approved`.
+- No workflow, schedule, or cron is added; Q8.4 remains on-demand/manual.
+
+Usage: set `ENVIRONMENT`, `STOA_CONTROL_PLANE_API_URL`, `STOA_API_TOKEN`,
+`DATABASE_URL`, and `KAFKA_BOOTSTRAP_SERVERS`, then run
+`python control-plane-api/scripts/probes/audit_pipeline_probe.py`.


### PR DESCRIPTION
## Summary

- Adds Option A: `control-plane-api/scripts/probes/audit_pipeline_probe.py`.
- The probe creates one synthetic API under the dedicated `audit-probe` tenant, observes the matching audit envelope on Kafka topic `stoa.audit.trail`, waits for `audit_events`, verifies `/v1/audit/audit-probe`, and cleans its own rows.
- Adds `docs/observability/audit-pipeline-probe.md` with the hop list, non-goals, prod gate, cleanup behavior, and cadence intent.

## Plan Traceability

- plan_ref: docs/plans/2026-05-09-observability-data-visibility.md
- phase: 5A
- plan decision: docs/decisions/2026-05-09-observability-data-visibility.md
- seed-vs-runtime contract: docs/decisions/2026-05-09-seed-vs-runtime-contract.md
- this PR validates the control-plane audit path only; gateway telemetry traces are Phase 5B and gated by Phase 0 verdict.

## Validation

- `python3 -m compileall scripts/probes/audit_pipeline_probe.py`
- `python3 scripts/probes/audit_pipeline_probe.py --help`
- `python3 -m ruff check scripts/probes/audit_pipeline_probe.py`
- `python3 -m black --check scripts/probes/audit_pipeline_probe.py`
- `python3 -m pytest tests/test_audit_trail_consumer.py tests/test_audit_router.py -q` — 54 passed
- `git diff --check`

## Scope Guardrails

- Phase 5 split honored: this is 5A only; no 5B gateway telemetry probe.
- No Prometheus, Tempo, or OpenSearch trace validation.
- No workflow, schedule, or cron added.
- No files under `stoa-gateway/`, `charts/`, or `alembic/` changed.
- Existing audit paths are not modified: no changes to `routers/audit.py`, `services/kafka_service.py`, `workers/audit_trail_consumer.py`, or `models/audit_event.py`.
