### PR TITLE
fix: reconcile vps-inventory.sh with the real fleet + add drift guard

### DIFF
--- a/scripts/ops/vps-inventory.sh
+++ b/scripts/ops/vps-inventory.sh
@@ -2,39 +2,117 @@
 # =============================================================================
 # STOA Platform — VPS Inventory
 # =============================================================================
-# Source of truth for VPS fleet. All deploy scripts MUST source this file
+# Source of truth for the VPS fleet. All deploy scripts MUST source this file
 # instead of hardcoding IPs and SSH keys.
 #
 # Usage:
 #   source "$(dirname "$0")/vps-inventory.sh"
-#   ssh_to kong-vps "docker ps"
+#   ssh_to worker-3 "docker ps"
 #   for_each_vps "uptime"
+#   vps_verify                      # probe every entry; non-zero exit on drift
+#
+# -----------------------------------------------------------------------------
+# LAST RECONCILED WITH REALITY: 2026-07-27 (every entry probed live).
+#
+# The previous revision claimed to be the source of truth while describing six
+# VPS, none of which matched the running estate, and omitting the five Contabo
+# hosts that actually carry the platform. It also aborted on `source` unless six
+# env vars were set (`${VAR:?}`), which is why nobody noticed it had rotted.
+#
+# Both faults are fixed here: the real fleet is unconditional, everything else is
+# optional and cannot break sourcing. Run `vps_verify` before trusting this file
+# — it exits non-zero when the fleet diverges from what is written below.
 # =============================================================================
 
-# --- SSH Key (per-device, overridable via env) ---
+# --- SSH key (per-device, overridable via env) -------------------------------
 STOA_SSH_KEY="${STOA_SSH_KEY:-$HOME/.ssh/id_ed25519_stoa}"
 
-# --- VPS Fleet ---
-# IPs sourced from env vars — see stoa-infra/docs/carto/dns-inventory.md for values.
-# Set all VPS_*_IP variables before sourcing this file (e.g. from Infisical/Vault).
-# Format: NAME|IP|USER|PURPOSE
+# --- stoa-infra checkout ------------------------------------------------------
+# Consumed by distribute-ssh-key.sh ($STOA_INFRA_DIR/deploy/vps/hegemon/workers.txt).
+# Defined here because nothing else defined it: under `set -u` the consumer
+# aborted on the unbound variable. The workers.txt mechanism is now redundant —
+# the five workers are first-class entries below — but the path stays valid.
+STOA_INFRA_DIR="${STOA_INFRA_DIR:-$HOME/stoa-platform/stoa-infra}"
+
+# =============================================================================
+# Fleet
+# =============================================================================
+# Format: NAME|SSH_DEST|USER|PURPOSE
+#
+# SSH_DEST is an ~/.ssh/config ALIAS, not an IP. Two reasons: no addresses in Git
+# (same intent as the env-var indirection below; the gitleaks allowlist only
+# tolerates IPs under deploy/vps/), and the alias already carries HostName, User
+# and IdentityFile. `ssh user@alias` resolves correctly, so the field stays
+# drop-in compatible with consumers that build "${user}@${ip}".
+
+# --- Contabo — the estate that actually runs the platform --------------------
+# 5 identical VPS: 8 vCPU AMD EPYC, 24 GB RAM, 400 GB SSD, 8 GB swap, Debian 12.
+# Total 40 vCPU / 120 GB / 2 TB. Measured CPU steal: 0 ticks on all five.
+# All five run claude-watchdog.service (HEGEMON agents) and node_exporter.
 VPS_FLEET=(
-  "kong-vps|${VPS_KONG_IP:?Set VPS_KONG_IP}|debian|Kong + STOA gateway (Arena benchmark)"
-  "gravitee-vps|${VPS_GRAVITEE_IP:?Set VPS_GRAVITEE_IP}|debian|Gravitee APIM v4 (Arena benchmark)"
-  "n8n-vps|${VPS_N8N_IP:?Set VPS_N8N_IP}|debian|n8n + PocketBase + Healthchecks"
-  "webmethods-vps|${VPS_WEBMETHODS_IP:?Set VPS_WEBMETHODS_IP}|debian|webMethods API Gateway trial (vps-wm.gostoa.dev)"
-  "infisical-vps|${VPS_INFISICAL_IP:?Set VPS_INFISICAL_IP}|debian|Infisical vault (vault.gostoa.dev) + Caddy TLS"
-  "bench-vps|${VPS_BENCH_IP:?Set VPS_BENCH_IP}|debian|OpenSearch bench + Arena runner (STOA-bench)"
-  # HEGEMON workers are dynamic — use hegemon/workers.txt
+  "worker-1|worker-1|hegemon|Contabo — IDLE (~23 GB free). fsync p99 10.0 ms"
+  "worker-2|worker-2|hegemon|Contabo — IDLE. Best measured disk (fsync p99 9.6 ms)"
+  "worker-3|worker-3|hegemon|Contabo — k3s agent + cluster ingress entrypoint; webMethods 10.15 + Elasticsearch (Docker); Caddy; vault-agent; stoa-connect-dev"
+  "worker-4|worker-4|hegemon|Contabo — IDLE. fsync p99 10.9 ms"
+  "worker-5|worker-5|hegemon|Contabo — k3s CONTROL-PLANE (v1.34.5, SQLite/kine)"
 )
 
-# --- Cloudflare Access (sourced from env or Infisical) ---
-# Set these in ~/.zprofile or export before running scripts.
-# Empty = no CF Access headers sent (backward compatible).
+# Disk note (fio, 2026-07-27, roles ansible/fleet_disk_bench in stoa-labs):
+# fsync p99 sits ON the etcd 10 ms limit across identical idle nodes, with a
+# p99.9 of 18-24 ms. Embedded-etcd HA on 3 nodes is therefore ruled out; the
+# single control-plane on SQLite/kine above is the deliberate topology, backed by
+# rebuild-from-Git rather than by consensus.
+
+# --- Other hosts, appended only when their address is provided ---------------
+# Never use ${VAR:?} here: one unset variable must not abort every consumer.
+_vps_add_optional() {
+  if [ -n "${2:-}" ]; then VPS_FLEET+=("$1|$2|$3|$4"); fi
+  return 0
+}
+
+# n8n — LIVE (probed 2026-07-27). n8n.gostoa.dev returns HTTP/2 200 and serves
+# the n8n UI behind a valid Let's Encrypt cert (CN=n8n.gostoa.dev, expires
+# 2026-10-02). The cert is issued to the ORIGIN, so Cloudflare proxying is OFF
+# and the instance is directly exposed to the internet. Not reachable with
+# STOA_SSH_KEY — credentials unknown, so it is unmanaged from here.
+_vps_add_optional n8n-vps "${VPS_N8N_IP:-}" debian \
+  "n8n + PocketBase + Healthchecks — LIVE, directly exposed, NO SSH ACCESS"
+
+# OVH Arena-benchmark pair — port 22 answers, but STOA_SSH_KEY is refused for
+# hegemon, debian and root alike. Hosts alive, outside our management.
+_vps_add_optional kong-vps "${VPS_KONG_IP:-}" debian \
+  "OVH — Kong (Arena benchmark) — ALIVE but SSH REFUSED, OUT OF MANAGEMENT"
+_vps_add_optional gravitee-vps "${VPS_GRAVITEE_IP:-}" debian \
+  "OVH — Gravitee APIM v4 (Arena benchmark) — ALIVE but SSH REFUSED, OUT OF MANAGEMENT"
+
+# webMethods VPS (OVH) — 443 listens but the TLS handshake fails for
+# vps-wm.gostoa.dev (tlsv1 alert internal error): most likely ours with an
+# expired or missing certificate rather than a reassigned address. To qualify.
+# NOTE: the webMethods instance actually in use is the Docker one on worker-3.
+_vps_add_optional webmethods-vps "${VPS_WEBMETHODS_IP:-}" debian \
+  "OVH — vps-wm.gostoa.dev, TLS BROKEN, DEGRADED — superseded by worker-3"
+
+# Infisical — DEAD. vault.gostoa.dev still resolves but 443 is unreachable.
+# Consequence worth remembering: the Cloudflare DNS token
+# (shared/cloudflare/API_TOKEN, DNS:Edit) lived in this vault, so the credential
+# required to delete its own dangling DNS record is locked behind the dead host.
+# Effective secret store is now Vault (ADR-074).
+_vps_add_optional infisical-vps "${VPS_INFISICAL_IP:-}" debian \
+  "vault.gostoa.dev — DEAD, leaves a dangling DNS record"
+
+# bench-vps — no reachable address found during reconciliation. Presumed gone.
+_vps_add_optional bench-vps "${VPS_BENCH_IP:-}" debian \
+  "OpenSearch bench + Arena runner — PRESUMED DECOMMISSIONED"
+
+# --- Cloudflare Access (service token, sourced from env or the vault) --------
+# NOT a DNS API token: these authenticate to Access-protected apps and cannot
+# write to the zone. Empty = no CF Access headers sent (backward compatible).
 CF_ACCESS_CLIENT_ID="${CF_ACCESS_CLIENT_ID:-}"
 CF_ACCESS_CLIENT_SECRET="${CF_ACCESS_CLIENT_SECRET:-}"
 
-# --- Infisical ---
+# --- Infisical ----------------------------------------------------------------
+# Kept for API compatibility with existing callers. The host is DOWN as of
+# 2026-07-27: every infisical_curl call will fail to connect.
 INFISICAL_URL="${INFISICAL_URL:-https://vault.gostoa.dev}"
 INFISICAL_PROJECT_ID="${INFISICAL_PROJECT_ID:-97972ffc-990b-4d28-9c4d-0664d217f03b}"
 
@@ -42,14 +120,15 @@ INFISICAL_PROJECT_ID="${INFISICAL_PROJECT_ID:-97972ffc-990b-4d28-9c4d-0664d217f0
 # Helper functions
 # =============================================================================
 
-# Get VPS field by name: vps_get kong-vps ip → returns VPS_KONG_IP value
+# Get a VPS field by name: vps_get worker-3 dest → the SSH destination.
+# 'ip' is accepted as a synonym of 'dest' for backward compatibility.
 vps_get() {
   local name="$1" field="$2"
   for entry in "${VPS_FLEET[@]}"; do
-    IFS='|' read -r n ip user purpose <<< "$entry"
+    IFS='|' read -r n dest user purpose <<< "$entry"
     if [ "$n" = "$name" ]; then
       case "$field" in
-        ip)      echo "$ip" ;;
+        ip|dest) echo "$dest" ;;
         user)    echo "$user" ;;
         purpose) echo "$purpose" ;;
         *)       echo "Unknown field: $field" >&2; return 1 ;;
@@ -61,33 +140,72 @@ vps_get() {
   return 1
 }
 
-# SSH to a named VPS: ssh_to kong-vps "docker ps"
+# List every entry name: vps_names
+vps_names() {
+  local entry n rest
+  for entry in "${VPS_FLEET[@]}"; do
+    IFS='|' read -r n rest <<< "$entry"
+    echo "$n"
+  done
+}
+
+# SSH to a named VPS: ssh_to worker-3 "docker ps"
 ssh_to() {
   local name="$1"; shift
-  local ip user
-  ip=$(vps_get "$name" ip)
-  user=$(vps_get "$name" user)
-  ssh -i "$STOA_SSH_KEY" -o ConnectTimeout=10 "${user}@${ip}" "$@"
+  local dest user
+  dest=$(vps_get "$name" dest) || return 1
+  user=$(vps_get "$name" user) || return 1
+  ssh -i "$STOA_SSH_KEY" -o ConnectTimeout=10 "${user}@${dest}" "$@"
 }
 
-# SCP to a named VPS: scp_to kong-vps local_file remote_path
+# SCP to a named VPS: scp_to worker-3 local_file remote_path
 scp_to() {
   local name="$1" local_file="$2" remote_path="$3"
-  local ip user
-  ip=$(vps_get "$name" ip)
-  user=$(vps_get "$name" user)
-  scp -i "$STOA_SSH_KEY" "$local_file" "${user}@${ip}:${remote_path}"
+  local dest user
+  dest=$(vps_get "$name" dest) || return 1
+  user=$(vps_get "$name" user) || return 1
+  scp -i "$STOA_SSH_KEY" "$local_file" "${user}@${dest}:${remote_path}"
 }
 
-# Run command on all VPS: for_each_vps "uptime"
+# Run a command on every VPS: for_each_vps "uptime"
 for_each_vps() {
   local cmd="$1"
   for entry in "${VPS_FLEET[@]}"; do
-    IFS='|' read -r name ip user purpose <<< "$entry"
-    echo "=== $name ($ip) ==="
-    ssh -i "$STOA_SSH_KEY" -o ConnectTimeout=10 "${user}@${ip}" "$cmd" 2>&1 || echo "[FAIL] $name unreachable"
+    IFS='|' read -r name dest user purpose <<< "$entry"
+    echo "=== $name ($dest) ==="
+    ssh -i "$STOA_SSH_KEY" -o ConnectTimeout=10 "${user}@${dest}" "$cmd" 2>&1 \
+      || echo "[FAIL] $name unreachable"
     echo ""
   done
+}
+
+# Probe every entry and report divergence. Read-only: runs `true` remotely.
+# Exits non-zero if any entry is unreachable — so CI or a pre-deploy hook can
+# fail instead of letting this file rot unnoticed again. Entries documented as
+# unmanaged (NO SSH ACCESS / OUT OF MANAGEMENT / DEAD / PRESUMED) are expected
+# to fail and are reported as KNOWN, not as drift.
+vps_verify() {
+  local rc=0 entry name dest user purpose
+  printf '%-16s %-14s %-12s %s\n' NAME DEST STATUS NOTE
+  printf '%.0s-' {1..78}; echo
+  for entry in "${VPS_FLEET[@]}"; do
+    IFS='|' read -r name dest user purpose <<< "$entry"
+    if ssh -i "$STOA_SSH_KEY" -o BatchMode=yes -o ConnectTimeout=10 \
+         -o StrictHostKeyChecking=accept-new "${user}@${dest}" true 2>/dev/null; then
+      printf '%-16s %-14s %-12s\n' "$name" "$dest" "OK"
+    elif printf '%s' "$purpose" | grep -qE "NO SSH ACCESS|OUT OF MANAGEMENT|DEAD|PRESUMED|DEGRADED"; then
+      printf '%-16s %-14s %-12s %s\n' "$name" "$dest" "KNOWN" "unreachable as documented"
+    else
+      printf '%-16s %-14s %-12s %s\n' "$name" "$dest" "DRIFT" "expected reachable"
+      rc=1
+    fi
+  done
+  if [ $rc -ne 0 ]; then
+    echo "" >&2
+    echo "vps_verify: the fleet diverges from this inventory." >&2
+    echo "Reconcile scripts/ops/vps-inventory.sh before deploying." >&2
+  fi
+  return $rc
 }
 
 # Build curl headers for Infisical (CF Access + Bearer)
@@ -102,8 +220,9 @@ infisical_curl_headers() {
   echo "${headers[@]}"
 }
 
-# Curl wrapper for Infisical API with CF Access headers
+# Curl wrapper for the Infisical API with CF Access headers.
 # Usage: infisical_curl GET "/api/v3/secrets/raw?..." "$INFISICAL_TOKEN"
+# WARNING: the Infisical host is down as of 2026-07-27 — expect connection errors.
 infisical_curl() {
   local method="$1" path="$2" token="${3:-${INFISICAL_TOKEN:-}}"
   local -a headers=(-H "Authorization: Bearer ${token}" -H "Content-Type: application/json")


### PR DESCRIPTION
## Problem

`scripts/ops/vps-inventory.sh` declares itself *"source of truth for VPS fleet"*, yet a live probe of every entry on 2026-07-27 found that it described **6 VPS, none of which matched the running estate**, while omitting the **5 Contabo hosts that actually carry the platform** (including the k3s control-plane and the node running webMethods 10.15).

Root cause of the silent rot: entries used `${VAR:?}`, so `source` aborted unless six env vars were set. Nobody could run it, so nobody noticed it was wrong.

## Changes

- **Contabo fleet is now unconditional** — the 5 workers, each with its measured role: `worker-5` = k3s control-plane, `worker-3` = agent + webMethods 10.15/Elasticsearch (Docker) + Caddy + vault-agent, and 3 idle nodes carrying their measured `fsync` p99.
- **Addressed by `~/.ssh/config` alias, not by IP.** No addresses in Git — same intent as the env-var indirection, and the gitleaks allowlist only tolerates IPs under `deploy/vps/`. Stays drop-in compatible with consumers building `"${user}@${ip}"`.
- **Secondary hosts via `_vps_add_optional`** — a missing variable can no longer abort a consumer. Each carries its measured state: n8n **live and directly exposed** (Let's Encrypt cert on the origin, so Cloudflare proxying is off), kong/gravitee alive but SSH refused, `webmethods-vps` TLS broken, infisical dead, bench presumed decommissioned.
- **`vps_verify()`** — probes every entry read-only and **exits non-zero on divergence**, so a pre-deploy hook or CI fails instead of letting this file rot again. Hosts documented as unreachable are reported `KNOWN`, not `DRIFT`; otherwise the guard would cry constantly and be ignored.
- **`$STOA_INFRA_DIR` is now defined here.** `distribute-ssh-key.sh` references it while nothing defined it — it aborted under `set -u`.
- **`infisical_curl` carries a warning**: the host is down. Worth recording — the Cloudflare `DNS:Edit` token was stored in that vault, so the credential needed to clean up its own dangling DNS record is locked behind the host the record points at.

## Verification

- `bash -n` clean.
- `source` succeeds **with no env vars set** (the previous revision aborted here).
- `vps_verify` → 5/5 reachable, exit 0.
- `distribute-ssh-key.sh --dry-run` → enumerates the 5 workers with the correct user.
- No IP present in the diff.

## Out of scope

`deploy/vps/bench/deploy.sh` and `demo/poc-31-mars.sh` read `VPS_*_IP` directly rather than sourcing this file, and reference further hosts (`VPS_STOA_IP`, `VPS_AGENTGATEWAY_IP`). Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)