### PR TITLE
fix(argocd): ignorer volumeClaimTemplates — l'écart ES est irréductible

### DIFF
--- a/deploy/bootstrap/argocd/app-wm-elasticsearch.yaml
+++ b/deploy/bootstrap/argocd/app-wm-elasticsearch.yaml
@@ -11,6 +11,27 @@ spec:
     repoURL: https://github.com/stoa-platform/stoa.git
     targetRevision: main
     path: deploy/bootstrap/wm/elasticsearch
+  # `volumeClaimTemplates` est IGNORÉ, et c'est le seul correctif possible.
+  # L'API ajoute au StatefulSet vivant trois champs absents de Git :
+  #   apiVersion: v1 · kind: PersistentVolumeClaim · status: {phase: Pending}
+  # `status` n'est déclarable dans AUCUN manifeste — l'écart est donc
+  # irréductible, et l'Application restait OutOfSync indéfiniment.
+  # Ignorer n'occulte rien d'actionnable : volumeClaimTemplates est un champ
+  # IMMUABLE sur un StatefulSet, donc Argo ne pourrait de toute façon jamais
+  # agir sur une différence à cet endroit.
+  # Ce qui était en jeu n'est pas la dérive mais sa conséquence : une alerte
+  # allumée en permanence est une alerte qu'on apprend à ignorer, et elle
+  # masque celle qui compterait.
+  # Une première tentative (#2834, déclarer volumeMode) n'a corrigé qu'un des
+  # champs : les blocs `spec` coïncident désormais, mais apiVersion/kind/status
+  # subsistaient. Écart re-mesuré avant d'écrire ceci, pas supposé.
+  ignoreDifferences:
+    - group: apps
+      kind: StatefulSet
+      name: wm-elasticsearch
+      namespace: wm
+      jsonPointers:
+        - /spec/volumeClaimTemplates
   destination:
     server: https://kubernetes.default.svc
     namespace: wm


### PR DESCRIPTION
**Correctif de mon propre correctif.** [#2834](https://github.com/stoa-platform/stoa/pull/2834) déclarait `volumeMode` en annonçant que cela solderait l'`OutOfSync` permanent de `wm-elasticsearch`. **C'était insuffisant**, et vérifié après merge : Argo est sur le commit exact qui l'ajoute, le StatefulSet vivant porte bien `volumeMode: Filesystem`, et l'Application reste `OutOfSync`.

## L'écart, re-mesuré plutôt que supposé une seconde fois

Les blocs `spec` **coïncident désormais** — #2834 a bien corrigé sa part. Subsistent trois champs que l'API ajoute au StatefulSet vivant et que Git ne porte pas :

```
apiVersion: v1
kind: PersistentVolumeClaim
status: {phase: Pending}
```

**`status` n'est déclarable dans aucun manifeste.** L'écart est donc irréductible par le manifeste, et `ignoreDifferences` est le seul correctif possible — ce que j'aurais dû établir *avant* d'annoncer le premier.

## Pourquoi ignorer ne cache rien

`volumeClaimTemplates` est un champ **immuable** sur un StatefulSet : Argo ne pourrait de toute façon **jamais** agir sur une différence à cet endroit. On ne masque donc aucune divergence actionnable — on cesse de signaler une divergence sur laquelle personne ne peut rien.

Ce qui est en jeu n'est pas la dérive, bénigne, mais sa conséquence : pour cette Application, « OutOfSync » ne signalait plus rien. Une alerte allumée en permanence est une alerte qu'on apprend à ignorer, et elle masque celle qui compterait vraiment.

## Après merge

L'Application est un objet de bootstrap **appliqué à la main** — ce manifeste devra être ré-appliqué, et le résultat vérifié. Je le ferai plutôt que de le supposer, cette fois.

🤖 Generated with [Claude Code](https://claude.com/claude-code)