### PR TITLE
fix(ci): e2e-tests sur ubuntu-latest — la suite ne s'exécutait plus du tout

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -69,7 +69,14 @@ env:
 jobs:
   e2e-tests:
     name: E2E Tests (shard ${{ matrix.shard }}/3)
-    runs-on: self-hosted
+    # `ubuntu-latest` : le dépôt n'a AUCUN runner auto-hébergé enregistré
+    # (0 au 2026-07-30), donc ces jobs restaient en file indéfiniment — la
+    # suite E2E ne s'exécutait tout simplement plus. Mesuré 38 min sans
+    # démarrer sur une PR, sans qu'aucun check ne rougisse : un contrôle qui
+    # ne peut pas s'exécuter n'alerte sur rien.
+    # Vérifié avant bascule : les cibles E2E sont publiques (portal 200,
+    # console 200, auth 302) et les 12 secrets de repli GitHub existent tous.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     # PR and scheduled runs are non-blocking — E2E requires live infra
     continue-on-error: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
@@ -84,7 +91,17 @@ jobs:
 
       - name: Fetch E2E secrets from Vault
         id: vault-secrets
-        continue-on-error: true  # Gracefully fall back to GitHub secrets if Vault fails
+        # ÉCHEC ATTENDU sur un runner GitHub, et c'est assumé : hcvault.gostoa.dev
+        # résout publiquement mais son 443 est FERMÉ de l'extérieur — mesuré le
+        # 2026-07-30. Seul un runner du réseau autorisé
+        # l'atteint. Le repli sur les secrets GitHub cesse donc d'être un
+        # filet et devient le chemin NORMAL ; les 12 secrets nécessaires sont
+        # présents (4 personas × user/password + 4 URL).
+        # À savoir : ce `continue-on-error` a DÉJÀ masqué une panne
+        # silencieuse (404 sur une mauvaise URL, cf. commentaire ci-dessous).
+        # Si des runners auto-hébergés sont réenregistrés, repasser
+        # `runs-on` ci-dessus suffit à redonner Vault comme source primaire.
+        continue-on-error: true
         uses: hashicorp/vault-action@v3
         with:
           # vault.gostoa.dev = Infisical (different product) — E2E secrets live on


### PR DESCRIPTION
Dernier workflow demandant `self-hosted` alors que le dépôt n'a **aucun runner auto-hébergé enregistré** (0 au 2026-07-30). Ces jobs restaient en file indéfiniment : **la suite E2E ne tournait tout simplement plus**, sans qu'aucun check ne rougisse. Même défaut que les CI front corrigées en [#2833](https://github.com/stoa-platform/stoa/pull/2833).

## Vérifié avant de basculer

Les E2E pouvaient légitimement dépendre de ressources locales — je ne l'ai donc pas fait à l'aveugle.

| Dépendance | Joignable depuis un runner GitHub ? |
|---|---|
| `portal.gostoa.dev` · `console.gostoa.dev` · `auth.gostoa.dev` | **oui** — 200 / 200 / 302 mesurés |
| `hcvault.gostoa.dev` (secrets) | **NON** — résout publiquement (`51.255.193.129`) mais **443 fermé** de l'extérieur |
| 12 secrets de repli GitHub (4 personas × user/password + 4 URL) | **oui, tous présents** |

Le workflow les consomme déjà via `${{ env.X || secrets.X }}`. **La bascule fonctionne donc**, en passant par le repli.

## Ce que je rends explicite

Le repli **cesse d'être un filet pour devenir le chemin normal**. Je l'ai écrit dans le fichier plutôt que de le laisser accidentel : un mécanisme de secours devenu principal sans que personne ne l'ait décidé est un piège à retardement.

D'autant que ce `continue-on-error: true` **a déjà masqué une panne silencieuse** — le commentaire voisin le raconte : un changement d'URL avait provoqué un 404 que personne n'a vu. Il masquera désormais un échec Vault **à chaque exécution** : c'est assumé et documenté, pas subi.

Si des runners auto-hébergés sont réenregistrés un jour, repasser `runs-on` suffit à redonner Vault comme source primaire.

## Vérification

Cette PR est son propre test : si les jobs E2E démarrent et rendent un verdict — vert ou rouge — c'est déjà mieux qu'aujourd'hui, où ils ne rendent rien. Un rouge serait une information ; le silence actuel n'en est pas une.

🤖 Generated with [Claude Code](https://claude.com/claude-code)