### PR TITLE
docs: renumber UAC corrective ADR drafts 067-071 to 069-073

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 ## UAC / Agent Contract Doctrine
 
-Canonical rule from ADR-067:
+Canonical rule from ADR-069 (draft — UAC enforcement doctrine; predecessor ADR-067 "UAC as LLM-Optimized Executable Contract" defines the metadata fields):
 
 ```text
 UAC describes.

--- a/docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/README.md
+++ b/docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/README.md
@@ -8,17 +8,19 @@ They are **not yet in `stoa-docs/docs/architecture/adr/`** because:
 2. They cite each other as companions; promoting one without the others breaks the doctrine.
 3. The current `stoa-docs` branch (`chore/cab-2137-security-deps`) is unrelated; ADR promotion must happen on a dedicated branch.
 
+> **2026-05-18 — ADR renumber (+1 shift).** This batch was originally numbered ADR-067…071. Between drafting and promotion, a duplicate-`adr-060` dedup on `stoa-docs` `main` shifted every ADR ≥066 up by one, so published `stoa-docs` `main` now holds `adr-067` (UAC LLM-Optimized) and `adr-068` (Audit Log Actor/Resource Views) — colliding with this batch. The batch was renumbered **+2 into the next free slots ADR-069…073** (Gateway Fail-Closed = ADR-072). All draft files, cross-references, the corrective plan, and the two decision records were updated. Verify the `stoa-docs` ADR index before any further promotion.
+
 ## Inventory
 
 > **Solo project mode** — the "Sign-off owner" column below was originally written with separate DPO / Legal / Security / Business / Product / Gateway / CP-API roles. Those roles **do not have separate humans** on this project. All decisions are made by the operator (founder) acting in those roles for this project stage. See memory `feedback_solo_project_mode_signoffs.md`.
 
 | ADR | Title | Depends on (other drafts) | Sign-off owner |
 |-----|-------|---------------------------|----------------|
-| ADR-067 | UAC Describes / MCP Projects / Smoke Proves | — | Operator |
-| ADR-068 | Audit Log Actor/Resource/Action Doctrine | ADR-069 (coupled) | Operator |
-| ADR-069 | GDPR ↔ DORA Audit Reconciliation | ADR-068 (coupled) | Operator (non-delegable to AI — the operator personally decides) |
-| ADR-070 | Gateway Fail-Closed Posture | ADR-067, ADR-068 | Operator (accepting product SLA impact) |
-| ADR-071 | API Subscription Lifecycle | ADR-067, ADR-068, ADR-070 | Operator |
+| ADR-069 | UAC Describes / MCP Projects / Smoke Proves | — | Operator |
+| ADR-070 | Audit Log Actor/Resource/Action Doctrine | ADR-071 (coupled) | Operator |
+| ADR-071 | GDPR ↔ DORA Audit Reconciliation | ADR-070 (coupled) | Operator (non-delegable to AI — the operator personally decides) |
+| ADR-072 | Gateway Fail-Closed Posture | ADR-069, ADR-070 | Operator (accepting product SLA impact) |
+| ADR-073 | API Subscription Lifecycle | ADR-069, ADR-070, ADR-072 | Operator |
 
 ## Promotion checklist (per ADR)
 
@@ -32,10 +34,10 @@ Before moving a file into `stoa-docs/docs/architecture/adr/`:
 
 ## Doctrinal notes
 
-- ADR-001 already exists in stoa-docs (Accepted, 2026-01-18) and covers the **architecture** of Third-Party API exposure. It is **not** amended by this batch. ADR-071 extends it for the subscription lifecycle inside that architecture.
-- ADR-066 already exists (Proposed, 2026-04-25) and defines the **fields** of the LLM metadata on UAC. ADR-067 is the **enforcement doctrine** on top.
-- ADR-068 and ADR-069 are **coupled**: promoting ADR-068's immutability trigger without ADR-069's pseudonymization model breaks the current `erase_user_pii()` code path. They must move together.
-- ADR-070 enforces fail-closed; that is a **product decision** with availability impact and requires Business sign-off, not just Security.
+- ADR-001 already exists in stoa-docs (Accepted, 2026-01-18) and covers the **architecture** of Third-Party API exposure. It is **not** amended by this batch. ADR-073 extends it for the subscription lifecycle inside that architecture.
+- ADR-067 already exists (Proposed, 2026-04-25) and defines the **fields** of the LLM metadata on UAC. ADR-069 is the **enforcement doctrine** on top.
+- ADR-070 and ADR-071 are **coupled**: promoting ADR-070's immutability trigger without ADR-071's pseudonymization model breaks the current `erase_user_pii()` code path. They must move together.
+- ADR-072 enforces fail-closed; that is a **product decision** with availability impact and requires Business sign-off, not just Security.
 
 ## References
 

--- a/docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/adr-069-uac-describes-mcp-projects-smoke-proves.md
+++ b/docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/adr-069-uac-describes-mcp-projects-smoke-proves.md
@@ -1,12 +1,12 @@
 ---
-title: "ADR-067: UAC Describes / MCP Projects / Smoke Proves"
-sidebar_label: "ADR-067: UAC Doctrine"
-sidebar_position: 67
+title: "ADR-069: UAC Describes / MCP Projects / Smoke Proves"
+sidebar_label: "ADR-069: UAC Doctrine"
+sidebar_position: 69
 description: "Formalizes the canonical doctrine that UAC is the primary product contract, MCP tools are projections of UAC operations, and smoke tests are the runtime proof of projection."
 keywords: [ADR, UAC, MCP, doctrine, projection, smoke tests, runtime enforcement]
 ---
 
-# ADR-067 — UAC Describes / MCP Projects / Smoke Proves
+# ADR-069 — UAC Describes / MCP Projects / Smoke Proves
 
 ## 1. Status
 
@@ -18,7 +18,7 @@ keywords: [ADR, UAC, MCP, doctrine, projection, smoke tests, runtime enforcement
 
 **Source:** `docs/audits/2026-05-11-uac-subscription-mcp/AUDIT-RESULTS.md` (MCP-1, MCP-2, MCP-3) + `docs/plans/2026-05-11-uac-subscription-mcp-corrective.md` §4.2 + challenger decision record §3.3 (C4).
 
-**Related decisions:** ADR-006 Tool Registry Architecture, ADR-012 MCP RBAC Architecture, ADR-021 UAC-Driven Observability, ADR-045 stoa.yaml Declarative Spec, ADR-051 Lazy MCP Discovery, ADR-066 UAC as LLM-Optimized Executable Contract.
+**Related decisions:** ADR-006 Tool Registry Architecture, ADR-012 MCP RBAC Architecture, ADR-021 UAC-Driven Observability, ADR-045 stoa.yaml Declarative Spec, ADR-051 Lazy MCP Discovery, ADR-067 UAC as LLM-Optimized Executable Contract.
 
 **Supersedes / amends:** none. Codifies a doctrine previously living only in `.claude/docs/uac-llm-ready.md`.
 
@@ -61,7 +61,7 @@ Concretely:
 ### 4.1 UAC describes
 
 - UAC is the **primary product contract**. Any operation exposed to a consumer (API, MCP tool, future protocols) must be attached to a UAC operation or flow contract.
-- Endpoint-level `llm` metadata (per ADR-066) is the **operational intent layer**.
+- Endpoint-level `llm` metadata (per ADR-067) is the **operational intent layer**.
 - The hard rule is binding at all layers: `side_effects=destructive ⇒ requires_human_approval=true`. Malformed metadata is an error.
 
 ### 4.2 MCP projects
@@ -73,7 +73,7 @@ Concretely:
   - `safe_for_agents: bool` typed
   - `tool_name` derived deterministically from `{tenant}:{contract}:{operation_id}`
 - The gateway runtime MUST read the typed fields and:
-  - refuse `tools/call` when `requires_human_approval=true` and no valid approval token is presented (cross-reference: ADR-070 fail-closed posture).
+  - refuse `tools/call` when `requires_human_approval=true` and no valid approval token is presented (cross-reference: ADR-072 fail-closed posture).
   - validate inputs against the UAC `inputSchema` before invocation; validate outputs before returning.
 
 ### 4.4 Approval token invariants (binding doctrine for §4.2)
@@ -111,7 +111,7 @@ Mandatory audit emissions:
 - `APPROVAL_TOKEN_USED` at successful consumption (gateway).
 - `APPROVAL_TOKEN_REJECTED` with `reason ∈ {signature, replay, scope_mismatch, arguments_mismatch, policy_version_mismatch, 4_eyes_violation, expired, ...}`.
 
-Without any of these invariants, the token does not prove what the doctrine requires. Implementations that omit `arguments_hash`, `jti` atomic single-use, or 4-eyes acteur separation are non-compliant with ADR-067 even if a JWT is technically present.
+Without any of these invariants, the token does not prove what the doctrine requires. Implementations that omit `arguments_hash`, `jti` atomic single-use, or 4-eyes acteur separation are non-compliant with ADR-069 even if a JWT is technically present.
 
 ### 4.3 Smoke proves
 
@@ -134,13 +134,13 @@ Without any of these invariants, the token does not prove what the doctrine requ
 
 ### Negative
 
-- Backward compatibility cost: existing tenants with UAC contracts missing `endpoint.llm` get warnings; new MCP-exposed endpoints will require completed metadata before merge (V2 target per ADR-066).
+- Backward compatibility cost: existing tenants with UAC contracts missing `endpoint.llm` get warnings; new MCP-exposed endpoints will require completed metadata before merge (V2 target per ADR-067).
 - Wire format change to MCP `ToolDefinition` requires gateway version bump and client SDK alignment.
 - Smoke gates add latency to publish pipelines (~minutes).
 
 ### Neutral
 
-- ADR-066 remains the authoritative spec for *which* fields exist. ADR-067 is the *enforcement* doctrine on top.
+- ADR-067 remains the authoritative spec for *which* fields exist. ADR-069 is the *enforcement* doctrine on top.
 
 ## 6. Implementation
 
@@ -161,9 +161,9 @@ Once signed:
 | Option | Verdict |
 |--------|---------|
 | Leave doctrine in `.claude/docs/` | ❌ Not citeable by regulators, drifts silently |
-| Embed doctrine in ADR-066 amendment | ❌ Conflates "what fields exist" with "how they are enforced" |
+| Embed doctrine in ADR-067 amendment | ❌ Conflates "what fields exist" with "how they are enforced" |
 | Codify only the typed wire format, skip the smoke gate | ❌ Drift invisible until prod incident |
-| **Standalone ADR-067 with three pillars** | ✅ Selected |
+| **Standalone ADR-069 with three pillars** | ✅ Selected |
 
 ## 8. References
 
@@ -171,9 +171,9 @@ Once signed:
 - Plan §4.2 "Doctrine exécutée au runtime"
 - Decision record §C4 (approval-token enrichment) and §3.3 (4-eyes proof)
 - `.claude/docs/uac-llm-ready.md` (canonical source of doctrine text, to be archived as historical)
-- ADR-066 (field definitions) — predecessor
+- ADR-067 (field definitions) — predecessor
 
 ## 9. Open questions for sign-off
 
-- Should `safe_for_agents=false` block all autonomous agents at the gateway, or only emit a warning that the client SDK can choose to honour? (Recommendation: **block** to align with fail-closed posture ADR-070.)
+- Should `safe_for_agents=false` block all autonomous agents at the gateway, or only emit a warning that the client SDK can choose to honour? (Recommendation: **block** to align with fail-closed posture ADR-072.)
 - Should the smoke gate run on every PR touching the tenant's UAC, or on every publish? (Recommendation: **every publish**, plus optional PR-level dry-run.)

--- a/docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/adr-070-audit-log-actor-resource-doctrine.md
+++ b/docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/adr-070-audit-log-actor-resource-doctrine.md
@@ -1,16 +1,16 @@
 ---
-title: "ADR-068: Audit Log Actor/Resource/Action Doctrine"
-sidebar_label: "ADR-068: Audit Log Doctrine"
-sidebar_position: 68
+title: "ADR-070: Audit Log Actor/Resource/Action Doctrine"
+sidebar_label: "ADR-070: Audit Log Doctrine"
+sidebar_position: 70
 description: "Defines the taxonomy and invariants for STOA platform audit events: actor identification, resource taxonomy, action verbs, immutability, and integrity. Foundation for DORA Art.5/8 and NIS2 Art.21 compliance."
 keywords: [ADR, audit log, DORA, NIS2, immutability, actor, resource, taxonomy, compliance]
 ---
 
-# ADR-068 — Audit Log Actor/Resource/Action Doctrine
+# ADR-070 — Audit Log Actor/Resource/Action Doctrine
 
 ## 1. Status
 
-**Status:** Draft (operator-approved 2026-05-13 — see `docs/decisions/2026-05-13-cab-2225-2229-operator-approvals.md` §CAB-2226 for conditions; jointly with ADR-069). Will be promoted to `Proposed` then `Accepted` in `stoa-docs/` after CAB-2229 closes.
+**Status:** Draft (operator-approved 2026-05-13 — see `docs/decisions/2026-05-13-cab-2225-2229-operator-approvals.md` §CAB-2226 for conditions; jointly with ADR-071). Will be promoted to `Proposed` then `Accepted` in `stoa-docs/` after CAB-2229 closes.
 
 **Date:** 2026-05-13
 
@@ -18,7 +18,7 @@ keywords: [ADR, audit log, DORA, NIS2, immutability, actor, resource, taxonomy, 
 
 **Source:** `docs/audits/2026-05-11-uac-subscription-mcp/AUDIT-RESULTS.md` Axe C (12 binary controls) + challenger decision record §C5.
 
-**Related decisions:** ADR-012 MCP RBAC, ADR-021 UAC-Driven Observability, ADR-054 RBAC Taxonomy v2, ADR-069 (draft, GDPR↔DORA audit reconciliation), ADR-070 (draft, Gateway Fail-Closed Posture).
+**Related decisions:** ADR-012 MCP RBAC, ADR-021 UAC-Driven Observability, ADR-054 RBAC Taxonomy v2, ADR-071 (draft, GDPR↔DORA audit reconciliation), ADR-072 (draft, Gateway Fail-Closed Posture).
 
 ## 2. Context
 
@@ -31,7 +31,7 @@ The 2026-05-11 audit scored audit log compliance at **3 PASS / 5 PARTIAL / 4 FAI
 - Approval workflow audit lacks `approval_justification` and a structured before/after diff.
 - The gateway emits to `tracing::info!` only; no inter-service chain reaches the CP audit table.
 
-ADR-068 fixes the **schema and identity invariants**. ADR-069 handles the GDPR/DORA tension. ADR-070 handles the gateway posture. The three ADRs are a triplet.
+ADR-070 fixes the **schema and identity invariants**. ADR-071 handles the GDPR/DORA tension. ADR-072 handles the gateway posture. The three ADRs are a triplet.
 
 ## 3. Problem
 
@@ -103,7 +103,7 @@ The `action` is an enum. Initial set, grouped:
 ```sql
 CREATE OR REPLACE FUNCTION audit_events_immutable() RETURNS trigger AS $$
 BEGIN
-  RAISE EXCEPTION 'audit_events is append-only (ADR-068)';
+  RAISE EXCEPTION 'audit_events is append-only (ADR-070)';
 END;
 $$ LANGUAGE plpgsql;
 
@@ -114,7 +114,7 @@ CREATE TRIGGER audit_events_no_delete BEFORE DELETE ON audit_events
   FOR EACH ROW EXECUTE FUNCTION audit_events_immutable();
 ```
 
-GDPR erasure does **not** mutate this table. See ADR-069 for the pseudonymization model (auxiliary table).
+GDPR erasure does **not** mutate this table. See ADR-071 for the pseudonymization model (auxiliary table).
 
 Bulk retention purges run via a break-glass procedure that temporarily drops the DELETE trigger inside a transaction with full audit of the operation itself. Procedure must be documented separately and require security sign-off per execution.
 
@@ -163,7 +163,7 @@ Out of scope: cross-tenant ordering. Tenants are independent chains by design.
 
 ### 4.6 Gateway → CP propagation
 
-Gateway-emitted events use the same schema and the same `correlation_id`. Transport is the inter-service endpoint defined in the corrective plan §6.1 and to be detailed in a follow-up ADR (or ADR-070 §gateway-emit). Buffered + signed + replayed if CP transiently unreachable. **Cache-and-deny if CP is durably unreachable** (per ADR-070).
+Gateway-emitted events use the same schema and the same `correlation_id`. Transport is the inter-service endpoint defined in the corrective plan §6.1 and to be detailed in a follow-up ADR (or ADR-072 §gateway-emit). Buffered + signed + replayed if CP transiently unreachable. **Cache-and-deny if CP is durably unreachable** (per ADR-072).
 
 ## 5. Consequences
 
@@ -178,7 +178,7 @@ Gateway-emitted events use the same schema and the same `correlation_id`. Transp
 
 - Migration cost: existing free-form `action`/`resource_type` strings must be normalized into enums. Backfill plan needed.
 - Insert latency increases by hash computation (~µs per row, negligible).
-- Inter-service emit requires gateway↔CP HMAC and replay buffer — engineering work shared with ADR-070.
+- Inter-service emit requires gateway↔CP HMAC and replay buffer — engineering work shared with ADR-072.
 
 ### Neutral
 
@@ -186,7 +186,7 @@ Gateway-emitted events use the same schema and the same `correlation_id`. Transp
 
 ## 6. Implementation
 
-This ADR is **non-executable until ADR-069 (GDPR↔DORA) is signed off, because the immutability invariant collides with the current `erase_user_pii()` behaviour**. The two ADRs are a coupled pair.
+This ADR is **non-executable until ADR-071 (GDPR↔DORA) is signed off, because the immutability invariant collides with the current `erase_user_pii()` behaviour**. The two ADRs are a coupled pair.
 
 | Deliverable | Owner | Surface |
 |-------------|-------|---------|
@@ -211,8 +211,8 @@ This ADR is **non-executable until ADR-069 (GDPR↔DORA) is signed off, because 
 
 - Audit §C "Audit log + traçabilité DORA/NIS2" (12-control matrix)
 - Decision record §C5 "Audit immutability: trigger strict, procédure migration séparée"
-- ADR-069 (companion, GDPR/DORA reconciliation)
-- ADR-070 (companion, gateway fail-closed + emit)
+- ADR-071 (companion, GDPR/DORA reconciliation)
+- ADR-072 (companion, gateway fail-closed + emit)
 - DORA Regulation (EU) 2022/2554 Art. 5, 8, 11, 17
 - NIS2 Directive (EU) 2022/2555 Art. 21
 - NIST SP 800-53 SC-7 (audit integrity)

--- a/docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/adr-071-gdpr-dora-audit-reconciliation.md
+++ b/docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/adr-071-gdpr-dora-audit-reconciliation.md
@@ -1,16 +1,16 @@
 ---
-title: "ADR-069: GDPR ↔ DORA Audit Reconciliation"
-sidebar_label: "ADR-069: GDPR/DORA Audit"
-sidebar_position: 69
+title: "ADR-071: GDPR ↔ DORA Audit Reconciliation"
+sidebar_label: "ADR-071: GDPR/DORA Audit"
+sidebar_position: 71
 description: "Resolves the tension between GDPR Art.17 (right to erasure) and DORA Art.11 (audit log integrity / 5-year retention) by codifying a pseudonymization model with an auxiliary table that preserves the source audit row."
 keywords: [ADR, GDPR, DORA, NIS2, audit log, pseudonymization, erasure, retention, compliance]
 ---
 
-# ADR-069 — GDPR ↔ DORA Audit Reconciliation
+# ADR-071 — GDPR ↔ DORA Audit Reconciliation
 
 ## 1. Status
 
-**Status:** Draft (operator-approved 2026-05-13 — see `docs/decisions/2026-05-13-cab-2225-2229-operator-approvals.md` §CAB-2226 for conditions; jointly with ADR-068). Key disposition: **retrievable-with-dual-control**. Vault wrap of `pseudonymization_key`: **mandatory before PR #2781 may exit DRAFT** — raw storage without Vault wrap is NOT the accepted final state. Will be promoted to `Proposed` then `Accepted` in `stoa-docs/` after CAB-2229 closes.
+**Status:** Draft (operator-approved 2026-05-13 — see `docs/decisions/2026-05-13-cab-2225-2229-operator-approvals.md` §CAB-2226 for conditions; jointly with ADR-070). Key disposition: **retrievable-with-dual-control**. Vault wrap of `pseudonymization_key`: **mandatory before PR #2781 may exit DRAFT** — raw storage without Vault wrap is NOT the accepted final state. Will be promoted to `Proposed` then `Accepted` in `stoa-docs/` after CAB-2229 closes.
 
 **Date:** 2026-05-13
 
@@ -18,11 +18,11 @@ keywords: [ADR, GDPR, DORA, NIS2, audit log, pseudonymization, erasure, retentio
 
 **Source:** `docs/audits/2026-05-11-uac-subscription-mcp/AUDIT-RESULTS.md` §C + cross-cutting pattern "Conflit GDPR vs DORA non résolu" + challenger decision record §C5 + §3.3 Q4.
 
-**Related decisions:** ADR-068 Audit Log Actor/Resource/Action Doctrine (companion). ADR-070 Gateway Fail-Closed Posture (companion).
+**Related decisions:** ADR-070 Audit Log Actor/Resource/Action Doctrine (companion). ADR-072 Gateway Fail-Closed Posture (companion).
 
 ## 2. Context
 
-STOA's audit log is the spine of DORA Art.5/8/11/17 and NIS2 Art.21 compliance. ADR-068 declares it append-only with a PostgreSQL trigger refusing `UPDATE`/`DELETE`.
+STOA's audit log is the spine of DORA Art.5/8/11/17 and NIS2 Art.21 compliance. ADR-070 declares it append-only with a PostgreSQL trigger refusing `UPDATE`/`DELETE`.
 
 GDPR Art.17 ("right to erasure") may, on data-subject request and after legal review, oblige STOA to **erase or pseudonymize personal data** about a natural person — including data carried in audit events such as `actor_email` and free-text justifications.
 
@@ -112,7 +112,7 @@ Data subject request →
 
 ### 4.6 What the trigger lets through
 
-The PG trigger from ADR-068 raises on `UPDATE`/`DELETE`. Three exceptions only:
+The PG trigger from ADR-070 raises on `UPDATE`/`DELETE`. Three exceptions only:
 
 1. **Retention purge** — break-glass procedure as above. Logged.
 2. **Schema migration** — alembic-managed, no row mutation, only structure. Trigger drop is per-deployment break-glass with Security sign-off.
@@ -165,7 +165,7 @@ GDPR erasure is **not** an exception. It works through the view, not through mut
 
 - Audit cross-cutting "Conflit GDPR vs DORA non résolu"
 - Decision record §C5 and §3.3 Q4
-- ADR-068 (immutability invariant — companion)
+- ADR-070 (immutability invariant — companion)
 - GDPR Regulation (EU) 2016/679 Art.5, 17, 25
 - DORA Regulation (EU) 2022/2554 Art.11
 - EDPB Guidelines 01/2022 on data subject rights

--- a/docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/adr-072-gateway-fail-closed-posture.md
+++ b/docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/adr-072-gateway-fail-closed-posture.md
@@ -1,12 +1,12 @@
 ---
-title: "ADR-070: Gateway Fail-Closed Posture"
-sidebar_label: "ADR-070: Gateway Fail-Closed"
-sidebar_position: 70
+title: "ADR-072: Gateway Fail-Closed Posture"
+sidebar_label: "ADR-072: Gateway Fail-Closed"
+sidebar_position: 72
 description: "Codifies the fail-closed defaults for stoa-gateway: deny on Control Plane unreachable, deny on policy load failure, deny on expired cache, no implicit read-only fallback, readiness probe reflects true enforcement state."
 keywords: [ADR, gateway, fail-closed, DORA, NIS2, resilience, policy, RBAC, cache]
 ---
 
-# ADR-070 — Gateway Fail-Closed Posture
+# ADR-072 — Gateway Fail-Closed Posture
 
 ## 1. Status
 
@@ -18,7 +18,7 @@ keywords: [ADR, gateway, fail-closed, DORA, NIS2, resilience, policy, RBAC, cach
 
 **Source:** `docs/audits/2026-05-11-uac-subscription-mcp/AUDIT-RESULTS.md` Axe D (findings GW-1 through GW-9) + challenger decision record §C2 + §C3 + §3.3 Q1 + Q2.
 
-**Related decisions:** ADR-035 Gateway Adapter Pattern, ADR-037 Deployment Modes (Sovereign First), ADR-044 MCP OAuth Gateway Proxy, ADR-066 UAC as LLM-Optimized Executable Contract, ADR-067 (draft, UAC Doctrine), ADR-068 (draft, Audit Log Doctrine).
+**Related decisions:** ADR-035 Gateway Adapter Pattern, ADR-037 Deployment Modes (Sovereign First), ADR-044 MCP OAuth Gateway Proxy, ADR-067 UAC as LLM-Optimized Executable Contract, ADR-069 (draft, UAC Doctrine), ADR-070 (draft, Audit Log Doctrine).
 
 ## 2. Context
 
@@ -27,7 +27,7 @@ The audit identifies **five permissive fallback paths** in `stoa-gateway`:
 1. **Control Plane unreachable** → `tool_permissions.rs:88-96` defaults all permissions to allow.
 2. **Policy engine load failure** → `state.rs:176-189` creates a disabled engine (`enabled=false`) that allows everything.
 3. **Classification VH soft-mode** → `proxy/dynamic.rs:410-422` logs decision but does not deny.
-4. **`requires_human_approval=true`** → never checked at runtime (cross-ref: ADR-067).
+4. **`requires_human_approval=true`** → never checked at runtime (cross-ref: ADR-069).
 5. **Deprovision one-shot** → revoked subscriptions can still be served if gateway was offline at revoke time.
 
 Combined, these turn the gateway into a **fail-open** component when its dependencies degrade. For a STOA tenant under DORA/NIS2, this is a regulatory NOGO.
@@ -58,7 +58,7 @@ The gateway adopts **deny-by-default** as its first-order posture. All exception
 | Policy bundle reload (SIGHUP) fails | **Keep previous bundle in force.** Emit alert. Subsequent SIGHUP retries. No silent transition to permissive. |
 | Permission for a (tenant, tool) absent from cache | **Deny.** Emit `tool_call_denied` with `reason="permission_absent_in_cache"`. |
 | Revocation event for (tenant, subscription) received | **Invalidate immediately**, even if cache has not expired. Revocation has priority over cache. |
-| `requires_human_approval=true` on tool with no valid approval token | **Deny.** Emit `approval_required`. (Cross-ref: ADR-067, plan §C4.) |
+| `requires_human_approval=true` on tool with no valid approval token | **Deny.** Emit `approval_required`. (Cross-ref: ADR-069, plan §C4.) |
 | `inputSchema` validation fails | **Deny.** No tool invocation. |
 | `outputSchema` validation fails | **Strip / replace response with error** (do not return malformed contract). |
 
@@ -90,9 +90,9 @@ The cache is verified on every consult. A stale or tampered cache is treated as 
 
 ### 4.3 No implicit read-only fallback
 
-The challenger (§3.3 Q1) explicitly forbids an implicit read-only degradation. STOA does not have, at this stage, a machine-readable proof per-operation that the operation is non-mutating (the UAC `side_effects` field is moving toward that state but is not universally typed yet — see ADR-067).
+The challenger (§3.3 Q1) explicitly forbids an implicit read-only degradation. STOA does not have, at this stage, a machine-readable proof per-operation that the operation is non-mutating (the UAC `side_effects` field is moving toward that state but is not universally typed yet — see ADR-069).
 
-Until ADR-067 (a) ships typed `side_effects` in `ToolDefinition` and (b) is itself signed off as the source of truth, a "read-only mode" does not exist. Any future read-only mode will require its own ADR amendment to this one.
+Until ADR-069 (a) ships typed `side_effects` in `ToolDefinition` and (b) is itself signed off as the source of truth, a "read-only mode" does not exist. Any future read-only mode will require its own ADR amendment to this one.
 
 ### 4.4 Readiness vs liveness
 
@@ -119,14 +119,14 @@ Per the challenger's §C1 Option A (recommended), a minimal version of the audit
 
 - Endpoint `/v1/internal/audit/emit` on CP-API (HMAC-signed inter-service auth).
 - Gateway audit client buffering only **denies** and **approval-gated** events at first (not every successful call — that's Phase 1).
-- Same schema as ADR-068.
+- Same schema as ADR-070.
 
 **Buffer durability and overflow semantics (challenger condition C1 reinforced).** A simple in-memory buffer with drop-on-overflow would re-introduce silent audit gaps and is **forbidden** for the critical events in scope (denies, approval-gated, health-degrade). The following semantics are mandatory:
 
 1. **Durable local spool.** The buffer is backed by an on-disk WAL (e.g., a bounded directory with rotated append-only segments). A process restart preserves unflushed events.
 2. **Bounded growth with readiness coupling.** A high-water mark is configurable (default: 80% of the spool capacity). Crossing it MUST flip the gateway's readiness probe to FAIL — orchestrator stops routing new traffic until the buffer drains. Liveness is not affected.
 3. **No silent drop.** If the spool genuinely cannot accept (disk full, corruption), the gateway emits a synchronous `audit_gap_declared` event locally (and to stderr / orchestrator alerts) **and** transitions to fail-closed for all in-scope decisions, deny-by-default. A declared gap is an incident, not a metric line.
-4. **Replay on recovery.** When CP-API becomes reachable again, the gateway drains the spool oldest-first, respecting the ADR-068 hash chain and `correlation_id` ordering. A successful drain emits `audit_chain_resumed` with the count and time window covered.
+4. **Replay on recovery.** When CP-API becomes reachable again, the gateway drains the spool oldest-first, respecting the ADR-070 hash chain and `correlation_id` ordering. A successful drain emits `audit_chain_resumed` with the count and time window covered.
 5. **Operator observability.** Spool depth, age of oldest entry, and the count of `audit_gap_declared` events are exposed as Prometheus metrics with alert thresholds.
 
 Phase 1 expands buffering to all events. Phase 0 only carries the critical subset, but with the full durable semantics above — that is the irreducible minimum for "audit chain operational" in the challenger sense.
@@ -153,7 +153,7 @@ Without this Phase 0 minimum, the global NOGO is not lifted at Phase 0 close (pe
 
 ## 6. Implementation
 
-This ADR is **non-executable until business sign-off** (the SLO change is not a purely technical decision) AND ADR-067/068/069 reach at least Proposed status (since fail-closed depends on typed metadata and audit chain).
+This ADR is **non-executable until business sign-off** (the SLO change is not a purely technical decision) AND ADR-069/ADR-070/ADR-071 reach at least Proposed status (since fail-closed depends on typed metadata and audit chain).
 
 | Deliverable | Owner | Surface |
 |-------------|-------|---------|
@@ -172,7 +172,7 @@ This ADR is **non-executable until business sign-off** (the SLO change is not a 
 |--------|---------|
 | Keep permissive fallbacks; document them | ❌ Manufactures paper compliance |
 | Allow stale cache indefinitely during outage | ❌ Drift in policy + invisibility of revocations |
-| Implement implicit read-only fallback today | ❌ No machine-readable proof of "read-only" yet (see ADR-067) |
+| Implement implicit read-only fallback today | ❌ No machine-readable proof of "read-only" yet (see ADR-069) |
 | Make CP-API a hard dependency at gateway startup | ❌ Boot couples too tightly; cache-on-boot mitigation is enough |
 | **Deny-by-default + signed cache + readiness gate + Phase 0 audit chain** | ✅ Selected |
 
@@ -180,9 +180,9 @@ This ADR is **non-executable until business sign-off** (the SLO change is not a 
 
 - Audit Axe D (GW-1 through GW-9)
 - Decision record §C2, §C3, §3.3 Q1, §3.3 Q2, §C1 (Option A recommendation)
-- ADR-067 (UAC doctrine — companion)
-- ADR-068 (audit log doctrine — companion)
-- ADR-069 (GDPR/DORA reconciliation — companion)
+- ADR-069 (UAC doctrine — companion)
+- ADR-070 (audit log doctrine — companion)
+- ADR-071 (GDPR/DORA reconciliation — companion)
 - DORA Regulation (EU) 2022/2554 Art. 5, 8, 9, 17
 - NIS2 Directive (EU) 2022/2555 Art. 21
 - NIST SP 800-160 (resilient systems)

--- a/docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/adr-073-api-subscription-lifecycle.md
+++ b/docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/adr-073-api-subscription-lifecycle.md
@@ -1,12 +1,12 @@
 ---
-title: "ADR-071: API Subscription Lifecycle"
-sidebar_label: "ADR-071: Subscription Lifecycle"
-sidebar_position: 71
+title: "ADR-073: API Subscription Lifecycle"
+sidebar_label: "ADR-073: Subscription Lifecycle"
+sidebar_position: 73
 description: "Formalizes the state machine, RBAC boundaries, and propagation contract of API subscriptions on STOA, extending ADR-001 for the consumer-producer relationship and providing the auditable workflow required by DORA/NIS2."
 keywords: [ADR, subscription, lifecycle, state machine, RBAC, propagation, DORA, NIS2]
 ---
 
-# ADR-071 — API Subscription Lifecycle
+# ADR-073 — API Subscription Lifecycle
 
 ## 1. Status
 
@@ -18,9 +18,9 @@ keywords: [ADR, subscription, lifecycle, state machine, RBAC, propagation, DORA,
 
 **Source:** `docs/audits/2026-05-11-uac-subscription-mcp/AUDIT-RESULTS.md` Axe A (findings SUB-1 through SUB-7) + challenger decision record §C6.
 
-**Extends:** ADR-001 Third-Party API Exposure Strategy (Control Plane / Data Plane separation). ADR-001 defines the architecture; ADR-071 defines the lifecycle inside it.
+**Extends:** ADR-001 Third-Party API Exposure Strategy (Control Plane / Data Plane separation). ADR-001 defines the architecture; ADR-073 defines the lifecycle inside it.
 
-**Related decisions:** ADR-022 UAC Tenant Architecture, ADR-054 RBAC Taxonomy v2, ADR-055 Portal/Console Governance, ADR-066 UAC as Executable Contract, ADR-067 UAC Doctrine, ADR-068 Audit Log Doctrine, ADR-070 Gateway Fail-Closed Posture.
+**Related decisions:** ADR-022 UAC Tenant Architecture, ADR-054 RBAC Taxonomy v2, ADR-055 Portal/Console Governance, ADR-067 UAC as Executable Contract, ADR-069 UAC Doctrine, ADR-070 Audit Log Doctrine, ADR-072 Gateway Fail-Closed Posture.
 
 ## 2. Context
 
@@ -33,7 +33,7 @@ A consumer tenant subscribes to a producer tenant's API on STOA. The current imp
 - **Cross-tenant subscription not validated** at create time (SUB-6).
 - **Approval not formally a state**: PENDING jumps to ACTIVE directly on auto-approve or manual approve, with no observable APPROVED-but-not-PROVISIONED moment.
 
-ADR-001 told us **how** STOA is architected. ADR-071 tells us **how a subscription lives, ages, and dies** inside that architecture.
+ADR-001 told us **how** STOA is architected. ADR-073 tells us **how a subscription lives, ages, and dies** inside that architecture.
 
 ## 3. Problem
 
@@ -99,19 +99,19 @@ We adopt a **single unified state machine** for subscription lifecycle, with **p
 | `PARTIALLY_PROVISIONED` | Some targets ack, others not | Allowed only on ack'd targets |
 | `PROVISIONING_FAILED` | Retries exhausted | No allow anywhere |
 | `ACTIVE` | Fully usable | All targets allow |
-| `SUSPENDED` | Temporary hold by producer or system | Deny everywhere (gateway invalidates immediately, per ADR-070) |
+| `SUSPENDED` | Temporary hold by producer or system | Deny everywhere (gateway invalidates immediately, per ADR-072) |
 | `REVOKING` | Revoke initiated, deprovision in flight | Deny new calls, drain in-flight |
 | `DEPROVISIONING` | Targets being notified to remove | Same as REVOKING |
-| `DEPROVISIONING_FAILED` | Retries exhausted; **alertable** | Deny enforced at gateway via ADR-070 cache invalidation; ops manual intervention |
+| `DEPROVISIONING_FAILED` | Retries exhausted; **alertable** | Deny enforced at gateway via ADR-072 cache invalidation; ops manual intervention |
 | `REVOKED` | Final; immutable | No allow anywhere |
 
-`ACTIVE` is reached **only if all required targets ack the provisioning**. `REVOKED` is reached **only if all required targets ack the revocation OR a higher-level deny mechanism guarantees no service** (e.g., the ADR-070 cache invalidation already prevents allow regardless of target ack).
+`ACTIVE` is reached **only if all required targets ack the provisioning**. `REVOKED` is reached **only if all required targets ack the revocation OR a higher-level deny mechanism guarantees no service** (e.g., the ADR-072 cache invalidation already prevents allow regardless of target ack).
 
 **Default doctrine on `required` flag.** In standard STOA deployments — a tenant served by one or more gateways behind a single Control Plane — every gateway reachable for that tenant is `required=true`. `PARTIALLY_PROVISIONED` is therefore an **operator-visible degradation state**, not a normal usage state: it means some gateways are out of sync with the policy intent and the situation must be reconciled. Consumer surface MAY display it (recommendation §9) but consumers should treat it as "temporary degraded availability", not as "feature partially enabled".
 
 The `required=false` value is reserved for explicit, advanced topologies: shadow/canary gateway, observability-only data plane, soft-launch region. Setting `required=false` requires an out-of-band justification recorded on the `subscription_target` row (`details.justification`) and is itself an audited event. The default for any new target is `required=true`.
 
-A subscription is "usable" iff `status=ACTIVE` AND every `required=true` target has `provisioned_at IS NOT NULL` AND no `required=true` target is in revocation/deprovisioning. No other combination is considered usable; the gateway-side cache invalidation (ADR-070) is the final fail-safe regardless of the field.
+A subscription is "usable" iff `status=ACTIVE` AND every `required=true` target has `provisioned_at IS NOT NULL` AND no `required=true` target is in revocation/deprovisioning. No other combination is considered usable; the gateway-side cache invalidation (ADR-072) is the final fail-safe regardless of the field.
 
 ### 4.3 Per-target ack model
 
@@ -131,14 +131,14 @@ CREATE TABLE subscription_targets (
 );
 ```
 
-Per-target ack is computed asynchronously via the gateway → CP audit emit chain (ADR-070 §4.6, promoted to Phase 0).
+Per-target ack is computed asynchronously via the gateway → CP audit emit chain (ADR-072 §4.6, promoted to Phase 0).
 
 ### 4.4 RBAC matrix
 
 | Action | Who | Notes |
 |--------|-----|-------|
 | `subscription:request` | `tenant-admin`, `devops` of the **consumer** tenant | |
-| `subscription:approve` | `tenant-admin` of the **producer** tenant (or `cpi-admin`) | If the api has any `destructive` endpoint per ADR-067, requires **4-eyes**: two distinct producer-tenant approvers |
+| `subscription:approve` | `tenant-admin` of the **producer** tenant (or `cpi-admin`) | If the api has any `destructive` endpoint per ADR-069, requires **4-eyes**: two distinct producer-tenant approvers |
 | `subscription:reject` | `tenant-admin` of producer | |
 | `subscription:suspend` | `tenant-admin` of producer; `cpi-admin` | |
 | `subscription:reactivate` | `tenant-admin` of producer; `cpi-admin` | Emits webhook (closes the audit gap SUB-3) |
@@ -149,11 +149,11 @@ At creation time, the CP-API **must validate** `request.tenant_id` matches the c
 
 ### 4.5 Audit emission
 
-Every state transition emits one `audit_events` row using the ADR-068 schema:
+Every state transition emits one `audit_events` row using the ADR-070 schema:
 
 - `resource_type=subscription`, `resource_id=<sub-id>`
 - `action ∈ {request, approve, reject, suspend, reactivate, revoke, expire, escalate, ...}`
-- `actor_id`, `actor_tenant_id`, `session_id` (per ADR-068)
+- `actor_id`, `actor_tenant_id`, `session_id` (per ADR-070)
 - `before`/`after` carrying the state field diff
 - `approval_justification` mandatory on `approve`, `reject`, `revoke`, `suspend`
 
@@ -168,7 +168,7 @@ Per-target ack updates emit `audit_events` of `resource_type=subscription_target
 ### 4.7 TTL extension
 
 - Extension writes go through an explicit `commit()`, not `flush()` (closes SUB-2, P0).
-- TTL extensions during a CP-API outage are **refused** by ADR-070's fail-closed posture (no local extension of cache).
+- TTL extensions during a CP-API outage are **refused** by ADR-072's fail-closed posture (no local extension of cache).
 - Each extension emits one audit event with the diff (`before.expires_at`, `after.expires_at`, `extend_days`).
 
 ## 5. Consequences
@@ -192,7 +192,7 @@ Per-target ack updates emit `audit_events` of `resource_type=subscription_target
 
 ## 6. Implementation
 
-This ADR is **non-executable until ADR-067 (typed metadata) and ADR-070 (cache + audit chain) reach Proposed**, because 4-eyes/destructive routing and target ack rely on them.
+This ADR is **non-executable until ADR-069 (typed metadata) and ADR-072 (cache + audit chain) reach Proposed**, because 4-eyes/destructive routing and target ack rely on them.
 
 | Deliverable | Owner | Surface |
 |-------------|-------|---------|
@@ -212,7 +212,7 @@ This ADR is **non-executable until ADR-067 (typed metadata) and ADR-070 (cache +
 | Keep dual `status`/`provisioning_status` fields; document mapping | ❌ UI lies; regulators see ambiguity |
 | Add states only to `provisioning_status`; leave `status` simple | ❌ Confuses what is "live" |
 | Per-target tracking but no `PARTIALLY_PROVISIONED` state | ❌ Half-states invisible to ops and consumers |
-| Drop 4-eyes; rely on ADR-067 approval token only | ❌ Approval token proves intent binding, 4-eyes proves separation of duties — both needed for destructive endpoints |
+| Drop 4-eyes; rely on ADR-069 approval token only | ❌ Approval token proves intent binding, 4-eyes proves separation of duties — both needed for destructive endpoints |
 | **Unified state machine + per-target ack + 4-eyes for destructive** | ✅ Selected |
 
 ## 8. References
@@ -220,9 +220,9 @@ This ADR is **non-executable until ADR-067 (typed metadata) and ADR-070 (cache +
 - Audit Axe A (SUB-1 through SUB-7) + state-machine current vs ideal diagram
 - Decision record §C6 (partial provisioning + failure states)
 - ADR-001 (architecture predecessor)
-- ADR-067 (destructive routing — companion)
-- ADR-068 (audit emission schema — companion)
-- ADR-070 (cache invalidation + audit chain — companion)
+- ADR-069 (destructive routing — companion)
+- ADR-070 (audit emission schema — companion)
+- ADR-072 (cache invalidation + audit chain — companion)
 - DORA Regulation (EU) 2022/2554 Art. 5, 17
 - NIS2 Directive (EU) 2022/2555 Art. 21
 

--- a/docs/decisions/2026-05-11-uac-subscription-mcp-corrective.md
+++ b/docs/decisions/2026-05-11-uac-subscription-mcp-corrective.md
@@ -13,6 +13,8 @@ phase0_authorization: "conditional_after_conditions_are_written_and_signed"
 
 # Decision — UAC Subscription MCP Corrective Plan
 
+> **2026-05-18 — ADR numbers renumbered +2.** The ADR references in this record were originally written as ADR-067…071. They were renumbered into free `stoa-docs` slots **ADR-069…073** (gateway fail-closed = ADR-072) after a duplicate-`adr-060` dedup on `stoa-docs` `main` took `adr-067`/`adr-068`. Verdict and conditions are unchanged. See `docs/plans/2026-05-11-uac-subscription-mcp-corrective.md` §8.
+
 ## 1. Verdict
 
 **Verdict challenger : `GO_WITH_CONDITIONS`.**
@@ -44,7 +46,7 @@ Mettre le plan à `validation_status: challenged`, pas `validated`.
 `validated` ne doit être utilisé qu’après :
 
 - acceptation écrite des conditions C1 à C7 ;
-- ADR-067, ADR-068, ADR-069 et ADR-070 au minimum en draft reviewable ;
+- ADR-069, ADR-070, ADR-071 et ADR-072 au minimum en draft reviewable ;
 - owners business, security, compliance, gateway et CP-API nommés.
 
 ### C1 — Clarifier le split Phase 0 / levée du NOGO régulateur
@@ -71,13 +73,13 @@ Condition : ajouter un sign-off business/security sur les règles suivantes :
 - aucun mode dégradé “read-only” implicite tant que le gateway ne peut pas prouver la séparation read-only / mutating par contrat UAC typé ;
 - readiness doit exposer l’état réel d’enforcement.
 
-Un mode “read-only” ne pourra être ajouté qu’ultérieurement, sous ADR-070, avec preuves typées et tests séparés.
+Un mode “read-only” ne pourra être ajouté qu’ultérieurement, sous ADR-072, avec preuves typées et tests séparés.
 
 ### C3 — Cache permissions gateway : artefact signé et non extensible
 
 Un cache frais peut être accepté pendant une indisponibilité CP, mais seulement comme artefact de politique explicite.
 
-Condition : formaliser dans ADR-070 :
+Condition : formaliser dans ADR-072 :
 
 - `policy_version` ;
 - `issued_at` ;
@@ -110,7 +112,7 @@ Sans `arguments_hash`, un token pourrait autoriser un appel différent de celui 
 
 Le trigger PostgreSQL doit bloquer `UPDATE` et `DELETE` sur `audit_events` en production.
 
-Condition : ADR-069 doit trancher avant migration :
+Condition : ADR-071 doit trancher avant migration :
 
 - aucune mutation applicative de `audit_events` ;
 - `erase_user_pii()` doit produire des événements append-only et/ou une table auxiliaire, sans altérer la ligne audit source ;
@@ -140,7 +142,7 @@ Condition : préciser les hypothèses de capacité :
 
 - au moins 1 owner gateway Rust ;
 - au moins 1 owner CP-API Python/DB ;
-- support security/compliance pour ADR-069/070 ;
+- support security/compliance pour ADR-071/ADR-072 ;
 - staging avec PostgreSQL, gateway, CP, Kafka/webhook ou équivalent ;
 - capacité QA/e2e dédiée pour smoke DORA/NIS2.
 
@@ -187,7 +189,7 @@ Avec `arguments_hash`, séparation des acteurs, store `jti` atomique, TTL court,
 
 ### 4. La pseudonymisation hors-table `audit_events` résout-elle correctement le conflit GDPR Art.17 vs DORA Art.11 ?
 
-**Réponse : direction correcte, mais résolution incomplète tant qu’ADR-069 n’est pas accepté.**
+**Réponse : direction correcte, mais résolution incomplète tant qu’ADR-071 n’est pas accepté.**
 
 La table auxiliaire est préférable à une mutation in-place, car elle préserve la ligne source et crée une preuve d’effacement/pseudonymisation. Mais il faut documenter :
 
@@ -220,7 +222,7 @@ Les volumes annoncés (~6800 LOC, ~67 tests) sont plausibles, mais le chemin cri
 - behavior change gateway fail-closed ;
 - endpoint audit inter-service ;
 - smoke e2e CP↔Gateway ;
-- ADR-069/070 avec sign-off sécurité/compliance ;
+- ADR-071/ADR-072 avec sign-off sécurité/compliance ;
 - state machine + compatibilité API/UI.
 
 Avec une seule équipe séquentielle, 9 semaines est optimiste. Avec deux workstreams techniques + support compliance/QA, 9 semaines est acceptable.
@@ -231,7 +233,7 @@ Avec une seule équipe séquentielle, 9 semaines est optimiste. Avec deux workst
 
 ### Autorisé immédiatement
 
-- Création des ADR drafts : ADR-067, ADR-068, ADR-069, ADR-070, puis ADR-001.
+- Création des ADR drafts : ADR-069, ADR-070, ADR-071, ADR-072, puis ADR-001.
 - Création des tickets Linear, sans assigner encore de date de merge P0.
 - Mise à jour du plan à `validation_status: challenged`.
 - Préparation des tests/smoke specs.
@@ -240,18 +242,18 @@ Avec une seule équipe séquentielle, 9 semaines est optimiste. Avec deux workst
 ### Autorisable après conditions écrites et signées
 
 - `P0-SUB-2` TTL commit, avec test transactionnel.
-- `P0-GW-1` et `P0-GW-2`, après ADR-070 draft et sign-off fail-closed.
+- `P0-GW-1` et `P0-GW-2`, après ADR-072 draft et sign-off fail-closed.
 - `P0-MCP-1`, après ajout des exigences `arguments_hash`, jti single-use atomique et preuve 4-eyes.
-- `P0-AUD-1`, après ADR-069 draft accepté par security/compliance.
+- `P0-AUD-1`, après ADR-071 draft accepté par security/compliance.
 - `P0-SUB-1`, après formalisation des états minimum `REVOKING/DEPROVISIONING/DEPROVISIONING_FAILED`.
 - `P0-AUD-2`, soit en Phase 0 minimal, soit explicitement reporté en Phase 1 avec mention que le NOGO régulateur n’est pas levé avant cette Phase.
 
 ### Refusé à ce stade
 
 - Marquer le plan `validated`.
-- Démarrer une migration `audit_events` sans ADR-069.
+- Démarrer une migration `audit_events` sans ADR-071.
 - Introduire un mode read-only ou cached-allow implicite pendant outage CP.
-- Déclarer la doctrine ADR-067 conforme sans enforcement runtime et smoke test.
+- Déclarer la doctrine ADR-069 conforme sans enforcement runtime et smoke test.
 - Déclarer la conformité DORA/NIS2 après Phase 0 si Gateway↔CP audit chain reste absente.
 
 ---

--- a/docs/decisions/2026-05-13-cab-2225-2229-operator-approvals.md
+++ b/docs/decisions/2026-05-13-cab-2225-2229-operator-approvals.md
@@ -16,11 +16,13 @@ related_audit: "docs/audits/2026-05-11-uac-subscription-mcp/AUDIT-RESULTS.md"
 > They are **not** to be represented as "DPO approved", "Legal approved", "Security approved", or any other multi-role fan-out.
 > See memory rule `feedback_solo_project_mode_signoffs`.
 
-This document is the canonical regulatory trace that the policies in ADR-067, ADR-068, ADR-069, ADR-070, ADR-071 came from the human operator — not from Claude or Codex. Agents may proceed within the accepted scope only; any deviation requires re-challenge.
+This document is the canonical regulatory trace that the policies in ADR-069, ADR-070, ADR-071, ADR-072, ADR-073 came from the human operator — not from Claude or Codex. Agents may proceed within the accepted scope only; any deviation requires re-challenge.
+
+> **2026-05-18 — ADR numbers renumbered +2.** This batch was approved on 2026-05-13 as ADR-067…071. A duplicate-`adr-060` dedup on `stoa-docs` `main` had already taken `adr-067`/`adr-068`, so the batch was renumbered into free slots **ADR-069…073** (UAC doctrine 069, audit doctrine 070, GDPR/DORA 071, gateway fail-closed 072, subscription lifecycle 073). The CAB ticket numbers (CAB-2225…2229) are unchanged, and the operator approvals themselves are unchanged — only the ADR identifiers were corrected. See `docs/plans/2026-05-11-uac-subscription-mcp-corrective.md` §8.
 
 ---
 
-## CAB-2225 — ADR-067 UAC describes / MCP projects / Smoke proves
+## CAB-2225 — ADR-069 UAC describes / MCP projects / Smoke proves
 
 **Verdict:** APPROVED by operator acting as product, security, privacy, legal, and business decision owner for this solo project stage.
 
@@ -38,11 +40,11 @@ This document is the canonical regulatory trace that the policies in ADR-067, AD
 
 ---
 
-## CAB-2226 — ADR-068 (audit immutability) + ADR-069 (GDPR ↔ DORA reconciliation), joint
+## CAB-2226 — ADR-070 (audit immutability) + ADR-071 (GDPR ↔ DORA reconciliation), joint
 
-**Verdict ADR-068:** APPROVED by operator acting as product, security, privacy, legal, and business decision owner for this solo project stage.
+**Verdict ADR-070:** APPROVED by operator acting as product, security, privacy, legal, and business decision owner for this solo project stage.
 
-**Verdict ADR-069:** APPROVED by operator acting as product, security, privacy, legal, and business decision owner for this solo project stage.
+**Verdict ADR-071:** APPROVED by operator acting as product, security, privacy, legal, and business decision owner for this solo project stage.
 
 **Date:** 2026-05-13.
 
@@ -61,7 +63,7 @@ This document is the canonical regulatory trace that the policies in ADR-067, AD
 
 ---
 
-## CAB-2227 — ADR-070 gateway fail-closed posture
+## CAB-2227 — ADR-072 gateway fail-closed posture
 
 **Verdict:** APPROVED by operator acting as product, security, privacy, legal, and business decision owner for this solo project stage.
 
@@ -90,7 +92,7 @@ This document is the canonical regulatory trace that the policies in ADR-067, AD
 
 ---
 
-## CAB-2228 — ADR-071 API subscription lifecycle
+## CAB-2228 — ADR-073 API subscription lifecycle
 
 **Verdict:** APPROVED by operator acting as product, security, privacy, legal, and business decision owner for this solo project stage.
 
@@ -108,7 +110,7 @@ This document is the canonical regulatory trace that the policies in ADR-067, AD
 
 1. `PARTIALLY_PROVISIONED` must surface target-by-target ack status to the consumer — not just a global degraded label.
 2. 4-eyes enforcement must verify **distinct human subjects** at the policy layer; technical equality of actor IDs is not sufficient evidence of separation. Audit events must record both actors.
-3. Every lifecycle transition emits one `audit_events` row per ADR-068 schema. Per-target updates emit `subscription_target` rows.
+3. Every lifecycle transition emits one `audit_events` row per ADR-070 schema. Per-target updates emit `subscription_target` rows.
 4. `DEPROVISIONING_FAILED` and `SUSPENDED` remain first-class degraded states (already partially delivered by PR #2782 and PR #2784).
 
 **Rationale:** Consumers need operational truth. Hiding partial provisioning behind a green light produces support escalations and erodes trust. Destructive operations (revoke, deprovision, suspend) affect access and potentially billing — strict 4-eyes is the correct posture for a regulated API gateway. 15 minutes is a generous but reasonable provisioning ceiling.

--- a/docs/plans/2026-05-11-uac-subscription-mcp-corrective.md
+++ b/docs/plans/2026-05-11-uac-subscription-mcp-corrective.md
@@ -20,7 +20,7 @@ implementation_pending:
   - "PR #2781 Vault wrap on _wrap_pseudonymization_key (CAB-2226 condition)"
   - "P0-MCP-1 approval-token runtime (gated on PR #2781 + #2780 lock-step deploy)"
   - "P0-GW-1 / P0-GW-2 gateway fail-closed runtime (CAB-2227)"
-  - "P0-AUD-2 minimal Gateway↔CP audit emit (in ADR-070 §4.6)"
+  - "P0-AUD-2 minimal Gateway↔CP audit emit (in ADR-072 §4.6)"
 scope:
   - control-plane-api/
   - stoa-gateway/
@@ -49,7 +49,7 @@ owners:
 > - Any future move to raw storage for `pseudonymization_key` without a NEW ADR explicitly narrowing the trust boundary.
 > - Multi-role sign-off framing on new artefacts — solo project mode applies (per `feedback_solo_project_mode_signoffs`).
 >
-> **Phase 0 rule preserved (challenger §5)**: Phase 0 closes local P0 blockers only if P0-AUD-2 minimal Gateway↔CP audit chain is included. ADR-070 §4.6 codifies this; the chain itself is part of PR #2781 scope.
+> **Phase 0 rule preserved (challenger §5)**: Phase 0 closes local P0 blockers only if P0-AUD-2 minimal Gateway↔CP audit chain is included. ADR-072 §4.6 codifies this; the chain itself is part of PR #2781 scope.
 >
 > **Historical (pre-validation) note** — the doctrine `challenged` state above became `validated` via operator decision on 2026-05-13. The "Refused now" list from the prior challenged-state has been folded into the live conditions above; the original wording is preserved in git history via this section's pre-validation revision.
 
@@ -72,7 +72,7 @@ Le plan cible une correction en **9 semaines**, structurée ainsi :
 | Phase 0 | Semaines 1-2 | Fermer les blockers P0 | 4 FAIL → 0 FAIL sur gates bloquants |
 | Phase 1 | Semaines 3-5 | Restaurer chaîne audit + observabilité + runtime validation | Audit Gateway↔CP opérationnel, metadata MCP typées |
 | Phase 2 | Semaines 6-9 | Workflow approval auditable + state machine unifiée | Souscription et révocation prouvables bout-en-bout |
-| ADRs | En parallèle | Versionner la doctrine absente | ADR-067, 068, 069, 070, 071 publiées (ADR-001 reste predecessor accepté, non amendé) |
+| ADRs | En parallèle | Versionner la doctrine absente | ADR-069, ADR-070, ADR-071, ADR-072, ADR-073 publiées (ADR-001 reste predecessor accepté, non amendé) |
 
 ---
 
@@ -133,7 +133,7 @@ Le gate doit refuser le démarrage si au moins une condition est vraie :
 - L’équipe sécurité refuse le design de token d’approbation.
 - La migration audit log ne définit pas précisément ce que devient `erase_user_pii`.
 - Le plan de rollback des migrations DB est absent.
-- Les ADR-067 et ADR-068 restent non versionnées.
+- Les ADR-069 et ADR-070 restent non versionnées.
 - Les tests de preuve DORA/NIS2 ne sont pas identifiés avant implémentation.
 
 ### 1.6 Intégration des conditions C1-C7 (CAB-2229, opérateur 2026-05-13)
@@ -142,12 +142,12 @@ Le gate est fermé : opérateur GO_WITH_CONDITIONS, validation_status flippé à
 
 | # | Condition | Statut | Référence canonique |
 |---|-----------|--------|---------------------|
-| C1 | Split Phase 0 / NOGO régulateur — Option A (Phase 0 minimal audit chain) ou SPLIT_GATE explicite | **CLOSED — Option A** | ADR-070 §4.6 codifie la chain minimum Phase 0 (denies + approval-gated, durable spool). Operator approval CAB-2227 confirme C1 Option A. |
-| C2 | Sign-off business du fail-closed | **CLOSED — operator** | Operator approval CAB-2227 enregistré : `validated_for_code_execution: true` côté opérateur, SLA impact accepté. Frontmatter §C2 conditions intégrées dans ADR-070 §4.1. |
-| C3 | Cache permissions = artefact signé non extensible | **CLOSED** | ADR-070 §4.2 codifie le `policy_cache_artefact` (policy_version, issued_at, expires_at ≤ 60 min, signature, deny_default). Operator parameters : TTL = 60 min, jamais extensible localement. |
-| C4 | Approval token avec intent binding + preuve 4-eyes | **CLOSED** | ADR-067 §4.4 codifie les 6 invariants approval token (jti single-use atomic, arguments_hash, policy_version, contract_version, requester/approver séparés, audit issued/used/rejected). Operator approval CAB-2225 confirme conditions binding. |
-| C5 | Audit immutability : trigger strict + procédure migration séparée | **CLOSED** | ADR-068 §4.4 (trigger + 3 exceptions break-glass), ADR-069 §4.2 (pseudo aux table). Operator approval CAB-2226 : key disposition = retrievable-with-dual-control ; **Vault wrap mandatory** sur PR #2781 (`implementation_pending`). |
-| C6 | State machine partial provisioning + failure states | **CLOSED** | ADR-071 §4.1 codifie `PARTIALLY_PROVISIONED`, `PROVISIONING_FAILED`, `DEPROVISIONING_FAILED`. Operator approval CAB-2228 : visibility consumer-visible avec target breakdown, 4-eyes strict 2 tenant-admins, time budget 15 min. PR #2782 (DEPROVISIONING_FAILED) + PR #2784 (suspend/reactivate webhooks) déjà mergées. |
+| C1 | Split Phase 0 / NOGO régulateur — Option A (Phase 0 minimal audit chain) ou SPLIT_GATE explicite | **CLOSED — Option A** | ADR-072 §4.6 codifie la chain minimum Phase 0 (denies + approval-gated, durable spool). Operator approval CAB-2227 confirme C1 Option A. |
+| C2 | Sign-off business du fail-closed | **CLOSED — operator** | Operator approval CAB-2227 enregistré : `validated_for_code_execution: true` côté opérateur, SLA impact accepté. Frontmatter §C2 conditions intégrées dans ADR-072 §4.1. |
+| C3 | Cache permissions = artefact signé non extensible | **CLOSED** | ADR-072 §4.2 codifie le `policy_cache_artefact` (policy_version, issued_at, expires_at ≤ 60 min, signature, deny_default). Operator parameters : TTL = 60 min, jamais extensible localement. |
+| C4 | Approval token avec intent binding + preuve 4-eyes | **CLOSED** | ADR-069 §4.4 codifie les 6 invariants approval token (jti single-use atomic, arguments_hash, policy_version, contract_version, requester/approver séparés, audit issued/used/rejected). Operator approval CAB-2225 confirme conditions binding. |
+| C5 | Audit immutability : trigger strict + procédure migration séparée | **CLOSED** | ADR-070 §4.4 (trigger + 3 exceptions break-glass), ADR-071 §4.2 (pseudo aux table). Operator approval CAB-2226 : key disposition = retrievable-with-dual-control ; **Vault wrap mandatory** sur PR #2781 (`implementation_pending`). |
+| C6 | State machine partial provisioning + failure states | **CLOSED** | ADR-073 §4.1 codifie `PARTIALLY_PROVISIONED`, `PROVISIONING_FAILED`, `DEPROVISIONING_FAILED`. Operator approval CAB-2228 : visibility consumer-visible avec target breakdown, 4-eyes strict 2 tenant-admins, time budget 15 min. PR #2782 (DEPROVISIONING_FAILED) + PR #2784 (suspend/reactivate webhooks) déjà mergées. |
 | C7 | Planning 9 semaines conditionnel staffing parallèle | **CLOSED — solo mode** | Solo project mode (`feedback_solo_project_mode_signoffs`) : l'opérateur s'engage personnellement sur le timeline. Si la capacité solo s'avère insuffisante en cours d'exécution, le plan rebase à 12-14 semaines sans drame. Aucun staffing tiers requis. |
 
 **Implications sur les PRs en cours** (cf. `implementation_pending` du frontmatter) :
@@ -445,7 +445,7 @@ Si `tool.requires_human_approval == true` :
 - Tout destructive call sans token → 403.
 - 403 produit un audit event structuré.
 - Token valide single-use → allow une seule fois.
-- La doctrine ADR-067 est exécutée au runtime, pas seulement décrite.
+- La doctrine ADR-069 est exécutée au runtime, pas seulement décrite.
 
 ---
 
@@ -523,7 +523,7 @@ After:
 - `UPDATE audit_events` échoue au niveau PostgreSQL.
 - `DELETE audit_events` échoue au niveau PostgreSQL.
 - `erase_user_pii()` ne mute jamais `audit_events`.
-- Le conflit GDPR/DORA est documenté dans ADR-069 avant merge.
+- Le conflit GDPR/DORA est documenté dans ADR-071 avant merge.
 
 **Point à trancher au Gate**
 
@@ -741,7 +741,7 @@ Design :
 - `AUDIT_RETENTION_DAYS=1825` par défaut.
 - Helm CronJob quotidien.
 - `purge_before()` utilisé uniquement sur données purgeables, pas sur `audit_events` append-only si DORA impose conservation.
-- En cas de conflit, ADR-069 tranche.
+- En cas de conflit, ADR-071 tranche.
 
 Acceptance criteria :
 
@@ -860,7 +860,7 @@ Actions :
 - Ajouter `approval_diff` JSONB.
 - Stocker approver actor/session/IP.
 - Exiger justification non vide pour approvals manuels.
-- Pour destructive endpoints, exiger enhanced approval si ADR-067 le décide.
+- Pour destructive endpoints, exiger enhanced approval si ADR-069 le décide.
 
 Acceptance criteria :
 
@@ -947,9 +947,11 @@ Acceptance criteria :
 
 ## 8. ADRs à formaliser
 
-### 8.1 ADR-071 — API subscription lifecycle
+> **2026-05-18 — Renumérotation +1 (collision stoa-docs).** Ce batch était initialement numéroté ADR-067…071. Une déduplication d'un `adr-060` en double sur `stoa-docs` `main` a décalé tous les ADR ≥066 d'un cran : `stoa-docs` `main` publie désormais `adr-067` (UAC LLM-Optimized) et `adr-068` (Audit Log Actor/Resource Views), en collision avec ce batch. Le batch a été renuméroté **+2 vers les slots libres ADR-069…073** : ADR-069 UAC doctrine, ADR-070 audit doctrine, ADR-071 GDPR/DORA, **ADR-072 gateway fail-closed**, ADR-073 subscription lifecycle. Toutes les références ci-dessous, le frontmatter, le README des drafts et les deux decision records ont été mis à jour. Vérifier l'index ADR de `stoa-docs` avant toute promotion ultérieure.
 
-> **2026-05-13 reconciliation note.** L'ancienne entrée "ADR-001 — API exposure strategy" est obsolète : ADR-001 existe déjà (Accepted 2026-01-18) et reste **predecessor non amendé**. Le manque réel = lifecycle souscription, traité par un ADR neuf (ADR-071) qui étend ADR-001 sans le modifier.
+### 8.1 ADR-073 — API subscription lifecycle
+
+> **2026-05-13 reconciliation note.** L'ancienne entrée "ADR-001 — API exposure strategy" est obsolète : ADR-001 existe déjà (Accepted 2026-01-18) et reste **predecessor non amendé**. Le manque réel = lifecycle souscription, traité par un ADR neuf (ADR-073) qui étend ADR-001 sans le modifier.
 
 But :
 
@@ -961,11 +963,11 @@ But :
 
 Statut cible : `accepted` avant Phase 2.
 
-Draft : `docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/adr-071-api-subscription-lifecycle.md`.
+Draft : `docs/audits/2026-05-11-uac-subscription-mcp/adrs-drafts/adr-073-api-subscription-lifecycle.md`.
 
 ---
 
-### 8.2 ADR-067 — UAC describes / MCP projects / Smoke proves
+### 8.2 ADR-069 — UAC describes / MCP projects / Smoke proves
 
 But :
 
@@ -981,7 +983,7 @@ Statut cible : `accepted` avant merge P0-3.
 
 ---
 
-### 8.3 ADR-068 — Audit log actor/resource doctrine
+### 8.3 ADR-070 — Audit log actor/resource doctrine
 
 But :
 
@@ -994,7 +996,7 @@ Statut cible : `accepted` avant merge P1-1.
 
 ---
 
-### 8.4 ADR-069 — GDPR ↔ DORA audit reconciliation
+### 8.4 ADR-071 — GDPR ↔ DORA audit reconciliation
 
 But :
 
@@ -1007,7 +1009,7 @@ Statut cible : `accepted` avant migration P0-4.
 
 ---
 
-### 8.5 ADR-070 — Gateway fail-closed posture
+### 8.5 ADR-072 — Gateway fail-closed posture
 
 But :
 
@@ -1078,7 +1080,7 @@ Le plan est terminé seulement si :
 
 - Les 12 gates DORA/NIS2 sont PASS ou explicitement acceptées avec justification externe.
 - Les 4 P0 FAIL sont fermés par tests.
-- Les ADR-067/068/069/070 sont versionnées.
+- Les ADR-069/ADR-070/ADR-071/ADR-072 sont versionnées.
 - Le smoke suite est automatisé en CI ou environnement pré-prod.
 - Le challenger externe signe un Decision Record final.
 - Le runbook ops décrit fail-closed, break-glass, audit replay, revocation failed.
@@ -1090,7 +1092,7 @@ Le plan est terminé seulement si :
 | Risque | Probabilité | Impact | Mitigation |
 |---|---:|---:|---|
 | Fail-closed provoque indisponibilité client lors d’un incident CP | Élevée | Élevé | Circuit breaker, status page, runbook, cache frais strict, communication business |
-| Trigger audit bloque migration légitime | Moyenne | Élevé | Procédure migration dédiée, tests staging, break-glass audité si accepté par ADR-069 |
+| Trigger audit bloque migration légitime | Moyenne | Élevé | Procédure migration dédiée, tests staging, break-glass audité si accepté par ADR-071 |
 | Approval token ralentit agents IA | Moyenne | Moyen | UX approval claire, TTL court mais réaliste, erreurs explicites |
 | Gateway audit buffer perd des events | Moyenne | Élevé | Buffer borné + métrique drop + alerte + option durable queue |
 | State machine migration casse UI/API | Moyenne | Élevé | Compatibility layer, migration progressive, tests contract |
@@ -1107,10 +1109,10 @@ Le plan est terminé seulement si :
 
 ```text
 PR-DOC-0: Plan correctif draft
-PR-DOC-1: ADR-067 draft
-PR-DOC-2: ADR-068 draft
-PR-DOC-3: ADR-069 draft
-PR-DOC-4: ADR-070 draft
+PR-DOC-1: ADR-069 draft
+PR-DOC-2: ADR-070 draft
+PR-DOC-3: ADR-071 draft
+PR-DOC-4: ADR-072 draft
 Decision record: GO / GO_WITH_CONDITIONS / NOGO
 ```
 
@@ -1179,7 +1181,7 @@ Rollback :
 
 - Ne pas supprimer le trigger sans Decision Record.
 - En cas de blocage, forward-fix recommandé.
-- Break-glass uniquement si ADR-069 le permet.
+- Break-glass uniquement si ADR-071 le permet.
 
 ### 12.3 Migration state machine
 
@@ -1283,10 +1285,10 @@ TBD.
 
 - [ ] Decision Record créé.
 - [ ] Challenger externe assigné.
-- [ ] ADR-067 draft disponible.
-- [ ] ADR-068 draft disponible.
 - [ ] ADR-069 draft disponible.
 - [ ] ADR-070 draft disponible.
+- [ ] ADR-071 draft disponible.
+- [ ] ADR-072 draft disponible.
 - [ ] Business owner informé de l’impact fail-closed.
 - [ ] Environnement staging prêt.
 - [ ] Snapshot DB anonymisé disponible.


### PR DESCRIPTION
## What

A duplicate-`adr-060` dedup on `stoa-docs` `main` shifted every ADR ≥066
up by one. `stoa-docs` `main` now publishes `adr-067` (UAC LLM-Optimized
Contract) and `adr-068` (Audit Actor/Resource Views) — colliding with
the UAC subscription + MCP corrective ADR batch (CAB-2225..2229).

This PR renumbers the corrective batch **+2** into the next free slots:

| Was | Now | Title |
|-----|-----|-------|
| ADR-067 | **ADR-069** | UAC Describes / MCP Projects / Smoke Proves |
| ADR-068 | **ADR-070** | Audit Log Actor/Resource Doctrine |
| ADR-069 | **ADR-071** | GDPR ↔ DORA Reconciliation |
| ADR-070 | **ADR-072** | Gateway Fail-Closed Posture |
| ADR-071 | **ADR-073** | API Subscription Lifecycle |

## Changed

- 5 draft files renamed + frontmatter (`sidebar_position`, title) + all
  internal cross-references updated.
- Corrective plan §8 + frontmatter; drafts README; both decision records.
- `CLAUDE.md` UAC doctrine reference repointed at ADR-069.
- CAB ticket numbers and all approvals/verdicts unchanged — only ADR
  identifiers corrected. Reconciliation notes added inline.

Companion PR in `stoa-docs` promotes ADR-072 (Gateway Fail-Closed) to the
published ADR index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)