### PR TITLE
ci: gateway Rust sur ubuntu-latest, et une garantie écrite qui n'existait pas

### DIFF
--- a/.github/workflows/mcp-sdk-smoke.yml
+++ b/.github/workflows/mcp-sdk-smoke.yml
@@ -55,7 +55,18 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev libsasl2-dev cmake build-essential \
             python3 python3-venv python3-pip
 
+      # `working-directory` est REQUIS par cette action (aucun défaut) et
+      # manquait ici : rust-cache lançait donc `cargo metadata` à la racine du
+      # dépôt, où il n'y a pas de Cargo.toml, et le job mourait au setup.
+      # Ce workflow n'avait donc JAMAIS pu s'exécuter — alors que son en-tête
+      # annonce qu'il attrape les régressions de schéma CAB-2106/2109/2112
+      # avant la prod. Un garde écrit EN RÉPONSE à des incidents, qui n'a jamais
+      # tourné. `defaults.run.working-directory` ne corrige pas le cas : il ne
+      # s'applique qu'aux étapes `run:`, jamais aux `uses:`.
+      # rust-scheduled-checks.yml, lui, passait bien l'entrée.
       - uses: ./.github/actions/setup-rust-env
+        with:
+          working-directory: stoa-gateway
 
       - name: Install MCP Python SDK
         working-directory: .

--- a/.github/workflows/stoa-gateway-ci.yml
+++ b/.github/workflows/stoa-gateway-ci.yml
@@ -56,13 +56,32 @@ jobs:
     with:
       component: stoa-gateway
       cargo-features: '--features kafka,pingora'
-      runner: self-hosted
+      # `ubuntu-latest` : le dépôt n'a AUCUN runner auto-hébergé enregistré
+      # (0 au 2026-07-30), donc ce job restait en file indéfiniment — le CI
+      # Rust de la gateway ne s'exécutait tout simplement plus.
+      # Vérifié avant bascule, car un build Rust peut légitimement dépendre
+      # de l'hôte : reusable-rust-ci installe LUI-MÊME ses dépendances
+      # système (libcurl, libsasl2, cmake, build-essential) et sccache y est
+      # configuré avec SCCACHE_GHA_ENABLED, c'est-à-dire le cache GitHub
+      # Actions — conçu pour les runners hébergés, pas un cache disque local.
+      # Le workflow a de plus un repli explicite si sccache est indisponible.
+      runner: ubuntu-latest
     permissions:
       contents: read
 
   # === Docker: build + push GHCR (AMD64 only) ===
   # Note: does NOT depend on ci — flaky integration tests must not block deploy.
-  # CI still runs in parallel for visibility. Clippy/fmt gate PR merges via required checks.
+  # CI still runs in parallel for visibility.
+  # ATTENTION — la phrase qui figurait ici (« Clippy/fmt gate PR merges via
+  # required checks ») était FAUSSE, vérifié le 2026-07-30. Les checks
+  # réellement requis sur `main` sont : License Compliance, SBOM Generation,
+  # Verify Signed Commits, Regression Test Guard. Ni clippy, ni fmt, ni aucun
+  # CI Rust n'y figure. Ce job ne gardait donc rien — et il ne s'exécutait
+  # même pas, faute de runner (corrigé ci-dessus).
+  # Une garantie écrite mais inexistante est pire qu'une absence de garantie :
+  # elle dispense de vérifier. Corriger la phrase AVANT de décider s'il faut
+  # ajouter ce check aux required — c'est une décision de politique de merge,
+  # qui appartient aux mainteneurs du dépôt.
   docker:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-docker-ghcr.yml

--- a/stoa-gateway/src/hegemon/messaging.rs
+++ b/stoa-gateway/src/hegemon/messaging.rs
@@ -55,7 +55,7 @@ impl AgentMessage {
             id: format!(
                 "msg-{}-{}",
                 chrono::Utc::now().timestamp_millis(),
-                &uuid_fragment()
+                uuid_fragment()
             ),
             from: from.to_string(),
             to: to.to_string(),

--- a/stoa-gateway/src/oauth/proxy.rs
+++ b/stoa-gateway/src/oauth/proxy.rs
@@ -447,7 +447,7 @@ async fn patch_public_client(
 
     let clients_resp = client
         .get(&clients_url)
-        .header("Authorization", format!("Bearer {}", &admin_token))
+        .header("Authorization", format!("Bearer {}", admin_token))
         .send()
         .await
         .map_err(|e| format!("Client lookup failed: {}", e))?;
@@ -505,7 +505,7 @@ async fn patch_public_client(
 
     let patch_resp = client
         .put(&update_url)
-        .header("Authorization", format!("Bearer {}", &admin_token))
+        .header("Authorization", format!("Bearer {}", admin_token))
         .json(&patch_body)
         .send()
         .await

--- a/stoa-gateway/tests/e2e/mcp_sdk_smoke.py
+++ b/stoa-gateway/tests/e2e/mcp_sdk_smoke.py
@@ -49,7 +49,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 
 DEFAULT_URL = "http://127.0.0.1:8080/mcp/sse"
@@ -71,7 +71,7 @@ async def run_smoke(
     headers = {"Authorization": f"Bearer {bearer}"} if bearer else None
 
     try:
-        async with streamablehttp_client(url, headers=headers) as (
+        async with streamable_http_client(url, headers=headers) as (
             read_stream,
             write_stream,
             _get_session_id,


### PR DESCRIPTION
Deux défauts dans le même fichier — **le second est plus grave que le premier**.

## 1. Le runner

Dernier appel demandant `self-hosted` alors que le dépôt n'a aucun runner enregistré : **le CI Rust de la gateway ne s'exécutait plus**.

Vérifié avant de basculer, car un build Rust peut légitimement dépendre de l'hôte. Ce n'est pas le cas :

| Objection | Réalité mesurée |
|---|---|
| « sccache ne persisterait pas » | `SCCACHE_GHA_ENABLED: 'true'` — c'est le cache **GitHub Actions**, conçu pour les runners hébergés, pas un cache disque local |
| « l'image self-hosted a les dépendances » | `reusable-rust-ci` fait lui-même `apt-get install libcurl4-openssl-dev libsasl2-dev cmake build-essential` |
| « et si sccache échoue ? » | repli déjà présent : *« sccache not functional — proceeding without it »* |

## 2. Le commentaire faux

Le fichier affirmait :

> `Clippy/fmt gate PR merges via required checks.`

Les checks **réellement** requis sur `main` sont : `License Compliance`, `SBOM Generation`, `Verify Signed Commits`, `Regression Test Guard`. **Ni clippy, ni fmt, ni aucun CI Rust.**

Donc ce job ne gardait rien, ne s'exécutait pas, **et** le fichier documentait une protection inexistante. C'est le motif rencontré trois fois aujourd'hui — un voyant incapable de rougir — poussé d'un cran : **une garantie écrite mais fausse est pire qu'une absence de garantie, parce qu'elle dispense de vérifier.**

La phrase est corrigée plutôt que supprimée, et nomme les checks réellement requis. **Ajouter ce CI aux required checks est une décision de politique de merge** : elle appartient aux mainteneurs, pas à cette PR.

## Une récidive, pas une découverte

`control-plane-api-ci.yml:82` porte déjà : *« CAB-2114: moved to ubuntu-latest. The self-hosted runner pool leaked… »*. Le correctif avait été appliqué à **un** workflow, pas à la classe. Avec [#2833](https://github.com/stoa-platform/stoa/pull/2833) et [#2836](https://github.com/stoa-platform/stoa/pull/2836), c'est le quatrième.

Cela plaide pour un audit **« quels contrôles de ce dépôt sont incapables de rougir ? »** plutôt que des correctifs au cas par cas. Reste notamment `e2e-cross-validation.yml`, lui **volontairement** sur self-hosted et hors PR gate — celui-là est légitime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)