### PR TITLE
feat(wm): backend-dev réel, ClusterIP gateway épinglée, cycle trial rechiffré (F5)

### DIFF
--- a/deploy/bootstrap/argocd/app-wm-backend-dev.yaml
+++ b/deploy/bootstrap/argocd/app-wm-backend-dev.yaml
@@ -1,0 +1,32 @@
+# Backend réel de l'API publiée (F5). Copie conforme du motif
+# app-wm-apigateway.yaml : seuls `name` et `path` changent.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: wm-backend-dev
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: stoa
+  source:
+    repoURL: https://github.com/stoa-platform/stoa.git
+    targetRevision: main
+    path: deploy/bootstrap/wm/backend-dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: wm
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 5m

--- a/deploy/bootstrap/wm/apigateway/cronjob.yaml
+++ b/deploy/bootstrap/wm/apigateway/cronjob.yaml
@@ -1,8 +1,19 @@
 # Cycle trial PILOTÉ (spéc F3 § D5, stoa-labs) : l'exploitant a tranché « pas
 # de licence » (2026-07-29) ; l'expiration ~25-30 min devient un redémarrage
 # contrôlé aux minutes 0/20/40 — le même motif que le cron root de worker-3,
-# porté avec le pod. Le ReplicaSet recrée le pod aussitôt ; retour Ready
-# ~5 min ; ~15 min de service par cycle de 20 min, conséquence assumée.
+# porté avec le pod. Le ReplicaSet recrée le pod aussitôt.
+#
+# CHIFFRE MESURÉ (F5, 2026-07-30) : la coupure dure 150 s, pas « ~5 min ».
+# Sonde à 5 s depuis l'hôte worker-3 sur la ClusterIP : 07:20:23 → 07:22:54.
+# Soit 17 min 30 de service par cycle de 20 min = 87,5 % de disponibilité.
+# L'estimation précédente (« retour Ready ~5 min ; ~15 min de service par
+# cycle ») surestimait le trou d'un facteur 2. Les jobs wm-restarter eux-mêmes
+# durent 4-9 s : les 150 s sont le DÉMARRAGE de webMethods, pas la suppression.
+#
+# Conséquence assumée. La haute disponibilité par répliques décalées (A à
+# :00/:20/:40, B à :10/:30/:50) est un SPIKE SÉPARÉ, pas à improviser ici :
+# deux instances wM 10.15 sur un ES partagé exigent un vrai clustering
+# (Terracotta/Ignite) non instruit. Spéc stoa-labs F5 § D9.
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/deploy/bootstrap/wm/apigateway/service.yaml
+++ b/deploy/bootstrap/wm/apigateway/service.yaml
@@ -1,13 +1,24 @@
 # ClusterIP uniquement — doctrine no-Ingress du lot 1 : l'admin REST (5555) et
 # la console (9072) ne sont joignables que du cluster ; accès humain par
-# `kubectl port-forward`. L'exposition publique du data-plane viendra par la
-# bascule Caddy (F5), pas par un Ingress.
+# `kubectl port-forward`. L'exposition publique du data-plane est venue par la
+# bascule Caddy (F5), pas par un Ingress — et elle ne publie QUE /gateway/*.
 apiVersion: v1
 kind: Service
 metadata:
   name: wm-apigateway
   namespace: wm
 spec:
+  # ClusterIP ÉPINGLÉE — F5. Caddy tourne au niveau HÔTE sur worker-3 et ignore
+  # CoreDNS (comme containerd) : sa cible amont est donc une IP, pas un nom.
+  # Sans épinglage, toute recréation du Service réattribue l'adresse et le
+  # Caddyfile pointe dans le vide — des 502 publics SANS aucune alerte, car
+  # rien ne relie mécaniquement les deux artefacts.
+  # Motif identique à la ClusterIP gitea (10.43.60.211) épinglée au lot 1.
+  # Mesuré joignable depuis l'hôte worker-3 : 200 en 18,7 ms (2026-07-30).
+  #
+  # SI CETTE VALEUR CHANGE, changer AUSSI, dans le dépôt stoa-labs :
+  #   ansible/roles/caddy_wm_cutover/defaults/main.yml → wm_cutover_upstream
+  clusterIP: 10.43.227.71
   selector:
     app: wm-apigateway
   ports:

--- a/deploy/bootstrap/wm/backend-dev/configmap.yaml
+++ b/deploy/bootstrap/wm/backend-dev/configmap.yaml
@@ -1,0 +1,62 @@
+# Backend RÉEL de l'API `accounts-read` publiée par F4.
+#
+# F4 avait posé l'URI `backend-dev.wm.svc.cluster.local:8080/accounts` en la
+# documentant honnêtement comme « nom honnête, aucun backend réel derrière » :
+# la route data-plane fonctionnait (500 mesuré = elle passe, le backend manque)
+# mais rien ne répondait. F5 fait EXISTER ce nom, ce qui rend l'API réellement
+# invocable SANS RIEN RENOMMER. Spéc stoa-labs F5 § D5.
+#
+# Le serveur répond 200 sur N'IMPORTE QUEL chemin, et JOURNALISE le chemin reçu.
+# Raison : webMethods concatène la ressource à l'URI de l'endpoint, et cet
+# endpoint se termine déjà par /accounts — le backend peut donc recevoir
+# /accounts/accounts. Plutôt que de deviner la règle de concaténation, on est
+# agnostique, et le chemin réellement reçu devient une PREUVE consignée.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend-dev-src
+  namespace: wm
+data:
+  server.py: |
+    import json
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    ACCOUNTS = [
+        {"id": "ACC-001", "holder": "Ada Lovelace", "balance": 1042.50, "currency": "EUR"},
+        {"id": "ACC-002", "holder": "Alan Turing",  "balance":  317.00, "currency": "EUR"},
+    ]
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def _respond(self, with_body):
+            payload = json.dumps({
+                "backend": "backend-dev.wm.svc.cluster.local",
+                "receivedPath": self.path,
+                "accounts": ACCOUNTS,
+            }).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            if with_body:
+                self.wfile.write(payload)
+
+        def do_GET(self):
+            self._respond(True)
+
+        def do_HEAD(self):
+            self._respond(False)
+
+        def log_message(self, fmt, *args):
+            print("backend-dev %s" % (fmt % args), flush=True)
+
+    # ThreadingHTTPServer, PAS HTTPServer : avec protocol_version HTTP/1.1 la
+    # connexion reste ouverte (keep-alive), et un HTTPServer mono-connexion
+    # resterait bloqué à servir le premier client — une gateway qui maintient
+    # un pool de connexions ferait alors expirer tous les autres appels.
+    # Constaté en exécutant le script avant de le déployer.
+    class Server(ThreadingHTTPServer):
+        daemon_threads = True
+
+    Server(("0.0.0.0", 8080), Handler).serve_forever()

--- a/deploy/bootstrap/wm/backend-dev/deployment.yaml
+++ b/deploy/bootstrap/wm/backend-dev/deployment.yaml
@@ -1,0 +1,63 @@
+# Image RÉUTILISÉE depuis le registre Gitea PAR DIGEST (doctrine F3 : aucune
+# image depuis Docker Hub, aucun tag mutable). `jenkins-go:v1` embarque python3
+# (dépendance d'ansible-core) : inutile de construire et de pousser une image
+# pour 40 lignes de serveur HTTP. Le code vit dans un ConfigMap, donc l'état de
+# ce backend se dérive entièrement de Git (ADR-076).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-dev
+  namespace: wm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend-dev
+  template:
+    metadata:
+      labels:
+        app: backend-dev
+    spec:
+      # Anti-affinité worker-3 (motif PR #2819) : la prod Docker wm-dev-* y
+      # tourne encore au moment où ce manifeste est posé (double-run F3–F5).
+      # À conserver après la décommission : worker-3 porte Caddy, le point
+      # d'entrée public de toute la flotte — on n'y empile pas de charge.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - worker-3
+      containers:
+        - name: backend
+          image: localhost:30300/ci/jenkins-go:v1@sha256:00ad5591be6f1c7b4eccfd7e498abe5e947dc07f01e4d7a247005b65ef0c565b
+          command: ["python3", "/opt/backend/server.py"]
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: src
+              mountPath: /opt/backend
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /accounts
+              port: 8080
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /accounts
+              port: 8080
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: src
+          configMap:
+            name: backend-dev-src

--- a/deploy/bootstrap/wm/backend-dev/kustomization.yaml
+++ b/deploy/bootstrap/wm/backend-dev/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: wm
+resources:
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/deploy/bootstrap/wm/backend-dev/service.yaml
+++ b/deploy/bootstrap/wm/backend-dev/service.yaml
@@ -1,0 +1,18 @@
+# ClusterIP, NON épinglée — et c'est délibéré. Ce Service n'est consommé que
+# par la gateway, DEPUIS UN POD, donc par son nom DNS résolu par CoreDNS.
+# Contrairement à wm-apigateway (dont Caddy est un consommateur au niveau HÔTE,
+# qui ignore CoreDNS), aucune raison d'épingler l'adresse ici : épingler ce
+# qu'on n'a pas besoin de figer ajoute une contrainte d'immutabilité sans
+# bénéfice.
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-dev
+  namespace: wm
+spec:
+  selector:
+    app: backend-dev
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080


### PR DESCRIPTION
Préalables du jalon **F5** (bascule du nom public `dev-wm.gostoa.dev` vers la gateway du cluster). Spéc : `stoa-labs docs/superpowers/specs/2026-07-30-f5-bascule-decommission-design.md`.

Une seule PR pour trois changements : ils vivent tous sous `deploy/bootstrap/wm/`, et chaque merge coûte un geste exploitant.

## 1. `backend-dev` — un backend réel pour `accounts-read`

F4 avait publié `accounts-read` avec l'URI `backend-dev.wm.svc.cluster.local:8080/accounts`, documentée honnêtement comme « nom honnête, aucun backend réel derrière ». Mesuré : `/gateway/accounts-read/1.0.0/accounts` rend **500** — la route data-plane passe, seul le backend manque. Cette PR **fait exister** ce nom, ce qui rend l'API invocable **sans rien renommer**.

- Image **réutilisée** depuis le registre Gitea **par digest** (`jenkins-go:v1` embarque python3) : aucune image nouvelle, aucun tag mutable, aucun Docker Hub.
- Le code vit dans un ConfigMap : l'état se dérive entièrement de Git (ADR-076).
- Le serveur répond 200 sur **n'importe quel chemin** et **journalise le chemin reçu** — webMethods concatène la ressource à l'URI de l'endpoint, lequel se termine déjà par `/accounts`. Plutôt que de deviner la règle, on est agnostique et le chemin réellement reçu devient une preuve.
- **`ThreadingHTTPServer` et non `HTTPServer`** : défaut trouvé en exécutant le script *avant* de le déployer. Avec `protocol_version = HTTP/1.1` la connexion reste ouverte, et un serveur mono-connexion reste bloqué sur le premier client. Mesuré : une connexion keep-alive tenue faisait **expirer 3 appels concurrents sur 3** ; après correction, **3/3 servis en moins de 5 ms**. Une gateway qui maintient un pool aurait rendu la porte F5 rouge pour une raison introuvable côté cluster.

## 2. ClusterIP de `wm-apigateway` épinglée

Caddy tourne au niveau **hôte** sur worker-3 et ignore CoreDNS (comme containerd) : sa cible amont est une **IP**, pas un nom. Sans épinglage, toute recréation du Service réattribue l'adresse et le Caddyfile pointe dans le vide — des **502 publics sans aucune alerte**, car rien ne relie mécaniquement les deux artefacts.

Motif identique à la ClusterIP gitea du lot 1. Mesurée joignable **depuis l'hôte worker-3** : 200 en 18,7 ms.

## 3. Cycle trial rechiffré

Le commentaire du CronJob annonçait « retour Ready ~5 min ; ~15 min de service par cycle de 20 min ». **Mesuré** (sonde à 5 s depuis l'hôte, 2026-07-30) : la coupure dure **150 s** (07:20:23 → 07:22:54), soit **17 min 30 de service par cycle et 87,5 % de disponibilité**. L'estimation surestimait le trou d'un facteur 2. Les jobs `wm-restarter` durent 4-9 s : les 150 s sont le démarrage de webMethods.

La haute disponibilité par répliques décalées est renvoyée à un **spike séparé** : deux instances wM 10.15 sur un ES partagé exigent un vrai clustering (Terracotta/Ignite) non instruit.

## Doctrine

Aucun Ingress, aucun NodePort, aucune règle ufw. La bascule ne publiera que `/gateway/*` — l'admin REST, aujourd'hui joignable publiquement en 401 sur worker-3, passera en 404.

## Vérification avant merge

`kubectl kustomize deploy/bootstrap/wm/backend-dev` et `.../apigateway` rendent sans erreur ; la `clusterIP` épinglée est la valeur **courante** du Service, donc l'apply est un no-op sur un champ immuable (une valeur périmée provoquerait, elle, une erreur d'immutabilité — fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)