### PR TITLE
chore(ci): épinglage par digest des images gitea et jenkins-go (dette lot 1, passe F3)

### DIFF
--- a/deploy/bootstrap/ci/gitea/statefulset.yaml
+++ b/deploy/bootstrap/ci/gitea/statefulset.yaml
@@ -16,7 +16,9 @@ spec:
     spec:
       containers:
         - name: gitea
-          image: gitea/gitea:1.22
+          # Épinglé par digest (dette lot 1, passe F3) : 1.22 est un tag
+          # flottant côté Docker Hub ; le digest fige ce qui tourne réellement.
+          image: gitea/gitea:1.22@sha256:538658de667c5d098a274f2f63aa6ec891d88f670cdd5282cf27221ba747dda4
           env:
             # ROOT_URL pointe sur le Service interne. La valeur du compose
             # (localhost:13000) est spécifique à Docker et casserait les URL de clone.

--- a/deploy/bootstrap/ci/jenkins/deployment.yaml
+++ b/deploy/bootstrap/ci/jenkins/deployment.yaml
@@ -32,7 +32,9 @@ spec:
                       - worker-3
       containers:
         - name: jenkins
-          image: localhost:30300/ci/jenkins-go:v1
+          # Épinglé par digest (dette lot 1, passe F3) : le tag v1 est mutable
+          # dans le registre ; le digest fige ce qui tourne réellement.
+          image: localhost:30300/ci/jenkins-go:v1@sha256:00ad5591be6f1c7b4eccfd7e498abe5e947dc07f01e4d7a247005b65ef0c565b
           env:
             - name: JAVA_OPTS
               value: "-Djenkins.install.runSetupWizard=false"


### PR DESCRIPTION
## Quoi

Dette du lot 1 « épinglage par digest des images du socle », affectée à la passe F3.

- `gitea/gitea:1.22` → `@sha256:538658de…` (digest en service, relevé sur worker-5)
- `localhost:30300/ci/jenkins-go:v1` → `@sha256:00ad5591…` (idem)

**Vault volontairement exclu** : changer son `image:` recréerait `vault-0`, qui redémarre **scellé** — descellement = geste exploitant. Reporté à la prochaine fenêtre exploitant.

## Ordre de merge

Indépendante de #2821/#2822, mais à merger **en dernier** (le selfHeal roule gitea et jenkins — brève coupure du registre et de Jenkins, à faire hors sauvegarde/build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)