### PR TITLE
fix(wm): déclarer volumeMode — l'Application ES était OutOfSync pour toujours

### DIFF
--- a/deploy/bootstrap/wm/elasticsearch/statefulset.yaml
+++ b/deploy/bootstrap/wm/elasticsearch/statefulset.yaml
@@ -71,6 +71,14 @@ spec:
       spec:
         accessModes: ["ReadWriteOnce"]
         storageClassName: local-path
+        # `volumeMode` déclaré EXPLICITEMENT alors que Filesystem est le défaut :
+        # sans lui, l'API l'ajoute au StatefulSet vivant, or volumeClaimTemplates
+        # est IMMUABLE — Argo voyait donc un écart qu'il ne pouvait jamais
+        # réconcilier, et l'Application restait OutOfSync indéfiniment (constaté
+        # F5, 2026-07-30). Ce qui compte n'est pas la dérive mais sa conséquence :
+        # pour cette Application, « OutOfSync » ne signalait plus rien — une
+        # alerte allumée en permanence est une alerte qu'on apprend à ignorer.
+        volumeMode: Filesystem
         resources:
           requests:
             storage: 10Gi


### PR DESCRIPTION
## Le défaut

`volumeMode: Filesystem` est la valeur par défaut, mais l'API Kubernetes l'**ajoute** au StatefulSet vivant. Or `volumeClaimTemplates` est un champ **immuable** : Argo voyait donc un écart entre Git et le cluster qu'il ne pouvait **jamais** réconcilier.

Résultat : l'Application `wm-elasticsearch` restait `OutOfSync` **indéfiniment**, tout en étant `Healthy`. Les seules ressources en écart étaient les champs ajoutés par l'API (`apiVersion`, `kind`, `volumeMode`, `status`) — pas nos manifestes.

## Pourquoi ce n'est pas cosmétique

La dérive elle-même est bénigne. Sa **conséquence** ne l'est pas : pour cette Application, « OutOfSync » ne signalait plus rien. Une alerte allumée en permanence est une alerte qu'on apprend à ignorer — et elle masque celle qui compterait vraiment.

C'est le même défaut que des checks CI incapables de s'exécuter (cf. [#2833](https://github.com/stoa-platform/stoa/pull/2833)) : **un voyant qui ne peut pas changer d'état n'informe pas.** Les deux ont été trouvés le même jour, par diagnostic, jamais par une alerte — ce qui est exactement le problème.

## Le correctif

Déclarer explicitement la valeur par défaut fait coïncider Git et le cluster. **Aucun changement de comportement** : le StatefulSet vivant a déjà `volumeMode: Filesystem`, donc l'apply est un no-op sur un champ immuable qui porte déjà cette valeur.

Trouvé en diagnostiquant pourquoi l'Application est passée `OutOfSync` après le merge de #2825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)