### PR TITLE
feat(gateway): porter le smoke MCP vers l'API 2.x, et lever l'épinglage d'attente

### DIFF
--- a/.github/workflows/mcp-sdk-smoke.yml
+++ b/.github/workflows/mcp-sdk-smoke.yml
@@ -39,10 +39,11 @@ env:
   # construit par l'appelant). Le smoke cassait donc sans qu'aucun commit ne
   # le provoque. Un plancher de version dans une suite de test n'est pas une
   # souplesse, c'est une dépendance non déterministe.
-  # 1.29.0 = dernière 1.x, et version de TRANSITION : elle porte les deux
-  # noms (vérifié en l'installant). Position d'attente assumée — le portage
-  # vers l'API 2.x est un travail à part, pas une correction mécanique.
-  PY_MCP_VERSION: '1.29.0'
+  # 2.0.0 = version courante, vers laquelle le script est désormais PORTÉ
+  # (plus de position d'attente sur une 1.x figée). L'épinglage reste : ce
+  # qui cassait n'était pas la version mais le PLANCHER, qui laissait entrer
+  # une majeure sans qu'aucun commit ne le décide.
+  PY_MCP_VERSION: '2.0.0'
 
 jobs:
   pre-merge:

--- a/stoa-gateway/tests/e2e/mcp_sdk_smoke.py
+++ b/stoa-gateway/tests/e2e/mcp_sdk_smoke.py
@@ -48,8 +48,10 @@ import traceback
 from dataclasses import dataclass, field
 from typing import Any
 
+import httpx2
+
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 
 DEFAULT_URL = "http://127.0.0.1:8080/mcp/sse"
@@ -71,110 +73,119 @@ async def run_smoke(
     headers = {"Authorization": f"Bearer {bearer}"} if bearer else None
 
     try:
-        async with streamablehttp_client(url, headers=headers) as (
-            read_stream,
-            write_stream,
-            _get_session_id,
-        ):
-            async with ClientSession(read_stream, write_stream) as session:
-                # 1. initialize — locks CAB-2112 (experimental shape) + CAB-2106 (Accept).
-                init = await session.initialize()
-                results.append(
-                    StageResult(
-                        "initialize",
-                        True,
-                        f"protocol={init.protocolVersion} "
-                        f"server={init.serverInfo.name}/{init.serverInfo.version}",
-                        init,
-                    )
-                )
-
-                # `ping` stays anonymous — part of PUBLIC_METHODS per CAB-2109.
-                ping = await session.send_ping()
-                results.append(StageResult("ping", True, str(ping), ping))
-
-                # 2. Discovery surface — CAB-2121 gated these behind Bearer.
-                #    Without a bearer, record an AUTH_SKIP so post-deploy cron
-                #    without a CI secret doesn't flap; pre-merge injects a
-                #    dummy bearer so `jwt_validator=None` accepts it
-                #    (stoa-gateway/src/mcp/sse.rs:280) and we exercise the
-                #    real discovery surface.
-                if bearer is None:
+        # SDK MCP 2.x : `streamable_http_client` ne prend plus `headers`. On lui
+        # passe un client HTTP pré-configuré — et c'est `httpx2`, pas `httpx` :
+        # le SDK 2.0 dépend d'un paquet distinct (httpx n'est même pas installé).
+        # PROPRIÉTÉ DU CLIENT : la source du SDK est explicite —
+        #   « Only manage client lifecycle if we created it »
+        # donc un client fourni par l'appelant doit être fermé PAR l'appelant.
+        # D'où le `async with` ci-dessous ; l'omettre fuirait des connexions à
+        # chaque exécution.
+        async with httpx2.AsyncClient(headers=headers) as http_client:
+            async with streamable_http_client(url, http_client=http_client) as (
+                read_stream,
+                write_stream,
+                _get_session_id,
+            ):
+                async with ClientSession(read_stream, write_stream) as session:
+                    # 1. initialize — locks CAB-2112 (experimental shape) + CAB-2106 (Accept).
+                    init = await session.initialize()
                     results.append(
                         StageResult(
-                            "discovery",
+                            "initialize",
                             True,
-                            "AUTH_SKIP: set STOA_GATEWAY_BEARER to exercise "
-                            "tools/list, resources/list, prompts/list, logging/setLevel",
-                        )
-                    )
-                else:
-                    tools = await session.list_tools()
-                    results.append(
-                        StageResult(
-                            "tools/list",
-                            len(tools.tools) > 0,
-                            f"{len(tools.tools)} tools",
-                            tools,
+                            f"protocol={init.protocolVersion} "
+                            f"server={init.serverInfo.name}/{init.serverInfo.version}",
+                            init,
                         )
                     )
 
-                    resources = await session.list_resources()
-                    results.append(
-                        StageResult(
-                            "resources/list",
-                            True,
-                            f"{len(resources.resources)} resources",
-                            resources,
-                        )
-                    )
+                    # `ping` stays anonymous — part of PUBLIC_METHODS per CAB-2109.
+                    ping = await session.send_ping()
+                    results.append(StageResult("ping", True, str(ping), ping))
 
-                    templates = await session.list_resource_templates()
-                    results.append(
-                        StageResult(
-                            "resources/templates/list",
-                            True,
-                            f"{len(templates.resourceTemplates)} templates",
-                            templates,
+                    # 2. Discovery surface — CAB-2121 gated these behind Bearer.
+                    #    Without a bearer, record an AUTH_SKIP so post-deploy cron
+                    #    without a CI secret doesn't flap; pre-merge injects a
+                    #    dummy bearer so `jwt_validator=None` accepts it
+                    #    (stoa-gateway/src/mcp/sse.rs:280) and we exercise the
+                    #    real discovery surface.
+                    if bearer is None:
+                        results.append(
+                            StageResult(
+                                "discovery",
+                                True,
+                                "AUTH_SKIP: set STOA_GATEWAY_BEARER to exercise "
+                                "tools/list, resources/list, prompts/list, logging/setLevel",
+                            )
                         )
-                    )
+                    else:
+                        tools = await session.list_tools()
+                        results.append(
+                            StageResult(
+                                "tools/list",
+                                len(tools.tools) > 0,
+                                f"{len(tools.tools)} tools",
+                                tools,
+                            )
+                        )
 
-                    prompts = await session.list_prompts()
-                    results.append(
-                        StageResult(
-                            "prompts/list",
-                            True,
-                            f"{len(prompts.prompts)} prompts",
-                            prompts,
+                        resources = await session.list_resources()
+                        results.append(
+                            StageResult(
+                                "resources/list",
+                                True,
+                                f"{len(resources.resources)} resources",
+                                resources,
+                            )
                         )
-                    )
 
-                    logging_result = await session.set_logging_level("info")
-                    results.append(
-                        StageResult(
-                            "logging/setLevel",
-                            True,
-                            "level=info accepted",
-                            logging_result,
+                        templates = await session.list_resource_templates()
+                        results.append(
+                            StageResult(
+                                "resources/templates/list",
+                                True,
+                                f"{len(templates.resourceTemplates)} templates",
+                                templates,
+                            )
                         )
-                    )
 
-                # 3. One concrete tool invocation (no external deps).
-                #    `stoa_platform_info` is a self-describing health tool.
-                #    Requires a bearer for the same CAB-2121 reason as
-                #    discovery; pre-merge supplies a dummy bearer.
-                if call_tool and bearer is not None:
-                    info = await session.call_tool(
-                        "stoa_platform_info", arguments={}
-                    )
-                    results.append(
-                        StageResult(
-                            "tools/call:stoa_platform_info",
-                            not info.isError,
-                            "ok" if not info.isError else "tool returned isError",
-                            info,
+                        prompts = await session.list_prompts()
+                        results.append(
+                            StageResult(
+                                "prompts/list",
+                                True,
+                                f"{len(prompts.prompts)} prompts",
+                                prompts,
+                            )
                         )
-                    )
+
+                        logging_result = await session.set_logging_level("info")
+                        results.append(
+                            StageResult(
+                                "logging/setLevel",
+                                True,
+                                "level=info accepted",
+                                logging_result,
+                            )
+                        )
+
+                    # 3. One concrete tool invocation (no external deps).
+                    #    `stoa_platform_info` is a self-describing health tool.
+                    #    Requires a bearer for the same CAB-2121 reason as
+                    #    discovery; pre-merge supplies a dummy bearer.
+                    if call_tool and bearer is not None:
+                        info = await session.call_tool(
+                            "stoa_platform_info", arguments={}
+                        )
+                        results.append(
+                            StageResult(
+                                "tools/call:stoa_platform_info",
+                                not info.isError,
+                                "ok" if not info.isError else "tool returned isError",
+                                info,
+                            )
+                        )
 
     except Exception as exc:  # noqa: BLE001
         results.append(

--- a/stoa-gateway/tests/e2e/mcp_sdk_smoke.py
+++ b/stoa-gateway/tests/e2e/mcp_sdk_smoke.py
@@ -82,10 +82,11 @@ async def run_smoke(
         # D'où le `async with` ci-dessous ; l'omettre fuirait des connexions à
         # chaque exécution.
         async with httpx2.AsyncClient(headers=headers) as http_client:
+            # 2.x ne rend que DEUX flux : `get_session_id` a disparu du tuple
+            # (la 1.x en rendait trois). Il n'était lié nulle part ailleurs ici.
             async with streamable_http_client(url, http_client=http_client) as (
                 read_stream,
                 write_stream,
-                _get_session_id,
             ):
                 async with ClientSession(read_stream, write_stream) as session:
                     # 1. initialize — locks CAB-2112 (experimental shape) + CAB-2106 (Accept).

--- a/stoa-gateway/tests/e2e/mcp_sdk_smoke.py
+++ b/stoa-gateway/tests/e2e/mcp_sdk_smoke.py
@@ -95,8 +95,8 @@ async def run_smoke(
                         StageResult(
                             "initialize",
                             True,
-                            f"protocol={init.protocolVersion} "
-                            f"server={init.serverInfo.name}/{init.serverInfo.version}",
+                            f"protocol={init.protocol_version} "
+                            f"server={init.server_info.name}/{init.server_info.version}",
                             init,
                         )
                     )
@@ -146,7 +146,7 @@ async def run_smoke(
                             StageResult(
                                 "resources/templates/list",
                                 True,
-                                f"{len(templates.resourceTemplates)} templates",
+                                f"{len(templates.resource_templates)} templates",
                                 templates,
                             )
                         )
@@ -182,8 +182,8 @@ async def run_smoke(
                         results.append(
                             StageResult(
                                 "tools/call:stoa_platform_info",
-                                not info.isError,
-                                "ok" if not info.isError else "tool returned isError",
+                                not info.is_error,
+                                "ok" if not info.is_error else "tool returned isError",
                                 info,
                             )
                         )


### PR DESCRIPTION
[#2838](https://github.com/stoa-platform/stoa/pull/2838) épinglait `1.29.0` comme **position d'attente**, en disant que le portage était un travail à part. Le voici — fait sur **lecture du SDK** plutôt qu'au jugé, ce qui était la raison de m'être abstenu.

## Trois faits établis en lisant le SDK — dont deux que j'aurais eus faux en devinant

**1. C'est `httpx2`, pas `httpx`.** La docstring dit : *« To configure headers, authentication, or other HTTP settings, create an `httpx2.AsyncClient` and pass it here »*. Le SDK 2.0 dépend d'un paquet **distinct** — `httpx` n'est même pas installé dans son environnement. Un portage écrit contre `httpx` aurait échoué à l'import.

**2. Le client fourni appartient à l'appelant.** La source tranche :

```python
# Only manage client lifecycle if we created it
if not client_provided:
    await stack.enter_async_context(client)
```

D'où le `async with httpx2.AsyncClient(...)`. **L'omettre aurait fui des connexions à chaque exécution**, sans rien casser de visible — le genre de défaut qui ne se manifeste qu'en production.

**3. La signature s'est réduite** : `streamable_http_client(url, http_client=…, terminate_on_close=…)`. Plus de `headers`, plus de `timeout`, plus d'`auth` — tout cela vit désormais dans le client HTTP.

## Le détail mécanique

Le niveau d'imbrication supplémentaire a imposé de **ré-indenter le corps du bloc** (91 lignes). Vérifié par `ast.parse`, qui avait d'ailleurs **rejeté ma première tentative** — l'erreur d'indentation a été attrapée avant d'atteindre la CI.

## L'épinglage reste, en 2.0.0

Ce qui cassait n'était pas la version mais le **plancher** `mcp>=1.0.0`, qui laissait entrer une majeure sans qu'aucun commit ne le décide.

> Le portage supprime la dette ; l'épinglage supprime la récidive.

## Vérification

Contre le SDK 2.0.0 réel : **tous les imports du script résolvent**, et les deux appels portés **se lient** aux signatures (`httpx2.AsyncClient(headers=…)`, `streamable_http_client(url, http_client=…)`).

La preuve finale est la CI : `Pre-merge (local gateway)` construit la gateway, la démarre et joue le smoke pour de bon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)