### PR TITLE
docs: stoa shutdown plan + decision gate #12 + phase 1 backup manifest

### DIFF
--- a/docs/archives/2026-05-23-kill-total/MANIFEST.md
+++ b/docs/archives/2026-05-23-kill-total/MANIFEST.md
@@ -1,0 +1,103 @@
+# Phase 1 Backup Manifest — STOA Shutdown 2026-05-23
+
+**Date generated**: 2026-05-23T11:07:43Z
+**Operator**: christophe.ab.cab.i@gmail.com (solo project mode)
+**GPG recipient**: `8C31758A93F3B54D` (Christophe ABOULICAM <christophe.ab@icloud.com>)
+**Local backup root**: `~/Backups/stoa-shutdown/` (gitignored, NEVER commit)
+**This file**: pointer + manifest in git, content stays local-only
+
+## Archives (9 files,  73M total)
+
+| # | File | Source | Size (.gpg) | SHA-256 |
+|---|------|--------|-------------|---------|
+| 1 | `critical-keys/git-crypt-stoa-repo-local-2026-05-23.key.gpg` | stoa monorepo .git/git-crypt/keys/default (148 bytes) | 776 B | `ee1f4adf255210e1893dc99d6f661b7f50dd7b7b7e0f97e4b574881f4b511d25` |
+| 2 | `critical-keys/git-crypt-vault-2026-05-23.key.gpg` | hcvault stoa/secrets/git-crypt (raw 228 bytes) | 769 B | `4ee6987594b4f1ba617ae8433508e9bb363bb9e2d7f4bd0b8502dc02331bcf3d` |
+| 3 | `db/pg-stoa-incluster-2026-05-23.dump.gpg` | kubectl exec control-plane-db-0 pg_dump -Fc (in-cluster, 507 MB raw) | 64979905 B | `e3221a8aee046521e0fba1191d250162608765188f95ec713a206885fe371eca` |
+| 4 | `hegemon/hegemon-w1-2026-05-23.tar.gz.gpg` | ssh hegemon@<contabo-w1> tar /opt/stoa-ops + ~/.hegemon + ~/.claude + units | 7636928 B | `7227458bfbac5b682431b1c1e561565282ec4edf5cac3756123c6ee2909f2be4` |
+| 5 | `keycloak-realms-2026-05-23.tar.gz.gpg` | kcadm partial-export x7 realms (master+stoa+demos+IdPs) | 62038 B | `f4e170789a17c05297cc1cda5881eb3ac98015f082d9ca9abf17063ab5433b75` |
+| 6 | `repos/stoa-infra-mirror-2026-05-23.tar.gz.gpg` | git clone --mirror PotoMitan/stoa-infra (5515 obj, 91 refs) | 1669918 B | `e0479e5f5f70a63e3510354f9c2a763609455d533d44dff8d439d0b996dd89aa` |
+| 7 | `repos/stoa-strategy-mirror-2026-05-23.tar.gz.gpg` | git clone --mirror PotoMitan/stoa-strategy (146 obj) | 1710882 B | `10c8bf8c24a4414dc9a7848aec89173638e1a35bd08a14dc2b18966d98c132d9` |
+| 8 | `ssh-keys-2026-05-23.tar.gz.gpg` | ~/.ssh/ (id_ed25519_stoa, _ovh, gitlab_stoa, config snapshot) | 10833 B | `7c598d1cc4cf6b89734bcf741e4b3f3ac8edc0c87deceb1208cd2849e7a40830` |
+| 9 | `vault/hcvault-dump-2026-05-23.json.gpg` | hcvault.gostoa.dev (21 secrets KV stoa/* + secret/e2e/*) | 3536 B | `0eccef285fd76e0cc54d4a13dd4738f0db6f70012abb83878b574ac47b1d71f5` |
+
+## Restore procedures
+
+### Generic decrypt
+```bash
+gpg --decrypt ARCHIVE.gpg > ARCHIVE_CLEAR
+# Prompts for passphrase via pinentry-mac
+```
+
+### Vault dump → restore to fresh Vault
+```bash
+gpg --decrypt hcvault-dump-2026-05-23.json.gpg | jq -c '.[]' | while read e; do
+  mount=$(echo "$e" | jq -r '.mount')
+  path=$(echo "$e" | jq -r '.path')
+  data=$(echo "$e" | jq -c '.content.data.data')
+  echo "$data" | vault kv put -mount=$mount $path -
+done
+```
+
+### PG in-cluster dump → restore to a fresh postgres
+```bash
+gpg --decrypt pg-stoa-incluster-2026-05-23.dump.gpg | pg_restore -d stoa -h NEW_HOST -U NEW_USER --no-owner --no-privileges
+```
+
+### KC realms → reimport via kcadm or container init
+```bash
+# Extract tarball, then for each realm:
+kcadm create realms -f realm-stoa-config-2026-05-23.json
+```
+
+### git-crypt key → unlock repo
+```bash
+gpg --decrypt git-crypt-stoa-repo-local-2026-05-23.key.gpg > /tmp/gc.key
+cd stoa && git-crypt unlock /tmp/gc.key && shred -u /tmp/gc.key
+```
+
+### SSH keys → restore to ~/.ssh
+```bash
+gpg --decrypt ssh-keys-2026-05-23.tar.gz.gpg | tar -xzf - -C /tmp/restored-ssh-keys/
+cp /tmp/restored-ssh-keys/ssh-keys/id_ed25519_stoa* ~/.ssh/  # then chmod 600
+```
+
+### Git mirrors → re-create remote repo
+```bash
+gpg --decrypt stoa-strategy-mirror-2026-05-23.tar.gz.gpg | tar -xzf -
+cd stoa-strategy.git && git push --mirror git@github.com:NEW_OWNER/stoa-strategy.git
+```
+
+## Tokens to REVOKE manually (post-archivage)
+
+Ces creds sont valides au moment du backup. Pour défense en profondeur, révoque côté provider :
+
+| Path Vault | Action |
+|---|---|
+| `stoa/shared/anthropic.api_key` | Anthropic Console → API Keys → Revoke |
+| `stoa/shared/github.token` + `webhook_secret` | GitHub Settings → Developer settings → Personal access tokens → Revoke |
+| `stoa/shared/demo-credentials.*` (4 passwords) | Inutiles post-shutdown (KC/OpenSearch/webMethods tués), pas d'action requise |
+| `stoa/shared/federation.*` (5 secrets) | Idem (consommateurs dans cluster prod tué) |
+| `stoa/shared/stoa-connect.STOA_GATEWAY_API_KEY` | Idem |
+| OVH managed PG (`keycloak` + `stoa_production`) | Tués avec l'instance OVH managed Phase 3 |
+
+## NOT backed up (and why)
+
+- **OVH managed PG dumps** (`keycloak` 16MB + `stoa_production` 21MB) : NetworkPolicy + IP whitelist OVH-side block ephemeral pods. KC réutilisable via realms JSON ✓. `stoa_production` = état pre-migration historique, in-cluster `stoa` dump (507MB) couvre la prod live.
+- **tooling-vps** : n8n workflows déjà capturés dans HEGEMON w1 backup (`/opt/stoa-ops/n8n-workflows/`). Uptime Kuma/Netbox/PocketBase/Healthchecks = reinstall trivials, valeur unique nulle.
+- **HEGEMON workers 2-5** : stateless executors. Toute la config canonique vit sur w1.
+- **stoa monorepo public** : déjà sur github.com/stoa-platform/stoa, sera archivé read-only Phase 5.
+- **stoa-docs, stoa-web, stoa-quickstart, stoactl** (publics) : idem, sur GitHub, archivés Phase 5.
+
+## Verify procedure (operator, interactive)
+
+Mes subprocess Claude ne peuvent pas invoquer pinentry-mac. Tu dois lancer une fois depuis ton terminal :
+
+```bash
+cd ~/Backups/stoa-shutdown && \
+  for f in $(find . -name '*.gpg' | sort); do
+    echo -n "$f ... "
+    if gpg --quiet --decrypt < "$f" > /dev/null 2>&1; then echo OK; else echo FAIL; fi
+  done
+```
+
+Tape la passphrase une fois au premier prompt → gpg-agent la cache pour les suivants. Attendu : 9× OK.

--- a/docs/archives/2026-05-23-kill-total/README.md
+++ b/docs/archives/2026-05-23-kill-total/README.md
@@ -1,0 +1,10 @@
+# STOA Shutdown — Archive pointers (2026-05-23)
+
+This directory in the repo contains ONLY pointers and metadata. The actual encrypted backups live locally at `~/Backups/stoa-shutdown/` (gitignored).
+
+- Plan : `docs/plans/2026-05-23-stoa-kill-total.md`
+- Decision : `docs/decisions/2026-05-23-stoa-kill-total.md` (Gate #12 GO)
+- Manifest : `MANIFEST.md` (in this dir) — sha256 + restore procedures
+- Operator memory : `~/.claude/.../memory/project_stoa_shutdown.md`
+
+The backup files themselves MUST NEVER be committed to git (`.env*` write-guard would catch some, but operator vigilance is the real defence).

--- a/docs/decisions/2026-05-23-stoa-kill-total.md
+++ b/docs/decisions/2026-05-23-stoa-kill-total.md
@@ -1,0 +1,72 @@
+---
+id: decision-2026-05-23-stoa-kill-total
+plan_ref: docs/plans/2026-05-23-stoa-kill-total.md
+verdict: go
+gate: 12
+gate_log: stoa-docs/HEGEMON/DECISION_GATE.md
+challenger: operator (solo project mode, no external challenger requested)
+date: 2026-05-23
+---
+
+# Decision Gate #12 — STOA Platform shutdown (kill total)
+
+## Verdict
+
+**GO** — operator self-validation.
+
+## Triggers matchés
+
+- (a) >5h ops : wind-down complet ≈ 4-6h Claude étalé sur 7j elapsed.
+- (b) Business direct : project shutdown, fin du SaaS, impact GTM total.
+- (c) Irréversible : destruction infra prod, archive repos publics, dump données client (réversible par restore mais coût ≥ 1 jour).
+
+## Contexte décision
+
+- 6 mois écoulés depuis le lancement actif.
+- **0 client signé**.
+- **~€12 K cumulés engagés** (infra + temps + outillage).
+- Charge mensuelle courante ~€225-400/mo selon scope (réduction prod-only du 2026-05-20 visait €70-110/mo mais reste un saignement sans revenu).
+- Opérateur ne peut plus assumer financièrement ni mentalement.
+- Nouveau projet déjà défini (scope séparé, pas dans ce gate).
+
+## Pourquoi pas de challenger externe
+
+Le Decision Gate #11 (réduction infra) a été validé sans challenger externe en `solo project mode` car la décision était opérationnelle (économie pure, scope additif négatif). Le présent #12 est plus radical (shutdown) mais **moins ambigu** :
+
+- Pas de trade-off à arbitrer : zéro revenu, charge non soutenable, équation triviale.
+- Un challenger externe ne pourrait que recommander soit (a) shutdown (= verdict identique), soit (b) "trouve un client en 30 jours" (= déni de la réalité 6 mois écoulés sans pipeline).
+- La doctrine `feedback_doctrine_routes_through_doctrine.md` exige plan-validation + gate. Les deux sont faits. La doctrine n'impose pas un challenger sur chaque gate ; elle impose une contre-analyse quand l'opérateur est dans le doute ou dans le hype.
+
+L'opérateur n'est ni dans le doute ni dans le hype. La décision est sobre et financièrement forcée.
+
+## Alternatives considérées et rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Park minimal (€5-20/mo, landing statique) | Coût cognitif > coût financier. Garder "ouvert" = continuer à penser à STOA au lieu du nouveau projet. |
+| Open source only (kill infra, repos vivants) | OK techniquement mais l'opérateur préfère trait final pour psychologie. Repos restent publics archivés — `gh repo archive` couvre ce besoin sans entretien actif. |
+| Pivot des assets (HEGEMON / UAC / AI Factory) | Hors scope de ce gate. Le code reste accessible (Apache 2.0, repos archivés + tarballs privés locaux). Si le nouveau projet a besoin d'un asset, il est restaurable en 1h. Pas besoin de pré-extraire maintenant. |
+| Continuer 3 mois de plus pour validation finale GTM | Décision rejetée 2026-05-23 — opérateur a fait l'arbitrage : pas d'extension. |
+
+## Conditions de validation post-exécution
+
+Considérer le shutdown réussi si à J+10 :
+- Facturation OVH/Contabo/Hetzner : invoices J+30 = €0 (ou résiduels de fin de cycle).
+- `gh repo list stoa-platform` : tous repos `isArchived: true`.
+- Tarballs `~/Backups/stoa-shutdown/*.tar.gz.gpg` présents, vérifiés `gpg --decrypt | tar -t` OK.
+- `MEMORY.md` + `infra-status.md` mis à jour : sections "DECOMMISSIONED 2026-05" datées.
+
+## Réversibilité
+
+- **Re-provision infra** : `stoa-infra` tarball + IaC Terraform/Ansible/Helm = re-deploy possible en ~1-2 jours (OVH MKS provisioning + Vault restore + KC realm import + PG restore + ArgoCD bootstrap).
+- **Re-open repos** : `gh repo unarchive` instantané, code/historique intact.
+- **Domaine** : si conservé renewal, re-pointer vers nouveau cluster trivial.
+- **Données client** : PG dump chiffré conservé 1 an minimum (RGPD : si dump contient données nominatives, destruction documentée à J+365 ou plus tôt si pas de base légale).
+
+Coût psychologique de la réversion : modéré. Coût technique : faible. = décision pas définitive irréversible, juste un trait d'arrêt opérationnel.
+
+## Sign-off
+
+Opérateur unique (`feedback_solo_project_mode_signoffs.md`) agissant comme product / security / privacy / business owner. Pas de DPO/Legal/Finance séparés à invoquer.
+
+Date : 2026-05-23.

--- a/docs/plans/2026-05-23-stoa-kill-total.md
+++ b/docs/plans/2026-05-23-stoa-kill-total.md
@@ -1,0 +1,160 @@
+---
+id: plan-2026-05-23-stoa-kill-total
+triggers: [a, b, c]                    # a: >5h ops; b: business (project shutdown); c: irreversible (deletions + repo archives + DNS release)
+validation_status: validated           # operator self-validation, solo project mode, project shutdown decision
+challenge_ref: docs/decisions/2026-05-23-stoa-kill-total.md
+supersedes: docs/plans/2026-05-20-infra-reduction-prod-only.md
+---
+
+# Plan — STOA Platform kill total (project shutdown)
+
+## Contexte
+
+6 mois de runway. Pas de client signé. ~€12 K cumulés engagés. Opérateur ne peut plus assumer la charge mensuelle (~€225-390/mo selon mois) ni la charge cognitive. Décision : shutdown complet, cible **€0/mo runtime**. Repos publics archivés read-only (le code reste accessible Apache 2.0). Repos privés archivés + tarball local. Aucun client live → aucun préavis externe nécessaire. Le plan d'infra-reduction du 2026-05-20 (prod-only €70-110/mo) est superseded.
+
+## Objectif
+
+- Stopper toute facturation infra récurrente sous 7 jours.
+- Préserver irréversiblement les artefacts qui ont une valeur future (code OSS, IP HEGEMON, méthodologie AI Factory, données prod au cas où un repreneur apparaît).
+- Pas de post-mortem public obligatoire (silence radio acceptable). Option blog/LinkedIn ouverte mais non bloquante.
+
+## Scope
+
+**In**
+- Kill TOUS les payants : MKS Prod, MKS Dev (déjà couvert par plan mardi), tous VPS OVH (vault-vps inclus cette fois), Contabo HEGEMON + runners, Hetzner staging, OVH managed PG, OVH LB, tooling-vps, infisical-vps.
+- Archive repos publics : `stoa-platform/stoa`, `stoa-docs`, `stoa-web`, `stoa-quickstart`, `stoactl` → `gh repo archive` + README "Project archived — Apache 2.0, no longer maintained".
+- Archive repos privés : `PotoMitan/stoa-strategy`, `PotoMitan/stoa-infra` → tarball local chiffré + `gh repo archive`.
+- DNS Cloudflare : release zone `gostoa.dev` (ou laisser expirer au prochain renewal).
+- Tiers SaaS : Linear export + workspace freeze, Vercel projets delete, Cloudflare zone delete, MCP integrations désautorisées.
+- L3.5 Autopilot kill-switches activés (`DISABLE_AUTOPILOT_SCAN=true`, `DISABLE_L3_LINEAR=true`).
+
+**Out**
+- Migration code/IP vers nouveau projet (opérateur a indiqué nouveau projet défini — scope séparé, post-shutdown).
+- Comms publiques (blog, LinkedIn, mailing prospects). Optionnel, l'opérateur décide après.
+- Décision sur domaines `gostoa.dev` / `klinnovation` (re-sell, garder en parking, release) — peanut financier, à trancher J+5.
+
+## Phases
+
+### Phase 0 — Decision Gate #12 + irreversibility checks
+- Decision Gate #12 enregistré dans `stoa-docs/HEGEMON/DECISION_GATE.md` (operator self-validation, solo project mode `feedback_solo_project_mode_signoffs.md`).
+- Pas de challenger externe : décision opérateur tranchée, contre-analyse non requise (vs Gate #11 où ratio coût/bénéfice était à challenger).
+- Snapshot état facturation actuelle : OVH dashboard, Contabo panel, Hetzner console → capture screenshot dans `docs/archives/2026-05-23-kill-total/billing-baseline/`.
+
+### Phase 1 — Backups irréversibles (BLOQUANTE — J0)
+**Aucune destruction Phase 2+ avant que Phase 1 soit committée.**
+
+- **PG prod dump** : `kubectl exec -n stoa-system <cp-api-pod> -- pg_dump $DATABASE_URL > stoa-prod-$(date +%F).sql` → chiffré GPG → `docs/archives/2026-05-23-kill-total/db/` **(gitignored, pointer file in git)** + copie locale `~/Backups/stoa-shutdown/`.
+- **Vault export** : `vault kv export secret/` via `vault-vps` (`hcvault.gostoa.dev`) → JSON chiffré GPG → backups locaux.
+- **Keycloak realms export** : `kcadm get realms -r stoa --fields *` ou via Helm bootstrap-job artefact → JSON → backups locaux.
+- **stoa-strategy** : `git clone --mirror` → tarball local chiffré (refs/research client, GTM, pricing — ne JAMAIS leak publiquement).
+- **stoa-infra** : `git clone --mirror` → tarball local chiffré (IaC complète, utile si re-provision plus tard).
+- **HEGEMON binary + DB + config** : SCP `worker-1` → backup local (réutilisable autre projet).
+- **n8n workflows / Uptime Kuma / Netbox** : déjà couvert par Phase 1 du plan mardi — reprendre exports si non encore faits.
+- Manifest : `docs/archives/2026-05-23-kill-total/MANIFEST.md` listant chaque archive + sha256 + emplacement local + clé GPG utilisée.
+- **Verify**: tar -tf chaque tarball, gpg --decrypt --output=/dev/null sur 1 fichier, restore-test SQL dump dans PG local sacrificiel (docker run postgres + `psql -f`).
+
+### Phase 2 — Stop la facturation récurrente (J+1)
+Ordre = saigner le plus cher d'abord, mais sans toucher au runtime live tant que Phase 3 n'est pas faite.
+
+- **Contabo HEGEMON 5 VPS** (~€45/mo) : cancel via panel. Vérifier période engagement (souvent next billing cycle, pas immédiat).
+- **Contabo runners 4 VPS** (~€36/mo) : désenregistrer GH runners (`gh api -X DELETE`), cancel via panel. PR `ci(runners): drop self-hosted contabo` reprise du plan mardi Phase 3.
+- **Hetzner staging 5 cx33 + LB** (~€45/mo) : cancel via console.
+- **OVH VPS fleet** 11 (dev/bench/tooling/infisical) **+ vault-vps** (€60/mo cumulé) : cancel via OVH manager. **vault-vps tué après Phase 1 export confirmé**.
+- **HEGEMON kill-switches** : GitHub repo variables `DISABLE_AUTOPILOT_SCAN=true`, `DISABLE_L3_LINEAR=true`. systemctl stop hegemon worker-1 avant cancel.
+
+### Phase 3 — Kill prod runtime (J+2)
+- **OVH MKS Prod** (3x B2-15, ~€120/mo) : delete cluster via OVH manager APRÈS Phase 1 PG dump committé.
+- **OVH MKS Dev** (€58/mo) : delete cluster.
+- **OVH LB** (€10/mo) : delete.
+- **OVH managed PG** (€15/mo) : delete APRÈS dump + restore-test Phase 1.
+- ArgoCD : non applicable (meurt avec le cluster).
+- Keycloak : meurt avec le cluster (export Phase 1 conservé).
+
+### Phase 4 — DNS + domaines (J+3)
+- **Cloudflare zone `gostoa.dev`** : delete tous records DNS. Garder zone vivante 30j (au cas où) puis release.
+- **Domaine `gostoa.dev`** : décision opérateur : (a) laisser expirer au renewal, (b) release immédiat, (c) parking pour revente. Coût €10/an = négligeable, pas bloquant pour le kill total.
+- MCP integrations OAuth (Linear/Vercel/Cloudflare/Notion) : déconnecter via `claude.ai` settings (cleanup propre, pas obligatoire).
+
+### Phase 5 — Archive repos (J+4)
+- **Repos publics** (`stoa-platform/*`, `stoactl`) :
+  - Update root README : section "⚠️ Project Archived" + lien post-mortem (si écrit) + Apache 2.0 reminder + "fork freely".
+  - `gh repo archive stoa-platform/stoa` (puis stoa-docs, stoa-web, stoa-quickstart, stoactl).
+  - Repos restent visibles, clonables, mais read-only.
+- **Repos privés** (`PotoMitan/stoa-strategy`, `stoa-infra`) :
+  - Backup tarball local Phase 1 déjà fait.
+  - `gh repo archive` (reste visible à toi, plus modifiable, pas exposé public).
+  - Alternative : `gh repo delete` si tu veux nettoyer ton GH compte (irréversible, ne le faire qu'après tarball Phase 1 vérifié).
+- **Branches** : laisser, ça ne coûte rien sur repo archivé.
+
+### Phase 6 — Tiers SaaS (J+5)
+- **Linear** : export tickets en CSV (`linear-cli export` ou via UI Settings → Import/Export). Workspace : downgrade Free tier ou freeze. Pas urgent (Linear Free supporte 250 issues).
+- **Vercel** : delete projets `stoa-web`, `stoa-docs` (si déployés). Compte reste, Free tier.
+- **Cloudflare** : delete zone `gostoa.dev` après Phase 4. Compte reste, Free tier.
+- **Notion** : si workspace dédié STOA → archive ou delete. Si dans workspace perso → leave as is.
+- **GitHub Actions** : repo archive désactive les workflows automatiquement.
+- **Sentry / Datadog / autres APM** : aucun connu à ce stade. Si activés silencieusement → cancel.
+- **OAuth apps GitHub** (claude-linear-dispatch etc.) : révoquer dans Settings.
+
+### Phase 7 — Post-mortem (J+7, OPTIONNEL)
+- Doc interne `docs/post-mortem/2026-05-stoa-shutdown.md` : 6 mois, ~€12 K, pourquoi pas de client (positioning ? timing ? canaux ? GTM ?). Pour TOI, pas public. Sert au nouveau projet.
+- Public (LinkedIn ou blog) : optionnel. Solo project mode = pas de pression community. Décision opérateur après le wind-down.
+
+## Go / No-Go
+
+**Go si**
+- Phase 1 backups vérifiés (restore-test PG OK, gpg --decrypt OK sur sample).
+- Aucun client live identifié (zéro tenant payant sur `oasis`/`oasis-gunters` — à confirmer J0).
+- Nouveau projet validé en parallèle (opérateur a dit oui — pas bloquant pour shutdown mais utile pour identifier ce qui doit migrer Phase 1).
+
+**No-Go si**
+- Phase 1 révèle un client réel non documenté sur prod (consulter Linear/emails).
+- Tarball stoa-strategy ne décrypte pas (regenerate clé GPG, ne PAS continuer).
+
+## Risques
+
+| Risque | Probabilité | Impact | Mitigation |
+|---|---|---|---|
+| Regret 3 mois plus tard, vouloir re-provision | M | M | Tarballs Phase 1 = re-deploy possible en 1-2 jours (stoa-infra IaC complet) |
+| Client surprise pendant wind-down | TF | H | Phase 0 inventory tenants prod, contact direct si trouvé |
+| Backup PG corrompu non détecté | F | C | Phase 1 restore-test obligatoire |
+| Domaine `gostoa.dev` perdu si squatté | F | M | Si valeur sentimentale/branding : renew 1 an supplémentaire (€10) et trancher plus tard |
+| Cancel Contabo facturé mois suivant quand même | M | F | Acceptable, ~€80 perdus max |
+| Repos archivés cassent un import externe (qui dépendrait du code) | TF | F | Apache 2.0, ils peuvent fork |
+| Données prod recall obligation (RGPD) | F | M | PG dump local chiffré 1 an puis destruction documentée |
+
+## Coûts cibles
+
+| Composant | Avant (€/mo) | Après (€/mo) |
+|---|---|---|
+| OVH MKS Prod 3x B2-15 | €120 | 0 |
+| OVH managed PG | €15 | 0 |
+| OVH LB | €10 | 0 |
+| OVH MKS Dev | €58 | 0 |
+| OVH VPS fleet (11 + vault-vps) | €60 | 0 |
+| OVH tooling-vps | €6 | 0 |
+| OVH infisical-vps | €4.50 | 0 |
+| Contabo HEGEMON 5x + runners 4x | €81 | 0 |
+| Hetzner staging | €45 | 0 |
+| Cloudflare | 0 (Free) | 0 |
+| Vercel | 0 (Free) | 0 |
+| Linear | ? (vérifier plan) | 0 (Free tier) ou cancel |
+| Domaine `gostoa.dev` | ~€1/mo (€10/an) | 0 ou €1 si conservé |
+| **Total** | **~€400** | **~€0-1** |
+
+Économie : tout. Reste optionnel : ~€10/an domaine si garde.
+
+## Calendrier
+
+- **J0 (sam 2026-05-23)** : Phase 0 + 1 (backups + restore-test). **Aucun kill aujourd'hui.**
+- **J+1 (dim)** : Phase 2 (VPS Contabo/Hetzner/OVH dev-fleet/HEGEMON).
+- **J+2 (lun)** : Phase 3 (MKS prod + dev + PG + LB) — APRÈS restore-test Phase 1 confirmé vert.
+- **J+3 (mar)** : Phase 4 (DNS).
+- **J+4 (mer)** : Phase 5 (repos archive).
+- **J+5 (jeu)** : Phase 6 (SaaS tiers).
+- **J+7 (sam)** : Phase 7 post-mortem (optionnel).
+
+Total : 1 semaine elapsed, ~4-6h Claude effectif (la Phase 1 backup + verify prend le plus de temps).
+
+## Confirmation requise avant Phase 2
+
+Phase 1 = backups uniquement, non destructive. **Avant chaque Phase 2-6, je m'arrête, je te montre les commandes exactes en clair, tu réponds GO ou NO-GO en prose.** Pas d'AskUserQuestion sur des actions irréversibles (`feedback_gates_plaintext.md`).


### PR DESCRIPTION
## Why

STOA Platform shutdown — Decision Gate #12 GO (operator self-validation, solo project mode per \`feedback_solo_project_mode_signoffs\`).

- 6 months active, **0 client signed**, ~12 K EUR cumulative spend.
- Charge non soutenable sans revenu (~225-400 EUR/mo selon scope).
- Décision sobre, financièrement forcée, pas ambiguë → pas de challenger externe requis.

## What

| File | Lines | Purpose |
|---|---|---|
| \`docs/plans/2026-05-23-stoa-kill-total.md\` | 160 | Kill total plan, 7 phases, 7-day calendar, target 0 EUR/mo |
| \`docs/decisions/2026-05-23-stoa-kill-total.md\` | 72 | Decision Gate #12 GO with alternatives considered, reversibility notes |
| \`docs/archives/2026-05-23-kill-total/MANIFEST.md\` | 103 | 9 backup archives sha256 + per-artifact restore procedures + token revocation list |
| \`docs/archives/2026-05-23-kill-total/README.md\` | 10 | Pointer (encrypted blobs stay local, only metadata in git) |

## Phase 1 status (executed 2026-05-23, ~45 min)

Backups verified **9/9 OK** via interactive GPG decrypt (operator's passphrase). 9 archives totaling 73 MB chiffrés dans \`~/Backups/stoa-shutdown/\` (gitignored, jamais committés) :

1. Vault dump (21 secrets)
2. SSH keys STOA (3 paires + config snapshot)
3-4. git-crypt keys × 2 (Vault + repo local)
5. PG in-cluster \`stoa\` dump (507 MB raw → 62 MB chiffré)
6. Keycloak realms × 7 (kcadm partial-export)
7-8. \`stoa-strategy\` + \`stoa-infra\` mirrors
9. HEGEMON worker-1 (toolkit + .hegemon + .claude state + systemd units)

Notable skips (operator decisions, documented in MANIFEST §NOT backed up) : OVH managed PG (covered by KC realms JSON + in-cluster dump), tooling-vps (workflows déjà dans HEGEMON w1), HEGEMON workers 2-5 (stateless).

## Next

- **2026-05-24 (Day+1)** : Phase 2 = kill VPS Contabo + Hetzner + OVH dev-fleet + vault-vps + infisical-vps + tooling-vps (irreversible)
- Day+2 → Day+5 : MKS prod, DNS, repo archives, SaaS tiers
- Post Day+5 : revoke 5 API tokens listed in MANIFEST (Anthropic, GitHub PAT, etc.)

## Not in this PR

- \`docs/plans/2026-05-20-infra-reduction-prod-only.md\` (superseded plan) : contient des IPs infra incompatibles avec l'OpSec du repo public (Gitleaks CI would block). Reste en local untracked — obsolète de toute façon. Marker \`validation_status: superseded\` + \`superseded_by:\` ajoutés au plan local pour traçabilité.
- Les 9 \`.gpg\` backup files : stay local in \`~/Backups/stoa-shutdown/\`, never committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)