### PR TITLE
ci: audit des garde-fous — la 6e occurrence, et un inventaire trompeur

### DIFF
--- a/.github/workflows/required-checks.yml
+++ b/.github/workflows/required-checks.yml
@@ -1,7 +1,13 @@
 # =============================================================================
 # GitHub Actions: Required Checks — Branch Protection Gates
 # =============================================================================
-# Lightweight workflow containing the 3 branch-protection required checks.
+# Lightweight workflow containing 3 des 4 checks requis par la protection de
+# branche. Le QUATRIÈME — `Regression Test Guard` — vit dans un autre
+# workflow. La formulation précédente (« the 3 branch-protection required
+# checks ») laissait croire que ce fichier les portait TOUS : quiconque veut
+# l'inventaire des gardes doit interroger la protection de branche, pas ce
+# fichier. Vérifié le 2026-07-30 : License Compliance, SBOM Generation,
+# Verify Signed Commits (ici) + Regression Test Guard (ailleurs).
 # Extracted from security-scan.yml to avoid trigger delays caused by the
 # heavy 15-job security workflow (SAST, container scans, dependency audits).
 #

--- a/.github/workflows/stoa-operator-ci.yml
+++ b/.github/workflows/stoa-operator-ci.yml
@@ -20,4 +20,13 @@ jobs:
       component: stoa-operator
       python-version: '3.11'
       coverage-threshold: 70
-      runner: self-hosted
+      # `ubuntu-latest` : le dépôt n'a AUCUN runner auto-hébergé enregistré,
+      # donc ce job restait en file indéfiniment — la CI Python de l'opérateur
+      # ne s'exécutait plus. Sixième et dernière occurrence illégitime du motif
+      # (après control-plane-api/CAB-2114, portal, control-plane-ui, e2e-tests,
+      # stoa-gateway) ; seul e2e-cross-validation reste sur self-hosted, lui
+      # LÉGITIMEMENT — son en-tête le déclare hors PR gate et exigeant des
+      # services vivants.
+      # Vérifié : reusable-python-ci ne fait que checkout / setup-python /
+      # lint / test / upload — aucune ressource locale.
+      runner: ubuntu-latest


### PR DESCRIPTION
Audit **systématique** après cinq corrections au cas par cas. Quatre questions posées mécaniquement plutôt qu'au fil des symptômes.

| # | Question | Résultat |
|---|---|---|
| 1 | Des `runs-on` désignent-ils des runners inexistants ? | **1 défaut** — 6ᵉ occurrence |
| 2 | Les checks requis déclarés correspondent-ils aux réels ? | **1 imprécision** |
| 3 | Des actions composites sont-elles appelées sans leurs entrées requises ? | **aucun** |
| 4 | Des dépendances de test sont-elles non épinglées ? | **aucune** |

## 1. Runners — la sixième occurrence

`0` runner auto-hébergé enregistré, et **deux** références subsistaient.

**`stoa-operator-ci.yml`** est la 6ᵉ occurrence illégitime du motif — après `control-plane-api` (via CAB-2114), `portal`, `control-plane-ui`, `e2e-tests`, `stoa-gateway`. **Sa CI Python ne s'exécutait plus.** Basculée, après avoir vérifié que `reusable-python-ci` ne fait que checkout / setup-python / lint / test / upload : aucune ressource locale.

**`e2e-cross-validation.yml`** reste sur `self-hosted` — **légitimement** : son en-tête le déclare hors PR gate et exigeant des services vivants. Un audit doit distinguer le défaut de la décision.

## 2. Checks requis — un inventaire qui trompe

La protection exige **4** checks : `License Compliance`, `SBOM Generation`, `Verify Signed Commits`, `Regression Test Guard`.

`required-checks.yml` en contient **3** et affirmait porter *« the 3 branch-protection required checks »* — exact sur lui-même, mais laissant croire qu'il les portait **tous**. Le quatrième vit ailleurs. Précisé : **l'inventaire des gardes s'obtient de la protection de branche, pas de ce fichier.**

## 3. Une mesure fausse, corrigée

12 actions composites ont des entrées requises sans défaut ; **toutes** leurs invocations les passent. Aucun défaut.

À noter : un premier passage au `grep` avait produit **9 faux positifs**, parce qu'il ne regardait que 4 lignes après le `uses:`. Rejoué en analysant le YAML — le résultat s'est **inversé**. Une mesure fausse est pire qu'une absence de mesure, et l'audit ne s'exempte pas de sa propre règle.

## 4. Dépendances

Aucun plancher `>=` ne subsiste dans les workflows ; l'épinglage du SDK MCP ([#2838](https://github.com/stoa-platform/stoa/pull/2838)) était le dernier.

## Ce qui ressort

Le motif n'était **jamais isolé**. `CAB-2114` l'avait vu une fois et corrigé une fois, sans généraliser — d'où cinq récidives découvertes en une journée, toutes par diagnostic et aucune par une alerte.

Un audit mécanique de la classe entière coûte moins qu'un sixième correctif au cas par cas, et il donne une **réponse bornée** plutôt qu'un soupçon persistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)