### PR TITLE
docs(wm): corriger le chiffre du cycle trial — 120-235 s, pas 150 s

### DIFF
--- a/deploy/bootstrap/wm/apigateway/cronjob.yaml
+++ b/deploy/bootstrap/wm/apigateway/cronjob.yaml
@@ -3,12 +3,32 @@
 # contrôlé aux minutes 0/20/40 — le même motif que le cron root de worker-3,
 # porté avec le pod. Le ReplicaSet recrée le pod aussitôt.
 #
-# CHIFFRE MESURÉ (F5, 2026-07-30) : la coupure dure 150 s, pas « ~5 min ».
-# Sonde à 5 s depuis l'hôte worker-3 sur la ClusterIP : 07:20:23 → 07:22:54.
-# Soit 17 min 30 de service par cycle de 20 min = 87,5 % de disponibilité.
-# L'estimation précédente (« retour Ready ~5 min ; ~15 min de service par
-# cycle ») surestimait le trou d'un facteur 2. Les jobs wm-restarter eux-mêmes
-# durent 4-9 s : les 150 s sont le DÉMARRAGE de webMethods, pas la suppression.
+# COUPURE MESURÉE : 120 à 235 s par cycle, soit ~85 % de disponibilité.
+#
+# Sonde à 5 s sur l'INVOCATION DATA-PLANE publique
+# (https://dev-wm.gostoa.dev/gateway/…), 36 min, deux cycles complets
+# (F5, 2026-07-30) :
+#     10:40:09 → 10:44:04   235 s
+#     11:00:14 → 11:02:18   120 s
+# La dispersion atteint un FACTEUR 2 : le chiffre honnête est un intervalle,
+# pas un point. Ne pas le réduire à une moyenne rassurante.
+#
+# CORRECTION d'une valeur précédemment inscrite ici. Ce commentaire annonçait
+# « 150 s » et « 87,5 % ». C'était mesuré sur /rest/apigateway/health — or le
+# health remonte ~85 s AVANT que l'API soit chargée et invocable. Un client
+# voit donc plus long qu'une sonde de santé, et c'est le client qui compte.
+# Les jobs wm-restarter durent 4-9 s : la coupure est le DÉMARRAGE de
+# webMethods, pas la suppression du pod.
+#
+# Ce que voit un client pendant la fenêtre (355 s cumulées sur les 2 cycles) :
+#     503  340 s  le handle_errors du Caddyfile (worker-3) — intention tenue
+#     500   10 s  webMethods répond lui-même 500 pendant son arrêt, et Caddy
+#                 RELAIE ce 5xx amont : handle_errors ne capture que les
+#                 erreurs DE Caddy, pas une réponse d'erreur transmise
+#     000    5 s  aucune réponse sous 6 s (connexion vers un amont mort)
+# Le couvrir exigerait d'intercepter les 5xx amont (handle_response), ce qui
+# masquerait aussi de vraies erreurs applicatives de la gateway. À connaître,
+# pas à maquiller.
 #
 # Conséquence assumée. La haute disponibilité par répliques décalées (A à
 # :00/:20/:40, B à :10/:30/:50) est un SPIKE SÉPARÉ, pas à improviser ici :


### PR DESCRIPTION
Correction d'une valeur que **cette même série de PR avait inscrite** (#2825). Commentaire seul, aucun changement de comportement.

## Ce qui était faux

Le commentaire annonçait « la coupure dure 150 s » et « 87,5 % de disponibilité ». C'était mesuré sur `/rest/apigateway/health` — or **le health remonte ~85 s avant que l'API soit chargée et invocable**. Un client voit donc plus long qu'une sonde de santé, et c'est le client qui compte.

Laisser un chiffre connu comme faux serait pire que l'estimation qu'il avait remplacée : il se présente comme une mesure.

## Ce qui est mesuré

Sonde à 5 s sur l'**invocation data-plane publique** (`https://dev-wm.gostoa.dev/gateway/accounts-read/1.0.0/accounts`), 36 min, **deux cycles complets** (2026-07-30) :

| Coupure | Durée |
|---|---|
| 10:40:09 → 10:44:04 | **235 s** |
| 11:00:14 → 11:02:18 | **120 s** |

**La dispersion atteint un facteur 2** : le chiffre honnête est un **intervalle**, pas un point. ~85 % de disponibilité. À ne pas réduire à une moyenne rassurante — la réserve posée en spéc (« un seul cycle observé ; le chiffre gravé sera un intervalle ») s'est vérifiée.

## Ce que voit réellement un client

Documenté au passage, parce que le 503 n'est pas total. Sur 355 s de coupure cumulée :

| Code | Durée | Origine |
|---|---|---|
| **503** | 340 s | le `handle_errors` du Caddyfile — l'intention est tenue |
| **500** | 10 s | webMethods répond lui-même 500 pendant son arrêt, et Caddy **relaie** ce 5xx amont. `handle_errors` ne capture que les erreurs *de Caddy*, pas une réponse d'erreur transmise avec succès. |
| **000** | 5 s | aucune réponse sous 6 s (connexion vers un amont mort) |

Le couvrir exigerait d'intercepter les 5xx amont (`handle_response`), ce qui masquerait aussi de vraies erreurs applicatives de la gateway. **À connaître, pas à maquiller.**

Contexte complet : `stoa-labs docs/superpowers/plans/2026-07-30-f5-bascule-decommission.md`, § T8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)