### PR TITLE
fix(security): remediate dependency and gateway image alerts

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -104,6 +104,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -772,9 +773,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -31,5 +31,10 @@
     "dotenv": "^17.4.2",
     "playwright-bdd": "^8.5.0",
     "typescript": "^6.0.3"
+  },
+  "overrides": {
+    "@cucumber/messages@27.2.0": {
+      "uuid": "^11.1.1"
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1076,9 +1076,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   },
   "dependencies": {
     "recharts": "^3.8.0"
+  },
+  "overrides": {
+    "fast-uri": "^3.1.2"
   }
 }

--- a/portal/package-lock.json
+++ b/portal/package-lock.json
@@ -4532,9 +4532,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/portal/package.json
+++ b/portal/package.json
@@ -65,6 +65,7 @@
   },
   "overrides": {
     "minimatch@^9.0.0": "9.0.7",
-    "follow-redirects": "^1.16.0"
+    "follow-redirects": "^1.16.0",
+    "fast-uri": "^3.1.2"
   }
 }

--- a/portal/src/pages/__tests__/MySubscriptions.test.tsx
+++ b/portal/src/pages/__tests__/MySubscriptions.test.tsx
@@ -27,6 +27,13 @@ vi.mock('../../services/mcpServers', () => ({
   },
 }));
 
+const mockListMyApiSubscriptions = vi.fn();
+vi.mock('../../services/apiSubscriptions', () => ({
+  apiSubscriptionsService: {
+    listMySubscriptions: () => mockListMyApiSubscriptions(),
+  },
+}));
+
 // Mock hooks
 const mockSubscriptionsData = vi.fn();
 const mockRevokeMutation = vi.fn();
@@ -81,6 +88,7 @@ describe('MySubscriptions', () => {
     vi.clearAllMocks();
     mockAuth.mockReturnValue(createAuthMock('tenant-admin'));
     mockGetMyServerSubscriptions.mockResolvedValue([]);
+    mockListMyApiSubscriptions.mockResolvedValue({ items: [] });
     mockSubscriptionsData.mockReturnValue({ subscriptions: [] });
   });
 
@@ -134,6 +142,7 @@ describe('MySubscriptions', () => {
         vi.clearAllMocks();
         mockAuth.mockReturnValue(createAuthMock(role));
         mockGetMyServerSubscriptions.mockResolvedValue([]);
+        mockListMyApiSubscriptions.mockResolvedValue({ items: [] });
         mockSubscriptionsData.mockReturnValue({ subscriptions: [] });
       });
 

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -145,9 +145,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -18,5 +18,8 @@
     "@types/react-dom": "^19.2.3",
     "lucide-react": "^0.475.0",
     "openapi-typescript": "^7.13.0"
+  },
+  "overrides": {
+    "brace-expansion": "^2.0.3"
   }
 }

--- a/stoa-gateway/Cargo.toml
+++ b/stoa-gateway/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 thiserror = "2"
 chrono = { version = "0.4", features = ["serde"] }
 prometheus = { version = "0.13", default-features = false }  # no protobuf (RUSTSEC-2024-0437)
-jsonwebtoken = { version = "10", features = ["rust_crypto"] }  # RUSTSEC-2023-0071: rsa timing vuln — no upstream fix, low risk (JWT verify only, no RSA decrypt)
+jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }  # avoid RustCrypto rsa timing advisory
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls", "http2"] }
 async-trait = "0.1"
 
@@ -68,7 +68,7 @@ regex = "1"
 notify = "8"
 
 # === Phase 2 OPA: Embedded Policy Engine (CAB-1094) ===
-regorus = "0.9"                              # Pure Rust OPA evaluator (no sidecar) — RUSTSEC-2025-0141: bincode unmaintained (transitive, no API exposed)
+regorus = "0.10"                             # Pure Rust OPA evaluator (no sidecar)
 
 # === Phase 8: Shadow Mode UAC Generation ===
 serde_yaml = "0.9"                           # YAML serialization for UAC contracts

--- a/stoa-gateway/Dockerfile
+++ b/stoa-gateway/Dockerfile
@@ -72,7 +72,7 @@ RUN cargo build --release --features "${FEATURES}" && strip target/release/stoa-
 # --- Stage 3: Runtime (minimal) -----------------------------------------------
 FROM debian:bookworm-slim AS runtime
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
       ca-certificates \
       libssl3 \
       curl \


### PR DESCRIPTION
## Summary
- update vulnerable NPM transitive packages via scoped overrides in root, portal, e2e, and shared lockfiles
- harden the stoa-gateway runtime image package refresh path for Debian OS CVEs
- move gateway JWT validation away from RustCrypto rsa and update regorus to remove default RustSec findings

## Verification
- npm audit (root): found 0 vulnerabilities
- npm audit (portal): found 0 vulnerabilities
- npm audit (e2e): found 0 vulnerabilities
- npm audit (shared): found 0 vulnerabilities
- npm run build (portal): passed after shared npm ci, matching CI setup
- npm run bddgen (e2e): passed with existing playwright-bdd warning
- cargo check: passed
- cargo fmt --check: passed
- cargo clippy --all-targets -- -D warnings: passed
- cargo test: 2328 unit tests + integration/contract/security suites passed

## Residual risk
- local Docker/Trivy scan could not run because Docker daemon is unavailable locally; GitHub Security Scan should validate the image change
- cargo audit still reports RUSTSEC-2024-0437 through optional pingora/protobuf, plus unmaintained pingora transitives daemonize/derivative; fixing that requires a separate pingora dependency decision or feature removal
