### PR TITLE
feat(ui): CAB-2223 split Live Calls status semantics

### DIFF
--- a/control-plane-ui/src/__tests__/regression/live-calls-metric-integrity.test.tsx
+++ b/control-plane-ui/src/__tests__/regression/live-calls-metric-integrity.test.tsx
@@ -44,10 +44,56 @@ function vector(value: number, metric: Record<string, string> = {}) {
   return [{ metric, value: [123, String(value)] as [number, string] }];
 }
 
-function mockLiveCallsMetrics(totalRequests = 42) {
+function statusVectors(values: Record<string, number>) {
+  return Object.entries(values).map(([status, value]) => ({
+    metric: { status },
+    value: [123, String(value)] as [number, string],
+  }));
+}
+
+function mockLiveCallsMetrics(totalRequests = 42, statusMix: Record<string, number> = {}) {
   vi.mocked(usePrometheusQuery).mockImplementation((query: string) => {
     if (query.startsWith('sum(increase(stoa_http_requests_total') && !query.includes('status=')) {
       return { data: vector(totalRequests), loading: false, error: null, refetch: mocks.refetch };
+    }
+    if (query.includes('status=~"2..|3..|4..|5.."')) {
+      return {
+        data: statusVectors(statusMix),
+        loading: false,
+        error: null,
+        refetch: mocks.refetch,
+      };
+    }
+    if (query.includes('sum by (status)') && query.includes('status=~"4.."')) {
+      return {
+        data: statusVectors(
+          Object.fromEntries(Object.entries(statusMix).filter(([s]) => s[0] === '4'))
+        ),
+        loading: false,
+        error: null,
+        refetch: mocks.refetch,
+      };
+    }
+    if (query.includes('sum by (status)') && query.includes('status=~"5.."')) {
+      return {
+        data: statusVectors(
+          Object.fromEntries(Object.entries(statusMix).filter(([s]) => s[0] === '5'))
+        ),
+        loading: false,
+        error: null,
+        refetch: mocks.refetch,
+      };
+    }
+    if (query.includes('status=~"5.."')) {
+      const serverFailures = Object.entries(statusMix)
+        .filter(([status]) => status[0] === '5')
+        .reduce((sum, [, value]) => sum + value, 0);
+      return {
+        data: vector(serverFailures),
+        loading: false,
+        error: null,
+        refetch: mocks.refetch,
+      };
     }
     if (query.includes('status=~')) {
       return { data: vector(0), loading: false, error: null, refetch: mocks.refetch };
@@ -84,8 +130,24 @@ describe('regression/live-calls-metric-integrity', () => {
     expect(queries.topRoutesCalls).toContain(`sum by (${ROUTE_LABEL})`);
     expect(queries.activeModes).toContain('count by (job)');
     expect(queries.activeModes).not.toContain('path');
+    expect(queries.errorsByStatus).toContain('status=~"5.."');
+    expect(queries.errorsByStatus).not.toContain('4..');
+    expect(queries.clientErrorsByStatus).toContain('status=~"4.."');
+    expect(queries.statusMix).toContain('status=~"2..|3..|4..|5.."');
     expect(queryText).toContain(MODE_FILTER);
     expect(queryText).not.toMatch(/sum by \(path\)|count by \(path\)|metric\.path/);
+  });
+
+  it('separates status semantics into success mix, client errors, and 5xx failures', async () => {
+    mockLiveCallsMetrics(100, { '200': 95, '302': 2, '404': 2, '500': 1 });
+
+    renderWithProviders(<CallFlowDashboard />, { route: '/observability/live-calls' });
+
+    expect(await screen.findByRole('heading', { name: 'Status Mix' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Failures (5xx only)' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Client errors (4xx)' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Error Breakdown' })).not.toBeInTheDocument();
+    expect(screen.getByTestId('status-mix-share-2xx')).toHaveTextContent('95.0%');
   });
 
   it('shows a scope mismatch banner when total requests exist but mode breakdowns are empty', async () => {

--- a/control-plane-ui/src/pages/CallFlow/CallFlowDashboard.tsx
+++ b/control-plane-ui/src/pages/CallFlow/CallFlowDashboard.tsx
@@ -28,6 +28,7 @@ import { SparklineChart } from '../../components/charts/SparklineChart';
 import { ThroughputChart } from './components/ThroughputChart';
 import { LatencyHistogram } from './components/LatencyHistogram';
 import { ErrorBreakdown } from './components/ErrorBreakdown';
+import { StatusMix, type StatusClass, type StatusMixEntry } from './components/StatusMix';
 import { TopRoutes } from './components/TopRoutes';
 import { TrafficHeatmap } from './components/TrafficHeatmap';
 import { LiveTraces } from './components/LiveTraces';
@@ -55,6 +56,18 @@ const LATENCY_BUCKETS = [
   { label: '50-100ms', le: 0.1 },
   { label: '100ms+', le: Infinity },
 ];
+
+const STATUS_MIX_CLASSES: Array<Omit<StatusMixEntry, 'count'>> = [
+  { statusClass: '2xx', label: '2xx Success' },
+  { statusClass: '3xx', label: '3xx Redirects' },
+  { statusClass: '4xx', label: '4xx Client' },
+  { statusClass: '5xx', label: '5xx Failures' },
+];
+
+function statusClassForCode(status: string): StatusClass | null {
+  if (!/^[2-5]\d\d$/.test(status)) return null;
+  return `${status[0]}xx` as StatusClass;
+}
 
 function latencyColorClass(ms: number | null): string | undefined {
   if (ms === null) return undefined;
@@ -188,7 +201,12 @@ export function CallFlowDashboard() {
 
   // ─── Error breakdown by status code ───
 
+  const statusMix = usePrometheusQuery(queries.statusMix, refreshMs || 15_000);
   const errorsByStatus = usePrometheusQuery(queries.errorsByStatus, refreshMs || 15_000);
+  const clientErrorsByStatus = usePrometheusQuery(
+    queries.clientErrorsByStatus,
+    refreshMs || 15_000
+  );
 
   // ─── Top routes by P95 latency ───
 
@@ -317,6 +335,36 @@ export function CallFlowDashboard() {
       .sort((a, b) => b.count - a.count);
   }, [errorsByStatus.data]);
 
+  const clientErrorEntries = useMemo(() => {
+    const map = groupByLabel(clientErrorsByStatus.data, 'status');
+    return Object.entries(map)
+      .map(([code, count]) => ({ code, count: Math.round(count) }))
+      .filter((e) => e.count > 0)
+      .sort((a, b) => b.count - a.count);
+  }, [clientErrorsByStatus.data]);
+
+  const statusMixEntries = useMemo<StatusMixEntry[]>(() => {
+    const counts: Record<StatusClass, number> = {
+      '2xx': 0,
+      '3xx': 0,
+      '4xx': 0,
+      '5xx': 0,
+    };
+    const map = groupByLabel(statusMix.data, 'status');
+
+    for (const [status, count] of Object.entries(map)) {
+      const statusClass = statusClassForCode(status);
+      if (statusClass) {
+        counts[statusClass] += count;
+      }
+    }
+
+    return STATUS_MIX_CLASSES.map((entry) => ({
+      ...entry,
+      count: Math.round(counts[entry.statusClass]),
+    }));
+  }, [statusMix.data]);
+
   // ─── Parse top routes ───
 
   const topRoutes = useMemo(() => {
@@ -377,7 +425,9 @@ export function CallFlowDashboard() {
     sidecarTrend.refetch();
     connectTrend.refetch();
     latencyBuckets.refetch();
+    statusMix.refetch();
     errorsByStatus.refetch();
+    clientErrorsByStatus.refetch();
     topRoutesP95.refetch();
     topRoutesCalls.refetch();
     fallbackRequests.refetch();
@@ -396,7 +446,9 @@ export function CallFlowDashboard() {
     sidecarTrend,
     connectTrend,
     latencyBuckets,
+    statusMix,
     errorsByStatus,
+    clientErrorsByStatus,
     topRoutesP95,
     topRoutesCalls,
     fallbackRequests,
@@ -626,13 +678,33 @@ export function CallFlowDashboard() {
             </ChartCard>
           </div>
 
-          {/* ─── Charts Row 2: Error Breakdown + Top Routes ─── */}
+          {/* ─── Charts Row 2: Status Mix + Failures ─── */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <ChartCard title="Error Breakdown">
+            <ChartCard title="Status Mix">
+              <StatusMix entries={statusMixEntries} />
+            </ChartCard>
+            <ChartCard title="Failures (5xx only)">
               <ErrorBreakdown
                 errors={errorEntries}
-                activeCode={statusFilter}
+                activeCode={statusFilter.startsWith('5') ? statusFilter : ''}
                 onSliceClick={setStatusFilter}
+                emptyMessage="No 5xx failures in this period"
+                tooltipLabel="Failures"
+                testId="failures-breakdown"
+              />
+            </ChartCard>
+          </div>
+
+          {/* ─── Charts Row 3: Client Errors + Top Routes ─── */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <ChartCard title="Client errors (4xx)">
+              <ErrorBreakdown
+                errors={clientErrorEntries}
+                activeCode={statusFilter.startsWith('4') ? statusFilter : ''}
+                onSliceClick={setStatusFilter}
+                emptyMessage="No 4xx client errors in this period"
+                tooltipLabel="Client errors"
+                testId="client-errors-breakdown"
               />
             </ChartCard>
             <ChartCard title="Top Routes by Latency (P95)">

--- a/control-plane-ui/src/pages/CallFlow/components/ErrorBreakdown.tsx
+++ b/control-plane-ui/src/pages/CallFlow/components/ErrorBreakdown.tsx
@@ -10,6 +10,9 @@ interface ErrorBreakdownProps {
   errors: ErrorEntry[];
   activeCode?: string;
   onSliceClick?: (code: string) => void;
+  emptyMessage?: string;
+  tooltipLabel?: string;
+  testId?: string;
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -23,61 +26,70 @@ const STATUS_COLORS: Record<string, string> = {
   '504': '#991B1B',
 };
 
-export function ErrorBreakdown({ errors, activeCode, onSliceClick }: ErrorBreakdownProps) {
+export function ErrorBreakdown({
+  errors,
+  activeCode,
+  onSliceClick,
+  emptyMessage = 'No errors in this period',
+  tooltipLabel = 'Requests',
+  testId = 'status-code-breakdown',
+}: ErrorBreakdownProps) {
   const data = errors.filter((e) => e.count > 0);
 
   if (data.length === 0) {
-    return <ChartEmptyState message="No errors in this period" />;
+    return <ChartEmptyState message={emptyMessage} />;
   }
 
   return (
-    <ResponsiveContainer width="100%" height={250}>
-      <PieChart>
-        <Pie
-          data={data}
-          cx="50%"
-          cy="50%"
-          innerRadius={activeCode ? 50 : 55}
-          outerRadius={90}
-          paddingAngle={3}
-          dataKey="count"
-          nameKey="code"
-          style={{ cursor: onSliceClick ? 'pointer' : 'default' }}
-          onClick={(_data, index) => {
-            if (!onSliceClick) return;
-            const code = data[index]?.code || '';
-            onSliceClick(code === activeCode ? '' : code);
-          }}
-        >
-          {data.map((entry) => (
-            <Cell
-              key={entry.code}
-              fill={STATUS_COLORS[entry.code] || '#6B7280'}
-              stroke={activeCode === entry.code ? '#fff' : 'transparent'}
-              strokeWidth={activeCode === entry.code ? 2 : 0}
-              fillOpacity={!activeCode || activeCode === entry.code ? 1 : 0.25}
-            />
-          ))}
-        </Pie>
-        <Tooltip
-          contentStyle={CHART_TOOLTIP_STYLE}
-          formatter={(value) => [`${value} requests`, 'Errors']}
-        />
-        <Legend
-          wrapperStyle={{
-            fontSize: 12,
-            paddingTop: 8,
-            cursor: onSliceClick ? 'pointer' : 'default',
-          }}
-          iconType="circle"
-          iconSize={8}
-          formatter={(value: string) => `HTTP ${value}`}
-          onClick={(entry) => {
-            if (!onSliceClick || !entry.value) return;
-            onSliceClick(entry.value === activeCode ? '' : entry.value);
-          }}
-        />
-      </PieChart>
-    </ResponsiveContainer>
+    <div data-testid={testId}>
+      <ResponsiveContainer width="100%" height={250}>
+        <PieChart>
+          <Pie
+            data={data}
+            cx="50%"
+            cy="50%"
+            innerRadius={activeCode ? 50 : 55}
+            outerRadius={90}
+            paddingAngle={3}
+            dataKey="count"
+            nameKey="code"
+            style={{ cursor: onSliceClick ? 'pointer' : 'default' }}
+            onClick={(_data, index) => {
+              if (!onSliceClick) return;
+              const code = data[index]?.code || '';
+              onSliceClick(code === activeCode ? '' : code);
+            }}
+          >
+            {data.map((entry) => (
+              <Cell
+                key={entry.code}
+                fill={STATUS_COLORS[entry.code] || '#6B7280'}
+                stroke={activeCode === entry.code ? '#fff' : 'transparent'}
+                strokeWidth={activeCode === entry.code ? 2 : 0}
+                fillOpacity={!activeCode || activeCode === entry.code ? 1 : 0.25}
+              />
+            ))}
+          </Pie>
+          <Tooltip
+            contentStyle={CHART_TOOLTIP_STYLE}
+            formatter={(value) => [`${value} requests`, tooltipLabel]}
+          />
+          <Legend
+            wrapperStyle={{
+              fontSize: 12,
+              paddingTop: 8,
+              cursor: onSliceClick ? 'pointer' : 'default',
+            }}
+            iconType="circle"
+            iconSize={8}
+            formatter={(value: string) => `HTTP ${value}`}
+            onClick={(entry) => {
+              if (!onSliceClick || !entry.value) return;
+              onSliceClick(entry.value === activeCode ? '' : entry.value);
+            }}
+          />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
   );
 }

--- a/control-plane-ui/src/pages/CallFlow/components/StatusMix.tsx
+++ b/control-plane-ui/src/pages/CallFlow/components/StatusMix.tsx
@@ -1,0 +1,96 @@
+import { ChartEmptyState } from '@stoa/shared/components/ChartCard';
+
+export type StatusClass = '2xx' | '3xx' | '4xx' | '5xx';
+
+export interface StatusMixEntry {
+  statusClass: StatusClass;
+  label: string;
+  count: number;
+}
+
+const STATUS_CLASS_COLORS: Record<StatusClass, string> = {
+  '2xx': '#10B981',
+  '3xx': '#3B82F6',
+  '4xx': '#F59E0B',
+  '5xx': '#EF4444',
+};
+
+function formatCount(count: number): string {
+  return count >= 1000 ? `${(count / 1000).toFixed(1)}K` : String(Math.round(count));
+}
+
+function formatShare(count: number, total: number): string {
+  if (total <= 0) return '0.0%';
+  return `${((count / total) * 100).toFixed(1)}%`;
+}
+
+export function StatusMix({ entries }: { entries: StatusMixEntry[] }) {
+  const total = entries.reduce((sum, entry) => sum + entry.count, 0);
+
+  if (total <= 0) {
+    return <ChartEmptyState message="No status mix data in this period" />;
+  }
+
+  return (
+    <div data-testid="status-mix-chart" className="h-[250px] flex flex-col justify-center gap-6">
+      <div
+        className="flex h-12 w-full overflow-hidden rounded-md bg-neutral-100 dark:bg-neutral-700"
+        aria-label="HTTP status class mix"
+      >
+        {entries
+          .filter((entry) => entry.count > 0)
+          .map((entry) => {
+            const share = (entry.count / total) * 100;
+            return (
+              <div
+                key={entry.statusClass}
+                data-testid={`status-mix-segment-${entry.statusClass}`}
+                className="flex shrink-0 items-center justify-center px-2 text-xs font-semibold text-white tabular-nums"
+                style={{
+                  width: `${share}%`,
+                  backgroundColor: STATUS_CLASS_COLORS[entry.statusClass],
+                }}
+                title={`${entry.label}: ${formatCount(entry.count)} requests (${formatShare(
+                  entry.count,
+                  total
+                )})`}
+              >
+                {share >= 8 ? entry.statusClass : ''}
+              </div>
+            );
+          })}
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4" role="list">
+        {entries.map((entry) => (
+          <div
+            key={entry.statusClass}
+            role="listitem"
+            className="rounded-md border border-neutral-200 px-3 py-2 dark:border-neutral-700"
+          >
+            <div className="flex items-center gap-2">
+              <span
+                className="h-2.5 w-2.5 rounded-sm"
+                style={{ backgroundColor: STATUS_CLASS_COLORS[entry.statusClass] }}
+              />
+              <span className="text-xs font-medium text-neutral-700 dark:text-neutral-300">
+                {entry.label}
+              </span>
+            </div>
+            <div className="mt-2 flex items-baseline justify-between gap-2">
+              <span className="text-sm font-semibold tabular-nums text-neutral-900 dark:text-white">
+                {formatCount(entry.count)}
+              </span>
+              <span
+                data-testid={`status-mix-share-${entry.statusClass}`}
+                className="text-xs tabular-nums text-neutral-500 dark:text-neutral-400"
+              >
+                {formatShare(entry.count, total)}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/control-plane-ui/src/pages/CallFlow/metrics.ts
+++ b/control-plane-ui/src/pages/CallFlow/metrics.ts
@@ -23,7 +23,9 @@ interface LiveCallsQueries {
   sidecarTrend: string;
   connectTrend: string;
   latencyBuckets: string;
+  statusMix: string;
   errorsByStatus: string;
+  clientErrorsByStatus: string;
   topRoutesP95: string;
   topRoutesCalls: string;
   requestsTrend: string;
@@ -42,7 +44,9 @@ export function buildLiveCallsQueries(timeRange: TimeRange): LiveCallsQueries {
     sidecarTrend: `sum(rate(stoa_http_requests_total{${MODE_FILTER}, job="stoa-link"}[5m]))`,
     connectTrend: `sum(rate(stoa_http_requests_total{${MODE_FILTER}, job="stoa-connect"}[5m]))`,
     latencyBuckets: `sum(increase(stoa_http_request_duration_seconds_bucket{${MODE_FILTER}}[${timeRange}])) by (le)`,
-    errorsByStatus: `sum by (status) (increase(stoa_http_requests_total{${MODE_FILTER}, status=~"4..|5.."}[${timeRange}]))`,
+    statusMix: `sum by (status) (increase(stoa_http_requests_total{${MODE_FILTER}, status=~"2..|3..|4..|5.."}[${timeRange}]))`,
+    errorsByStatus: `sum by (status) (increase(stoa_http_requests_total{${MODE_FILTER}, status=~"5.."}[${timeRange}]))`,
+    clientErrorsByStatus: `sum by (status) (increase(stoa_http_requests_total{${MODE_FILTER}, status=~"4.."}[${timeRange}]))`,
     topRoutesP95: `topk(8, histogram_quantile(0.95, sum by (le, ${ROUTE_LABEL}) (rate(stoa_http_request_duration_seconds_bucket{${MODE_FILTER}, ${ROUTE_LABEL_FILTER}}[5m]))))`,
     topRoutesCalls: `sum by (${ROUTE_LABEL}) (increase(stoa_http_requests_total{${MODE_FILTER}, ${ROUTE_LABEL_FILTER}}[${timeRange}]))`,
     requestsTrend: `sum(rate(stoa_http_requests_total{${MODE_FILTER}}[5m]))`,

--- a/memory.md
+++ b/memory.md
@@ -1,6 +1,10 @@
 # STOA Memory
 
-> Dernière MAJ: 2026-05-12. Archive complète (cycles passés, DONE, etc.) → `memory-archive.md`.
+> Dernière MAJ: 2026-05-13. Archive complète (cycles passés, DONE, etc.) → `memory-archive.md`.
+
+## Session Notes — 2026-05-13
+
+- CAB-2223 Live Calls HTTP status semantics implemented on branch `codex/cab-2223-live-calls-status-mix` in worktree `/Users/torpedo/hlfh-repos/.worktrees/stoa-cab-2223`. Scope stayed `control-plane-ui`: `errorsByStatus` is now 5xx-only, a new `statusMix` query renders 2xx/3xx/4xx/5xx distribution, 4xx are split into a separate Client errors panel, and regression coverage asserts the public PromQL/query labels plus green-dominant Status Mix. Council S2 recorded on Linear with 8.25/10 Go; context compiler attempted but failed with `file is not a database (26)`. Validation passed: targeted Live Calls regression, focused CallFlow tests, full `npm run test -- --run` (2340 passed, 11 skipped), `npm run lint` (49 pre-existing warnings, 0 errors), `npm run format:check`, `npm run build` after `control-plane-ui/npm ci` + `shared/npm ci`, and `git diff --check`. Browser smoke reached the local app but `/observability/live-calls` redirected to `/login` because the in-app browser had no Keycloak session, so visual inspection of the protected page was auth-gated.
 
 ## Session Notes — 2026-05-12
 


### PR DESCRIPTION
## Summary

Splits the Live Calls dashboard status semantics so 4xx client errors and 5xx platform failures are no longer conflated.

- `errorsByStatus` PromQL is now **5xx-only**; new `clientErrorsByStatus` covers 4xx; new `statusMix` returns the full 2xx/3xx/4xx/5xx distribution.
- New `StatusMix.tsx` panel (stacked bar + legend grid) renders the four-class success/redirect/client/server share.
- `ErrorBreakdown` refactored to a reusable component, used twice: **Failures (5xx only)** and **Client errors (4xx)**.
- Regression coverage in `live-calls-metric-integrity.test.tsx` asserts the new PromQL labels, the three panel headings, and that the old combined "Error Breakdown" heading is gone.

Linear: [CAB-2223](https://linear.app/stoa-platform/issue/CAB-2223) — Council S2 8.25/10 Go recorded.

## Test plan

- [x] Targeted regression: `live-calls-metric-integrity.test.tsx`
- [x] Full UI suite: `npm run test -- --run` (2340 passed, 11 skipped)
- [x] `npm run lint` (0 errors, 49 pre-existing warnings)
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `git diff --check`
- [ ] Visual smoke on `/observability/live-calls` (auth-gated locally; verify post-deploy on console.gostoa.dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)