### PR TITLE
fix(control-plane-api): borner pytest-asyncio sous 1.0 — suite CI cassée par dérive de résolution

### DIFF
--- a/control-plane-api/pyproject.toml
+++ b/control-plane-api/pyproject.toml
@@ -20,7 +20,11 @@ dev = [
     "mypy>=1.8.0",
     "pytest>=8.0.0",
     "pytest-cov>=4.1.0",
-    "pytest-asyncio>=0.23.0",
+    # Borne haute : pytest-asyncio 1.x ne crée plus implicitement de boucle
+    # d'événements, et la suite (asyncio_mode = "auto") en dépend — d'où des
+    # « RuntimeError: There is no current event loop in thread 'MainThread' ».
+    # À retirer le jour où la suite est migrée vers la sémantique 1.x.
+    "pytest-asyncio>=0.23.0,<1.0",
     "pytest-mock>=3.12.0",
     "pytest-httpx>=0.29.0,<0.37.0",
     "httpx>=0.27.0,<0.29.0",


### PR DESCRIPTION
## Symptôme

`ci / Lint and Test (control-plane-api)` échoue : **79 tests en erreur, 7166
passés**, tous sur le même message —

```
RuntimeError: There is no current event loop in thread 'MainThread'
```

Répartis sur `test_gateway_service_unit.py` (35), `test_http_logging_middleware.py`
(14), `test_metrics_middleware.py` (8), `federation`, `mcp_connectors`, `quotas`.

## Cause

Aucun commit n'en est responsable. La dépendance de développement était déclarée
**sans borne haute** :

```toml
pytest-asyncio>=0.23.0     # aucune limite
asyncio_mode = "auto"
```

La résolution CI ramène aujourd'hui **pytest-asyncio 1.4.0**. La série 1.x ne
crée plus implicitement de boucle d'événements — comportement dont dépend la
suite via `asyncio_mode = "auto"`.

La dernière PR fusionnée touchant `control-plane-api` (#2793) passait ce job. La
rupture vient donc de la **dérive de résolution**, pas d'un changement de code —
et elle frappe désormais toute PR touchant du Python, quel qu'en soit le contenu.
Elle a été révélée par #2812 (correctif CVE) simplement parce que c'était la
première PR Python depuis.

## Correctif

Borne haute, exactement comme le fichier le fait déjà deux lignes plus bas pour
`pytest-httpx>=0.29.0,<0.37.0` :

```toml
pytest-asyncio>=0.23.0,<1.0
```

## Vérification

Reproduit dans `python:3.11-slim` aux versions exactes de la CI (pytest 9.1.1),
sur les fichiers que la CI signale :

| pytest-asyncio | Résultat |
|---|---|
| 1.4.0 (résolution actuelle) | **4 failed**, 105 passed |
| 0.26.0 (avec la borne) | **109 passed** |

Le décompte local (4) est inférieur à celui de la CI (79) parce que la suite
complète amplifie l'effet par ordre d'exécution — le mode de défaillance est
bien le même.

## Portée

Correctif de **circonstance**, pas de fond. La sortie durable est de migrer la
suite vers la sémantique pytest-asyncio 1.x ; un commentaire dans le fichier le
signale, pour que la borne ne devienne pas silencieusement permanente.

## Ordre de fusion suggéré

1. **Cette PR** — débloque `Lint and Test` pour toute PR Python
2. #2812 — correctif CVE-2026-53539 (son `Container Scan` passe déjà)
3. #2811 — CRD invalide + amorçage GitOps (son unique échec est le scan que #2812 corrige)

🤖 Generated with [Claude Code](https://claude.com/claude-code)