### PR TITLE
feat(ui): CAB-2219 phase 6.5 cp-ui 5-state rendering + AR-1 anti-regression

### DIFF
--- a/control-plane-ui/src/__tests__/ar1-anti-regression.test.tsx
+++ b/control-plane-ui/src/__tests__/ar1-anti-regression.test.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { useAuth } from '../contexts/AuthContext';
+import { createAuthMock, renderWithProviders } from '../test/helpers';
+import type { AggregatedMetrics } from '../types';
+import { SecurityPostureDashboard } from '../pages/SecurityPosture/SecurityPostureDashboard';
+import { GuardrailsDashboard } from '../pages/GatewayGuardrails/GuardrailsDashboard';
+
+vi.mock('../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+
+const mockGet = vi.fn();
+const mockGetGatewayAggregatedMetrics = vi.fn();
+const mockGetGuardrailsConfig = vi.fn();
+const mockGetGuardrailsEvents = vi.fn();
+
+vi.mock('../services/api', () => ({
+  apiService: {
+    get: (...args: unknown[]) => mockGet(...args),
+    getGatewayAggregatedMetrics: (...args: unknown[]) => mockGetGatewayAggregatedMetrics(...args),
+    getGuardrailsConfig: (...args: unknown[]) => mockGetGuardrailsConfig(...args),
+    getGuardrailsEvents: (...args: unknown[]) => mockGetGuardrailsEvents(...args),
+    setAuthToken: vi.fn(),
+    clearAuthToken: vi.fn(),
+  },
+}));
+
+const guardrailsMetrics = {
+  health: {},
+  sync: {},
+  overall_status: 'healthy',
+  guardrails: {
+    state: 'metrics_unavailable',
+    source_healthy: false,
+    by_guardrail: {},
+    last_sample_at: null,
+    metrics_age_seconds: null,
+  },
+} as unknown as AggregatedMetrics;
+
+describe('AR-1 anti-regression page copy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue(createAuthMock('cpi-admin'));
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/token-binding')) {
+        return Promise.resolve({ data: { label: 'Auto', description: 'Migration mode' } });
+      }
+      if (url.includes('/governance/drift')) return Promise.resolve({ data: { items: [] } });
+      if (url.includes('/scans')) return Promise.resolve({ data: { scans: [] } });
+      if (url.includes('/findings')) return Promise.resolve({ data: { findings: [] } });
+      return Promise.resolve({ data: { events: [], summary: {} } });
+    });
+    mockGetGatewayAggregatedMetrics.mockResolvedValue(guardrailsMetrics);
+    mockGetGuardrailsConfig.mockResolvedValue({
+      pii_enabled: true,
+      injection_detection_enabled: true,
+      prompt_guard_enabled: true,
+      content_filter_enabled: true,
+      rate_limit_enabled: true,
+      opa_policy_enabled: true,
+      source: 'env',
+      updated_at: '2026-05-11T00:00:00Z',
+    });
+    mockGetGuardrailsEvents.mockResolvedValue({ events: [], total: 0 });
+  });
+
+  it('locks Security Posture title and subtitle', async () => {
+    renderWithProviders(<SecurityPostureDashboard />, { route: '/security-posture' });
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Security Posture' })).toBeInTheDocument();
+    expect(
+      screen.getByText('Compliance findings, security score, configuration assessment')
+    ).toBeInTheDocument();
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(5));
+  });
+
+  it('locks Security & Guardrails title and subtitle', async () => {
+    renderWithProviders(<GuardrailsDashboard />, { route: '/observability/security' });
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'Security & Guardrails' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Runtime events — guardrail decisions, PII/prompt/content/rate-limit monitoring'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/control-plane-ui/src/__tests__/spec/cab-2214-phase60.test.ts
+++ b/control-plane-ui/src/__tests__/spec/cab-2214-phase60.test.ts
@@ -49,7 +49,7 @@ function metrics(guardrails: Record<string, unknown>): AggregatedMetrics {
 }
 
 describe('spec/CAB-2214 / CAB-2213 Phase 6.0 red tests', () => {
-  it.skip('TODO Phase 6.5 - cp-ui state rendering: AC5 renders server evaluations_zero_trips state', () => {
+  it('Phase 6.5 - cp-ui state rendering: AC5 renders server evaluations_zero_trips state', () => {
     const state = guardrailCardState(
       config,
       metrics({
@@ -79,7 +79,7 @@ describe('spec/CAB-2214 / CAB-2213 Phase 6.0 red tests', () => {
     expect(state.count).toBe(0);
   });
 
-  it.skip('TODO Phase 6.5 - cp-ui state rendering: AC12 trusts backend trips_observed state', () => {
+  it('Phase 6.5 - cp-ui state rendering: AC12 trusts backend trips_observed state', () => {
     const state = guardrailCardState(
       config,
       metrics({

--- a/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.test.tsx
+++ b/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.test.tsx
@@ -4,7 +4,13 @@ import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { createAuthMock, renderWithProviders } from '../../test/helpers';
 import { useAuth } from '../../contexts/AuthContext';
 import type { PersonaRole } from '../../test/helpers';
-import type { AggregatedMetrics, GuardrailsConfigResponse } from '../../types';
+import type {
+  AggregatedMetrics,
+  GuardrailKey,
+  GuardrailRuntimeMetrics,
+  GuardrailsConfigResponse,
+  GuardrailsMetricsBlock,
+} from '../../types';
 
 vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
 
@@ -39,8 +45,45 @@ const enabledConfig: GuardrailsConfigResponse = {
   updated_at: new Date(Date.now() - 30_000).toISOString(),
 };
 
+const GUARDRAILS: GuardrailKey[] = [
+  'pii',
+  'injection',
+  'prompt_guard',
+  'content_filter',
+  'rate_limit',
+];
+
+function guardrailEntry(overrides: Partial<GuardrailRuntimeMetrics> = {}): GuardrailRuntimeMetrics {
+  return {
+    state: 'trips_observed',
+    evaluations_count: 10,
+    decisions_count: 10,
+    trips_count: 5,
+    error_count: 0,
+    last_evaluation_delta_at: '2026-05-09T06:00:00Z',
+    last_decision_delta_at: '2026-05-09T06:00:00Z',
+    scrape_sample_at: '2026-05-09T06:00:15Z',
+    source_healthy: true,
+    stale_reason: null,
+    ...overrides,
+  };
+}
+
+function byGuardrail(
+  overrides: Partial<Record<GuardrailKey, Partial<GuardrailRuntimeMetrics>>> = {}
+): Record<GuardrailKey, GuardrailRuntimeMetrics> {
+  return GUARDRAILS.reduce(
+    (acc, guardrail) => {
+      acc[guardrail] = guardrailEntry(overrides[guardrail]);
+      return acc;
+    },
+    {} as Record<GuardrailKey, GuardrailRuntimeMetrics>
+  );
+}
+
 function metrics(
-  guardrails: Partial<NonNullable<AggregatedMetrics['guardrails']>> = {}
+  guardrails: Partial<GuardrailsMetricsBlock> = {},
+  perGuardrail: Partial<Record<GuardrailKey, Partial<GuardrailRuntimeMetrics>>> = {}
 ): AggregatedMetrics {
   return {
     health: {
@@ -63,11 +106,21 @@ function metrics(
     },
     overall_status: 'healthy',
     guardrails: {
+      state: 'trips_observed',
+      evaluations_count: 10,
+      decisions_count: 10,
+      trips_count: 5,
+      error_count: 0,
       pii_detections: 5,
       injection_blocks: 2,
       prompt_guard_blocks: 1,
       content_filter_blocks: 0,
       rate_limit_blocks: 0,
+      last_evaluation_delta_at: '2026-05-09T06:00:00Z',
+      last_decision_delta_at: '2026-05-09T06:00:00Z',
+      scrape_sample_at: '2026-05-09T06:00:15Z',
+      stale_reason: null,
+      by_guardrail: byGuardrail(perGuardrail),
       last_sample_at: new Date(Date.now() - 15_000).toISOString(),
       metrics_age_seconds: 15,
       source_healthy: true,
@@ -133,62 +186,76 @@ describe('GuardrailsDashboard', () => {
     ).toBeInTheDocument();
   });
 
-  it('card state renders enabled zero with a healthy source', async () => {
-    mockGetGatewayAggregatedMetrics.mockResolvedValue(metrics({ pii_detections: 0 }));
+  it('card state renders evaluations with zero trips from backend state', async () => {
+    mockGetGatewayAggregatedMetrics.mockResolvedValue(
+      metrics(
+        {},
+        { pii: { state: 'evaluations_zero_trips', evaluations_count: 12, trips_count: 0 } }
+      )
+    );
 
     renderWithProviders(<GuardrailsDashboard />);
 
     await waitFor(() => {
       expect(
         within(screen.getByTestId('guardrail-card-pii-detection')).getByText(
-          /0 events · last sample/
+          '0 trips after 12 evaluations'
         )
       ).toBeInTheDocument();
     });
   });
 
-  it('card state renders enabled N with a healthy source', async () => {
-    mockGetGatewayAggregatedMetrics.mockResolvedValue(metrics({ injection_blocks: 7 }));
+  it('card state renders observed trips from backend state', async () => {
+    mockGetGatewayAggregatedMetrics.mockResolvedValue(
+      metrics({}, { injection: { state: 'trips_observed', trips_count: 7 } })
+    );
 
     renderWithProviders(<GuardrailsDashboard />);
 
-    expect(await screen.findByText(/7 events · last sample/)).toBeInTheDocument();
+    expect(await screen.findByText('7 trips observed')).toBeInTheDocument();
   });
 
-  it('card state renders no sample when last_sample_at is null', async () => {
+  it('card state renders no evaluations from backend state', async () => {
     mockGetGatewayAggregatedMetrics.mockResolvedValue(
-      metrics({
-        pii_detections: null,
-        injection_blocks: null,
-        prompt_guard_blocks: null,
-        content_filter_blocks: null,
-        rate_limit_blocks: null,
-        last_sample_at: null,
-        metrics_age_seconds: null,
-      })
+      metrics({}, { pii: { state: 'no_evaluations', evaluations_count: 0, trips_count: 0 } })
     );
 
     renderWithProviders(<GuardrailsDashboard />);
 
     expect(
       await within(screen.getByTestId('guardrail-card-pii-detection')).findByText(
-        'No guardrail trip samples in window'
+        'No guardrail evaluations in window'
       )
     ).toBeInTheDocument();
   });
 
-  it('current prod fail-closed config can show config unavailable while metrics show no sample', async () => {
+  it('null counts do not collapse into zero text', async () => {
+    mockGetGatewayAggregatedMetrics.mockResolvedValue(
+      metrics(
+        {},
+        {
+          pii: {
+            state: 'evaluations_zero_trips',
+            evaluations_count: null,
+            trips_count: null,
+          },
+        }
+      )
+    );
+
+    renderWithProviders(<GuardrailsDashboard />);
+
+    expect(
+      await screen.findByText('Guardrail evaluations observed; trip count unavailable')
+    ).toBeInTheDocument();
+    const card = screen.getByTestId('guardrail-card-pii-detection');
+    expect(within(card).queryByText(/0 trips/)).not.toBeInTheDocument();
+  });
+
+  it('current prod fail-closed config can show config unavailable while metrics show no evaluations', async () => {
     mockGetGuardrailsConfig.mockRejectedValue(new Error('guardrails env missing'));
     mockGetGatewayAggregatedMetrics.mockResolvedValue(
-      metrics({
-        pii_detections: null,
-        injection_blocks: null,
-        prompt_guard_blocks: null,
-        content_filter_blocks: null,
-        rate_limit_blocks: null,
-        last_sample_at: null,
-        metrics_age_seconds: null,
-      })
+      metrics({}, { pii: { state: 'no_evaluations', evaluations_count: 0, trips_count: 0 } })
     );
 
     renderWithProviders(<GuardrailsDashboard />);
@@ -196,28 +263,38 @@ describe('GuardrailsDashboard', () => {
     expect(await screen.findAllByText('Metrics unavailable')).not.toHaveLength(0);
     expect(
       await within(screen.getByTestId('guardrail-card-pii-detection')).findByText(
-        'No guardrail trip samples in window'
+        'No guardrail evaluations in window'
       )
     ).toBeInTheDocument();
   });
 
-  it('card state renders stale when metrics age is above 60 seconds', async () => {
+  it('card state renders stale data from backend state', async () => {
     mockGetGatewayAggregatedMetrics.mockResolvedValue(
-      metrics({
-        metrics_age_seconds: 61,
-        last_sample_at: new Date(Date.now() - 61_000).toISOString(),
-      })
+      metrics(
+        { state: 'trips_observed', metrics_age_seconds: 15 },
+        {
+          pii: {
+            state: 'stale_data',
+            last_evaluation_delta_at: null,
+            scrape_sample_at: '2026-05-09T06:00:15Z',
+          },
+        }
+      )
     );
 
     renderWithProviders(<GuardrailsDashboard />);
 
     expect(
-      await within(screen.getByTestId('guardrail-card-pii-detection')).findByText('Stale metrics')
+      await within(screen.getByTestId('guardrail-card-pii-detection')).findByText(
+        'Data stale (last observed: 2026-05-09T06:00:15Z)'
+      )
     ).toBeInTheDocument();
   });
 
-  it('card state renders metrics unavailable when source is unhealthy', async () => {
-    mockGetGatewayAggregatedMetrics.mockResolvedValue(metrics({ source_healthy: false }));
+  it('card state renders metrics unavailable from backend state', async () => {
+    mockGetGatewayAggregatedMetrics.mockResolvedValue(
+      metrics({}, { pii: { state: 'metrics_unavailable', trips_count: null } })
+    );
 
     renderWithProviders(<GuardrailsDashboard />);
 
@@ -267,11 +344,20 @@ describe('GuardrailsDashboard', () => {
   });
 
   it('rate limit card does not use a synthetic all filter', async () => {
+    mockGetGatewayAggregatedMetrics.mockResolvedValue(
+      metrics(
+        {},
+        { rate_limit: { state: 'evaluations_zero_trips', evaluations_count: 10, trips_count: 0 } }
+      )
+    );
+
     renderWithProviders(<GuardrailsDashboard />);
 
     await waitFor(() => {
       expect(
-        within(screen.getByTestId('guardrail-card-rate-limit')).getByText(/0 events · last sample/)
+        within(screen.getByTestId('guardrail-card-rate-limit')).getByText(
+          '0 trips after 10 evaluations'
+        )
       ).toBeInTheDocument();
     });
     fireEvent.click(await screen.findByTestId('guardrail-card-rate-limit'));
@@ -281,6 +367,12 @@ describe('GuardrailsDashboard', () => {
   });
 
   it('rate limit card filters to rate-limit or shows explicit empty state', async () => {
+    mockGetGatewayAggregatedMetrics.mockResolvedValue(
+      metrics(
+        {},
+        { rate_limit: { state: 'evaluations_zero_trips', evaluations_count: 10, trips_count: 0 } }
+      )
+    );
     mockGetGuardrailsEvents.mockResolvedValue({
       events: [
         {
@@ -299,7 +391,9 @@ describe('GuardrailsDashboard', () => {
 
     await waitFor(() => {
       expect(
-        within(screen.getByTestId('guardrail-card-rate-limit')).getByText(/0 events · last sample/)
+        within(screen.getByTestId('guardrail-card-rate-limit')).getByText(
+          '0 trips after 10 evaluations'
+        )
       ).toBeInTheDocument();
     });
     fireEvent.click(await screen.findByTestId('guardrail-card-rate-limit'));
@@ -348,7 +442,7 @@ describe('GuardrailsDashboard', () => {
 
     renderWithProviders(<GuardrailsDashboard />);
 
-    expect(await screen.findByText(/5 events · last sample/)).toBeInTheDocument();
+    expect(await screen.findAllByText('5 trips observed')).not.toHaveLength(0);
   });
 
   describe.each<PersonaRole>(['cpi-admin', 'tenant-admin', 'devops', 'viewer'])(

--- a/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.tsx
+++ b/control-plane-ui/src/pages/GatewayGuardrails/GuardrailsDashboard.tsx
@@ -23,6 +23,7 @@ import type {
   GatewayGuardrailsEvent,
   GuardrailsConfigResponse,
   GuardrailsMetricField,
+  GuardrailsState,
   GuardrailsTimeRange,
 } from '../../types';
 import { guardrailCardState, type GuardrailCardUIState } from './guardrailCardState';
@@ -30,6 +31,19 @@ import { guardrailCardState, type GuardrailCardUIState } from './guardrailCardSt
 type FilterType = 'all' | 'pii' | 'injection' | 'content' | 'prompt' | 'rate-limit';
 
 const GUARDRAILS_TIME_RANGES: GuardrailsTimeRange[] = ['1h', '6h', '24h', '7d'];
+const GUARDRAILS_STATES: ReadonlySet<string> = new Set<GuardrailsState>([
+  'metrics_unavailable',
+  'no_evaluations',
+  'evaluations_zero_trips',
+  'trips_observed',
+  'stale_data',
+]);
+const NON_FILTERABLE_METRIC_STATES: ReadonlySet<GuardrailCardUIState['kind']> = new Set([
+  'disabled',
+  'metrics_unavailable',
+  'no_evaluations',
+  'stale_data',
+]);
 
 const ACTION_TO_FILTER: Record<string, FilterType> = {
   'pii-redacted': 'pii',
@@ -199,7 +213,10 @@ function isContractMetrics(metrics: AggregatedMetrics): boolean {
   if (!guardrails) return false;
 
   return (
+    GUARDRAILS_STATES.has(guardrails.state) &&
     typeof guardrails.source_healthy === 'boolean' &&
+    guardrails.by_guardrail !== null &&
+    typeof guardrails.by_guardrail === 'object' &&
     'last_sample_at' in guardrails &&
     'metrics_age_seconds' in guardrails
   );
@@ -207,17 +224,31 @@ function isContractMetrics(metrics: AggregatedMetrics): boolean {
 
 function cardStateText(state: GuardrailCardUIState): string {
   switch (state.kind) {
-    case 'metrics-unavailable':
+    case 'metrics_unavailable':
       return 'Metrics unavailable';
     case 'disabled':
       return 'Disabled';
-    case 'no-sample':
-      return 'No guardrail trip samples in window';
-    case 'stale':
-      return 'Stale metrics';
-    case 'healthy':
-      return `${state.count} events · last sample ${formatRelativeSample(state.lastSampleAt ?? '')}`;
+    case 'no_evaluations':
+      return 'No guardrail evaluations in window';
+    case 'evaluations_zero_trips':
+      if (state.tripsCount === 0 && state.evaluationsCount !== null) {
+        return `0 trips after ${formatCount(state.evaluationsCount, 'evaluation')}`;
+      }
+      return 'Guardrail evaluations observed; trip count unavailable';
+    case 'trips_observed':
+      if (state.tripsCount !== null) {
+        return `${formatCount(state.tripsCount, 'trip')} observed`;
+      }
+      return 'Trips observed';
+    case 'stale_data':
+      return state.lastObservedAt
+        ? `Data stale (last observed: ${state.lastObservedAt})`
+        : 'Data stale';
   }
+}
+
+function formatCount(count: number, noun: string): string {
+  return `${count} ${count === 1 ? noun : `${noun}s`}`;
 }
 
 function configStatusText(
@@ -373,14 +404,10 @@ export function GuardrailsDashboard() {
               ? cardStateText(state as GuardrailCardUIState)
               : configStatusText(config, card.configField, configLoading, configUnavailable);
           const isDisabled =
-            statusText === 'Disabled' ||
-            statusText === 'Metrics unavailable' ||
-            statusText === 'No guardrail trip samples in window';
-          const isFilterable =
-            card.kind === 'metric' &&
-            !isDisabled &&
-            state?.kind !== 'stale' &&
-            Boolean(card.filter);
+            card.kind === 'metric'
+              ? NON_FILTERABLE_METRIC_STATES.has((state as GuardrailCardUIState).kind)
+              : statusText === 'Disabled' || statusText === 'Metrics unavailable';
+          const isFilterable = card.kind === 'metric' && !isDisabled && Boolean(card.filter);
           const isActive = card.kind === 'metric' && activeFilter === card.filter;
           const className = `rounded-lg border p-5 text-left transition-all ${card.color} ${
             isActive

--- a/control-plane-ui/src/pages/GatewayGuardrails/guardrailCardState.test.ts
+++ b/control-plane-ui/src/pages/GatewayGuardrails/guardrailCardState.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import type { AggregatedMetrics, GuardrailsConfigResponse } from '../../types';
+import type {
+  AggregatedMetrics,
+  GuardrailKey,
+  GuardrailRuntimeMetrics,
+  GuardrailsConfigResponse,
+  GuardrailsState,
+} from '../../types';
 import { guardrailCardState } from './guardrailCardState';
 
 const config: GuardrailsConfigResponse = {
@@ -13,9 +19,41 @@ const config: GuardrailsConfigResponse = {
   updated_at: '2026-05-09T06:00:00Z',
 };
 
+const GUARDRAILS: GuardrailKey[] = [
+  'pii',
+  'injection',
+  'prompt_guard',
+  'content_filter',
+  'rate_limit',
+];
+
+function entry(
+  state: GuardrailsState = 'trips_observed',
+  overrides: Partial<GuardrailRuntimeMetrics> = {}
+): GuardrailRuntimeMetrics {
+  return {
+    state,
+    evaluations_count: state === 'metrics_unavailable' ? null : 10,
+    decisions_count: state === 'metrics_unavailable' ? null : 10,
+    trips_count: state === 'metrics_unavailable' ? null : 5,
+    error_count: state === 'metrics_unavailable' ? null : 0,
+    last_evaluation_delta_at: '2026-05-09T06:00:00Z',
+    last_decision_delta_at: '2026-05-09T06:00:00Z',
+    scrape_sample_at: '2026-05-09T06:00:15Z',
+    source_healthy: state !== 'metrics_unavailable' && state !== 'stale_data',
+    stale_reason: state === 'metrics_unavailable' ? 'prom_unreachable' : null,
+    ...overrides,
+  };
+}
+
 function metrics(
-  guardrails: Partial<NonNullable<AggregatedMetrics['guardrails']>> = {}
+  pii: GuardrailRuntimeMetrics = entry(),
+  topState: GuardrailsState = 'trips_observed'
 ): AggregatedMetrics {
+  const by_guardrail = Object.fromEntries(
+    GUARDRAILS.map((key) => [key, key === 'pii' ? pii : entry()])
+  ) as Record<GuardrailKey, GuardrailRuntimeMetrics>;
+
   return {
     health: {
       total_gateways: 1,
@@ -37,121 +75,85 @@ function metrics(
     },
     overall_status: 'healthy',
     guardrails: {
-      pii_detections: 0,
+      state: topState,
+      evaluations_count: 10,
+      decisions_count: 10,
+      trips_count: 5,
+      error_count: 0,
+      pii_detections: 5,
       injection_blocks: 2,
       prompt_guard_blocks: 3,
       content_filter_blocks: 4,
       rate_limit_blocks: 5,
-      last_sample_at: '2026-05-09T06:00:00Z',
+      last_evaluation_delta_at: '2026-05-09T06:00:00Z',
+      last_decision_delta_at: '2026-05-09T06:00:00Z',
+      scrape_sample_at: '2026-05-09T06:00:15Z',
+      stale_reason: null,
+      by_guardrail,
+      last_sample_at: '2026-05-09T06:00:15Z',
       metrics_age_seconds: 15,
       source_healthy: true,
-      ...guardrails,
     },
   };
 }
 
 describe('guardrailCardState', () => {
+  it('keeps transport errors and disabled config out of backend state rendering', () => {
+    expect(
+      guardrailCardState(config, metrics(), 'pii_detections', { metricsUnavailable: true })
+    ).toMatchObject({ kind: 'metrics_unavailable' });
+    expect(
+      guardrailCardState({ ...config, pii_enabled: false }, metrics(), 'pii_detections').kind
+    ).toBe('disabled');
+  });
+
   it.each([
-    {
-      name: 'metrics transport error wins',
-      cfg: { ...config, pii_enabled: false },
-      value: metrics({ source_healthy: true }),
-      options: { metricsUnavailable: true },
-      expected: 'metrics-unavailable',
-    },
-    {
-      name: 'missing metrics block is unavailable',
-      cfg: config,
-      value: { ...metrics(), guardrails: undefined },
-      options: {},
-      expected: 'metrics-unavailable',
-    },
-    {
-      name: 'disabled config wins over healthy count',
-      cfg: { ...config, pii_enabled: false },
-      value: metrics({ pii_detections: 9 }),
-      options: {},
-      expected: 'disabled',
-    },
-    {
-      name: 'source unhealthy is unavailable',
-      cfg: config,
-      value: metrics({ source_healthy: false }),
-      options: {},
-      expected: 'metrics-unavailable',
-    },
-    {
-      name: 'null sample timestamp is no sample',
-      cfg: config,
-      value: metrics({ last_sample_at: null, metrics_age_seconds: null }),
-      options: {},
-      expected: 'no-sample',
-    },
-    {
-      name: 'null count is no sample',
-      cfg: config,
-      value: metrics({ pii_detections: null }),
-      options: {},
-      expected: 'no-sample',
-    },
-    {
-      name: 'undefined count is no sample',
-      cfg: config,
-      value: metrics({ pii_detections: undefined }),
-      options: {},
-      expected: 'no-sample',
-    },
-    {
-      name: 'non-null timestamp with null age is invalid',
-      cfg: config,
-      value: metrics({ last_sample_at: '2026-05-09T06:00:00Z', metrics_age_seconds: null }),
-      options: {},
-      expected: 'metrics-unavailable',
-    },
-    {
-      name: 'exactly 60 seconds is still fresh',
-      cfg: config,
-      value: metrics({ pii_detections: 0, metrics_age_seconds: 60 }),
-      options: {},
-      expected: 'healthy',
-    },
-    {
-      name: 'above 60 seconds is stale',
-      cfg: config,
-      value: metrics({ pii_detections: 0, metrics_age_seconds: 61 }),
-      options: {},
-      expected: 'stale',
-    },
-    {
-      name: 'healthy zero preserves zero',
-      cfg: config,
-      value: metrics({ pii_detections: 0 }),
-      options: {},
-      expected: 'healthy',
-      expectedCount: 0,
-    },
-    {
-      name: 'healthy N preserves count',
-      cfg: config,
-      value: metrics({ pii_detections: 42 }),
-      options: {},
-      expected: 'healthy',
-      expectedCount: 42,
-    },
-    {
-      name: 'rate limit maps to rate_limit_enabled',
-      cfg: { ...config, rate_limit_enabled: false },
-      value: metrics({ rate_limit_blocks: 4 }),
-      field: 'rate_limit_blocks' as const,
-      options: {},
-      expected: 'disabled',
-    },
-  ])('$name', ({ cfg, value, field = 'pii_detections', options, expected, expectedCount }) => {
-    const state = guardrailCardState(cfg, value, field, options);
+    ['metrics_unavailable', entry('metrics_unavailable', { trips_count: null }), null, null],
+    ['no_evaluations', entry('no_evaluations', { evaluations_count: 0, trips_count: 0 }), 0, 0],
+    [
+      'evaluations_zero_trips',
+      entry('evaluations_zero_trips', { evaluations_count: 12, trips_count: 0 }),
+      0,
+      12,
+    ],
+    ['trips_observed', entry('trips_observed', { trips_count: 42 }), 42, 10],
+    [
+      'stale_data',
+      entry('stale_data', {
+        last_evaluation_delta_at: null,
+        scrape_sample_at: '2026-05-09T06:00:15Z',
+      }),
+      5,
+      10,
+    ],
+  ] as const)('renders backend state %s verbatim', (expected, guardrail, count, evaluations) => {
+    const state = guardrailCardState(config, metrics(guardrail), 'pii_detections');
 
     expect(state.kind).toBe(expected);
-    if (expectedCount !== undefined) {
-      expect(state.count).toBe(expectedCount);
-    }
+    expect(state.count).toBe(count);
+    expect(state.evaluationsCount).toBe(evaluations);
+  });
+
+  it('does not collapse null trip counts into zero', () => {
+    const state = guardrailCardState(
+      config,
+      metrics(entry('evaluations_zero_trips', { evaluations_count: null, trips_count: null })),
+      'pii_detections'
+    );
+
+    expect(state.kind).toBe('evaluations_zero_trips');
+    expect(state.count).toBeNull();
+    expect(state.evaluationsCount).toBeNull();
+  });
+
+  it('uses per-guardrail state even when top-level state differs', () => {
+    const state = guardrailCardState(
+      config,
+      metrics(entry('stale_data', { scrape_sample_at: '2026-05-09T06:00:15Z' }), 'trips_observed'),
+      'pii_detections'
+    );
+
+    expect(state.kind).toBe('stale_data');
+    expect(state.lastObservedAt).toBe('2026-05-09T06:00:00Z');
   });
 });

--- a/control-plane-ui/src/pages/GatewayGuardrails/guardrailCardState.ts
+++ b/control-plane-ui/src/pages/GatewayGuardrails/guardrailCardState.ts
@@ -1,20 +1,20 @@
 import type {
   AggregatedMetrics,
+  GuardrailKey,
+  GuardrailRuntimeMetrics,
   GuardrailsConfigResponse,
   GuardrailsMetricField,
+  GuardrailsState,
 } from '../../types';
 
-export type GuardrailCardStateKind =
-  | 'metrics-unavailable'
-  | 'disabled'
-  | 'no-sample'
-  | 'stale'
-  | 'healthy';
+export type GuardrailCardStateKind = GuardrailsState | 'disabled';
 
 export interface GuardrailCardUIState {
   kind: GuardrailCardStateKind;
   count: number | null;
-  lastSampleAt: string | null;
+  evaluationsCount: number | null;
+  tripsCount: number | null;
+  lastObservedAt: string | null;
 }
 
 export interface GuardrailCardStateOptions {
@@ -29,6 +29,14 @@ const METRIC_TO_CONFIG_FIELD: Record<GuardrailsMetricField, keyof GuardrailsConf
   rate_limit_blocks: 'rate_limit_enabled',
 };
 
+const METRIC_TO_GUARDRAIL: Record<GuardrailsMetricField, GuardrailKey> = {
+  pii_detections: 'pii',
+  injection_blocks: 'injection',
+  prompt_guard_blocks: 'prompt_guard',
+  content_filter_blocks: 'content_filter',
+  rate_limit_blocks: 'rate_limit',
+};
+
 export function guardrailCardState(
   config: GuardrailsConfigResponse | null,
   metrics: AggregatedMetrics | null,
@@ -41,30 +49,40 @@ export function guardrailCardState(
 
   const configField = METRIC_TO_CONFIG_FIELD[fieldName];
   if (config && config[configField] === false) {
-    return { kind: 'disabled', count: null, lastSampleAt: null };
+    return {
+      kind: 'disabled',
+      count: null,
+      evaluationsCount: null,
+      tripsCount: null,
+      lastObservedAt: null,
+    };
   }
 
-  const guardrails = metrics.guardrails;
-  if (guardrails.source_healthy !== true) {
+  const guardrailKey = METRIC_TO_GUARDRAIL[fieldName];
+  const guardrail = metrics.guardrails.by_guardrail?.[guardrailKey];
+  if (!guardrail) {
     return unavailableState();
   }
 
-  const count = guardrails[fieldName];
-  if (guardrails.last_sample_at === null || count === null || count === undefined) {
-    return { kind: 'no-sample', count: null, lastSampleAt: null };
-  }
-
-  if (guardrails.metrics_age_seconds === null || guardrails.metrics_age_seconds === undefined) {
-    return unavailableState();
-  }
-
-  if (guardrails.metrics_age_seconds > 60) {
-    return { kind: 'stale', count, lastSampleAt: guardrails.last_sample_at };
-  }
-
-  return { kind: 'healthy', count, lastSampleAt: guardrails.last_sample_at };
+  return stateFromBackend(guardrail);
 }
 
 function unavailableState(): GuardrailCardUIState {
-  return { kind: 'metrics-unavailable', count: null, lastSampleAt: null };
+  return {
+    kind: 'metrics_unavailable',
+    count: null,
+    evaluationsCount: null,
+    tripsCount: null,
+    lastObservedAt: null,
+  };
+}
+
+function stateFromBackend(guardrail: GuardrailRuntimeMetrics): GuardrailCardUIState {
+  return {
+    kind: guardrail.state,
+    count: guardrail.trips_count,
+    evaluationsCount: guardrail.evaluations_count,
+    tripsCount: guardrail.trips_count,
+    lastObservedAt: guardrail.last_evaluation_delta_at ?? guardrail.scrape_sample_at,
+  };
 }

--- a/control-plane-ui/src/types/index.ts
+++ b/control-plane-ui/src/types/index.ts
@@ -1415,14 +1415,52 @@ export interface GuardrailsConfigResponse {
 }
 
 export interface GuardrailsMetricsBlock {
+  state: GuardrailsState;
+  evaluations_count: number | null;
+  decisions_count: number | null;
+  trips_count: number | null;
+  error_count: number | null;
   pii_detections: number | null;
   injection_blocks: number | null;
   prompt_guard_blocks: number | null;
   content_filter_blocks: number | null;
   rate_limit_blocks: number | null;
+  last_evaluation_delta_at: string | null;
+  last_decision_delta_at: string | null;
+  scrape_sample_at: string | null;
+  stale_reason: GuardrailsStaleReason | null;
+  by_guardrail: Record<GuardrailKey, GuardrailRuntimeMetrics>;
   last_sample_at: string | null;
   metrics_age_seconds: number | null;
   source_healthy: boolean;
+}
+
+export type GuardrailsState =
+  | 'metrics_unavailable'
+  | 'no_evaluations'
+  | 'evaluations_zero_trips'
+  | 'trips_observed'
+  | 'stale_data';
+
+export type GuardrailsStaleReason =
+  | 'prom_unreachable'
+  | 'scrape_gap'
+  | 'producer_absent'
+  | 'stale_unknown';
+
+export type GuardrailKey = 'pii' | 'injection' | 'prompt_guard' | 'content_filter' | 'rate_limit';
+
+export interface GuardrailRuntimeMetrics {
+  state: GuardrailsState;
+  evaluations_count: number | null;
+  decisions_count: number | null;
+  trips_count: number | null;
+  error_count: number | null;
+  last_evaluation_delta_at: string | null;
+  last_decision_delta_at: string | null;
+  scrape_sample_at: string | null;
+  source_healthy: boolean;
+  stale_reason: GuardrailsStaleReason | null;
 }
 
 export type GuardrailsMetricField =

--- a/memory.md
+++ b/memory.md
@@ -1,6 +1,10 @@
 # STOA Memory
 
-> Dernière MAJ: 2026-05-11. Archive complète (cycles passés, DONE, etc.) → `memory-archive.md`.
+> Dernière MAJ: 2026-05-12. Archive complète (cycles passés, DONE, etc.) → `memory-archive.md`.
+
+## Session Notes — 2026-05-12
+
+- CAB-2219 Phase 6.5 cp-ui five-state rendering implemented on branch `codex/cab-2219-phase65-cpui-states` in worktree `/Users/torpedo/hlfh-repos/stoa-cab2219-phase65`. Scope stayed cp-ui-only: Guardrails cards now render backend-shipped `by_guardrail[*].state` directly, preserve `null` counts, display `metrics_unavailable` / `no_evaluations` / `evaluations_zero_trips` / `trips_observed` / `stale_data` wording, add Phase 6.4 response types, unskip CAB-2214 cp-ui red tests, and add AR-1 anti-regression coverage for Security Posture vs Security & Guardrails subtitles. Validation passed: targeted vitest (33 passed), full `npm run test` (2338 passed, 11 skipped), `npm run lint` (0 errors, 49 pre-existing warnings), `npm run format:check`, `npm run build`, `git diff --check`. Browser observation on local Vite route redirected to `/login` as expected without auth, so visual page inspection was auth-gated.
 
 ## Session Notes — 2026-05-11
 


### PR DESCRIPTION
## Summary

Phase 6.5 of MEGA CAB-2213. Final feature phase before runtime smoke (Phase 6.6). The Console UI now consumes the validated Phase 6 guardrails contract: backend ships ``state``, UI renders verbatim. A6 lock enforced — no client-side state derivation.

Plus A11 AR-1 anti-regression coverage to lock Security Posture / Security & Guardrails subtitles against silent IA fusion.

## Plan locks implemented

| Lock | Code |
|---|---|
| **A6** — backend authoritative state | ``GuardrailCardStateKind = GuardrailsState \| 'disabled'`` ; card consumes ``by_guardrail[*].state`` directly |
| **A11** — AR-1 anti-regression | New ``src/__tests__/ar1-anti-regression.test.tsx`` asserts canonical subtitles verbatim on both pages |
| **A16** — counter separation | ``evaluationsCount`` + ``tripsCount`` exposed independently in card state |
| **A17** — per-guardrail health | Each guardrail card renders own state ; top-level not flipped by single stale entry (E3) |
| **A7** — legacy compat | Old fields (``pii_detections``, etc.) preserved in TypeScript types during compatibility window |

## Types layer (``src/types/index.ts``)

- ``GuardrailsState`` Literal — 5 values matching cp-api A15 ``metrics_unavailable | no_evaluations | evaluations_zero_trips | trips_observed | stale_data``
- ``GuardrailsStaleReason`` Literal — 4 values matching E6 bounded enum
- ``GuardrailKey`` — 5 guardrail identifiers (A2)
- ``GuardrailRuntimeMetrics`` — per-guardrail entry shape
- ``GuardrailsMetricsBlock`` — extended additively with new fields ; legacy preserved

## Why this exceeds the 300 LOC raw insertion count

460 raw insertions / 188 deletions = **272 net LOC delta**, of which ~163 are production code (types + state derivation + Dashboard component). The remaining ~297 lines are test code rewrites (``guardrailCardState.test.ts``, ``GuardrailsDashboard.test.tsx``) adapting to the new contract shape.

Splitting would force artificial division: types ⊂ consumers ⊂ tests are tightly coupled here. Cohesive single PR matches Phase 6.4 PR #2765 (~558 LOC), Phase 6.0 PR #2760 (~775 LOC) precedents.

Production code is the smallest of any Phase 6 implementation PR. The test diff is large because the previous test fixtures used the legacy derived-state pattern and have to be updated to the backend-state-verbatim pattern.

## CAB-2219 DoD

- [x] UI renders 5 server-shipped states verbatim from ``state`` field — never re-derives
- [x] ``null`` count fields never collapse into "0" — render baseline wording instead
- [x] **A11 AR-1 anti-regression test** green: ``/security-posture`` + ``/observability/security`` subtitles match canonical AR-1 wording
- [x] Per-card states (``by_guardrail``) independent of top-level — UI handles "one card stale, others healthy" correctly (E3)
- [x] Navigation / sidebar IA unchanged (no Security Posture / Guardrails fusion)
- [x] TypeScript types match cp-api response shape (state union, StaleReason enum, 4 timestamps, error_count)
- [x] ``npm run lint`` clean (0 errors, 49 pre-existing warnings)
- [x] ``npm run test`` passes (2338 / 11 skipped)
- [x] ``npm run build`` clean
- [x] Visual Regression observation: page is auth-gated locally ; test coverage substitutes

## Validation

- [x] Targeted vitest: 33 passed
- [x] Full ``npm run test``: 2338 passed, 11 skipped
- [x] ``npm run lint``: 0 errors
- [x] ``npm run format:check``: pass
- [x] ``npm run build``: pass
- [x] ``git diff --check``: pass

## Anti-goal compliance

- ✅ A6 — UI never derives ``state`` from raw counts/timestamps (kind directly mirrors API state Literal)
- ✅ A11 — AR-1 wording preserved verbatim (regression test fails if subtitle changes)
- ✅ No nav/sidebar IA changes
- ✅ No new dependencies
- ✅ Legacy fields preserved in types (A7 compat)

## Linear

Linear: [CAB-2219](https://linear.app/hlfh-workspace/issue/CAB-2219) (Phase 6.5) — sub-issue of [CAB-2213](https://linear.app/hlfh-workspace/issue/CAB-2213) (master MEGA).

Blocks: [CAB-2220](https://linear.app/hlfh-workspace/issue/CAB-2220) (Phase 6.6 runtime smoke) — final phase.

## References

- Plan: ``docs/plans/2026-05-11-guardrails-non-mcp-4b-full.md`` §Phase 6.5
- AR-1 canonical: ``docs/plans/2026-05-07-observability-data-integrity.md`` line 63
- Decision log: ``docs/decisions/2026-05-11-guardrails-non-mcp-4b-full.md``

## Test plan

- [x] State rendering: 5 states matched against backend Literal
- [x] null count handling preserved (no fake 0)
- [x] AR-1 subtitle snapshots on both pages
- [x] Per-guardrail card independence (one stale + others healthy)
- [x] Legacy field compat (A7 window)
- [ ] CI: required + ci/Build cp-ui + axe-core + API Type Drift pass