### PR TITLE
fix(control-plane-api): CVE-2026-53539 — python-multipart 0.0.27 → 0.0.32

### DIFF
--- a/control-plane-api/requirements.txt
+++ b/control-plane-api/requirements.txt
@@ -5,7 +5,9 @@ pydantic[email]==2.13.3
 pydantic-settings==2.14.0
 python-jose[cryptography]==3.5.0
 passlib[bcrypt]==1.7.4
-python-multipart==0.0.27
+# CVE-2026-53539 (HIGH) — DoS via crafted form-urlencoded bodies. Corrigé en
+# 0.0.30 ; on prend le dernier correctif de la série 0.0.x.
+python-multipart==0.0.32
 httpx==0.28.1
 kafka-python==2.3.1
 python-snappy==0.7.3

--- a/control-plane-api/tests/test_regression_cve_2026_53539_python_multipart.py
+++ b/control-plane-api/tests/test_regression_cve_2026_53539_python_multipart.py
@@ -1,0 +1,76 @@
+"""Régression : CVE-2026-53539 — python-multipart, DoS via corps form-urlencoded.
+
+Le Container Scan avait remonté `python-multipart==0.0.27` (HIGH, corrigé en
+0.0.30). La régression à empêcher n'est pas un bug de notre code : c'est le
+retour silencieux du pin vers une version vulnérable — par un rollback, une
+résolution de conflit, ou une génération automatique de dépendances.
+
+Le test porte donc sur le PIN DÉCLARÉ dans requirements.txt, qui est ce qui
+détermine l'image construite. Il ne dépend d'aucun environnement installé et
+échoue sur un `git revert` du correctif.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+# Première version corrigée, telle que rapportée par l'avis amont et le scan.
+FIRST_FIXED = (0, 0, 30)
+
+REQUIREMENTS = Path(__file__).resolve().parents[1] / "requirements.txt"
+
+_PIN_RE = re.compile(r"^python-multipart\s*==\s*([0-9][^\s;#]*)", re.IGNORECASE)
+
+
+def _parse_version(raw: str) -> tuple[int, ...]:
+    """`0.0.32` -> (0, 0, 32). Les suffixes non numériques sont ignorés."""
+    parts: list[int] = []
+    for chunk in raw.split("."):
+        match = re.match(r"^(\d+)", chunk)
+        if match is None:
+            break
+        parts.append(int(match.group(1)))
+    if not parts:
+        raise AssertionError(f"version python-multipart illisible : {raw!r}")
+    return tuple(parts)
+
+
+def _pinned_version() -> tuple[int, ...]:
+    for line in REQUIREMENTS.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = _PIN_RE.match(stripped)
+        if match is not None:
+            return _parse_version(match.group(1))
+    raise AssertionError(
+        "python-multipart n'est plus épinglé dans requirements.txt — "
+        "la dépendance serait alors résolue librement, y compris vers une "
+        "version vulnérable à CVE-2026-53539."
+    )
+
+
+def test_regression_cve_2026_53539_pin_is_not_vulnerable():
+    """Le pin de requirements.txt doit rester >= 0.0.30 (correctif CVE-2026-53539)."""
+    pinned = _pinned_version()
+    assert pinned >= FIRST_FIXED, (
+        f"python-multipart est épinglé en {'.'.join(map(str, pinned))}, "
+        f"vulnérable à CVE-2026-53539 (DoS via corps form-urlencoded). "
+        f"Corrigé à partir de {'.'.join(map(str, FIRST_FIXED))}."
+    )
+
+
+def test_regression_cve_2026_53539_installed_is_not_vulnerable():
+    """Contrôle secondaire : la version réellement installée, si elle l'est."""
+    metadata = pytest.importorskip("importlib.metadata")
+    try:
+        raw = metadata.version("python-multipart")
+    except Exception:  # pragma: no cover - paquet absent de l'environnement
+        pytest.skip("python-multipart n'est pas installé dans cet environnement")
+
+    installed = _parse_version(raw)
+    assert installed >= FIRST_FIXED, (
+        f"python-multipart installé en {raw}, vulnérable à CVE-2026-53539. "
+        f"Corrigé à partir de {'.'.join(map(str, FIRST_FIXED))}."
+    )


### PR DESCRIPTION
## Problème

Le job **Container Scan (control-plane-api)** échoue — y compris sur `main`,
indépendamment de toute PR en cours :

```
Total: 1 (HIGH: 1, CRITICAL: 0)

Library            Vulnerability    Severity  Status  Installed  Fixed
python-multipart   CVE-2026-53539   HIGH      fixed   0.0.27     0.0.30
python-multipart: Denial of Service via crafted form-urlencoded bodies
```

## Correctif

`control-plane-api/requirements.txt` : `python-multipart==0.0.27` → `==0.0.32`.

Le correctif arrive en **0.0.30** ; je prends **0.0.32**, dernier patch publié de
la série, pour éviter de rouvrir le même ticket au prochain scan. Dites-le si
vous préférez le bump minimal `0.0.30` — c'est un caractère.

**Compatibilité Python** : 0.0.30 comme 0.0.32 exigent `>=3.10`. L'image est
`python:3.11-slim` et `pyproject.toml` impose `requires-python = ">=3.11"`.

## Surface concernée

`python-multipart` sert l'analyse des corps multipart pour FastAPI. Deux points
d'entrée l'utilisent :

- `src/routers/certificates.py:214` — `upload_certificate`
- `src/routers/consumers.py:560`

La CVE porte sur les corps **form-urlencoded**, pas sur le téléversement de
fichiers, mais ces deux routes sont la surface exposée par la dépendance.

## Vérification

Résolution de l'ensemble des dépendances sur l'image cible, sans conflit :

```
$ docker run --rm -v requirements.txt:/req.txt:ro python:3.11-slim \
    pip install --dry-run -r /req.txt
Would install ... fastapi-0.136.1 ... python-multipart-0.0.32 ... starlette-1.3.1 ...
```

Aucune autre dépendance n'est déplacée par ce changement.

## Note

Distinct de #2811, qui touche des manifestes YAML et ne peut pas causer cet
échec de scan. Cette PR est ce qui repasse le job au vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)