### PR TITLE
feat(api): add CAB-2227 audit emit endpoint

### DIFF
--- a/control-plane-api/alembic/versions/108_audit_emit_idempotency.py
+++ b/control-plane-api/alembic/versions/108_audit_emit_idempotency.py
@@ -1,0 +1,23 @@
+"""Add audit emit idempotency store (CAB-2227)."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "108_audit_emit_idempotency"
+down_revision = "107_audit_immutability_pseudonymization"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audit_emit_idempotency",
+        sa.Column("key", sa.String(length=255), nullable=False),
+        sa.Column("event_id", sa.String(length=36), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.PrimaryKeyConstraint("key"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("audit_emit_idempotency")

--- a/control-plane-api/src/auth/internal_hmac.py
+++ b/control-plane-api/src/auth/internal_hmac.py
@@ -1,0 +1,43 @@
+import hashlib
+import hmac
+import time
+
+from fastapi import Header, HTTPException, Request, status
+
+from src.config import settings
+
+_AUTH_SCHEME = "HMAC-SHA256 "
+_REPLAY_WINDOW_SECONDS = 300
+
+
+def _shared_secret() -> str:
+    secret = settings.INTERNAL_AUDIT_HMAC_SECRET
+    if hasattr(secret, "get_secret_value"):
+        return str(secret.get_secret_value())
+    return str(secret)
+
+
+async def verify_internal_hmac(
+    request: Request,
+    authorization: str | None = Header(None, alias="Authorization"),
+    x_timestamp: str | None = Header(None, alias="X-Timestamp"),
+) -> None:
+    if not authorization or not authorization.startswith(_AUTH_SCHEME) or not x_timestamp:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid internal signature")
+
+    try:
+        timestamp = int(x_timestamp)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid internal signature") from exc
+
+    if abs(int(time.time()) - timestamp) > _REPLAY_WINDOW_SECONDS:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid internal signature")
+
+    body = await request.body()
+    body_hash = hashlib.sha256(body).hexdigest()
+    signing_string = f"{timestamp}\n{request.method.upper()}\n{request.url.path}\n{body_hash}"
+    expected = hmac.new(_shared_secret().encode("utf-8"), signing_string.encode("utf-8"), hashlib.sha256).hexdigest()
+    supplied = authorization.removeprefix(_AUTH_SCHEME).strip()
+
+    if not hmac.compare_digest(expected, supplied):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid internal signature")

--- a/control-plane-api/src/config.py
+++ b/control-plane-api/src/config.py
@@ -477,6 +477,11 @@ class Settings(BaseSettings):
     # Gateway Auto-Registration (ADR-028)
     # Comma-separated list of valid API keys for gateway self-registration
     GATEWAY_API_KEYS: str = ""
+    INTERNAL_AUDIT_HMAC_SECRET: SecretStr = Field(
+        default=SecretStr("REPLACE_FROM_VAULT"),
+        exclude=True,
+        description="Shared HMAC secret for /v1/internal/audit/emit; sourced from Vault in deployed envs.",
+    )
     # Heartbeat timeout in seconds (gateway marked OFFLINE after this)
     GATEWAY_HEARTBEAT_TIMEOUT_SECONDS: int = 90
     # Health check interval in seconds (how often to check for stale gateways)

--- a/control-plane-api/src/main.py
+++ b/control-plane-api/src/main.py
@@ -44,6 +44,7 @@ from .routers import (
     applications,
     argocd_admin,
     audit,
+    audit_internal,
     backend_apis,
     billing,
     billing_internal,
@@ -909,6 +910,8 @@ app.include_router(gateway_internal.router)
 app.include_router(telemetry_router)
 # Internal billing API for gateway budget enforcement (CAB-1457)
 app.include_router(billing_internal.router)
+# Internal gateway audit emit API (CAB-2227)
+app.include_router(audit_internal.router)
 # Billing CRUD API for tenant admins (CAB-1458)
 app.include_router(billing.router)
 

--- a/control-plane-api/src/models/audit_emit_idempotency.py
+++ b/control-plane-api/src/models/audit_emit_idempotency.py
@@ -1,0 +1,16 @@
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..database import Base
+
+
+class AuditEmitIdempotency(Base):
+    __tablename__ = "audit_emit_idempotency"
+
+    key: Mapped[str] = mapped_column(String(255), primary_key=True)
+    event_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )

--- a/control-plane-api/src/routers/audit_internal.py
+++ b/control-plane-api/src/routers/audit_internal.py
@@ -1,0 +1,85 @@
+from datetime import UTC, datetime
+from typing import Any, Literal
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
+from pydantic import BaseModel, ConfigDict, field_validator
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.auth.internal_hmac import verify_internal_hmac
+from src.database import get_db
+from src.models.audit_emit_idempotency import AuditEmitIdempotency
+from src.services.audit_service import AuditService
+
+router = APIRouter(prefix="/v1/internal", tags=["Internal - Audit"])
+
+
+class AuditEmitRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: Literal["stoa-gateway"]
+    event_type: Literal["TOOL_CALL_DECISION"]
+    decision: Literal["allow", "deny"]
+    reason: str
+    tenant_id: UUID
+    actor_id: UUID | None
+    session_id: str | None
+    resource_type: Literal["mcp_tool"]
+    resource_id: str
+    tool_call_id: UUID
+    approval_id: UUID | None
+    policy_version: str | None
+    correlation_id: UUID
+    occurred_at: datetime
+    details: dict[str, Any]
+
+    @field_validator("occurred_at")
+    @classmethod
+    def occurred_at_must_be_utc(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() != UTC.utcoffset(value):
+            raise ValueError("occurred_at must be ISO8601 UTC")
+        return value
+
+
+@router.post("/audit/emit", status_code=status.HTTP_202_ACCEPTED, dependencies=[Depends(verify_internal_hmac)])
+async def emit_audit_event(
+    payload: AuditEmitRequest,
+    idempotency_key: str = Header(..., alias="Idempotency-Key"),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    event_id = str(uuid4())
+    stmt = insert(AuditEmitIdempotency).values(key=idempotency_key, event_id=event_id)
+    result = await db.execute(stmt.on_conflict_do_nothing(index_elements=[AuditEmitIdempotency.key]))
+    if result.rowcount == 0:
+        return Response(status_code=status.HTTP_202_ACCEPTED)
+
+    audit_details: dict[str, Any] = {
+        "reason": payload.reason,
+        "tool_call_id": str(payload.tool_call_id),
+        "approval_id": str(payload.approval_id) if payload.approval_id else None,
+        "policy_version": payload.policy_version,
+        "source": payload.source,
+        "decision": payload.decision,
+        "session_id": payload.session_id,
+        "gateway_details": payload.details,
+    }
+    event = await AuditService(db).record_event(
+        tenant_id=str(payload.tenant_id),
+        action=payload.event_type.lower(),
+        method="POST",
+        path="/v1/internal/audit/emit",
+        resource_type=payload.resource_type,
+        resource_id=payload.resource_id,
+        actor_id=str(payload.actor_id) if payload.actor_id else None,
+        actor_type="service",
+        outcome="failure" if payload.decision == "deny" else "success",
+        status_code=status.HTTP_202_ACCEPTED,
+        correlation_id=str(payload.correlation_id),
+        details=audit_details,
+        event_id=event_id,
+        created_at=payload.occurred_at,
+    )
+    if event is None:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to record audit event")
+    return Response(status_code=status.HTTP_202_ACCEPTED)

--- a/control-plane-api/tests/test_regression_cab_2227_audit_emit.py
+++ b/control-plane-api/tests/test_regression_cab_2227_audit_emit.py
@@ -1,0 +1,124 @@
+import hashlib
+import hmac
+import json
+import time
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import func, select
+
+from src.config import settings
+from src.database import get_db
+from src.main import app
+from src.models.audit_event import AuditEvent
+
+PATH = "/v1/internal/audit/emit"
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+def _payload(tenant_id: str | None = None) -> dict[str, object]:
+    return {
+        "source": "stoa-gateway",
+        "event_type": "TOOL_CALL_DECISION",
+        "decision": "deny",
+        "reason": "approval_required",
+        "tenant_id": tenant_id or str(uuid4()),
+        "actor_id": str(uuid4()),
+        "session_id": "sess-1",
+        "resource_type": "mcp_tool",
+        "resource_id": "customer_get_customer",
+        "tool_call_id": str(uuid4()),
+        "approval_id": None,
+        "policy_version": "v2026-05-18",
+        "correlation_id": str(uuid4()),
+        "occurred_at": datetime(2026, 5, 18, 10, 0, tzinfo=UTC).isoformat().replace("+00:00", "Z"),
+        "details": {"side_effects": "read"},
+    }
+
+
+def _body(payload: dict[str, object]) -> bytes:
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+
+
+def _headers(body: bytes, key: str = "idem-1", timestamp: int | None = None, bad: bool = False) -> dict[str, str]:
+    ts = int(time.time()) if timestamp is None else timestamp
+    signing_string = f"{ts}\nPOST\n{PATH}\n{hashlib.sha256(body).hexdigest()}"
+    secret = settings.INTERNAL_AUDIT_HMAC_SECRET.get_secret_value().encode()
+    signature = hmac.new(secret, signing_string.encode(), hashlib.sha256).hexdigest()
+    return {
+        "Authorization": f"HMAC-SHA256 {'0' * 64 if bad else signature}",
+        "X-Timestamp": str(ts),
+        "Idempotency-Key": key,
+        "Content-Type": "application/json",
+    }
+
+
+async def _post(client: AsyncClient, payload: dict[str, object], **header_kwargs: object):
+    body = _body(payload)
+    return await client.post(PATH, content=body, headers=_headers(body, **header_kwargs))
+
+
+@pytest.fixture
+async def audit_emit_client(integration_db):
+    async def override_db():
+        yield integration_db
+
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            yield client
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+
+async def test_regression_cab_2227_audit_emit_records_deny_event(audit_emit_client, integration_db) -> None:
+    payload = _payload()
+
+    response = await _post(audit_emit_client, payload)
+
+    assert response.status_code == 202
+    event = await integration_db.scalar(select(AuditEvent).where(AuditEvent.tenant_id == payload["tenant_id"]))
+    assert event is not None
+    assert event.action == "tool_call_decision"
+    assert event.outcome == "failure"
+    assert event.actor_type == "service"
+
+
+async def test_regression_cab_2227_audit_emit_rejects_bad_hmac(audit_emit_client) -> None:
+    response = await _post(audit_emit_client, _payload(), bad=True)
+
+    assert response.status_code == 401
+
+
+async def test_regression_cab_2227_audit_emit_rejects_stale_timestamp(audit_emit_client) -> None:
+    response = await _post(audit_emit_client, _payload(), timestamp=int(time.time()) - 301)
+
+    assert response.status_code == 401
+
+
+async def test_regression_cab_2227_audit_emit_is_idempotent(audit_emit_client, integration_db) -> None:
+    tenant_id = str(uuid4())
+    payload = _payload(tenant_id)
+
+    first = await _post(audit_emit_client, payload, key="repeat-key")
+    second = await _post(audit_emit_client, payload, key="repeat-key")
+
+    assert first.status_code == 202
+    assert second.status_code == 202
+    count = await integration_db.scalar(
+        select(func.count()).select_from(AuditEvent).where(AuditEvent.tenant_id == tenant_id)
+    )
+    assert count == 1
+
+
+async def test_regression_cab_2227_audit_emit_validates_payload(audit_emit_client) -> None:
+    payload = _payload()
+    del payload["reason"]
+
+    response = await _post(audit_emit_client, payload)
+
+    assert response.status_code == 422


### PR DESCRIPTION
Linear: [CAB-2227]

## Summary
- Adds `POST /v1/internal/audit/emit` for stoa-gateway audit decisions.
- Authenticates with ADR-070 HMAC-SHA256 over timestamp, method, path, and body hash.
- Adds `audit_emit_idempotency` to atomically suppress duplicate gateway retries.

## Important auth note
This introduces a second inter-service auth scheme beside existing `X-Gateway-Key` internal routes. This is intentional per ADR-070 for tamper-evident audit delivery; operator follow-up may reconcile the schemes later.

## Frozen request schema
`source=stoa-gateway`, `event_type=TOOL_CALL_DECISION`, `decision=allow|deny`, `reason`, `tenant_id`, `actor_id|null`, `session_id|null`, `resource_type=mcp_tool`, `resource_id`, `tool_call_id`, `approval_id|null`, `policy_version|null`, `correlation_id`, `occurred_at` ISO8601 UTC, `details` object. Extra fields are rejected.

## HMAC signing string
`f"{timestamp}\n{method}\n{path}\n{sha256(body)}"` signed as HMAC-SHA256 with `INTERNAL_AUDIT_HMAC_SECRET`. Headers: `Authorization: HMAC-SHA256 <hex>`, `X-Timestamp: <unix>`. Replay window: 300 seconds.

## Idempotency semantics
`Idempotency-Key` is required. First accepted key inserts `audit_emit_idempotency(key,event_id)` and records one audit event in the same transaction. Duplicate key returns `202 Accepted` without recording another audit event.

## Validation
- `ruff check src/config.py src/main.py src/auth/internal_hmac.py src/routers/audit_internal.py src/models/audit_emit_idempotency.py tests/test_regression_cab_2227_audit_emit.py alembic/versions/108_audit_emit_idempotency.py`
- `black --check src/config.py src/main.py src/auth/internal_hmac.py src/routers/audit_internal.py src/models/audit_emit_idempotency.py tests/test_regression_cab_2227_audit_emit.py alembic/versions/108_audit_emit_idempotency.py`
- `mypy --follow-imports=skip src/auth/internal_hmac.py src/routers/audit_internal.py src/models/audit_emit_idempotency.py`
- `pytest tests/test_regression_cab_2227_audit_emit.py -q` (skipped: `DATABASE_URL` not set)
- `alembic -c alembic.ini heads` -> `108_audit_emit_idempotency (head)`

## Local blockers
Real async DB regression execution and cp-api coverage gate could not run here because `DATABASE_URL` is unset, localhost PostgreSQL refused connections, and Docker daemon is unavailable.