### PR TITLE
feat(wm): API Gateway 10.15 en cluster — cycle trial piloté, doctrine no-Ingress (F3 lot 2)

### DIFF
--- a/deploy/bootstrap/argocd/app-wm-apigateway.yaml
+++ b/deploy/bootstrap/argocd/app-wm-apigateway.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: wm-apigateway
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: stoa
+  source:
+    repoURL: https://github.com/stoa-platform/stoa.git
+    targetRevision: main
+    path: deploy/bootstrap/wm/apigateway
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: wm
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 5m

--- a/deploy/bootstrap/wm/apigateway/cronjob.yaml
+++ b/deploy/bootstrap/wm/apigateway/cronjob.yaml
@@ -1,0 +1,34 @@
+# Cycle trial PILOTÉ (spéc F3 § D5, stoa-labs) : l'exploitant a tranché « pas
+# de licence » (2026-07-29) ; l'expiration ~25-30 min devient un redémarrage
+# contrôlé aux minutes 0/20/40 — le même motif que le cron root de worker-3,
+# porté avec le pod. Le ReplicaSet recrée le pod aussitôt ; retour Ready
+# ~5 min ; ~15 min de service par cycle de 20 min, conséquence assumée.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: wm-restarter
+  namespace: wm
+spec:
+  schedule: "*/20 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          serviceAccountName: wm-restarter
+          restartPolicy: Never
+          containers:
+            - name: restart
+              image: localhost:30300/ci/curl:8.10.1@sha256:3a57427a38852a03f246297e21aebaeaab5da747f5444b7b3383c1f4c49a4aa3
+              command:
+                - /bin/sh
+                - -c
+                - >
+                  curl -sf --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                  -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+                  -X DELETE
+                  "https://kubernetes.default.svc/api/v1/namespaces/wm/pods?labelSelector=app%3Dwm-apigateway"
+                  -o /dev/null -w "restart-pilote: %{http_code}\n"

--- a/deploy/bootstrap/wm/apigateway/deployment.yaml
+++ b/deploy/bootstrap/wm/apigateway/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wm-apigateway
+  namespace: wm
+spec:
+  replicas: 1
+  # Recreate : miroir des sémantiques `docker restart` du poste worker-3 ;
+  # deux gateways trial simultanées sur le même ES n'ont aucun sens.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: wm-apigateway
+  template:
+    metadata:
+      labels:
+        app: wm-apigateway
+    spec:
+      # Anti-affinité worker-3 (motif PR #2819) : la prod Docker wm-dev-* y
+      # tourne encore (double-run F3–F5) — GOAL socle→gateway, jalon F3.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - worker-3
+      containers:
+        - name: apigateway
+          image: localhost:30300/ci/apigateway-trial:10.15@sha256:b6aee2b436f6d1053e881844c1f4a6cd12b168a4e2784af97dc84419cef59c49
+          env:
+            # Copie conforme du compose dev worker-3
+            # (deploy/vps/webmethods/docker-compose.dev.yml) : l'état vit dans
+            # ES, la gateway n'a AUCUN volume (constaté sur le Docker de
+            # référence — 2 mois de service).
+            - name: apigw_elasticsearch_hosts
+              value: "elasticsearch:9200"
+            - name: apigw_elasticsearch_http_username
+              value: ""
+            - name: apigw_elasticsearch_http_password
+              value: ""
+          ports:
+            - containerPort: 5555
+            - containerPort: 9072
+          # Identifiants des sondes = Administrator:manage, les identifiants PAR
+          # DÉFAUT de l'image trial, déjà publics dans le healthcheck du compose
+          # de ce dépôt. Retour mesuré ~5 min après restart (handoff stoa-labs
+          # 2026-07-29) : la startupProbe laisse 10 min ; ensuite readiness 15 s
+          # (cadence du healthcheck compose) et liveness en filet du cas
+          # « bloqué sans exit » (l'expiration trial, elle, sort en ExitCode 0
+          # → restartPolicy Always la couvre).
+          startupProbe:
+            httpGet:
+              path: /rest/apigateway/health
+              port: 5555
+              httpHeaders:
+                - name: Authorization
+                  value: "Basic QWRtaW5pc3RyYXRvcjptYW5hZ2U="
+            periodSeconds: 15
+            failureThreshold: 40
+          readinessProbe:
+            httpGet:
+              path: /rest/apigateway/health
+              port: 5555
+              httpHeaders:
+                - name: Authorization
+                  value: "Basic QWRtaW5pc3RyYXRvcjptYW5hZ2U="
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /rest/apigateway/health
+              port: 5555
+              httpHeaders:
+                - name: Authorization
+                  value: "Basic QWRtaW5pc3RyYXRvcjptYW5hZ2U="
+            periodSeconds: 30
+            failureThreshold: 10
+          resources:
+            requests:
+              cpu: 500m
+              memory: 3Gi
+            limits:
+              memory: 4Gi

--- a/deploy/bootstrap/wm/apigateway/kustomization.yaml
+++ b/deploy/bootstrap/wm/apigateway/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: wm
+resources:
+  - rbac.yaml
+  - service.yaml
+  - deployment.yaml
+  - cronjob.yaml

--- a/deploy/bootstrap/wm/apigateway/rbac.yaml
+++ b/deploy/bootstrap/wm/apigateway/rbac.yaml
@@ -1,0 +1,31 @@
+# ServiceAccount du CronJob de redémarrage piloté (cycle trial, spéc F3 § D5,
+# stoa-labs). deletecollection : c'est le verbe RBAC du DELETE par labelSelector.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wm-restarter
+  namespace: wm
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: wm-restarter
+  namespace: wm
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "deletecollection"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: wm-restarter
+  namespace: wm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: wm-restarter
+subjects:
+  - kind: ServiceAccount
+    name: wm-restarter
+    namespace: wm

--- a/deploy/bootstrap/wm/apigateway/service.yaml
+++ b/deploy/bootstrap/wm/apigateway/service.yaml
@@ -1,0 +1,19 @@
+# ClusterIP uniquement — doctrine no-Ingress du lot 1 : l'admin REST (5555) et
+# la console (9072) ne sont joignables que du cluster ; accès humain par
+# `kubectl port-forward`. L'exposition publique du data-plane viendra par la
+# bascule Caddy (F5), pas par un Ingress.
+apiVersion: v1
+kind: Service
+metadata:
+  name: wm-apigateway
+  namespace: wm
+spec:
+  selector:
+    app: wm-apigateway
+  ports:
+    - name: is-admin-data
+      port: 5555
+      targetPort: 5555
+    - name: console-ui
+      port: 9072
+      targetPort: 9072


### PR DESCRIPTION
## Quoi

Second étage du jalon **F3** (après #2821, l'Elasticsearch) : la gateway elle-même.

- Deployment `wm-apigateway` **sans volume** — l'état vit dans l'ES du namespace (constaté sur le Docker de référence worker-3) ; env copie conforme du compose `deploy/vps/webmethods/docker-compose.dev.yml`
- Image **par digest** depuis le registre Gitea (`ci/apigateway-trial:10.15@sha256:b6aee2…`)
- **Anti-affinité worker-3** (motif PR #2819) — la prod Docker `wm-dev-*` y tourne encore (double-run F3–F5)
- **Cycle trial piloté** (décision exploitant 2026-07-29 : pas de licence) : CronJob `*/20` + SA/Role `deletecollection` — le même motif que le cron root de worker-3, porté avec le pod ; sondes calquées sur le healthcheck compose (startup 10 min, retour mesuré ~5 min)
- Services **ClusterIP uniquement** (5555 admin/data, 9072 console) — aucun Ingress, doctrine lot 1 ; l'exposition publique viendra par la bascule Caddy (F5)

## Ordre de merge

Après #2821 (qui porte le namespace `wm` dans l'AppProject et l'ES).

Spec et plan : `stoa-labs/docs/superpowers/{specs,plans}/2026-07-29-f3-webmethods-cluster*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)