### PR TITLE
feat(ci): Vault persistant avec auth Kubernetes

### DIFF
--- a/deploy/bootstrap/argocd/app-ci-vault.yaml
+++ b/deploy/bootstrap/argocd/app-ci-vault.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ci-vault
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: stoa
+  source:
+    repoURL: https://github.com/stoa-platform/stoa.git
+    targetRevision: main
+    path: deploy/bootstrap/ci/vault
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ci
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 5m

--- a/deploy/bootstrap/ci/vault/kustomization.yaml
+++ b/deploy/bootstrap/ci/vault/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ci
+resources:
+  - serviceaccount.yaml
+  - service.yaml
+  - statefulset.yaml
+  - prometheusrule.yaml

--- a/deploy/bootstrap/ci/vault/prometheusrule.yaml
+++ b/deploy/bootstrap/ci/vault/prometheusrule.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vault-rules
+  namespace: ci
+spec:
+  groups:
+    - name: vault
+      rules:
+        # Vault scellé fait échouer les pipelines — comportement correct, mais
+        # qui doit être VISIBLE. Sans cette alerte, un Vault scellé après
+        # redémarrage se traduit par des builds rouges sans cause apparente.
+        - alert: VaultSealed
+          expr: |
+            max_over_time(kube_pod_container_status_ready{namespace="ci", pod=~"vault-.*"}[5m]) == 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Vault indisponible ou scellé"
+            description: "Les pipelines Jenkins ne peuvent plus obtenir d'identifiants."

--- a/deploy/bootstrap/ci/vault/service.yaml
+++ b/deploy/bootstrap/ci/vault/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault
+  namespace: ci
+spec:
+  type: ClusterIP
+  selector:
+    app: vault
+  ports:
+    - name: http
+      port: 8200
+      targetPort: 8200

--- a/deploy/bootstrap/ci/vault/serviceaccount.yaml
+++ b/deploy/bootstrap/ci/vault/serviceaccount.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins-agent
+  namespace: ci
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault
+  namespace: ci
+---
+# Vault doit pouvoir valider les jetons de ServiceAccount présentés par les pods.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-tokenreview
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: vault
+    namespace: ci

--- a/deploy/bootstrap/ci/vault/statefulset.yaml
+++ b/deploy/bootstrap/ci/vault/statefulset.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: vault
+  namespace: ci
+spec:
+  serviceName: vault
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vault
+  template:
+    metadata:
+      labels:
+        app: vault
+    spec:
+      serviceAccountName: vault
+      containers:
+        - name: vault
+          image: hashicorp/vault:1.18
+          args: ["server"]
+          env:
+            - name: VAULT_ADDR
+              value: "http://127.0.0.1:8200"
+            # Stockage FICHIER sur PVC — pas le mode dev du POC, dont tout
+            # disparaît au redémarrage.
+            - name: VAULT_LOCAL_CONFIG
+              value: |
+                storage "file" { path = "/vault/data" }
+                listener "tcp" {
+                  address     = "0.0.0.0:8200"
+                  tls_disable = 1
+                }
+                disable_mlock = true
+                ui = false
+          ports:
+            - containerPort: 8200
+          securityContext:
+            capabilities:
+              add: ["IPC_LOCK"]
+          volumeMounts:
+            - name: vault-data
+              mountPath: /vault/data
+          # Amendement contrôleur validé : Vault scellé renvoie 503
+          # (non-initialisé 501) → pod NotReady → le Service ferme les flux
+          # (échec fermé) ET l'alerte VaultSealed (readiness) peut réellement
+          # rougir ; sans cette sonde, un Vault scellé mais démarré resterait
+          # « Ready » et l'alerte ne rougirait jamais.
+          readinessProbe:
+            httpGet:
+              path: /v1/sys/health?standbyok=true
+              port: 8200
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: vault-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 5Gi


### PR DESCRIPTION
Stockage fichier sur PVC. Auth Kubernetes pour l'identité de job Jenkins.

Amendements contrôleur validés (voir plan docs/superpowers/plans/2026-07-28-socle-ci-cluster.md):
- Step 8 : rôle Vault créé avec `token_policies=jenkins-agent` (pas `policy=`).
- Step 3 : readinessProbe httpGet /v1/sys/health?standbyok=true ajoutée au conteneur vault (503/501 scellé/non-initialisé → NotReady → alerte VaultSealed peut rougir).

Signed-off-by: PotoMitan <christophe.ab.cab.i@gmail.com>