### PR TITLE
spike(wm): deux répliques à redémarrages décalés — expérience, pas décision

### DIFF
--- a/deploy/bootstrap/wm/apigateway/cronjob-a.yaml
+++ b/deploy/bootstrap/wm/apigateway/cronjob-a.yaml
@@ -1,3 +1,8 @@
+# Rotation A du spike « répliques décalées » — décalée d'une DEMI-période
+# (0,20,40) par rapport à l'autre, pour qu'une réplique serve pendant que
+# l'autre redémarre. Le labelSelector est SCOPÉ à `rotation=a` : sans cela
+# le CronJob tuerait les DEUX répliques ensemble et la rotation ne servirait
+# à rien — c'est le défaut que la version mono-réplique ne pouvait pas avoir.
 # Cycle trial PILOTÉ (spéc F3 § D5, stoa-labs) : l'exploitant a tranché « pas
 # de licence » (2026-07-29) ; l'expiration ~25-30 min devient un redémarrage
 # contrôlé aux minutes 0/20/40 — le même motif que le cron root de worker-3,
@@ -37,10 +42,10 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: wm-restarter
+  name: wm-restarter-a
   namespace: wm
 spec:
-  schedule: "*/20 * * * *"
+  schedule: "0,20,40 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -61,5 +66,5 @@ spec:
                   curl -sf --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                   -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
                   -X DELETE
-                  "https://kubernetes.default.svc/api/v1/namespaces/wm/pods?labelSelector=app%3Dwm-apigateway"
-                  -o /dev/null -w "restart-pilote: %{http_code}\n"
+                  "https://kubernetes.default.svc/api/v1/namespaces/wm/pods?labelSelector=app%3Dwm-apigateway%2Crotation%3Da"
+                  -o /dev/null -w "restart-pilote-a: %{http_code}\n"

--- a/deploy/bootstrap/wm/apigateway/cronjob-b.yaml
+++ b/deploy/bootstrap/wm/apigateway/cronjob-b.yaml
@@ -1,0 +1,70 @@
+# Rotation B du spike « répliques décalées » — décalée d'une DEMI-période
+# (10,30,50) par rapport à l'autre, pour qu'une réplique serve pendant que
+# l'autre redémarre. Le labelSelector est SCOPÉ à `rotation=b` : sans cela
+# le CronJob tuerait les DEUX répliques ensemble et la rotation ne servirait
+# à rien — c'est le défaut que la version mono-réplique ne pouvait pas avoir.
+# Cycle trial PILOTÉ (spéc F3 § D5, stoa-labs) : l'exploitant a tranché « pas
+# de licence » (2026-07-29) ; l'expiration ~25-30 min devient un redémarrage
+# contrôlé aux minutes 0/20/40 — le même motif que le cron root de worker-3,
+# porté avec le pod. Le ReplicaSet recrée le pod aussitôt.
+#
+# COUPURE MESURÉE : 120 à 235 s par cycle, soit ~85 % de disponibilité.
+#
+# Sonde à 5 s sur l'INVOCATION DATA-PLANE publique
+# (https://dev-wm.gostoa.dev/gateway/…), 36 min, deux cycles complets
+# (F5, 2026-07-30) :
+#     10:40:09 → 10:44:04   235 s
+#     11:00:14 → 11:02:18   120 s
+# La dispersion atteint un FACTEUR 2 : le chiffre honnête est un intervalle,
+# pas un point. Ne pas le réduire à une moyenne rassurante.
+#
+# CORRECTION d'une valeur précédemment inscrite ici. Ce commentaire annonçait
+# « 150 s » et « 87,5 % ». C'était mesuré sur /rest/apigateway/health — or le
+# health remonte ~85 s AVANT que l'API soit chargée et invocable. Un client
+# voit donc plus long qu'une sonde de santé, et c'est le client qui compte.
+# Les jobs wm-restarter durent 4-9 s : la coupure est le DÉMARRAGE de
+# webMethods, pas la suppression du pod.
+#
+# Ce que voit un client pendant la fenêtre (355 s cumulées sur les 2 cycles) :
+#     503  340 s  le handle_errors du Caddyfile (worker-3) — intention tenue
+#     500   10 s  webMethods répond lui-même 500 pendant son arrêt, et Caddy
+#                 RELAIE ce 5xx amont : handle_errors ne capture que les
+#                 erreurs DE Caddy, pas une réponse d'erreur transmise
+#     000    5 s  aucune réponse sous 6 s (connexion vers un amont mort)
+# Le couvrir exigerait d'intercepter les 5xx amont (handle_response), ce qui
+# masquerait aussi de vraies erreurs applicatives de la gateway. À connaître,
+# pas à maquiller.
+#
+# Conséquence assumée. La haute disponibilité par répliques décalées (A à
+# :00/:20/:40, B à :10/:30/:50) est un SPIKE SÉPARÉ, pas à improviser ici :
+# deux instances wM 10.15 sur un ES partagé exigent un vrai clustering
+# (Terracotta/Ignite) non instruit. Spéc stoa-labs F5 § D9.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: wm-restarter-b
+  namespace: wm
+spec:
+  schedule: "10,30,50 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          serviceAccountName: wm-restarter
+          restartPolicy: Never
+          containers:
+            - name: restart
+              image: localhost:30300/ci/curl:8.10.1@sha256:3a57427a38852a03f246297e21aebaeaab5da747f5444b7b3383c1f4c49a4aa3
+              command:
+                - /bin/sh
+                - -c
+                - >
+                  curl -sf --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                  -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+                  -X DELETE
+                  "https://kubernetes.default.svc/api/v1/namespaces/wm/pods?labelSelector=app%3Dwm-apigateway%2Crotation%3Db"
+                  -o /dev/null -w "restart-pilote-b: %{http_code}\n"

--- a/deploy/bootstrap/wm/apigateway/deployment-a.yaml
+++ b/deploy/bootstrap/wm/apigateway/deployment-a.yaml
@@ -1,0 +1,107 @@
+# Réplique A du SPIKE « répliques décalées » (stoa-labs
+# SPIKE-wm-repliques-decalees-ignite.md). DEUX Deployments d'une réplique
+# plutôt qu'un Deployment de deux : le CronJob de rotation doit pouvoir cibler
+# UNE réplique, or les noms de pods d'un Deployment sont aléatoires. Le label
+# `rotation` donne cette prise ; le Service, lui, sélectionne toujours
+# `app: wm-apigateway` et voit donc les deux.
+#
+# HYPOTHÈSE À RÉFUTER : deux nœuds Ignite en rotation permanente peuvent servir
+# MOINS BIEN qu'un nœud seul avec son trou de 120-235 s (mesuré en F5, ~85 %).
+# Chaque départ est détecté en ~30 s (igniteFailureDetectionTimeout) et entraîne
+# un rééquilibrage de cache. Le critère d'arrêt est la sonde publique de F5.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wm-apigateway-a
+  namespace: wm
+spec:
+  replicas: 1
+  # Recreate : miroir des sémantiques `docker restart` du poste worker-3 ;
+  # deux gateways trial simultanées sur le même ES n'ont aucun sens.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: wm-apigateway
+      rotation: a
+  template:
+    metadata:
+      labels:
+        app: wm-apigateway
+        rotation: a
+    spec:
+      # Anti-affinité worker-3 (motif PR #2819) : la prod Docker wm-dev-* y
+      # tourne encore (double-run F3–F5) — GOAL socle→gateway, jalon F3.
+      affinity:
+        # Les deux répliques sur des nœuds DISTINCTS : sans cela, la perte d'un
+        # nœud emporterait les deux et la rotation ne protégerait de rien.
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: wm-apigateway
+              topologyKey: kubernetes.io/hostname
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - worker-3
+      containers:
+        - name: apigateway
+          image: localhost:30300/ci/apigateway-trial:10.15@sha256:b6aee2b436f6d1053e881844c1f4a6cd12b168a4e2784af97dc84419cef59c49
+          env:
+            # Copie conforme du compose dev worker-3
+            # (deploy/vps/webmethods/docker-compose.dev.yml) : l'état vit dans
+            # ES, la gateway n'a AUCUN volume (constaté sur le Docker de
+            # référence — 2 mois de service).
+            - name: apigw_elasticsearch_hosts
+              value: "elasticsearch:9200"
+            - name: apigw_elasticsearch_http_username
+              value: ""
+            - name: apigw_elasticsearch_http_password
+              value: ""
+          ports:
+            - containerPort: 5555
+            - containerPort: 9072
+          # Identifiants des sondes = Administrator:manage, les identifiants PAR
+          # DÉFAUT de l'image trial, déjà publics dans le healthcheck du compose
+          # de ce dépôt. Retour mesuré ~5 min après restart (handoff stoa-labs
+          # 2026-07-29) : la startupProbe laisse 10 min ; ensuite readiness 15 s
+          # (cadence du healthcheck compose) et liveness en filet du cas
+          # « bloqué sans exit » (l'expiration trial, elle, sort en ExitCode 0
+          # → restartPolicy Always la couvre).
+          startupProbe:
+            httpGet:
+              path: /rest/apigateway/health
+              port: 5555
+              httpHeaders:
+                - name: Authorization
+                  value: "Basic QWRtaW5pc3RyYXRvcjptYW5hZ2U="
+            periodSeconds: 15
+            failureThreshold: 40
+          readinessProbe:
+            httpGet:
+              path: /rest/apigateway/health
+              port: 5555
+              httpHeaders:
+                - name: Authorization
+                  value: "Basic QWRtaW5pc3RyYXRvcjptYW5hZ2U="
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /rest/apigateway/health
+              port: 5555
+              httpHeaders:
+                - name: Authorization
+                  value: "Basic QWRtaW5pc3RyYXRvcjptYW5hZ2U="
+            periodSeconds: 30
+            failureThreshold: 10
+          resources:
+            requests:
+              cpu: 500m
+              memory: 3Gi
+            limits:
+              memory: 4Gi

--- a/deploy/bootstrap/wm/apigateway/deployment-b.yaml
+++ b/deploy/bootstrap/wm/apigateway/deployment-b.yaml
@@ -1,7 +1,18 @@
+# Réplique B du SPIKE « répliques décalées » (stoa-labs
+# SPIKE-wm-repliques-decalees-ignite.md). DEUX Deployments d'une réplique
+# plutôt qu'un Deployment de deux : le CronJob de rotation doit pouvoir cibler
+# UNE réplique, or les noms de pods d'un Deployment sont aléatoires. Le label
+# `rotation` donne cette prise ; le Service, lui, sélectionne toujours
+# `app: wm-apigateway` et voit donc les deux.
+#
+# HYPOTHÈSE À RÉFUTER : deux nœuds Ignite en rotation permanente peuvent servir
+# MOINS BIEN qu'un nœud seul avec son trou de 120-235 s (mesuré en F5, ~85 %).
+# Chaque départ est détecté en ~30 s (igniteFailureDetectionTimeout) et entraîne
+# un rééquilibrage de cache. Le critère d'arrêt est la sonde publique de F5.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: wm-apigateway
+  name: wm-apigateway-b
   namespace: wm
 spec:
   replicas: 1
@@ -12,14 +23,24 @@ spec:
   selector:
     matchLabels:
       app: wm-apigateway
+      rotation: b
   template:
     metadata:
       labels:
         app: wm-apigateway
+        rotation: b
     spec:
       # Anti-affinité worker-3 (motif PR #2819) : la prod Docker wm-dev-* y
       # tourne encore (double-run F3–F5) — GOAL socle→gateway, jalon F3.
       affinity:
+        # Les deux répliques sur des nœuds DISTINCTS : sans cela, la perte d'un
+        # nœud emporterait les deux et la rotation ne protégerait de rien.
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: wm-apigateway
+              topologyKey: kubernetes.io/hostname
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:

--- a/deploy/bootstrap/wm/apigateway/kustomization.yaml
+++ b/deploy/bootstrap/wm/apigateway/kustomization.yaml
@@ -4,5 +4,10 @@ namespace: wm
 resources:
   - rbac.yaml
   - service.yaml
-  - deployment.yaml
-  - cronjob.yaml
+  # Deux Deployments d'une réplique, et non un Deployment de deux : le CronJob
+  # de rotation doit cibler UNE réplique, or les noms de pods d'un Deployment
+  # sont aléatoires. Le label `rotation` donne cette prise.
+  - deployment-a.yaml
+  - deployment-b.yaml
+  - cronjob-a.yaml
+  - cronjob-b.yaml


### PR DESCRIPTION
Met en place la **mesure** que réclame le spike (`stoa-labs SPIKE-wm-repliques-decalees-ignite.md`). **Ce n'est pas une amélioration proposée : c'est une hypothèse à réfuter.**

## Le contexte

F5 a mesuré côté public **120 à 235 s de coupure par cycle de 20 min** (~85 % de disponibilité). L'idée : deux répliques redémarrées en alternance pour qu'une serve toujours.

Deux prérequis étaient inconnus ; l'exploitant les avait **déjà levés** lors d'un test antérieur — la licence trial accepte plusieurs instances, et des pods **dynamiques** s'intègrent au cluster Ignite. Reste **une** question, celle que son test n'a pas couverte : ses nœuds *rejoignaient*, aucun ne **partait et revenait toutes les 10 minutes**.

## La forme, et pourquoi

**Deux Deployments d'une réplique**, pas un Deployment de deux. Le CronJob de rotation doit cibler **une** réplique, or les noms de pods d'un Deployment sont aléatoires. Le label `rotation` donne cette prise ; le Service continue de sélectionner `app: wm-apigateway` et voit donc les deux. **Sa ClusterIP épinglée est inchangée — Caddy n'est pas touché.**

Le `labelSelector` de chaque CronJob est **scopé à sa rotation**. Sans cela il tuerait les **deux** répliques ensemble et la rotation ne servirait à rien — défaut que la version mono-réplique ne pouvait pas avoir, et qui serait passé inaperçu puisque le service resterait « à peu près » disponible.

**Anti-affinité entre répliques** : A et B sur des nœuds distincts, sinon la perte d'un nœud emporterait les deux. Capacité vérifiée avant d'écrire — ~24 Gi par nœud pour 3 Gi demandés, sur trois nœuds éligibles (worker-3 reste exclu).

```
Service      wm-apigateway     {app: wm-apigateway}  clusterIP=10.43.227.71  ← inchangé
Deployment   wm-apigateway-a   {app: wm-apigateway, rotation: a}
Deployment   wm-apigateway-b   {app: wm-apigateway, rotation: b}
CronJob      wm-restarter-a    0,20,40 * * * *
CronJob      wm-restarter-b    10,30,50 * * * *
```

## Ce que cette PR n'affirme pas

Elle ne prétend pas que la rotation améliore quoi que ce soit. Chaque départ de nœud est détecté en ~30 s (`igniteFailureDetectionTimeout`) et déclenche un rééquilibrage de cache : **deux nœuds en rotation permanente peuvent servir moins bien qu'un nœud seul**.

## Critère d'arrêt

La sonde publique de F5 rejouée — 5 s, ≥ 2 cycles, sur l'invocation data-plane réelle. **Si la disponibilité ne dépasse pas franchement les ~85 % mesurés, on revient.** L'état actuel est simple, compris et mesuré ; le retour arrière est la révocation de cette PR.

## À savoir avant de merger

L'application provoque une **coupure de transition** : l'ancien Deployment est élagué, les deux nouveaux démarrent (~120-235 s chacun). Comparable à un cycle de redémarrage normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)