### PR TITLE
ci: épingler le SDK MCP en 1.29.0 — un plancher n'est pas une version

### DIFF
--- a/.github/workflows/mcp-sdk-smoke.yml
+++ b/.github/workflows/mcp-sdk-smoke.yml
@@ -32,7 +32,17 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
-  PY_MCP_VERSION: '1.0.0'
+  # ÉPINGLÉ, et non un plancher. `mcp>=1.0.0` prenait la dernière
+  # publication à chaque exécution : le SDK est passé en 2.0.0, qui SUPPRIME
+  # `streamablehttp_client` et le remplace par `streamable_http_client` — une
+  # API différente (plus de `headers` : on lui passe un httpx.AsyncClient
+  # construit par l'appelant). Le smoke cassait donc sans qu'aucun commit ne
+  # le provoque. Un plancher de version dans une suite de test n'est pas une
+  # souplesse, c'est une dépendance non déterministe.
+  # 1.29.0 = dernière 1.x, et version de TRANSITION : elle porte les deux
+  # noms (vérifié en l'installant). Position d'attente assumée — le portage
+  # vers l'API 2.x est un travail à part, pas une correction mécanique.
+  PY_MCP_VERSION: '1.29.0'
 
 jobs:
   pre-merge:
@@ -72,7 +82,7 @@ jobs:
         working-directory: .
         run: |
           python3 -m venv .venv-mcp
-          .venv-mcp/bin/pip install --quiet "mcp>=${PY_MCP_VERSION}"
+          .venv-mcp/bin/pip install --quiet "mcp==${PY_MCP_VERSION}"
 
       - name: Build gateway binary
         run: cargo build --release
@@ -136,7 +146,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y python3 python3-venv python3-pip
           python3 -m venv .venv-mcp
-          .venv-mcp/bin/pip install --quiet "mcp>=${PY_MCP_VERSION}"
+          .venv-mcp/bin/pip install --quiet "mcp==${PY_MCP_VERSION}"
 
       - name: Run MCP SDK smoke against prod
         env:

--- a/stoa-gateway/tests/e2e/mcp_sdk_smoke.py
+++ b/stoa-gateway/tests/e2e/mcp_sdk_smoke.py
@@ -49,7 +49,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from mcp import ClientSession
-from mcp.client.streamable_http import streamable_http_client
+from mcp.client.streamable_http import streamablehttp_client
 
 
 DEFAULT_URL = "http://127.0.0.1:8080/mcp/sse"
@@ -71,7 +71,7 @@ async def run_smoke(
     headers = {"Authorization": f"Bearer {bearer}"} if bearer else None
 
     try:
-        async with streamable_http_client(url, headers=headers) as (
+        async with streamablehttp_client(url, headers=headers) as (
             read_stream,
             write_stream,
             _get_session_id,


### PR DESCRIPTION
`pip install "mcp>=1.0.0"` prenait la **dernière** publication à chaque exécution. Le SDK est passé en **2.0.0**, qui supprime `streamablehttp_client` au profit de `streamable_http_client` — une API différente : plus de `headers`, on lui passe un `httpx.AsyncClient` construit par l'appelant.

**Le smoke cassait donc sans qu'aucun commit ne l'ait provoqué.** Un plancher de version dans une suite de test n'est pas une souplesse : c'est une dépendance non déterministe dont le résultat dépend du jour où on l'exécute. C'était la cause profonde ; le renommage corrigé en [#2837](https://github.com/stoa-platform/stoa/pull/2837) n'en était que le symptôme.

## Le choix de la version, mesuré

Versions publiées relevées, puis **1.29.0 installée et inspectée** :

| | `streamablehttp_client` | `streamable_http_client` |
|---|---|---|
| **1.29.0** | présent, accepte `headers` | présent, **pas** de `headers` |
| **2.0.0** | **supprimé** | seul restant |

1.29.0 est la dernière 1.x, et une version de **transition** qui porte les deux noms. C'est ce qui en fait le point d'ancrage sûr.

## Cohérence avec #2837

#2837 avait renommé le script vers l'API 2.x. **Épingler une 1.x sans revenir dessus aurait produit l'inverse du défaut corrigé** : le script aurait appelé `streamable_http_client(headers=…)`, qui n'accepte pas `headers`. Le renommage est donc annulé — version épinglée et script visent désormais la même API.

## Vérifié localement contre 1.29.0

- l'import passe ;
- l'appel `(url, headers=…)` **se lie** à la signature ;
- tous les symboles importés par le script existent.

## Position d'attente assumée

1.29.0 fige une SDK d'avant la 2.0. Le portage vers l'API 2.x — construire l'`httpx.AsyncClient`, en gérer le cycle de vie — est un vrai travail sur du code de test produit, pas une correction mécanique. À ouvrir séparément. **L'épinglage rend au moins le test reproductible en attendant.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)