### PR TITLE
feat(wm): Elasticsearch 8.13.4 en cluster — namespace wm, PVC worker-4 (F3 lot 2)

### DIFF
--- a/deploy/bootstrap/argocd/app-wm-elasticsearch.yaml
+++ b/deploy/bootstrap/argocd/app-wm-elasticsearch.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: wm-elasticsearch
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: stoa
+  source:
+    repoURL: https://github.com/stoa-platform/stoa.git
+    targetRevision: main
+    path: deploy/bootstrap/wm/elasticsearch
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: wm
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 5m

--- a/deploy/bootstrap/argocd/appproject-stoa.yaml
+++ b/deploy/bootstrap/argocd/appproject-stoa.yaml
@@ -45,6 +45,10 @@ spec:
       namespace: stoa-system
     - server: https://kubernetes.default.svc
       namespace: ci
+    # F3 (lot 2) : webMethods 10.15 + son Elasticsearch, porté en cluster par
+    # la chaîne du lot 1 — spéc stoa-labs 2026-07-29-f3-webmethods-cluster.
+    - server: https://kubernetes.default.svc
+      namespace: wm
 
   # Ressources cluster-scoped autorisées. ingress-nginx et kube-prometheus-stack
   # en posent (CRD, ClusterRole, IngressClass) : on les nomme au lieu d'ouvrir.

--- a/deploy/bootstrap/ci/gitea/service.yaml
+++ b/deploy/bootstrap/ci/gitea/service.yaml
@@ -19,6 +19,14 @@ spec:
   # toute recréation du Service, et les /etc/hosts deviendraient périmés EN
   # SILENCE. `localhost` ne change jamais et le NodePort est versionné ici.
   type: NodePort
+  # ClusterIP épinglée (F3, dette realm OCI du lot 1) : le realm du registre
+  # suit ROOT_URL (gitea.ci.svc.cluster.local:3000), que les HÔTES résolvent
+  # par une entrée /etc/hosts vers cette ClusterIP (rôle registry_config,
+  # stoa-labs). Tant que l'adresse n'était que runtime, une recréation du
+  # Service l'aurait périmée en silence — exactement l'objection du commentaire
+  # ci-dessus. La déclarer ici la rend stable et versionnée. Valeur = adresse
+  # actuelle du Service (immuable côté API ; apply server-side = no-op).
+  clusterIP: 10.43.60.211
   selector:
     app: gitea
   ports:

--- a/deploy/bootstrap/wm/elasticsearch/kustomization.yaml
+++ b/deploy/bootstrap/wm/elasticsearch/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: wm
+resources:
+  - service.yaml
+  - statefulset.yaml

--- a/deploy/bootstrap/wm/elasticsearch/service.yaml
+++ b/deploy/bootstrap/wm/elasticsearch/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  namespace: wm
+spec:
+  # ClusterIP, pas de NodePort : seul le data store de la gateway. Le nom court
+  # `elasticsearch` reproduit à l'identique l'adressage du compose worker-3
+  # (apigw_elasticsearch_hosts=elasticsearch:9200) — zéro delta de config.
+  selector:
+    app: wm-elasticsearch
+  ports:
+    - name: http
+      port: 9200
+      targetPort: 9200

--- a/deploy/bootstrap/wm/elasticsearch/statefulset.yaml
+++ b/deploy/bootstrap/wm/elasticsearch/statefulset.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: wm-elasticsearch
+  namespace: wm
+spec:
+  serviceName: elasticsearch
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wm-elasticsearch
+  template:
+    metadata:
+      labels:
+        app: wm-elasticsearch
+    spec:
+      # Placement VOULU, pas subi : worker-4 est le seul nœud à la fois mesuré
+      # (fio p99 10,95 ms — ES est le composant sensible au fsync du lot 2) et
+      # vide ; worker-5 n'a jamais été mesuré et porte déjà les 3 PVC `ci`.
+      # local-path épinglerait de toute façon le pod à son premier nœud : on
+      # l'écrit. Exclut worker-3 par construction (motif PR #2819).
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - worker-4
+      containers:
+        - name: elasticsearch
+          image: localhost:30300/ci/elasticsearch:8.13.4@sha256:8efa98b161b85cd4ca692a7585efc03a72c71d650569dfe948ca8176ffa9a776
+          env:
+            # Copie conforme du Docker prouvé (worker-3, 2 mois de service —
+            # deploy/vps/webmethods/docker-compose.dev.yml). xpack off : le
+            # namespace n'est pas exposé (aucun Ingress/NodePort) ;
+            # NetworkPolicy = dette actée F4 (spéc F3, stoa-labs).
+            - name: discovery.type
+              value: single-node
+            - name: xpack.security.enabled
+              value: "false"
+            - name: ES_JAVA_OPTS
+              value: "-Xms512m -Xmx512m"
+          ports:
+            - containerPort: 9200
+          volumeMounts:
+            - name: es-data
+              mountPath: /usr/share/elasticsearch/data
+          readinessProbe:
+            httpGet:
+              path: /_cluster/health
+              port: 9200
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /_cluster/health
+              port: 9200
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1536Mi
+            limits:
+              memory: 2560Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: es-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 10Gi


### PR DESCRIPTION
## Quoi

Premier étage du jalon **F3** (webMethods 10.15 dans le cluster, lot 2) : le data store Elasticsearch de la gateway, porté en cluster par la chaîne prouvée au lot 1.

- Namespace `wm` dédié (destination ajoutée à l'AppProject `stoa`, fail-closed)
- StatefulSet `wm-elasticsearch` : copie conforme du Docker prouvé de worker-3 (`deploy/vps/webmethods/docker-compose.dev.yml` — single-node, xpack off, heap 512m), image **par digest** depuis le registre Gitea, PVC `local-path` 10 Gi
- Placement mesuré : `nodeAffinity In [worker-4]` — seul nœud à la fois mesuré en fio (p99 10,95 ms) et vide ; exclut worker-3 par construction (motif PR #2819)
- ClusterIP du Service `gitea` épinglée : solde le résidu « liaison mutable hors Git » de la dette realm OCI du lot 1
- Aucun Ingress, aucun NodePort — doctrine lot 1

## Preuves déjà jouées

- Push registre + `crictl pull` par digest depuis worker-4 : `PULL-OK` ; tag inexistant → `NotFound`
- `kubectl kustomize` du dossier : rendu propre (validé sur worker-1)

Spec et plan : `stoa-labs/docs/superpowers/{specs,plans}/2026-07-29-f3-webmethods-cluster*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)