### PR TITLE
feat(api): audit immutability + pseudonymization migration DRAFT (CAB-2226)

### DIFF
--- a/control-plane-api/alembic/versions/107_README.md
+++ b/control-plane-api/alembic/versions/107_README.md
@@ -1,0 +1,88 @@
+# Migration 107 — Audit immutability + pseudonymization (DRAFT)
+
+**Status: DRAFT. DO NOT APPLY TO PRODUCTION UNTIL SIGN-OFF.**
+
+This migration is the concrete artefact for [CAB-2226](https://linear.app/hlfh-workspace/issue/CAB-2226) — joint sign-off of ADR-068 (audit immutability + hash chain) and ADR-069 (GDPR ↔ DORA reconciliation via pseudonymization).
+
+## Why this file exists
+
+The audit of 2026-05-11 (`docs/audits/2026-05-11-uac-subscription-mcp/AUDIT-RESULTS.md`) found that `audit_events` is declared "immutable" in the model docstring but is mutated by `erase_user_pii()` (`control-plane-api/src/services/audit_service.py:420-461`). This breaks DORA Art.11 (5-year integrity) silently while satisfying GDPR Art.17.
+
+ADR-068 + ADR-069 (drafts in `docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/`) reconcile the conflict by:
+
+1. Forbidding UPDATE / DELETE on `audit_events` via a PostgreSQL trigger.
+2. Routing GDPR erasure requests through a separate `pseudonymized_audit_erasures` table.
+3. Exposing a `audit_events_redacted` view that applies redaction at read time.
+4. Preparing a per-tenant hash chain (`audit_chain_heads` + `row_hash` column) for integrity proof.
+
+This migration **creates the schema**. It does **not** rewrite application code (`erase_user_pii`, audit insert path, hash chain computation) — those are separate PRs, also blocked on sign-off.
+
+## What the migration changes
+
+| Object | Type | Purpose |
+|--------|------|---------|
+| `audit_events.row_hash` | column (BYTEA, nullable) | Per-tenant hash chain link |
+| `audit_chain_heads` | table | Serializes per-tenant chain inserts |
+| `audit_events_immutable()` | trigger function | Raises on UPDATE/DELETE of audit_events |
+| `audit_events_no_update` | trigger | Wires immutability on UPDATE |
+| `audit_events_no_delete` | trigger | Wires immutability on DELETE |
+| `pseudonymized_audit_erasures` | table | GDPR Art.17 records, DPO-controlled |
+| `_audit_is_redacted(event_id, actor_id)` | SQL helper | Redaction predicate, STABLE |
+| `audit_events_redacted` | view | Default read surface with redaction |
+| `pgcrypto` | extension | sha256/digest for view pseudonyms |
+
+## What the migration deliberately does NOT do
+
+- **Backfill `row_hash` for existing rows.** Trigger only enforces on new inserts; existing rows tolerate NULL. Backfill is a separate break-glass operation under DPO/Compliance sign-off, with documented batch hash, count, and operator.
+- **Rewrite `erase_user_pii()`.** Without that rewrite, applying this migration to a live system breaks the existing GDPR erasure path (the trigger refuses the UPDATE). A code-side PR must land in lock-step.
+- **Enable hash-chain computation in audit_service.py inserts.** Schema only.
+- **Add SQLAlchemy models for the new tables.** Comes with the code PR.
+- **Drop `row_hash` on downgrade.** Preserved for safety; explicit drop under a separate procedure if needed.
+
+## Sign-off pre-requisites (CAB-2226)
+
+This migration is **non-mergeable** until all of the following are recorded on CAB-2226:
+
+- [ ] **Security** sign-off: SQL-level review of the immutability trigger and trigger exception path.
+- [ ] **Compliance** sign-off: pseudonymization model satisfies DORA Art.11 retention vs GDPR Art.17 erasure.
+- [ ] **DPO** sign-off (non-delegable): `pseudonymized_audit_erasures` workflow, redaction_map shape, pseudonymization_key disposition (default proposal: retrievable with dual-control per ENISA; DPO may override).
+- [ ] **Legal** sign-off: legal-basis taxonomy, jurisdictional coverage, retention default for the auxiliary table.
+- [ ] **CP-API WG** sign-off: alembic + ORM model addition path agreed; `erase_user_pii` rewrite scoped as a follow-up PR with lock-step deploy ordering.
+- [ ] **Platform Ops** sign-off: break-glass procedure for the three trigger exceptions (retention purge, schema migration, disaster-recovery restore) documented as runbook.
+
+## Lock-step deploy ordering
+
+When sign-off is complete, deployment must follow this order:
+
+1. **PR A — code-side (separate, blocked by sign-off):** rewrite `erase_user_pii()` to insert into `pseudonymized_audit_erasures` instead of UPDATE; route audit reads through the new view; add hash-chain computation in audit_service insert path; add SQLAlchemy models.
+2. **PR B — this migration:** apply `107_audit_immutability_pseudonymization` to all environments (dev → staging → prod).
+3. **PR C — backfill (separate):** compute `row_hash` for existing rows in `created_at` order per tenant. Break-glass procedure, audited operator.
+
+PR A must be MERGED and DEPLOYED to a given environment before PR B is applied there. Otherwise the trigger will reject in-flight erasure UPDATEs and break tenant-facing functionality.
+
+## How to test this migration locally (after sign-off, NOT before)
+
+```bash
+cd control-plane-api
+# Bring up a disposable Postgres
+docker run -d --name stoa-audit-test -e POSTGRES_PASSWORD=test -p 5433:5432 postgres:16
+# Apply existing migrations to head
+DATABASE_URL=postgresql+asyncpg://postgres:test@localhost:5433/postgres \
+  alembic upgrade 106_drop_api_catalog_full_unique
+# Apply this draft
+DATABASE_URL=postgresql+asyncpg://postgres:test@localhost:5433/postgres \
+  alembic upgrade 107_audit_immutability_pseudonymization
+# Smoke: try to UPDATE — must raise P0001
+DATABASE_URL=postgresql+asyncpg://postgres:test@localhost:5433/postgres \
+  python -c "import asyncio; from sqlalchemy.ext.asyncio import create_async_engine; \
+    asyncio.run(create_async_engine('postgresql+asyncpg://postgres:test@localhost:5433/postgres').execute('UPDATE audit_events SET actor_email=NULL'))"
+# Expect: asyncpg.exceptions.RaiseError: audit_events is append-only (ADR-068)
+```
+
+## Companion documents
+
+- **Audit**: `docs/audits/2026-05-11-uac-subscription-mcp/AUDIT-RESULTS.md` (Axe C, controls 5/6/7/10/11)
+- **Plan**: `docs/plans/2026-05-11-uac-subscription-mcp-corrective.md` §5.4 (P0-4)
+- **Decision record**: `docs/decisions/2026-05-11-uac-subscription-mcp-corrective.md` C5 + §3.3 Q4 + Q5
+- **ADR-068 draft**: `docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/adr-068-audit-log-actor-resource-doctrine.md`
+- **ADR-069 draft**: `docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/adr-069-gdpr-dora-audit-reconciliation.md`

--- a/control-plane-api/alembic/versions/107_audit_immutability_pseudonymization.py
+++ b/control-plane-api/alembic/versions/107_audit_immutability_pseudonymization.py
@@ -1,0 +1,246 @@
+"""Audit immutability + pseudonymization auxiliary table (ADR-068 + ADR-069 DRAFT).
+
+Revision ID: 107_audit_immutability_pseudonymization
+Revises: 106_drop_api_catalog_full_unique
+Create Date: 2026-05-13
+
+============================================================================
+DRAFT MIGRATION — DO NOT APPLY TO PRODUCTION UNTIL SIGN-OFF.
+============================================================================
+
+See `107_README.md` in this directory for the full sign-off pre-requisites
+(Linear ticket CAB-2226: ADR-068 + ADR-069 joint sign-off).
+
+What this migration does (per ADR-068 + ADR-069 drafts):
+
+1. Adds a PostgreSQL trigger to refuse UPDATE / DELETE on `audit_events`.
+   The current `erase_user_pii()` code path WILL break the moment this
+   trigger is in force — a code-side rewrite (separate PR, also blocked
+   on sign-off) is required for production deployment.
+2. Adds `audit_chain_heads` table for per-tenant hash-chain ordering.
+   Schema only. Insertion logic lives in a follow-up code PR.
+3. Adds a nullable `row_hash` column on `audit_events`. Existing rows
+   keep NULL until a backfill migration runs under break-glass procedure.
+4. Adds `pseudonymized_audit_erasures` auxiliary table — the GDPR Art.17
+   path that satisfies erasure requests WITHOUT mutating the source row.
+5. Adds `audit_events_redacted` view — the default read surface for SOC,
+   support, tenant admins. Applies redaction at read time per the
+   `redaction_map` in `pseudonymized_audit_erasures`.
+
+What this migration does NOT do:
+
+- Does NOT rewrite `audit_service.erase_user_pii()`. Without that rewrite,
+  applying this migration to a live system breaks the GDPR erasure path.
+- Does NOT backfill `row_hash` for existing rows. The trigger only blocks
+  UPDATE/DELETE — existing NULL row_hash values are tolerated.
+- Does NOT enable hash-chain validation in audit_service.py inserts.
+- Does NOT add SQLAlchemy models for `audit_chain_heads` /
+  `pseudonymized_audit_erasures`. Those come with the code PR.
+
+Why DRAFT: regulatory + DPO + Legal sign-off required (CAB-2226).
+Reviewers see the concrete SQL artefact before approving the abstract
+ADR. This file IS the reviewable artefact.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "107_audit_immutability_pseudonymization"
+down_revision: str | tuple[str, ...] | None = "106_drop_api_catalog_full_unique"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply ADR-068 + ADR-069 schema changes.
+
+    Idempotent where possible (IF NOT EXISTS / OR REPLACE) so re-runs
+    against a partially-applied DB do not panic. Triggers are not
+    idempotent in the standard sense; they are explicitly DROPped-then-
+    recreated to guarantee a known state.
+    """
+
+    # ----- 1. Extensions (pgcrypto for sha256/digest in the redacted view).
+    op.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+
+    # ----- 2. row_hash column on audit_events.
+    # Nullable. Existing rows keep NULL. Insertion code (separate PR)
+    # populates new rows. Backfill of existing rows is a separate
+    # break-glass operation under DPO/Compliance sign-off.
+    op.execute("ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS row_hash BYTEA")
+    op.execute(
+        "COMMENT ON COLUMN audit_events.row_hash IS "
+        "'Per-tenant hash chain (ADR-068 §4.5). sha256(prev_hash || event_id || "
+        "created_at || tenant_id || actor_id || action || resource_type:resource_id "
+        "|| outcome). NULL on rows created before the chain was enabled.'"
+    )
+
+    # ----- 3. audit_chain_heads — per-tenant chain head.
+    # ADR-068 §4.5 concurrency invariant. Insertion path locks the
+    # row with `SELECT ... FOR UPDATE` (or pg_advisory_xact_lock) before
+    # computing the next row_hash.
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS audit_chain_heads (
+            tenant_id     VARCHAR(255) PRIMARY KEY,
+            last_row_hash BYTEA NOT NULL,
+            last_event_id VARCHAR(36) NOT NULL,
+            updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """)
+    op.execute(
+        "COMMENT ON TABLE audit_chain_heads IS "
+        "'ADR-068 §4.5: serializes per-tenant audit hash chain inserts. "
+        "Concurrency: SELECT ... FOR UPDATE or pg_advisory_xact_lock(hashtext(tenant_id)::bigint).'"
+    )
+
+    # ----- 4. Immutability trigger function + 2 triggers.
+    # Refuses UPDATE and DELETE on audit_events. GDPR erasure path
+    # uses the auxiliary pseudonymization table instead (see §6 view).
+    # Three documented exceptions (ADR-069 §4.6): retention purge,
+    # schema migration, disaster-recovery restore. Each is a break-glass
+    # procedure that temporarily drops the relevant trigger inside a
+    # transaction and re-creates it before commit, with the operation
+    # itself audited.
+    op.execute("""
+        CREATE OR REPLACE FUNCTION audit_events_immutable() RETURNS trigger AS $$
+        BEGIN
+            RAISE EXCEPTION
+                'audit_events is append-only (ADR-068). '
+                'Use the pseudonymization auxiliary table for GDPR Art.17 erasure.'
+                USING ERRCODE = 'P0001';
+        END;
+        $$ LANGUAGE plpgsql
+        """)
+    # DROP-then-CREATE for idempotency on re-runs against a partial state.
+    op.execute("DROP TRIGGER IF EXISTS audit_events_no_update ON audit_events")
+    op.execute("""
+        CREATE TRIGGER audit_events_no_update
+            BEFORE UPDATE ON audit_events
+            FOR EACH ROW EXECUTE FUNCTION audit_events_immutable()
+        """)
+    op.execute("DROP TRIGGER IF EXISTS audit_events_no_delete ON audit_events")
+    op.execute("""
+        CREATE TRIGGER audit_events_no_delete
+            BEFORE DELETE ON audit_events
+            FOR EACH ROW EXECUTE FUNCTION audit_events_immutable()
+        """)
+
+    # ----- 5. pseudonymized_audit_erasures — GDPR Art.17 auxiliary table.
+    # ADR-069 §4.2. DPO-controlled inserts. The pseudonymization_key is
+    # encrypted at the application layer before insertion; pgcrypto here
+    # is only used for the view's `digest()` call, not for key handling.
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS pseudonymized_audit_erasures (
+            erasure_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            request_received_at   TIMESTAMPTZ NOT NULL,
+            legal_basis           TEXT NOT NULL,
+            dpo_approver_id       VARCHAR(255) NOT NULL,
+            dpo_approved_at       TIMESTAMPTZ NOT NULL,
+            subject_external_ref  TEXT,
+            pseudonymization_key  BYTEA NOT NULL,
+            scope_actor_ids       VARCHAR(255)[] NOT NULL DEFAULT '{}',
+            scope_event_ids       VARCHAR(36)[] NOT NULL DEFAULT '{}',
+            redaction_map         JSONB NOT NULL,
+            created_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """)
+    op.execute(
+        "COMMENT ON TABLE pseudonymized_audit_erasures IS "
+        "'ADR-069 §4.2: GDPR Art.17 erasures recorded without mutating audit_events. "
+        "DPO-approved inserts only. Pseudonymization_key encrypted at app layer.'"
+    )
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_pseudo_erasures_actor_ids
+            ON pseudonymized_audit_erasures USING GIN (scope_actor_ids)
+        """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_pseudo_erasures_event_ids
+            ON pseudonymized_audit_erasures USING GIN (scope_event_ids)
+        """)
+
+    # ----- 6. _audit_is_redacted() helper (stable SQL function).
+    # The redacted view consults it for each row; STABLE means the
+    # planner can cache it within a single query.
+    op.execute("""
+        CREATE OR REPLACE FUNCTION _audit_is_redacted(
+            p_event_id VARCHAR,
+            p_actor_id VARCHAR
+        ) RETURNS BOOLEAN AS $$
+            SELECT EXISTS (
+                SELECT 1 FROM pseudonymized_audit_erasures p
+                WHERE
+                    (p_actor_id IS NOT NULL AND p.scope_actor_ids @> ARRAY[p_actor_id]::VARCHAR[])
+                    OR p.scope_event_ids @> ARRAY[p_event_id]::VARCHAR[]
+            );
+        $$ LANGUAGE SQL STABLE
+        """)
+
+    # ----- 7. audit_events_redacted view — default read surface.
+    # ADR-069 §4.2. Regulatory fields are preserved as-is. Identifying
+    # fields are pseudonymized or NULLed when an erasure entry references
+    # the row's actor or event id.
+    op.execute("""
+        CREATE OR REPLACE VIEW audit_events_redacted AS
+        SELECT
+            e.id,
+            e.tenant_id,
+            CASE
+                WHEN _audit_is_redacted(e.id, e.actor_id)
+                THEN 'pseudo:' || encode(digest(coalesce(e.actor_id, e.id), 'sha256'), 'hex')
+                ELSE e.actor_id
+            END AS actor_id,
+            CASE
+                WHEN _audit_is_redacted(e.id, e.actor_id) THEN NULL
+                ELSE e.actor_email
+            END AS actor_email,
+            e.actor_type,
+            e.action,
+            e.method,
+            e.path,
+            e.resource_type,
+            e.resource_id,
+            e.resource_name,
+            e.outcome,
+            e.status_code,
+            CASE
+                WHEN _audit_is_redacted(e.id, e.actor_id) THEN NULL
+                ELSE e.client_ip
+            END AS client_ip,
+            CASE
+                WHEN _audit_is_redacted(e.id, e.actor_id) THEN NULL
+                ELSE e.user_agent
+            END AS user_agent,
+            e.correlation_id,
+            e.details,
+            e.diff,
+            e.duration_ms,
+            e.created_at,
+            e.row_hash
+        FROM audit_events e
+        """)
+    op.execute(
+        "COMMENT ON VIEW audit_events_redacted IS "
+        "'ADR-069 §4.2: default read surface for SOC/support/tenant-admin. "
+        "Regulatory fields preserved; identifying fields redacted per pseudonymized_audit_erasures.'"
+    )
+
+
+def downgrade() -> None:
+    """Break-glass downgrade — drops triggers, view, helper, and aux tables.
+
+    The `row_hash` column on `audit_events` is INTENTIONALLY preserved
+    so that any computed chain data survives. Operator must explicitly
+    drop the column under a separate procedure if truly needed.
+    """
+    op.execute("DROP VIEW IF EXISTS audit_events_redacted")
+    op.execute("DROP FUNCTION IF EXISTS _audit_is_redacted(VARCHAR, VARCHAR)")
+    op.execute("DROP TRIGGER IF EXISTS audit_events_no_delete ON audit_events")
+    op.execute("DROP TRIGGER IF EXISTS audit_events_no_update ON audit_events")
+    op.execute("DROP FUNCTION IF EXISTS audit_events_immutable()")
+    op.execute("DROP INDEX IF EXISTS idx_pseudo_erasures_event_ids")
+    op.execute("DROP INDEX IF EXISTS idx_pseudo_erasures_actor_ids")
+    op.execute("DROP TABLE IF EXISTS pseudonymized_audit_erasures")
+    op.execute("DROP TABLE IF EXISTS audit_chain_heads")
+    # NOTE: row_hash column on audit_events is intentionally preserved.


### PR DESCRIPTION
## ⚠️ DRAFT — NOT MERGEABLE UNTIL CAB-2226 SIGN-OFF

This PR is the **concrete SQL artefact** for ADR-068 (audit immutability + hash chain) and ADR-069 (GDPR ↔ DORA reconciliation). It exists so that the joint sign-off review on [CAB-2226](https://linear.app/hlfh-workspace/issue/CAB-2226) has a real migration file to evaluate, not just prose.

**Do not merge.** Do not apply to staging or production. Read the README in the migration directory for the full sign-off pre-requisites.

## Summary

- 1 alembic migration: `107_audit_immutability_pseudonymization.py`
- 1 README explaining draft status + sign-off matrix + lock-step deploy ordering
- 334 LOC total. No code change. No model change. Schema only.

## What the migration creates

| Object | Purpose | ADR ref |
|--------|---------|---------|
| `audit_events_immutable()` PG function + 2 triggers | Block UPDATE/DELETE on `audit_events` with P0001 error | ADR-068 §4.4 |
| `audit_events.row_hash` (BYTEA, nullable) | Per-tenant hash chain link | ADR-068 §4.5 |
| `audit_chain_heads` table | Per-tenant chain-head serialization | ADR-068 §4.5 |
| `pseudonymized_audit_erasures` table | GDPR Art.17 path without UPDATE on audit_events | ADR-069 §4.2 |
| `audit_events_redacted` view + `_audit_is_redacted()` helper | Default read surface with redaction | ADR-069 §4.2 |
| `pgcrypto` extension | sha256/digest in the view's pseudonym computation | implementation detail |

## What this PR deliberately does NOT do

- ❌ No rewrite of `erase_user_pii()` (`src/services/audit_service.py:420-461`). That's a follow-up code PR which must land in lock-step.
- ❌ No backfill of `row_hash` for existing rows. Trigger only fires on new mutations; existing NULL row_hash is tolerated.
- ❌ No hash-chain computation in the audit insert path. Schema only.
- ❌ No SQLAlchemy models for the new tables. Follow-up code PR.
- ❌ No `row_hash` drop on downgrade. Preserved as safety net.

## Why DRAFT (and why open the PR anyway)

The challenger decision record on the corrective plan (2026-05-13, GO_WITH_CONDITIONS) demands DPO + Legal + Compliance + Security + CP-API WG + Platform Ops sign-off **before** any change touches `audit_events`. Producing the SQL upfront is what makes the sign-off review possible — reviewers see exactly what the trigger and the view will do, not a paraphrased ADR.

This is "prep ammunition": the artefact feeds the review, but doesn't merge until the review concludes.

## Sign-off checklist (mirrors CAB-2226)

- [ ] **Security** sign-off (SQL-level review of trigger + exception path)
- [ ] **Compliance** sign-off (pseudonymization model satisfies DORA Art.11 vs GDPR Art.17)
- [ ] **DPO** sign-off — **non-delegable** (workflow, redaction_map, pseudonymization_key disposition)
- [ ] **Legal** sign-off (legal-basis taxonomy, jurisdictional coverage, aux-table retention)
- [ ] **CP-API WG** sign-off (alembic + ORM addition path, lock-step ordering with code rewrite)
- [ ] **Platform Ops** sign-off (break-glass procedures for the three trigger exceptions)

## Lock-step deploy ordering (post-sign-off)

| Order | PR | Scope |
|------:|----|-------|
| 1 | New code PR (not yet opened) | Rewrite `erase_user_pii` → insert into aux table; route audit reads through the view; add hash-chain computation in insert path; ORM models |
| 2 | **This PR** | Apply migration 107 to dev → staging → prod |
| 3 | New backfill PR (not yet opened) | Compute `row_hash` for existing rows per tenant in `created_at` order, under break-glass procedure |

PR #1 must MERGE + DEPLOY before #2 is applied to a given environment. Otherwise the trigger rejects in-flight erasure UPDATEs and breaks tenant-facing functionality.

## Static checks

- ✅ `alembic heads` → single head `107_audit_immutability_pseudonymization`
- ✅ `alembic history` shows clean chain off `106_drop_api_catalog_full_unique`
- ✅ ruff clean
- ✅ black clean
- ✅ Python module imports OK (revision/down_revision resolved)
- ⚠️ No DB-level test run. Will run as part of CI on this PR + as an explicit smoke step under DPO observation post-sign-off.

## Test plan (post-sign-off, NOT in this PR)

```bash
# Disposable Postgres
docker run -d --name stoa-audit-test -e POSTGRES_PASSWORD=test -p 5433:5432 postgres:16
# Apply chain
DATABASE_URL=postgresql+asyncpg://postgres:test@localhost:5433/postgres \
  alembic upgrade 107_audit_immutability_pseudonymization
# Smoke: UPDATE must raise P0001
psql -h localhost -p 5433 -U postgres -c "UPDATE audit_events SET actor_email = NULL"
# Expected: ERROR: audit_events is append-only (ADR-068)
# Smoke: DELETE must raise P0001
psql -h localhost -p 5433 -U postgres -c "DELETE FROM audit_events"
# Expected: same error
# View round-trip with an erasure entry: separate fixture test
```

## Files

- `control-plane-api/alembic/versions/107_audit_immutability_pseudonymization.py` (migration)
- `control-plane-api/alembic/versions/107_README.md` (sign-off + risk + deploy ordering doc)

Refs: CAB-2226

🤖 Generated with [Claude Code](https://claude.com/claude-code)