### PR TITLE
docs(gateway): l'alerte opentelemetry_sdk n'est pas atteignable — analyse actée

### DIFF
--- a/stoa-gateway/Cargo.toml
+++ b/stoa-gateway/Cargo.toml
@@ -94,6 +94,29 @@ k8s-openapi = { version = "0.27", features = ["latest"], optional = true }
 schemars = { version = "1", optional = true }
 
 # === Phase 5: OpenTelemetry Distributed Tracing (CAB-1374 / CAB-1831: always-on) ===
+# ALERTE DEPENDABOT NON ATTEIGNABLE, et migration délibérément différée.
+# (analysé le 2026-07-30 — relire cette note avant de rouvrir le sujet)
+#
+# L'alerte vise `opentelemetry_sdk` <= 0.32.0 : « unbounded memory allocation
+# in W3C Baggage propagation », corrigée en 0.32.1 seulement.
+#
+# NON ATTEIGNABLE ICI : le mot `baggage` n'apparaît nulle part dans
+# stoa-gateway/src, et la feature n'est pas activée — on ne demande que
+# ["trace"]. La propagation utilisée est TraceContext, pas Baggage.
+#
+# POURQUOI CE N'EST PAS UN SIMPLE BUMP. Passer de 0.27 à 0.32 traverse cinq
+# mineures et casse deux points que ce code utilise, vérifiés sur docs.rs :
+#   - `opentelemetry::global::shutdown_tracer_provider` N'EXISTE PLUS en 0.32
+#     (il faut garder un handle sur le TracerProvider et appeler .shutdown()) ;
+#   - `opentelemetry_sdk::runtime::Tokio` est passé derrière le drapeau
+#     `experimental_async_runtime` ; la feature `rt-tokio` d'ici ne suffit plus.
+# S'y ajoutent les crates en verrou : opentelemetry, -otlp et
+# tracing-opentelemetry doivent monter ensemble.
+#
+# Cela touche l'initialisation ET l'arrêt du traçage — du code qu'on ne valide
+# pas sans exécuter le binaire. Le faire par tours de CI successifs
+# reviendrait à découvrir l'API par ses échecs ; à faire avec une chaîne Rust
+# locale, comme une passe dédiée.
 opentelemetry = { version = "0.27", features = ["trace"] }
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.27", default-features = false, features = ["grpc-tonic", "trace"] }


### PR DESCRIPTION
Dernière alerte Rust du dépôt. **Analysée plutôt que bumpée**, et le résultat justifie de ne pas la traiter maintenant.

## Non atteignable

L'avis vise *« unbounded memory allocation in W3C Baggage propagation »*.

Or **le mot `baggage` n'apparaît nulle part** dans `stoa-gateway/src`, et la feature n'est pas activée — on ne demande que `["trace"]`. La propagation utilisée est **TraceContext**, pas Baggage. Vérifié par lecture du code, pas supposé. Même raisonnement que pour react-router en mode déclaratif.

## Ce n'est pas un simple bump

Le correctif n'existe qu'en **0.32.1**, or on déclare **0.27** : cinq mineures, et **deux ruptures sur des points que ce code utilise** — vérifiées sur docs.rs plutôt que de mémoire :

| API utilisée | État en 0.32 |
|---|---|
| `opentelemetry::global::shutdown_tracer_provider` | **n'existe plus** — il faut garder un handle sur le `TracerProvider` et appeler `.shutdown()` |
| `opentelemetry_sdk::runtime::Tokio` | passé derrière le drapeau `experimental_async_runtime` ; la feature `rt-tokio` d'ici ne suffit plus |

S'y ajoutent les crates **en verrou** : `opentelemetry`, `opentelemetry-otlp` et `tracing-opentelemetry` doivent monter ensemble.

## Pourquoi différer est le bon choix ici

Cela touche l'**initialisation et l'arrêt du traçage** — du code qu'on ne valide pas sans exécuter le binaire. Le faire par tours de CI successifs reviendrait à découvrir l'API par ses échecs, ce que la migration du SDK MCP vient de coûter cher : **quatre allers-retours** avant que j'énumère la surface d'un coup.

À faire avec une **chaîne Rust locale**, comme une passe dédiée.

## Où vit la note

Dans le `Cargo.toml`, à côté des dépendances concernées — c'est là que le prochain regardera, pas dans un ticket. Elle dit ce qui est vérifié, ce qui casse, et ce qu'il faut pour le faire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)