### PR TITLE
feat(wm): NetworkPolicy ES — ingress restreint à la gateway (F4)

### DIFF
--- a/deploy/bootstrap/wm/elasticsearch/kustomization.yaml
+++ b/deploy/bootstrap/wm/elasticsearch/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: wm
 resources:
   - service.yaml
   - statefulset.yaml
+  - networkpolicy.yaml

--- a/deploy/bootstrap/wm/elasticsearch/networkpolicy.yaml
+++ b/deploy/bootstrap/wm/elasticsearch/networkpolicy.yaml
@@ -1,0 +1,22 @@
+# ES ne sert QUE la gateway (F4 : les clients réels sont connus — le CronJob
+# wm-restarter ne parle qu'à l'API k8s, les agents Jenkins qu'à la
+# gateway:5555). 9300 omis : ES mono-pod (à rouvrir intra-ES si le cluster ES
+# grandit). Spéc F4 § D8 (stoa-labs).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: wm-elasticsearch-ingress
+  namespace: wm
+spec:
+  podSelector:
+    matchLabels:
+      app: wm-elasticsearch
+  policyTypes: ["Ingress"]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: wm-apigateway
+      ports:
+        - port: 9200
+          protocol: TCP


### PR DESCRIPTION
## Objet

Jalon F4 (stoa-labs) : les clients réels du ns `wm` sont connus — seule la gateway parle à ES.

- `NetworkPolicy wm-elasticsearch-ingress` : ingress 9200 limité aux pods `app=wm-apigateway` du ns `wm`.
- 9300 omis : ES mono-pod (à rouvrir intra-ES si le cluster ES grandit).
- Le CronJob `wm-restarter` ne parle qu'à l'API k8s ; les agents Jenkins qu'à la gateway (5555) — aucun autre client légitime de 9200.

## Contre-épreuve prévue (après merge + sync)

- `curl 9200` depuis un pod du ns `ci` → bloqué (timeout) ;
- `GET /rest/apigateway/health` → 200 (la gateway passe toujours).

Spéc : `stoa-labs docs/superpowers/specs/2026-07-29-f4-chaine-publication-design.md` § D8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)