### PR TITLE
fix(ci): portal et control-plane-ui sur ubuntu-latest — leurs jobs ne partaient jamais

### DIFF
--- a/.github/workflows/control-plane-ui-ci.yml
+++ b/.github/workflows/control-plane-ui-ci.yml
@@ -61,7 +61,16 @@ jobs:
       run-coverage: true
       run-build: true
       upload-artifact: true
-      runner: self-hosted
+      # `ubuntu-latest` et non `self-hosted` : le dépôt n'a AUCUN runner
+      # auto-hébergé enregistré (0 au 2026-07-30), donc ce job restait en file
+      # indéfiniment — mesuré 38 min sans démarrer, seul run en attente du
+      # dépôt. Conséquence : tout changement front atteignait `main` SANS
+      # aucune validation CI. Un contrôle qui ne peut pas s'exécuter n'est pas
+      # un garde-fou, c'est un voyant éteint qu'on croit allumé.
+      # reusable-node-ci ne fait que lint/format/i18n/test/build Node : il n'a
+      # besoin d'aucune ressource locale. Si des runners sont réenregistrés un
+      # jour, repasser ce paramètre suffit — l'entrée `runner` est prévue pour.
+      runner: ubuntu-latest
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/stoa-portal-ci.yml
+++ b/.github/workflows/stoa-portal-ci.yml
@@ -61,7 +61,16 @@ jobs:
       run-coverage: true
       run-build: true
       upload-artifact: true
-      runner: self-hosted
+      # `ubuntu-latest` et non `self-hosted` : le dépôt n'a AUCUN runner
+      # auto-hébergé enregistré (0 au 2026-07-30), donc ce job restait en file
+      # indéfiniment — mesuré 38 min sans démarrer, seul run en attente du
+      # dépôt. Conséquence : tout changement front atteignait `main` SANS
+      # aucune validation CI. Un contrôle qui ne peut pas s'exécuter n'est pas
+      # un garde-fou, c'est un voyant éteint qu'on croit allumé.
+      # reusable-node-ci ne fait que lint/format/i18n/test/build Node : il n'a
+      # besoin d'aucune ressource locale. Si des runners sont réenregistrés un
+      # jour, repasser ce paramètre suffit — l'entrée `runner` est prévue pour.
+      runner: ubuntu-latest
     permissions:
       contents: read
       checks: write


### PR DESCRIPTION
## Le défaut

Le dépôt n'a **aucun runner auto-hébergé enregistré** (`actions/runners` → `total_count: 0`), or `stoa-portal-ci.yml` et `control-plane-ui-ci.yml` demandaient `runner: self-hosted`.

Leurs jobs restaient donc **en file indéfiniment** — mesuré **38 minutes sans démarrer** sur la PR #2828, et c'étaient les *seuls* runs en attente de tout le dépôt. Ce n'était pas un embouteillage, c'était une impasse.

## Pourquoi ça compte plus qu'il n'y paraît

**Tout changement front atteignait `main` sans aucune validation CI.** Et le trou était invisible : les checks s'affichaient « en cours », jamais en échec, donc rien ne le signalait. Un contrôle qui ne peut pas s'exécuter n'est pas un garde-fou — c'est un voyant éteint qu'on croit allumé, ce qui est pire que pas de contrôle, puisqu'il inspire une confiance qu'il ne mérite pas.

Découvert en cherchant pourquoi #2828 stagnait, pas par une alerte.

## Le correctif

`reusable-node-ci` ne fait que `lint` / `format:check` / `i18n:check` / `test` / `build` Node avec upload d'artefacts : **aucune ressource locale, aucun accès cluster, aucun registre privé**. `ubuntu-latest` lui suffit.

L'entrée `runner` du workflow réutilisable est **déjà prévue** pour ce choix — sa description dit « e.g., ubuntu-latest or self-hosted ». Si des runners sont réenregistrés un jour, repasser ce paramètre suffira.

## Non touché, volontairement

`e2e-tests.yml` demande aussi `self-hosted`. Les tests E2E peuvent légitimement dépendre de ressources locales, et je n'ai pas les éléments pour trancher. Le basculer à l'aveugle échangerait un voyant éteint contre une suite rouge — à instruire séparément.

## Vérification

Cette PR est son propre test : si les jobs `Build and Test (portal)` et `(control-plane-ui)` passent ici, c'est qu'ils s'exécutent enfin. Ils valideront au passage les bumps de lockfile mergés en #2828, qui n'ont jamais pu l'être.

🤖 Generated with [Claude Code](https://claude.com/claude-code)