### PR TITLE
docs(wm): inscrire le résultat mesuré — 99,1 %, et distinguer les deux régimes

### DIFF
--- a/deploy/bootstrap/wm/apigateway/cronjob-a.yaml
+++ b/deploy/bootstrap/wm/apigateway/cronjob-a.yaml
@@ -8,7 +8,13 @@
 # contrôlé aux minutes 0/20/40 — le même motif que le cron root de worker-3,
 # porté avec le pod. Le ReplicaSet recrée le pod aussitôt.
 #
-# COUPURE MESURÉE : 120 à 235 s par cycle, soit ~85 % de disponibilité.
+# COUPURE MESURÉE — DEUX RÉGIMES, à ne pas confondre.
+#   mono-réplique (avant le 2026-07-30) : 120 à 235 s par cycle de 20 min,
+#     soit ~85 % de disponibilité ;
+#   ROTATION DÉCALÉE (régime actuel)    : moins de 5 s par rotation de
+#     10 min, soit 99,1 % mesuré sur 63 min.
+# Les chiffres détaillés ci-dessous décrivent le PREMIER régime : ils
+# expliquent pourquoi la rotation existe, pas ce qu'elle produit.
 #
 # Sonde à 5 s sur l'INVOCATION DATA-PLANE publique
 # (https://dev-wm.gostoa.dev/gateway/…), 36 min, deux cycles complets

--- a/deploy/bootstrap/wm/apigateway/cronjob-b.yaml
+++ b/deploy/bootstrap/wm/apigateway/cronjob-b.yaml
@@ -8,7 +8,13 @@
 # contrôlé aux minutes 0/20/40 — le même motif que le cron root de worker-3,
 # porté avec le pod. Le ReplicaSet recrée le pod aussitôt.
 #
-# COUPURE MESURÉE : 120 à 235 s par cycle, soit ~85 % de disponibilité.
+# COUPURE MESURÉE — DEUX RÉGIMES, à ne pas confondre.
+#   mono-réplique (avant le 2026-07-30) : 120 à 235 s par cycle de 20 min,
+#     soit ~85 % de disponibilité ;
+#   ROTATION DÉCALÉE (régime actuel)    : moins de 5 s par rotation de
+#     10 min, soit 99,1 % mesuré sur 63 min.
+# Les chiffres détaillés ci-dessous décrivent le PREMIER régime : ils
+# expliquent pourquoi la rotation existe, pas ce qu'elle produit.
 #
 # Sonde à 5 s sur l'INVOCATION DATA-PLANE publique
 # (https://dev-wm.gostoa.dev/gateway/…), 36 min, deux cycles complets

--- a/deploy/bootstrap/wm/apigateway/deployment-a.yaml
+++ b/deploy/bootstrap/wm/apigateway/deployment-a.yaml
@@ -5,10 +5,21 @@
 # `rotation` donne cette prise ; le Service, lui, sélectionne toujours
 # `app: wm-apigateway` et voit donc les deux.
 #
-# HYPOTHÈSE À RÉFUTER : deux nœuds Ignite en rotation permanente peuvent servir
-# MOINS BIEN qu'un nœud seul avec son trou de 120-235 s (mesuré en F5, ~85 %).
-# Chaque départ est détecté en ~30 s (igniteFailureDetectionTimeout) et entraîne
-# un rééquilibrage de cache. Le critère d'arrêt est la sonde publique de F5.
+# RÉSULTAT MESURÉ (2026-07-30, 63 min de sonde publique à 5 s sur l'invocation
+# data-plane) : 99,1 % de disponibilité, contre ~85 % en mono-réplique. La
+# coupure passe de 120-235 s par cycle de 20 min à MOINS DE 5 s par rotation de
+# 10 min — sept rotations observées, chacune coûtant un seul échantillon, donc
+# la coupure réelle est SOUS la résolution de la sonde.
+#
+# L'hypothèse posée en ouvrant ce spike — « deux nœuds Ignite en rotation
+# permanente peuvent servir MOINS BIEN qu'un nœud seul » — n'a PAS été réfutée
+# par les faits : le rééquilibrage redouté ne se manifeste pas à cette échelle.
+#
+# À SAVOIR, et ce n'est pas un détail : le code d'erreur passe de 503 à 500. En
+# mono-réplique, Caddy rendait son handle_errors pendant 2-4 min ; désormais un
+# client malchanceux reçoit un 500 de webMethods relayé par Caddy, pendant moins
+# de 5 s. Il voit donc une erreur APPLICATIVE brève là où il voyait une
+# indisponibilité franche et longue. Un client qui réessaie réussit.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/bootstrap/wm/apigateway/deployment-b.yaml
+++ b/deploy/bootstrap/wm/apigateway/deployment-b.yaml
@@ -5,10 +5,21 @@
 # `rotation` donne cette prise ; le Service, lui, sélectionne toujours
 # `app: wm-apigateway` et voit donc les deux.
 #
-# HYPOTHÈSE À RÉFUTER : deux nœuds Ignite en rotation permanente peuvent servir
-# MOINS BIEN qu'un nœud seul avec son trou de 120-235 s (mesuré en F5, ~85 %).
-# Chaque départ est détecté en ~30 s (igniteFailureDetectionTimeout) et entraîne
-# un rééquilibrage de cache. Le critère d'arrêt est la sonde publique de F5.
+# RÉSULTAT MESURÉ (2026-07-30, 63 min de sonde publique à 5 s sur l'invocation
+# data-plane) : 99,1 % de disponibilité, contre ~85 % en mono-réplique. La
+# coupure passe de 120-235 s par cycle de 20 min à MOINS DE 5 s par rotation de
+# 10 min — sept rotations observées, chacune coûtant un seul échantillon, donc
+# la coupure réelle est SOUS la résolution de la sonde.
+#
+# L'hypothèse posée en ouvrant ce spike — « deux nœuds Ignite en rotation
+# permanente peuvent servir MOINS BIEN qu'un nœud seul » — n'a PAS été réfutée
+# par les faits : le rééquilibrage redouté ne se manifeste pas à cette échelle.
+#
+# À SAVOIR, et ce n'est pas un détail : le code d'erreur passe de 503 à 500. En
+# mono-réplique, Caddy rendait son handle_errors pendant 2-4 min ; désormais un
+# client malchanceux reçoit un 500 de webMethods relayé par Caddy, pendant moins
+# de 5 s. Il voit donc une erreur APPLICATIVE brève là où il voyait une
+# indisponibilité franche et longue. Un client qui réessaie réussit.
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Les commentaires posés en ouvrant le spike ([#2842](https://github.com/stoa-platform/stoa/pull/2842)) décrivaient une **hypothèse** et le régime mono-réplique. Le spike a été exécuté : ils décrivent désormais le passé **sans le dire**.

C'est exactement le défaut corrigé plus tôt sur le chiffre du cycle trial ([#2826](https://github.com/stoa-platform/stoa/pull/2826)) — **une valeur périmée dans Git se présente comme une mesure courante**.

## Le résultat

63 min de sonde publique à 5 s, sur l'invocation data-plane réelle :

| | Mono-réplique | Rotation décalée |
|---|---|---|
| Coupure par cycle | 120–235 s / 20 min | **< 5 s / 10 min** |
| Disponibilité | ~85 % | **99,1 %** |

**Sept rotations observées**, chacune coûtant un seul échantillon — la coupure réelle est donc **sous la résolution de la sonde**, et non « 5 s ».

## L'hypothèse n'a pas été réfutée

En ouvrant le spike j'avais écrit : *« deux nœuds Ignite en rotation permanente peuvent servir moins bien qu'un nœud seul »*, chaque départ étant détecté en ~30 s et déclenchant un rééquilibrage.

Le commentaire le dit ainsi plutôt que de faire disparaître la crainte : **elle était légitime, elle a été mesurée, elle est levée**. À cette échelle, le rééquilibrage ne se manifeste pas.

## Ce qui change de nature — conservé en clair

**Le code d'erreur passe de 503 à 500.** En mono-réplique, Caddy rendait son `handle_errors` pendant 2–4 min. Désormais un client malchanceux reçoit un **500 de webMethods** relayé par Caddy, pendant moins de 5 s.

Il voit donc une **erreur applicative brève** là où il voyait une indisponibilité franche et longue. Un client qui réessaie réussit — mais celui qui ne réessaie pas voit autre chose qu'avant.

## Pourquoi les CronJobs distinguent explicitement deux régimes

Leurs chiffres détaillés (120–235 s, 30 s de `failureDetection`) expliquent **pourquoi la rotation existe**, pas ce qu'elle produit. Les confondre ferait lire l'ancien régime comme l'actuel — c'est précisément le piège que cette PR ferme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)