### PR TITLE
fix(api): deprovision retry loop with DEPROVISIONING_FAILED state

### DIFF
--- a/control-plane-api/src/models/subscription.py
+++ b/control-plane-api/src/models/subscription.py
@@ -30,6 +30,7 @@ class ProvisioningStatus(enum.StrEnum):
     READY = "ready"  # Route active in gateway
     FAILED = "failed"  # Provisioning failed
     DEPROVISIONING = "deprovisioning"  # Removal in progress
+    DEPROVISIONING_FAILED = "deprovisioning_failed"  # Removal failed after retries
     DEPROVISIONED = "deprovisioned"  # Removed from gateway
 
 
@@ -102,7 +103,9 @@ class Subscription(Base):
     environment = Column(String(50), nullable=True)
 
     # Gateway provisioning (CAB-800)
-    provisioning_status = Column(String(32), nullable=False, default=ProvisioningStatus.NONE.value, server_default="none")
+    provisioning_status = Column(
+        String(32), nullable=False, default=ProvisioningStatus.NONE.value, server_default="none"
+    )
     gateway_app_id = Column(String(255), nullable=True)  # webMethods application ID
     provisioning_error = Column(Text, nullable=True)  # Last error message
     provisioned_at = Column(DateTime, nullable=True)  # When route was created

--- a/control-plane-api/src/services/provisioning_service.py
+++ b/control-plane-api/src/services/provisioning_service.py
@@ -34,9 +34,7 @@ _default_adapter = AdapterRegistry.create("webmethods")
 gateway_service = _default_adapter._svc
 
 
-async def _resolve_adapter(
-    db: AsyncSession, api_id: str, tenant_id: str
-) -> GatewayAdapterInterface | None:
+async def _resolve_adapter(db: AsyncSession, api_id: str, tenant_id: str) -> GatewayAdapterInterface | None:
     """Resolve the gateway adapter for an API.
 
     Looks up gateway_deployments to find which gateway the API is deployed to.
@@ -71,8 +69,11 @@ async def _resolve_adapter(
         from ..services.credential_resolver import create_adapter_with_credentials
 
         return await create_adapter_with_credentials(
-            gateway.gateway_type.value, gateway.base_url, gateway.auth_config,
-            source=gateway.source, gateway_name=gateway.name,
+            gateway.gateway_type.value,
+            gateway.base_url,
+            gateway.auth_config,
+            source=gateway.source,
+            gateway_name=gateway.name,
         )
     except Exception as e:
         logger.error("Failed to resolve gateway adapter for API %s: %s", api_id, e)
@@ -385,42 +386,66 @@ async def _deprovision_with_session(
 
     adapter = await _resolve_adapter(db, subscription.api_id, subscription.tenant_id)
     if adapter is None:
-        subscription.provisioning_status = ProvisioningStatus.FAILED
-        subscription.provisioning_error = (
-            "Deprovision failed: no gateway adapter resolved for existing gateway_app_id"
-        )
+        subscription.provisioning_status = ProvisioningStatus.DEPROVISIONING_FAILED
+        subscription.provisioning_error = "Deprovision failed: no gateway adapter resolved for existing gateway_app_id"
         await db.commit()
         logger.error(
             "Deprovision failed for subscription %s: no gateway adapter resolved",
             subscription.id,
-            extra={"correlation_id": correlation_id, "tenant_id": subscription.tenant_id},
+            extra={
+                "correlation_id": correlation_id,
+                "tenant_id": subscription.tenant_id,
+                "subscription_id": str(subscription.id),
+                "ops_alert": "deprovision_failed",
+            },
         )
         return
 
-    try:
-        # Clean up rate-limit policy first (CAB-1121 Phase 3)
-        await _cleanup_rate_limit_policy(adapter, subscription, auth_token, correlation_id)
+    last_error = None
 
-        result = await adapter.deprovision_application(subscription.gateway_app_id, auth_token=auth_token)
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            # Clean up rate-limit policy first (CAB-1121 Phase 3)
+            await _cleanup_rate_limit_policy(adapter, subscription, auth_token, correlation_id)
 
-        if not result.success:
-            raise RuntimeError(result.error or "Adapter returned failure")
+            result = await adapter.deprovision_application(subscription.gateway_app_id, auth_token=auth_token)
 
-        subscription.provisioning_status = ProvisioningStatus.DEPROVISIONED
-        subscription.gateway_app_id = None
-        await db.commit()
+            if not result.success:
+                raise RuntimeError(result.error or "Adapter returned failure")
 
-        logger.info(
-            f"Deprovisioned gateway app for subscription {subscription.id}",
-            extra={"correlation_id": correlation_id},
-        )
+            subscription.provisioning_status = ProvisioningStatus.DEPROVISIONED
+            subscription.gateway_app_id = None
+            await db.commit()
 
-    except Exception as e:
-        subscription.provisioning_status = ProvisioningStatus.FAILED
-        subscription.provisioning_error = f"Deprovision failed: {e}"
-        await db.commit()
+            logger.info(
+                f"Deprovisioned gateway app for subscription {subscription.id} (attempt {attempt})",
+                extra={"correlation_id": correlation_id, "tenant_id": subscription.tenant_id},
+            )
+            return
 
-        logger.error(
-            f"Deprovision failed for subscription {subscription.id}: {e}",
-            extra={"correlation_id": correlation_id},
-        )
+        except Exception as e:
+            last_error = str(e)
+            logger.warning(
+                f"Deprovision attempt {attempt}/{MAX_RETRIES} failed for " f"subscription {subscription.id}: {e}",
+                extra={"correlation_id": correlation_id},
+            )
+
+            if attempt < MAX_RETRIES:
+                delay = RETRY_DELAYS[attempt - 1]
+                await asyncio.sleep(delay)
+
+    # All retries exhausted.
+    subscription.provisioning_status = ProvisioningStatus.DEPROVISIONING_FAILED
+    subscription.provisioning_error = f"Deprovision failed after {MAX_RETRIES} attempts: {last_error}"
+    await db.commit()
+    # TODO(CAB-2225 SUB-1): add Prometheus counter once metrics module is finalized.
+
+    logger.error(
+        f"Deprovision failed after {MAX_RETRIES} attempts for subscription {subscription.id}: {last_error}",
+        extra={
+            "correlation_id": correlation_id,
+            "tenant_id": subscription.tenant_id,
+            "subscription_id": str(subscription.id),
+            "ops_alert": "deprovision_failed",
+        },
+    )

--- a/control-plane-api/tests/test_provisioning.py
+++ b/control-plane-api/tests/test_provisioning.py
@@ -14,28 +14,30 @@ Tests cover:
 - Mappers: map_app_spec_to_route, map_quota_to_policy
 """
 
-import pytest
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
+
+import pytest
 
 from src.adapters.gateway_adapter_interface import AdapterResult
 
 
-class SubscriptionStatus(str, Enum):
+class SubscriptionStatus(StrEnum):
     PENDING = "pending"
     ACTIVE = "active"
     REVOKED = "revoked"
 
 
-class ProvisioningStatus(str, Enum):
+class ProvisioningStatus(StrEnum):
     NONE = "none"
     PENDING = "pending"
     PROVISIONING = "provisioning"
     READY = "ready"
     FAILED = "failed"
     DEPROVISIONING = "deprovisioning"
+    DEPROVISIONING_FAILED = "deprovisioning_failed"
     DEPROVISIONED = "deprovisioned"
 
 
@@ -302,7 +304,7 @@ class TestDeprovisionOnRevocation:
 
     @pytest.mark.asyncio
     async def test_deprovision_failure(self):
-        """Failed deprovision sets status FAILED."""
+        """Failed deprovision sets status DEPROVISIONING_FAILED."""
         sub = _make_subscription(
             gateway_app_id="wm-app-999",
             provisioning_status=ProvisioningStatus.READY,
@@ -312,21 +314,24 @@ class TestDeprovisionOnRevocation:
         adapter = AsyncMock()
         adapter.deprovision_application = AsyncMock(side_effect=RuntimeError("not found"))
 
-        with patch(
-            "src.services.provisioning_service._resolve_adapter",
-            new_callable=AsyncMock,
-            return_value=adapter,
+        with (
+            patch(
+                "src.services.provisioning_service._resolve_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter,
+            ),
+            patch("src.services.provisioning_service.asyncio.sleep", new_callable=AsyncMock),
         ):
             from src.services.provisioning_service import deprovision_on_revocation
 
             await deprovision_on_revocation(db, sub, "jwt-token", "corr-300")
 
-        assert sub.provisioning_status == ProvisioningStatus.FAILED
+        assert sub.provisioning_status == ProvisioningStatus.DEPROVISIONING_FAILED
         assert "not found" in sub.provisioning_error
 
     @pytest.mark.asyncio
     async def test_deprovision_adapter_failure_result(self):
-        """AdapterResult with success=False sets status FAILED."""
+        """AdapterResult with success=False sets status DEPROVISIONING_FAILED."""
         sub = _make_subscription(
             gateway_app_id="wm-app-500",
             provisioning_status=ProvisioningStatus.READY,
@@ -336,16 +341,19 @@ class TestDeprovisionOnRevocation:
         fail_result = AdapterResult(success=False, error="gateway rejected")
         adapter = _mock_adapter(deprovision_result=fail_result)
 
-        with patch(
-            "src.services.provisioning_service._resolve_adapter",
-            new_callable=AsyncMock,
-            return_value=adapter,
+        with (
+            patch(
+                "src.services.provisioning_service._resolve_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter,
+            ),
+            patch("src.services.provisioning_service.asyncio.sleep", new_callable=AsyncMock),
         ):
             from src.services.provisioning_service import deprovision_on_revocation
 
             await deprovision_on_revocation(db, sub, "jwt-token", "corr-400")
 
-        assert sub.provisioning_status == ProvisioningStatus.FAILED
+        assert sub.provisioning_status == ProvisioningStatus.DEPROVISIONING_FAILED
         assert "gateway rejected" in sub.provisioning_error
 
 
@@ -656,9 +664,10 @@ class TestCleanupRateLimitPolicy:
 
         from src.services.provisioning_service import _cleanup_rate_limit_policy
 
-        await _cleanup_rate_limit_policy(adapter, sub, "jwt", "corr-cleanup")
+        token = "jwt"
+        await _cleanup_rate_limit_policy(adapter, sub, token, "corr-cleanup")
 
-        adapter.delete_policy.assert_awaited_once_with(f"quota-{sub.id}", auth_token="jwt")
+        adapter.delete_policy.assert_awaited_once_with(f"quota-{sub.id}", auth_token=token)
 
     @pytest.mark.asyncio
     async def test_cleanup_policy_non_blocking_on_failure(self):

--- a/control-plane-api/tests/test_provisioning_service.py
+++ b/control-plane-api/tests/test_provisioning_service.py
@@ -5,9 +5,7 @@ deprovision_on_revocation, _push_rate_limit_policy, _cleanup_rate_limit_policy.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import UUID, uuid4
-
-import pytest
+from uuid import uuid4
 
 from src.services.provisioning_service import (
     _cleanup_rate_limit_policy,
@@ -16,7 +14,6 @@ from src.services.provisioning_service import (
     deprovision_on_revocation,
     provision_on_approval,
 )
-
 
 # ─────────────────────────────────────────────
 # Helpers
@@ -131,14 +128,21 @@ class TestResolveAdapter:
         with (
             patch("src.repositories.gateway_deployment.GatewayDeploymentRepository", return_value=mock_deploy_repo),
             patch("src.repositories.gateway_instance.GatewayInstanceRepository", return_value=mock_gw_repo),
-            patch("src.services.credential_resolver.create_adapter_with_credentials", new_callable=AsyncMock, return_value=mock_adapter) as mock_create,
+            patch(
+                "src.services.credential_resolver.create_adapter_with_credentials",
+                new_callable=AsyncMock,
+                return_value=mock_adapter,
+            ) as mock_create,
         ):
             result = await _resolve_adapter(db, "api-1", "tenant-1")
 
         assert result is mock_adapter
         mock_create.assert_awaited_once_with(
-            "kong", "https://kong.example.com", {"token": "secret"},
-            source=gateway.source, gateway_name=gateway.name,
+            "kong",
+            "https://kong.example.com",
+            {"token": "secret"},
+            source=gateway.source,
+            gateway_name=gateway.name,
         )
 
     async def test_no_deployment_returns_none(self):
@@ -239,9 +243,7 @@ class TestProvisionOnApproval:
         db = _make_db()
         sub = _make_subscription()
         adapter = _make_adapter()
-        adapter.provision_application = AsyncMock(
-            side_effect=RuntimeError("Gateway unreachable")
-        )
+        adapter.provision_application = AsyncMock(side_effect=RuntimeError("Gateway unreachable"))
 
         with (
             patch("src.services.provisioning_service._resolve_adapter", new_callable=AsyncMock, return_value=adapter),
@@ -402,7 +404,7 @@ class TestDeprovisionOnRevocation:
         # No adapter calls, no status change
         db.commit.assert_not_called()
 
-    async def test_existing_gateway_app_without_adapter_sets_failed(self):
+    async def test_existing_gateway_app_without_adapter_sets_deprovisioning_failed(self):
         db = _make_db()
         sub = _make_subscription(gateway_app_id="app-123")
 
@@ -414,47 +416,45 @@ class TestDeprovisionOnRevocation:
 
         from src.models.subscription import ProvisioningStatus
 
-        assert sub.provisioning_status == ProvisioningStatus.FAILED
+        assert sub.provisioning_status == ProvisioningStatus.DEPROVISIONING_FAILED
         assert "no gateway adapter resolved" in sub.provisioning_error
         assert sub.gateway_app_id == "app-123"
         cleanup.assert_not_called()
 
-    async def test_adapter_failure_sets_failed(self):
+    async def test_adapter_failure_sets_deprovisioning_failed(self):
         db = _make_db()
         sub = _make_subscription(gateway_app_id="app-123")
         adapter = _make_adapter()
-        adapter.deprovision_application = AsyncMock(
-            side_effect=RuntimeError("Gateway down")
-        )
+        adapter.deprovision_application = AsyncMock(side_effect=RuntimeError("Gateway down"))
 
         with (
             patch("src.services.provisioning_service._resolve_adapter", new_callable=AsyncMock, return_value=adapter),
             patch("src.services.provisioning_service._cleanup_rate_limit_policy", new_callable=AsyncMock),
+            patch("src.services.provisioning_service.asyncio.sleep", new_callable=AsyncMock),
         ):
             await deprovision_on_revocation(db, sub, "token", "corr-1")
 
         from src.models.subscription import ProvisioningStatus
 
-        assert sub.provisioning_status == ProvisioningStatus.FAILED
+        assert sub.provisioning_status == ProvisioningStatus.DEPROVISIONING_FAILED
         assert "Deprovision failed" in sub.provisioning_error
 
-    async def test_adapter_returns_failure_sets_failed(self):
+    async def test_adapter_returns_failure_sets_deprovisioning_failed(self):
         db = _make_db()
         sub = _make_subscription(gateway_app_id="app-123")
         adapter = _make_adapter()
-        adapter.deprovision_application = AsyncMock(
-            return_value=_make_adapter_result(success=False, error="Not found")
-        )
+        adapter.deprovision_application = AsyncMock(return_value=_make_adapter_result(success=False, error="Not found"))
 
         with (
             patch("src.services.provisioning_service._resolve_adapter", new_callable=AsyncMock, return_value=adapter),
             patch("src.services.provisioning_service._cleanup_rate_limit_policy", new_callable=AsyncMock),
+            patch("src.services.provisioning_service.asyncio.sleep", new_callable=AsyncMock),
         ):
             await deprovision_on_revocation(db, sub, "token", "corr-1")
 
         from src.models.subscription import ProvisioningStatus
 
-        assert sub.provisioning_status == ProvisioningStatus.FAILED
+        assert sub.provisioning_status == ProvisioningStatus.DEPROVISIONING_FAILED
 
     async def test_cleanup_rate_limit_called_before_deprovision(self):
         db = _make_db()
@@ -531,9 +531,7 @@ class TestPushRateLimitPolicy:
 
     async def test_adapter_returns_failure_does_not_raise(self):
         adapter = _make_adapter()
-        adapter.upsert_policy = AsyncMock(
-            return_value=_make_adapter_result(success=False, error="Policy rejected")
-        )
+        adapter.upsert_policy = AsyncMock(return_value=_make_adapter_result(success=False, error="Policy rejected"))
         sub = _make_subscription()
         plan = _make_plan()
 
@@ -569,9 +567,7 @@ class TestCleanupRateLimitPolicy:
 
     async def test_adapter_returns_failure_does_not_raise(self):
         adapter = _make_adapter()
-        adapter.delete_policy = AsyncMock(
-            return_value=_make_adapter_result(success=False, error="Not found")
-        )
+        adapter.delete_policy = AsyncMock(return_value=_make_adapter_result(success=False, error="Not found"))
         sub = _make_subscription()
 
         # Should not raise

--- a/control-plane-api/tests/test_regression_cab_2225_sub_1_deprovision_retry.py
+++ b/control-plane-api/tests/test_regression_cab_2225_sub_1_deprovision_retry.py
@@ -1,0 +1,106 @@
+# CAB-2225 SUB-1 deprovision retry regression tests.
+# Guards the retry loop for gateway route removal.
+#
+# regression for CAB-2225
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.adapters.gateway_adapter_interface import AdapterResult
+from src.models.subscription import ProvisioningStatus
+from src.services.provisioning_service import MAX_RETRIES, _deprovision_with_session, deprovision_on_revocation
+
+
+class _Subscription:
+    def __init__(self, *, gateway_app_id: str | None = "gw-app-1") -> None:
+        object.__setattr__(self, "provisioning_status_writes", [])
+        self.id = uuid4()
+        self.api_id = "api-weather"
+        self.tenant_id = "tenant-acme"
+        self.gateway_app_id = gateway_app_id
+        self.provisioning_error = None
+        self.provisioning_status = ProvisioningStatus.READY
+        self.provisioning_status_writes.clear()
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if name == "provisioning_status":
+            self.provisioning_status_writes.append(value)
+        object.__setattr__(self, name, value)
+
+
+def _adapter_with_deprovision(*results: AdapterResult) -> AsyncMock:
+    adapter = AsyncMock()
+    adapter.delete_policy = AsyncMock(return_value=AdapterResult(success=True))
+    adapter.deprovision_application = AsyncMock(side_effect=list(results))
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_deprovision_retries_then_succeeds(mock_db_session) -> None:
+    sub = _Subscription()
+    adapter = _adapter_with_deprovision(
+        AdapterResult(success=False, error="transient"),
+        AdapterResult(success=False, error="transient"),
+        AdapterResult(success=True, resource_id="gw-app-1"),
+    )
+
+    with (
+        patch("src.services.provisioning_service._resolve_adapter", new_callable=AsyncMock, return_value=adapter),
+        patch("src.services.provisioning_service.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await _deprovision_with_session(mock_db_session, sub, "token", "corr-sub-1")
+
+    assert sub.provisioning_status == ProvisioningStatus.DEPROVISIONED
+    assert adapter.deprovision_application.await_count == 3
+    assert ProvisioningStatus.DEPROVISIONING_FAILED not in sub.provisioning_status_writes
+
+
+@pytest.mark.asyncio
+async def test_deprovision_retries_exhausted_marks_deprovisioning_failed(mock_db_session) -> None:
+    sub = _Subscription()
+    adapter = _adapter_with_deprovision(*[AdapterResult(success=False, error="transient") for _ in range(MAX_RETRIES)])
+
+    with (
+        patch("src.services.provisioning_service._resolve_adapter", new_callable=AsyncMock, return_value=adapter),
+        patch("src.services.provisioning_service.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await _deprovision_with_session(mock_db_session, sub, "token", "corr-sub-1")
+
+    assert sub.provisioning_status == ProvisioningStatus.DEPROVISIONING_FAILED
+    assert f"Deprovision failed after {MAX_RETRIES} attempts" in sub.provisioning_error
+    assert adapter.deprovision_application.await_count == MAX_RETRIES
+
+
+@pytest.mark.asyncio
+async def test_deprovision_logs_ops_alert_on_exhaustion(mock_db_session, caplog) -> None:
+    sub = _Subscription()
+    adapter = _adapter_with_deprovision(*[AdapterResult(success=False, error="transient") for _ in range(MAX_RETRIES)])
+    caplog.set_level(logging.ERROR, logger="src.services.provisioning_service")
+
+    with (
+        patch("src.services.provisioning_service._resolve_adapter", new_callable=AsyncMock, return_value=adapter),
+        patch("src.services.provisioning_service.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await _deprovision_with_session(mock_db_session, sub, "token", "corr-sub-1")
+
+    record = next(record for record in caplog.records if getattr(record, "ops_alert", None) == "deprovision_failed")
+    assert record.correlation_id == "corr-sub-1"
+    assert record.tenant_id == "tenant-acme"
+    assert record.subscription_id == str(sub.id)
+    assert record.ops_alert == "deprovision_failed"
+
+
+@pytest.mark.asyncio
+async def test_deprovision_no_gateway_app_id_is_noop(mock_db_session) -> None:
+    sub = _Subscription(gateway_app_id=None)
+
+    with patch("src.services.provisioning_service._resolve_adapter", new_callable=AsyncMock) as resolve_adapter:
+        await deprovision_on_revocation(mock_db_session, sub, "token", "corr-sub-1")
+
+    resolve_adapter.assert_not_awaited()
+    mock_db_session.commit.assert_not_awaited()
+    assert sub.provisioning_status == ProvisioningStatus.READY


### PR DESCRIPTION
## Summary

Adds a retrying gateway deprovision path and a distinct `DEPROVISIONING_FAILED` provisioning state so transient gateway failures no longer leave revoked subscriptions with live gateway routes indefinitely.

## References

- Audit: `docs/audits/2026-05-11-uac-subscription-mcp/AUDIT-RESULTS.md` — finding SUB-1 / P0 deprovision one-shot gap.
- Plan: `docs/plans/2026-05-11-uac-subscription-mcp-corrective.md` §5.5 — P0-5 deprovision retry.
- Decision context: `docs/decisions/2026-05-11-uac-subscription-mcp-corrective.md` §C6.

## Implementation

- Adds `ProvisioningStatus.DEPROVISIONING_FAILED = "deprovisioning_failed"`.
- Rewrites `_deprovision_with_session` to mirror the existing provisioning retry loop with `MAX_RETRIES` and `RETRY_DELAYS`.
- Emits structured ops-alert logging on retry exhaustion with `ops_alert="deprovision_failed"`.
- Leaves a TODO for a Prometheus counter because `provisioning_service.py` does not currently import or own finalized metrics wiring.

## Test plan

- `test_deprovision_retries_then_succeeds`: adapter fails twice, succeeds on third call, final state is `DEPROVISIONED`.
- `test_deprovision_retries_exhausted_marks_deprovisioning_failed`: all attempts fail, final state is `DEPROVISIONING_FAILED`.
- `test_deprovision_logs_ops_alert_on_exhaustion`: retry exhaustion logs `correlation_id`, `tenant_id`, `subscription_id`, and `ops_alert="deprovision_failed"`.
- `test_deprovision_no_gateway_app_id_is_noop`: no gateway app id returns early with no adapter call.

Validation run locally:

- `python3 -m pytest tests/test_regression_cab_2225_sub_1_deprovision_retry.py tests/test_provisioning.py tests/test_provisioning_service.py -q` — 64 passed.
- `python3 -m pytest -m "not integration" -q` — 7234 passed, 7 skipped, 97 deselected.
- `python3 -m black --check src/models/subscription.py src/services/provisioning_service.py tests/test_provisioning.py tests/test_provisioning_service.py tests/test_regression_cab_2225_sub_1_deprovision_retry.py` — pass.
- `python3 -m ruff check src/` — pass.
- `python3 -m mypy src --ignore-missing-imports` — fails with the existing repo typing baseline: 1865 errors on this branch and 1865 errors verified on `origin/main`.

## Risk assessment

Low. This is a resilience-only change, not a doctrine change, and it does not modify provisioning strategy or schemas.

`Subscription.provisioning_status` is declared as `Column(String(32), ...)`, not a PostgreSQL enum, so `DEPROVISIONING_FAILED` stores as a plain string and no Alembic migration is needed.
