### PR TITLE
fix(ci): exclure worker-3 du placement de Vault

### DIFF
--- a/deploy/bootstrap/ci/vault/statefulset.yaml
+++ b/deploy/bootstrap/ci/vault/statefulset.yaml
@@ -15,6 +15,19 @@ spec:
         app: vault
     spec:
       serviceAccountName: vault
+      # Amendement contrôleur validé (constat en cours de déploiement) : le
+      # scheduler avait placé vault-0 sur worker-3, or les règles de sécurité
+      # de la tâche interdisent de toucher worker-3 (nœud hors périmètre,
+      # héberge des charges hors socle CI). Cette anti-affinité l'exclut.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - worker-3
       containers:
         - name: vault
           image: hashicorp/vault:1.18


### PR DESCRIPTION
Constat en cours de déploiement de #2818 : le scheduler a placé vault-0
sur worker-3. Les règles de sécurité de la tâche 3 (socle CI) interdisent
de toucher ce nœud (hors périmètre, héberge des charges non liées au
socle CI). Ajout d'une anti-affinité de nœud (`kubernetes.io/hostname
NotIn [worker-3]`) sur le StatefulSet vault pour garantir qu'il ne peut
plus y être planifié, y compris après un self-heal Argo CD.

Signed-off-by: PotoMitan <christophe.ab.cab.i@gmail.com>