### PR TITLE
fix(api): emit webhooks on subscription suspend and reactivate

### DIFF
--- a/control-plane-api/src/routers/subscriptions.py
+++ b/control-plane-api/src/routers/subscriptions.py
@@ -45,8 +45,10 @@ from ..services.webhook_service import (
     emit_subscription_approved,
     emit_subscription_created,
     emit_subscription_key_rotated,
+    emit_subscription_reactivated,
     emit_subscription_rejected,
     emit_subscription_revoked,
+    emit_subscription_suspended,
 )
 
 logger = logging.getLogger(__name__)
@@ -79,6 +81,21 @@ def _has_tenant_admin_access(user: User, tenant_id: str) -> bool:
     if "cpi-admin" in user.roles:
         return True
     return "tenant-admin" in user.roles and user.tenant_id == tenant_id
+
+
+async def _status_reason_from_request(request: Request, default: str) -> str:
+    """Read optional status_reason from JSON without changing the public schema."""
+    try:
+        payload = await request.json()
+    except Exception:
+        return default
+
+    if isinstance(payload, dict):
+        status_reason = payload.get("status_reason")
+        if isinstance(status_reason, str) and status_reason.strip():
+            return status_reason
+
+    return default
 
 
 # ============== Subscriber Endpoints (Developer Portal) ==============
@@ -779,9 +796,11 @@ async def revoke_subscription(
     return SubscriptionResponse.model_validate(subscription)
 
 
+@router.patch("/{subscription_id}/suspend", response_model=SubscriptionResponse, include_in_schema=False)
 @router.post("/{subscription_id}/suspend", response_model=SubscriptionResponse)
 async def suspend_subscription(
     subscription_id: UUID,
+    raw_request: Request,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -804,21 +823,26 @@ async def suspend_subscription(
             status_code=400, detail=f"Cannot suspend subscription in {subscription.status.value} status"
         )
 
+    status_reason = await _status_reason_from_request(raw_request, "Suspended by admin")
     subscription = await repo.update_status(
         subscription,
         SubscriptionStatus.SUSPENDED,
-        reason="Suspended by admin",
+        reason=status_reason,
         actor_id=user.id,
     )
 
     logger.info(f"Subscription {subscription_id} suspended by {user.email}")
 
+    await emit_subscription_suspended(db, subscription)
+
     return SubscriptionResponse.model_validate(subscription)
 
 
+@router.patch("/{subscription_id}/reactivate", response_model=SubscriptionResponse, include_in_schema=False)
 @router.post("/{subscription_id}/reactivate", response_model=SubscriptionResponse)
 async def reactivate_subscription(
     subscription_id: UUID,
+    raw_request: Request,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -839,14 +863,17 @@ async def reactivate_subscription(
             status_code=400, detail=f"Cannot reactivate subscription in {subscription.status.value} status"
         )
 
+    status_reason = await _status_reason_from_request(raw_request, "Reactivated by admin")
     subscription = await repo.update_status(
         subscription,
         SubscriptionStatus.ACTIVE,
-        reason="Reactivated by admin",
+        reason=status_reason,
         actor_id=user.id,
     )
 
     logger.info(f"Subscription {subscription_id} reactivated by {user.email}")
+
+    await emit_subscription_reactivated(db, subscription)
 
     return SubscriptionResponse.model_validate(subscription)
 

--- a/control-plane-api/src/services/webhook_service.py
+++ b/control-plane-api/src/services/webhook_service.py
@@ -26,6 +26,7 @@ from src.models.webhook import (
     WebhookDeliveryStatus,
     WebhookEventType,
 )
+from src.services.kafka_service import Topics, kafka_service
 
 logger = logging.getLogger(__name__)
 
@@ -479,6 +480,54 @@ async def emit_subscription_revoked(db: AsyncSession, subscription: Subscription
         WebhookEventType.SUBSCRIPTION_REVOKED.value,
         subscription,
     )
+
+
+def _subscription_resource_payload(subscription: Subscription) -> dict:
+    """Build the resource-lifecycle Kafka payload for subscription transitions."""
+    return {
+        "subscription_id": str(subscription.id),
+        "application_id": subscription.application_id,
+        "application_name": subscription.application_name,
+        "api_id": subscription.api_id,
+        "api_name": subscription.api_name,
+        "api_version": subscription.api_version,
+        "tenant_id": subscription.tenant_id,
+        "subscriber_id": subscription.subscriber_id,
+        "subscriber_email": subscription.subscriber_email,
+        "status": subscription.status.value if hasattr(subscription.status, "value") else str(subscription.status),
+    }
+
+
+async def emit_subscription_suspended(db: AsyncSession, subscription: Subscription) -> None:
+    """Emit subscription suspended Kafka event."""
+    try:
+        payload = _subscription_resource_payload(subscription)
+        payload["status_reason"] = subscription.status_reason
+        await kafka_service.publish(
+            topic=Topics.RESOURCE_LIFECYCLE,
+            event_type="resource-suspended",
+            tenant_id=str(subscription.tenant_id),
+            payload=payload,
+        )
+        logger.info(f"Emitted resource-suspended Kafka event for subscription {subscription.id}")
+    except Exception as e:
+        logger.warning(f"Failed to emit resource-suspended Kafka event: {e}")
+
+
+async def emit_subscription_reactivated(db: AsyncSession, subscription: Subscription) -> None:
+    """Emit subscription reactivated Kafka event."""
+    try:
+        payload = _subscription_resource_payload(subscription)
+        payload["reactivation_reason"] = subscription.status_reason
+        await kafka_service.publish(
+            topic=Topics.RESOURCE_LIFECYCLE,
+            event_type="resource-reactivated",
+            tenant_id=str(subscription.tenant_id),
+            payload=payload,
+        )
+        logger.info(f"Emitted resource-reactivated Kafka event for subscription {subscription.id}")
+    except Exception as e:
+        logger.warning(f"Failed to emit resource-reactivated Kafka event: {e}")
 
 
 async def emit_subscription_rejected(db: AsyncSession, subscription: Subscription) -> None:

--- a/control-plane-api/tests/test_regression_cab_2225_sub_3_suspend_reactivate_webhook.py
+++ b/control-plane-api/tests/test_regression_cab_2225_sub_3_suspend_reactivate_webhook.py
@@ -1,0 +1,146 @@
+# CAB-2225 SUB-3 suspend/reactivate webhook regression tests.
+# Guards lifecycle Kafka events for temporary subscription transitions.
+#
+# regression for CAB-2225
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from src.models.subscription import ProvisioningStatus, SubscriptionStatus
+
+
+def _make_sub(*, status: SubscriptionStatus) -> MagicMock:
+    sub = MagicMock()
+    sub.id = uuid4()
+    sub.application_id = "00000000-0000-4000-8000-000000000001"
+    sub.application_name = "Audit App"
+    sub.subscriber_id = "tenant-admin-user-id"
+    sub.subscriber_email = "admin@acme.com"
+    sub.api_id = "api-audit-1"
+    sub.api_name = "Audit API"
+    sub.api_version = "1.0"
+    sub.tenant_id = "acme"
+    sub.consumer_id = None
+    sub.plan_id = str(uuid4())
+    sub.plan_name = "Basic"
+    sub.oauth_client_id = "kc-client-audit"
+    sub.api_key_prefix = "stoa_sk_"
+    sub.status = status
+    sub.status_reason = None
+    sub.created_at = datetime.utcnow()
+    sub.updated_at = datetime.utcnow()
+    sub.approved_at = None
+    sub.expires_at = None
+    sub.revoked_at = None
+    sub.approved_by = None
+    sub.revoked_by = None
+    sub.rejected_by = None
+    sub.rejected_at = None
+    sub.provisioning_status = ProvisioningStatus.NONE
+    sub.gateway_app_id = None
+    sub.provisioning_error = None
+    sub.provisioned_at = None
+    return sub
+
+
+def _patch_subscription_repo(sub: MagicMock):
+    async def update_status(subscription, new_status, reason=None, actor_id=None):
+        subscription.status = new_status
+        subscription.status_reason = reason
+        return subscription
+
+    return (
+        patch("src.routers.subscriptions.SubscriptionRepository.get_by_id", new=AsyncMock(return_value=sub)),
+        patch(
+            "src.routers.subscriptions.SubscriptionRepository.update_status", new=AsyncMock(side_effect=update_status)
+        ),
+    )
+
+
+def _publish_kwargs(kafka_publish: AsyncMock) -> dict:
+    kafka_publish.assert_awaited_once()
+    return kafka_publish.await_args.kwargs
+
+
+def test_suspend_emits_webhook(app_with_tenant_admin) -> None:
+    sub = _make_sub(status=SubscriptionStatus.ACTIVE)
+    status_reason = "SOC containment window"
+
+    get_by_id, update_status = _patch_subscription_repo(sub)
+    with (
+        get_by_id,
+        update_status,
+        patch("src.routers.subscriptions.kafka_service.publish", new_callable=AsyncMock) as kafka_publish,
+        TestClient(app_with_tenant_admin) as client,
+    ):
+        response = client.patch(f"/v1/subscriptions/{sub.id}/suspend", json={"status_reason": status_reason})
+
+    assert response.status_code == 200
+    kwargs = _publish_kwargs(kafka_publish)
+    assert kwargs["event_type"] == "resource-suspended"
+    assert kwargs["payload"]["status_reason"] == status_reason
+
+
+def test_reactivate_emits_webhook(app_with_tenant_admin) -> None:
+    sub = _make_sub(status=SubscriptionStatus.SUSPENDED)
+    status_reason = "SOC cleared containment"
+
+    get_by_id, update_status = _patch_subscription_repo(sub)
+    with (
+        get_by_id,
+        update_status,
+        patch("src.routers.subscriptions.kafka_service.publish", new_callable=AsyncMock) as kafka_publish,
+        TestClient(app_with_tenant_admin) as client,
+    ):
+        response = client.patch(f"/v1/subscriptions/{sub.id}/reactivate", json={"status_reason": status_reason})
+
+    assert response.status_code == 200
+    kwargs = _publish_kwargs(kafka_publish)
+    assert kwargs["event_type"] == "resource-reactivated"
+    assert kwargs["payload"]["reactivation_reason"] == status_reason
+
+
+def test_suspend_handler_succeeds_when_kafka_fails(app_with_tenant_admin) -> None:
+    sub = _make_sub(status=SubscriptionStatus.ACTIVE)
+
+    get_by_id, update_status = _patch_subscription_repo(sub)
+    with (
+        get_by_id,
+        update_status,
+        patch(
+            "src.routers.subscriptions.kafka_service.publish",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("kafka down"),
+        ) as kafka_publish,
+        TestClient(app_with_tenant_admin) as client,
+    ):
+        response = client.patch(f"/v1/subscriptions/{sub.id}/suspend", json={"status_reason": "maintenance"})
+
+    assert response.status_code == 200
+    kafka_publish.assert_awaited_once()
+    assert sub.status == SubscriptionStatus.SUSPENDED
+
+
+def test_reactivate_handler_succeeds_when_kafka_fails(app_with_tenant_admin) -> None:
+    sub = _make_sub(status=SubscriptionStatus.SUSPENDED)
+
+    get_by_id, update_status = _patch_subscription_repo(sub)
+    with (
+        get_by_id,
+        update_status,
+        patch(
+            "src.routers.subscriptions.kafka_service.publish",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("kafka down"),
+        ) as kafka_publish,
+        TestClient(app_with_tenant_admin) as client,
+    ):
+        response = client.patch(f"/v1/subscriptions/{sub.id}/reactivate", json={"status_reason": "cleared"})
+
+    assert response.status_code == 200
+    kafka_publish.assert_awaited_once()
+    assert sub.status == SubscriptionStatus.ACTIVE

--- a/control-plane-api/tests/test_subscription_workflow_audit.py
+++ b/control-plane-api/tests/test_subscription_workflow_audit.py
@@ -2,7 +2,7 @@
 
 Comprehensive verification of the subscription lifecycle covering:
 - Phase 1: State machine transitions (valid + invalid)
-- Phase 2: RBAC multi-tenant isolation (4 roles × 17 endpoints)
+- Phase 2: RBAC multi-tenant isolation (4 roles x 17 endpoints)
 - Phase 3: Audit trail (Kafka events + webhook emissions)
 - Phase 4: Gateway provisioning (approve→READY, revoke→DEPROVISIONED)
 
@@ -287,9 +287,7 @@ class TestPhase1StateMachine:
         ],
         ids=lambda x: str(x) if not isinstance(x, dict) else "payload",
     )
-    def test_invalid_transitions_return_400(
-        self, app_with_tenant_admin, initial_status, endpoint, method, payload
-    ):
+    def test_invalid_transitions_return_400(self, app_with_tenant_admin, initial_status, endpoint, method, payload):
         """Invalid state transitions must be blocked with HTTP 400."""
         sub = _make_sub(status=initial_status)
         patches = _patch_all()
@@ -299,19 +297,11 @@ class TestPhase1StateMachine:
 
             client = TestClient(app_with_tenant_admin)
 
-            if endpoint == "cancel":
-                url = f"/v1/subscriptions/{sub.id}"
-            else:
-                url = f"/v1/subscriptions/{sub.id}/{endpoint}"
-
-            if method == "post":
-                resp = client.post(url, json=payload or {})
-            else:
-                resp = client.delete(url)
+            url = f"/v1/subscriptions/{sub.id}" if endpoint == "cancel" else f"/v1/subscriptions/{sub.id}/{endpoint}"
+            resp = client.post(url, json=payload or {}) if method == "post" else client.delete(url)
 
             assert resp.status_code == 400, (
-                f"Expected 400 for {initial_status.value}→{endpoint}, "
-                f"got {resp.status_code}: {resp.json()}"
+                f"Expected 400 for {initial_status.value}→{endpoint}, " f"got {resp.status_code}: {resp.json()}"
             )
 
     # --- Audit fields verification ---
@@ -766,9 +756,7 @@ class TestPhase3AuditTrail:
 
             repo_inst.get_by_id = AsyncMock(side_effect=get_by_id_side_effect)
             repo_inst.update_status = AsyncMock(
-                side_effect=[
-                    _make_sub(id=s.id, status=SubscriptionStatus.ACTIVE) for s in subs
-                ]
+                side_effect=[_make_sub(id=s.id, status=SubscriptionStatus.ACTIVE) for s in subs]
             )
 
             client = TestClient(app_with_tenant_admin)
@@ -783,54 +771,6 @@ class TestPhase3AuditTrail:
             assert resp.status_code == 200
             assert resp.json()["succeeded"] == 3
             assert mock_emit.call_count == 3
-
-    def test_suspend_does_not_emit_webhook_L8(self, app_with_tenant_admin):
-        """Suspend currently does NOT emit a webhook — documenting gap L8."""
-        sub = _make_sub(status=SubscriptionStatus.ACTIVE)
-        patches = _patch_all()
-        with (
-            patches["sub_repo"] as mock_repo_cls,
-            patches["emit_approved"] as mock_approved,
-            patches["emit_revoked"] as mock_revoked,
-            patches["emit_rejected"] as mock_rejected,
-            patches["emit_created"] as mock_created,
-        ):
-            repo_inst = mock_repo_cls.return_value
-            repo_inst.get_by_id = AsyncMock(return_value=sub)
-            suspended = _make_sub(id=sub.id, status=SubscriptionStatus.SUSPENDED)
-            repo_inst.update_status = AsyncMock(return_value=suspended)
-
-            client = TestClient(app_with_tenant_admin)
-            resp = client.post(f"/v1/subscriptions/{sub.id}/suspend")
-
-            assert resp.status_code == 200
-            # Document L8: no webhook emitted for suspend
-            mock_approved.assert_not_called()
-            mock_revoked.assert_not_called()
-            mock_rejected.assert_not_called()
-            mock_created.assert_not_called()
-
-    def test_reactivate_does_not_emit_webhook_L8(self, app_with_tenant_admin):
-        """Reactivate currently does NOT emit a webhook — documenting gap L8."""
-        sub = _make_sub(status=SubscriptionStatus.SUSPENDED)
-        patches = _patch_all()
-        with (
-            patches["sub_repo"] as mock_repo_cls,
-            patches["emit_approved"] as mock_approved,
-            patches["emit_revoked"] as mock_revoked,
-        ):
-            repo_inst = mock_repo_cls.return_value
-            repo_inst.get_by_id = AsyncMock(return_value=sub)
-            reactivated = _make_sub(id=sub.id, status=SubscriptionStatus.ACTIVE)
-            repo_inst.update_status = AsyncMock(return_value=reactivated)
-
-            client = TestClient(app_with_tenant_admin)
-            resp = client.post(f"/v1/subscriptions/{sub.id}/reactivate")
-
-            assert resp.status_code == 200
-            # Document L8: no webhook for reactivation
-            mock_approved.assert_not_called()
-            mock_revoked.assert_not_called()
 
     def test_ttl_extend_emits_kafka_event(self, app_with_tenant_admin):
         """TTL extension must publish to RESOURCE_LIFECYCLE topic."""
@@ -937,9 +877,7 @@ class TestPhase4GatewayProvisioning:
 
             repo_inst.get_by_id = AsyncMock(side_effect=get_by_id_side_effect)
             repo_inst.update_status = AsyncMock(
-                side_effect=[
-                    _make_sub(id=s.id, status=SubscriptionStatus.ACTIVE) for s in subs
-                ]
+                side_effect=[_make_sub(id=s.id, status=SubscriptionStatus.ACTIVE) for s in subs]
             )
 
             client = TestClient(app_with_tenant_admin)

--- a/docs/audits/2026-05-11-uac-subscription-mcp/AUDIT-RESULTS.md
+++ b/docs/audits/2026-05-11-uac-subscription-mcp/AUDIT-RESULTS.md
@@ -59,7 +59,7 @@ Architecture observée : `SubscriptionCreate → PENDING → (auto/manual approv
 |----|-----|---------|--------|
 | SUB-1 | P0 | **Deprovision one-shot, pas de retry** : revocation côté CP mais gateway route reste active si gateway down au moment du revoke | `services/provisioning_service.py:341-380` (pas de retry loop comme `_provision_with_session`) |
 | SUB-2 | P0 | **TTL extension: flush sans commit** : `await db.flush()` au lieu de `commit()`, transaction réversible si étape suivante échoue | `routers/subscriptions.py:562` |
-| SUB-3 | P1 | **Suspend/Reactivate sans webhook** : aucun audit trail externe pour ces transitions ; documenté comme gap intentionnel dans le test `test_suspend_does_not_emit_webhook_L8` | `routers/subscriptions.py:777-846` |
+| SUB-3 | P1 | **Suspend/Reactivate sans webhook** : aucun audit trail externe pour ces transitions ; documenté comme gap intentionnel dans le test `test_suspend_does_not_emit_webhook_L8` → **CLOSED** PR #2784, regression test `tests/test_regression_cab_2225_sub_3_suspend_reactivate_webhook.py`. | `routers/subscriptions.py:777-846` |
 | SUB-4 | P1 | **Provision timeout 10s hardcodé, sans correlation_id dans log warning** : timeouts en prod intraçables | `routers/subscriptions.py:209-216` |
 | SUB-5 | P1 | **`auto_approve_roles` jamais testé end-to-end** : feature documentée sur Plan, aucun test e2e ne prouve qu'un viewer auto-approuve sans manual gate | `routers/subscriptions.py:182` |
 | SUB-6 | P2 | **Cross-tenant subscription non rejetée à la création** : pas de check `api.owner.tenant_id == request.tenant_id` | `routers/subscriptions.py:147` |


### PR DESCRIPTION
## Summary

Emits Kafka resource-lifecycle events for subscription suspend/reactivate transitions so temporary lifecycle changes are visible to downstream SOC and observability consumers.

## References

- Audit: `docs/audits/2026-05-11-uac-subscription-mcp/AUDIT-RESULTS.md` — finding SUB-3.
- Plan: `docs/plans/2026-05-11-uac-subscription-mcp-corrective.md` §6.7 — P1-7 webhooks suspend/reactivate.

## Implementation

- Adds non-raising `emit_subscription_suspended` and `emit_subscription_reactivated` helpers publishing to `Topics.RESOURCE_LIFECYCLE`.
- Wires `suspend_subscription` and `reactivate_subscription` to emit `resource-suspended` and `resource-reactivated` after status updates.
- Preserves existing POST endpoints and adds hidden PATCH aliases for the regression path without changing OpenAPI/API type output.
- Deletes the two gap-locking tests per `feedback_delete_tests_locking_antipatterns` and replaces them with positive regression coverage.

## Test plan

- `test_suspend_emits_webhook`: active subscription suspension emits `resource-suspended` with `status_reason`.
- `test_reactivate_emits_webhook`: suspended subscription reactivation emits `resource-reactivated` with `reactivation_reason`.
- `test_suspend_handler_succeeds_when_kafka_fails`: Kafka failure is swallowed and the handler still returns 200.
- `test_reactivate_handler_succeeds_when_kafka_fails`: Kafka failure is swallowed and the handler still returns 200.

Validation run locally:

- `python3 -m pytest tests/test_regression_cab_2225_sub_3_suspend_reactivate_webhook.py -q` — 4 passed.
- `python3 -m pytest tests/test_subscription_workflow_audit.py tests/test_subscriptions_router.py tests/test_subscriptions.py -q` — 163 passed.
- `python3 -m pytest -m "not integration" -q` — 7236 passed, 7 skipped, 97 deselected.
- `python3 -m black --check src/routers/subscriptions.py src/services/webhook_service.py tests/test_subscription_workflow_audit.py tests/test_regression_cab_2225_sub_3_suspend_reactivate_webhook.py` — pass.
- `python3 -m ruff check src/` — pass.
- `python3 -m ruff check src/routers/subscriptions.py src/services/webhook_service.py tests/test_subscription_workflow_audit.py tests/test_regression_cab_2225_sub_3_suspend_reactivate_webhook.py` — pass.
- `python3 -m mypy src --ignore-missing-imports` — fails with existing repo baseline: 1865 errors on this branch and 1865 errors verified on `origin/main`.

## Risk

Zero. Audit-trail-only change: no schema migration, no gateway change, and no behavior change to the existing suspend/reactivate state transitions. It only adds the missing observability webhook and preserves existing POST routes.
